### PR TITLE
script: Further implement fontsize command

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -4660,6 +4660,13 @@ impl Document {
         }
     }
 
+    /// <https://w3c.github.io/editing/docs/execCommand/#value-override>
+    /// and <https://w3c.github.io/editing/docs/execCommand/#state-override>
+    pub(crate) fn clear_command_overrides(&self) {
+        self.state_override.borrow_mut().clear();
+        self.value_override.borrow_mut().clear();
+    }
+
     /// <https://w3c.github.io/editing/docs/execCommand/#default-single-line-container-name>
     pub(crate) fn default_single_line_container_name(&self) -> DefaultSingleLineContainerName {
         self.default_single_line_container_name.get()

--- a/components/script/dom/execcommand/commands/fontsize.rs
+++ b/components/script/dom/execcommand/commands/fontsize.rs
@@ -112,18 +112,9 @@ pub(crate) fn execute_fontsize_command(
     };
     // Step 9. If number is less than one, let number equal 1.
     // Step 10. If number is greater than seven, let number equal 7.
-    let number = number.clamp(1, 7);
+    let number = number.clamp(1, 7) as u32;
     // Step 11. Set value to the string here corresponding to number:
-    let value = match number {
-        1 => "x-small",
-        2 => "small",
-        3 => "medium",
-        4 => "large",
-        5 => "x-large",
-        6 => "xx-large",
-        7 => "xxx-large",
-        _ => unreachable!("Must be bounded by 1 and 7"),
-    };
+    let value = font_size_to_css_font(&number);
     // Step 12. Set the selection's value to value.
     selection.set_the_selection_value(cx, Some(value.into()), CommandName::FontSize, document);
     // Step 13. Return true.
@@ -147,22 +138,28 @@ pub(crate) fn value_for_fontsize_command(
         .unwrap_or_else(|| active_range.start_container())
         .effective_command_value(&CommandName::FontSize)?;
     // Step 3. Return the legacy font size for pixel size.
-    //
-    // Only in the case we have resolved to actual pixels, we need to
-    // do its conversion. In other cases, we already have the relevant
-    // font size or corresponding css value. This avoids expensive
-    // conversions of pixels to other values.
+    maybe_normalize_pixels(&command_value, document)
+}
+
+/// Only in the case we have resolved to actual pixels, we need to
+/// do its conversion. In other cases, we already have the relevant
+/// font size or corresponding css value. This avoids expensive
+/// conversions of pixels to other values.
+pub(crate) fn maybe_normalize_pixels(
+    command_value: &DOMString,
+    document: &Document,
+) -> Option<DOMString> {
     if command_value.ends_with_str("px") {
         command_value.str()[0..command_value.len() - 2]
             .parse::<f32>()
             .ok()
             .map(|value| legacy_font_size_for(value, document))
     } else {
-        Some(normalize_font_string(&command_value.str()).into())
+        Some(css_font_to_font_size(&command_value.str()).into())
     }
 }
 
-fn normalize_font_string(str_: &str) -> &str {
+fn css_font_to_font_size(str_: &str) -> &str {
     match str_ {
         "x-small" => "1",
         "small" => "2",
@@ -175,11 +172,24 @@ fn normalize_font_string(str_: &str) -> &str {
     }
 }
 
+pub(crate) fn font_size_to_css_font(value: &u32) -> &str {
+    match value {
+        1 => "x-small",
+        2 => "small",
+        3 => "medium",
+        4 => "large",
+        5 => "x-large",
+        6 => "xx-large",
+        7 => "xxx-large",
+        _ => unreachable!(),
+    }
+}
+
 /// Handles fontsize command part of
 /// <https://w3c.github.io/editing/docs/execCommand/#loosely-equivalent-values>
 pub(crate) fn font_size_loosely_equivalent(first: &DOMString, second: &DOMString) -> bool {
     // > one of the quantities is one of "x-small", "small", "medium", "large", "x-large", "xx-large", or "xxx-large";
     // > and the other quantity is the resolved value of "font-size" on a font element whose size attribute
     // > has the corresponding value set ("1" through "7" respectively).
-    normalize_font_string(&first.str()) == second || first == normalize_font_string(&second.str())
+    css_font_to_font_size(&first.str()) == second || first == css_font_to_font_size(&second.str())
 }

--- a/components/script/dom/execcommand/contenteditable.rs
+++ b/components/script/dom/execcommand/contenteditable.rs
@@ -7,8 +7,12 @@ use std::ops::Deref;
 
 use html5ever::local_name;
 use script_bindings::inheritance::Castable;
+use style::attr::AttrValue;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
+use style::properties::PropertyDeclarationId;
+use style::properties::generated::{LonghandId, PropertyDeclaration};
 use style::values::specified::box_::DisplayOutside;
+use style::values::specified::text::TextDecorationLine;
 
 use crate::dom::abstractrange::bp_position;
 use crate::dom::bindings::cell::Ref;
@@ -30,6 +34,7 @@ use crate::dom::characterdata::CharacterData;
 use crate::dom::document::Document;
 use crate::dom::element::Element;
 use crate::dom::execcommand::basecommand::{CommandName, CssPropertyName};
+use crate::dom::execcommand::commands::fontsize::{font_size_to_css_font, legacy_font_size_for};
 use crate::dom::html::htmlanchorelement::HTMLAnchorElement;
 use crate::dom::html::htmlbrelement::HTMLBRElement;
 use crate::dom::html::htmlelement::HTMLElement;
@@ -358,7 +363,13 @@ impl Element {
         }
         // Step 11. If element is a font element that has an attribute whose effect is to create a presentational hint for property,
         // return the value that the hint sets property to. (For a size of 7, this will be the non-CSS value "xxx-large".)
-        // TODO
+        if self.is::<HTMLFontElement>() {
+            if let Some(font_size) = self.get_attribute(&local_name!("size")) {
+                if let AttrValue::UInt(_, value) = *font_size.value() {
+                    return Some(font_size_to_css_font(&value).into());
+                }
+            }
+        }
 
         // Step 12. If element is in the following list, and property is equal to the CSS property name listed for it,
         // return the string listed for it.
@@ -381,19 +392,74 @@ impl Element {
 
     /// <https://w3c.github.io/editing/docs/execCommand/#simple-modifiable-element>
     fn is_simple_modifiable_element(&self) -> bool {
-        // > It is an a, b, em, font, i, s, span, strike, strong, sub, sup, or u element with no attributes.
-        // TODO
+        let attrs = self.attrs();
+        let attr_count = attrs.len();
+        let type_id = self.upcast::<Node>().type_id();
 
-        // > It is an a, b, em, font, i, s, span, strike, strong, sub, sup, or u element
-        // > with exactly one attribute, which is style,
-        // > which sets no CSS properties (including invalid or unrecognized properties).
-        // TODO
+        if matches!(
+            type_id,
+            NodeTypeId::Element(ElementTypeId::HTMLElement(
+                HTMLElementTypeId::HTMLAnchorElement,
+            )) | NodeTypeId::Element(ElementTypeId::HTMLElement(
+                HTMLElementTypeId::HTMLFontElement,
+            )) | NodeTypeId::Element(ElementTypeId::HTMLElement(
+                HTMLElementTypeId::HTMLSpanElement,
+            ))
+        ) {
+            // > It is an a, b, em, font, i, s, span, strike, strong, sub, sup, or u element with no attributes.
+            //
+            // TODO: All elements that are HTMLElement rather than a specific one
+            if attr_count == 0 {
+                return true;
+            }
+
+            // > It is an a, b, em, font, i, s, span, strike, strong, sub, sup, or u element
+            // > with exactly one attribute, which is style,
+            // > which sets no CSS properties (including invalid or unrecognized properties).
+            if attr_count == 1 &&
+                self.attrs().first().expect("Size is 1").local_name() == &local_name!("style")
+            {
+                let style_attribute = self.style_attribute().borrow();
+                if style_attribute.as_ref().is_some_and(|declarations| {
+                    let document = self.owner_document();
+                    let shared_lock = document.style_shared_lock();
+                    let read_lock = shared_lock.read();
+                    let style = declarations.read_with(&read_lock);
+
+                    style.is_empty()
+                }) {
+                    return true;
+                }
+            }
+        }
+
+        if attr_count != 1 {
+            return false;
+        }
+
+        let only_attribute = attrs.first().expect("Size is 1").local_name();
 
         // > It is an a element with exactly one attribute, which is href.
-        // TODO
+        if matches!(
+            type_id,
+            NodeTypeId::Element(ElementTypeId::HTMLElement(
+                HTMLElementTypeId::HTMLAnchorElement,
+            ))
+        ) {
+            return only_attribute == &local_name!("href");
+        }
 
         // > It is a font element with exactly one attribute, which is either color, face, or size.
-        // TODO
+        if matches!(
+            type_id,
+            NodeTypeId::Element(ElementTypeId::HTMLElement(
+                HTMLElementTypeId::HTMLFontElement,
+            ))
+        ) {
+            return only_attribute == &local_name!("color") ||
+                only_attribute == &local_name!("face") ||
+                only_attribute == &local_name!("size");
+        }
 
         // > It is a b or strong element with exactly one attribute, which is style,
         // > and the style attribute sets exactly one CSS property
@@ -408,13 +474,55 @@ impl Element {
         // > It is an a, font, or span element with exactly one attribute, which is style,
         // > and the style attribute sets exactly one CSS property (including invalid or unrecognized properties),
         // > and that property is not "text-decoration".
-        // TODO
+        if matches!(
+            type_id,
+            NodeTypeId::Element(ElementTypeId::HTMLElement(
+                HTMLElementTypeId::HTMLAnchorElement,
+            )) | NodeTypeId::Element(ElementTypeId::HTMLElement(
+                HTMLElementTypeId::HTMLFontElement,
+            )) | NodeTypeId::Element(ElementTypeId::HTMLElement(
+                HTMLElementTypeId::HTMLSpanElement,
+            ))
+        ) {
+            if only_attribute != &local_name!("style") {
+                return false;
+            }
+            let style_attribute = self.style_attribute().borrow();
+            let Some(declarations) = style_attribute.as_ref() else {
+                return false;
+            };
+            let document = self.owner_document();
+            let shared_lock = document.style_shared_lock();
+            let read_lock = shared_lock.read();
+            let style = declarations.read_with(&read_lock);
 
-        // > It is an a, font, s, span, strike, or u element with exactly one attribute,
-        // > which is style, and the style attribute sets exactly one CSS property
-        // > (including invalid or unrecognized properties), which is "text-decoration",
-        // > which is set to "line-through" or "underline" or "overline" or "none".
-        // TODO
+            if style.len() == 1 {
+                if let Some((text_decoration, _)) = style.get(PropertyDeclarationId::Longhand(
+                    LonghandId::TextDecorationLine,
+                )) {
+                    // > It is an a, font, s, span, strike, or u element with exactly one attribute,
+                    // > which is style, and the style attribute sets exactly one CSS property
+                    // > (including invalid or unrecognized properties), which is "text-decoration",
+                    // > which is set to "line-through" or "underline" or "overline" or "none".
+                    //
+                    // TODO: Also the other element types
+                    return matches!(
+                        text_decoration,
+                        PropertyDeclaration::TextDecorationLine(
+                            TextDecorationLine::LINE_THROUGH |
+                                TextDecorationLine::UNDERLINE |
+                                TextDecorationLine::OVERLINE |
+                                TextDecorationLine::NONE
+                        )
+                    );
+                } else {
+                    // > It is an a, font, or span element with exactly one attribute, which is style,
+                    // > and the style attribute sets exactly one CSS property (including invalid or unrecognized properties),
+                    // > and that property is not "text-decoration".
+                    return true;
+                }
+            }
+        }
 
         false
     }
@@ -926,9 +1034,9 @@ pub(crate) fn split_the_parent<'a>(cx: &mut js::context::JSContext, node_list: &
 }
 
 /// <https://w3c.github.io/editing/docs/execCommand/#wrap>
-fn wrap_node_list<'a, SiblingCriteria, NewParentInstructions>(
+fn wrap_node_list<SiblingCriteria, NewParentInstructions>(
     cx: &mut js::context::JSContext,
-    node_list: &'a [&'a Node],
+    node_list: Vec<DomRoot<Node>>,
     sibling_criteria: SiblingCriteria,
     new_parent_instructions: NewParentInstructions,
 ) -> Option<DomRoot<Node>>
@@ -938,16 +1046,43 @@ where
 {
     // Step 1. If every member of node list is invisible,
     // and none is a br, return null and abort these steps.
-    // TODO
+    if node_list
+        .iter()
+        .all(|node| node.is_invisible() && !node.is::<HTMLBRElement>())
+    {
+        return None;
+    }
     // Step 2. If node list's first member's parent is null, return null and abort these steps.
-    // TODO
+    node_list.first().and_then(|first| first.GetParentNode())?;
     // Step 3. If node list's last member is an inline node that's not a br,
     // and node list's last member's nextSibling is a br, append that br to node list.
-    // TODO
+    let mut node_list = node_list;
+    if let Some(last) = node_list.last() {
+        if last.is_inline_node() && !last.is::<HTMLBRElement>() {
+            if let Some(next_of_last) = last.GetNextSibling() {
+                if next_of_last.is::<HTMLBRElement>() {
+                    node_list.push(next_of_last);
+                }
+            }
+        }
+    }
     // Step 4. While node list's first member's previousSibling is invisible, prepend it to node list.
-    // TODO
+    while let Some(previous_of_first) = node_list.first().and_then(|last| last.GetPreviousSibling())
+    {
+        if previous_of_first.is_invisible() {
+            node_list.insert(0, previous_of_first);
+            continue;
+        }
+        break;
+    }
     // Step 5. While node list's last member's nextSibling is invisible, append it to node list.
-    // TODO
+    while let Some(next_of_last) = node_list.last().and_then(|last| last.GetNextSibling()) {
+        if next_of_last.is_invisible() {
+            node_list.push(next_of_last);
+            continue;
+        }
+        break;
+    }
     // Step 6. If the previousSibling of the first member of node list is editable
     // and running sibling criteria on it returns true,
     // let new parent be the previousSibling of the first member of node list.
@@ -989,7 +1124,26 @@ where
         // Step 10.2. If any range has a boundary point with node equal
         // to the parent of new parent and offset equal to the index of new parent,
         // add one to that boundary point's offset.
-        // TODO
+        if let Some(range) = first_in_node_list
+            .owner_document()
+            .GetSelection(CanGc::from_cx(cx))
+            .and_then(|selection| selection.active_range())
+        {
+            let parent_of_new_parent = new_parent.GetParentNode().expect("Must have a parent");
+            let start_container = range.start_container();
+            let start_offset = range.start_offset();
+
+            if start_container == parent_of_new_parent && start_offset == new_parent.index() {
+                range.set_start(&start_container, start_offset + 1);
+            }
+
+            let end_container = range.end_container();
+            let end_offset = range.end_offset();
+
+            if end_container == parent_of_new_parent && end_offset == new_parent.index() {
+                range.set_start(&end_container, end_offset + 1);
+            }
+        }
     }
     // Step 12. If new parent is before the first member of node list in tree order:
     if new_parent.is_before(first_in_node_list) {
@@ -1001,7 +1155,7 @@ where
         // TODO
         // Step 12.2. For each node in node list, append node as the last child of new parent, preserving ranges.
         for node in node_list {
-            move_preserving_ranges(cx, node, |cx| new_parent.AppendChild(cx, node));
+            move_preserving_ranges(cx, &node, |cx| new_parent.AppendChild(cx, &node));
         }
     } else {
         // Step 13. Otherwise:
@@ -1026,7 +1180,39 @@ where
         original_parent.remove_self(cx);
     }
     // Step 15. If new parent's nextSibling is editable and running sibling criteria on it returns true:
-    // TODO
+    if let Some(next_of_new_parent) = new_parent.GetNextSibling() {
+        if next_of_new_parent.is_editable() && sibling_criteria(&next_of_new_parent) {
+            // Step 15.1. If new parent is not an inline node,
+            // but new parent's last child and new parent's nextSibling's first child are both inline nodes,
+            // and new parent's last child is not a br, call createElement("br") on the ownerDocument
+            // of new parent and append the result as the last child of new parent.
+            if !new_parent.is_inline_node() {
+                if let Some(last_child_of_new_parent) = new_parent.children().last() {
+                    if last_child_of_new_parent.is_inline_node() &&
+                        !last_child_of_new_parent.is::<HTMLBRElement>() &&
+                        next_of_new_parent
+                            .children()
+                            .next()
+                            .is_some_and(|first| first.is_inline_node())
+                    {
+                        let new_br_element = new_parent.owner_document().create_element(cx, "br");
+                        if new_parent.AppendChild(cx, new_br_element.upcast()).is_err() {
+                            unreachable!("Must always be able to append");
+                        }
+                    }
+                }
+            }
+            // Step 15.2. While new parent's nextSibling has children,
+            // append its first child as the last child of new parent, preserving ranges.
+            while let Some(first_of_next) = next_of_new_parent.children().next() {
+                move_preserving_ranges(cx, &first_of_next, |cx| {
+                    new_parent.AppendChild(cx, &first_of_next)
+                });
+            }
+            // Step 15.3. Remove new parent's nextSibling from its parent.
+            next_of_new_parent.remove_self(cx);
+        }
+    }
     // Step 16. Remove extraneous line breaks from new parent.
     new_parent.remove_extraneous_line_breaks_from(cx);
     // Step 17. Return new parent.
@@ -1136,7 +1322,17 @@ impl Node {
                 }
                 // Step 11.6.2. If child is an Element whose specified command value for command is neither null
                 // nor equivalent to propagated value, continue with the next child.
-                // TODO
+                if let Some(child_element) = child.downcast::<Element>() {
+                    let specified_value = child_element.specified_command_value(command);
+                    if specified_value.is_some() &&
+                        !command.are_equivalent_values(
+                            specified_value.as_ref(),
+                            propagated_value.as_ref(),
+                        )
+                    {
+                        continue;
+                    }
+                }
 
                 // Step 11.6.3. If child is the last member of ancestor list, continue with the next child.
                 //
@@ -1189,19 +1385,20 @@ impl Node {
             // and with new parent instructions returning null.
             wrap_node_list(
                 cx,
-                &[self],
+                vec![DomRoot::from_ref(self)],
                 |sibling| {
-                    // TODO: Check for simple modifiable
                     sibling
                         .downcast::<Element>()
                         .is_some_and(|sibling_element| {
-                            command.are_equivalent_values(
-                                sibling_element.specified_command_value(command).as_ref(),
-                                Some(new_value),
-                            ) && command.are_loosely_equivalent_values(
-                                sibling.effective_command_value(command).as_ref(),
-                                Some(new_value),
-                            )
+                            sibling_element.is_simple_modifiable_element() &&
+                                command.are_equivalent_values(
+                                    sibling_element.specified_command_value(command).as_ref(),
+                                    Some(new_value),
+                                ) &&
+                                command.are_loosely_equivalent_values(
+                                    sibling.effective_command_value(command).as_ref(),
+                                    Some(new_value),
+                                )
                         })
                 },
                 || None,
@@ -1219,7 +1416,28 @@ impl Node {
             return;
         }
         // Step 7. If node is not an allowed child of "span":
-        // TODO
+        if !is_allowed_child(
+            NodeOrString::Node(DomRoot::from_ref(self)),
+            NodeOrString::String("span".to_owned()),
+        ) {
+            for child in self.children() {
+                // Step 7.1. Let children be all children of node, omitting any that are Elements whose
+                // specified command value for command is neither null nor equivalent to new value.
+                if let Some(child_element) = child.downcast::<Element>() {
+                    let specified_value = child_element.specified_command_value(command);
+                    if specified_value.is_some() &&
+                        !command.are_equivalent_values(specified_value.as_ref(), Some(new_value))
+                    {
+                        continue;
+                    }
+                }
+                // Step 7.2. Force the value of each node in children,
+                // with command and new value as in this invocation of the algorithm.
+                child.force_the_value(cx, command, Some(new_value));
+            }
+            // Step 7.3. Abort this algorithm.
+            return;
+        }
         // Step 8. If the effective command value of command is loosely equivalent to new value on node, abort this algorithm.
         if command.are_loosely_equivalent_values(
             self.effective_command_value(command).as_ref(),
@@ -1294,7 +1512,10 @@ impl Node {
         // and the relevant CSS property for command is not null,
         // set that CSS property of new parent to new value (if the new value would be valid).
         if !command.are_loosely_equivalent_values(
-            self.effective_command_value(command).as_ref(),
+            new_parent
+                .upcast::<Node>()
+                .effective_command_value(command)
+                .as_ref(),
             Some(new_value),
         ) {
             if let Some(css_property) = command.relevant_css_property() {
@@ -2421,14 +2642,109 @@ impl Range {
     /// <https://w3c.github.io/editing/docs/execCommand/#restore-states-and-values>
     fn restore_states_and_values(
         &self,
+        cx: &mut js::context::JSContext,
+        selection: &Selection,
         context_object: &Document,
         overrides: Vec<RecordedStateOfNode>,
     ) {
         // Step 1. Let node be the first formattable node effectively contained in the active range,
         // or null if there is none.
-        let Some(_node) = self.first_formattable_contained_node() else {
-            // Step 3. Otherwise, for each (command, override) pair in overrides, in order:
-            for override_state in overrides {
+        let mut first_formattable_contained_node = self.first_formattable_contained_node();
+        for override_state in overrides {
+            // Step 2. If node is not null, then for each (command, override) pair in overrides, in order:
+            if let Some(ref node) = first_formattable_contained_node {
+                match override_state.value {
+                    // Step 2.1. If override is a boolean, and queryCommandState(command)
+                    // returns something different from override, take the action for command,
+                    // with value equal to the empty string.
+                    BoolOrOptionalString::Bool(bool_)
+                        if override_state
+                            .command
+                            .current_state(context_object)
+                            .is_some_and(|value| value != bool_) =>
+                    {
+                        override_state
+                            .command
+                            .execute(cx, context_object, selection, "".into());
+                    },
+                    BoolOrOptionalString::OptionalString(optional_string) => {
+                        match override_state.command {
+                            // Step 2.3. Otherwise, if override is a string; and command is "createLink";
+                            // and either there is a value override for "createLink" that is not equal to override,
+                            // or there is no value override for "createLink" and node's effective command value
+                            // for "createLink" is not equal to override: take the action for "createLink", with value equal to override.
+                            CommandName::CreateLink => {
+                                let value_override =
+                                    context_object.value_override(&CommandName::CreateLink);
+                                if value_override != optional_string {
+                                    CommandName::CreateLink.execute(
+                                        cx,
+                                        context_object,
+                                        selection,
+                                        optional_string.unwrap_or_default(),
+                                    );
+                                }
+                            },
+                            // Step 2.4. Otherwise, if override is a string; and command is "fontSize";
+                            // and either there is a value override for "fontSize" that is not equal to override,
+                            // or there is no value override for "fontSize" and node's effective command value for "fontSize"
+                            // is not loosely equivalent to override:
+                            CommandName::FontSize => {
+                                let value_override =
+                                    context_object.value_override(&CommandName::FontSize);
+                                if value_override != optional_string ||
+                                    (value_override.is_none() &&
+                                        !CommandName::FontSize.are_loosely_equivalent_values(
+                                            node.effective_command_value(&CommandName::FontSize)
+                                                .as_ref(),
+                                            optional_string.as_ref(),
+                                        ))
+                                {
+                                    // Step 2.5. Convert override to an integer number of pixels,
+                                    // and set override to the legacy font size for the result.
+                                    let pixels = optional_string
+                                        .and_then(|value| value.parse::<i32>().ok())
+                                        .map(|value| {
+                                            legacy_font_size_for(value as f32, context_object)
+                                        })
+                                        .unwrap_or("7".into());
+                                    // Step 2.6. Take the action for "fontSize", with value equal to override.
+                                    CommandName::FontSize.execute(
+                                        cx,
+                                        context_object,
+                                        selection,
+                                        pixels,
+                                    );
+                                }
+                            },
+                            // Step 2.2. Otherwise, if override is a string, and command is neither "createLink" nor "fontSize",
+                            // and queryCommandValue(command) returns something not equivalent to override,
+                            // take the action for command, with value equal to override.
+                            command
+                                if command.current_value(cx, context_object) != optional_string =>
+                            {
+                                command.execute(
+                                    cx,
+                                    context_object,
+                                    selection,
+                                    optional_string.unwrap_or_default(),
+                                );
+                            },
+                            // Step 2.5. Otherwise, continue this loop from the beginning.
+                            _ => {
+                                continue;
+                            },
+                        }
+                    },
+                    // Step 2.5. Otherwise, continue this loop from the beginning.
+                    _ => {
+                        continue;
+                    },
+                }
+                // Step 2.6. Set node to the first formattable node effectively contained in the active range, if there is one.
+                first_formattable_contained_node = self.first_formattable_contained_node();
+            } else {
+                // Step 3. Otherwise, for each (command, override) pair in overrides, in order:
                 // Step 3.1. If override is a boolean, set the state override for command to override.
                 match override_state.value {
                     BoolOrOptionalString::Bool(bool_) => {
@@ -2440,38 +2756,7 @@ impl Range {
                     },
                 }
             }
-            return;
-        };
-        // Step 2. If node is not null, then for each (command, override) pair in overrides, in order:
-        // TODO
-
-        // Step 2.1. If override is a boolean, and queryCommandState(command)
-        // returns something different from override, take the action for command,
-        // with value equal to the empty string.
-        // TODO
-
-        // Step 2.2. Otherwise, if override is a string, and command is neither "createLink" nor "fontSize",
-        // and queryCommandValue(command) returns something not equivalent to override,
-        // take the action for command, with value equal to override.
-        // TODO
-
-        // Step 2.3. Otherwise, if override is a string; and command is "createLink";
-        // and either there is a value override for "createLink" that is not equal to override,
-        // or there is no value override for "createLink" and node's effective command value
-        // for "createLink" is not equal to override: take the action for "createLink", with value equal to override.
-        // TODO
-
-        // Step 2.4. Otherwise, if override is a string; and command is "fontSize";
-        // and either there is a value override for "fontSize" that is not equal to override,
-        // or there is no value override for "fontSize" and node's effective command value for "fontSize"
-        // is not loosely equivalent to override:
-        // TODO
-
-        // Step 2.5. Otherwise, continue this loop from the beginning.
-        // TODO
-
-        // Step 2.6. Set node to the first formattable node effectively contained in the active range, if there is one.
-        // TODO
+        }
     }
 }
 
@@ -2701,7 +2986,7 @@ impl SelectionExecCommandSupport for Selection {
                     }
                 }
                 // Step 21.5. Restore states and values from overrides.
-                active_range.restore_states_and_values(context_object, overrides);
+                active_range.restore_states_and_values(cx, self, context_object, overrides);
 
                 // Step 21.6. Abort these steps.
                 return;
@@ -2841,7 +3126,7 @@ impl SelectionExecCommandSupport for Selection {
                 }
             }
             // Step 30.3. Restore states and values from overrides.
-            active_range.restore_states_and_values(context_object, overrides);
+            active_range.restore_states_and_values(cx, self, context_object, overrides);
 
             // Step 30.4. Abort these steps.
             return;
@@ -2936,7 +3221,7 @@ impl SelectionExecCommandSupport for Selection {
                     end_block.remove_self(cx);
                 }
                 // Step 32.4.4. Restore states and values from overrides.
-                active_range.restore_states_and_values(context_object, overrides);
+                active_range.restore_states_and_values(cx, self, context_object, overrides);
 
                 // Step 32.4.5. Abort these steps.
                 return;
@@ -3151,7 +3436,7 @@ impl SelectionExecCommandSupport for Selection {
         start_block.remove_extraneous_line_breaks_at_the_end_of(cx);
 
         // Step 41. Restore states and values from overrides.
-        active_range.restore_states_and_values(context_object, overrides);
+        active_range.restore_states_and_values(cx, self, context_object, overrides);
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#set-the-selection%27s-value>

--- a/components/script/dom/execcommand/execcommands.rs
+++ b/components/script/dom/execcommand/execcommands.rs
@@ -13,7 +13,7 @@ use crate::dom::document::Document;
 use crate::dom::event::Event;
 use crate::dom::event::inputevent::InputEvent;
 use crate::dom::execcommand::basecommand::CommandName;
-use crate::dom::execcommand::commands::fontsize::legacy_font_size_for;
+use crate::dom::execcommand::commands::fontsize::maybe_normalize_pixels;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::Node;
 use crate::dom::selection::Selection;
@@ -194,10 +194,7 @@ impl DocumentExecCommandSupport for Document {
                 // Step 2. If command is "fontSize" and its value override is set,
                 // convert the value override to an integer number of pixels and return the legacy font size for the result.
                 if command == CommandName::FontSize {
-                    value_override
-                        .parse::<i32>()
-                        .map(|parsed| legacy_font_size_for(parsed as f32, self))
-                        .unwrap_or(value_override)
+                    maybe_normalize_pixels(&value_override, self).unwrap_or(value_override)
                 } else {
                     value_override
                 }

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -82,6 +82,13 @@ impl Selection {
     }
 
     pub(crate) fn queue_selectionchange_task(&self) {
+        // https://w3c.github.io/editing/docs/execCommand/#state-override
+        // https://w3c.github.io/editing/docs/execCommand/#value-override
+        // > Whenever the number of ranges in the selection changes to something different,
+        // > and whenever a boundary point of the range at a given index in the selection changes
+        // > to something different, the state override and value override must be unset for every command.
+        self.document.clear_command_overrides();
+
         if self.task_queued.get() {
             // Spec doesn't specify not to queue multiple tasks,
             // but it's much easier to code range operations if

--- a/tests/wpt/meta/editing/run/delete.html.ini
+++ b/tests/wpt/meta/editing/run/delete.html.ini
@@ -878,46 +878,16 @@
   [[["styleWithCSS","false"\],["defaultparagraphseparator","p"\],["delete",""\]\] "<p><font color=blue>foo</font><p><font color=brown>[\]bar</font>" queryCommandValue("foreColor") after]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["defaultparagraphseparator","div"\],["delete",""\]\] "<p><font size=3>foo</font><p><font size=5>[\]bar</font>" queryCommandValue("fontSize") before]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["defaultparagraphseparator","div"\],["delete",""\]\] "<p><font size=3>foo</font><p><font size=5>[\]bar</font>" queryCommandValue("fontSize") after]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["defaultparagraphseparator","p"\],["delete",""\]\] "<p><font size=3>foo</font><p><font size=5>[\]bar</font>" queryCommandValue("fontSize") before]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["defaultparagraphseparator","p"\],["delete",""\]\] "<p><font size=3>foo</font><p><font size=5>[\]bar</font>" queryCommandValue("fontSize") after]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["defaultparagraphseparator","div"\],["delete",""\]\] "<p><font size=4>foo</font><p><font size=5>[\]bar</font>" queryCommandValue("fontSize") before]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["defaultparagraphseparator","div"\],["delete",""\]\] "<p><font size=4>foo</font><p><font size=5>[\]bar</font>" queryCommandValue("fontSize") after]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["defaultparagraphseparator","p"\],["delete",""\]\] "<p><font size=4>foo</font><p><font size=5>[\]bar</font>" queryCommandValue("fontSize") before]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["defaultparagraphseparator","p"\],["delete",""\]\] "<p><font size=4>foo</font><p><font size=5>[\]bar</font>" queryCommandValue("fontSize") after]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["defaultparagraphseparator","div"\],["delete",""\]\] "<p><font color=blue>foo</font><p><font size=5>[\]bar</font>" queryCommandValue("fontSize") before]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["defaultparagraphseparator","div"\],["delete",""\]\] "<p><font color=blue>foo</font><p><font size=5>[\]bar</font>" queryCommandValue("fontSize") after]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["defaultparagraphseparator","div"\],["delete",""\]\] "<p><font color=blue>foo</font><p><font size=5>[\]bar</font>" queryCommandValue("foreColor") before]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["defaultparagraphseparator","div"\],["delete",""\]\] "<p><font color=blue>foo</font><p><font size=5>[\]bar</font>" queryCommandValue("foreColor") after]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["defaultparagraphseparator","p"\],["delete",""\]\] "<p><font color=blue>foo</font><p><font size=5>[\]bar</font>" queryCommandValue("fontSize") before]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["defaultparagraphseparator","p"\],["delete",""\]\] "<p><font color=blue>foo</font><p><font size=5>[\]bar</font>" queryCommandValue("fontSize") after]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["defaultparagraphseparator","p"\],["delete",""\]\] "<p><font color=blue>foo</font><p><font size=5>[\]bar</font>" queryCommandValue("foreColor") before]

--- a/tests/wpt/meta/editing/run/fontsize.html.ini
+++ b/tests/wpt/meta/editing/run/fontsize.html.ini
@@ -1,383 +1,23 @@
 [fontsize.html?1-1000]
-  [[["fontsize","4"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<p>[foo</p> <p>bar\]</p>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<p>[foo</p> <p>bar\]</p>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<p>[foo</p> <p>bar\]</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<p>[foo</p> <p>bar\]</p>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<p>[foo</p> <p>bar\]</p>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<span>[foo</span> <span>bar\]</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<span>[foo</span> <span>bar\]</span>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<span>[foo</span> <span>bar\]</span>" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<span>[foo</span> <span>bar\]</span>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<span>[foo</span> <span>bar\]</span>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<span>[foo</span> <span>bar\]</span>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<p>[foo</p><p> <span>bar</span> </p><p>baz\]</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<p>[foo</p><p> <span>bar</span> </p><p>baz\]</p>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<p>[foo</p><p> <span>bar</span> </p><p>baz\]</p>" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<p>[foo</p><p> <span>bar</span> </p><p>baz\]</p>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<p>[foo</p><p> <span>bar</span> </p><p>baz\]</p>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<p>[foo</p><p> <span>bar</span> </p><p>baz\]</p>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<p>[foo<p><br><p>bar\]" queryCommandValue("fontsize") before]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<p>[foo<p><br><p>bar\]" queryCommandIndeterm("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<p>[foo<p><br><p>bar\]" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<p>[foo<p><br><p>bar\]" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<p>[foo<p><br><p>bar\]" queryCommandValue("fontsize") before]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<p>[foo<p><br><p>bar\]" queryCommandIndeterm("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<p>[foo<p><br><p>bar\]" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["fontsize","4"\]\] "<b>foo[\]bar</b>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\]\] "<b>foo[\]bar</b>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["fontsize","4"\]\] "<i>foo[\]bar</i>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\]\] "<i>foo[\]bar</i>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["fontsize","4"\]\] "<span>foo</span>{}<span>bar</span>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\]\] "<span>foo</span>{}<span>bar</span>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["fontsize","4"\]\] "<span>foo[</span><span>\]bar</span>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\]\] "<span>foo[</span><span>\]bar</span>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[bar\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo[bar<b>baz\]qoz</b>quz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo[bar<b>baz\]qoz</b>quz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[bar<b>baz\]qoz</b>quz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[bar<b>baz\]qoz</b>quz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[bar<b>baz\]qoz</b>quz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo[bar<i>baz\]qoz</i>quz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo[bar<i>baz\]qoz</i>quz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[bar<i>baz\]qoz</i>quz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[bar<i>baz\]qoz</i>quz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[bar<i>baz\]qoz</i>quz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "{<p><p> <p>foo</p>}" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "{<p><p> <p>foo</p>}" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "{<p><p> <p>foo</p>}" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "{<p><p> <p>foo</p>}" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "{<p><p> <p>foo</p>}" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","1"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","1"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","1"\]\] "foo[bar\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","1"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","1"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","0"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","0"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","0"\]\] "foo[bar\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","0"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","0"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","-5"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","-5"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","-5"\]\] "foo[bar\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","-5"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","-5"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","6"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","6"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","6"\]\] "foo[bar\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","6"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","6"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","7"\]\] "foo[bar\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","7"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","7"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","7"\]\] "foo[bar\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","7"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","7"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","8"\]\] "foo[bar\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","8"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","8"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","8"\]\] "foo[bar\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","8"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","8"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","100"\]\] "foo[bar\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","100"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","100"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","100"\]\] "foo[bar\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","100"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","100"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["fontsize","2em"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","2em"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["fontsize","20pt"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","20pt"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["fontsize","xx-large"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","xx-large"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize"," 1 "\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize"," 1 "\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize"," 1 "\]\] "foo[bar\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize"," 1 "\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize"," 1 "\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["fontsize","1."\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","1."\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","1.0"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","1.0"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","1.0"\]\] "foo[bar\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","1.0"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","1.0"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","1.0e2"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","1.0e2"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","1.0e2"\]\] "foo[bar\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","1.0e2"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","1.0e2"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","1.1"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","1.1"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","1.1"\]\] "foo[bar\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","1.1"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","1.1"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","1.9"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","1.9"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","1.9"\]\] "foo[bar\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","1.9"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","1.9"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["fontsize","+0"\]\] "foo[bar\]baz": execCommand("fontsize", false, "+0") return value]
-    expected: FAIL
-
-  [[["fontsize","+0"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","+0"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","+1"\]\] "foo[bar\]baz": execCommand("fontsize", false, "+1") return value]
@@ -386,31 +26,16 @@
   [[["stylewithcss","true"\],["fontsize","+1"\]\] "foo[bar\]baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","+1"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","+1"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","+1"\]\] "foo[bar\]baz": execCommand("fontsize", false, "+1") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","+1"\]\] "foo[bar\]baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","+1"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","+1"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","+9"\]\] "foo[bar\]baz": execCommand("fontsize", false, "+9") return value]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","+9"\]\] "foo[bar\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","+9"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","+9"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
@@ -422,106 +47,7 @@
   [[["stylewithcss","false"\],["fontsize","+9"\]\] "foo[bar\]baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","+9"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","+9"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["fontsize","-0"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","-0"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","-1"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","-1"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","-1"\]\] "foo[bar\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","-1"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","-1"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","-9"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","-9"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","-9"\]\] "foo[bar\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","-9"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","-9"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["fontsize",""\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize",""\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<table><tbody><tr><td>foo<td>b[a\]r<td>baz</table>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<table><tbody><tr><td>foo<td>b[a\]r<td>baz</table>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<table><tbody><tr><td>foo<td>b[a\]r<td>baz</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<table><tbody><tr><td>foo<td>b[a\]r<td>baz</table>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<table><tbody><tr><td>foo<td>b[a\]r<td>baz</table>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<table><tbody><tr data-start=1 data-end=2><td>foo<td>bar<td>baz</table>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<table><tbody><tr data-start=1 data-end=2><td>foo<td>bar<td>baz</table>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<table><tbody><tr data-start=1 data-end=2><td>foo<td>bar<td>baz</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<table><tbody><tr data-start=1 data-end=2><td>foo<td>bar<td>baz</table>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<table><tbody><tr data-start=1 data-end=2><td>foo<td>bar<td>baz</table>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<table><tbody><tr data-start=0 data-end=2><td>foo<td>bar<td>baz</table>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<table><tbody><tr data-start=0 data-end=2><td>foo<td>bar<td>baz</table>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<table><tbody><tr data-start=0 data-end=2><td>foo<td>bar<td>baz</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<table><tbody><tr data-start=0 data-end=2><td>foo<td>bar<td>baz</table>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<table><tbody><tr data-start=0 data-end=2><td>foo<td>bar<td>baz</table>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<table><tbody data-start=0 data-end=1><tr><td>foo<td>bar<td>baz</table>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<table><tbody data-start=0 data-end=1><tr><td>foo<td>bar<td>baz</table>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<table><tbody data-start=0 data-end=1><tr><td>foo<td>bar<td>baz</table>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<p>[foo</p> <p>bar\]</p>" queryCommandState("stylewithcss") before]
@@ -530,15 +56,15 @@
   [[["fontsize","-0"\]\] "foo[bar\]baz" compare innerHTML]
     expected: FAIL
 
+  [[["stylewithcss","true"\],["fontsize","+1"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["fontsize","+1"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
+    expected: FAIL
+
 
 [fontsize.html?1001-2000]
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<table><tbody data-start=0 data-end=1><tr><td>foo<td>bar<td>baz</table>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<table data-start=0 data-end=1><tbody><tr><td>foo<td>bar<td>baz</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "{<table><tr><td>foo<td>bar<td>baz</table>}" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=1>[bar\]</font>baz" compare innerHTML]
@@ -667,19 +193,10 @@
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<p style=\\"font-size: xx-small\\">foo[bar\]baz</p>" queryCommandValue("fontsize") before]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<p style=\\"font-size: xx-small\\">foo[bar\]baz</p>" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<p style=\\"font-size: xx-small\\">foo[bar\]baz</p>" queryCommandValue("fontsize") before]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<p style=\\"font-size: medium\\">foo[bar\]baz</p>" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<p style=\\"font-size: 2em\\">foo[bar\]baz</p>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<p style=\\"font-size: 2em\\">foo[bar\]baz</p>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<p style=\\"font-size: 2em\\">foo[bar\]baz</p>" queryCommandValue("fontsize") before]
@@ -727,18 +244,6 @@
   [[["stylewithcss","false"\],["fontsize","3"\]\] "<font size=6>foo <span style=\\"font-size: 2em\\">b[a\]r</span> baz</font>" queryCommandValue("fontsize") before]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","3"\]\] "foo<big>[bar\]</big>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","3"\]\] "foo<big>b[a\]r</big>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","3"\]\] "foo<small>[bar\]</small>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","3"\]\] "foo<small>b[a\]r</small>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "fo[o<font size=2>b\]ar</font>baz" compare innerHTML]
     expected: FAIL
 
@@ -774,9 +279,6 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=2>ba[r</font>b\]az" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "fo[o<font size=2>bar</font>b\]az" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "fo[o<font size=2>bar</font>b\]az" queryCommandIndeterm("fontsize") before]
     expected: FAIL
 
@@ -798,22 +300,10 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=2>ba[r</font>\]baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo[<font size=2>bar</font>\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[<font size=2>bar</font>\]baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=2>[bar\]</font>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=2>[bar\]</font>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo{<font size=2>bar</font>}baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo{<font size=2>bar</font>}baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=1>fo[o</font><span style=font-size:xx-small>b\]ar</span>" compare innerHTML]
@@ -861,18 +351,6 @@
   [[["styleWithCSS","false"\],["fontSize","7"\]\] "<font color=#ff0000 face=monospace>[abc\]</font>" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["fontSize","7"\]\] "<font color=#ff0000>[a\]bc</font>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["fontSize","7"\]\] "<font color=#ff0000>ab[c\]</font>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["fontSize","7"\]\] "<font face=monospace>[a\]bc</font>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["fontSize","7"\]\] "<font face=monospace>ab[c\]</font>" compare innerHTML]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["fontSize","5"\]\] "<span style=\\"font-size:32px; background-color:rgb(0, 128, 128)\\">[abc\]</span>" compare innerHTML]
     expected: FAIL
 
@@ -886,9 +364,6 @@
     expected: FAIL
 
   [[["styleWithCSS","false"\],["fontSize","5"\]\] "<p><span style=\\"font-size:32px; background-color:rgb(0, 128, 128)\\">[abc</span></p><p><span style=\\"font-size:64px; background-color:rgb(128, 128, 0)\\">def\]</span></p>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","5"\]\] "{ <span contenteditable=\\"false\\">A</span> ; <span contenteditable=\\"false\\">B</span> ; <span contenteditable=\\"false\\">C</span> }" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=2>ba[r</font>b\]az" queryCommandState("stylewithcss") after]

--- a/tests/wpt/meta/editing/run/multitest.html.ini
+++ b/tests/wpt/meta/editing/run/multitest.html.ini
@@ -2501,9 +2501,6 @@
   [[["fontsize","4"\],["insertimage","/img/lion.svg"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["fontsize","4"\],["insertimage","/img/lion.svg"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["fontsize","4"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertimage", false, "/img/lion.svg") return value]
     expected: FAIL
 
@@ -2513,22 +2510,10 @@
   [[["fontsize","4"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["fontsize","4"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["fontsize","4"\],["insertlinebreak",""\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["fontsize","4"\],["insertlinebreak",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["fontsize","4"\],["insertlinebreak",""\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\],["insertlinebreak",""\]\] "foo[\]bar" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["fontsize","4"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
@@ -2540,22 +2525,10 @@
   [[["fontsize","4"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["fontsize","4"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["fontsize","4"\],["insertorderedlist",""\]\] "foo[\]bar": execCommand("insertorderedlist", false, "") return value]
     expected: FAIL
 
   [[["fontsize","4"\],["insertorderedlist",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["fontsize","4"\],["insertorderedlist",""\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\],["insertorderedlist",""\]\] "foo[\]bar" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["fontsize","4"\],["insertorderedlist",""\]\] "foo[\]bar" queryCommandState("insertorderedlist") after]
@@ -2570,12 +2543,6 @@
   [[["fontsize","4"\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["fontsize","4"\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["fontsize","4"\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("insertorderedlist") after]
     expected: FAIL
 
@@ -2583,12 +2550,6 @@
     expected: FAIL
 
   [[["fontsize","4"\],["insertparagraph",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["fontsize","4"\],["insertparagraph",""\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\],["insertparagraph",""\]\] "foo[\]bar" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["fontsize","4"\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertparagraph", false, "") return value]
@@ -2600,22 +2561,10 @@
   [[["fontsize","4"\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["fontsize","4"\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["fontsize","4"\],["insertunorderedlist",""\]\] "foo[\]bar": execCommand("insertunorderedlist", false, "") return value]
     expected: FAIL
 
   [[["fontsize","4"\],["insertunorderedlist",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["fontsize","4"\],["insertunorderedlist",""\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\],["insertunorderedlist",""\]\] "foo[\]bar" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["fontsize","4"\],["insertunorderedlist",""\]\] "foo[\]bar" queryCommandState("insertunorderedlist") after]
@@ -2630,12 +2579,6 @@
   [[["fontsize","4"\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["fontsize","4"\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["fontsize","4"\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("insertunorderedlist") after]
     expected: FAIL
 
@@ -2643,12 +2586,6 @@
     expected: FAIL
 
   [[["fontsize","4"\],["justifycenter",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["fontsize","4"\],["justifycenter",""\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\],["justifycenter",""\]\] "foo[\]bar" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["fontsize","4"\],["justifycenter",""\]\] "foo[\]bar" queryCommandValue("justifycenter") before]
@@ -2669,12 +2606,6 @@
   [[["fontsize","4"\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["fontsize","4"\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["fontsize","4"\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("justifycenter") before]
     expected: FAIL
 
@@ -2688,12 +2619,6 @@
     expected: FAIL
 
   [[["fontsize","4"\],["justifyfull",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["fontsize","4"\],["justifyfull",""\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\],["justifyfull",""\]\] "foo[\]bar" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["fontsize","4"\],["justifyfull",""\]\] "foo[\]bar" queryCommandValue("justifyfull") before]
@@ -2714,12 +2639,6 @@
   [[["fontsize","4"\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["fontsize","4"\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["fontsize","4"\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("justifyfull") before]
     expected: FAIL
 
@@ -2730,12 +2649,6 @@
     expected: FAIL
 
   [[["fontsize","4"\],["justifyleft",""\]\] "foo[\]bar": execCommand("justifyleft", false, "") return value]
-    expected: FAIL
-
-  [[["fontsize","4"\],["justifyleft",""\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\],["justifyleft",""\]\] "foo[\]bar" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["fontsize","4"\],["justifyleft",""\]\] "foo[\]bar" queryCommandState("justifyleft") before]
@@ -2759,12 +2672,6 @@
   [[["fontsize","4"\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["fontsize","4"\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["fontsize","4"\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("justifyleft") before]
     expected: FAIL
 
@@ -2781,12 +2688,6 @@
     expected: FAIL
 
   [[["fontsize","4"\],["justifyright",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["fontsize","4"\],["justifyright",""\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\],["justifyright",""\]\] "foo[\]bar" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["fontsize","4"\],["justifyright",""\]\] "foo[\]bar" queryCommandValue("justifyright") before]
@@ -2807,12 +2708,6 @@
   [[["fontsize","4"\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["fontsize","4"\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["fontsize","4"\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("justifyright") before]
     expected: FAIL
 
@@ -2825,12 +2720,6 @@
   [[["fontsize","4"\],["outdent",""\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
     expected: FAIL
 
-  [[["fontsize","4"\],["outdent",""\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\],["outdent",""\]\] "foo[\]bar" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["fontsize","4"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
     expected: FAIL
 
@@ -2838,12 +2727,6 @@
     expected: FAIL
 
   [[["fontsize","4"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["fontsize","4"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["forecolor","#0000FF"\],["inserttext","a"\]\] "foo[\]bar": execCommand("forecolor", false, "#0000FF") return value]
@@ -4078,15 +3961,6 @@
   [[["fontsize","4"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["fontsize","4"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["fontsize","4"\],["delete",""\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
   [[["fontsize","4"\],["delete",""\]\] "foo[\]bar" queryCommandValue("fontsize") after]
     expected: FAIL
 
@@ -4096,9 +3970,6 @@
   [[["fontsize","4"\],["delete",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["fontsize","4"\],["delete",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
   [[["fontsize","4"\],["delete",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
     expected: FAIL
 
@@ -4106,12 +3977,6 @@
     expected: FAIL
 
   [[["fontsize","4"\],["formatblock","<div>"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["fontsize","4"\],["formatblock","<div>"\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\],["formatblock","<div>"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["fontsize","4"\],["formatblock","<div>"\]\] "foo[\]bar" queryCommandValue("formatblock") after]
@@ -4126,12 +3991,6 @@
   [[["fontsize","4"\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["fontsize","4"\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["fontsize","4"\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("formatblock") after]
     expected: FAIL
 
@@ -4139,12 +3998,6 @@
     expected: FAIL
 
   [[["fontsize","4"\],["forwarddelete",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["fontsize","4"\],["forwarddelete",""\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\],["forwarddelete",""\]\] "foo[\]bar" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["fontsize","4"\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("forwarddelete", false, "") return value]
@@ -4156,22 +4009,10 @@
   [[["fontsize","4"\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["fontsize","4"\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["fontsize","4"\],["indent",""\]\] "foo[\]bar": execCommand("indent", false, "") return value]
     expected: FAIL
 
   [[["fontsize","4"\],["indent",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["fontsize","4"\],["indent",""\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\],["indent",""\]\] "foo[\]bar" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["fontsize","4"\],["indent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("indent", false, "") return value]
@@ -4183,22 +4024,10 @@
   [[["fontsize","4"\],["indent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["fontsize","4"\],["indent",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\],["indent",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["fontsize","4"\],["inserthorizontalrule",""\]\] "foo[\]bar": execCommand("inserthorizontalrule", false, "") return value]
     expected: FAIL
 
   [[["fontsize","4"\],["inserthorizontalrule",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["fontsize","4"\],["inserthorizontalrule",""\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\],["inserthorizontalrule",""\]\] "foo[\]bar" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["fontsize","4"\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserthorizontalrule", false, "") return value]
@@ -4210,22 +4039,10 @@
   [[["fontsize","4"\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["fontsize","4"\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["fontsize","4"\],["inserthtml","ab<b>c</b>d"\]\] "foo[\]bar": execCommand("inserthtml", false, "ab<b>c</b>d") return value]
     expected: FAIL
 
   [[["fontsize","4"\],["inserthtml","ab<b>c</b>d"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["fontsize","4"\],["inserthtml","ab<b>c</b>d"\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\],["inserthtml","ab<b>c</b>d"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["fontsize","4"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserthtml", false, "ab<b>c</b>d") return value]
@@ -4235,12 +4052,6 @@
     expected: FAIL
 
   [[["fontsize","4"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["fontsize","4"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
     expected: FAIL
 
 
@@ -5045,9 +4856,6 @@
   [[["subscript",""\],["fontsize","2"\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("subscript") after]
     expected: FAIL
 
-  [[["subscript",""\],["fontsize","2"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["fontsize","2"\],["subscript",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("subscript", false, "") return value]
     expected: FAIL
 
@@ -5055,12 +4863,6 @@
     expected: FAIL
 
   [[["fontsize","2"\],["subscript",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["fontsize","2"\],["subscript",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","2"\],["subscript",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["fontsize","2"\],["subscript",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("subscript") after]
@@ -5078,12 +4880,6 @@
   [[["subscript",""\],["fontsize","3"\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("subscript") after]
     expected: FAIL
 
-  [[["subscript",""\],["fontsize","3"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["subscript",""\],["fontsize","3"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["fontsize","3"\],["subscript",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("subscript", false, "") return value]
     expected: FAIL
 
@@ -5091,12 +4887,6 @@
     expected: FAIL
 
   [[["fontsize","3"\],["subscript",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["fontsize","3"\],["subscript",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","3"\],["subscript",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["fontsize","3"\],["subscript",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("subscript") after]
@@ -6541,9 +6331,6 @@
   [[["stylewithcss","false"\],["fontsize","4"\],["insertText","a"\]\] "<font size=7>{}<br></font>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\],["insertText","a"\]\] "<font size=7>{}<br></font>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["italic",""\],["insertText","a"\]\] "<span style=font-weight:bold>{}<br></span></b>": execCommand("italic", false, "") return value]
     expected: FAIL
 
@@ -7193,9 +6980,6 @@
     expected: FAIL
 
   [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc<b><i>[def</i></b>\]ghi</div>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\],["insertText","a"\]\] "<font size=7>{}<br></font>" queryCommandValue("fontsize") before]
     expected: FAIL
 
 


### PR DESCRIPTION
Several more TODO's are now implemented:

1. We correctly restore values for fontsize now
2. We implement relevant logic in wrap_node_list
3. We implement simple modifiable
4. We clear overrides whenever the selection changes
(which is triggered for both the selection itself and
any containing  ranges).

Part of #25005

Testing: WPT