### PR TITLE
pref: Remove unsigned Option from config values

### DIFF
--- a/components/config/pref_util.rs
+++ b/components/config/pref_util.rs
@@ -10,7 +10,6 @@ use serde_json::Value;
 pub enum PrefValue {
     Float(f64),
     Int(i64),
-    UInt(u64),
     Str(String),
     Bool(bool),
     Array(Vec<PrefValue>),
@@ -89,7 +88,6 @@ macro_rules! impl_from_pref {
 impl_pref_from! {
     f64 => PrefValue::Float,
     i64 => PrefValue::Int,
-    u64 => PrefValue::UInt,
     String => PrefValue::Str,
     &str => PrefValue::Str,
     bool => PrefValue::Bool,
@@ -98,7 +96,6 @@ impl_pref_from! {
 impl_from_pref! {
     PrefValue::Float => f64,
     PrefValue::Int => i64,
-    PrefValue::UInt => u64,
     PrefValue::Str => String,
     PrefValue::Bool => bool,
 }

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -283,7 +283,7 @@ pub struct Preferences {
     /// if for the entire process of connecting to an address. For instance, if a particular host is
     /// associated with multiple IP addresses, this timeout will be divided equally among
     /// each IP address.
-    pub network_connection_timeout: u64,
+    pub network_connection_timeout: i64,
     pub network_enforce_tls_enabled: bool,
     pub network_enforce_tls_localhost: bool,
     pub network_enforce_tls_onion: bool,
@@ -298,7 +298,7 @@ pub struct Preferences {
     pub network_http_no_proxy: String,
     /// The weight of the http memory cache
     /// Notice that this is not equal to the number of different urls in the cache.
-    pub network_http_cache_size: u64,
+    pub network_http_cache_size: i64,
     pub network_local_directory_listing_enabled: bool,
     /// Force the use of `rust-webpki` verification for CA roots. If this is false (the
     /// default), then `rustls-platform-verifier` will be used, except on Android where

--- a/components/net/connector.rs
+++ b/components/net/connector.rs
@@ -50,7 +50,11 @@ impl ServoHttpConnector {
         let mut inner = HyperHttpConnector::new();
         inner.enforce_http(false);
         inner.set_happy_eyeballs_timeout(None);
-        inner.set_connect_timeout(Some(Duration::from_secs(pref!(network_connection_timeout))));
+        inner.set_connect_timeout(Some(Duration::from_secs(
+            pref!(network_connection_timeout)
+                .try_into()
+                .expect("Could not convert network_connectioN_timeout to unsigned"),
+        )));
         ServoHttpConnector { inner }
     }
 }

--- a/components/script/dom/servointernals.rs
+++ b/components/script/dom/servointernals.rs
@@ -33,7 +33,6 @@ fn pref_to_jsval(pref: &PrefValue, cx: JSContext, rval: MutableHandleValue, can_
     match pref {
         PrefValue::Bool(b) => b.safe_to_jsval(cx, rval, can_gc),
         PrefValue::Int(i) => i.safe_to_jsval(cx, rval, can_gc),
-        PrefValue::UInt(u) => u.safe_to_jsval(cx, rval, can_gc),
         PrefValue::Str(s) => s.safe_to_jsval(cx, rval, can_gc),
         PrefValue::Float(f) => f.safe_to_jsval(cx, rval, can_gc),
         PrefValue::Array(arr) => {

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -318,7 +318,6 @@ impl Serialize for WebDriverPrefValue {
                 .map(|value| WebDriverPrefValue(value.clone()))
                 .collect::<Vec<WebDriverPrefValue>>()
                 .serialize(serializer),
-            PrefValue::UInt(u) => serializer.serialize_u64(u),
         }
     }
 }


### PR DESCRIPTION
Currently the command line parsing for unsigned config values (u64) is broken and returns unable to parse.

This moves all unsigned pref values to signed and removes the PrefValue::UInt so that all preferences work with command line arguments.

Testing: We do not have automatic testing for command line parsing of preference values. 
