### PR TITLE
config: Fix panic when converting convertible `PrefValue::Int` to u64

### DIFF
--- a/components/config/pref_util.rs
+++ b/components/config/pref_util.rs
@@ -98,9 +98,21 @@ impl_pref_from! {
 impl_from_pref! {
     PrefValue::Float => f64,
     PrefValue::Int => i64,
-    PrefValue::UInt => u64,
     PrefValue::Str => String,
     PrefValue::Bool => bool,
+}
+
+// The default generated from `impl_from_pref` would cause panic
+// when converting from PrefValue::Int.
+impl TryFrom<PrefValue> for u64 {
+    type Error = String;
+    fn try_from(other: PrefValue) -> Result<Self, Self::Error> {
+        match other {
+            PrefValue::UInt(value) => Ok(value),
+            PrefValue::Int(value) if value >= 0 => Ok(value as u64),
+            _ => Err(format!("Cannot convert {other:?} to u64")),
+        }
+    }
 }
 
 impl From<[f64; 4]> for PrefValue {

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -745,6 +745,12 @@ fn test_parse_pref_from_command_line() {
     let preferences = test_parse_pref("layout_threads=42");
     assert_eq!(preferences.layout_threads, 42);
 
+    // Test with unsigned numbers
+    let preferences = test_parse_pref("network_http_cache_size=50");
+    assert_eq!(preferences.network_http_cache_size, 50);
+    let preferences = test_parse_pref("network_connection_timeout=30");
+    assert_eq!(preferences.network_connection_timeout, 30);
+
     // Test string.
     let preferences = test_parse_pref("fonts_default=Lucida");
     assert_eq!(preferences.fonts_default, "Lucida");


### PR DESCRIPTION
The macro `impl_from_pref!` would cause panic in this case.

Testing: Add more test cases to existing UT.
Fixes: #44078
