### PR TITLE
script: Rename `CanGc::note()` to `CanGc::deprecated_note()`

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -215,7 +215,7 @@ impl TransmitBodyConnectHandler {
                     // TODO: Step 2, If body is null.
 
                     // Step 3, get a reader for stream.
-                    rooted_stream.acquire_default_reader(CanGc::note())
+                    rooted_stream.acquire_default_reader(CanGc::deprecated_note())
                         .expect("Couldn't acquire a reader for the body stream.");
 
                     // Note: this algorithm continues when the first chunk is requested by `net`.

--- a/components/script/dom/audio/audiocontext.rs
+++ b/components/script/dom/audio/audiocontext.rs
@@ -167,7 +167,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
                         let base_context = base_context.root();
                         let context = context.root();
                         let promise = trusted_promise.root();
-                        promise.resolve_native(&(), CanGc::note());
+                        promise.resolve_native(&(), CanGc::deprecated_note());
                         if base_context.State() != AudioContextState::Suspended {
                             base_context.set_state_attribute(AudioContextState::Suspended);
                             context.global().task_manager().dom_manipulation_task_source().queue_simple_event(
@@ -186,7 +186,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
                     .dom_manipulation_task_source()
                     .queue(task!(suspend_error: move || {
                         let promise = trusted_promise.root();
-                        promise.reject_error(Error::Type(c"Something went wrong".to_owned()), CanGc::note());
+                        promise.reject_error(Error::Type(c"Something went wrong".to_owned()), CanGc::deprecated_note());
                     }));
             },
         };
@@ -223,7 +223,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
                         let base_context = base_context.root();
                         let context = context.root();
                         let promise = trusted_promise.root();
-                        promise.resolve_native(&(), CanGc::note());
+                        promise.resolve_native(&(), CanGc::deprecated_note());
                         if base_context.State() != AudioContextState::Closed {
                             base_context.set_state_attribute(AudioContextState::Closed);
                             context.global().task_manager().dom_manipulation_task_source().queue_simple_event(
@@ -242,7 +242,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
                     .dom_manipulation_task_source()
                     .queue(task!(suspend_error: move || {
                         let promise = trusted_promise.root();
-                        promise.reject_error(Error::Type(c"Something went wrong".to_owned()), CanGc::note());
+                        promise.reject_error(Error::Type(c"Something went wrong".to_owned()), CanGc::deprecated_note());
                     }));
             },
         };

--- a/components/script/dom/audio/audiotracklist.rs
+++ b/components/script/dom/audio/audiotracklist.rs
@@ -93,7 +93,7 @@ impl AudioTrackList {
         let task_source = global.task_manager().media_element_task_source();
         task_source.queue(task!(media_track_change: move || {
             let this = this.root();
-            this.upcast::<EventTarget>().fire_event(atom!("change"), CanGc::note());
+            this.upcast::<EventTarget>().fire_event(atom!("change"), CanGc::deprecated_note());
         }));
     }
 

--- a/components/script/dom/audio/baseaudiocontext.rs
+++ b/components/script/dom/audio/baseaudiocontext.rs
@@ -211,8 +211,8 @@ impl BaseAudioContext {
         f();
         for promise in &*promises {
             match result {
-                Ok(ref value) => promise.resolve_native(value, CanGc::note()),
-                Err(ref error) => promise.reject_error(error.clone(), CanGc::note()),
+                Ok(ref value) => promise.resolve_native(value, CanGc::deprecated_note()),
+                Err(ref error) => promise.reject_error(error.clone(), CanGc::deprecated_note()),
             }
         }
     }
@@ -542,14 +542,14 @@ impl BaseAudioContextMethods<crate::DomTypeHolder> for BaseAudioContext {
                             length as u32,
                             this.sample_rate,
                             Some(decoded_audio.as_slice()),
-                            CanGc::note());
+                            CanGc::deprecated_note());
                         let mut resolvers = this.decode_resolvers.borrow_mut();
                         assert!(resolvers.contains_key(&uuid_));
                         let resolver = resolvers.remove(&uuid_).unwrap();
                         if let Some(callback) = resolver.success_callback {
-                            let _ = callback.Call__(&buffer, ExceptionHandling::Report, CanGc::note());
+                            let _ = callback.Call__(&buffer, ExceptionHandling::Report, CanGc::deprecated_note());
                         }
-                        resolver.promise.resolve_native(&buffer, CanGc::note());
+                        resolver.promise.resolve_native(&buffer, CanGc::deprecated_note());
                     }));
                 })
                 .error(move |error| {
@@ -560,11 +560,11 @@ impl BaseAudioContextMethods<crate::DomTypeHolder> for BaseAudioContext {
                         let resolver = resolvers.remove(&uuid).unwrap();
                         if let Some(callback) = resolver.error_callback {
                             let _ = callback.Call__(
-                                &DOMException::new(&this.global(), DOMErrorName::DataCloneError, CanGc::note()),
-                                ExceptionHandling::Report, CanGc::note());
+                                &DOMException::new(&this.global(), DOMErrorName::DataCloneError, CanGc::deprecated_note()),
+                                ExceptionHandling::Report, CanGc::deprecated_note());
                         }
                         let error = cformat!("Audio decode error {:?}", error);
-                        resolver.promise.reject_error(Error::Type(error), CanGc::note());
+                        resolver.promise.reject_error(Error::Type(error), CanGc::deprecated_note());
                     }));
                 })
                 .build();

--- a/components/script/dom/audio/offlineaudiocontext.rs
+++ b/components/script/dom/audio/offlineaudiocontext.rs
@@ -196,19 +196,19 @@ impl OfflineAudioContextMethods<crate::DomTypeHolder> for OfflineAudioContext {
                         this.length,
                         *this.context.SampleRate(),
                         Some(processed_audio.as_slice()),
-                        CanGc::note());
+                        CanGc::deprecated_note());
                     (*this.pending_rendering_promise.borrow_mut())
                         .take()
                         .unwrap()
-                        .resolve_native(&buffer, CanGc::note());
+                        .resolve_native(&buffer, CanGc::deprecated_note());
                     let global = &this.global();
                     let window = global.as_window();
                     let event = OfflineAudioCompletionEvent::new(window,
                                                                  atom!("complete"),
                                                                  EventBubbles::DoesNotBubble,
                                                                  EventCancelable::NotCancelable,
-                                                                 &buffer, CanGc::note());
-                    event.upcast::<Event>().fire(this.upcast(), CanGc::note());
+                                                                 &buffer, CanGc::deprecated_note());
+                    event.upcast::<Event>().fire(this.upcast(), CanGc::deprecated_note());
                 }));
             })
             .unwrap();

--- a/components/script/dom/bindings/refcounted.rs
+++ b/components/script/dom/bindings/refcounted.rs
@@ -139,7 +139,7 @@ impl TrustedPromise {
         let this = self;
         task!(reject_promise: move || {
             debug!("Rejecting promise.");
-            this.root().reject_error(error, CanGc::note());
+            this.root().reject_error(error, CanGc::deprecated_note());
         })
     }
 
@@ -151,7 +151,7 @@ impl TrustedPromise {
         let this = self;
         task!(resolve_promise: move || {
             debug!("Resolving promise.");
-            this.root().resolve_native(&value, CanGc::note());
+            this.root().resolve_native(&value, CanGc::deprecated_note());
         })
     }
 }

--- a/components/script/dom/bindings/structuredclone.rs
+++ b/components/script/dom/bindings/structuredclone.rs
@@ -252,7 +252,7 @@ unsafe extern "C" fn read_callback(
         for serializable in SerializableInterface::iter() {
             if tag == StructuredCloneTags::from(serializable) as u32 {
                 let reader = reader_for_type(serializable);
-                return reader(&global, r, sc_reader, CanGc::note());
+                return reader(&global, r, sc_reader, CanGc::deprecated_note());
             }
         }
     }
@@ -716,7 +716,7 @@ pub(crate) fn write(
     unsafe {
         rooted!(in(*cx) let mut val = UndefinedValue());
         if let Some(transfer) = transfer {
-            transfer.safe_to_jsval(cx, val.handle_mut(), CanGc::note());
+            transfer.safe_to_jsval(cx, val.handle_mut(), CanGc::deprecated_note());
         }
         let mut sc_writer = StructuredDataWriter::default();
         let sc_writer_ptr = &mut sc_writer as *mut _;

--- a/components/script/dom/canvas/imagebitmap.rs
+++ b/components/script/dom/canvas/imagebitmap.rs
@@ -329,7 +329,7 @@ impl ImageBitmap {
                         let promise = trusted_promise.root();
                         let image_bitmap = trusted_image_bitmap.root();
 
-                        promise.resolve_native(&image_bitmap, CanGc::note());
+                        promise.resolve_native(&image_bitmap, CanGc::deprecated_note());
                     }),
                 );
             };
@@ -345,7 +345,7 @@ impl ImageBitmap {
                 .queue(task!(reject_promise: move || {
                     let promise = trusted_promise.root();
 
-                    promise.reject_error(Error::InvalidState(None), CanGc::note());
+                    promise.reject_error(Error::InvalidState(None), CanGc::deprecated_note());
                 }));
         };
 

--- a/components/script/dom/canvas/offscreencanvas.rs
+++ b/components/script/dom/canvas/offscreencanvas.rs
@@ -451,16 +451,16 @@ impl OffscreenCanvasMethods<crate::DomTypeHolder> for OffscreenCanvas {
                 if snapshot.encode_for_mime_type(&image_type, quality, &mut encoded).is_err() {
                     // Step 7.2.1. If file is null, then reject result with an
                     // "EncodingError" DOMException.
-                    promise.reject_error(Error::Encoding(None), CanGc::note());
+                    promise.reject_error(Error::Encoding(None), CanGc::deprecated_note());
                     return;
                 };
 
                 // Step 7.2.2. Otherwise, resolve result with a new Blob object,
                 // created in global's relevant realm, representing file.
                 let blob_impl = BlobImpl::new_from_bytes(encoded, image_type.as_mime_type());
-                let blob = Blob::new(&this.global(), blob_impl, CanGc::note());
+                let blob = Blob::new(&this.global(), blob_impl, CanGc::deprecated_note());
 
-                promise.resolve_native(&blob, CanGc::note());
+                promise.resolve_native(&blob, CanGc::deprecated_note());
             }));
 
         // Step 8. Return result.

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -228,7 +228,11 @@ fn console_argument_from_handle_value(
         Ok(arg) => arg,
         Err(()) => {
             let in_realm_proof = AlreadyInRealm::assert_for_cx(cx);
-            report_pending_exception(cx, InRealm::Already(&in_realm_proof), CanGc::note());
+            report_pending_exception(
+                cx,
+                InRealm::Already(&in_realm_proof),
+                CanGc::deprecated_note(),
+            );
             DebuggerValue::StringValue("<error>".into())
         },
     }

--- a/components/script/dom/cookiestore.rs
+++ b/components/script/dom/cookiestore.rs
@@ -89,10 +89,10 @@ impl CookieListener {
                     // (There is currently no way for list to result in failure)
                     if let Some(cookie) = cookie {
                         // Otherwise, resolve p with the first item of list.
-                        promise.resolve_native(&cookie_to_list_item(cookie.into_inner()), CanGc::note());
+                        promise.resolve_native(&cookie_to_list_item(cookie.into_inner()), CanGc::deprecated_note());
                     } else {
                         // If list is empty, then resolve p with null.
-                        promise.resolve_native(&NullValue(), CanGc::note());
+                        promise.resolve_native(&NullValue(), CanGc::deprecated_note());
                     }
                 },
                 CookieData::GetAll(cookies) => {
@@ -102,10 +102,10 @@ impl CookieListener {
                         .into_iter()
                         .map(|cookie| cookie_to_list_item(cookie.0))
                         .collect_vec(),
-                    CanGc::note());
+                    CanGc::deprecated_note());
                 },
                 CookieData::Delete(_) | CookieData::Change(_) | CookieData::Set(_) => {
-                    promise.resolve_native(&(), CanGc::note());
+                    promise.resolve_native(&(), CanGc::deprecated_note());
                 }
             }
         }));

--- a/components/script/dom/css/fontface.rs
+++ b/components/script/dom/css/fontface.rs
@@ -346,7 +346,7 @@ impl FontFace {
             // Step 1. If the load was successful, font face now represents the parsed font; fulfill font face’s
             // [[FontStatusPromise]] with font face, and set its status attribute to "loaded".
             self.font_status_promise
-                .resolve_native(&self, CanGc::note());
+                .resolve_native(&self, CanGc::deprecated_note());
             self.status.set(FontFaceLoadStatus::Loaded);
             *self.template.borrow_mut() = Some(template);
 
@@ -362,7 +362,7 @@ impl FontFace {
             // Step 2. Otherwise, reject font face’s [[FontStatusPromise]] with a DOMException named "SyntaxError"
             // and set font face’s status attribute to "error".
             self.font_status_promise
-                .reject_error(Error::Syntax(None), CanGc::note());
+                .reject_error(Error::Syntax(None), CanGc::deprecated_note());
             self.status.set(FontFaceLoadStatus::Error);
 
             // For each FontFaceSet font face is in:
@@ -600,7 +600,7 @@ impl FontFaceMethods<crate::DomTypeHolder> for FontFace {
                             // [[FontStatusPromise]] with a DOMException whose name is "NetworkError"
                             // and set font face’s status attribute to "error".
                             font_face.status.set(FontFaceLoadStatus::Error);
-                            font_face.font_status_promise.reject_error(Error::Network(None), CanGc::note());
+                            font_face.font_status_promise.reject_error(Error::Network(None), CanGc::deprecated_note());
                         }
                         Some(template) => {
                             // Step 5.2. Otherwise, font face now represents the loaded font;
@@ -609,7 +609,7 @@ impl FontFaceMethods<crate::DomTypeHolder> for FontFace {
                             font_face.status.set(FontFaceLoadStatus::Loaded);
                             let old_template = font_face.template.borrow_mut().replace((family_name, template));
                             debug_assert!(old_template.is_none(), "FontFace's template must be intialized only once");
-                            font_face.font_status_promise.resolve_native(&font_face, CanGc::note());
+                            font_face.font_status_promise.resolve_native(&font_face, CanGc::deprecated_note());
                         }
                     }
 

--- a/components/script/dom/css/fontfaceset.rs
+++ b/components/script/dom/css/fontfaceset.rs
@@ -181,7 +181,7 @@ impl FontFaceSetMethods<crate::DomTypeHolder> for FontFaceSet {
                 // TODO: Step 4.2. Resolve promise with the result of waiting for all of the
                 // [[FontStatusPromise]]s of each font face in the font face list, in order.
                 let matched_fonts = Vec::<&FontFace>::new();
-                promise.resolve_native(&matched_fonts, CanGc::note());
+                promise.resolve_native(&matched_fonts, CanGc::deprecated_note());
             }));
 
         // Step 2. Return promise. Complete the rest of these steps asynchronously.

--- a/components/script/dom/css/stylesheet.rs
+++ b/components/script/dom/css/stylesheet.rs
@@ -58,7 +58,7 @@ impl StyleSheetMethods<crate::DomTypeHolder> for StyleSheet {
     fn Media(&self) -> DomRoot<MediaList> {
         self.downcast::<CSSStyleSheet>()
             .unwrap()
-            .medialist(CanGc::note())
+            .medialist(CanGc::deprecated_note())
     }
 
     /// <https://drafts.csswg.org/cssom/#dom-stylesheet-title>

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -611,9 +611,11 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
     /// <https://html.spec.whatwg.org/multipage/#dom-customelementregistry-get>
     fn Get(&self, cx: JSContext, name: DOMString, mut retval: MutableHandleValue) {
         match self.definitions.borrow().get(&LocalName::from(name)) {
-            Some(definition) => definition
-                .constructor
-                .safe_to_jsval(cx, retval, CanGc::note()),
+            Some(definition) => {
+                definition
+                    .constructor
+                    .safe_to_jsval(cx, retval, CanGc::deprecated_note())
+            },
             None => retval.set(UndefinedValue()),
         }
     }
@@ -1241,22 +1243,26 @@ impl CustomElementReactionStack {
 
                 let local_name = DOMString::from(&*local_name);
                 rooted!(in(*cx) let mut name_value = UndefinedValue());
-                local_name.safe_to_jsval(cx, name_value.handle_mut(), CanGc::note());
+                local_name.safe_to_jsval(cx, name_value.handle_mut(), CanGc::deprecated_note());
 
                 rooted!(in(*cx) let mut old_value = NullValue());
                 if let Some(old_val) = old_val {
-                    old_val.safe_to_jsval(cx, old_value.handle_mut(), CanGc::note());
+                    old_val.safe_to_jsval(cx, old_value.handle_mut(), CanGc::deprecated_note());
                 }
 
                 rooted!(in(*cx) let mut value = NullValue());
                 if let Some(val) = val {
-                    val.safe_to_jsval(cx, value.handle_mut(), CanGc::note());
+                    val.safe_to_jsval(cx, value.handle_mut(), CanGc::deprecated_note());
                 }
 
                 rooted!(in(*cx) let mut namespace_value = NullValue());
                 if namespace != ns!() {
                     let namespace = DOMString::from(&*namespace);
-                    namespace.safe_to_jsval(cx, namespace_value.handle_mut(), CanGc::note());
+                    namespace.safe_to_jsval(
+                        cx,
+                        namespace_value.handle_mut(),
+                        CanGc::deprecated_note(),
+                    );
                 }
 
                 let args = vec![

--- a/components/script/dom/datatransfer/datatransferitem.rs
+++ b/components/script/dom/datatransfer/datatransferitem.rs
@@ -126,7 +126,7 @@ impl DataTransferItemMethods<crate::DomTypeHolder> for DataTransferItem {
                     let maybe_index = this.root().pending_callbacks.borrow().iter().position(|val| val.id == id);
                     if let Some(index) = maybe_index {
                         let callback = this.root().pending_callbacks.borrow_mut().swap_remove(index).callback;
-                        let _ = callback.Call__(DOMString::from(string), ExceptionHandling::Report, CanGc::note());
+                        let _ = callback.Call__(DOMString::from(string), ExceptionHandling::Report, CanGc::deprecated_note());
                     }
                 }));
         }

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -902,7 +902,7 @@ impl Document {
                 // Step 4.6.2 Set document's page showing flag to true.
                 document.page_showing.set(true);
                 // Step 4.6.3 Update the visibility state of document to "visible".
-                document.update_visibility_state(DocumentVisibilityState::Visible, CanGc::note());
+                document.update_visibility_state(DocumentVisibilityState::Visible, CanGc::deprecated_note());
                 // Step 4.6.4 Fire a page transition event named pageshow at document's relevant
                 // global object with true.
                 let event = PageTransitionEvent::new(
@@ -911,11 +911,11 @@ impl Document {
                     false, // bubbles
                     false, // cancelable
                     true, // persisted
-                    CanGc::note(),
+                    CanGc::deprecated_note(),
                 );
                 let event = event.upcast::<Event>();
                 event.set_trusted(true);
-                window.dispatch_event_with_target_override(event, CanGc::note());
+                window.dispatch_event_with_target_override(event, CanGc::deprecated_note());
             }))
     }
 
@@ -1941,10 +1941,10 @@ impl Document {
                             false,
                             old_url,
                             new_url,
-                            CanGc::note(),
+                            CanGc::deprecated_note(),
                         )
                         .upcast::<Event>()
-                        .fire(window.upcast(), CanGc::note());
+                        .fire(window.upcast(), CanGc::deprecated_note());
                 }));
         }
     }
@@ -2224,7 +2224,7 @@ impl Document {
                 }
 
                 // Step 9.1. Update the current document readiness to "complete".
-                document.set_ready_state(DocumentReadyState::Complete, CanGc::note());
+                document.set_ready_state(DocumentReadyState::Complete, CanGc::deprecated_note());
 
                 // Step 9.2. If the Document object's browsing context is null, then abort these steps.
                 if document.browsing_context().is_none() {
@@ -2240,11 +2240,11 @@ impl Document {
                     atom!("load"),
                     EventBubbles::DoesNotBubble,
                     EventCancelable::NotCancelable,
-                    CanGc::note(),
+                    CanGc::deprecated_note(),
                 );
                 load_event.set_trusted(true);
                 debug!("About to dispatch load for {:?}", document.url());
-                window.dispatch_event_with_target_override(&load_event, CanGc::note());
+                window.dispatch_event_with_target_override(&load_event, CanGc::deprecated_note());
 
                 // Step 9.6. Invoke WebDriver BiDi load complete with the Document's browsing context,
                 // and a new WebDriver BiDi navigation status whose id is the Document object's during-loading navigation ID
@@ -2270,11 +2270,11 @@ impl Document {
                     false, // bubbles
                     false, // cancelable
                     false, // persisted
-                    CanGc::note(),
+                    CanGc::deprecated_note(),
                 );
                 let page_show_event = page_show_event.upcast::<Event>();
                 page_show_event.set_trusted(true);
-                page_show_event.fire(window.upcast(), CanGc::note());
+                page_show_event.fire(window.upcast(), CanGc::deprecated_note());
 
                 // Step 9.12. Completely finish loading the Document.
                 document.completely_finish_loading();
@@ -2283,7 +2283,7 @@ impl Document {
                 // TODO
 
                 if let Some(fragment) = document.url().fragment() {
-                    document.scroll_to_the_fragment(fragment, CanGc::note());
+                    document.scroll_to_the_fragment(fragment, CanGc::deprecated_note());
                 }
             }));
 
@@ -2476,7 +2476,7 @@ impl Document {
 
                 // Step 6.2 Fire an event named DOMContentLoaded at the Document object, with its bubbles
                 // attribute initialized to true.
-                document.upcast::<EventTarget>().fire_bubbling_event(atom!("DOMContentLoaded"), CanGc::note());
+                document.upcast::<EventTarget>().fire_bubbling_event(atom!("DOMContentLoaded"), CanGc::deprecated_note());
 
                 // Step 6.3 Set the Document's load timing info's DOM content loaded event end time to the current
                 // high resolution time given the Document's relevant global object.
@@ -3220,7 +3220,7 @@ impl Document {
             .task_manager()
             .intersection_observer_task_source()
             .queue(task!(notify_intersection_observers: move || {
-                document.root().notify_intersection_observers(CanGc::note());
+                document.root().notify_intersection_observers(CanGc::deprecated_note());
             }));
     }
 

--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -1577,9 +1577,9 @@ impl DocumentEventHandler {
                     button_bounds,
                     supported_haptic_effects,
                     false,
-                    CanGc::note(),
+                    CanGc::deprecated_note(),
                 );
-                navigator.set_gamepad(selected_index as usize, &gamepad, CanGc::note());
+                navigator.set_gamepad(selected_index as usize, &gamepad, CanGc::deprecated_note());
             }));
     }
 
@@ -1596,7 +1596,7 @@ impl DocumentEventHandler {
                 let navigator = window.Navigator();
                 if let Some(gamepad) = navigator.get_gamepad(index) {
                     if window.Document().is_fully_active() {
-                        gamepad.update_connected(false, gamepad.exposed(), CanGc::note());
+                        gamepad.update_connected(false, gamepad.exposed(), CanGc::deprecated_note());
                         navigator.remove_gamepad(index);
                     }
                 }
@@ -1637,7 +1637,7 @@ impl DocumentEventHandler {
                                         window.upcast::<GlobalScope>().task_manager().gamepad_task_source().queue(
                                             task!(update_gamepad_connect: move || {
                                                 let gamepad = new_gamepad.root();
-                                                gamepad.notify_event(GamepadEventType::Connected, CanGc::note());
+                                                gamepad.notify_event(GamepadEventType::Connected, CanGc::deprecated_note());
                                             })
                                         );
                                     }

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -2432,7 +2432,7 @@ impl Element {
         // Step 2.1: Let nonce be element's [[CryptographicNonce]].
         let nonce = self.nonce_value();
         // Step 2.2: Set an attribute value for element using "nonce" and the empty string.
-        self.set_string_attribute(&local_name!("nonce"), "".into(), CanGc::note());
+        self.set_string_attribute(&local_name!("nonce"), "".into(), CanGc::deprecated_note());
         // Step 2.3: Set element's [[CryptographicNonce]] to nonce.
         self.update_nonce_internal_slot(nonce);
     }
@@ -4251,9 +4251,9 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
 
     /// <https://drafts.csswg.org/css-shadow-parts/#dom-element-part>
     fn Part(&self) -> DomRoot<DOMTokenList> {
-        self.ensure_rare_data()
-            .part
-            .or_init(|| DOMTokenList::new(self, &local_name!("part"), None, CanGc::note()))
+        self.ensure_rare_data().part.or_init(|| {
+            DOMTokenList::new(self, &local_name!("part"), None, CanGc::deprecated_note())
+        })
     }
 }
 

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -153,7 +153,7 @@ impl EventSourceContext {
                 let event_source = event_source.root();
                 if event_source.ready_state.get() != ReadyState::Closed {
                     event_source.ready_state.set(ReadyState::Open);
-                    event_source.upcast::<EventTarget>().fire_event(atom!("open"), CanGc::note());
+                    event_source.upcast::<EventTarget>().fire_event(atom!("open"), CanGc::deprecated_note());
                 }
             }),
         );
@@ -203,7 +203,7 @@ impl EventSourceContext {
                 event_source.ready_state.set(ReadyState::Connecting);
 
                 // Step 1.3.
-                event_source.upcast::<EventTarget>().fire_event(atom!("error"), CanGc::note());
+                event_source.upcast::<EventTarget>().fire_event(atom!("error"), CanGc::deprecated_note());
 
                 // Step 2.
                 let duration = event_source.reconnection_time.get();
@@ -552,7 +552,7 @@ impl EventSource {
                 let event_source = event_source.root();
                 if event_source.ready_state.get() != ReadyState::Closed {
                     event_source.ready_state.set(ReadyState::Closed);
-                    event_source.upcast::<EventTarget>().fire_event(atom!("error"), CanGc::note());
+                    event_source.upcast::<EventTarget>().fire_event(atom!("error"), CanGc::deprecated_note());
                 }
             }),
         );

--- a/components/script/dom/formdata.rs
+++ b/components/script/dom/formdata.rs
@@ -157,7 +157,7 @@ impl FormDataMethods<crate::DomTypeHolder> for FormData {
             value: FormDatumValue::File(DomRoot::from_ref(&*self.create_an_entry(
                 blob,
                 filename,
-                CanGc::note(),
+                CanGc::deprecated_note(),
             ))),
         };
 
@@ -232,7 +232,7 @@ impl FormDataMethods<crate::DomTypeHolder> for FormData {
 
     /// <https://xhr.spec.whatwg.org/#dom-formdata-set>
     fn Set_(&self, name: USVString, blob: &Blob, filename: Option<USVString>) {
-        let file = self.create_an_entry(blob, filename, CanGc::note());
+        let file = self.create_an_entry(blob, filename, CanGc::deprecated_note());
 
         let mut data = self.data.borrow_mut();
         let local_name = LocalName::from(name.0.clone());

--- a/components/script/dom/gamepad/gamepadhapticactuator.rs
+++ b/components/script/dom/gamepad/gamepadhapticactuator.rs
@@ -47,7 +47,7 @@ impl HapticEffectListener {
         self.task_source
             .queue(task!(handle_haptic_effect_completed: move || {
                 let actuator = context.root();
-                actuator.handle_haptic_effect_completed(completed_successfully, CanGc::note());
+                actuator.handle_haptic_effect_completed(completed_successfully, CanGc::deprecated_note());
             }));
     }
 }
@@ -202,7 +202,7 @@ impl GamepadHapticActuatorMethods<crate::DomTypeHolder> for GamepadHapticActuato
                 task!(preempt_promise: move || {
                     let promise = trusted_promise.root();
                     let message = DOMString::from("preempted");
-                    promise.resolve_native(&message, CanGc::note());
+                    promise.resolve_native(&message, CanGc::deprecated_note());
                 }),
             );
         }
@@ -266,7 +266,7 @@ impl GamepadHapticActuatorMethods<crate::DomTypeHolder> for GamepadHapticActuato
                 task!(preempt_promise: move || {
                     let promise = trusted_promise.root();
                     let message = DOMString::from("preempted");
-                    promise.resolve_native(&message, CanGc::note());
+                    promise.resolve_native(&message, CanGc::deprecated_note());
                 }),
             );
         }
@@ -337,7 +337,7 @@ impl GamepadHapticActuator {
                     }
                     let promise = trusted_promise.root();
                     let message = DOMString::from("complete");
-                    promise.resolve_native(&message, CanGc::note());
+                    promise.resolve_native(&message, CanGc::deprecated_note());
                 })
             );
         }
@@ -357,7 +357,7 @@ impl GamepadHapticActuator {
                     return;
                 };
                 let message = DOMString::from("preempted");
-                promise.resolve_native(&message, CanGc::note());
+                promise.resolve_native(&message, CanGc::deprecated_note());
             }),
         );
 

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -611,7 +611,7 @@ impl MessageListener {
                 self.task_source
                     .queue(task!(try_complete_disentanglement: move || {
                         let global = context.root();
-                        global.try_complete_disentanglement(port_id, CanGc::note());
+                        global.try_complete_disentanglement(port_id, CanGc::deprecated_note());
                     }));
             },
             MessagePortMsg::NewTask(port_id, task) => {
@@ -652,7 +652,7 @@ impl FileListener {
 
                         let task = task!(enqueue_stream_chunk: move || {
                             let stream = trusted.root();
-                            stream_handle_incoming(&stream, Ok(blob_buf.bytes), CanGc::note());
+                            stream_handle_incoming(&stream, Ok(blob_buf.bytes), CanGc::deprecated_note());
                         });
                         self.task_source.queue(task);
 
@@ -674,7 +674,7 @@ impl FileListener {
 
                         let task = task!(enqueue_stream_chunk: move || {
                             let stream = trusted.root();
-                            stream_handle_incoming(&stream, Ok(bytes_in), CanGc::note());
+                            stream_handle_incoming(&stream, Ok(bytes_in), CanGc::deprecated_note());
                         });
 
                         self.task_source.queue(task);
@@ -702,7 +702,7 @@ impl FileListener {
                     FileListenerTarget::Stream(trusted_stream) => {
                         let task = task!(enqueue_stream_chunk: move || {
                             let stream = trusted_stream.root();
-                            stream_handle_eof(&stream, CanGc::note());
+                            stream_handle_eof(&stream, CanGc::deprecated_note());
                         });
 
                         self.task_source.queue(task);
@@ -728,7 +728,7 @@ impl FileListener {
                         FileListenerTarget::Stream(trusted_stream) => {
                             self.task_source.queue(task!(error_stream: move || {
                                 let stream = trusted_stream.root();
-                                stream_handle_incoming(&stream, error, CanGc::note());
+                                stream_handle_incoming(&stream, error, CanGc::deprecated_note());
                             }));
                         },
                     }
@@ -1358,7 +1358,7 @@ impl GlobalScope {
                                 rooted!(in(*GlobalScope::get_cx()) let mut message = UndefinedValue());
 
                                 // Step 10.3 StructuredDeserialize(serialized, targetRealm).
-                                if let Ok(ports) = structuredclone::read(&global, data, message.handle_mut(), CanGc::note()) {
+                                if let Ok(ports) = structuredclone::read(&global, data, message.handle_mut(), CanGc::deprecated_note()) {
                                     // Step 10.4, Fire an event named message at destination.
                                     MessageEvent::dispatch_jsval(
                                         destination.upcast(),
@@ -1367,11 +1367,11 @@ impl GlobalScope {
                                         Some(&origin.ascii_serialization()),
                                         None,
                                         ports,
-                                        CanGc::note()
+                                        CanGc::deprecated_note()
                                     );
                                 } else {
                                     // Step 10.3, fire an event named messageerror at destination.
-                                    MessageEvent::dispatch_error(destination.upcast(), &global, CanGc::note());
+                                    MessageEvent::dispatch_error(destination.upcast(), &global, CanGc::deprecated_note());
                                 }
                             })
                         );
@@ -3003,7 +3003,7 @@ impl GlobalScope {
     /// Returns the idb factory for this global.
     pub(crate) fn get_indexeddb(&self) -> DomRoot<IDBFactory> {
         self.indexeddb
-            .or_init(|| IDBFactory::new(self, CanGc::note()))
+            .or_init(|| IDBFactory::new(self, CanGc::deprecated_note()))
     }
 
     pub(crate) fn get_existing_indexeddb(&self) -> Option<DomRoot<IDBFactory>> {

--- a/components/script/dom/html/htmlcanvaselement.rs
+++ b/components/script/dom/html/htmlcanvaselement.rs
@@ -594,7 +594,7 @@ impl HTMLCanvasElementMethods<crate::DomTypeHolder> for HTMLCanvasElement {
                 };
 
                 let Some(mut snapshot) = result else {
-                    let _ = callback.Call__(None, ExceptionHandling::Report, CanGc::note());
+                    let _ = callback.Call__(None, ExceptionHandling::Report, CanGc::deprecated_note());
                     return;
                 };
 
@@ -611,14 +611,14 @@ impl HTMLCanvasElementMethods<crate::DomTypeHolder> for HTMLCanvasElement {
                        // object, created in the relevant realm of this canvas element,
                        // representing result. [FILEAPI]
                        blob_impl = BlobImpl::new_from_bytes(encoded, image_type.as_mime_type());
-                       blob = Blob::new(&this.global(), blob_impl, CanGc::note());
+                       blob = Blob::new(&this.global(), blob_impl, CanGc::deprecated_note());
                        Some(&*blob)
                    }
                    Err(..) => None,
                 };
 
                 // Step 4.2.2: Invoke callback with « result » and "report".
-                let _ = callback.Call__(result, ExceptionHandling::Report, CanGc::note());
+                let _ = callback.Call__(result, ExceptionHandling::Report, CanGc::deprecated_note());
             }));
 
         Ok(())

--- a/components/script/dom/html/htmldetailselement.rs
+++ b/components/script/dom/html/htmldetailselement.rs
@@ -476,10 +476,10 @@ impl VirtualMethods for HTMLDetailsElement {
                             DOMString::from(old_state),
                             DOMString::from(new_state),
                             None,
-                            CanGc::note(),
+                            CanGc::deprecated_note(),
                         );
                         let event = event.upcast::<Event>();
-                        event.fire(this.upcast::<EventTarget>(), CanGc::note());
+                        event.fire(this.upcast::<EventTarget>(), CanGc::deprecated_note());
                     }
                 }));
             self.upcast::<Node>().dirty(NodeDamage::Other);

--- a/components/script/dom/html/htmldialogelement.rs
+++ b/components/script/dom/html/htmldialogelement.rs
@@ -261,10 +261,10 @@ impl HTMLDialogElement {
                     DOMString::from(old_state),
                     DOMString::from(new_state),
                     source,
-                    CanGc::note(),
+                    CanGc::deprecated_note(),
                 );
                 let event = event.upcast::<Event>();
-                event.fire(this.upcast::<EventTarget>(), CanGc::note());
+                event.fire(this.upcast::<EventTarget>(), CanGc::deprecated_note());
 
                 // TODO: Step 2.2. Set element's dialog toggle task tracker to null.
             }));

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -1470,7 +1470,7 @@ impl FormControl for HTMLElement {
     fn set_form_owner(&self, form: Option<&HTMLFormElement>) {
         debug_assert!(self.is_form_associated_custom_element());
         self.element
-            .ensure_element_internals(CanGc::note())
+            .ensure_element_internals(CanGc::deprecated_note())
             .set_form_owner(form);
     }
 

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -436,7 +436,7 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-form-length>
     fn Length(&self) -> u32 {
-        self.Elements(CanGc::note()).Length()
+        self.Elements(CanGc::deprecated_note()).Length()
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-form-item>

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -1395,7 +1395,7 @@ impl HTMLImageElement {
             .dom_manipulation_task_source()
             .queue(task!(fulfill_image_decode_promises: move || {
                 for trusted_promise in trusted_image_decode_promises {
-                    trusted_promise.root().resolve_native(&(), CanGc::note());
+                    trusted_promise.root().resolve_native(&(), CanGc::deprecated_note());
                 }
             }));
     }
@@ -1422,7 +1422,7 @@ impl HTMLImageElement {
             .dom_manipulation_task_source()
             .queue(task!(reject_image_decode_promises: move || {
                 for trusted_promise in trusted_image_decode_promises {
-                    trusted_promise.root().reject_error(Error::Encoding(None), CanGc::note());
+                    trusted_promise.root().reject_error(Error::Encoding(None), CanGc::deprecated_note());
                 }
             }));
     }

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -1100,7 +1100,10 @@ impl StylesheetOwner for HTMLLinkElement {
     }
 
     fn referrer_policy(&self) -> ReferrerPolicy {
-        if self.RelList(CanGc::note()).Contains("noreferrer".into()) {
+        if self
+            .RelList(CanGc::deprecated_note())
+            .Contains("noreferrer".into())
+        {
             return ReferrerPolicy::NoReferrer;
         }
 
@@ -1108,7 +1111,7 @@ impl StylesheetOwner for HTMLLinkElement {
     }
 
     fn set_origin_clean(&self, origin_clean: bool) {
-        if let Some(stylesheet) = self.get_cssom_stylesheet(CanGc::note()) {
+        if let Some(stylesheet) = self.get_cssom_stylesheet(CanGc::deprecated_note()) {
             stylesheet.set_origin_clean(origin_clean);
         }
     }

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -876,10 +876,10 @@ impl HTMLMediaElement {
 
                     this.fulfill_in_flight_play_promises(|| {
                         // Step 2.3.1. Fire an event named timeupdate at the element.
-                        this.upcast::<EventTarget>().fire_event(atom!("timeupdate"), CanGc::note());
+                        this.upcast::<EventTarget>().fire_event(atom!("timeupdate"), CanGc::deprecated_note());
 
                         // Step 2.3.2. Fire an event named pause at the element.
-                        this.upcast::<EventTarget>().fire_event(atom!("pause"), CanGc::note());
+                        this.upcast::<EventTarget>().fire_event(atom!("pause"), CanGc::deprecated_note());
 
                         // Step 2.3.3. Reject pending play promises with promises and an
                         // "AbortError" DOMException.
@@ -920,7 +920,7 @@ impl HTMLMediaElement {
 
                 this.fulfill_in_flight_play_promises(|| {
                     // Step 2.1. Fire an event named playing at the element.
-                    this.upcast::<EventTarget>().fire_event(atom!("playing"), CanGc::note());
+                    this.upcast::<EventTarget>().fire_event(atom!("playing"), CanGc::deprecated_note());
 
                     // Step 2.2. Resolve pending play promises with promises.
                     // Done after running this closure in `fulfill_in_flight_play_promises`.
@@ -1858,8 +1858,8 @@ impl HTMLMediaElement {
         f();
         for promise in &*promises {
             match result {
-                Ok(ref value) => promise.resolve_native(value, CanGc::note()),
-                Err(ref error) => promise.reject_error(error.clone(), CanGc::note()),
+                Ok(ref value) => promise.resolve_native(value, CanGc::deprecated_note()),
+                Err(ref error) => promise.reject_error(error.clone(), CanGc::deprecated_note()),
             }
         }
     }
@@ -2300,7 +2300,7 @@ impl HTMLMediaElement {
                 }
 
                 // Step 3.1. Fire an event named timeupdate at the media element.
-                this.upcast::<EventTarget>().fire_event(atom!("timeupdate"), CanGc::note());
+                this.upcast::<EventTarget>().fire_event(atom!("timeupdate"), CanGc::deprecated_note());
 
                 // Step 3.2. If the media element has ended playback, the direction of playback is
                 // forwards, and paused is false, then:
@@ -2311,7 +2311,7 @@ impl HTMLMediaElement {
                     this.paused.set(true);
 
                     // Step 3.2.2. Fire an event named pause at the media element.
-                    this.upcast::<EventTarget>().fire_event(atom!("pause"), CanGc::note());
+                    this.upcast::<EventTarget>().fire_event(atom!("pause"), CanGc::deprecated_note());
 
                     // Step 3.2.3. Take pending play promises and reject pending play promises with
                     // the result and an "AbortError" DOMException.
@@ -2320,7 +2320,7 @@ impl HTMLMediaElement {
                 }
 
                 // Step 3.3. Fire an event named ended at the media element.
-                this.upcast::<EventTarget>().fire_event(atom!("ended"), CanGc::note());
+                this.upcast::<EventTarget>().fire_event(atom!("ended"), CanGc::deprecated_note());
             }));
 
         // <https://html.spec.whatwg.org/multipage/#dom-media-have_current_data>

--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -465,13 +465,13 @@ impl HTMLSelectElement {
                         EventBubbles::Bubbles,
                         EventCancelable::NotCancelable,
                         EventComposed::Composed,
-                        CanGc::note(),
+                        CanGc::deprecated_note(),
                     );
 
                 // Step 3. Fire an event named change at the select element, with the bubbles attribute initialized
                 // to true.
                 this.upcast::<EventTarget>()
-                    .fire_bubbling_event(atom!("change"), CanGc::note());
+                    .fire_bubbling_event(atom!("change"), CanGc::deprecated_note());
             }));
     }
 
@@ -562,7 +562,12 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
     fn Options(&self) -> DomRoot<HTMLOptionsCollection> {
         self.options.or_init(|| {
             let window = self.owner_window();
-            HTMLOptionsCollection::new(&window, self, Box::new(OptionsFilter), CanGc::note())
+            HTMLOptionsCollection::new(
+                &window,
+                self,
+                Box::new(OptionsFilter),
+                CanGc::deprecated_note(),
+            )
         })
     }
 
@@ -574,7 +579,7 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
                 &window,
                 self.upcast(),
                 Box::new(SelectedOptionsSource),
-                CanGc::note(),
+                CanGc::deprecated_note(),
             )
         })
     }

--- a/components/script/dom/html/htmlstyleelement.rs
+++ b/components/script/dom/html/htmlstyleelement.rs
@@ -254,7 +254,7 @@ impl HTMLStyleElement {
                     None, // todo handle title
                     sheet,
                     None, // constructor_document
-                    CanGc::note(),
+                    CanGc::deprecated_note(),
                 )
             })
         })

--- a/components/script/dom/html/htmltableelement.rs
+++ b/components/script/dom/html/htmltableelement.rs
@@ -204,7 +204,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
             &self.owner_window(),
             self.upcast(),
             Box::new(filter),
-            CanGc::note(),
+            CanGc::deprecated_note(),
         )
     }
 
@@ -327,7 +327,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
                         element.local_name() == &local_name!("tbody") &&
                         element.upcast::<Node>().GetParentNode().as_deref() == Some(root)
                 },
-                CanGc::note(),
+                CanGc::deprecated_note(),
             )
         })
     }

--- a/components/script/dom/html/htmltablerowelement.rs
+++ b/components/script/dom/html/htmltablerowelement.rs
@@ -96,7 +96,7 @@ impl HTMLTableRowElementMethods<crate::DomTypeHolder> for HTMLTableRowElement {
                     (element.is::<HTMLTableCellElement>()) &&
                         element.upcast::<Node>().GetParentNode().as_deref() == Some(root)
                 },
-                CanGc::note(),
+                CanGc::deprecated_note(),
             )
         })
     }

--- a/components/script/dom/html/htmltablesectionelement.rs
+++ b/components/script/dom/html/htmltablesectionelement.rs
@@ -74,7 +74,7 @@ impl HTMLTableSectionElementMethods<crate::DomTypeHolder> for HTMLTableSectionEl
                 element.is::<HTMLTableRowElement>() &&
                     element.upcast::<Node>().GetParentNode().as_deref() == Some(root)
             },
-            CanGc::note(),
+            CanGc::deprecated_note(),
         )
     }
 

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -816,7 +816,7 @@ impl VirtualMethods for HTMLTextAreaElement {
         self.super_type().unwrap().pop();
 
         // https://html.spec.whatwg.org/multipage/#the-textarea-element:stack-of-open-elements
-        self.reset(CanGc::note());
+        self.reset(CanGc::deprecated_note());
     }
 }
 

--- a/components/script/dom/indexeddb/idbdatabase.rs
+++ b/components/script/dom/indexeddb/idbdatabase.rs
@@ -92,7 +92,7 @@ impl IDBDatabase {
         DOMStringList::new(
             &self.global(),
             self.object_store_names.borrow().clone(),
-            CanGc::note(),
+            CanGc::deprecated_note(),
         )
     }
 
@@ -220,14 +220,14 @@ impl IDBDatabaseMethods<crate::DomTypeHolder> for IDBDatabase {
         // connection, mode, options’ durability member, and the set of object
         // stores named in scope.
         let durability = options.durability;
-        let scope = DOMStringList::new(&self.global(), scope, CanGc::note());
+        let scope = DOMStringList::new(&self.global(), scope, CanGc::deprecated_note());
         let transaction = IDBTransaction::new(
             &self.global(),
             self,
             mode,
             durability,
             &scope,
-            CanGc::note(),
+            CanGc::deprecated_note(),
         );
 
         // Step 8. Set transaction’s cleanup event loop to the current event loop.

--- a/components/script/dom/indexeddb/idbfactory.rs
+++ b/components/script/dom/indexeddb/idbfactory.rs
@@ -221,7 +221,7 @@ impl IDBFactory {
             };
             task_source.queue(task!(set_request_result_to_database: move || {
                 let factory = response_listener.root();
-                factory.handle_connection_message(response, CanGc::note())
+                factory.handle_connection_message(response, CanGc::deprecated_note())
             }));
         })
         .expect("Could not create open database callback");
@@ -525,7 +525,7 @@ impl IDBFactoryMethods<crate::DomTypeHolder> for IDBFactory {
         }
 
         // Step 4: Let request be a new open request.
-        let request = IDBOpenDBRequest::new(&self.global(), CanGc::note());
+        let request = IDBOpenDBRequest::new(&self.global(), CanGc::deprecated_note());
 
         // Step 5: Runs in parallel
         if self.open_database(name, version, &request).is_err() {
@@ -554,7 +554,7 @@ impl IDBFactoryMethods<crate::DomTypeHolder> for IDBFactory {
         }
 
         // Step 3: Let request be a new open request
-        let request = IDBOpenDBRequest::new(&self.global(), CanGc::note());
+        let request = IDBOpenDBRequest::new(&self.global(), CanGc::deprecated_note());
 
         // Step 4: Runs in parallel
         if request.delete_database(name.to_string()).is_err() {

--- a/components/script/dom/indexeddb/idbopendbrequest.rs
+++ b/components/script/dom/indexeddb/idbopendbrequest.rs
@@ -227,7 +227,7 @@ impl IDBOpenDBRequest {
         let callback = GenericCallback::new(global.time_profiler_chan().clone(), move |message| {
             let response_listener = response_listener.clone();
             task_source.queue(task!(request_callback: move || {
-                response_listener.handle_delete_db(message.unwrap(), CanGc::note());
+                response_listener.handle_delete_db(message.unwrap(), CanGc::deprecated_note());
             }))
         })
         .expect("Could not create delete database callback");
@@ -284,7 +284,7 @@ impl IDBOpenDBRequest {
 
         let _ac = enter_realm(&*result);
         rooted!(in(*cx) let mut result_val = UndefinedValue());
-        result.safe_to_jsval(cx, result_val.handle_mut(), CanGc::note());
+        result.safe_to_jsval(cx, result_val.handle_mut(), CanGc::deprecated_note());
         self.set_result(result_val.handle());
 
         let event = Event::new(
@@ -292,9 +292,9 @@ impl IDBOpenDBRequest {
             Atom::from("success"),
             EventBubbles::DoesNotBubble,
             EventCancelable::NotCancelable,
-            CanGc::note(),
+            CanGc::deprecated_note(),
         );
-        event.fire(self.upcast(), CanGc::note());
+        event.fire(self.upcast(), CanGc::deprecated_note());
     }
 
     /// <https://w3c.github.io/IndexedDB/#eventdef-idbopendbrequest-blocked>

--- a/components/script/dom/indexeddb/idbtransaction.rs
+++ b/components/script/dom/indexeddb/idbtransaction.rs
@@ -294,7 +294,7 @@ impl IDBTransaction {
                         }
                         Err(_err) => {
                              // TODO: Map backend commit/rollback failure to an appropriate DOMException
-                            this.initiate_abort(Error::Operation(None), CanGc::note());
+                            this.initiate_abort(Error::Operation(None), CanGc::deprecated_note());
 
                             this.finalize_abort();
                         }
@@ -353,7 +353,7 @@ impl IDBTransaction {
             // We failed to initiate the commit algorithm (backend task could not be queued),
             // so the transaction cannot progress to a successful "complete".
             // Choose the most appropriate DOMException mapping for Servo here.
-            self.initiate_abort(Error::InvalidState(None), CanGc::note());
+            self.initiate_abort(Error::InvalidState(None), CanGc::deprecated_note());
             self.finalize_abort();
         }
     }
@@ -547,9 +547,9 @@ impl IDBTransaction {
                     Atom::from("abort"),
                     EventBubbles::DoesNotBubble,
                     EventCancelable::NotCancelable,
-                    CanGc::note(),
+                    CanGc::deprecated_note(),
                 );
-                event.fire(this.upcast(), CanGc::note());
+                event.fire(this.upcast(), CanGc::deprecated_note());
                 if this.mode == IDBTransactionMode::Versionchange {
                     this.global()
                         .get_indexeddb()
@@ -617,9 +617,9 @@ impl IDBTransaction {
                     Atom::from("complete"),
                     EventBubbles::DoesNotBubble,
                     EventCancelable::NotCancelable,
-                    CanGc::note()
+                    CanGc::deprecated_note()
                 );
-                event.fire(this.upcast(), CanGc::note());
+                event.fire(this.upcast(), CanGc::deprecated_note());
                 if this.mode == IDBTransactionMode::Versionchange {
                     this.global()
                         .get_indexeddb()
@@ -768,7 +768,7 @@ impl IDBTransactionMethods<crate::DomTypeHolder> for IDBTransaction {
             return Err(Error::InvalidState(None));
         }
         self.active.set(false);
-        self.initiate_abort(Error::Abort(None), CanGc::note());
+        self.initiate_abort(Error::Abort(None), CanGc::deprecated_note());
         self.request_backend_abort();
 
         Ok(())

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -41,7 +41,7 @@ macro_rules! make_limited_int_setter(
             };
 
             let element = self.upcast::<Element>();
-            element.set_int_attribute(&html5ever::local_name!($htmlname), value, CanGc::note());
+            element.set_int_attribute(&html5ever::local_name!($htmlname), value, CanGc::deprecated_note());
             Ok(())
         }
     );
@@ -113,7 +113,7 @@ macro_rules! make_url_setter(
             use $crate::script_runtime::CanGc;
             let element = self.upcast::<Element>();
             element.set_url_attribute(&html5ever::local_name!($htmlname),
-                                         value, CanGc::note());
+                                         value, CanGc::deprecated_note());
         }
     );
 );
@@ -149,7 +149,7 @@ macro_rules! make_labels_getter(
             self.$memo.or_init(|| NodeList::new_labels_list(
                 self.upcast::<Node>().owner_doc().window(),
                 self.upcast::<HTMLElement>(),
-                CanGc::note()
+                CanGc::deprecated_note()
                 )
             )
         }
@@ -273,7 +273,7 @@ macro_rules! make_setter(
             use $crate::dom::element::Element;
             use $crate::script_runtime::CanGc;
             let element = self.upcast::<Element>();
-            element.set_string_attribute(&html5ever::local_name!($htmlname), value, CanGc::note())
+            element.set_string_attribute(&html5ever::local_name!($htmlname), value, CanGc::deprecated_note())
         }
     );
 );
@@ -286,7 +286,7 @@ macro_rules! make_bool_setter(
             use $crate::dom::element::Element;
             use $crate::script_runtime::CanGc;
             let element = self.upcast::<Element>();
-            element.set_bool_attribute(&html5ever::local_name!($htmlname), value, CanGc::note())
+            element.set_bool_attribute(&html5ever::local_name!($htmlname), value, CanGc::deprecated_note())
         }
     );
 );
@@ -305,7 +305,7 @@ macro_rules! make_uint_setter(
                 value
             };
             let element = self.upcast::<Element>();
-            element.set_uint_attribute(&html5ever::local_name!($htmlname), value, CanGc::note())
+            element.set_uint_attribute(&html5ever::local_name!($htmlname), value, CanGc::deprecated_note())
         }
     );
     ($attr:ident, $htmlname:tt) => {
@@ -328,7 +328,7 @@ macro_rules! make_clamped_uint_setter(
             };
 
             let element = self.upcast::<Element>();
-            element.set_uint_attribute(&html5ever::local_name!($htmlname), value, CanGc::note())
+            element.set_uint_attribute(&html5ever::local_name!($htmlname), value, CanGc::deprecated_note())
         }
     );
 );
@@ -349,7 +349,7 @@ macro_rules! make_limited_uint_setter(
                 value
             };
             let element = self.upcast::<Element>();
-            element.set_uint_attribute(&html5ever::local_name!($htmlname), value, CanGc::note());
+            element.set_uint_attribute(&html5ever::local_name!($htmlname), value, CanGc::deprecated_note());
             Ok(())
         }
     );
@@ -372,7 +372,7 @@ macro_rules! make_atomic_setter_inner(
 macro_rules! make_atomic_setter(
     ( $attr:ident, $htmlname:tt ) => (
         fn $attr(&self, value: DOMString) {
-            make_atomic_setter_inner!(self, value, $htmlname, CanGc::note());
+            make_atomic_setter_inner!(self, value, $htmlname, CanGc::deprecated_note());
         }
     );
     ( $cx:ident, $attr:ident, $htmlname:tt ) => (
@@ -392,7 +392,7 @@ macro_rules! make_legacy_color_setter(
             use $crate::script_runtime::CanGc;
             let element = self.upcast::<Element>();
             let value = AttrValue::from_legacy_color(value.into());
-            element.set_attribute(&html5ever::local_name!($htmlname), value, CanGc::note())
+            element.set_attribute(&html5ever::local_name!($htmlname), value, CanGc::deprecated_note())
         }
     );
 );
@@ -406,7 +406,7 @@ macro_rules! make_dimension_setter(
             use $crate::script_runtime::CanGc;
             let element = self.upcast::<Element>();
             let value = AttrValue::from_dimension(value.into());
-            element.set_attribute(&html5ever::local_name!($htmlname), value, CanGc::note())
+            element.set_attribute(&html5ever::local_name!($htmlname), value, CanGc::deprecated_note())
         }
     );
 );
@@ -420,7 +420,7 @@ macro_rules! make_nonzero_dimension_setter(
             use $crate::script_runtime::CanGc;
             let element = self.upcast::<Element>();
             let value = AttrValue::from_nonzero_dimension(value.into());
-            element.set_attribute(&html5ever::local_name!($htmlname), value, CanGc::note())
+            element.set_attribute(&html5ever::local_name!($htmlname), value, CanGc::deprecated_note())
         }
     );
 );
@@ -467,7 +467,7 @@ macro_rules! make_dimension_uint_setter(
                 value
             };
             let value = AttrValue::from_dimension(value.to_string());
-            element.set_attribute(&html5ever::local_name!($htmlname), value, CanGc::note())
+            element.set_attribute(&html5ever::local_name!($htmlname), value, CanGc::deprecated_note())
         }
     );
     ($attr:ident, $htmlname:tt) => {
@@ -499,7 +499,7 @@ macro_rules! define_event_handler(
             use crate::dom::eventtarget::EventTarget;
             use crate::script_runtime::CanGc;
             let eventtarget = self.upcast::<EventTarget>();
-            eventtarget.get_event_handler_common(stringify!($event_type), CanGc::note())
+            eventtarget.get_event_handler_common(stringify!($event_type), CanGc::deprecated_note())
         }
 
         fn $setter(&self, listener: Option<::std::rc::Rc<$handler>>) {
@@ -797,7 +797,7 @@ macro_rules! impl_performance_entry_struct(
                        start_time: CrossProcessInstant,
                        duration: Duration) -> DomRoot<$struct> {
                 let entry = $struct::new_inherited(name, start_time, duration);
-                reflect_dom_object(Box::new(entry), global, CanGc::note())
+                reflect_dom_object(Box::new(entry), global, CanGc::deprecated_note())
             }
         }
     );

--- a/components/script/dom/media/mediastreamtrack.rs
+++ b/components/script/dom/media/mediastreamtrack.rs
@@ -72,6 +72,6 @@ impl MediaStreamTrackMethods<crate::DomTypeHolder> for MediaStreamTrack {
 
     /// <https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack-clone>
     fn Clone(&self) -> DomRoot<MediaStreamTrack> {
-        MediaStreamTrack::new(&self.global(), self.id, self.ty, CanGc::note())
+        MediaStreamTrack::new(&self.global(), self.id, self.ty, CanGc::deprecated_note())
     }
 }

--- a/components/script/dom/media/videotracklist.rs
+++ b/components/script/dom/media/videotracklist.rs
@@ -97,7 +97,7 @@ impl VideoTrackList {
             .media_element_task_source()
             .queue(task!(media_track_change: move || {
                 let this = this.root();
-                this.upcast::<EventTarget>().fire_event(atom!("change"), CanGc::note());
+                this.upcast::<EventTarget>().fire_event(atom!("change"), CanGc::deprecated_note());
             }));
     }
 

--- a/components/script/dom/mutationobserver/mutationobserver.rs
+++ b/components/script/dom/mutationobserver/mutationobserver.rs
@@ -214,12 +214,14 @@ impl MutationObserver {
                         name,
                         namespace,
                         mapped_old_value,
-                        CanGc::note(),
+                        CanGc::deprecated_note(),
                     )
                 },
-                Mutation::CharacterData { .. } => {
-                    MutationRecord::character_data_mutated(target, mapped_old_value, CanGc::note())
-                },
+                Mutation::CharacterData { .. } => MutationRecord::character_data_mutated(
+                    target,
+                    mapped_old_value,
+                    CanGc::deprecated_note(),
+                ),
                 Mutation::ChildList {
                     ref added,
                     ref removed,
@@ -231,7 +233,7 @@ impl MutationObserver {
                     *removed,
                     *next,
                     *prev,
-                    CanGc::note(),
+                    CanGc::deprecated_note(),
                 ),
             };
             // Step 4.2 Enqueue record to observer’s record queue.

--- a/components/script/dom/mutationobserver/mutationrecord.rs
+++ b/components/script/dom/mutationobserver/mutationrecord.rs
@@ -159,13 +159,13 @@ impl MutationRecordMethods<crate::DomTypeHolder> for MutationRecord {
     /// <https://dom.spec.whatwg.org/#dom-mutationrecord-addednodes>
     fn AddedNodes(&self) -> DomRoot<NodeList> {
         self.added_nodes
-            .or_init(|| NodeList::empty(&self.target.owner_window(), CanGc::note()))
+            .or_init(|| NodeList::empty(&self.target.owner_window(), CanGc::deprecated_note()))
     }
 
     /// <https://dom.spec.whatwg.org/#dom-mutationrecord-removednodes>
     fn RemovedNodes(&self) -> DomRoot<NodeList> {
         self.removed_nodes
-            .or_init(|| NodeList::empty(&self.target.owner_window(), CanGc::note()))
+            .or_init(|| NodeList::empty(&self.target.owner_window(), CanGc::deprecated_note()))
     }
 
     /// <https://dom.spec.whatwg.org/#dom-mutationrecord-previoussibling>

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -346,18 +346,18 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
     #[cfg(feature = "bluetooth")]
     fn Bluetooth(&self) -> DomRoot<Bluetooth> {
         self.bluetooth
-            .or_init(|| Bluetooth::new(&self.global(), CanGc::note()))
+            .or_init(|| Bluetooth::new(&self.global(), CanGc::deprecated_note()))
     }
 
     /// <https://www.w3.org/TR/credential-management-1/#framework-credential-management>
     fn Credentials(&self) -> DomRoot<CredentialsContainer> {
         self.credentials
-            .or_init(|| CredentialsContainer::new(&self.global(), CanGc::note()))
+            .or_init(|| CredentialsContainer::new(&self.global(), CanGc::deprecated_note()))
     }
 
     /// <https://www.w3.org/TR/geolocation/#navigator_interface>
     fn Geolocation(&self) -> DomRoot<Geolocation> {
-        Geolocation::new(&self.global(), CanGc::note())
+        Geolocation::new(&self.global(), CanGc::deprecated_note())
     }
 
     /// <https://html.spec.whatwg.org/multipage/#navigatorlanguage>
@@ -378,13 +378,13 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
     /// <https://html.spec.whatwg.org/multipage/#dom-navigator-plugins>
     fn Plugins(&self) -> DomRoot<PluginArray> {
         self.plugins
-            .or_init(|| PluginArray::new(&self.global(), CanGc::note()))
+            .or_init(|| PluginArray::new(&self.global(), CanGc::deprecated_note()))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-navigator-mimetypes>
     fn MimeTypes(&self) -> DomRoot<MimeTypeArray> {
         self.mime_types
-            .or_init(|| MimeTypeArray::new(&self.global(), CanGc::note()))
+            .or_init(|| MimeTypeArray::new(&self.global(), CanGc::deprecated_note()))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-navigator-javaenabled>
@@ -400,7 +400,7 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
     /// <https://w3c.github.io/ServiceWorker/#navigator-service-worker-attribute>
     fn ServiceWorker(&self) -> DomRoot<ServiceWorkerContainer> {
         self.service_worker
-            .or_init(|| ServiceWorkerContainer::new(&self.global(), CanGc::note()))
+            .or_init(|| ServiceWorkerContainer::new(&self.global(), CanGc::deprecated_note()))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-navigator-cookieenabled>
@@ -425,20 +425,20 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
     /// <https://w3c.github.io/permissions/#navigator-and-workernavigator-extension>
     fn Permissions(&self) -> DomRoot<Permissions> {
         self.permissions
-            .or_init(|| Permissions::new(&self.global(), CanGc::note()))
+            .or_init(|| Permissions::new(&self.global(), CanGc::deprecated_note()))
     }
 
     /// <https://immersive-web.github.io/webxr/#dom-navigator-xr>
     #[cfg(feature = "webxr")]
     fn Xr(&self) -> DomRoot<XRSystem> {
         self.xr
-            .or_init(|| XRSystem::new(self.global().as_window(), CanGc::note()))
+            .or_init(|| XRSystem::new(self.global().as_window(), CanGc::deprecated_note()))
     }
 
     /// <https://w3c.github.io/mediacapture-main/#dom-navigator-mediadevices>
     fn MediaDevices(&self) -> DomRoot<MediaDevices> {
         self.mediadevices
-            .or_init(|| MediaDevices::new(&self.global(), CanGc::note()))
+            .or_init(|| MediaDevices::new(&self.global(), CanGc::deprecated_note()))
     }
 
     /// <https://w3c.github.io/mediasession/#dom-navigator-mediasession>
@@ -453,14 +453,15 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
             // - If a media instance (HTMLMediaElement so far) starts playing media.
             let global = self.global();
             let window = global.as_window();
-            MediaSession::new(window, CanGc::note())
+            MediaSession::new(window, CanGc::deprecated_note())
         })
     }
 
     // https://gpuweb.github.io/gpuweb/#dom-navigator-gpu
     #[cfg(feature = "webgpu")]
     fn Gpu(&self) -> DomRoot<GPU> {
-        self.gpu.or_init(|| GPU::new(&self.global(), CanGc::note()))
+        self.gpu
+            .or_init(|| GPU::new(&self.global(), CanGc::deprecated_note()))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-navigator-hardwareconcurrency>
@@ -563,7 +564,7 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
     /// <https://servo.org/internal-no-spec>
     fn Servo(&self) -> DomRoot<ServoInternals> {
         self.servo_internals
-            .or_init(|| ServoInternals::new(&self.global(), CanGc::note()))
+            .or_init(|| ServoInternals::new(&self.global(), CanGc::deprecated_note()))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-navigator-registerprotocolhandler>

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -1583,7 +1583,7 @@ impl Node {
         Ok(NodeList::new_simple_list(
             &self.owner_window(),
             iter,
-            CanGc::note(),
+            CanGc::deprecated_note(),
         ))
     }
 
@@ -1857,7 +1857,7 @@ impl Node {
         if let Some(node) = self.downcast::<HTMLStyleElement>() {
             node.get_cssom_stylesheet()
         } else if let Some(node) = self.downcast::<HTMLLinkElement>() {
-            node.get_cssom_stylesheet(CanGc::note())
+            node.get_cssom_stylesheet(CanGc::deprecated_note())
         } else {
             None
         }

--- a/components/script/dom/notification.rs
+++ b/components/script/dom/notification.rs
@@ -427,11 +427,11 @@ impl NotificationMethods<crate::DomTypeHolder> for Notification {
                 // Step 3.2.1: If deprecatedCallback is given,
                 //             then invoke deprecatedCallback with « permissionState » and "report".
                 if let Some(callback) = global.remove_notification_permission_request_callback(uuid_) {
-                    let _ = callback.Call__(notification_permission, ExceptionHandling::Report, CanGc::note());
+                    let _ = callback.Call__(notification_permission, ExceptionHandling::Report, CanGc::deprecated_note());
                 }
 
                 // Step 3.2.2: Resolve promise with permissionState.
-                promise.resolve_native(&notification_permission, CanGc::note());
+                promise.resolve_native(&notification_permission, CanGc::deprecated_note());
             }),
         );
 

--- a/components/script/dom/origin.rs
+++ b/components/script/dom/origin.rs
@@ -112,7 +112,7 @@ impl OriginMethods<crate::DomTypeHolder> for Origin {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-origin-from>
     fn From(cx: JSContext, global: &GlobalScope, value: HandleValue) -> Fallible<DomRoot<Origin>> {
-        let can_gc = CanGc::note();
+        let can_gc = CanGc::deprecated_note();
 
         // Step 1. If value is a platform object:
         //   1. Let origin be the result of executing value's extract an origin operation.

--- a/components/script/dom/paintworkletglobalscope.rs
+++ b/components/script/dom/paintworkletglobalscope.rs
@@ -153,7 +153,7 @@ impl PaintWorkletGlobalScope {
                     let map = StylePropertyMapReadOnly::from_iter(
                         self.upcast(),
                         properties.iter().cloned(),
-                        CanGc::note(),
+                        CanGc::deprecated_note(),
                     );
                     let result =
                         self.draw_a_paint_image(&name, size, device_pixel_ratio, &map, &arguments);
@@ -179,7 +179,7 @@ impl PaintWorkletGlobalScope {
                     let map = StylePropertyMapReadOnly::from_iter(
                         self.upcast(),
                         properties.iter().cloned(),
-                        CanGc::note(),
+                        CanGc::deprecated_note(),
                     );
                     let result =
                         self.draw_a_paint_image(&name, size, device_pixel_ratio, &map, &arguments);
@@ -219,7 +219,7 @@ impl PaintWorkletGlobalScope {
             device_pixel_ratio,
             properties,
             arguments,
-            CanGc::note(),
+            CanGc::deprecated_note(),
         )
     }
 
@@ -555,7 +555,7 @@ impl PaintWorkletGlobalScopeMethods<crate::DomTypeHolder> for PaintWorkletGlobal
         }
 
         // Step 19.
-        let Some(context) = PaintRenderingContext2D::new(self, CanGc::note()) else {
+        let Some(context) = PaintRenderingContext2D::new(self, CanGc::deprecated_note()) else {
             return Err(Error::Operation(None));
         };
         let definition = PaintDefinition::new(

--- a/components/script/dom/performance/performance.rs
+++ b/components/script/dom/performance/performance.rs
@@ -367,7 +367,7 @@ impl Performance {
 
         // Step 7.3.
         for o in observers.iter() {
-            o.notify(CanGc::note());
+            o.notify(CanGc::deprecated_note());
         }
     }
 
@@ -448,7 +448,7 @@ impl Performance {
                 .task_manager()
                 .performance_timeline_task_source()
                 .queue(task!(fire_a_buffer_full_event: move || {
-                    performance.root().fire_buffer_full_event(CanGc::note());
+                    performance.root().fire_buffer_full_event(CanGc::deprecated_note());
                 }));
         }
 
@@ -520,7 +520,7 @@ impl PerformanceMethods<crate::DomTypeHolder> for Performance {
 
     /// <https://w3c.github.io/navigation-timing/#dom-performance-navigation>
     fn Navigation(&self) -> DomRoot<PerformanceNavigation> {
-        PerformanceNavigation::new(&self.global(), CanGc::note())
+        PerformanceNavigation::new(&self.global(), CanGc::deprecated_note())
     }
 
     /// <https://w3c.github.io/hr-time/#dom-performance-now>

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -425,7 +425,7 @@ impl FromJSValConvertibleRc for Promise {
         let global_scope =
             unsafe { GlobalScope::from_context(*cx, InRealm::Already(&in_realm_proof)) };
 
-        let promise = Promise::new_resolved(&global_scope, cx, value, CanGc::note());
+        let promise = Promise::new_resolved(&global_scope, cx, value, CanGc::deprecated_note());
         Ok(ConversionResult::Success(promise))
     }
 }

--- a/components/script/dom/reporting/reportingobserver.rs
+++ b/components/script/dom/reporting/reportingobserver.rs
@@ -151,7 +151,7 @@ impl ReportingObserver {
                 reports,
                 observer,
                 ExceptionHandling::Report,
-                CanGc::note(),
+                CanGc::deprecated_note(),
             );
         }
     }

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -97,7 +97,7 @@ impl Selection {
                 task!(selectionchange_task_steps: move || {
                     let this = this.root();
                     this.task_queued.set(false);
-                    this.document.upcast::<EventTarget>().fire_event(atom!("selectionchange"), CanGc::note());
+                    this.document.upcast::<EventTarget>().fire_event(atom!("selectionchange"), CanGc::deprecated_note());
                 })
             );
         self.task_queued.set(true);

--- a/components/script/dom/servointernals.rs
+++ b/components/script/dom/servointernals.rs
@@ -120,7 +120,7 @@ impl ServoInternalsMethods<crate::DomTypeHolder> for ServoInternals {
             return Err(Error::NotFound(None));
         }
         let pref = Preferences::default().get_value(&name);
-        pref_to_jsval(&pref, cx, rval, CanGc::note());
+        pref_to_jsval(&pref, cx, rval, CanGc::deprecated_note());
         Ok(())
     }
 
@@ -135,7 +135,7 @@ impl ServoInternalsMethods<crate::DomTypeHolder> for ServoInternals {
             return Err(Error::NotFound(None));
         }
         let pref = prefs::get().get_value(&name);
-        pref_to_jsval(&pref, cx, rval, CanGc::note());
+        pref_to_jsval(&pref, cx, rval, CanGc::deprecated_note());
         Ok(())
     }
 

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -326,7 +326,7 @@ impl ServoParser {
             ParserKind::ScriptCreated,
             None,
             None,
-            CanGc::note(),
+            CanGc::deprecated_note(),
         );
         document.set_current_parser(Some(&parser));
     }
@@ -1249,7 +1249,7 @@ impl ParserContext {
             &document.global(),
             CrossProcessInstant::now(),
             document,
-            CanGc::note(),
+            CanGc::deprecated_note(),
         );
         self.pushed_entry_index = document
             .global()
@@ -1780,7 +1780,7 @@ impl TreeSink for Sink {
         let control = elem.and_then(|e| e.as_maybe_form_control());
 
         if let Some(control) = control {
-            control.set_form_owner_from_parser(&form, CanGc::note());
+            control.set_form_owner_from_parser(&form, CanGc::deprecated_note());
         }
     }
 
@@ -1882,7 +1882,7 @@ impl TreeSink for Sink {
                 attr.name,
                 DOMString::from(String::from(attr.value)),
                 None,
-                CanGc::note(),
+                CanGc::deprecated_note(),
             );
         }
     }

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -454,7 +454,7 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
             StyleSheetList::new(
                 &self.window,
                 StyleSheetListOwner::ShadowRoot(Dom::from_ref(self)),
-                CanGc::note(),
+                CanGc::deprecated_note(),
             )
         })
     }

--- a/components/script/dom/storage.rs
+++ b/components/script/dom/storage.rs
@@ -253,9 +253,9 @@ impl Storage {
                     new_value.map(DOMString::from),
                     DOMString::from(url.into_string()),
                     Some(&this),
-                    CanGc::note()
+                    CanGc::deprecated_note()
                 );
-                event.upcast::<Event>().fire(global.upcast(), CanGc::note());
+                event.upcast::<Event>().fire(global.upcast(), CanGc::deprecated_note());
             }),
         );
     }

--- a/components/script/dom/svg/svgelement.rs
+++ b/components/script/dom/svg/svgelement.rs
@@ -112,7 +112,7 @@ impl SVGElementMethods<crate::DomTypeHolder> for SVGElement {
                 CSSStyleOwner::Element(Dom::from_ref(self.upcast())),
                 None,
                 CSSModificationAccess::ReadWrite,
-                CanGc::note(),
+                CanGc::deprecated_note(),
             )
         })
     }

--- a/components/script/dom/testing/testbinding.rs
+++ b/components/script/dom/testing/testbinding.rs
@@ -229,7 +229,7 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
         let data: [u8; 16] = [0; 16];
 
         rooted!(in (*cx) let mut array = ptr::null_mut::<JSObject>());
-        create_buffer_source(cx, &data, array.handle_mut(), CanGc::note())
+        create_buffer_source(cx, &data, array.handle_mut(), CanGc::deprecated_note())
             .expect("Creating ClampedU8 array should never fail")
     }
     fn AnyAttribute(&self, _: SafeJSContext, _: MutableHandleValue) {}
@@ -1025,11 +1025,11 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
     }
 
     fn ReturnResolvedPromise(&self, cx: SafeJSContext, v: HandleValue) -> Rc<Promise> {
-        Promise::new_resolved(&self.global(), cx, v, CanGc::note())
+        Promise::new_resolved(&self.global(), cx, v, CanGc::deprecated_note())
     }
 
     fn ReturnRejectedPromise(&self, cx: SafeJSContext, v: HandleValue) -> Rc<Promise> {
-        Promise::new_rejected(&self.global(), cx, v, CanGc::note())
+        Promise::new_rejected(&self.global(), cx, v, CanGc::deprecated_note())
     }
 
     fn PromiseResolveNative(&self, cx: SafeJSContext, p: &Promise, v: HandleValue, can_gc: CanGc) {
@@ -1205,7 +1205,7 @@ impl TestBindingCallback {
     pub(crate) fn invoke(self) {
         self.promise
             .root()
-            .resolve_native(&self.value, CanGc::note());
+            .resolve_native(&self.value, CanGc::deprecated_note());
     }
 }
 

--- a/components/script/dom/testing/testutils.rs
+++ b/components/script/dom/testing/testutils.rs
@@ -24,7 +24,7 @@ impl TestUtilsMethods<crate::DomTypeHolder> for TestUtils {
     #[expect(unsafe_code)]
     fn Gc(global: &GlobalScope) -> Rc<Promise> {
         // 1. Let p be a new promise.
-        let promise = Promise::new(global, CanGc::note());
+        let promise = Promise::new(global, CanGc::deprecated_note());
         let trusted = TrustedPromise::new(promise.clone());
         // 2. Run the following in parallel:
         // 2.1 Run implementation-defined steps to perform a garbage collection covering at least the entry Realm.
@@ -36,7 +36,7 @@ impl TestUtilsMethods<crate::DomTypeHolder> for TestUtils {
                 JS_GC(*GlobalScope::get_cx(), GCReason::DOM_TESTUTILS);
             }
             let promise = trusted.root();
-            promise.resolve_native(&(), CanGc::note());
+            promise.resolve_native(&(), CanGc::deprecated_note());
         });
 
         global

--- a/components/script/dom/treewalker.rs
+++ b/components/script/dom/treewalker.rs
@@ -68,7 +68,13 @@ impl TreeWalker {
             None => Filter::None,
             Some(jsfilter) => Filter::Dom(jsfilter),
         };
-        TreeWalker::new_with_filter(document, root_node, what_to_show, filter, CanGc::note())
+        TreeWalker::new_with_filter(
+            document,
+            root_node,
+            what_to_show,
+            filter,
+            CanGc::deprecated_note(),
+        )
     }
 }
 

--- a/components/script/dom/validation.rs
+++ b/components/script/dom/validation.rs
@@ -91,8 +91,10 @@ pub(crate) trait Validatable {
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-validationmessage>
     fn validation_message(&self) -> DOMString {
         if self.is_instance_validatable() {
-            let flags = self.validity_state(CanGc::note()).invalid_flags();
-            validation_message_for_flags(&self.validity_state(CanGc::note()), flags)
+            let flags = self
+                .validity_state(CanGc::deprecated_note())
+                .invalid_flags();
+            validation_message_for_flags(&self.validity_state(CanGc::deprecated_note()), flags)
         } else {
             DOMString::new()
         }

--- a/components/script/dom/validitystate.rs
+++ b/components/script/dom/validitystate.rs
@@ -107,7 +107,7 @@ impl ValidityState {
     // https://html.spec.whatwg.org/multipage/#custom-validity-error-message
     pub(crate) fn set_custom_error_message(&self, error: DOMString) {
         *self.custom_error_message.borrow_mut() = error;
-        self.perform_validation_and_update(ValidationFlags::CUSTOM_ERROR, CanGc::note());
+        self.perform_validation_and_update(ValidationFlags::CUSTOM_ERROR, CanGc::deprecated_note());
     }
 
     /// Given a set of [ValidationFlags], recalculate their value by performing

--- a/components/script/dom/webgl/extensions/wrapper.rs
+++ b/components/script/dom/webgl/extensions/wrapper.rs
@@ -58,7 +58,7 @@ where
         let mut enabled = true;
         let extension = self.extension.or_init(|| {
             enabled = false;
-            T::new(ctx, CanGc::note())
+            T::new(ctx, CanGc::deprecated_note())
         });
         if !enabled {
             self.enable(ext);

--- a/components/script/dom/webgl/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl/webgl2renderingcontext.rs
@@ -698,10 +698,10 @@ impl WebGL2RenderingContext {
         if pname == constants::FRAMEBUFFER_ATTACHMENT_OBJECT_NAME {
             match fb.attachment(attachment) {
                 Some(Renderbuffer(rb)) => {
-                    rb.safe_to_jsval(cx, rval, CanGc::note());
+                    rb.safe_to_jsval(cx, rval, CanGc::deprecated_note());
                 },
                 Some(Texture(texture)) => {
-                    texture.safe_to_jsval(cx, rval, CanGc::note());
+                    texture.safe_to_jsval(cx, rval, CanGc::deprecated_note());
                 },
                 _ => rval.set(NullValue()),
             }
@@ -1042,11 +1042,11 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     fn GetParameter(&self, cx: JSContext, parameter: u32, mut rval: MutableHandleValue) {
         match parameter {
             constants::VERSION => {
-                "WebGL 2.0".safe_to_jsval(cx, rval, CanGc::note());
+                "WebGL 2.0".safe_to_jsval(cx, rval, CanGc::deprecated_note());
                 return;
             },
             constants::SHADING_LANGUAGE_VERSION => {
-                "WebGL GLSL ES 3.00".safe_to_jsval(cx, rval, CanGc::note());
+                "WebGL GLSL ES 3.00".safe_to_jsval(cx, rval, CanGc::deprecated_note());
                 return;
             },
             constants::MAX_CLIENT_WAIT_TIMEOUT_WEBGL => {
@@ -1065,68 +1065,79 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
                 let idx = (self.base.textures().active_unit_enum() - constants::TEXTURE0) as usize;
                 assert!(idx < self.samplers.len());
                 let sampler = self.samplers[idx].get();
-                sampler.safe_to_jsval(cx, rval, CanGc::note());
+                sampler.safe_to_jsval(cx, rval, CanGc::deprecated_note());
                 return;
             },
             constants::COPY_READ_BUFFER_BINDING => {
                 self.bound_copy_read_buffer
                     .get()
-                    .safe_to_jsval(cx, rval, CanGc::note());
+                    .safe_to_jsval(cx, rval, CanGc::deprecated_note());
                 return;
             },
             constants::COPY_WRITE_BUFFER_BINDING => {
-                self.bound_copy_write_buffer
-                    .get()
-                    .safe_to_jsval(cx, rval, CanGc::note());
+                self.bound_copy_write_buffer.get().safe_to_jsval(
+                    cx,
+                    rval,
+                    CanGc::deprecated_note(),
+                );
                 return;
             },
             constants::PIXEL_PACK_BUFFER_BINDING => {
-                self.bound_pixel_pack_buffer
-                    .get()
-                    .safe_to_jsval(cx, rval, CanGc::note());
+                self.bound_pixel_pack_buffer.get().safe_to_jsval(
+                    cx,
+                    rval,
+                    CanGc::deprecated_note(),
+                );
                 return;
             },
             constants::PIXEL_UNPACK_BUFFER_BINDING => {
-                self.bound_pixel_unpack_buffer
-                    .get()
-                    .safe_to_jsval(cx, rval, CanGc::note());
+                self.bound_pixel_unpack_buffer.get().safe_to_jsval(
+                    cx,
+                    rval,
+                    CanGc::deprecated_note(),
+                );
                 return;
             },
             constants::TRANSFORM_FEEDBACK_BUFFER_BINDING => {
-                self.bound_transform_feedback_buffer
-                    .get()
-                    .safe_to_jsval(cx, rval, CanGc::note());
+                self.bound_transform_feedback_buffer.get().safe_to_jsval(
+                    cx,
+                    rval,
+                    CanGc::deprecated_note(),
+                );
                 return;
             },
             constants::UNIFORM_BUFFER_BINDING => {
                 self.bound_uniform_buffer
                     .get()
-                    .safe_to_jsval(cx, rval, CanGc::note());
+                    .safe_to_jsval(cx, rval, CanGc::deprecated_note());
                 return;
             },
             constants::TRANSFORM_FEEDBACK_BINDING => {
-                self.current_transform_feedback
-                    .get()
-                    .safe_to_jsval(cx, rval, CanGc::note());
+                self.current_transform_feedback.get().safe_to_jsval(
+                    cx,
+                    rval,
+                    CanGc::deprecated_note(),
+                );
                 return;
             },
             constants::ELEMENT_ARRAY_BUFFER_BINDING => {
                 let buffer = self.current_vao().element_array_buffer().get();
-                buffer.safe_to_jsval(cx, rval, CanGc::note());
+                buffer.safe_to_jsval(cx, rval, CanGc::deprecated_note());
                 return;
             },
             constants::VERTEX_ARRAY_BINDING => {
                 let vao = self.current_vao();
                 let vao = vao.id().map(|_| &*vao);
-                vao.safe_to_jsval(cx, rval, CanGc::note());
+                vao.safe_to_jsval(cx, rval, CanGc::deprecated_note());
                 return;
             },
             // NOTE: DRAW_FRAMEBUFFER_BINDING is the same as FRAMEBUFFER_BINDING, handled on the WebGL1 side
             constants::READ_FRAMEBUFFER_BINDING => {
-                self.base
-                    .get_read_framebuffer_slot()
-                    .get()
-                    .safe_to_jsval(cx, rval, CanGc::note());
+                self.base.get_read_framebuffer_slot().get().safe_to_jsval(
+                    cx,
+                    rval,
+                    CanGc::deprecated_note(),
+                );
                 return;
             },
             constants::READ_BUFFER => {
@@ -2086,7 +2097,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
                 binding
                     .buffer
                     .get()
-                    .safe_to_jsval(cx, retval, CanGc::note())
+                    .safe_to_jsval(cx, retval, CanGc::deprecated_note())
             },
             constants::TRANSFORM_FEEDBACK_BUFFER_START | constants::UNIFORM_BUFFER_START => {
                 retval.set(Int32Value(binding.start.get() as _))
@@ -3801,7 +3812,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.12>
     fn CreateQuery(&self) -> Option<DomRoot<WebGLQuery>> {
-        Some(WebGLQuery::new(&self.base, CanGc::note()))
+        Some(WebGLQuery::new(&self.base, CanGc::deprecated_note()))
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.12>
@@ -3842,7 +3853,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.13>
     fn CreateSampler(&self) -> Option<DomRoot<WebGLSampler>> {
-        Some(WebGLSampler::new(&self.base, CanGc::note()))
+        Some(WebGLSampler::new(&self.base, CanGc::deprecated_note()))
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.13>
@@ -3982,7 +3993,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
             return None;
         }
 
-        Some(WebGLSync::new(&self.base, CanGc::note()))
+        Some(WebGLSync::new(&self.base, CanGc::deprecated_note()))
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.14>
@@ -4174,7 +4185,10 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.15>
     fn CreateTransformFeedback(&self) -> Option<DomRoot<WebGLTransformFeedback>> {
-        Some(WebGLTransformFeedback::new(&self.base, CanGc::note()))
+        Some(WebGLTransformFeedback::new(
+            &self.base,
+            CanGc::deprecated_note(),
+        ))
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.15>
@@ -4401,7 +4415,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
             size,
             ty,
             DOMString::from(name),
-            CanGc::note(),
+            CanGc::deprecated_note(),
         ))
     }
 
@@ -4572,11 +4586,11 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
             constants::UNIFORM_OFFSET |
             constants::UNIFORM_ARRAY_STRIDE |
             constants::UNIFORM_MATRIX_STRIDE => {
-                values.safe_to_jsval(cx, rval, CanGc::note());
+                values.safe_to_jsval(cx, rval, CanGc::deprecated_note());
             },
             constants::UNIFORM_IS_ROW_MAJOR => {
                 let values = values.iter().map(|&v| v != 0).collect::<Vec<_>>();
-                values.safe_to_jsval(cx, rval, CanGc::note());
+                values.safe_to_jsval(cx, rval, CanGc::deprecated_note());
             },
             _ => unreachable!(),
         }

--- a/components/script/dom/webgl/webglrenderbuffer.rs
+++ b/components/script/dom/webgl/webglrenderbuffer.rs
@@ -112,7 +112,7 @@ impl WebGLRenderbuffer {
         receiver
             .recv()
             .unwrap()
-            .map(|id| WebGLRenderbuffer::new(context, id, CanGc::note()))
+            .map(|id| WebGLRenderbuffer::new(context, id, CanGc::deprecated_note()))
     }
 
     pub(crate) fn new(

--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -387,8 +387,9 @@ impl WebGLRenderingContext {
     pub(crate) fn current_vao(&self) -> DomRoot<WebGLVertexArrayObjectOES> {
         self.current_vao.or_init(|| {
             DomRoot::from_ref(
-                self.default_vao
-                    .init_once(|| WebGLVertexArrayObjectOES::new(self, None, CanGc::note())),
+                self.default_vao.init_once(|| {
+                    WebGLVertexArrayObjectOES::new(self, None, CanGc::deprecated_note())
+                }),
             )
         })
     }
@@ -396,8 +397,9 @@ impl WebGLRenderingContext {
     pub(crate) fn current_vao_webgl2(&self) -> DomRoot<WebGLVertexArrayObject> {
         self.current_vao_webgl2.or_init(|| {
             DomRoot::from_ref(
-                self.default_vao_webgl2
-                    .init_once(|| WebGLVertexArrayObject::new(self, None, CanGc::note())),
+                self.default_vao_webgl2.init_once(|| {
+                    WebGLVertexArrayObject::new(self, None, CanGc::deprecated_note())
+                }),
             )
         })
     }
@@ -1204,7 +1206,7 @@ impl WebGLRenderingContext {
         receiver
             .recv()
             .unwrap()
-            .map(|id| WebGLVertexArrayObjectOES::new(self, Some(id), CanGc::note()))
+            .map(|id| WebGLVertexArrayObjectOES::new(self, Some(id), CanGc::deprecated_note()))
     }
 
     pub(crate) fn create_vertex_array_webgl2(&self) -> Option<DomRoot<WebGLVertexArrayObject>> {
@@ -1213,7 +1215,7 @@ impl WebGLRenderingContext {
         receiver
             .recv()
             .unwrap()
-            .map(|id| WebGLVertexArrayObject::new(self, Some(id), CanGc::note()))
+            .map(|id| WebGLVertexArrayObject::new(self, Some(id), CanGc::deprecated_note()))
     }
 
     pub(crate) fn delete_vertex_array(&self, vao: Option<&WebGLVertexArrayObjectOES>) {
@@ -2189,30 +2191,32 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
             constants::ARRAY_BUFFER_BINDING => {
                 self.bound_buffer_array
                     .get()
-                    .safe_to_jsval(cx, retval, CanGc::note());
+                    .safe_to_jsval(cx, retval, CanGc::deprecated_note());
                 return;
             },
             constants::CURRENT_PROGRAM => {
                 self.current_program
                     .get()
-                    .safe_to_jsval(cx, retval, CanGc::note());
+                    .safe_to_jsval(cx, retval, CanGc::deprecated_note());
                 return;
             },
             constants::ELEMENT_ARRAY_BUFFER_BINDING => {
                 let buffer = self.current_vao().element_array_buffer().get();
-                buffer.safe_to_jsval(cx, retval, CanGc::note());
+                buffer.safe_to_jsval(cx, retval, CanGc::deprecated_note());
                 return;
             },
             constants::FRAMEBUFFER_BINDING => {
-                self.bound_draw_framebuffer
-                    .get()
-                    .safe_to_jsval(cx, retval, CanGc::note());
+                self.bound_draw_framebuffer.get().safe_to_jsval(
+                    cx,
+                    retval,
+                    CanGc::deprecated_note(),
+                );
                 return;
             },
             constants::RENDERBUFFER_BINDING => {
                 self.bound_renderbuffer
                     .get()
-                    .safe_to_jsval(cx, retval, CanGc::note());
+                    .safe_to_jsval(cx, retval, CanGc::deprecated_note());
                 return;
             },
             constants::TEXTURE_BINDING_2D => {
@@ -2221,7 +2225,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                     .active_texture_slot(constants::TEXTURE_2D, self.webgl_version())
                     .unwrap()
                     .get();
-                texture.safe_to_jsval(cx, retval, CanGc::note());
+                texture.safe_to_jsval(cx, retval, CanGc::deprecated_note());
                 return;
             },
             WebGL2RenderingContextConstants::TEXTURE_BINDING_2D_ARRAY => {
@@ -2233,7 +2237,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                     )
                     .unwrap()
                     .get();
-                texture.safe_to_jsval(cx, retval, CanGc::note());
+                texture.safe_to_jsval(cx, retval, CanGc::deprecated_note());
                 return;
             },
             WebGL2RenderingContextConstants::TEXTURE_BINDING_3D => {
@@ -2245,7 +2249,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                     )
                     .unwrap()
                     .get();
-                texture.safe_to_jsval(cx, retval, CanGc::note());
+                texture.safe_to_jsval(cx, retval, CanGc::deprecated_note());
                 return;
             },
             constants::TEXTURE_BINDING_CUBE_MAP => {
@@ -2254,12 +2258,12 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                     .active_texture_slot(constants::TEXTURE_CUBE_MAP, self.webgl_version())
                     .unwrap()
                     .get();
-                texture.safe_to_jsval(cx, retval, CanGc::note());
+                texture.safe_to_jsval(cx, retval, CanGc::deprecated_note());
                 return;
             },
             OESVertexArrayObjectConstants::VERTEX_ARRAY_BINDING_OES => {
                 let vao = self.current_vao.get().filter(|vao| vao.id().is_some());
-                vao.safe_to_jsval(cx, retval, CanGc::note());
+                vao.safe_to_jsval(cx, retval, CanGc::deprecated_note());
                 return;
             },
             // In readPixels we currently support RGBA/UBYTE only.  If
@@ -2290,15 +2294,15 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                 return retval.set(ObjectValue(rval.get()));
             },
             constants::VERSION => {
-                "WebGL 1.0".safe_to_jsval(cx, retval, CanGc::note());
+                "WebGL 1.0".safe_to_jsval(cx, retval, CanGc::deprecated_note());
                 return;
             },
             constants::RENDERER | constants::VENDOR => {
-                "Mozilla/Servo".safe_to_jsval(cx, retval, CanGc::note());
+                "Mozilla/Servo".safe_to_jsval(cx, retval, CanGc::deprecated_note());
                 return;
             },
             constants::SHADING_LANGUAGE_VERSION => {
-                "WebGL GLSL ES 1.0".safe_to_jsval(cx, retval, CanGc::note());
+                "WebGL GLSL ES 1.0".safe_to_jsval(cx, retval, CanGc::deprecated_note());
                 return;
             },
             constants::UNPACK_FLIP_Y_WEBGL => {
@@ -2382,7 +2386,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                 receiver
                     .recv()
                     .unwrap()
-                    .safe_to_jsval(cx, retval, CanGc::note());
+                    .safe_to_jsval(cx, retval, CanGc::deprecated_note());
             },
             Parameter::Int(param) => {
                 let (sender, receiver) = webgl_channel().unwrap();
@@ -3101,12 +3105,12 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5>
     fn CreateBuffer(&self) -> Option<DomRoot<WebGLBuffer>> {
-        WebGLBuffer::maybe_new(self, CanGc::note())
+        WebGLBuffer::maybe_new(self, CanGc::deprecated_note())
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6>
     fn CreateFramebuffer(&self) -> Option<DomRoot<WebGLFramebuffer>> {
-        WebGLFramebuffer::maybe_new(self, CanGc::note())
+        WebGLFramebuffer::maybe_new(self, CanGc::deprecated_note())
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.7>
@@ -3121,7 +3125,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
     fn CreateProgram(&self) -> Option<DomRoot<WebGLProgram>> {
-        WebGLProgram::maybe_new(self, CanGc::note())
+        WebGLProgram::maybe_new(self, CanGc::deprecated_note())
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
@@ -3295,7 +3299,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
         index: u32,
     ) -> Option<DomRoot<WebGLActiveInfo>> {
         handle_potential_webgl_error!(self, self.validate_ownership(program), return None);
-        match program.get_active_uniform(index, CanGc::note()) {
+        match program.get_active_uniform(index, CanGc::deprecated_note()) {
             Ok(ret) => Some(ret),
             Err(e) => {
                 self.webgl_error(e);
@@ -3313,7 +3317,9 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
         handle_potential_webgl_error!(self, self.validate_ownership(program), return None);
         handle_potential_webgl_error!(
             self,
-            program.get_active_attrib(index, CanGc::note()).map(Some),
+            program
+                .get_active_attrib(index, CanGc::deprecated_note())
+                .map(Some),
             None
         )
     }
@@ -3421,11 +3427,11 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
             if let Some(webgl_attachment) = fb.attachment(attachment) {
                 match webgl_attachment {
                     WebGLFramebufferAttachmentRoot::Renderbuffer(rb) => {
-                        rb.safe_to_jsval(cx, retval, CanGc::note());
+                        rb.safe_to_jsval(cx, retval, CanGc::deprecated_note());
                         return;
                     },
                     WebGLFramebufferAttachmentRoot::Texture(texture) => {
-                        texture.safe_to_jsval(cx, retval, CanGc::note());
+                        texture.safe_to_jsval(cx, retval, CanGc::deprecated_note());
                         return;
                     },
                 }
@@ -3622,7 +3628,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
             range_min,
             range_max,
             precision,
-            CanGc::note(),
+            CanGc::deprecated_note(),
         ))
     }
 
@@ -3635,7 +3641,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
         handle_potential_webgl_error!(self, self.validate_ownership(program), return None);
         handle_potential_webgl_error!(
             self,
-            program.get_uniform_location(name, CanGc::note()),
+            program.get_uniform_location(name, CanGc::deprecated_note()),
             None
         )
     }
@@ -3710,7 +3716,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                 constants::VERTEX_ATTRIB_ARRAY_STRIDE => retval.set(Int32Value(data.stride as i32)),
                 constants::VERTEX_ATTRIB_ARRAY_BUFFER_BINDING => {
                     if let Some(buffer) = data.buffer() {
-                        buffer.safe_to_jsval(cx, retval.reborrow(), CanGc::note());
+                        buffer.safe_to_jsval(cx, retval.reborrow(), CanGc::deprecated_note());
                     } else {
                         retval.set(NullValue());
                     }
@@ -4334,11 +4340,11 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                 WebGLCommand::GetUniformBool,
             ))),
             constants::BOOL_VEC2 => uniform_get(triple, WebGLCommand::GetUniformBool2)
-                .safe_to_jsval(cx, rval, CanGc::note()),
+                .safe_to_jsval(cx, rval, CanGc::deprecated_note()),
             constants::BOOL_VEC3 => uniform_get(triple, WebGLCommand::GetUniformBool3)
-                .safe_to_jsval(cx, rval, CanGc::note()),
+                .safe_to_jsval(cx, rval, CanGc::deprecated_note()),
             constants::BOOL_VEC4 => uniform_get(triple, WebGLCommand::GetUniformBool4)
-                .safe_to_jsval(cx, rval, CanGc::note()),
+                .safe_to_jsval(cx, rval, CanGc::deprecated_note()),
             constants::INT |
             constants::SAMPLER_2D |
             constants::SAMPLER_CUBE |

--- a/components/script/dom/webgl/webglshader.rs
+++ b/components/script/dom/webgl/webglshader.rs
@@ -73,7 +73,7 @@ impl WebGLShader {
         receiver
             .recv()
             .unwrap()
-            .map(|id| WebGLShader::new(context, id, shader_type, CanGc::note()))
+            .map(|id| WebGLShader::new(context, id, shader_type, CanGc::deprecated_note()))
     }
 
     pub(crate) fn new(

--- a/components/script/dom/webgl/webgltexture.rs
+++ b/components/script/dom/webgl/webgltexture.rs
@@ -106,7 +106,7 @@ impl WebGLTexture {
         receiver
             .recv()
             .unwrap()
-            .map(|id| WebGLTexture::new(context, id, CanGc::note()))
+            .map(|id| WebGLTexture::new(context, id, CanGc::deprecated_note()))
     }
 
     pub(crate) fn new(

--- a/components/script/dom/webgpu/gpubuffer.rs
+++ b/components/script/dom/webgpu/gpubuffer.rs
@@ -194,7 +194,7 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
         // Step 1
         let promise = self.pending_map.borrow_mut().take();
         if let Some(promise) = promise {
-            promise.reject_error(Error::Abort(None), CanGc::note());
+            promise.reject_error(Error::Abort(None), CanGc::deprecated_note());
             *self.pending_map.borrow_mut() = Some(promise);
         }
         // Step 2

--- a/components/script/dom/webgpu/gpucommandencoder.rs
+++ b/components/script/dom/webgpu/gpucommandencoder.rs
@@ -148,7 +148,7 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
             self,
             WebGPUComputePass(compute_pass_id),
             descriptor.parent.label.clone(),
-            CanGc::note(),
+            CanGc::deprecated_note(),
         )
     }
 
@@ -219,7 +219,7 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
             WebGPURenderPass(render_pass_id),
             self,
             descriptor.parent.label.clone(),
-            CanGc::note(),
+            CanGc::deprecated_note(),
         ))
     }
 
@@ -324,7 +324,7 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
             self.channel.clone(),
             buffer,
             descriptor.parent.label.clone(),
-            CanGc::note(),
+            CanGc::deprecated_note(),
         )
     }
 }

--- a/components/script/dom/webgpu/gpucomputepipeline.rs
+++ b/components/script/dom/webgpu/gpucomputepipeline.rs
@@ -163,7 +163,7 @@ impl GPUComputePipelineMethods<crate::DomTypeHolder> for GPUComputePipeline {
             self.droppable.channel.clone(),
             WebGPUBindGroupLayout(id),
             USVString::default(),
-            CanGc::note(),
+            CanGc::deprecated_note(),
         ))
     }
 }

--- a/components/script/dom/webgpu/gpudevice.rs
+++ b/components/script/dom/webgpu/gpudevice.rs
@@ -226,7 +226,7 @@ impl GPUDevice {
         self.global().task_manager().webgpu_task_source().queue(
             task!(fire_uncaptured_error: move || {
                 let this = this.root();
-                let error = GPUError::from_error(&this.global(), error, CanGc::note());
+                let error = GPUError::from_error(&this.global(), error, CanGc::deprecated_note());
 
                 let event = GPUUncapturedErrorEvent::new(
                     &this.global(),
@@ -235,10 +235,10 @@ impl GPUDevice {
                         error,
                         parent: EventInit::empty(),
                     },
-                    CanGc::note(),
+                    CanGc::deprecated_note(),
                 );
 
-                event.upcast::<Event>().fire(this.upcast(), CanGc::note());
+                event.upcast::<Event>().fire(this.upcast(), CanGc::deprecated_note());
             }),
         );
     }
@@ -414,8 +414,8 @@ impl GPUDevice {
                 let this = this.root();
 
                 let lost_promise = &(*this.lost_promise.borrow());
-                let lost = GPUDeviceLostInfo::new(&this.global(), msg.into(), reason, CanGc::note());
-                lost_promise.resolve_native(&*lost, CanGc::note());
+                let lost = GPUDeviceLostInfo::new(&this.global(), msg.into(), reason, CanGc::deprecated_note());
+                lost_promise.resolve_native(&*lost, CanGc::deprecated_note());
             }),
         );
     }
@@ -459,7 +459,7 @@ impl GPUDeviceMethods<crate::DomTypeHolder> for GPUDevice {
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createbuffer>
     fn CreateBuffer(&self, descriptor: &GPUBufferDescriptor) -> Fallible<DomRoot<GPUBuffer>> {
-        GPUBuffer::create(self, descriptor, CanGc::note())
+        GPUBuffer::create(self, descriptor, CanGc::deprecated_note())
     }
 
     /// <https://gpuweb.github.io/gpuweb/#GPUDevice-createBindGroupLayout>
@@ -467,7 +467,7 @@ impl GPUDeviceMethods<crate::DomTypeHolder> for GPUDevice {
         &self,
         descriptor: &GPUBindGroupLayoutDescriptor,
     ) -> Fallible<DomRoot<GPUBindGroupLayout>> {
-        GPUBindGroupLayout::create(self, descriptor, CanGc::note())
+        GPUBindGroupLayout::create(self, descriptor, CanGc::deprecated_note())
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createpipelinelayout>
@@ -475,12 +475,12 @@ impl GPUDeviceMethods<crate::DomTypeHolder> for GPUDevice {
         &self,
         descriptor: &GPUPipelineLayoutDescriptor,
     ) -> DomRoot<GPUPipelineLayout> {
-        GPUPipelineLayout::create(self, descriptor, CanGc::note())
+        GPUPipelineLayout::create(self, descriptor, CanGc::deprecated_note())
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createbindgroup>
     fn CreateBindGroup(&self, descriptor: &GPUBindGroupDescriptor) -> DomRoot<GPUBindGroup> {
-        GPUBindGroup::create(self, descriptor, CanGc::note())
+        GPUBindGroup::create(self, descriptor, CanGc::deprecated_note())
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createshadermodule>
@@ -504,7 +504,7 @@ impl GPUDeviceMethods<crate::DomTypeHolder> for GPUDevice {
             compute_pipeline,
             descriptor.parent.parent.label.clone(),
             self,
-            CanGc::note(),
+            CanGc::deprecated_note(),
         )
     }
 
@@ -530,17 +530,17 @@ impl GPUDeviceMethods<crate::DomTypeHolder> for GPUDevice {
         &self,
         descriptor: &GPUCommandEncoderDescriptor,
     ) -> DomRoot<GPUCommandEncoder> {
-        GPUCommandEncoder::create(self, descriptor, CanGc::note())
+        GPUCommandEncoder::create(self, descriptor, CanGc::deprecated_note())
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createtexture>
     fn CreateTexture(&self, descriptor: &GPUTextureDescriptor) -> Fallible<DomRoot<GPUTexture>> {
-        GPUTexture::create(self, descriptor, CanGc::note())
+        GPUTexture::create(self, descriptor, CanGc::deprecated_note())
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createsampler>
     fn CreateSampler(&self, descriptor: &GPUSamplerDescriptor) -> DomRoot<GPUSampler> {
-        GPUSampler::create(self, descriptor, CanGc::note())
+        GPUSampler::create(self, descriptor, CanGc::deprecated_note())
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createrenderpipeline>
@@ -555,7 +555,7 @@ impl GPUDeviceMethods<crate::DomTypeHolder> for GPUDevice {
             render_pipeline,
             descriptor.parent.parent.label.clone(),
             self,
-            CanGc::note(),
+            CanGc::deprecated_note(),
         ))
     }
 
@@ -582,7 +582,7 @@ impl GPUDeviceMethods<crate::DomTypeHolder> for GPUDevice {
         &self,
         descriptor: &GPURenderBundleEncoderDescriptor,
     ) -> Fallible<DomRoot<GPURenderBundleEncoder>> {
-        GPURenderBundleEncoder::create(self, descriptor, CanGc::note())
+        GPURenderBundleEncoder::create(self, descriptor, CanGc::deprecated_note())
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-pusherrorscope>

--- a/components/script/dom/webgpu/gpurenderbundleencoder.rs
+++ b/components/script/dom/webgpu/gpurenderbundleencoder.rs
@@ -279,7 +279,7 @@ impl GPURenderBundleEncoderMethods<crate::DomTypeHolder> for GPURenderBundleEnco
             self.device.id(),
             self.channel.clone(),
             descriptor.parent.label.clone(),
-            CanGc::note(),
+            CanGc::deprecated_note(),
         )
     }
 }

--- a/components/script/dom/webgpu/gpurenderpipeline.rs
+++ b/components/script/dom/webgpu/gpurenderpipeline.rs
@@ -152,7 +152,7 @@ impl GPURenderPipelineMethods<crate::DomTypeHolder> for GPURenderPipeline {
             self.droppable.channel.clone(),
             WebGPUBindGroupLayout(id),
             USVString::default(),
-            CanGc::note(),
+            CanGc::deprecated_note(),
         ))
     }
 }

--- a/components/script/dom/webgpu/gputexture.rs
+++ b/components/script/dom/webgpu/gputexture.rs
@@ -239,7 +239,7 @@ impl GPUTextureMethods<crate::DomTypeHolder> for GPUTexture {
             texture_view,
             self,
             descriptor.parent.label.clone(),
-            CanGc::note(),
+            CanGc::deprecated_note(),
         ))
     }
 

--- a/components/script/dom/webrtc/rtcpeerconnection.rs
+++ b/components/script/dom/webrtc/rtcpeerconnection.rs
@@ -86,7 +86,7 @@ impl WebRtcSignaller for RTCSignaller {
         let this = self.trusted.clone();
         self.task_source.queue(task!(on_ice_candidate: move || {
             let this = this.root();
-            this.on_ice_candidate(candidate, CanGc::note());
+            this.on_ice_candidate(candidate, CanGc::deprecated_note());
         }));
     }
 
@@ -95,7 +95,7 @@ impl WebRtcSignaller for RTCSignaller {
         self.task_source
             .queue(task!(on_negotiation_needed: move || {
                 let this = this.root();
-                this.on_negotiation_needed(CanGc::note());
+                this.on_negotiation_needed(CanGc::deprecated_note());
             }));
     }
 
@@ -104,7 +104,7 @@ impl WebRtcSignaller for RTCSignaller {
         self.task_source
             .queue(task!(update_gathering_state: move || {
                 let this = this.root();
-                this.update_gathering_state(state, CanGc::note());
+                this.update_gathering_state(state, CanGc::deprecated_note());
             }));
     }
 
@@ -113,7 +113,7 @@ impl WebRtcSignaller for RTCSignaller {
         self.task_source
             .queue(task!(update_ice_connection_state: move || {
                 let this = this.root();
-                this.update_ice_connection_state(state, CanGc::note());
+                this.update_ice_connection_state(state, CanGc::deprecated_note());
             }));
     }
 
@@ -122,7 +122,7 @@ impl WebRtcSignaller for RTCSignaller {
         self.task_source
             .queue(task!(update_signaling_state: move || {
                 let this = this.root();
-                this.update_signaling_state(state, CanGc::note());
+                this.update_signaling_state(state, CanGc::deprecated_note());
             }));
     }
 
@@ -131,7 +131,7 @@ impl WebRtcSignaller for RTCSignaller {
         let id = *id;
         self.task_source.queue(task!(on_add_stream: move || {
             let this = this.root();
-            this.on_add_stream(id, ty, CanGc::note());
+            this.on_add_stream(id, ty, CanGc::deprecated_note());
         }));
     }
 
@@ -148,7 +148,7 @@ impl WebRtcSignaller for RTCSignaller {
                 let this = this.root();
                 let global = this.global();
                 let _ac = enter_realm(&*global);
-                this.on_data_channel_event(channel, event, CanGc::note());
+                this.on_data_channel_event(channel, event, CanGc::deprecated_note());
             }));
     }
 
@@ -463,7 +463,7 @@ impl RTCPeerConnection {
                     } else {
                         let init: RTCSessionDescriptionInit = desc.convert();
                         for promise in this.offer_promises.borrow_mut().drain(..) {
-                            promise.resolve_native(&init, CanGc::note());
+                            promise.resolve_native(&init, CanGc::deprecated_note());
                         }
                     }
                 }));
@@ -492,7 +492,7 @@ impl RTCPeerConnection {
                     } else {
                         let init: RTCSessionDescriptionInit = desc.convert();
                         for promise in this.answer_promises.borrow_mut().drain(..) {
-                            promise.resolve_native(&init, CanGc::note());
+                            promise.resolve_native(&init, CanGc::deprecated_note());
                         }
                     }
                 }));
@@ -661,11 +661,11 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
                         let desc = RTCSessionDescription::Constructor(
                             this.global().as_window(),
                             None,
-                            CanGc::note(),
+                            CanGc::deprecated_note(),
                             &desc,
                         ).unwrap();
                         this.local_description.set(Some(&desc));
-                        trusted_promise.root().resolve_native(&(), CanGc::note())
+                        trusted_promise.root().resolve_native(&(), CanGc::deprecated_note())
                     }));
                 }),
             );
@@ -704,11 +704,11 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
                         let desc = RTCSessionDescription::Constructor(
                             this.global().as_window(),
                             None,
-                            CanGc::note(),
+                            CanGc::deprecated_note(),
                             &desc,
                         ).unwrap();
                         this.remote_description.set(Some(&desc));
-                        trusted_promise.root().resolve_native(&(), CanGc::note())
+                        trusted_promise.root().resolve_native(&(), CanGc::deprecated_note())
                     }));
                 }),
             );
@@ -777,7 +777,14 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
         label: USVString,
         init: &RTCDataChannelInit,
     ) -> DomRoot<RTCDataChannel> {
-        RTCDataChannel::new(&self.global(), self, label, init, None, CanGc::note())
+        RTCDataChannel::new(
+            &self.global(),
+            self,
+            label,
+            init,
+            None,
+            CanGc::deprecated_note(),
+        )
     }
 
     /// <https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-addtransceiver>
@@ -786,7 +793,7 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
         _track_or_kind: MediaStreamTrackOrString,
         init: &RTCRtpTransceiverInit,
     ) -> DomRoot<RTCRtpTransceiver> {
-        RTCRtpTransceiver::new(&self.global(), init.direction, CanGc::note())
+        RTCRtpTransceiver::new(&self.global(), init.direction, CanGc::deprecated_note())
     }
 }
 

--- a/components/script/dom/webvtt/texttrack.rs
+++ b/components/script/dom/webvtt/texttrack.rs
@@ -75,8 +75,9 @@ impl TextTrack {
     }
 
     pub(crate) fn get_cues(&self) -> DomRoot<TextTrackCueList> {
-        self.cue_list
-            .or_init(|| TextTrackCueList::new(self.global().as_window(), &[], CanGc::note()))
+        self.cue_list.or_init(|| {
+            TextTrackCueList::new(self.global().as_window(), &[], CanGc::deprecated_note())
+        })
     }
 
     pub(crate) fn id(&self) -> &str {
@@ -138,7 +139,7 @@ impl TextTrackMethods<crate::DomTypeHolder> for TextTrack {
         Some(TextTrackCueList::new(
             self.global().as_window(),
             &[],
-            CanGc::note(),
+            CanGc::deprecated_note(),
         ))
     }
 

--- a/components/script/dom/webvtt/texttracklist.rs
+++ b/components/script/dom/webvtt/texttracklist.rs
@@ -86,10 +86,10 @@ impl TextTrackList {
                             &Some(VideoTrackOrAudioTrackOrTextTrack::TextTrack(
                                 DomRoot::from_ref(&track)
                             )),
-                            CanGc::note()
+                            CanGc::deprecated_note()
                         );
 
-                        event.upcast::<Event>().fire(this.upcast::<EventTarget>(), CanGc::note());
+                        event.upcast::<Event>().fire(this.upcast::<EventTarget>(), CanGc::deprecated_note());
                     }
                 }));
             track.add_track_list(self);

--- a/components/script/dom/webxr/fakexrdevice.rs
+++ b/components/script/dom/webxr/fakexrdevice.rs
@@ -298,7 +298,7 @@ impl FakeXRDeviceMethods<crate::DomTypeHolder> for FakeXRDevice {
         let _ = self.sender.send(MockDeviceMsg::AddInputSource(init));
 
         let controller =
-            FakeXRInputController::new(&global, self.sender.clone(), id, CanGc::note());
+            FakeXRInputController::new(&global, self.sender.clone(), id, CanGc::deprecated_note());
 
         Ok(controller)
     }

--- a/components/script/dom/webxr/xrframe.rs
+++ b/components/script/dom/webxr/xrframe.rs
@@ -197,7 +197,14 @@ impl XRFrameMethods<crate::DomTypeHolder> for XRFrame {
             .hit_test_results
             .iter()
             .filter(|r| r.id == source.id())
-            .map(|r| XRHitTestResult::new(self.global().as_window(), *r, self, CanGc::note()))
+            .map(|r| {
+                XRHitTestResult::new(
+                    self.global().as_window(),
+                    *r,
+                    self,
+                    CanGc::deprecated_note(),
+                )
+            })
             .collect()
     }
 

--- a/components/script/dom/webxr/xrhand.rs
+++ b/components/script/dom/webxr/xrhand.rs
@@ -135,7 +135,16 @@ impl XRHand {
                 .find(|&&(_, value)| value == joint)
                 .map(|&(hand_joint, _)| hand_joint)
                 .expect("Invalid joint name");
-            field.map(|_| XRJointSpace::new(global, session, id, joint, hand_joint, CanGc::note()))
+            field.map(|_| {
+                XRJointSpace::new(
+                    global,
+                    session,
+                    id,
+                    joint,
+                    hand_joint,
+                    CanGc::deprecated_note(),
+                )
+            })
         });
         reflect_dom_object(
             Box::new(XRHand::new_inherited(source, &spaces)),

--- a/components/script/dom/webxr/xrinputsource.rs
+++ b/components/script/dom/webxr/xrinputsource.rs
@@ -145,7 +145,13 @@ impl XRInputSourceMethods<crate::DomTypeHolder> for XRInputSource {
     fn TargetRaySpace(&self) -> DomRoot<XRSpace> {
         self.target_ray_space.or_init(|| {
             let global = self.global();
-            XRSpace::new_inputspace(&global, &self.session, self, false, CanGc::note())
+            XRSpace::new_inputspace(
+                &global,
+                &self.session,
+                self,
+                false,
+                CanGc::deprecated_note(),
+            )
         })
     }
 
@@ -154,7 +160,13 @@ impl XRInputSourceMethods<crate::DomTypeHolder> for XRInputSource {
         if self.info.supports_grip {
             Some(self.grip_space.or_init(|| {
                 let global = self.global();
-                XRSpace::new_inputspace(&global, &self.session, self, true, CanGc::note())
+                XRSpace::new_inputspace(
+                    &global,
+                    &self.session,
+                    self,
+                    true,
+                    CanGc::deprecated_note(),
+                )
             }))
         } else {
             None
@@ -180,8 +192,9 @@ impl XRInputSourceMethods<crate::DomTypeHolder> for XRInputSource {
     /// <https://github.com/immersive-web/webxr-hands-input/blob/master/explainer.md>
     fn GetHand(&self) -> Option<DomRoot<XRHand>> {
         self.info.hand_support.as_ref().map(|hand| {
-            self.hand
-                .or_init(|| XRHand::new(&self.global(), self, hand.clone(), CanGc::note()))
+            self.hand.or_init(|| {
+                XRHand::new(&self.global(), self, hand.clone(), CanGc::deprecated_note())
+            })
         })
     }
 }

--- a/components/script/dom/webxr/xrreferencespace.rs
+++ b/components/script/dom/webxr/xrreferencespace.rs
@@ -90,7 +90,7 @@ impl XRReferenceSpaceMethods<crate::DomTypeHolder> for XRReferenceSpace {
             self.upcast::<XRSpace>().session(),
             self.ty,
             &offset,
-            CanGc::note(),
+            CanGc::deprecated_note(),
         )
     }
 

--- a/components/script/dom/webxr/xrrenderstate.rs
+++ b/components/script/dom/webxr/xrrenderstate.rs
@@ -78,7 +78,7 @@ impl XRRenderState {
             self.inline_vertical_fov.get(),
             self.base_layer.get().as_deref(),
             self.layers.borrow().iter().map(|x| &**x).collect(),
-            CanGc::note(),
+            CanGc::deprecated_note(),
         )
     }
 

--- a/components/script/dom/webxr/xrsession.rs
+++ b/components/script/dom/webxr/xrsession.rs
@@ -214,7 +214,7 @@ impl XRSession {
                 let time = CrossProcessInstant::now();
                 let this = this.clone();
                 task_source.queue(task!(xr_raf_callback: move || {
-                    this.root().raf_callback(frame, time, CanGc::note());
+                    this.root().raf_callback(frame, time, CanGc::deprecated_note());
                 }));
             }),
         );
@@ -237,7 +237,7 @@ impl XRSession {
             ProfileGenericCallback::new(global.time_profiler_chan().clone(), move |message| {
                 let this = this.clone();
                 task_source.queue(task!(xr_event_callback: move || {
-                    this.root().event_callback(message.unwrap(), CanGc::note());
+                    this.root().event_callback(message.unwrap(), CanGc::deprecated_note());
                 }))
             })
             .expect("Could not create callback");
@@ -267,7 +267,7 @@ impl XRSession {
             .dom_manipulation_task_source()
             .queue(task!(session_initial_inputs: move || {
                 let this = this.root();
-                this.input_sources.add_input_sources(&this, &initial_inputs, CanGc::note());
+                this.input_sources.add_input_sources(&this, &initial_inputs, CanGc::deprecated_note());
             }));
     }
 
@@ -466,7 +466,12 @@ impl XRSession {
         }
 
         let time = self.global().performance().to_dom_high_res_time_stamp(time);
-        let frame = XRFrame::new(self.global().as_window(), self, frame, CanGc::note());
+        let frame = XRFrame::new(
+            self.global().as_window(),
+            self,
+            frame,
+            CanGc::deprecated_note(),
+        );
 
         // Step 8-9
         frame.set_active(true);
@@ -1071,9 +1076,9 @@ impl XRSessionMethods<crate::DomTypeHolder> for XRSession {
                 let this = this.clone();
                 task_source.queue(task!(update_session_framerate: move || {
                     let session = this.root();
-                    session.apply_nominal_framerate(message.unwrap(), CanGc::note());
+                    session.apply_nominal_framerate(message.unwrap(), CanGc::deprecated_note());
                     if let Some(promise) = session.update_framerate_promise.borrow_mut().take() {
-                        promise.resolve_native(&(), CanGc::note());
+                        promise.resolve_native(&(), CanGc::deprecated_note());
                     };
                 }));
             })

--- a/components/script/dom/webxr/xrsystem.rs
+++ b/components/script/dom/webxr/xrsystem.rs
@@ -256,7 +256,7 @@ impl XRSystemMethods<crate::DomTypeHolder> for XRSystem {
                     return;
                 };
                 task_source.queue(task!(request_session: move || {
-                    this.root().session_obtained(message, trusted.root(), mode, frame_receiver, CanGc::note());
+                    this.root().session_obtained(message, trusted.root(), mode, frame_receiver, CanGc::deprecated_note());
                 }));
             }),
         );
@@ -269,7 +269,7 @@ impl XRSystemMethods<crate::DomTypeHolder> for XRSystem {
     /// <https://github.com/immersive-web/webxr-test-api/blob/master/explainer.md>
     fn Test(&self) -> DomRoot<XRTest> {
         self.test
-            .or_init(|| XRTest::new(&self.global(), CanGc::note()))
+            .or_init(|| XRTest::new(&self.global(), CanGc::deprecated_note()))
     }
 }
 
@@ -298,7 +298,7 @@ impl XRSystem {
             session,
             mode,
             frame_receiver,
-            CanGc::note(),
+            CanGc::deprecated_note(),
         );
         if mode == XRSessionMode::Inline {
             self.active_inline_sessions
@@ -324,7 +324,7 @@ impl XRSystem {
                     // The sessionavailable event indicates user intent to enter an XR session
                     let xr = xr.root();
                         let _guard = ScriptThread::user_interacting_guard();
-                        xr.upcast::<EventTarget>().fire_bubbling_event(atom!("sessionavailable"), CanGc::note());
+                        xr.upcast::<EventTarget>().fire_bubbling_event(atom!("sessionavailable"), CanGc::deprecated_note());
                 })
             );
     }

--- a/components/script/dom/webxr/xrtest.rs
+++ b/components/script/dom/webxr/xrtest.rs
@@ -54,7 +54,7 @@ impl XRTest {
     ) {
         let promise = trusted.root();
         if let Ok(sender) = response {
-            let device = FakeXRDevice::new(&self.global(), sender, CanGc::note());
+            let device = FakeXRDevice::new(&self.global(), sender, CanGc::deprecated_note());
             self.devices_connected
                 .borrow_mut()
                 .push(Dom::from_ref(&device));
@@ -164,7 +164,7 @@ impl XRTestMethods<crate::DomTypeHolder> for XRTest {
                     message.expect("SimulateDeviceConnection callback given incorrect payload");
 
                 task_source.queue(task!(request_session: move || {
-                    this.root().device_obtained(message, trusted, CanGc::note());
+                    this.root().device_obtained(message, trusted, CanGc::deprecated_note());
                 }));
             })
             .expect("Could not create callback");

--- a/components/script/dom/webxr/xrwebgllayer.rs
+++ b/components/script/dom/webxr/xrwebgllayer.rs
@@ -144,8 +144,12 @@ impl XRWebGLLayer {
 
         // TODO: Cache this texture
         let color_texture_id = WebGLTextureId::new(sub_images.sub_image.as_ref()?.color_texture?);
-        let color_texture =
-            WebGLTexture::new_webxr(&context, color_texture_id, session, CanGc::note());
+        let color_texture = WebGLTexture::new_webxr(
+            &context,
+            color_texture_id,
+            session,
+            CanGc::deprecated_note(),
+        );
         let target = self.texture_target();
 
         // Save the current bindings
@@ -179,8 +183,12 @@ impl XRWebGLLayer {
         if let Some(id) = sub_images.sub_image.as_ref()?.depth_stencil_texture {
             // TODO: Cache this texture
             let depth_stencil_texture_id = WebGLTextureId::new(id);
-            let depth_stencil_texture =
-                WebGLTexture::new_webxr(&context, depth_stencil_texture_id, session, CanGc::note());
+            let depth_stencil_texture = WebGLTexture::new_webxr(
+                &context,
+                depth_stencil_texture_id,
+                session,
+                CanGc::deprecated_note(),
+            );
             framebuffer
                 .texture2d_even_if_opaque(
                     constants::DEPTH_STENCIL_ATTACHMENT,
@@ -357,6 +365,10 @@ impl XRWebGLLayerMethods<crate::DomTypeHolder> for XRWebGLLayer {
         // don't seem to do this for stereoscopic immersive sessions.
         // Revisit if Servo gets support for handheld AR/VR via ARCore/ARKit
 
-        Some(XRViewport::new(&self.global(), viewport, CanGc::note()))
+        Some(XRViewport::new(
+            &self.global(),
+            viewport,
+            CanGc::deprecated_note(),
+        ))
     }
 }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1426,7 +1426,8 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-history>
     fn History(&self) -> DomRoot<History> {
-        self.history.or_init(|| History::new(self, CanGc::note()))
+        self.history
+            .or_init(|| History::new(self, CanGc::deprecated_note()))
     }
 
     /// <https://w3c.github.io/IndexedDB/#factory-interface>
@@ -1437,7 +1438,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     /// <https://html.spec.whatwg.org/multipage/#dom-window-customelements>
     fn CustomElements(&self) -> DomRoot<CustomElementRegistry> {
         self.custom_element_registry
-            .or_init(|| CustomElementRegistry::new(self, CanGc::note()))
+            .or_init(|| CustomElementRegistry::new(self, CanGc::deprecated_note()))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-location>
@@ -1506,7 +1507,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
 
     /// <https://dvcs.w3.org/hg/webcrypto-api/raw-file/tip/spec/Overview.html#dfn-GlobalCrypto>
     fn Crypto(&self) -> DomRoot<Crypto> {
-        self.as_global_scope().crypto(CanGc::note())
+        self.as_global_scope().crypto(CanGc::deprecated_note())
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-frameelement>
@@ -1542,7 +1543,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     /// <https://html.spec.whatwg.org/multipage/#dom-navigator>
     fn Navigator(&self) -> DomRoot<Navigator> {
         self.navigator
-            .or_init(|| Navigator::new(self, CanGc::note()))
+            .or_init(|| Navigator::new(self, CanGc::deprecated_note()))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-clientinformation>
@@ -1711,7 +1712,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
             Performance::new(
                 self.as_global_scope(),
                 self.navigation_start.get(),
-                CanGc::note(),
+                CanGc::deprecated_note(),
             )
         })
     }
@@ -1938,7 +1939,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
             },
             pseudo,
             CSSModificationAccess::Readonly,
-            CanGc::note(),
+            CanGc::deprecated_note(),
         )
     }
 
@@ -2142,7 +2143,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     fn MatchMedia(&self, query: DOMString) -> DomRoot<MediaQueryList> {
         let media_query_list = MediaList::parse_media_list(&query.str(), self);
         let document = self.Document();
-        let mql = MediaQueryList::new(&document, media_query_list, CanGc::note());
+        let mql = MediaQueryList::new(&document, media_query_list, CanGc::deprecated_note());
         self.media_query_lists.track(&*mql);
         mql
     }
@@ -2170,7 +2171,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     #[cfg(feature = "bluetooth")]
     fn TestRunner(&self) -> DomRoot<TestRunner> {
         self.test_runner
-            .or_init(|| TestRunner::new(self.upcast(), CanGc::note()))
+            .or_init(|| TestRunner::new(self.upcast(), CanGc::deprecated_note()))
     }
 
     fn RunningAnimationCount(&self) -> u32 {
@@ -2203,7 +2204,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     fn GetSelection(&self) -> Option<DomRoot<Selection>> {
         self.document
             .get()
-            .and_then(|d| d.GetSelection(CanGc::note()))
+            .and_then(|d| d.GetSelection(CanGc::deprecated_note()))
     }
 
     /// <https://dom.spec.whatwg.org/#dom-window-event>
@@ -2212,7 +2213,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
             event
                 .reflector()
                 .get_jsobject()
-                .safe_to_jsval(cx, rval, CanGc::note());
+                .safe_to_jsval(cx, rval, CanGc::deprecated_note());
         }
     }
 
@@ -2304,7 +2305,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
             self,
             document.upcast(),
             Box::new(WindowNamedGetter { name }),
-            CanGc::note(),
+            CanGc::deprecated_note(),
         );
         Some(NamedPropertyValue::HTMLCollection(collection))
     }
@@ -2447,7 +2448,7 @@ impl Window {
     // https://drafts.css-houdini.org/css-paint-api-1/#paint-worklet
     pub(crate) fn paint_worklet(&self) -> DomRoot<Worklet> {
         self.paint_worklet
-            .or_init(|| self.new_paint_worklet(CanGc::note()))
+            .or_init(|| self.new_paint_worklet(CanGc::deprecated_note()))
     }
 
     pub(crate) fn has_document(&self) -> bool {
@@ -3860,7 +3861,7 @@ impl Window {
             let obj = this.reflector().get_jsobject();
             let _ac = JSAutoRealm::new(*cx, obj.get());
             rooted!(in(*cx) let mut message_clone = UndefinedValue());
-            if let Ok(ports) = structuredclone::read(this.upcast(), data, message_clone.handle_mut(), CanGc::note()) {
+            if let Ok(ports) = structuredclone::read(this.upcast(), data, message_clone.handle_mut(), CanGc::deprecated_note()) {
                 // Step 7.6, 7.7
                 MessageEvent::dispatch_jsval(
                     this.upcast(),
@@ -3869,14 +3870,14 @@ impl Window {
                     Some(&source_origin.ascii_serialization()),
                     Some(&*source),
                     ports,
-                    CanGc::note()
+                    CanGc::deprecated_note()
                 );
             } else {
                 // Step 4, fire messageerror.
                 MessageEvent::dispatch_error(
                     this.upcast(),
                     this.upcast(),
-                    CanGc::note()
+                    CanGc::deprecated_note()
                 );
             }
         });

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -1258,7 +1258,7 @@ impl Drop for WindowProxyHandler {
 fn throw_security_error(cx: SafeJSContext, realm: InRealm) -> bool {
     if !unsafe { JS_IsExceptionPending(*cx) } {
         let global = unsafe { GlobalScope::from_context(*cx, realm) };
-        throw_dom_exception(cx, &global, Error::Security(None), CanGc::note());
+        throw_dom_exception(cx, &global, Error::Security(None), CanGc::deprecated_note());
     }
     false
 }

--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -715,12 +715,12 @@ impl DedicatedWorkerGlobalScope {
                 error_info.lineno,
                 error_info.column,
                 HandleValue::null(),
-                CanGc::note(),
+                CanGc::deprecated_note(),
             );
 
             // Step 7.2.3. If notHandled is true, then report exception for workerObject's relevant global object with omitError set to true.
-            if event.upcast::<Event>().fire(worker.upcast::<EventTarget>(), CanGc::note()) {
-                global.report_an_error(error_info, HandleValue::null(), CanGc::note());
+            if event.upcast::<Event>().fire(worker.upcast::<EventTarget>(), CanGc::deprecated_note()) {
+                global.report_an_error(error_info, HandleValue::null(), CanGc::deprecated_note());
             }
         }));
         self.parent_event_loop_sender

--- a/components/script/dom/workers/serviceworkercontainer.rs
+++ b/components/script/dom/workers/serviceworkercontainer.rs
@@ -212,11 +212,11 @@ impl RegisterJobResultHandler {
                             JobError::TypeError => {
                                 promise.reject_error(
                                     Error::Type(c"Failed to register a ServiceWorker".to_owned()),
-                                    CanGc::note(),
+                                    CanGc::deprecated_note(),
                                 );
                             },
                             JobError::SecurityError => {
-                                promise.reject_error(Error::Security(None), CanGc::note());
+                                promise.reject_error(Error::Security(None), CanGc::deprecated_note());
                             },
                         }
 
@@ -252,11 +252,11 @@ impl RegisterJobResultHandler {
                         installing_worker,
                         waiting_worker,
                         active_worker,
-                        CanGc::note()
+                        CanGc::deprecated_note()
                     );
 
                     // Step 1.4
-                    promise.resolve_native(&*registration, CanGc::note());
+                    promise.resolve_native(&*registration, CanGc::deprecated_note());
                 }));
 
                 // TODO: step 2, handle equivalent jobs.

--- a/components/script/dom/workers/serviceworkerregistration.rs
+++ b/components/script/dom/workers/serviceworkerregistration.rs
@@ -214,7 +214,8 @@ impl ServiceWorkerRegistrationMethods<crate::DomTypeHolder> for ServiceWorkerReg
 
     /// <https://w3c.github.io/ServiceWorker/#service-worker-registration-navigationpreload>
     fn NavigationPreload(&self) -> DomRoot<NavigationPreloadManager> {
-        self.navigation_preload
-            .or_init(|| NavigationPreloadManager::new(&self.global(), self, CanGc::note()))
+        self.navigation_preload.or_init(|| {
+            NavigationPreloadManager::new(&self.global(), self, CanGc::deprecated_note())
+        })
     }
 }

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -655,8 +655,13 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-workerglobalscope-location>
     fn Location(&self) -> DomRoot<WorkerLocation> {
-        self.location
-            .or_init(|| WorkerLocation::new(self, self.worker_url.borrow().clone(), CanGc::note()))
+        self.location.or_init(|| {
+            WorkerLocation::new(
+                self,
+                self.worker_url.borrow().clone(),
+                CanGc::deprecated_note(),
+            )
+        })
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-workerglobalscope-importscripts>
@@ -805,12 +810,13 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
     /// <https://html.spec.whatwg.org/multipage/#dom-worker-navigator>
     fn Navigator(&self) -> DomRoot<WorkerNavigator> {
         self.navigator
-            .or_init(|| WorkerNavigator::new(self, CanGc::note()))
+            .or_init(|| WorkerNavigator::new(self, CanGc::deprecated_note()))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dfn-Crypto>
     fn Crypto(&self) -> DomRoot<Crypto> {
-        self.upcast::<GlobalScope>().crypto(CanGc::note())
+        self.upcast::<GlobalScope>()
+            .crypto(CanGc::deprecated_note())
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-reporterror>
@@ -947,7 +953,11 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
     fn Performance(&self) -> DomRoot<Performance> {
         self.performance.or_init(|| {
             let global_scope = self.upcast::<GlobalScope>();
-            Performance::new(global_scope, self.navigation_start, CanGc::note())
+            Performance::new(
+                global_scope,
+                self.navigation_start,
+                CanGc::deprecated_note(),
+            )
         })
     }
 

--- a/components/script/dom/workers/workernavigator.rs
+++ b/components/script/dom/workers/workernavigator.rs
@@ -112,13 +112,14 @@ impl WorkerNavigatorMethods<crate::DomTypeHolder> for WorkerNavigator {
     /// <https://w3c.github.io/permissions/#navigator-and-workernavigator-extension>
     fn Permissions(&self) -> DomRoot<Permissions> {
         self.permissions
-            .or_init(|| Permissions::new(&self.global(), CanGc::note()))
+            .or_init(|| Permissions::new(&self.global(), CanGc::deprecated_note()))
     }
 
     // https://gpuweb.github.io/gpuweb/#dom-navigator-gpu
     #[cfg(feature = "webgpu")]
     fn Gpu(&self) -> DomRoot<GPU> {
-        self.gpu.or_init(|| GPU::new(&self.global(), CanGc::note()))
+        self.gpu
+            .or_init(|| GPU::new(&self.global(), CanGc::deprecated_note()))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-navigator-hardwareconcurrency>

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -426,7 +426,7 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
 
                 // Step 13
                 if self.ready_state.get() != XMLHttpRequestState::Opened {
-                    self.change_ready_state(XMLHttpRequestState::Opened, CanGc::note());
+                    self.change_ready_state(XMLHttpRequestState::Opened, CanGc::deprecated_note());
                 }
                 Ok(())
             },

--- a/components/script/iframe_collection.rs
+++ b/components/script/iframe_collection.rs
@@ -146,7 +146,7 @@ impl IFrameCollection {
                         PinchZoomInfos::new_from_viewport_size(viewport_details.size),
                         // Theoritically it wouldn't do GC since it is impossible to initialize
                         // the `VisualViewport` interface here.
-                        CanGc::note(),
+                        CanGc::deprecated_note(),
                     )
                 });
 

--- a/components/script/indexeddb.rs
+++ b/components/script/indexeddb.rs
@@ -648,7 +648,7 @@ pub(crate) fn evaluate_key_path_on_value(
                         object.handle(),
                         identifier_name.as_c_str(),
                         current_value.handle_mut(),
-                        CanGc::note(),
+                        CanGc::deprecated_note(),
                     ) {
                         Ok(true) => {},
                         Ok(false) => return Ok(EvaluationResult::Failure),
@@ -733,7 +733,7 @@ pub(crate) fn can_inject_key_into_value(
                 current_object.handle(),
                 identifier_name.as_c_str(),
                 current_value.handle_mut(),
-                CanGc::note(),
+                CanGc::deprecated_note(),
             )
         } {
             Ok(true) => {},
@@ -813,7 +813,7 @@ pub(crate) fn inject_key_into_value(
                 current_object.handle(),
                 identifier_name.as_c_str(),
                 current_value.handle_mut(),
-                CanGc::note(),
+                CanGc::deprecated_note(),
             )
         } {
             Ok(true) => {},

--- a/components/script/module_loading.rs
+++ b/components/script/module_loading.rs
@@ -388,7 +388,7 @@ fn continue_dynamic_import(
                 Some(Box::new(OnRejectedHandler {
                     promise: inner_promise,
                 })),
-                CanGc::note(),
+                CanGc::deprecated_note(),
             );
             let in_realm = InRealm::Already(&in_realm_proof);
             evaluate_promise.append_native_handler(&handler, in_realm, CanGc::from_cx(cx));

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -1453,7 +1453,7 @@ unsafe extern "C" fn invoke_script_environment_preparer(
 
     run_a_script::<DomTypeHolder, _>(&global, || {
         if unsafe { !RunScriptEnvironmentPreparerClosure(*cx, closure) } {
-            report_pending_exception(cx, InRealm::Entered(&ar), CanGc::note());
+            report_pending_exception(cx, InRealm::Entered(&ar), CanGc::deprecated_note());
         };
     });
 }

--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -1156,11 +1156,11 @@ impl<T: ClipboardProvider> TextInput<T> {
                     data.map(DOMString::from),
                     is_composing.into(),
                     input_type.as_str().into(),
-                    CanGc::note(),
+                    CanGc::deprecated_note(),
                 );
                 let event = event.upcast::<Event>();
                 event.set_composed(true);
-                event.fire(&target, CanGc::note());
+                event.fire(&target, CanGc::deprecated_note());
             }),
         );
     }

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -334,13 +334,13 @@ fn object_has_to_json_property(
         rooted!(in(*cx) let mut value = UndefinedValue());
         let result = unsafe { JS_GetProperty(*cx, object, name.as_ptr(), value.handle_mut()) };
         if !result {
-            throw_dom_exception(cx, global_scope, Error::JSFailed, CanGc::note());
+            throw_dom_exception(cx, global_scope, Error::JSFailed, CanGc::deprecated_note());
             false
         } else {
             result && unsafe { JS_TypeOfValue(*cx, value.handle()) } == JSType::JSTYPE_FUNCTION
         }
     } else if unsafe { JS_IsExceptionPending(*cx) } {
-        throw_dom_exception(cx, global_scope, Error::JSFailed, CanGc::note());
+        throw_dom_exception(cx, global_scope, Error::JSFailed, CanGc::deprecated_note());
         false
     } else {
         false
@@ -475,7 +475,7 @@ fn jsval_to_webdriver_inner(
                     seen,
                 )?)
             } else {
-                throw_dom_exception(cx, global_scope, Error::JSFailed, CanGc::note());
+                throw_dom_exception(cx, global_scope, Error::JSFailed, CanGc::deprecated_note());
                 Err(JavaScriptEvaluationError::SerializationError(
                     JavaScriptEvaluationResultSerializationError::OtherJavaScriptError,
                 ))
@@ -526,7 +526,7 @@ fn clone_an_object(
                 },
             },
             Err(error) => {
-                throw_dom_exception(cx, global_scope, error, CanGc::note());
+                throw_dom_exception(cx, global_scope, error, CanGc::deprecated_note());
                 return Err(JavaScriptEvaluationError::SerializationError(
                     JavaScriptEvaluationResultSerializationError::OtherJavaScriptError,
                 ));
@@ -548,7 +548,7 @@ fn clone_an_object(
                     }
                 },
                 Err(error) => {
-                    throw_dom_exception(cx, global_scope, error, CanGc::note());
+                    throw_dom_exception(cx, global_scope, error, CanGc::deprecated_note());
                     return Err(JavaScriptEvaluationError::SerializationError(
                         JavaScriptEvaluationResultSerializationError::OtherJavaScriptError,
                     ));

--- a/components/script/xpath.rs
+++ b/components/script/xpath.rs
@@ -278,7 +278,7 @@ impl xpath::NamespaceResolver for XPathWrapper<Rc<XPathNSResolver>> {
             .LookupNamespaceURI__(
                 Some(DOMString::from(prefix)),
                 ExceptionHandling::Report,
-                CanGc::note(),
+                CanGc::deprecated_note(),
             )
             .ok()
             .flatten()

--- a/components/script_bindings/callback.rs
+++ b/components/script_bindings/callback.rs
@@ -283,7 +283,7 @@ pub fn call_setup<D: DomTypes, T: CallbackContainer<D>, R>(
                 <D as DomHelpers<D>>::report_pending_exception(
                     cx,
                     InRealm::Entered(&ar),
-                    CanGc::note(),
+                    CanGc::deprecated_note(),
                 );
             }
             result

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -4228,7 +4228,7 @@ class CGCallGenerator(CGThing):
             if nativeMethodName in descriptor.inRealmMethods:
                 args.append(CGGeneric("InRealm::already(&AlreadyInRealm::assert_for_cx(SafeJSContext::from_ptr(cx.raw_cx())))"))
             if nativeMethodName in descriptor.canGcMethods:
-                args.append(CGGeneric("CanGc::note()"))
+                args.append(CGGeneric("CanGc::deprecated_note()"))
         if rootType:
             args.append(CGGeneric("retval.handle_mut()"))
 
@@ -4270,7 +4270,7 @@ class CGCallGenerator(CGThing):
                 "let result = match result {\n"
                 "    Ok(result) => result,\n"
                 "    Err(e) => {\n"
-                f"        <D as DomHelpers<D>>::throw_dom_exception(SafeJSContext::from_ptr(cx.raw_cx()), {glob}, e, CanGc::note());\n"
+                f"        <D as DomHelpers<D>>::throw_dom_exception(SafeJSContext::from_ptr(cx.raw_cx()), {glob}, e, CanGc::deprecated_note());\n"
                 f"        return{errorResult};\n"
                 "    },\n"
                 "};"))
@@ -4580,7 +4580,7 @@ class CGMethodPromiseWrapper(CGAbstractExternMethod):
             if ok {
               return true;
             }
-            return exception_to_promise(cx, (*args).rval(), CanGc::note());
+            return exception_to_promise(cx, (*args).rval(), CanGc::deprecated_note());
             """,
             methodName=self.method.identifier.name,
             args=", ".join(arg.name for arg in self.args),
@@ -4615,7 +4615,7 @@ class CGGetterPromiseWrapper(CGAbstractExternMethod):
             if ok {
               return true;
             }
-            return exception_to_promise(cx, args.rval(), CanGc::note());
+            return exception_to_promise(cx, args.rval(), CanGc::deprecated_note());
             """,
             methodName=self.method_call,
             args=", ".join(arg.name for arg in self.args),
@@ -7788,7 +7788,7 @@ impl{self.generic} Clone for {self.makeClassName(self.dictionary)}{self.genericS
             "    type Config = ();\n"
             "    unsafe fn from_jsval(cx: *mut RawJSContext, value: HandleValue, _option: ())\n"
             f"                         -> Result<ConversionResult<{actualType}>, ()> {{\n"
-            f"        {selfName}::new(SafeJSContext::from_ptr(cx), value, CanGc::note())\n"
+            f"        {selfName}::new(SafeJSContext::from_ptr(cx), value, CanGc::deprecated_note())\n"
             "    }\n"
             "}\n"
             "\n"

--- a/components/script_bindings/iterable.rs
+++ b/components/script_bindings/iterable.rs
@@ -108,7 +108,11 @@ impl<D: DomTypes, T: DomObjectIteratorWrap<D> + JSTraceable + Iterable + DomGlob
             index: Cell::new(0),
             _marker: NoTrace(PhantomData),
         });
-        <D as DomHelpers<D>>::reflect_dom_object(iterator, &*iterable.global_(realm), CanGc::note())
+        <D as DomHelpers<D>>::reflect_dom_object(
+            iterator,
+            &*iterable.global_(realm),
+            CanGc::deprecated_note(),
+        )
     }
 
     /// Return the next value from the iterable object.

--- a/components/script_bindings/proxyhandler.rs
+++ b/components/script_bindings/proxyhandler.rs
@@ -562,7 +562,7 @@ pub(crate) fn report_cross_origin_denial<D: DomTypes>(
                 cx.into(),
                 &global,
                 Error::Security(None),
-                CanGc::note(),
+                CanGc::deprecated_note(),
             );
         }
     }

--- a/components/script_bindings/script_runtime.rs
+++ b/components/script_bindings/script_runtime.rs
@@ -97,12 +97,15 @@ pub struct CanGc(PhantomData<*mut ()>);
 impl CanGc {
     /// Create a new CanGc value, representing that a GC operation is possible within the
     /// current stack frame.
-    pub fn note() -> CanGc {
+    ///
+    /// Deprecrated: do not use. Instead, use [`CanGc::from_cx(cx)`] with a `cx` from a task
+    /// callback or by declaring it in Bindings.conf.
+    pub fn deprecated_note() -> CanGc {
         CanGc(PhantomData)
     }
 
     /// &mut SafeJSContext is always an indication that GC is possible.
     pub fn from_cx(_cx: &mut SafeJSContext) -> CanGc {
-        CanGc::note()
+        CanGc::deprecated_note()
     }
 }

--- a/components/script_bindings/utils.rs
+++ b/components/script_bindings/utils.rs
@@ -674,7 +674,7 @@ pub(crate) unsafe extern "C" fn generic_method<
         vp,
         Policy::INFO,
         CallJitMethodOp,
-        CanGc::note(),
+        CanGc::deprecated_note(),
     )
 }
 
@@ -698,7 +698,7 @@ pub(crate) unsafe extern "C" fn generic_getter<
         vp,
         Policy::INFO,
         CallJitGetterOp,
-        CanGc::note(),
+        CanGc::deprecated_note(),
     )
 }
 
@@ -727,7 +727,14 @@ pub(crate) unsafe extern "C" fn generic_setter<D: DomTypes, Policy: CallPolicy>(
     argc: libc::c_uint,
     vp: *mut JSVal,
 ) -> bool {
-    generic_call::<D, false>(cx, argc, vp, Policy::INFO, call_setter, CanGc::note())
+    generic_call::<D, false>(
+        cx,
+        argc,
+        vp,
+        Policy::INFO,
+        call_setter,
+        CanGc::deprecated_note(),
+    )
 }
 
 /// <https://searchfox.org/mozilla-central/rev/7279a1df13a819be254fd4649e07c4ff93e4bd45/dom/bindings/BindingUtils.cpp#3300>
@@ -750,7 +757,7 @@ pub(crate) unsafe extern "C" fn generic_static_promise_method(
     if static_fn(cx, argc, vp) {
         return true;
     }
-    exception_to_promise(cx, args.rval(), CanGc::note())
+    exception_to_promise(cx, args.rval(), CanGc::deprecated_note())
 }
 
 /// Coverts exception to promise rejection


### PR DESCRIPTION
Per the suggestion in
https://servo.zulipchat.com/#narrow/channel/263398-general/topic/PSA.3A.20avoid.20new.20usages.20of.20CanGc.20whenever.20possible/near/583995807 to mark this method as deprecated and make clear it shouldn't be used anymore, as alternatives exist.

Part of #40600

Testing: It compiles