### PR TITLE
devtools: Clean up `StyleRuleActor` variable names

### DIFF
--- a/components/devtools/actors/inspector/page_style.rs
+++ b/components/devtools/actors/inspector/page_style.rs
@@ -207,8 +207,9 @@ impl PageStyleActor {
                         })
                         .clone();
 
-                    let actor = registry.find::<StyleRuleActor>(&style_rule_name);
-                    let rule = actor.applied(registry)?;
+                    let rule = registry
+                        .find::<StyleRuleActor>(&style_rule_name)
+                        .applied(registry)?;
                     if inherited.is_some() && rule.declarations.is_empty() {
                         return None;
                     }
@@ -249,20 +250,19 @@ impl PageStyleActor {
             ancestor_data: vec![],
         };
 
-        let computed = {
-            let style_rule_name = node_actor
-                .style_rules
-                .borrow_mut()
-                .entry(style_attribute_rule)
-                .or_insert_with(|| StyleRuleActor::register(registry, node_name.into(), None))
-                .clone();
-
-            let actor = registry.find::<StyleRuleActor>(&style_rule_name);
-            actor.computed(registry)
-        };
+        let style_rule_name = node_actor
+            .style_rules
+            .borrow_mut()
+            .entry(style_attribute_rule)
+            .or_insert_with(|| StyleRuleActor::register(registry, node_name.into(), None))
+            .clone();
+        let computed = registry
+            .find::<StyleRuleActor>(&style_rule_name)
+            .computed(registry)
+            .unwrap_or_default();
 
         let msg = GetComputedReply {
-            computed: computed.unwrap_or_default(),
+            computed,
             from: self.name(),
         };
         request.reply_final(&msg)


### PR DESCRIPTION
Last naming changes for `StyleRuleActor`.

Testing: Existing tests pass
Part of: #43606
