### PR TITLE
mach: respect --yes when installing GStreamer on Macos

### DIFF
--- a/python/servo/bootstrap_commands.py
+++ b/python/servo/bootstrap_commands.py
@@ -65,9 +65,9 @@ class MachCommands(CommandBase):
         category="bootstrap",
     )
     @CommandArgument("--force", "-f", action="store_true", help="Boostrap without confirmation")
-    def bootstrap_gstreamer(self, force: bool = False) -> int:
+    def bootstrap_gstreamer(self, force: bool = False, yes: bool = False) -> int:
         try:
-            servo.platform.get().bootstrap_gstreamer(force)
+            servo.platform.get().bootstrap_gstreamer(force, yes)
         except NotImplementedError as exception:
             print(exception)
             return 1

--- a/python/servo/platform/base.py
+++ b/python/servo/platform/base.py
@@ -32,7 +32,7 @@ class Base:
     def _platform_bootstrap(self, force: bool, yes: bool) -> bool:
         raise NotImplementedError("Bootstrap installation detection not yet available.")
 
-    def _platform_bootstrap_gstreamer(self, target: BuildTarget, force: bool) -> bool:
+    def _platform_bootstrap_gstreamer(self, target: BuildTarget, force: bool, yes: bool) -> bool:
         raise NotImplementedError("GStreamer bootstrap support is not yet available for your OS.")
 
     def is_gstreamer_installed(self, target: BuildTarget) -> bool:
@@ -143,7 +143,7 @@ class Base:
 
     def bootstrap_gstreamer(self, force: bool) -> None:
         target = BuildTarget.from_triple(self.triple)
-        if not self._platform_bootstrap_gstreamer(target, force):
+        if not self._platform_bootstrap_gstreamer(target, force, False):
             root = self.gstreamer_root(target)
             if root:
                 print(f"GStreamer found at: {root}")

--- a/python/servo/platform/base.py
+++ b/python/servo/platform/base.py
@@ -141,9 +141,9 @@ class Base:
         as fast as possible."""
         return False
 
-    def bootstrap_gstreamer(self, force: bool) -> None:
+    def bootstrap_gstreamer(self, force: bool, yes: bool) -> None:
         target = BuildTarget.from_triple(self.triple)
-        if not self._platform_bootstrap_gstreamer(target, force, False):
+        if not self._platform_bootstrap_gstreamer(target, force, yes):
             root = self.gstreamer_root(target)
             if root:
                 print(f"GStreamer found at: {root}")

--- a/python/servo/platform/linux.py
+++ b/python/servo/platform/linux.py
@@ -195,7 +195,7 @@ class Linux(Base):
     def gstreamer_root(self, target: BuildTarget) -> Optional[str]:
         return None
 
-    def _platform_bootstrap_gstreamer(self, target: BuildTarget, force: bool) -> bool:
+    def _platform_bootstrap_gstreamer(self, target: BuildTarget, force: bool, yes: bool) -> bool:
         raise EnvironmentError(
             "Bootstrapping GStreamer on Linux is not supported. "
             + "Please install it using your distribution package manager."

--- a/python/servo/platform/macos.py
+++ b/python/servo/platform/macos.py
@@ -91,8 +91,7 @@ class MacOS(Base):
                     "sudo",
                     "sh",
                     "-c",
-                    f"installer -pkg '{libs_pkg}' -target / &&installer -pkg '{
-                        devel_pkg}' -target /",
+                    f"installer -pkg '{libs_pkg}' -target / && installer -pkg '{devel_pkg}' -target /",
                 ]
             )
 

--- a/python/servo/platform/macos.py
+++ b/python/servo/platform/macos.py
@@ -66,19 +66,15 @@ class MacOS(Base):
             devel_pkg = os.path.join(temp_dir, GSTREAMER_DEVEL_FILENAME)
 
             if not (yes or force):
-                print(
-                    "Warning: GStreamer was not installed since it requires elevated permissions.\n")
+                print("Warning: GStreamer was not installed since it requires elevated permissions.\n")
                 print("To install GStreamer, either: ")
                 print("a) Run mach bootstrap again with --yes")
                 print("b) OR install GStreamer manually:")
                 print("\t1. Download both GStreamer packages:")
-                print(
-                    f"\tcurl -L -# -o /tmp/{GSTREAMER_FILENAME} {GSTREAMER_URL}\n")
-                print(
-                    f"\tcurl -L -# -o /tmp/{GSTREAMER_DEVEL_FILENAME} {GSTREAMER_DEVEL_URL}\n")
+                print(f"\tcurl -L -# -o /tmp/{GSTREAMER_FILENAME} {GSTREAMER_URL}\n")
+                print(f"\tcurl -L -# -o /tmp/{GSTREAMER_DEVEL_FILENAME} {GSTREAMER_DEVEL_URL}\n")
                 print("\t2. Install GStreamer packages:")
-                print(f"\tsudo installer -pkg '/tmp/{GSTREAMER_FILENAME}' -target / && installer -pkg '/tmp/{
-                      GSTREAMER_DEVEL_FILENAME}' -target / \n")
+                print(f"\tsudo installer -pkg '/tmp/{GSTREAMER_FILENAME}' -target / && installer -pkg '/tmp/{GSTREAMER_DEVEL_FILENAME}' -target / \n")
                 return False
 
             util.download_file("GStreamer libraries", GSTREAMER_URL, libs_pkg)

--- a/python/servo/platform/macos.py
+++ b/python/servo/platform/macos.py
@@ -43,15 +43,18 @@ class MacOS(Base):
     def _platform_bootstrap(self, force: bool, yes: bool) -> bool:
         installed_something = False
         try:
-            brewfile = os.path.join(util.SERVO_ROOT, "support", "macos", "Brewfile")
-            output = subprocess.check_output(["brew", "bundle", "install", "--file", brewfile]).decode("utf-8")
+            brewfile = os.path.join(
+                util.SERVO_ROOT, "support", "macos", "Brewfile")
+            output = subprocess.check_output(
+                ["brew", "bundle", "install", "--file", brewfile]).decode("utf-8")
             print(output)
             installed_something = "Installing" in output
         except subprocess.CalledProcessError as e:
             print("Could not run homebrew. Is it installed?")
             raise e
         target = BuildTarget.from_triple(None)
-        installed_something |= self._platform_bootstrap_gstreamer(target, force, yes)
+        installed_something |= self._platform_bootstrap_gstreamer(
+            target, force, yes)
         return installed_something
 
     def _platform_bootstrap_gstreamer(self, target: BuildTarget, force: bool, yes: bool) -> bool:
@@ -63,20 +66,24 @@ class MacOS(Base):
             devel_pkg = os.path.join(temp_dir, GSTREAMER_DEVEL_FILENAME)
 
             if not (yes or force):
-                print("Warning: GStreamer was not installed since it requires elevated permissions.\n")
+                print(
+                    "Warning: GStreamer was not installed since it requires elevated permissions.\n")
                 print("To install GStreamer, either: ")
-                print("1. Run mach bootstrap again with --yes")
-                print("2. Do it Manually:")
-                print(f"\t1. Download the GStreamer Libraries:")
-                print(f"\tcurl -L -# -o /tmp/{GSTREAMER_FILENAME} {GSTREAMER_URL}\n")
-                print(f"\t2. Download the GStreamer Development Support:")
-                print(f"\tcurl -L -# -o /tmp/{GSTREAMER_DEVEL_FILENAME} {GSTREAMER_DEVEL_URL}\n")
-                print("\t3. Install GStreamer:")
-                print(f"\tsudo installer -pkg '/tmp/{GSTREAMER_FILENAME}' -target / &&installer -pkg '/tmp/{GSTREAMER_DEVEL_FILENAME}' -target / \n")
+                print("a) Run mach bootstrap again with --yes")
+                print("b) OR install GStreamer manually:")
+                print("\t1. Download both GStreamer packages:")
+                print(
+                    f"\tcurl -L -# -o /tmp/{GSTREAMER_FILENAME} {GSTREAMER_URL}\n")
+                print(
+                    f"\tcurl -L -# -o /tmp/{GSTREAMER_DEVEL_FILENAME} {GSTREAMER_DEVEL_URL}\n")
+                print("\t2. Install GStreamer packages:")
+                print(f"\tsudo installer -pkg '/tmp/{GSTREAMER_FILENAME}' -target / && installer -pkg '/tmp/{
+                      GSTREAMER_DEVEL_FILENAME}' -target / \n")
                 return False
 
             util.download_file("GStreamer libraries", GSTREAMER_URL, libs_pkg)
-            util.download_file("GStreamer development support", GSTREAMER_DEVEL_URL, devel_pkg)
+            util.download_file("GStreamer development support",
+                               GSTREAMER_DEVEL_URL, devel_pkg)
 
             print("Installing GStreamer packages...")
             subprocess.check_call(
@@ -84,7 +91,8 @@ class MacOS(Base):
                     "sudo",
                     "sh",
                     "-c",
-                    f"installer -pkg '{libs_pkg}' -target / &&installer -pkg '{devel_pkg}' -target /",
+                    f"installer -pkg '{libs_pkg}' -target / &&installer -pkg '{
+                        devel_pkg}' -target /",
                 ]
             )
 

--- a/python/servo/platform/macos.py
+++ b/python/servo/platform/macos.py
@@ -18,8 +18,10 @@ from .build_target import BuildTarget
 
 URL_BASE = "https://github.com/servo/servo-build-deps/releases/download/macOS"
 GSTREAMER_PLUGIN_VERSION = "1.22.3"
-GSTREAMER_URL = f"{URL_BASE}/gstreamer-1.0-1.22.3-universal.pkg"
-GSTREAMER_DEVEL_URL = f"{URL_BASE}/gstreamer-1.0-devel-1.22.3-universal.pkg"
+GSTREAMER_FILENAME = "gstreamer-1.0-1.22.3-universal.pkg"
+GSTREAMER_URL = f"{URL_BASE}/{GSTREAMER_FILENAME}"
+GSTREAMER_DEVEL_FILENAME = "gstreamer-1.0-devel-1.22.3-universal.pkg"
+GSTREAMER_DEVEL_URL = f"{URL_BASE}/{GSTREAMER_DEVEL_FILENAME}"
 GSTREAMER_ROOT = "/Library/Frameworks/GStreamer.framework/Versions/1.0"
 
 
@@ -57,16 +59,20 @@ class MacOS(Base):
             return False
 
         with tempfile.TemporaryDirectory() as temp_dir:
-            libs_pkg = os.path.join(temp_dir, GSTREAMER_URL.rsplit("/", maxsplit=1)[-1])
-            devel_pkg = os.path.join(temp_dir, GSTREAMER_DEVEL_URL.rsplit("/", maxsplit=1)[-1])
-            install_command = f"installer -pkg '{libs_pkg}' -target / &&installer -pkg '{devel_pkg}' -target /"
+            libs_pkg = os.path.join(temp_dir, GSTREAMER_FILENAME)
+            devel_pkg = os.path.join(temp_dir, GSTREAMER_DEVEL_FILENAME)
 
             if not (yes or force):
                 print("Warning: GStreamer was not installed since it requires elevated permissions.\n")
                 print("To install GStreamer, either: ")
                 print("1. Run mach bootstrap again with --yes")
-                print("2. Manually run:")
-                print("sudo " + install_command + "\n")
+                print("2. Do it Manually:")
+                print(f"\t1. Download the GStreamer Libraries:")
+                print(f"\tcurl -L -# -o /tmp/{GSTREAMER_FILENAME} {GSTREAMER_URL}\n")
+                print(f"\t2. Download the GStreamer Development Support:")
+                print(f"\tcurl -L -# -o /tmp/{GSTREAMER_DEVEL_FILENAME} {GSTREAMER_DEVEL_URL}\n")
+                print("\t3. Install GStreamer:")
+                print(f"\tsudo installer -pkg '/tmp/{GSTREAMER_FILENAME}' -target / &&installer -pkg '/tmp/{GSTREAMER_DEVEL_FILENAME}' -target / \n")
                 return False
 
             util.download_file("GStreamer libraries", GSTREAMER_URL, libs_pkg)
@@ -78,7 +84,7 @@ class MacOS(Base):
                     "sudo",
                     "sh",
                     "-c",
-                    install_command,
+                    f"installer -pkg '{libs_pkg}' -target / &&installer -pkg '{devel_pkg}' -target /",
                 ]
             )
 

--- a/python/servo/platform/macos.py
+++ b/python/servo/platform/macos.py
@@ -43,18 +43,15 @@ class MacOS(Base):
     def _platform_bootstrap(self, force: bool, yes: bool) -> bool:
         installed_something = False
         try:
-            brewfile = os.path.join(
-                util.SERVO_ROOT, "support", "macos", "Brewfile")
-            output = subprocess.check_output(
-                ["brew", "bundle", "install", "--file", brewfile]).decode("utf-8")
+            brewfile = os.path.join(util.SERVO_ROOT, "support", "macos", "Brewfile")
+            output = subprocess.check_output(["brew", "bundle", "install", "--file", brewfile]).decode("utf-8")
             print(output)
             installed_something = "Installing" in output
         except subprocess.CalledProcessError as e:
             print("Could not run homebrew. Is it installed?")
             raise e
         target = BuildTarget.from_triple(None)
-        installed_something |= self._platform_bootstrap_gstreamer(
-            target, force, yes)
+        installed_something |= self._platform_bootstrap_gstreamer(target, force, yes)
         return installed_something
 
     def _platform_bootstrap_gstreamer(self, target: BuildTarget, force: bool, yes: bool) -> bool:
@@ -74,12 +71,13 @@ class MacOS(Base):
                 print(f"\tcurl -L -# -o /tmp/{GSTREAMER_FILENAME} {GSTREAMER_URL}\n")
                 print(f"\tcurl -L -# -o /tmp/{GSTREAMER_DEVEL_FILENAME} {GSTREAMER_DEVEL_URL}\n")
                 print("\t2. Install GStreamer packages:")
-                print(f"\tsudo installer -pkg '/tmp/{GSTREAMER_FILENAME}' -target / && installer -pkg '/tmp/{GSTREAMER_DEVEL_FILENAME}' -target / \n")
+                print(
+                    f"\tsudo installer -pkg '/tmp/{GSTREAMER_FILENAME}' -target / && installer -pkg '/tmp/{GSTREAMER_DEVEL_FILENAME}' -target / \n"
+                )
                 return False
 
             util.download_file("GStreamer libraries", GSTREAMER_URL, libs_pkg)
-            util.download_file("GStreamer development support",
-                               GSTREAMER_DEVEL_URL, devel_pkg)
+            util.download_file("GStreamer development support", GSTREAMER_DEVEL_URL, devel_pkg)
 
             print("Installing GStreamer packages...")
             subprocess.check_call(

--- a/python/servo/platform/macos.py
+++ b/python/servo/platform/macos.py
@@ -49,7 +49,7 @@ class MacOS(Base):
             print("Could not run homebrew. Is it installed?")
             raise e
         target = BuildTarget.from_triple(None)
-        installed_something |= self._platform_bootstrap_gstreamer(target, False, yes)
+        installed_something |= self._platform_bootstrap_gstreamer(target, force, yes)
         return installed_something
 
     def _platform_bootstrap_gstreamer(self, target: BuildTarget, force: bool, yes: bool) -> bool:

--- a/python/servo/platform/macos.py
+++ b/python/servo/platform/macos.py
@@ -49,16 +49,25 @@ class MacOS(Base):
             print("Could not run homebrew. Is it installed?")
             raise e
         target = BuildTarget.from_triple(None)
-        installed_something |= self._platform_bootstrap_gstreamer(target, False)
+        installed_something |= self._platform_bootstrap_gstreamer(target, False, yes)
         return installed_something
 
-    def _platform_bootstrap_gstreamer(self, target: BuildTarget, force: bool) -> bool:
+    def _platform_bootstrap_gstreamer(self, target: BuildTarget, force: bool, yes: bool) -> bool:
         if not force and self.is_gstreamer_installed(target):
             return False
 
         with tempfile.TemporaryDirectory() as temp_dir:
             libs_pkg = os.path.join(temp_dir, GSTREAMER_URL.rsplit("/", maxsplit=1)[-1])
             devel_pkg = os.path.join(temp_dir, GSTREAMER_DEVEL_URL.rsplit("/", maxsplit=1)[-1])
+            install_command = f"installer -pkg '{libs_pkg}' -target / &&installer -pkg '{devel_pkg}' -target /"
+
+            if not (yes or force):
+                print("Warning: GStreamer was not installed since it requires elevated permissions.\n")
+                print("To install GStreamer, either: ")
+                print("1. Run mach bootstrap again with --yes")
+                print("2. Manually run:")
+                print("sudo " + install_command + "\n")
+                return False
 
             util.download_file("GStreamer libraries", GSTREAMER_URL, libs_pkg)
             util.download_file("GStreamer development support", GSTREAMER_DEVEL_URL, devel_pkg)
@@ -69,7 +78,7 @@ class MacOS(Base):
                     "sudo",
                     "sh",
                     "-c",
-                    f"installer -pkg '{libs_pkg}' -target / &&installer -pkg '{devel_pkg}' -target /",
+                    install_command,
                 ]
             )
 

--- a/python/servo/platform/windows.py
+++ b/python/servo/platform/windows.py
@@ -110,7 +110,7 @@ class Windows(Base):
             _winget_import(force, yes)
 
         target = BuildTarget.from_triple(None)
-        installed_something |= self._platform_bootstrap_gstreamer(target, force)
+        installed_something |= self._platform_bootstrap_gstreamer(target, force, yes)
         return installed_something
 
     def passive_bootstrap(self) -> bool:
@@ -165,7 +165,7 @@ class Windows(Base):
     def is_gstreamer_installed(self, target: BuildTarget) -> bool:
         return self.gstreamer_root(target) is not None
 
-    def _platform_bootstrap_gstreamer(self, target: BuildTarget, force: bool) -> bool:
+    def _platform_bootstrap_gstreamer(self, target: BuildTarget, force: bool, yes: bool) -> bool:
         if not force and self.is_gstreamer_installed(target):
             return False
 


### PR DESCRIPTION
When `mach bootstrap` is run without `--yes` or `--force` on macos:
Add warning that `mach bootstrap` command is being run without elevated permissions.
Stop execution and ask user to run the command with `--yes` or install GStreamer manually.

Testing:  mach does not have testing
Fixes: #44021