### PR TITLE
script: Remove layout helper traits

### DIFF
--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -233,26 +233,20 @@ impl Attr {
     }
 }
 
-pub(crate) trait AttrHelpersForLayout<'dom> {
-    fn value(self) -> &'dom AttrValue;
-    fn local_name(self) -> &'dom LocalName;
-    fn namespace(self) -> &'dom Namespace;
-}
-
 #[expect(unsafe_code)]
-impl<'dom> AttrHelpersForLayout<'dom> for LayoutDom<'dom, Attr> {
+impl<'dom> LayoutDom<'dom, Attr> {
     #[inline]
-    fn value(self) -> &'dom AttrValue {
+    pub(crate) fn value(self) -> &'dom AttrValue {
         unsafe { self.unsafe_get().value.borrow_for_layout() }
     }
 
     #[inline]
-    fn local_name(self) -> &'dom LocalName {
+    pub(crate) fn local_name(self) -> &'dom LocalName {
         &self.unsafe_get().identifier.local_name.0
     }
 
     #[inline]
-    fn namespace(self) -> &'dom Namespace {
+    pub(crate) fn namespace(self) -> &'dom Namespace {
         &self.unsafe_get().identifier.namespace.0
     }
 }

--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -287,14 +287,10 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
     }
 }
 
-pub(crate) trait LayoutCharacterDataHelpers<'dom> {
-    fn data_for_layout(self) -> &'dom str;
-}
-
-impl<'dom> LayoutCharacterDataHelpers<'dom> for LayoutDom<'dom, CharacterData> {
+impl<'dom> LayoutDom<'dom, CharacterData> {
     #[expect(unsafe_code)]
     #[inline]
-    fn data_for_layout(self) -> &'dom str {
+    pub(crate) fn data_for_layout(self) -> &'dom str {
         unsafe { self.unsafe_get().data.borrow_for_layout() }
     }
 }

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -3362,35 +3362,25 @@ pub(crate) enum DocumentSource {
     NotFromParser,
 }
 
-pub(crate) trait LayoutDocumentHelpers<'dom> {
-    fn is_html_document_for_layout(&self) -> bool;
-    fn quirks_mode(self) -> QuirksMode;
-    fn style_shared_lock(self) -> &'dom StyleSharedRwLock;
-    fn shadow_roots(self) -> Vec<LayoutDom<'dom, ShadowRoot>>;
-    fn shadow_roots_styles_changed(self) -> bool;
-    fn flush_shadow_roots_stylesheets(self);
-    fn elements_with_id(self, id: &Atom) -> &[LayoutDom<'dom, Element>];
-}
-
 #[expect(unsafe_code)]
-impl<'dom> LayoutDocumentHelpers<'dom> for LayoutDom<'dom, Document> {
+impl<'dom> LayoutDom<'dom, Document> {
     #[inline]
-    fn is_html_document_for_layout(&self) -> bool {
+    pub(crate) fn is_html_document_for_layout(&self) -> bool {
         self.unsafe_get().is_html_document
     }
 
     #[inline]
-    fn quirks_mode(self) -> QuirksMode {
+    pub(crate) fn quirks_mode(self) -> QuirksMode {
         self.unsafe_get().quirks_mode.get()
     }
 
     #[inline]
-    fn style_shared_lock(self) -> &'dom StyleSharedRwLock {
+    pub(crate) fn style_shared_lock(self) -> &'dom StyleSharedRwLock {
         self.unsafe_get().style_shared_lock()
     }
 
     #[inline]
-    fn shadow_roots(self) -> Vec<LayoutDom<'dom, ShadowRoot>> {
+    pub(crate) fn shadow_roots(self) -> Vec<LayoutDom<'dom, ShadowRoot>> {
         // FIXME(nox): We should just return a
         // &'dom HashSet<LayoutDom<'dom, ShadowRoot>> here but not until
         // I rework the ToLayout trait as mentioned in
@@ -3406,16 +3396,16 @@ impl<'dom> LayoutDocumentHelpers<'dom> for LayoutDom<'dom, Document> {
     }
 
     #[inline]
-    fn shadow_roots_styles_changed(self) -> bool {
+    pub(crate) fn shadow_roots_styles_changed(self) -> bool {
         self.unsafe_get().shadow_roots_styles_changed.get()
     }
 
     #[inline]
-    fn flush_shadow_roots_stylesheets(self) {
+    pub(crate) fn flush_shadow_roots_stylesheets(self) {
         (*self.unsafe_get()).flush_shadow_roots_stylesheets()
     }
 
-    fn elements_with_id(self, id: &Atom) -> &[LayoutDom<'dom, Element>] {
+    pub(crate) fn elements_with_id(self, id: &Atom) -> &[LayoutDom<'dom, Element>] {
         let id_map = unsafe { self.unsafe_get().id_map.borrow_for_layout() };
         let matching_elements = id_map.get(id).map(Vec::as_slice).unwrap_or_default();
         unsafe { LayoutDom::to_layout_slice(matching_elements) }

--- a/components/script/dom/document/documentfragment.rs
+++ b/components/script/dom/document/documentfragment.rs
@@ -82,13 +82,9 @@ impl DocumentFragment {
     }
 }
 
-pub(crate) trait LayoutDocumentFragmentHelpers<'dom> {
-    fn shadowroot_host_for_layout(self) -> LayoutDom<'dom, Element>;
-}
-
-impl<'dom> LayoutDocumentFragmentHelpers<'dom> for LayoutDom<'dom, DocumentFragment> {
+impl<'dom> LayoutDom<'dom, DocumentFragment> {
     #[inline]
-    fn shadowroot_host_for_layout(self) -> LayoutDom<'dom, Element> {
+    pub(crate) fn shadowroot_host_for_layout(self) -> LayoutDom<'dom, Element> {
         #[expect(unsafe_code)]
         unsafe {
             // https://dom.spec.whatwg.org/#shadowroot

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -68,7 +68,7 @@ use xml5ever::serialize::TraversalScope::{
 
 use crate::conversions::Convert;
 use crate::dom::activation::Activatable;
-use crate::dom::attr::{Attr, AttrHelpersForLayout, is_relevant_attribute};
+use crate::dom::attr::{Attr, is_relevant_attribute};
 use crate::dom::bindings::cell::{DomRefCell, Ref, RefMut};
 use crate::dom::bindings::codegen::Bindings::AttrBinding::AttrMethods;
 use crate::dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
@@ -107,7 +107,7 @@ use crate::dom::customelementregistry::{
     CallbackReaction, CustomElementDefinition, CustomElementReaction, CustomElementRegistry,
     CustomElementState, is_valid_custom_element_name,
 };
-use crate::dom::document::{Document, LayoutDocumentHelpers};
+use crate::dom::document::Document;
 use crate::dom::documentfragment::DocumentFragment;
 use crate::dom::domrect::DOMRect;
 use crate::dom::domrectlist::DOMRectList;
@@ -115,16 +115,16 @@ use crate::dom::domtokenlist::DOMTokenList;
 use crate::dom::elementinternals::ElementInternals;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::html::htmlanchorelement::HTMLAnchorElement;
-use crate::dom::html::htmlbodyelement::{HTMLBodyElement, HTMLBodyElementLayoutHelpers};
+use crate::dom::html::htmlbodyelement::HTMLBodyElement;
 use crate::dom::html::htmlbuttonelement::HTMLButtonElement;
 use crate::dom::html::htmlcollection::HTMLCollection;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::html::htmlfieldsetelement::HTMLFieldSetElement;
-use crate::dom::html::htmlfontelement::{HTMLFontElement, HTMLFontElementLayoutHelpers};
+use crate::dom::html::htmlfontelement::HTMLFontElement;
 use crate::dom::html::htmlformelement::FormControlElementHelpers;
-use crate::dom::html::htmlhrelement::{HTMLHRElement, HTMLHRLayoutHelpers, SizePresentationalHint};
-use crate::dom::html::htmliframeelement::{HTMLIFrameElement, HTMLIFrameElementLayoutMethods};
-use crate::dom::html::htmlimageelement::{HTMLImageElement, LayoutHTMLImageElementHelpers};
+use crate::dom::html::htmlhrelement::{HTMLHRElement, SizePresentationalHint};
+use crate::dom::html::htmliframeelement::HTMLIFrameElement;
+use crate::dom::html::htmlimageelement::HTMLImageElement;
 use crate::dom::html::htmllabelelement::HTMLLabelElement;
 use crate::dom::html::htmllegendelement::HTMLLegendElement;
 use crate::dom::html::htmllinkelement::HTMLLinkElement;
@@ -135,31 +135,21 @@ use crate::dom::html::htmlscriptelement::HTMLScriptElement;
 use crate::dom::html::htmlselectelement::HTMLSelectElement;
 use crate::dom::html::htmlslotelement::{HTMLSlotElement, Slottable};
 use crate::dom::html::htmlstyleelement::HTMLStyleElement;
-use crate::dom::html::htmltablecellelement::{
-    HTMLTableCellElement, HTMLTableCellElementLayoutHelpers,
-};
-use crate::dom::html::htmltablecolelement::{
-    HTMLTableColElement, HTMLTableColElementLayoutHelpers,
-};
-use crate::dom::html::htmltableelement::{HTMLTableElement, HTMLTableElementLayoutHelpers};
-use crate::dom::html::htmltablerowelement::{
-    HTMLTableRowElement, HTMLTableRowElementLayoutHelpers,
-};
-use crate::dom::html::htmltablesectionelement::{
-    HTMLTableSectionElement, HTMLTableSectionElementLayoutHelpers,
-};
+use crate::dom::html::htmltablecellelement::HTMLTableCellElement;
+use crate::dom::html::htmltablecolelement::HTMLTableColElement;
+use crate::dom::html::htmltableelement::HTMLTableElement;
+use crate::dom::html::htmltablerowelement::HTMLTableRowElement;
+use crate::dom::html::htmltablesectionelement::HTMLTableSectionElement;
 use crate::dom::html::htmltemplateelement::HTMLTemplateElement;
-use crate::dom::html::htmltextareaelement::{
-    HTMLTextAreaElement, LayoutHTMLTextAreaElementHelpers,
-};
-use crate::dom::html::htmlvideoelement::{HTMLVideoElement, LayoutHTMLVideoElementHelpers};
-use crate::dom::input_element::{HTMLInputElement, LayoutHTMLInputElementHelpers};
+use crate::dom::html::htmltextareaelement::HTMLTextAreaElement;
+use crate::dom::html::htmlvideoelement::HTMLVideoElement;
+use crate::dom::input_element::HTMLInputElement;
 use crate::dom::intersectionobserver::{IntersectionObserver, IntersectionObserverRegistration};
 use crate::dom::mutationobserver::{Mutation, MutationObserver};
 use crate::dom::namednodemap::NamedNodeMap;
 use crate::dom::node::{
-    BindContext, ChildrenMutation, CloneChildrenFlag, IsShadowTree, LayoutNodeHelpers, Node,
-    NodeDamage, NodeFlags, NodeTraits, ShadowIncluding, UnbindContext,
+    BindContext, ChildrenMutation, CloneChildrenFlag, IsShadowTree, Node, NodeDamage, NodeFlags,
+    NodeTraits, ShadowIncluding, UnbindContext,
 };
 use crate::dom::nodelist::NodeList;
 use crate::dom::promise::Promise;
@@ -168,7 +158,7 @@ use crate::dom::raredata::ElementRareData;
 use crate::dom::scrolling_box::{ScrollAxisState, ScrollingBox};
 use crate::dom::servoparser::ServoParser;
 use crate::dom::shadowroot::{IsUserAgentWidget, ShadowRoot};
-use crate::dom::svg::svgsvgelement::{LayoutSVGSVGElementHelpers, SVGSVGElement};
+use crate::dom::svg::svgsvgelement::SVGSVGElement;
 use crate::dom::text::Text;
 use crate::dom::trustedtypes::trustedhtml::TrustedHTML;
 use crate::dom::trustedtypes::trustedtypepolicyfactory::TrustedTypePolicyFactory;
@@ -1035,54 +1025,15 @@ pub(crate) fn get_attr_for_layout<'dom>(
         .map(|attr| attr.value())
 }
 
-pub(crate) trait LayoutElementHelpers<'dom> {
-    fn attrs(self) -> &'dom [LayoutDom<'dom, Attr>];
-    fn has_class_or_part_for_layout(
-        self,
-        name: &AtomIdent,
-        attr_name: &LocalName,
-        case_sensitivity: CaseSensitivity,
-    ) -> bool;
-    fn get_classes_for_layout(self) -> Option<&'dom [Atom]>;
-    fn get_parts_for_layout(self) -> Option<&'dom [Atom]>;
-
-    fn synthesize_presentational_hints_for_legacy_attributes<V>(self, hints: &mut V)
-    where
-        V: Push<ApplicableDeclarationBlock>;
-    fn get_span(self) -> Option<u32>;
-    fn get_colspan(self) -> Option<u32>;
-    fn get_rowspan(self) -> Option<u32>;
-    fn is_html_element(&self) -> bool;
-    fn id_attribute(self) -> *const Option<Atom>;
-    fn style_attribute(self) -> *const Option<Arc<Locked<PropertyDeclarationBlock>>>;
-    fn local_name(self) -> &'dom LocalName;
-    fn namespace(self) -> &'dom Namespace;
-    fn get_lang_attr_val_for_layout(self) -> Option<&'dom str>;
-    fn get_lang_for_layout(self) -> String;
-    fn get_state_for_layout(self) -> ElementState;
-    fn insert_selector_flags(self, flags: ElementSelectorFlags);
-    fn get_selector_flags(self) -> ElementSelectorFlags;
-    /// The shadow root this element is a host of.
-    fn get_shadow_root_for_layout(self) -> Option<LayoutDom<'dom, ShadowRoot>>;
-    fn get_attr_for_layout(
-        self,
-        namespace: &Namespace,
-        name: &LocalName,
-    ) -> Option<&'dom AttrValue>;
-    fn get_attr_val_for_layout(self, namespace: &Namespace, name: &LocalName) -> Option<&'dom str>;
-    fn get_attr_vals_for_layout(self, name: &LocalName) -> impl Iterator<Item = &'dom AttrValue>;
-    fn each_custom_state_for_layout(self, allback: impl FnMut(&AtomIdent));
-}
-
-impl<'dom> LayoutElementHelpers<'dom> for LayoutDom<'dom, Element> {
+impl<'dom> LayoutDom<'dom, Element> {
     #[expect(unsafe_code)]
     #[inline]
-    fn attrs(self) -> &'dom [LayoutDom<'dom, Attr>] {
+    pub(crate) fn attrs(self) -> &'dom [LayoutDom<'dom, Attr>] {
         unsafe { LayoutDom::to_layout_slice(self.unsafe_get().attrs.borrow_for_layout()) }
     }
 
     #[inline]
-    fn has_class_or_part_for_layout(
+    pub(crate) fn has_class_or_part_for_layout(
         self,
         name: &AtomIdent,
         attr_name: &LocalName,
@@ -1096,15 +1047,15 @@ impl<'dom> LayoutElementHelpers<'dom> for LayoutDom<'dom, Element> {
     }
 
     #[inline]
-    fn get_classes_for_layout(self) -> Option<&'dom [Atom]> {
+    pub(crate) fn get_classes_for_layout(self) -> Option<&'dom [Atom]> {
         get_attr_for_layout(self, &ns!(), &local_name!("class")).map(|attr| attr.as_tokens())
     }
 
-    fn get_parts_for_layout(self) -> Option<&'dom [Atom]> {
+    pub(crate) fn get_parts_for_layout(self) -> Option<&'dom [Atom]> {
         get_attr_for_layout(self, &ns!(), &local_name!("part")).map(|attr| attr.as_tokens())
     }
 
-    fn synthesize_presentational_hints_for_legacy_attributes<V>(self, hints: &mut V)
+    pub(crate) fn synthesize_presentational_hints_for_legacy_attributes<V>(self, hints: &mut V)
     where
         V: Push<ApplicableDeclarationBlock>,
     {
@@ -1181,7 +1132,7 @@ impl<'dom> LayoutElementHelpers<'dom> for LayoutDom<'dom, Element> {
 
         let font_face = self
             .downcast::<HTMLFontElement>()
-            .and_then(HTMLFontElementLayoutHelpers::get_face);
+            .and_then(LayoutDom::get_face);
         if let Some(font_face) = font_face {
             push(PropertyDeclaration::FontFamily(
                 font_family::SpecifiedValue::Values(computed::font::FontFamilyList {
@@ -1194,7 +1145,7 @@ impl<'dom> LayoutElementHelpers<'dom> for LayoutDom<'dom, Element> {
 
         let font_size = self
             .downcast::<HTMLFontElement>()
-            .and_then(HTMLFontElementLayoutHelpers::get_size);
+            .and_then(LayoutDom::get_size);
         if let Some(font_size) = font_size {
             push(PropertyDeclaration::FontSize(
                 font_size::SpecifiedValue::from_html_size(font_size as u8),
@@ -1340,7 +1291,7 @@ impl<'dom> LayoutElementHelpers<'dom> for LayoutDom<'dom, Element> {
 
         let cols = self
             .downcast::<HTMLTextAreaElement>()
-            .map(LayoutHTMLTextAreaElementHelpers::get_cols);
+            .map(LayoutDom::get_cols);
         if let Some(cols) = cols {
             let cols = cols as i32;
             if cols > 0 {
@@ -1361,7 +1312,7 @@ impl<'dom> LayoutElementHelpers<'dom> for LayoutDom<'dom, Element> {
 
         let rows = self
             .downcast::<HTMLTextAreaElement>()
-            .map(LayoutHTMLTextAreaElementHelpers::get_rows);
+            .map(LayoutDom::get_rows);
         if let Some(rows) = rows {
             let rows = rows as i32;
             if rows > 0 {
@@ -1453,48 +1404,48 @@ impl<'dom> LayoutElementHelpers<'dom> for LayoutDom<'dom, Element> {
         ));
     }
 
-    fn get_span(self) -> Option<u32> {
+    pub(crate) fn get_span(self) -> Option<u32> {
         // Don't panic since `display` can cause this to be called on arbitrary elements.
         self.downcast::<HTMLTableColElement>()
             .and_then(|element| element.get_span())
     }
 
-    fn get_colspan(self) -> Option<u32> {
+    pub(crate) fn get_colspan(self) -> Option<u32> {
         // Don't panic since `display` can cause this to be called on arbitrary elements.
         self.downcast::<HTMLTableCellElement>()
             .and_then(|element| element.get_colspan())
     }
 
-    fn get_rowspan(self) -> Option<u32> {
+    pub(crate) fn get_rowspan(self) -> Option<u32> {
         // Don't panic since `display` can cause this to be called on arbitrary elements.
         self.downcast::<HTMLTableCellElement>()
             .and_then(|element| element.get_rowspan())
     }
 
     #[inline]
-    fn is_html_element(&self) -> bool {
+    pub(crate) fn is_html_element(&self) -> bool {
         *self.namespace() == ns!(html)
     }
 
     #[expect(unsafe_code)]
-    fn id_attribute(self) -> *const Option<Atom> {
+    pub(crate) fn id_attribute(self) -> *const Option<Atom> {
         unsafe { (self.unsafe_get()).id_attribute.borrow_for_layout() }
     }
 
     #[expect(unsafe_code)]
-    fn style_attribute(self) -> *const Option<Arc<Locked<PropertyDeclarationBlock>>> {
+    pub(crate) fn style_attribute(self) -> *const Option<Arc<Locked<PropertyDeclarationBlock>>> {
         unsafe { (self.unsafe_get()).style_attribute.borrow_for_layout() }
     }
 
-    fn local_name(self) -> &'dom LocalName {
+    pub(crate) fn local_name(self) -> &'dom LocalName {
         &(self.unsafe_get()).local_name
     }
 
-    fn namespace(self) -> &'dom Namespace {
+    pub(crate) fn namespace(self) -> &'dom Namespace {
         &(self.unsafe_get()).namespace
     }
 
-    fn get_lang_attr_val_for_layout(self) -> Option<&'dom str> {
+    pub(crate) fn get_lang_attr_val_for_layout(self) -> Option<&'dom str> {
         if let Some(attr) = self.get_attr_val_for_layout(&ns!(xml), &local_name!("lang")) {
             return Some(attr);
         }
@@ -1504,7 +1455,7 @@ impl<'dom> LayoutElementHelpers<'dom> for LayoutDom<'dom, Element> {
         None
     }
 
-    fn get_lang_for_layout(self) -> String {
+    pub(crate) fn get_lang_for_layout(self) -> String {
         let mut current_node = Some(self.upcast::<Node>());
         while let Some(node) = current_node {
             current_node = node.composed_parent_node_ref();
@@ -1523,24 +1474,24 @@ impl<'dom> LayoutElementHelpers<'dom> for LayoutDom<'dom, Element> {
     }
 
     #[inline]
-    fn get_state_for_layout(self) -> ElementState {
+    pub(crate) fn get_state_for_layout(self) -> ElementState {
         (self.unsafe_get()).state.get()
     }
 
     #[inline]
-    fn insert_selector_flags(self, flags: ElementSelectorFlags) {
+    pub(crate) fn insert_selector_flags(self, flags: ElementSelectorFlags) {
         debug_assert!(thread_state::get().is_layout());
         self.unsafe_get().insert_selector_flags(flags);
     }
 
     #[inline]
-    fn get_selector_flags(self) -> ElementSelectorFlags {
+    pub(crate) fn get_selector_flags(self) -> ElementSelectorFlags {
         self.unsafe_get().get_selector_flags()
     }
 
     #[inline]
     #[expect(unsafe_code)]
-    fn get_shadow_root_for_layout(self) -> Option<LayoutDom<'dom, ShadowRoot>> {
+    pub(crate) fn get_shadow_root_for_layout(self) -> Option<LayoutDom<'dom, ShadowRoot>> {
         unsafe {
             self.unsafe_get()
                 .rare_data
@@ -1553,7 +1504,7 @@ impl<'dom> LayoutElementHelpers<'dom> for LayoutDom<'dom, Element> {
     }
 
     #[inline]
-    fn get_attr_for_layout(
+    pub(crate) fn get_attr_for_layout(
         self,
         namespace: &Namespace,
         name: &LocalName,
@@ -1562,12 +1513,19 @@ impl<'dom> LayoutElementHelpers<'dom> for LayoutDom<'dom, Element> {
     }
 
     #[inline]
-    fn get_attr_val_for_layout(self, namespace: &Namespace, name: &LocalName) -> Option<&'dom str> {
+    pub(crate) fn get_attr_val_for_layout(
+        self,
+        namespace: &Namespace,
+        name: &LocalName,
+    ) -> Option<&'dom str> {
         get_attr_for_layout(self, namespace, name).map(|attr| &**attr)
     }
 
     #[inline]
-    fn get_attr_vals_for_layout(self, name: &LocalName) -> impl Iterator<Item = &'dom AttrValue> {
+    pub(crate) fn get_attr_vals_for_layout(
+        self,
+        name: &LocalName,
+    ) -> impl Iterator<Item = &'dom AttrValue> {
         self.attrs().iter().filter_map(move |attr| {
             if name == attr.local_name() {
                 Some(attr.value())
@@ -1578,7 +1536,7 @@ impl<'dom> LayoutElementHelpers<'dom> for LayoutDom<'dom, Element> {
     }
 
     #[expect(unsafe_code)]
-    fn each_custom_state_for_layout(self, mut callback: impl FnMut(&AtomIdent)) {
+    pub(crate) fn each_custom_state_for_layout(self, mut callback: impl FnMut(&AtomIdent)) {
         let rare_data = unsafe { self.unsafe_get().rare_data.borrow_for_layout() };
         let Some(rare_data) = rare_data.as_ref() else {
             return;

--- a/components/script/dom/html/htmlbodyelement.rs
+++ b/components/script/dom/html/htmlbodyelement.rs
@@ -17,7 +17,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::{DomRoot, LayoutDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
-use crate::dom::element::{AttributeMutation, Element, LayoutElementHelpers};
+use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::{BindContext, Node, NodeTraits};
@@ -84,20 +84,15 @@ impl HTMLBodyElementMethods<crate::DomTypeHolder> for HTMLBodyElement {
     window_event_handlers!(ForwardToWindow);
 }
 
-pub(crate) trait HTMLBodyElementLayoutHelpers {
-    fn get_background_color(self) -> Option<AbsoluteColor>;
-    fn get_color(self) -> Option<AbsoluteColor>;
-}
-
-impl HTMLBodyElementLayoutHelpers for LayoutDom<'_, HTMLBodyElement> {
-    fn get_background_color(self) -> Option<AbsoluteColor> {
+impl LayoutDom<'_, HTMLBodyElement> {
+    pub(crate) fn get_background_color(self) -> Option<AbsoluteColor> {
         self.upcast::<Element>()
             .get_attr_for_layout(&ns!(), &local_name!("bgcolor"))
             .and_then(AttrValue::as_color)
             .cloned()
     }
 
-    fn get_color(self) -> Option<AbsoluteColor> {
+    pub(crate) fn get_color(self) -> Option<AbsoluteColor> {
         self.upcast::<Element>()
             .get_attr_for_layout(&ns!(), &local_name!("text"))
             .and_then(AttrValue::as_color)

--- a/components/script/dom/html/htmlcanvaselement.rs
+++ b/components/script/dom/html/htmlcanvaselement.rs
@@ -46,7 +46,7 @@ use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::blob::Blob;
 use crate::dom::canvasrenderingcontext2d::CanvasRenderingContext2D;
 use crate::dom::document::Document;
-use crate::dom::element::{AttributeMutation, Element, LayoutElementHelpers};
+use crate::dom::element::{AttributeMutation, Element};
 #[cfg(not(feature = "webgpu"))]
 use crate::dom::gpucanvascontext::GPUCanvasContext;
 use crate::dom::html::htmlelement::HTMLElement;
@@ -164,12 +164,8 @@ impl HTMLCanvasElement {
     }
 }
 
-pub(crate) trait LayoutHTMLCanvasElementHelpers {
-    fn data(self) -> HTMLCanvasData;
-}
-
-impl LayoutHTMLCanvasElementHelpers for LayoutDom<'_, HTMLCanvasElement> {
-    fn data(self) -> HTMLCanvasData {
+impl LayoutDom<'_, HTMLCanvasElement> {
+    pub(crate) fn data(self) -> HTMLCanvasData {
         let width_attr = self
             .upcast::<Element>()
             .get_attr_for_layout(&ns!(), &local_name!("width"));

--- a/components/script/dom/html/htmlfontelement.rs
+++ b/components/script/dom/html/htmlfontelement.rs
@@ -20,7 +20,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::{DomRoot, LayoutDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
-use crate::dom::element::{Element, LayoutElementHelpers};
+use crate::dom::element::Element;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::Node;
 use crate::dom::virtualmethods::VirtualMethods;
@@ -143,28 +143,22 @@ impl VirtualMethods for HTMLFontElement {
     }
 }
 
-pub(crate) trait HTMLFontElementLayoutHelpers {
-    fn get_color(self) -> Option<AbsoluteColor>;
-    fn get_face(self) -> Option<Atom>;
-    fn get_size(self) -> Option<u32>;
-}
-
-impl HTMLFontElementLayoutHelpers for LayoutDom<'_, HTMLFontElement> {
-    fn get_color(self) -> Option<AbsoluteColor> {
+impl LayoutDom<'_, HTMLFontElement> {
+    pub(crate) fn get_color(self) -> Option<AbsoluteColor> {
         self.upcast::<Element>()
             .get_attr_for_layout(&ns!(), &local_name!("color"))
             .and_then(AttrValue::as_color)
             .cloned()
     }
 
-    fn get_face(self) -> Option<Atom> {
+    pub(crate) fn get_face(self) -> Option<Atom> {
         self.upcast::<Element>()
             .get_attr_for_layout(&ns!(), &local_name!("face"))
             .map(AttrValue::as_atom)
             .cloned()
     }
 
-    fn get_size(self) -> Option<u32> {
+    pub(crate) fn get_size(self) -> Option<u32> {
         let size = self
             .upcast::<Element>()
             .get_attr_for_layout(&ns!(), &local_name!("size"));

--- a/components/script/dom/html/htmlhrelement.rs
+++ b/components/script/dom/html/htmlhrelement.rs
@@ -20,7 +20,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::{DomRoot, LayoutDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
-use crate::dom::element::{Element, LayoutElementHelpers};
+use crate::dom::element::Element;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::Node;
 use crate::dom::virtualmethods::VirtualMethods;
@@ -99,21 +99,15 @@ pub(crate) enum SizePresentationalHint {
     SetBottomBorderWidthToZero,
 }
 
-pub(crate) trait HTMLHRLayoutHelpers {
-    fn get_color(self) -> Option<AbsoluteColor>;
-    fn get_width(self) -> LengthOrPercentageOrAuto;
-    fn get_size_info(self) -> Option<SizePresentationalHint>;
-}
-
-impl HTMLHRLayoutHelpers for LayoutDom<'_, HTMLHRElement> {
-    fn get_color(self) -> Option<AbsoluteColor> {
+impl LayoutDom<'_, HTMLHRElement> {
+    pub(crate) fn get_color(self) -> Option<AbsoluteColor> {
         self.upcast::<Element>()
             .get_attr_for_layout(&ns!(), &local_name!("color"))
             .and_then(AttrValue::as_color)
             .cloned()
     }
 
-    fn get_width(self) -> LengthOrPercentageOrAuto {
+    pub(crate) fn get_width(self) -> LengthOrPercentageOrAuto {
         self.upcast::<Element>()
             .get_attr_for_layout(&ns!(), &local_name!("width"))
             .map(AttrValue::as_dimension)
@@ -121,7 +115,7 @@ impl HTMLHRLayoutHelpers for LayoutDom<'_, HTMLHRElement> {
             .unwrap_or(LengthOrPercentageOrAuto::Auto)
     }
 
-    fn get_size_info(self) -> Option<SizePresentationalHint> {
+    pub(crate) fn get_size_info(self) -> Option<SizePresentationalHint> {
         // https://html.spec.whatwg.org/multipage/#the-hr-element-2
         let element = self.upcast::<Element>();
         let size_value = element

--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -41,9 +41,7 @@ use crate::dom::bindings::root::{DomRoot, LayoutDom, MutNullableDom};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::document::Document;
 use crate::dom::domtokenlist::DOMTokenList;
-use crate::dom::element::{
-    AttributeMutation, Element, LayoutElementHelpers, reflect_referrer_policy_attribute,
-};
+use crate::dom::element::{AttributeMutation, Element, reflect_referrer_policy_attribute};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::html::htmlelement::HTMLElement;
@@ -918,25 +916,18 @@ impl HTMLIFrameElement {
     }
 }
 
-pub(crate) trait HTMLIFrameElementLayoutMethods {
-    fn pipeline_id(self) -> Option<PipelineId>;
-    fn browsing_context_id(self) -> Option<BrowsingContextId>;
-    fn get_width(self) -> LengthOrPercentageOrAuto;
-    fn get_height(self) -> LengthOrPercentageOrAuto;
-}
-
-impl HTMLIFrameElementLayoutMethods for LayoutDom<'_, HTMLIFrameElement> {
+impl LayoutDom<'_, HTMLIFrameElement> {
     #[inline]
-    fn pipeline_id(self) -> Option<PipelineId> {
+    pub(crate) fn pipeline_id(self) -> Option<PipelineId> {
         (self.unsafe_get()).pipeline_id.get()
     }
 
     #[inline]
-    fn browsing_context_id(self) -> Option<BrowsingContextId> {
+    pub(crate) fn browsing_context_id(self) -> Option<BrowsingContextId> {
         (self.unsafe_get()).browsing_context_id.get()
     }
 
-    fn get_width(self) -> LengthOrPercentageOrAuto {
+    pub(crate) fn get_width(self) -> LengthOrPercentageOrAuto {
         self.upcast::<Element>()
             .get_attr_for_layout(&ns!(), &local_name!("width"))
             .map(AttrValue::as_dimension)
@@ -944,7 +935,7 @@ impl HTMLIFrameElementLayoutMethods for LayoutDom<'_, HTMLIFrameElement> {
             .unwrap_or(LengthOrPercentageOrAuto::Auto)
     }
 
-    fn get_height(self) -> LengthOrPercentageOrAuto {
+    pub(crate) fn get_height(self) -> LengthOrPercentageOrAuto {
         self.upcast::<Element>()
             .get_attr_for_layout(&ns!(), &local_name!("height"))
             .map(AttrValue::as_dimension)

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -59,7 +59,7 @@ use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::csp::{GlobalCspReporting, Violation};
 use crate::dom::document::Document;
 use crate::dom::element::{
-    AttributeMutation, CustomElementCreationMode, Element, ElementCreator, LayoutElementHelpers,
+    AttributeMutation, CustomElementCreationMode, Element, ElementCreator,
     cors_setting_for_element, referrer_policy_for_element, reflect_cross_origin_attribute,
     reflect_referrer_policy_attribute, set_cross_origin_attribute,
 };
@@ -1678,15 +1678,6 @@ impl MicrotaskRunnable for ImageElementMicrotask {
     }
 }
 
-pub(crate) trait LayoutHTMLImageElementHelpers {
-    fn image_url(self) -> Option<ServoUrl>;
-    fn image_density(self) -> Option<f64>;
-    fn image_data(self) -> (Option<Image>, Option<ImageMetadata>);
-    fn get_width(self) -> LengthOrPercentageOrAuto;
-    fn get_height(self) -> LengthOrPercentageOrAuto;
-    fn showing_broken_image_icon(self) -> bool;
-}
-
 impl<'dom> LayoutDom<'dom, HTMLImageElement> {
     #[expect(unsafe_code)]
     fn current_request(self) -> &'dom ImageRequest {
@@ -1702,27 +1693,25 @@ impl<'dom> LayoutDom<'dom, HTMLImageElement> {
                 .expect("dimension attribute source should be always non-null")
         }
     }
-}
 
-impl LayoutHTMLImageElementHelpers for LayoutDom<'_, HTMLImageElement> {
-    fn image_url(self) -> Option<ServoUrl> {
+    pub(crate) fn image_url(self) -> Option<ServoUrl> {
         self.current_request().parsed_url.clone()
     }
 
-    fn image_data(self) -> (Option<Image>, Option<ImageMetadata>) {
+    pub(crate) fn image_data(self) -> (Option<Image>, Option<ImageMetadata>) {
         let current_request = self.current_request();
         (current_request.image.clone(), current_request.metadata)
     }
 
-    fn image_density(self) -> Option<f64> {
+    pub(crate) fn image_density(self) -> Option<f64> {
         self.current_request().current_pixel_density
     }
 
-    fn showing_broken_image_icon(self) -> bool {
+    pub(crate) fn showing_broken_image_icon(self) -> bool {
         matches!(self.current_request().state, State::Broken)
     }
 
-    fn get_width(self) -> LengthOrPercentageOrAuto {
+    pub(crate) fn get_width(self) -> LengthOrPercentageOrAuto {
         self.dimension_attribute_source()
             .get_attr_for_layout(&ns!(), &local_name!("width"))
             .map(AttrValue::as_dimension)
@@ -1730,7 +1719,7 @@ impl LayoutHTMLImageElementHelpers for LayoutDom<'_, HTMLImageElement> {
             .unwrap_or(LengthOrPercentageOrAuto::Auto)
     }
 
-    fn get_height(self) -> LengthOrPercentageOrAuto {
+    pub(crate) fn get_height(self) -> LengthOrPercentageOrAuto {
         self.dimension_attribute_source()
             .get_attr_for_layout(&ns!(), &local_name!("height"))
             .map(AttrValue::as_dimension)

--- a/components/script/dom/html/htmltablecellelement.rs
+++ b/components/script/dom/html/htmltablecellelement.rs
@@ -15,12 +15,12 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::{DomRoot, LayoutDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
-use crate::dom::element::{AttributeMutation, Element, LayoutElementHelpers};
+use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::html::htmltableelement::HTMLTableElement;
 use crate::dom::html::htmltablerowelement::HTMLTableRowElement;
 use crate::dom::html::htmltablesectionelement::HTMLTableSectionElement;
-use crate::dom::node::{LayoutNodeHelpers, Node, NodeDamage};
+use crate::dom::node::{Node, NodeDamage};
 use crate::dom::virtualmethods::VirtualMethods;
 
 const DEFAULT_COLSPAN: u32 = 1;
@@ -116,36 +116,27 @@ impl HTMLTableCellElementMethods<crate::DomTypeHolder> for HTMLTableCellElement 
     }
 }
 
-pub(crate) trait HTMLTableCellElementLayoutHelpers<'dom> {
-    fn get_background_color(self) -> Option<AbsoluteColor>;
-    fn get_colspan(self) -> Option<u32>;
-    fn get_rowspan(self) -> Option<u32>;
-    fn get_table(self) -> Option<LayoutDom<'dom, HTMLTableElement>>;
-    fn get_width(self) -> LengthOrPercentageOrAuto;
-    fn get_height(self) -> LengthOrPercentageOrAuto;
-}
-
-impl<'dom> HTMLTableCellElementLayoutHelpers<'dom> for LayoutDom<'dom, HTMLTableCellElement> {
-    fn get_background_color(self) -> Option<AbsoluteColor> {
+impl<'dom> LayoutDom<'dom, HTMLTableCellElement> {
+    pub(crate) fn get_background_color(self) -> Option<AbsoluteColor> {
         self.upcast::<Element>()
             .get_attr_for_layout(&ns!(), &local_name!("bgcolor"))
             .and_then(AttrValue::as_color)
             .cloned()
     }
 
-    fn get_colspan(self) -> Option<u32> {
+    pub(crate) fn get_colspan(self) -> Option<u32> {
         self.upcast::<Element>()
             .get_attr_for_layout(&ns!(), &local_name!("colspan"))
             .map(AttrValue::as_uint)
     }
 
-    fn get_rowspan(self) -> Option<u32> {
+    pub(crate) fn get_rowspan(self) -> Option<u32> {
         self.upcast::<Element>()
             .get_attr_for_layout(&ns!(), &local_name!("rowspan"))
             .map(AttrValue::as_uint)
     }
 
-    fn get_table(self) -> Option<LayoutDom<'dom, HTMLTableElement>> {
+    pub(crate) fn get_table(self) -> Option<LayoutDom<'dom, HTMLTableElement>> {
         let row = self.upcast::<Node>().composed_parent_node_ref()?;
         row.downcast::<HTMLTableRowElement>()?;
         let section = row.composed_parent_node_ref()?;
@@ -156,7 +147,7 @@ impl<'dom> HTMLTableCellElementLayoutHelpers<'dom> for LayoutDom<'dom, HTMLTable
         })
     }
 
-    fn get_width(self) -> LengthOrPercentageOrAuto {
+    pub(crate) fn get_width(self) -> LengthOrPercentageOrAuto {
         self.upcast::<Element>()
             .get_attr_for_layout(&ns!(), &local_name!("width"))
             .map(AttrValue::as_dimension)
@@ -164,7 +155,7 @@ impl<'dom> HTMLTableCellElementLayoutHelpers<'dom> for LayoutDom<'dom, HTMLTable
             .unwrap_or(LengthOrPercentageOrAuto::Auto)
     }
 
-    fn get_height(self) -> LengthOrPercentageOrAuto {
+    pub(crate) fn get_height(self) -> LengthOrPercentageOrAuto {
         self.upcast::<Element>()
             .get_attr_for_layout(&ns!(), &local_name!("height"))
             .map(AttrValue::as_dimension)

--- a/components/script/dom/html/htmltablecolelement.rs
+++ b/components/script/dom/html/htmltablecolelement.rs
@@ -13,7 +13,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::{DomRoot, LayoutDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
-use crate::dom::element::{AttributeMutation, Element, LayoutElementHelpers};
+use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::{Node, NodeDamage};
 use crate::dom::virtualmethods::VirtualMethods;
@@ -70,19 +70,14 @@ impl HTMLTableColElementMethods<crate::DomTypeHolder> for HTMLTableColElement {
     make_dimension_setter!(SetWidth, "width");
 }
 
-pub(crate) trait HTMLTableColElementLayoutHelpers<'dom> {
-    fn get_span(self) -> Option<u32>;
-    fn get_width(self) -> LengthOrPercentageOrAuto;
-}
-
-impl<'dom> HTMLTableColElementLayoutHelpers<'dom> for LayoutDom<'dom, HTMLTableColElement> {
-    fn get_span(self) -> Option<u32> {
+impl<'dom> LayoutDom<'dom, HTMLTableColElement> {
+    pub(crate) fn get_span(self) -> Option<u32> {
         self.upcast::<Element>()
             .get_attr_for_layout(&ns!(), &local_name!("span"))
             .map(AttrValue::as_uint)
     }
 
-    fn get_width(self) -> LengthOrPercentageOrAuto {
+    pub(crate) fn get_width(self) -> LengthOrPercentageOrAuto {
         self.upcast::<Element>()
             .get_attr_for_layout(&ns!(), &local_name!("width"))
             .map(AttrValue::as_dimension)

--- a/components/script/dom/html/htmltableelement.rs
+++ b/components/script/dom/html/htmltableelement.rs
@@ -20,9 +20,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::{Dom, DomRoot, LayoutDom, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
-use crate::dom::element::{
-    AttributeMutation, CustomElementCreationMode, Element, ElementCreator, LayoutElementHelpers,
-};
+use crate::dom::element::{AttributeMutation, CustomElementCreationMode, Element, ElementCreator};
 use crate::dom::html::htmlcollection::{CollectionFilter, HTMLCollection};
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::html::htmltablecaptionelement::HTMLTableCaptionElement;
@@ -489,36 +487,27 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
     make_getter!(CellSpacing, "cellspacing");
 }
 
-pub(crate) trait HTMLTableElementLayoutHelpers {
-    fn get_background_color(self) -> Option<AbsoluteColor>;
-    fn get_border(self) -> Option<u32>;
-    fn get_cellpadding(self) -> Option<u32>;
-    fn get_cellspacing(self) -> Option<u32>;
-    fn get_width(self) -> LengthOrPercentageOrAuto;
-    fn get_height(self) -> LengthOrPercentageOrAuto;
-}
-
-impl HTMLTableElementLayoutHelpers for LayoutDom<'_, HTMLTableElement> {
-    fn get_background_color(self) -> Option<AbsoluteColor> {
+impl LayoutDom<'_, HTMLTableElement> {
+    pub(crate) fn get_background_color(self) -> Option<AbsoluteColor> {
         self.upcast::<Element>()
             .get_attr_for_layout(&ns!(), &local_name!("bgcolor"))
             .and_then(AttrValue::as_color)
             .cloned()
     }
 
-    fn get_border(self) -> Option<u32> {
+    pub(crate) fn get_border(self) -> Option<u32> {
         (self.unsafe_get()).border.get()
     }
 
-    fn get_cellpadding(self) -> Option<u32> {
+    pub(crate) fn get_cellpadding(self) -> Option<u32> {
         (self.unsafe_get()).cellpadding.get()
     }
 
-    fn get_cellspacing(self) -> Option<u32> {
+    pub(crate) fn get_cellspacing(self) -> Option<u32> {
         (self.unsafe_get()).cellspacing.get()
     }
 
-    fn get_width(self) -> LengthOrPercentageOrAuto {
+    pub(crate) fn get_width(self) -> LengthOrPercentageOrAuto {
         self.upcast::<Element>()
             .get_attr_for_layout(&ns!(), &local_name!("width"))
             .map(AttrValue::as_dimension)
@@ -526,7 +515,7 @@ impl HTMLTableElementLayoutHelpers for LayoutDom<'_, HTMLTableElement> {
             .unwrap_or(LengthOrPercentageOrAuto::Auto)
     }
 
-    fn get_height(self) -> LengthOrPercentageOrAuto {
+    pub(crate) fn get_height(self) -> LengthOrPercentageOrAuto {
         self.upcast::<Element>()
             .get_attr_for_layout(&ns!(), &local_name!("height"))
             .map(AttrValue::as_dimension)

--- a/components/script/dom/html/htmltablerowelement.rs
+++ b/components/script/dom/html/htmltablerowelement.rs
@@ -19,9 +19,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::{DomRoot, LayoutDom, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
-use crate::dom::element::{
-    CustomElementCreationMode, Element, ElementCreator, LayoutElementHelpers,
-};
+use crate::dom::element::{CustomElementCreationMode, Element, ElementCreator};
 use crate::dom::html::htmlcollection::HTMLCollection;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::html::htmltablecellelement::HTMLTableCellElement;
@@ -172,20 +170,15 @@ impl HTMLTableRowElementMethods<crate::DomTypeHolder> for HTMLTableRowElement {
     }
 }
 
-pub(crate) trait HTMLTableRowElementLayoutHelpers {
-    fn get_background_color(self) -> Option<AbsoluteColor>;
-    fn get_height(self) -> LengthOrPercentageOrAuto;
-}
-
-impl HTMLTableRowElementLayoutHelpers for LayoutDom<'_, HTMLTableRowElement> {
-    fn get_background_color(self) -> Option<AbsoluteColor> {
+impl LayoutDom<'_, HTMLTableRowElement> {
+    pub(crate) fn get_background_color(self) -> Option<AbsoluteColor> {
         self.upcast::<Element>()
             .get_attr_for_layout(&ns!(), &local_name!("bgcolor"))
             .and_then(AttrValue::as_color)
             .cloned()
     }
 
-    fn get_height(self) -> LengthOrPercentageOrAuto {
+    pub(crate) fn get_height(self) -> LengthOrPercentageOrAuto {
         self.upcast::<Element>()
             .get_attr_for_layout(&ns!(), &local_name!("height"))
             .map(AttrValue::as_dimension)

--- a/components/script/dom/html/htmltablesectionelement.rs
+++ b/components/script/dom/html/htmltablesectionelement.rs
@@ -17,9 +17,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::{DomRoot, LayoutDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
-use crate::dom::element::{
-    CustomElementCreationMode, Element, ElementCreator, LayoutElementHelpers,
-};
+use crate::dom::element::{CustomElementCreationMode, Element, ElementCreator};
 use crate::dom::html::htmlcollection::HTMLCollection;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::html::htmltablerowelement::HTMLTableRowElement;
@@ -107,20 +105,15 @@ impl HTMLTableSectionElementMethods<crate::DomTypeHolder> for HTMLTableSectionEl
     }
 }
 
-pub(crate) trait HTMLTableSectionElementLayoutHelpers {
-    fn get_background_color(self) -> Option<AbsoluteColor>;
-    fn get_height(self) -> LengthOrPercentageOrAuto;
-}
-
-impl HTMLTableSectionElementLayoutHelpers for LayoutDom<'_, HTMLTableSectionElement> {
-    fn get_background_color(self) -> Option<AbsoluteColor> {
+impl LayoutDom<'_, HTMLTableSectionElement> {
+    pub(crate) fn get_background_color(self) -> Option<AbsoluteColor> {
         self.upcast::<Element>()
             .get_attr_for_layout(&ns!(), &local_name!("bgcolor"))
             .and_then(AttrValue::as_color)
             .cloned()
     }
 
-    fn get_height(self) -> LengthOrPercentageOrAuto {
+    pub(crate) fn get_height(self) -> LengthOrPercentageOrAuto {
         self.upcast::<Element>()
             .get_attr_for_layout(&ns!(), &local_name!("height"))
             .map(AttrValue::as_dimension)

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -31,7 +31,7 @@ use crate::dom::clipboardevent::{ClipboardEvent, ClipboardEventType};
 use crate::dom::compositionevent::CompositionEvent;
 use crate::dom::document::Document;
 use crate::dom::document_embedder_controls::ControlElement;
-use crate::dom::element::{AttributeMutation, Element, LayoutElementHelpers};
+use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::event::Event;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::html::htmlfieldsetelement::HTMLFieldSetElement;
@@ -71,24 +71,18 @@ pub(crate) struct HTMLTextAreaElement {
     shared_selection: SharedSelection,
 }
 
-pub(crate) trait LayoutHTMLTextAreaElementHelpers {
-    fn selection_for_layout(self) -> SharedSelection;
-    fn get_cols(self) -> u32;
-    fn get_rows(self) -> u32;
-}
-
-impl LayoutHTMLTextAreaElementHelpers for LayoutDom<'_, HTMLTextAreaElement> {
-    fn selection_for_layout(self) -> SharedSelection {
+impl LayoutDom<'_, HTMLTextAreaElement> {
+    pub(crate) fn selection_for_layout(self) -> SharedSelection {
         self.unsafe_get().shared_selection.clone()
     }
 
-    fn get_cols(self) -> u32 {
+    pub(crate) fn get_cols(self) -> u32 {
         self.upcast::<Element>()
             .get_attr_for_layout(&ns!(), &local_name!("cols"))
             .map_or(DEFAULT_COLS, AttrValue::as_uint)
     }
 
-    fn get_rows(self) -> u32 {
+    pub(crate) fn get_rows(self) -> u32 {
         self.upcast::<Element>()
             .get_attr_for_layout(&ns!(), &local_name!("rows"))
             .map_or(DEFAULT_ROWS, AttrValue::as_uint)

--- a/components/script/dom/html/htmlvideoelement.rs
+++ b/components/script/dom/html/htmlvideoelement.rs
@@ -35,7 +35,7 @@ use crate::dom::bindings::root::{DomRoot, LayoutDom};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::csp::{GlobalCspReporting, Violation};
 use crate::dom::document::Document;
-use crate::dom::element::{AttributeMutation, Element, LayoutElementHelpers};
+use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::html::htmlmediaelement::{HTMLMediaElement, NetworkState, ReadyState};
 use crate::dom::node::{Node, NodeDamage, NodeTraits};
@@ -521,14 +521,8 @@ impl PosterFrameFetchContext {
     }
 }
 
-pub(crate) trait LayoutHTMLVideoElementHelpers {
-    fn data(self) -> HTMLMediaData;
-    fn get_width(self) -> LengthOrPercentageOrAuto;
-    fn get_height(self) -> LengthOrPercentageOrAuto;
-}
-
-impl LayoutHTMLVideoElementHelpers for LayoutDom<'_, HTMLVideoElement> {
-    fn data(self) -> HTMLMediaData {
+impl LayoutDom<'_, HTMLVideoElement> {
+    pub(crate) fn data(self) -> HTMLMediaData {
         let video = self.unsafe_get();
 
         // Get the current frame being rendered.
@@ -548,7 +542,7 @@ impl LayoutHTMLVideoElementHelpers for LayoutDom<'_, HTMLVideoElement> {
         }
     }
 
-    fn get_width(self) -> LengthOrPercentageOrAuto {
+    pub(crate) fn get_width(self) -> LengthOrPercentageOrAuto {
         self.upcast::<Element>()
             .get_attr_for_layout(&ns!(), &local_name!("width"))
             .map(AttrValue::as_dimension)
@@ -556,7 +550,7 @@ impl LayoutHTMLVideoElementHelpers for LayoutDom<'_, HTMLVideoElement> {
             .unwrap_or(LengthOrPercentageOrAuto::Auto)
     }
 
-    fn get_height(self) -> LengthOrPercentageOrAuto {
+    pub(crate) fn get_height(self) -> LengthOrPercentageOrAuto {
         self.upcast::<Element>()
             .get_attr_for_layout(&ns!(), &local_name!("height"))
             .map(AttrValue::as_dimension)

--- a/components/script/dom/html/input_element/mod.rs
+++ b/components/script/dom/html/input_element/mod.rs
@@ -907,12 +907,7 @@ impl HTMLInputElement {
     }
 }
 
-pub(crate) trait LayoutHTMLInputElementHelpers<'dom> {
-    fn size_for_layout(self) -> u32;
-    fn selection_for_layout(self) -> Option<SharedSelection>;
-}
-
-impl<'dom> LayoutHTMLInputElementHelpers<'dom> for LayoutDom<'dom, HTMLInputElement> {
+impl<'dom> LayoutDom<'dom, HTMLInputElement> {
     /// Textual input, specifically text entry and domain specific input has
     /// a default preferred size.
     ///
@@ -922,11 +917,11 @@ impl<'dom> LayoutHTMLInputElementHelpers<'dom> for LayoutDom<'dom, HTMLInputElem
     //                       for domain specific input widgets correctly.
     // FIXME(#4378): Implement the calculation of average character width for
     //               textual input correctly.
-    fn size_for_layout(self) -> u32 {
+    pub(crate) fn size_for_layout(self) -> u32 {
         self.unsafe_get().size.get()
     }
 
-    fn selection_for_layout(self) -> Option<SharedSelection> {
+    pub(crate) fn selection_for_layout(self) -> Option<SharedSelection> {
         Some(self.unsafe_get().shared_selection.clone())
     }
 }

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -92,7 +92,7 @@ use crate::dom::bindings::root::{
     Dom, DomRoot, DomSlice, LayoutDom, MutNullableDom, ToLayout, UnrootedDom,
 };
 use crate::dom::bindings::str::{DOMString, USVString};
-use crate::dom::characterdata::{CharacterData, LayoutCharacterDataHelpers};
+use crate::dom::characterdata::CharacterData;
 use crate::dom::css::cssstylesheet::CSSStyleSheet;
 use crate::dom::css::stylesheetlist::StyleSheetListOwner;
 use crate::dom::customelementregistry::{
@@ -107,19 +107,17 @@ use crate::dom::element::{
 use crate::dom::event::{Event, EventBubbles, EventCancelable, EventFlags};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::html::htmlcanvaselement::{HTMLCanvasElement, LayoutHTMLCanvasElementHelpers};
+use crate::dom::html::htmlcanvaselement::HTMLCanvasElement;
 use crate::dom::html::htmlcollection::HTMLCollection;
 use crate::dom::html::htmlelement::HTMLElement;
-use crate::dom::html::htmliframeelement::{HTMLIFrameElement, HTMLIFrameElementLayoutMethods};
-use crate::dom::html::htmlimageelement::{HTMLImageElement, LayoutHTMLImageElementHelpers};
+use crate::dom::html::htmliframeelement::HTMLIFrameElement;
+use crate::dom::html::htmlimageelement::HTMLImageElement;
 use crate::dom::html::htmllinkelement::HTMLLinkElement;
 use crate::dom::html::htmlslotelement::{HTMLSlotElement, Slottable};
 use crate::dom::html::htmlstyleelement::HTMLStyleElement;
-use crate::dom::html::htmltextareaelement::{
-    HTMLTextAreaElement, LayoutHTMLTextAreaElementHelpers,
-};
-use crate::dom::html::htmlvideoelement::{HTMLVideoElement, LayoutHTMLVideoElementHelpers};
-use crate::dom::html::input_element::{HTMLInputElement, LayoutHTMLInputElementHelpers};
+use crate::dom::html::htmltextareaelement::HTMLTextAreaElement;
+use crate::dom::html::htmlvideoelement::HTMLVideoElement;
+use crate::dom::html::input_element::HTMLInputElement;
 use crate::dom::mutationobserver::{Mutation, MutationObserver, RegisteredObserver};
 use crate::dom::node::nodelist::NodeList;
 use crate::dom::pointerevent::{PointerEvent, PointerId};
@@ -128,8 +126,8 @@ use crate::dom::range::WeakRangeVec;
 use crate::dom::raredata::NodeRareData;
 use crate::dom::servoparser::html::HtmlSerialize;
 use crate::dom::servoparser::{ServoParser, serialize_html_fragment};
-use crate::dom::shadowroot::{IsUserAgentWidget, LayoutShadowRootHelpers, ShadowRoot};
-use crate::dom::svg::svgsvgelement::{LayoutSVGSVGElementHelpers, SVGSVGElement};
+use crate::dom::shadowroot::{IsUserAgentWidget, ShadowRoot};
+use crate::dom::svg::svgsvgelement::SVGSVGElement;
 use crate::dom::text::Text;
 use crate::dom::types::{CDATASection, KeyboardEvent};
 use crate::dom::virtualmethods::{VirtualMethods, vtable_for};
@@ -2083,111 +2081,30 @@ pub(crate) unsafe fn from_untrusted_node_address(candidate: UntrustedNodeAddress
     DomRoot::from_ref(node)
 }
 
-#[expect(unsafe_code)]
-pub(crate) trait LayoutNodeHelpers<'dom> {
-    fn type_id_for_layout(self) -> NodeTypeId;
-
-    fn parent_node_ref(self) -> Option<LayoutDom<'dom, Node>>;
-    fn composed_parent_node_ref(self) -> Option<LayoutDom<'dom, Node>>;
-    fn first_child_ref(self) -> Option<LayoutDom<'dom, Node>>;
-    fn last_child_ref(self) -> Option<LayoutDom<'dom, Node>>;
-    fn prev_sibling_ref(self) -> Option<LayoutDom<'dom, Node>>;
-    fn next_sibling_ref(self) -> Option<LayoutDom<'dom, Node>>;
-
-    fn owner_doc_for_layout(self) -> LayoutDom<'dom, Document>;
-    fn containing_shadow_root_for_layout(self) -> Option<LayoutDom<'dom, ShadowRoot>>;
-    fn assigned_slot_for_layout(self) -> Option<LayoutDom<'dom, HTMLSlotElement>>;
-
-    fn is_element_for_layout(&self) -> bool;
-    fn is_text_node_for_layout(&self) -> bool;
-    unsafe fn get_flag(self, flag: NodeFlags) -> bool;
-    unsafe fn set_flag(self, flag: NodeFlags, value: bool);
-
-    fn style_data(self) -> Option<&'dom StyleData>;
-    fn layout_data(self) -> Option<&'dom GenericLayoutData>;
-
-    /// Initialize the style data of this node.
-    ///
-    /// # Safety
-    ///
-    /// This method is unsafe because it modifies the given node during
-    /// layout. Callers should ensure that no other layout thread is
-    /// attempting to read or modify the opaque layout data of this node.
-    unsafe fn initialize_style_data(self);
-
-    /// Initialize the opaque layout data of this node.
-    ///
-    /// # Safety
-    ///
-    /// This method is unsafe because it modifies the given node during
-    /// layout. Callers should ensure that no other layout thread is
-    /// attempting to read or modify the opaque layout data of this node.
-    unsafe fn initialize_layout_data(self, data: Box<GenericLayoutData>);
-
-    /// Clear the style and opaque layout data of this node.
-    ///
-    /// # Safety
-    ///
-    /// This method is unsafe because it modifies the given node during
-    /// layout. Callers should ensure that no other layout thread is
-    /// attempting to read or modify the opaque layout data of this node.
-    unsafe fn clear_style_and_layout_data(self);
-
-    /// Whether this element serve as a container of editable text for a text input
-    /// that is implemented as an UA widget.
-    fn is_single_line_text_inner_editor(&self) -> bool;
-
-    /// Whether this element serve as a container of any text inside a text input
-    /// that is implemented as an UA widget.
-    fn is_text_container_of_single_line_input(&self) -> bool;
-    fn text_content(self) -> Cow<'dom, str>;
-    fn selection(self) -> Option<SharedSelection>;
-    fn image_url(self) -> Option<ServoUrl>;
-    fn image_density(self) -> Option<f64>;
-    fn image_data(self) -> Option<(Option<Image>, Option<ImageMetadata>)>;
-    fn showing_broken_image_icon(self) -> bool;
-    fn canvas_data(self) -> Option<HTMLCanvasData>;
-    fn media_data(self) -> Option<HTMLMediaData>;
-    fn svg_data(self) -> Option<SVGElementData<'dom>>;
-    fn iframe_browsing_context_id(self) -> Option<BrowsingContextId>;
-    fn iframe_pipeline_id(self) -> Option<PipelineId>;
-    fn opaque(self) -> OpaqueNode;
-    fn implemented_pseudo_element(&self) -> Option<PseudoElement>;
-    fn is_in_ua_widget(&self) -> bool;
-}
-
 impl<'dom> LayoutDom<'dom, Node> {
     #[inline]
     #[expect(unsafe_code)]
     pub(crate) fn parent_node_ref(self) -> Option<LayoutDom<'dom, Node>> {
         unsafe { self.unsafe_get().parent_node.get_inner_as_layout() }
     }
-}
 
-impl<'dom> LayoutNodeHelpers<'dom> for LayoutDom<'dom, Node> {
     #[inline]
-    fn type_id_for_layout(self) -> NodeTypeId {
+    pub(crate) fn type_id_for_layout(self) -> NodeTypeId {
         self.unsafe_get().type_id()
     }
 
     #[inline]
-    fn is_element_for_layout(&self) -> bool {
+    pub(crate) fn is_element_for_layout(&self) -> bool {
         (*self).is::<Element>()
     }
 
-    fn is_text_node_for_layout(&self) -> bool {
+    pub(crate) fn is_text_node_for_layout(&self) -> bool {
         self.type_id_for_layout() ==
             NodeTypeId::CharacterData(CharacterDataTypeId::Text(TextTypeId::Text))
     }
 
     #[inline]
-    #[expect(unsafe_code)]
-    fn parent_node_ref(self) -> Option<LayoutDom<'dom, Node>> {
-        unsafe { self.unsafe_get().parent_node.get_inner_as_layout() }
-    }
-
-    #[inline]
-    fn composed_parent_node_ref(self) -> Option<LayoutDom<'dom, Node>> {
+    pub(crate) fn composed_parent_node_ref(self) -> Option<LayoutDom<'dom, Node>> {
         let parent = self.parent_node_ref();
         if let Some(parent) = parent {
             if let Some(shadow_root) = parent.downcast::<ShadowRoot>() {
@@ -2199,37 +2116,37 @@ impl<'dom> LayoutNodeHelpers<'dom> for LayoutDom<'dom, Node> {
 
     #[inline]
     #[expect(unsafe_code)]
-    fn first_child_ref(self) -> Option<LayoutDom<'dom, Node>> {
+    pub(crate) fn first_child_ref(self) -> Option<LayoutDom<'dom, Node>> {
         unsafe { self.unsafe_get().first_child.get_inner_as_layout() }
     }
 
     #[inline]
     #[expect(unsafe_code)]
-    fn last_child_ref(self) -> Option<LayoutDom<'dom, Node>> {
+    pub(crate) fn last_child_ref(self) -> Option<LayoutDom<'dom, Node>> {
         unsafe { self.unsafe_get().last_child.get_inner_as_layout() }
     }
 
     #[inline]
     #[expect(unsafe_code)]
-    fn prev_sibling_ref(self) -> Option<LayoutDom<'dom, Node>> {
+    pub(crate) fn prev_sibling_ref(self) -> Option<LayoutDom<'dom, Node>> {
         unsafe { self.unsafe_get().prev_sibling.get_inner_as_layout() }
     }
 
     #[inline]
     #[expect(unsafe_code)]
-    fn next_sibling_ref(self) -> Option<LayoutDom<'dom, Node>> {
+    pub(crate) fn next_sibling_ref(self) -> Option<LayoutDom<'dom, Node>> {
         unsafe { self.unsafe_get().next_sibling.get_inner_as_layout() }
     }
 
     #[inline]
     #[expect(unsafe_code)]
-    fn owner_doc_for_layout(self) -> LayoutDom<'dom, Document> {
+    pub(crate) fn owner_doc_for_layout(self) -> LayoutDom<'dom, Document> {
         unsafe { self.unsafe_get().owner_doc.get_inner_as_layout().unwrap() }
     }
 
     #[inline]
     #[expect(unsafe_code)]
-    fn containing_shadow_root_for_layout(self) -> Option<LayoutDom<'dom, ShadowRoot>> {
+    pub(crate) fn containing_shadow_root_for_layout(self) -> Option<LayoutDom<'dom, ShadowRoot>> {
         unsafe {
             self.unsafe_get()
                 .rare_data
@@ -2243,7 +2160,7 @@ impl<'dom> LayoutNodeHelpers<'dom> for LayoutDom<'dom, Node> {
 
     #[inline]
     #[expect(unsafe_code)]
-    fn assigned_slot_for_layout(self) -> Option<LayoutDom<'dom, HTMLSlotElement>> {
+    pub(crate) fn assigned_slot_for_layout(self) -> Option<LayoutDom<'dom, HTMLSlotElement>> {
         unsafe {
             self.unsafe_get()
                 .rare_data
@@ -2262,13 +2179,13 @@ impl<'dom> LayoutNodeHelpers<'dom> for LayoutDom<'dom, Node> {
 
     #[inline]
     #[expect(unsafe_code)]
-    unsafe fn get_flag(self, flag: NodeFlags) -> bool {
+    pub(crate) unsafe fn get_flag(self, flag: NodeFlags) -> bool {
         (self.unsafe_get()).flags.get().contains(flag)
     }
 
     #[inline]
     #[expect(unsafe_code)]
-    unsafe fn set_flag(self, flag: NodeFlags, value: bool) {
+    pub(crate) unsafe fn set_flag(self, flag: NodeFlags, value: bool) {
         let this = self.unsafe_get();
         let mut flags = (this).flags.get();
 
@@ -2285,49 +2202,74 @@ impl<'dom> LayoutNodeHelpers<'dom> for LayoutDom<'dom, Node> {
     // revisited so we can do that more cleanly and safely in layout 2020.
     #[inline]
     #[expect(unsafe_code)]
-    fn style_data(self) -> Option<&'dom StyleData> {
+    pub(crate) fn style_data(self) -> Option<&'dom StyleData> {
         unsafe { self.unsafe_get().style_data.borrow_for_layout().as_deref() }
     }
 
     #[inline]
     #[expect(unsafe_code)]
-    fn layout_data(self) -> Option<&'dom GenericLayoutData> {
+    pub(crate) fn layout_data(self) -> Option<&'dom GenericLayoutData> {
         unsafe { self.unsafe_get().layout_data.borrow_for_layout().as_deref() }
     }
 
+    /// Initialize the style data of this node.
+    ///
+    /// # Safety
+    ///
+    /// This method is unsafe because it modifies the given node during
+    /// layout. Callers should ensure that no other layout thread is
+    /// attempting to read or modify the opaque layout data of this node.
     #[inline]
     #[expect(unsafe_code)]
-    unsafe fn initialize_style_data(self) {
+    pub(crate) unsafe fn initialize_style_data(self) {
         let data = unsafe { self.unsafe_get().style_data.borrow_mut_for_layout() };
         debug_assert!(data.is_none());
         *data = Some(Box::default());
     }
 
+    /// Initialize the opaque layout data of this node.
+    ///
+    /// # Safety
+    ///
+    /// This method is unsafe because it modifies the given node during
+    /// layout. Callers should ensure that no other layout thread is
+    /// attempting to read or modify the opaque layout data of this node.
     #[inline]
     #[expect(unsafe_code)]
-    unsafe fn initialize_layout_data(self, new_data: Box<GenericLayoutData>) {
+    pub(crate) unsafe fn initialize_layout_data(self, new_data: Box<GenericLayoutData>) {
         let data = unsafe { self.unsafe_get().layout_data.borrow_mut_for_layout() };
         debug_assert!(data.is_none());
         *data = Some(new_data);
     }
 
+    /// Clear the style and opaque layout data of this node.
+    ///
+    /// # Safety
+    ///
+    /// This method is unsafe because it modifies the given node during
+    /// layout. Callers should ensure that no other layout thread is
+    /// attempting to read or modify the opaque layout data of this node.
     #[inline]
     #[expect(unsafe_code)]
-    unsafe fn clear_style_and_layout_data(self) {
+    pub(crate) unsafe fn clear_style_and_layout_data(self) {
         unsafe {
             self.unsafe_get().style_data.borrow_mut_for_layout().take();
             self.unsafe_get().layout_data.borrow_mut_for_layout().take();
         }
     }
 
-    fn is_single_line_text_inner_editor(&self) -> bool {
+    /// Whether this element serve as a container of editable text for a text input
+    /// that is implemented as an UA widget.
+    pub(crate) fn is_single_line_text_inner_editor(&self) -> bool {
         matches!(
             self.implemented_pseudo_element(),
             Some(PseudoElement::ServoTextControlInnerEditor)
         )
     }
 
-    fn is_text_container_of_single_line_input(&self) -> bool {
+    /// Whether this element serve as a container of any text inside a text input
+    /// that is implemented as an UA widget.
+    pub(crate) fn is_text_container_of_single_line_input(&self) -> bool {
         let is_single_line_text_inner_placeholder = matches!(
             self.implemented_pseudo_element(),
             Some(PseudoElement::Placeholder)
@@ -2344,7 +2286,7 @@ impl<'dom> LayoutNodeHelpers<'dom> for LayoutDom<'dom, Node> {
         self.is_single_line_text_inner_editor() || is_single_line_text_inner_placeholder
     }
 
-    fn text_content(self) -> Cow<'dom, str> {
+    pub(crate) fn text_content(self) -> Cow<'dom, str> {
         self.downcast::<Text>()
             .expect("Called LayoutDom::text_content on non-Text node!")
             .upcast()
@@ -2358,7 +2300,7 @@ impl<'dom> LayoutNodeHelpers<'dom> for LayoutDom<'dom, Node> {
     ///
     /// As we want to expose the selection on the inner text node of the widget's shadow
     /// DOM, we must find the shadow root and then access the containing element itself.
-    fn selection(self) -> Option<SharedSelection> {
+    pub(crate) fn selection(self) -> Option<SharedSelection> {
         if let Some(input) = self.downcast::<HTMLInputElement>() {
             return input.selection_for_layout();
         }
@@ -2377,59 +2319,59 @@ impl<'dom> LayoutNodeHelpers<'dom> for LayoutDom<'dom, Node> {
             .map(|textarea| textarea.selection_for_layout())
     }
 
-    fn image_url(self) -> Option<ServoUrl> {
+    pub(crate) fn image_url(self) -> Option<ServoUrl> {
         self.downcast::<HTMLImageElement>()
             .expect("not an image!")
             .image_url()
     }
 
-    fn image_data(self) -> Option<(Option<Image>, Option<ImageMetadata>)> {
+    pub(crate) fn image_data(self) -> Option<(Option<Image>, Option<ImageMetadata>)> {
         self.downcast::<HTMLImageElement>().map(|e| e.image_data())
     }
 
-    fn image_density(self) -> Option<f64> {
+    pub(crate) fn image_density(self) -> Option<f64> {
         self.downcast::<HTMLImageElement>()
             .expect("not an image!")
             .image_density()
     }
 
-    fn showing_broken_image_icon(self) -> bool {
+    pub(crate) fn showing_broken_image_icon(self) -> bool {
         self.downcast::<HTMLImageElement>()
             .map(|image_element| image_element.showing_broken_image_icon())
             .unwrap_or_default()
     }
 
-    fn canvas_data(self) -> Option<HTMLCanvasData> {
+    pub(crate) fn canvas_data(self) -> Option<HTMLCanvasData> {
         self.downcast::<HTMLCanvasElement>()
             .map(|canvas| canvas.data())
     }
 
-    fn media_data(self) -> Option<HTMLMediaData> {
+    pub(crate) fn media_data(self) -> Option<HTMLMediaData> {
         self.downcast::<HTMLVideoElement>()
             .map(|media| media.data())
     }
 
-    fn svg_data(self) -> Option<SVGElementData<'dom>> {
+    pub(crate) fn svg_data(self) -> Option<SVGElementData<'dom>> {
         self.downcast::<SVGSVGElement>().map(|svg| svg.data())
     }
 
-    fn iframe_browsing_context_id(self) -> Option<BrowsingContextId> {
+    pub(crate) fn iframe_browsing_context_id(self) -> Option<BrowsingContextId> {
         self.downcast::<HTMLIFrameElement>()
             .and_then(|iframe_element| iframe_element.browsing_context_id())
     }
 
-    fn iframe_pipeline_id(self) -> Option<PipelineId> {
+    pub(crate) fn iframe_pipeline_id(self) -> Option<PipelineId> {
         self.downcast::<HTMLIFrameElement>()
             .and_then(|iframe_element| iframe_element.pipeline_id())
     }
 
     #[expect(unsafe_code)]
-    fn opaque(self) -> OpaqueNode {
+    pub(crate) fn opaque(self) -> OpaqueNode {
         unsafe { OpaqueNode(self.get_jsobject() as usize) }
     }
 
     #[expect(unsafe_code)]
-    fn implemented_pseudo_element(&self) -> Option<PseudoElement> {
+    pub(crate) fn implemented_pseudo_element(&self) -> Option<PseudoElement> {
         unsafe {
             self.unsafe_get()
                 .rare_data
@@ -2439,7 +2381,7 @@ impl<'dom> LayoutNodeHelpers<'dom> for LayoutDom<'dom, Node> {
         }
     }
 
-    fn is_in_ua_widget(&self) -> bool {
+    pub(crate) fn is_in_ua_widget(&self) -> bool {
         self.unsafe_get().is_in_ua_widget()
     }
 }

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -39,7 +39,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::css::cssstylesheet::CSSStyleSheet;
 use crate::dom::css::stylesheetlist::{StyleSheetList, StyleSheetListOwner};
 use crate::dom::document::Document;
-use crate::dom::documentfragment::{DocumentFragment, LayoutDocumentFragmentHelpers};
+use crate::dom::documentfragment::DocumentFragment;
 use crate::dom::documentorshadowroot::{
     DocumentOrShadowRoot, ServoStylesheetInDocument, StylesheetSource,
 };
@@ -638,31 +638,23 @@ impl VirtualMethods for ShadowRoot {
     }
 }
 
-#[expect(unsafe_code)]
-pub(crate) trait LayoutShadowRootHelpers<'dom> {
-    fn get_host_for_layout(self) -> LayoutDom<'dom, Element>;
-    fn get_style_data_for_layout(self) -> &'dom CascadeData;
-    fn is_ua_widget(&self) -> bool;
-    unsafe fn flush_stylesheets(self, stylist: &mut Stylist, guard: &SharedRwLockReadGuard);
-}
-
-impl<'dom> LayoutShadowRootHelpers<'dom> for LayoutDom<'dom, ShadowRoot> {
+impl<'dom> LayoutDom<'dom, ShadowRoot> {
     #[inline]
-    fn get_host_for_layout(self) -> LayoutDom<'dom, Element> {
+    pub(crate) fn get_host_for_layout(self) -> LayoutDom<'dom, Element> {
         self.upcast::<DocumentFragment>()
             .shadowroot_host_for_layout()
     }
 
     #[inline]
     #[expect(unsafe_code)]
-    fn get_style_data_for_layout(self) -> &'dom CascadeData {
+    pub(crate) fn get_style_data_for_layout(self) -> &'dom CascadeData {
         fn is_sync<T: Sync>() {}
         let _ = is_sync::<CascadeData>;
         unsafe { &self.unsafe_get().author_styles.borrow_for_layout().data }
     }
 
     #[inline]
-    fn is_ua_widget(&self) -> bool {
+    pub(crate) fn is_ua_widget(&self) -> bool {
         self.unsafe_get().is_user_agent_widget()
     }
 
@@ -670,7 +662,11 @@ impl<'dom> LayoutShadowRootHelpers<'dom> for LayoutDom<'dom, ShadowRoot> {
     // probably be revisited.
     #[inline]
     #[expect(unsafe_code)]
-    unsafe fn flush_stylesheets(self, stylist: &mut Stylist, guard: &SharedRwLockReadGuard) {
+    pub(crate) unsafe fn flush_stylesheets(
+        self,
+        stylist: &mut Stylist,
+        guard: &SharedRwLockReadGuard,
+    ) {
         let author_styles = unsafe { self.unsafe_get().author_styles.borrow_mut_for_layout() };
         if author_styles.stylesheets.dirty() {
             author_styles.flush(stylist, guard);

--- a/components/script/dom/svg/svgsvgelement.rs
+++ b/components/script/dom/svg/svgsvgelement.rs
@@ -26,7 +26,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::{DomRoot, LayoutDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
-use crate::dom::element::{AttributeMutation, Element, LayoutElementHelpers};
+use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::node::{
     ChildrenMutation, CloneChildrenFlag, Node, NodeDamage, NodeTraits, ShadowIncluding,
     UnbindContext,
@@ -167,13 +167,9 @@ impl SVGSVGElement {
     }
 }
 
-pub(crate) trait LayoutSVGSVGElementHelpers<'dom> {
-    fn data(self) -> SVGElementData<'dom>;
-}
-
-impl<'dom> LayoutSVGSVGElementHelpers<'dom> for LayoutDom<'dom, SVGSVGElement> {
+impl<'dom> LayoutDom<'dom, SVGSVGElement> {
     #[expect(unsafe_code)]
-    fn data(self) -> SVGElementData<'dom> {
+    pub(crate) fn data(self) -> SVGElementData<'dom> {
         let svg_id = self.unsafe_get().uuid.clone();
         let element = self.upcast::<Element>();
         let width = element.get_attr_for_layout(&ns!(), &local_name!("width"));

--- a/components/script/layout_dom/document.rs
+++ b/components/script/layout_dom/document.rs
@@ -10,8 +10,8 @@ use style::shared_lock::{
 use style::stylist::Stylist;
 
 use crate::dom::bindings::root::LayoutDom;
-use crate::dom::document::{Document, LayoutDocumentHelpers};
-use crate::dom::node::{LayoutNodeHelpers, Node, NodeFlags};
+use crate::dom::document::Document;
+use crate::dom::node::{Node, NodeFlags};
 use crate::layout_dom::{ServoLayoutElement, ServoLayoutNode, ServoShadowRoot};
 
 // A wrapper around documents that ensures ayout can only ever access safe properties.

--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -42,16 +42,14 @@ use style::values::{AtomIdent, AtomString};
 use stylo_atoms::Atom;
 use stylo_dom::ElementState;
 
-use crate::dom::attr::AttrHelpersForLayout;
 use crate::dom::bindings::inheritance::{
     Castable, CharacterDataTypeId, DocumentFragmentTypeId, ElementTypeId, HTMLElementTypeId,
     NodeTypeId, TextTypeId,
 };
 use crate::dom::bindings::root::LayoutDom;
-use crate::dom::characterdata::LayoutCharacterDataHelpers;
-use crate::dom::element::{Element, LayoutElementHelpers};
+use crate::dom::element::Element;
 use crate::dom::html::htmlslotelement::HTMLSlotElement;
-use crate::dom::node::{LayoutNodeHelpers, Node, NodeFlags};
+use crate::dom::node::{Node, NodeFlags};
 use crate::layout_dom::{ServoLayoutNode, ServoShadowRoot, ServoThreadSafeLayoutNode};
 
 /// A wrapper around elements that ensures layout can only ever access safe properties.

--- a/components/script/layout_dom/node.rs
+++ b/components/script/layout_dom/node.rs
@@ -38,8 +38,8 @@ use super::{
 use crate::dom::bindings::error::Error;
 use crate::dom::bindings::inheritance::NodeTypeId;
 use crate::dom::bindings::root::LayoutDom;
-use crate::dom::element::{Element, LayoutElementHelpers};
-use crate::dom::node::{LayoutNodeHelpers, Node, NodeFlags, NodeTypeIdWrapper};
+use crate::dom::element::Element;
+use crate::dom::node::{Node, NodeFlags, NodeTypeIdWrapper};
 
 /// A wrapper around a `LayoutDom<Node>` which provides a safe interface that
 /// can be used during layout. This implements the `LayoutNode` trait as well as

--- a/components/script/layout_dom/shadow_root.rs
+++ b/components/script/layout_dom/shadow_root.rs
@@ -9,7 +9,7 @@ use style::shared_lock::SharedRwLockReadGuard as StyleSharedRwLockReadGuard;
 use style::stylist::{CascadeData, Stylist};
 
 use crate::dom::bindings::root::LayoutDom;
-use crate::dom::shadowroot::{LayoutShadowRootHelpers, ShadowRoot};
+use crate::dom::shadowroot::ShadowRoot;
 use crate::layout_dom::{ServoLayoutElement, ServoLayoutNode};
 
 #[derive(Clone, Copy, PartialEq)]


### PR DESCRIPTION
Servo has lots of `LayoutXYZHelper` traits that are used to define additional methods on `LayoutDom<XYZ>`. We can replace them with `impl LayoutDom<XYZ>` blocks, reducing the number of LoC and making it easier to add or modify methods.

Testing: These should be covered by existing tests