### PR TITLE
deps: Fix sea-query pre-release versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,8 +158,8 @@ rustc-hash = "2.1.2"
 rustls = { version = "0.23", default-features = false, features = ["logging", "std", "tls12"] }
 rustls-pki-types = "1.14"
 rustls-platform-verifier = "0.6.2"
-sea-query = { version = "1.0.0-rc.31", default-features = false, features = ["backend-sqlite", "derive"] }
-sea-query-rusqlite = { version = "0.8.0-rc.15" }
+sea-query = { version = "=1.0.0-rc.31", default-features = false, features = ["backend-sqlite", "derive"] }
+sea-query-rusqlite = { version = "=0.8.0-rc.15" }
 sec1 = "0.7"
 selectors = { git = "https://github.com/servo/stylo", rev = "96ceb5405bd7ce10c4141c62e860d50745a75547" }
 serde = "1.0.228"


### PR DESCRIPTION
This prevents issues for users that don't already have a lockfile, since prerelease versions can have breaking changes.
This should also be backported to the release branch.

Testing: No changes, covered by existing tests.
Fixes: #44089