### PR TITLE
script: make all keyboard events composed

### DIFF
--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -1375,10 +1375,7 @@ impl DocumentEventHandler {
 
         let event = keyevent.upcast::<Event>();
 
-        // FIXME: https://github.com/servo/servo/issues/43809
-        if event.type_() != atom!("keydown") {
-            event.set_composed(true);
-        }
+        event.set_composed(true);
 
         event.fire(target, can_gc);
 

--- a/components/script/dom/event/event.rs
+++ b/components/script/dom/event/event.rs
@@ -641,7 +641,7 @@ impl Event {
         // https://w3c.github.io/uievents/#default-action
         // https://dom.spec.whatwg.org/#action-versus-occurance
         if !self.DefaultPrevented() {
-            if self.downcast::<KeyboardEvent>().is_some() {
+            if self.is::<KeyboardEvent>() {
                 // For keyboard events, use the original dispatch target rather than
                 // event.GetTarget(). Composed keyboard events may retarget across
                 // shadow boundaries, but the default action (character input, Tab

--- a/components/script/dom/event/event.rs
+++ b/components/script/dom/event/event.rs
@@ -327,6 +327,10 @@ impl Event {
 
         let mut target = DomRoot::from_ref(target);
 
+        // Save the original dispatch target. Keyboard default actions need the
+        // element the event was originally fired on, not the retargeted host.
+        let original_target = target.clone();
+
         // Step 1. Set event’s dispatch flag.
         self.set_flags(EventFlags::Dispatch);
 
@@ -637,7 +641,16 @@ impl Event {
         // https://w3c.github.io/uievents/#default-action
         // https://dom.spec.whatwg.org/#action-versus-occurance
         if !self.DefaultPrevented() {
-            if let Some(target) = self.GetTarget() {
+            if self.downcast::<KeyboardEvent>().is_some() {
+                // For keyboard events, use the original dispatch target rather than
+                // event.GetTarget(). Composed keyboard events may retarget across
+                // shadow boundaries, but the default action (character input, Tab
+                // navigation) should use the element the event was originally fired on.
+                if let Some(node) = original_target.downcast::<Node>() {
+                    let vtable = vtable_for(node);
+                    vtable.handle_event(self, can_gc);
+                }
+            } else if let Some(target) = self.GetTarget() {
                 if let Some(node) = target.downcast::<Node>() {
                     let vtable = vtable_for(node);
                     vtable.handle_event(self, can_gc);

--- a/tests/wpt/meta/html/semantics/disabled-elements/event-propagate-disabled-keyboard.tentative.html.ini
+++ b/tests/wpt/meta/html/semantics/disabled-elements/event-propagate-disabled-keyboard.tentative.html.ini
@@ -1,6 +1,3 @@
 [event-propagate-disabled-keyboard.tentative.html]
   [Untrusted key events on <custom-control disabled="">Text</custom-control>, observed from <form>]
     expected: FAIL
-
-  [Trusted key events on <custom-control disabled="">Text</custom-control>, observed from <form>]
-    expected: FAIL

--- a/tests/wpt/meta/uievents/keyboard/keyboardevent-composed.html.ini
+++ b/tests/wpt/meta/uievents/keyboard/keyboardevent-composed.html.ini
@@ -1,3 +1,0 @@
-[keyboardevent-composed.html]
-  [keydown event must be composed]
-    expected: FAIL


### PR DESCRIPTION
Adjust event targeting for keyboard events when a shadow host is involved. This is needed to not interfere with keyboard default action like tabindex focusing.

Testing: Updated WPT tests expectations
Fixes: #43809 
