### PR TITLE
ci: Secure release workflow using environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,9 @@ jobs:
     if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
     name: Create Draft GH Release
     runs-on: ubuntu-latest
+    environment: &publish-environment
+      name: publish
+      deployment: false
     steps:
       - id: create-release
         run: |
@@ -70,6 +73,7 @@ jobs:
         && (inputs.regular_release || false) == false
     name: Publish GH Release
     runs-on: ubuntu-latest
+    environment: *publish-environment
     steps:
       - name: Publish release (success)
         if: ${{ !contains(needs.*.result, 'failure') && (!contains(needs.*.result, 'cancelled') && !cancelled()) }}
@@ -143,6 +147,7 @@ jobs:
     if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
     name: Upload vendored source archive
     runs-on: ubuntu-latest
+    environment: *publish-environment
     permissions:
       contents: write
       id-token: write
@@ -180,6 +185,7 @@ jobs:
     permissions:
       id-token: write
       attestations: write
+    environment: *publish-environment
     needs: &upload-artifacts-needs
       - create-draft-release
       - build-win
@@ -248,6 +254,7 @@ jobs:
   upload-artifacts-release:
     if: github.event_name == 'workflow_dispatch' && inputs.regular_release
     runs-on: ubuntu-latest
+    environment: *publish-environment
     permissions:
       id-token: write
       attestations: write


### PR DESCRIPTION
The publish environment enforces additional restrictions, mainly that the workflow can only be run from protected branches and additional prevents access of the publish secrets from workflows which do not use this environment.

Testing: Requires a manual workflow run on a protected branch. Given that we already tested environments in previous PRs, I think this PR might be safe to test after merging, instead of protecting the PR branch.

