### PR TITLE
bootstrap/devcontainer: Install required packages for wpt.

### DIFF
--- a/.devcontainer/Ubuntu.Dockerfile
+++ b/.devcontainer/Ubuntu.Dockerfile
@@ -14,6 +14,9 @@ RUN apt-get update \
     &&  /tmp/linux_packages/generate_pkg_list.sh /tmp/linux_packages/apt/* | xargs apt-get install -y --no-install-recommends \
     && curl --version
 
+# Required due to https://github.com/servo/servo/issues/35029
+RUN apt purge -y fonts-droid-fallback
+
 # Please keep `RUST_VERSION` in sync with the `rust-toolchain.toml` file.
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \

--- a/python/servo/platform/linux_packages/apt/wpt.txt
+++ b/python/servo/platform/linux_packages/apt/wpt.txt
@@ -1,0 +1,7 @@
+# The following packages are required by wpt:
+# TODO: What is this required for? `linux-wpt.yml` workflow installs it.
+mesa-vulkan-drivers
+# https://github.com/servo/servo/issues/41044
+fonts-noto-cjk
+# https://github.com/servo/servo/issues/41043
+fonts-dejavu-extra


### PR DESCRIPTION
Based on our linux-wpt.yml workflow update our bootstrap and devcontainer package list.
This should make the local environment closer to our CI environment when running WPT. We only purge the droid font in the devcontainer, since we shouldn't purge packages for the user.


mesa-vulkan-drivers was added in 71e0372ac18709da66e581cf4a777a7cc5d4cb92, so it's probably required for WebGPU.
fonts-noto-cjk was added in 2b0d2ecc7378f653e4755fd7d948dcc15914ffca.

In both cases no reason was given why it can't be in bootstrap, so presumably its just an oversight.

Testing: bootstrap is ran in CI, and the packages were already being installed by the wpt workflow.

