### PR TITLE
bootstrap: Stop installing cargo-about

### DIFF
--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -578,6 +578,10 @@ class PackageCommands(CommandBase):
             print(f"Updated occurrence in {filename}.")
         print("\r ➤  Updating license.html...")
         # cargo about generate etc/about.hbs > resources/resource_protocol/license.html
+        if shutil.which("cargo-about") is None:
+            print("Updating license.html requires cargo-about, but it is not installed.", file=sys.stderr)
+            print("Install it with: `cargo install cargo-about --locked`", file=sys.stderr)
+            return 1
         try:
             # Remove resources/resource_protocol/license.html before regenerating it
             license_html_path = path.join("resources", "resource_protocol", "license.html")

--- a/python/servo/platform/base.py
+++ b/python/servo/platform/base.py
@@ -62,7 +62,6 @@ class Base:
         if not skip_nextest:
             installed_something |= self.install_cargo_nextest(force)
         if not skip_lints:
-            installed_something |= self.install_cargo_about(force)
             installed_something |= self.install_taplo(force)
             installed_something |= self.install_cargo_deny(force)
             installed_something |= self.install_crown(force)
@@ -110,14 +109,6 @@ class Base:
         print(" * Installing cargo-deny...")
         if subprocess.call(["cargo", "install", "cargo-deny@0.19.0", "--locked"]) != 0:
             raise EnvironmentError("Installation of cargo-deny failed.")
-        return True
-
-    def install_cargo_about(self, force: bool) -> bool:
-        if not force and shutil.which("cargo-about") is not None:
-            return False
-        print(" * Installing cargo-about...")
-        if subprocess.call(["cargo", "install", "cargo-about", "--locked"]) != 0:
-            raise EnvironmentError("Installation of cargo-about failed.")
         return True
 
     def install_cargo_nextest(self, force: bool) -> bool:


### PR DESCRIPTION
cargo-about is only used in the ./mach release command, which will only be used by very few people (when preparing a release). Hence it doesn't make sense to install it for everyone, and instead we can just tell the user how to install if it is missing, and save resources for everyone else.

Testing: Not tested, but trivial