### PR TITLE
devcontainer: Fix build error on macos

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,9 +16,17 @@
 	"postCreateCommand":
 		"./mach bootstrap --yes",
 
+	"mounts": [
+		"source=servo-cargo-target,target=/var/servo-cargo-target,type=volume"
+	],
+
 	"containerEnv": {
 		"CC": "clang",
 		"CXX": "clang++",
+		// at least on macOS the workspace directory can be mounted as case-insensitve,
+		// which causes build errors in mozjs. Using a volume avoids this issue, and can
+		// also improve performance.
+		"CARGO_TARGET_DIR": "/var/servo-cargo-target",
 		"UV_PROJECT_ENVIRONMENT": ".devcontainer-venv"
 	}
 }


### PR DESCRIPTION
When building the devcontainer from source on arm macOS, we get arm Ubuntu, for which we don't have a prebuild mozjs version. That triggers a compilation from source, which fails, due to issues finding String.h. I can't confirm this, but it might be because the mounted workspace is case-insensitive. We definitly don't want that, so just make sure that the cargo target directory is in a named volume. That also has the advantage that we don't clobber the hosts target dir and still persist.

Testing: Manually tested on macOS.
Fixes:  ./mach build in a devcontainer built from source on arm64 macOS.
