### PR TITLE
script: Unbind `<script>` elements properly from the tree

### DIFF
--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -1328,7 +1328,9 @@ impl VirtualMethods for HTMLScriptElement {
         }
     }
 
-    fn unbind_from_tree(&self, _context: &UnbindContext, _can_gc: CanGc) {
+    fn unbind_from_tree(&self, context: &UnbindContext, can_gc: CanGc) {
+        self.super_type().unwrap().unbind_from_tree(context, can_gc);
+
         if self.marked_as_render_blocking.replace(false) {
             let document = self.owner_document();
             document.decrement_render_blocking_element_count();


### PR DESCRIPTION
Necessary for https://github.com/servo/servo/pull/44120

Testing: After https://github.com/servo/servo/pull/44120 we would crash on WPT without this change. Given that this is a pretty obscure bug with next to no chance of regressing, I think its okay to wait for that PR for test coverage?