### PR TITLE
layout: Produce an empty display list when the `Document` element is removed

### DIFF
--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -31,7 +31,7 @@ use log::{debug, error, warn};
 use malloc_size_of::{MallocConditionalSizeOf, MallocSizeOf, MallocSizeOfOps};
 use net_traits::image_cache::ImageCache;
 use paint_api::CrossProcessPaintApi;
-use paint_api::display_list::ScrollType;
+use paint_api::display_list::{AxesScrollSensitivity, PaintDisplayListInfo, ScrollType};
 use parking_lot::{Mutex, RwLock};
 use profile_traits::mem::{Report, ReportKind};
 use profile_traits::time::{
@@ -164,6 +164,9 @@ pub struct LayoutThread {
 
     /// Is this the first reflow in this LayoutThread?
     have_ever_generated_display_list: Cell<bool>,
+
+    /// Whether the last display list we sent was effectively empty.
+    last_display_list_was_empty: Cell<bool>,
 
     /// Whether a new overflow calculation needs to happen due to changes to the fragment
     /// tree. This is set to true every time a restyle requests overflow calculation.
@@ -779,6 +782,7 @@ impl LayoutThread {
             font_context: config.font_context,
             have_added_user_agent_stylesheets: false,
             have_ever_generated_display_list: Cell::new(false),
+            last_display_list_was_empty: Cell::new(true),
             device_has_changed: false,
             need_overflow_calculation: Cell::new(false),
             need_new_display_list: Cell::new(false),
@@ -965,6 +969,9 @@ impl LayoutThread {
             .as_document()
             .unwrap();
         let Some(root_element) = document.root_element() else {
+            if !self.last_display_list_was_empty.get() {
+                return self.clear_layout_trees_and_send_empty_display_list(&reflow_request);
+            }
             debug!("layout: No root node: bailing");
             return None;
         };
@@ -1416,7 +1423,7 @@ impl LayoutThread {
             .collect_unused_webrender_resources(false /* all */);
         self.paint_api
             .remove_unused_font_resources(self.webview_id.into(), keys, instance_keys);
-
+        self.last_display_list_was_empty.set(false);
         self.have_ever_generated_display_list.set(true);
         self.need_new_display_list.set(false);
         self.previously_highlighted_dom_node
@@ -1469,6 +1476,43 @@ impl LayoutThread {
             } else {
                 TimerMetadataReflowType::FirstReflow
             },
+        })
+    }
+
+    /// Clear all cached layout trees and send an empty display list to paint.
+    fn clear_layout_trees_and_send_empty_display_list(
+        &self,
+        reflow_request: &ReflowRequest,
+    ) -> Option<ReflowResult> {
+        // Clear layout trees.
+        self.box_tree.borrow_mut().take();
+        self.fragment_tree.borrow_mut().take();
+        self.stacking_context_tree.borrow_mut().take();
+
+        // Send empty display list.
+        let paint_info = PaintDisplayListInfo::new(
+            reflow_request.viewport_details,
+            Size2D::zero(),
+            self.id.into(),
+            reflow_request.epoch,
+            AxesScrollSensitivity {
+                x: ScrollType::InputEvents | ScrollType::Script,
+                y: ScrollType::InputEvents | ScrollType::Script,
+            },
+            !self.have_ever_generated_display_list.get(),
+        );
+        let mut builder = webrender_api::DisplayListBuilder::new(paint_info.pipeline_id);
+        builder.begin();
+        let (_, empty_display_list) = builder.end();
+
+        self.paint_api
+            .send_display_list(self.webview_id, &paint_info, empty_display_list);
+        self.last_display_list_was_empty.set(true);
+        self.have_ever_generated_display_list.set(true);
+
+        Some(ReflowResult {
+            reflow_phases_run: ReflowPhasesRun::BuiltDisplayList,
+            ..Default::default()
         })
     }
 }

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -585,6 +585,8 @@ pub(crate) struct Document {
     /// waiting it will not do any new layout until the canvas images are up-to-date in
     /// the renderer.
     waiting_on_canvas_image_updates: Cell<bool>,
+    /// Whether we have already noted that the document element was removed.
+    root_removal_noted: Cell<bool>,
     /// The current rendering epoch, which is used to track updates in the renderer.
     ///
     ///   - Every display list update also advances the Epoch, so that the renderer knows
@@ -695,10 +697,18 @@ impl Document {
             None => {
                 // There is no parent so this is the Document node, so we
                 // behave as if we were called with the document element.
-                let document_element = match self.GetDocumentElement() {
-                    Some(element) => element,
-                    None => return,
+                let Some(document_element) = self.GetDocumentElement() else {
+                    // Trigger update if the document element was removed.
+                    if !self.root_removal_noted.get() {
+                        self.add_restyle_reason(RestyleReason::DOMChanged);
+                        self.root_removal_noted.set(true);
+                    }
+                    return;
                 };
+                // This ensures that if the document element is removed in the future, it
+                // will trigger a new empty display list.
+                self.root_removal_noted.set(false);
+
                 if let Some(dirty_root) = self.dirty_root.get() {
                     // There was an existing dirty root so we mark its
                     // ancestors as dirty until the document element.
@@ -3631,6 +3641,7 @@ impl Document {
             pending_scroll_events: Default::default(),
             rendering_update_reasons: Default::default(),
             waiting_on_canvas_image_updates: Cell::new(false),
+            root_removal_noted: Cell::new(true),
             current_rendering_epoch: Default::default(),
             custom_element_reaction_stack,
             active_sandboxing_flag_set: Cell::new(creation_sandboxing_flag_set),

--- a/tests/wpt/meta/css/cssom-view/elementFromPoint.html.ini
+++ b/tests/wpt/meta/css/cssom-view/elementFromPoint.html.ini
@@ -1,7 +1,4 @@
 [elementFromPoint.html]
-  [no hit target at x,y]
-    expected: FAIL
-
   [transformed element at x,y]
     expected: FAIL
 

--- a/tests/wpt/meta/css/cssom-view/elementsFromPoint.html.ini
+++ b/tests/wpt/meta/css/cssom-view/elementsFromPoint.html.ini
@@ -1,6 +1,3 @@
 [elementsFromPoint.html]
   [transformed element at x,y]
     expected: FAIL
-
-  [no hit target at x,y]
-    expected: FAIL

--- a/tests/wpt/tests/html/rendering/non-replaced-elements/the-page/Document-documentElement-remove-clears-content.html
+++ b/tests/wpt/tests/html/rendering/non-replaced-elements/the-page/Document-documentElement-remove-clears-content.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html class="reftest-wait" style="background-color: red;">
+<head>
+    <meta charset="utf-8">
+    <title>Content clearing on documentElement removal</title>
+    <link rel="match" href="/css/reference/blank.html">
+    <script src="/common/reftest-wait.js"></script>
+</head>
+<body>
+    <p>This is a content which should not be displayed</p>
+    <script>
+        addEventListener("load", () => {
+            document.documentElement.remove();
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Previously, when the `Document` element was removed, no further display list updates would be sent to paint. This change makes it so that when the `Document` element is removed a single new empty display list is sent.

Testing: This change adds a new WPT test .
Fixes: #44101

