### PR TITLE
script: Implement recording and restoring of values

### DIFF
--- a/components/script/dom/execcommand/contenteditable/htmlelement.rs
+++ b/components/script/dom/execcommand/contenteditable/htmlelement.rs
@@ -15,6 +15,7 @@ use crate::dom::bindings::inheritance::{ElementTypeId, HTMLElementTypeId, NodeTy
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::element::Element;
 use crate::dom::execcommand::basecommand::{CommandName, CssPropertyName};
+use crate::dom::execcommand::contenteditable::node::move_preserving_ranges;
 use crate::dom::html::htmlanchorelement::HTMLAnchorElement;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::html::htmlfontelement::HTMLFontElement;
@@ -51,9 +52,9 @@ impl HTMLElement {
             // Step 4.2. For each child in children, insert child into element's parent immediately before element, preserving ranges.
             let element_parent = node.GetParentNode().expect("Must always have a parent");
             for child in node.children() {
-                if element_parent.InsertBefore(cx, &child, Some(node)).is_err() {
-                    unreachable!("Must always be able to insert");
-                }
+                move_preserving_ranges(cx, &child, |cx| {
+                    element_parent.InsertBefore(cx, &child, Some(node))
+                });
             }
             // Step 4.3. Remove element from its parent.
             node.remove_self(cx);

--- a/components/script/dom/execcommand/contenteditable/node.rs
+++ b/components/script/dom/execcommand/contenteditable/node.rs
@@ -721,6 +721,110 @@ where
     Some(new_parent)
 }
 
+pub(crate) struct RecordedValueAndCommandOfNode {
+    node: DomRoot<Node>,
+    command: CommandName,
+    specified_command_value: Option<DOMString>,
+}
+
+/// <https://w3c.github.io/editing/docs/execCommand/#record-the-values>
+pub(crate) fn record_the_values(
+    node_list: Vec<DomRoot<Node>>,
+) -> Vec<RecordedValueAndCommandOfNode> {
+    // Step 1. Let values be a list of (node, command, specified command value) triples, initially empty.
+    let mut values = vec![];
+    // Step 2. For each node in node list,
+    // for each command in the list "subscript", "bold", "fontName", "fontSize", "foreColor",
+    // "hiliteColor", "italic", "strikethrough", and "underline" in that order:
+    for node in node_list {
+        for command in vec![
+            CommandName::Subscript,
+            CommandName::Bold,
+            CommandName::FontName,
+            CommandName::FontSize,
+            CommandName::ForeColor,
+            CommandName::HiliteColor,
+            CommandName::Italic,
+            CommandName::Strikethrough,
+            CommandName::Underline,
+        ] {
+            // Step 2.1. Let ancestor equal node.
+            let mut ancestor =
+                if let Some(node_element) = DomRoot::downcast::<Element>(node.clone()) {
+                    Some(node_element)
+                } else {
+                    // Step 2.2. If ancestor is not an Element, set it to its parent.
+                    node.GetParentElement()
+                };
+            // Step 2.3. While ancestor is an Element and its specified command value for command is null, set it to its parent.
+            while let Some(ref ancestor_element) = ancestor {
+                if ancestor_element.specified_command_value(&command).is_none() {
+                    ancestor = ancestor_element.upcast::<Node>().GetParentElement();
+                    continue;
+                }
+                break;
+            }
+            // Step 2.4. If ancestor is an Element,
+            // add (node, command, ancestor's specified command value for command) to values.
+            // Otherwise add (node, command, null) to values.
+            let specified_command_value =
+                ancestor.and_then(|ancestor| ancestor.specified_command_value(&command));
+            values.push(RecordedValueAndCommandOfNode {
+                node: node.clone(),
+                command,
+                specified_command_value,
+            });
+        }
+    }
+    // Step 3. Return values.
+    values
+}
+
+/// <https://w3c.github.io/editing/docs/execCommand/#restore-the-values>
+pub(crate) fn restore_the_values(cx: &mut JSContext, values: Vec<RecordedValueAndCommandOfNode>) {
+    // Step 1. For each (node, command, value) triple in values:
+    for triple in values {
+        let RecordedValueAndCommandOfNode {
+            node,
+            command,
+            specified_command_value,
+        } = triple;
+        // Step 1.1. Let ancestor equal node.
+        let mut ancestor = if let Some(node_element) = DomRoot::downcast::<Element>(node.clone()) {
+            Some(node_element)
+        } else {
+            // Step 1.2. If ancestor is not an Element, set it to its parent.
+            node.GetParentElement()
+        };
+        // Step 1.3. While ancestor is an Element and its specified command value for command is null, set it to its parent.
+        while let Some(ref ancestor_element) = ancestor {
+            if ancestor_element.specified_command_value(&command).is_none() {
+                ancestor = ancestor_element.upcast::<Node>().GetParentElement();
+                continue;
+            }
+            break;
+        }
+        // Step 1.4. If value is null and ancestor is an Element,
+        // push down values on node for command, with new value null.
+        if specified_command_value.is_none() && ancestor.is_some() {
+            node.push_down_values(cx, &command, None);
+        } else {
+            // Step 1.5. Otherwise, if ancestor is an Element and its specified command value for command is not equivalent to value,
+            // or if ancestor is not an Element and value is not null, force the value of command to value on node.
+            if match (ancestor, specified_command_value.as_ref()) {
+                (Some(ancestor), value) => !command.are_equivalent_values(
+                    ancestor.specified_command_value(&command).as_ref(),
+                    value,
+                ),
+                (None, Some(_)) => true,
+                _ => false,
+            } {
+                node.force_the_value(cx, &command, specified_command_value.as_ref());
+            }
+        }
+    }
+}
+
 impl HTMLBRElement {
     /// <https://w3c.github.io/editing/docs/execCommand/#extraneous-line-break>
     fn is_extraneous_line_break(&self) -> bool {

--- a/components/script/dom/execcommand/contenteditable/selection.rs
+++ b/components/script/dom/execcommand/contenteditable/selection.rs
@@ -18,7 +18,8 @@ use crate::dom::characterdata::CharacterData;
 use crate::dom::document::Document;
 use crate::dom::execcommand::basecommand::CommandName;
 use crate::dom::execcommand::contenteditable::node::{
-    NodeOrString, is_allowed_child, move_preserving_ranges, split_the_parent,
+    NodeOrString, is_allowed_child, move_preserving_ranges, record_the_values, restore_the_values,
+    split_the_parent,
 };
 use crate::dom::html::htmlbrelement::HTMLBRElement;
 use crate::dom::html::htmlelement::HTMLElement;
@@ -506,7 +507,7 @@ impl Selection {
         }
 
         // Step 32. If start block is an ancestor of end block:
-        if start_block.is_ancestor_of(&end_block) {
+        let values = if start_block.is_ancestor_of(&end_block) {
             // Step 32.1. Let reference node be end block.
             let mut reference_node = end_block.clone();
             // Step 32.2. While reference node is not a child of start block, set reference node to its parent.
@@ -593,7 +594,7 @@ impl Selection {
             // Step 32.5. If end block's firstChild is not an inline node,
             // restore states and values from record, then abort these steps.
             if !first_child.is_inline_node() {
-                // TODO: Restore state
+                active_range.restore_states_and_values(cx, self, context_object, overrides);
                 return;
             }
             // Step 32.6. Let children be a list of nodes, initially empty.
@@ -620,7 +621,7 @@ impl Selection {
                 break;
             }
             // Step 32.9. Record the values of children, and let values be the result.
-            // TODO
+            let values = record_the_values(children.iter().map(|dom| dom.as_rooted()).collect());
 
             // Step 32.10. While children's first member's parent is not start block,
             // split the parent of children.
@@ -645,6 +646,8 @@ impl Selection {
                     }
                 }
             }
+
+            values
         // Step 33. Otherwise, if start block is a descendant of end block:
         } else if end_block.is_ancestor_of(&start_block) {
             // Step 33.1. Call collapse() on the context object's selection,
@@ -706,13 +709,15 @@ impl Selection {
                 break;
             }
             // Step 33.8. Record the values of nodes to move, and let values be the result.
-            // TODO
+            let values = record_the_values(nodes_to_move.iter().cloned().collect());
 
             // Step 33.9. For each node in nodes to move,
             // append node as the last child of start block, preserving ranges.
             for node in nodes_to_move.iter() {
                 move_preserving_ranges(cx, node, |cx| start_block.AppendChild(cx, node));
             }
+
+            values
         // Step 34. Otherwise:
         } else {
             // Step 34.1. Call collapse() on the context object's selection,
@@ -738,7 +743,7 @@ impl Selection {
                 }
             }
             // Step 34.3. Record the values of end block's children, and let values be the result.
-            // TODO
+            let values = record_the_values(end_block.children().collect());
 
             // Step 34.4. While end block has children,
             // append the first child of end block to start block, preserving ranges.
@@ -766,7 +771,9 @@ impl Selection {
                 }
                 break;
             }
-        }
+
+            values
+        };
 
         // Step 35.
         //
@@ -781,7 +788,7 @@ impl Selection {
         // TODO
 
         // Step 38. Restore the values from values.
-        // TODO
+        restore_the_values(cx, values);
 
         // Step 39. If start block has no children, call createElement("br") on the context object and
         // append the result as the last child of start block.

--- a/tests/wpt/meta/editing/run/fontsize.html.ini
+++ b/tests/wpt/meta/editing/run/fontsize.html.ini
@@ -271,6 +271,18 @@
   [[["fontsize","4"\]\] "<font size=+1>foo[bar\]baz</font>" compare innerHTML]
     expected: FAIL
 
+  [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=4>foo<font size=1>b[a\]r</font>baz</font>" queryCommandValue("fontsize") after]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=4>foo<font size=1>b[a\]r</font>baz</font>" queryCommandValue("fontsize") after]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["fontsize","4"\]\] "<span style=\\"font-size: large\\">foo<span style=\\"font-size: xx-small\\">b[a\]r</span>baz</span>" queryCommandValue("fontsize") after]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["fontsize","4"\]\] "<span style=\\"font-size: large\\">foo<span style=\\"font-size: xx-small\\">b[a\]r</span>baz</span>" queryCommandValue("fontsize") after]
+    expected: FAIL
+
 
 [fontsize.html?2001-last]
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=2>ba[r</font>b\]az" queryCommandIndeterm("fontsize") before]
@@ -376,10 +388,4 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[<font size=2>b\]ar</font>baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo{<font size=2>bar</font>}baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo{<font size=2>bar</font>}baz" queryCommandValue("fontsize") after]
     expected: FAIL


### PR DESCRIPTION
It fixes two new tests, but also regresses 4. That's because we don't handle xx-small (we shouldn't, at least browsers are inconsistent on what to do with that) and pre-existing issues where a `<font>` element is already present as parent of the selected node. These are pre-existing issues that are now correctly exposed.

Part of #25005

Testing: WPT