### PR TITLE
script: Don't re-parse link relations when binding element to tree

### DIFF
--- a/components/script/dom/html/htmlanchorelement.rs
+++ b/components/script/dom/html/htmlanchorelement.rs
@@ -33,7 +33,7 @@ use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::html::htmlhyperlinkelementutils::{HyperlinkElement, HyperlinkElementTraits};
 use crate::dom::html::htmlimageelement::HTMLImageElement;
 use crate::dom::mouseevent::MouseEvent;
-use crate::dom::node::{BindContext, Node, NodeTraits};
+use crate::dom::node::{Node, NodeTraits};
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::links::{LinkRelations, follow_hyperlink};
 use crate::script_runtime::CanGc;
@@ -129,15 +129,6 @@ impl VirtualMethods for HTMLAnchorElement {
             },
             _ => {},
         }
-    }
-
-    fn bind_to_tree(&self, cx: &mut JSContext, context: &BindContext) {
-        if let Some(s) = self.super_type() {
-            s.bind_to_tree(cx, context);
-        }
-
-        self.relations
-            .set(LinkRelations::for_element(self.upcast()));
     }
 }
 

--- a/components/script/dom/html/htmlareaelement.rs
+++ b/components/script/dom/html/htmlareaelement.rs
@@ -10,7 +10,6 @@ use cssparser::match_ignore_ascii_case;
 use dom_struct::dom_struct;
 use euclid::default::Point2D;
 use html5ever::{LocalName, Prefix, local_name};
-use js::context::JSContext;
 use js::rust::HandleObject;
 use servo_url::ServoUrl;
 use style::attr::AttrValue;
@@ -31,7 +30,7 @@ use crate::dom::event::Event;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::html::htmlhyperlinkelementutils::{HyperlinkElement, HyperlinkElementTraits};
-use crate::dom::node::{BindContext, Node};
+use crate::dom::node::Node;
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::links::{LinkRelations, follow_hyperlink};
 use crate::script_runtime::CanGc;
@@ -364,15 +363,6 @@ impl VirtualMethods for HTMLAreaElement {
             },
             _ => {},
         }
-    }
-
-    fn bind_to_tree(&self, cx: &mut JSContext, context: &BindContext) {
-        if let Some(s) = self.super_type() {
-            s.bind_to_tree(cx, context);
-        }
-
-        self.relations
-            .set(LinkRelations::for_element(self.upcast()));
     }
 }
 

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -77,9 +77,7 @@ use crate::dom::html::htmlselectelement::HTMLSelectElement;
 use crate::dom::html::htmltextareaelement::HTMLTextAreaElement;
 use crate::dom::html::input_element::HTMLInputElement;
 use crate::dom::input_element::input_type::InputType;
-use crate::dom::node::{
-    BindContext, Node, NodeFlags, NodeTraits, UnbindContext, VecPreOrderInsertionHelper,
-};
+use crate::dom::node::{Node, NodeFlags, NodeTraits, UnbindContext, VecPreOrderInsertionHelper};
 use crate::dom::nodelist::{NodeList, RadioListMode};
 use crate::dom::radionodelist::RadioNodeList;
 use crate::dom::submitevent::SubmitEvent;
@@ -91,6 +89,7 @@ use crate::navigation::navigate;
 use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 
+/// <https://html.spec.whatwg.org/multipage/#the-form-element>
 #[dom_struct]
 pub(crate) struct HTMLFormElement {
     htmlelement: HTMLElement,
@@ -114,6 +113,7 @@ pub(crate) struct HTMLFormElement {
     /// <https://html.spec.whatwg.org/multipage/#planned-navigation>
     planned_navigation: Cell<usize>,
 
+    /// <https://html.spec.whatwg.org/multipage/#attr-form-rel>
     #[no_trace]
     relations: Cell<LinkRelations>,
 }
@@ -1921,15 +1921,6 @@ impl VirtualMethods for HTMLFormElement {
             },
             _ => {},
         }
-    }
-
-    fn bind_to_tree(&self, cx: &mut JSContext, context: &BindContext) {
-        if let Some(s) = self.super_type() {
-            s.bind_to_tree(cx, context);
-        }
-
-        self.relations
-            .set(LinkRelations::for_element(self.upcast()));
     }
 }
 

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -444,9 +444,6 @@ impl VirtualMethods for HTMLLinkElement {
             s.bind_to_tree(cx, context);
         }
 
-        self.relations
-            .set(LinkRelations::for_element(self.upcast()));
-
         if context.tree_connected {
             let element = self.upcast();
 

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -256,12 +256,25 @@ impl VirtualMethods for HTMLLinkElement {
 
         let local_name = attr.local_name();
         let is_removal = mutation.is_removal();
-        if *local_name == local_name!("disabled") {
-            self.handle_disabled_attribute_change(is_removal);
-            return;
-        }
-        let node = self.upcast::<Node>();
+        match *local_name {
+            local_name!("disabled") => {
+                self.handle_disabled_attribute_change(is_removal);
+                return;
+            },
+            local_name!("rel") | local_name!("rev") => {
+                let previous_relations = self.relations.get();
+                self.relations
+                    .set(LinkRelations::for_element(self.upcast()));
 
+                // If relations haven't changed, we shouldn't do anything
+                if previous_relations == self.relations.get() {
+                    return;
+                }
+            },
+            _ => {},
+        }
+
+        let node = self.upcast::<Node>();
         if !node.is_connected() {
             return;
         }
@@ -278,15 +291,6 @@ impl VirtualMethods for HTMLLinkElement {
 
         match *local_name {
             local_name!("rel") | local_name!("rev") => {
-                let previous_relations = self.relations.get();
-                self.relations
-                    .set(LinkRelations::for_element(self.upcast()));
-
-                // If relations haven't changed, we shouldn't do anything
-                if previous_relations == self.relations.get() {
-                    return;
-                }
-
                 // https://html.spec.whatwg.org/multipage/#link-type-stylesheet:fetch-and-process-the-linked-resource
                 // > When the external resource link is created on a link element that is already browsing-context connected.
                 if self.relations.get().contains(LinkRelations::STYLESHEET) {


### PR DESCRIPTION
The parsed relations of a element don't depend on its position in the DOM tree at all, so this does nothing.

Testing: This should not change observable behaviour, WPT should catch regressions