### PR TITLE
canvas: fix unrecognized offscreen webgl context

### DIFF
--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -700,11 +700,35 @@ impl CanvasState {
                     ));
                 },
                 OffscreenRenderingContext::WebGL(ref _context) => {
-                    // TODO send canvas message?
+                    let Some(snapshot) = context.get_image_data() else {
+                        return Ok(());
+                    };
+
+                    self.send_canvas_2d_msg(Canvas2dMsg::DrawImage(
+                        snapshot.to_shared(),
+                        dest_rect,
+                        source_rect,
+                        smoothing_enabled,
+                        self.state.borrow().shadow_options(),
+                        self.state.borrow().composition_options(),
+                        self.state.borrow().transform,
+                    ));
                 },
 
                 OffscreenRenderingContext::WebGL2(ref _context) => {
-                    // TODO send canvas message?
+                    let Some(snapshot) = context.get_image_data() else {
+                        return Ok(());
+                    };
+
+                    self.send_canvas_2d_msg(Canvas2dMsg::DrawImage(
+                        snapshot.to_shared(),
+                        dest_rect,
+                        source_rect,
+                        smoothing_enabled,
+                        self.state.borrow().shadow_options(),
+                        self.state.borrow().composition_options(),
+                        self.state.borrow().transform,
+                    ));
                 },
                 OffscreenRenderingContext::Detached => return Err(Error::InvalidState(None)),
             }
@@ -816,11 +840,35 @@ impl CanvasState {
                             ));
                         },
                         OffscreenRenderingContext::WebGL(ref _context) => {
-                            // TODO send canvas message
+                            let Some(snapshot) = context.get_image_data() else {
+                                return Ok(());
+                            };
+
+                            self.send_canvas_2d_msg(Canvas2dMsg::DrawImage(
+                                snapshot.to_shared(),
+                                dest_rect,
+                                source_rect,
+                                smoothing_enabled,
+                                self.state.borrow().shadow_options(),
+                                self.state.borrow().composition_options(),
+                                self.state.borrow().transform,
+                            ));
                         },
 
                         OffscreenRenderingContext::WebGL2(ref _context) => {
-                            // TODO send canvas message
+                            let Some(snapshot) = context.get_image_data() else {
+                                return Ok(());
+                            };
+
+                            self.send_canvas_2d_msg(Canvas2dMsg::DrawImage(
+                                snapshot.to_shared(),
+                                dest_rect,
+                                source_rect,
+                                smoothing_enabled,
+                                self.state.borrow().shadow_options(),
+                                self.state.borrow().composition_options(),
+                                self.state.borrow().transform,
+                            ));
                         },
                         OffscreenRenderingContext::Detached => {
                             return Err(Error::InvalidState(None));

--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -699,6 +699,13 @@ impl CanvasState {
                         self.state.borrow().transform,
                     ));
                 },
+                OffscreenRenderingContext::WebGL(ref _context) => {
+                    // TODO send canvas message?
+                },
+
+                OffscreenRenderingContext::WebGL2(ref _context) => {
+                    // TODO send canvas message?
+                },
                 OffscreenRenderingContext::Detached => return Err(Error::InvalidState(None)),
             }
         } else {
@@ -807,6 +814,13 @@ impl CanvasState {
                                 self.state.borrow().composition_options(),
                                 self.state.borrow().transform,
                             ));
+                        },
+                        OffscreenRenderingContext::WebGL(ref _context) => {
+                            // TODO send canvas message
+                        },
+
+                        OffscreenRenderingContext::WebGL2(ref _context) => {
+                            // TODO send canvas message
                         },
                         OffscreenRenderingContext::Detached => {
                             return Err(Error::InvalidState(None));

--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -699,7 +699,7 @@ impl CanvasState {
                         self.state.borrow().transform,
                     ));
                 },
-                OffscreenRenderingContext::WebGL(ref _context) => {
+                OffscreenRenderingContext::WebGL(ref context) => {
                     let Some(snapshot) = context.get_image_data() else {
                         return Ok(());
                     };
@@ -715,7 +715,7 @@ impl CanvasState {
                     ));
                 },
 
-                OffscreenRenderingContext::WebGL2(ref _context) => {
+                OffscreenRenderingContext::WebGL2(ref context) => {
                     let Some(snapshot) = context.get_image_data() else {
                         return Ok(());
                     };
@@ -839,7 +839,7 @@ impl CanvasState {
                                 self.state.borrow().transform,
                             ));
                         },
-                        OffscreenRenderingContext::WebGL(ref _context) => {
+                        OffscreenRenderingContext::WebGL(ref context) => {
                             let Some(snapshot) = context.get_image_data() else {
                                 return Ok(());
                             };
@@ -855,7 +855,7 @@ impl CanvasState {
                             ));
                         },
 
-                        OffscreenRenderingContext::WebGL2(ref _context) => {
+                        OffscreenRenderingContext::WebGL2(ref context) => {
                             let Some(snapshot) = context.get_image_data() else {
                                 return Ok(());
                             };

--- a/components/script/dom/canvas/canvas_context.rs
+++ b/components/script/dom/canvas/canvas_context.rs
@@ -320,7 +320,7 @@ impl CanvasContext for RenderingContext {
 pub(crate) enum OffscreenRenderingContext {
     Context2d(Dom<OffscreenCanvasRenderingContext2D>),
     BitmapRenderer(Dom<ImageBitmapRenderingContext>),
-    // WebGL(Dom<WebGLRenderingContext>),
+    WebGL(Dom<WebGLRenderingContext>),
     // WebGL2(Dom<WebGL2RenderingContext>),
     // #[cfg(feature = "webgpu")]
     // WebGPU(Dom<GPUCanvasContext>),
@@ -336,6 +336,7 @@ impl CanvasContext for OffscreenRenderingContext {
         match self {
             OffscreenRenderingContext::Context2d(context) => context.canvas(),
             OffscreenRenderingContext::BitmapRenderer(context) => context.canvas(),
+            OffscreenRenderingContext::WebGL(context) => context.canvas(),
             OffscreenRenderingContext::Detached => None,
         }
     }
@@ -344,6 +345,7 @@ impl CanvasContext for OffscreenRenderingContext {
         match self {
             OffscreenRenderingContext::Context2d(context) => context.resize(),
             OffscreenRenderingContext::BitmapRenderer(context) => context.resize(),
+            OffscreenRenderingContext::WebGL(context) => context.resize(),
             OffscreenRenderingContext::Detached => {},
         }
     }
@@ -352,6 +354,7 @@ impl CanvasContext for OffscreenRenderingContext {
         match self {
             OffscreenRenderingContext::Context2d(context) => context.reset_bitmap(),
             OffscreenRenderingContext::BitmapRenderer(context) => context.reset_bitmap(),
+            OffscreenRenderingContext::WebGL(context) => context.reset_bitmap(),
             OffscreenRenderingContext::Detached => {},
         }
     }
@@ -360,6 +363,7 @@ impl CanvasContext for OffscreenRenderingContext {
         match self {
             OffscreenRenderingContext::Context2d(context) => context.get_image_data(),
             OffscreenRenderingContext::BitmapRenderer(context) => context.get_image_data(),
+            OffscreenRenderingContext::WebGL(context) => context.get_image_data(),
             OffscreenRenderingContext::Detached => None,
         }
     }
@@ -368,6 +372,7 @@ impl CanvasContext for OffscreenRenderingContext {
         match self {
             OffscreenRenderingContext::Context2d(context) => context.origin_is_clean(),
             OffscreenRenderingContext::BitmapRenderer(context) => context.origin_is_clean(),
+            OffscreenRenderingContext::WebGL(context) => context.origin_is_clean(),
             OffscreenRenderingContext::Detached => true,
         }
     }
@@ -376,6 +381,7 @@ impl CanvasContext for OffscreenRenderingContext {
         match self {
             OffscreenRenderingContext::Context2d(context) => context.size(),
             OffscreenRenderingContext::BitmapRenderer(context) => context.size(),
+            OffscreenRenderingContext::WebGL(context) => context.size(),
             OffscreenRenderingContext::Detached => Size2D::default(),
         }
     }
@@ -384,6 +390,7 @@ impl CanvasContext for OffscreenRenderingContext {
         match self {
             OffscreenRenderingContext::Context2d(context) => context.mark_as_dirty(),
             OffscreenRenderingContext::BitmapRenderer(context) => context.mark_as_dirty(),
+            OffscreenRenderingContext::WebGL(context) => context.mark_as_dirty(),
             OffscreenRenderingContext::Detached => {},
         }
     }
@@ -392,6 +399,7 @@ impl CanvasContext for OffscreenRenderingContext {
         match self {
             OffscreenRenderingContext::Context2d(context) => context.onscreen(),
             OffscreenRenderingContext::BitmapRenderer(context) => context.onscreen(),
+            OffscreenRenderingContext::WebGL(context) => context.onscreen(),
             OffscreenRenderingContext::Detached => false,
         }
     }

--- a/components/script/dom/canvas/canvas_context.rs
+++ b/components/script/dom/canvas/canvas_context.rs
@@ -321,7 +321,7 @@ pub(crate) enum OffscreenRenderingContext {
     Context2d(Dom<OffscreenCanvasRenderingContext2D>),
     BitmapRenderer(Dom<ImageBitmapRenderingContext>),
     WebGL(Dom<WebGLRenderingContext>),
-    // WebGL2(Dom<WebGL2RenderingContext>),
+    WebGL2(Dom<WebGL2RenderingContext>),
     // #[cfg(feature = "webgpu")]
     // WebGPU(Dom<GPUCanvasContext>),
     Detached,
@@ -337,6 +337,7 @@ impl CanvasContext for OffscreenRenderingContext {
             OffscreenRenderingContext::Context2d(context) => context.canvas(),
             OffscreenRenderingContext::BitmapRenderer(context) => context.canvas(),
             OffscreenRenderingContext::WebGL(context) => context.canvas(),
+            OffscreenRenderingContext::WebGL2(context) => context.canvas(),
             OffscreenRenderingContext::Detached => None,
         }
     }
@@ -346,6 +347,7 @@ impl CanvasContext for OffscreenRenderingContext {
             OffscreenRenderingContext::Context2d(context) => context.resize(),
             OffscreenRenderingContext::BitmapRenderer(context) => context.resize(),
             OffscreenRenderingContext::WebGL(context) => context.resize(),
+            OffscreenRenderingContext::WebGL2(context) => context.resize(),
             OffscreenRenderingContext::Detached => {},
         }
     }
@@ -355,6 +357,7 @@ impl CanvasContext for OffscreenRenderingContext {
             OffscreenRenderingContext::Context2d(context) => context.reset_bitmap(),
             OffscreenRenderingContext::BitmapRenderer(context) => context.reset_bitmap(),
             OffscreenRenderingContext::WebGL(context) => context.reset_bitmap(),
+            OffscreenRenderingContext::WebGL2(context) => context.reset_bitmap(),
             OffscreenRenderingContext::Detached => {},
         }
     }
@@ -364,6 +367,7 @@ impl CanvasContext for OffscreenRenderingContext {
             OffscreenRenderingContext::Context2d(context) => context.get_image_data(),
             OffscreenRenderingContext::BitmapRenderer(context) => context.get_image_data(),
             OffscreenRenderingContext::WebGL(context) => context.get_image_data(),
+            OffscreenRenderingContext::WebGL2(context) => context.get_image_data(),
             OffscreenRenderingContext::Detached => None,
         }
     }
@@ -373,6 +377,7 @@ impl CanvasContext for OffscreenRenderingContext {
             OffscreenRenderingContext::Context2d(context) => context.origin_is_clean(),
             OffscreenRenderingContext::BitmapRenderer(context) => context.origin_is_clean(),
             OffscreenRenderingContext::WebGL(context) => context.origin_is_clean(),
+            OffscreenRenderingContext::WebGL2(context) => context.origin_is_clean(),
             OffscreenRenderingContext::Detached => true,
         }
     }
@@ -382,6 +387,7 @@ impl CanvasContext for OffscreenRenderingContext {
             OffscreenRenderingContext::Context2d(context) => context.size(),
             OffscreenRenderingContext::BitmapRenderer(context) => context.size(),
             OffscreenRenderingContext::WebGL(context) => context.size(),
+            OffscreenRenderingContext::WebGL2(context) => context.size(),
             OffscreenRenderingContext::Detached => Size2D::default(),
         }
     }
@@ -391,6 +397,7 @@ impl CanvasContext for OffscreenRenderingContext {
             OffscreenRenderingContext::Context2d(context) => context.mark_as_dirty(),
             OffscreenRenderingContext::BitmapRenderer(context) => context.mark_as_dirty(),
             OffscreenRenderingContext::WebGL(context) => context.mark_as_dirty(),
+            OffscreenRenderingContext::WebGL2(context) => context.mark_as_dirty(),
             OffscreenRenderingContext::Detached => {},
         }
     }
@@ -400,6 +407,7 @@ impl CanvasContext for OffscreenRenderingContext {
             OffscreenRenderingContext::Context2d(context) => context.onscreen(),
             OffscreenRenderingContext::BitmapRenderer(context) => context.onscreen(),
             OffscreenRenderingContext::WebGL(context) => context.onscreen(),
+            OffscreenRenderingContext::WebGL2(context) => context.onscreen(),
             OffscreenRenderingContext::Detached => false,
         }
     }

--- a/components/script/dom/canvas/offscreencanvas.rs
+++ b/components/script/dom/canvas/offscreencanvas.rs
@@ -14,6 +14,7 @@ use script_bindings::match_domstring_ascii;
 use script_bindings::weakref::WeakRef;
 use servo_base::id::{OffscreenCanvasId, OffscreenCanvasIndex};
 use servo_constellation_traits::{BlobImpl, TransferableOffscreenCanvas};
+use servo_canvas_traits::webgl::{WebGLVersion};
 
 use crate::canvas_context::{CanvasContext, OffscreenRenderingContext};
 use crate::dom::bindings::cell::{DomRefCell, Ref};
@@ -37,6 +38,7 @@ use crate::dom::imagebitmap::ImageBitmap;
 use crate::dom::imagebitmaprenderingcontext::ImageBitmapRenderingContext;
 use crate::dom::offscreencanvasrenderingcontext2d::OffscreenCanvasRenderingContext2D;
 use crate::dom::promise::Promise;
+use crate::dom::types::WebGLRenderingContext;
 use crate::realms::{AlreadyInRealm, InRealm};
 use crate::script_runtime::{CanGc, JSContext};
 
@@ -175,6 +177,42 @@ impl OffscreenCanvas {
         Some(context)
     }
 
+    // <https://html.spec.whatwg.org/multipage/#offscreen-context-type-webgl>
+    pub(crate) fn get_or_init_webgl_context(
+        &self,
+        cx: JSContext,
+        options: HandleValue,
+        can_gc: CanGc,
+    ) -> Option<DomRoot<WebGLRenderingContext>> {
+        if let Some(ctx) = self.context() {
+            return match *ctx {
+                OffscreenRenderingContext::WebGL(ref ctx) => Some(DomRoot::from_ref(ctx)),
+                _ => None,
+            };
+        }
+        let window = self.global();
+        let canvas =
+            RootedHTMLCanvasElementOrOffscreenCanvas::OffscreenCanvas(DomRoot::from_ref(self));
+        let size = self.get_size();
+        let attrs = Self::get_gl_attributes(cx, options, can_gc)?;
+        let context = WebGLRenderingContext::new(
+            &window,
+            &canvas,
+            WebGLVersion::WebGL1,
+            size,
+            attrs,
+            can_gc,
+        )?;
+
+        // Step 2. Set this's context mode to WebGL Renderer.
+        *self.context.borrow_mut() = Some(OffscreenRenderingContext::WebGL(
+            Dom::from_ref(&*context),
+        ));
+
+        // Step 3. Return context.
+        Some(context)
+    }
+
     pub(crate) fn placeholder(&self) -> Option<DomRoot<HTMLCanvasElement>> {
         self.placeholder
             .as_ref()
@@ -291,9 +329,9 @@ impl OffscreenCanvasMethods<crate::DomTypeHolder> for OffscreenCanvas {
     /// <https://html.spec.whatwg.org/multipage/#dom-offscreencanvas-getcontext>
     fn GetContext(
         &self,
-        _cx: JSContext,
+        cx: JSContext,
         id: DOMString,
-        _options: HandleValue,
+        options: HandleValue,
         can_gc: CanGc,
     ) -> Fallible<Option<RootedOffscreenRenderingContext>> {
         // Step 3. Throw an "InvalidStateError" DOMException if the
@@ -309,10 +347,14 @@ impl OffscreenCanvasMethods<crate::DomTypeHolder> for OffscreenCanvas {
         "bitmaprenderer" => Ok(self
             .get_or_init_bitmaprenderer_context(can_gc)
             .map(RootedOffscreenRenderingContext::ImageBitmapRenderingContext)),
-        /*"webgl" | "experimental-webgl" => self
-            .get_or_init_webgl_context(cx, options)
-            .map(OffscreenRenderingContext::WebGLRenderingContext),
-        "webgl2" | "experimental-webgl2" => self
+        "webgl" => self
+            .get_or_init_webgl_context(cx, options, can_gc)
+            .map(OffscreenRenderingContext::WebGL),
+
+        "experimental-webgl" => self
+            .get_or_init_webgl_context(cx, options,can_gc)
+            .map(OffscreenRenderingContext::WebGL),
+        /*"webgl2" | "experimental-webgl2" => self
             .get_or_init_webgl2_context(cx, options)
             .map(OffscreenRenderingContext::WebGL2RenderingContext),*/
             _ => Err(Error::Type(c"Unrecognized OffscreenCanvas context type".to_owned())),

--- a/components/script/dom/canvas/offscreencanvas.rs
+++ b/components/script/dom/canvas/offscreencanvas.rs
@@ -7,25 +7,30 @@ use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use euclid::default::Size2D;
+use js::error::throw_type_error;
 use js::rust::{HandleObject, HandleValue};
 use pixels::{EncodedImageType, Snapshot};
 use rustc_hash::FxHashMap;
+use script_bindings::inheritance::Castable;
 use script_bindings::match_domstring_ascii;
 use script_bindings::weakref::WeakRef;
 use servo_base::id::{OffscreenCanvasId, OffscreenCanvasIndex};
+use servo_canvas_traits::webgl::{GLContextAttributes, WebGLVersion};
 use servo_constellation_traits::{BlobImpl, TransferableOffscreenCanvas};
-use servo_canvas_traits::webgl::{WebGLVersion};
 
 use crate::canvas_context::{CanvasContext, OffscreenRenderingContext};
+use crate::conversions::Convert;
 use crate::dom::bindings::cell::{DomRefCell, Ref};
 use crate::dom::bindings::codegen::Bindings::OffscreenCanvasBinding::{
     ImageEncodeOptions, OffscreenCanvasMethods,
     OffscreenRenderingContext as RootedOffscreenRenderingContext,
 };
+use crate::dom::bindings::codegen::Bindings::WebGLRenderingContextBinding::WebGLContextAttributes;
 use crate::dom::bindings::codegen::UnionTypes::HTMLCanvasElementOrOffscreenCanvas as RootedHTMLCanvasElementOrOffscreenCanvas;
+use crate::dom::bindings::conversions::ConversionResult;
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::refcounted::{Trusted, TrustedPromise};
-use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object_with_proto};
+use crate::dom::bindings::reflector::{DomGlobal, DomObject, reflect_dom_object_with_proto};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::structuredclone::StructuredData;
@@ -38,7 +43,8 @@ use crate::dom::imagebitmap::ImageBitmap;
 use crate::dom::imagebitmaprenderingcontext::ImageBitmapRenderingContext;
 use crate::dom::offscreencanvasrenderingcontext2d::OffscreenCanvasRenderingContext2D;
 use crate::dom::promise::Promise;
-use crate::dom::types::WebGLRenderingContext;
+use crate::dom::types::{WebGLRenderingContext, Window};
+use crate::dom::webgl::webgl2renderingcontext::WebGL2RenderingContext;
 use crate::realms::{AlreadyInRealm, InRealm};
 use crate::script_runtime::{CanGc, JSContext};
 
@@ -95,6 +101,27 @@ impl OffscreenCanvas {
             self.Width().try_into().unwrap_or(u32::MAX),
             self.Height().try_into().unwrap_or(u32::MAX),
         )
+    }
+
+    #[expect(unsafe_code)]
+    fn get_gl_attributes(
+        cx: JSContext,
+        options: HandleValue,
+        can_gc: CanGc,
+    ) -> Option<GLContextAttributes> {
+        unsafe {
+            match WebGLContextAttributes::new(cx, options, can_gc) {
+                Ok(ConversionResult::Success(attrs)) => Some(attrs.convert()),
+                Ok(ConversionResult::Failure(error)) => {
+                    throw_type_error(*cx, &error);
+                    None
+                },
+                _ => {
+                    debug!("Unexpected error on conversion of WebGLContextAttributes");
+                    None
+                },
+            }
+        }
     }
 
     pub(crate) fn origin_is_clean(&self) -> bool {
@@ -190,26 +217,52 @@ impl OffscreenCanvas {
                 _ => None,
             };
         }
-        let window = self.global();
+        let global = self.global();
+        // TODO: Better error handling
+        let window = global.downcast::<Window>().unwrap();
         let canvas =
             RootedHTMLCanvasElementOrOffscreenCanvas::OffscreenCanvas(DomRoot::from_ref(self));
         let size = self.get_size();
         let attrs = Self::get_gl_attributes(cx, options, can_gc)?;
-        let context = WebGLRenderingContext::new(
-            &window,
-            &canvas,
-            WebGLVersion::WebGL1,
-            size,
-            attrs,
-            can_gc,
-        )?;
+        let context =
+            WebGLRenderingContext::new(window, &canvas, WebGLVersion::WebGL1, size, attrs, can_gc)?;
 
         // Step 2. Set this's context mode to WebGL Renderer.
-        *self.context.borrow_mut() = Some(OffscreenRenderingContext::WebGL(
-            Dom::from_ref(&*context),
-        ));
+        *self.context.borrow_mut() =
+            Some(OffscreenRenderingContext::WebGL(Dom::from_ref(&*context)));
 
         // Step 3. Return context.
+        Some(context)
+    }
+
+    fn get_or_init_webgl2_context(
+        &self,
+        cx: JSContext,
+        options: HandleValue,
+        can_gc: CanGc,
+    ) -> Option<DomRoot<WebGL2RenderingContext>> {
+        if !WebGL2RenderingContext::is_webgl2_enabled(cx, self.global().reflector().get_jsobject())
+        {
+            return None;
+        }
+        if let Some(ctx) = self.context() {
+            return match *ctx {
+                OffscreenRenderingContext::WebGL2(ref ctx) => Some(DomRoot::from_ref(ctx)),
+                _ => None,
+            };
+        }
+        let global = self.global();
+        // TODO: Better error handling
+        let window = global.downcast::<Window>().unwrap();
+        let canvas =
+            RootedHTMLCanvasElementOrOffscreenCanvas::OffscreenCanvas(DomRoot::from_ref(self));
+        let size = self.get_size();
+        let attrs = Self::get_gl_attributes(cx, options, can_gc)?;
+        let context = WebGL2RenderingContext::new(window, &canvas, size, attrs, can_gc)?;
+
+        *self.context.borrow_mut() =
+            Some(OffscreenRenderingContext::WebGL2(Dom::from_ref(&*context)));
+
         Some(context)
     }
 
@@ -347,16 +400,18 @@ impl OffscreenCanvasMethods<crate::DomTypeHolder> for OffscreenCanvas {
         "bitmaprenderer" => Ok(self
             .get_or_init_bitmaprenderer_context(can_gc)
             .map(RootedOffscreenRenderingContext::ImageBitmapRenderingContext)),
-        "webgl" => self
+        "webgl" => Ok(self
             .get_or_init_webgl_context(cx, options, can_gc)
-            .map(OffscreenRenderingContext::WebGL),
-
-        "experimental-webgl" => self
+            .map(RootedOffscreenRenderingContext::WebGLRenderingContext)),
+        "experimental-webgl" => Ok(self
             .get_or_init_webgl_context(cx, options,can_gc)
-            .map(OffscreenRenderingContext::WebGL),
-        /*"webgl2" | "experimental-webgl2" => self
-            .get_or_init_webgl2_context(cx, options)
-            .map(OffscreenRenderingContext::WebGL2RenderingContext),*/
+            .map(RootedOffscreenRenderingContext::WebGLRenderingContext)),
+        "webgl2"  => Ok(self
+            .get_or_init_webgl2_context(cx, options, can_gc)
+            .map(RootedOffscreenRenderingContext::WebGL2RenderingContext)),
+        "experimental-webgl2" => Ok(self
+            .get_or_init_webgl2_context(cx, options, can_gc)
+            .map(RootedOffscreenRenderingContext::WebGL2RenderingContext)),
             _ => Err(Error::Type(c"Unrecognized OffscreenCanvas context type".to_owned())),
         )
     }

--- a/components/script/dom/canvas/offscreencanvas.rs
+++ b/components/script/dom/canvas/offscreencanvas.rs
@@ -217,24 +217,37 @@ impl OffscreenCanvas {
                 _ => None,
             };
         }
-        let global = self.global();
-        // TODO: Better error handling
-        let window = global.downcast::<Window>().unwrap();
+
+        // 1. Let context be the result of following the instructions given in the
+        // WebGL specifications' Context Creation sections.
         let canvas =
             RootedHTMLCanvasElementOrOffscreenCanvas::OffscreenCanvas(DomRoot::from_ref(self));
         let size = self.get_size();
         let attrs = Self::get_gl_attributes(cx, options, can_gc)?;
-        let context =
-            WebGLRenderingContext::new(window, &canvas, WebGLVersion::WebGL1, size, attrs, can_gc)?;
+        self.global()
+            .downcast::<Window>()
+            .and_then(|window| {
+                WebGLRenderingContext::new(
+                    window,
+                    &canvas,
+                    WebGLVersion::WebGL1,
+                    size,
+                    attrs,
+                    can_gc,
+                )
+            })
+            .map(|context| {
+                // Step 2. If context is null, then return null;
+                // otherwise set this's context mode to webgl or webgl2.
+                *self.context.borrow_mut() =
+                    Some(OffscreenRenderingContext::WebGL(Dom::from_ref(&*context)));
 
-        // Step 2. Set this's context mode to WebGL Renderer.
-        *self.context.borrow_mut() =
-            Some(OffscreenRenderingContext::WebGL(Dom::from_ref(&*context)));
-
-        // Step 3. Return context.
-        Some(context)
+                // Step 3. Return context.
+                context
+            })
     }
 
+    // <https://html.spec.whatwg.org/multipage/#offscreen-context-type-webgl>
     fn get_or_init_webgl2_context(
         &self,
         cx: JSContext,
@@ -251,19 +264,25 @@ impl OffscreenCanvas {
                 _ => None,
             };
         }
-        let global = self.global();
-        // TODO: Better error handling
-        let window = global.downcast::<Window>().unwrap();
+
+        // 1. Let context be the result of following the instructions given in the
+        // WebGL specifications' Context Creation sections.
         let canvas =
             RootedHTMLCanvasElementOrOffscreenCanvas::OffscreenCanvas(DomRoot::from_ref(self));
         let size = self.get_size();
         let attrs = Self::get_gl_attributes(cx, options, can_gc)?;
-        let context = WebGL2RenderingContext::new(window, &canvas, size, attrs, can_gc)?;
+        self.global()
+            .downcast::<Window>()
+            .and_then(|window| WebGL2RenderingContext::new(window, &canvas, size, attrs, can_gc))
+            .map(|context| {
+                // Step 2. If context is null, then return null;
+                // otherwise set this's context mode to webgl or webgl2.
+                *self.context.borrow_mut() =
+                    Some(OffscreenRenderingContext::WebGL2(Dom::from_ref(&*context)));
 
-        *self.context.borrow_mut() =
-            Some(OffscreenRenderingContext::WebGL2(Dom::from_ref(&*context)));
-
-        Some(context)
+                // Step 3. Return context.
+                context
+            })
     }
 
     pub(crate) fn placeholder(&self) -> Option<DomRoot<HTMLCanvasElement>> {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -687,6 +687,11 @@ impl Window {
             .map(|chan| WebGLCommandSender::new(chan.clone()))
     }
 
+    // TODO: rename the function to webgl_chan after the existing `webgl_chan` function is removed.
+    pub(crate) fn webgl_chan_value(&self) -> Option<WebGLChan> {
+        self.webgl_chan.clone()
+    }
+
     #[cfg(feature = "webxr")]
     pub(crate) fn webxr_registry(&self) -> Option<webxr_api::Registry> {
         self.webxr_registry.clone()

--- a/components/script/dom/workers/serviceworkerregistration.rs
+++ b/components/script/dom/workers/serviceworkerregistration.rs
@@ -126,12 +126,12 @@ impl ServiceWorkerRegistration {
             pipeline_id: global.pipeline_id(),
         };
 
-        // TODO:  handle error better
-        let window = global.downcast::<Window>().unwrap();
+        let webgl_chan = global
+            .downcast::<Window>()
+            .and_then(|window| window.webgl_chan_value());
         let worker_id = WorkerId(Uuid::new_v4());
         let devtools_chan = global.devtools_chan().cloned();
-        let init =
-            prepare_workerscope_init(global, None, Some(worker_id), window.webgl_chan_value());
+        let init = prepare_workerscope_init(global, None, Some(worker_id), webgl_chan);
         let browsing_context_id = global
             .downcast::<Window>()
             .map(|w: &Window| w.window_proxy().browsing_context_id())

--- a/components/script/dom/workers/serviceworkerregistration.rs
+++ b/components/script/dom/workers/serviceworkerregistration.rs
@@ -126,9 +126,12 @@ impl ServiceWorkerRegistration {
             pipeline_id: global.pipeline_id(),
         };
 
+        // TODO:  handle error better
+        let window = global.downcast::<Window>().unwrap();
         let worker_id = WorkerId(Uuid::new_v4());
         let devtools_chan = global.devtools_chan().cloned();
-        let init = prepare_workerscope_init(global, None, Some(worker_id));
+        let init =
+            prepare_workerscope_init(global, None, Some(worker_id), window.webgl_chan_value());
         let browsing_context_id = global
             .downcast::<Window>()
             .map(|w: &Window| w.window_proxy().browsing_context_id())

--- a/components/script/dom/workers/worker.rs
+++ b/components/script/dom/workers/worker.rs
@@ -245,13 +245,11 @@ impl WorkerMethods<crate::DomTypeHolder> for Worker {
             }
         }
 
-        let window = global.downcast::<Window>().unwrap();
-        let init = prepare_workerscope_init(
-            global,
-            Some(devtools_sender),
-            Some(worker_id),
-            window.webgl_chan_value(),
-        );
+        let webgl_chan = global
+            .downcast::<Window>()
+            .and_then(|window| window.webgl_chan_value());
+        let init =
+            prepare_workerscope_init(global, Some(devtools_sender), Some(worker_id), webgl_chan);
 
         let (control_sender, control_receiver) = unbounded();
         let (context_sender, context_receiver) = unbounded();

--- a/components/script/dom/workers/worker.rs
+++ b/components/script/dom/workers/worker.rs
@@ -245,7 +245,13 @@ impl WorkerMethods<crate::DomTypeHolder> for Worker {
             }
         }
 
-        let init = prepare_workerscope_init(global, Some(devtools_sender), Some(worker_id));
+        let window = global.downcast::<Window>().unwrap();
+        let init = prepare_workerscope_init(
+            global,
+            Some(devtools_sender),
+            Some(worker_id),
+            window.webgl_chan_value(),
+        );
 
         let (control_sender, control_receiver) = unbounded();
         let (context_sender, context_receiver) = unbounded();

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -28,6 +28,7 @@ use profile_traits::mem::{ProcessReports, perform_memory_report};
 use servo_base::cross_process_instant::CrossProcessInstant;
 use servo_base::generic_channel::{GenericSend, GenericSender, RoutedReceiver};
 use servo_base::id::{PipelineId, PipelineNamespace};
+use servo_canvas_traits::webgl::WebGLChan;
 use servo_constellation_traits::WorkerGlobalScopeInit;
 use servo_url::{MutableOrigin, ServoUrl};
 use timers::TimerScheduler;
@@ -89,6 +90,7 @@ pub(crate) fn prepare_workerscope_init(
     global: &GlobalScope,
     devtools_sender: Option<GenericSender<DevtoolScriptControlMsg>>,
     worker_id: Option<WorkerId>,
+    webgl_chan: Option<WebGLChan>,
 ) -> WorkerGlobalScopeInit {
     WorkerGlobalScopeInit {
         resource_threads: global.resource_threads().clone(),
@@ -104,6 +106,7 @@ pub(crate) fn prepare_workerscope_init(
         origin: global.origin().immutable().clone(),
         inherited_secure_context: Some(global.is_secure_context()),
         unminify_js: global.unminify_js(),
+        webgl_chan,
     }
 }
 

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -35,6 +35,7 @@ use servo_base::id::{
     ServiceWorkerRegistrationId, WebViewId,
 };
 use servo_canvas_traits::canvas::{CanvasId, CanvasMsg};
+use servo_canvas_traits::webgl::WebGLChan;
 use servo_url::{ImmutableOrigin, OriginSnapshot, ServoUrl};
 use storage_traits::StorageThreads;
 use storage_traits::webstorage_thread::WebStorageType;
@@ -483,6 +484,8 @@ pub struct WorkerGlobalScopeInit {
     pub inherited_secure_context: Option<bool>,
     /// Unminify Javascript.
     pub unminify_js: bool,
+    /// Handle for communicating messages to the WebGL thread, if available.
+    pub webgl_chan: Option<WebGLChan>,
 }
 
 /// Common entities representing a network load origin

--- a/tests/wpt/meta/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.getcontext.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.getcontext.html.ini
@@ -1,12 +1,3 @@
 [offscreencanvas.getcontext.html]
-  [Test that getContext with supported string returns correct results]
-    expected: FAIL
-
-  [Test that webglcontext.canvas should return the original OffscreenCanvas]
-    expected: FAIL
-
   [Test that OffscreenCanvasRenderingContext2D with alpha disabled makes the OffscreenCanvas opaque]
-    expected: FAIL
-
-  [Test that getContext twice with different context type returns null the second time]
     expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.resize.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.resize.html.ini
@@ -4,6 +4,3 @@
 
   [Verify that resizing an OffscreenCanvas with a 2d context propagates the new size to its placeholder canvas asynchronously.]
     expected: FAIL
-
-  [Verify that writing to the width and height attributes of an OffscreenCanvas works when there is a webgl context attached.]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transfer.to.imagebitmap.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transfer.to.imagebitmap.html.ini
@@ -1,6 +1,3 @@
 [offscreencanvas.transfer.to.imagebitmap.html]
   [Test that transferToImageBitmap returns an ImageBitmap with correct color]
     expected: FAIL
-
-  [Test that transferToImageBitmap returns an ImageBitmap with correct width and height]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transferrable.w.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transferrable.w.html.ini
@@ -1,4 +1,3 @@
 [offscreencanvas.transferrable.w.html]
-  expected: ERROR
   [Test that transfer an OffscreenCanvas that has a webgl context throws exception in a worker.]
     expected: FAIL

--- a/tests/wpt/webgl/meta/conformance/offscreencanvas/context-attribute-preserve-drawing-buffer.html.ini
+++ b/tests/wpt/webgl/meta/conformance/offscreencanvas/context-attribute-preserve-drawing-buffer.html.ini
@@ -1,7 +1,3 @@
 [context-attribute-preserve-drawing-buffer.html]
-  expected: ERROR
-  [Overall test]
-    expected: NOTRUN
-
-  [WebGL test #0]
+  [WebGL test #1]
     expected: FAIL

--- a/tests/wpt/webgl/meta/conformance/offscreencanvas/context-creation-worker.html.ini
+++ b/tests/wpt/webgl/meta/conformance/offscreencanvas/context-creation-worker.html.ini
@@ -1,4 +1,3 @@
 [context-creation-worker.html]
-  expected: ERROR
   [WebGL test #0]
     expected: FAIL

--- a/tests/wpt/webgl/meta/conformance/offscreencanvas/context-creation.html.ini
+++ b/tests/wpt/webgl/meta/conformance/offscreencanvas/context-creation.html.ini
@@ -1,4 +1,0 @@
-[context-creation.html]
-  expected: ERROR
-  [WebGL test #0]
-    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance/offscreencanvas/context-lost-restored.html.ini
+++ b/tests/wpt/webgl/meta/conformance/offscreencanvas/context-lost-restored.html.ini
@@ -1,2 +1,3 @@
 [context-lost-restored.html]
-  expected: ERROR
+  [WebGL test #0]
+    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance/offscreencanvas/context-lost.html.ini
+++ b/tests/wpt/webgl/meta/conformance/offscreencanvas/context-lost.html.ini
@@ -1,2 +1,3 @@
 [context-lost.html]
-  expected: ERROR
+  [WebGL test #0]
+    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance/offscreencanvas/methods-worker.html.ini
+++ b/tests/wpt/webgl/meta/conformance/offscreencanvas/methods-worker.html.ini
@@ -1,4 +1,3 @@
 [methods-worker.html]
-  expected: ERROR
   [WebGL test #0]
     expected: FAIL

--- a/tests/wpt/webgl/meta/conformance/offscreencanvas/methods.html.ini
+++ b/tests/wpt/webgl/meta/conformance/offscreencanvas/methods.html.ini
@@ -1,4 +1,0 @@
-[methods.html]
-  expected: ERROR
-  [WebGL test #0]
-    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance/offscreencanvas/offscreencanvas-resize.html.ini
+++ b/tests/wpt/webgl/meta/conformance/offscreencanvas/offscreencanvas-resize.html.ini
@@ -1,2 +1,0 @@
-[offscreencanvas-resize.html]
-  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance/textures/misc/origin-clean-conformance-offscreencanvas.html.ini
+++ b/tests/wpt/webgl/meta/conformance/textures/misc/origin-clean-conformance-offscreencanvas.html.ini
@@ -1,7 +1,6 @@
 [origin-clean-conformance-offscreencanvas.html]
-  expected: ERROR
-  [Overall test]
-    expected: NOTRUN
-
   [WebGL test #2]
+    expected: FAIL
+
+  [WebGL test #3]
     expected: FAIL

--- a/tests/wpt/webgl/meta/conformance/textures/webgl_canvas/tex-2d-alpha-alpha-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance/textures/webgl_canvas/tex-2d-alpha-alpha-unsigned_byte.html.ini
@@ -3,6 +3,3 @@
   expected: ERROR
   [Overall test]
     expected: NOTRUN
-
-  [WebGL test #0]
-    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance/textures/webgl_canvas/tex-2d-luminance-luminance-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance/textures/webgl_canvas/tex-2d-luminance-luminance-unsigned_byte.html.ini
@@ -4,52 +4,25 @@
   [Overall test]
     expected: NOTRUN
 
-  [WebGL test #0]
-    expected: FAIL
-
-  [WebGL test #6]
-    expected: FAIL
-
   [WebGL test #11]
-    expected: FAIL
-
-  [WebGL test #12]
     expected: FAIL
 
   [WebGL test #17]
     expected: FAIL
 
-  [WebGL test #18]
-    expected: FAIL
-
   [WebGL test #23]
-    expected: FAIL
-
-  [WebGL test #24]
     expected: FAIL
 
   [WebGL test #29]
     expected: FAIL
 
-  [WebGL test #30]
-    expected: FAIL
-
   [WebGL test #35]
-    expected: FAIL
-
-  [WebGL test #36]
     expected: FAIL
 
   [WebGL test #41]
     expected: FAIL
 
-  [WebGL test #42]
-    expected: FAIL
-
   [WebGL test #47]
-    expected: FAIL
-
-  [WebGL test #48]
     expected: FAIL
 
   [WebGL test #5]
@@ -58,23 +31,47 @@
   [WebGL test #53]
     expected: FAIL
 
-  [WebGL test #54]
-    expected: FAIL
-
   [WebGL test #59]
-    expected: FAIL
-
-  [WebGL test #60]
     expected: FAIL
 
   [WebGL test #65]
     expected: FAIL
 
-  [WebGL test #66]
-    expected: FAIL
-
   [WebGL test #71]
     expected: FAIL
 
-  [WebGL test #72]
+  [WebGL test #4]
+    expected: FAIL
+
+  [WebGL test #10]
+    expected: FAIL
+
+  [WebGL test #16]
+    expected: FAIL
+
+  [WebGL test #22]
+    expected: FAIL
+
+  [WebGL test #28]
+    expected: FAIL
+
+  [WebGL test #34]
+    expected: FAIL
+
+  [WebGL test #40]
+    expected: FAIL
+
+  [WebGL test #46]
+    expected: FAIL
+
+  [WebGL test #52]
+    expected: FAIL
+
+  [WebGL test #58]
+    expected: FAIL
+
+  [WebGL test #64]
+    expected: FAIL
+
+  [WebGL test #70]
     expected: FAIL

--- a/tests/wpt/webgl/meta/conformance/textures/webgl_canvas/tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance/textures/webgl_canvas/tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html.ini
@@ -4,52 +4,25 @@
   [Overall test]
     expected: NOTRUN
 
-  [WebGL test #0]
-    expected: FAIL
-
-  [WebGL test #6]
-    expected: FAIL
-
   [WebGL test #11]
-    expected: FAIL
-
-  [WebGL test #12]
     expected: FAIL
 
   [WebGL test #17]
     expected: FAIL
 
-  [WebGL test #18]
-    expected: FAIL
-
   [WebGL test #23]
-    expected: FAIL
-
-  [WebGL test #24]
     expected: FAIL
 
   [WebGL test #29]
     expected: FAIL
 
-  [WebGL test #30]
-    expected: FAIL
-
   [WebGL test #35]
-    expected: FAIL
-
-  [WebGL test #36]
     expected: FAIL
 
   [WebGL test #41]
     expected: FAIL
 
-  [WebGL test #42]
-    expected: FAIL
-
   [WebGL test #47]
-    expected: FAIL
-
-  [WebGL test #48]
     expected: FAIL
 
   [WebGL test #5]
@@ -58,23 +31,47 @@
   [WebGL test #53]
     expected: FAIL
 
-  [WebGL test #54]
-    expected: FAIL
-
   [WebGL test #59]
-    expected: FAIL
-
-  [WebGL test #60]
     expected: FAIL
 
   [WebGL test #65]
     expected: FAIL
 
-  [WebGL test #66]
-    expected: FAIL
-
   [WebGL test #71]
     expected: FAIL
 
-  [WebGL test #72]
+  [WebGL test #4]
+    expected: FAIL
+
+  [WebGL test #10]
+    expected: FAIL
+
+  [WebGL test #16]
+    expected: FAIL
+
+  [WebGL test #22]
+    expected: FAIL
+
+  [WebGL test #28]
+    expected: FAIL
+
+  [WebGL test #34]
+    expected: FAIL
+
+  [WebGL test #40]
+    expected: FAIL
+
+  [WebGL test #46]
+    expected: FAIL
+
+  [WebGL test #52]
+    expected: FAIL
+
+  [WebGL test #58]
+    expected: FAIL
+
+  [WebGL test #64]
+    expected: FAIL
+
+  [WebGL test #70]
     expected: FAIL

--- a/tests/wpt/webgl/meta/conformance/textures/webgl_canvas/tex-2d-rgb-rgb-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance/textures/webgl_canvas/tex-2d-rgb-rgb-unsigned_byte.html.ini
@@ -4,49 +4,25 @@
   [Overall test]
     expected: NOTRUN
 
-  [WebGL test #0]
-    expected: FAIL
-
   [WebGL test #11]
-    expected: FAIL
-
-  [WebGL test #12]
     expected: FAIL
 
   [WebGL test #17]
     expected: FAIL
 
-  [WebGL test #18]
-    expected: FAIL
-
   [WebGL test #23]
-    expected: FAIL
-
-  [WebGL test #24]
     expected: FAIL
 
   [WebGL test #29]
     expected: FAIL
 
-  [WebGL test #30]
-    expected: FAIL
-
   [WebGL test #35]
-    expected: FAIL
-
-  [WebGL test #36]
     expected: FAIL
 
   [WebGL test #41]
     expected: FAIL
 
-  [WebGL test #42]
-    expected: FAIL
-
   [WebGL test #47]
-    expected: FAIL
-
-  [WebGL test #48]
     expected: FAIL
 
   [WebGL test #5]
@@ -55,26 +31,47 @@
   [WebGL test #53]
     expected: FAIL
 
-  [WebGL test #54]
-    expected: FAIL
-
   [WebGL test #59]
-    expected: FAIL
-
-  [WebGL test #6]
-    expected: FAIL
-
-  [WebGL test #60]
     expected: FAIL
 
   [WebGL test #65]
     expected: FAIL
 
-  [WebGL test #66]
-    expected: FAIL
-
   [WebGL test #71]
     expected: FAIL
 
-  [WebGL test #72]
+  [WebGL test #4]
+    expected: FAIL
+
+  [WebGL test #10]
+    expected: FAIL
+
+  [WebGL test #16]
+    expected: FAIL
+
+  [WebGL test #22]
+    expected: FAIL
+
+  [WebGL test #28]
+    expected: FAIL
+
+  [WebGL test #34]
+    expected: FAIL
+
+  [WebGL test #40]
+    expected: FAIL
+
+  [WebGL test #46]
+    expected: FAIL
+
+  [WebGL test #52]
+    expected: FAIL
+
+  [WebGL test #58]
+    expected: FAIL
+
+  [WebGL test #64]
+    expected: FAIL
+
+  [WebGL test #70]
     expected: FAIL

--- a/tests/wpt/webgl/meta/conformance/textures/webgl_canvas/tex-2d-rgb-rgb-unsigned_short_5_6_5.html.ini
+++ b/tests/wpt/webgl/meta/conformance/textures/webgl_canvas/tex-2d-rgb-rgb-unsigned_short_5_6_5.html.ini
@@ -4,49 +4,25 @@
   [Overall test]
     expected: NOTRUN
 
-  [WebGL test #0]
-    expected: FAIL
-
   [WebGL test #11]
-    expected: FAIL
-
-  [WebGL test #12]
     expected: FAIL
 
   [WebGL test #17]
     expected: FAIL
 
-  [WebGL test #18]
-    expected: FAIL
-
   [WebGL test #23]
-    expected: FAIL
-
-  [WebGL test #24]
     expected: FAIL
 
   [WebGL test #29]
     expected: FAIL
 
-  [WebGL test #30]
-    expected: FAIL
-
   [WebGL test #35]
-    expected: FAIL
-
-  [WebGL test #36]
     expected: FAIL
 
   [WebGL test #41]
     expected: FAIL
 
-  [WebGL test #42]
-    expected: FAIL
-
   [WebGL test #47]
-    expected: FAIL
-
-  [WebGL test #48]
     expected: FAIL
 
   [WebGL test #5]
@@ -55,26 +31,47 @@
   [WebGL test #53]
     expected: FAIL
 
-  [WebGL test #54]
-    expected: FAIL
-
   [WebGL test #59]
-    expected: FAIL
-
-  [WebGL test #6]
-    expected: FAIL
-
-  [WebGL test #60]
     expected: FAIL
 
   [WebGL test #65]
     expected: FAIL
 
-  [WebGL test #66]
-    expected: FAIL
-
   [WebGL test #71]
     expected: FAIL
 
-  [WebGL test #72]
+  [WebGL test #4]
+    expected: FAIL
+
+  [WebGL test #10]
+    expected: FAIL
+
+  [WebGL test #16]
+    expected: FAIL
+
+  [WebGL test #22]
+    expected: FAIL
+
+  [WebGL test #28]
+    expected: FAIL
+
+  [WebGL test #34]
+    expected: FAIL
+
+  [WebGL test #40]
+    expected: FAIL
+
+  [WebGL test #46]
+    expected: FAIL
+
+  [WebGL test #52]
+    expected: FAIL
+
+  [WebGL test #58]
+    expected: FAIL
+
+  [WebGL test #64]
+    expected: FAIL
+
+  [WebGL test #70]
     expected: FAIL

--- a/tests/wpt/webgl/meta/conformance/textures/webgl_canvas/tex-2d-rgba-rgba-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance/textures/webgl_canvas/tex-2d-rgba-rgba-unsigned_byte.html.ini
@@ -4,49 +4,25 @@
   [Overall test]
     expected: NOTRUN
 
-  [WebGL test #0]
-    expected: FAIL
-
   [WebGL test #11]
-    expected: FAIL
-
-  [WebGL test #12]
     expected: FAIL
 
   [WebGL test #17]
     expected: FAIL
 
-  [WebGL test #18]
-    expected: FAIL
-
   [WebGL test #23]
-    expected: FAIL
-
-  [WebGL test #24]
     expected: FAIL
 
   [WebGL test #29]
     expected: FAIL
 
-  [WebGL test #30]
-    expected: FAIL
-
   [WebGL test #35]
-    expected: FAIL
-
-  [WebGL test #36]
     expected: FAIL
 
   [WebGL test #41]
     expected: FAIL
 
-  [WebGL test #42]
-    expected: FAIL
-
   [WebGL test #47]
-    expected: FAIL
-
-  [WebGL test #48]
     expected: FAIL
 
   [WebGL test #5]
@@ -55,26 +31,47 @@
   [WebGL test #53]
     expected: FAIL
 
-  [WebGL test #54]
-    expected: FAIL
-
   [WebGL test #59]
-    expected: FAIL
-
-  [WebGL test #6]
-    expected: FAIL
-
-  [WebGL test #60]
     expected: FAIL
 
   [WebGL test #65]
     expected: FAIL
 
-  [WebGL test #66]
-    expected: FAIL
-
   [WebGL test #71]
     expected: FAIL
 
-  [WebGL test #72]
+  [WebGL test #4]
+    expected: FAIL
+
+  [WebGL test #10]
+    expected: FAIL
+
+  [WebGL test #16]
+    expected: FAIL
+
+  [WebGL test #22]
+    expected: FAIL
+
+  [WebGL test #28]
+    expected: FAIL
+
+  [WebGL test #34]
+    expected: FAIL
+
+  [WebGL test #40]
+    expected: FAIL
+
+  [WebGL test #46]
+    expected: FAIL
+
+  [WebGL test #52]
+    expected: FAIL
+
+  [WebGL test #58]
+    expected: FAIL
+
+  [WebGL test #64]
+    expected: FAIL
+
+  [WebGL test #70]
     expected: FAIL

--- a/tests/wpt/webgl/meta/conformance/textures/webgl_canvas/tex-2d-rgba-rgba-unsigned_short_4_4_4_4.html.ini
+++ b/tests/wpt/webgl/meta/conformance/textures/webgl_canvas/tex-2d-rgba-rgba-unsigned_short_4_4_4_4.html.ini
@@ -4,49 +4,25 @@
   [Overall test]
     expected: NOTRUN
 
-  [WebGL test #0]
-    expected: FAIL
-
   [WebGL test #11]
-    expected: FAIL
-
-  [WebGL test #12]
     expected: FAIL
 
   [WebGL test #17]
     expected: FAIL
 
-  [WebGL test #18]
-    expected: FAIL
-
   [WebGL test #23]
-    expected: FAIL
-
-  [WebGL test #24]
     expected: FAIL
 
   [WebGL test #29]
     expected: FAIL
 
-  [WebGL test #30]
-    expected: FAIL
-
   [WebGL test #35]
-    expected: FAIL
-
-  [WebGL test #36]
     expected: FAIL
 
   [WebGL test #41]
     expected: FAIL
 
-  [WebGL test #42]
-    expected: FAIL
-
   [WebGL test #47]
-    expected: FAIL
-
-  [WebGL test #48]
     expected: FAIL
 
   [WebGL test #5]
@@ -55,26 +31,47 @@
   [WebGL test #53]
     expected: FAIL
 
-  [WebGL test #54]
-    expected: FAIL
-
   [WebGL test #59]
-    expected: FAIL
-
-  [WebGL test #6]
-    expected: FAIL
-
-  [WebGL test #60]
     expected: FAIL
 
   [WebGL test #65]
     expected: FAIL
 
-  [WebGL test #66]
-    expected: FAIL
-
   [WebGL test #71]
     expected: FAIL
 
-  [WebGL test #72]
+  [WebGL test #4]
+    expected: FAIL
+
+  [WebGL test #10]
+    expected: FAIL
+
+  [WebGL test #16]
+    expected: FAIL
+
+  [WebGL test #22]
+    expected: FAIL
+
+  [WebGL test #28]
+    expected: FAIL
+
+  [WebGL test #34]
+    expected: FAIL
+
+  [WebGL test #40]
+    expected: FAIL
+
+  [WebGL test #46]
+    expected: FAIL
+
+  [WebGL test #52]
+    expected: FAIL
+
+  [WebGL test #58]
+    expected: FAIL
+
+  [WebGL test #64]
+    expected: FAIL
+
+  [WebGL test #70]
     expected: FAIL

--- a/tests/wpt/webgl/meta/conformance/textures/webgl_canvas/tex-2d-rgba-rgba-unsigned_short_5_5_5_1.html.ini
+++ b/tests/wpt/webgl/meta/conformance/textures/webgl_canvas/tex-2d-rgba-rgba-unsigned_short_5_5_5_1.html.ini
@@ -4,49 +4,25 @@
   [Overall test]
     expected: NOTRUN
 
-  [WebGL test #0]
-    expected: FAIL
-
   [WebGL test #11]
-    expected: FAIL
-
-  [WebGL test #12]
     expected: FAIL
 
   [WebGL test #17]
     expected: FAIL
 
-  [WebGL test #18]
-    expected: FAIL
-
   [WebGL test #23]
-    expected: FAIL
-
-  [WebGL test #24]
     expected: FAIL
 
   [WebGL test #29]
     expected: FAIL
 
-  [WebGL test #30]
-    expected: FAIL
-
   [WebGL test #35]
-    expected: FAIL
-
-  [WebGL test #36]
     expected: FAIL
 
   [WebGL test #41]
     expected: FAIL
 
-  [WebGL test #42]
-    expected: FAIL
-
   [WebGL test #47]
-    expected: FAIL
-
-  [WebGL test #48]
     expected: FAIL
 
   [WebGL test #5]
@@ -55,26 +31,47 @@
   [WebGL test #53]
     expected: FAIL
 
-  [WebGL test #54]
-    expected: FAIL
-
   [WebGL test #59]
-    expected: FAIL
-
-  [WebGL test #6]
-    expected: FAIL
-
-  [WebGL test #60]
     expected: FAIL
 
   [WebGL test #65]
     expected: FAIL
 
-  [WebGL test #66]
-    expected: FAIL
-
   [WebGL test #71]
     expected: FAIL
 
-  [WebGL test #72]
+  [WebGL test #4]
+    expected: FAIL
+
+  [WebGL test #10]
+    expected: FAIL
+
+  [WebGL test #16]
+    expected: FAIL
+
+  [WebGL test #22]
+    expected: FAIL
+
+  [WebGL test #28]
+    expected: FAIL
+
+  [WebGL test #34]
+    expected: FAIL
+
+  [WebGL test #40]
+    expected: FAIL
+
+  [WebGL test #46]
+    expected: FAIL
+
+  [WebGL test #52]
+    expected: FAIL
+
+  [WebGL test #58]
+    expected: FAIL
+
+  [WebGL test #64]
+    expected: FAIL
+
+  [WebGL test #70]
     expected: FAIL

--- a/tests/wpt/webgl/meta/conformance2/offscreencanvas/context-creation.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/offscreencanvas/context-creation.html.ini
@@ -1,4 +1,0 @@
-[context-creation.html]
-  expected: ERROR
-  [WebGL test #0]
-    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance2/offscreencanvas/methods-2-worker.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/offscreencanvas/methods-2-worker.html.ini
@@ -1,4 +1,3 @@
 [methods-2-worker.html]
-  expected: ERROR
   [WebGL test #0]
     expected: FAIL

--- a/tests/wpt/webgl/meta/conformance2/offscreencanvas/methods-2.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/offscreencanvas/methods-2.html.ini
@@ -1,4 +1,3 @@
 [methods-2.html]
-  expected: ERROR
   [WebGL test #0]
     expected: FAIL


### PR DESCRIPTION
fix unrecognized type error on `OffscreenCanvas`

Testing: existing WPT:
- `tests/wpt/webgl/tests/conformance/offscreencanvas`
- `tests/wpt/webgl/tests/conformance2/offscreencanvas`

Fixes: #43540

