### PR TITLE
script: Return zero for naviagationStart, as per spec

### DIFF
--- a/components/script/dom/performance/performance.rs
+++ b/components/script/dom/performance/performance.rs
@@ -481,7 +481,7 @@ impl Performance {
 
         // Step 2. If name is navigationStart, return 0.
         if name == "navigationStart" {
-            return Ok(self.time_origin);
+            return Ok(CrossProcessInstant::epoch());
         }
 
         // Step 3. Let startTime be the value of navigationStart in the PerformanceTiming interface.


### PR DESCRIPTION
As per [spec](https://w3c.github.io/user-timing/#convert-a-name-to-a-timestamp): 
`If name is navigationStart, return 0.`

Testing: Existing WPT Tests Passed