### PR TITLE
script: Simplify the way that layout flushes shadow root stylesheets

### DIFF
--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -970,8 +970,7 @@ impl LayoutThread {
                 .force_stylesheet_origins_dirty(Origin::Author.into());
         }
 
-        // Flush shadow roots stylesheets if dirty.
-        document.flush_shadow_roots_stylesheets(&mut self.stylist, guards.author);
+        document.flush_shadow_root_stylesheets_if_necessary(&mut self.stylist, guards.author);
 
         self.stylist.flush(guards)
     }

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -64,10 +64,11 @@ use style::attr::AttrValue;
 use style::context::QuirksMode;
 use style::invalidation::element::restyle_hints::RestyleHint;
 use style::selector_parser::Snapshot;
-use style::shared_lock::SharedRwLock as StyleSharedRwLock;
+use style::shared_lock::{SharedRwLock as StyleSharedRwLock, SharedRwLockReadGuard};
 use style::str::{split_html_space_chars, str_join};
 use style::stylesheet_set::DocumentStylesheetSet;
 use style::stylesheets::{Origin, OriginSet, Stylesheet};
+use style::stylist::Stylist;
 use stylo_atoms::Atom;
 use time::Duration as TimeDuration;
 use url::{Host, Position};
@@ -3357,29 +3358,17 @@ impl<'dom> LayoutDom<'dom, Document> {
     }
 
     #[inline]
-    pub(crate) fn shadow_roots(self) -> Vec<LayoutDom<'dom, ShadowRoot>> {
-        // FIXME(nox): We should just return a
-        // &'dom HashSet<LayoutDom<'dom, ShadowRoot>> here but not until
-        // I rework the ToLayout trait as mentioned in
-        // LayoutDom::to_layout_slice.
-        unsafe {
-            self.unsafe_get()
-                .shadow_roots
-                .borrow_for_layout()
-                .iter()
-                .map(|sr| sr.to_layout())
-                .collect()
-        }
+    pub(crate) fn flush_shadow_root_stylesheets_if_necessary(
+        self,
+        stylist: &mut Stylist,
+        guard: &SharedRwLockReadGuard,
+    ) {
+        (*self.unsafe_get()).flush_shadow_root_stylesheets_if_necessary_for_layout(stylist, guard)
     }
 
     #[inline]
     pub(crate) fn shadow_roots_styles_changed(self) -> bool {
         self.unsafe_get().shadow_roots_styles_changed.get()
-    }
-
-    #[inline]
-    pub(crate) fn flush_shadow_roots_stylesheets(self) {
-        (*self.unsafe_get()).flush_shadow_roots_stylesheets()
     }
 
     pub(crate) fn elements_with_id(self, id: &Atom) -> &[LayoutDom<'dom, Element>] {
@@ -4149,9 +4138,21 @@ impl Document {
         self.shadow_roots_styles_changed.get()
     }
 
-    pub(crate) fn flush_shadow_roots_stylesheets(&self) {
+    pub(crate) fn flush_shadow_root_stylesheets_if_necessary_for_layout(
+        &self,
+        stylist: &mut Stylist,
+        guard: &SharedRwLockReadGuard,
+    ) {
         if !self.shadow_roots_styles_changed.get() {
             return;
+        }
+        #[expect(unsafe_code)]
+        unsafe {
+            for shadow_root in self.shadow_roots.borrow_for_layout().iter() {
+                shadow_root
+                    .to_layout()
+                    .flush_stylesheets_for_layout(stylist, guard);
+            }
         }
         self.shadow_roots_styles_changed.set(false);
     }

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -662,11 +662,14 @@ impl<'dom> LayoutDom<'dom, ShadowRoot> {
     // probably be revisited.
     #[inline]
     #[expect(unsafe_code)]
-    pub(crate) unsafe fn flush_stylesheets(
+    pub(crate) unsafe fn flush_stylesheets_for_layout(
         self,
         stylist: &mut Stylist,
         guard: &SharedRwLockReadGuard,
     ) {
+        unsafe {
+            debug_assert!(self.upcast::<Node>().get_flag(NodeFlags::IS_CONNECTED));
+        };
         let author_styles = unsafe { self.unsafe_get().author_styles.borrow_mut_for_layout() };
         if author_styles.stylesheets.dirty() {
             author_styles.flush(stylist, guard);

--- a/components/script/layout_dom/servo_dangerous_style_document.rs
+++ b/components/script/layout_dom/servo_dangerous_style_document.rs
@@ -15,11 +15,7 @@ use style::values::AtomIdent;
 
 use crate::dom::bindings::root::LayoutDom;
 use crate::dom::document::Document;
-use crate::dom::node::{Node, NodeFlags};
-use crate::layout_dom::{
-    ServoDangerousStyleElement, ServoDangerousStyleNode, ServoDangerousStyleShadowRoot,
-    ServoLayoutElement,
-};
+use crate::layout_dom::{ServoDangerousStyleElement, ServoDangerousStyleNode, ServoLayoutElement};
 
 /// A wrapper around documents that ensures layout can only ever access safe properties.
 ///
@@ -92,39 +88,13 @@ impl<'dom> ServoDangerousStyleDocument<'dom> {
         self.document.style_shared_lock()
     }
 
-    fn shadow_roots(&self) -> Vec<ServoDangerousStyleShadowRoot<'_>> {
-        #[expect(unsafe_code)]
-        unsafe {
-            self.document
-                .shadow_roots()
-                .iter()
-                .map(|shadow_root| {
-                    debug_assert!(
-                        shadow_root
-                            .upcast::<Node>()
-                            .get_flag(NodeFlags::IS_CONNECTED)
-                    );
-                    (*shadow_root).into()
-                })
-                .collect()
-        }
-    }
-
     /// Flush the the stylesheets of all descendant shadow roots.
-    pub fn flush_shadow_roots_stylesheets(
+    pub fn flush_shadow_root_stylesheets_if_necessary(
         &self,
         stylist: &mut Stylist,
         guard: &StyleSharedRwLockReadGuard,
     ) {
-        #[expect(unsafe_code)]
-        unsafe {
-            if !self.document.shadow_roots_styles_changed() {
-                return;
-            }
-            self.document.flush_shadow_roots_stylesheets();
-            for shadow_root in self.shadow_roots() {
-                shadow_root.flush_stylesheets(stylist, guard);
-            }
-        }
+        self.document
+            .flush_shadow_root_stylesheets_if_necessary(stylist, guard);
     }
 }

--- a/components/script/layout_dom/servo_dangerous_style_shadow_root.rs
+++ b/components/script/layout_dom/servo_dangerous_style_shadow_root.rs
@@ -7,8 +7,7 @@
 use std::fmt;
 
 use style::dom::TShadowRoot;
-use style::shared_lock::SharedRwLockReadGuard as StyleSharedRwLockReadGuard;
-use style::stylist::{CascadeData, Stylist};
+use style::stylist::CascadeData;
 
 use crate::dom::bindings::root::LayoutDom;
 use crate::dom::shadowroot::ShadowRoot;
@@ -57,21 +56,6 @@ impl<'dom> TShadowRoot for ServoDangerousStyleShadowRoot<'dom> {
 }
 
 impl<'dom> ServoDangerousStyleShadowRoot<'dom> {
-    /// Flush the stylesheets for the underlying shadow root.
-    ///
-    /// # Safety
-    ///
-    /// This modifies a DOM object, so should care should be taken that only one
-    /// thread has a reference to this object.
-    #[expect(unsafe_code)]
-    pub(crate) unsafe fn flush_stylesheets(
-        &self,
-        stylist: &mut Stylist,
-        guard: &StyleSharedRwLockReadGuard,
-    ) {
-        unsafe { self.shadow_root.flush_stylesheets(stylist, guard) }
-    }
-
     /// Whether or not this [`ServoDangerousStyleShadowRoot`] is the root
     /// of a user agent widget.
     pub fn is_ua_widget(&self) -> bool {


### PR DESCRIPTION
This change is a minor cleanup of the way that layout flushes the
stylesheets of shadow roots. This avoids exposing so many public methods
in our and gradually to stop using Stylo's `TShadowRoot` in layout
entirely.

Testing: This should not change behavior, so should be covered by existing tests.
