### PR TITLE
net: Remove duplicate `CoreResourceMsg::GetCookiesDataForUrl`

### DIFF
--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -574,15 +574,6 @@ impl ResourceChannelManager {
                     .sw_managers
                     .insert(origin, mediator_chan);
             },
-            CoreResourceMsg::GetCookiesDataForUrl(url, consumer, source) => {
-                let mut cookie_jar = http_state.cookie_jar.write();
-                cookie_jar.remove_expired_cookies_for_url(&url);
-                let cookies = cookie_jar
-                    .cookies_data_for_url(&url, source)
-                    .map(Serde)
-                    .collect();
-                consumer.send(cookies).unwrap();
-            },
             CoreResourceMsg::ListCookies(sender) => {
                 let mut cookie_jar = http_state.cookie_jar.write();
                 cookie_jar.remove_all_expired_cookies();

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -25,9 +25,7 @@ use js::realm::CurrentRealm;
 use js::rust::wrappers::{JS_CallFunctionName, JS_GetProperty, JS_HasOwnProperty, JS_TypeOfValue};
 use js::rust::{Handle, HandleObject, HandleValue, IdVector, ToString};
 use net_traits::CookieSource::{HTTP, NonHTTP};
-use net_traits::CoreResourceMsg::{
-    DeleteCookie, DeleteCookies, GetCookiesDataForUrl, SetCookieForUrl,
-};
+use net_traits::CoreResourceMsg::{DeleteCookie, DeleteCookies, GetCookiesForUrl, SetCookieForUrl};
 use script_bindings::codegen::GenericBindings::ShadowRootBinding::ShadowRootMethods;
 use script_bindings::conversions::is_array_like;
 use script_bindings::num::Finite;
@@ -1414,7 +1412,7 @@ pub(crate) fn handle_get_cookies(
                         .window()
                         .as_global_scope()
                         .resource_threads()
-                        .send(GetCookiesDataForUrl(url, sender, NonHTTP));
+                        .send(GetCookiesForUrl(url, sender, NonHTTP));
                     Ok(receiver.recv().unwrap())
                 },
                 None => Ok(Vec::new()),
@@ -1441,7 +1439,7 @@ pub(crate) fn handle_get_cookie(
                         .window()
                         .as_global_scope()
                         .resource_threads()
-                        .send(GetCookiesDataForUrl(url, sender, NonHTTP));
+                        .send(GetCookiesForUrl(url, sender, NonHTTP));
                     let cookies = receiver.recv().unwrap();
                     Ok(cookies
                         .into_iter()

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -663,12 +663,6 @@ pub enum CoreResourceMsg {
         GenericSender<Vec<Serde<Cookie<'static>>>>,
         CookieSource,
     ),
-    /// Get a cookie by name for a given originating URL
-    GetCookiesDataForUrl(
-        ServoUrl,
-        GenericSender<Vec<Serde<Cookie<'static>>>>,
-        CookieSource,
-    ),
     GetCookieDataForUrlAsync(CookieStoreId, ServoUrl, Option<String>),
     GetAllCookieDataForUrlAsync(CookieStoreId, ServoUrl, Option<String>),
     DeleteCookiesForSites(Vec<String>, GenericSender<()>),


### PR DESCRIPTION
In https://github.com/servo/servo/pull/43600, we introduce the new `CoreResourceMsg::GetCookiesForUrl`.
However after some updates, it is exactly the same with an existing one `CoreResourceMsg::GetCookiesDataForUrl` which is used by `webdriver`.
This PR removes the duplication.
