### PR TITLE
API: document which Preferences are experimental or enabled by default

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -83,6 +83,15 @@ macro_rules! pref {
 }
 
 /// The set of global preferences supported by Servo.
+///
+/// Each preference can be in one of three states depending on its default value:
+/// - **Stable**: enabled by default for all users.
+/// - **Experimental**: disabled by default, but enabled in servoshell's experimental mode
+///   via the `--experimental` flag.
+/// - **Unstable**: disabled by default in all modes.
+///
+/// For a full overview of which preferences are experimental, see the
+/// [experimental features documentation](https://book.servo.org/design-documentation/experimental-features.html).
 #[derive(Clone, Deserialize, Serialize, ServoPreferences)]
 pub struct Preferences {
     pub fonts_default: String,

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -84,11 +84,11 @@ macro_rules! pref {
 
 /// The set of global preferences supported by Servo.
 ///
-/// Each preference can be in one of three states depending on its default value:
-/// - **Stable**: enabled by default for all users.
-/// - **Experimental**: disabled by default, but enabled in servoshell's experimental mode
-///   via the `--experimental` flag.
-/// - **Unstable**: disabled by default in all modes.
+/// Each preference has a default value that determines its initial state. These defaults
+/// fall into roughly three categories:
+/// - **Stable**: enabled by default.
+/// - **Experimental**: disabled by default, but intended to be enabled for experimental use.
+/// - **Unstable**: disabled by default.
 ///
 /// For a full overview of which preferences are experimental, see the
 /// [experimental features documentation](https://book.servo.org/design-documentation/experimental-features.html).

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -25,8 +25,7 @@ use url::Url;
 
 use crate::VERSION;
 
-/// Preferences enabled when servoshell is launched with the `--experimental` flag
-/// (`--enable-experimental-web-platform-features`).
+/// Preferences enabled when servoshell is launched with the `--enable-experimental-web-platform-features` flag.
 ///
 /// These preferences are disabled by default but activated in experimental mode.
 /// For more details, see the

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -25,6 +25,12 @@ use url::Url;
 
 use crate::VERSION;
 
+/// Preferences enabled when servoshell is launched with the `--experimental` flag
+/// (`--enable-experimental-web-platform-features`).
+///
+/// These preferences are disabled by default but activated in experimental mode.
+/// For more details, see the
+/// [experimental features documentation](https://book.servo.org/design-documentation/experimental-features.html).
 pub(crate) static EXPERIMENTAL_PREFS: &[&str] = &[
     "dom_async_clipboard_enabled",
     "dom_exec_command_enabled",


### PR DESCRIPTION
Referred users to ```https://book.servo.org/design-documentation/experimental-features.html``` documentation for ```Preferences``` and ```EXPERIMENTAL_PREFS```

Testing: No testing required, build was successful.
Fixes: #43706