### PR TITLE
devtools: Implement showing `ArrayItems` in preview

### DIFF
--- a/components/default-resources/resources/debugger.js
+++ b/components/default-resources/resources/debugger.js
@@ -196,14 +196,35 @@ previewers.Function.push(function FunctionPreviewer(obj, depth) {
 });
 
 // <https://searchfox.org/mozilla-central/source/devtools/server/actors/object/previewers.js#172>
-// TODO: Add implementation for showing Array items
 previewers.Array.push(function ArrayPreviewer(obj, depth) {
     const lengthDescriptor = obj.getOwnPropertyDescriptor("length");
     const length = lengthDescriptor ? lengthDescriptor.value : 0;
 
+    if (depth > 1) {
+        return {
+            kind: "ArrayLike",
+            arrayLength: length,
+        };
+    }
+
+    const items = [];
+    for (let i = 0; i < length; i++) {
+        try {
+            const desc = obj.getOwnPropertyDescriptor(i);
+            if (desc && desc.value !== undefined) {
+                const grip = createValueGrip(desc.value, depth);
+                delete grip.preview;
+                items.push(grip);
+            }
+        } catch (e) {
+            // For now skip properties that throw on access
+        }
+    }
+
     return {
         kind: "ArrayLike",
         arrayLength: length,
+        items: items,
     };
 });
 

--- a/components/devtools/actors/object.rs
+++ b/components/devtools/actors/object.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use devtools_traits::{ObjectPreview, PropertyDescriptor};
+use devtools_traits::{DebuggerValue, ObjectPreview, PropertyDescriptor};
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
@@ -101,11 +101,45 @@ impl Actor for ObjectActor {
     ) -> Result<(), ActorError> {
         match msg_type {
             "enumProperties" => {
-                let properties = self
-                    .preview
-                    .as_ref()
-                    .and_then(|preview| preview.own_properties.clone())
-                    .unwrap_or_default();
+                let properties = self.preview.as_ref().map_or_else(Vec::new, |preview| {
+                    if preview.kind == "ArrayLike" {
+                        // For arrays, convert items to indexed properties
+                        // <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor#description>
+                        let mut props: Vec<PropertyDescriptor> = preview
+                            .items
+                            .as_ref()
+                            .map(|items| {
+                                items
+                                    .iter()
+                                    .enumerate()
+                                    .map(|(index, value)| PropertyDescriptor {
+                                        name: index.to_string(),
+                                        value: value.clone(),
+                                        configurable: true,
+                                        enumerable: true,
+                                        writable: true,
+                                        is_accessor: false,
+                                    })
+                                    .collect()
+                            })
+                            .unwrap_or_default();
+                        // Add length property
+                        if let Some(length) = preview.array_length {
+                            // <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/length#value>
+                            props.push(PropertyDescriptor {
+                                name: "length".to_string(),
+                                value: DebuggerValue::NumberValue(length as f64),
+                                configurable: false,
+                                enumerable: false,
+                                writable: true,
+                                is_accessor: false,
+                            });
+                        }
+                        props
+                    } else {
+                        preview.own_properties.clone().unwrap_or_default()
+                    }
+                });
                 let property_iterator_name = PropertyIteratorActor::register(registry, properties);
                 let property_iterator_actor =
                     registry.find::<PropertyIteratorActor>(&property_iterator_name);
@@ -207,9 +241,22 @@ impl ActorEncode<Value> for ObjectActor {
         };
         let mut preview_map = Map::new();
 
+        preview_map.insert("kind".to_owned(), Value::String(preview.kind.clone()));
+
         if preview.kind == "ArrayLike" {
             if let Some(length) = preview.array_length {
                 preview_map.insert("length".to_owned(), Value::Number(length.into()));
+                m.insert(
+                    "ownPropertyLength".to_owned(),
+                    Value::Number((length + 1).into()),
+                );
+            }
+            if let Some(ref items) = preview.items {
+                let items_json: Vec<Value> = items
+                    .iter()
+                    .map(|item| debugger_value_to_json(registry, item.clone()))
+                    .collect();
+                preview_map.insert("items".to_owned(), Value::Array(items_json));
             }
         } else {
             if let Some(ref props) = preview.own_properties {
@@ -232,7 +279,6 @@ impl ActorEncode<Value> for ObjectActor {
                 m.insert("ownPropertyLength".to_owned(), Value::Number(length.into()));
             }
         }
-        preview_map.insert("kind".to_owned(), Value::String(preview.kind));
 
         // Function-specific metadata
         if let Some(function) = preview.function {

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -320,6 +320,7 @@ fn console_object_from_handle_value(
         own_properties: Some(own_properties),
         function: None,
         array_length: None,
+        items: None,
     })
 }
 

--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -640,6 +640,12 @@ fn parse_object_preview(preview: &ObjectPreview) -> devtools_traits::ObjectPrevi
                 is_generator: fields.isGenerator,
             }),
         array_length: preview.arrayLength,
+        items: preview.items.as_ref().map(|items| {
+            items
+                .iter()
+                .map(|item| parse_debugger_value(item, None))
+                .collect()
+        }),
     }
 }
 

--- a/components/script_bindings/webidls/DebuggerEvalEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerEvalEvent.webidl
@@ -45,6 +45,7 @@ dictionary ObjectPreview {
     sequence<PropertyDescriptor> ownProperties;
     unsigned long ownPropertiesLength;
     unsigned long arrayLength;
+    sequence<DebuggerValue> items;
     FunctionPreview function;
 };
 

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -159,6 +159,7 @@ pub struct ObjectPreview {
     pub own_properties_length: Option<u32>,
     pub function: Option<FunctionPreview>,
     pub array_length: Option<u32>,
+    pub items: Option<Vec<DebuggerValue>>,
 }
 
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]


### PR DESCRIPTION
implement showing `ArrayItems` in preview

Testing: Current tests are passing.
Fixes: Part of #36027 

<img width="1146" height="913" alt="image" src="https://github.com/user-attachments/assets/af5b009c-5983-4949-a30b-39ea32b24d20" />
