### PR TITLE
devtools: Do not use `MAX_ITEMS` in object preview

### DIFF
--- a/components/default-resources/resources/debugger.js
+++ b/components/default-resources/resources/debugger.js
@@ -72,9 +72,6 @@ addEventListener("addDebuggee", event => {
     }
 });
 
-// Maximum number of properties to include in preview
-// <https://searchfox.org/firefox-main/source/devtools/server/actors/object/previewers.js#29>
-const OBJECT_PREVIEW_MAX_ITEMS = 10;
 
 // <https://searchfox.org/mozilla-central/source/devtools/server/actors/object/previewers.js#80>
 const previewers = {
@@ -123,7 +120,7 @@ function createValueGrip(value, depth = 0) {
 
 // Extract own properties from a debuggee object
 // <https://firefox-source-docs.mozilla.org/devtools-user/debugger-api/debugger.object/index.html#function-properties-of-the-debugger-object-prototype>
-function extractOwnProperties(obj, depth, maxItems = OBJECT_PREVIEW_MAX_ITEMS) {
+function extractOwnProperties(obj, depth) {
     const ownProperties = [];
     let totalLength = 0;
 
@@ -135,9 +132,7 @@ function extractOwnProperties(obj, depth, maxItems = OBJECT_PREVIEW_MAX_ITEMS) {
         return { ownProperties, ownPropertiesLength: 0 };
     }
 
-    let count = 0;
     for (const name of names) {
-        if (count >= maxItems) break;
         try {
             const desc = obj.getOwnPropertyDescriptor(name);
             if (desc) {
@@ -162,7 +157,6 @@ function extractOwnProperties(obj, depth, maxItems = OBJECT_PREVIEW_MAX_ITEMS) {
                 }
 
                 ownProperties.push(prop);
-                count++;
             }
         } catch (e) {
             // For now skip properties that throw on access


### PR DESCRIPTION
Do not use `OBJECT_PREVIEW_MAX_ITEMS` in object preview(same as array). With this it matches the Firefox behavior and shows the complete object.

Testing: Current tests are passing.
Fixes: part of #36027 
<img width="1174" height="1056" alt="image" src="https://github.com/user-attachments/assets/3b1a738d-4fbe-4aee-a918-88a699d6be14" />
