### PR TITLE
script: Pass down &mut JSContext/CurrentRealm to AudioContext methods

### DIFF
--- a/components/script/dom/audio/audiocontext.rs
+++ b/components/script/dom/audio/audiocontext.rs
@@ -84,10 +84,10 @@ impl AudioContext {
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn new(
+        cx: &mut js::context::JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         options: &AudioContextOptions,
-        cx: &mut js::context::JSContext,
     ) -> Fallible<DomRoot<AudioContext>> {
         let pipeline_id = window.pipeline_id();
         let context = AudioContext::new_inherited(options, pipeline_id)?;
@@ -117,7 +117,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
         proto: Option<HandleObject>,
         options: &AudioContextOptions,
     ) -> Fallible<DomRoot<AudioContext>> {
-        AudioContext::new(window, proto, options, cx)
+        AudioContext::new(cx, window, proto, options)
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-audiocontext-baselatency>
@@ -270,7 +270,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
     ) -> Fallible<DomRoot<MediaStreamAudioSourceNode>> {
         let global = self.global();
         let window = global.as_window();
-        MediaStreamAudioSourceNode::new(window, self, stream, cx)
+        MediaStreamAudioSourceNode::new(cx, window, self, stream)
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-audiocontext-createmediastreamtracksource>
@@ -281,7 +281,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
     ) -> Fallible<DomRoot<MediaStreamTrackAudioSourceNode>> {
         let global = self.global();
         let window = global.as_window();
-        MediaStreamTrackAudioSourceNode::new(window, self, track, cx)
+        MediaStreamTrackAudioSourceNode::new(cx, window, self, track)
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-audiocontext-createmediastreamdestination>
@@ -291,7 +291,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
     ) -> Fallible<DomRoot<MediaStreamAudioDestinationNode>> {
         let global = self.global();
         let window = global.as_window();
-        MediaStreamAudioDestinationNode::new(window, self, &AudioNodeOptions::empty(), cx)
+        MediaStreamAudioDestinationNode::new(cx, window, self, &AudioNodeOptions::empty())
     }
 }
 

--- a/components/script/dom/audio/audiocontext.rs
+++ b/components/script/dom/audio/audiocontext.rs
@@ -5,6 +5,7 @@
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::realm::CurrentRealm;
 use js::rust::HandleObject;
 use servo_base::id::PipelineId;
 use servo_media::audio::context::{LatencyCategory, ProcessingState, RealTimeAudioContextOptions};
@@ -33,7 +34,6 @@ use crate::dom::mediastream::MediaStream;
 use crate::dom::mediastreamtrack::MediaStreamTrack;
 use crate::dom::promise::Promise;
 use crate::dom::window::Window;
-use crate::realms::InRealm;
 use crate::script_runtime::CanGc;
 
 #[dom_struct]
@@ -140,19 +140,19 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-audiocontext-suspend>
-    fn Suspend(&self, comp: InRealm, can_gc: CanGc) -> Rc<Promise> {
+    fn Suspend(&self, cx: &mut CurrentRealm) -> Rc<Promise> {
         // Step 1.
-        let promise = Promise::new_in_current_realm(comp, can_gc);
+        let promise = Promise::new_in_realm(cx);
 
         // Step 2.
         if self.context.control_thread_state() == ProcessingState::Closed {
-            promise.reject_error(Error::InvalidState(None), can_gc);
+            promise.reject_error(Error::InvalidState(None), CanGc::from_cx(cx));
             return promise;
         }
 
         // Step 3.
         if self.context.State() == AudioContextState::Suspended {
-            promise.resolve_native(&(), can_gc);
+            promise.resolve_native(&(), CanGc::from_cx(cx));
             return promise;
         }
 
@@ -163,11 +163,11 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
                 let base_context = Trusted::new(&self.context);
                 let context = Trusted::new(self);
                 self.global().task_manager().dom_manipulation_task_source().queue(
-                    task!(suspend_ok: move || {
+                    task!(suspend_ok: move |cx| {
                         let base_context = base_context.root();
                         let context = context.root();
                         let promise = trusted_promise.root();
-                        promise.resolve_native(&(), CanGc::deprecated_note());
+                        promise.resolve_native(&(), CanGc::from_cx(cx));
                         if base_context.State() != AudioContextState::Suspended {
                             base_context.set_state_attribute(AudioContextState::Suspended);
                             context.global().task_manager().dom_manipulation_task_source().queue_simple_event(
@@ -184,9 +184,9 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
                 self.global()
                     .task_manager()
                     .dom_manipulation_task_source()
-                    .queue(task!(suspend_error: move || {
+                    .queue(task!(suspend_error: move |cx| {
                         let promise = trusted_promise.root();
-                        promise.reject_error(Error::Type(c"Something went wrong".to_owned()), CanGc::deprecated_note());
+                        promise.reject_error(Error::Type(c"Something went wrong".to_owned()), CanGc::from_cx(cx));
                     }));
             },
         };
@@ -196,19 +196,19 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-audiocontext-close>
-    fn Close(&self, comp: InRealm, can_gc: CanGc) -> Rc<Promise> {
+    fn Close(&self, cx: &mut CurrentRealm) -> Rc<Promise> {
         // Step 1.
-        let promise = Promise::new_in_current_realm(comp, can_gc);
+        let promise = Promise::new_in_realm(cx);
 
         // Step 2.
         if self.context.control_thread_state() == ProcessingState::Closed {
-            promise.reject_error(Error::InvalidState(None), can_gc);
+            promise.reject_error(Error::InvalidState(None), CanGc::from_cx(cx));
             return promise;
         }
 
         // Step 3.
         if self.context.State() == AudioContextState::Closed {
-            promise.resolve_native(&(), can_gc);
+            promise.resolve_native(&(), CanGc::from_cx(cx));
             return promise;
         }
 
@@ -219,11 +219,11 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
                 let base_context = Trusted::new(&self.context);
                 let context = Trusted::new(self);
                 self.global().task_manager().dom_manipulation_task_source().queue(
-                    task!(suspend_ok: move || {
+                    task!(suspend_ok: move |cx| {
                         let base_context = base_context.root();
                         let context = context.root();
                         let promise = trusted_promise.root();
-                        promise.resolve_native(&(), CanGc::deprecated_note());
+                        promise.resolve_native(&(), CanGc::from_cx(cx));
                         if base_context.State() != AudioContextState::Closed {
                             base_context.set_state_attribute(AudioContextState::Closed);
                             context.global().task_manager().dom_manipulation_task_source().queue_simple_event(
@@ -240,9 +240,9 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
                 self.global()
                     .task_manager()
                     .dom_manipulation_task_source()
-                    .queue(task!(suspend_error: move || {
+                    .queue(task!(suspend_error: move |cx| {
                         let promise = trusted_promise.root();
-                        promise.reject_error(Error::Type(c"Something went wrong".to_owned()), CanGc::deprecated_note());
+                        promise.reject_error(Error::Type(c"Something went wrong".to_owned()), CanGc::from_cx(cx));
                     }));
             },
         };
@@ -265,33 +265,33 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
     /// <https://webaudio.github.io/web-audio-api/#dom-audiocontext-createmediastreamsource>
     fn CreateMediaStreamSource(
         &self,
+        cx: &mut js::context::JSContext,
         stream: &MediaStream,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<MediaStreamAudioSourceNode>> {
         let global = self.global();
         let window = global.as_window();
-        MediaStreamAudioSourceNode::new(window, self, stream, can_gc)
+        MediaStreamAudioSourceNode::new(window, self, stream, cx)
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-audiocontext-createmediastreamtracksource>
     fn CreateMediaStreamTrackSource(
         &self,
+        cx: &mut js::context::JSContext,
         track: &MediaStreamTrack,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<MediaStreamTrackAudioSourceNode>> {
         let global = self.global();
         let window = global.as_window();
-        MediaStreamTrackAudioSourceNode::new(window, self, track, can_gc)
+        MediaStreamTrackAudioSourceNode::new(window, self, track, cx)
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-audiocontext-createmediastreamdestination>
     fn CreateMediaStreamDestination(
         &self,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) -> Fallible<DomRoot<MediaStreamAudioDestinationNode>> {
         let global = self.global();
         let window = global.as_window();
-        MediaStreamAudioDestinationNode::new(window, self, &AudioNodeOptions::empty(), can_gc)
+        MediaStreamAudioDestinationNode::new(window, self, &AudioNodeOptions::empty(), cx)
     }
 }
 

--- a/components/script/dom/audio/audiocontext.rs
+++ b/components/script/dom/audio/audiocontext.rs
@@ -27,7 +27,7 @@ use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::refcounted::{Trusted, TrustedPromise};
-use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object_with_proto};
+use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object_with_proto_and_cx};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::html::htmlmediaelement::HTMLMediaElement;
 use crate::dom::mediastream::MediaStream;
@@ -87,11 +87,11 @@ impl AudioContext {
         window: &Window,
         proto: Option<HandleObject>,
         options: &AudioContextOptions,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) -> Fallible<DomRoot<AudioContext>> {
         let pipeline_id = window.pipeline_id();
         let context = AudioContext::new_inherited(options, pipeline_id)?;
-        let context = reflect_dom_object_with_proto(Box::new(context), window, proto, can_gc);
+        let context = reflect_dom_object_with_proto_and_cx(Box::new(context), window, proto, cx);
         context.resume();
         Ok(context)
     }
@@ -112,12 +112,12 @@ impl AudioContext {
 impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
     /// <https://webaudio.github.io/web-audio-api/#AudioContext-constructors>
     fn Constructor(
+        cx: &mut js::context::JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         options: &AudioContextOptions,
     ) -> Fallible<DomRoot<AudioContext>> {
-        AudioContext::new(window, proto, options, can_gc)
+        AudioContext::new(window, proto, options, cx)
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-audiocontext-baselatency>

--- a/components/script/dom/audio/mediastreamaudiodestinationnode.rs
+++ b/components/script/dom/audio/mediastreamaudiodestinationnode.rs
@@ -16,11 +16,10 @@ use crate::dom::bindings::codegen::Bindings::AudioNodeBinding::{
 use crate::dom::bindings::codegen::Bindings::MediaStreamAudioDestinationNodeBinding::MediaStreamAudioDestinationNodeMethods;
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::inheritance::Castable;
-use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object_with_proto};
+use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object_with_proto_and_cx};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::mediastream::MediaStream;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct MediaStreamAudioDestinationNode {
@@ -33,11 +32,11 @@ impl MediaStreamAudioDestinationNode {
     pub(crate) fn new_inherited(
         context: &AudioContext,
         options: &AudioNodeOptions,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) -> Fallible<MediaStreamAudioDestinationNode> {
         let media = ServoMedia::get();
         let (socket, id) = media.create_stream_and_socket(MediaStreamType::Audio);
-        let stream = MediaStream::new_single(&context.global(), id, MediaStreamType::Audio, can_gc);
+        let stream = MediaStream::new_single(&context.global(), id, MediaStreamType::Audio, cx);
         let node_options = options.unwrap_or(
             2,
             ChannelCountMode::Explicit,
@@ -60,9 +59,9 @@ impl MediaStreamAudioDestinationNode {
         window: &Window,
         context: &AudioContext,
         options: &AudioNodeOptions,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) -> Fallible<DomRoot<MediaStreamAudioDestinationNode>> {
-        Self::new_with_proto(window, None, context, options, can_gc)
+        Self::new_with_proto(window, None, context, options, cx)
     }
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
@@ -71,14 +70,14 @@ impl MediaStreamAudioDestinationNode {
         proto: Option<HandleObject>,
         context: &AudioContext,
         options: &AudioNodeOptions,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) -> Fallible<DomRoot<MediaStreamAudioDestinationNode>> {
-        let node = MediaStreamAudioDestinationNode::new_inherited(context, options, can_gc)?;
-        Ok(reflect_dom_object_with_proto(
+        let node = MediaStreamAudioDestinationNode::new_inherited(context, options, cx)?;
+        Ok(reflect_dom_object_with_proto_and_cx(
             Box::new(node),
             window,
             proto,
-            can_gc,
+            cx,
         ))
     }
 }
@@ -88,13 +87,13 @@ impl MediaStreamAudioDestinationNodeMethods<crate::DomTypeHolder>
 {
     /// <https://webaudio.github.io/web-audio-api/#dom-mediastreamaudiodestinationnode-mediastreamaudiodestinationnode>
     fn Constructor(
+        cx: &mut js::context::JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         context: &AudioContext,
         options: &AudioNodeOptions,
     ) -> Fallible<DomRoot<MediaStreamAudioDestinationNode>> {
-        MediaStreamAudioDestinationNode::new_with_proto(window, proto, context, options, can_gc)
+        MediaStreamAudioDestinationNode::new_with_proto(window, proto, context, options, cx)
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-mediastreamaudiodestinationnode-stream>

--- a/components/script/dom/audio/mediastreamaudiodestinationnode.rs
+++ b/components/script/dom/audio/mediastreamaudiodestinationnode.rs
@@ -30,13 +30,13 @@ pub(crate) struct MediaStreamAudioDestinationNode {
 impl MediaStreamAudioDestinationNode {
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new_inherited(
+        cx: &mut js::context::JSContext,
         context: &AudioContext,
         options: &AudioNodeOptions,
-        cx: &mut js::context::JSContext,
     ) -> Fallible<MediaStreamAudioDestinationNode> {
         let media = ServoMedia::get();
         let (socket, id) = media.create_stream_and_socket(MediaStreamType::Audio);
-        let stream = MediaStream::new_single(&context.global(), id, MediaStreamType::Audio, cx);
+        let stream = MediaStream::new_single(cx, &context.global(), id, MediaStreamType::Audio);
         let node_options = options.unwrap_or(
             2,
             ChannelCountMode::Explicit,
@@ -56,23 +56,23 @@ impl MediaStreamAudioDestinationNode {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         window: &Window,
         context: &AudioContext,
         options: &AudioNodeOptions,
-        cx: &mut js::context::JSContext,
     ) -> Fallible<DomRoot<MediaStreamAudioDestinationNode>> {
-        Self::new_with_proto(window, None, context, options, cx)
+        Self::new_with_proto(cx, window, None, context, options)
     }
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn new_with_proto(
+        cx: &mut js::context::JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         context: &AudioContext,
         options: &AudioNodeOptions,
-        cx: &mut js::context::JSContext,
     ) -> Fallible<DomRoot<MediaStreamAudioDestinationNode>> {
-        let node = MediaStreamAudioDestinationNode::new_inherited(context, options, cx)?;
+        let node = MediaStreamAudioDestinationNode::new_inherited(cx, context, options)?;
         Ok(reflect_dom_object_with_proto_and_cx(
             Box::new(node),
             window,
@@ -93,7 +93,7 @@ impl MediaStreamAudioDestinationNodeMethods<crate::DomTypeHolder>
         context: &AudioContext,
         options: &AudioNodeOptions,
     ) -> Fallible<DomRoot<MediaStreamAudioDestinationNode>> {
-        MediaStreamAudioDestinationNode::new_with_proto(window, proto, context, options, cx)
+        MediaStreamAudioDestinationNode::new_with_proto(cx, window, proto, context, options)
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-mediastreamaudiodestinationnode-stream>

--- a/components/script/dom/audio/mediastreamaudiosourcenode.rs
+++ b/components/script/dom/audio/mediastreamaudiosourcenode.rs
@@ -14,11 +14,10 @@ use crate::dom::bindings::codegen::Bindings::MediaStreamAudioSourceNodeBinding::
 };
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::inheritance::Castable;
-use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
+use crate::dom::bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::mediastream::MediaStream;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct MediaStreamAudioSourceNode {
@@ -55,9 +54,9 @@ impl MediaStreamAudioSourceNode {
         window: &Window,
         context: &AudioContext,
         stream: &MediaStream,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) -> Fallible<DomRoot<MediaStreamAudioSourceNode>> {
-        Self::new_with_proto(window, None, context, stream, can_gc)
+        Self::new_with_proto(window, None, context, stream, cx)
     }
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
@@ -66,14 +65,14 @@ impl MediaStreamAudioSourceNode {
         proto: Option<HandleObject>,
         context: &AudioContext,
         stream: &MediaStream,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) -> Fallible<DomRoot<MediaStreamAudioSourceNode>> {
         let node = MediaStreamAudioSourceNode::new_inherited(context, stream)?;
-        Ok(reflect_dom_object_with_proto(
+        Ok(reflect_dom_object_with_proto_and_cx(
             Box::new(node),
             window,
             proto,
-            can_gc,
+            cx,
         ))
     }
 }
@@ -81,19 +80,13 @@ impl MediaStreamAudioSourceNode {
 impl MediaStreamAudioSourceNodeMethods<crate::DomTypeHolder> for MediaStreamAudioSourceNode {
     /// <https://webaudio.github.io/web-audio-api/#dom-mediastreamaudiosourcenode-mediastreamaudiosourcenode>
     fn Constructor(
+        cx: &mut js::context::JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         context: &AudioContext,
         options: &MediaStreamAudioSourceOptions,
     ) -> Fallible<DomRoot<MediaStreamAudioSourceNode>> {
-        MediaStreamAudioSourceNode::new_with_proto(
-            window,
-            proto,
-            context,
-            &options.mediaStream,
-            can_gc,
-        )
+        MediaStreamAudioSourceNode::new_with_proto(window, proto, context, &options.mediaStream, cx)
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-MediaStreamAudioSourceNode-stream>

--- a/components/script/dom/audio/mediastreamaudiosourcenode.rs
+++ b/components/script/dom/audio/mediastreamaudiosourcenode.rs
@@ -51,21 +51,21 @@ impl MediaStreamAudioSourceNode {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         window: &Window,
         context: &AudioContext,
         stream: &MediaStream,
-        cx: &mut js::context::JSContext,
     ) -> Fallible<DomRoot<MediaStreamAudioSourceNode>> {
-        Self::new_with_proto(window, None, context, stream, cx)
+        Self::new_with_proto(cx, window, None, context, stream)
     }
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn new_with_proto(
+        cx: &mut js::context::JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         context: &AudioContext,
         stream: &MediaStream,
-        cx: &mut js::context::JSContext,
     ) -> Fallible<DomRoot<MediaStreamAudioSourceNode>> {
         let node = MediaStreamAudioSourceNode::new_inherited(context, stream)?;
         Ok(reflect_dom_object_with_proto_and_cx(
@@ -86,7 +86,7 @@ impl MediaStreamAudioSourceNodeMethods<crate::DomTypeHolder> for MediaStreamAudi
         context: &AudioContext,
         options: &MediaStreamAudioSourceOptions,
     ) -> Fallible<DomRoot<MediaStreamAudioSourceNode>> {
-        MediaStreamAudioSourceNode::new_with_proto(window, proto, context, &options.mediaStream, cx)
+        MediaStreamAudioSourceNode::new_with_proto(cx, window, proto, context, &options.mediaStream)
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-MediaStreamAudioSourceNode-stream>

--- a/components/script/dom/audio/mediastreamtrackaudiosourcenode.rs
+++ b/components/script/dom/audio/mediastreamtrackaudiosourcenode.rs
@@ -13,11 +13,10 @@ use crate::dom::bindings::codegen::Bindings::MediaStreamTrackAudioSourceNodeBind
 };
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::inheritance::Castable;
-use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
+use crate::dom::bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::mediastreamtrack::MediaStreamTrack;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct MediaStreamTrackAudioSourceNode {
@@ -48,9 +47,9 @@ impl MediaStreamTrackAudioSourceNode {
         window: &Window,
         context: &AudioContext,
         track: &MediaStreamTrack,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) -> Fallible<DomRoot<MediaStreamTrackAudioSourceNode>> {
-        Self::new_with_proto(window, None, context, track, can_gc)
+        Self::new_with_proto(window, None, context, track, cx)
     }
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
@@ -59,14 +58,14 @@ impl MediaStreamTrackAudioSourceNode {
         proto: Option<HandleObject>,
         context: &AudioContext,
         track: &MediaStreamTrack,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) -> Fallible<DomRoot<MediaStreamTrackAudioSourceNode>> {
         let node = MediaStreamTrackAudioSourceNode::new_inherited(context, track)?;
-        Ok(reflect_dom_object_with_proto(
+        Ok(reflect_dom_object_with_proto_and_cx(
             Box::new(node),
             window,
             proto,
-            can_gc,
+            cx,
         ))
     }
 }
@@ -76,9 +75,9 @@ impl MediaStreamTrackAudioSourceNodeMethods<crate::DomTypeHolder>
 {
     /// <https://webaudio.github.io/web-audio-api/#dom-mediastreamtrackaudiosourcenode-mediastreamtrackaudiosourcenode>
     fn Constructor(
+        cx: &mut js::context::JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         context: &AudioContext,
         options: &MediaStreamTrackAudioSourceOptions,
     ) -> Fallible<DomRoot<MediaStreamTrackAudioSourceNode>> {
@@ -87,7 +86,7 @@ impl MediaStreamTrackAudioSourceNodeMethods<crate::DomTypeHolder>
             proto,
             context,
             &options.mediaStreamTrack,
-            can_gc,
+            cx,
         )
     }
 }

--- a/components/script/dom/audio/mediastreamtrackaudiosourcenode.rs
+++ b/components/script/dom/audio/mediastreamtrackaudiosourcenode.rs
@@ -44,21 +44,21 @@ impl MediaStreamTrackAudioSourceNode {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         window: &Window,
         context: &AudioContext,
         track: &MediaStreamTrack,
-        cx: &mut js::context::JSContext,
     ) -> Fallible<DomRoot<MediaStreamTrackAudioSourceNode>> {
-        Self::new_with_proto(window, None, context, track, cx)
+        Self::new_with_proto(cx, window, None, context, track)
     }
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn new_with_proto(
+        cx: &mut js::context::JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         context: &AudioContext,
         track: &MediaStreamTrack,
-        cx: &mut js::context::JSContext,
     ) -> Fallible<DomRoot<MediaStreamTrackAudioSourceNode>> {
         let node = MediaStreamTrackAudioSourceNode::new_inherited(context, track)?;
         Ok(reflect_dom_object_with_proto_and_cx(
@@ -82,11 +82,11 @@ impl MediaStreamTrackAudioSourceNodeMethods<crate::DomTypeHolder>
         options: &MediaStreamTrackAudioSourceOptions,
     ) -> Fallible<DomRoot<MediaStreamTrackAudioSourceNode>> {
         MediaStreamTrackAudioSourceNode::new_with_proto(
+            cx,
             window,
             proto,
             context,
             &options.mediaStreamTrack,
-            cx,
         )
     }
 }

--- a/components/script/dom/html/htmlcanvaselement.rs
+++ b/components/script/dom/html/htmlcanvaselement.rs
@@ -660,9 +660,9 @@ impl HTMLCanvasElementMethods<crate::DomTypeHolder> for HTMLCanvasElement {
         _frame_request_rate: Option<Finite<f64>>,
     ) -> DomRoot<MediaStream> {
         let global = self.global();
-        let stream = MediaStream::new(&global, cx);
+        let stream = MediaStream::new(cx, &global);
         let track =
-            MediaStreamTrack::new(&global, MediaStreamId::new(), MediaStreamType::Video, cx);
+            MediaStreamTrack::new(cx, &global, MediaStreamId::new(), MediaStreamType::Video);
         stream.AddTrack(&track);
         stream
     }

--- a/components/script/dom/html/htmlcanvaselement.rs
+++ b/components/script/dom/html/htmlcanvaselement.rs
@@ -656,17 +656,13 @@ impl HTMLCanvasElementMethods<crate::DomTypeHolder> for HTMLCanvasElement {
     /// <https://w3c.github.io/mediacapture-fromelement/#dom-htmlcanvaselement-capturestream>
     fn CaptureStream(
         &self,
+        cx: &mut js::context::JSContext,
         _frame_request_rate: Option<Finite<f64>>,
-        can_gc: CanGc,
     ) -> DomRoot<MediaStream> {
         let global = self.global();
-        let stream = MediaStream::new(&global, can_gc);
-        let track = MediaStreamTrack::new(
-            &global,
-            MediaStreamId::new(),
-            MediaStreamType::Video,
-            can_gc,
-        );
+        let stream = MediaStream::new(&global, cx);
+        let track =
+            MediaStreamTrack::new(&global, MediaStreamId::new(), MediaStreamType::Video, cx);
         stream.AddTrack(&track);
         stream
     }

--- a/components/script/dom/media/mediadevices.rs
+++ b/components/script/dom/media/mediadevices.rs
@@ -5,6 +5,7 @@
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::realm::CurrentRealm;
 use servo_media::ServoMedia;
 use servo_media::streams::MediaStreamType;
 use servo_media::streams::capture::{Constrain, ConstrainRange, MediaTrackConstraintSet};
@@ -49,29 +50,28 @@ impl MediaDevicesMethods<crate::DomTypeHolder> for MediaDevices {
     /// <https://w3c.github.io/mediacapture-main/#dom-mediadevices-getusermedia>
     fn GetUserMedia(
         &self,
+        cx: &mut CurrentRealm,
         constraints: &MediaStreamConstraints,
-        comp: InRealm,
-        can_gc: CanGc,
     ) -> Rc<Promise> {
-        let p = Promise::new_in_current_realm(comp, can_gc);
+        let p = Promise::new_in_realm(cx);
         let media = ServoMedia::get();
-        let stream = MediaStream::new(&self.global(), can_gc);
+        let stream = MediaStream::new(&self.global(), cx);
         if let Some(constraints) = convert_constraints(&constraints.audio) {
             if let Some(audio) = media.create_audioinput_stream(constraints) {
                 let track =
-                    MediaStreamTrack::new(&self.global(), audio, MediaStreamType::Audio, can_gc);
+                    MediaStreamTrack::new(&self.global(), audio, MediaStreamType::Audio, cx);
                 stream.add_track(&track);
             }
         }
         if let Some(constraints) = convert_constraints(&constraints.video) {
             if let Some(video) = media.create_videoinput_stream(constraints) {
                 let track =
-                    MediaStreamTrack::new(&self.global(), video, MediaStreamType::Video, can_gc);
+                    MediaStreamTrack::new(&self.global(), video, MediaStreamType::Video, cx);
                 stream.add_track(&track);
             }
         }
 
-        p.resolve_native(&stream, can_gc);
+        p.resolve_native(&stream, CanGc::from_cx(cx));
         p
     }
 

--- a/components/script/dom/media/mediadevices.rs
+++ b/components/script/dom/media/mediadevices.rs
@@ -55,18 +55,18 @@ impl MediaDevicesMethods<crate::DomTypeHolder> for MediaDevices {
     ) -> Rc<Promise> {
         let p = Promise::new_in_realm(cx);
         let media = ServoMedia::get();
-        let stream = MediaStream::new(&self.global(), cx);
+        let stream = MediaStream::new(cx, &self.global());
         if let Some(constraints) = convert_constraints(&constraints.audio) {
             if let Some(audio) = media.create_audioinput_stream(constraints) {
                 let track =
-                    MediaStreamTrack::new(&self.global(), audio, MediaStreamType::Audio, cx);
+                    MediaStreamTrack::new(cx, &self.global(), audio, MediaStreamType::Audio);
                 stream.add_track(&track);
             }
         }
         if let Some(constraints) = convert_constraints(&constraints.video) {
             if let Some(video) = media.create_videoinput_stream(constraints) {
                 let track =
-                    MediaStreamTrack::new(&self.global(), video, MediaStreamType::Video, cx);
+                    MediaStreamTrack::new(cx, &self.global(), video, MediaStreamType::Video);
                 stream.add_track(&track);
             }
         }

--- a/components/script/dom/media/mediastream.rs
+++ b/components/script/dom/media/mediastream.rs
@@ -10,14 +10,13 @@ use servo_media::streams::registry::MediaStreamId;
 use crate::dom::bindings::cell::{DomRefCell, Ref};
 use crate::dom::bindings::codegen::Bindings::MediaStreamBinding::MediaStreamMethods;
 use crate::dom::bindings::error::Fallible;
-use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object_with_proto};
+use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object_with_proto_and_cx};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::media::mediastreamtrack::MediaStreamTrack;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct MediaStream {
@@ -33,20 +32,23 @@ impl MediaStream {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<MediaStream> {
-        Self::new_with_proto(global, None, can_gc)
+    pub(crate) fn new(
+        global: &GlobalScope,
+        cx: &mut js::context::JSContext,
+    ) -> DomRoot<MediaStream> {
+        Self::new_with_proto(global, None, cx)
     }
 
     fn new_with_proto(
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) -> DomRoot<MediaStream> {
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(MediaStream::new_inherited()),
             global,
             proto,
-            can_gc,
+            cx,
         )
     }
 
@@ -54,10 +56,10 @@ impl MediaStream {
         global: &GlobalScope,
         id: MediaStreamId,
         ty: MediaStreamType,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) -> DomRoot<MediaStream> {
-        let this = Self::new(global, can_gc);
-        let track = MediaStreamTrack::new(global, id, ty, can_gc);
+        let this = Self::new(global, cx);
+        let track = MediaStreamTrack::new(global, id, ty, cx);
         this.AddTrack(&track);
         this
     }
@@ -74,31 +76,31 @@ impl MediaStream {
 impl MediaStreamMethods<crate::DomTypeHolder> for MediaStream {
     /// <https://w3c.github.io/mediacapture-main/#dom-mediastream-constructor>
     fn Constructor(
+        cx: &mut js::context::JSContext,
         global: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<MediaStream>> {
-        Ok(MediaStream::new_with_proto(&global.global(), proto, can_gc))
+        Ok(MediaStream::new_with_proto(&global.global(), proto, cx))
     }
 
     /// <https://w3c.github.io/mediacapture-main/#dom-mediastream-constructor>
     fn Constructor_(
+        cx: &mut js::context::JSContext,
         _: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         stream: &MediaStream,
     ) -> Fallible<DomRoot<MediaStream>> {
-        Ok(stream.clone_with_proto(proto, can_gc))
+        Ok(stream.clone_with_proto(proto, cx))
     }
 
     /// <https://w3c.github.io/mediacapture-main/#dom-mediastream-constructor>
     fn Constructor__(
+        cx: &mut js::context::JSContext,
         global: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         tracks: Vec<DomRoot<MediaStreamTrack>>,
     ) -> Fallible<DomRoot<MediaStream>> {
-        let new = MediaStream::new_with_proto(&global.global(), proto, can_gc);
+        let new = MediaStream::new_with_proto(&global.global(), proto, cx);
         for track in tracks {
             // this is quadratic, but shouldn't matter much
             // if this becomes a problem we can use a hash map
@@ -161,14 +163,18 @@ impl MediaStreamMethods<crate::DomTypeHolder> for MediaStream {
     }
 
     /// <https://w3c.github.io/mediacapture-main/#dom-mediastream-clone>
-    fn Clone(&self, can_gc: CanGc) -> DomRoot<MediaStream> {
-        self.clone_with_proto(None, can_gc)
+    fn Clone(&self, cx: &mut js::context::JSContext) -> DomRoot<MediaStream> {
+        self.clone_with_proto(None, cx)
     }
 }
 
 impl MediaStream {
-    fn clone_with_proto(&self, proto: Option<HandleObject>, can_gc: CanGc) -> DomRoot<MediaStream> {
-        let new = MediaStream::new_with_proto(&self.global(), proto, can_gc);
+    fn clone_with_proto(
+        &self,
+        proto: Option<HandleObject>,
+        cx: &mut js::context::JSContext,
+    ) -> DomRoot<MediaStream> {
+        let new = MediaStream::new_with_proto(&self.global(), proto, cx);
         for track in &*self.tracks.borrow() {
             new.add_track(track)
         }

--- a/components/script/dom/media/mediastream.rs
+++ b/components/script/dom/media/mediastream.rs
@@ -33,16 +33,16 @@ impl MediaStream {
     }
 
     pub(crate) fn new(
-        global: &GlobalScope,
         cx: &mut js::context::JSContext,
+        global: &GlobalScope,
     ) -> DomRoot<MediaStream> {
-        Self::new_with_proto(global, None, cx)
+        Self::new_with_proto(cx, global, None)
     }
 
     fn new_with_proto(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        cx: &mut js::context::JSContext,
     ) -> DomRoot<MediaStream> {
         reflect_dom_object_with_proto_and_cx(
             Box::new(MediaStream::new_inherited()),
@@ -53,13 +53,13 @@ impl MediaStream {
     }
 
     pub(crate) fn new_single(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         id: MediaStreamId,
         ty: MediaStreamType,
-        cx: &mut js::context::JSContext,
     ) -> DomRoot<MediaStream> {
-        let this = Self::new(global, cx);
-        let track = MediaStreamTrack::new(global, id, ty, cx);
+        let this = Self::new(cx, global);
+        let track = MediaStreamTrack::new(cx, global, id, ty);
         this.AddTrack(&track);
         this
     }
@@ -80,7 +80,7 @@ impl MediaStreamMethods<crate::DomTypeHolder> for MediaStream {
         global: &Window,
         proto: Option<HandleObject>,
     ) -> Fallible<DomRoot<MediaStream>> {
-        Ok(MediaStream::new_with_proto(&global.global(), proto, cx))
+        Ok(MediaStream::new_with_proto(cx, &global.global(), proto))
     }
 
     /// <https://w3c.github.io/mediacapture-main/#dom-mediastream-constructor>
@@ -90,7 +90,7 @@ impl MediaStreamMethods<crate::DomTypeHolder> for MediaStream {
         proto: Option<HandleObject>,
         stream: &MediaStream,
     ) -> Fallible<DomRoot<MediaStream>> {
-        Ok(stream.clone_with_proto(proto, cx))
+        Ok(stream.clone_with_proto(cx, proto))
     }
 
     /// <https://w3c.github.io/mediacapture-main/#dom-mediastream-constructor>
@@ -100,7 +100,7 @@ impl MediaStreamMethods<crate::DomTypeHolder> for MediaStream {
         proto: Option<HandleObject>,
         tracks: Vec<DomRoot<MediaStreamTrack>>,
     ) -> Fallible<DomRoot<MediaStream>> {
-        let new = MediaStream::new_with_proto(&global.global(), proto, cx);
+        let new = MediaStream::new_with_proto(cx, &global.global(), proto);
         for track in tracks {
             // this is quadratic, but shouldn't matter much
             // if this becomes a problem we can use a hash map
@@ -164,17 +164,17 @@ impl MediaStreamMethods<crate::DomTypeHolder> for MediaStream {
 
     /// <https://w3c.github.io/mediacapture-main/#dom-mediastream-clone>
     fn Clone(&self, cx: &mut js::context::JSContext) -> DomRoot<MediaStream> {
-        self.clone_with_proto(None, cx)
+        self.clone_with_proto(cx, None)
     }
 }
 
 impl MediaStream {
     fn clone_with_proto(
         &self,
-        proto: Option<HandleObject>,
         cx: &mut js::context::JSContext,
+        proto: Option<HandleObject>,
     ) -> DomRoot<MediaStream> {
-        let new = MediaStream::new_with_proto(&self.global(), proto, cx);
+        let new = MediaStream::new_with_proto(cx, &self.global(), proto);
         for track in &*self.tracks.borrow() {
             new.add_track(track)
         }

--- a/components/script/dom/media/mediastreamtrack.rs
+++ b/components/script/dom/media/mediastreamtrack.rs
@@ -34,10 +34,10 @@ impl MediaStreamTrack {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         id: MediaStreamId,
         ty: MediaStreamType,
-        cx: &mut js::context::JSContext,
     ) -> DomRoot<MediaStreamTrack> {
         reflect_dom_object_with_cx(
             Box::new(MediaStreamTrack::new_inherited(id, ty)),
@@ -71,6 +71,6 @@ impl MediaStreamTrackMethods<crate::DomTypeHolder> for MediaStreamTrack {
 
     /// <https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack-clone>
     fn Clone(&self, cx: &mut js::context::JSContext) -> DomRoot<MediaStreamTrack> {
-        MediaStreamTrack::new(&self.global(), self.id, self.ty, cx)
+        MediaStreamTrack::new(cx, &self.global(), self.id, self.ty)
     }
 }

--- a/components/script/dom/media/mediastreamtrack.rs
+++ b/components/script/dom/media/mediastreamtrack.rs
@@ -7,12 +7,11 @@ use servo_media::streams::MediaStreamType;
 use servo_media::streams::registry::MediaStreamId;
 
 use crate::dom::bindings::codegen::Bindings::MediaStreamTrackBinding::MediaStreamTrackMethods;
-use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object};
+use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object_with_cx};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct MediaStreamTrack {
@@ -38,12 +37,12 @@ impl MediaStreamTrack {
         global: &GlobalScope,
         id: MediaStreamId,
         ty: MediaStreamType,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) -> DomRoot<MediaStreamTrack> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(MediaStreamTrack::new_inherited(id, ty)),
             global,
-            can_gc,
+            cx,
         )
     }
 
@@ -71,7 +70,7 @@ impl MediaStreamTrackMethods<crate::DomTypeHolder> for MediaStreamTrack {
     }
 
     /// <https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack-clone>
-    fn Clone(&self) -> DomRoot<MediaStreamTrack> {
-        MediaStreamTrack::new(&self.global(), self.id, self.ty, CanGc::deprecated_note())
+    fn Clone(&self, cx: &mut js::context::JSContext) -> DomRoot<MediaStreamTrack> {
+        MediaStreamTrack::new(&self.global(), self.id, self.ty, cx)
     }
 }

--- a/components/script/dom/webrtc/rtcpeerconnection.rs
+++ b/components/script/dom/webrtc/rtcpeerconnection.rs
@@ -129,9 +129,9 @@ impl WebRtcSignaller for RTCSignaller {
     fn on_add_stream(&self, id: &MediaStreamId, ty: MediaStreamType) {
         let this = self.trusted.clone();
         let id = *id;
-        self.task_source.queue(task!(on_add_stream: move || {
+        self.task_source.queue(task!(on_add_stream: move |cx| {
             let this = this.root();
-            this.on_add_stream(id, ty, CanGc::deprecated_note());
+            this.on_add_stream(id, ty, cx);
         }));
     }
 
@@ -261,20 +261,27 @@ impl RTCPeerConnection {
         event.upcast::<Event>().fire(self.upcast(), can_gc);
     }
 
-    fn on_add_stream(&self, id: MediaStreamId, ty: MediaStreamType, can_gc: CanGc) {
+    fn on_add_stream(
+        &self,
+        id: MediaStreamId,
+        ty: MediaStreamType,
+        cx: &mut js::context::JSContext,
+    ) {
         if self.closed.get() {
             return;
         }
-        let track = MediaStreamTrack::new(&self.global(), id, ty, can_gc);
+        let track = MediaStreamTrack::new(&self.global(), id, ty, cx);
         let event = RTCTrackEvent::new(
             self.global().as_window(),
             atom!("track"),
             false,
             false,
             &track,
-            can_gc,
+            cx,
         );
-        event.upcast::<Event>().fire(self.upcast(), can_gc);
+        event
+            .upcast::<Event>()
+            .fire(self.upcast(), CanGc::from_cx(cx));
     }
 
     fn on_data_channel_event(

--- a/components/script/dom/webrtc/rtcpeerconnection.rs
+++ b/components/script/dom/webrtc/rtcpeerconnection.rs
@@ -131,7 +131,7 @@ impl WebRtcSignaller for RTCSignaller {
         let id = *id;
         self.task_source.queue(task!(on_add_stream: move |cx| {
             let this = this.root();
-            this.on_add_stream(id, ty, cx);
+            this.on_add_stream(cx, id, ty, );
         }));
     }
 
@@ -263,21 +263,21 @@ impl RTCPeerConnection {
 
     fn on_add_stream(
         &self,
+        cx: &mut js::context::JSContext,
         id: MediaStreamId,
         ty: MediaStreamType,
-        cx: &mut js::context::JSContext,
     ) {
         if self.closed.get() {
             return;
         }
-        let track = MediaStreamTrack::new(&self.global(), id, ty, cx);
+        let track = MediaStreamTrack::new(cx, &self.global(), id, ty);
         let event = RTCTrackEvent::new(
+            cx,
             self.global().as_window(),
             atom!("track"),
             false,
             false,
             &track,
-            cx,
         );
         event
             .upcast::<Event>()

--- a/components/script/dom/webrtc/rtctrackevent.rs
+++ b/components/script/dom/webrtc/rtctrackevent.rs
@@ -32,24 +32,24 @@ impl RTCTrackEvent {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         window: &Window,
         type_: Atom,
         bubbles: bool,
         cancelable: bool,
         track: &MediaStreamTrack,
-        cx: &mut js::context::JSContext,
     ) -> DomRoot<RTCTrackEvent> {
-        Self::new_with_proto(window, None, type_, bubbles, cancelable, track, cx)
+        Self::new_with_proto(cx, window, None, type_, bubbles, cancelable, track)
     }
 
     fn new_with_proto(
+        cx: &mut js::context::JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         type_: Atom,
         bubbles: bool,
         cancelable: bool,
         track: &MediaStreamTrack,
-        cx: &mut js::context::JSContext,
     ) -> DomRoot<RTCTrackEvent> {
         let trackevent = reflect_dom_object_with_proto_and_cx(
             Box::new(RTCTrackEvent::new_inherited(track)),
@@ -75,13 +75,13 @@ impl RTCTrackEventMethods<crate::DomTypeHolder> for RTCTrackEvent {
         init: &RTCTrackEventBinding::RTCTrackEventInit,
     ) -> Fallible<DomRoot<RTCTrackEvent>> {
         Ok(RTCTrackEvent::new_with_proto(
+            cx,
             window,
             proto,
             Atom::from(type_),
             init.parent.bubbles,
             init.parent.cancelable,
             &init.track,
-            cx,
         ))
     }
 

--- a/components/script/dom/webrtc/rtctrackevent.rs
+++ b/components/script/dom/webrtc/rtctrackevent.rs
@@ -10,13 +10,12 @@ use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventM
 use crate::dom::bindings::codegen::Bindings::RTCTrackEventBinding::{self, RTCTrackEventMethods};
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::inheritance::Castable;
-use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
+use crate::dom::bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::event::Event;
 use crate::dom::mediastreamtrack::MediaStreamTrack;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct RTCTrackEvent {
@@ -38,9 +37,9 @@ impl RTCTrackEvent {
         bubbles: bool,
         cancelable: bool,
         track: &MediaStreamTrack,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) -> DomRoot<RTCTrackEvent> {
-        Self::new_with_proto(window, None, type_, bubbles, cancelable, track, can_gc)
+        Self::new_with_proto(window, None, type_, bubbles, cancelable, track, cx)
     }
 
     fn new_with_proto(
@@ -50,13 +49,13 @@ impl RTCTrackEvent {
         bubbles: bool,
         cancelable: bool,
         track: &MediaStreamTrack,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) -> DomRoot<RTCTrackEvent> {
-        let trackevent = reflect_dom_object_with_proto(
+        let trackevent = reflect_dom_object_with_proto_and_cx(
             Box::new(RTCTrackEvent::new_inherited(track)),
             window,
             proto,
-            can_gc,
+            cx,
         );
         {
             let event = trackevent.upcast::<Event>();
@@ -69,9 +68,9 @@ impl RTCTrackEvent {
 impl RTCTrackEventMethods<crate::DomTypeHolder> for RTCTrackEvent {
     /// <https://w3c.github.io/webrtc-pc/#dom-rtctrackevent-constructor>
     fn Constructor(
+        cx: &mut js::context::JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         type_: DOMString,
         init: &RTCTrackEventBinding::RTCTrackEventInit,
     ) -> Fallible<DomRoot<RTCTrackEvent>> {
@@ -82,7 +81,7 @@ impl RTCTrackEventMethods<crate::DomTypeHolder> for RTCTrackEvent {
             init.parent.bubbles,
             init.parent.cancelable,
             &init.track,
-            can_gc,
+            cx,
         ))
     }
 

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -38,7 +38,7 @@ DOMInterfaces = {
 
 'AudioContext': {
     'realm': ['Close', 'Suspend'],
-    'cx':['CreateMediaElementSource', 'CreateMediaStreamDestination', 'CreateMediaStreamSource', 'CreateMediaStreamTrackSource'],
+    'cx':['Constructor', 'CreateMediaElementSource', 'CreateMediaStreamDestination', 'CreateMediaStreamSource', 'CreateMediaStreamTrackSource'],
 },
 
 'BaseAudioContext': {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -37,9 +37,8 @@ DOMInterfaces = {
 },
 
 'AudioContext': {
-    'inRealms': ['Close', 'Suspend'],
-    'cx': ['CreateMediaElementSource'],
-    'canGc':['CreateMediaStreamDestination', 'CreateMediaStreamSource', 'CreateMediaStreamTrackSource', 'Suspend', 'Close'],
+    'realm': ['Close', 'Suspend'],
+    'cx':['CreateMediaElementSource', 'CreateMediaStreamDestination', 'CreateMediaStreamSource', 'CreateMediaStreamTrackSource'],
 },
 
 'BaseAudioContext': {
@@ -418,7 +417,8 @@ DOMInterfaces = {
 },
 
 'HTMLCanvasElement': {
-    'canGc': ['CaptureStream', 'GetContext', 'SetHeight', 'SetWidth', 'TransferControlToOffscreen'],
+    'cx': ['CaptureStream'],
+    'canGc': ['GetContext', 'SetHeight', 'SetWidth', 'TransferControlToOffscreen'],
     'weakReferenceable': True,
 },
 
@@ -641,11 +641,24 @@ DOMInterfaces = {
 },
 
 'MediaDevices': {
-    'canGc': ['GetUserMedia', 'EnumerateDevices'],
+    'realm': ['GetUserMedia'],
+    'canGc': ['EnumerateDevices'],
     'inRealms': ['GetUserMedia', 'GetClientRects', 'GetBoundingClientRect'],
 },
 
 'MediaElementAudioSourceNode': {
+    'cx': ['Constructor'],
+},
+
+'MediaStreamAudioSourceNode': {
+    'cx': ['Constructor'],
+},
+
+'MediaStreamAudioDestinationNode': {
+    'cx': ['Constructor'],
+},
+
+'MediaStreamTrackAudioSourceNode': {
     'cx': ['Constructor'],
 },
 
@@ -657,8 +670,12 @@ DOMInterfaces = {
     'canGc': ['GetMetadata'],
 },
 
+'MediaStreamTrack': {
+    'cx': ['Clone'],
+},
+
 'MediaStream': {
-    'canGc': ['Clone'],
+    'cx': ['Constructor', 'Constructor_', 'Constructor__', 'Clone'],
 },
 
 'MessagePort': {
@@ -756,6 +773,10 @@ DOMInterfaces = {
 
 'RTCRtpSender': {
     'canGc': ['SetParameters'],
+},
+
+'RTCTrackEvent': {
+    'cx': ['Constructor'],
 },
 
 'Selection': {


### PR DESCRIPTION
Refactor AudioContext methods to use &mut JSContext 

Testing:  Just refactor.
Fixes: Part of #42638
