### PR TITLE
Disable debug_assertions in release profile

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -8,7 +8,7 @@ on:
     inputs:
       profile:
         required: false
-        default: "release-ci"
+        default: "checked-release"
         type: string
       bencher:
         required: false
@@ -19,9 +19,9 @@ on:
     inputs:
       profile:
         required: false
-        default: "release-ci"
+        default: "checked-release"
         type: choice
-        options: ["release-ci", "release", "debug", "production"]
+        options: ["checked-release", "release", "debug", "production"]
       bencher:
         required: false
         default: false

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -8,7 +8,7 @@ on:
     inputs:
       profile:
         required: false
-        default: "release"
+        default: "release-ci"
         type: string
       bencher:
         required: false
@@ -19,9 +19,9 @@ on:
     inputs:
       profile:
         required: false
-        default: "release"
+        default: "release-ci"
         type: choice
-        options: ["release", "debug", "production"]
+        options: ["release-ci", "release", "debug", "production"]
       bencher:
         required: false
         default: false

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -8,7 +8,7 @@ on:
         type: string
       profile:
         required: false
-        default: "release"
+        default: "release-ci"
         type: string
       compressed-file-path:
         required: false

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -8,7 +8,7 @@ on:
         type: string
       profile:
         required: false
-        default: "release-ci"
+        default: "checked-release"
         type: string
       compressed-file-path:
         required: false

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,7 +8,7 @@ on:
     inputs:
       profile:
         required: false
-        default: "release-ci"
+        default: "checked-release"
         type: string
       build-args:
         default: ""
@@ -53,9 +53,9 @@ on:
     inputs:
       profile:
         required: false
-        default: "release-ci"
+        default: "checked-release"
         type: choice
-        options: ["release-ci", "release", "debug", "production"]
+        options: ["checked-release", "release", "debug", "production"]
       wpt-args:
         default: ""
         required: false

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,7 +8,7 @@ on:
     inputs:
       profile:
         required: false
-        default: "release"
+        default: "release-ci"
         type: string
       build-args:
         default: ""
@@ -53,9 +53,9 @@ on:
     inputs:
       profile:
         required: false
-        default: "release"
+        default: "release-ci"
         type: choice
-        options: ["release", "debug", "production"]
+        options: ["release-ci", "release", "debug", "production"]
       wpt-args:
         default: ""
         required: false

--- a/.github/workflows/mac-arm64.yml
+++ b/.github/workflows/mac-arm64.yml
@@ -9,7 +9,7 @@ on:
     inputs:
       profile:
         required: false
-        default: "release-ci"
+        default: "checked-release"
         type: string
       build-args:
         default: ""
@@ -42,9 +42,9 @@ on:
     inputs:
       profile:
         required: false
-        default: "release-ci"
+        default: "checked-release"
         type: choice
-        options: ["release-ci", "release", "debug", "production"]
+        options: ["checked-release", "release", "debug", "production"]
       wpt-args:
         default: ""
         required: false

--- a/.github/workflows/mac-arm64.yml
+++ b/.github/workflows/mac-arm64.yml
@@ -9,7 +9,7 @@ on:
     inputs:
       profile:
         required: false
-        default: "release"
+        default: "release-ci"
         type: string
       build-args:
         default: ""
@@ -42,9 +42,9 @@ on:
     inputs:
       profile:
         required: false
-        default: "release"
+        default: "release-ci"
         type: choice
-        options: ["release", "debug", "production"]
+        options: ["release-ci", "release", "debug", "production"]
       wpt-args:
         default: ""
         required: false

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -9,7 +9,7 @@ on:
     inputs:
       profile:
         required: false
-        default: "release-ci"
+        default: "checked-release"
         type: string
       build-args:
         default: ""
@@ -42,9 +42,9 @@ on:
     inputs:
       profile:
         required: false
-        default: "release-ci"
+        default: "checked-release"
         type: choice
-        options: ["release-ci", "release", "debug", "production"]
+        options: ["checked-release", "release", "debug", "production"]
       wpt-args:
         default: ""
         required: false

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -9,7 +9,7 @@ on:
     inputs:
       profile:
         required: false
-        default: "release"
+        default: "release-ci"
         type: string
       build-args:
         default: ""
@@ -42,9 +42,9 @@ on:
     inputs:
       profile:
         required: false
-        default: "release"
+        default: "release-ci"
         type: choice
-        options: ["release", "debug", "production"]
+        options: ["release-ci", "release", "debug", "production"]
       wpt-args:
         default: ""
         required: false

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       profile:
         required: false
-        default: "release-ci"
+        default: "checked-release"
         type: string
       upload_library:
         required: false
@@ -25,10 +25,10 @@ on:
     inputs:
       profile:
         required: false
-        default: "release-ci"
+        default: "checked-release"
         type: choice
         description: "Cargo build profile"
-        options: ["release-ci", "release", "debug", "production"]
+        options: ["checked-release", "release", "debug", "production"]
       bencher:
         required: false
         default: false

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       profile:
         required: false
-        default: "release"
+        default: "release-ci"
         type: string
       upload_library:
         required: false
@@ -25,10 +25,10 @@ on:
     inputs:
       profile:
         required: false
-        default: "release"
+        default: "release-ci"
         type: choice
         description: "Cargo build profile"
-        options: ["release", "debug", "production"]
+        options: ["release-ci", "release", "debug", "production"]
       bencher:
         required: false
         default: false

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -7,9 +7,9 @@ on:
     inputs:
       profile:
         required: false
-        default: "release"
+        default: "release-ci"
         type: choice
-        options: ["release", "debug", "production"]
+        options: ["release-ci", "release", "debug", "production"]
       build-args:
         default: ""
         required: false

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -7,9 +7,9 @@ on:
     inputs:
       profile:
         required: false
-        default: "release-ci"
+        default: "checked-release"
         type: choice
-        options: ["release-ci", "release", "debug", "production"]
+        options: ["checked-release", "release", "debug", "production"]
       build-args:
         default: ""
         required: false

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       profile:
         required: false
-        default: "release-ci"
+        default: "checked-release"
         type: string
       build-args:
         default: ""
@@ -40,8 +40,8 @@ on:
     inputs:
       profile:
         required: false
-        default: "release-ci"
-        options: ["release-ci", "release", "debug", "production"]
+        default: "checked-release"
+        options: ["checked-release", "release", "debug", "production"]
         type: choice
       unit-tests:
         required: false

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       profile:
         required: false
-        default: "release"
+        default: "release-ci"
         type: string
       build-args:
         default: ""
@@ -40,8 +40,8 @@ on:
     inputs:
       profile:
         required: false
-        default: "release"
-        options: ["release", "debug", "production"]
+        default: "release-ci"
+        options: ["release-ci", "release", "debug", "production"]
         type: choice
       unit-tests:
         required: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -324,7 +324,7 @@ opt-level = 1
 opt-level = 3
 
 # An optimized build for CI, to improve test runtime, but with assertions turned on.
-[profile.release-ci]
+[profile.checked-release]
 inherits = "release"
 debug-assertions = true
 overflow-checks = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -320,9 +320,6 @@ opt-level = 3
 [profile.dev.package.tikv-jemalloc-sys]
 opt-level = 1
 
-[profile.release]
-opt-level = 3
-
 # An optimized build for CI, to improve test runtime, but with debug assertions turned on.
 [profile.checked-release]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -323,7 +323,7 @@ opt-level = 1
 [profile.release]
 opt-level = 3
 
-# An optimized build for CI, to improve test runtime, but with assertions turned on.
+# An optimized build for CI, to improve test runtime, but with debug assertions turned on.
 [profile.checked-release]
 inherits = "release"
 debug-assertions = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -322,7 +322,12 @@ opt-level = 1
 
 [profile.release]
 opt-level = 3
+
+# An optimized build for CI, to improve test runtime, but with assertions turned on.
+[profile.release-ci]
+inherits = "release"
 debug-assertions = true
+overflow-checks = true
 
 # Disk-space is limited in CI, so we disabled features that are not needed for code coverage.
 # Locally using the default `dev` profile is perfectly fine.
@@ -334,7 +339,7 @@ debug = false
 # A profile between `dev` and `release` which aims to offer a compromise between
 # fast incremental rebuilds and runtime speed.
 [profile.medium]
-inherits = "release"
+inherits = "dev"
 opt-level = 2
 incremental = true
 debug = "line-tables-only"

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -169,7 +169,7 @@ class PackageCommands(CommandBase):
 
             if build_type.is_dev():
                 build_type_string = "Debug"
-            elif build_type.is_release() or build_type.is_prod() or build_type.profile == "release-ci":
+            elif build_type.is_release() or build_type.is_prod() or build_type.profile == "checked-release":
                 build_type_string = "Release"
             else:
                 print(f"Servo was built with custom cargo profile `{build_type.profile}`.")

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -169,7 +169,7 @@ class PackageCommands(CommandBase):
 
             if build_type.is_dev():
                 build_type_string = "Debug"
-            elif build_type.is_release() or build_type.is_prod():
+            elif build_type.is_release() or build_type.is_prod() or build_type.profile == "release-ci":
                 build_type_string = "Release"
             else:
                 print(f"Servo was built with custom cargo profile `{build_type.profile}`.")

--- a/python/servo/try_parser.py
+++ b/python/servo/try_parser.py
@@ -36,7 +36,7 @@ class JobConfig(object):
     name: str
     workflow: Workflow = Workflow.LINUX
     wpt: bool = False
-    profile: str = "release-ci"
+    profile: str = "checked-release"
     unit_tests: bool = False
     build_libservo: bool = False
     bencher: bool = False
@@ -78,7 +78,7 @@ class JobConfig(object):
         elif self.workflow is Workflow.OHOS:
             self.name = "OpenHarmony"
         modifier = []
-        if self.profile != "release-ci":
+        if self.profile != "checked-release":
             modifier.append(self.profile.title())
         if self.unit_tests:
             modifier.append("Unit Tests")
@@ -276,7 +276,7 @@ class TestParser(unittest.TestCase):
                         "bencher": False,
                         "name": "Linux (Unit Tests)",
                         "number_of_wpt_chunks": 20,
-                        "profile": "release-ci",
+                        "profile": "checked-release",
                         "unit_tests": True,
                         "build_libservo": False,
                         "workflow": "linux",
@@ -299,7 +299,7 @@ class TestParser(unittest.TestCase):
                         "name": "Linux (Unit Tests, Build libservo, WPT, Bencher)",
                         "workflow": "linux",
                         "wpt": True,
-                        "profile": "release-ci",
+                        "profile": "checked-release",
                         "unit_tests": True,
                         "build_libservo": True,
                         "bencher": True,
@@ -312,7 +312,7 @@ class TestParser(unittest.TestCase):
                         "name": "Windows (Unit Tests, Build libservo)",
                         "workflow": "windows",
                         "wpt": False,
-                        "profile": "release-ci",
+                        "profile": "checked-release",
                         "unit_tests": True,
                         "build_libservo": True,
                         "bencher": False,
@@ -325,7 +325,7 @@ class TestParser(unittest.TestCase):
                         "name": "MacOS Arm64 (Unit Tests)",
                         "workflow": "macos-arm64",
                         "wpt": False,
-                        "profile": "release-ci",
+                        "profile": "checked-release",
                         "unit_tests": True,
                         "build_libservo": False,
                         "bencher": False,
@@ -338,7 +338,7 @@ class TestParser(unittest.TestCase):
                         "name": "Android",
                         "workflow": "android",
                         "wpt": False,
-                        "profile": "release-ci",
+                        "profile": "checked-release",
                         "unit_tests": False,
                         "build_libservo": False,
                         "bencher": False,
@@ -351,7 +351,7 @@ class TestParser(unittest.TestCase):
                         "name": "OpenHarmony",
                         "workflow": "ohos",
                         "wpt": False,
-                        "profile": "release-ci",
+                        "profile": "checked-release",
                         "unit_tests": False,
                         "build_libservo": False,
                         "bencher": False,
@@ -364,7 +364,7 @@ class TestParser(unittest.TestCase):
                         "name": "Lint",
                         "workflow": "lint",
                         "wpt": False,
-                        "profile": "release-ci",
+                        "profile": "checked-release",
                         "unit_tests": False,
                         "build_libservo": False,
                         "bencher": False,
@@ -387,7 +387,7 @@ class TestParser(unittest.TestCase):
                         "bencher": False,
                         "name": "Linux (WPT)",
                         "number_of_wpt_chunks": 20,
-                        "profile": "release-ci",
+                        "profile": "checked-release",
                         "unit_tests": False,
                         "build_libservo": False,
                         "workflow": "linux",

--- a/python/servo/try_parser.py
+++ b/python/servo/try_parser.py
@@ -36,7 +36,7 @@ class JobConfig(object):
     name: str
     workflow: Workflow = Workflow.LINUX
     wpt: bool = False
-    profile: str = "release"
+    profile: str = "release-ci"
     unit_tests: bool = False
     build_libservo: bool = False
     bencher: bool = False
@@ -78,7 +78,7 @@ class JobConfig(object):
         elif self.workflow is Workflow.OHOS:
             self.name = "OpenHarmony"
         modifier = []
-        if self.profile != "release":
+        if self.profile != "release-ci":
             modifier.append(self.profile.title())
         if self.unit_tests:
             modifier.append("Unit Tests")
@@ -272,7 +272,7 @@ class TestParser(unittest.TestCase):
                         "bencher": False,
                         "name": "Linux (Unit Tests)",
                         "number_of_wpt_chunks": 20,
-                        "profile": "release",
+                        "profile": "release-ci",
                         "unit_tests": True,
                         "build_libservo": False,
                         "workflow": "linux",
@@ -295,7 +295,7 @@ class TestParser(unittest.TestCase):
                         "name": "Linux (Unit Tests, Build libservo, WPT, Bencher)",
                         "workflow": "linux",
                         "wpt": True,
-                        "profile": "release",
+                        "profile": "release-ci",
                         "unit_tests": True,
                         "build_libservo": True,
                         "bencher": True,
@@ -308,7 +308,7 @@ class TestParser(unittest.TestCase):
                         "name": "Windows (Unit Tests, Build libservo)",
                         "workflow": "windows",
                         "wpt": False,
-                        "profile": "release",
+                        "profile": "release-ci",
                         "unit_tests": True,
                         "build_libservo": True,
                         "bencher": False,
@@ -321,7 +321,7 @@ class TestParser(unittest.TestCase):
                         "name": "MacOS Arm64 (Unit Tests)",
                         "workflow": "macos-arm64",
                         "wpt": False,
-                        "profile": "release",
+                        "profile": "release-ci",
                         "unit_tests": True,
                         "build_libservo": False,
                         "bencher": False,
@@ -334,7 +334,7 @@ class TestParser(unittest.TestCase):
                         "name": "Android",
                         "workflow": "android",
                         "wpt": False,
-                        "profile": "release",
+                        "profile": "release-ci",
                         "unit_tests": False,
                         "build_libservo": False,
                         "bencher": False,
@@ -347,7 +347,7 @@ class TestParser(unittest.TestCase):
                         "name": "OpenHarmony",
                         "workflow": "ohos",
                         "wpt": False,
-                        "profile": "release",
+                        "profile": "release-ci",
                         "unit_tests": False,
                         "build_libservo": False,
                         "bencher": False,
@@ -360,7 +360,7 @@ class TestParser(unittest.TestCase):
                         "name": "Lint",
                         "workflow": "lint",
                         "wpt": False,
-                        "profile": "release",
+                        "profile": "release-ci",
                         "unit_tests": False,
                         "build_libservo": False,
                         "bencher": False,
@@ -383,7 +383,7 @@ class TestParser(unittest.TestCase):
                         "bencher": False,
                         "name": "Linux (WPT)",
                         "number_of_wpt_chunks": 20,
-                        "profile": "release",
+                        "profile": "release-ci",
                         "unit_tests": False,
                         "build_libservo": False,
                         "workflow": "linux",

--- a/python/servo/try_parser.py
+++ b/python/servo/try_parser.py
@@ -158,6 +158,10 @@ def handle_modifier(config: Optional[JobConfig], s: str) -> Optional[JobConfig]:
         config.build_libservo = True
     if "production" in s:
         config.profile = "production"
+    elif "release" in s:
+        config.profile = "release"
+    elif "debug" in s:
+        config.profile = "dev"
     if "bencher" in s:
         config.bencher = True
     if "coverage" in s:


### PR DESCRIPTION
The default for release builds in Rust is to turn off debug assertions.
We previously had them turned on, since for a long time servo was too
slow in the `dev` profile. This has not been the case for a long time
anymore, and servo can actually be used in the dev profile.
Debug-assertions in servo can be quite costly, and having a release profile
with debug-assertions disabled would be valuable for quick performance testing.

In CI however, we want to catch as many issues as possible, so we add a **new custom profile`checked-release`** which is the default in CI, and turns on **debug_assertions and overflow checks** (the latter is new).


Making a new `real-release` profile instead would also be an option, but probably overall
more confusing, than keeping `release` the same as Rust defines by default
and adding a modified `ci` profile.

The medium profile is also available as a good in-between option
which has optimization enabled (O2) for fast local development. 
`medium` could also be an option for CI, but we want `debug` information
stripped (size limitations) and incremental disabled in CI. We could probably override 
those settings via environment variables, but I find it beneficial if the CI profile is not
magic, and matches the local profiles.

Since the try_parser currently apparently only supports `production` as a custom profile,
also add support for `debug`  (=dev) and `release`.

Previous zulip discussion with a bit of context around the origins of our custom profile:
[#general > release profile in servo and debug-assertions @ 💬](https://servo.zulipchat.com/#narrow/channel/263398-general/topic/release.20profile.20in.20servo.20and.20debug-assertions/near/562263791)

Testing: This is a CI policy change

