### PR TITLE
Expand `fmt` and `tidy` TOML_GLOBS range

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -79,5 +79,3 @@ jobs:
           ./mach clippy --locked --github-annotations -- -- --deny warnings
       - name: Tidy
         run: ./mach test-tidy --no-progress --all --github-annotations
-      - name: Taplo
-        run: taplo format --check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -79,3 +79,5 @@ jobs:
           ./mach clippy --locked --github-annotations -- -- --deny warnings
       - name: Tidy
         run: ./mach test-tidy --no-progress --all --github-annotations
+      - name: Taplo
+        run: taplo format --check

--- a/components/media/backends/auto/Cargo.toml
+++ b/components/media/backends/auto/Cargo.toml
@@ -18,4 +18,3 @@ servo-media-gstreamer = { workspace = true }
 
 [target.'cfg(not(any(all(target_os = "android", any(target_arch = "arm", target_arch = "aarch64")), target_arch = "x86_64", target_arch = "aarch64")))'.dependencies]
 servo-media-dummy = { workspace = true }
-

--- a/components/media/backends/ohos/Cargo.toml
+++ b/components/media/backends/ohos/Cargo.toml
@@ -23,7 +23,7 @@ servo-media-webrtc = { workspace = true }
 mime = "0.3.13"
 once_cell = "1.18.0"
 log = "0.4"
-ohos-media-sys = { version = "0.0.5" ,features = ["api-21"] }
+ohos-media-sys = { version = "0.0.5", features = ["api-21"] }
 ohos-window-sys = { version = "0.1.3", features = ["api-13"] }
 ohos-sys-opaque-types = { version = "0.1.7" }
 ipc-channel = { workspace = true }

--- a/components/media/player/Cargo.toml
+++ b/components/media/player/Cargo.toml
@@ -21,4 +21,3 @@ malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 servo-media-streams = { workspace = true }
 servo-media-traits = { workspace = true }
-

--- a/components/media/servo-media/Cargo.toml
+++ b/components/media/servo-media/Cargo.toml
@@ -20,4 +20,3 @@ servo-media-player = { workspace = true }
 servo-media-streams = { workspace = true }
 servo-media-traits = { workspace = true }
 servo-media-webrtc = { workspace = true }
-

--- a/etc/ci/scenario/pyproject.toml
+++ b/etc/ci/scenario/pyproject.toml
@@ -6,7 +6,7 @@ dependencies = [
     "selenium",
     "hdc-py>=0.1.2",
     "pillow",
-    "matplotlib"
+    "matplotlib",
 ]
 license = "Apache-2.0 OR MIT"
 

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -63,9 +63,15 @@ TOML_GLOBS = [
     "*.toml",
     ".cargo/*.toml",
     "components/*/*.toml",
-    "components/shared/*/*.toml",
+    "components/*/*/*.toml",
+    "components/media/backends/*/*.toml",
+    "components/media/*/*/*/*.toml",
+    "etc/ci/scenario/*.toml",
     "ports/*/*.toml",
     "support/*/*.toml",
+    "python/tidy/tests/*.toml",
+    "python/tidy/tests/*/*.toml",
+    "tests/unit/*/*.toml",
 ]
 
 

--- a/python/tidy/tests/path_dependency/self-reference.Cargo.toml
+++ b/python/tidy/tests/path_dependency/self-reference.Cargo.toml
@@ -9,4 +9,4 @@ test-feature = []
 
 [dev-dependencies]
 test-package = { path = "." }
-other-name = { package = "test-package", path = "."}
+other-name = { package = "test-package", path = "." }


### PR DESCRIPTION
Add a check for formatting of the `Cargo.toml` files to CI, and run `taplo format` to fix existing formatting issues.