### PR TITLE
android: Support custom build profiles

### DIFF
--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -177,7 +177,6 @@ class PackageCommands(CommandBase):
                 build_type_string = "Debug"
             # Inform the android build of where `libservoshell.so` is located.
             env["SERVO_TARGET_DIR"] = target_dir
-            env["SERVO_ANDROID_BUILD_TYPE_DIRECTORY"] = build_type.directory_name()
 
             flavor_name = "Basic"
             if flavor is not None:

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -177,6 +177,7 @@ class PackageCommands(CommandBase):
                 build_type_string = "Debug"
             # Inform the android build of where `libservoshell.so` is located.
             env["SERVO_TARGET_DIR"] = target_dir
+            env["SERVO_ANDROID_BUILD_TYPE_DIRECTORY"] = build_type.directory_name()
 
             flavor_name = "Basic"
             if flavor is not None:

--- a/support/android/apk/buildSrc/src/main/kotlin/Interop.kt
+++ b/support/android/apk/buildSrc/src/main/kotlin/Interop.kt
@@ -23,7 +23,9 @@ fun Project.getNativeTargetDir(debug: Boolean, arch: String): String {
 }
 
 fun getSubTargetDir(debug: Boolean, arch: String): String {
-    val buildTypeDirectory = System.getenv("SERVO_ANDROID_BUILD_TYPE_DIRECTORY") ?: if (debug) "debug" else "release"
+    val buildTypeDirectory = System.getenv("SERVO_TARGET_DIR")
+        ?.let { File(it).name }
+        ?: if (debug) "debug" else "release"
     return getRustTarget(arch) + "/" + buildTypeDirectory
 }
 

--- a/support/android/apk/buildSrc/src/main/kotlin/Interop.kt
+++ b/support/android/apk/buildSrc/src/main/kotlin/Interop.kt
@@ -23,7 +23,8 @@ fun Project.getNativeTargetDir(debug: Boolean, arch: String): String {
 }
 
 fun getSubTargetDir(debug: Boolean, arch: String): String {
-    return getRustTarget(arch) + "/" + if (debug) "debug" else "release"
+    val buildTypeDirectory = System.getenv("SERVO_ANDROID_BUILD_TYPE_DIRECTORY") ?: if (debug) "debug" else "release"
+    return getRustTarget(arch) + "/" + buildTypeDirectory
 }
 
 fun Project.getJniLibsPath(debug: Boolean, arch: String): String =


### PR DESCRIPTION
Pass the build directory to gradle via an environment variable, to support custom profiles.
Building the custom profiles already works, but follow-up commands expect the artifact at the location of the profile.
This allows switching the android release build to production (in a follow-up PR). 

Testing: We don't run any runtime tests for android in CI

