### PR TITLE
script: Initialize Sanitizer API implementation

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -162,6 +162,8 @@ pub struct Preferences {
     pub dom_permissions_testing_allowed_in_nonsecure_contexts: bool,
     // feature: ResizeObserver | #39790 | Web/API/ResizeObserver
     pub dom_resize_observer_enabled: bool,
+    // feature: Sanitizer API | #43948 | Web/API/HTML_Sanitizer_API
+    pub dom_sanitizer_enabled: bool,
     pub dom_script_asynch: bool,
     // feature: ServiceWorker | #36538 | Web/API/Service_Worker_API
     pub dom_serviceworker_enabled: bool,
@@ -376,6 +378,7 @@ impl Preferences {
             dom_permissions_enabled: false,
             dom_permissions_testing_allowed_in_nonsecure_contexts: false,
             dom_resize_observer_enabled: true,
+            dom_sanitizer_enabled: false,
             dom_script_asynch: true,
             dom_serviceworker_enabled: false,
             dom_serviceworker_timeout_seconds: 60,

--- a/components/script/dom/security/mod.rs
+++ b/components/script/dom/security/mod.rs
@@ -5,5 +5,6 @@
 pub(crate) mod csp;
 pub(crate) mod csppolicyviolationreport;
 pub(crate) mod cspviolationreporttask;
+pub(crate) mod sanitizer;
 pub(crate) mod securitypolicyviolationevent;
 pub(crate) mod xframeoptions;

--- a/components/script/dom/security/sanitizer.rs
+++ b/components/script/dom/security/sanitizer.rs
@@ -1,0 +1,111 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use dom_struct::dom_struct;
+use js::context::JSContext;
+use js::rust::HandleObject;
+
+use crate::dom::bindings::cell::DomRefCell;
+use crate::dom::bindings::codegen::Bindings::SanitizerBinding::{
+    SanitizerConfig, SanitizerMethods, SanitizerPresets,
+};
+use crate::dom::bindings::codegen::UnionTypes::SanitizerConfigOrSanitizerPresets;
+use crate::dom::bindings::error::{Error, Fallible};
+use crate::dom::bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::window::Window;
+
+#[dom_struct]
+pub(crate) struct Sanitizer {
+    reflector_: Reflector,
+    /// <https://wicg.github.io/sanitizer-api/#sanitizer-configuration>
+    configuration: DomRefCell<SanitizerConfig>,
+}
+
+impl Sanitizer {
+    fn new_inherited(configuration: SanitizerConfig) -> Sanitizer {
+        Sanitizer {
+            reflector_: Reflector::new(),
+            configuration: DomRefCell::new(configuration),
+        }
+    }
+
+    pub(crate) fn new_with_proto(
+        cx: &mut JSContext,
+        window: &Window,
+        proto: Option<HandleObject>,
+        configuration: SanitizerConfig,
+    ) -> DomRoot<Sanitizer> {
+        reflect_dom_object_with_proto_and_cx(
+            Box::new(Sanitizer::new_inherited(configuration)),
+            window,
+            proto,
+            cx,
+        )
+    }
+
+    /// <https://wicg.github.io/sanitizer-api/#sanitizer-set-a-configuration>
+    fn set_configuration(
+        &self,
+        configuration: SanitizerConfig,
+        _allow_comments_and_data_attributes: bool,
+    ) -> bool {
+        // TODO:
+        // Step 1. Canonicalize configuration with allowCommentsAndDataAttributes.
+
+        // TODO:
+        // Step 2. If configuration is not valid, then return false.
+
+        // Step 3. Set sanitizer’s configuration to configuration.
+        let mut sanitizer_configuration = self.configuration.borrow_mut();
+        *sanitizer_configuration = configuration;
+
+        // Step 4. Return true.
+        true
+    }
+}
+
+impl SanitizerMethods<crate::DomTypeHolder> for Sanitizer {
+    /// <https://wicg.github.io/sanitizer-api/#dom-sanitizer-constructor>
+    fn Constructor(
+        cx: &mut JSContext,
+        window: &Window,
+        proto: Option<HandleObject>,
+        configuration: SanitizerConfigOrSanitizerPresets,
+    ) -> Fallible<DomRoot<Sanitizer>> {
+        let configuration = match configuration {
+            // Step 1. If configuration is a SanitizerPresets string, then:
+            SanitizerConfigOrSanitizerPresets::SanitizerPresets(configuration) => {
+                // Step 1.1. Assert: configuration is default.
+                assert_eq!(configuration, SanitizerPresets::Default);
+
+                // TODO:
+                // Step 1.2. Set configuration to the built-in safe default configuration.
+                SanitizerConfig::default()
+            },
+            SanitizerConfigOrSanitizerPresets::SanitizerConfig(configuration) => configuration,
+        };
+
+        // Step 2. Let valid be the return value of set a configuration with configuration and true
+        // on this.
+        // Step 3. If valid is false, then throw a TypeError.
+        let sanitizer = Sanitizer::new_with_proto(cx, window, proto, SanitizerConfig::default());
+        if !sanitizer.set_configuration(configuration, true) {
+            return Err(Error::Type(c"The configuration is invalid".into()));
+        }
+
+        Ok(sanitizer)
+    }
+
+    /// <https://wicg.github.io/sanitizer-api/#dom-sanitizer-get>
+    fn Get(&self) -> SanitizerConfig {
+        // Step 1. Let config be this’s configuration.
+        let config = self.configuration.borrow_mut();
+
+        // TODO: Step 2 to Step 7
+
+        // Step 8. Return config.
+        (*config).clone()
+    }
+}

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -779,6 +779,10 @@ DOMInterfaces = {
     'cx': ['Constructor'],
 },
 
+'Sanitizer': {
+    'cx': ['Constructor'],
+},
+
 'Selection': {
     'canGc': ['Collapse', 'CollapseToEnd', 'CollapseToStart', 'Extend', 'SelectAllChildren', 'SetBaseAndExtent', 'SetPosition'],
     'cx': ['DeleteFromDocument']
@@ -1126,6 +1130,22 @@ Dictionaries = {
     'derives': ['Clone', 'MallocSizeOf'],
 },
 
+'SanitizerAttributeNamespace': {
+    'derives': ['Clone', 'MallocSizeOf']
+},
+
+'SanitizerElementNamespace': {
+    'derives': ['Clone', 'MallocSizeOf'],
+},
+
+'SanitizerElementNamespaceWithAttributes': {
+    'derives': ['Clone', 'MallocSizeOf'],
+},
+
+'SanitizerConfig': {
+    'derives': ['Clone', 'MallocSizeOf']
+},
+
 'ScrollOptions': {
     'derives': ['Clone'],
 },
@@ -1167,6 +1187,18 @@ Unions = {
 
 'HTMLCanvasElementOrOffscreenCanvas': {
     'derives': ['Clone', 'MallocSizeOf']
+},
+
+'StringOrSanitizerAttributeNamespace': {
+    'derives': ['Clone', 'MallocSizeOf'],
+},
+
+'StringOrSanitizerElementNamespace': {
+    'derives': ['Clone', 'MallocSizeOf'],
+},
+
+'StringOrSanitizerElementNamespaceWithAttributes': {
+    'derives': ['Clone', 'MallocSizeOf'],
 },
 
 'RangeEnforcedUnsignedLongSequenceOrGPUExtent3DDict': {

--- a/components/script_bindings/webidls/Sanitizer.webidl
+++ b/components/script_bindings/webidls/Sanitizer.webidl
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://wicg.github.io/sanitizer-api/#configobject
+enum SanitizerPresets { "default" };
+dictionary SetHTMLOptions {
+  (Sanitizer or SanitizerConfig or SanitizerPresets) sanitizer = "default";
+};
+dictionary SetHTMLUnsafeOptions {
+  (Sanitizer or SanitizerConfig or SanitizerPresets) sanitizer = {};
+};
+
+// https://wicg.github.io/sanitizer-api/#sanitizer
+[Exposed=Window, Pref="dom_sanitizer_enabled"]
+interface Sanitizer {
+  [Throws] constructor(optional (SanitizerConfig or SanitizerPresets) configuration = "default");
+
+  // Query configuration:
+  SanitizerConfig get();
+
+  // Modify a Sanitizer's lists and fields:
+  // boolean allowElement(SanitizerElementWithAttributes element);
+  // boolean removeElement(SanitizerElement element);
+  // boolean replaceElementWithChildren(SanitizerElement element);
+  // boolean allowAttribute(SanitizerAttribute attribute);
+  // boolean removeAttribute(SanitizerAttribute attribute);
+  // boolean setComments(boolean allow);
+  // boolean setDataAttributes(boolean allow);
+
+  // Remove markup that executes script.
+  // boolean removeUnsafe();
+};
+
+// https://wicg.github.io/sanitizer-api/#config
+dictionary SanitizerElementNamespace {
+  required DOMString name;
+  DOMString? _namespace = "http://www.w3.org/1999/xhtml";
+};
+
+// Used by "elements"
+dictionary SanitizerElementNamespaceWithAttributes : SanitizerElementNamespace {
+  sequence<SanitizerAttribute> attributes;
+  sequence<SanitizerAttribute> removeAttributes;
+};
+
+typedef (DOMString or SanitizerElementNamespace) SanitizerElement;
+typedef (DOMString or SanitizerElementNamespaceWithAttributes) SanitizerElementWithAttributes;
+
+dictionary SanitizerAttributeNamespace {
+  required DOMString name;
+  DOMString? _namespace = null;
+};
+typedef (DOMString or SanitizerAttributeNamespace) SanitizerAttribute;
+
+dictionary SanitizerConfig {
+  sequence<SanitizerElementWithAttributes> elements;
+  sequence<SanitizerElement> removeElements;
+  sequence<SanitizerElement> replaceWithChildrenElements;
+
+  sequence<SanitizerAttribute> attributes;
+  sequence<SanitizerAttribute> removeAttributes;
+
+  boolean comments;
+  boolean dataAttributes;
+};
+

--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -252,6 +252,8 @@ skip: true
   skip: false
 [resource-timing]
   skip: false
+[sanitizer-api]
+  skip: false
 [secure-contexts]
   skip: false
 [selection]

--- a/tests/wpt/meta/sanitizer-api/__dir__.ini
+++ b/tests/wpt/meta/sanitizer-api/__dir__.ini
@@ -1,0 +1,1 @@
+prefs: [dom_sanitizer_enabled: true]

--- a/tests/wpt/meta/sanitizer-api/idlharness.https.window.js.ini
+++ b/tests/wpt/meta/sanitizer-api/idlharness.https.window.js.ini
@@ -1,0 +1,99 @@
+[idlharness.https.window.html]
+  [Sanitizer interface: existence and properties of interface object]
+    expected: FAIL
+
+  [Sanitizer interface object length]
+    expected: FAIL
+
+  [Sanitizer interface object name]
+    expected: FAIL
+
+  [Sanitizer interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [Sanitizer interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [Sanitizer interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [Sanitizer interface: operation get()]
+    expected: FAIL
+
+  [Sanitizer interface: operation allowElement(SanitizerElementWithAttributes)]
+    expected: FAIL
+
+  [Sanitizer interface: operation removeElement(SanitizerElement)]
+    expected: FAIL
+
+  [Sanitizer interface: operation replaceElementWithChildren(SanitizerElement)]
+    expected: FAIL
+
+  [Sanitizer interface: operation allowAttribute(SanitizerAttribute)]
+    expected: FAIL
+
+  [Sanitizer interface: operation removeAttribute(SanitizerAttribute)]
+    expected: FAIL
+
+  [Sanitizer interface: operation setComments(boolean)]
+    expected: FAIL
+
+  [Sanitizer interface: operation setDataAttributes(boolean)]
+    expected: FAIL
+
+  [Sanitizer interface: operation removeUnsafe()]
+    expected: FAIL
+
+  [Sanitizer must be primary interface of new Sanitizer({})]
+    expected: FAIL
+
+  [Stringification of new Sanitizer({})]
+    expected: FAIL
+
+  [Sanitizer interface: new Sanitizer({}) must inherit property "get()" with the proper type]
+    expected: FAIL
+
+  [Sanitizer interface: new Sanitizer({}) must inherit property "allowElement(SanitizerElementWithAttributes)" with the proper type]
+    expected: FAIL
+
+  [Sanitizer interface: calling allowElement(SanitizerElementWithAttributes) on new Sanitizer({}) with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Sanitizer interface: new Sanitizer({}) must inherit property "removeElement(SanitizerElement)" with the proper type]
+    expected: FAIL
+
+  [Sanitizer interface: calling removeElement(SanitizerElement) on new Sanitizer({}) with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Sanitizer interface: new Sanitizer({}) must inherit property "replaceElementWithChildren(SanitizerElement)" with the proper type]
+    expected: FAIL
+
+  [Sanitizer interface: calling replaceElementWithChildren(SanitizerElement) on new Sanitizer({}) with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Sanitizer interface: new Sanitizer({}) must inherit property "allowAttribute(SanitizerAttribute)" with the proper type]
+    expected: FAIL
+
+  [Sanitizer interface: calling allowAttribute(SanitizerAttribute) on new Sanitizer({}) with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Sanitizer interface: new Sanitizer({}) must inherit property "removeAttribute(SanitizerAttribute)" with the proper type]
+    expected: FAIL
+
+  [Sanitizer interface: calling removeAttribute(SanitizerAttribute) on new Sanitizer({}) with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Sanitizer interface: new Sanitizer({}) must inherit property "setComments(boolean)" with the proper type]
+    expected: FAIL
+
+  [Sanitizer interface: calling setComments(boolean) on new Sanitizer({}) with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Sanitizer interface: new Sanitizer({}) must inherit property "setDataAttributes(boolean)" with the proper type]
+    expected: FAIL
+
+  [Sanitizer interface: calling setDataAttributes(boolean) on new Sanitizer({}) with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Sanitizer interface: new Sanitizer({}) must inherit property "removeUnsafe()" with the proper type]
+    expected: FAIL

--- a/tests/wpt/meta/sanitizer-api/idlharness.https.window.js.ini
+++ b/tests/wpt/meta/sanitizer-api/idlharness.https.window.js.ini
@@ -1,25 +1,4 @@
 [idlharness.https.window.html]
-  [Sanitizer interface: existence and properties of interface object]
-    expected: FAIL
-
-  [Sanitizer interface object length]
-    expected: FAIL
-
-  [Sanitizer interface object name]
-    expected: FAIL
-
-  [Sanitizer interface: existence and properties of interface prototype object]
-    expected: FAIL
-
-  [Sanitizer interface: existence and properties of interface prototype object's "constructor" property]
-    expected: FAIL
-
-  [Sanitizer interface: existence and properties of interface prototype object's @@unscopables property]
-    expected: FAIL
-
-  [Sanitizer interface: operation get()]
-    expected: FAIL
-
   [Sanitizer interface: operation allowElement(SanitizerElementWithAttributes)]
     expected: FAIL
 
@@ -42,15 +21,6 @@
     expected: FAIL
 
   [Sanitizer interface: operation removeUnsafe()]
-    expected: FAIL
-
-  [Sanitizer must be primary interface of new Sanitizer({})]
-    expected: FAIL
-
-  [Stringification of new Sanitizer({})]
-    expected: FAIL
-
-  [Sanitizer interface: new Sanitizer({}) must inherit property "get()" with the proper type]
     expected: FAIL
 
   [Sanitizer interface: new Sanitizer({}) must inherit property "allowElement(SanitizerElementWithAttributes)" with the proper type]

--- a/tests/wpt/meta/sanitizer-api/sanitizer-basic-filtering.tentative.html.ini
+++ b/tests/wpt/meta/sanitizer-api/sanitizer-basic-filtering.tentative.html.ini
@@ -1,0 +1,31 @@
+[sanitizer-basic-filtering.tentative.html]
+  expected: ERROR
+  [setHTML testcase text/0, "text"]
+    expected: FAIL
+
+  [ShadowRoot.setHTML testcase text/0, "text"]
+    expected: FAIL
+
+  [parseHTML testcase text/0, "text"]
+    expected: FAIL
+
+  [setHTML testcase elements/0, "<div><p>Hello <b>World!</b>"]
+    expected: FAIL
+
+  [ShadowRoot.setHTML testcase elements/0, "<div><p>Hello <b>World!</b>"]
+    expected: FAIL
+
+  [parseHTML testcase elements/0, "<div><p>Hello <b>World!</b>"]
+    expected: FAIL
+
+  [setHTML testcase elements/1, "<div><p>Hello <b>World!</b>"]
+    expected: FAIL
+
+  [setHTMLUnsafe testcase elements/1, "<div><p>Hello <b>World!</b>"]
+    expected: FAIL
+
+  [ShadowRoot.setHTML testcase elements/1, "<div><p>Hello <b>World!</b>"]
+    expected: FAIL
+
+  [ShadowRoot.setHTMLUnsafe testcase elements/1, "<div><p>Hello <b>World!</b>"]
+    expected: FAIL

--- a/tests/wpt/meta/sanitizer-api/sanitizer-boolean-defaults.tentative.html.ini
+++ b/tests/wpt/meta/sanitizer-api/sanitizer-boolean-defaults.tentative.html.ini
@@ -1,0 +1,6 @@
+[sanitizer-boolean-defaults.tentative.html]
+  [comments]
+    expected: FAIL
+
+  [data attributes]
+    expected: FAIL

--- a/tests/wpt/meta/sanitizer-api/sanitizer-config.tentative.html.ini
+++ b/tests/wpt/meta/sanitizer-api/sanitizer-config.tentative.html.ini
@@ -1,0 +1,183 @@
+[sanitizer-config.tentative.html]
+  [Sanitizer constructor without config.]
+    expected: FAIL
+
+  [Sanitizer constructor with empty config.]
+    expected: FAIL
+
+  [Sanitizer constructor with null as config.]
+    expected: FAIL
+
+  [Sanitizer constructor with undefined as config.]
+    expected: FAIL
+
+  [Sanitizer constructor with config ignore unknown values.]
+    expected: FAIL
+
+  [SanitizerConfig comments field.]
+    expected: FAIL
+
+  [SanitizerConfig dataAttributes field.]
+    expected: FAIL
+
+  [SanitizerConfig, normalization: elements: ["div"\]]
+    expected: FAIL
+
+  [SanitizerConfig, normalization: elements: [{"name":"b"}\]]
+    expected: FAIL
+
+  [SanitizerConfig, normalization: elements: [{"name":"b","namespace":null}\]]
+    expected: FAIL
+
+  [SanitizerConfig, normalization: elements: [{"name":"b","namespace":""}\]]
+    expected: FAIL
+
+  [SanitizerConfig, normalization: elements: [{"name":"p","namespace":"http://www.w3.org/1999/xhtml"}\]]
+    expected: FAIL
+
+  [SanitizerConfig, normalization: elements: [{"name":"bla","namespace":"http://fantasy.org/namespace"}\]]
+    expected: FAIL
+
+  [SanitizerConfig, normalization: removeElements: ["div"\]]
+    expected: FAIL
+
+  [SanitizerConfig, normalization: removeElements: [{"name":"b"}\]]
+    expected: FAIL
+
+  [SanitizerConfig, normalization: removeElements: [{"name":"b","namespace":null}\]]
+    expected: FAIL
+
+  [SanitizerConfig, normalization: removeElements: [{"name":"b","namespace":""}\]]
+    expected: FAIL
+
+  [SanitizerConfig, normalization: removeElements: [{"name":"p","namespace":"http://www.w3.org/1999/xhtml"}\]]
+    expected: FAIL
+
+  [SanitizerConfig, normalization: removeElements: [{"name":"bla","namespace":"http://fantasy.org/namespace"}\]]
+    expected: FAIL
+
+  [SanitizerConfig, normalization: replaceWithChildrenElements: ["div"\]]
+    expected: FAIL
+
+  [SanitizerConfig, normalization: replaceWithChildrenElements: [{"name":"b"}\]]
+    expected: FAIL
+
+  [SanitizerConfig, normalization: replaceWithChildrenElements: [{"name":"b","namespace":null}\]]
+    expected: FAIL
+
+  [SanitizerConfig, normalization: replaceWithChildrenElements: [{"name":"b","namespace":""}\]]
+    expected: FAIL
+
+  [SanitizerConfig, normalization: replaceWithChildrenElements: [{"name":"p","namespace":"http://www.w3.org/1999/xhtml"}\]]
+    expected: FAIL
+
+  [SanitizerConfig, normalization: replaceWithChildrenElements: [{"name":"bla","namespace":"http://fantasy.org/namespace"}\]]
+    expected: FAIL
+
+  [SanitizerConfig, normalization: attributes: ["href"\]]
+    expected: FAIL
+
+  [SanitizerConfig, normalization: attributes: [{"name":"href","namespace":null}\]]
+    expected: FAIL
+
+  [SanitizerConfig, normalization: attributes: [{"name":"href","namespace":""}\]]
+    expected: FAIL
+
+  [SanitizerConfig, normalization: attributes: [{"name":"href","namespace":"https://www.w3.org/1999/xlink"}\]]
+    expected: FAIL
+
+  [SanitizerConfig, normalization: removeAttributes: ["href"\]]
+    expected: FAIL
+
+  [SanitizerConfig, normalization: removeAttributes: [{"name":"href","namespace":null}\]]
+    expected: FAIL
+
+  [SanitizerConfig, normalization: removeAttributes: [{"name":"href","namespace":""}\]]
+    expected: FAIL
+
+  [SanitizerConfig, normalization: removeAttributes: [{"name":"href","namespace":"https://www.w3.org/1999/xlink"}\]]
+    expected: FAIL
+
+  [Test elements addition.]
+    expected: FAIL
+
+  [Test elements removal.]
+    expected: FAIL
+
+  [Test elements replacewithchildren.]
+    expected: FAIL
+
+  [Test attribute addition.]
+    expected: FAIL
+
+  [Test attribute removal.]
+    expected: FAIL
+
+  [Test attribute-per-element sets (i.e. overwrites).]
+    expected: FAIL
+
+  [Test removeAttribute-per-element sets (i.e. overwrites).]
+    expected: FAIL
+
+  [Both elements and removeElements should not be allowed.]
+    expected: FAIL
+
+  [Both attributes and removeAttributes should not be allowed.]
+    expected: FAIL
+
+  [config[elements\] should not allow duplicates]
+    expected: FAIL
+
+  [config[removeElements\] should not allow duplicates]
+    expected: FAIL
+
+  [config[replaceWithChildrenElements\] should not allow duplicates]
+    expected: FAIL
+
+  [config[attributes\] should not allow duplicates]
+    expected: FAIL
+
+  [config[removeAttributes\] should not allow duplicates]
+    expected: FAIL
+
+  [config[elements\] and config[replaceWithChildrenElements\] should not intersect]
+    expected: FAIL
+
+  [config[removeElements\] and config[replaceWithChildrenElements\] should not intersect]
+    expected: FAIL
+
+  [Duplicates in element[attributes\] with config[attributes\] should not be allowed.]
+    expected: FAIL
+
+  [Duplicates in element[removeAttributes\] with config[attributes\] should not be allowed.]
+    expected: FAIL
+
+  [config[attributes\] and element[attributes\] should not intersect.]
+    expected: FAIL
+
+  [element[removeAttributes\] should be a subset of config[attributes\]]
+    expected: FAIL
+
+  [element[attributes\] with a data attribute must not co-exist with config[dataAttributes\] set to true.]
+    expected: FAIL
+
+  [config[attributes\] with a data attribute must not co-exist with config[dataAttributes\] set to true.]
+    expected: FAIL
+
+  [element[attributes\] and element[removeAttributes\] should not both exist with config[removeAttributes\].]
+    expected: FAIL
+
+  [Duplicates in element[attributes\] with config[removeAttributes\] should not be allowed.]
+    expected: FAIL
+
+  [Duplicates in element[removeAttributes\] with config[removeAttributes\] should not be allowed.]
+    expected: FAIL
+
+  [config[removeAttributes\] and element[attributes\] should not intersect.]
+    expected: FAIL
+
+  [config[removeAttributes\] and element[removeAttributes\] should not intersect.]
+    expected: FAIL
+
+  [Can not use config[dataAttributes\] and config[removeAttributes\] together.]
+    expected: FAIL

--- a/tests/wpt/meta/sanitizer-api/sanitizer-config.tentative.html.ini
+++ b/tests/wpt/meta/sanitizer-api/sanitizer-config.tentative.html.ini
@@ -1,19 +1,4 @@
 [sanitizer-config.tentative.html]
-  [Sanitizer constructor without config.]
-    expected: FAIL
-
-  [Sanitizer constructor with empty config.]
-    expected: FAIL
-
-  [Sanitizer constructor with null as config.]
-    expected: FAIL
-
-  [Sanitizer constructor with undefined as config.]
-    expected: FAIL
-
-  [Sanitizer constructor with config ignore unknown values.]
-    expected: FAIL
-
   [SanitizerConfig comments field.]
     expected: FAIL
 
@@ -41,61 +26,25 @@
   [SanitizerConfig, normalization: removeElements: ["div"\]]
     expected: FAIL
 
-  [SanitizerConfig, normalization: removeElements: [{"name":"b"}\]]
-    expected: FAIL
-
-  [SanitizerConfig, normalization: removeElements: [{"name":"b","namespace":null}\]]
-    expected: FAIL
-
   [SanitizerConfig, normalization: removeElements: [{"name":"b","namespace":""}\]]
-    expected: FAIL
-
-  [SanitizerConfig, normalization: removeElements: [{"name":"p","namespace":"http://www.w3.org/1999/xhtml"}\]]
-    expected: FAIL
-
-  [SanitizerConfig, normalization: removeElements: [{"name":"bla","namespace":"http://fantasy.org/namespace"}\]]
     expected: FAIL
 
   [SanitizerConfig, normalization: replaceWithChildrenElements: ["div"\]]
     expected: FAIL
 
-  [SanitizerConfig, normalization: replaceWithChildrenElements: [{"name":"b"}\]]
-    expected: FAIL
-
-  [SanitizerConfig, normalization: replaceWithChildrenElements: [{"name":"b","namespace":null}\]]
-    expected: FAIL
-
   [SanitizerConfig, normalization: replaceWithChildrenElements: [{"name":"b","namespace":""}\]]
-    expected: FAIL
-
-  [SanitizerConfig, normalization: replaceWithChildrenElements: [{"name":"p","namespace":"http://www.w3.org/1999/xhtml"}\]]
-    expected: FAIL
-
-  [SanitizerConfig, normalization: replaceWithChildrenElements: [{"name":"bla","namespace":"http://fantasy.org/namespace"}\]]
     expected: FAIL
 
   [SanitizerConfig, normalization: attributes: ["href"\]]
     expected: FAIL
 
-  [SanitizerConfig, normalization: attributes: [{"name":"href","namespace":null}\]]
-    expected: FAIL
-
   [SanitizerConfig, normalization: attributes: [{"name":"href","namespace":""}\]]
-    expected: FAIL
-
-  [SanitizerConfig, normalization: attributes: [{"name":"href","namespace":"https://www.w3.org/1999/xlink"}\]]
     expected: FAIL
 
   [SanitizerConfig, normalization: removeAttributes: ["href"\]]
     expected: FAIL
 
-  [SanitizerConfig, normalization: removeAttributes: [{"name":"href","namespace":null}\]]
-    expected: FAIL
-
   [SanitizerConfig, normalization: removeAttributes: [{"name":"href","namespace":""}\]]
-    expected: FAIL
-
-  [SanitizerConfig, normalization: removeAttributes: [{"name":"href","namespace":"https://www.w3.org/1999/xlink"}\]]
     expected: FAIL
 
   [Test elements addition.]

--- a/tests/wpt/meta/sanitizer-api/sanitizer-default-config.tentative.html.ini
+++ b/tests/wpt/meta/sanitizer-api/sanitizer-default-config.tentative.html.ini
@@ -1,0 +1,3 @@
+[sanitizer-default-config.tentative.html]
+  [Get the expected default config]
+    expected: FAIL

--- a/tests/wpt/meta/sanitizer-api/sanitizer-get.tentative.html.ini
+++ b/tests/wpt/meta/sanitizer-api/sanitizer-get.tentative.html.ini
@@ -1,0 +1,21 @@
+[sanitizer-get.tentative.html]
+  [Sorting of attributes]
+    expected: FAIL
+
+  [Sorting of removeAttributes]
+    expected: FAIL
+
+  [Sorting of elements]
+    expected: FAIL
+
+  [Sorting of removeElements]
+    expected: FAIL
+
+  [Sorting of replaceWithChildrenElements]
+    expected: FAIL
+
+  [Sorting of element's attributes]
+    expected: FAIL
+
+  [Sorting of element's removeAttributes]
+    expected: FAIL

--- a/tests/wpt/meta/sanitizer-api/sanitizer-inert-document.tentative.html.ini
+++ b/tests/wpt/meta/sanitizer-api/sanitizer-inert-document.tentative.html.ini
@@ -1,0 +1,12 @@
+[sanitizer-inert-document.tentative.html]
+  [Test whether setHTML executes the fail handler.]
+    expected: FAIL
+
+  [Test whether setHTMLUnsafe executes the fail handler.]
+    expected: FAIL
+
+  [Test whether setHTML loads the image.]
+    expected: FAIL
+
+  [Test whether setHTMLUnsafe loads the image.]
+    expected: FAIL

--- a/tests/wpt/meta/sanitizer-api/sanitizer-javascript-url.html.ini
+++ b/tests/wpt/meta/sanitizer-api/sanitizer-javascript-url.html.ini
@@ -1,0 +1,132 @@
+[sanitizer-javascript-url.html]
+  [setHTML testcase built-in-navigating-url-attributes-list/0, "<a href="javascript:alert(1)"></a>"]
+    expected: FAIL
+
+  [parseHTML testcase built-in-navigating-url-attributes-list/0, "<a href="javascript:alert(1)"></a>"]
+    expected: FAIL
+
+  [setHTML testcase built-in-navigating-url-attributes-list/1, "<area href="javascript:alert(1)"></area>"]
+    expected: FAIL
+
+  [parseHTML testcase built-in-navigating-url-attributes-list/1, "<area href="javascript:alert(1)"></area>"]
+    expected: FAIL
+
+  [setHTML testcase built-in-navigating-url-attributes-list/2, "<base href="javascript:alert(1)"></base>"]
+    expected: FAIL
+
+  [parseHTML testcase built-in-navigating-url-attributes-list/2, "<base href="javascript:alert(1)"></base>"]
+    expected: FAIL
+
+  [setHTML testcase built-in-navigating-url-attributes-list/3, "<button formaction="javascript:alert(1)"></button>"]
+    expected: FAIL
+
+  [parseHTML testcase built-in-navigating-url-attributes-list/3, "<button formaction="javascript:alert(1)"></button>"]
+    expected: FAIL
+
+  [setHTML testcase built-in-navigating-url-attributes-list/4, "<form action="javascript:alert(1)"></form>"]
+    expected: FAIL
+
+  [parseHTML testcase built-in-navigating-url-attributes-list/4, "<form action="javascript:alert(1)"></form>"]
+    expected: FAIL
+
+  [setHTML testcase built-in-navigating-url-attributes-list/5, "<input formaction="javascript:alert(1)"></input>"]
+    expected: FAIL
+
+  [parseHTML testcase built-in-navigating-url-attributes-list/5, "<input formaction="javascript:alert(1)"></input>"]
+    expected: FAIL
+
+  [setHTML testcase built-in-navigating-url-attributes-list/6, "<svg><a href="javascript:alert(1)"></a></svg>"]
+    expected: FAIL
+
+  [parseHTML testcase built-in-navigating-url-attributes-list/6, "<svg><a href="javascript:alert(1)"></a></svg>"]
+    expected: FAIL
+
+  [setHTML testcase built-in-navigating-url-attributes-list/7, "<svg><a xlink:href="javascript:alert(1)"></a></svg>"]
+    expected: FAIL
+
+  [parseHTML testcase built-in-navigating-url-attributes-list/7, "<svg><a xlink:href="javascript:alert(1)"></a></svg>"]
+    expected: FAIL
+
+  [setHTML testcase mathml/0, "<math><mrow href="javascript:alert(1)"></mrow></math>"]
+    expected: FAIL
+
+  [parseHTML testcase mathml/0, "<math><mrow href="javascript:alert(1)"></mrow></math>"]
+    expected: FAIL
+
+  [setHTML testcase mathml/1, "<math><msqrt href="javascript:alert(1)"></msqrt></math>"]
+    expected: FAIL
+
+  [parseHTML testcase mathml/1, "<math><msqrt href="javascript:alert(1)"></msqrt></math>"]
+    expected: FAIL
+
+  [setHTML testcase mathml/2, "<math><mtext href="javascript:alert(1)">Test</mtext></math>"]
+    expected: FAIL
+
+  [parseHTML testcase mathml/2, "<math><mtext href="javascript:alert(1)">Test</mtext></math>"]
+    expected: FAIL
+
+  [setHTML testcase built-in-animating-url-attributes-list/0, "<svg><animate attributeName="href"></svg>"]
+    expected: FAIL
+
+  [parseHTML testcase built-in-animating-url-attributes-list/0, "<svg><animate attributeName="href"></svg>"]
+    expected: FAIL
+
+  [setHTML testcase built-in-animating-url-attributes-list/1, "<svg><animate attributeName="xlink:href"></svg>"]
+    expected: FAIL
+
+  [parseHTML testcase built-in-animating-url-attributes-list/1, "<svg><animate attributeName="xlink:href"></svg>"]
+    expected: FAIL
+
+  [setHTML testcase built-in-animating-url-attributes-list/2, "<svg><animateMotion attributeName="href"></svg>"]
+    expected: FAIL
+
+  [parseHTML testcase built-in-animating-url-attributes-list/2, "<svg><animateMotion attributeName="href"></svg>"]
+    expected: FAIL
+
+  [setHTML testcase built-in-animating-url-attributes-list/3, "<svg><animateMotion attributeName="xlink:href"></svg>"]
+    expected: FAIL
+
+  [parseHTML testcase built-in-animating-url-attributes-list/3, "<svg><animateMotion attributeName="xlink:href"></svg>"]
+    expected: FAIL
+
+  [setHTML testcase built-in-animating-url-attributes-list/4, "<svg><animateTransform attributeName="href"></svg>"]
+    expected: FAIL
+
+  [parseHTML testcase built-in-animating-url-attributes-list/4, "<svg><animateTransform attributeName="href"></svg>"]
+    expected: FAIL
+
+  [setHTML testcase built-in-animating-url-attributes-list/5, "<svg><animateTransform attributeName="xlink:href"></svg>"]
+    expected: FAIL
+
+  [parseHTML testcase built-in-animating-url-attributes-list/5, "<svg><animateTransform attributeName="xlink:href"></svg>"]
+    expected: FAIL
+
+  [setHTML testcase built-in-animating-url-attributes-list/6, "<svg><set attributeName="href"></svg>"]
+    expected: FAIL
+
+  [parseHTML testcase built-in-animating-url-attributes-list/6, "<svg><set attributeName="href"></svg>"]
+    expected: FAIL
+
+  [setHTML testcase built-in-animating-url-attributes-list/7, "<svg><set attributeName="xlink:href"></svg>"]
+    expected: FAIL
+
+  [parseHTML testcase built-in-animating-url-attributes-list/7, "<svg><set attributeName="xlink:href"></svg>"]
+    expected: FAIL
+
+  [setHTML testcase allowed/0, "<a nothref="javascript:alert(1)"></a>"]
+    expected: FAIL
+
+  [parseHTML testcase allowed/0, "<a nothref="javascript:alert(1)"></a>"]
+    expected: FAIL
+
+  [setHTML testcase allowed/1, "<svg><a xlink:href="data:text/html,foobar"></a></svg>"]
+    expected: FAIL
+
+  [parseHTML testcase allowed/1, "<svg><a xlink:href="data:text/html,foobar"></a></svg>"]
+    expected: FAIL
+
+  [setHTML testcase allowed/2, "<svg><set attributeName=" href "></svg>"]
+    expected: FAIL
+
+  [parseHTML testcase allowed/2, "<svg><set attributeName=" href "></svg>"]
+    expected: FAIL

--- a/tests/wpt/meta/sanitizer-api/sanitizer-modifiers.tentative.html.ini
+++ b/tests/wpt/meta/sanitizer-api/sanitizer-modifiers.tentative.html.ini
@@ -1,0 +1,57 @@
+[sanitizer-modifiers.tentative.html]
+  [sanitizer.allowAttribute() with global attributes]
+    expected: FAIL
+
+  [sanitizer.allowAttribute() with global removeAttributes]
+    expected: FAIL
+
+  [sanitizer.allowAttribute() with global attributes and elements]
+    expected: FAIL
+
+  [sanitizer.allowAttribute() with global removeAttributes and element's attributes]
+    expected: FAIL
+
+  [sanitizer.allowAttribute() with global removeAttributes and element's removeAttributes]
+    expected: FAIL
+
+  [sanitizer.removeAttribute() with global attributes]
+    expected: FAIL
+
+  [sanitizer.removeAttribute() with global removeAttributes]
+    expected: FAIL
+
+  [sanitizer.removeAttribute() with global attributes and elements]
+    expected: FAIL
+
+  [sanitizer.removeAttribute() with global removeAttributes and element's attributes]
+    expected: FAIL
+
+  [sanitizer.removeAttribute() with global removeAttributes and element's removeAttributes]
+    expected: FAIL
+
+  [sanitizer.removeElement() with global elements]
+    expected: FAIL
+
+  [sanitizer.removeElement() with global removeElements]
+    expected: FAIL
+
+  [sanitizer.replaceElementWithChildren() with global elements]
+    expected: FAIL
+
+  [sanitizer.replaceElementWithChildren() with global removeElements]
+    expected: FAIL
+
+  [sanitizer.allowElement() with global elements]
+    expected: FAIL
+
+  [sanitizer.allowElement() with global removeElements]
+    expected: FAIL
+
+  [sanitizer.allowElement() with global elements and attributes]
+    expected: FAIL
+
+  [sanitizer.allowElement() with global elements and removeAttributes]
+    expected: FAIL
+
+  [sanitizer.replaceElementWithChildren does not allow 'html' element.]
+    expected: FAIL

--- a/tests/wpt/meta/sanitizer-api/sanitizer-names.tentative.html.ini
+++ b/tests/wpt/meta/sanitizer-api/sanitizer-names.tentative.html.ini
@@ -1,0 +1,60 @@
+[sanitizer-names.tentative.html]
+  [Namespaced elements #0: elements: ["p"\]]
+    expected: FAIL
+
+  [Namespaced elements #1: elements: ["svg"\]]
+    expected: FAIL
+
+  [Namespaced elements #2: elements: [{"name":"svg","namespace":"http://www.w3.org/2000/svg"}\]]
+    expected: FAIL
+
+  [Namespaced elements #3: elements: ["math"\]]
+    expected: FAIL
+
+  [Namespaced elements #4: elements: [{"name":"math","namespace":"http://www.w3.org/2000/svg"}\]]
+    expected: FAIL
+
+  [Namespaced elements #5: elements: [{"name":"math","namespace":"http://www.w3.org/1998/Math/MathML"}\]]
+    expected: FAIL
+
+  [Namespaced attributes #0: attributes: [{"name":"style"}\]]
+    expected: FAIL
+
+  [Namespaced attributes #1: attributes: [{"name":"href"}\]]
+    expected: FAIL
+
+  [Namespaced attributes #2: attributes: [{"name":"xlink:href"}\]]
+    expected: FAIL
+
+  [Namespaced attributes #3: attributes: [{"name":"href","namespace":"http://www.w3.org/1999/xlink"}\]]
+    expected: FAIL
+
+  [Namespaced attributes #4: attributes: [{"name":"href","namespace":"http://www.w3.org/1999/xlink"}\]]
+    expected: FAIL
+
+  [Namespaced attributes #5: attributes: [{"name":"href"}\]]
+    expected: FAIL
+
+  [Namespaced attributes #6: attributes: [{"name":"xlink:href"}\]]
+    expected: FAIL
+
+  [Namespaced attributes #7: attributes: [{"name":"href","namespace":"http://www.w3.org/1999/xlink"}\]]
+    expected: FAIL
+
+  [Namespaced attributes #8: attributes: [{"name":"href","namespace":"http://www.w3.org/1999/xlink"}\]]
+    expected: FAIL
+
+  [Namespaced attributes #9: attributes: [{"name":"href"}\]]
+    expected: FAIL
+
+  [Namespaced attribute xlink:href inside SVG tree]
+    expected: FAIL
+
+  [Mixed-case element names #0: "svg:feBlend"]
+    expected: FAIL
+
+  [Mixed-case element names #1: "svg:feColorMatrix"]
+    expected: FAIL
+
+  [Mixed-case element names #2: "svg:textPath"]
+    expected: FAIL

--- a/tests/wpt/meta/sanitizer-api/sanitizer-parseHTML.tentative.html.ini
+++ b/tests/wpt/meta/sanitizer-api/sanitizer-parseHTML.tentative.html.ini
@@ -1,0 +1,57 @@
+[sanitizer-parseHTML.tentative.html]
+  [parseHTML testcase 0, "text"]
+    expected: FAIL
+
+  [parseHTML testcase 1, "<div>text"]
+    expected: FAIL
+
+  [parseHTML testcase 2, "<div>text"]
+    expected: FAIL
+
+  [parseHTML testcase 3, "<div>text"]
+    expected: FAIL
+
+  [parseHTMLUnsafe testcase 1, "<div>text"]
+    expected: FAIL
+
+  [parseHTMLUnsafe testcase 2, "<div>text"]
+    expected: FAIL
+
+  [parseHTMLUnsafe testcase 3, "<div>text"]
+    expected: FAIL
+
+  [parseHTMLUnsafe testcase 4, "<html onload="3 + 3"><div>a"]
+    expected: FAIL
+
+  [parseHTML testcase 0, "<script>hello"]
+    expected: FAIL
+
+  [parseHTML testcase 1, "<html onload="2+2"><body onload="3+3"><div>hello"]
+    expected: FAIL
+
+  [parseHTML testcase 2, "<div data-xyz="1" id="2" title="3">"]
+    expected: FAIL
+
+  [parseHTML testcase 3, "<div>a<!-- xx -->b"]
+    expected: FAIL
+
+  [parseHTML testcase 5, "<br id="document">"]
+    expected: FAIL
+
+  [parseHTML testcase 6, "<br id="document">"]
+    expected: FAIL
+
+  [parseHTML testcase 7, "<p onclick="alert(document.cookie)">Click handler!</p>"]
+    expected: FAIL
+
+  [parseHTML testcase 8, "<p onclick="alert(document.cookie)">Click handler!</p>"]
+    expected: FAIL
+
+  [parseHTMLUnsafe testcase 2, "<div data-xyz="1" id="2" title="3">"]
+    expected: FAIL
+
+  [parseHTMLUnsafe testcase 4, "<html onload="2 + 2"><div>a"]
+    expected: FAIL
+
+  [parseHTML full document testcase 0, "<!DOCTYPE html>\ntext"]
+    expected: FAIL

--- a/tests/wpt/meta/sanitizer-api/sanitizer-removeUnsafe.tentative.html.ini
+++ b/tests/wpt/meta/sanitizer-api/sanitizer-removeUnsafe.tentative.html.ini
@@ -1,0 +1,6 @@
+[sanitizer-removeUnsafe.tentative.html]
+  [removeUnsafe removes the right elements and attributes]
+    expected: FAIL
+
+  [removeUnsafe with default config]
+    expected: FAIL

--- a/tests/wpt/meta/sanitizer-api/sanitizer-unknown.tentative.html.ini
+++ b/tests/wpt/meta/sanitizer-api/sanitizer-unknown.tentative.html.ini
@@ -1,0 +1,12 @@
+[sanitizer-unknown.tentative.html]
+  [Unknown element names get blocked without being allowed.]
+    expected: FAIL
+
+  [Unknown element names pass when allowed.]
+    expected: FAIL
+
+  [Unknown attributes names get blocked without being allowed.]
+    expected: FAIL
+
+  [Unknown attribute names pass when allowed.]
+    expected: FAIL

--- a/tests/wpt/meta/sanitizer-api/sethtml-safety.tentative.html.ini
+++ b/tests/wpt/meta/sanitizer-api/sethtml-safety.tentative.html.ini
@@ -1,0 +1,27 @@
+[sethtml-safety.tentative.html]
+  [Testcase #0, setHTML("test)".]
+    expected: FAIL
+
+  [Testcase #1, setHTML("<p>Hello</p>)".]
+    expected: FAIL
+
+  [Testcase #2, setHTML("<div>Hello<script>World</script>xxx)".]
+    expected: FAIL
+
+  [Testcase #3, setHTML("<div>Hello<script>World</script>xxx)".]
+    expected: FAIL
+
+  [Testcase #4, setHTML("<svg>Hello<script>World</script>xxx)".]
+    expected: FAIL
+
+  [Testcase #5, setHTML("<a href="https://web-platform.test/" onclick="2+2" one="two">)".]
+    expected: FAIL
+
+  [Testcase #6, setHTML("<a href="https://web-platform.test/" onclick="2+2" one="two">)".]
+    expected: FAIL
+
+  [Testcase #7, setHTML("<img src="https://web-platform.test/test-image" onclick="2+2" one="two">)".]
+    expected: FAIL
+
+  [Testcase #8, setHTML("<p data-x="1" data-y="2" data-z="3">)".]
+    expected: FAIL

--- a/tests/wpt/meta/sanitizer-api/sethtml-tree-construction.tentative.html.ini
+++ b/tests/wpt/meta/sanitizer-api/sethtml-tree-construction.tentative.html.ini
@@ -1,0 +1,243 @@
+[sethtml-tree-construction.tentative.html]
+  [Non-string input: empty object.]
+    expected: FAIL
+
+  [Non-string input: number.]
+    expected: FAIL
+
+  [Non-string input: octal number.]
+    expected: FAIL
+
+  [Non-string input: expression.]
+    expected: FAIL
+
+  [Non-string input: undefined.]
+    expected: FAIL
+
+  [Testcase #0, "test", config: "undefined".]
+    expected: FAIL
+
+  [Testcase #1, "<b>bla</b>", config: "undefined".]
+    expected: FAIL
+
+  [Testcase #2, "<a<embla", config: "undefined".]
+    expected: FAIL
+
+  [Testcase #3, "<html><head></head><body>test</body></html>", config: "undefined".]
+    expected: FAIL
+
+  [Testcase #4, "<div>test", config: "undefined".]
+    expected: FAIL
+
+  [Testcase #5, "<script>alert('i am a test')</script>", config: "undefined".]
+    expected: FAIL
+
+  [Testcase #6, "hello<script>alert('i am a test')</script>", config: "undefined".]
+    expected: FAIL
+
+  [Testcase #7, "<div><b>hello<script>alert('i am a test')</script>", config: "undefined".]
+    expected: FAIL
+
+  [Testcase #8, "<p onclick='a= 123'>Click.</p>", config: "undefined".]
+    expected: FAIL
+
+  [Testcase #9, "<plaintext><p>text</p>", config: "{}".]
+    expected: FAIL
+
+  [Testcase #10, "<xmp>TEXT</xmp>", config: "{}".]
+    expected: FAIL
+
+  [Testcase #11, "test", config: "{ "test": 123 }".]
+    expected: FAIL
+
+  [Testcase #12, "test", config: "{ "removeElements": [\] }".]
+    expected: FAIL
+
+  [Testcase #13, "<div>test</div><p>bla", config: "{ "removeElements": ["div"\] }".]
+    expected: FAIL
+
+  [Testcase #14, "<custom-element>test1</custom-element>bla", config: "undefined".]
+    expected: FAIL
+
+  [Testcase #15, "<custom-element>test3</custom-element>bla", config: "{ "elements": ["custom-element"\] }".]
+    expected: FAIL
+
+  [Testcase #16, "<custom-element>test5</custom-element>bla", config: "{ "removeElements": ["custom-element"\] }".]
+    expected: FAIL
+
+  [Testcase #17, "<script>alert('i am a test')</script>", config: "{ "removeElements": ["script"\] }".]
+    expected: FAIL
+
+  [Testcase #18, "<div>balabala<i>test</i></div><test-element>t</test-element>", config: "{ "removeElements": ["test-element", "i"\] }".]
+    expected: FAIL
+
+  [Testcase #19, "<div>balabala<i>i</i><p>t</p></div>", config: "{ "removeElements": ["dl", "p"\] }".]
+    expected: FAIL
+
+  [Testcase #20, "<div>test<div>p</div>tt<p>div</p></div>", config: "{ "elements": ["p"\], "replaceWithChildrenElements": ["div"\] }".]
+    expected: FAIL
+
+  [Testcase #22, "<p id='test'>Click.</p>", config: "{ "removeAttributes": [\] }".]
+    expected: FAIL
+
+  [Testcase #23, "<p id='test'>Click.</p>", config: "{ "removeAttributes": ["id"\] }".]
+    expected: FAIL
+
+  [Testcase #24, "<p id='test'>Click.</p>", config: "{ "elements": ["p"\], "removeAttributes": ["id"\] }".]
+    expected: FAIL
+
+  [Testcase #25, "<p id='p' data-attribute-with-dashes='123'>Click.</p><script>document.getElementById('p').dataset.attributeWithDashes=123;</script>", config: "{ "elements": ["p"\], "removeAttributes": ["data-attribute-with-dashes"\] }".]
+    expected: FAIL
+
+  [Testcase #26, "<p id='p' title='p'>P</p><div id='div' title='div'>DIV</div>", config: "{ "elements": [\n  { "name": "p", "attributes": ["title"\] },\n  { "name": "div", "attributes": ["id"\] }\n\]}".]
+    expected: FAIL
+
+  [Testcase #27, "<p id='p' title='p'>P</p><div id='div' title='div'>DIV</div>", config: "{ "elements":\n  [\n    { "name": "p", "removeAttributes": ["title"\] },\n    { "name": "div", "removeAttributes": ["id"\] }\n  \]\n}".]
+    expected: FAIL
+
+  [Testcase #29, "<div id='div' title='div'>DIV</div>", config: "{ "elements": [{ "name": "div", "attributes": ["id", "title"\] }\],\n  "attributes": [\]}".]
+    expected: FAIL
+
+  [Testcase #30, "<div id='div' title='div'>DIV</div>", config: "{\n  "elements": [{ "name": "div", "attributes": [\] }\],\n  "removeAttributes": ["id", "title"\]\n}".]
+    expected: FAIL
+
+  [Testcase #31, "<div id='div' title='div'>DIV</div>", config: "{\n  "elements": [{ "name": "div", "removeAttributes": ["id", "title"\] }\],\n  "attributes": ["id", "title"\]\n}".]
+    expected: FAIL
+
+  [Testcase #32, "<p id='test' onclick='a= 123'>Click.</p>", config: "{ "attributes": ["id"\] }".]
+    expected: FAIL
+
+  [Testcase #34, "<template><script>test</script><div>hello</div></template>", config: "{ "elements": ["template", "div"\] }".]
+    expected: FAIL
+
+  [Testcase #35, "<a href='javascript:evil.com'>Click.</a>", config: "undefined".]
+    expected: FAIL
+
+  [Testcase #36, "<a href='  javascript:evil.com'>Click.</a>", config: "undefined".]
+    expected: FAIL
+
+  [Testcase #37, "<a href='http:evil.com'>Click.</a>", config: "undefined".]
+    expected: FAIL
+
+  [Testcase #38, "<area href='javascript:evil.com'>", config: "{}".]
+    expected: FAIL
+
+  [Testcase #39, "<area href=' javascript:evil.com'>", config: "{}".]
+    expected: FAIL
+
+  [Testcase #40, "<area href='http:evil.com'>", config: "{}".]
+    expected: FAIL
+
+  [Testcase #41, "<form action='javascript:evil.com'>Click.</form>", config: "{}".]
+    expected: FAIL
+
+  [Testcase #42, "<form action=' javascript:evil.com'>Click.</form>", config: "{}".]
+    expected: FAIL
+
+  [Testcase #43, "<form action='http:evil.com'>Click.</form>", config: "{}".]
+    expected: FAIL
+
+  [Testcase #44, "<input formaction='javascript:evil.com'>", config: "{}".]
+    expected: FAIL
+
+  [Testcase #45, "<input formaction=' javascript:evil.com'>", config: "{}".]
+    expected: FAIL
+
+  [Testcase #46, "<input formaction='http:evil.com'>", config: "{}".]
+    expected: FAIL
+
+  [Testcase #47, "<button formaction='javascript:evil.com'>Click.</button>", config: "{}".]
+    expected: FAIL
+
+  [Testcase #48, "<button formaction=' javascript:evil.com'>Click.</button>", config: "{}".]
+    expected: FAIL
+
+  [Testcase #49, "<button formaction='http:evil.com'>Click.</button>", config: "{}".]
+    expected: FAIL
+
+  [Testcase #50, "<p>Some text</p></body><!-- 1 --></html><!-- 2 --><p>Some more text</p>", config: "undefined".]
+    expected: FAIL
+
+  [Testcase #51, "<p>Some text</p><!-- 1 --><!-- 2 --><p>Some more text</p>", config: "undefined".]
+    expected: FAIL
+
+  [Testcase #52, "<p>Some text</p><!-- 1 --><!-- 2 --><p>Some more text</p>", config: "{ "comments": true }".]
+    expected: FAIL
+
+  [Testcase #53, "<p>Some text</p><!-- 1 --><!-- 2 --><p>Some more text</p>", config: "{ "comments": false }".]
+    expected: FAIL
+
+  [Testcase #54, "<p>comment<!-- hello -->in<!-- </p> -->text</p>", config: "undefined".]
+    expected: FAIL
+
+  [Testcase #55, "<p>comment<!-- hello -->in<!-- </p> -->text</p>", config: "{ "comments": true }".]
+    expected: FAIL
+
+  [Testcase #56, "<p>comment<!-- hello -->in<!-- </p> -->text</p>", config: "{ "comments": false }".]
+    expected: FAIL
+
+  [Testcase #57, "<svg></svg>", config: "{ "elements": ["svg"\] }".]
+    expected: FAIL
+
+  [Testcase #58, "<div><svg></svg></div>", config: "{ "elements": ["div", "svg"\] }".]
+    expected: FAIL
+
+  [Testcase #59, "<div>balabala<dl>test</dl></div>", config: "{ "removeElements": ["I", "DL"\] }".]
+    expected: FAIL
+
+  [Testcase #60, "<div>balabala<dl>test</dl></div>", config: "{ "removeElements": ["i", "dl"\] }".]
+    expected: FAIL
+
+  [Testcase #61, "<DIV>balabala<DL>test</DL></DIV>", config: "{ "removeElements": ["i", "dl"\] }".]
+    expected: FAIL
+
+  [Testcase #62, "<p id="test">Click.</p>", config: "{ "removeAttributes": ["ID"\] }".]
+    expected: FAIL
+
+  [Testcase #63, "<p ID="test">Click.</p>", config: "{ "removeAttributes": ["ID"\] }".]
+    expected: FAIL
+
+  [Testcase #64, "<p ID="test">Click.</p>", config: "{ "removeAttributes": ["id"\] }".]
+    expected: FAIL
+
+  [Testcase #65, "<div>balabala<i>test</i></div><test>t</test><custom-element>custom-element</custom-element>", config: "{ "removeElements": [123, "test", "i", "custom-element"\] }".]
+    expected: FAIL
+
+  [Testcase #66, "<div>balabala<i>test</i></div><test>t</test><custom-element>custom-element</custom-element>", config: "{ "replaceWithChildrenElements": [123, "test", "i", "custom-element"\],\n  "elements": ["div"\]}".]
+    expected: FAIL
+
+  [Testcase #67, "<div>test<div>p</div>tt<p>div</p></div><test>test</test>", config: "{ "elements": ["p", "test"\], "replaceWithChildrenElements": ["div"\] }".]
+    expected: FAIL
+
+  [Testcase #68, "test<div>p</div>tt<p>div</p><test>test</test>", config: "{ "elements": ["p", "test"\], "replaceWithChildrenElements": ["div"\] }".]
+    expected: FAIL
+
+  [Testcase #69, "<div hello='1' world='2'><b hello='3' world='4'>", config: "{ "elements": ["div", "b"\], "attributes": ["hello", "world"\] }".]
+    expected: FAIL
+
+  [Testcase #70, "<div hello='1' world='2'><b hello='3' world='4'>", config: "{ "elements": ["div", "b"\], "removeAttributes": ["hello", "world"\] }".]
+    expected: FAIL
+
+  [Testcase #71, "<table><div><td>", config: "{ "replaceWithChildrenElements": ["table"\] }".]
+    expected: FAIL
+
+  [Testcase #72, "<template><div>Hello</div></template>", config: "{}".]
+    expected: FAIL
+
+  [Testcase #73, "<template><div>Hello</div></template>", config: "{ "elements": ["div"\]}".]
+    expected: FAIL
+
+  [Testcase #74, "<template><div>Hello</div></template>", config: "{ "elements": ["template"\]}".]
+    expected: FAIL
+
+  [Testcase #75, "<template><div>Hello</div></template>", config: "{ "elements": ["div", "template"\]}".]
+    expected: FAIL
+
+  [Testcase #76, "<template><div>Hello</div></template>", config: "{ "elements": ["template"\], "replaceWithChildrenElements": ["div"\]}".]
+    expected: FAIL
+
+  [Testcase #77, "<a href="about:blank" rel="opener">Click.</a>", config: "undefined".]
+    expected: FAIL
+
+  [Testcase #78, "<div><b><em><foo><foob><fooc><aside></b></em></div>", config: "{ "removeElements": ["em"\] }".]
+    expected: FAIL

--- a/tests/wpt/meta/sanitizer-api/sethtml-with-custom-elements.tentative.html.ini
+++ b/tests/wpt/meta/sanitizer-api/sethtml-with-custom-elements.tentative.html.ini
@@ -1,0 +1,9 @@
+[sethtml-with-custom-elements.tentative.html]
+  [Custom element that is removed during sanitization.]
+    expected: FAIL
+
+  [Custom element that is allowed.]
+    expected: FAIL
+
+  [Scoped custom element registry still works.]
+    expected: FAIL

--- a/tests/wpt/meta/sanitizer-api/sethtml-with-declarative-shadow-root.tentative.html.ini
+++ b/tests/wpt/meta/sanitizer-api/sethtml-with-declarative-shadow-root.tentative.html.ini
@@ -1,0 +1,27 @@
+[sethtml-with-declarative-shadow-root.tentative.html]
+  [template with shadowrootmode should be removed by safe default]
+    expected: FAIL
+
+  [template with shadowrootmode should not be processed when <template> is forbidden]
+    expected: FAIL
+
+  [template with shadowrootmode should be processed as a normal template when the shadowRootMode attribute is forbidden]
+    expected: FAIL
+
+  [shadowRoot.delegatesFocus does not propagate to the shadow root when shadowrootdelegatesfocus is removed by sanitizer]
+    expected: FAIL
+
+  [shadowRoot.serializable does not propagate to the shadow root when shadowrootserializable is removed by sanitizer]
+    expected: FAIL
+
+  [shadowRoot.clonable does not propagate to the shadow root when shadowrootclonable is removed by sanitizer]
+    expected: FAIL
+
+  [shadowRoot.referenceTarget does not propagate to the shadow root when shadowrootreferencetarget is removed by sanitizer]
+    expected: FAIL
+
+  [shadowRoot.customElementRegistry does not propagate to the shadow root when shadowrootcustomelementregistry is removed by sanitizer]
+    expected: FAIL
+
+  [shadowRoot.adoptedStyleSheets does not propagate to the shadow root when shadowrootadoptedstylesheets is removed by sanitizer]
+    expected: FAIL

--- a/tests/wpt/meta/sanitizer-api/sethtml-with-trustedtypes-createParserOptions.tentative.html.ini
+++ b/tests/wpt/meta/sanitizer-api/sethtml-with-trustedtypes-createParserOptions.tentative.html.ini
@@ -1,0 +1,6 @@
+[sethtml-with-trustedtypes-createParserOptions.tentative.html]
+  [ShadowRoot.setHTMLUnsafe: passing a TrustedParserOptions overrides default policy]
+    expected: FAIL
+
+  [Element.setHTMLUnsafe: passing a TrustedParserOptions overrides default policy]
+    expected: FAIL

--- a/tests/wpt/meta/sanitizer-api/sethtml-with-trustedtypes-immutable.tentative.html.ini
+++ b/tests/wpt/meta/sanitizer-api/sethtml-with-trustedtypes-immutable.tentative.html.ini
@@ -1,0 +1,6 @@
+[sethtml-with-trustedtypes-immutable.tentative.html]
+  [createParserOptions doesn't mutate original object]
+    expected: FAIL
+
+  [createParserOptions doesn't mutate sanitizer object]
+    expected: FAIL

--- a/tests/wpt/meta/sanitizer-api/sethtml-with-trustedtypes.tentative.html.ini
+++ b/tests/wpt/meta/sanitizer-api/sethtml-with-trustedtypes.tentative.html.ini
@@ -1,0 +1,300 @@
+[sethtml-with-trustedtypes.tentative.html]
+  [ShadowRoot.setHTMLUnsafe: createParserOptions can inject a sanitizer config]
+    expected: FAIL
+
+  [ShadowRoot.setHTMLUnsafe: createParserOptions can inject a sanitizer]
+    expected: FAIL
+
+  [ShadowRoot.setHTMLUnsafe: createParserOptions can override a sanitizer config]
+    expected: FAIL
+
+  [ShadowRoot.setHTMLUnsafe: createParserOptions returning null fails]
+    expected: FAIL
+
+  [ShadowRoot.setHTMLUnsafe: createParserOptions returning undefined fails]
+    expected: FAIL
+
+  [ShadowRoot.setHTMLUnsafe: createParserOptions returning 0 fails]
+    expected: FAIL
+
+  [ShadowRoot.setHTMLUnsafe: createParserOptions returning 123 fails]
+    expected: FAIL
+
+  [ShadowRoot.setHTMLUnsafe: createParserOptions returning "foo" fails]
+    expected: FAIL
+
+  [ShadowRoot.innerHTML: createParserOptions can inject a sanitizer config]
+    expected: FAIL
+
+  [ShadowRoot.innerHTML: createParserOptions can inject a sanitizer]
+    expected: FAIL
+
+  [ShadowRoot.innerHTML: createParserOptions can override a sanitizer config]
+    expected: FAIL
+
+  [ShadowRoot.innerHTML: createParserOptions returning null fails]
+    expected: FAIL
+
+  [ShadowRoot.innerHTML: createParserOptions returning undefined fails]
+    expected: FAIL
+
+  [ShadowRoot.innerHTML: createParserOptions returning 0 fails]
+    expected: FAIL
+
+  [ShadowRoot.innerHTML: createParserOptions returning 123 fails]
+    expected: FAIL
+
+  [ShadowRoot.innerHTML: createParserOptions returning "foo" fails]
+    expected: FAIL
+
+  [ShadowRoot.beforebegin: createParserOptions can inject a sanitizer config]
+    expected: FAIL
+
+  [ShadowRoot.beforebegin: createParserOptions can inject a sanitizer]
+    expected: FAIL
+
+  [ShadowRoot.beforebegin: createParserOptions can override a sanitizer config]
+    expected: FAIL
+
+  [ShadowRoot.beforebegin: createParserOptions returning null fails]
+    expected: FAIL
+
+  [ShadowRoot.beforebegin: createParserOptions returning undefined fails]
+    expected: FAIL
+
+  [ShadowRoot.beforebegin: createParserOptions returning 0 fails]
+    expected: FAIL
+
+  [ShadowRoot.beforebegin: createParserOptions returning 123 fails]
+    expected: FAIL
+
+  [ShadowRoot.beforebegin: createParserOptions returning "foo" fails]
+    expected: FAIL
+
+  [ShadowRoot.afterend: createParserOptions can inject a sanitizer config]
+    expected: FAIL
+
+  [ShadowRoot.afterend: createParserOptions can inject a sanitizer]
+    expected: FAIL
+
+  [ShadowRoot.afterend: createParserOptions can override a sanitizer config]
+    expected: FAIL
+
+  [ShadowRoot.afterend: createParserOptions returning null fails]
+    expected: FAIL
+
+  [ShadowRoot.afterend: createParserOptions returning undefined fails]
+    expected: FAIL
+
+  [ShadowRoot.afterend: createParserOptions returning 0 fails]
+    expected: FAIL
+
+  [ShadowRoot.afterend: createParserOptions returning 123 fails]
+    expected: FAIL
+
+  [ShadowRoot.afterend: createParserOptions returning "foo" fails]
+    expected: FAIL
+
+  [ShadowRoot.setHTMLUnsafe: createParserOptions works after createHTML]
+    expected: FAIL
+
+  [ShadowRoot: createParserOptions cannot add unsafe elements to safe HTML setting]
+    expected: FAIL
+
+  [Element.setHTMLUnsafe: createParserOptions can inject a sanitizer config]
+    expected: FAIL
+
+  [Element.setHTMLUnsafe: createParserOptions can inject a sanitizer]
+    expected: FAIL
+
+  [Element.setHTMLUnsafe: createParserOptions can override a sanitizer config]
+    expected: FAIL
+
+  [Element.setHTMLUnsafe: createParserOptions returning null fails]
+    expected: FAIL
+
+  [Element.setHTMLUnsafe: createParserOptions returning undefined fails]
+    expected: FAIL
+
+  [Element.setHTMLUnsafe: createParserOptions returning 0 fails]
+    expected: FAIL
+
+  [Element.setHTMLUnsafe: createParserOptions returning 123 fails]
+    expected: FAIL
+
+  [Element.setHTMLUnsafe: createParserOptions returning "foo" fails]
+    expected: FAIL
+
+  [Element.innerHTML: createParserOptions can inject a sanitizer config]
+    expected: FAIL
+
+  [Element.innerHTML: createParserOptions can inject a sanitizer]
+    expected: FAIL
+
+  [Element.innerHTML: createParserOptions can override a sanitizer config]
+    expected: FAIL
+
+  [Element.innerHTML: createParserOptions returning null fails]
+    expected: FAIL
+
+  [Element.innerHTML: createParserOptions returning undefined fails]
+    expected: FAIL
+
+  [Element.innerHTML: createParserOptions returning 0 fails]
+    expected: FAIL
+
+  [Element.innerHTML: createParserOptions returning 123 fails]
+    expected: FAIL
+
+  [Element.innerHTML: createParserOptions returning "foo" fails]
+    expected: FAIL
+
+  [Element.outerHTML: createParserOptions can inject a sanitizer config]
+    expected: FAIL
+
+  [Element.outerHTML: createParserOptions can inject a sanitizer]
+    expected: FAIL
+
+  [Element.outerHTML: createParserOptions can override a sanitizer config]
+    expected: FAIL
+
+  [Element.outerHTML: createParserOptions returning null fails]
+    expected: FAIL
+
+  [Element.outerHTML: createParserOptions returning undefined fails]
+    expected: FAIL
+
+  [Element.outerHTML: createParserOptions returning 0 fails]
+    expected: FAIL
+
+  [Element.outerHTML: createParserOptions returning 123 fails]
+    expected: FAIL
+
+  [Element.outerHTML: createParserOptions returning "foo" fails]
+    expected: FAIL
+
+  [Element.createContextualFragment: createParserOptions can inject a sanitizer config]
+    expected: FAIL
+
+  [Element.createContextualFragment: createParserOptions can inject a sanitizer]
+    expected: FAIL
+
+  [Element.createContextualFragment: createParserOptions can override a sanitizer config]
+    expected: FAIL
+
+  [Element.createContextualFragment: createParserOptions returning null fails]
+    expected: FAIL
+
+  [Element.createContextualFragment: createParserOptions returning undefined fails]
+    expected: FAIL
+
+  [Element.createContextualFragment: createParserOptions returning 0 fails]
+    expected: FAIL
+
+  [Element.createContextualFragment: createParserOptions returning 123 fails]
+    expected: FAIL
+
+  [Element.createContextualFragment: createParserOptions returning "foo" fails]
+    expected: FAIL
+
+  [Element.afterbegin: createParserOptions can inject a sanitizer config]
+    expected: FAIL
+
+  [Element.afterbegin: createParserOptions can inject a sanitizer]
+    expected: FAIL
+
+  [Element.afterbegin: createParserOptions can override a sanitizer config]
+    expected: FAIL
+
+  [Element.afterbegin: createParserOptions returning null fails]
+    expected: FAIL
+
+  [Element.afterbegin: createParserOptions returning undefined fails]
+    expected: FAIL
+
+  [Element.afterbegin: createParserOptions returning 0 fails]
+    expected: FAIL
+
+  [Element.afterbegin: createParserOptions returning 123 fails]
+    expected: FAIL
+
+  [Element.afterbegin: createParserOptions returning "foo" fails]
+    expected: FAIL
+
+  [Element.beforeend: createParserOptions can inject a sanitizer config]
+    expected: FAIL
+
+  [Element.beforeend: createParserOptions can inject a sanitizer]
+    expected: FAIL
+
+  [Element.beforeend: createParserOptions can override a sanitizer config]
+    expected: FAIL
+
+  [Element.beforeend: createParserOptions returning null fails]
+    expected: FAIL
+
+  [Element.beforeend: createParserOptions returning undefined fails]
+    expected: FAIL
+
+  [Element.beforeend: createParserOptions returning 0 fails]
+    expected: FAIL
+
+  [Element.beforeend: createParserOptions returning 123 fails]
+    expected: FAIL
+
+  [Element.beforeend: createParserOptions returning "foo" fails]
+    expected: FAIL
+
+  [Element.beforebegin: createParserOptions can inject a sanitizer config]
+    expected: FAIL
+
+  [Element.beforebegin: createParserOptions can inject a sanitizer]
+    expected: FAIL
+
+  [Element.beforebegin: createParserOptions can override a sanitizer config]
+    expected: FAIL
+
+  [Element.beforebegin: createParserOptions returning null fails]
+    expected: FAIL
+
+  [Element.beforebegin: createParserOptions returning undefined fails]
+    expected: FAIL
+
+  [Element.beforebegin: createParserOptions returning 0 fails]
+    expected: FAIL
+
+  [Element.beforebegin: createParserOptions returning 123 fails]
+    expected: FAIL
+
+  [Element.beforebegin: createParserOptions returning "foo" fails]
+    expected: FAIL
+
+  [Element.afterend: createParserOptions can inject a sanitizer config]
+    expected: FAIL
+
+  [Element.afterend: createParserOptions can inject a sanitizer]
+    expected: FAIL
+
+  [Element.afterend: createParserOptions can override a sanitizer config]
+    expected: FAIL
+
+  [Element.afterend: createParserOptions returning null fails]
+    expected: FAIL
+
+  [Element.afterend: createParserOptions returning undefined fails]
+    expected: FAIL
+
+  [Element.afterend: createParserOptions returning 0 fails]
+    expected: FAIL
+
+  [Element.afterend: createParserOptions returning 123 fails]
+    expected: FAIL
+
+  [Element.afterend: createParserOptions returning "foo" fails]
+    expected: FAIL
+
+  [Element.setHTMLUnsafe: createParserOptions works after createHTML]
+    expected: FAIL
+
+  [Element: createParserOptions cannot add unsafe elements to safe HTML setting]
+    expected: FAIL

--- a/tests/wpt/meta/sanitizer-api/sethtml-xml-document.html.ini
+++ b/tests/wpt/meta/sanitizer-api/sethtml-xml-document.html.ini
@@ -1,0 +1,12 @@
+[sethtml-xml-document.html]
+  [Testcase #0 with xmlDoc.setHTML("Hello!")]
+    expected: FAIL
+
+  [Testcase #1 with xmlDoc.setHTML("<br>")]
+    expected: FAIL
+
+  [Testcase #2 with xmlDoc.setHTML("<p>Hi</p>")]
+    expected: FAIL
+
+  [Testcase #3 with xmlDoc.setHTML("<iframe></iframe><p>text</p>")]
+    expected: FAIL


### PR DESCRIPTION
Initialize Sanitizer API implementation with partially implemented constructor and `get()` methods of the `Sanitizer` interface, which allows the sub-sequential implementation to be tested by WPT.

The `Sanitizer` interface is hidden behind the feature flag `dom_sanitizer_enabled`, which is disabled by default.

Specification: https://wicg.github.io/sanitizer-api/

Testing: Enable WPT tests for Sanitizer API.
Fixes: Part of #43948
