### PR TITLE
servoshell: Fix incorrect calculation of WebView dimension.

### DIFF
--- a/ports/servoshell/desktop/gui.rs
+++ b/ports/servoshell/desktop/gui.rs
@@ -554,7 +554,7 @@ impl Gui {
 
             // If the top parts of the GUI changed size, then update the size of the WebView and also
             // the size of its RenderingContext.
-            let rect = ctx.content_rect();
+            let available_rect = ctx.available_rect_before_wrap();
 
             // Build a graft node for each WebView.
             for (webview_id, webview) in window.webviews() {
@@ -565,7 +565,7 @@ impl Gui {
                     });
                 }
             }
-            let size = Size2D::new(rect.width(), rect.height()) * scale;
+            let size = Size2D::new(available_rect.width(), available_rect.height()) * scale;
             if let Some(webview) = window.active_webview() &&
                 size != webview.size()
             {
@@ -580,7 +580,7 @@ impl Gui {
                     ctx.clone(),
                     LayerId::new(Order::Tooltip, Id::new("tooltip")),
                     "tooltip layer".into(),
-                    pos2(0.0, ctx.content_rect().max.y),
+                    pos2(0.0, available_rect.max.y),
                 )
                 .show(|ui| ui.add(Label::new(status_text.clone()).extend()));
                 window.set_needs_repaint();
@@ -589,12 +589,8 @@ impl Gui {
             window.repaint_webviews();
 
             if let Some(render_to_parent) = rendering_context.render_to_parent_callback() {
-                let rect = egui::Rect::from_two_pos(
-                    (0.0, toolbar_height.0).into(),
-                    ctx.content_rect().max,
-                );
                 ctx.layer_painter(LayerId::background()).add(PaintCallback {
-                    rect,
+                    rect: available_rect,
                     callback: Arc::new(CallbackFn::new(move |info, painter| {
                         let clip = info.viewport_in_pixels();
                         let rect_in_parent = Rect::new(


### PR DESCRIPTION
The upgrade to egui 0.34.0 in #44053 replaced the usage of the deprecated `Ui::available_rect` method with `Ui::content_rect` as suggested in the deprecation notice in egui. However, `content_rect` is not equivalent to `available_rect` and doesn't seem to account for the area occupied by the egui panels.

Since `content_rect` returns the window's inner dimensions, we don't ask the webview to resize itself to the correct dimension that excludes the toolbar (tabs and url). We also pass the correct dimension to egui's paint callback, which meant that the WebView appeared vertically squashed.

Fix this by using `available_rect_before_wrap` method instead of `content_rect`. This seems to return the correct area that we need for the WebView's dimenstion. The code in egui also seems closer to what we want as it relies on a cursor that is advanced after each widget is added. However, I'm not sure in which scenario the wrapping matters as there is no documentation for this method.

Testing: Tested manually as we don't have automated tests for the shell.
Fixes: #44136