### PR TITLE
webdriver: Wait until browsing context is open

### DIFF
--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -624,6 +624,7 @@ impl Handler {
         match self.focused_webview_id()? {
             Some(webview_id) => {
                 self.session_mut()?.set_webview_id(webview_id);
+                self.wait_until_browsing_context_is_open(BrowsingContextId::from(webview_id))?;
                 self.session_mut()?
                     .set_browsing_context_id(BrowsingContextId::from(webview_id));
             },
@@ -642,6 +643,7 @@ impl Handler {
                     .expect("IPC failure when creating new webview for new session");
                 self.focus_webview(webview_id)?;
                 self.session_mut()?.set_webview_id(webview_id);
+                self.wait_until_browsing_context_is_open(BrowsingContextId::from(webview_id))?;
                 self.session_mut()?
                     .set_browsing_context_id(BrowsingContextId::from(webview_id));
                 let _ = self.wait_document_ready(Some(DEFAULT_PAGE_LOAD_TIMEOUT));
@@ -2637,6 +2639,37 @@ impl Handler {
         } else {
             Ok(())
         }
+    }
+
+    fn wait_until_browsing_context_is_open(
+        &self,
+        browsing_context_id: BrowsingContextId,
+    ) -> WebDriverResult<()> {
+        let now = Instant::now();
+        let (timeout, sleep_interval) = {
+            let timeouts = self.session()?.session_timeouts();
+            (
+                timeouts
+                    .page_load
+                    .map_or(Duration::MAX, Duration::from_millis),
+                Duration::from_millis(timeouts.sleep_interval),
+            )
+        };
+
+        while now.elapsed() < timeout {
+            if self
+                .verify_browsing_context_is_open(browsing_context_id)
+                .is_ok()
+            {
+                return Ok(());
+            }
+
+            sleep(sleep_interval);
+        }
+        Err(WebDriverError::new(
+            ErrorStatus::Timeout,
+            "Timed out waiting for the top-level browsing context to be ready",
+        ))
     }
 
     fn focus_webview(&self, webview_id: WebViewId) -> WebDriverResult<()> {

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -623,6 +623,7 @@ impl Handler {
         match self.focused_webview_id()? {
             Some(webview_id) => {
                 self.session_mut()?.set_webview_id(webview_id);
+                self.wait_until_browsing_context_is_open(BrowsingContextId::from(webview_id))?;
                 self.session_mut()?
                     .set_browsing_context_id(BrowsingContextId::from(webview_id));
             },
@@ -641,6 +642,7 @@ impl Handler {
                     .expect("IPC failure when creating new webview for new session");
                 self.focus_webview(webview_id)?;
                 self.session_mut()?.set_webview_id(webview_id);
+                self.wait_until_browsing_context_is_open(BrowsingContextId::from(webview_id))?;
                 self.session_mut()?
                     .set_browsing_context_id(BrowsingContextId::from(webview_id));
                 let _ = self.wait_document_ready(Some(DEFAULT_PAGE_LOAD_TIMEOUT));
@@ -2636,6 +2638,37 @@ impl Handler {
         } else {
             Ok(())
         }
+    }
+
+    fn wait_until_browsing_context_is_open(
+        &self,
+        browsing_context_id: BrowsingContextId,
+    ) -> WebDriverResult<()> {
+        let now = Instant::now();
+        let (timeout, sleep_interval) = {
+            let timeouts = self.session()?.session_timeouts();
+            (
+                timeouts
+                    .page_load
+                    .map_or(Duration::MAX, Duration::from_millis),
+                Duration::from_millis(timeouts.sleep_interval),
+            )
+        };
+
+        while now.elapsed() < timeout {
+            if self
+                .verify_browsing_context_is_open(browsing_context_id)
+                .is_ok()
+            {
+                return Ok(());
+            }
+
+            sleep(sleep_interval);
+        }
+        Err(WebDriverError::new(
+            ErrorStatus::Timeout,
+            "Timed out waiting for the top-level browsing context to be ready",
+        ))
     }
 
     fn focus_webview(&self, webview_id: WebViewId) -> WebDriverResult<()> {

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -2645,18 +2645,17 @@ impl Handler {
         &self,
         browsing_context_id: BrowsingContextId,
     ) -> WebDriverResult<()> {
+        // There is no timeout specified in the spec (Step 8), so we use a default value.
+        // <https://w3c.github.io/webdriver/#new-session>
+        // We can't use the user defined value - it causes the webdriver timeout tests to fail.
+        const OPEN_BROWSING_CONTEXT_TIMEOUT: Duration =
+            Duration::from_millis(DEFAULT_PAGE_LOAD_TIMEOUT);
         let now = Instant::now();
-        let (timeout, sleep_interval) = {
-            let timeouts = self.session()?.session_timeouts();
-            (
-                timeouts
-                    .page_load
-                    .map_or(Duration::MAX, Duration::from_millis),
-                Duration::from_millis(timeouts.sleep_interval),
-            )
-        };
+        let timeouts = self.session()?.session_timeouts();
 
-        while now.elapsed() < timeout {
+        let sleep_interval = Duration::from_millis(timeouts.sleep_interval);
+
+        while now.elapsed() < OPEN_BROWSING_CONTEXT_TIMEOUT {
             if self
                 .verify_browsing_context_is_open(browsing_context_id)
                 .is_ok()

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -2645,9 +2645,8 @@ impl Handler {
         &self,
         browsing_context_id: BrowsingContextId,
     ) -> WebDriverResult<()> {
-        // There is no timeout specified in the spec (Step 8), so we use a default value.
-        // <https://w3c.github.io/webdriver/#new-session>
-        // We can't use the user defined value - it causes the webdriver timeout tests to fail.
+        // We cannot use provided timeout from configuration, as `fn wait_until_browsing_context_is_open` is not a standard step in spec.
+        // Some tests use `page_load = 0` deliberately, which would always fail with the function.
         const OPEN_BROWSING_CONTEXT_TIMEOUT: Duration =
             Duration::from_millis(DEFAULT_PAGE_LOAD_TIMEOUT);
         let now = Instant::now();

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -2666,7 +2666,9 @@ impl Handler {
         }
         Err(WebDriverError::new(
             ErrorStatus::Timeout,
-            "Timed out waiting for the top-level browsing context to be ready",
+            format!(
+                "Timed out waiting for the top-level browsing context {browsing_context_id} to be ready"
+            ),
         ))
     }
 


### PR DESCRIPTION
When running servo with --debug-mozjs and gc-zeal, everything is extremely slow.
We need to wait until the browsing context is open, before replying, otherwise the webdriver client will tell us to do something before servo finished creating the browsing context, causing a failure.

Testing: We don't run gczeal in CI, but existing tests should continue to pass.
Fixes: #43172
