### PR TITLE
script: Construct attribute nodes lazily

### DIFF
--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -890,7 +890,7 @@ pub(crate) fn upgrade_element(
     // with element, callback name "attributeChangedCallback", and « attribute's local name, null, attribute's value,
     // attribute's namespace ».
     let custom_element_reaction_stack = ScriptThread::custom_element_reaction_stack();
-    for attr in element.attrs().iter() {
+    for attr in element.attrs().borrow().iter() {
         let local_name = attr.local_name().clone();
         let value = DOMString::from(&**attr.value());
         let namespace = attr.namespace().clone();

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -135,6 +135,7 @@ use crate::dom::documentorshadowroot::{
 use crate::dom::documenttimeline::DocumentTimeline;
 use crate::dom::documenttype::DocumentType;
 use crate::dom::domimplementation::DOMImplementation;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{CustomElementCreationMode, Element, ElementCreator};
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
@@ -4023,7 +4024,7 @@ impl Document {
         })
     }
 
-    pub(crate) fn element_attr_will_change(&self, el: &Element, attr: &Attr) {
+    pub(crate) fn element_attr_will_change(&self, el: &Element, attr: AttrRef<'_>) {
         // FIXME(emilio): Kind of a shame we have to duplicate this.
         //
         // I'm getting rid of the whole hashtable soon anyway, since all it does
@@ -4062,6 +4063,7 @@ impl Document {
         if snapshot.attrs.is_none() {
             let attrs = el
                 .attrs()
+                .borrow()
                 .iter()
                 .map(|attr| (attr.identifier().clone(), attr.value().clone()))
                 .collect();

--- a/components/script/dom/domstringmap.rs
+++ b/components/script/dom/domstringmap.rs
@@ -182,6 +182,7 @@ impl DOMStringMapMethods<crate::DomTypeHolder> for DOMStringMap {
         // > name in the list returned from getting the DOMStringMap's name-value pairs.
         self.as_element()
             .attrs()
+            .borrow()
             .iter()
             .find(|attr| to_camel_case(attr.local_name()).as_ref() == Some(&name))
             .map(|attr| DOMString::from(&**attr.value()))
@@ -194,6 +195,7 @@ impl DOMStringMapMethods<crate::DomTypeHolder> for DOMStringMap {
         // > pairs at that instant, in the order returned.
         self.as_element()
             .attrs()
+            .borrow()
             .iter()
             .filter_map(|attr| to_camel_case(attr.local_name()))
             .collect()

--- a/components/script/dom/element/attributes/accessors.rs
+++ b/components/script/dom/element/attributes/accessors.rs
@@ -8,11 +8,10 @@ use servo_arc::Arc as ServoArc;
 use style::attr::AttrValue;
 use stylo_atoms::Atom;
 
-use crate::dom::attr::Attr;
 use crate::dom::bindings::codegen::Bindings::AttrBinding::AttrMethods;
 use crate::dom::bindings::codegen::UnionTypes::{TrustedHTMLOrString, TrustedScriptURLOrUSVString};
-use crate::dom::bindings::root::Dom;
 use crate::dom::bindings::str::{DOMString, USVString};
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{AttributeMutationReason, Element};
 use crate::dom::node::NodeTraits;
 
@@ -192,7 +191,7 @@ impl Element {
     /// 1. It uses the same fast-path as CSSStyleDeclaration
     /// 2. It also avoids the CSP checks when cloning (it shouldn't run any when cloning
     ///    existing valid attributes)
-    fn compute_attribute_value_with_style_fast_path(&self, attr: &Dom<Attr>) -> AttrValue {
+    fn compute_attribute_value_with_style_fast_path(&self, attr: AttrRef<'_>) -> AttrValue {
         if *attr.local_name() == local_name!("style") {
             if let Some(ref pdb) = *self.style_attribute().borrow() {
                 let document = self.owner_document();
@@ -215,7 +214,7 @@ impl Element {
         target_element: &Element,
     ) {
         // Step 2.5. For each attribute of node’s attribute list:
-        for attr in self.attrs().iter() {
+        for attr in self.attrs().borrow().iter() {
             // Step 2.5.1. Let copyAttribute be the result of cloning a single node given attribute, document, and null.
             let new_value = self.compute_attribute_value_with_style_fast_path(attr);
             // Step 2.5.2. Append copyAttribute to copy.

--- a/components/script/dom/element/attributes/mod.rs
+++ b/components/script/dom/element/attributes/mod.rs
@@ -1,0 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+pub(crate) mod accessors;
+pub(crate) mod storage;

--- a/components/script/dom/element/attributes/storage.rs
+++ b/components/script/dom/element/attributes/storage.rs
@@ -1,0 +1,346 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use devtools_traits::AttrInfo;
+use html5ever::{LocalName, Namespace, Prefix};
+use script_bindings::root::{Dom, DomRoot};
+use script_bindings::str::DOMString;
+use style::attr::{AttrIdentifier, AttrValue};
+
+use crate::dom::attr::Attr;
+use crate::dom::bindings::cell::{DomRefCell, Ref};
+use crate::dom::bindings::root::ToLayout;
+use crate::dom::element::Element;
+use crate::dom::node::node::NodeTraits;
+
+/// Lightweight attribute storage that avoids allocating a full DOM `Attr` node.
+#[derive(MallocSizeOf)]
+pub(crate) struct ContentAttributeData {
+    pub identifier: AttrIdentifier,
+    pub value: AttrValue,
+}
+
+impl ContentAttributeData {
+    #[inline]
+    pub(crate) fn local_name(&self) -> &LocalName {
+        &self.identifier.local_name.0
+    }
+
+    #[inline]
+    pub(crate) fn name(&self) -> &LocalName {
+        &self.identifier.name.0
+    }
+
+    #[inline]
+    pub(crate) fn namespace(&self) -> &Namespace {
+        &self.identifier.namespace.0
+    }
+
+    #[inline]
+    pub(crate) fn prefix(&self) -> Option<&Prefix> {
+        Some(&self.identifier.prefix.as_ref()?.0)
+    }
+
+    #[inline]
+    pub(crate) fn value(&self) -> &AttrValue {
+        &self.value
+    }
+}
+
+/// A reference to an attribute value, abstracting over direct and RefCell-borrowed access.
+pub(crate) enum AttrValueRef<'a> {
+    /// Direct reference to a value (from [`ContentAttributeData`]).
+    Direct(&'a AttrValue),
+    /// Borrowed from a [`DomRefCell`] (from [`Attr`]).
+    Borrowed(Ref<'a, AttrValue>),
+}
+
+impl std::ops::Deref for AttrValueRef<'_> {
+    type Target = AttrValue;
+
+    fn deref(&self) -> &AttrValue {
+        match self {
+            AttrValueRef::Direct(value) => value,
+            AttrValueRef::Borrowed(value) => value,
+        }
+    }
+}
+
+/// A reference to attribute data, either from a lightweight [`ContentAttributeData`]
+/// or from a full [`Attr`] DOM node. Provides the same accessor interface regardless
+/// of storage form.
+#[derive(Clone, Copy)]
+pub(crate) enum AttrRef<'a> {
+    /// Lightweight data (no DOM node allocated).
+    Raw(&'a ContentAttributeData),
+    /// Full Attr DOM node.
+    Dom(&'a Attr),
+}
+
+impl<'a> AttrRef<'a> {
+    #[inline]
+    pub(crate) fn local_name(&self) -> &'a LocalName {
+        match self {
+            AttrRef::Raw(data) => data.local_name(),
+            AttrRef::Dom(attr) => attr.local_name(),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn name(&self) -> &'a LocalName {
+        match self {
+            AttrRef::Raw(data) => data.name(),
+            AttrRef::Dom(attr) => attr.name(),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn namespace(&self) -> &'a Namespace {
+        match self {
+            AttrRef::Raw(data) => data.namespace(),
+            AttrRef::Dom(attr) => attr.namespace(),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn prefix(&self) -> Option<&'a Prefix> {
+        match self {
+            AttrRef::Raw(data) => data.prefix(),
+            AttrRef::Dom(attr) => attr.prefix(),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn value(&self) -> AttrValueRef<'a> {
+        match self {
+            AttrRef::Raw(data) => AttrValueRef::Direct(data.value()),
+            AttrRef::Dom(attr) => AttrValueRef::Borrowed(attr.value()),
+        }
+    }
+
+    /// Returns the underlying `&Attr` if this is a `Dom` reference.
+    /// Returns `None` for `Raw` data (no DOM node exists).
+    #[inline]
+    pub(crate) fn as_attr(&self) -> Option<&'a Attr> {
+        match self {
+            AttrRef::Dom(attr) => Some(attr),
+            AttrRef::Raw(_) => None,
+        }
+    }
+
+    /// Returns the attribute value as a `DOMString`, equivalent to `Attr::Value()`.
+    pub(crate) fn to_dom_string(self) -> DOMString {
+        DOMString::from(&**self.value())
+    }
+
+    /// Returns a summary for devtools, equivalent to `Attr::summarize()`.
+    pub(crate) fn summarize(&self) -> AttrInfo {
+        AttrInfo {
+            namespace: (**self.namespace()).to_owned(),
+            name: (**self.name()).to_owned(),
+            value: (**self.value()).to_owned(),
+        }
+    }
+
+    /// Returns the `AttrIdentifier` for this attribute.
+    pub(crate) fn identifier(&self) -> &AttrIdentifier {
+        match self {
+            AttrRef::Raw(data) => &data.identifier,
+            AttrRef::Dom(attr) => attr.identifier(),
+        }
+    }
+}
+
+/// A single attribute entry, either lightweight raw data or a full DOM Attr node.
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
+#[derive(MallocSizeOf)]
+pub(crate) enum AttributeEntry {
+    /// Lightweight data — no Attr DOM node allocated.
+    Raw(ContentAttributeData),
+    /// Full Attr DOM node.
+    Dom(Dom<Attr>),
+}
+
+impl AttributeEntry {
+    /// Get an `AttrRef` for this entry.
+    #[inline]
+    pub(crate) fn as_ref(&self) -> AttrRef<'_> {
+        match self {
+            AttributeEntry::Raw(data) => AttrRef::Raw(data),
+            AttributeEntry::Dom(attr) => AttrRef::Dom(attr),
+        }
+    }
+
+    /// Get the value of this attribute for layout.
+    #[expect(unsafe_code)]
+    #[inline]
+    pub(crate) fn value_for_layout(&self) -> &AttrValue {
+        match self {
+            AttributeEntry::Raw(data) => &data.value,
+            AttributeEntry::Dom(attr) => unsafe { attr.to_layout() }.value(),
+        }
+    }
+
+    /// Get the local name of this attribute for layout.
+    #[expect(unsafe_code)]
+    #[inline]
+    pub(crate) fn local_name_for_layout(&self) -> &LocalName {
+        match self {
+            AttributeEntry::Raw(data) => data.local_name(),
+            AttributeEntry::Dom(attr) => unsafe { attr.to_layout() }.local_name(),
+        }
+    }
+
+    /// Get the namespace of this attribute for layout.
+    #[expect(unsafe_code)]
+    #[inline]
+    pub(crate) fn namespace_for_layout(&self) -> &Namespace {
+        match self {
+            AttributeEntry::Raw(data) => data.namespace(),
+            AttributeEntry::Dom(attr) => unsafe { attr.to_layout() }.namespace(),
+        }
+    }
+}
+
+/// Storage for an element's attributes. Contains an internal `DomRefCell` so that
+/// `ensure_dom` can split its borrow around `Attr::new()` allocation, preventing
+/// GC-during-allocation panics from double-borrowing.
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
+#[derive(Default, MallocSizeOf)]
+pub(crate) struct AttributeStorage(DomRefCell<Vec<AttributeEntry>>);
+
+/// A borrowed view of attribute storage that provides convenient access
+/// to attributes as `AttrRef` items.
+pub(crate) struct AttributesBorrow<'a>(Ref<'a, Vec<AttributeEntry>>);
+
+impl<'a> AttributesBorrow<'a> {
+    /// Iterate over attributes as `AttrRef`.
+    #[inline]
+    pub(crate) fn iter(&self) -> impl Iterator<Item = AttrRef<'_>> + '_ {
+        self.0.iter().map(AttributeEntry::as_ref)
+    }
+
+    #[inline]
+    pub(crate) fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    #[inline]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    #[inline]
+    pub(crate) fn first(&self) -> Option<AttrRef<'_>> {
+        self.0.first().map(AttributeEntry::as_ref)
+    }
+
+    #[inline]
+    pub(crate) fn get(&self, index: usize) -> Option<AttrRef<'_>> {
+        self.0.get(index).map(AttributeEntry::as_ref)
+    }
+}
+
+impl AttributeStorage {
+    /// Borrow the attributes for read access with convenient `AttrRef` iteration.
+    #[inline]
+    pub(crate) fn borrow(&self) -> AttributesBorrow<'_> {
+        AttributesBorrow(self.0.borrow())
+    }
+
+    /// Borrow the underlying entries for layout access (unsafe).
+    #[expect(unsafe_code)]
+    #[inline]
+    pub(crate) unsafe fn borrow_for_layout(&self) -> &Vec<AttributeEntry> {
+        unsafe { self.0.borrow_for_layout() }
+    }
+
+    /// Push raw attribute data.
+    pub(crate) fn push_raw(&self, data: ContentAttributeData) {
+        self.0.borrow_mut().push(AttributeEntry::Raw(data));
+    }
+
+    /// Push a Dom Attr node.
+    pub(crate) fn push_dom(&self, attr: &Attr) {
+        self.0
+            .borrow_mut()
+            .push(AttributeEntry::Dom(Dom::from_ref(attr)));
+    }
+
+    /// Remove an attribute by index, returning the entry.
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
+    pub(crate) fn remove(&self, index: usize) -> AttributeEntry {
+        self.0.borrow_mut().remove(index)
+    }
+
+    /// Set an attribute entry by index.
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
+    pub(crate) fn set(&self, index: usize, entry: AttributeEntry) {
+        self.0.borrow_mut()[index] = entry;
+    }
+
+    /// Ensure entry at index is a Dom Attr node, materializing if needed.
+    /// Returns a `DomRoot<Attr>`.
+    ///
+    /// This method carefully splits the mutable borrow around the `Attr::new()`
+    /// allocation so that GC tracing can safely borrow the storage.
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
+    #[expect(unsafe_code)]
+    pub(crate) fn ensure_dom(&self, index: usize, element: &Element) -> DomRoot<Attr> {
+        // Fast path: already materialized.
+        if let AttributeEntry::Dom(attr) = &self.0.borrow()[index] {
+            return DomRoot::from_ref(&**attr);
+        }
+
+        // Extract the raw data, dropping the mutable borrow before allocating.
+        let data = {
+            let mut entries = self.0.borrow_mut();
+            let placeholder = AttributeEntry::Raw(ContentAttributeData {
+                identifier: AttrIdentifier {
+                    local_name: style::values::GenericAtomIdent(html5ever::local_name!("")),
+                    name: style::values::GenericAtomIdent(html5ever::local_name!("")),
+                    namespace: style::values::GenericAtomIdent(html5ever::ns!()),
+                    prefix: None,
+                },
+                value: AttrValue::String(String::new()),
+            });
+            let old = std::mem::replace(&mut entries[index], placeholder);
+            match old {
+                AttributeEntry::Raw(data) => data,
+                _ => unreachable!(),
+            }
+        };
+
+        // TODO: https://github.com/servo/servo/issues/42812
+        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
+        let cx = &mut cx;
+        let doc = element.owner_document();
+        let attr = Attr::new(
+            cx,
+            &doc,
+            data.identifier.local_name.0,
+            data.value,
+            data.identifier.name.0,
+            data.identifier.namespace.0,
+            data.identifier.prefix.map(|p| p.0),
+            Some(element),
+        );
+
+        self.0.borrow_mut()[index] = AttributeEntry::Dom(Dom::from_ref(&*attr));
+        attr
+    }
+}
+
+// Safety: Only Dom entries contain GC-traced Dom<Attr> pointers.
+// Raw entries have no pointers to trace.
+#[expect(unsafe_code)]
+unsafe impl crate::dom::bindings::trace::JSTraceable for AttributeStorage {
+    unsafe fn trace(&self, trc: *mut js::jsapi::JSTracer) {
+        for entry in self.0.borrow().iter() {
+            if let AttributeEntry::Dom(attr) = entry {
+                unsafe { js::rust::Trace::trace(attr, trc) };
+            }
+        }
+    }
+}

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -32,7 +32,7 @@ use selectors::matching::ElementSelectorFlags;
 use selectors::sink::Push;
 use servo_arc::Arc as ServoArc;
 use style::applicable_declarations::ApplicableDeclarationBlock;
-use style::attr::{AttrValue, LengthOrPercentageOrAuto};
+use style::attr::{AttrIdentifier, AttrValue, LengthOrPercentageOrAuto};
 use style::context::QuirksMode;
 use style::invalidation::element::restyle_hints::RestyleHint;
 use style::properties::longhands::{
@@ -51,7 +51,7 @@ use style::values::computed::Overflow;
 use style::values::generics::NonNegative;
 use style::values::generics::position::PreferredRatio;
 use style::values::generics::ratio::Ratio;
-use style::values::{AtomIdent, CSSFloat, computed, specified};
+use style::values::{AtomIdent, CSSFloat, GenericAtomIdent, computed, specified};
 use style::{ArcSlice, CaseSensitivityExt, dom_apis, thread_state};
 use style_traits::CSSPixel;
 use stylo_atoms::Atom;
@@ -105,6 +105,9 @@ use crate::dom::documentfragment::DocumentFragment;
 use crate::dom::domrect::DOMRect;
 use crate::dom::domrectlist::DOMRectList;
 use crate::dom::domtokenlist::DOMTokenList;
+use crate::dom::element::attributes::storage::{
+    AttrRef, AttrValueRef, AttributeEntry, AttributeStorage, ContentAttributeData,
+};
 use crate::dom::elementinternals::ElementInternals;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::html::htmlanchorelement::HTMLAnchorElement;
@@ -178,7 +181,7 @@ pub struct Element {
     namespace: Namespace,
     #[no_trace]
     prefix: DomRefCell<Option<Prefix>>,
-    attrs: DomRefCell<Vec<Dom<Attr>>>,
+    attrs: AttributeStorage,
     #[no_trace]
     id_attribute: DomRefCell<Option<Atom>>,
     /// <https://dom.spec.whatwg.org/#concept-element-is-value>
@@ -303,7 +306,7 @@ impl Element {
             tag_name: TagName::new(),
             namespace,
             prefix: DomRefCell::new(prefix),
-            attrs: DomRefCell::new(vec![]),
+            attrs: Default::default(),
             id_attribute: DomRefCell::new(None),
             is: DomRefCell::new(None),
             style_attribute: DomRefCell::new(None),
@@ -1036,15 +1039,19 @@ pub(crate) fn is_valid_shadow_host_name(name: &LocalName) -> bool {
 }
 
 #[inline]
+#[expect(unsafe_code)]
 pub(crate) fn get_attr_for_layout<'dom>(
     elem: LayoutDom<'dom, Element>,
     namespace: &Namespace,
     name: &LocalName,
 ) -> Option<&'dom AttrValue> {
-    elem.attrs()
+    let storage = unsafe { elem.unsafe_get().attrs.borrow_for_layout() };
+    storage
         .iter()
-        .find(|attr| name == attr.local_name() && namespace == attr.namespace())
-        .map(|attr| attr.value())
+        .find(|e: &&AttributeEntry| {
+            name == e.local_name_for_layout() && namespace == e.namespace_for_layout()
+        })
+        .map(|e: &AttributeEntry| e.value_for_layout())
 }
 
 impl<'dom> LayoutDom<'dom, Element> {
@@ -1069,10 +1076,17 @@ impl<'dom> LayoutDom<'dom, Element> {
         parent_element.local_name() == &local_name!("html")
     }
 
+    /// Iterate over attribute local names for layout, handling mixed Raw and Dom entries.
     #[expect(unsafe_code)]
     #[inline]
-    pub(crate) fn attrs(self) -> &'dom [LayoutDom<'dom, Attr>] {
-        unsafe { LayoutDom::to_layout_slice(self.unsafe_get().attrs.borrow_for_layout()) }
+    pub(crate) fn each_attr_name_for_layout<F>(self, mut callback: F)
+    where
+        F: FnMut(&LocalName),
+    {
+        let storage = unsafe { self.unsafe_get().attrs.borrow_for_layout() };
+        for entry in storage.iter() {
+            callback(entry.local_name_for_layout());
+        }
     }
 
     #[inline]
@@ -1589,17 +1603,16 @@ impl<'dom> LayoutDom<'dom, Element> {
     }
 
     #[inline]
+    #[expect(unsafe_code)]
     pub(crate) fn get_attr_vals_for_layout(
         self,
         name: &LocalName,
     ) -> impl Iterator<Item = &'dom AttrValue> {
-        self.attrs().iter().filter_map(move |attr| {
-            if name == attr.local_name() {
-                Some(attr.value())
-            } else {
-                None
-            }
-        })
+        let storage = unsafe { self.unsafe_get().attrs.borrow_for_layout() };
+        storage
+            .iter()
+            .filter(move |e: &&AttributeEntry| name == e.local_name_for_layout())
+            .map(|e: &AttributeEntry| e.value_for_layout())
     }
 
     #[expect(unsafe_code)]
@@ -1669,8 +1682,17 @@ impl Element {
             .map(DomRoot::from_ref)
     }
 
-    pub(crate) fn attrs(&self) -> Ref<'_, [Dom<Attr>]> {
-        Ref::map(self.attrs.borrow(), |attrs| &**attrs)
+    pub(crate) fn attrs(&self) -> &AttributeStorage {
+        &self.attrs
+    }
+
+    pub(crate) fn dom_attrs(&self) -> &AttributeStorage {
+        // Materialize all entries to Dom<Attr> so callers can access full Attr nodes.
+        let len = self.attrs.borrow().len();
+        for i in 0..len {
+            self.attrs.ensure_dom(i, self);
+        }
+        &self.attrs
     }
 
     /// Element branch of <https://dom.spec.whatwg.org/#locate-a-namespace>
@@ -1708,24 +1730,31 @@ impl Element {
             // is "xmlns", and local name is prefix, or if prefix is null and it has an attribute
             // whose namespace is the XMLNS namespace, namespace prefix is null, and local name is
             // "xmlns", then return its value if it is not the empty string, and null otherwise.
-            let attr = Ref::filter_map(self.attrs(), |attrs| {
-                attrs.iter().find(|attr| {
-                    if attr.namespace() != &ns!(xmlns) {
-                        return false;
-                    }
-                    match (attr.prefix(), prefix.as_ref()) {
-                        (Some(&namespace_prefix!("xmlns")), Some(prefix)) => {
-                            attr.local_name() == prefix
-                        },
-                        (None, None) => attr.local_name() == &local_name!("xmlns"),
-                        _ => false,
-                    }
-                })
-            })
-            .ok();
+            let found_ns = element.attrs.borrow().iter().find_map(|attr| {
+                if attr.namespace() != &ns!(xmlns) {
+                    return None;
+                }
+                match (attr.prefix(), prefix.as_ref()) {
+                    (Some(&namespace_prefix!("xmlns")), Some(prefix)) => {
+                        if attr.local_name() == prefix {
+                            Some(Namespace::from(&**attr.value()))
+                        } else {
+                            None
+                        }
+                    },
+                    (None, None) => {
+                        if attr.local_name() == &local_name!("xmlns") {
+                            Some(Namespace::from(&**attr.value()))
+                        } else {
+                            None
+                        }
+                    },
+                    _ => None,
+                }
+            });
 
-            if let Some(attr) = attr {
-                return (**attr.value()).into();
+            if let Some(ns) = found_ns {
+                return ns;
             }
         }
 
@@ -1813,7 +1842,7 @@ impl Element {
                 if attr.prefix() == Some(&namespace_prefix!("xmlns")) &&
                     **attr.value() == *namespace
                 {
-                    return Some(attr.LocalName());
+                    return Some(DOMString::from(&**attr.local_name()));
                 }
             }
         }
@@ -1886,24 +1915,36 @@ impl Element {
         prefix: Option<Prefix>,
         reason: AttributeMutationReason,
     ) {
-        let attr = Attr::new(
-            cx,
-            &self.node.owner_doc(),
-            local_name,
+        // Build ContentAttributeData on the stack. We keep the original on the
+        // stack for the AttrRef (used by handle_attribute_changes / attribute_mutated),
+        // and push a clone into the RefCell. This avoids holding a RefCell borrow
+        // while attribute_mutated callbacks run (they may call get_attribute() etc.).
+        let data = ContentAttributeData {
+            identifier: AttrIdentifier {
+                local_name: GenericAtomIdent(local_name),
+                name: GenericAtomIdent(name),
+                namespace: GenericAtomIdent(namespace),
+                prefix: prefix.map(GenericAtomIdent),
+            },
             value,
-            name,
-            namespace,
-            prefix,
-            Some(self),
-        );
-        self.push_attribute(cx, &attr, reason);
+        };
+        let attr_ref = AttrRef::Raw(&data);
+        self.will_mutate_attr(attr_ref);
+        // Step 1: Append to attribute list (push clone, keep original on stack).
+        self.attrs.push_raw(ContentAttributeData {
+            identifier: data.identifier.clone(),
+            value: data.value.clone(),
+        });
+        // Step 4: Handle attribute changes using stack-local AttrRef.
+        let new_value = DOMString::from(&**attr_ref.value());
+        self.handle_attribute_changes(cx, attr_ref, None, Some(new_value), reason);
     }
 
     /// <https://dom.spec.whatwg.org/#handle-attribute-changes>
     fn handle_attribute_changes(
         &self,
         cx: &mut JSContext,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         old_value: Option<&AttrValue>,
         new_value: Option<DOMString>,
         reason: AttributeMutationReason,
@@ -1953,7 +1994,7 @@ impl Element {
         // Clone to avoid double borrow
         let old_value = &attr.value().clone();
         // Step 2. Set attribute’s value to value.
-        self.will_mutate_attr(attr);
+        self.will_mutate_attr(AttrRef::Dom(attr));
         attr.swap_value(&mut value);
         // Step 3. Handle attribute changes for attribute with attribute’s element, oldValue, and value.
         //
@@ -1961,7 +2002,7 @@ impl Element {
         let new_value = DOMString::from(&**attr.value());
         self.handle_attribute_changes(
             cx,
-            attr,
+            AttrRef::Dom(attr),
             Some(old_value),
             Some(new_value),
             AttributeMutationReason::Directly,
@@ -1984,13 +2025,13 @@ impl Element {
         // Handled by callers of this function and asserted here.
         assert!(attr.upcast::<Node>().owner_doc() == self.node.owner_doc());
         // Step 1. Append attribute to element’s attribute list.
-        self.will_mutate_attr(attr);
-        self.attrs.borrow_mut().push(Dom::from_ref(attr));
+        self.will_mutate_attr(AttrRef::Dom(attr));
+        self.attrs.push_dom(attr);
         // Step 4. Handle attribute changes for attribute with element, null, and attribute’s value.
         //
         // Put on a separate line to avoid double borrow
         let new_value = DOMString::from(&**attr.value());
-        self.handle_attribute_changes(cx, attr, None, Some(new_value), reason);
+        self.handle_attribute_changes(cx, AttrRef::Dom(attr), None, Some(new_value), reason);
     }
 
     /// This is the inner logic for:
@@ -2003,11 +2044,12 @@ impl Element {
         namespace: &Namespace,
         local_name: &LocalName,
     ) -> Option<DomRoot<Attr>> {
-        self.attrs
+        let idx = self
+            .attrs
             .borrow()
             .iter()
-            .find(|attr| attr.local_name() == local_name && attr.namespace() == namespace)
-            .map(|js| DomRoot::from_ref(&**js))
+            .position(|a| a.local_name() == local_name && a.namespace() == namespace)?;
+        Some(self.attrs.ensure_dom(idx, self))
     }
 
     /// This is the inner logic for:
@@ -2026,12 +2068,8 @@ impl Element {
     /// <https://dom.spec.whatwg.org/#concept-element-attributes-get-by-name>
     pub(crate) fn get_attribute_by_name(&self, name: DOMString) -> Option<DomRoot<Attr>> {
         let name = &self.parsed_name(name);
-        let maybe_attribute = self
-            .attrs
-            .borrow()
-            .iter()
-            .find(|a| a.name() == name)
-            .map(|js| DomRoot::from_ref(&**js));
+        let idx = self.attrs.borrow().iter().position(|a| a.name() == name)?;
+        let attr_dom = Some(self.attrs.ensure_dom(idx, self));
         fn id_and_name_must_be_atoms(name: &LocalName, maybe_attr: &Option<DomRoot<Attr>>) -> bool {
             if *name == local_name!("id") || *name == local_name!("name") {
                 match maybe_attr {
@@ -2042,8 +2080,8 @@ impl Element {
                 true
             }
         }
-        debug_assert!(id_and_name_must_be_atoms(name, &maybe_attribute));
-        maybe_attribute
+        debug_assert!(id_and_name_must_be_atoms(name, &attr_dom));
+        attr_dom
     }
 
     pub(crate) fn set_attribute_from_parser(
@@ -2133,18 +2171,15 @@ impl Element {
         prefix: Option<Prefix>,
         find: F,
     ) where
-        F: Fn(&Attr) -> bool,
+        F: Fn(AttrRef<'_>) -> bool,
     {
         // Step 1. Let attribute be the result of getting an attribute given namespace, localName, and element.
-        let attr = self
-            .attrs
-            .borrow()
-            .iter()
-            .find(|attr| find(attr))
-            .map(|js| DomRoot::from_ref(&**js));
-        if let Some(attr) = attr {
+        // First check if a matching attribute exists (works for both Raw and Dom).
+        let found_idx = self.attrs.borrow().iter().position(find);
+        if let Some(idx) = found_idx {
+            let attr = self.attrs.ensure_dom(idx, self);
             // Step 3. Change attribute to value.
-            self.will_mutate_attr(&attr);
+            self.will_mutate_attr(AttrRef::Dom(&attr));
             self.change_attribute(cx, &attr, value);
         } else {
             // Step 2. If attribute is null, create an attribute whose namespace is namespace,
@@ -2202,21 +2237,21 @@ impl Element {
         find: F,
     ) -> Option<DomRoot<Attr>>
     where
-        F: Fn(&Attr) -> bool,
+        F: Fn(AttrRef<'_>) -> bool,
     {
-        let idx = self.attrs.borrow().iter().position(|attr| find(attr));
+        let idx = self.attrs.borrow().iter().position(find);
         idx.map(|idx| {
-            let attr = DomRoot::from_ref(&*(*self.attrs.borrow())[idx]);
+            let attr = self.attrs.ensure_dom(idx, self);
 
             // Step 2. Remove attribute from element’s attribute list.
-            self.will_mutate_attr(&attr);
-            self.attrs.borrow_mut().remove(idx);
+            self.will_mutate_attr(AttrRef::Dom(&attr));
+            self.attrs.remove(idx);
             // Step 3. Set attribute’s element to null.
             attr.set_owner(None);
             // Step 4. Handle attribute changes for attribute with element, attribute’s value, and null.
             self.handle_attribute_changes(
                 cx,
-                &attr,
+                AttrRef::Dom(&attr),
                 Some(&attr.value()),
                 None,
                 AttributeMutationReason::Directly,
@@ -2249,33 +2284,47 @@ impl Element {
             .any(|attr| attr.local_name() == local_name && attr.namespace() == &ns!())
     }
 
-    pub(crate) fn will_mutate_attr(&self, attr: &Attr) {
+    pub(crate) fn will_mutate_attr(&self, attr: AttrRef<'_>) {
         let node = self.upcast::<Node>();
         node.owner_doc().element_attr_will_change(self, attr);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-style-attribute>
-    fn update_style_attribute(&self, attr: &Attr, mutation: AttributeMutation) {
+    fn update_style_attribute(&self, attr: AttrRef<'_>, mutation: AttributeMutation) {
         let doc = self.upcast::<Node>().owner_doc();
         // Modifying the `style` attribute might change style.
         *self.style_attribute.borrow_mut() = match mutation {
             AttributeMutation::Set(..) => {
-                // This is the fast path we use from
-                // CSSStyleDeclaration.
-                //
-                // Juggle a bit to keep the borrow checker happy
-                // while avoiding the extra clone.
-                let is_declaration = matches!(*attr.value(), AttrValue::Declaration(..));
+                let maybe_block = if let Some(attr) = attr.as_attr() {
+                    // This is the fast path we use from
+                    // CSSStyleDeclaration.
+                    //
+                    // Juggle a bit to keep the borrow checker happy
+                    // while avoiding the extra clone.
+                    let is_declaration = matches!(*attr.value(), AttrValue::Declaration(..));
+                    if is_declaration {
+                        let mut value = AttrValue::String(String::new());
+                        attr.swap_value(&mut value);
+                        let (serialization, block) = match value {
+                            AttrValue::Declaration(s, b) => (s, b),
+                            _ => unreachable!(),
+                        };
+                        let mut value = AttrValue::String(serialization);
+                        attr.swap_value(&mut value);
+                        Some(block)
+                    } else {
+                        None
+                    }
+                } else {
+                    let value = attr.value();
+                    if let AttrValue::Declaration(_, ref block) = *value {
+                        Some(block.clone())
+                    } else {
+                        None
+                    }
+                };
 
-                let block = if is_declaration {
-                    let mut value = AttrValue::String(String::new());
-                    attr.swap_value(&mut value);
-                    let (serialization, block) = match value {
-                        AttrValue::Declaration(s, b) => (s, b),
-                        _ => unreachable!(),
-                    };
-                    let mut value = AttrValue::String(serialization);
-                    attr.swap_value(&mut value);
+                let block = if let Some(block) = maybe_block {
                     block
                 } else {
                     let win = self.owner_window();
@@ -2358,7 +2407,7 @@ impl Element {
         });
 
         let old_attr = if let Some(position) = position {
-            let old_attr = DomRoot::from_ref(&*self.attrs.borrow()[position]);
+            let old_attr = self.attrs.ensure_dom(position, self);
 
             // Step 4. If oldAttr is attr, return attr.
             if &*old_attr == attr {
@@ -2374,8 +2423,9 @@ impl Element {
             // Skipped, as that points to self.
 
             // Step 2. Replace oldAttribute by newAttribute in element’s attribute list.
-            self.will_mutate_attr(attr);
-            self.attrs.borrow_mut()[position] = Dom::from_ref(attr);
+            self.will_mutate_attr(AttrRef::Dom(attr));
+            self.attrs
+                .set(position, AttributeEntry::Dom(Dom::from_ref(attr)));
             // Step 3. Set newAttribute’s element to element.
             attr.set_owner(Some(self));
             // Step 4. Set newAttribute’s node document to element’s node document.
@@ -2385,7 +2435,7 @@ impl Element {
             // Step 6. Handle attribute changes for oldAttribute with element, oldAttribute’s value, and newAttribute’s value.
             self.handle_attribute_changes(
                 cx,
-                attr,
+                AttrRef::Dom(attr),
                 Some(&old_attr.value()),
                 Some(verified_value),
                 AttributeMutationReason::Directly,
@@ -2454,7 +2504,7 @@ impl Element {
         }
         // Step 2: If element is a script element, then for each attribute of element’s attribute list:
         if self.downcast::<HTMLScriptElement>().is_some() {
-            for attr in self.attrs().iter() {
+            for attr in self.attrs().borrow().iter() {
                 // Step 2.1: If attribute’s name contains an ASCII case-insensitive match
                 // for "<script" or "<style", return "Not Nonceable".
                 let attr_name = attr.name().to_ascii_lowercase();
@@ -2816,7 +2866,11 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
 
     /// <https://dom.spec.whatwg.org/#dom-element-getattributenames>
     fn GetAttributeNames(&self) -> Vec<DOMString> {
-        self.attrs.borrow().iter().map(|attr| attr.Name()).collect()
+        self.attrs
+            .borrow()
+            .iter()
+            .map(|attr| DOMString::from(&**attr.name()))
+            .collect()
     }
 
     /// <https://dom.spec.whatwg.org/#dom-element-getattribute>
@@ -3014,8 +3068,12 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
 
     /// <https://dom.spec.whatwg.org/#dom-element-removeattributenode>
     fn RemoveAttributeNode(&self, cx: &mut JSContext, attr: &Attr) -> Fallible<DomRoot<Attr>> {
-        self.remove_first_matching_attribute(cx, |a| a == attr)
-            .ok_or(Error::NotFound(None))
+        // The attr parameter passed here is already a Dom<Attr> that is somewhere present in the DOM,
+        // hence already materialized. That means that `as_attr()` will never fail.
+        self.remove_first_matching_attribute(cx, |a| {
+            a.as_attr().is_some_and(|a| std::ptr::eq(a, attr))
+        })
+        .ok_or(Error::NotFound(None))
     }
 
     /// <https://dom.spec.whatwg.org/#dom-element-hasattribute>
@@ -4268,7 +4326,7 @@ impl VirtualMethods for Element {
         Some(self.upcast::<Node>() as &dyn VirtualMethods)
     }
 
-    fn attribute_affects_presentational_hints(&self, attr: &Attr) -> bool {
+    fn attribute_affects_presentational_hints(&self, attr: AttrRef<'_>) -> bool {
         // FIXME: This should be more fine-grained, not all elements care about these.
         if attr.local_name() == &local_name!("lang") {
             return true;
@@ -4279,7 +4337,12 @@ impl VirtualMethods for Element {
             .attribute_affects_presentational_hints(attr)
     }
 
-    fn attribute_mutated(&self, cx: &mut JSContext, attr: &Attr, mutation: AttributeMutation) {
+    fn attribute_mutated(
+        &self,
+        cx: &mut JSContext,
+        attr: AttrRef<'_>,
+        mutation: AttributeMutation,
+    ) {
         self.super_type()
             .unwrap()
             .attribute_mutated(cx, attr, mutation);
@@ -4960,7 +5023,7 @@ impl AttributeMutation<'_> {
         }
     }
 
-    pub(crate) fn new_value<'b>(&self, attr: &'b Attr) -> Option<Ref<'b, AttrValue>> {
+    pub(crate) fn new_value<'b>(&self, attr: AttrRef<'b>) -> Option<AttrValueRef<'b>> {
         match *self {
             AttributeMutation::Set(..) => Some(attr.value()),
             AttributeMutation::Removed => None,

--- a/components/script/dom/execcommand/contenteditable/element.rs
+++ b/components/script/dom/execcommand/contenteditable/element.rs
@@ -110,7 +110,7 @@ impl Element {
 
     /// <https://w3c.github.io/editing/docs/execCommand/#modifiable-element>
     pub(crate) fn is_modifiable_element(&self) -> bool {
-        let attrs = self.attrs();
+        let attrs = self.attrs().borrow();
         let mut attrs = attrs.iter();
         let type_id = self.upcast::<Node>().type_id();
 
@@ -186,7 +186,7 @@ impl Element {
 
     /// <https://w3c.github.io/editing/docs/execCommand/#simple-modifiable-element>
     pub(crate) fn is_simple_modifiable_element(&self) -> bool {
-        let attrs = self.attrs();
+        let attrs = self.attrs().borrow();
         let attr_count = attrs.len();
         let type_id = self.upcast::<Node>().type_id();
 
@@ -231,7 +231,8 @@ impl Element {
             return false;
         }
 
-        let only_attribute = attrs.first().expect("Size is 1").local_name();
+        let first_attr = attrs.first().expect("Size is 1");
+        let only_attribute = first_attr.local_name();
 
         // > It is an a element with exactly one attribute, which is href.
         if matches!(

--- a/components/script/dom/html/htmlanchorelement.rs
+++ b/components/script/dom/html/htmlanchorelement.rs
@@ -16,7 +16,6 @@ use stylo_atoms::Atom;
 use stylo_dom::ElementState;
 
 use crate::dom::activation::Activatable;
-use crate::dom::attr::Attr;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::HTMLAnchorElementBinding::HTMLAnchorElementMethods;
 use crate::dom::bindings::codegen::Bindings::MouseEventBinding::MouseEventMethods;
@@ -26,6 +25,7 @@ use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::document::Document;
 use crate::dom::domtokenlist::DOMTokenList;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{AttributeMutation, Element, reflect_referrer_policy_attribute};
 use crate::dom::event::Event;
 use crate::dom::eventtarget::EventTarget;
@@ -112,7 +112,7 @@ impl VirtualMethods for HTMLAnchorElement {
     fn attribute_mutated(
         &self,
         cx: &mut js::context::JSContext,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
         self.super_type()

--- a/components/script/dom/html/htmlareaelement.rs
+++ b/components/script/dom/html/htmlareaelement.rs
@@ -18,7 +18,6 @@ use stylo_atoms::Atom;
 use stylo_dom::ElementState;
 
 use crate::dom::activation::Activatable;
-use crate::dom::attr::Attr;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::HTMLAreaElementBinding::HTMLAreaElementMethods;
 use crate::dom::bindings::inheritance::Castable;
@@ -26,6 +25,7 @@ use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::document::Document;
 use crate::dom::domtokenlist::DOMTokenList;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{AttributeMutation, Element, reflect_referrer_policy_attribute};
 use crate::dom::event::Event;
 use crate::dom::eventtarget::EventTarget;
@@ -347,7 +347,7 @@ impl VirtualMethods for HTMLAreaElement {
     fn attribute_mutated(
         &self,
         cx: &mut js::context::JSContext,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
         self.super_type()

--- a/components/script/dom/html/htmlbaseelement.rs
+++ b/components/script/dom/html/htmlbaseelement.rs
@@ -8,13 +8,13 @@ use js::context::JSContext;
 use js::rust::HandleObject;
 use servo_url::ServoUrl;
 
-use crate::dom::attr::Attr;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::HTMLBaseElementBinding::HTMLBaseElementMethods;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::html::htmlelement::HTMLElement;
@@ -147,7 +147,7 @@ impl VirtualMethods for HTMLBaseElement {
     fn attribute_mutated(
         &self,
         cx: &mut js::context::JSContext,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
         self.super_type()

--- a/components/script/dom/html/htmlbodyelement.rs
+++ b/components/script/dom/html/htmlbodyelement.rs
@@ -10,13 +10,13 @@ use js::rust::HandleObject;
 use style::attr::AttrValue;
 use style::color::AbsoluteColor;
 
-use crate::dom::attr::Attr;
 use crate::dom::bindings::codegen::Bindings::HTMLBodyElementBinding::HTMLBodyElementMethods;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::{DomRoot, LayoutDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::html::htmlelement::HTMLElement;
@@ -104,7 +104,7 @@ impl VirtualMethods for HTMLBodyElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn attribute_affects_presentational_hints(&self, attr: &Attr) -> bool {
+    fn attribute_affects_presentational_hints(&self, attr: AttrRef<'_>) -> bool {
         if attr.local_name() == &local_name!("bgcolor") {
             return true;
         }
@@ -145,7 +145,12 @@ impl VirtualMethods for HTMLBodyElement {
         }
     }
 
-    fn attribute_mutated(&self, cx: &mut JSContext, attr: &Attr, mutation: AttributeMutation) {
+    fn attribute_mutated(
+        &self,
+        cx: &mut JSContext,
+        attr: AttrRef<'_>,
+        mutation: AttributeMutation,
+    ) {
         let do_super_mutate = match (attr.local_name(), mutation) {
             (name, AttributeMutation::Set(..)) if name.starts_with("on") => {
                 let document = self.owner_document();

--- a/components/script/dom/html/htmlbuttonelement.rs
+++ b/components/script/dom/html/htmlbuttonelement.rs
@@ -17,7 +17,6 @@ use style::selector_parser::PseudoElement;
 use stylo_dom::ElementState;
 
 use crate::dom::activation::Activatable;
-use crate::dom::attr::Attr;
 use crate::dom::bindings::codegen::Bindings::HTMLButtonElementBinding::HTMLButtonElementMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::GetRootNodeOptions;
 use crate::dom::bindings::inheritance::Castable;
@@ -26,6 +25,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::commandevent::CommandEvent;
 use crate::dom::document::Document;
 use crate::dom::documentfragment::DocumentFragment;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
@@ -366,7 +366,7 @@ impl VirtualMethods for HTMLButtonElement {
     fn attribute_mutated(
         &self,
         cx: &mut js::context::JSContext,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
         self.super_type()
@@ -390,7 +390,7 @@ impl VirtualMethods for HTMLButtonElement {
                 self.validity_state(CanGc::from_cx(cx))
                     .perform_validation_and_update(ValidationFlags::all(), CanGc::from_cx(cx));
             },
-            local_name!("type") => self.set_type(attr.Value(), CanGc::from_cx(cx)),
+            local_name!("type") => self.set_type(attr.to_dom_string(), CanGc::from_cx(cx)),
             local_name!("command") => self.set_type(
                 self.upcast::<Element>()
                     .get_string_attribute(&local_name!("type")),

--- a/components/script/dom/html/htmlcanvaselement.rs
+++ b/components/script/dom/html/htmlcanvaselement.rs
@@ -26,7 +26,6 @@ use webrender_api::ImageKey;
 
 use crate::canvas_context::{CanvasContext, RenderingContext};
 use crate::conversions::Convert;
-use crate::dom::attr::Attr;
 use crate::dom::bindings::callback::ExceptionHandling;
 use crate::dom::bindings::cell::{DomRefCell, Ref};
 use crate::dom::bindings::codegen::Bindings::HTMLCanvasElementBinding::{
@@ -46,6 +45,7 @@ use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::blob::Blob;
 use crate::dom::canvasrenderingcontext2d::CanvasRenderingContext2D;
 use crate::dom::document::Document;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{AttributeMutation, Element};
 #[cfg(not(feature = "webgpu"))]
 use crate::dom::gpucanvascontext::GPUCanvasContext;
@@ -691,7 +691,7 @@ impl VirtualMethods for HTMLCanvasElement {
     fn attribute_mutated(
         &self,
         cx: &mut js::context::JSContext,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
         self.super_type()
@@ -706,7 +706,7 @@ impl VirtualMethods for HTMLCanvasElement {
         };
     }
 
-    fn attribute_affects_presentational_hints(&self, attr: &Attr) -> bool {
+    fn attribute_affects_presentational_hints(&self, attr: AttrRef<'_>) -> bool {
         match attr.local_name() {
             &local_name!("width") | &local_name!("height") => true,
             _ => self

--- a/components/script/dom/html/htmldetailselement.rs
+++ b/components/script/dom/html/htmldetailselement.rs
@@ -13,7 +13,6 @@ use js::rust::HandleObject;
 use script_bindings::domstring::DOMString;
 use style::selector_parser::PseudoElement;
 
-use crate::dom::attr::Attr;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::HTMLDetailsElementBinding::HTMLDetailsElementMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLSlotElementBinding::HTMLSlotElement_Binding::HTMLSlotElementMethods;
@@ -25,6 +24,7 @@ use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::document::Document;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{AttributeMutation, CustomElementCreationMode, Element, ElementCreator};
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
@@ -399,7 +399,7 @@ impl VirtualMethods for HTMLDetailsElement {
     fn attribute_mutated(
         &self,
         cx: &mut js::context::JSContext,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
         self.super_type()

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -18,7 +18,6 @@ use style::attr::AttrValue;
 use stylo_dom::ElementState;
 
 use crate::dom::activation::Activatable;
-use crate::dom::attr::Attr;
 use crate::dom::bindings::codegen::Bindings::CharacterDataBinding::CharacterData_Binding::CharacterDataMethods;
 use crate::dom::bindings::codegen::Bindings::EventHandlerBinding::{
     EventHandlerNonNull, OnErrorEventHandlerNonNull,
@@ -43,6 +42,7 @@ use crate::dom::document::focus::FocusableArea;
 use crate::dom::document_event_handler::character_to_code;
 use crate::dom::documentfragment::DocumentFragment;
 use crate::dom::domstringmap::DOMStringMap;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{
     AttributeMutation, CustomElementCreationMode, Element, ElementCreator,
     is_element_affected_by_legacy_background_presentational_hint,
@@ -1204,7 +1204,12 @@ impl VirtualMethods for HTMLElement {
         Some(self.as_element() as &dyn VirtualMethods)
     }
 
-    fn attribute_mutated(&self, cx: &mut JSContext, attr: &Attr, mutation: AttributeMutation) {
+    fn attribute_mutated(
+        &self,
+        cx: &mut JSContext,
+        attr: AttrRef<'_>,
+        mutation: AttributeMutation,
+    ) {
         self.super_type()
             .unwrap()
             .attribute_mutated(cx, attr, mutation);
@@ -1382,7 +1387,7 @@ impl VirtualMethods for HTMLElement {
         }
     }
 
-    fn attribute_affects_presentational_hints(&self, attr: &Attr) -> bool {
+    fn attribute_affects_presentational_hints(&self, attr: AttrRef<'_>) -> bool {
         if is_element_affected_by_legacy_background_presentational_hint(
             self.element.namespace(),
             self.element.local_name(),

--- a/components/script/dom/html/htmlfieldsetelement.rs
+++ b/components/script/dom/html/htmlfieldsetelement.rs
@@ -10,13 +10,13 @@ use js::context::JSContext;
 use js::rust::HandleObject;
 use stylo_dom::ElementState;
 
-use crate::dom::attr::Attr;
 use crate::dom::bindings::codegen::Bindings::HTMLFieldSetElementBinding::HTMLFieldSetElementMethods;
 use crate::dom::bindings::inheritance::{Castable, ElementTypeId, HTMLElementTypeId, NodeTypeId};
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::customelementregistry::CallbackReaction;
 use crate::dom::document::Document;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::html::htmlcollection::HTMLCollection;
 use crate::dom::html::htmlelement::HTMLElement;
@@ -156,7 +156,7 @@ impl VirtualMethods for HTMLFieldSetElement {
     fn attribute_mutated(
         &self,
         cx: &mut js::context::JSContext,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
         self.super_type()

--- a/components/script/dom/html/htmlfontelement.rs
+++ b/components/script/dom/html/htmlfontelement.rs
@@ -15,13 +15,13 @@ use style::values::computed::font::{
 };
 use stylo_atoms::Atom;
 
-use crate::dom::attr::Attr;
 use crate::dom::bindings::codegen::Bindings::HTMLFontElementBinding::HTMLFontElementMethods;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::{DomRoot, LayoutDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
 use crate::dom::element::Element;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::Node;
 use crate::dom::virtualmethods::VirtualMethods;
@@ -117,7 +117,7 @@ impl VirtualMethods for HTMLFontElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn attribute_affects_presentational_hints(&self, attr: &Attr) -> bool {
+    fn attribute_affects_presentational_hints(&self, attr: AttrRef<'_>) -> bool {
         if attr.local_name() == &local_name!("color") ||
             attr.local_name() == &local_name!("size") ||
             attr.local_name() == &local_name!("face")

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -27,7 +27,6 @@ use stylo_atoms::Atom;
 use stylo_dom::ElementState;
 
 use crate::body::Extractable;
-use crate::dom::attr::Attr;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::AttrBinding::Attr_Binding::AttrMethods;
 use crate::dom::bindings::codegen::Bindings::BlobBinding::BlobMethods;
@@ -56,6 +55,7 @@ use crate::dom::blob::Blob;
 use crate::dom::customelementregistry::CallbackReaction;
 use crate::dom::document::Document;
 use crate::dom::domtokenlist::DOMTokenList;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{AttributeMutation, AttributeMutationReason, Element};
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
@@ -1926,7 +1926,7 @@ impl VirtualMethods for HTMLFormElement {
     fn attribute_mutated(
         &self,
         cx: &mut js::context::JSContext,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
         self.super_type()

--- a/components/script/dom/html/htmlhrelement.rs
+++ b/components/script/dom/html/htmlhrelement.rs
@@ -14,13 +14,13 @@ use style::values::specified::border::BorderSideWidth;
 use style::values::specified::length::Size;
 use style::values::specified::{LengthPercentage, NoCalcLength};
 
-use crate::dom::attr::Attr;
 use crate::dom::bindings::codegen::Bindings::HTMLHRElementBinding::HTMLHRElementMethods;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::{DomRoot, LayoutDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
 use crate::dom::element::Element;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::Node;
 use crate::dom::virtualmethods::VirtualMethods;
@@ -150,7 +150,7 @@ impl VirtualMethods for HTMLHRElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn attribute_affects_presentational_hints(&self, attr: &Attr) -> bool {
+    fn attribute_affects_presentational_hints(&self, attr: AttrRef<'_>) -> bool {
         match attr.local_name() {
             &local_name!("width") => true,
             _ => self

--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -27,7 +27,6 @@ use style::attr::{AttrValue, LengthOrPercentageOrAuto};
 use stylo_atoms::Atom;
 
 use crate::document_loader::{LoadBlocker, LoadType};
-use crate::dom::attr::Attr;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::HTMLIFrameElementBinding::HTMLIFrameElementMethods;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::Window_Binding::WindowMethods;
@@ -40,6 +39,7 @@ use crate::dom::bindings::root::{DomRoot, LayoutDom, MutNullableDom};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::document::Document;
 use crate::dom::domtokenlist::DOMTokenList;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{AttributeMutation, Element, reflect_referrer_policy_attribute};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
@@ -1095,7 +1095,12 @@ impl VirtualMethods for HTMLIFrameElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn attribute_mutated(&self, cx: &mut JSContext, attr: &Attr, mutation: AttributeMutation) {
+    fn attribute_mutated(
+        &self,
+        cx: &mut JSContext,
+        attr: AttrRef<'_>,
+        mutation: AttributeMutation,
+    ) {
         self.super_type()
             .unwrap()
             .attribute_mutated(cx, attr, mutation);
@@ -1168,7 +1173,7 @@ impl VirtualMethods for HTMLIFrameElement {
         }
     }
 
-    fn attribute_affects_presentational_hints(&self, attr: &Attr) -> bool {
+    fn attribute_affects_presentational_hints(&self, attr: AttrRef<'_>) -> bool {
         match attr.local_name() {
             &local_name!("width") | &local_name!("height") => true,
             _ => self

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -41,7 +41,6 @@ use url::Url;
 use crate::css::parser_context_for_anonymous_content;
 use crate::document_loader::{LoadBlocker, LoadType};
 use crate::dom::activation::Activatable;
-use crate::dom::attr::Attr;
 use crate::dom::bindings::cell::{DomRefCell, RefMut};
 use crate::dom::bindings::codegen::Bindings::DOMRectBinding::DOMRect_Binding::DOMRectMethods;
 use crate::dom::bindings::codegen::Bindings::ElementBinding::Element_Binding::ElementMethods;
@@ -57,6 +56,7 @@ use crate::dom::bindings::root::{DomRoot, LayoutDom, MutNullableDom};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::csp::{GlobalCspReporting, Violation};
 use crate::dom::document::Document;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{
     AttributeMutation, CustomElementCreationMode, Element, ElementCreator,
     cors_setting_for_element, referrer_policy_for_element, reflect_cross_origin_attribute,
@@ -1993,7 +1993,7 @@ impl VirtualMethods for HTMLImageElement {
     fn attribute_mutated(
         &self,
         cx: &mut js::context::JSContext,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
         self.super_type()
@@ -2047,7 +2047,7 @@ impl VirtualMethods for HTMLImageElement {
         }
     }
 
-    fn attribute_affects_presentational_hints(&self, attr: &Attr) -> bool {
+    fn attribute_affects_presentational_hints(&self, attr: AttrRef<'_>) -> bool {
         match attr.local_name() {
             &local_name!("width") | &local_name!("height") => true,
             _ => self

--- a/components/script/dom/html/htmllabelelement.rs
+++ b/components/script/dom/html/htmllabelelement.rs
@@ -8,7 +8,6 @@ use js::rust::HandleObject;
 use style::attr::AttrValue;
 
 use crate::dom::activation::Activatable;
-use crate::dom::attr::Attr;
 use crate::dom::bindings::codegen::Bindings::AttrBinding::AttrMethods;
 use crate::dom::bindings::codegen::Bindings::ElementBinding::ElementMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLElementBinding::HTMLElementMethods;
@@ -18,6 +17,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::event::Event;
 use crate::dom::eventtarget::EventTarget;
@@ -161,7 +161,7 @@ impl VirtualMethods for HTMLLabelElement {
     fn attribute_mutated(
         &self,
         cx: &mut js::context::JSContext,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
         self.super_type()

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -30,7 +30,6 @@ use style::stylesheets::Stylesheet;
 use stylo_atoms::Atom;
 use webrender_api::units::DeviceIntSize;
 
-use crate::dom::attr::Attr;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::DOMTokenListBinding::DOMTokenList_Binding::DOMTokenListMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLLinkElementBinding::HTMLLinkElementMethods;
@@ -45,6 +44,7 @@ use crate::dom::css::stylesheet::StyleSheet as DOMStyleSheet;
 use crate::dom::document::Document;
 use crate::dom::documentorshadowroot::StylesheetSource;
 use crate::dom::domtokenlist::DOMTokenList;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{
     AttributeMutation, Element, ElementCreator, cors_setting_for_element,
     cors_settings_attribute_credential_mode, referrer_policy_for_element,
@@ -247,7 +247,7 @@ impl VirtualMethods for HTMLLinkElement {
     fn attribute_mutated(
         &self,
         cx: &mut js::context::JSContext,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
         self.super_type()

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -50,7 +50,6 @@ use webrender_api::{
 };
 
 use crate::document_loader::{LoadBlocker, LoadType};
-use crate::dom::attr::Attr;
 use crate::dom::audio::audiotrack::AudioTrack;
 use crate::dom::audio::audiotracklist::AudioTrackList;
 use crate::dom::bindings::cell::DomRefCell;
@@ -77,6 +76,7 @@ use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::blob::Blob;
 use crate::dom::csp::{GlobalCspReporting, Violation};
 use crate::dom::document::Document;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{
     AttributeMutation, AttributeMutationReason, CustomElementCreationMode, Element, ElementCreator,
     cors_setting_for_element, reflect_cross_origin_attribute, set_cross_origin_attribute,
@@ -3392,7 +3392,7 @@ impl VirtualMethods for HTMLMediaElement {
     fn attribute_mutated(
         &self,
         cx: &mut js::context::JSContext,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
         self.super_type()

--- a/components/script/dom/html/htmlmetaelement.rs
+++ b/components/script/dom/html/htmlmetaelement.rs
@@ -14,13 +14,13 @@ use paint_api::viewport_description::ViewportDescription;
 use servo_config::pref;
 use style::str::HTML_SPACE_CHARACTERS;
 
-use crate::dom::attr::Attr;
 use crate::dom::bindings::codegen::Bindings::HTMLMetaElementBinding::HTMLMetaElementMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::html::htmlheadelement::HTMLHeadElement;
@@ -246,7 +246,7 @@ impl VirtualMethods for HTMLMetaElement {
     fn attribute_mutated(
         &self,
         cx: &mut js::context::JSContext,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
         if let Some(s) = self.super_type() {

--- a/components/script/dom/html/htmlmeterelement.rs
+++ b/components/script/dom/html/htmlmeterelement.rs
@@ -11,7 +11,6 @@ use js::context::JSContext;
 use js::rust::HandleObject;
 use stylo_dom::ElementState;
 
-use crate::dom::attr::Attr;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::HTMLMeterElementBinding::HTMLMeterElementMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::Node_Binding::NodeMethods;
@@ -20,6 +19,7 @@ use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::{BindContext, ChildrenMutation, Node, NodeTraits};
@@ -310,7 +310,7 @@ impl VirtualMethods for HTMLMeterElement {
     fn attribute_mutated(
         &self,
         cx: &mut js::context::JSContext,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
         self.super_type()

--- a/components/script/dom/html/htmlobjectelement.rs
+++ b/components/script/dom/html/htmlobjectelement.rs
@@ -11,13 +11,13 @@ use js::rust::HandleObject;
 use pixels::RasterImage;
 use servo_arc::Arc;
 
-use crate::dom::attr::Attr;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::HTMLObjectElementBinding::HTMLObjectElementMethods;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::html::htmlformelement::{FormControl, HTMLFormElement};
@@ -162,7 +162,7 @@ impl VirtualMethods for HTMLObjectElement {
     fn attribute_mutated(
         &self,
         cx: &mut js::context::JSContext,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
         self.super_type()

--- a/components/script/dom/html/htmloptgroupelement.rs
+++ b/components/script/dom/html/htmloptgroupelement.rs
@@ -9,12 +9,12 @@ use js::rust::HandleObject;
 use script_bindings::str::DOMString;
 use stylo_dom::ElementState;
 
-use crate::dom::attr::Attr;
 use crate::dom::bindings::codegen::Bindings::HTMLOptGroupElementBinding::HTMLOptGroupElementMethods;
 use crate::dom::bindings::codegen::GenericBindings::NodeBinding::Node_Binding::NodeMethods;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::html::htmloptionelement::HTMLOptionElement;
@@ -101,7 +101,7 @@ impl VirtualMethods for HTMLOptGroupElement {
     fn attribute_mutated(
         &self,
         cx: &mut js::context::JSContext,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
         self.super_type()

--- a/components/script/dom/html/htmloptionelement.rs
+++ b/components/script/dom/html/htmloptionelement.rs
@@ -12,7 +12,6 @@ use js::rust::HandleObject;
 use style::str::{split_html_space_chars, str_join};
 use stylo_dom::ElementState;
 
-use crate::dom::attr::Attr;
 use crate::dom::bindings::codegen::Bindings::CharacterDataBinding::CharacterDataMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLOptionElementBinding::HTMLOptionElementMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLSelectElementBinding::HTMLSelectElement_Binding::HTMLSelectElementMethods;
@@ -24,6 +23,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::characterdata::CharacterData;
 use crate::dom::document::Document;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{AttributeMutation, CustomElementCreationMode, Element, ElementCreator};
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::html::htmlformelement::HTMLFormElement;
@@ -395,7 +395,7 @@ impl VirtualMethods for HTMLOptionElement {
     fn attribute_mutated(
         &self,
         cx: &mut js::context::JSContext,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
         self.super_type()

--- a/components/script/dom/html/htmloutputelement.rs
+++ b/components/script/dom/html/htmloutputelement.rs
@@ -7,13 +7,13 @@ use html5ever::{LocalName, Prefix, local_name};
 use js::context::JSContext;
 use js::rust::HandleObject;
 
-use crate::dom::attr::Attr;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::HTMLOutputElementBinding::HTMLOutputElementMethods;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::html::htmlformelement::{FormControl, HTMLFormElement};
@@ -162,7 +162,7 @@ impl VirtualMethods for HTMLOutputElement {
     fn attribute_mutated(
         &self,
         cx: &mut js::context::JSContext,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
         self.super_type()

--- a/components/script/dom/html/htmlprogresselement.rs
+++ b/components/script/dom/html/htmlprogresselement.rs
@@ -9,7 +9,6 @@ use html5ever::{LocalName, Prefix, QualName, local_name, ns};
 use js::context::JSContext;
 use js::rust::HandleObject;
 
-use crate::dom::attr::Attr;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::ElementBinding::Element_Binding::ElementMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLProgressElementBinding::HTMLProgressElementMethods;
@@ -19,6 +18,7 @@ use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{AttributeMutation, CustomElementCreationMode, Element, ElementCreator};
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::{BindContext, Node, NodeTraits};
@@ -210,7 +210,7 @@ impl VirtualMethods for HTMLProgressElement {
     fn attribute_mutated(
         &self,
         cx: &mut js::context::JSContext,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
         self.super_type()

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -27,7 +27,6 @@ use stylo_atoms::Atom;
 use uuid::Uuid;
 
 use crate::document_loader::{LoadBlocker, LoadType};
-use crate::dom::attr::Attr;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::DOMTokenListBinding::DOMTokenListMethods;
 use crate::dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
@@ -45,6 +44,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::csp::{CspReporting, GlobalCspReporting, InlineCheckType, Violation};
 use crate::dom::document::Document;
 use crate::dom::domtokenlist::DOMTokenList;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{
     AttributeMutation, Element, ElementCreator, cors_setting_for_element,
     cors_settings_attribute_credential_mode, referrer_policy_for_element,
@@ -1240,7 +1240,7 @@ impl VirtualMethods for HTMLScriptElement {
     fn attribute_mutated(
         &self,
         cx: &mut js::context::JSContext,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
         self.super_type()

--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -6,7 +6,7 @@ use std::default::Default;
 use std::iter;
 
 use crate::dom::activation::Activatable;
-use crate::dom::attr::Attr;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::bindings::cell::{DomRefCell, Ref};
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
 use crate::dom::bindings::codegen::Bindings::ElementBinding::ElementMethods;
@@ -799,7 +799,7 @@ impl VirtualMethods for HTMLSelectElement {
     fn attribute_mutated(
         &self,
         cx: &mut js::context::JSContext,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
         let could_have_had_embedder_control = self.may_have_embedder_control();

--- a/components/script/dom/html/htmlslotelement.rs
+++ b/components/script/dom/html/htmlslotelement.rs
@@ -12,7 +12,6 @@ use js::rust::HandleObject;
 use script_bindings::codegen::InheritTypes::{CharacterDataTypeId, NodeTypeId};
 
 use crate::ScriptThread;
-use crate::dom::attr::Attr;
 use crate::dom::bindings::codegen::Bindings::HTMLSlotElementBinding::{
     AssignedNodesOptions, HTMLSlotElementMethods,
 };
@@ -26,6 +25,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::html::htmlelement::HTMLElement;
@@ -468,7 +468,7 @@ impl VirtualMethods for HTMLSlotElement {
     fn attribute_mutated(
         &self,
         cx: &mut js::context::JSContext,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
         self.super_type()

--- a/components/script/dom/html/htmlsourceelement.rs
+++ b/components/script/dom/html/htmlsourceelement.rs
@@ -8,7 +8,6 @@ use js::context::JSContext;
 use js::rust::HandleObject;
 use style::attr::AttrValue;
 
-use crate::dom::attr::Attr;
 use crate::dom::bindings::codegen::Bindings::HTMLSourceElementBinding::HTMLSourceElementMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::Node_Binding::NodeMethods;
 use crate::dom::bindings::inheritance::Castable;
@@ -16,6 +15,7 @@ use crate::dom::bindings::root::{Dom, DomRoot, Root};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::document::Document;
 use crate::dom::element::AttributeMutation;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::html::htmlimageelement::HTMLImageElement;
 use crate::dom::html::htmlmediaelement::HTMLMediaElement;
@@ -88,7 +88,7 @@ impl VirtualMethods for HTMLSourceElement {
     fn attribute_mutated(
         &self,
         cx: &mut js::context::JSContext,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
         self.super_type()

--- a/components/script/dom/html/htmlstyleelement.rs
+++ b/components/script/dom/html/htmlstyleelement.rs
@@ -16,7 +16,6 @@ use style::media_queries::MediaList as StyleMediaList;
 use style::stylesheets::{Stylesheet, StylesheetInDocument, UrlExtraData};
 use stylo_atoms::Atom;
 
-use crate::dom::attr::Attr;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::DOMTokenListBinding::DOMTokenList_Binding::DOMTokenListMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLStyleElementBinding::HTMLStyleElementMethods;
@@ -33,6 +32,7 @@ use crate::dom::css::stylesheetcontentscache::{
 use crate::dom::document::Document;
 use crate::dom::documentorshadowroot::StylesheetSource;
 use crate::dom::domtokenlist::DOMTokenList;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{AttributeMutation, Element, ElementCreator};
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::medialist::MediaList;
@@ -362,7 +362,7 @@ impl VirtualMethods for HTMLStyleElement {
     fn attribute_mutated(
         &self,
         cx: &mut js::context::JSContext,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
         if let Some(s) = self.super_type() {

--- a/components/script/dom/html/htmltablecellelement.rs
+++ b/components/script/dom/html/htmltablecellelement.rs
@@ -8,13 +8,13 @@ use js::rust::HandleObject;
 use style::attr::{AttrValue, LengthOrPercentageOrAuto};
 use style::color::AbsoluteColor;
 
-use crate::dom::attr::Attr;
 use crate::dom::bindings::codegen::Bindings::HTMLTableCellElementBinding::HTMLTableCellElementMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::{DomRoot, LayoutDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::html::htmltableelement::HTMLTableElement;
@@ -172,7 +172,7 @@ impl VirtualMethods for HTMLTableCellElement {
     fn attribute_mutated(
         &self,
         cx: &mut js::context::JSContext,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
         if let Some(super_type) = self.super_type() {
@@ -187,7 +187,7 @@ impl VirtualMethods for HTMLTableCellElement {
         }
     }
 
-    fn attribute_affects_presentational_hints(&self, attr: &Attr) -> bool {
+    fn attribute_affects_presentational_hints(&self, attr: AttrRef<'_>) -> bool {
         match attr.local_name() {
             &local_name!("width") | &local_name!("height") => true,
             _ => self

--- a/components/script/dom/html/htmltablecolelement.rs
+++ b/components/script/dom/html/htmltablecolelement.rs
@@ -7,12 +7,12 @@ use html5ever::{LocalName, Prefix, local_name, ns};
 use js::rust::HandleObject;
 use style::attr::{AttrValue, LengthOrPercentageOrAuto};
 
-use crate::dom::attr::Attr;
 use crate::dom::bindings::codegen::Bindings::HTMLTableColElementBinding::HTMLTableColElementMethods;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::{DomRoot, LayoutDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::{Node, NodeDamage};
@@ -94,7 +94,7 @@ impl VirtualMethods for HTMLTableColElement {
     fn attribute_mutated(
         &self,
         cx: &mut js::context::JSContext,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
         if let Some(super_type) = self.super_type() {
@@ -106,7 +106,7 @@ impl VirtualMethods for HTMLTableColElement {
         }
     }
 
-    fn attribute_affects_presentational_hints(&self, attr: &Attr) -> bool {
+    fn attribute_affects_presentational_hints(&self, attr: AttrRef<'_>) -> bool {
         match attr.local_name() {
             &local_name!("width") => true,
             _ => self

--- a/components/script/dom/html/htmltableelement.rs
+++ b/components/script/dom/html/htmltableelement.rs
@@ -11,7 +11,6 @@ use js::rust::HandleObject;
 use style::attr::{AttrValue, LengthOrPercentageOrAuto, parse_unsigned_integer};
 use style::color::AbsoluteColor;
 
-use crate::dom::attr::Attr;
 use crate::dom::bindings::codegen::Bindings::HTMLCollectionBinding::HTMLCollectionMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLTableElementBinding::HTMLTableElementMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
@@ -20,6 +19,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::{Dom, DomRoot, LayoutDom, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{AttributeMutation, CustomElementCreationMode, Element, ElementCreator};
 use crate::dom::html::htmlcollection::{CollectionFilter, HTMLCollection};
 use crate::dom::html::htmlelement::HTMLElement;
@@ -522,7 +522,7 @@ impl VirtualMethods for HTMLTableElement {
     fn attribute_mutated(
         &self,
         cx: &mut js::context::JSContext,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
         self.super_type()
@@ -555,7 +555,7 @@ impl VirtualMethods for HTMLTableElement {
         }
     }
 
-    fn attribute_affects_presentational_hints(&self, attr: &Attr) -> bool {
+    fn attribute_affects_presentational_hints(&self, attr: AttrRef<'_>) -> bool {
         match attr.local_name() {
             &local_name!("width") | &local_name!("height") => true,
             _ => self

--- a/components/script/dom/html/htmltablerowelement.rs
+++ b/components/script/dom/html/htmltablerowelement.rs
@@ -9,7 +9,6 @@ use js::rust::HandleObject;
 use style::attr::{AttrValue, LengthOrPercentageOrAuto};
 use style::color::AbsoluteColor;
 
-use crate::dom::attr::Attr;
 use crate::dom::bindings::codegen::Bindings::HTMLTableElementBinding::HTMLTableElementMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLTableRowElementBinding::HTMLTableRowElementMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLTableSectionElementBinding::HTMLTableSectionElementMethods;
@@ -19,6 +18,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::{DomRoot, LayoutDom, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{CustomElementCreationMode, Element, ElementCreator};
 use crate::dom::html::htmlcollection::HTMLCollection;
 use crate::dom::html::htmlelement::HTMLElement;
@@ -191,7 +191,7 @@ impl VirtualMethods for HTMLTableRowElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn attribute_affects_presentational_hints(&self, attr: &Attr) -> bool {
+    fn attribute_affects_presentational_hints(&self, attr: AttrRef<'_>) -> bool {
         match attr.local_name() {
             &local_name!("height") => true,
             _ => self

--- a/components/script/dom/html/htmltablesectionelement.rs
+++ b/components/script/dom/html/htmltablesectionelement.rs
@@ -9,7 +9,6 @@ use js::rust::HandleObject;
 use style::attr::{AttrValue, LengthOrPercentageOrAuto};
 use style::color::AbsoluteColor;
 
-use crate::dom::attr::Attr;
 use crate::dom::bindings::codegen::Bindings::HTMLTableSectionElementBinding::HTMLTableSectionElementMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use crate::dom::bindings::error::{ErrorResult, Fallible};
@@ -17,6 +16,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::{DomRoot, LayoutDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{CustomElementCreationMode, Element, ElementCreator};
 use crate::dom::html::htmlcollection::HTMLCollection;
 use crate::dom::html::htmlelement::HTMLElement;
@@ -131,7 +131,7 @@ impl VirtualMethods for HTMLTableSectionElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn attribute_affects_presentational_hints(&self, attr: &Attr) -> bool {
+    fn attribute_affects_presentational_hints(&self, attr: AttrRef<'_>) -> bool {
         match attr.local_name() {
             &local_name!("height") => true,
             _ => self

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -17,7 +17,6 @@ use style::attr::AttrValue;
 use stylo_dom::ElementState;
 
 use crate::clipboard_provider::EmbedderClipboardProvider;
-use crate::dom::attr::Attr;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLFormElementBinding::SelectionMode;
@@ -32,6 +31,7 @@ use crate::dom::clipboardevent::{ClipboardEvent, ClipboardEventType};
 use crate::dom::compositionevent::CompositionEvent;
 use crate::dom::document::Document;
 use crate::dom::document_embedder_controls::ControlElement;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::event::Event;
 use crate::dom::event::event::{EventBubbles, EventCancelable, EventComposed};
@@ -623,7 +623,7 @@ impl VirtualMethods for HTMLTextAreaElement {
     fn attribute_mutated(
         &self,
         cx: &mut js::context::JSContext,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
         self.super_type()

--- a/components/script/dom/html/htmlvideoelement.rs
+++ b/components/script/dom/html/htmlvideoelement.rs
@@ -25,7 +25,6 @@ use servo_url::ServoUrl;
 use style::attr::{AttrValue, LengthOrPercentageOrAuto};
 
 use crate::document_loader::{LoadBlocker, LoadType};
-use crate::dom::attr::Attr;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::HTMLVideoElementBinding::HTMLVideoElementMethods;
 use crate::dom::bindings::inheritance::Castable;
@@ -35,6 +34,7 @@ use crate::dom::bindings::root::{DomRoot, LayoutDom};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::csp::{GlobalCspReporting, Violation};
 use crate::dom::document::Document;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::html::htmlmediaelement::{HTMLMediaElement, NetworkState, ReadyState};
@@ -362,7 +362,7 @@ impl VirtualMethods for HTMLVideoElement {
     fn attribute_mutated(
         &self,
         cx: &mut js::context::JSContext,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
         self.super_type()
@@ -378,7 +378,7 @@ impl VirtualMethods for HTMLVideoElement {
         };
     }
 
-    fn attribute_affects_presentational_hints(&self, attr: &Attr) -> bool {
+    fn attribute_affects_presentational_hints(&self, attr: AttrRef<'_>) -> bool {
         match attr.local_name() {
             &local_name!("width") | &local_name!("height") => true,
             _ => self

--- a/components/script/dom/html/input_element/color_input_type.rs
+++ b/components/script/dom/html/input_element/color_input_type.rs
@@ -20,11 +20,11 @@ use style::values::specified::Color;
 use style_traits::{ParsingMode, ToCss};
 use url::Url;
 
-use crate::dom::attr::Attr;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::str::{DOMString, FromInputValueString};
 use crate::dom::document_embedder_controls::ControlElement;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{AttributeMutation, CustomElementCreationMode, Element, ElementCreator};
 use crate::dom::event::Event;
 use crate::dom::eventtarget::EventTarget;
@@ -234,7 +234,7 @@ impl SpecificInputType for ColorInputType {
         &self,
         _cx: &mut JSContext,
         input: &HTMLInputElement,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         _mutation: AttributeMutation,
     ) {
         match *attr.local_name() {

--- a/components/script/dom/html/input_element/input_type.rs
+++ b/components/script/dom/html/input_element/input_type.rs
@@ -10,8 +10,8 @@ use script_bindings::script_runtime::CanGc;
 use stylo_atoms::Atom;
 use time::OffsetDateTime;
 
-use crate::dom::attr::Attr;
 use crate::dom::element::AttributeMutation;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::event::Event;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::filelist::FileList;
@@ -345,7 +345,7 @@ pub(crate) trait SpecificInputType {
         &self,
         _cx: &mut JSContext,
         _input: &HTMLInputElement,
-        _attr: &Attr,
+        _attr: AttrRef<'_>,
         _mutation: AttributeMutation,
     ) {
     }

--- a/components/script/dom/html/input_element/mod.rs
+++ b/components/script/dom/html/input_element/mod.rs
@@ -35,7 +35,6 @@ use webdriver::error::ErrorStatus;
 
 use crate::clipboard_provider::EmbedderClipboardProvider;
 use crate::dom::activation::Activatable;
-use crate::dom::attr::Attr;
 use crate::dom::bindings::cell::{DomRefCell, Ref};
 use crate::dom::bindings::codegen::Bindings::ElementBinding::ElementMethods;
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -52,6 +51,7 @@ use crate::dom::clipboardevent::{ClipboardEvent, ClipboardEventType};
 use crate::dom::compositionevent::CompositionEvent;
 use crate::dom::document::Document;
 use crate::dom::document_embedder_controls::ControlElement;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::event::Event;
 use crate::dom::event::event::{EventBubbles, EventCancelable, EventComposed};
@@ -2001,7 +2001,12 @@ impl VirtualMethods for HTMLInputElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn attribute_mutated(&self, cx: &mut JSContext, attr: &Attr, mutation: AttributeMutation) {
+    fn attribute_mutated(
+        &self,
+        cx: &mut JSContext,
+        attr: AttrRef<'_>,
+        mutation: AttributeMutation,
+    ) {
         let could_have_had_embedder_control = self.may_have_embedder_control();
 
         self.super_type()

--- a/components/script/dom/html/input_element/radio_input_type.rs
+++ b/components/script/dom/html/input_element/radio_input_type.rs
@@ -10,11 +10,11 @@ use script_bindings::root::DomRoot;
 use script_bindings::script_runtime::CanGc;
 use stylo_atoms::Atom;
 
-use crate::dom::attr::Attr;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::GetRootNodeOptions;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::element::AttributeMutation;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::event::{Event, EventBubbles, EventCancelable, EventComposed};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::htmlformelement::{FormControl, HTMLFormElement};
@@ -157,7 +157,7 @@ impl SpecificInputType for RadioInputType {
         &self,
         cx: &mut JSContext,
         input: &HTMLInputElement,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
         match *attr.local_name() {

--- a/components/script/dom/namednodemap.rs
+++ b/components/script/dom/namednodemap.rs
@@ -39,15 +39,17 @@ impl NamedNodeMap {
 impl NamedNodeMapMethods<crate::DomTypeHolder> for NamedNodeMap {
     /// <https://dom.spec.whatwg.org/#dom-namednodemap-length>
     fn Length(&self) -> u32 {
-        self.owner.attrs().len() as u32
+        self.owner.attrs().borrow().len() as u32
     }
 
     /// <https://dom.spec.whatwg.org/#dom-namednodemap-item>
     fn Item(&self, index: u32) -> Option<DomRoot<Attr>> {
-        self.owner
-            .attrs()
-            .get(index as usize)
-            .map(|js| DomRoot::from_ref(&**js))
+        let index: usize = index as _;
+        if self.owner.attrs().borrow().len() < index {
+            None
+        } else {
+            Some(self.owner.attrs().ensure_dom(index, &self.owner))
+        }
     }
 
     /// <https://dom.spec.whatwg.org/#dom-namednodemap-getnameditem>
@@ -123,7 +125,7 @@ impl NamedNodeMapMethods<crate::DomTypeHolder> for NamedNodeMap {
     fn SupportedPropertyNames(&self) -> Vec<DOMString> {
         let mut names = vec![];
         let html_element_in_html_document = self.owner.html_element_in_html_document();
-        for attr in self.owner.attrs().iter() {
+        for attr in self.owner.attrs().borrow().iter() {
             let s = &**attr.name();
             if html_element_in_html_document && !s.bytes().all(|b| b.to_ascii_lowercase() == b) {
                 continue;

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -2857,8 +2857,10 @@ impl Node {
                 // Step 3.1.2 If inclusiveDescendant is an element, then set the node document of each
                 // attribute in inclusiveDescendant’s attribute list to document.
                 if let Some(element) = descendant.downcast::<Element>() {
-                    for attribute in element.attrs().iter() {
-                        attribute.upcast::<Node>().set_owner_doc(document);
+                    for attribute in element.attrs().borrow().iter() {
+                        if let Some(attr) = attribute.as_attr() {
+                            attr.upcast::<Node>().set_owner_doc(document);
+                        }
                     }
                 }
             }
@@ -4397,7 +4399,7 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
             (*element.namespace() == *other_element.namespace()) &&
                 (*element.prefix() == *other_element.prefix()) &&
                 (*element.local_name() == *other_element.local_name()) &&
-                (element.attrs().len() == other_element.attrs().len())
+                (element.attrs().borrow().len() == other_element.attrs().borrow().len())
         }
         fn is_equal_processinginstruction(node: &Node, other: &Node) -> bool {
             let pi = node.downcast::<ProcessingInstruction>().unwrap();
@@ -4421,9 +4423,9 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
         fn is_equal_element_attrs(node: &Node, other: &Node) -> bool {
             let element = node.downcast::<Element>().unwrap();
             let other_element = other.downcast::<Element>().unwrap();
-            assert!(element.attrs().len() == other_element.attrs().len());
-            element.attrs().iter().all(|attr| {
-                other_element.attrs().iter().any(|other_attr| {
+            assert!(element.attrs().borrow().len() == other_element.attrs().borrow().len());
+            element.attrs().borrow().iter().all(|attr| {
+                other_element.attrs().borrow().iter().any(|other_attr| {
                     (*attr.namespace() == *other_attr.namespace()) &&
                         (attr.local_name() == other_attr.local_name()) &&
                         (**attr.value() == **other_attr.value())
@@ -4537,7 +4539,7 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
                     // go through the attrs in order to see if self
                     // or other is first; spec is clear that we
                     // want value-equality, not reference-equality
-                    for attr in attrs.iter() {
+                    for attr in attrs.borrow().iter() {
                         if (*attr.namespace() == *a1.namespace()) &&
                             (attr.local_name() == a1.local_name()) &&
                             (**attr.value() == **a1.value())

--- a/components/script/dom/servoparser/html.rs
+++ b/components/script/dom/servoparser/html.rs
@@ -148,7 +148,7 @@ fn start_element<S: Serializer>(element: &Element, serializer: &mut S) -> io::Re
     }
 
     // Collect all the "normal" attributes
-    attributes.extend(element.attrs().iter().map(|attr| {
+    attributes.extend(element.attrs().borrow().iter().map(|attr| {
         let qname = QualName::new(None, attr.namespace().clone(), attr.local_name().clone());
         let value = attr.value().clone();
         (qname, value)

--- a/components/script/dom/svg/svgelement.rs
+++ b/components/script/dom/svg/svgelement.rs
@@ -11,7 +11,6 @@ use script_bindings::codegen::GenericBindings::WindowBinding::ScrollBehavior;
 use script_bindings::str::DOMString;
 use stylo_dom::ElementState;
 
-use crate::dom::attr::Attr;
 use crate::dom::bindings::codegen::Bindings::HTMLOrSVGElementBinding::FocusOptions;
 use crate::dom::bindings::codegen::Bindings::SVGElementBinding::SVGElementMethods;
 use crate::dom::bindings::inheritance::Castable;
@@ -21,6 +20,7 @@ use crate::dom::css::cssstyledeclaration::{
 };
 use crate::dom::document::Document;
 use crate::dom::document::focus::FocusableArea;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::node::{Node, NodeTraits};
 use crate::dom::scrolling_box::{ScrollAxisState, ScrollRequirement};
@@ -82,7 +82,7 @@ impl VirtualMethods for SVGElement {
     fn attribute_mutated(
         &self,
         cx: &mut js::context::JSContext,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
         self.super_type()

--- a/components/script/dom/svg/svgimageelement.rs
+++ b/components/script/dom/svg/svgimageelement.rs
@@ -7,12 +7,12 @@ use html5ever::{LocalName, Prefix, local_name, ns};
 use js::rust::HandleObject;
 use style::attr::AttrValue;
 
-use crate::dom::attr::Attr;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
 use crate::dom::element::AttributeMutation;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::node::{Node, NodeTraits};
 use crate::dom::svg::svggraphicselement::SVGGraphicsElement;
 use crate::dom::virtualmethods::VirtualMethods;
@@ -71,7 +71,7 @@ impl VirtualMethods for SVGImageElement {
     fn attribute_mutated(
         &self,
         cx: &mut js::context::JSContext,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
         self.super_type()
@@ -86,7 +86,7 @@ impl VirtualMethods for SVGImageElement {
         }
     }
 
-    fn attribute_affects_presentational_hints(&self, attr: &Attr) -> bool {
+    fn attribute_affects_presentational_hints(&self, attr: AttrRef<'_>) -> bool {
         match attr.local_name() {
             &local_name!("width") | &local_name!("height") => true,
             _ => self

--- a/components/script/dom/svg/svgsvgelement.rs
+++ b/components/script/dom/svg/svgsvgelement.rs
@@ -18,7 +18,6 @@ use style_traits::ParsingMode;
 use uuid::Uuid;
 use xml5ever::serialize::TraversalScope;
 
-use crate::dom::attr::Attr;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
@@ -26,6 +25,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::{DomRoot, LayoutDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::node::{
     ChildrenMutation, CloneChildrenFlag, Node, NodeDamage, NodeTraits, ShadowIncluding,
@@ -197,7 +197,7 @@ impl VirtualMethods for SVGSVGElement {
     fn attribute_mutated(
         &self,
         cx: &mut js::context::JSContext,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
         self.super_type()
@@ -207,7 +207,7 @@ impl VirtualMethods for SVGSVGElement {
         self.invalidate_cached_serialized_subtree();
     }
 
-    fn attribute_affects_presentational_hints(&self, attr: &Attr) -> bool {
+    fn attribute_affects_presentational_hints(&self, attr: AttrRef<'_>) -> bool {
         match attr.local_name() {
             &local_name!("width") | &local_name!("height") => true,
             _ => self

--- a/components/script/dom/virtualmethods.rs
+++ b/components/script/dom/virtualmethods.rs
@@ -7,7 +7,6 @@ use js::context::JSContext;
 use script_bindings::root::DomRoot;
 use style::attr::AttrValue;
 
-use crate::dom::attr::Attr;
 use crate::dom::bindings::inheritance::{
     Castable, DocumentFragmentTypeId, ElementTypeId, HTMLElementTypeId, HTMLMediaElementTypeId,
     NodeTypeId, SVGElementTypeId, SVGGraphicsElementTypeId,
@@ -15,6 +14,7 @@ use crate::dom::bindings::inheritance::{
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
 use crate::dom::documentfragment::DocumentFragment;
+use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::event::Event;
 use crate::dom::html::htmlanchorelement::HTMLAnchorElement;
@@ -82,7 +82,7 @@ pub(crate) trait VirtualMethods {
     fn attribute_mutated(
         &self,
         cx: &mut js::context::JSContext,
-        attr: &Attr,
+        attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
         if let Some(s) = self.super_type() {
@@ -92,7 +92,7 @@ pub(crate) trait VirtualMethods {
 
     /// Returns `true` if given attribute `attr` affects style of the
     /// given element.
-    fn attribute_affects_presentational_hints(&self, attr: &Attr) -> bool {
+    fn attribute_affects_presentational_hints(&self, attr: AttrRef<'_>) -> bool {
         match self.super_type() {
             Some(s) => s.attribute_affects_presentational_hints(attr),
             None => false,

--- a/components/script/layout_dom/servo_dangerous_style_element.rs
+++ b/components/script/layout_dom/servo_dangerous_style_element.rs
@@ -228,9 +228,8 @@ impl<'dom> style::dom::TElement for ServoDangerousStyleElement<'dom> {
     where
         F: FnMut(&style::LocalName),
     {
-        for attr in self.element.attrs() {
-            callback(style::values::GenericAtomIdent::cast(attr.local_name()))
-        }
+        self.element
+            .each_attr_name_for_layout(|name| callback(style::values::GenericAtomIdent::cast(name)))
     }
 
     fn each_part<F>(&self, mut callback: F)

--- a/components/script/xpath.rs
+++ b/components/script/xpath.rs
@@ -26,6 +26,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::comment::Comment;
 use crate::dom::document::Document;
 use crate::dom::element::Element;
+use crate::dom::element::attributes::storage::AttributeStorage;
 use crate::dom::node::{Node, NodeTraits, PrecedingNodeIterator, ShadowIncluding};
 use crate::dom::processinginstruction::ProcessingInstruction;
 use crate::dom::text::Text;
@@ -209,7 +210,7 @@ impl xpath::Element for XPathWrapper<DomRoot<Element>> {
 
     fn attributes(&self) -> impl Iterator<Item = Self::Attribute> {
         struct AttributeIterator<'a> {
-            attributes: Ref<'a, [Dom<Attr>]>,
+            attributes: &'a AttributeStorage,
             position: usize,
         }
 
@@ -217,19 +218,21 @@ impl xpath::Element for XPathWrapper<DomRoot<Element>> {
             type Item = XPathWrapper<DomRoot<Attr>>;
 
             fn next(&mut self) -> Option<Self::Item> {
-                let attribute = self.attributes.get(self.position)?;
+                let entries = self.attributes.borrow();
+                let entry = entries.get(self.position)?;
                 self.position += 1;
-                Some(attribute.as_rooted().into())
+                Some(DomRoot::from_ref(entry.as_attr().unwrap()).into())
             }
 
             fn size_hint(&self) -> (usize, Option<usize>) {
-                let exact_length = self.attributes.len() - self.position;
+                let exact_length = self.attributes.borrow().len() - self.position;
                 (exact_length, Some(exact_length))
             }
         }
 
+        // XPath needs full DOM attribute nodes.
         AttributeIterator {
-            attributes: self.0.attrs(),
+            attributes: self.0.dom_attrs(),
             position: 0,
         }
     }


### PR DESCRIPTION
Switch from always building Dom attributes to a lightweight data structure that is lazily converted to a Dom one when required.

Testing: No new test needed
Fixes:  #36697 
