### PR TITLE
webgl: replace WebGLCommandSender with WebGLChan

### DIFF
--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -29,9 +29,9 @@ use servo_base::{Epoch, generic_channel};
 use servo_canvas_traits::webgl::WebGLError::*;
 use servo_canvas_traits::webgl::{
     AlphaTreatment, GLContextAttributes, GLLimits, GlType, Parameter, SizedDataType, TexDataType,
-    TexFormat, TexParameter, WebGLChan, WebGLCommand, WebGLCommandBacktrace, WebGLContextId,
-    WebGLError, WebGLFramebufferBindingRequest, WebGLMsg, WebGLMsgSender, WebGLProgramId,
-    WebGLResult, WebGLSLVersion, WebGLSendResult, WebGLVersion, YAxisTreatment, webgl_channel,
+    TexFormat, TexParameter, WebGLCommand, WebGLCommandBacktrace, WebGLContextId, WebGLError,
+    WebGLFramebufferBindingRequest, WebGLMsg, WebGLMsgSender, WebGLProgramId, WebGLResult,
+    WebGLSLVersion, WebGLVersion, YAxisTreatment, webgl_channel,
 };
 use servo_config::pref;
 use webrender_api::ImageKey;
@@ -5253,22 +5253,6 @@ impl TexPixels {
 pub(crate) enum TexSource {
     Pixels(TexPixels),
     BufferOffset(i64),
-}
-
-#[derive(JSTraceable)]
-pub(crate) struct WebGLCommandSender {
-    #[no_trace]
-    sender: WebGLChan,
-}
-
-impl WebGLCommandSender {
-    pub(crate) fn new(sender: WebGLChan) -> WebGLCommandSender {
-        WebGLCommandSender { sender }
-    }
-
-    pub(crate) fn send(&self, msg: WebGLMsg) -> WebGLSendResult {
-        self.sender.send(msg)
-    }
 }
 
 fn array_buffer_type_to_sized_type(type_: Type) -> Option<SizedDataType> {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -181,7 +181,6 @@ use crate::dom::trustedtypes::trustedtypepolicyfactory::TrustedTypePolicyFactory
 use crate::dom::types::{ImageBitmap, MouseEvent, UIEvent};
 use crate::dom::useractivation::UserActivationTimestamp;
 use crate::dom::visualviewport::{VisualViewport, VisualViewportChanges};
-use crate::dom::webgl::webglrenderingcontext::WebGLCommandSender;
 #[cfg(feature = "webgpu")]
 use crate::dom::webgpu::identityhub::IdentityHub;
 use crate::dom::windowproxy::{WindowProxy, WindowProxyHandler};
@@ -677,10 +676,8 @@ impl Window {
         &self.error_reporter
     }
 
-    pub(crate) fn webgl_chan(&self) -> Option<WebGLCommandSender> {
-        self.webgl_chan
-            .as_ref()
-            .map(|chan| WebGLCommandSender::new(chan.clone()))
+    pub(crate) fn webgl_chan(&self) -> Option<WebGLChan> {
+        self.webgl_chan.clone()
     }
 
     #[cfg(feature = "webxr")]


### PR DESCRIPTION
Remove the `WebGLCommandSender` wrapper and return `Option<WebGLChan>` directly from the `webgl_chan` method.

Testing: no tests required as runtime behavior is not affected 
Fixes: #44193
