### PR TITLE
Match on NonNull::new instead of using is_null() and expect()

### DIFF
--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2870,13 +2870,11 @@ impl GlobalScope {
                 no_script_rval,
             ));
 
-            if compiled_script.is_null() {
+            let Some(script) = NonNull::new(*compiled_script) else {
                 debug!("error compiling Dom string");
                 report_pending_exception(cx.into(), in_realm, CanGc::from_cx(cx));
                 return Err(JavaScriptEvaluationError::CompilationFailure);
-            }
-
-            let script = NonNull::new(*compiled_script).expect("Can't be null");
+            };
 
             rooted!(&in(cx) let mut value = UndefinedValue());
             let rval = rval.unwrap_or_else(|| value.handle_mut());


### PR DESCRIPTION
The code was doing repetitive work by checking if `compiled_script` is null and then assigning and expecting the same, combined and replaced with condition based working
Testing: The flow remains the same no new tests needed
Fixes: #44210
