### PR TITLE
embedding: Use non-advertised (standard) shortcut

### DIFF
--- a/support/windows/servoshell.wxs.mako
+++ b/support/windows/servoshell.wxs.mako
@@ -20,7 +20,6 @@
     <Media Id="1"
            Cabinet="Servo.cab"
            EmbedCab="yes"/>
-    <Property Id="SERVOEXEPATH" Value="[INSTALLDIR]servoshell.exe"/>
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="ProgramFiles64Folder" Name="PFiles">
         <Directory Id="Servo" Name="Servo">
@@ -54,7 +53,7 @@
             <Shortcut Id="StartMenuServoTechDemo"
               Directory="ProgramMenuDir"
               Name="Servo Tech Demo"
-               Target="[SERVOEXEPATH]"
+              Target="[INSTALLDIR]servoshell.exe"
               WorkingDirectory="INSTALLDIR"
               Icon="servoshell.exe"/>
           </Component>

--- a/support/windows/servoshell.wxs.mako
+++ b/support/windows/servoshell.wxs.mako
@@ -32,11 +32,6 @@
                     DiskId="1"
                     Source="${windowize(exe_path)}\servoshell.exe"
                     KeyPath="yes">
-                <Shortcut Id="StartMenuServoTechDemo"
-                          Directory="ProgramMenuDir"
-                          Name="Servo Tech Demo"
-                          WorkingDirectory="INSTALLDIR"
-                          Icon="servoshell.exe"/>
               </File>
 	            ${include_dependencies()}
             </Component>
@@ -55,6 +50,12 @@
                            Type="string"
                            Value=""
                            KeyPath="yes"/>
+            <Shortcut Id="StartMenuServoTechDemo"
+              Directory="ProgramMenuDir"
+              Name="Servo Tech Demo"
+              Target="[#ServoEXE]"
+              WorkingDirectory="INSTALLDIR"
+              Icon="servoshell.exe"/>
           </Component>
         </Directory>
       </Directory>

--- a/support/windows/servoshell.wxs.mako
+++ b/support/windows/servoshell.wxs.mako
@@ -20,6 +20,7 @@
     <Media Id="1"
            Cabinet="Servo.cab"
            EmbedCab="yes"/>
+    <Property Id="SERVOEXEPATH" Value="[INSTALLDIR]servoshell.exe"/>
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="ProgramFiles64Folder" Name="PFiles">
         <Directory Id="Servo" Name="Servo">
@@ -53,7 +54,7 @@
             <Shortcut Id="StartMenuServoTechDemo"
               Directory="ProgramMenuDir"
               Name="Servo Tech Demo"
-              Target="[#ServoEXE]"
+               Target="[SERVOEXEPATH]"
               WorkingDirectory="INSTALLDIR"
               Icon="servoshell.exe"/>
           </Component>

--- a/support/windows/servoshell.wxs.mako
+++ b/support/windows/servoshell.wxs.mako
@@ -36,8 +36,7 @@
                           Directory="ProgramMenuDir"
                           Name="Servo Tech Demo"
                           WorkingDirectory="INSTALLDIR"
-                          Icon="servoshell.exe"
-                          Advertise="yes"/>
+                          Icon="servoshell.exe"/>
               </File>
 	            ${include_dependencies()}
             </Component>


### PR DESCRIPTION
Right now we are using [advertised shortcut](https://learn.microsoft.com/en-au/windows/win32/msi/advertisement).
This is drastically different from standard Windows shortcut. For example, when you right click,
then click "open file position", nothing happens.

Advertisement is mostly for "install-on-demand", but that is not the case for our installer, as files already
installed in the path even if you do not launch.

Testing: [Windows Try](https://github.com/servo/servo/actions/runs/24436253745). Now things work as other apps.

Reference: 
[Advanced installer](https://www.advancedinstaller.com/versus/wix-toolset/how-to-create-non-advertised-shortcuts-using-wix.html). (Yes, they make great business by making it easier to build MSI installer)
