### PR TITLE
ci: Install cargo nextest conditionally; Give the step consistent name for linux & mac

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -157,7 +157,7 @@ jobs:
           sudo apt update
           echo "wireshark-common wireshark-common/install-setuid boolean true" | sudo debconf-set-selections
           sudo apt install -qy tshark
-          ./mach bootstrap --yes --skip-lints
+          ./mach bootstrap --yes --skip-lints --skip-nextest
 
       # Always install crown, even on self-hosted runners, because it is tightly
       # coupled to the rustc version, and we may have the wrong version if the

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -145,7 +145,9 @@ jobs:
       - name: Change Mirror Priorities
         if: ${{ runner.environment != 'self-hosted' }}
         uses: ./.github/actions/apt-mirrors
-      - uses: taiki-e/install-action@v2
+      - name: Install cargo nextest
+        if: ${{ inputs.unit-tests }}
+        uses: taiki-e/install-action@v2
         with:
           tool: nextest
       - name: Bootstrap dependencies

--- a/.github/workflows/mac-arm64.yml
+++ b/.github/workflows/mac-arm64.yml
@@ -125,7 +125,9 @@ jobs:
       - name: Install crown
         run: cargo install --path support/crown
 
-      - uses: taiki-e/install-action@v2
+      - name: Install cargo nextest
+        if: ${{ inputs.unit-tests }}
+        uses: taiki-e/install-action@v2
         with:
           tool: nextest
 

--- a/.github/workflows/mac-arm64.yml
+++ b/.github/workflows/mac-arm64.yml
@@ -134,7 +134,7 @@ jobs:
       - if: runner.environment != 'self-hosted'
         name: Bootstrap
         run: |
-          ./mach bootstrap --yes --skip-lints
+          ./mach bootstrap --yes --skip-lints --skip-nextest
           brew install gnu-tar
       - name: Build (${{ inputs.profile }})
         run: |

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -135,7 +135,7 @@ jobs:
       - if: runner.environment != 'self-hosted'
         name: Bootstrap
         run: |
-          ./mach bootstrap --yes --skip-lints
+          ./mach bootstrap --yes --skip-lints --skip-nextest
           brew install gnu-tar
       - name: Build (${{ inputs.profile }})
         run: |

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -126,7 +126,9 @@ jobs:
       - name: Install crown
         run: cargo install --path support/crown
 
-      - uses: taiki-e/install-action@v2
+      - name: Install cargo nextest
+        if: ${{ inputs.unit-tests }}
+        uses: taiki-e/install-action@v2
         with:
           tool: nextest
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -157,13 +157,13 @@ jobs:
       - name: Smoketest
         run: .\mach smoketest --profile ${{ inputs.profile }}
       - name: Install cargo nextest
-        if: ${{ runner.environment != 'self-hosted' }}
+        if: ${{ runner.environment != 'self-hosted' && inputs.unit-tests }}
         uses: taiki-e/install-action@v2
         with:
           tool: nextest
       # On self-hosted windows runners the install-action fails
       - name: Install cargo nextest (self-hosted)
-        if: ${{ runner.environment == 'self-hosted' }}
+        if: ${{ runner.environment == 'self-hosted' && inputs.unit-tests }}
         run: cargo install cargo-nextest --locked
       - name: Unit tests
         if: ${{ inputs.unit-tests }}


### PR DESCRIPTION
There is no point to install it if we don't run UT. 
This step takes 1 min to install for self-hosted runner: [try](https://github.com/servo/servo/actions/runs/24436253745/job/71391055444#step:15:11). Given the rising energy price nowadays, let's save it.

Also take the chance to give the consistent name. Somehow only Windows had the name "Install cargo nextest"

Testing: Previously, the step is called "Run taiki-e/install-action@v2" in the linux/mac CI.
Now it has the proper name and skipped if UT will not be run: [try](https://github.com/servo/servo/actions/runs/24440166415/job/71403276390).