### PR TITLE
script: Use OffscreenRenderingContextId instead of DOMString in OffscreenCanvas

### DIFF
--- a/components/script/dom/canvas/offscreencanvas.rs
+++ b/components/script/dom/canvas/offscreencanvas.rs
@@ -12,7 +12,6 @@ use js::rust::{HandleObject, HandleValue};
 use pixels::{EncodedImageType, Snapshot};
 use rustc_hash::FxHashMap;
 use script_bindings::inheritance::Castable;
-use script_bindings::match_domstring_ascii;
 use script_bindings::weakref::WeakRef;
 use servo_base::id::{OffscreenCanvasId, OffscreenCanvasIndex};
 use servo_canvas_traits::webgl::{GLContextAttributes, WebGLVersion};
@@ -23,7 +22,7 @@ use crate::conversions::Convert;
 use crate::dom::bindings::cell::{DomRefCell, Ref};
 use crate::dom::bindings::codegen::Bindings::OffscreenCanvasBinding::{
     ImageEncodeOptions, OffscreenCanvasMethods,
-    OffscreenRenderingContext as RootedOffscreenRenderingContext,
+    OffscreenRenderingContext as RootedOffscreenRenderingContext, OffscreenRenderingContextId,
 };
 use crate::dom::bindings::codegen::Bindings::WebGLRenderingContextBinding::WebGLContextAttributes;
 use crate::dom::bindings::codegen::UnionTypes::HTMLCanvasElementOrOffscreenCanvas as RootedHTMLCanvasElementOrOffscreenCanvas;
@@ -32,7 +31,6 @@ use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::refcounted::{Trusted, TrustedPromise};
 use crate::dom::bindings::reflector::{DomGlobal, DomObject, reflect_dom_object_with_proto};
 use crate::dom::bindings::root::{Dom, DomRoot};
-use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::structuredclone::StructuredData;
 use crate::dom::bindings::transferable::Transferable;
 use crate::dom::blob::Blob;
@@ -402,7 +400,7 @@ impl OffscreenCanvasMethods<crate::DomTypeHolder> for OffscreenCanvas {
     fn GetContext(
         &self,
         cx: JSContext,
-        id: DOMString,
+        id: OffscreenRenderingContextId,
         options: HandleValue,
         can_gc: CanGc,
     ) -> Fallible<Option<RootedOffscreenRenderingContext>> {
@@ -412,27 +410,26 @@ impl OffscreenCanvasMethods<crate::DomTypeHolder> for OffscreenCanvas {
             return Err(Error::InvalidState(None));
         }
 
-        match_domstring_ascii!(id,
-        "2d" => Ok(self
-            .get_or_init_2d_context(can_gc)
-            .map(RootedOffscreenRenderingContext::OffscreenCanvasRenderingContext2D)),
-        "bitmaprenderer" => Ok(self
-            .get_or_init_bitmaprenderer_context(can_gc)
-            .map(RootedOffscreenRenderingContext::ImageBitmapRenderingContext)),
-        "webgl" => Ok(self
-            .get_or_init_webgl_context(cx, options, can_gc)
-            .map(RootedOffscreenRenderingContext::WebGLRenderingContext)),
-        "experimental-webgl" => Ok(self
-            .get_or_init_webgl_context(cx, options,can_gc)
-            .map(RootedOffscreenRenderingContext::WebGLRenderingContext)),
-        "webgl2"  => Ok(self
-            .get_or_init_webgl2_context(cx, options, can_gc)
-            .map(RootedOffscreenRenderingContext::WebGL2RenderingContext)),
-        "experimental-webgl2" => Ok(self
-            .get_or_init_webgl2_context(cx, options, can_gc)
-            .map(RootedOffscreenRenderingContext::WebGL2RenderingContext)),
-            _ => Err(Error::Type(c"Unrecognized OffscreenCanvas context type".to_owned())),
-        )
+        match id {
+            OffscreenRenderingContextId::_2d => Ok(self
+                .get_or_init_2d_context(can_gc)
+                .map(RootedOffscreenRenderingContext::OffscreenCanvasRenderingContext2D)),
+            OffscreenRenderingContextId::Bitmaprenderer => Ok(self
+                .get_or_init_bitmaprenderer_context(can_gc)
+                .map(RootedOffscreenRenderingContext::ImageBitmapRenderingContext)),
+            OffscreenRenderingContextId::Webgl => Ok(self
+                .get_or_init_webgl_context(cx, options, can_gc)
+                .map(RootedOffscreenRenderingContext::WebGLRenderingContext)),
+            OffscreenRenderingContextId::Experimental_webgl => Ok(self
+                .get_or_init_webgl_context(cx, options, can_gc)
+                .map(RootedOffscreenRenderingContext::WebGLRenderingContext)),
+            OffscreenRenderingContextId::Webgl2 => Ok(self
+                .get_or_init_webgl2_context(cx, options, can_gc)
+                .map(RootedOffscreenRenderingContext::WebGL2RenderingContext)),
+            OffscreenRenderingContextId::Experimental_webgl2 => Ok(self
+                .get_or_init_webgl2_context(cx, options, can_gc)
+                .map(RootedOffscreenRenderingContext::WebGL2RenderingContext)),
+        }
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-offscreencanvas-width>

--- a/components/script_bindings/webidls/OffscreenCanvas.webidl
+++ b/components/script_bindings/webidls/OffscreenCanvas.webidl
@@ -13,7 +13,7 @@ dictionary ImageEncodeOptions {
   unrestricted double quality;
 };
 
-//enum OffscreenRenderingContextId { "2d", "bitmaprenderer", "webgl", "webgl2" };
+enum OffscreenRenderingContextId { "2d", "bitmaprenderer", "webgl", "webgl2", "experimental-webgl", "experimental-webgl2" };
 
 [Exposed=(Window,Worker), Transferable, Pref="dom_offscreen_canvas_enabled"]
 interface OffscreenCanvas : EventTarget {
@@ -21,7 +21,7 @@ interface OffscreenCanvas : EventTarget {
   attribute [EnforceRange] unsigned long long width;
   attribute [EnforceRange] unsigned long long height;
 
-  [Throws] OffscreenRenderingContext? getContext(DOMString contextId, optional any options = null);
+  [Throws] OffscreenRenderingContext? getContext(OffscreenRenderingContextId contextId, optional any options = null);
   [Throws] ImageBitmap transferToImageBitmap();
   Promise<Blob> convertToBlob(optional ImageEncodeOptions options = {});
 };


### PR DESCRIPTION

replaced use of `DOMString` with `OffscreenRenderingContextId`  made the enum be initialized in bindings ([OffscreenCanvas.webidl](https://github.com/servo/servo/compare/main...rovertrack:servo:issue-44211?expand=1#diff-3a74afa4763f3f36099b9717328f9516edc3eecd5131d216a8cd024fa4fd96d9)) and use them in `getcontext()`
Testing: `./mach test-wpt tests/wpt/tests/html/canvas/offscreen` there are no failing tests regarding the use of `OffscreenRenderingContextId`  but there were some regarding other things such as `TextMetrics`.
Fixes:  #44211
