### PR TITLE
script: Correctly apply resource timing buffer limit

### DIFF
--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -438,6 +438,9 @@ impl FetchResponseListener for ClassicContext {
         response: Result<(), NetworkError>,
         timing: ResourceFetchTiming,
     ) {
+        // Resource timing is expected to be available before "error" or "load" events are fired.
+        network_listener::submit_timing(cx, &self, &response, &timing);
+
         let elem = self.elem.root();
 
         match (response.as_ref(), self.status.as_ref()) {
@@ -446,9 +449,6 @@ impl FetchResponseListener for ClassicContext {
                 // Step 6, response is an error.
                 *elem.result.borrow_mut() = Some(Err(()));
                 finish_fetching_a_script(&elem, self.kind, cx);
-
-                // Resource timing is expected to be available before "error" or "load" events are fired.
-                network_listener::submit_timing(cx, &self, &response, &timing);
                 return;
             },
             _ => {},
@@ -522,8 +522,6 @@ impl FetchResponseListener for ClassicContext {
         *elem.result.borrow_mut() = Some(Ok(Script::Classic(script)));
         finish_fetching_a_script(&elem, self.kind, cx);
         // }
-
-        network_listener::submit_timing(cx, &self, &response, &timing);
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {

--- a/components/script/dom/performance/performance.rs
+++ b/components/script/dom/performance/performance.rs
@@ -377,8 +377,7 @@ impl Performance {
     fn can_add_resource_timing_entry(&self) -> bool {
         // Step 1. If resource timing buffer current size is smaller than resource timing buffer size limit, return true.
         // Step 2. Return false.
-        // TODO: Changing this to "<" (as per spec) does not result in passing tests, needs investigation
-        self.resource_timing_buffer_current_size.get() <=
+        self.resource_timing_buffer_current_size.get() <
             self.resource_timing_buffer_size_limit.get()
     }
 

--- a/tests/wpt/meta/performance-timeline/droppedentriescount.any.js.ini
+++ b/tests/wpt/meta/performance-timeline/droppedentriescount.any.js.ini
@@ -1,16 +1,16 @@
 [droppedentriescount.any.worker.html]
   expected: TIMEOUT
   [Dropped entries count is 0 when there are no dropped entries of relevant type.]
-    expected: FAIL
+    expected: TIMEOUT
 
   [Dropped entries correctly counted with multiple types.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Dropped entries counted even if observer was not registered at the time.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Dropped entries only surfaced on the first callback.]
-    expected: TIMEOUT
+    expected: NOTRUN
 
   [Dropped entries surfaced after an observe() call!]
     expected: NOTRUN

--- a/tests/wpt/meta/performance-timeline/po-resource.html.ini
+++ b/tests/wpt/meta/performance-timeline/po-resource.html.ini
@@ -1,3 +1,0 @@
-[po-resource.html]
-  [resource entries are observable]
-    expected: FAIL

--- a/tests/wpt/meta/preload/prefetch-document.html.ini
+++ b/tests/wpt/meta/preload/prefetch-document.html.ini
@@ -4,6 +4,3 @@
 
   [different-site document prefetch without 'as' should not be consumed]
     expected: FAIL
-
-  [different-site document prefetch with 'as=document' should not be consumed]
-    expected: FAIL

--- a/tests/wpt/meta/preload/preload-error.sub.html.ini
+++ b/tests/wpt/meta/preload/preload-error.sub.html.ini
@@ -1,10 +1,4 @@
 [preload-error.sub.html]
-  [CORS-error (script): main]
-    expected: FAIL
-
-  [CSP-error (script): main]
-    expected: FAIL
-
   [CORS-error (xhr): main]
     expected: FAIL
 
@@ -24,9 +18,6 @@
     expected: FAIL
 
   [MIME-blocked-nosniff (style): main]
-    expected: FAIL
-
-  [MIME-blocked-nosniff (script): main]
     expected: FAIL
 
   [404 (style): main]

--- a/tests/wpt/meta/preload/subresource-integrity.html.ini
+++ b/tests/wpt/meta/preload/subresource-integrity.html.ini
@@ -1,25 +1,4 @@
 [subresource-integrity.html]
-  [Same-origin script with incorrect hash.]
-    expected: FAIL
-
-  [Same-origin script with sha256 match, sha512 mismatch]
-    expected: FAIL
-
-  [<crossorigin='anonymous'> script with incorrect hash, ACAO: *]
-    expected: FAIL
-
-  [<crossorigin='use-credentials'> script with incorrect hash CORS-eligible]
-    expected: FAIL
-
-  [<crossorigin='anonymous'> script with CORS-ineligible resource]
-    expected: FAIL
-
-  [Cross-origin script, not CORS request, with correct hash]
-    expected: FAIL
-
-  [Cross-origin script, not CORS request, with hash mismatch]
-    expected: FAIL
-
   [Same-origin script with non-matching digest does not re-use preload with matching digest.]
     expected: FAIL
 
@@ -29,16 +8,7 @@
   [Same-origin script with non-matching digest does not re-use preload with non-matching digest.]
     expected: FAIL
 
-  [Same-origin script with matching digest does not reuse preload without digest.]
-    expected: FAIL
-
-  [Same-origin script with matching digest does not reuse preload with matching but stronger digest.]
-    expected: FAIL
-
   [Same-origin script with wrong digest does not reuse preload with correct and stronger digest.]
-    expected: FAIL
-
-  [Same-origin script with matching digest does not reuse preload with matching but weaker digest.]
     expected: FAIL
 
   [Same-origin script with non-matching digest reuses preload with no digest but fails.]

--- a/tests/wpt/meta/resource-timing/buffer-full-add-after-full-event.html.ini
+++ b/tests/wpt/meta/resource-timing/buffer-full-add-after-full-event.html.ini
@@ -1,3 +1,4 @@
 [buffer-full-add-after-full-event.html]
+  expected: TIMEOUT
   [Test that entry was added to the buffer after a buffer full event]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/resource-timing/buffer-full-add-entries-during-callback-that-drop.html.ini
+++ b/tests/wpt/meta/resource-timing/buffer-full-add-entries-during-callback-that-drop.html.ini
@@ -1,3 +1,0 @@
-[buffer-full-add-entries-during-callback-that-drop.html]
-  [Test that entries synchronously added to the buffer during the callback are dropped]
-    expected: FAIL

--- a/tests/wpt/meta/resource-timing/buffer-full-add-entries-during-callback.html.ini
+++ b/tests/wpt/meta/resource-timing/buffer-full-add-entries-during-callback.html.ini
@@ -1,3 +1,0 @@
-[buffer-full-add-entries-during-callback.html]
-  [Test that entries synchronously added to the buffer during the callback don't get dropped if the buffer is increased]
-    expected: FAIL

--- a/tests/wpt/meta/resource-timing/buffer-full-decrease-buffer-during-callback.html.ini
+++ b/tests/wpt/meta/resource-timing/buffer-full-decrease-buffer-during-callback.html.ini
@@ -1,3 +1,0 @@
-[buffer-full-decrease-buffer-during-callback.html]
-  [Test that decreasing the buffer limit during the callback does not drop entries]
-    expected: FAIL

--- a/tests/wpt/meta/resource-timing/buffer-full-increase-buffer-during-callback.html.ini
+++ b/tests/wpt/meta/resource-timing/buffer-full-increase-buffer-during-callback.html.ini
@@ -1,3 +1,0 @@
-[buffer-full-increase-buffer-during-callback.html]
-  [Test that increasing the buffer during the callback is enough for entries not to be dropped]
-    expected: FAIL

--- a/tests/wpt/meta/resource-timing/buffer-full-inspect-buffer-during-callback.html.ini
+++ b/tests/wpt/meta/resource-timing/buffer-full-inspect-buffer-during-callback.html.ini
@@ -1,3 +1,0 @@
-[buffer-full-inspect-buffer-during-callback.html]
-  [Test that entries in the secondary buffer are not exposed during the callback and before they are copied to the primary buffer]
-    expected: FAIL

--- a/tests/wpt/meta/resource-timing/buffer-full-set-to-current-buffer.html.ini
+++ b/tests/wpt/meta/resource-timing/buffer-full-set-to-current-buffer.html.ini
@@ -1,3 +1,0 @@
-[buffer-full-set-to-current-buffer.html]
-  [Test that adding entries and firing the buffer full event happen in the right order.]
-    expected: FAIL

--- a/tests/wpt/meta/resource-timing/buffer-full-store-and-clear-during-callback.html.ini
+++ b/tests/wpt/meta/resource-timing/buffer-full-store-and-clear-during-callback.html.ini
@@ -1,3 +1,0 @@
-[buffer-full-store-and-clear-during-callback.html]
-  [Test that entries overflowing the buffer trigger the buffer full event, can be stored, and make their way to the primary buffer after it's cleared in the buffer full event.]
-    expected: FAIL

--- a/tests/wpt/meta/resource-timing/buffer-full-then-decreased.html.ini
+++ b/tests/wpt/meta/resource-timing/buffer-full-then-decreased.html.ini
@@ -1,3 +1,0 @@
-[buffer-full-then-decreased.html]
-  [Test that if the buffer is reduced after entries were added to it, those entries don't get cleared, nor is the resourcetimingbufferfull event being called.]
-    expected: FAIL

--- a/tests/wpt/meta/resource-timing/buffer-full-then-increased.html.ini
+++ b/tests/wpt/meta/resource-timing/buffer-full-then-increased.html.ini
@@ -1,3 +1,0 @@
-[buffer-full-then-increased.html]
-  [Test that overflowing the buffer and immediately increasing its limit does not trigger the resourcetimingbufferfull event]
-    expected: FAIL

--- a/tests/wpt/meta/resource-timing/buffer-full-when-populate-entries.html.ini
+++ b/tests/wpt/meta/resource-timing/buffer-full-when-populate-entries.html.ini
@@ -1,3 +1,0 @@
-[buffer-full-when-populate-entries.html]
-  [Test that a buffer full event does not bubble and that resourcetimingbufferfull is called only once per overflow]
-    expected: FAIL

--- a/tests/wpt/meta/resource-timing/buffered-flag.any.js.ini
+++ b/tests/wpt/meta/resource-timing/buffered-flag.any.js.ini
@@ -1,6 +1,0 @@
-[buffered-flag.any.html]
-  [PerformanceObserver with buffered flag sees previous resource entries.]
-    expected: FAIL
-
-
-[buffered-flag.any.worker.html]

--- a/tests/wpt/meta/resource-timing/clear-resource-timings.html.ini
+++ b/tests/wpt/meta/resource-timing/clear-resource-timings.html.ini
@@ -1,3 +1,0 @@
-[clear-resource-timings.html]
-  [Test that clearResourceTimings() clears the performance timeline buffer]
-    expected: FAIL

--- a/tests/wpt/meta/resource-timing/render-blocking-status-link.html.ini
+++ b/tests/wpt/meta/resource-timing/render-blocking-status-link.html.ini
@@ -1,4 +1,3 @@
 [render-blocking-status-link.html]
-  expected: CRASH
   [Validate render blocking status of link resources in PerformanceResourceTiming]
     expected: FAIL

--- a/tests/wpt/meta/resource-timing/script-rt-entries.html.ini
+++ b/tests/wpt/meta/resource-timing/script-rt-entries.html.ini
@@ -1,6 +1,0 @@
-[script-rt-entries.html]
-  [The RT entry for script should be available when the script 'load' event fires]
-    expected: FAIL
-
-  [The RT entry for a non-existent script should be available when the script 'error' event fires]
-    expected: FAIL

--- a/tests/wpt/meta/resource-timing/test_resource_timing.html.ini
+++ b/tests/wpt/meta/resource-timing/test_resource_timing.html.ini
@@ -29,9 +29,6 @@
   [PerformanceEntry has correct protocol attribute (link)]
     expected: FAIL
 
-  [window.performance.getEntriesByName() and window.performance.getEntriesByNameType() return same data (script)]
-    expected: FAIL
-
   [PerformanceEntry has correct name, initiatorType, startTime, and duration (script)]
     expected: FAIL
 

--- a/tests/wpt/meta/resource-timing/test_resource_timing.https.html.ini
+++ b/tests/wpt/meta/resource-timing/test_resource_timing.https.html.ini
@@ -20,9 +20,6 @@
   [PerformanceEntry has correct protocol attribute (img)]
     expected: FAIL
 
-  [PerformanceEntry has correct name, initiatorType, startTime, and duration (link)]
-    expected: FAIL
-
   [PerformanceEntry has correct order of timing attributes (link)]
     expected: FAIL
 
@@ -30,9 +27,6 @@
     expected: FAIL
 
   [PerformanceEntry has correct protocol attribute (link)]
-    expected: FAIL
-
-  [window.performance.getEntriesByName() and window.performance.getEntriesByNameType() return same data (script)]
     expected: FAIL
 
   [PerformanceEntry has correct name, initiatorType, startTime, and duration (script)]
@@ -57,6 +51,9 @@
     expected: FAIL
 
   [PerformanceEntry has correct name, initiatorType, startTime, and duration (img)]
+    expected: FAIL
+
+  [PerformanceEntry has correct name, initiatorType, startTime, and duration (link)]
     expected: FAIL
 
   [PerformanceEntry has correct name, initiatorType, startTime, and duration (xmlhttprequest)]

--- a/tests/wpt/meta/workers/worker-performance.worker.js.ini
+++ b/tests/wpt/meta/workers/worker-performance.worker.js.ini
@@ -1,6 +1,3 @@
 [worker-performance.worker.html]
   [Can use performance.getEntriesByType in workers]
     expected: FAIL
-
-  [performance.setResourceTimingBufferSize in workers]
-    expected: FAIL


### PR DESCRIPTION
Strictly follow the [specs](https://w3c.github.io/resource-timing/#performance-can-add-resource-timing-entry)

Also fires the performance resource timing earlier to
match WPT expectations.

Testing: More WPT tests Passed.