### PR TITLE
net: Replace custom HttpStatus type with a wrapper around http::StatusCode

### DIFF
--- a/components/devtools/actors/network_event.rs
+++ b/components/devtools/actors/network_event.rs
@@ -613,8 +613,8 @@ impl NetworkEventActor {
             response_cookies_available: cookies.is_some(),
             response_headers_available: headers.is_some(),
             response_start_available: true,
-            status: status.code().to_string(),
-            status_text: String::from_utf8_lossy(status.message()).to_string(),
+            status: status.as_str().to_owned(),
+            status_text: status.canonical_reason().unwrap().to_string(),
         })
     }
 

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -169,7 +169,7 @@ pub(crate) fn transfers_request_body_stream_to_later_manual_redirect(
         response
             .actual_response()
             .status
-            .try_code()
+            .as_ref()
             .is_some_and(|status| status.is_redirection())
 }
 
@@ -771,7 +771,10 @@ pub async fn main_fetch(
         // read status of a network error if we blocked the request above.
         let internal_response = if !internal_response.is_network_error() &&
             response_type == ResponseType::Opaque &&
-            internal_response.status.code() == StatusCode::PARTIAL_CONTENT &&
+            internal_response
+                .status
+                .as_ref()
+                .is_some_and(|status| *status == StatusCode::PARTIAL_CONTENT) &&
             internal_response.range_requested &&
             !request.headers.contains_key(RANGE)
         {
@@ -974,7 +977,7 @@ fn create_blank_reply(url: ServoUrl, timing_type: ResourceTimingType) -> Respons
         .headers
         .typed_insert(ContentType::from(mime::TEXT_HTML_UTF_8));
     *response.body.lock() = ResponseBody::Done(vec![]);
-    response.status = HttpStatus::default();
+    response.status = Some(HttpStatus::default());
     response
 }
 
@@ -984,7 +987,7 @@ fn create_about_memory(url: ServoUrl, timing_type: ResourceTimingType) -> Respon
         .headers
         .typed_insert(ContentType::from(mime::TEXT_HTML_UTF_8));
     *response.body.lock() = ResponseBody::Done(resources::read_bytes(Resource::AboutMemoryHTML));
-    response.status = HttpStatus::default();
+    response.status = Some(HttpStatus::default());
     response
 }
 
@@ -1101,14 +1104,18 @@ async fn scheme_fetch(
     }
 }
 
-fn is_null_body_status(status: &HttpStatus) -> bool {
-    matches!(
-        status.try_code(),
-        Some(StatusCode::SWITCHING_PROTOCOLS) |
-            Some(StatusCode::NO_CONTENT) |
-            Some(StatusCode::RESET_CONTENT) |
-            Some(StatusCode::NOT_MODIFIED)
-    )
+fn is_null_body_status(status: &Option<HttpStatus>) -> bool {
+    if let Some(status) = status {
+        [
+            StatusCode::SWITCHING_PROTOCOLS,
+            StatusCode::NO_CONTENT,
+            StatusCode::RESET_CONTENT,
+            StatusCode::NOT_MODIFIED,
+        ]
+        .contains(status)
+    } else {
+        false
+    }
 }
 
 /// <https://fetch.spec.whatwg.org/#should-response-to-request-be-blocked-due-to-nosniff?>

--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -910,11 +910,7 @@ impl<'a> CachedResourcesOrGuard<'a> {
             metadata: cacheable_metadata,
             location_url: response.location_url.clone(),
             https_state: response.https_state,
-            status: response
-                .status
-                .as_ref()
-                .expect("Cached Resource should always have a response status")
-                .clone(),
+            status: response.status.as_ref().cloned().unwrap_or_default(), // If we do not have a response code, we assume Ok
             url_list: response.url_list.clone(),
             expires: expiry,
             last_validated: Instant::now(),

--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -217,7 +217,7 @@ fn get_response_expiry(response: &Response) -> Duration {
     }
     // Calculating Heuristic Freshness
     // <https://tools.ietf.org/html/rfc7234#section-4.2.2>
-    if let Some(ref code) = response.status.try_code() {
+    if let Some(ref code) = response.status {
         // <https://tools.ietf.org/html/rfc7234#section-5.5.4>
         // Since presently we do not generate a Warning header field with a 113 warn-code,
         // 24 hours minus response age is the max for heuristic calculation.
@@ -243,7 +243,7 @@ fn get_response_expiry(response: &Response) -> Duration {
         } else {
             max_heuristic
         };
-        if is_cacheable_by_default(*code) {
+        if is_cacheable_by_default(**code) {
             // Status codes that are cacheable by default can use heuristics to determine freshness.
             return heuristic_freshness;
         }
@@ -313,7 +313,7 @@ fn create_cached_response(
     response
         .location_url
         .clone_from(&cached_resource.location_url);
-    response.status.clone_from(&cached_resource.status);
+    response.status = Some(cached_resource.status.clone());
     response.url_list.clone_from(&cached_resource.url_list);
     response.https_state = cached_resource.https_state;
     response.referrer = request.referrer.to_url().cloned();
@@ -610,13 +610,8 @@ pub(crate) fn construct_response(
         //
         // TODO: Combining partial content to fulfill a non-Range request
         // see https://tools.ietf.org/html/rfc7234#section-3.3
-        match cached_resource.status.try_code() {
-            Some(ref code) => {
-                if *code == StatusCode::PARTIAL_CONTENT {
-                    continue;
-                }
-            },
-            None => continue,
+        if *cached_resource.status == StatusCode::PARTIAL_CONTENT {
+            continue;
         }
         // Returning a response that can be constructed
         // TODO: select the most appropriate one, using a known mechanism from a selecting header field,
@@ -641,7 +636,7 @@ pub fn refresh(
     done_chan: &mut DoneChannel,
     cached_resources: &mut [CachedResource],
 ) -> Option<Response> {
-    assert_eq!(response.status, StatusCode::NOT_MODIFIED);
+    assert_eq!(response.status, Some(StatusCode::NOT_MODIFIED.into()));
 
     let cached_resource = cached_resources.iter_mut().next()?;
 
@@ -673,15 +668,10 @@ pub fn refresh(
 
         constructed_response.body = cached_resource.body.clone();
 
-        constructed_response
-            .status
-            .clone_from(&cached_resource.status);
         constructed_response.https_state = cached_resource.https_state;
         constructed_response.referrer = request.referrer.to_url().cloned();
         constructed_response.referrer_policy = request.referrer_policy;
-        constructed_response
-            .status
-            .clone_from(&cached_resource.status);
+        constructed_response.status = Some(cached_resource.status.clone());
         constructed_response
             .url_list
             .clone_from(&cached_resource.url_list);
@@ -767,7 +757,10 @@ impl HttpCache {
             if actual_response.is_network_error() {
                 return *resource.body.lock() == ResponseBody::Empty;
             }
-            resource.status == actual_response.status
+            actual_response
+                .status
+                .as_ref()
+                .is_some_and(|status| *status == resource.status)
         });
 
         for cached_resource in relevant_cached_resources {
@@ -917,7 +910,11 @@ impl<'a> CachedResourcesOrGuard<'a> {
             metadata: cacheable_metadata,
             location_url: response.location_url.clone(),
             https_state: response.https_state,
-            status: response.status.clone(),
+            status: response
+                .status
+                .as_ref()
+                .expect("Cached Resource should always have a response status")
+                .clone(),
             url_list: response.url_list.clone(),
             expires: expiry,
             last_validated: Instant::now(),

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -32,7 +32,6 @@ use http_body_util::combinators::BoxBody;
 use http_body_util::{BodyExt, Full};
 use hyper::Response as HyperResponse;
 use hyper::body::{Bytes, Frame};
-use hyper::ext::ReasonPhrase;
 use hyper::header::{HeaderName, TRANSFER_ENCODING};
 use hyper_serde::Serde;
 use ipc_channel::IpcError;
@@ -140,7 +139,7 @@ impl HttpState {
     ) -> Option<AuthenticationResponse> {
         // We do not make an authentication request for non-WebView associated HTTP requests.
         let webview_id = request.target_webview_id?;
-        let for_proxy = response.status == StatusCode::PROXY_AUTHENTICATION_REQUIRED;
+        let for_proxy = response.status == Some(StatusCode::PROXY_AUTHENTICATION_REQUIRED.into());
 
         // If this is not actually a navigation request return None.
         if request.mode != RequestMode::Navigate {
@@ -1092,13 +1091,15 @@ pub async fn http_fetch(
     if response
         .actual_response()
         .status
-        .try_code()
-        .is_some_and(is_redirect_status)
+        .as_ref()
+        .is_some_and(|code| is_redirect_status(**code))
     {
         // Step 6.1. If internalResponse’s status is not 303, request’s body is non-null,
         // and the connection uses HTTP/2, then user agents may, and are even encouraged to,
         // transmit an RST_STREAM frame.
-        if response.actual_response().status != StatusCode::SEE_OTHER {
+        if response.actual_response().status != Some(StatusCode::SEE_OTHER.into()) ||
+            response.actual_response().status.is_none()
+        {
             // TODO: send RST_STREAM frame
         }
 
@@ -1192,8 +1193,8 @@ fn location_url_for_response(
         response
             .actual_response()
             .status
-            .try_code()
-            .is_some_and(is_redirect_status)
+            .as_ref()
+            .is_some_and(|status| is_redirect_status(**status))
     );
     // Step 2. Let location be the result of extracting header list values given `Location` and response’s header list.
     let mut location = response
@@ -1321,7 +1322,8 @@ pub async fn http_redirect_fetch(
 
     // Step 11: If internalResponse’s status is not 303, request’s body is non-null, and request’s
     // body’s source is null, then return a network error.
-    if response.actual_response().status != StatusCode::SEE_OTHER &&
+    if (response.actual_response().status != Some(StatusCode::SEE_OTHER.into()) ||
+        response.actual_response().status.is_none()) &&
         request.body.as_ref().is_some_and(|b| b.source_is_null())
     {
         return Response::network_error(NetworkError::ConnectionFailure);
@@ -1331,7 +1333,7 @@ pub async fn http_redirect_fetch(
     if response
         .actual_response()
         .status
-        .try_code()
+        .as_ref()
         .is_some_and(|code| {
             // internalResponse’s status is 301 or 302 and request’s method is `POST`
             ((code == StatusCode::MOVED_PERMANENTLY || code == StatusCode::FOUND) &&
@@ -1717,7 +1719,14 @@ async fn http_network_or_cache_fetch(
             // Step 10.3 If httpRequest’s method is unsafe and forwardResponse’s status is in the range 200 to 399,
             // inclusive, invalidate appropriate stored responses in httpCache, as per the
             // "Invalidating Stored Responses" chapter of HTTP Caching, and set storedResponse to null.
-            if forward_response.status.in_range(200..=399) && !http_request.method.is_safe() {
+            if (200..=399).contains(
+                &forward_response
+                    .status
+                    .as_ref()
+                    .map(|status| status.as_u16())
+                    .unwrap_or(0),
+            ) && !http_request.method.is_safe()
+            {
                 if let Some(guard) = cache_guard.try_as_mut() {
                     invalidate(http_request, &forward_response, guard).await;
                 }
@@ -1729,7 +1738,8 @@ async fn http_network_or_cache_fetch(
             }
 
             // Step 10.4 If the revalidatingFlag is set and forwardResponse’s status is 304, then:
-            if revalidating_flag && forward_response.status == StatusCode::NOT_MODIFIED {
+            if revalidating_flag && forward_response.status == Some(StatusCode::NOT_MODIFIED.into())
+            {
                 // Ensure done_chan is None,
                 // since the network response will be replaced by the revalidated stored one.
                 *done_chan = None;
@@ -1792,7 +1802,7 @@ async fn http_network_or_cache_fetch(
     // TODO(#33616): Figure out what to do with request window objects
     // NOTE: Requiring a WWW-Authenticate header here is ad-hoc, but seems to match what other browsers are
     // doing. See Step 14.1.
-    if response.status.try_code() == Some(StatusCode::UNAUTHORIZED) &&
+    if response.status == Some(StatusCode::UNAUTHORIZED.into()) &&
         !cors_flag &&
         include_credentials &&
         response.headers.contains_key(WWW_AUTHENTICATE)
@@ -1849,7 +1859,7 @@ async fn http_network_or_cache_fetch(
     }
 
     // Step 15. If response’s status is 407, then:
-    if response.status == StatusCode::PROXY_AUTHENTICATION_REQUIRED {
+    if response.status == Some(StatusCode::PROXY_AUTHENTICATION_REQUIRED.into()) {
         let request = &mut fetch_params.request;
         // Step 15.1 If request’s traversable for user prompts is "no-traversable", then return a network error.
 
@@ -2289,14 +2299,7 @@ async fn http_network_fetch(
         response.tls_security_info = Some(build_tls_security_info(handshake_info, hsts_enabled));
     }
 
-    let status_text = res
-        .extensions()
-        .get::<ReasonPhrase>()
-        .map(ReasonPhrase::as_bytes)
-        .or_else(|| res.status().canonical_reason().map(str::as_bytes))
-        .map(Vec::from)
-        .unwrap_or_default();
-    response.status = HttpStatus::new(res.status(), status_text);
+    response.status = Some(res.status().into());
 
     info!("got {:?} response for {:?}", res.status(), request.url());
     response.headers = res.headers().clone();
@@ -2365,7 +2368,8 @@ async fn http_network_fetch(
                 *body = ResponseBody::Done(completed_body);
                 send_response_values_to_devtools(
                     Some(headers),
-                    status,
+                    // TODO: Change to use Option<HttpStatus>
+                    status.unwrap_or_default(),
                     Some(devtools_response_body),
                     CacheState::None,
                     &devtools_request,
@@ -2523,7 +2527,12 @@ async fn cors_preflight_fetch(
         http_network_or_cache_fetch(&mut fetch_params, false, false, &mut None, context).await;
 
     // Step 7. If a CORS check for request and response returns success and response’s status is an ok status, then:
-    if cors_check(request, &response).is_ok() && response.status.code().is_success() {
+    if cors_check(request, &response).is_ok() &&
+        response
+            .status
+            .as_ref()
+            .is_some_and(|status| status.is_success())
+    {
         // Step 7.1 Let methods be the result of extracting header list values given
         // `Access-Control-Allow-Methods` and response’s header list.
         let mut methods = if response

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -32,6 +32,7 @@ use http_body_util::combinators::BoxBody;
 use http_body_util::{BodyExt, Full};
 use hyper::Response as HyperResponse;
 use hyper::body::{Bytes, Frame};
+use hyper::ext::ReasonPhrase;
 use hyper::header::{HeaderName, TRANSFER_ENCODING};
 use hyper_serde::Serde;
 use ipc_channel::IpcError;
@@ -2299,7 +2300,12 @@ async fn http_network_fetch(
         response.tls_security_info = Some(build_tls_security_info(handshake_info, hsts_enabled));
     }
 
-    response.status = Some(res.status().into());
+    let status_text = res
+        .extensions()
+        .get::<ReasonPhrase>()
+        .map(ReasonPhrase::as_bytes)
+        .map(Vec::from);
+    response.status = HttpStatus::try_new(res.status().as_u16(), status_text);
 
     info!("got {:?} response for {:?}", res.status(), request.url());
     response.headers = res.headers().clone();

--- a/components/net/protocols/blob.rs
+++ b/components/net/protocols/blob.rs
@@ -55,7 +55,7 @@ impl ProtocolHandler for BlobProtocolHander {
             url_and_blob_claim.url(),
             ResourceFetchTiming::new(request.timing_type()),
         );
-        response.status = HttpStatus::default();
+        response.status = Some(HttpStatus::default());
 
         if is_range_request {
             response.range_requested = true;

--- a/components/net/protocols/data.rs
+++ b/components/net/protocols/data.rs
@@ -40,7 +40,7 @@ impl ProtocolHandler for DataProtocolHander {
                         http::header::CONTENT_TYPE,
                         HeaderValue::from_str(&mime.to_string()).unwrap(),
                     );
-                    response.status = HttpStatus::default();
+                    response.status = Some(HttpStatus::default());
                     Some(response)
                 },
                 Err(_) => None,

--- a/components/net/protocols/mod.rs
+++ b/components/net/protocols/mod.rs
@@ -238,7 +238,7 @@ pub fn is_url_potentially_trustworthy(
 }
 
 pub fn range_not_satisfiable_error(response: &mut Response) {
-    response.status = StatusCode::RANGE_NOT_SATISFIABLE.into();
+    response.status = Some(StatusCode::RANGE_NOT_SATISFIABLE.into());
 }
 
 /// Get the range bounds if the `Range` header is present.
@@ -262,5 +262,5 @@ pub fn get_range_request_bounds(range: Option<Range>, len: u64) -> RangeRequestB
 }
 
 pub fn partial_content(response: &mut Response) {
-    response.status = StatusCode::PARTIAL_CONTENT.into();
+    response.status = Some(StatusCode::PARTIAL_CONTENT.into());
 }

--- a/components/net/request_interceptor.rs
+++ b/components/net/request_interceptor.rs
@@ -6,7 +6,6 @@ use content_security_policy::Destination;
 use embedder_traits::{GenericEmbedderProxy, WebResourceRequest, WebResourceResponseMsg};
 use log::error;
 use net_traits::NetworkError;
-use net_traits::http_status::HttpStatus;
 use net_traits::request::Request;
 use net_traits::response::{Response, ResponseBody};
 
@@ -55,10 +54,7 @@ impl RequestInterceptor {
                     let mut response_override =
                         Response::new(webresource_response.url.into(), timing);
                     response_override.headers = webresource_response.headers;
-                    response_override.status = HttpStatus::new(
-                        webresource_response.status_code,
-                        webresource_response.status_message,
-                    );
+                    response_override.status = Some(webresource_response.status_code.into());
                     *response = Some(response_override);
                 },
                 WebResourceResponseMsg::SendBodyData(data) => {

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -650,7 +650,7 @@ fn test_fetch_response_is_opaque_filtered() {
     assert!(fetch_response.url().is_none());
     assert!(fetch_response.url_list.is_empty());
     // this also asserts that status message is "the empty byte sequence"
-    assert!(fetch_response.status.is_error());
+    assert!(fetch_response.status.is_none());
     assert_eq!(fetch_response.headers, HeaderMap::new());
     match *fetch_response.body.lock() {
         ResponseBody::Empty => {},
@@ -700,7 +700,7 @@ fn test_fetch_response_is_opaque_redirect_filtered() {
     assert_eq!(fetch_response.response_type, ResponseType::OpaqueRedirect);
 
     // this also asserts that status message is "the empty byte sequence"
-    assert!(fetch_response.status.is_error());
+    assert!(fetch_response.status.is_none());
     assert_eq!(fetch_response.headers, HeaderMap::new());
     match *fetch_response.body.lock() {
         ResponseBody::Empty => {},
@@ -878,7 +878,7 @@ fn test_load_adds_host_to_hsts_list_when_url_is_https() {
             .internal_response
             .unwrap()
             .status
-            .code()
+            .unwrap()
             .is_success()
     );
     assert!(
@@ -958,7 +958,7 @@ fn test_fetch_self_signed() {
 
     let response = fetch_with_context(request, &mut context);
 
-    assert!(response.status.code().is_success());
+    assert!(response.status.unwrap().is_success());
 
     let _ = server.close();
 }
@@ -1602,14 +1602,8 @@ fn test_fetch_request_intercepted() {
     }
 
     assert_eq!(
-        response.status.code(),
-        StatusCode::FOUND,
+        response.status,
+        Some(StatusCode::FOUND.into()),
         "Status code does not match!"
-    );
-
-    assert_eq!(
-        response.status.message(),
-        STATUS_MESSAGE,
-        "The status_message was not set correctly!"
     );
 }

--- a/components/net/tests/http_cache.rs
+++ b/components/net/tests/http_cache.rs
@@ -45,7 +45,7 @@ async fn test_refreshing_resource_sets_done_chan_the_appropriate_value() {
             cache.get_or_guard(CacheKey::new(&request)).await
         };
         // Second, mutate the response into a 304 response, and refresh the stored one.
-        response.status = StatusCode::NOT_MODIFIED.into();
+        response.status = Some(StatusCode::NOT_MODIFIED.into());
         let (send, recv) = unbounded();
         let mut done_chan = Some((send, recv));
         let refreshed_response = refresh(
@@ -107,7 +107,7 @@ async fn test_skip_incomplete_cache_for_range_request_with_no_end_bound() {
     initial_incomplete_response
         .headers
         .insert(EXPIRES, HeaderValue::from_str("0").unwrap());
-    initial_incomplete_response.status = StatusCode::PARTIAL_CONTENT.into();
+    initial_incomplete_response.status = Some(StatusCode::PARTIAL_CONTENT.into());
     cache.store(&request, &initial_incomplete_response).await;
 
     // Try to construct response from http_cache

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -241,7 +241,7 @@ fn test_check_default_headers_loaded_in_every_request() {
             .internal_response
             .unwrap()
             .status
-            .code()
+            .unwrap()
             .is_success()
     );
 
@@ -270,7 +270,7 @@ fn test_check_default_headers_loaded_in_every_request() {
             .internal_response
             .unwrap()
             .status
-            .code()
+            .unwrap()
             .is_success()
     );
 
@@ -304,7 +304,7 @@ fn test_load_when_request_is_not_get_or_head_and_there_is_no_body_content_length
             .internal_response
             .unwrap()
             .status
-            .code()
+            .unwrap()
             .is_success()
     );
 
@@ -342,7 +342,7 @@ fn test_request_and_response_data_with_network_messages() {
             .internal_response
             .unwrap()
             .status
-            .code()
+            .unwrap()
             .is_success()
     );
 
@@ -451,7 +451,14 @@ fn test_request_and_response_message_from_devtool_without_pipeline_id() {
 
     let (devtools_chan, devtools_port) = unbounded();
     let response = fetch(request, Some(devtools_chan));
-    assert!(response.actual_response().status.code().is_success());
+    assert!(
+        response
+            .actual_response()
+            .status
+            .clone()
+            .unwrap()
+            .is_success()
+    );
 
     let _ = server.close();
 
@@ -557,7 +564,7 @@ fn test_load_when_redirecting_from_a_post_should_rewrite_next_request_as_get() {
     let _ = pre_server.close();
     let _ = post_server.close();
 
-    assert!(response.to_actual().status.code().is_success());
+    assert!(response.to_actual().status.unwrap().is_success());
 }
 
 #[test]
@@ -591,7 +598,7 @@ fn test_load_should_decode_the_response_as_deflate_when_response_headers_have_co
     let _ = server.close();
 
     let internal_response = response.internal_response.unwrap();
-    assert!(internal_response.status.clone().code().is_success());
+    assert!(internal_response.status.clone().unwrap().is_success());
     assert_eq!(
         *internal_response.body.lock(),
         ResponseBody::Done(b"Yay!".to_vec())
@@ -627,7 +634,7 @@ fn test_load_should_decode_the_response_as_gzip_when_response_headers_have_conte
     let _ = server.close();
 
     let internal_response = response.internal_response.unwrap();
-    assert!(internal_response.status.clone().code().is_success());
+    assert!(internal_response.status.clone().unwrap().is_success());
     assert_eq!(
         *internal_response.body.lock(),
         ResponseBody::Done(b"Yay!".to_vec())
@@ -675,7 +682,7 @@ fn test_load_doesnt_send_request_body_on_any_redirect() {
     let _ = pre_server.close();
     let _ = post_server.close();
 
-    assert!(response.to_actual().status.code().is_success());
+    assert!(response.to_actual().status.unwrap().is_success());
 }
 
 #[test]
@@ -711,7 +718,7 @@ fn test_load_doesnt_add_host_to_hsts_list_when_url_is_http_even_if_hsts_headers_
             .internal_response
             .unwrap()
             .status
-            .code()
+            .unwrap()
             .is_success()
     );
     assert_eq!(
@@ -760,7 +767,7 @@ fn test_load_sets_cookies_in_the_resource_manager_when_it_get_set_cookie_header_
             .internal_response
             .unwrap()
             .status
-            .code()
+            .unwrap()
             .is_success()
     );
 
@@ -816,7 +823,7 @@ fn test_load_sets_requests_cookies_header_for_url_by_getting_cookies_from_the_re
             .internal_response
             .unwrap()
             .status
-            .code()
+            .unwrap()
             .is_success()
     );
 }
@@ -866,7 +873,7 @@ fn test_load_sends_cookie_if_nonhttp() {
             .internal_response
             .unwrap()
             .status
-            .code()
+            .unwrap()
             .is_success()
     );
 }
@@ -907,7 +914,7 @@ fn test_cookie_set_with_httponly_should_not_be_available_using_getcookiesforurl(
             .internal_response
             .unwrap()
             .status
-            .code()
+            .unwrap()
             .is_success()
     );
 
@@ -955,7 +962,14 @@ fn test_when_cookie_received_marked_secure_is_ignored_for_http() {
 
     let _ = server.close();
 
-    assert!(response.actual_response().status.code().is_success());
+    assert!(
+        response
+            .actual_response()
+            .status
+            .clone()
+            .unwrap()
+            .is_success()
+    );
 
     assert_cookie_for_domain(&context.state.cookie_jar, url.as_str(), None);
 }
@@ -996,7 +1010,7 @@ fn test_load_sets_content_length_to_length_of_request_body() {
             .internal_response
             .unwrap()
             .status
-            .code()
+            .unwrap()
             .is_success()
     );
 }
@@ -1039,7 +1053,7 @@ fn test_load_uses_explicit_accept_from_headers_in_load_data() {
             .internal_response
             .unwrap()
             .status
-            .code()
+            .unwrap()
             .is_success()
     );
 }
@@ -1079,7 +1093,7 @@ fn test_load_sets_default_accept_to_html_xhtml_xml_and_then_anything_else() {
             .internal_response
             .unwrap()
             .status
-            .code()
+            .unwrap()
             .is_success()
     );
 }
@@ -1122,7 +1136,7 @@ fn test_load_uses_explicit_accept_encoding_from_load_data_headers() {
             .internal_response
             .unwrap()
             .status
-            .code()
+            .unwrap()
             .is_success()
     );
 }
@@ -1162,7 +1176,7 @@ fn test_load_sets_default_accept_encoding_to_gzip_and_deflate() {
             .internal_response
             .unwrap()
             .status
-            .code()
+            .unwrap()
             .is_success()
     );
 }
@@ -1309,7 +1323,7 @@ fn test_load_follows_a_redirect() {
     let _ = post_server.close();
 
     let internal_response = response.internal_response.unwrap();
-    assert!(internal_response.status.clone().code().is_success());
+    assert!(internal_response.status.clone().unwrap().is_success());
     assert_eq!(
         *internal_response.body.lock(),
         ResponseBody::Done(b"Yay!".to_vec())
@@ -1399,7 +1413,7 @@ fn test_redirect_from_x_to_y_provides_y_cookies_from_y() {
     let _ = server.close();
 
     let internal_response = response.internal_response.unwrap();
-    assert!(internal_response.status.clone().code().is_success());
+    assert!(internal_response.status.clone().unwrap().is_success());
     assert_eq!(
         *internal_response.body.lock(),
         ResponseBody::Done(b"Yay!".to_vec())
@@ -1455,7 +1469,7 @@ fn test_redirect_from_x_to_x_provides_x_with_cookie_from_first_response() {
     let _ = server.close();
 
     let internal_response = response.internal_response.unwrap();
-    assert!(internal_response.status.clone().code().is_success());
+    assert!(internal_response.status.clone().unwrap().is_success());
     assert_eq!(
         *internal_response.body.lock(),
         ResponseBody::Done(b"Yay!".to_vec())
@@ -1509,7 +1523,7 @@ fn test_if_auth_creds_not_in_url_but_in_cache_it_sets_it() {
             .internal_response
             .unwrap()
             .status
-            .code()
+            .unwrap()
             .is_success()
     );
 }
@@ -1540,7 +1554,7 @@ fn test_auth_ui_needs_www_auth() {
 
     assert_eq!(
         response.internal_response.unwrap().status,
-        StatusCode::UNAUTHORIZED
+        Some(StatusCode::UNAUTHORIZED.into())
     );
 }
 
@@ -1708,7 +1722,7 @@ fn test_user_credentials_prompt_when_proxy_authentication_is_required() {
             .internal_response
             .unwrap()
             .status
-            .code()
+            .unwrap()
             .is_success()
     );
 }
@@ -1761,8 +1775,8 @@ fn test_prompt_credentials_when_client_receives_unauthorized_response() {
     server.close();
 
     assert_eq!(
-        response.internal_response.unwrap().status.code(),
-        StatusCode::OK
+        response.internal_response.unwrap().status,
+        Some(StatusCode::OK.into())
     );
 }
 
@@ -1817,8 +1831,8 @@ fn test_dont_prompt_credentials_when_unauthorized_response_contains_no_www_authe
     server.close();
 
     assert_eq!(
-        response.internal_response.unwrap().status.code(),
-        StatusCode::UNAUTHORIZED
+        response.internal_response.unwrap().status,
+        Some(StatusCode::UNAUTHORIZED.into())
     );
 
     // Without this join we won't notice if the mock embedder thread panics!
@@ -1868,7 +1882,7 @@ fn test_prompt_credentials_user_cancels_dialog_input() {
             .internal_response
             .unwrap()
             .status
-            .code()
+            .unwrap()
             .is_client_error()
     );
 }
@@ -1921,7 +1935,7 @@ fn test_prompt_credentials_user_input_incorrect_credentials() {
             .internal_response
             .unwrap()
             .status
-            .code()
+            .unwrap()
             .is_client_error()
     );
 }
@@ -2024,7 +2038,7 @@ fn test_security_info_for_https_connection() {
     let response = fetch_with_context(request, &mut context);
     server.close();
 
-    assert!(response.status.code().is_success());
+    assert!(response.status.is_some_and(|code| code.is_success()));
 
     let events = collect_all_network_events(&devtools_receiver);
     let security_info_event = events.iter().find_map(|event| {
@@ -2091,7 +2105,7 @@ fn test_no_security_info_for_http_connection() {
     let response = fetch_with_context(request, &mut context);
     server.close();
 
-    assert!(response.status.code().is_success());
+    assert!(response.status.is_some_and(|code| code.is_success()));
 
     let events = collect_all_network_events(&devtools_receiver);
     let security_info_events: Vec<_> = events

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -403,7 +403,7 @@ impl FetchResponseListener for EventSourceContext {
                 };
                 // Step 15.3 if res's status is not 200, or if res's `Content-Type` is not
                 // `text/event-stream`, then fail the connection.
-                if meta.status.code() != StatusCode::OK {
+                if meta.status != StatusCode::OK {
                     return self.fail_the_connection();
                 }
                 let mime = match meta.content_type {

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -17,7 +17,6 @@ use js::context::JSContext;
 use js::realm::AutoRealm;
 use js::rust::HandleObject;
 use mime::{self, Mime};
-use net_traits::http_status::HttpStatus;
 use net_traits::image_cache::{
     Image, ImageCache, ImageCacheResult, ImageLoadListener, ImageOrMetadataAvailable,
     ImageResponse, PendingImageId,
@@ -278,23 +277,21 @@ impl FetchResponseListener for ImageContext {
             }
         }
 
-        let status = metadata
-            .as_ref()
-            .map(|m| m.status.clone())
-            .unwrap_or_else(HttpStatus::new_error);
-
         self.status = {
-            if status.is_error() {
+            let status = metadata.as_ref().map(|m| &m.status);
+            if let Some(status) = status &&
+                status.is_success()
+            {
+                Ok(())
+            } else if let Some(status) = status {
+                Err(NetworkError::ResourceLoadError(format!(
+                    "HTTP error code {}",
+                    **status,
+                )))
+            } else {
                 Err(NetworkError::ResourceLoadError(
                     "No http status code received".to_owned(),
                 ))
-            } else if status.is_success() {
-                Ok(())
-            } else {
-                Err(NetworkError::ResourceLoadError(format!(
-                    "HTTP error code {}",
-                    status.code()
-                )))
             }
         };
     }

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -14,7 +14,6 @@ use encoding_rs::Encoding;
 use html5ever::{LocalName, Prefix, local_name};
 use js::context::JSContext;
 use js::rust::{HandleObject, Stencil};
-use net_traits::http_status::HttpStatus;
 use net_traits::request::{
     CorsSettings, Destination, ParserMetadata, Referrer, RequestBuilder, RequestId,
 };
@@ -416,24 +415,21 @@ impl FetchResponseListener for ClassicContext {
             }
         });
 
-        let status = self
-            .metadata
-            .as_ref()
-            .map(|m| m.status.clone())
-            .unwrap_or_else(HttpStatus::new_error);
-
         self.status = {
-            if status.is_error() {
+            let status = self.metadata.as_ref().map(|m| &m.status);
+            if let Some(status) = status &&
+                status.is_success()
+            {
+                Ok(())
+            } else if let Some(status) = status {
+                Err(NetworkError::ResourceLoadError(format!(
+                    "HTTP error code {}",
+                    **status,
+                )))
+            } else {
                 Err(NetworkError::ResourceLoadError(
                     "No http status code received".to_owned(),
                 ))
-            } else if status.is_success() {
-                Ok(())
-            } else {
-                Err(NetworkError::ResourceLoadError(format!(
-                    "HTTP error code {}",
-                    status.code()
-                )))
             }
         };
     }

--- a/components/script/dom/html/htmlvideoelement.rs
+++ b/components/script/dom/html/htmlvideoelement.rs
@@ -439,7 +439,7 @@ impl FetchResponseListener for PosterFrameFetchContext {
 
         let status_is_ok = metadata
             .as_ref()
-            .map_or(true, |m| m.status.in_range(200..300));
+            .is_none_or(|m| (200..300).contains(&m.status.as_u16()));
 
         if !status_is_ok {
             self.cancelled = true;

--- a/components/script/dom/notification.rs
+++ b/components/script/dom/notification.rs
@@ -15,7 +15,6 @@ use js::context::JSContext;
 use js::jsapi::Heap;
 use js::jsval::JSVal;
 use js::rust::{HandleObject, MutableHandleValue};
-use net_traits::http_status::HttpStatus;
 use net_traits::image_cache::{
     ImageCache, ImageCacheResponseMessage, ImageCacheResult, ImageLoadListener,
     ImageOrMetadataAvailable, ImageResponse, PendingImageId,
@@ -771,23 +770,21 @@ impl FetchResponseListener for ResourceFetchListener {
             FetchMetadata::Filtered { unsafe_, .. } => unsafe_,
         });
 
-        let status = metadata
-            .as_ref()
-            .map(|m| m.status.clone())
-            .unwrap_or_else(HttpStatus::new_error);
-
         self.status = {
-            if status.is_success() {
+            let status = metadata.as_ref().map(|m| &m.status);
+            if let Some(status) = status &&
+                status.is_success()
+            {
                 Ok(())
-            } else if status.is_error() {
+            } else if let Some(status) = status {
+                Err(NetworkError::ResourceLoadError(format!(
+                    "HTTP error code {}",
+                    **status,
+                )))
+            } else {
                 Err(NetworkError::ResourceLoadError(
                     "No http status code received".to_owned(),
                 ))
-            } else {
-                Err(NetworkError::ResourceLoadError(format!(
-                    "HTTP error code {}",
-                    status.code()
-                )))
             }
         };
     }

--- a/components/script/dom/response.rs
+++ b/components/script/dom/response.rs
@@ -41,7 +41,7 @@ pub(crate) struct Response {
     reflector_: Reflector,
     headers_reflector: MutNullableDom<Headers>,
     #[no_trace]
-    status: DomRefCell<HttpStatus>,
+    status: DomRefCell<Option<HttpStatus>>,
     response_type: DomRefCell<DOMResponseType>,
     #[no_trace]
     url: DomRefCell<Option<ServoUrl>>,
@@ -70,7 +70,7 @@ impl Response {
         Response {
             reflector_: Reflector::new(),
             headers_reflector: Default::default(),
-            status: DomRefCell::new(HttpStatus::default()),
+            status: DomRefCell::new(Some(HttpStatus::default())),
             response_type: DomRefCell::new(DOMResponseType::Default),
             url: DomRefCell::new(None),
             url_list: DomRefCell::new(vec![]),
@@ -199,7 +199,7 @@ impl ResponseMethods<crate::DomTypeHolder> for Response {
         let response = Response::new(global, can_gc);
         *response.response_type.borrow_mut() = DOMResponseType::Error;
         response.Headers(can_gc).set_guard(Guard::Immutable);
-        *response.status.borrow_mut() = HttpStatus::new_error();
+        *response.status.borrow_mut() = None;
         response
     }
 
@@ -230,7 +230,9 @@ impl ResponseMethods<crate::DomTypeHolder> for Response {
         let response = Response::new(global, can_gc);
 
         // Step 5
-        *response.status.borrow_mut() = HttpStatus::new_raw(status, vec![]);
+        *response.status.borrow_mut() = http::StatusCode::from_u16(status)
+            .ok()
+            .map(|code| code.into());
 
         // Step 6
         let url_bytestring =
@@ -301,17 +303,33 @@ impl ResponseMethods<crate::DomTypeHolder> for Response {
 
     /// <https://fetch.spec.whatwg.org/#dom-response-status>
     fn Status(&self) -> u16 {
-        self.status.borrow().raw_code()
+        self.status
+            .borrow()
+            .as_ref()
+            .expect("Status not set")
+            .as_u16()
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-response-ok>
     fn Ok(&self) -> bool {
-        self.status.borrow().is_success()
+        self.status
+            .borrow()
+            .as_ref()
+            .is_some_and(|status| status.is_success())
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-response-statustext>
     fn StatusText(&self) -> ByteString {
-        ByteString::new(self.status.borrow().message().to_vec())
+        ByteString::new(
+            self.status
+                .borrow()
+                .as_ref()
+                .expect("Status not set")
+                .canonical_reason()
+                .unwrap()
+                .as_bytes()
+                .to_owned(),
+        )
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-response-headers>
@@ -425,8 +443,9 @@ fn initialize_response(
 
     // 3. Set response’s response’s status to init["status"].
     // 4. Set response’s response’s status message to init["statusText"].
-    *response.status.borrow_mut() =
-        HttpStatus::new_raw(init.status, init.statusText.clone().into());
+    *response.status.borrow_mut() = http::StatusCode::from_u16(init.status)
+        .ok()
+        .map(|status| status.into());
 
     // 5. If init["headers"] exists, then fill response’s headers with init["headers"].
     if let Some(ref headers_member) = init.headers {
@@ -498,7 +517,7 @@ impl Response {
     }
 
     pub(crate) fn set_status(&self, status: &HttpStatus) {
-        self.status.borrow_mut().clone_from(status);
+        *self.status.borrow_mut() = Some(status.clone());
     }
 
     pub(crate) fn set_final_url(&self, final_url: ServoUrl) {
@@ -512,18 +531,18 @@ impl Response {
     fn set_response_members_by_type(&self, response_type: DOMResponseType, can_gc: CanGc) {
         match response_type {
             DOMResponseType::Error => {
-                *self.status.borrow_mut() = HttpStatus::new_error();
+                *self.status.borrow_mut() = None;
                 self.set_headers(None, can_gc);
             },
             DOMResponseType::Opaque => {
                 *self.url_list.borrow_mut() = vec![];
-                *self.status.borrow_mut() = HttpStatus::new_error();
+                *self.status.borrow_mut() = None;
                 self.set_headers(None, can_gc);
                 self.body_stream.set(None);
                 self.fetch_body_stream.set(None);
             },
             DOMResponseType::Opaqueredirect => {
-                *self.status.borrow_mut() = HttpStatus::new_error();
+                *self.status.borrow_mut() = None;
                 self.set_headers(None, can_gc);
                 self.body_stream.set(None);
                 self.fetch_body_stream.set(None);

--- a/components/script/dom/response.rs
+++ b/components/script/dom/response.rs
@@ -230,9 +230,7 @@ impl ResponseMethods<crate::DomTypeHolder> for Response {
         let response = Response::new(global, can_gc);
 
         // Step 5
-        *response.status.borrow_mut() = http::StatusCode::from_u16(status)
-            .ok()
-            .map(|code| code.into());
+        *response.status.borrow_mut() = HttpStatus::try_new(status, None);
 
         // Step 6
         let url_bytestring =
@@ -324,9 +322,8 @@ impl ResponseMethods<crate::DomTypeHolder> for Response {
             self.status
                 .borrow()
                 .as_ref()
-                .and_then(|status| status.canonical_reason())
+                .map(|status| status.message())
                 .unwrap_or_default()
-                .as_bytes()
                 .to_owned(),
         )
     }
@@ -442,9 +439,8 @@ fn initialize_response(
 
     // 3. Set response’s response’s status to init["status"].
     // 4. Set response’s response’s status message to init["statusText"].
-    *response.status.borrow_mut() = http::StatusCode::from_u16(init.status)
-        .ok()
-        .map(|status| status.into());
+    *response.status.borrow_mut() =
+        HttpStatus::try_new(init.status, Some(init.statusText.clone().into()));
 
     // 5. If init["headers"] exists, then fill response’s headers with init["headers"].
     if let Some(ref headers_member) = init.headers {

--- a/components/script/dom/response.rs
+++ b/components/script/dom/response.rs
@@ -306,8 +306,8 @@ impl ResponseMethods<crate::DomTypeHolder> for Response {
         self.status
             .borrow()
             .as_ref()
-            .expect("Status not set")
-            .as_u16()
+            .map(|status| status.as_u16())
+            .unwrap_or(0)
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-response-ok>
@@ -324,9 +324,8 @@ impl ResponseMethods<crate::DomTypeHolder> for Response {
             self.status
                 .borrow()
                 .as_ref()
-                .expect("Status not set")
-                .canonical_reason()
-                .unwrap()
+                .and_then(|status| status.canonical_reason())
+                .unwrap_or_default()
                 .as_bytes()
                 .to_owned(),
         )

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -845,10 +845,9 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
             self.status
                 .borrow()
                 .as_ref()
-                .and_then(|status| status.canonical_reason())
+                .map(|status| status.message())
                 .unwrap_or_default()
-                .as_bytes()
-                .to_vec(),
+                .to_owned(),
         )
     }
 

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -172,7 +172,7 @@ impl ResourceTimingListener for XHRContext {
 #[derive(Clone)]
 pub(crate) enum XHRProgress {
     /// Notify that headers have been received
-    HeadersReceived(GenerationId, Option<HeaderMap>, HttpStatus),
+    HeadersReceived(GenerationId, Option<HeaderMap>, Option<HttpStatus>),
     /// Partial progress (after receiving headers), containing portion of the response
     Loading(GenerationId, Vec<u8>),
     /// Loading is done
@@ -201,7 +201,7 @@ pub(crate) struct XMLHttpRequest {
     upload: Dom<XMLHttpRequestUpload>,
     response_url: DomRefCell<String>,
     #[no_trace]
-    status: DomRefCell<HttpStatus>,
+    status: DomRefCell<Option<HttpStatus>>,
     response: DomRefCell<Vec<u8>>,
     response_type: Cell<XMLHttpRequestResponseType>,
     response_xml: MutNullableDom<Document>,
@@ -248,7 +248,7 @@ impl XMLHttpRequest {
             with_credentials: Cell::new(false),
             upload: Dom::from_ref(&*XMLHttpRequestUpload::new(global, can_gc)),
             response_url: DomRefCell::new(String::new()),
-            status: DomRefCell::new(HttpStatus::new_error()),
+            status: DomRefCell::new(None),
             response: DomRefCell::new(vec![]),
             response_type: Cell::new(XMLHttpRequestResponseType::_empty),
             response_xml: Default::default(),
@@ -422,7 +422,7 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
                 *self.request_headers.borrow_mut() = HeaderMap::new();
                 self.send_flag.set(false);
                 self.upload_listener.set(false);
-                *self.status.borrow_mut() = HttpStatus::new_error();
+                *self.status.borrow_mut() = None;
 
                 // Step 13
                 if self.ready_state.get() != XMLHttpRequestState::Opened {
@@ -819,7 +819,7 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
         if self.ready_state.get() == XMLHttpRequestState::Done {
             self.change_ready_state(XMLHttpRequestState::Unsent, can_gc);
             self.response_status.set(Err(()));
-            *self.status.borrow_mut() = HttpStatus::new_error();
+            *self.status.borrow_mut() = None;
             self.response.borrow_mut().clear();
             self.response_headers.borrow_mut().clear();
         }
@@ -832,12 +832,25 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
 
     /// <https://xhr.spec.whatwg.org/#the-status-attribute>
     fn Status(&self) -> u16 {
-        self.status.borrow().raw_code()
+        self.status
+            .borrow()
+            .as_ref()
+            .expect("Expected valid status")
+            .as_u16()
     }
 
     /// <https://xhr.spec.whatwg.org/#the-statustext-attribute>
     fn StatusText(&self) -> ByteString {
-        ByteString::new(self.status.borrow().message().to_vec())
+        ByteString::new(
+            self.status
+                .borrow()
+                .as_ref()
+                .expect("Expected valid status")
+                .canonical_reason()
+                .unwrap()
+                .as_bytes()
+                .to_vec(),
+        )
     }
 
     /// <https://xhr.spec.whatwg.org/#the-getresponseheader()-method>
@@ -1072,7 +1085,7 @@ impl XMLHttpRequest {
             XHRProgress::HeadersReceived(
                 gen_id,
                 metadata.headers.map(Serde::into_inner),
-                metadata.status,
+                Some(metadata.status),
             ),
             can_gc,
         );
@@ -1146,7 +1159,7 @@ impl XMLHttpRequest {
                 // Part of step 13, send() (processing response)
                 // XXXManishearth handle errors, if any (substep 1)
                 // Substep 2
-                if !status.is_error() {
+                if status.is_some() {
                     *self.status.borrow_mut() = status;
                 }
                 if let Some(h) = headers.as_ref() {
@@ -1225,7 +1238,7 @@ impl XMLHttpRequest {
 
                 self.discard_subsequent_responses();
                 self.send_flag.set(false);
-                *self.status.borrow_mut() = HttpStatus::new_error();
+                *self.status.borrow_mut() = None;
                 self.response_headers.borrow_mut().clear();
                 // XXXManishearth set response to NetworkError
                 self.change_ready_state(XMLHttpRequestState::Done, can_gc);

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -835,8 +835,8 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
         self.status
             .borrow()
             .as_ref()
-            .expect("Expected valid status")
-            .as_u16()
+            .map(|status| status.as_u16())
+            .unwrap_or(0)
     }
 
     /// <https://xhr.spec.whatwg.org/#the-statustext-attribute>
@@ -845,9 +845,8 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
             self.status
                 .borrow()
                 .as_ref()
-                .expect("Expected valid status")
-                .canonical_reason()
-                .unwrap()
+                .and_then(|status| status.canonical_reason())
+                .unwrap_or_default()
                 .as_bytes()
                 .to_vec(),
         )

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -42,7 +42,6 @@ use js::rust::{
 };
 use mime::Mime;
 use net_traits::blob_url_store::UrlWithBlobClaim;
-use net_traits::http_status::HttpStatus;
 use net_traits::mime_classifier::MimeClassifier;
 use net_traits::policy_container::PolicyContainer;
 use net_traits::request::{
@@ -740,24 +739,21 @@ impl FetchResponseListener for ModuleContext {
             FetchMetadata::Filtered { unsafe_, .. } => unsafe_,
         });
 
-        let status = self
-            .metadata
-            .as_ref()
-            .map(|m| m.status.clone())
-            .unwrap_or_else(HttpStatus::new_error);
-
         self.status = {
-            if status.is_error() {
+            let status = self.metadata.as_ref().map(|m| &m.status);
+            if let Some(status) = status &&
+                status.is_success()
+            {
+                Ok(())
+            } else if let Some(status) = status {
+                Err(NetworkError::ResourceLoadError(format!(
+                    "HTTP error code {}",
+                    **status,
+                )))
+            } else {
                 Err(NetworkError::ResourceLoadError(
                     "No http status code received".to_owned(),
                 ))
-            } else if status.is_success() {
-                Ok(())
-            } else {
-                Err(NetworkError::ResourceLoadError(format!(
-                    "HTTP error code {}",
-                    status.code()
-                )))
             }
         };
     }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3095,7 +3095,7 @@ impl ScriptThread {
         //
         // TODO: The specification has been updated and we no longer should abort.
         let is_204_205 = match metadata {
-            Some(metadata) => metadata.status.in_range(204..=205),
+            Some(metadata) => (204..=205).contains(&metadata.status.as_u16()),
             _ => false,
         };
 
@@ -3536,7 +3536,7 @@ impl ScriptThread {
             DocumentSource::FromParser,
             loader,
             referrer,
-            Some(metadata.status.raw_code()),
+            Some(metadata.status.as_u16()),
             incomplete.canceller,
             is_initial_about_blank,
             true,
@@ -4010,11 +4010,7 @@ impl ScriptThread {
             location_url: metadata.location_url.clone(),
             headers,
             referrer: metadata.referrer.clone(),
-            status_code: metadata
-                .status
-                .try_code()
-                .map(|code| code.as_u16())
-                .unwrap_or(200),
+            status_code: metadata.status.as_u16(),
         });
 
         incomplete_load.canceller = FetchCanceller::new(

--- a/components/shared/net/http_status.rs
+++ b/components/shared/net/http_status.rs
@@ -23,16 +23,12 @@ pub struct HttpStatus {
 
 impl HttpStatus {
     /// Creates a new [`HttpStatus`] with a potential message
-    pub fn try_new(code: u16, msg: Option<Vec<u8>>) -> Option<Self> {
+    pub fn try_new(code: u16, message: Option<Vec<u8>>) -> Option<Self> {
         let code = http::StatusCode::from_u16(code).ok()?;
-        let message = msg
-            .or_else(|| {
-                code.canonical_reason()
-                    .map(|reason| reason.as_bytes().to_owned())
-            })
-            .unwrap_or_default();
-
-        Some(HttpStatus { code, message })
+        Some(HttpStatus {
+            code,
+            message: message.unwrap_or_default(),
+        })
     }
 
     /// The inner message will construct the canonical reason if none given.

--- a/components/shared/net/http_status.rs
+++ b/components/shared/net/http_status.rs
@@ -9,50 +9,85 @@ use std::ops::Deref;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
 
-/// A thin wrapper around [`http::StatusCode`]. Default value is OK
+/// A thin wrapper around [`http::StatusCode`] with a custom message. Default value is OK
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
-pub struct HttpStatus(
+pub struct HttpStatus {
     #[serde(
         deserialize_with = "hyper_serde::deserialize",
         serialize_with = "hyper_serde::serialize"
     )]
-    http::StatusCode,
-);
+    code: http::StatusCode,
+    /// Custom message. This can be different than canonical_reason
+    message: Vec<u8>,
+}
+
+impl HttpStatus {
+    /// Creates a new [`HttpStatus`] with a potential message
+    pub fn try_new(code: u16, msg: Option<Vec<u8>>) -> Option<Self> {
+        let code = http::StatusCode::from_u16(code).ok()?;
+        let message = msg
+            .or_else(|| {
+                code.canonical_reason()
+                    .map(|reason| reason.as_bytes().to_owned())
+            })
+            .unwrap_or_default();
+
+        Some(HttpStatus { code, message })
+    }
+
+    /// The inner message will construct the canonical reason if none given.
+    pub fn message(&self) -> &[u8] {
+        if self.message.is_empty() {
+            self.code
+                .canonical_reason()
+                .map(|reason| reason.as_bytes())
+                .unwrap_or_default()
+        } else {
+            &self.message
+        }
+    }
+}
 
 impl Deref for HttpStatus {
     type Target = http::StatusCode;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.code
     }
 }
 
 impl Default for HttpStatus {
     fn default() -> Self {
-        Self(http::StatusCode::OK)
+        Self {
+            code: http::StatusCode::OK,
+            message: vec![],
+        }
     }
 }
 
 impl PartialEq<http::StatusCode> for HttpStatus {
     fn eq(&self, other: &http::StatusCode) -> bool {
-        self.0.eq(other)
+        self.code.eq(other)
     }
 }
 
 impl PartialEq<HttpStatus> for http::StatusCode {
     fn eq(&self, other: &HttpStatus) -> bool {
-        self.eq(&other.0)
+        self.eq(&other.code)
     }
 }
 
 impl PartialEq<http::StatusCode> for &HttpStatus {
     fn eq(&self, other: &http::StatusCode) -> bool {
-        self.0.eq(other)
+        self.code.eq(other)
     }
 }
 
 impl From<http::StatusCode> for HttpStatus {
     fn from(value: http::StatusCode) -> Self {
-        HttpStatus(value)
+        HttpStatus {
+            code: value,
+            message: vec![],
+        }
     }
 }

--- a/components/shared/net/http_status.rs
+++ b/components/shared/net/http_status.rs
@@ -4,114 +4,55 @@
 
 #![deny(unsafe_code)]
 
-use std::ops::RangeBounds;
+use std::ops::Deref;
 
+use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
 
-use crate::{MallocSizeOf, StatusCode};
-
-/// A representation of a HTTP Status Code and Message that can be used for
-/// DOM Response objects and other cases.
-/// These objects are immutable once created.
+/// A thin wrapper around [`http::StatusCode`]. Default value is OK
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
-pub struct HttpStatus {
-    code: u16,
-    message: Vec<u8>,
-}
+pub struct HttpStatus(
+    #[serde(
+        deserialize_with = "hyper_serde::deserialize",
+        serialize_with = "hyper_serde::serialize"
+    )]
+    http::StatusCode,
+);
 
-impl HttpStatus {
-    /// Creates a new HttpStatus for a valid status code.
-    pub fn new(code: StatusCode, message: Vec<u8>) -> Self {
-        Self {
-            code: code.as_u16(),
-            message,
-        }
-    }
+impl Deref for HttpStatus {
+    type Target = http::StatusCode;
 
-    /// Creates a new HttpStatus from a raw status code, but will panic
-    /// if the code is not in the 100 to 599 valid range.
-    pub fn new_raw(code: u16, message: Vec<u8>) -> Self {
-        if !(100..=599).contains(&code) {
-            panic!(
-                "HttpStatus code must be in the range 100 to 599, inclusive, but is {}",
-                code
-            );
-        }
-
-        Self { code, message }
-    }
-
-    /// Creates an instance that represents a Response.error() instance.
-    pub fn new_error() -> Self {
-        Self {
-            code: 0,
-            message: vec![],
-        }
-    }
-
-    /// Returns the StatusCode for non-error cases, panics otherwise.
-    pub fn code(&self) -> StatusCode {
-        StatusCode::from_u16(self.code).expect("HttpStatus code is 0, can't return a StatusCode")
-    }
-
-    /// Returns the StatusCode if not an error instance, or None otherwise.
-    pub fn try_code(&self) -> Option<StatusCode> {
-        StatusCode::from_u16(self.code).ok()
-    }
-
-    /// Returns the u16 representation of the access code. This is usable both for
-    /// valid HTTP status codes and in the error case.
-    pub fn raw_code(&self) -> u16 {
-        self.code
-    }
-
-    /// Get access to a reference of the message part.
-    pub fn message(&self) -> &[u8] {
-        &self.message
-    }
-
-    /// Helper that relays is_success() from the underlying code.
-    pub fn is_success(&self) -> bool {
-        StatusCode::from_u16(self.code).is_ok_and(|s| s.is_success())
-    }
-
-    /// True when the object was created with `new_error`.
-    pub fn is_error(&self) -> bool {
-        self.code == 0
-    }
-
-    /// Returns true if this status is in the given range.
-    /// Always return false for error statuses.
-    pub fn in_range<T: RangeBounds<u16>>(&self, range: T) -> bool {
-        self.code != 0 && range.contains(&self.code)
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 
 impl Default for HttpStatus {
-    /// The default implementation creates a "200 OK" response.
     fn default() -> Self {
-        Self {
-            code: 200,
-            message: b"OK".to_vec(),
-        }
+        Self(http::StatusCode::OK)
     }
 }
 
-impl PartialEq<StatusCode> for HttpStatus {
-    fn eq(&self, other: &StatusCode) -> bool {
-        self.code == other.as_u16()
+impl PartialEq<http::StatusCode> for HttpStatus {
+    fn eq(&self, other: &http::StatusCode) -> bool {
+        self.0.eq(other)
     }
 }
 
-impl From<StatusCode> for HttpStatus {
-    fn from(code: StatusCode) -> Self {
-        Self {
-            code: code.as_u16(),
-            message: code
-                .canonical_reason()
-                .unwrap_or_default()
-                .as_bytes()
-                .to_vec(),
-        }
+impl PartialEq<HttpStatus> for http::StatusCode {
+    fn eq(&self, other: &HttpStatus) -> bool {
+        self.eq(&other.0)
+    }
+}
+
+impl PartialEq<http::StatusCode> for &HttpStatus {
+    fn eq(&self, other: &http::StatusCode) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl From<http::StatusCode> for HttpStatus {
+    fn from(value: http::StatusCode) -> Self {
+        HttpStatus(value)
     }
 }

--- a/components/shared/net/response.rs
+++ b/components/shared/net/response.rs
@@ -104,7 +104,7 @@ pub struct Response {
     pub termination_reason: Option<TerminationReason>,
     url: Option<ServoUrl>,
     pub url_list: Vec<ServoUrl>,
-    pub status: HttpStatus,
+    pub status: Option<HttpStatus>,
     #[serde(
         deserialize_with = "::hyper_serde::deserialize",
         serialize_with = "::hyper_serde::serialize"
@@ -150,7 +150,7 @@ impl Response {
             termination_reason: None,
             url: Some(url),
             url_list: vec![],
-            status: HttpStatus::default(),
+            status: Some(HttpStatus::default()),
             headers: HeaderMap::new(),
             body: Arc::new(Mutex::new(ResponseBody::Empty)),
             cache_state: CacheState::None,
@@ -175,7 +175,9 @@ impl Response {
         res.location_url = init.location_url;
         res.headers = init.headers;
         res.referrer = init.referrer;
-        res.status = HttpStatus::new_raw(init.status_code, vec![]);
+        res.status = http::StatusCode::from_u16(init.status_code)
+            .ok()
+            .map(|status_code| status_code.into());
         res
     }
 
@@ -185,7 +187,7 @@ impl Response {
             termination_reason: None,
             url: None,
             url_list: vec![],
-            status: HttpStatus::new_error(),
+            status: None,
             headers: HeaderMap::new(),
             body: Arc::new(Mutex::new(ResponseBody::Empty)),
             cache_state: CacheState::None,
@@ -305,14 +307,14 @@ impl Response {
                 response.url_list = vec![];
                 response.url = None;
                 response.headers = HeaderMap::new();
-                response.status = HttpStatus::new_error();
+                response.status = None;
                 response.body = Arc::new(Mutex::new(ResponseBody::Empty));
                 response.cache_state = CacheState::None;
             },
 
             ResponseType::OpaqueRedirect => {
                 response.headers = HeaderMap::new();
-                response.status = HttpStatus::new_error();
+                response.status = None;
                 response.body = Arc::new(Mutex::new(ResponseBody::Empty));
                 response.cache_state = CacheState::None;
             },
@@ -327,7 +329,8 @@ impl Response {
             metadata.set_content_type(extract_mime_type_as_mime(&response.headers).as_ref());
             metadata.location_url.clone_from(&response.location_url);
             metadata.headers = Some(Serde(response.headers.clone()));
-            metadata.status.clone_from(&response.status);
+            // TODO: Add Option<HttpStatus> to Metadata
+            metadata.status = response.status.clone().unwrap_or(metadata.status);
             metadata.https_state = response.https_state;
             metadata.referrer.clone_from(&response.referrer);
             metadata.referrer_policy = response.referrer_policy;

--- a/ports/servoshell/desktop/protocols/urlinfo.rs
+++ b/ports/servoshell/desktop/protocols/urlinfo.rs
@@ -36,7 +36,7 @@ impl ProtocolHandler for UrlInfoProtocolHander {
         let mut response = Response::new(url, ResourceFetchTiming::new(request.timing_type()));
         *response.body.lock() = ResponseBody::Done(content.as_bytes().to_vec());
         response.headers.typed_insert(ContentType::text());
-        response.status = HttpStatus::default();
+        response.status = Some(HttpStatus::default());
 
         Box::pin(std::future::ready(response))
     }


### PR DESCRIPTION
Before this PR, servo implemented a custom HttpStatus type which contained the code (u16) and a message (Vec<u8>). The rust ecosystem standardizes around StatusCode from the http crate which is just a NonZeroU16, making it more efficient.

Additionally, the previous HttpStatus encoded an uninitialized value with a separate method new_error and (setting u16=0) and is_error. These can be confusing as HttpStatus::is_error is different than !StatusCode::is_success.

This PR fixes this in the following way:
- HttpStatus is now a newtype around StatusCode (necessary for serde) with the Deref to http::StatusCode and PartialEq implementations.
- Whenever a function used HttpStatus::new_error() we transformed the type from HttpStatus to Option<HttpStatus> for easier distinction between uninitialized and StatusCode.
- Send_response_values_to_devtools in http_loader.rs we opted for unwrap_or_default to keep the changes manageable.
- init_metadata in net/response.rs currently defaults to status.unwrap_or(StatusCode::OK)

Testing: WPT tests will catch any issues for the dom parts and the net parts are used throughout almost all tests.
