### PR TITLE
script: Fix command state for underline command

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -6158,8 +6158,8 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#querycommandstate()>
-    fn QueryCommandState(&self, command_id: DOMString) -> bool {
-        self.command_state_for_command(command_id)
+    fn QueryCommandState(&self, cx: &mut js::context::JSContext, command_id: DOMString) -> bool {
+        self.command_state_for_command(cx, command_id)
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#querycommandvalue()>

--- a/components/script/dom/execcommand/basecommand.rs
+++ b/components/script/dom/execcommand/basecommand.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use js::context::JSContext;
 use script_bindings::inheritance::Castable;
 use style::properties::PropertyDeclarationId;
 use style::properties::generated::LonghandId;
@@ -9,6 +10,7 @@ use style::values::specified::text::TextDecorationLine;
 use style_traits::ToCss;
 
 use crate::dom::bindings::codegen::Bindings::CSSStyleDeclarationBinding::CSSStyleDeclarationMethods;
+use crate::dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLElementBinding::HTMLElementMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLFontElementBinding::HTMLFontElementMethods;
 use crate::dom::bindings::str::DOMString;
@@ -144,7 +146,7 @@ impl CssPropertyName {
 
     pub(crate) fn set_for_element(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         element: &HTMLElement,
         new_value: DOMString,
     ) {
@@ -153,21 +155,13 @@ impl CssPropertyName {
         let _ = style.SetProperty(cx, self.property_name(), new_value, "".into());
     }
 
-    pub(crate) fn remove_from_element(
-        &self,
-        cx: &mut js::context::JSContext,
-        element: &HTMLElement,
-    ) {
+    pub(crate) fn remove_from_element(&self, cx: &mut JSContext, element: &HTMLElement) {
         let _ = element
             .Style(CanGc::from_cx(cx))
             .RemoveProperty(cx, self.property_name());
     }
 
-    pub(crate) fn value_for_element(
-        &self,
-        cx: &mut js::context::JSContext,
-        element: &HTMLElement,
-    ) -> DOMString {
+    pub(crate) fn value_for_element(&self, cx: &mut JSContext, element: &HTMLElement) -> DOMString {
         element
             .Style(CanGc::from_cx(cx))
             .GetPropertyValue(self.property_name())
@@ -224,21 +218,36 @@ impl CommandName {
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#state>
-    pub(crate) fn current_state(&self, document: &Document) -> Option<bool> {
+    pub(crate) fn current_state(&self, cx: &mut JSContext, document: &Document) -> Option<bool> {
         Some(match self {
             CommandName::StyleWithCss => {
                 // https://w3c.github.io/editing/docs/execCommand/#the-stylewithcss-command
                 // > True if the CSS styling flag is true, otherwise false.
                 document.css_styling_flag()
             },
-            _ => return None,
+            CommandName::FontSize => {
+                // Font size does not have a state defined for its command
+                false
+            },
+            _ => {
+                // https://w3c.github.io/editing/docs/execCommand/#state
+                // > The state of a command is true if it is already in effect,
+                // > in some sense specific to the command.
+                let selection = document.GetSelection(CanGc::from_cx(cx))?;
+                let active_range = selection.active_range()?;
+                active_range
+                    .first_formattable_contained_node()
+                    .unwrap_or_else(|| active_range.start_container())
+                    .effective_command_value(self)
+                    .is_some()
+            },
         })
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#value>
     pub(crate) fn current_value(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         document: &Document,
     ) -> Option<DOMString> {
         Some(match self {
@@ -348,7 +357,7 @@ impl CommandName {
     /// <https://w3c.github.io/editing/docs/execCommand/#action>
     pub(crate) fn execute(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         document: &Document,
         selection: &Selection,
         value: DOMString,

--- a/components/script/dom/execcommand/commands/underline.rs
+++ b/components/script/dom/execcommand/commands/underline.rs
@@ -18,7 +18,7 @@ pub(crate) fn execute_underline_command(
     // > If queryCommandState("underline") returns true, set the selection's value to null.
     // > Otherwise set the selection's value to "underline". Either way, return true.
     let value = Some("underline".into())
-        .filter(|_| !document.command_state_for_command("underline".into()));
+        .filter(|_| !document.command_state_for_command(cx, "underline".into()));
     selection.set_the_selection_value(cx, value, CommandName::Underline, document);
 
     true

--- a/components/script/dom/execcommand/contenteditable/element.rs
+++ b/components/script/dom/execcommand/contenteditable/element.rs
@@ -109,10 +109,19 @@ impl Element {
             )) | NodeTypeId::Element(ElementTypeId::HTMLElement(
                 HTMLElementTypeId::HTMLSpanElement,
             ))
+        ) || matches!(
+            *self.local_name(),
+            local_name!("b") |
+                local_name!("em") |
+                local_name!("i") |
+                local_name!("s") |
+                local_name!("strike") |
+                local_name!("strong") |
+                local_name!("sub") |
+                local_name!("sup") |
+                local_name!("u")
         ) {
             // > It is an a, b, em, font, i, s, span, strike, strong, sub, sup, or u element with no attributes.
-            //
-            // TODO: All elements that are HTMLElement rather than a specific one
             if attr_count == 0 {
                 return true;
             }
@@ -165,20 +174,37 @@ impl Element {
                 only_attribute == &local_name!("size");
         }
 
+        if only_attribute != &local_name!("style") {
+            return false;
+        }
+        let style_attribute = self.style_attribute().borrow();
+        let Some(declarations) = style_attribute.as_ref() else {
+            return false;
+        };
+        let document = self.owner_document();
+        let shared_lock = document.style_shared_lock();
+        let read_lock = shared_lock.read();
+        let style = declarations.read_with(&read_lock);
+
+        if style.len() != 1 {
+            return false;
+        }
+
         // > It is a b or strong element with exactly one attribute, which is style,
         // > and the style attribute sets exactly one CSS property
         // > (including invalid or unrecognized properties), which is "font-weight".
-        // TODO
+        if matches!(*self.local_name(), local_name!("b") | local_name!("strong")) {
+            return style.contains(PropertyDeclarationId::Longhand(LonghandId::FontWeight));
+        }
 
         // > It is an i or em element with exactly one attribute, which is style,
         // > and the style attribute sets exactly one CSS property (including invalid or unrecognized properties),
         // > which is "font-style".
-        // TODO
+        if matches!(*self.local_name(), local_name!("i") | local_name!("em")) {
+            return style.contains(PropertyDeclarationId::Longhand(LonghandId::FontStyle));
+        }
 
-        // > It is an a, font, or span element with exactly one attribute, which is style,
-        // > and the style attribute sets exactly one CSS property (including invalid or unrecognized properties),
-        // > and that property is not "text-decoration".
-        if matches!(
+        let a_font_or_span = matches!(
             type_id,
             NodeTypeId::Element(ElementTypeId::HTMLElement(
                 HTMLElementTypeId::HTMLAnchorElement,
@@ -187,44 +213,33 @@ impl Element {
             )) | NodeTypeId::Element(ElementTypeId::HTMLElement(
                 HTMLElementTypeId::HTMLSpanElement,
             ))
-        ) {
-            if only_attribute != &local_name!("style") {
-                return false;
-            }
-            let style_attribute = self.style_attribute().borrow();
-            let Some(declarations) = style_attribute.as_ref() else {
-                return false;
-            };
-            let document = self.owner_document();
-            let shared_lock = document.style_shared_lock();
-            let read_lock = shared_lock.read();
-            let style = declarations.read_with(&read_lock);
-
-            if style.len() == 1 {
-                if let Some((text_decoration, _)) = style.get(PropertyDeclarationId::Longhand(
-                    LonghandId::TextDecorationLine,
-                )) {
-                    // > It is an a, font, s, span, strike, or u element with exactly one attribute,
-                    // > which is style, and the style attribute sets exactly one CSS property
-                    // > (including invalid or unrecognized properties), which is "text-decoration",
-                    // > which is set to "line-through" or "underline" or "overline" or "none".
-                    //
-                    // TODO: Also the other element types
-                    return matches!(
-                        text_decoration,
-                        PropertyDeclaration::TextDecorationLine(
-                            TextDecorationLine::LINE_THROUGH |
-                                TextDecorationLine::UNDERLINE |
-                                TextDecorationLine::OVERLINE |
-                                TextDecorationLine::NONE
-                        )
-                    );
-                } else {
-                    // > It is an a, font, or span element with exactly one attribute, which is style,
-                    // > and the style attribute sets exactly one CSS property (including invalid or unrecognized properties),
-                    // > and that property is not "text-decoration".
-                    return true;
-                }
+        );
+        let s_strike_or_u = matches!(
+            *self.local_name(),
+            local_name!("s") | local_name!("strike") | local_name!("u")
+        );
+        if a_font_or_span || s_strike_or_u {
+            if let Some((text_decoration, _)) = style.get(PropertyDeclarationId::Longhand(
+                LonghandId::TextDecorationLine,
+            )) {
+                // > It is an a, font, s, span, strike, or u element with exactly one attribute,
+                // > which is style, and the style attribute sets exactly one CSS property
+                // > (including invalid or unrecognized properties), which is "text-decoration",
+                // > which is set to "line-through" or "underline" or "overline" or "none".
+                return matches!(
+                    text_decoration,
+                    PropertyDeclaration::TextDecorationLine(
+                        TextDecorationLine::LINE_THROUGH |
+                            TextDecorationLine::UNDERLINE |
+                            TextDecorationLine::OVERLINE |
+                            TextDecorationLine::NONE
+                    )
+                );
+            } else {
+                // > It is an a, font, or span element with exactly one attribute, which is style,
+                // > and the style attribute sets exactly one CSS property (including invalid or unrecognized properties),
+                // > and that property is not "text-decoration".
+                return a_font_or_span;
             }
         }
 

--- a/components/script/dom/execcommand/contenteditable/node.rs
+++ b/components/script/dom/execcommand/contenteditable/node.rs
@@ -904,9 +904,11 @@ impl Node {
             !last_ancestor
                 .upcast::<Node>()
                 .GetParentNode()
-                .is_some_and(|last_ancestor| {
+                .is_some_and(|last_ancestor_parent| {
                     command.are_loosely_equivalent_values(
-                        last_ancestor.effective_command_value(command).as_ref(),
+                        last_ancestor_parent
+                            .effective_command_value(command)
+                            .as_ref(),
                         new_value.as_ref(),
                     )
                 })

--- a/components/script/dom/execcommand/contenteditable/range.rs
+++ b/components/script/dom/execcommand/contenteditable/range.rs
@@ -189,7 +189,7 @@ impl Range {
                     BoolOrOptionalString::Bool(bool_)
                         if override_state
                             .command
-                            .current_state(context_object)
+                            .current_state(cx, context_object)
                             .is_some_and(|value| value != bool_) =>
                     {
                         override_state

--- a/components/script/dom/execcommand/execcommands.rs
+++ b/components/script/dom/execcommand/execcommands.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use js::context::JSContext;
 use script_bindings::inheritance::Castable;
 
 use crate::dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
@@ -76,7 +77,7 @@ impl Document {
     /// <https://w3c.github.io/editing/docs/execCommand/#enabled>
     fn selection_if_command_is_enabled(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         command_name: CommandName,
     ) -> Option<DomRoot<Selection>> {
         let selection = self.GetSelection(CanGc::from_cx(cx))?;
@@ -129,20 +130,16 @@ impl Document {
 pub(crate) trait DocumentExecCommandSupport {
     fn is_command_supported(&self, command_id: DOMString) -> bool;
     fn is_command_indeterminate(&self, command_id: DOMString) -> bool;
-    fn command_state_for_command(&self, command_id: DOMString) -> bool;
-    fn command_value_for_command(
-        &self,
-        cx: &mut js::context::JSContext,
-        command_id: DOMString,
-    ) -> DOMString;
+    fn command_state_for_command(&self, cx: &mut JSContext, command_id: DOMString) -> bool;
+    fn command_value_for_command(&self, cx: &mut JSContext, command_id: DOMString) -> DOMString;
     fn check_support_and_enabled(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         command_id: &DOMString,
     ) -> Option<(CommandName, DomRoot<Selection>)>;
     fn exec_command_for_command_id(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         command_id: DOMString,
         value: DOMString,
     ) -> bool;
@@ -163,12 +160,12 @@ impl DocumentExecCommandSupport for Document {
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#querycommandstate()>
-    fn command_state_for_command(&self, command_id: DOMString) -> bool {
+    fn command_state_for_command(&self, cx: &mut JSContext, command_id: DOMString) -> bool {
         // Step 1. If command is not supported or has no state, return false.
         let Some(command) = self.command_if_command_is_supported(&command_id) else {
             return false;
         };
-        let Some(state) = command.current_state(self) else {
+        let Some(state) = command.current_state(cx, self) else {
             return false;
         };
         // Step 2. If the state override for command is set, return it.
@@ -177,11 +174,7 @@ impl DocumentExecCommandSupport for Document {
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#querycommandvalue()>
-    fn command_value_for_command(
-        &self,
-        cx: &mut js::context::JSContext,
-        command_id: DOMString,
-    ) -> DOMString {
+    fn command_value_for_command(&self, cx: &mut JSContext, command_id: DOMString) -> DOMString {
         // Step 1. If command is not supported or has no value, return the empty string.
         let Some(command) = self.command_if_command_is_supported(&command_id) else {
             return DOMString::new();
@@ -207,7 +200,7 @@ impl DocumentExecCommandSupport for Document {
     /// <https://w3c.github.io/editing/docs/execCommand/#querycommandenabled()>
     fn check_support_and_enabled(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         command_id: &DOMString,
     ) -> Option<(CommandName, DomRoot<Selection>)> {
         // Step 2. Return true if command is both supported and enabled, false otherwise.
@@ -219,7 +212,7 @@ impl DocumentExecCommandSupport for Document {
     /// <https://w3c.github.io/editing/docs/execCommand/#execcommand()>
     fn exec_command_for_command_id(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         command_id: DOMString,
         value: DOMString,
     ) -> bool {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -223,6 +223,7 @@ DOMInterfaces = {
         'ParseHTMLUnsafe',
         'Prepend',
         'QueryCommandEnabled',
+        'QueryCommandState',
         'QueryCommandValue',
         'ReplaceChildren',
         'SetBody',

--- a/tests/wpt/meta/editing/run/multitest.html.ini
+++ b/tests/wpt/meta/editing/run/multitest.html.ini
@@ -800,9 +800,6 @@
   [[["createlink","http://www.google.com/"\],["underline",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["createlink","http://www.google.com/"\],["underline",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["underline",""\],["createlink","http://www.google.com/"\],["inserttext","a"\]\] "foo[\]bar": execCommand("createlink", false, "http://www.google.com/") return value]
     expected: FAIL
 
@@ -810,9 +807,6 @@
     expected: FAIL
 
   [[["underline",""\],["createlink","http://www.google.com/"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["underline",""\],["createlink","http://www.google.com/"\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("underline") after]
     expected: FAIL
 
   [[["createlink","http://www.google.com/"\],["underline","","first application"\],["underline","","second application"\],["inserttext","a"\]\] "foo[\]bar": execCommand("createlink", false, "http://www.google.com/") return value]
@@ -7179,9 +7173,6 @@
   [[["underline",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["underline",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["underline",""\],["delete",""\]\] "foo[\]bar" queryCommandState("underline") after]
     expected: FAIL
 
@@ -7200,9 +7191,6 @@
   [[["underline",""\],["formatblock","<div>"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["underline",""\],["formatblock","<div>"\]\] "foo[\]bar" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["underline",""\],["formatblock","<div>"\]\] "foo[\]bar" queryCommandValue("formatblock") after]
     expected: FAIL
 
@@ -7215,9 +7203,6 @@
   [[["underline",""\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["underline",""\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["underline",""\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("formatblock") after]
     expected: FAIL
 
@@ -7225,9 +7210,6 @@
     expected: FAIL
 
   [[["underline",""\],["forwarddelete",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["underline",""\],["forwarddelete",""\]\] "foo[\]bar" queryCommandState("underline") after]
     expected: FAIL
 
   [[["underline",""\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("forwarddelete", false, "") return value]
@@ -7239,16 +7221,10 @@
   [[["underline",""\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["underline",""\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["underline",""\],["indent",""\]\] "foo[\]bar": execCommand("indent", false, "") return value]
     expected: FAIL
 
   [[["underline",""\],["indent",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["underline",""\],["indent",""\]\] "foo[\]bar" queryCommandState("underline") after]
     expected: FAIL
 
   [[["underline",""\],["indent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("indent", false, "") return value]
@@ -7260,16 +7236,10 @@
   [[["underline",""\],["indent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["underline",""\],["indent",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["underline",""\],["inserthorizontalrule",""\]\] "foo[\]bar": execCommand("inserthorizontalrule", false, "") return value]
     expected: FAIL
 
   [[["underline",""\],["inserthorizontalrule",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["underline",""\],["inserthorizontalrule",""\]\] "foo[\]bar" queryCommandState("underline") after]
     expected: FAIL
 
   [[["underline",""\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserthorizontalrule", false, "") return value]
@@ -7281,16 +7251,10 @@
   [[["underline",""\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["underline",""\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["underline",""\],["inserthtml","ab<b>c</b>d"\]\] "foo[\]bar": execCommand("inserthtml", false, "ab<b>c</b>d") return value]
     expected: FAIL
 
   [[["underline",""\],["inserthtml","ab<b>c</b>d"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["underline",""\],["inserthtml","ab<b>c</b>d"\]\] "foo[\]bar" queryCommandState("underline") after]
     expected: FAIL
 
   [[["underline",""\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserthtml", false, "ab<b>c</b>d") return value]
@@ -7302,16 +7266,10 @@
   [[["underline",""\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["underline",""\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["underline",""\],["insertimage","/img/lion.svg"\]\] "foo[\]bar": execCommand("insertimage", false, "/img/lion.svg") return value]
     expected: FAIL
 
   [[["underline",""\],["insertimage","/img/lion.svg"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["underline",""\],["insertimage","/img/lion.svg"\]\] "foo[\]bar" queryCommandState("underline") after]
     expected: FAIL
 
   [[["underline",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertimage", false, "/img/lion.svg") return value]
@@ -7323,16 +7281,10 @@
   [[["underline",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["underline",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["underline",""\],["insertlinebreak",""\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["underline",""\],["insertlinebreak",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["underline",""\],["insertlinebreak",""\]\] "foo[\]bar" queryCommandState("underline") after]
     expected: FAIL
 
   [[["underline",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
@@ -7344,16 +7296,10 @@
   [[["underline",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["underline",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["underline",""\],["insertorderedlist",""\]\] "foo[\]bar": execCommand("insertorderedlist", false, "") return value]
     expected: FAIL
 
   [[["underline",""\],["insertorderedlist",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["underline",""\],["insertorderedlist",""\]\] "foo[\]bar" queryCommandState("underline") after]
     expected: FAIL
 
   [[["underline",""\],["insertorderedlist",""\]\] "foo[\]bar" queryCommandState("insertorderedlist") after]
@@ -7368,9 +7314,6 @@
   [[["underline",""\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["underline",""\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["underline",""\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("insertorderedlist") after]
     expected: FAIL
 
@@ -7378,9 +7321,6 @@
     expected: FAIL
 
   [[["underline",""\],["insertparagraph",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["underline",""\],["insertparagraph",""\]\] "foo[\]bar" queryCommandState("underline") after]
     expected: FAIL
 
   [[["underline",""\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertparagraph", false, "") return value]
@@ -7392,16 +7332,10 @@
   [[["underline",""\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["underline",""\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["underline",""\],["insertunorderedlist",""\]\] "foo[\]bar": execCommand("insertunorderedlist", false, "") return value]
     expected: FAIL
 
   [[["underline",""\],["insertunorderedlist",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["underline",""\],["insertunorderedlist",""\]\] "foo[\]bar" queryCommandState("underline") after]
     expected: FAIL
 
   [[["underline",""\],["insertunorderedlist",""\]\] "foo[\]bar" queryCommandState("insertunorderedlist") after]
@@ -7416,9 +7350,6 @@
   [[["underline",""\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["underline",""\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["underline",""\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("insertunorderedlist") after]
     expected: FAIL
 
@@ -7426,9 +7357,6 @@
     expected: FAIL
 
   [[["underline",""\],["justifycenter",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["underline",""\],["justifycenter",""\]\] "foo[\]bar" queryCommandState("underline") after]
     expected: FAIL
 
   [[["underline",""\],["justifycenter",""\]\] "foo[\]bar" queryCommandValue("justifycenter") before]
@@ -7449,9 +7377,6 @@
   [[["underline",""\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["underline",""\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["underline",""\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("justifycenter") before]
     expected: FAIL
 
@@ -7465,9 +7390,6 @@
     expected: FAIL
 
   [[["underline",""\],["justifyfull",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["underline",""\],["justifyfull",""\]\] "foo[\]bar" queryCommandState("underline") after]
     expected: FAIL
 
   [[["underline",""\],["justifyfull",""\]\] "foo[\]bar" queryCommandValue("justifyfull") before]
@@ -7488,9 +7410,6 @@
   [[["underline",""\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["underline",""\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["underline",""\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("justifyfull") before]
     expected: FAIL
 
@@ -7501,9 +7420,6 @@
     expected: FAIL
 
   [[["underline",""\],["justifyleft",""\]\] "foo[\]bar": execCommand("justifyleft", false, "") return value]
-    expected: FAIL
-
-  [[["underline",""\],["justifyleft",""\]\] "foo[\]bar" queryCommandState("underline") after]
     expected: FAIL
 
   [[["underline",""\],["justifyleft",""\]\] "foo[\]bar" queryCommandState("justifyleft") before]
@@ -7527,9 +7443,6 @@
   [[["underline",""\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["underline",""\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["underline",""\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("justifyleft") before]
     expected: FAIL
 
@@ -7546,9 +7459,6 @@
     expected: FAIL
 
   [[["underline",""\],["justifyright",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["underline",""\],["justifyright",""\]\] "foo[\]bar" queryCommandState("underline") after]
     expected: FAIL
 
   [[["underline",""\],["justifyright",""\]\] "foo[\]bar" queryCommandValue("justifyright") before]
@@ -7569,9 +7479,6 @@
   [[["underline",""\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["underline",""\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["underline",""\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("justifyright") before]
     expected: FAIL
 
@@ -7584,9 +7491,6 @@
   [[["underline",""\],["outdent",""\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
     expected: FAIL
 
-  [[["underline",""\],["outdent",""\]\] "foo[\]bar" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["underline",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
     expected: FAIL
 
@@ -7594,9 +7498,6 @@
     expected: FAIL
 
   [[["underline",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["underline",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("underline") after]
     expected: FAIL
 
   [[["backcolor","#00FFFF"\],["inserttext","a"\]\] "foo[\]bar": execCommand("backcolor", false, "#00FFFF") return value]

--- a/tests/wpt/meta/editing/run/underline.html.ini
+++ b/tests/wpt/meta/editing/run/underline.html.ini
@@ -1,7 +1,4 @@
 [underline.html?1-1000]
-  [[["underline",""\]\] "foo[\]bar" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<p>[foo</p> <p>bar\]</p>" compare innerHTML]
     expected: FAIL
 
@@ -45,18 +42,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["underline",""\]\] "<p>[foo<p><br><p>bar\]" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["underline",""\]\] "<b>foo[\]bar</b>" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["underline",""\]\] "<i>foo[\]bar</i>" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["underline",""\]\] "<span>foo</span>{}<span>bar</span>" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["underline",""\]\] "<span>foo[</span><span>\]bar</span>" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "foo[bar\]baz" compare innerHTML]


### PR DESCRIPTION
For any generic command, the spec doesn't specify how to determine whether its state is set. In the case of underline, it at least means that it has an effective command value that is set (to underline in this case).

Also implements "simple modifiable" elements, since the relevant tests depend on that for correctness.

Lastly, also rewrite `JSContext` to use imports.

Part of #25005

Testing: WPT