### PR TITLE
wpt: Remove empty test `ini` for `/_mozilla/mozilla/localeCompare.html`

### DIFF
--- a/tests/wpt/mozilla/meta/mozilla/localeCompare.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/localeCompare.html.ini
@@ -1,2 +1,0 @@
-[localeCompare.html]
-  bug: https://github.com/servo/servo/issues/25802


### PR DESCRIPTION
Judging by the expected result in the test, the situation described in
the bug is no longer the case.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

Testing: This updates test results.
Closes: #25802.
