### PR TITLE
wpt: Make `/_mozilla/mozilla/getBoundingClientRect.html` wait for fonts to load

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -14062,7 +14062,7 @@
      ]
     ],
     "getBoundingClientRect.html": [
-     "447c782db3582529a29fe7db200f32d7490421c4",
+     "50e7d2d9b425092f550e49d57b0d35cf8d6541f7",
      [
       null,
       {}

--- a/tests/wpt/mozilla/tests/mozilla/getBoundingClientRect.html
+++ b/tests/wpt/mozilla/tests/mozilla/getBoundingClientRect.html
@@ -36,9 +36,7 @@
     height: 40px;
 }
 #span1 {
-    font-family: 'ahem';
-    font-size: 20px;
-    line-height: 1;
+    font: 20px/1 Ahem;
 }
 </style>
 </head>
@@ -62,7 +60,8 @@
       assert_equals(rect.right, right);
     }
 
-    test(function() {
+    promise_test(async () => {
+      await document.fonts.ready;
       assert_equals(String(DOMRect).indexOf("function DOMRect("), 0);
 
       var elems = document.getElementsByTagName('div');
@@ -80,7 +79,8 @@
       assert_equals(rect.height, rect.bottom - rect.top);
     });
 
-    test(function() {
+    promise_test(async () => {
+        await document.fonts.ready;
         test_rect('abs1', 55, 45, 165, 155);
         test_rect('abs2', 60, 50, 130, 140);
         test_rect('abs3', 74, 62, 102, 122);


### PR DESCRIPTION
This is a speculative fix for #39668. Although I could not get this test
to flake locally, it is obviously wrong to assumee that web fonts (Ahem
in this case) is loaded at the time script was run. This change
makes all the tests Promise tests and has them await
`document.fonts.ready` before running. This should fix the
intermittency.

Testing: This should fix intermittency as seen on the CI.
Fixes: #39668
