### PR TITLE
storage: Update index data in indexeddb backend

### DIFF
--- a/components/script/dom/indexeddb/idbindex.rs
+++ b/components/script/dom/indexeddb/idbindex.rs
@@ -2,17 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 use dom_struct::dom_struct;
-use js::gc::MutableHandleValue;
+use js::context::JSContext;
+use js::gc::{HandleValue, MutableHandleValue};
 use script_bindings::codegen::GenericBindings::IDBIndexBinding::IDBIndexMethods;
 use script_bindings::conversions::SafeToJSValConvertible;
+use script_bindings::error::{Error, ErrorResult, Fallible};
 use script_bindings::str::DOMString;
+use storage_traits::indexeddb::{AsyncOperation, AsyncReadOnlyOperation};
 
 use crate::dom::bindings::import::base::SafeJSContext;
 use crate::dom::bindings::reflector::{Reflector, reflect_dom_object};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::idbobjectstore::KeyPath;
+use crate::dom::idbrequest::IDBRequest;
 use crate::dom::indexeddb::idbobjectstore::IDBObjectStore;
+use crate::indexeddb::convert_value_to_key_range;
 use crate::script_runtime::CanGc;
 
 #[dom_struct]
@@ -64,6 +69,34 @@ impl IDBIndex {
             can_gc,
         )
     }
+
+    pub(crate) fn name(&self) -> String {
+        self.name.to_string()
+    }
+
+    pub(crate) fn key_path(&self) -> &KeyPath {
+        &self.key_path
+    }
+
+    pub(crate) fn multi_entry(&self) -> bool {
+        self.multi_entry
+    }
+
+    pub(crate) fn unique(&self) -> bool {
+        self.unique
+    }
+
+    pub(crate) fn object_store(&self) -> &DomRoot<IDBObjectStore> {
+        &self.object_store
+    }
+
+    fn verify_not_deleted(&self) -> ErrorResult {
+        if !self.object_store.index_exists(&self.name) {
+            return Err(Error::InvalidState(None));
+        }
+        self.object_store.verify_not_deleted()?;
+        Ok(())
+    }
 }
 
 impl IDBIndexMethods<crate::DomTypeHolder> for IDBIndex {
@@ -92,5 +125,93 @@ impl IDBIndexMethods<crate::DomTypeHolder> for IDBIndex {
                 sequence.safe_to_jsval(cx, retval, can_gc);
             },
         }
+    }
+
+    /// <https://www.w3.org/TR/IndexedDB/#dom-idbindex-get>
+    fn Get(&self, cx: &mut JSContext, query: HandleValue) -> Fallible<DomRoot<IDBRequest>> {
+        // Step 3. If index or index’s object store has been deleted, throw an "InvalidStateError" DOMException.
+        self.verify_not_deleted()?;
+
+        // Step 4. If transaction’s state is not active, then throw a "TransactionInactiveError" DOMException.
+        self.object_store.check_transaction_active()?;
+
+        // Step 5. Let range be the result of converting a value to a key range with query and true. Rethrow any exceptions.
+        let range = convert_value_to_key_range(cx, query, None);
+
+        // Step 6. Let operation be an algorithm to run retrieve a referenced value from an index with the current Realm record, index, and range.
+        // Step 7. Return the result (an IDBRequest) of running asynchronously execute a request with this and operation.
+        range.and_then(|q| {
+            IDBRequest::execute_async(
+                self,
+                |callback| {
+                    AsyncOperation::ReadOnly(AsyncReadOnlyOperation::IndexGetItem {
+                        callback,
+                        index_name: self.name.to_string(),
+                        key_range: q,
+                    })
+                },
+                None,
+                None,
+                CanGc::from_cx(cx),
+            )
+        })
+    }
+
+    /// <https://www.w3.org/TR/IndexedDB/#dom-idbindex-getkey>
+    fn GetKey(
+        &self,
+        cx: &mut JSContext,
+        query_or_options: HandleValue,
+    ) -> Fallible<DomRoot<IDBRequest>> {
+        // Step 3. If index or index’s object store has been deleted, throw an "InvalidStateError" DOMException.
+        self.verify_not_deleted()?;
+
+        // Step 4. If transaction’s state is not active, then throw a "TransactionInactiveError" DOMException.
+        self.object_store.check_transaction_active()?;
+
+        // Step 5. Let range be the result of converting a value to a key range with query and true. Rethrow any exceptions.
+        let range = convert_value_to_key_range(cx, query_or_options, None);
+        range.and_then(|q| {
+            IDBRequest::execute_async(
+                self,
+                |callback| {
+                    AsyncOperation::ReadOnly(AsyncReadOnlyOperation::IndexGetKey {
+                        callback,
+                        index_name: self.name.to_string(),
+                        key_range: q,
+                    })
+                },
+                None,
+                None,
+                CanGc::from_cx(cx),
+            )
+        })
+    }
+
+    /// <https://www.w3.org/TR/IndexedDB/#dom-idbindex-count>
+    fn Count(&self, cx: &mut JSContext, query: HandleValue) -> Fallible<DomRoot<IDBRequest>> {
+        // Step 3. If index or index’s object store has been deleted, throw an "InvalidStateError" DOMException.
+        self.verify_not_deleted()?;
+
+        // Step 4. If transaction’s state is not active, then throw a "TransactionInactiveError" DOMException.
+        self.object_store.check_transaction_active()?;
+
+        // Step 5. Let range be the result of converting a value to a key range with query. Rethrow any exceptions.
+        let range = convert_value_to_key_range(cx, query, None);
+        range.and_then(|q| {
+            IDBRequest::execute_async(
+                self,
+                |callback| {
+                    AsyncOperation::ReadOnly(AsyncReadOnlyOperation::IndexCount {
+                        callback,
+                        index_name: self.name.to_string(),
+                        key_range: q,
+                    })
+                },
+                None,
+                None,
+                CanGc::from_cx(cx),
+            )
+        })
     }
 }

--- a/components/script/dom/indexeddb/idbindex.rs
+++ b/components/script/dom/indexeddb/idbindex.rs
@@ -3,19 +3,22 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use js::gc::MutableHandleValue;
+use js::gc::{HandleValue, MutableHandleValue};
 use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::IDBIndexBinding::IDBIndexMethods;
 use script_bindings::codegen::GenericBindings::IDBTransactionBinding::IDBTransactionMode;
 use script_bindings::conversions::SafeToJSValConvertible;
-use script_bindings::error::{Error, ErrorResult};
+use script_bindings::error::{Error, ErrorResult, Fallible};
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use script_bindings::str::DOMString;
+use storage_traits::indexeddb::{AsyncOperation, AsyncReadOnlyOperation};
 
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::idbobjectstore::KeyPath;
+use crate::dom::idbrequest::IDBRequest;
 use crate::dom::indexeddb::idbobjectstore::IDBObjectStore;
+use crate::indexeddb::convert_value_to_key_range;
 
 #[dom_struct]
 pub(crate) struct IDBIndex {
@@ -65,6 +68,34 @@ impl IDBIndex {
             global,
             cx,
         )
+    }
+
+    pub(crate) fn name(&self) -> String {
+        self.name.borrow().to_string()
+    }
+
+    pub(crate) fn key_path(&self) -> &KeyPath {
+        &self.key_path
+    }
+
+    pub(crate) fn multi_entry(&self) -> bool {
+        self.multi_entry
+    }
+
+    pub(crate) fn unique(&self) -> bool {
+        self.unique
+    }
+
+    pub(crate) fn object_store(&self) -> DomRoot<IDBObjectStore> {
+        self.object_store.as_rooted()
+    }
+
+    fn verify_not_deleted(&self) -> ErrorResult {
+        if !self.object_store.index_exists(&self.name.borrow()) {
+            return Err(Error::InvalidState(None));
+        }
+        self.object_store.verify_not_deleted()?;
+        Ok(())
     }
 }
 
@@ -154,5 +185,93 @@ impl IDBIndexMethods<crate::DomTypeHolder> for IDBIndex {
                 sequence.safe_to_jsval(cx, retval);
             },
         }
+    }
+
+    /// <https://www.w3.org/TR/IndexedDB/#dom-idbindex-get>
+    fn Get(&self, cx: &mut JSContext, query: HandleValue) -> Fallible<DomRoot<IDBRequest>> {
+        // Step 3. If index or index’s object store has been deleted, throw an "InvalidStateError" DOMException.
+        self.verify_not_deleted()?;
+
+        // Step 4. If transaction’s state is not active, then throw a "TransactionInactiveError" DOMException.
+        self.object_store.check_transaction_active()?;
+
+        // Step 5. Let range be the result of converting a value to a key range with query and true. Rethrow any exceptions.
+        let range = convert_value_to_key_range(cx, query, None);
+
+        // Step 6. Let operation be an algorithm to run retrieve a referenced value from an index with the current Realm record, index, and range.
+        // Step 7. Return the result (an IDBRequest) of running asynchronously execute a request with this and operation.
+        range.and_then(|q| {
+            IDBRequest::execute_async(
+                cx,
+                self,
+                |callback| {
+                    AsyncOperation::ReadOnly(AsyncReadOnlyOperation::IndexGetItem {
+                        callback,
+                        index_name: self.name.borrow().to_string(),
+                        key_range: q,
+                    })
+                },
+                None,
+                None,
+            )
+        })
+    }
+
+    /// <https://www.w3.org/TR/IndexedDB/#dom-idbindex-getkey>
+    fn GetKey(
+        &self,
+        cx: &mut JSContext,
+        query_or_options: HandleValue,
+    ) -> Fallible<DomRoot<IDBRequest>> {
+        // Step 3. If index or index’s object store has been deleted, throw an "InvalidStateError" DOMException.
+        self.verify_not_deleted()?;
+
+        // Step 4. If transaction’s state is not active, then throw a "TransactionInactiveError" DOMException.
+        self.object_store.check_transaction_active()?;
+
+        // Step 5. Let range be the result of converting a value to a key range with query and true. Rethrow any exceptions.
+        let range = convert_value_to_key_range(cx, query_or_options, None);
+        range.and_then(|q| {
+            IDBRequest::execute_async(
+                cx,
+                self,
+                |callback| {
+                    AsyncOperation::ReadOnly(AsyncReadOnlyOperation::IndexGetKey {
+                        callback,
+                        index_name: self.name.borrow().to_string(),
+                        key_range: q,
+                    })
+                },
+                None,
+                None,
+            )
+        })
+    }
+
+    /// <https://www.w3.org/TR/IndexedDB/#dom-idbindex-count>
+    fn Count(&self, cx: &mut JSContext, query: HandleValue) -> Fallible<DomRoot<IDBRequest>> {
+        // Step 3. If index or index’s object store has been deleted, throw an "InvalidStateError" DOMException.
+        self.verify_not_deleted()?;
+
+        // Step 4. If transaction’s state is not active, then throw a "TransactionInactiveError" DOMException.
+        self.object_store.check_transaction_active()?;
+
+        // Step 5. Let range be the result of converting a value to a key range with query. Rethrow any exceptions.
+        let range = convert_value_to_key_range(cx, query, None);
+        range.and_then(|q| {
+            IDBRequest::execute_async(
+                cx,
+                self,
+                |callback| {
+                    AsyncOperation::ReadOnly(AsyncReadOnlyOperation::IndexCount {
+                        callback,
+                        index_name: self.name.borrow().to_string(),
+                        key_range: q,
+                    })
+                },
+                None,
+                None,
+            )
+        })
     }
 }

--- a/components/script/dom/indexeddb/idbobjectstore.rs
+++ b/components/script/dom/indexeddb/idbobjectstore.rs
@@ -89,7 +89,7 @@ pub struct IDBObjectStore {
     reflector_: Reflector,
     name: DomRefCell<DOMString>,
     key_path: Option<KeyPath>,
-    index_set: DomRefCell<HashMap<DOMString, Dom<IDBIndex>>>,
+    index_set: DomRefCell<HashMap<DOMString, DomRoot<IDBIndex>>>,
     transaction: Dom<IDBTransaction>,
     has_key_generator: bool,
     key_generator_current_number: Cell<Option<i32>>,
@@ -261,7 +261,11 @@ impl IDBObjectStore {
         self.key_path.is_some()
     }
 
-    fn verify_not_deleted(&self) -> ErrorResult {
+    pub(crate) fn index_exists(&self, name: &DOMString) -> bool {
+        self.index_set.borrow().contains_key(name)
+    }
+
+    pub(crate) fn verify_not_deleted(&self) -> ErrorResult {
         let db = self.transaction.Db();
         if !db.object_store_exists(&self.name.borrow()) {
             return Err(Error::InvalidState(None));
@@ -270,7 +274,7 @@ impl IDBObjectStore {
     }
 
     /// Checks if the transaction is active, throwing a "TransactionInactiveError" DOMException if not.
-    fn check_transaction_active(&self) -> Fallible<()> {
+    pub(crate) fn check_transaction_active(&self) -> Fallible<()> {
         // Let transaction be this object store handle's transaction.
         let transaction = &self.transaction;
 
@@ -287,7 +291,7 @@ impl IDBObjectStore {
 
     /// Checks if the transaction is active, throwing a "TransactionInactiveError" DOMException if not.
     /// it then checks if the transaction is a read-only transaction, throwing a "ReadOnlyError" DOMException if so.
-    fn check_readwrite_transaction_active(&self) -> Fallible<()> {
+    pub(crate) fn check_readwrite_transaction_active(&self) -> Fallible<()> {
         // Let transaction be this object store handle's transaction.
         let transaction = &self.transaction;
 
@@ -407,6 +411,19 @@ impl IDBObjectStore {
         };
         // Step 12. Let operation be an algorithm to run store a record into an object store with
         // store, clone, key, and no-overwrite flag.
+        let mut index_key_value = Vec::new();
+        let index_set = self.index_set.borrow();
+        for index in index_set.values() {
+            // https://www.w3.org/TR/IndexedDB/#store-a-record-into-an-object-store: Step 5.1
+            // Let index key be the result of extracting a key from a value using a key path with value, index’s key path, and index’s multiEntry flag.
+            let index_key = extract_key(cx, value, index.key_path(), Some(index.multi_entry()))?;
+
+            // https://www.w3.org/TR/IndexedDB/#store-a-record-into-an-object-store: Step 5.2
+            // If index key is an exception, or invalid, or failure, take no further actions for index, and continue these steps for the next index.
+            if let ExtractionResult::Key(key) = index_key {
+                index_key_value.push((index.name(), index.unique(), key));
+            }
+        }
         let request = IDBRequest::execute_async(
             self,
             |callback| {
@@ -416,6 +433,7 @@ impl IDBObjectStore {
                     value: serialized_value,
                     should_overwrite: !no_overwrite,
                     key_generator_current_number: key_generator_current_number_for_put,
+                    index_key_value,
                 })
             },
             None,
@@ -531,7 +549,7 @@ impl IDBObjectStore {
         );
         self.index_set
             .borrow_mut()
-            .insert(name, Dom::from_ref(&index));
+            .insert(name, DomRoot::from_ref(&index));
         index
     }
 }
@@ -981,6 +999,6 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
         let index = index_set.get(&name).ok_or(Error::NotFound(None))?;
 
         // Step 6. Return an index handle associated with index and this.
-        Ok(index.as_rooted())
+        Ok(index.clone())
     }
 }

--- a/components/script/dom/indexeddb/idbobjectstore.rs
+++ b/components/script/dom/indexeddb/idbobjectstore.rs
@@ -322,7 +322,11 @@ impl IDBObjectStore {
         self.key_path.is_some()
     }
 
-    fn verify_not_deleted(&self) -> ErrorResult {
+    pub(crate) fn index_exists(&self, name: &DOMString) -> bool {
+        self.index_set.borrow().contains_key(name)
+    }
+
+    pub(crate) fn verify_not_deleted(&self) -> ErrorResult {
         let db = self.transaction.Db();
         if !db.object_store_exists(&self.name.borrow()) {
             return Err(Error::InvalidState(None));
@@ -331,7 +335,7 @@ impl IDBObjectStore {
     }
 
     /// Checks if the transaction is active, throwing a "TransactionInactiveError" DOMException if not.
-    fn check_transaction_active(&self) -> Fallible<()> {
+    pub(crate) fn check_transaction_active(&self) -> Fallible<()> {
         // Let transaction be this object store handle's transaction.
         let transaction = &self.transaction;
 
@@ -348,7 +352,7 @@ impl IDBObjectStore {
 
     /// Checks if the transaction is active, throwing a "TransactionInactiveError" DOMException if not.
     /// it then checks if the transaction is a read-only transaction, throwing a "ReadOnlyError" DOMException if so.
-    fn check_readwrite_transaction_active(&self) -> Fallible<()> {
+    pub(crate) fn check_readwrite_transaction_active(&self) -> Fallible<()> {
         // Let transaction be this object store handle's transaction.
         let transaction = &self.transaction;
 
@@ -468,6 +472,24 @@ impl IDBObjectStore {
         };
         // Step 12. Let operation be an algorithm to run store a record into an object store with
         // store, clone, key, and no-overwrite flag.
+        let mut index_key_value = Vec::new();
+        let index_set = self.index_set.borrow();
+        for index in index_set.values() {
+            // https://www.w3.org/TR/IndexedDB/#store-a-record-into-an-object-store: Step 5.1
+            // Let index key be the result of extracting a key from a value using a key path with value, index’s key path, and index’s multiEntry flag.
+            let index_key = extract_key(
+                cx,
+                cloned_js_value.handle(),
+                index.key_path(),
+                Some(index.multi_entry()),
+            )?;
+
+            // https://www.w3.org/TR/IndexedDB/#store-a-record-into-an-object-store: Step 5.2
+            // If index key is an exception, or invalid, or failure, take no further actions for index, and continue these steps for the next index.
+            if let ExtractionResult::Key(key) = index_key {
+                index_key_value.push((index.name(), index.unique(), key));
+            }
+        }
         let request = IDBRequest::execute_async(
             cx,
             self,
@@ -478,6 +500,7 @@ impl IDBObjectStore {
                     value: serialized_value,
                     should_overwrite: !no_overwrite,
                     key_generator_current_number: key_generator_current_number_for_put,
+                    index_key_value,
                 })
             },
             None,

--- a/components/script/dom/indexeddb/idbrequest.rs
+++ b/components/script/dom/indexeddb/idbrequest.rs
@@ -19,10 +19,12 @@ use storage_traits::indexeddb::{
 };
 use stylo_atoms::Atom;
 
+use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::IDBRequestBinding::{
     IDBRequestMethods, IDBRequestReadyState,
 };
 use crate::dom::bindings::codegen::Bindings::IDBTransactionBinding::IDBTransactionMode;
+use crate::dom::bindings::codegen::UnionTypes::IDBObjectStoreOrIDBIndexOrIDBCursor;
 use crate::dom::bindings::error::{Error, Fallible, create_dom_exception};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
@@ -35,9 +37,8 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::indexeddb::idbcursor::{IterationParam, iterate_cursor};
 use crate::dom::indexeddb::idbcursorwithvalue::IDBCursorWithValue;
-use crate::dom::indexeddb::idbobjectstore::IDBObjectStore;
 use crate::dom::indexeddb::idbtransaction::IDBTransaction;
-use crate::indexeddb::key_type_to_jsval;
+use crate::indexeddb::{IDBSource, key_type_to_jsval};
 use crate::realms::enter_auto_realm;
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 
@@ -406,7 +407,8 @@ pub struct IDBRequest {
     #[ignore_malloc_size_of = "mozjs"]
     result: Heap<JSVal>,
     error: MutNullableDom<DOMException>,
-    source: MutNullableDom<IDBObjectStore>,
+    #[ignore_malloc_size_of = "refcell"]
+    source: DomRefCell<Option<IDBObjectStoreOrIDBIndexOrIDBCursor>>,
     transaction: MutNullableDom<IDBTransaction>,
     ready_state: Cell<IDBRequestReadyState>,
 }
@@ -428,8 +430,8 @@ impl IDBRequest {
         reflect_dom_object(Box::new(IDBRequest::new_inherited()), global, can_gc)
     }
 
-    pub fn set_source(&self, source: Option<&IDBObjectStore>) {
-        self.source.set(source);
+    pub fn set_source(&self, source: Option<IDBObjectStoreOrIDBIndexOrIDBCursor>) {
+        *self.source.borrow_mut() = source;
     }
 
     pub fn set_ready_state_done(&self) {
@@ -458,25 +460,26 @@ impl IDBRequest {
         self.transaction.set(None);
     }
 
-    fn is_done(&self) -> bool {
-        self.ready_state.get() == IDBRequestReadyState::Done
-    }
-
     pub(crate) fn transaction(&self) -> Option<DomRoot<IDBTransaction>> {
         self.transaction.get()
     }
 
+    fn is_done(&self) -> bool {
+        self.ready_state.get() == IDBRequestReadyState::Done
+    }
+
     // https://www.w3.org/TR/IndexedDB-3/#asynchronously-execute-a-request
-    pub fn execute_async<T, F>(
-        source: &IDBObjectStore,
+    pub fn execute_async<S, F, T>(
+        source: &S,
         operation_fn: F,
         request: Option<DomRoot<IDBRequest>>,
         iteration_param: Option<IterationParam>,
         can_gc: CanGc,
     ) -> Fallible<DomRoot<IDBRequest>>
     where
-        T: Into<IdbResult> + for<'a> Deserialize<'a> + Serialize + Send + Sync + 'static,
+        S: IDBSource,
         F: FnOnce(GenericCallback<BackendResult<T>>) -> AsyncOperation,
+        T: Into<IdbResult> + for<'a> Deserialize<'a> + Serialize + Send + Sync + 'static,
     {
         // Step 1: Let transaction be the transaction associated with source.
         let transaction = source.transaction();
@@ -491,7 +494,7 @@ impl IDBRequest {
         // Step 3: If request was not given, let request be a new request with source as source.
         let request = request.unwrap_or_else(|| {
             let new_request = IDBRequest::new(&global, can_gc);
-            new_request.set_source(Some(source));
+            new_request.set_source(Some(source.as_source()));
             new_request.set_transaction(&transaction);
             new_request
         });
@@ -558,7 +561,7 @@ impl IDBRequest {
             .send(IndexedDBThreadMsg::Async(
                 global.origin().immutable().clone(),
                 transaction.get_db_name().to_string(),
-                source.get_name().to_string(),
+                source.object_store_name().to_string(),
                 transaction.get_serial_number(),
                 request_id,
                 transaction_mode,
@@ -604,8 +607,20 @@ impl IDBRequestMethods<crate::DomTypeHolder> for IDBRequest {
     }
 
     /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbrequest-source>
-    fn GetSource(&self) -> Option<DomRoot<IDBObjectStore>> {
-        self.source.get()
+    fn GetSource(&self) -> Option<IDBObjectStoreOrIDBIndexOrIDBCursor> {
+        // IDBObjectStoreOrIDBIndexOrIDBCursor doesn't implement Copy
+        match &*self.source.borrow() {
+            Some(IDBObjectStoreOrIDBIndexOrIDBCursor::IDBObjectStore(store)) => Some(
+                IDBObjectStoreOrIDBIndexOrIDBCursor::IDBObjectStore(DomRoot::from_ref(store)),
+            ),
+            Some(IDBObjectStoreOrIDBIndexOrIDBCursor::IDBIndex(index)) => Some(
+                IDBObjectStoreOrIDBIndexOrIDBCursor::IDBIndex(DomRoot::from_ref(index)),
+            ),
+            Some(IDBObjectStoreOrIDBIndexOrIDBCursor::IDBCursor(cursor)) => Some(
+                IDBObjectStoreOrIDBIndexOrIDBCursor::IDBCursor(DomRoot::from_ref(cursor)),
+            ),
+            None => None,
+        }
     }
 
     /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbrequest-transaction>

--- a/components/script/dom/indexeddb/idbrequest.rs
+++ b/components/script/dom/indexeddb/idbrequest.rs
@@ -11,6 +11,7 @@ use js::jsapi::Heap;
 use js::jsval::{DoubleValue, JSVal, ObjectValue, UndefinedValue};
 use js::rust::HandleValue;
 use profile_traits::generic_callback::GenericCallback;
+use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::{DomObject, reflect_dom_object_with_cx};
 use serde::{Deserialize, Serialize};
 use servo_base::generic_channel::GenericSend;
@@ -24,6 +25,7 @@ use crate::dom::bindings::codegen::Bindings::IDBRequestBinding::{
     IDBRequestMethods, IDBRequestReadyState,
 };
 use crate::dom::bindings::codegen::Bindings::IDBTransactionBinding::IDBTransactionMode;
+use crate::dom::bindings::codegen::UnionTypes::IDBObjectStoreOrIDBIndexOrIDBCursor;
 use crate::dom::bindings::error::{Error, Fallible, create_dom_exception};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
@@ -36,9 +38,8 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::indexeddb::idbcursor::{IterationParam, iterate_cursor};
 use crate::dom::indexeddb::idbcursorwithvalue::IDBCursorWithValue;
-use crate::dom::indexeddb::idbobjectstore::IDBObjectStore;
 use crate::dom::indexeddb::idbtransaction::IDBTransaction;
-use crate::indexeddb::key_type_to_jsval;
+use crate::indexeddb::{IDBSource, key_type_to_jsval};
 use crate::realms::enter_auto_realm;
 
 #[derive(Clone)]
@@ -396,7 +397,8 @@ pub struct IDBRequest {
     #[ignore_malloc_size_of = "mozjs"]
     result: Heap<JSVal>,
     error: MutNullableDom<DOMException>,
-    source: MutNullableDom<IDBObjectStore>,
+    #[ignore_malloc_size_of = "refcell"]
+    source: DomRefCell<Option<IDBObjectStoreOrIDBIndexOrIDBCursor>>,
     transaction: MutNullableDom<IDBTransaction>,
     ready_state: Cell<IDBRequestReadyState>,
 }
@@ -418,8 +420,8 @@ impl IDBRequest {
         reflect_dom_object_with_cx(Box::new(IDBRequest::new_inherited()), global, cx)
     }
 
-    pub fn set_source(&self, source: Option<&IDBObjectStore>) {
-        self.source.set(source);
+    pub fn set_source(&self, source: Option<IDBObjectStoreOrIDBIndexOrIDBCursor>) {
+        *self.source.borrow_mut() = source;
     }
 
     pub fn set_ready_state_done(&self) {
@@ -448,25 +450,26 @@ impl IDBRequest {
         self.transaction.set(None);
     }
 
-    fn is_done(&self) -> bool {
-        self.ready_state.get() == IDBRequestReadyState::Done
-    }
-
     pub(crate) fn transaction(&self) -> Option<DomRoot<IDBTransaction>> {
         self.transaction.get()
     }
 
+    fn is_done(&self) -> bool {
+        self.ready_state.get() == IDBRequestReadyState::Done
+    }
+
     // https://www.w3.org/TR/IndexedDB-3/#asynchronously-execute-a-request
-    pub fn execute_async<T, F>(
+    pub fn execute_async<S, F, T>(
         cx: &mut JSContext,
-        source: &IDBObjectStore,
+        source: &S,
         operation_fn: F,
         request: Option<DomRoot<IDBRequest>>,
         iteration_param: Option<IterationParam>,
     ) -> Fallible<DomRoot<IDBRequest>>
     where
-        T: Into<IdbResult> + for<'a> Deserialize<'a> + Serialize + Send + Sync + 'static,
+        S: IDBSource,
         F: FnOnce(GenericCallback<BackendResult<T>>) -> AsyncOperation,
+        T: Into<IdbResult> + for<'a> Deserialize<'a> + Serialize + Send + Sync + 'static,
     {
         // Step 1: Let transaction be the transaction associated with source.
         let transaction = source.transaction();
@@ -481,7 +484,7 @@ impl IDBRequest {
         // Step 3: If request was not given, let request be a new request with source as source.
         let request = request.unwrap_or_else(|| {
             let new_request = IDBRequest::new(cx, &global);
-            new_request.set_source(Some(source));
+            new_request.set_source(Some(source.as_source()));
             new_request.set_transaction(&transaction);
             new_request
         });
@@ -548,7 +551,7 @@ impl IDBRequest {
             .send(IndexedDBThreadMsg::Async(
                 global.origin().immutable().clone(),
                 String::from(transaction.get_db_name()),
-                String::from(source.get_name()),
+                String::from(source.object_store_name()),
                 transaction.get_serial_number(),
                 request_id,
                 transaction_mode,
@@ -594,8 +597,20 @@ impl IDBRequestMethods<crate::DomTypeHolder> for IDBRequest {
     }
 
     /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbrequest-source>
-    fn GetSource(&self) -> Option<DomRoot<IDBObjectStore>> {
-        self.source.get()
+    fn GetSource(&self) -> Option<IDBObjectStoreOrIDBIndexOrIDBCursor> {
+        // IDBObjectStoreOrIDBIndexOrIDBCursor doesn't implement Copy
+        match &*self.source.borrow() {
+            Some(IDBObjectStoreOrIDBIndexOrIDBCursor::IDBObjectStore(store)) => Some(
+                IDBObjectStoreOrIDBIndexOrIDBCursor::IDBObjectStore(DomRoot::from_ref(&**store)),
+            ),
+            Some(IDBObjectStoreOrIDBIndexOrIDBCursor::IDBIndex(index)) => Some(
+                IDBObjectStoreOrIDBIndexOrIDBCursor::IDBIndex(DomRoot::from_ref(&**index)),
+            ),
+            Some(IDBObjectStoreOrIDBIndexOrIDBCursor::IDBCursor(cursor)) => Some(
+                IDBObjectStoreOrIDBIndexOrIDBCursor::IDBCursor(DomRoot::from_ref(&**cursor)),
+            ),
+            None => None,
+        }
     }
 
     /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbrequest-transaction>

--- a/components/script/indexeddb.rs
+++ b/components/script/indexeddb.rs
@@ -21,11 +21,14 @@ use js::rust::wrappers2::{
 };
 use js::rust::{HandleValue, MutableHandleValue};
 use js::typedarray::{ArrayBuffer, ArrayBufferView, CreateWith};
+use script_bindings::root::DomRoot;
 use storage_traits::indexeddb::{BackendError, IndexedDBKeyRange, IndexedDBKeyType};
 
 use crate::dom::bindings::codegen::Bindings::BlobBinding::BlobMethods;
 use crate::dom::bindings::codegen::Bindings::FileBinding::FileMethods;
-use crate::dom::bindings::codegen::UnionTypes::StringOrStringSequence as StrOrStringSequence;
+use crate::dom::bindings::codegen::UnionTypes::{
+    IDBObjectStoreOrIDBIndexOrIDBCursor, StringOrStringSequence as StrOrStringSequence,
+};
 use crate::dom::bindings::conversions::{
     get_property_jsval, root_from_handlevalue, root_from_object,
 };
@@ -36,8 +39,44 @@ use crate::dom::bindings::utils::{
 };
 use crate::dom::blob::Blob;
 use crate::dom::file::File;
+use crate::dom::idbindex::IDBIndex;
 use crate::dom::idbkeyrange::IDBKeyRange;
-use crate::dom::idbobjectstore::KeyPath;
+use crate::dom::idbobjectstore::{IDBObjectStore, KeyPath};
+use crate::dom::idbtransaction::IDBTransaction;
+
+pub(crate) trait IDBSource {
+    fn transaction(&self) -> DomRoot<IDBTransaction>;
+    fn object_store_name(&self) -> DOMString;
+    fn as_source(&self) -> IDBObjectStoreOrIDBIndexOrIDBCursor;
+}
+
+impl IDBSource for IDBObjectStore {
+    fn transaction(&self) -> DomRoot<IDBTransaction> {
+        self.transaction()
+    }
+
+    fn object_store_name(&self) -> DOMString {
+        self.get_name()
+    }
+
+    fn as_source(&self) -> IDBObjectStoreOrIDBIndexOrIDBCursor {
+        IDBObjectStoreOrIDBIndexOrIDBCursor::IDBObjectStore(DomRoot::from_ref(self))
+    }
+}
+
+impl IDBSource for IDBIndex {
+    fn transaction(&self) -> DomRoot<IDBTransaction> {
+        self.object_store().transaction()
+    }
+
+    fn object_store_name(&self) -> DOMString {
+        self.object_store().get_name()
+    }
+
+    fn as_source(&self) -> IDBObjectStoreOrIDBIndexOrIDBCursor {
+        IDBObjectStoreOrIDBIndexOrIDBCursor::IDBIndex(DomRoot::from_ref(self))
+    }
+}
 use crate::script_runtime::CanGc;
 
 // https://www.w3.org/TR/IndexedDB-3/#convert-key-to-value
@@ -874,9 +913,11 @@ pub(crate) fn extract_key(
     // multiEntry flag is unset, and the result of running the steps to convert a value to a
     // multiEntry key with r otherwise. Rethrow any exceptions.
     let key = match multi_entry {
-        Some(true) => {
-            // TODO: implement convert_value_to_multientry_key
-            unimplemented!("multiEntry keys are not yet supported");
+        // TODO(arihant2math): implement multiEntry key conversion
+        Some(true) => match convert_value_to_key(cx, r.handle(), None)? {
+            ConversionResult::Valid(key) => key,
+            // Step 4. If key is invalid, return invalid.
+            ConversionResult::Invalid => return Ok(ExtractionResult::Invalid),
         },
         _ => match convert_value_to_key(cx, r.handle(), None)? {
             ConversionResult::Valid(key) => key,

--- a/components/script/indexeddb.rs
+++ b/components/script/indexeddb.rs
@@ -19,11 +19,14 @@ use js::rust::wrappers2::{
 };
 use js::rust::{HandleValue, MutableHandleValue};
 use js::typedarray::{ArrayBuffer, ArrayBufferView, CreateWith};
+use script_bindings::root::DomRoot;
 use storage_traits::indexeddb::{BackendError, IndexedDBKeyRange, IndexedDBKeyType};
 
 use crate::dom::bindings::codegen::Bindings::BlobBinding::BlobMethods;
 use crate::dom::bindings::codegen::Bindings::FileBinding::FileMethods;
-use crate::dom::bindings::codegen::UnionTypes::StringOrStringSequence as StrOrStringSequence;
+use crate::dom::bindings::codegen::UnionTypes::{
+    IDBObjectStoreOrIDBIndexOrIDBCursor, StringOrStringSequence as StrOrStringSequence,
+};
 use crate::dom::bindings::conversions::{
     get_property_jsval, root_from_handlevalue, root_from_object,
 };
@@ -32,8 +35,44 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::utils::{define_dictionary_property, has_own_property};
 use crate::dom::blob::Blob;
 use crate::dom::file::File;
+use crate::dom::idbindex::IDBIndex;
 use crate::dom::idbkeyrange::IDBKeyRange;
-use crate::dom::idbobjectstore::KeyPath;
+use crate::dom::idbobjectstore::{IDBObjectStore, KeyPath};
+use crate::dom::idbtransaction::IDBTransaction;
+
+pub(crate) trait IDBSource {
+    fn transaction(&self) -> DomRoot<IDBTransaction>;
+    fn object_store_name(&self) -> DOMString;
+    fn as_source(&self) -> IDBObjectStoreOrIDBIndexOrIDBCursor;
+}
+
+impl IDBSource for IDBObjectStore {
+    fn transaction(&self) -> DomRoot<IDBTransaction> {
+        self.transaction()
+    }
+
+    fn object_store_name(&self) -> DOMString {
+        self.get_name()
+    }
+
+    fn as_source(&self) -> IDBObjectStoreOrIDBIndexOrIDBCursor {
+        IDBObjectStoreOrIDBIndexOrIDBCursor::IDBObjectStore(DomRoot::from_ref(self))
+    }
+}
+
+impl IDBSource for IDBIndex {
+    fn transaction(&self) -> DomRoot<IDBTransaction> {
+        self.object_store().transaction()
+    }
+
+    fn object_store_name(&self) -> DOMString {
+        self.object_store().get_name()
+    }
+
+    fn as_source(&self) -> IDBObjectStoreOrIDBIndexOrIDBCursor {
+        IDBObjectStoreOrIDBIndexOrIDBCursor::IDBIndex(DomRoot::from_ref(self))
+    }
+}
 
 // https://www.w3.org/TR/IndexedDB-3/#convert-key-to-value
 #[expect(unsafe_code, deprecated)]
@@ -820,9 +859,11 @@ pub(crate) fn extract_key(
     // multiEntry flag is unset, and the result of running the steps to convert a value to a
     // multiEntry key with r otherwise. Rethrow any exceptions.
     let key = match multi_entry {
-        Some(true) => {
-            // TODO: implement convert_value_to_multientry_key
-            unimplemented!("multiEntry keys are not yet supported");
+        // TODO(arihant2math): implement multiEntry key conversion
+        Some(true) => match convert_value_to_key(cx, r.handle(), None)? {
+            ConversionResult::Valid(key) => key,
+            // Step 4. If key is invalid, return invalid.
+            ConversionResult::Invalid => return Ok(ExtractionResult::Invalid),
         },
         _ => match convert_value_to_key(cx, r.handle(), None)? {
             ConversionResult::Valid(key) => key,

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -615,6 +615,7 @@ DOMInterfaces = {
 
 'IDBIndex': {
     'canGc': ['KeyPath'],
+    'cx': ['Count', 'Get', 'GetKey'],
 },
 
 'IDBKeyRange': {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -795,7 +795,7 @@ DOMInterfaces = {
 },
 
 'IDBIndex': {
-    'cx': ['KeyPath'],
+    'cx': ['Count', 'Get', 'GetKey', 'KeyPath'],
 },
 
 'IDBKeyRange': {

--- a/components/script_bindings/webidls/IDBIndex.webidl
+++ b/components/script_bindings/webidls/IDBIndex.webidl
@@ -15,14 +15,14 @@ interface IDBIndex {
   readonly attribute boolean multiEntry;
   readonly attribute boolean unique;
 
-  // [NewObject] IDBRequest get(any query);
-  // [NewObject] IDBRequest getKey(any query);
+  [Throws, NewObject] IDBRequest get(any query);
+  [Throws, NewObject] IDBRequest getKey(any query);
   // [NewObject] IDBRequest getAll(optional any queryOrOptions,
   //                               optional [EnforceRange] unsigned long count);
   // [NewObject] IDBRequest getAllKeys(optional any queryOrOptions,
   //                                   optional [EnforceRange] unsigned long count);
   // [NewObject] IDBRequest getAllRecords(optional IDBGetAllOptions options = {});
-  // [NewObject] IDBRequest count(optional any query);
+  [Throws, NewObject] IDBRequest count(optional any query);
 
   // [NewObject] IDBRequest openCursor(optional any query,
   //                                   optional IDBCursorDirection direction = "next");

--- a/components/script_bindings/webidls/IDBRequest.webidl
+++ b/components/script_bindings/webidls/IDBRequest.webidl
@@ -12,8 +12,7 @@
 interface IDBRequest : EventTarget {
   [Throws] readonly attribute any result;
   [Throws] readonly attribute DOMException? error;
-  // readonly attribute (IDBObjectStore or IDBIndex or IDBCursor)? source;
-  readonly attribute IDBObjectStore? source;
+  readonly attribute (IDBObjectStore or IDBIndex or IDBCursor)? source;
   readonly attribute IDBTransaction? transaction;
   readonly attribute IDBRequestReadyState readyState;
 

--- a/components/shared/storage/indexeddb.rs
+++ b/components/shared/storage/indexeddb.rs
@@ -311,6 +311,36 @@ pub enum AsyncReadOnlyOperation {
         callback: GenericCallback<BackendResult<Vec<IndexedDBRecord>>>,
         key_range: IndexedDBKeyRange,
     },
+
+    IndexGetKey {
+        callback: GenericCallback<BackendResult<Option<IndexedDBKeyType>>>,
+        index_name: String,
+        key_range: IndexedDBKeyRange,
+    },
+    IndexGetItem {
+        callback: GenericCallback<BackendResult<Option<Vec<u8>>>>,
+        index_name: String,
+        key_range: IndexedDBKeyRange,
+    },
+
+    IndexGetAllKeys {
+        callback: GenericCallback<BackendResult<Vec<IndexedDBKeyType>>>,
+        index_name: String,
+        key_range: IndexedDBKeyRange,
+        count: Option<u32>,
+    },
+    IndexGetAllItems {
+        callback: GenericCallback<BackendResult<Vec<Vec<u8>>>>,
+        index_name: String,
+        key_range: IndexedDBKeyRange,
+        count: Option<u32>,
+    },
+
+    IndexCount {
+        callback: GenericCallback<BackendResult<u64>>,
+        index_name: String,
+        key_range: IndexedDBKeyRange,
+    },
 }
 
 impl AsyncReadOnlyOperation {
@@ -322,6 +352,11 @@ impl AsyncReadOnlyOperation {
             Self::GetAllItems { callback, .. } => callback.send(Err(error)),
             Self::Count { callback, .. } => callback.send(Err(error)),
             Self::Iterate { callback, .. } => callback.send(Err(error)),
+            Self::IndexGetKey { callback, .. } => callback.send(Err(error)),
+            Self::IndexGetItem { callback, .. } => callback.send(Err(error)),
+            Self::IndexGetAllKeys { callback, .. } => callback.send(Err(error)),
+            Self::IndexGetAllItems { callback, .. } => callback.send(Err(error)),
+            Self::IndexCount { callback, .. } => callback.send(Err(error)),
         };
     }
 }
@@ -336,6 +371,8 @@ pub enum AsyncReadWriteOperation {
         should_overwrite: bool,
         /// New object store key generator current number to persist if the put succeeds.
         key_generator_current_number: Option<i32>,
+        /// Keys of indexes, (index_name, unique, key)
+        index_key_value: Vec<(String, bool, IndexedDBKeyType)>,
     },
 
     /// Removes the key/value pair for the given key in the associated idb data

--- a/components/shared/storage/indexeddb.rs
+++ b/components/shared/storage/indexeddb.rs
@@ -313,6 +313,36 @@ pub enum AsyncReadOnlyOperation {
         callback: GenericCallback<BackendResult<Vec<IndexedDBRecord>>>,
         key_range: IndexedDBKeyRange,
     },
+
+    IndexGetKey {
+        callback: GenericCallback<BackendResult<Option<IndexedDBKeyType>>>,
+        index_name: String,
+        key_range: IndexedDBKeyRange,
+    },
+    IndexGetItem {
+        callback: GenericCallback<BackendResult<Option<Vec<u8>>>>,
+        index_name: String,
+        key_range: IndexedDBKeyRange,
+    },
+
+    IndexGetAllKeys {
+        callback: GenericCallback<BackendResult<Vec<IndexedDBKeyType>>>,
+        index_name: String,
+        key_range: IndexedDBKeyRange,
+        count: Option<u32>,
+    },
+    IndexGetAllItems {
+        callback: GenericCallback<BackendResult<Vec<Vec<u8>>>>,
+        index_name: String,
+        key_range: IndexedDBKeyRange,
+        count: Option<u32>,
+    },
+
+    IndexCount {
+        callback: GenericCallback<BackendResult<u64>>,
+        index_name: String,
+        key_range: IndexedDBKeyRange,
+    },
 }
 
 impl AsyncReadOnlyOperation {
@@ -324,6 +354,11 @@ impl AsyncReadOnlyOperation {
             Self::GetAllItems { callback, .. } => callback.send(Err(error)),
             Self::Count { callback, .. } => callback.send(Err(error)),
             Self::Iterate { callback, .. } => callback.send(Err(error)),
+            Self::IndexGetKey { callback, .. } => callback.send(Err(error)),
+            Self::IndexGetItem { callback, .. } => callback.send(Err(error)),
+            Self::IndexGetAllKeys { callback, .. } => callback.send(Err(error)),
+            Self::IndexGetAllItems { callback, .. } => callback.send(Err(error)),
+            Self::IndexCount { callback, .. } => callback.send(Err(error)),
         };
     }
 }
@@ -338,6 +373,8 @@ pub enum AsyncReadWriteOperation {
         should_overwrite: bool,
         /// New object store key generator current number to persist if the put succeeds.
         key_generator_current_number: Option<i64>,
+        /// Keys of indexes, (index_name, unique, key)
+        index_key_value: Vec<(String, bool, IndexedDBKeyType)>,
     },
 
     /// Removes the key/value pair for the given key in the associated idb data

--- a/components/storage/indexeddb/engines/sqlite.rs
+++ b/components/storage/indexeddb/engines/sqlite.rs
@@ -7,7 +7,9 @@ use std::sync::Arc;
 use log::{error, info, warn};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use rusqlite::{Connection, Error, OptionalExtension, params};
-use sea_query::{Condition, Expr, ExprTrait, IntoCondition, SqliteQueryBuilder};
+use sea_query::{
+    Condition, Expr, ExprTrait, IntoColumnRef, IntoCondition, Order, SqliteQueryBuilder,
+};
 use sea_query_rusqlite::RusqliteBinder;
 use servo_base::threadpool::ThreadPool;
 use storage_traits::indexeddb::{
@@ -23,34 +25,33 @@ use crate::shared::{DB_INIT_PRAGMAS, DB_PRAGMAS};
 mod create;
 mod database_model;
 mod encoding;
+pub mod index_data_model;
 mod object_data_model;
 mod object_store_index_model;
 mod object_store_model;
 
-fn range_to_query(range: IndexedDBKeyRange) -> Condition {
+fn range_to_query<T: Copy + IntoColumnRef>(col: T, range: IndexedDBKeyRange) -> Condition {
     // Special case for optimization
     if let Some(singleton) = range.as_singleton() {
         let encoded = encoding::serialize(singleton);
-        return Expr::column(object_data_model::Column::Key)
-            .eq(encoded)
-            .into_condition();
+        return Expr::column(col).eq(encoded).into_condition();
     }
     let mut parts = vec![];
     if let Some(upper) = range.upper.as_ref() {
         let upper_bytes = encoding::serialize(upper);
         let query = if range.upper_open {
-            Expr::column(object_data_model::Column::Key).lt(upper_bytes)
+            Expr::column(col).lt(upper_bytes)
         } else {
-            Expr::column(object_data_model::Column::Key).lte(upper_bytes)
+            Expr::column(col).lte(upper_bytes)
         };
         parts.push(query);
     }
     if let Some(lower) = range.lower.as_ref() {
         let lower_bytes = encoding::serialize(lower);
         let query = if range.lower_open {
-            Expr::column(object_data_model::Column::Key).gt(lower_bytes)
+            Expr::column(col).gt(lower_bytes)
         } else {
-            Expr::column(object_data_model::Column::Key).gte(lower_bytes)
+            Expr::column(col).gte(lower_bytes)
         };
         parts.push(query);
     }
@@ -147,12 +148,28 @@ impl SqliteEngine {
         Ok(connection)
     }
 
+    /// Gets the associated index model for a given object store and index name
+    /// Returns `Ok(None)` if no such index exists.
+    fn get_index_model(
+        connection: &Connection,
+        store: object_store_model::Model,
+        index: String,
+    ) -> Result<Option<object_store_index_model::Model>, Error> {
+        connection
+            .query_one(
+                "SELECT * FROM object_store_index WHERE object_store_id = ? AND name = ?",
+                params![store.id, index],
+                |row| object_store_index_model::Model::try_from(row),
+            )
+            .optional()
+    }
+
     fn get(
         connection: &Connection,
         store: object_store_model::Model,
         key_range: IndexedDBKeyRange,
     ) -> Result<Option<object_data_model::Model>, Error> {
-        let query = range_to_query(key_range);
+        let query = range_to_query(object_data_model::Column::Key, key_range);
         let (sql, values) = sea_query::Query::select()
             .from(object_data_model::Column::Table)
             .columns(vec![
@@ -171,12 +188,78 @@ impl SqliteEngine {
             .optional()
     }
 
+    fn index_get(
+        connection: &Connection,
+        store: object_store_model::Model,
+        index: String,
+        key_range: IndexedDBKeyRange,
+    ) -> Result<Option<index_data_model::Model>, Error> {
+        let Some(index_model) = Self::get_index_model(connection, store, index)? else {
+            return Ok(None);
+        };
+        let query = range_to_query(index_data_model::Column::IndexKey, key_range);
+        let (sql, values) = sea_query::Query::select()
+            .from(index_data_model::Column::Table)
+            .columns(vec![
+                index_data_model::Column::IndexId,
+                index_data_model::Column::IndexKey,
+                index_data_model::Column::ObjectKey,
+            ])
+            .and_where(query.and(Expr::col(index_data_model::Column::IndexId).is(index_model.id)))
+            .order_by(index_data_model::Column::IndexKey, Order::Asc)
+            .order_by(index_data_model::Column::ObjectKey, Order::Asc)
+            .limit(1)
+            .build_rusqlite(SqliteQueryBuilder);
+        connection
+            .prepare(&sql)?
+            .query_one(&*values.as_params(), |row| {
+                index_data_model::Model::try_from(row)
+            })
+            .optional()
+    }
+
+    fn get_by_serialized_key(
+        connection: &Connection,
+        store: object_store_model::Model,
+        key: &[u8],
+    ) -> Result<Option<object_data_model::Model>, Error> {
+        connection
+            .prepare("SELECT * FROM object_data WHERE object_store_id = ? AND key = ?")?
+            .query_row(params![store.id, key], |row| {
+                object_data_model::Model::try_from(row)
+            })
+            .optional()
+    }
+
+    fn delete_index_entries_for_object_key(
+        connection: &Connection,
+        store: object_store_model::Model,
+        object_key: &[u8],
+    ) -> Result<(), Error> {
+        connection.execute(
+            "DELETE FROM index_data WHERE object_key = ? AND index_id IN \
+             (SELECT id FROM object_store_index WHERE object_store_id = ?)",
+            params![object_key, store.id],
+        )?;
+        Ok(())
+    }
+
     fn get_key(
         connection: &Connection,
         store: object_store_model::Model,
         key_range: IndexedDBKeyRange,
     ) -> Result<Option<Vec<u8>>, Error> {
         Self::get(connection, store, key_range).map(|opt| opt.map(|model| model.key))
+    }
+
+    fn index_get_key(
+        connection: &Connection,
+        store: object_store_model::Model,
+        index_name: String,
+        key_range: IndexedDBKeyRange,
+    ) -> Result<Option<Vec<u8>>, Error> {
+        Self::index_get(connection, store, index_name, key_range)
+            .map(|opt| opt.map(|model| model.object_key))
     }
 
     fn get_item(
@@ -187,13 +270,27 @@ impl SqliteEngine {
         Self::get(connection, store, key_range).map(|opt| opt.map(|model| model.data))
     }
 
+    fn index_get_item(
+        connection: &Connection,
+        store: object_store_model::Model,
+        index_name: String,
+        key_range: IndexedDBKeyRange,
+    ) -> Result<Option<Vec<u8>>, Error> {
+        let Some(index_data) = Self::index_get(connection, store.clone(), index_name, key_range)?
+        else {
+            return Ok(None);
+        };
+        Self::get_by_serialized_key(connection, store, &index_data.object_key)
+            .map(|opt| opt.map(|model| model.data))
+    }
+
     fn get_all(
         connection: &Connection,
         store: object_store_model::Model,
         key_range: IndexedDBKeyRange,
         count: Option<u32>,
     ) -> Result<Vec<object_data_model::Model>, Error> {
-        let query = range_to_query(key_range);
+        let query = range_to_query(object_data_model::Column::Key, key_range);
         let mut sql_query = sea_query::Query::select();
         sql_query
             .from(object_data_model::Column::Table)
@@ -216,6 +313,41 @@ impl SqliteEngine {
         Ok(models)
     }
 
+    fn index_get_all(
+        connection: &Connection,
+        store: object_store_model::Model,
+        index_name: String,
+        key_range: IndexedDBKeyRange,
+        count: Option<u32>,
+    ) -> Result<Vec<index_data_model::Model>, Error> {
+        let Some(index_model) = Self::get_index_model(connection, store, index_name)? else {
+            return Ok(vec![]);
+        };
+        let query = range_to_query(index_data_model::Column::IndexKey, key_range);
+        let mut sql_query = sea_query::Query::select();
+        sql_query
+            .from(index_data_model::Column::Table)
+            .columns(vec![
+                index_data_model::Column::IndexId,
+                index_data_model::Column::IndexKey,
+                index_data_model::Column::ObjectKey,
+            ])
+            .and_where(query.and(Expr::col(index_data_model::Column::IndexId).is(index_model.id)))
+            .order_by(index_data_model::Column::IndexKey, Order::Asc)
+            .order_by(index_data_model::Column::ObjectKey, Order::Asc);
+        if let Some(count) = count {
+            sql_query.limit(count as u64);
+        }
+        let (sql, values) = sql_query.build_rusqlite(SqliteQueryBuilder);
+        let mut stmt = connection.prepare(&sql)?;
+        let models = stmt
+            .query_and_then(&*values.as_params(), |row| {
+                index_data_model::Model::try_from(row)
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(models)
+    }
+
     fn get_all_keys(
         connection: &Connection,
         store: object_store_model::Model,
@@ -226,6 +358,17 @@ impl SqliteEngine {
             .map(|models| models.into_iter().map(|m| m.key).collect())
     }
 
+    fn index_get_all_keys(
+        connection: &Connection,
+        store: object_store_model::Model,
+        index: String,
+        key_range: IndexedDBKeyRange,
+        count: Option<u32>,
+    ) -> Result<Vec<Vec<u8>>, Error> {
+        Self::index_get_all(connection, store, index, key_range, count)
+            .map(|models| models.into_iter().map(|m| m.object_key).collect())
+    }
+
     fn get_all_items(
         connection: &Connection,
         store: object_store_model::Model,
@@ -234,6 +377,25 @@ impl SqliteEngine {
     ) -> Result<Vec<Vec<u8>>, Error> {
         Self::get_all(connection, store, key_range, count)
             .map(|models| models.into_iter().map(|m| m.data).collect())
+    }
+
+    fn index_get_all_items(
+        connection: &Connection,
+        store: object_store_model::Model,
+        index: String,
+        key_range: IndexedDBKeyRange,
+        count: Option<u32>,
+    ) -> Result<Vec<Vec<u8>>, Error> {
+        let index_models = Self::index_get_all(connection, store.clone(), index, key_range, count)?;
+        let mut items = Vec::with_capacity(index_models.len());
+        for model in index_models {
+            if let Some(item) =
+                Self::get_by_serialized_key(connection, store.clone(), &model.object_key)?
+            {
+                items.push(item.data);
+            }
+        }
+        Ok(items)
     }
 
     #[expect(clippy::type_complexity)]
@@ -253,6 +415,7 @@ impl SqliteEngine {
         value: Vec<u8>,
         should_overwrite: bool,
         key_generator_current_number: Option<i32>,
+        index_key_value: Vec<(String, bool, IndexedDBKeyType)>,
     ) -> Result<PutItemResult, Error> {
         let no_overwrite = !should_overwrite;
         let serialized_key: Vec<u8> = encoding::serialize(&key);
@@ -264,20 +427,50 @@ impl SqliteEngine {
                 })
                 .optional()
             })?;
-        if existing_item.is_some() {
-            if no_overwrite {
-                return Ok(PutItemResult::CannotOverwrite);
+        if existing_item.is_some() && no_overwrite {
+            return Ok(PutItemResult::CannotOverwrite);
+        }
+
+        let mut index_entries = Vec::with_capacity(index_key_value.len());
+        for (index_name, _unique, index_key) in index_key_value {
+            let index_model = Self::get_index_model(connection, store.clone(), index_name)?
+                .ok_or(Error::QueryReturnedNoRows)?;
+            let serialized_index_key = encoding::serialize(&index_key);
+            if index_model.unique_index {
+                let has_conflict: bool = connection.query_row(
+                    "SELECT EXISTS(SELECT 1 FROM index_data WHERE index_id = ? AND index_key = ? AND object_key != ?)",
+                    params![index_model.id, &serialized_index_key, &serialized_key],
+                    |row| row.get(0),
+                )?;
+                if has_conflict {
+                    return Err(Error::SqliteFailure(
+                        rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_CONSTRAINT_UNIQUE),
+                        Some("Unique index constraint violated".to_string()),
+                    ));
+                }
             }
+            index_entries.push((index_model.id, serialized_index_key));
+        }
+
+        if existing_item.is_some() {
             // Preserve `put()` semantics by replacing the stored value when the primary
             // key already exists.
             connection.execute(
                 "UPDATE object_data SET data = ? WHERE object_store_id = ? AND key = ?",
                 params![value, store.id, serialized_key],
             )?;
+            Self::delete_index_entries_for_object_key(connection, store.clone(), &serialized_key)?;
         } else {
             connection.execute(
                 "INSERT INTO object_data (object_store_id, key, data) VALUES (?, ?, ?)",
                 params![store.id, serialized_key, value],
+            )?;
+        }
+
+        for (index_id, serialized_index_key) in index_entries {
+            connection.execute(
+                "INSERT INTO index_data (index_id, index_key, object_key) VALUES (?, ?, ?)",
+                params![index_id, serialized_index_key, &serialized_key],
             )?;
         }
         if let Some(next_key_generator_current_number) = key_generator_current_number {
@@ -294,7 +487,11 @@ impl SqliteEngine {
         store: object_store_model::Model,
         key_range: IndexedDBKeyRange,
     ) -> Result<(), Error> {
-        let query = range_to_query(key_range);
+        let keys = Self::get_all_keys(connection, store.clone(), key_range.clone(), None)?;
+        for key in &keys {
+            Self::delete_index_entries_for_object_key(connection, store.clone(), key)?;
+        }
+        let query = range_to_query(object_data_model::Column::Key, key_range);
         let (sql, values) = sea_query::Query::delete()
             .from_table(object_data_model::Column::Table)
             .and_where(query.and(Expr::col(object_data_model::Column::ObjectStoreId).is(store.id)))
@@ -303,11 +500,20 @@ impl SqliteEngine {
         Ok(())
     }
 
+    /// <https://www.w3.org/TR/IndexedDB/#clear-an-object-store>
     fn clear(connection: &Connection, store: object_store_model::Model) -> Result<(), Error> {
+        // Step 1. Remove all records from store.
         connection.execute(
             "DELETE FROM object_data WHERE object_store_id = ?",
             params![store.id],
         )?;
+        // Step 2. In all indexes which reference store, remove all records.
+        connection.execute(
+            "DELETE FROM index_data WHERE index_id IN \
+             (SELECT id FROM object_store_index WHERE object_store_id = ?)",
+            params![store.id],
+        )?;
+        // Step 3. Return undefined.
         Ok(())
     }
 
@@ -316,11 +522,31 @@ impl SqliteEngine {
         store: object_store_model::Model,
         key_range: IndexedDBKeyRange,
     ) -> Result<usize, Error> {
-        let query = range_to_query(key_range);
+        let query = range_to_query(object_data_model::Column::Key, key_range);
         let (sql, values) = sea_query::Query::select()
             .expr(Expr::col(object_data_model::Column::Key).count())
             .from(object_data_model::Column::Table)
             .and_where(query.and(Expr::col(object_data_model::Column::ObjectStoreId).is(store.id)))
+            .build_rusqlite(SqliteQueryBuilder);
+        connection
+            .prepare(&sql)?
+            .query_row(&*values.as_params(), |row| row.get(0))
+            .map(|count: i64| count as usize)
+    }
+
+    fn index_count(
+        connection: &Connection,
+        store: object_store_model::Model,
+        index_name: String,
+        key_range: IndexedDBKeyRange,
+    ) -> Result<usize, Error> {
+        let index = Self::get_index_model(connection, store, index_name)?
+            .ok_or_else(|| Error::QueryReturnedNoRows)?;
+        let query = range_to_query(index_data_model::Column::IndexKey, key_range);
+        let (sql, values) = sea_query::Query::select()
+            .expr(Expr::col(index_data_model::Column::IndexKey).count())
+            .from(index_data_model::Column::Table)
+            .and_where(query.and(Expr::col(index_data_model::Column::IndexId).is(index.id)))
             .build_rusqlite(SqliteQueryBuilder);
         connection
             .prepare(&sql)?
@@ -363,11 +589,8 @@ impl KvsEngine for SqliteEngine {
         let object_store = Self::object_store_by_name(&self.connection, store_name)?;
 
         self.connection.execute(
-            "DELETE FROM index_data WHERE object_store_id = ?",
-            params![object_store.id],
-        )?;
-        self.connection.execute(
-            "DELETE FROM unique_index_data WHERE object_store_id = ?",
+            "DELETE FROM index_data WHERE index_id IN \
+             (SELECT id FROM object_store_index WHERE object_store_id = ?)",
             params![object_store.id],
         )?;
         self.connection.execute(
@@ -461,6 +684,7 @@ impl KvsEngine for SqliteEngine {
                         value,
                         should_overwrite,
                         key_generator_current_number,
+                        index_key_value
                     }) => {
                         let (key, key_generator_current_number) = match key {
                             Some(key) => (key, key_generator_current_number),
@@ -499,6 +723,7 @@ impl KvsEngine for SqliteEngine {
                                 value,
                                 should_overwrite,
                                 key_generator_current_number,
+                                index_key_value
                             )
                             .map_err(|e| BackendError::DbErr(format!("{:?}", e))),
                         );
@@ -588,6 +813,77 @@ impl KvsEngine for SqliteEngine {
                         let _ = callback.send(
                             Self::get_key(&connection, object_store, key_range)
                                 .map(|key| key.map(|k| encoding::deserialize(&k).unwrap()))
+                                .map_err(|e| BackendError::DbErr(format!("{:?}", e))),
+                        );
+                    },
+                    AsyncOperation::ReadOnly(AsyncReadOnlyOperation::IndexGetKey {
+                                                 callback,
+                                                 index_name,
+                                                 key_range,
+                                             }) => {
+                        let _ = callback.send(
+                            Self::index_get_key(&connection, object_store, index_name, key_range)
+                                .map(|key| key.map(|k| encoding::deserialize(&k).unwrap()))
+                                .map_err(|e| BackendError::DbErr(format!("{:?}", e))),
+                        );
+                    },
+                    AsyncOperation::ReadOnly(AsyncReadOnlyOperation::IndexGetItem {
+                                                 callback,
+                                                 index_name,
+                                                 key_range,
+                                             }) => {
+                        let _ = callback.send(
+                            Self::index_get_item(&connection, object_store, index_name, key_range)
+                                .map_err(|e| BackendError::DbErr(format!("{:?}", e))),
+                        );
+                    },
+                    AsyncOperation::ReadOnly(AsyncReadOnlyOperation::IndexGetAllKeys {
+                                                 callback,
+                                                 index_name,
+                                                 key_range,
+                                                 count,
+                                             }) => {
+                        let _ = callback.send(
+                            Self::index_get_all_keys(
+                                &connection,
+                                object_store,
+                                index_name,
+                                key_range,
+                                count,
+                            )
+                                .map(|keys| {
+                                    keys.into_iter()
+                                        .map(|k| encoding::deserialize(&k).unwrap())
+                                        .collect()
+                                })
+                                .map_err(|e| BackendError::DbErr(format!("{:?}", e))),
+                        );
+                    },
+                    AsyncOperation::ReadOnly(AsyncReadOnlyOperation::IndexGetAllItems {
+                                                 callback,
+                                                 index_name,
+                                                 key_range,
+                                                 count,
+                                             }) => {
+                        let _ = callback.send(
+                            Self::index_get_all_items(
+                                &connection,
+                                object_store,
+                                index_name,
+                                key_range,
+                                count,
+                            )
+                                .map_err(|e| BackendError::DbErr(format!("{:?}", e))),
+                        );
+                    },
+                    AsyncOperation::ReadOnly(AsyncReadOnlyOperation::IndexCount {
+                                                 callback,
+                                                 index_name,
+                                                 key_range,
+                                             }) => {
+                        let _ = callback.send(
+                            Self::index_count(&connection, object_store, index_name, key_range)
+                                .map(|r| r as u64)
                                 .map_err(|e| BackendError::DbErr(format!("{:?}", e))),
                         );
                     },
@@ -702,11 +998,25 @@ impl KvsEngine for SqliteEngine {
             |r| Ok(object_store_model::Model::try_from(r).unwrap()),
         )?;
 
-        // Delete the index if it exists
-        let _ = self.connection.execute(
-            "DELETE FROM object_store_index WHERE name = ? AND object_store_id = ?",
-            params![index_name, object_store.id],
-        )?;
+        let index_id: Option<i32> = self
+            .connection
+            .query_row(
+                "SELECT id FROM object_store_index WHERE name = ? AND object_store_id = ?",
+                params![index_name, object_store.id],
+                |row| row.get(0),
+            )
+            .optional()?;
+
+        if let Some(index_id) = index_id {
+            self.connection.execute(
+                "DELETE FROM index_data WHERE index_id = ?",
+                params![index_id],
+            )?;
+            self.connection.execute(
+                "DELETE FROM object_store_index WHERE id = ?",
+                params![index_id],
+            )?;
+        }
         Ok(())
     }
 
@@ -960,6 +1270,14 @@ mod tests {
 
         db.create_store("test_store", None, false)
             .expect("Failed to create store");
+        db.create_index(
+            "test_store",
+            "by_value".to_string(),
+            KeyPath::String("value".to_string()),
+            false,
+            false,
+        )
+        .expect("Failed to create index");
         let object_store = SqliteEngine::object_store_by_name(&db.connection, "test_store")
             .expect("Failed to fetch store metadata");
         SqliteEngine::put_item(
@@ -969,6 +1287,11 @@ mod tests {
             vec![1, 2, 3],
             true,
             None,
+            vec![(
+                "by_value".to_string(),
+                false,
+                IndexedDBKeyType::String("alpha".to_string()),
+            )],
         )
         .expect("Failed to insert item");
 
@@ -982,6 +1305,12 @@ mod tests {
             .expect("Failed to count rows before delete");
         assert_eq!(row_count_before, 1);
 
+        let index_row_count_before: i64 = db
+            .connection
+            .query_row("SELECT COUNT(*) FROM index_data", [], |row| row.get(0))
+            .expect("Failed to count index rows before delete");
+        assert_eq!(index_row_count_before, 1);
+
         db.delete_store("test_store")
             .expect("Failed to delete store");
 
@@ -994,6 +1323,362 @@ mod tests {
             )
             .expect("Failed to count rows after delete");
         assert_eq!(row_count_after, 0);
+
+        let index_row_count_after: i64 = db
+            .connection
+            .query_row("SELECT COUNT(*) FROM index_data", [], |row| row.get(0))
+            .expect("Failed to count index rows after delete");
+        assert_eq!(index_row_count_after, 0);
+    }
+
+    #[test]
+    fn test_index_reads_and_unique_constraints() {
+        let base_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let thread_pool = get_pool();
+        let db = SqliteEngine::new(
+            base_dir.path(),
+            &IndexedDBDescription {
+                name: "test_db".to_string(),
+                origin: test_origin(),
+            },
+            thread_pool,
+        )
+        .unwrap();
+
+        db.create_store("test_store", None, false)
+            .expect("Failed to create store");
+        assert_eq!(
+            db.create_index(
+                "test_store",
+                "by_value".to_string(),
+                KeyPath::String("value".to_string()),
+                false,
+                false,
+            )
+            .expect("Failed to create value index"),
+            CreateObjectResult::Created
+        );
+        assert_eq!(
+            db.create_index(
+                "test_store",
+                "by_unique".to_string(),
+                KeyPath::String("unique".to_string()),
+                true,
+                false,
+            )
+            .expect("Failed to create unique index"),
+            CreateObjectResult::Created
+        );
+
+        let store = SqliteEngine::object_store_by_name(&db.connection, "test_store")
+            .expect("Failed to get object store");
+
+        SqliteEngine::put_item(
+            &db.connection,
+            store.clone(),
+            IndexedDBKeyType::Number(1.0),
+            vec![1],
+            false,
+            None,
+            vec![
+                (
+                    "by_value".to_string(),
+                    false,
+                    IndexedDBKeyType::String("alpha".to_string()),
+                ),
+                (
+                    "by_unique".to_string(),
+                    true,
+                    IndexedDBKeyType::String("email-1".to_string()),
+                ),
+            ],
+        )
+        .expect("Failed to insert first indexed item");
+        SqliteEngine::put_item(
+            &db.connection,
+            store.clone(),
+            IndexedDBKeyType::Number(2.0),
+            vec![2],
+            false,
+            None,
+            vec![
+                (
+                    "by_value".to_string(),
+                    false,
+                    IndexedDBKeyType::String("alpha".to_string()),
+                ),
+                (
+                    "by_unique".to_string(),
+                    true,
+                    IndexedDBKeyType::String("email-2".to_string()),
+                ),
+            ],
+        )
+        .expect("Failed to insert second indexed item");
+
+        let key = SqliteEngine::index_get_key(
+            &db.connection,
+            store.clone(),
+            "by_value".to_string(),
+            IndexedDBKeyRange::only(IndexedDBKeyType::String("alpha".to_string())),
+        )
+        .expect("Failed to get indexed key")
+        .map(|key| encoding::deserialize(&key).unwrap());
+        assert_eq!(key, Some(IndexedDBKeyType::Number(1.0)));
+
+        let item = SqliteEngine::index_get_item(
+            &db.connection,
+            store.clone(),
+            "by_value".to_string(),
+            IndexedDBKeyRange::only(IndexedDBKeyType::String("alpha".to_string())),
+        )
+        .expect("Failed to get indexed item");
+        assert_eq!(item, Some(vec![1]));
+
+        let keys = SqliteEngine::index_get_all_keys(
+            &db.connection,
+            store.clone(),
+            "by_value".to_string(),
+            IndexedDBKeyRange::only(IndexedDBKeyType::String("alpha".to_string())),
+            None,
+        )
+        .expect("Failed to get indexed keys")
+        .into_iter()
+        .map(|key| encoding::deserialize(&key).unwrap())
+        .collect::<Vec<_>>();
+        assert_eq!(
+            keys,
+            vec![IndexedDBKeyType::Number(1.0), IndexedDBKeyType::Number(2.0)]
+        );
+
+        let items = SqliteEngine::index_get_all_items(
+            &db.connection,
+            store.clone(),
+            "by_value".to_string(),
+            IndexedDBKeyRange::only(IndexedDBKeyType::String("alpha".to_string())),
+            None,
+        )
+        .expect("Failed to get indexed items");
+        assert_eq!(items, vec![vec![1], vec![2]]);
+
+        let count = SqliteEngine::index_count(
+            &db.connection,
+            store.clone(),
+            "by_value".to_string(),
+            IndexedDBKeyRange::only(IndexedDBKeyType::String("alpha".to_string())),
+        )
+        .expect("Failed to count indexed entries");
+        assert_eq!(count, 2);
+
+        SqliteEngine::put_item(
+            &db.connection,
+            store.clone(),
+            IndexedDBKeyType::Number(1.0),
+            vec![10],
+            true,
+            None,
+            vec![
+                (
+                    "by_value".to_string(),
+                    false,
+                    IndexedDBKeyType::String("beta".to_string()),
+                ),
+                (
+                    "by_unique".to_string(),
+                    true,
+                    IndexedDBKeyType::String("email-1b".to_string()),
+                ),
+            ],
+        )
+        .expect("Failed to overwrite indexed item");
+
+        let alpha_count = SqliteEngine::index_count(
+            &db.connection,
+            store.clone(),
+            "by_value".to_string(),
+            IndexedDBKeyRange::only(IndexedDBKeyType::String("alpha".to_string())),
+        )
+        .expect("Failed to count alpha indexed entries");
+        assert_eq!(alpha_count, 1);
+
+        let beta_item = SqliteEngine::index_get_item(
+            &db.connection,
+            store.clone(),
+            "by_value".to_string(),
+            IndexedDBKeyRange::only(IndexedDBKeyType::String("beta".to_string())),
+        )
+        .expect("Failed to get beta indexed item");
+        assert_eq!(beta_item, Some(vec![10]));
+
+        let duplicate_unique_result = SqliteEngine::put_item(
+            &db.connection,
+            store,
+            IndexedDBKeyType::Number(3.0),
+            vec![3],
+            false,
+            None,
+            vec![(
+                "by_unique".to_string(),
+                true,
+                IndexedDBKeyType::String("email-2".to_string()),
+            )],
+        );
+        assert!(duplicate_unique_result.is_err());
+    }
+
+    #[test]
+    fn test_index_cleanup_and_store_scoped_names() {
+        let base_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let thread_pool = get_pool();
+        let db = SqliteEngine::new(
+            base_dir.path(),
+            &IndexedDBDescription {
+                name: "test_db".to_string(),
+                origin: test_origin(),
+            },
+            thread_pool,
+        )
+        .unwrap();
+
+        db.create_store("store_a", None, false)
+            .expect("Failed to create first store");
+        db.create_store("store_b", None, false)
+            .expect("Failed to create second store");
+        assert_eq!(
+            db.create_index(
+                "store_a",
+                "shared_name".to_string(),
+                KeyPath::String("a".to_string()),
+                false,
+                false,
+            )
+            .expect("Failed to create first shared-name index"),
+            CreateObjectResult::Created
+        );
+        assert_eq!(
+            db.create_index(
+                "store_b",
+                "shared_name".to_string(),
+                KeyPath::String("b".to_string()),
+                false,
+                false,
+            )
+            .expect("Failed to create second shared-name index"),
+            CreateObjectResult::Created
+        );
+
+        let store_a = SqliteEngine::object_store_by_name(&db.connection, "store_a")
+            .expect("Failed to get first store");
+        SqliteEngine::put_item(
+            &db.connection,
+            store_a.clone(),
+            IndexedDBKeyType::Number(1.0),
+            vec![1],
+            false,
+            None,
+            vec![(
+                "shared_name".to_string(),
+                false,
+                IndexedDBKeyType::String("alpha".to_string()),
+            )],
+        )
+        .expect("Failed to insert indexed item");
+
+        let index_rows_before_delete: i64 = db
+            .connection
+            .query_row("SELECT COUNT(*) FROM index_data", [], |row| row.get(0))
+            .expect("Failed to count index rows before index delete");
+        assert_eq!(index_rows_before_delete, 1);
+
+        db.delete_index("store_a", "shared_name".to_string())
+            .expect("Failed to delete index");
+
+        let index_rows_after_delete: i64 = db
+            .connection
+            .query_row("SELECT COUNT(*) FROM index_data", [], |row| row.get(0))
+            .expect("Failed to count index rows after index delete");
+        assert_eq!(index_rows_after_delete, 0);
+
+        SqliteEngine::put_item(
+            &db.connection,
+            store_a.clone(),
+            IndexedDBKeyType::Number(2.0),
+            vec![2],
+            false,
+            None,
+            vec![],
+        )
+        .expect("Failed to insert item before clear");
+        SqliteEngine::clear(&db.connection, store_a.clone()).expect("Failed to clear store");
+        let remaining_records =
+            SqliteEngine::count(&db.connection, store_a, IndexedDBKeyRange::default())
+                .expect("Failed to count records after clear");
+        assert_eq!(remaining_records, 0);
+    }
+
+    #[test]
+    fn test_delete_item_removes_index_entries() {
+        let base_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let thread_pool = get_pool();
+        let db = SqliteEngine::new(
+            base_dir.path(),
+            &IndexedDBDescription {
+                name: "test_db".to_string(),
+                origin: test_origin(),
+            },
+            thread_pool,
+        )
+        .unwrap();
+
+        db.create_store("test_store", None, false)
+            .expect("Failed to create store");
+        db.create_index(
+            "test_store",
+            "by_value".to_string(),
+            KeyPath::String("value".to_string()),
+            false,
+            false,
+        )
+        .expect("Failed to create index");
+        let store = SqliteEngine::object_store_by_name(&db.connection, "test_store")
+            .expect("Failed to get object store");
+
+        SqliteEngine::put_item(
+            &db.connection,
+            store.clone(),
+            IndexedDBKeyType::Number(1.0),
+            vec![1],
+            false,
+            None,
+            vec![(
+                "by_value".to_string(),
+                false,
+                IndexedDBKeyType::String("alpha".to_string()),
+            )],
+        )
+        .expect("Failed to insert indexed item");
+
+        SqliteEngine::delete_item(
+            &db.connection,
+            store.clone(),
+            IndexedDBKeyRange::only(IndexedDBKeyType::Number(1.0)),
+        )
+        .expect("Failed to delete indexed item");
+
+        let indexed_key = SqliteEngine::index_get_key(
+            &db.connection,
+            store.clone(),
+            "by_value".to_string(),
+            IndexedDBKeyRange::only(IndexedDBKeyType::String("alpha".to_string())),
+        )
+        .expect("Failed to get indexed key after delete");
+        assert_eq!(indexed_key, None);
+
+        let index_rows_after_delete: i64 = db
+            .connection
+            .query_row("SELECT COUNT(*) FROM index_data", [], |row| row.get(0))
+            .expect("Failed to count index rows after item delete");
+        assert_eq!(index_rows_after_delete, 0);
     }
 
     #[test]
@@ -1053,6 +1738,7 @@ mod tests {
                             value: vec![1, 2, 3],
                             should_overwrite: false,
                             key_generator_current_number: None,
+                            index_key_value: vec![],
                         }),
                     },
                     KvsOperation {
@@ -1063,6 +1749,7 @@ mod tests {
                             value: vec![4, 5, 6],
                             should_overwrite: false,
                             key_generator_current_number: None,
+                            index_key_value: vec![],
                         }),
                     },
                     KvsOperation {
@@ -1076,6 +1763,7 @@ mod tests {
                             value: vec![7, 8, 9],
                             should_overwrite: false,
                             key_generator_current_number: None,
+                            index_key_value: vec![],
                         }),
                     },
                     // Try to put a duplicate key without overwrite
@@ -1087,6 +1775,7 @@ mod tests {
                             value: vec![10, 11, 12],
                             should_overwrite: false,
                             key_generator_current_number: None,
+                            index_key_value: vec![],
                         }),
                     },
                     KvsOperation {
@@ -1097,6 +1786,7 @@ mod tests {
                             value: vec![13, 14, 15],
                             should_overwrite: true,
                             key_generator_current_number: None,
+                            index_key_value: vec![],
                         }),
                     },
                     KvsOperation {
@@ -1212,6 +1902,7 @@ mod tests {
                     vec![key as u8],
                     false,
                     None,
+                    vec![],
                 )
                 .expect("Failed to seed object store");
             }

--- a/components/storage/indexeddb/engines/sqlite.rs
+++ b/components/storage/indexeddb/engines/sqlite.rs
@@ -7,7 +7,9 @@ use std::sync::Arc;
 use log::{info, warn};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use rusqlite::{Connection, Error, OptionalExtension, params};
-use sea_query::{Condition, Expr, ExprTrait, IntoCondition, SqliteQueryBuilder};
+use sea_query::{
+    Condition, Expr, ExprTrait, IntoColumnRef, IntoCondition, Order, SqliteQueryBuilder,
+};
 use sea_query_rusqlite::RusqliteBinder;
 use servo_base::threadpool::ThreadPool;
 use storage_traits::indexeddb::{
@@ -23,34 +25,33 @@ use crate::shared::{DB_INIT_PRAGMAS, DB_PRAGMAS};
 mod create;
 mod database_model;
 mod encoding;
+pub mod index_data_model;
 mod object_data_model;
 mod object_store_index_model;
 mod object_store_model;
 
-fn range_to_query(range: IndexedDBKeyRange) -> Condition {
+fn range_to_query<T: Copy + IntoColumnRef>(col: T, range: IndexedDBKeyRange) -> Condition {
     // Special case for optimization
     if let Some(singleton) = range.as_singleton() {
         let encoded = encoding::serialize(singleton);
-        return Expr::column(object_data_model::Column::Key)
-            .eq(encoded)
-            .into_condition();
+        return Expr::column(col).eq(encoded).into_condition();
     }
     let mut parts = vec![];
     if let Some(upper) = range.upper.as_ref() {
         let upper_bytes = encoding::serialize(upper);
         let query = if range.upper_open {
-            Expr::column(object_data_model::Column::Key).lt(upper_bytes)
+            Expr::column(col).lt(upper_bytes)
         } else {
-            Expr::column(object_data_model::Column::Key).lte(upper_bytes)
+            Expr::column(col).lte(upper_bytes)
         };
         parts.push(query);
     }
     if let Some(lower) = range.lower.as_ref() {
         let lower_bytes = encoding::serialize(lower);
         let query = if range.lower_open {
-            Expr::column(object_data_model::Column::Key).gt(lower_bytes)
+            Expr::column(col).gt(lower_bytes)
         } else {
-            Expr::column(object_data_model::Column::Key).gte(lower_bytes)
+            Expr::column(col).gte(lower_bytes)
         };
         parts.push(query);
     }
@@ -135,12 +136,28 @@ impl SqliteEngine {
         Ok(connection)
     }
 
+    /// Gets the associated index model for a given object store and index name
+    /// Returns `Ok(None)` if no such index exists.
+    fn get_index_model(
+        connection: &Connection,
+        store: object_store_model::Model,
+        index: String,
+    ) -> Result<Option<object_store_index_model::Model>, Error> {
+        connection
+            .query_one(
+                "SELECT * FROM object_store_index WHERE object_store_id = ? AND name = ?",
+                params![store.id, index],
+                |row| object_store_index_model::Model::try_from(row),
+            )
+            .optional()
+    }
+
     fn get(
         connection: &Connection,
         store: object_store_model::Model,
         key_range: IndexedDBKeyRange,
     ) -> Result<Option<object_data_model::Model>, Error> {
-        let query = range_to_query(key_range);
+        let query = range_to_query(object_data_model::Column::Key, key_range);
         let (sql, values) = sea_query::Query::select()
             .from(object_data_model::Column::Table)
             .columns(vec![
@@ -159,12 +176,78 @@ impl SqliteEngine {
             .optional()
     }
 
+    fn index_get(
+        connection: &Connection,
+        store: object_store_model::Model,
+        index: String,
+        key_range: IndexedDBKeyRange,
+    ) -> Result<Option<index_data_model::Model>, Error> {
+        let Some(index_model) = Self::get_index_model(connection, store, index)? else {
+            return Ok(None);
+        };
+        let query = range_to_query(index_data_model::Column::IndexKey, key_range);
+        let (sql, values) = sea_query::Query::select()
+            .from(index_data_model::Column::Table)
+            .columns(vec![
+                index_data_model::Column::IndexId,
+                index_data_model::Column::IndexKey,
+                index_data_model::Column::ObjectKey,
+            ])
+            .and_where(query.and(Expr::col(index_data_model::Column::IndexId).is(index_model.id)))
+            .order_by(index_data_model::Column::IndexKey, Order::Asc)
+            .order_by(index_data_model::Column::ObjectKey, Order::Asc)
+            .limit(1)
+            .build_rusqlite(SqliteQueryBuilder);
+        connection
+            .prepare(&sql)?
+            .query_one(&*values.as_params(), |row| {
+                index_data_model::Model::try_from(row)
+            })
+            .optional()
+    }
+
+    fn get_by_serialized_key(
+        connection: &Connection,
+        store: object_store_model::Model,
+        key: &[u8],
+    ) -> Result<Option<object_data_model::Model>, Error> {
+        connection
+            .prepare("SELECT * FROM object_data WHERE object_store_id = ? AND key = ?")?
+            .query_row(params![store.id, key], |row| {
+                object_data_model::Model::try_from(row)
+            })
+            .optional()
+    }
+
+    fn delete_index_entries_for_object_key(
+        connection: &Connection,
+        store: object_store_model::Model,
+        object_key: &[u8],
+    ) -> Result<(), Error> {
+        connection.execute(
+            "DELETE FROM index_data WHERE object_key = ? AND index_id IN \
+             (SELECT id FROM object_store_index WHERE object_store_id = ?)",
+            params![object_key, store.id],
+        )?;
+        Ok(())
+    }
+
     fn get_key(
         connection: &Connection,
         store: object_store_model::Model,
         key_range: IndexedDBKeyRange,
     ) -> Result<Option<Vec<u8>>, Error> {
         Self::get(connection, store, key_range).map(|opt| opt.map(|model| model.key))
+    }
+
+    fn index_get_key(
+        connection: &Connection,
+        store: object_store_model::Model,
+        index_name: String,
+        key_range: IndexedDBKeyRange,
+    ) -> Result<Option<Vec<u8>>, Error> {
+        Self::index_get(connection, store, index_name, key_range)
+            .map(|opt| opt.map(|model| model.object_key))
     }
 
     fn get_item(
@@ -175,13 +258,27 @@ impl SqliteEngine {
         Self::get(connection, store, key_range).map(|opt| opt.map(|model| model.data))
     }
 
+    fn index_get_item(
+        connection: &Connection,
+        store: object_store_model::Model,
+        index_name: String,
+        key_range: IndexedDBKeyRange,
+    ) -> Result<Option<Vec<u8>>, Error> {
+        let Some(index_data) = Self::index_get(connection, store.clone(), index_name, key_range)?
+        else {
+            return Ok(None);
+        };
+        Self::get_by_serialized_key(connection, store, &index_data.object_key)
+            .map(|opt| opt.map(|model| model.data))
+    }
+
     fn get_all(
         connection: &Connection,
         store: object_store_model::Model,
         key_range: IndexedDBKeyRange,
         count: Option<u32>,
     ) -> Result<Vec<object_data_model::Model>, Error> {
-        let query = range_to_query(key_range);
+        let query = range_to_query(object_data_model::Column::Key, key_range);
         let mut sql_query = sea_query::Query::select();
         sql_query
             .from(object_data_model::Column::Table)
@@ -204,6 +301,41 @@ impl SqliteEngine {
         Ok(models)
     }
 
+    fn index_get_all(
+        connection: &Connection,
+        store: object_store_model::Model,
+        index_name: String,
+        key_range: IndexedDBKeyRange,
+        count: Option<u32>,
+    ) -> Result<Vec<index_data_model::Model>, Error> {
+        let Some(index_model) = Self::get_index_model(connection, store, index_name)? else {
+            return Ok(vec![]);
+        };
+        let query = range_to_query(index_data_model::Column::IndexKey, key_range);
+        let mut sql_query = sea_query::Query::select();
+        sql_query
+            .from(index_data_model::Column::Table)
+            .columns(vec![
+                index_data_model::Column::IndexId,
+                index_data_model::Column::IndexKey,
+                index_data_model::Column::ObjectKey,
+            ])
+            .and_where(query.and(Expr::col(index_data_model::Column::IndexId).is(index_model.id)))
+            .order_by(index_data_model::Column::IndexKey, Order::Asc)
+            .order_by(index_data_model::Column::ObjectKey, Order::Asc);
+        if let Some(count) = count {
+            sql_query.limit(count as u64);
+        }
+        let (sql, values) = sql_query.build_rusqlite(SqliteQueryBuilder);
+        let mut stmt = connection.prepare(&sql)?;
+        let models = stmt
+            .query_and_then(&*values.as_params(), |row| {
+                index_data_model::Model::try_from(row)
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(models)
+    }
+
     fn get_all_keys(
         connection: &Connection,
         store: object_store_model::Model,
@@ -214,6 +346,17 @@ impl SqliteEngine {
             .map(|models| models.into_iter().map(|m| m.key).collect())
     }
 
+    fn index_get_all_keys(
+        connection: &Connection,
+        store: object_store_model::Model,
+        index: String,
+        key_range: IndexedDBKeyRange,
+        count: Option<u32>,
+    ) -> Result<Vec<Vec<u8>>, Error> {
+        Self::index_get_all(connection, store, index, key_range, count)
+            .map(|models| models.into_iter().map(|m| m.object_key).collect())
+    }
+
     fn get_all_items(
         connection: &Connection,
         store: object_store_model::Model,
@@ -222,6 +365,25 @@ impl SqliteEngine {
     ) -> Result<Vec<Vec<u8>>, Error> {
         Self::get_all(connection, store, key_range, count)
             .map(|models| models.into_iter().map(|m| m.data).collect())
+    }
+
+    fn index_get_all_items(
+        connection: &Connection,
+        store: object_store_model::Model,
+        index: String,
+        key_range: IndexedDBKeyRange,
+        count: Option<u32>,
+    ) -> Result<Vec<Vec<u8>>, Error> {
+        let index_models = Self::index_get_all(connection, store.clone(), index, key_range, count)?;
+        let mut items = Vec::with_capacity(index_models.len());
+        for model in index_models {
+            if let Some(item) =
+                Self::get_by_serialized_key(connection, store.clone(), &model.object_key)?
+            {
+                items.push(item.data);
+            }
+        }
+        Ok(items)
     }
 
     #[expect(clippy::type_complexity)]
@@ -241,6 +403,7 @@ impl SqliteEngine {
         value: Vec<u8>,
         should_overwrite: bool,
         key_generator_current_number: Option<i64>,
+        index_key_value: Vec<(String, bool, IndexedDBKeyType)>,
     ) -> Result<PutItemResult, Error> {
         let no_overwrite = !should_overwrite;
         let serialized_key: Vec<u8> = encoding::serialize(&key);
@@ -252,20 +415,50 @@ impl SqliteEngine {
                 })
                 .optional()
             })?;
-        if existing_item.is_some() {
-            if no_overwrite {
-                return Ok(PutItemResult::CannotOverwrite);
+        if existing_item.is_some() && no_overwrite {
+            return Ok(PutItemResult::CannotOverwrite);
+        }
+
+        let mut index_entries = Vec::with_capacity(index_key_value.len());
+        for (index_name, _unique, index_key) in index_key_value {
+            let index_model = Self::get_index_model(connection, store.clone(), index_name)?
+                .ok_or(Error::QueryReturnedNoRows)?;
+            let serialized_index_key = encoding::serialize(&index_key);
+            if index_model.unique_index {
+                let has_conflict: bool = connection.query_row(
+                    "SELECT EXISTS(SELECT 1 FROM index_data WHERE index_id = ? AND index_key = ? AND object_key != ?)",
+                    params![index_model.id, &serialized_index_key, &serialized_key],
+                    |row| row.get(0),
+                )?;
+                if has_conflict {
+                    return Err(Error::SqliteFailure(
+                        rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_CONSTRAINT_UNIQUE),
+                        Some("Unique index constraint violated".to_string()),
+                    ));
+                }
             }
+            index_entries.push((index_model.id, serialized_index_key));
+        }
+
+        if existing_item.is_some() {
             // Preserve `put()` semantics by replacing the stored value when the primary
             // key already exists.
             connection.execute(
                 "UPDATE object_data SET data = ? WHERE object_store_id = ? AND key = ?",
                 params![value, store.id, serialized_key],
             )?;
+            Self::delete_index_entries_for_object_key(connection, store.clone(), &serialized_key)?;
         } else {
             connection.execute(
                 "INSERT INTO object_data (object_store_id, key, data) VALUES (?, ?, ?)",
                 params![store.id, serialized_key, value],
+            )?;
+        }
+
+        for (index_id, serialized_index_key) in index_entries {
+            connection.execute(
+                "INSERT INTO index_data (index_id, index_key, object_key) VALUES (?, ?, ?)",
+                params![index_id, serialized_index_key, &serialized_key],
             )?;
         }
         if let Some(next_key_generator_current_number) = key_generator_current_number {
@@ -282,7 +475,11 @@ impl SqliteEngine {
         store: object_store_model::Model,
         key_range: IndexedDBKeyRange,
     ) -> Result<(), Error> {
-        let query = range_to_query(key_range);
+        let keys = Self::get_all_keys(connection, store.clone(), key_range.clone(), None)?;
+        for key in &keys {
+            Self::delete_index_entries_for_object_key(connection, store.clone(), key)?;
+        }
+        let query = range_to_query(object_data_model::Column::Key, key_range);
         let (sql, values) = sea_query::Query::delete()
             .from_table(object_data_model::Column::Table)
             .and_where(query.and(Expr::col(object_data_model::Column::ObjectStoreId).is(store.id)))
@@ -291,11 +488,20 @@ impl SqliteEngine {
         Ok(())
     }
 
+    /// <https://www.w3.org/TR/IndexedDB/#clear-an-object-store>
     fn clear(connection: &Connection, store: object_store_model::Model) -> Result<(), Error> {
+        // Step 1. Remove all records from store.
         connection.execute(
             "DELETE FROM object_data WHERE object_store_id = ?",
             params![store.id],
         )?;
+        // Step 2. In all indexes which reference store, remove all records.
+        connection.execute(
+            "DELETE FROM index_data WHERE index_id IN \
+             (SELECT id FROM object_store_index WHERE object_store_id = ?)",
+            params![store.id],
+        )?;
+        // Step 3. Return undefined.
         Ok(())
     }
 
@@ -304,11 +510,31 @@ impl SqliteEngine {
         store: object_store_model::Model,
         key_range: IndexedDBKeyRange,
     ) -> Result<usize, Error> {
-        let query = range_to_query(key_range);
+        let query = range_to_query(object_data_model::Column::Key, key_range);
         let (sql, values) = sea_query::Query::select()
             .expr(Expr::col(object_data_model::Column::Key).count())
             .from(object_data_model::Column::Table)
             .and_where(query.and(Expr::col(object_data_model::Column::ObjectStoreId).is(store.id)))
+            .build_rusqlite(SqliteQueryBuilder);
+        connection
+            .prepare(&sql)?
+            .query_row(&*values.as_params(), |row| row.get(0))
+            .map(|count: i64| count as usize)
+    }
+
+    fn index_count(
+        connection: &Connection,
+        store: object_store_model::Model,
+        index_name: String,
+        key_range: IndexedDBKeyRange,
+    ) -> Result<usize, Error> {
+        let index = Self::get_index_model(connection, store, index_name)?
+            .ok_or_else(|| Error::QueryReturnedNoRows)?;
+        let query = range_to_query(index_data_model::Column::IndexKey, key_range);
+        let (sql, values) = sea_query::Query::select()
+            .expr(Expr::col(index_data_model::Column::IndexKey).count())
+            .from(index_data_model::Column::Table)
+            .and_where(query.and(Expr::col(index_data_model::Column::IndexId).is(index.id)))
             .build_rusqlite(SqliteQueryBuilder);
         connection
             .prepare(&sql)?
@@ -351,11 +577,8 @@ impl KvsEngine for SqliteEngine {
         let object_store = Self::object_store_by_name(&self.connection, store_name)?;
 
         self.connection.execute(
-            "DELETE FROM index_data WHERE object_store_id = ?",
-            params![object_store.id],
-        )?;
-        self.connection.execute(
-            "DELETE FROM unique_index_data WHERE object_store_id = ?",
+            "DELETE FROM index_data WHERE index_id IN \
+             (SELECT id FROM object_store_index WHERE object_store_id = ?)",
             params![object_store.id],
         )?;
         self.connection.execute(
@@ -438,6 +661,7 @@ impl KvsEngine for SqliteEngine {
                         value,
                         should_overwrite,
                         key_generator_current_number,
+                        index_key_value
                     }) => {
                         let (key, key_generator_current_number) = match key {
                             Some(key) => (key, key_generator_current_number),
@@ -476,6 +700,7 @@ impl KvsEngine for SqliteEngine {
                                 value,
                                 should_overwrite,
                                 key_generator_current_number,
+                                index_key_value
                             )
                             .map_err(|e| BackendError::DbErr(format!("{:?}", e))),
                         );
@@ -565,6 +790,77 @@ impl KvsEngine for SqliteEngine {
                         let _ = callback.send(
                             Self::get_key(&connection, object_store, key_range)
                                 .map(|key| key.map(|k| encoding::deserialize(&k).unwrap()))
+                                .map_err(|e| BackendError::DbErr(format!("{:?}", e))),
+                        );
+                    },
+                    AsyncOperation::ReadOnly(AsyncReadOnlyOperation::IndexGetKey {
+                                                 callback,
+                                                 index_name,
+                                                 key_range,
+                                             }) => {
+                        let _ = callback.send(
+                            Self::index_get_key(&connection, object_store, index_name, key_range)
+                                .map(|key| key.map(|k| encoding::deserialize(&k).unwrap()))
+                                .map_err(|e| BackendError::DbErr(format!("{:?}", e))),
+                        );
+                    },
+                    AsyncOperation::ReadOnly(AsyncReadOnlyOperation::IndexGetItem {
+                                                 callback,
+                                                 index_name,
+                                                 key_range,
+                                             }) => {
+                        let _ = callback.send(
+                            Self::index_get_item(&connection, object_store, index_name, key_range)
+                                .map_err(|e| BackendError::DbErr(format!("{:?}", e))),
+                        );
+                    },
+                    AsyncOperation::ReadOnly(AsyncReadOnlyOperation::IndexGetAllKeys {
+                                                 callback,
+                                                 index_name,
+                                                 key_range,
+                                                 count,
+                                             }) => {
+                        let _ = callback.send(
+                            Self::index_get_all_keys(
+                                &connection,
+                                object_store,
+                                index_name,
+                                key_range,
+                                count,
+                            )
+                                .map(|keys| {
+                                    keys.into_iter()
+                                        .map(|k| encoding::deserialize(&k).unwrap())
+                                        .collect()
+                                })
+                                .map_err(|e| BackendError::DbErr(format!("{:?}", e))),
+                        );
+                    },
+                    AsyncOperation::ReadOnly(AsyncReadOnlyOperation::IndexGetAllItems {
+                                                 callback,
+                                                 index_name,
+                                                 key_range,
+                                                 count,
+                                             }) => {
+                        let _ = callback.send(
+                            Self::index_get_all_items(
+                                &connection,
+                                object_store,
+                                index_name,
+                                key_range,
+                                count,
+                            )
+                                .map_err(|e| BackendError::DbErr(format!("{:?}", e))),
+                        );
+                    },
+                    AsyncOperation::ReadOnly(AsyncReadOnlyOperation::IndexCount {
+                                                 callback,
+                                                 index_name,
+                                                 key_range,
+                                             }) => {
+                        let _ = callback.send(
+                            Self::index_count(&connection, object_store, index_name, key_range)
+                                .map(|r| r as u64)
                                 .map_err(|e| BackendError::DbErr(format!("{:?}", e))),
                         );
                     },
@@ -725,11 +1021,25 @@ impl KvsEngine for SqliteEngine {
             |r| Ok(object_store_model::Model::try_from(r).unwrap()),
         )?;
 
-        // Delete the index if it exists
-        let _ = self.connection.execute(
-            "DELETE FROM object_store_index WHERE name = ? AND object_store_id = ?",
-            params![index_name, object_store.id],
-        )?;
+        let index_id: Option<i32> = self
+            .connection
+            .query_row(
+                "SELECT id FROM object_store_index WHERE name = ? AND object_store_id = ?",
+                params![index_name, object_store.id],
+                |row| row.get(0),
+            )
+            .optional()?;
+
+        if let Some(index_id) = index_id {
+            self.connection.execute(
+                "DELETE FROM index_data WHERE index_id = ?",
+                params![index_id],
+            )?;
+            self.connection.execute(
+                "DELETE FROM object_store_index WHERE id = ?",
+                params![index_id],
+            )?;
+        }
         Ok(())
     }
 
@@ -1042,6 +1352,14 @@ mod tests {
 
         db.create_store("test_store", None, false)
             .expect("Failed to create store");
+        db.create_index(
+            "test_store",
+            "by_value".to_string(),
+            KeyPath::String("value".to_string()),
+            false,
+            false,
+        )
+        .expect("Failed to create index");
         let object_store = SqliteEngine::object_store_by_name(&db.connection, "test_store")
             .expect("Failed to fetch store metadata");
         SqliteEngine::put_item(
@@ -1051,6 +1369,11 @@ mod tests {
             vec![1, 2, 3],
             true,
             None,
+            vec![(
+                "by_value".to_string(),
+                false,
+                IndexedDBKeyType::String("alpha".to_string()),
+            )],
         )
         .expect("Failed to insert item");
 
@@ -1064,6 +1387,12 @@ mod tests {
             .expect("Failed to count rows before delete");
         assert_eq!(row_count_before, 1);
 
+        let index_row_count_before: i64 = db
+            .connection
+            .query_row("SELECT COUNT(*) FROM index_data", [], |row| row.get(0))
+            .expect("Failed to count index rows before delete");
+        assert_eq!(index_row_count_before, 1);
+
         db.delete_store("test_store")
             .expect("Failed to delete store");
 
@@ -1076,6 +1405,362 @@ mod tests {
             )
             .expect("Failed to count rows after delete");
         assert_eq!(row_count_after, 0);
+
+        let index_row_count_after: i64 = db
+            .connection
+            .query_row("SELECT COUNT(*) FROM index_data", [], |row| row.get(0))
+            .expect("Failed to count index rows after delete");
+        assert_eq!(index_row_count_after, 0);
+    }
+
+    #[test]
+    fn test_index_reads_and_unique_constraints() {
+        let base_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let thread_pool = get_pool();
+        let db = SqliteEngine::new(
+            base_dir.path(),
+            &IndexedDBDescription {
+                name: "test_db".to_string(),
+                origin: test_origin(),
+            },
+            thread_pool,
+        )
+        .unwrap();
+
+        db.create_store("test_store", None, false)
+            .expect("Failed to create store");
+        assert_eq!(
+            db.create_index(
+                "test_store",
+                "by_value".to_string(),
+                KeyPath::String("value".to_string()),
+                false,
+                false,
+            )
+            .expect("Failed to create value index"),
+            CreateObjectResult::Created
+        );
+        assert_eq!(
+            db.create_index(
+                "test_store",
+                "by_unique".to_string(),
+                KeyPath::String("unique".to_string()),
+                true,
+                false,
+            )
+            .expect("Failed to create unique index"),
+            CreateObjectResult::Created
+        );
+
+        let store = SqliteEngine::object_store_by_name(&db.connection, "test_store")
+            .expect("Failed to get object store");
+
+        SqliteEngine::put_item(
+            &db.connection,
+            store.clone(),
+            IndexedDBKeyType::Number(1.0),
+            vec![1],
+            false,
+            None,
+            vec![
+                (
+                    "by_value".to_string(),
+                    false,
+                    IndexedDBKeyType::String("alpha".to_string()),
+                ),
+                (
+                    "by_unique".to_string(),
+                    true,
+                    IndexedDBKeyType::String("email-1".to_string()),
+                ),
+            ],
+        )
+        .expect("Failed to insert first indexed item");
+        SqliteEngine::put_item(
+            &db.connection,
+            store.clone(),
+            IndexedDBKeyType::Number(2.0),
+            vec![2],
+            false,
+            None,
+            vec![
+                (
+                    "by_value".to_string(),
+                    false,
+                    IndexedDBKeyType::String("alpha".to_string()),
+                ),
+                (
+                    "by_unique".to_string(),
+                    true,
+                    IndexedDBKeyType::String("email-2".to_string()),
+                ),
+            ],
+        )
+        .expect("Failed to insert second indexed item");
+
+        let key = SqliteEngine::index_get_key(
+            &db.connection,
+            store.clone(),
+            "by_value".to_string(),
+            IndexedDBKeyRange::only(IndexedDBKeyType::String("alpha".to_string())),
+        )
+        .expect("Failed to get indexed key")
+        .map(|key| encoding::deserialize(&key).unwrap());
+        assert_eq!(key, Some(IndexedDBKeyType::Number(1.0)));
+
+        let item = SqliteEngine::index_get_item(
+            &db.connection,
+            store.clone(),
+            "by_value".to_string(),
+            IndexedDBKeyRange::only(IndexedDBKeyType::String("alpha".to_string())),
+        )
+        .expect("Failed to get indexed item");
+        assert_eq!(item, Some(vec![1]));
+
+        let keys = SqliteEngine::index_get_all_keys(
+            &db.connection,
+            store.clone(),
+            "by_value".to_string(),
+            IndexedDBKeyRange::only(IndexedDBKeyType::String("alpha".to_string())),
+            None,
+        )
+        .expect("Failed to get indexed keys")
+        .into_iter()
+        .map(|key| encoding::deserialize(&key).unwrap())
+        .collect::<Vec<_>>();
+        assert_eq!(
+            keys,
+            vec![IndexedDBKeyType::Number(1.0), IndexedDBKeyType::Number(2.0)]
+        );
+
+        let items = SqliteEngine::index_get_all_items(
+            &db.connection,
+            store.clone(),
+            "by_value".to_string(),
+            IndexedDBKeyRange::only(IndexedDBKeyType::String("alpha".to_string())),
+            None,
+        )
+        .expect("Failed to get indexed items");
+        assert_eq!(items, vec![vec![1], vec![2]]);
+
+        let count = SqliteEngine::index_count(
+            &db.connection,
+            store.clone(),
+            "by_value".to_string(),
+            IndexedDBKeyRange::only(IndexedDBKeyType::String("alpha".to_string())),
+        )
+        .expect("Failed to count indexed entries");
+        assert_eq!(count, 2);
+
+        SqliteEngine::put_item(
+            &db.connection,
+            store.clone(),
+            IndexedDBKeyType::Number(1.0),
+            vec![10],
+            true,
+            None,
+            vec![
+                (
+                    "by_value".to_string(),
+                    false,
+                    IndexedDBKeyType::String("beta".to_string()),
+                ),
+                (
+                    "by_unique".to_string(),
+                    true,
+                    IndexedDBKeyType::String("email-1b".to_string()),
+                ),
+            ],
+        )
+        .expect("Failed to overwrite indexed item");
+
+        let alpha_count = SqliteEngine::index_count(
+            &db.connection,
+            store.clone(),
+            "by_value".to_string(),
+            IndexedDBKeyRange::only(IndexedDBKeyType::String("alpha".to_string())),
+        )
+        .expect("Failed to count alpha indexed entries");
+        assert_eq!(alpha_count, 1);
+
+        let beta_item = SqliteEngine::index_get_item(
+            &db.connection,
+            store.clone(),
+            "by_value".to_string(),
+            IndexedDBKeyRange::only(IndexedDBKeyType::String("beta".to_string())),
+        )
+        .expect("Failed to get beta indexed item");
+        assert_eq!(beta_item, Some(vec![10]));
+
+        let duplicate_unique_result = SqliteEngine::put_item(
+            &db.connection,
+            store,
+            IndexedDBKeyType::Number(3.0),
+            vec![3],
+            false,
+            None,
+            vec![(
+                "by_unique".to_string(),
+                true,
+                IndexedDBKeyType::String("email-2".to_string()),
+            )],
+        );
+        assert!(duplicate_unique_result.is_err());
+    }
+
+    #[test]
+    fn test_index_cleanup_and_store_scoped_names() {
+        let base_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let thread_pool = get_pool();
+        let db = SqliteEngine::new(
+            base_dir.path(),
+            &IndexedDBDescription {
+                name: "test_db".to_string(),
+                origin: test_origin(),
+            },
+            thread_pool,
+        )
+        .unwrap();
+
+        db.create_store("store_a", None, false)
+            .expect("Failed to create first store");
+        db.create_store("store_b", None, false)
+            .expect("Failed to create second store");
+        assert_eq!(
+            db.create_index(
+                "store_a",
+                "shared_name".to_string(),
+                KeyPath::String("a".to_string()),
+                false,
+                false,
+            )
+            .expect("Failed to create first shared-name index"),
+            CreateObjectResult::Created
+        );
+        assert_eq!(
+            db.create_index(
+                "store_b",
+                "shared_name".to_string(),
+                KeyPath::String("b".to_string()),
+                false,
+                false,
+            )
+            .expect("Failed to create second shared-name index"),
+            CreateObjectResult::Created
+        );
+
+        let store_a = SqliteEngine::object_store_by_name(&db.connection, "store_a")
+            .expect("Failed to get first store");
+        SqliteEngine::put_item(
+            &db.connection,
+            store_a.clone(),
+            IndexedDBKeyType::Number(1.0),
+            vec![1],
+            false,
+            None,
+            vec![(
+                "shared_name".to_string(),
+                false,
+                IndexedDBKeyType::String("alpha".to_string()),
+            )],
+        )
+        .expect("Failed to insert indexed item");
+
+        let index_rows_before_delete: i64 = db
+            .connection
+            .query_row("SELECT COUNT(*) FROM index_data", [], |row| row.get(0))
+            .expect("Failed to count index rows before index delete");
+        assert_eq!(index_rows_before_delete, 1);
+
+        db.delete_index("store_a", "shared_name".to_string())
+            .expect("Failed to delete index");
+
+        let index_rows_after_delete: i64 = db
+            .connection
+            .query_row("SELECT COUNT(*) FROM index_data", [], |row| row.get(0))
+            .expect("Failed to count index rows after index delete");
+        assert_eq!(index_rows_after_delete, 0);
+
+        SqliteEngine::put_item(
+            &db.connection,
+            store_a.clone(),
+            IndexedDBKeyType::Number(2.0),
+            vec![2],
+            false,
+            None,
+            vec![],
+        )
+        .expect("Failed to insert item before clear");
+        SqliteEngine::clear(&db.connection, store_a.clone()).expect("Failed to clear store");
+        let remaining_records =
+            SqliteEngine::count(&db.connection, store_a, IndexedDBKeyRange::default())
+                .expect("Failed to count records after clear");
+        assert_eq!(remaining_records, 0);
+    }
+
+    #[test]
+    fn test_delete_item_removes_index_entries() {
+        let base_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let thread_pool = get_pool();
+        let db = SqliteEngine::new(
+            base_dir.path(),
+            &IndexedDBDescription {
+                name: "test_db".to_string(),
+                origin: test_origin(),
+            },
+            thread_pool,
+        )
+        .unwrap();
+
+        db.create_store("test_store", None, false)
+            .expect("Failed to create store");
+        db.create_index(
+            "test_store",
+            "by_value".to_string(),
+            KeyPath::String("value".to_string()),
+            false,
+            false,
+        )
+        .expect("Failed to create index");
+        let store = SqliteEngine::object_store_by_name(&db.connection, "test_store")
+            .expect("Failed to get object store");
+
+        SqliteEngine::put_item(
+            &db.connection,
+            store.clone(),
+            IndexedDBKeyType::Number(1.0),
+            vec![1],
+            false,
+            None,
+            vec![(
+                "by_value".to_string(),
+                false,
+                IndexedDBKeyType::String("alpha".to_string()),
+            )],
+        )
+        .expect("Failed to insert indexed item");
+
+        SqliteEngine::delete_item(
+            &db.connection,
+            store.clone(),
+            IndexedDBKeyRange::only(IndexedDBKeyType::Number(1.0)),
+        )
+        .expect("Failed to delete indexed item");
+
+        let indexed_key = SqliteEngine::index_get_key(
+            &db.connection,
+            store.clone(),
+            "by_value".to_string(),
+            IndexedDBKeyRange::only(IndexedDBKeyType::String("alpha".to_string())),
+        )
+        .expect("Failed to get indexed key after delete");
+        assert_eq!(indexed_key, None);
+
+        let index_rows_after_delete: i64 = db
+            .connection
+            .query_row("SELECT COUNT(*) FROM index_data", [], |row| row.get(0))
+            .expect("Failed to count index rows after item delete");
+        assert_eq!(index_rows_after_delete, 0);
     }
 
     #[test]
@@ -1136,6 +1821,7 @@ mod tests {
                             value: vec![1, 2, 3],
                             should_overwrite: false,
                             key_generator_current_number: None,
+                            index_key_value: vec![],
                         }),
                     },
                     KvsOperation {
@@ -1146,6 +1832,7 @@ mod tests {
                             value: vec![4, 5, 6],
                             should_overwrite: false,
                             key_generator_current_number: None,
+                            index_key_value: vec![],
                         }),
                     },
                     KvsOperation {
@@ -1159,6 +1846,7 @@ mod tests {
                             value: vec![7, 8, 9],
                             should_overwrite: false,
                             key_generator_current_number: None,
+                            index_key_value: vec![],
                         }),
                     },
                     // Try to put a duplicate key without overwrite
@@ -1170,6 +1858,7 @@ mod tests {
                             value: vec![10, 11, 12],
                             should_overwrite: false,
                             key_generator_current_number: None,
+                            index_key_value: vec![],
                         }),
                     },
                     KvsOperation {
@@ -1180,6 +1869,7 @@ mod tests {
                             value: vec![13, 14, 15],
                             should_overwrite: true,
                             key_generator_current_number: None,
+                            index_key_value: vec![],
                         }),
                     },
                     KvsOperation {
@@ -1296,6 +1986,7 @@ mod tests {
                     vec![key as u8],
                     false,
                     None,
+                    vec![],
                 )
                 .expect("Failed to seed object store");
             }

--- a/components/storage/indexeddb/engines/sqlite/create.rs
+++ b/components/storage/indexeddb/engines/sqlite/create.rs
@@ -43,40 +43,25 @@ create table object_store_index (
     primary key autoincrement,
     object_store_id   integer        not null
     references object_store,
-    name              varchar        not null
-    unique,
+    name              varchar        not null,
     key_path          varbinary_blob not null,
     unique_index      boolean        not null,
-    multi_entry_index boolean        not null
+    multi_entry_index boolean        not null,
+    constraint "uq-object_store_index-name"
+        unique (object_store_id, name)
 );"#;
     conn.execute(OBJECT_STORE_INDEX, [])?;
 
     const INDEX_DATA: &str = r#"
-CREATE TABLE index_data (
-    index_id INTEGER NOT NULL,
-    value BLOB NOT NULL,
-    object_data_key BLOB NOT NULL,
-    object_store_id INTEGER NOT NULL,
-    value_locale BLOB,
-    PRIMARY KEY (index_id, value, object_data_key)
-    FOREIGN KEY (index_id) REFERENCES object_store_index(id),
-    FOREIGN KEY (object_store_id, object_data_key)
-    REFERENCES object_data(object_store_id, key)
+create table index_data (
+    index_id        integer not null
+        references object_store_index,
+    index_key       blob    not null,
+    object_key      blob    not null,
+    constraint "pk-index_data"
+        primary key (index_id, index_key, object_key)
 ) WITHOUT ROWID;"#;
     conn.execute(INDEX_DATA, [])?;
 
-    const UNIQUE_INDEX_DATA: &str = r#"
-CREATE TABLE unique_index_data (
-    index_id INTEGER NOT NULL,
-    value BLOB NOT NULL,
-    object_store_id INTEGER NOT NULL,
-    object_data_key BLOB NOT NULL,
-    value_locale BLOB,
-    PRIMARY KEY (index_id, value),
-    FOREIGN KEY (index_id) REFERENCES object_store_index(id),
-    FOREIGN KEY (object_store_id, object_data_key)
-    REFERENCES object_data(object_store_id, key)
-) WITHOUT ROWID;"#;
-    conn.execute(UNIQUE_INDEX_DATA, [])?;
     Ok(())
 }

--- a/components/storage/indexeddb/engines/sqlite/index_data_model.rs
+++ b/components/storage/indexeddb/engines/sqlite/index_data_model.rs
@@ -6,18 +6,18 @@ use sea_query::Iden;
 
 #[derive(Copy, Clone, Iden)]
 pub enum Column {
-    #[iden = "object_data"]
+    #[iden = "index_data"]
     Table,
-    ObjectStoreId,
-    Key,
-    Data,
+    IndexId,   // References object_store_index.id
+    IndexKey,  // The value extracted from the object (serialized)
+    ObjectKey, // The primary key of the object in object_data
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Model {
-    pub object_store_id: i32,
-    pub key: Vec<u8>,
-    pub data: Vec<u8>,
+    pub index_id: i32,
+    pub index_key: Vec<u8>,
+    pub object_key: Vec<u8>,
 }
 
 impl TryFrom<&Row<'_>> for Model {
@@ -25,9 +25,9 @@ impl TryFrom<&Row<'_>> for Model {
 
     fn try_from(value: &Row) -> Result<Self, Self::Error> {
         Ok(Self {
-            object_store_id: value.get(0)?,
-            key: value.get(1)?,
-            data: value.get(2)?,
+            index_id: value.get(0)?,
+            index_key: value.get(1)?,
+            object_key: value.get(2)?,
         })
     }
 }

--- a/tests/wpt/meta/IndexedDB/clone-before-keypath-eval.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/clone-before-keypath-eval.any.js.ini
@@ -2,12 +2,26 @@
   [Cursor update checks and keypath evaluations operate on a clone]
     expected: FAIL
 
+  [Index key path evaluations operate on a clone]
+    expected: FAIL
+
+  [Store and index key path evaluations operate on the same clone]
+    expected: FAIL
+
+
 [clone-before-keypath-eval.any.serviceworker.html]
   expected: ERROR
 
 [clone-before-keypath-eval.any.html]
   [Cursor update checks and keypath evaluations operate on a clone]
     expected: FAIL
+
+  [Index key path evaluations operate on a clone]
+    expected: FAIL
+
+  [Store and index key path evaluations operate on the same clone]
+    expected: FAIL
+
 
 [clone-before-keypath-eval.any.sharedworker.html]
   expected: ERROR

--- a/tests/wpt/meta/IndexedDB/idbindex-cross-realm-methods.html.ini
+++ b/tests/wpt/meta/IndexedDB/idbindex-cross-realm-methods.html.ini
@@ -1,17 +1,8 @@
 [idbindex-cross-realm-methods.html]
-  [Cross-realm IDBIndex::get() method from detached <iframe> works as expected]
-    expected: FAIL
-
-  [Cross-realm IDBIndex::getKey() method from detached <iframe> works as expected]
-    expected: FAIL
-
   [Cross-realm IDBIndex::getAll() method from detached <iframe> works as expected]
     expected: FAIL
 
   [Cross-realm IDBIndex::getAllKeys() method from detached <iframe> works as expected]
-    expected: FAIL
-
-  [Cross-realm IDBIndex::count() method from detached <iframe> works as expected]
     expected: FAIL
 
   [Cross-realm IDBIndex::openCursor() method from detached <iframe> works as expected]

--- a/tests/wpt/meta/IndexedDB/idbindex-query-exception-order.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbindex-query-exception-order.any.js.ini
@@ -5,12 +5,6 @@
   expected: ERROR
 
 [idbindex-query-exception-order.any.html]
-  [IDBIndex.get exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
-
-  [IDBIndex.get exception order: TransactionInactiveError vs. DataError]
-    expected: FAIL
-
   [IDBIndex.getAll exception order: InvalidStateError vs. TransactionInactiveError]
     expected: FAIL
 
@@ -21,12 +15,6 @@
     expected: FAIL
 
   [IDBIndex.getAllKeys exception order: TransactionInactiveError vs. DataError]
-    expected: FAIL
-
-  [IDBIndex.count exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
-
-  [IDBIndex.count exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBIndex.openCursor exception order: InvalidStateError vs. TransactionInactiveError]
@@ -43,12 +31,6 @@
 
 
 [idbindex-query-exception-order.any.worker.html]
-  [IDBIndex.get exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
-
-  [IDBIndex.get exception order: TransactionInactiveError vs. DataError]
-    expected: FAIL
-
   [IDBIndex.getAll exception order: InvalidStateError vs. TransactionInactiveError]
     expected: FAIL
 
@@ -59,12 +41,6 @@
     expected: FAIL
 
   [IDBIndex.getAllKeys exception order: TransactionInactiveError vs. DataError]
-    expected: FAIL
-
-  [IDBIndex.count exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
-
-  [IDBIndex.count exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBIndex.openCursor exception order: InvalidStateError vs. TransactionInactiveError]

--- a/tests/wpt/meta/IndexedDB/idbindex-query-exception-order.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbindex-query-exception-order.any.js.ini
@@ -1,10 +1,4 @@
 [idbindex-query-exception-order.any.sharedworker.html]
-  [IDBIndex.get exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
-
-  [IDBIndex.get exception order: TransactionInactiveError vs. DataError]
-    expected: FAIL
-
   [IDBIndex.getAll exception order: InvalidStateError vs. TransactionInactiveError]
     expected: FAIL
 
@@ -15,12 +9,6 @@
     expected: FAIL
 
   [IDBIndex.getAllKeys exception order: TransactionInactiveError vs. DataError]
-    expected: FAIL
-
-  [IDBIndex.count exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
-
-  [IDBIndex.count exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBIndex.openCursor exception order: InvalidStateError vs. TransactionInactiveError]
@@ -40,12 +28,6 @@
   expected: ERROR
 
 [idbindex-query-exception-order.any.html]
-  [IDBIndex.get exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
-
-  [IDBIndex.get exception order: TransactionInactiveError vs. DataError]
-    expected: FAIL
-
   [IDBIndex.getAll exception order: InvalidStateError vs. TransactionInactiveError]
     expected: FAIL
 
@@ -56,12 +38,6 @@
     expected: FAIL
 
   [IDBIndex.getAllKeys exception order: TransactionInactiveError vs. DataError]
-    expected: FAIL
-
-  [IDBIndex.count exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
-
-  [IDBIndex.count exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBIndex.openCursor exception order: InvalidStateError vs. TransactionInactiveError]
@@ -78,12 +54,6 @@
 
 
 [idbindex-query-exception-order.any.worker.html]
-  [IDBIndex.get exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
-
-  [IDBIndex.get exception order: TransactionInactiveError vs. DataError]
-    expected: FAIL
-
   [IDBIndex.getAll exception order: InvalidStateError vs. TransactionInactiveError]
     expected: FAIL
 
@@ -94,12 +64,6 @@
     expected: FAIL
 
   [IDBIndex.getAllKeys exception order: TransactionInactiveError vs. DataError]
-    expected: FAIL
-
-  [IDBIndex.count exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
-
-  [IDBIndex.count exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBIndex.openCursor exception order: InvalidStateError vs. TransactionInactiveError]

--- a/tests/wpt/meta/IndexedDB/idbindex-rename.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbindex-rename.any.js.ini
@@ -5,9 +5,6 @@
   [IndexedDB index rename in the transaction where it is created]
     expected: FAIL
 
-  [IndexedDB index rename to the same name succeeds]
-    expected: FAIL
-
   [IndexedDB index rename to the name of a deleted index succeeds]
     expected: FAIL
 
@@ -35,9 +32,6 @@
     expected: FAIL
 
   [IndexedDB index rename in the transaction where it is created]
-    expected: FAIL
-
-  [IndexedDB index rename to the same name succeeds]
     expected: FAIL
 
   [IndexedDB index rename to the name of a deleted index succeeds]

--- a/tests/wpt/meta/IndexedDB/idbindex-rename.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbindex-rename.any.js.ini
@@ -1,26 +1,5 @@
 [idbindex-rename.any.html]
-  [IndexedDB index rename in new transaction]
-    expected: FAIL
-
   [IndexedDB index rename in the transaction where it is created]
-    expected: FAIL
-
-  [IndexedDB index rename to the same name succeeds]
-    expected: FAIL
-
-  [IndexedDB index rename to the name of a deleted index succeeds]
-    expected: FAIL
-
-  [IndexedDB index swapping via renames succeeds]
-    expected: FAIL
-
-  [IndexedDB index rename stringifies non-string names]
-    expected: FAIL
-
-  [IndexedDB index can be renamed to ""]
-    expected: FAIL
-
-  [IndexedDB index can be renamed to "\\u0000"]
     expected: FAIL
 
   [IndexedDB index can be renamed to "\\uDC00\\uD800"]
@@ -31,28 +10,7 @@
   expected: ERROR
 
 [idbindex-rename.any.worker.html]
-  [IndexedDB index rename in new transaction]
-    expected: FAIL
-
   [IndexedDB index rename in the transaction where it is created]
-    expected: FAIL
-
-  [IndexedDB index rename to the same name succeeds]
-    expected: FAIL
-
-  [IndexedDB index rename to the name of a deleted index succeeds]
-    expected: FAIL
-
-  [IndexedDB index swapping via renames succeeds]
-    expected: FAIL
-
-  [IndexedDB index rename stringifies non-string names]
-    expected: FAIL
-
-  [IndexedDB index can be renamed to ""]
-    expected: FAIL
-
-  [IndexedDB index can be renamed to "\\u0000"]
     expected: FAIL
 
   [IndexedDB index can be renamed to "\\uDC00\\uD800"]
@@ -60,28 +18,7 @@
 
 
 [idbindex-rename.any.sharedworker.html]
-  [IndexedDB index rename in new transaction]
-    expected: FAIL
-
   [IndexedDB index rename in the transaction where it is created]
-    expected: FAIL
-
-  [IndexedDB index rename to the same name succeeds]
-    expected: FAIL
-
-  [IndexedDB index rename to the name of a deleted index succeeds]
-    expected: FAIL
-
-  [IndexedDB index swapping via renames succeeds]
-    expected: FAIL
-
-  [IndexedDB index rename stringifies non-string names]
-    expected: FAIL
-
-  [IndexedDB index can be renamed to ""]
-    expected: FAIL
-
-  [IndexedDB index can be renamed to "\\u0000"]
     expected: FAIL
 
   [IndexedDB index can be renamed to "\\uDC00\\uD800"]

--- a/tests/wpt/meta/IndexedDB/idbindex-request-source.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbindex-request-source.any.js.ini
@@ -1,17 +1,8 @@
 [idbindex-request-source.any.html]
-  [The source of the request from index => index.get(0) is the index itself]
-    expected: FAIL
-
-  [The source of the request from index => index.getKey(0) is the index itself]
-    expected: FAIL
-
   [The source of the request from index => index.getAll() is the index itself]
     expected: FAIL
 
   [The source of the request from index => index.getAllKeys() is the index itself]
-    expected: FAIL
-
-  [The source of the request from index => index.count() is the index itself]
     expected: FAIL
 
   [The source of the request from index => index.openCursor() is the index itself]
@@ -22,19 +13,10 @@
 
 
 [idbindex-request-source.any.worker.html]
-  [The source of the request from index => index.get(0) is the index itself]
-    expected: FAIL
-
-  [The source of the request from index => index.getKey(0) is the index itself]
-    expected: FAIL
-
   [The source of the request from index => index.getAll() is the index itself]
     expected: FAIL
 
   [The source of the request from index => index.getAllKeys() is the index itself]
-    expected: FAIL
-
-  [The source of the request from index => index.count() is the index itself]
     expected: FAIL
 
   [The source of the request from index => index.openCursor() is the index itself]

--- a/tests/wpt/meta/IndexedDB/idbindex-request-source.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbindex-request-source.any.js.ini
@@ -1,17 +1,8 @@
 [idbindex-request-source.any.html]
-  [The source of the request from index => index.get(0) is the index itself]
-    expected: FAIL
-
-  [The source of the request from index => index.getKey(0) is the index itself]
-    expected: FAIL
-
   [The source of the request from index => index.getAll() is the index itself]
     expected: FAIL
 
   [The source of the request from index => index.getAllKeys() is the index itself]
-    expected: FAIL
-
-  [The source of the request from index => index.count() is the index itself]
     expected: FAIL
 
   [The source of the request from index => index.openCursor() is the index itself]
@@ -22,19 +13,10 @@
 
 
 [idbindex-request-source.any.worker.html]
-  [The source of the request from index => index.get(0) is the index itself]
-    expected: FAIL
-
-  [The source of the request from index => index.getKey(0) is the index itself]
-    expected: FAIL
-
   [The source of the request from index => index.getAll() is the index itself]
     expected: FAIL
 
   [The source of the request from index => index.getAllKeys() is the index itself]
-    expected: FAIL
-
-  [The source of the request from index => index.count() is the index itself]
     expected: FAIL
 
   [The source of the request from index => index.openCursor() is the index itself]
@@ -48,19 +30,10 @@
   expected: ERROR
 
 [idbindex-request-source.any.sharedworker.html]
-  [The source of the request from index => index.get(0) is the index itself]
-    expected: FAIL
-
-  [The source of the request from index => index.getKey(0) is the index itself]
-    expected: FAIL
-
   [The source of the request from index => index.getAll() is the index itself]
     expected: FAIL
 
   [The source of the request from index => index.getAllKeys() is the index itself]
-    expected: FAIL
-
-  [The source of the request from index => index.count() is the index itself]
     expected: FAIL
 
   [The source of the request from index => index.openCursor() is the index itself]

--- a/tests/wpt/meta/IndexedDB/idbindex_count.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbindex_count.any.js.ini
@@ -5,28 +5,5 @@
   expected: ERROR
 
 [idbindex_count.any.worker.html]
-  [count() returns the number of records in the index]
-    expected: FAIL
-
-  [count() returns the number of records that have keys within the range]
-    expected: FAIL
-
-  [count() returns the number of records that have keys with the key]
-    expected: FAIL
-
-  [count() throws DataError when using invalid key]
-    expected: FAIL
-
 
 [idbindex_count.any.html]
-  [count() returns the number of records in the index]
-    expected: FAIL
-
-  [count() returns the number of records that have keys within the range]
-    expected: FAIL
-
-  [count() returns the number of records that have keys with the key]
-    expected: FAIL
-
-  [count() throws DataError when using invalid key]
-    expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbindex_count.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbindex_count.any.js.ini
@@ -2,42 +2,7 @@
   expected: ERROR
 
 [idbindex_count.any.sharedworker.html]
-  [count() returns the number of records in the index]
-    expected: FAIL
-
-  [count() returns the number of records that have keys within the range]
-    expected: FAIL
-
-  [count() returns the number of records that have keys with the key]
-    expected: FAIL
-
-  [count() throws DataError when using invalid key]
-    expected: FAIL
-
 
 [idbindex_count.any.worker.html]
-  [count() returns the number of records in the index]
-    expected: FAIL
-
-  [count() returns the number of records that have keys within the range]
-    expected: FAIL
-
-  [count() returns the number of records that have keys with the key]
-    expected: FAIL
-
-  [count() throws DataError when using invalid key]
-    expected: FAIL
-
 
 [idbindex_count.any.html]
-  [count() returns the number of records in the index]
-    expected: FAIL
-
-  [count() returns the number of records that have keys within the range]
-    expected: FAIL
-
-  [count() returns the number of records that have keys with the key]
-    expected: FAIL
-
-  [count() throws DataError when using invalid key]
-    expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbindex_get.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbindex_get.any.js.ini
@@ -1,54 +1,6 @@
 [idbindex_get.any.html]
-  [get() returns the record]
-    expected: FAIL
-
-  [get() returns the record where the index contains duplicate values]
-    expected: FAIL
-
-  [get() attempts to retrieve a record that does not exist]
-    expected: FAIL
-
-  [get() returns the record with the first key in the range]
-    expected: FAIL
-
-  [get() throws DataError when using invalid key]
-    expected: FAIL
-
-  [get() throws InvalidStateError when the index is deleted]
-    expected: FAIL
-
-  [get() throws TransactionInactiveError on aborted transaction]
-    expected: FAIL
-
-  [get() throws InvalidStateError on index deleted by aborted upgrade]
-    expected: FAIL
-
 
 [idbindex_get.any.worker.html]
-  [get() returns the record]
-    expected: FAIL
-
-  [get() returns the record where the index contains duplicate values]
-    expected: FAIL
-
-  [get() attempts to retrieve a record that does not exist]
-    expected: FAIL
-
-  [get() returns the record with the first key in the range]
-    expected: FAIL
-
-  [get() throws DataError when using invalid key]
-    expected: FAIL
-
-  [get() throws InvalidStateError when the index is deleted]
-    expected: FAIL
-
-  [get() throws TransactionInactiveError on aborted transaction]
-    expected: FAIL
-
-  [get() throws InvalidStateError on index deleted by aborted upgrade]
-    expected: FAIL
-
 
 [idbindex_get.any.sharedworker.html]
   expected: ERROR

--- a/tests/wpt/meta/IndexedDB/idbindex_get.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbindex_get.any.js.ini
@@ -1,80 +1,8 @@
 [idbindex_get.any.html]
-  [get() returns the record]
-    expected: FAIL
-
-  [get() returns the record where the index contains duplicate values]
-    expected: FAIL
-
-  [get() attempts to retrieve a record that does not exist]
-    expected: FAIL
-
-  [get() returns the record with the first key in the range]
-    expected: FAIL
-
-  [get() throws DataError when using invalid key]
-    expected: FAIL
-
-  [get() throws InvalidStateError when the index is deleted]
-    expected: FAIL
-
-  [get() throws TransactionInactiveError on aborted transaction]
-    expected: FAIL
-
-  [get() throws InvalidStateError on index deleted by aborted upgrade]
-    expected: FAIL
-
 
 [idbindex_get.any.worker.html]
-  [get() returns the record]
-    expected: FAIL
-
-  [get() returns the record where the index contains duplicate values]
-    expected: FAIL
-
-  [get() attempts to retrieve a record that does not exist]
-    expected: FAIL
-
-  [get() returns the record with the first key in the range]
-    expected: FAIL
-
-  [get() throws DataError when using invalid key]
-    expected: FAIL
-
-  [get() throws InvalidStateError when the index is deleted]
-    expected: FAIL
-
-  [get() throws TransactionInactiveError on aborted transaction]
-    expected: FAIL
-
-  [get() throws InvalidStateError on index deleted by aborted upgrade]
-    expected: FAIL
-
 
 [idbindex_get.any.sharedworker.html]
-  [get() returns the record]
-    expected: FAIL
-
-  [get() returns the record where the index contains duplicate values]
-    expected: FAIL
-
-  [get() attempts to retrieve a record that does not exist]
-    expected: FAIL
-
-  [get() returns the record with the first key in the range]
-    expected: FAIL
-
-  [get() throws DataError when using invalid key]
-    expected: FAIL
-
-  [get() throws InvalidStateError when the index is deleted]
-    expected: FAIL
-
-  [get() throws TransactionInactiveError on aborted transaction]
-    expected: FAIL
-
-  [get() throws InvalidStateError on index deleted by aborted upgrade]
-    expected: FAIL
-
 
 [idbindex_get.any.serviceworker.html]
   expected: ERROR

--- a/tests/wpt/meta/IndexedDB/idbindex_getKey.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbindex_getKey.any.js.ini
@@ -2,55 +2,8 @@
   expected: ERROR
 
 [idbindex_getKey.any.html]
-  [getKey() returns the record's primary key]
-    expected: FAIL
-
-  [getKey() returns the record's primary key where the index contains duplicate values]
-    expected: FAIL
-
-  [getKey() attempt to retrieve the primary key of a record that doesn't exist]
-    expected: FAIL
-
-  [getKey() returns the key of the first record within the range]
-    expected: FAIL
-
-  [getKey() throws DataError when using invalid key]
-    expected: FAIL
-
-  [getKey() throws InvalidStateError when the index is deleted]
-    expected: FAIL
-
-  [getKey() throws TransactionInactiveError on aborted transaction]
-    expected: FAIL
-
-  [getKey() throws InvalidStateError on index deleted by aborted upgrade]
-    expected: FAIL
-
 
 [idbindex_getKey.any.sharedworker.html]
   expected: ERROR
 
 [idbindex_getKey.any.worker.html]
-  [getKey() returns the record's primary key]
-    expected: FAIL
-
-  [getKey() returns the record's primary key where the index contains duplicate values]
-    expected: FAIL
-
-  [getKey() attempt to retrieve the primary key of a record that doesn't exist]
-    expected: FAIL
-
-  [getKey() returns the key of the first record within the range]
-    expected: FAIL
-
-  [getKey() throws DataError when using invalid key]
-    expected: FAIL
-
-  [getKey() throws InvalidStateError when the index is deleted]
-    expected: FAIL
-
-  [getKey() throws TransactionInactiveError on aborted transaction]
-    expected: FAIL
-
-  [getKey() throws InvalidStateError on index deleted by aborted upgrade]
-    expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbindex_getKey.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbindex_getKey.any.js.ini
@@ -2,78 +2,7 @@
   expected: ERROR
 
 [idbindex_getKey.any.html]
-  [getKey() returns the record's primary key]
-    expected: FAIL
-
-  [getKey() returns the record's primary key where the index contains duplicate values]
-    expected: FAIL
-
-  [getKey() attempt to retrieve the primary key of a record that doesn't exist]
-    expected: FAIL
-
-  [getKey() returns the key of the first record within the range]
-    expected: FAIL
-
-  [getKey() throws DataError when using invalid key]
-    expected: FAIL
-
-  [getKey() throws InvalidStateError when the index is deleted]
-    expected: FAIL
-
-  [getKey() throws TransactionInactiveError on aborted transaction]
-    expected: FAIL
-
-  [getKey() throws InvalidStateError on index deleted by aborted upgrade]
-    expected: FAIL
-
 
 [idbindex_getKey.any.sharedworker.html]
-  [getKey() returns the record's primary key]
-    expected: FAIL
-
-  [getKey() returns the record's primary key where the index contains duplicate values]
-    expected: FAIL
-
-  [getKey() attempt to retrieve the primary key of a record that doesn't exist]
-    expected: FAIL
-
-  [getKey() returns the key of the first record within the range]
-    expected: FAIL
-
-  [getKey() throws DataError when using invalid key]
-    expected: FAIL
-
-  [getKey() throws InvalidStateError when the index is deleted]
-    expected: FAIL
-
-  [getKey() throws TransactionInactiveError on aborted transaction]
-    expected: FAIL
-
-  [getKey() throws InvalidStateError on index deleted by aborted upgrade]
-    expected: FAIL
-
 
 [idbindex_getKey.any.worker.html]
-  [getKey() returns the record's primary key]
-    expected: FAIL
-
-  [getKey() returns the record's primary key where the index contains duplicate values]
-    expected: FAIL
-
-  [getKey() attempt to retrieve the primary key of a record that doesn't exist]
-    expected: FAIL
-
-  [getKey() returns the key of the first record within the range]
-    expected: FAIL
-
-  [getKey() throws DataError when using invalid key]
-    expected: FAIL
-
-  [getKey() throws InvalidStateError when the index is deleted]
-    expected: FAIL
-
-  [getKey() throws TransactionInactiveError on aborted transaction]
-    expected: FAIL
-
-  [getKey() throws InvalidStateError on index deleted by aborted upgrade]
-    expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idlharness.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idlharness.any.js.ini
@@ -5,19 +5,10 @@
   [IDBIndex interface: attribute name]
     expected: FAIL
 
-  [IDBIndex interface: operation get(any)]
-    expected: FAIL
-
-  [IDBIndex interface: operation getKey(any)]
-    expected: FAIL
-
   [IDBIndex interface: operation getAll(optional any, optional unsigned long)]
     expected: FAIL
 
   [IDBIndex interface: operation getAllKeys(optional any, optional unsigned long)]
-    expected: FAIL
-
-  [IDBIndex interface: operation count(optional any)]
     expected: FAIL
 
   [IDBIndex interface: operation openCursor(optional any, optional IDBCursorDirection)]
@@ -82,19 +73,10 @@
   [IDBIndex interface: attribute name]
     expected: FAIL
 
-  [IDBIndex interface: operation get(any)]
-    expected: FAIL
-
-  [IDBIndex interface: operation getKey(any)]
-    expected: FAIL
-
   [IDBIndex interface: operation getAll(optional any, optional unsigned long)]
     expected: FAIL
 
   [IDBIndex interface: operation getAllKeys(optional any, optional unsigned long)]
-    expected: FAIL
-
-  [IDBIndex interface: operation count(optional any)]
     expected: FAIL
 
   [IDBIndex interface: operation openCursor(optional any, optional IDBCursorDirection)]

--- a/tests/wpt/meta/IndexedDB/idlharness.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idlharness.any.js.ini
@@ -2,12 +2,6 @@
   [IDBObjectStore interface: operation getAllRecords(optional IDBGetAllOptions)]
     expected: FAIL
 
-  [IDBIndex interface: operation get(any)]
-    expected: FAIL
-
-  [IDBIndex interface: operation getKey(any)]
-    expected: FAIL
-
   [IDBIndex interface: operation getAll(optional any, optional unsigned long)]
     expected: FAIL
 
@@ -15,9 +9,6 @@
     expected: FAIL
 
   [IDBIndex interface: operation getAllRecords(optional IDBGetAllOptions)]
-    expected: FAIL
-
-  [IDBIndex interface: operation count(optional any)]
     expected: FAIL
 
   [IDBIndex interface: operation openCursor(optional any, optional IDBCursorDirection)]
@@ -70,19 +61,10 @@
 
 
 [idlharness.any.html]
-  [IDBIndex interface: operation get(any)]
-    expected: FAIL
-
-  [IDBIndex interface: operation getKey(any)]
-    expected: FAIL
-
   [IDBIndex interface: operation getAll(optional any, optional unsigned long)]
     expected: FAIL
 
   [IDBIndex interface: operation getAllKeys(optional any, optional unsigned long)]
-    expected: FAIL
-
-  [IDBIndex interface: operation count(optional any)]
     expected: FAIL
 
   [IDBIndex interface: operation openCursor(optional any, optional IDBCursorDirection)]
@@ -144,19 +126,10 @@
   expected: ERROR
 
 [idlharness.any.worker.html]
-  [IDBIndex interface: operation get(any)]
-    expected: FAIL
-
-  [IDBIndex interface: operation getKey(any)]
-    expected: FAIL
-
   [IDBIndex interface: operation getAll(optional any, optional unsigned long)]
     expected: FAIL
 
   [IDBIndex interface: operation getAllKeys(optional any, optional unsigned long)]
-    expected: FAIL
-
-  [IDBIndex interface: operation count(optional any)]
     expected: FAIL
 
   [IDBIndex interface: operation openCursor(optional any, optional IDBCursorDirection)]

--- a/tests/wpt/meta/IndexedDB/key-conversion-exceptions.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/key-conversion-exceptions.any.js.ini
@@ -5,15 +5,6 @@
   [IndexedDB: Exceptions thrown during key conversion]
     expected: FAIL
 
-  [IDBIndex get() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBIndex getKey() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBIndex count() method with throwing/invalid keys]
-    expected: FAIL
-
   [IDBIndex openCursor() method with throwing/invalid keys]
     expected: FAIL
 
@@ -29,15 +20,6 @@
 
 [key-conversion-exceptions.any.html]
   [IndexedDB: Exceptions thrown during key conversion]
-    expected: FAIL
-
-  [IDBIndex get() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBIndex getKey() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBIndex count() method with throwing/invalid keys]
     expected: FAIL
 
   [IDBIndex openCursor() method with throwing/invalid keys]

--- a/tests/wpt/meta/IndexedDB/key-conversion-exceptions.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/key-conversion-exceptions.any.js.ini
@@ -5,15 +5,6 @@
   [IndexedDB: Exceptions thrown during key conversion]
     expected: FAIL
 
-  [IDBIndex get() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBIndex getKey() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBIndex count() method with throwing/invalid keys]
-    expected: FAIL
-
   [IDBIndex openCursor() method with throwing/invalid keys]
     expected: FAIL
 
@@ -29,15 +20,6 @@
 
 [key-conversion-exceptions.any.html]
   [IndexedDB: Exceptions thrown during key conversion]
-    expected: FAIL
-
-  [IDBIndex get() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBIndex getKey() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBIndex count() method with throwing/invalid keys]
     expected: FAIL
 
   [IDBIndex openCursor() method with throwing/invalid keys]
@@ -61,15 +43,6 @@
     expected: FAIL
 
   [IDBCursor update() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBIndex get() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBIndex getKey() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBIndex count() method with throwing/invalid keys]
     expected: FAIL
 
   [IDBIndex openCursor() method with throwing/invalid keys]

--- a/tests/wpt/meta/IndexedDB/name-scopes.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/name-scopes.any.js.ini
@@ -2,7 +2,6 @@
   expected: ERROR
 
 [name-scopes.any.worker.html]
-  expected: ERROR
   [Non-unique index keys]
     expected: FAIL
 
@@ -11,7 +10,6 @@
 
 
 [name-scopes.any.html]
-  expected: ERROR
   [Non-unique index keys]
     expected: FAIL
 

--- a/tests/wpt/meta/IndexedDB/name-scopes.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/name-scopes.any.js.ini
@@ -2,7 +2,6 @@
   expected: ERROR
 
 [name-scopes.any.worker.html]
-  expected: ERROR
   [Non-unique index keys]
     expected: FAIL
 
@@ -11,7 +10,6 @@
 
 
 [name-scopes.any.html]
-  expected: ERROR
   [Non-unique index keys]
     expected: FAIL
 
@@ -20,7 +18,6 @@
 
 
 [name-scopes.any.sharedworker.html]
-  expected: ERROR
   [Non-unique index keys]
     expected: FAIL
 

--- a/tests/wpt/meta/IndexedDB/reading-autoincrement-indexes.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/reading-autoincrement-indexes.any.js.ini
@@ -14,9 +14,6 @@
   [IDBIndex.getAllKeys() returns correct result for an index not covering the autoincrement key]
     expected: FAIL
 
-  [IDBIndex.get() for an index not covering the autoincrement key]
-    expected: FAIL
-
 
 [reading-autoincrement-indexes.any.sharedworker.html]
   expected: ERROR
@@ -38,7 +35,4 @@
     expected: FAIL
 
   [IDBIndex.getAllKeys() returns correct result for an index not covering the autoincrement key]
-    expected: FAIL
-
-  [IDBIndex.get() for an index not covering the autoincrement key]
     expected: FAIL

--- a/tests/wpt/meta/IndexedDB/reading-autoincrement-indexes.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/reading-autoincrement-indexes.any.js.ini
@@ -5,16 +5,10 @@
   [IDBIndex.getAllKeys() for an index on the autoincrement key]
     expected: FAIL
 
-  [IDBIndex.get() for an index on the autoincrement key]
-    expected: FAIL
-
   [IDBIndex.getAll() for an index not covering the autoincrement key]
     expected: FAIL
 
   [IDBIndex.getAllKeys() returns correct result for an index not covering the autoincrement key]
-    expected: FAIL
-
-  [IDBIndex.get() for an index not covering the autoincrement key]
     expected: FAIL
 
 
@@ -25,16 +19,10 @@
   [IDBIndex.getAllKeys() for an index on the autoincrement key]
     expected: FAIL
 
-  [IDBIndex.get() for an index on the autoincrement key]
-    expected: FAIL
-
   [IDBIndex.getAll() for an index not covering the autoincrement key]
     expected: FAIL
 
   [IDBIndex.getAllKeys() returns correct result for an index not covering the autoincrement key]
-    expected: FAIL
-
-  [IDBIndex.get() for an index not covering the autoincrement key]
     expected: FAIL
 
 
@@ -48,14 +36,8 @@
   [IDBIndex.getAllKeys() for an index on the autoincrement key]
     expected: FAIL
 
-  [IDBIndex.get() for an index on the autoincrement key]
-    expected: FAIL
-
   [IDBIndex.getAll() for an index not covering the autoincrement key]
     expected: FAIL
 
   [IDBIndex.getAllKeys() returns correct result for an index not covering the autoincrement key]
-    expected: FAIL
-
-  [IDBIndex.get() for an index not covering the autoincrement key]
     expected: FAIL

--- a/tests/wpt/meta/IndexedDB/transaction-abort-index-metadata-revert.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/transaction-abort-index-metadata-revert.any.js.ini
@@ -14,9 +14,6 @@
   [Deleted indexes get marked as not-deleted after the transaction aborts]
     expected: FAIL
 
-  [Created+deleted indexes are still marked as deleted after their transaction aborts]
-    expected: FAIL
-
 
 [transaction-abort-index-metadata-revert.any.serviceworker.html]
   expected: ERROR
@@ -35,9 +32,6 @@
     expected: FAIL
 
   [Deleted indexes get marked as not-deleted after the transaction aborts]
-    expected: FAIL
-
-  [Created+deleted indexes are still marked as deleted after their transaction aborts]
     expected: FAIL
 
 

--- a/tests/wpt/meta/IndexedDB/transaction-abort-index-metadata-revert.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/transaction-abort-index-metadata-revert.any.js.ini
@@ -1,20 +1,8 @@
 [transaction-abort-index-metadata-revert.any.html]
-  [Created stores get their indexes marked as deleted after the transaction that created them aborts]
-    expected: FAIL
-
   [Deleted stores get their indexes marked as not-deleted after the transaction that deleted them aborts]
     expected: FAIL
 
   [Created+deleted stores still have their indexes marked as deleted after the transaction aborts]
-    expected: FAIL
-
-  [Created indexes get marked as deleted after their transaction aborts]
-    expected: FAIL
-
-  [Deleted indexes get marked as not-deleted after the transaction aborts]
-    expected: FAIL
-
-  [Created+deleted indexes are still marked as deleted after their transaction aborts]
     expected: FAIL
 
 
@@ -22,40 +10,16 @@
   expected: ERROR
 
 [transaction-abort-index-metadata-revert.any.worker.html]
-  [Created stores get their indexes marked as deleted after the transaction that created them aborts]
-    expected: FAIL
-
   [Deleted stores get their indexes marked as not-deleted after the transaction that deleted them aborts]
     expected: FAIL
 
   [Created+deleted stores still have their indexes marked as deleted after the transaction aborts]
-    expected: FAIL
-
-  [Created indexes get marked as deleted after their transaction aborts]
-    expected: FAIL
-
-  [Deleted indexes get marked as not-deleted after the transaction aborts]
-    expected: FAIL
-
-  [Created+deleted indexes are still marked as deleted after their transaction aborts]
     expected: FAIL
 
 
 [transaction-abort-index-metadata-revert.any.sharedworker.html]
-  [Created stores get their indexes marked as deleted after the transaction that created them aborts]
-    expected: FAIL
-
   [Deleted stores get their indexes marked as not-deleted after the transaction that deleted them aborts]
     expected: FAIL
 
   [Created+deleted stores still have their indexes marked as deleted after the transaction aborts]
-    expected: FAIL
-
-  [Created indexes get marked as deleted after their transaction aborts]
-    expected: FAIL
-
-  [Deleted indexes get marked as not-deleted after the transaction aborts]
-    expected: FAIL
-
-  [Created+deleted indexes are still marked as deleted after their transaction aborts]
     expected: FAIL


### PR DESCRIPTION
Updates indices in the course of regular object store operations. Also allows for querying of indices.

Followups:

- https://www.w3.org/TR/IndexedDB/#store-a-record-into-an-object-store has a few missing pieces
- Handling of index population if there are pre-existing items in the database. We would likely need coordination with the script thread in order to deserialize the stored values and extract the key paths. It would be nice if we could manage values without having to rely on the script thread.
- Proper multi-entry key conversion
- Store index id on frontend to avoid name change issues and to reduce necessary DB queries for index operations.
- unique index data in it's own table?

Testing: More WPT tests
Fixes: Partially #38100 
