### PR TITLE
script: Correctly handle modifiable elements in contenteditable

### DIFF
--- a/components/script/dom/element/attributes.rs
+++ b/components/script/dom/element/attributes.rs
@@ -2,15 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use html5ever::{LocalName, ns};
+use html5ever::{LocalName, local_name, ns};
 use js::context::JSContext;
+use servo_arc::Arc as ServoArc;
 use style::attr::AttrValue;
 use stylo_atoms::Atom;
 
+use crate::dom::attr::Attr;
 use crate::dom::bindings::codegen::Bindings::AttrBinding::AttrMethods;
 use crate::dom::bindings::codegen::UnionTypes::{TrustedHTMLOrString, TrustedScriptURLOrUSVString};
+use crate::dom::bindings::root::Dom;
 use crate::dom::bindings::str::{DOMString, USVString};
-use crate::dom::element::Element;
+use crate::dom::element::{AttributeMutationReason, Element};
 use crate::dom::node::NodeTraits;
 use crate::script_runtime::CanGc;
 
@@ -177,5 +180,49 @@ impl Element {
             AttrValue::UInt(value.to_string(), value),
             can_gc,
         );
+    }
+
+    /// Ensure that for styles, we clone the already-parsed property declaration block.
+    /// This does two things:
+    /// 1. It uses the same fast-path as CSSStyleDeclaration
+    /// 2. It also avoids the CSP checks when cloning (it shouldn't run any when cloning
+    ///    existing valid attributes)
+    fn compute_attribute_value_with_style_fast_path(&self, attr: &Dom<Attr>) -> AttrValue {
+        if *attr.local_name() == local_name!("style") {
+            if let Some(ref pdb) = *self.style_attribute().borrow() {
+                let document = self.owner_document();
+                let shared_lock = document.style_shared_lock();
+                let new_pdb = pdb.read_with(&shared_lock.read()).clone();
+                return AttrValue::Declaration(
+                    (**attr.value()).to_owned(),
+                    ServoArc::new(shared_lock.wrap(new_pdb)),
+                );
+            }
+        }
+
+        attr.value().clone()
+    }
+
+    /// <https://dom.spec.whatwg.org/#concept-node-clone>
+    pub(crate) fn copy_all_attributes_to_other_element(
+        &self,
+        cx: &mut JSContext,
+        target_element: &Element,
+    ) {
+        // Step 2.5. For each attribute of node’s attribute list:
+        for attr in self.attrs().iter() {
+            // Step 2.5.1. Let copyAttribute be the result of cloning a single node given attribute, document, and null.
+            let new_value = self.compute_attribute_value_with_style_fast_path(attr);
+            // Step 2.5.2. Append copyAttribute to copy.
+            target_element.push_new_attribute(
+                attr.local_name().clone(),
+                new_value,
+                attr.name().clone(),
+                attr.namespace().clone(),
+                attr.prefix().cloned(),
+                AttributeMutationReason::ByCloning,
+                CanGc::from_cx(cx),
+            );
+        }
     }
 }

--- a/components/script/dom/execcommand/basecommand.rs
+++ b/components/script/dom/execcommand/basecommand.rs
@@ -57,7 +57,7 @@ pub(crate) enum CssPropertyName {
 }
 
 impl CssPropertyName {
-    fn resolved_value_for_node(&self, element: &Element) -> Option<DOMString> {
+    pub(crate) fn resolved_value_for_node(&self, element: &Element) -> Option<DOMString> {
         let style = element.style()?;
 
         Some(

--- a/components/script/dom/execcommand/contenteditable/element.rs
+++ b/components/script/dom/execcommand/contenteditable/element.rs
@@ -94,6 +94,70 @@ impl Element {
         }
     }
 
+    /// <https://w3c.github.io/editing/docs/execCommand/#modifiable-element>
+    pub(crate) fn is_modifiable_element(&self) -> bool {
+        let attrs = self.attrs();
+        let mut attrs = attrs.iter();
+        let type_id = self.upcast::<Node>().type_id();
+
+        // > A modifiable element is a b, em, i, s, span, strike, strong, sub, sup, or u element
+        // > with no attributes except possibly style;
+        if matches!(
+            type_id,
+            NodeTypeId::Element(ElementTypeId::HTMLElement(
+                HTMLElementTypeId::HTMLSpanElement,
+            ))
+        ) || matches!(
+            *self.local_name(),
+            local_name!("b") |
+                local_name!("em") |
+                local_name!("i") |
+                local_name!("s") |
+                local_name!("strike") |
+                local_name!("strong") |
+                local_name!("sub") |
+                local_name!("sup") |
+                local_name!("u")
+        ) {
+            return attrs.all(|attr| attr.local_name() == &local_name!("style"));
+        }
+
+        // > or a font element with no attributes except possibly style, color, face, and/or size;
+        if matches!(
+            type_id,
+            NodeTypeId::Element(ElementTypeId::HTMLElement(
+                HTMLElementTypeId::HTMLFontElement,
+            ))
+        ) {
+            return attrs.all(|attr| {
+                matches!(
+                    *attr.local_name(),
+                    local_name!("style") |
+                        local_name!("color") |
+                        local_name!("face") |
+                        local_name!("size")
+                )
+            });
+        }
+
+        // > or an a element with no attributes except possibly style and/or href.
+        if matches!(
+            type_id,
+            NodeTypeId::Element(ElementTypeId::HTMLElement(
+                HTMLElementTypeId::HTMLAnchorElement,
+            ))
+        ) {
+            return attrs.all(|attr| {
+                matches!(
+                    *attr.local_name(),
+                    local_name!("style") | local_name!("href")
+                )
+            });
+        }
+
+        false
+    }
+
     /// <https://w3c.github.io/editing/docs/execCommand/#simple-modifiable-element>
     pub(crate) fn is_simple_modifiable_element(&self) -> bool {
         let attrs = self.attrs();
@@ -130,7 +194,7 @@ impl Element {
             // > with exactly one attribute, which is style,
             // > which sets no CSS properties (including invalid or unrecognized properties).
             if attr_count == 1 &&
-                self.attrs().first().expect("Size is 1").local_name() == &local_name!("style")
+                attrs.first().expect("Size is 1").local_name() == &local_name!("style")
             {
                 let style_attribute = self.style_attribute().borrow();
                 if style_attribute.as_ref().is_some_and(|declarations| {

--- a/components/script/dom/execcommand/contenteditable/htmlelement.rs
+++ b/components/script/dom/execcommand/contenteditable/htmlelement.rs
@@ -47,13 +47,13 @@ impl HTMLElement {
             return;
         }
         // Step 4. If element is a simple modifiable element:
+        let node_parent = node.GetParentNode().expect("Must always have a parent");
         if element.is_simple_modifiable_element() {
             // Step 4.1. Let children be the children of element.
             // Step 4.2. For each child in children, insert child into element's parent immediately before element, preserving ranges.
-            let element_parent = node.GetParentNode().expect("Must always have a parent");
             for child in node.children() {
                 move_preserving_ranges(cx, &child, |cx| {
-                    element_parent.InsertBefore(cx, &child, Some(node))
+                    node_parent.InsertBefore(cx, &child, Some(node))
                 });
             }
             // Step 4.3. Remove element from its parent.
@@ -116,11 +116,34 @@ impl HTMLElement {
         // Step 10. If element's specified command value for command is null,
         // return the empty list.
         if element.specified_command_value(command).is_none() {
-            // TODO
+            return;
         }
         // Step 11. Set the tag name of element to "span",
         // and return the one-node list consisting of the result.
-        // TODO
+        //
+        // Yeah, here we are. The spec makes this look easy, but the way we
+        // model elements, it's not. We can't simply set the `local_name`,
+        // since the struct also must change. Therefore, instead of only
+        // changing the tag name, we perform all necessary changes to make
+        // it seem like we "changed it to a span". To do so, we move all
+        // of its children and copy its attributes, after which we remove
+        // the original node.
+        let document = node.owner_document();
+        let new_span = document.create_element(cx, "span");
+        let new_span_node = new_span.upcast::<Node>();
+        if node_parent
+            .InsertBefore(cx, new_span_node, Some(node))
+            .is_err()
+        {
+            unreachable!("Must always be able to insert");
+        }
+        for child in node.children() {
+            move_preserving_ranges(cx, &child, |cx| new_span_node.AppendChild(cx, &child));
+        }
+
+        element.copy_all_attributes_to_other_element(cx, &new_span);
+
+        node.remove_self(cx);
     }
 
     /// There is no specification for this implementation. Instead, it is

--- a/components/script/dom/execcommand/contenteditable/node.rs
+++ b/components/script/dom/execcommand/contenteditable/node.rs
@@ -706,10 +706,8 @@ where
             }
             // Step 15.2. While new parent's nextSibling has children,
             // append its first child as the last child of new parent, preserving ranges.
-            while let Some(first_of_next) = next_of_new_parent.children().next() {
-                move_preserving_ranges(cx, &first_of_next, |cx| {
-                    new_parent.AppendChild(cx, &first_of_next)
-                });
+            for child in next_of_new_parent.children() {
+                move_preserving_ranges(cx, &child, |cx| new_parent.AppendChild(cx, &child));
             }
             // Step 15.3. Remove new parent's nextSibling from its parent.
             next_of_new_parent.remove_self(cx);
@@ -972,6 +970,84 @@ impl Node {
         }
     }
 
+    /// <https://w3c.github.io/editing/docs/execCommand/#reorder-modifiable-descendants>
+    fn reorder_modifiable_descendants(
+        &self,
+        cx: &mut JSContext,
+        command: &CommandName,
+        new_value: &DOMString,
+    ) {
+        // Step 1. Let candidate equal node.
+        let mut candidate = DomRoot::from_ref(self);
+        // Step 2. While candidate is a modifiable element, and candidate has exactly one child,
+        // and that child is also a modifiable element,
+        // and candidate is not a simple modifiable element or candidate's specified command value
+        // for command is not equivalent to new value, set candidate to its child.
+        loop {
+            if let Some(candidate_element) = candidate.downcast::<Element>() {
+                if candidate_element.is_modifiable_element() &&
+                    candidate.children_count() == 1 &&
+                    (!candidate_element.is_simple_modifiable_element() ||
+                        !command.are_equivalent_values(
+                            candidate_element.specified_command_value(command).as_ref(),
+                            Some(new_value),
+                        ))
+                {
+                    let child = candidate.children().next().expect("Has one child");
+
+                    if let Some(child_element) = child.downcast::<Element>() {
+                        if child_element.is_modifiable_element() {
+                            candidate = child;
+                            continue;
+                        }
+                    }
+                }
+            }
+            break;
+        }
+        // Step 3. If candidate is node, or is not a simple modifiable element,
+        // or its specified command value is not equivalent to new value,
+        // or its effective command value is not loosely equivalent to new value, abort these steps.
+        if *candidate == *self ||
+            !command.are_loosely_equivalent_values(
+                candidate.effective_command_value(command).as_ref(),
+                Some(new_value),
+            )
+        {
+            return;
+        }
+        if let Some(candidate) = candidate.downcast::<Element>() {
+            if !candidate.is_simple_modifiable_element() ||
+                !command.are_equivalent_values(
+                    candidate.specified_command_value(command).as_ref(),
+                    Some(new_value),
+                )
+            {
+                return;
+            }
+        }
+        // Step 4. While candidate has children,
+        // insert the first child of candidate into candidate's parent immediately before candidate, preserving ranges.
+        let parent_of_candidate = candidate
+            .GetParentNode()
+            .expect("Must always have a parent");
+        for child in candidate.children() {
+            move_preserving_ranges(cx, &child, |cx| {
+                parent_of_candidate.InsertBefore(cx, &child, Some(&candidate))
+            });
+        }
+        // Step 5. Insert candidate into node's parent immediately after node.
+        let parent_of_node = self.GetParentNode().expect("Must always have a parent");
+        if parent_of_node
+            .InsertBefore(cx, &candidate, self.GetNextSibling().as_deref())
+            .is_err()
+        {
+            unreachable!("Must always be able to insert");
+        }
+        // Step 6. Append the node as the last child of candidate, preserving ranges.
+        move_preserving_ranges(cx, self, |cx| candidate.AppendChild(cx, self));
+    }
+
     /// <https://w3c.github.io/editing/docs/execCommand/#force-the-value>
     pub(crate) fn force_the_value(
         &self,
@@ -997,9 +1073,13 @@ impl Node {
             NodeOrString::String("span".to_owned()),
         ) {
             // Step 4.1. Reorder modifiable descendants of node's previousSibling.
-            // TODO
+            if let Some(previous) = self.GetPreviousSibling() {
+                previous.reorder_modifiable_descendants(cx, command, new_value);
+            }
             // Step 4.2. Reorder modifiable descendants of node's nextSibling.
-            // TODO
+            if let Some(next) = self.GetNextSibling() {
+                next.reorder_modifiable_descendants(cx, command, new_value);
+            }
             // Step 4.3. Wrap the one-node list consisting of node,
             // with sibling criteria returning true for a simple modifiable element whose
             // specified command value is equivalent to new value and whose effective command value
@@ -1959,7 +2039,9 @@ impl Node {
             CommandName::Underline => Some("underline".into()).filter(|_| {
                 self.inclusive_ancestors(ShadowIncluding::No).any(|node| {
                     node.downcast::<Element>()
-                        .and_then(|element| CommandName::Underline.resolved_value_for_node(element))
+                        .and_then(|element| {
+                            CssPropertyName::TextDecorationLine.resolved_value_for_node(element)
+                        })
                         .is_some_and(|property| property.contains("underline"))
                 })
             }),

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -45,7 +45,6 @@ use servo_config::pref;
 use servo_url::ServoUrl;
 use smallvec::SmallVec;
 use style::Atom;
-use style::attr::AttrValue;
 use style::context::QuirksMode;
 use style::dom::OpaqueNode;
 use style::dom_apis::{QueryAll, QueryFirst};
@@ -100,9 +99,7 @@ use crate::dom::customelementregistry::{
 use crate::dom::document::{Document, DocumentSource, HasBrowsingContext, IsHTMLDocument};
 use crate::dom::documentfragment::DocumentFragment;
 use crate::dom::documenttype::DocumentType;
-use crate::dom::element::{
-    AttributeMutationReason, CustomElementCreationMode, Element, ElementCreator,
-};
+use crate::dom::element::{CustomElementCreationMode, Element, ElementCreator};
 use crate::dom::event::{Event, EventBubbles, EventCancelable, EventFlags};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
@@ -3409,27 +3406,6 @@ impl Node {
         Some(index)
     }
 
-    /// Ensure that for styles, we clone the already-parsed property declaration block.
-    /// This does two things:
-    /// 1. it uses the same fast-path as CSSStyleDeclaration
-    /// 2. it also avoids the CSP checks when cloning (it shouldn't run any when cloning
-    ///    existing valid attributes)
-    fn compute_attribute_value_with_style_fast_path(attr: &Dom<Attr>, elem: &Element) -> AttrValue {
-        if *attr.local_name() == local_name!("style") {
-            if let Some(ref pdb) = *elem.style_attribute().borrow() {
-                let document = elem.owner_document();
-                let shared_lock = document.style_shared_lock();
-                let new_pdb = pdb.read_with(&shared_lock.read()).clone();
-                return AttrValue::Declaration(
-                    (**attr.value()).to_owned(),
-                    ServoArc::new(shared_lock.wrap(new_pdb)),
-                );
-            }
-        }
-
-        attr.value().clone()
-    }
-
     /// <https://dom.spec.whatwg.org/#concept-node-clone>
     pub(crate) fn clone(
         cx: &mut JSContext,
@@ -3578,21 +3554,7 @@ impl Node {
                 let copy_elem = copy.downcast::<Element>().unwrap();
 
                 // Step 2.5. For each attribute of node’s attribute list:
-                for attr in node_elem.attrs().iter() {
-                    // Step 2.5.1. Let copyAttribute be the result of cloning a single node given attribute, document, and null.
-                    let new_value =
-                        Node::compute_attribute_value_with_style_fast_path(attr, node_elem);
-                    // Step 2.5.2. Append copyAttribute to copy.
-                    copy_elem.push_new_attribute(
-                        attr.local_name().clone(),
-                        new_value,
-                        attr.name().clone(),
-                        attr.namespace().clone(),
-                        attr.prefix().cloned(),
-                        AttributeMutationReason::ByCloning,
-                        CanGc::from_cx(cx),
-                    );
-                }
+                node_elem.copy_all_attributes_to_other_element(cx, copy_elem);
             },
             _ => (),
         }

--- a/tests/wpt/meta/editing/other/removing-inline-style-specified-by-parent-block.tentative.html.ini
+++ b/tests/wpt/meta/editing/other/removing-inline-style-specified-by-parent-block.tentative.html.ini
@@ -2,12 +2,6 @@
   [Disabling style to text, it's applied to the parent block]
     expected: FAIL
 
-  [Disabling style to text, it's applied to the editing host]
-    expected: FAIL
-
-  [Disabling style to text, it's applied to the body]
-    expected: FAIL
-
 
 [removing-inline-style-specified-by-parent-block.tentative.html?i]
   [Disabling style to text, it's applied to the parent block]

--- a/tests/wpt/meta/editing/run/underline.html.ini
+++ b/tests/wpt/meta/editing/run/underline.html.ini
@@ -5,9 +5,6 @@
   [[["stylewithcss","true"\],["underline",""\]\] "<p>[foo</p> <p>bar\]</p>" queryCommandState("underline") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["underline",""\]\] "<p>[foo</p> <p>bar\]</p>" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<span>[foo</span> <span>bar\]</span>" compare innerHTML]
     expected: FAIL
 
@@ -15,9 +12,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["underline",""\]\] "<span>[foo</span> <span>bar\]</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "<span>[foo</span> <span>bar\]</span>" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<p>[foo</p><p> <span>bar</span> </p><p>baz\]</p>" compare innerHTML]
@@ -29,9 +23,6 @@
   [[["stylewithcss","false"\],["underline",""\]\] "<p>[foo</p><p> <span>bar</span> </p><p>baz\]</p>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["underline",""\]\] "<p>[foo</p><p> <span>bar</span> </p><p>baz\]</p>" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<p>[foo<p><br><p>bar\]" compare innerHTML]
     expected: FAIL
 
@@ -41,16 +32,10 @@
   [[["stylewithcss","false"\],["underline",""\]\] "<p>[foo<p><br><p>bar\]" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["underline",""\]\] "<p>[foo<p><br><p>bar\]" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "foo[bar\]baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "foo[bar\]baz" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "foo[bar\]baz" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "foo[bar<b>baz\]qoz</b>quz" compare innerHTML]
@@ -59,16 +44,10 @@
   [[["stylewithcss","true"\],["underline",""\]\] "foo[bar<b>baz\]qoz</b>quz" queryCommandState("underline") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["underline",""\]\] "foo[bar<b>baz\]qoz</b>quz" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "foo[bar<i>baz\]qoz</i>quz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "foo[bar<i>baz\]qoz</i>quz" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "foo[bar<i>baz\]qoz</i>quz" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "{<p><p> <p>foo</p>}" compare innerHTML]
@@ -77,16 +56,10 @@
   [[["stylewithcss","true"\],["underline",""\]\] "{<p><p> <p>foo</p>}" queryCommandState("underline") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["underline",""\]\] "{<p><p> <p>foo</p>}" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<table><tbody><tr><td>foo<td>b[a\]r<td>baz</table>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<table><tbody><tr><td>foo<td>b[a\]r<td>baz</table>" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "<table><tbody><tr><td>foo<td>b[a\]r<td>baz</table>" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<table><tbody><tr data-start=1 data-end=2><td>foo<td>bar<td>baz</table>" compare innerHTML]
@@ -95,16 +68,10 @@
   [[["stylewithcss","true"\],["underline",""\]\] "<table><tbody><tr data-start=1 data-end=2><td>foo<td>bar<td>baz</table>" queryCommandState("underline") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["underline",""\]\] "<table><tbody><tr data-start=1 data-end=2><td>foo<td>bar<td>baz</table>" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<table><tbody><tr data-start=0 data-end=2><td>foo<td>bar<td>baz</table>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<table><tbody><tr data-start=0 data-end=2><td>foo<td>bar<td>baz</table>" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "<table><tbody><tr data-start=0 data-end=2><td>foo<td>bar<td>baz</table>" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<table><tbody data-start=0 data-end=1><tr><td>foo<td>bar<td>baz</table>" compare innerHTML]
@@ -113,16 +80,10 @@
   [[["stylewithcss","true"\],["underline",""\]\] "<table><tbody data-start=0 data-end=1><tr><td>foo<td>bar<td>baz</table>" queryCommandState("underline") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["underline",""\]\] "<table><tbody data-start=0 data-end=1><tr><td>foo<td>bar<td>baz</table>" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<table data-start=0 data-end=1><tbody><tr><td>foo<td>bar<td>baz</table>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<table data-start=0 data-end=1><tbody><tr><td>foo<td>bar<td>baz</table>" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "<table data-start=0 data-end=1><tbody><tr><td>foo<td>bar<td>baz</table>" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "{<table><tr><td>foo<td>bar<td>baz</table>}" compare innerHTML]
@@ -131,100 +92,49 @@
   [[["stylewithcss","true"\],["underline",""\]\] "{<table><tr><td>foo<td>bar<td>baz</table>}" queryCommandState("underline") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["underline",""\]\] "{<table><tr><td>foo<td>bar<td>baz</table>}" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "foo<span style=\\"text-decoration: underline\\">[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "foo<span style=\\"text-decoration: underline\\">[bar\]</span>baz" queryCommandState("underline") before]
     expected: FAIL
 
   [[["stylewithcss","false"\],["underline",""\]\] "foo<span style=\\"text-decoration: underline\\">[bar\]</span>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["underline",""\]\] "foo<span style=\\"text-decoration: underline\\">[bar\]</span>baz" queryCommandState("underline") before]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<u>foo[bar\]baz</u>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<u>foo[bar\]baz</u>" queryCommandState("underline") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "<u>foo[bar\]baz</u>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "<u>foo[bar\]baz</u>" queryCommandState("underline") before]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<u>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</u>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "<u>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</u>" queryCommandState("underline") before]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["underline",""\]\] "<u>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</u>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "<u>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</u>" queryCommandState("underline") before]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<u>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</u>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "<u>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</u>" queryCommandState("underline") before]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["underline",""\]\] "<u>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</u>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "<u>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</u>" queryCommandState("underline") before]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<u>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</u>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "<u>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</u>" queryCommandState("underline") before]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["underline",""\]\] "<u>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</u>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "<u>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</u>" queryCommandState("underline") before]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<u>foo[b<i>ar\]ba</i>z</u>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "<u>foo[b<i>ar\]ba</i>z</u>" queryCommandState("underline") before]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["underline",""\]\] "<u>foo[b<i>ar\]ba</i>z</u>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "<u>foo[b<i>ar\]ba</i>z</u>" queryCommandState("underline") before]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<p style=\\"text-decoration: underline\\">foo[bar\]baz</p>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "<p style=\\"text-decoration: underline\\">foo[bar\]baz</p>" queryCommandState("underline") before]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["underline",""\]\] "<p style=\\"text-decoration: underline\\">foo[bar\]baz</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "<p style=\\"text-decoration: underline\\">foo[bar\]baz</p>" queryCommandState("underline") before]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "foo<s>[bar\]</s>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "foo<s>[bar\]</s>baz" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "foo<s>[bar\]</s>baz" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "foo<span style=\\"text-decoration: line-through\\">[bar\]</span>baz" compare innerHTML]
@@ -236,16 +146,10 @@
   [[["stylewithcss","false"\],["underline",""\]\] "foo<span style=\\"text-decoration: line-through\\">[bar\]</span>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["underline",""\]\] "foo<span style=\\"text-decoration: line-through\\">[bar\]</span>baz" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<s>foo[bar\]baz</s>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<s>foo[bar\]baz</s>" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "<s>foo[bar\]baz</s>" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<s>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</s>" compare innerHTML]
@@ -254,16 +158,10 @@
   [[["stylewithcss","true"\],["underline",""\]\] "<s>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</s>" queryCommandState("underline") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["underline",""\]\] "<s>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</s>" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<s>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</s>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<s>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</s>" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "<s>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</s>" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<s>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</s>" compare innerHTML]
@@ -272,25 +170,16 @@
   [[["stylewithcss","true"\],["underline",""\]\] "<s>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</s>" queryCommandState("underline") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["underline",""\]\] "<s>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</s>" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<s>foo[b<i>ar\]ba</i>z</s>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<s>foo[b<i>ar\]ba</i>z</s>" queryCommandState("underline") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["underline",""\]\] "<s>foo[b<i>ar\]ba</i>z</s>" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<p style=\\"text-decoration: line-through\\">foo[bar\]baz</p>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<p style=\\"text-decoration: line-through\\">foo[bar\]baz</p>" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "<p style=\\"text-decoration: line-through\\">foo[bar\]baz</p>" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "foo<strike>[bar\]</strike>baz" compare innerHTML]
@@ -302,24 +191,24 @@
   [[["stylewithcss","true"\],["underline",""\]\] "<p>[foo</p> <p>bar\]</p>" queryCommandState("stylewithcss") before]
     expected: FAIL
 
+  [[["stylewithcss","false"\],["underline",""\]\] "<u>foo[bar\]baz</u>" queryCommandState("underline") after]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["underline",""\]\] "<u>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</u>" queryCommandState("underline") after]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["underline",""\]\] "<u>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</u>" queryCommandState("underline") after]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["underline",""\]\] "<u>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</u>" queryCommandState("underline") after]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["underline",""\]\] "<u>foo[b<i>ar\]ba</i>z</u>" queryCommandState("underline") after]
+    expected: FAIL
+
 
 [underline.html?2001-last]
   [[["stylewithcss","false"\],["underline",""\]\] "foo<u>[bar\]</u>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "foo<u>[bar\]</u>baz" queryCommandState("underline") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "foo{<u>bar</u>}baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "foo{<u>bar</u>}baz" queryCommandState("underline") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "foo{<u>bar</u>}baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "foo{<u>bar</u>}baz" queryCommandState("underline") before]
     expected: FAIL
 
   [[["underline",""\]\] "fo[o<span style=text-decoration:underline>b\]ar</span>baz" compare innerHTML]
@@ -328,22 +217,10 @@
   [[["underline",""\]\] "fo[o<span style=text-decoration:underline>b\]ar</span>baz" queryCommandIndeterm("underline") before]
     expected: FAIL
 
-  [[["underline",""\]\] "fo[o<span style=text-decoration:underline>b\]ar</span>baz" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<ins>fo[o</ins><u>b\]ar</u>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "<ins>fo[o</ins><u>b\]ar</u>" queryCommandState("underline") before]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<ins>fo[o</ins><u>b\]ar</u>" queryCommandIndeterm("underline") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "<ins>fo[o</ins><u>b\]ar</u>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "<ins>fo[o</ins><u>b\]ar</u>" queryCommandState("underline") before]
     expected: FAIL
 
   [[["stylewithcss","false"\],["underline",""\]\] "<ins>fo[o</ins><u>b\]ar</u>" queryCommandIndeterm("underline") after]
@@ -352,16 +229,7 @@
   [[["stylewithcss","true"\],["underline",""\]\] "<u>fo[o</u><ins>b\]ar</ins>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "<u>fo[o</u><ins>b\]ar</ins>" queryCommandState("underline") before]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<u>fo[o</u><ins>b\]ar</ins>" queryCommandIndeterm("underline") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "<u>fo[o</u><ins>b\]ar</ins>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "<u>fo[o</u><ins>b\]ar</ins>" queryCommandState("underline") before]
     expected: FAIL
 
   [[["stylewithcss","false"\],["underline",""\]\] "<u>fo[o</u><ins>b\]ar</ins>" queryCommandIndeterm("underline") after]
@@ -382,6 +250,18 @@
   [[["stylewithcss","true"\],["underline",""\]\] "abc<span style=\\"text-decoration:underline line-through blue dotted\\">[def\]</span>ghi" compare innerHTML]
     expected: FAIL
 
+  [[["stylewithcss","true"\],["underline",""\]\] "foo<u>[bar\]</u>baz" queryCommandState("underline") after]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["underline",""\]\] "<ins>fo[o</ins><u>b\]ar</u>" queryCommandState("underline") after]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["underline",""\]\] "<ins>fo[o</ins><u>b\]ar</u>" queryCommandState("underline") after]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["underline",""\]\] "<u>fo[o</u><ins>b\]ar</ins>" queryCommandState("underline") after]
+    expected: FAIL
+
 
 [underline.html?1001-2000]
   [[["stylewithcss","false"\],["underline",""\]\] "foo<strike>[bar\]</strike>baz" queryCommandState("underline") after]
@@ -393,16 +273,10 @@
   [[["stylewithcss","true"\],["underline",""\]\] "<strike>foo[bar\]baz</strike>" queryCommandState("underline") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["underline",""\]\] "<strike>foo[bar\]baz</strike>" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<strike>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</strike>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<strike>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</strike>" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "<strike>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</strike>" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<strike>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</strike>" compare innerHTML]
@@ -411,16 +285,10 @@
   [[["stylewithcss","true"\],["underline",""\]\] "<strike>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</strike>" queryCommandState("underline") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["underline",""\]\] "<strike>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</strike>" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<strike>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</strike>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<strike>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</strike>" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "<strike>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</strike>" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<strike>foo[b<i>ar\]ba</i>z</strike>" compare innerHTML]
@@ -429,52 +297,10 @@
   [[["stylewithcss","true"\],["underline",""\]\] "<strike>foo[b<i>ar\]ba</i>z</strike>" queryCommandState("underline") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["underline",""\]\] "<strike>foo[b<i>ar\]ba</i>z</strike>" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["underline",""\]\] "foo<ins>[bar\]</ins>baz" queryCommandState("underline") before]
-    expected: FAIL
-
-  [[["underline",""\]\] "foo<ins>[bar\]</ins>baz" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["underline",""\]\] "<ins>foo[bar\]baz</ins>" queryCommandState("underline") before]
-    expected: FAIL
-
-  [[["underline",""\]\] "<ins>foo[bar\]baz</ins>" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["underline",""\]\] "<ins>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</ins>" queryCommandState("underline") before]
-    expected: FAIL
-
-  [[["underline",""\]\] "<ins>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</ins>" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["underline",""\]\] "<ins>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</ins>" queryCommandState("underline") before]
-    expected: FAIL
-
-  [[["underline",""\]\] "<ins>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</ins>" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["underline",""\]\] "<ins>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</ins>" queryCommandState("underline") before]
-    expected: FAIL
-
-  [[["underline",""\]\] "<ins>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</ins>" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["underline",""\]\] "<ins>foo[b<i>ar\]ba</i>z</ins>" queryCommandState("underline") before]
-    expected: FAIL
-
-  [[["underline",""\]\] "<ins>foo[b<i>ar\]ba</i>z</ins>" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "foo<del>[bar\]</del>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "foo<del>[bar\]</del>baz" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "foo<del>[bar\]</del>baz" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<del>foo[bar\]baz</del>" compare innerHTML]
@@ -483,16 +309,10 @@
   [[["stylewithcss","true"\],["underline",""\]\] "<del>foo[bar\]baz</del>" queryCommandState("underline") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["underline",""\]\] "<del>foo[bar\]baz</del>" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<del>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</del>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<del>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</del>" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "<del>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</del>" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<del>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</del>" compare innerHTML]
@@ -501,16 +321,10 @@
   [[["stylewithcss","true"\],["underline",""\]\] "<del>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</del>" queryCommandState("underline") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["underline",""\]\] "<del>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</del>" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<del>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</del>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<del>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</del>" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "<del>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</del>" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<del>foo[b<i>ar\]ba</i>z</del>" compare innerHTML]
@@ -519,49 +333,25 @@
   [[["stylewithcss","true"\],["underline",""\]\] "<del>foo[b<i>ar\]ba</i>z</del>" queryCommandState("underline") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["underline",""\]\] "<del>foo[b<i>ar\]ba</i>z</del>" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["underline",""\]\] "foo<span style=\\"text-decoration: underline line-through\\">[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["underline",""\]\] "foo<span style=\\"text-decoration: underline line-through\\">[bar\]</span>baz" queryCommandState("underline") before]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "foo<span style=\\"text-decoration: underline line-through\\">b[a\]r</span>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "foo<span style=\\"text-decoration: underline line-through\\">b[a\]r</span>baz" queryCommandState("underline") before]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["underline",""\]\] "foo<span style=\\"text-decoration: underline line-through\\">b[a\]r</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "foo<span style=\\"text-decoration: underline line-through\\">b[a\]r</span>baz" queryCommandState("underline") before]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "foo<s style=\\"text-decoration: underline\\">[bar\]</s>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "foo<s style=\\"text-decoration: underline\\">[bar\]</s>baz" queryCommandState("underline") before]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["underline",""\]\] "foo<s style=\\"text-decoration: underline\\">[bar\]</s>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "foo<s style=\\"text-decoration: underline\\">[bar\]</s>baz" queryCommandState("underline") before]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "foo<s style=\\"text-decoration: underline\\">b[a\]r</s>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "foo<s style=\\"text-decoration: underline\\">b[a\]r</s>baz" queryCommandState("underline") before]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["underline",""\]\] "foo<s style=\\"text-decoration: underline\\">b[a\]r</s>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "foo<s style=\\"text-decoration: underline\\">b[a\]r</s>baz" queryCommandState("underline") before]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "foo<u style=\\"text-decoration: line-through\\">[bar\]</u>baz" compare innerHTML]
@@ -573,16 +363,10 @@
   [[["stylewithcss","false"\],["underline",""\]\] "foo<u style=\\"text-decoration: line-through\\">[bar\]</u>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["underline",""\]\] "foo<u style=\\"text-decoration: line-through\\">[bar\]</u>baz" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "foo<u style=\\"text-decoration: line-through\\">b[a\]r</u>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "foo<u style=\\"text-decoration: line-through\\">b[a\]r</u>baz" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "foo<u style=\\"text-decoration: line-through\\">b[a\]r</u>baz" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "foo<s style=\\"text-decoration: overline\\">[bar\]</s>baz" compare innerHTML]
@@ -594,16 +378,10 @@
   [[["stylewithcss","false"\],["underline",""\]\] "foo<s style=\\"text-decoration: overline\\">[bar\]</s>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["underline",""\]\] "foo<s style=\\"text-decoration: overline\\">[bar\]</s>baz" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "foo<s style=\\"text-decoration: overline\\">b[a\]r</s>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "foo<s style=\\"text-decoration: overline\\">b[a\]r</s>baz" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "foo<s style=\\"text-decoration: overline\\">b[a\]r</s>baz" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "foo<u style=\\"text-decoration: overline\\">[bar\]</u>baz" compare innerHTML]
@@ -615,16 +393,10 @@
   [[["stylewithcss","false"\],["underline",""\]\] "foo<u style=\\"text-decoration: overline\\">[bar\]</u>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["underline",""\]\] "foo<u style=\\"text-decoration: overline\\">[bar\]</u>baz" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "foo<u style=\\"text-decoration: overline\\">b[a\]r</u>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "foo<u style=\\"text-decoration: overline\\">b[a\]r</u>baz" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "foo<u style=\\"text-decoration: overline\\">b[a\]r</u>baz" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<p style=\\"text-decoration: overline\\">foo[bar\]baz</p>" compare innerHTML]
@@ -633,28 +405,10 @@
   [[["stylewithcss","true"\],["underline",""\]\] "<p style=\\"text-decoration: overline\\">foo[bar\]baz</p>" queryCommandState("underline") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["underline",""\]\] "<p style=\\"text-decoration: overline\\">foo[bar\]baz</p>" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["underline",""\]\] "foo<span class=\\"underline\\">[bar\]</span>baz" queryCommandState("underline") before]
-    expected: FAIL
-
-  [[["underline",""\]\] "foo<span class=\\"underline\\">[bar\]</span>baz" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["underline",""\]\] "foo<span class=\\"underline\\">b[a\]r</span>baz" queryCommandState("underline") before]
-    expected: FAIL
-
-  [[["underline",""\]\] "foo<span class=\\"underline\\">b[a\]r</span>baz" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "foo<span class=\\"line-through\\">[bar\]</span>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "foo<span class=\\"line-through\\">[bar\]</span>baz" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "foo<span class=\\"line-through\\">[bar\]</span>baz" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "foo<span class=\\"line-through\\">b[a\]r</span>baz" compare innerHTML]
@@ -663,37 +417,13 @@
   [[["stylewithcss","true"\],["underline",""\]\] "foo<span class=\\"line-through\\">b[a\]r</span>baz" queryCommandState("underline") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["underline",""\]\] "foo<span class=\\"line-through\\">b[a\]r</span>baz" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["underline",""\]\] "foo<span class=\\"underline-and-line-through\\">[bar\]</span>baz" queryCommandState("underline") before]
-    expected: FAIL
-
-  [[["underline",""\]\] "foo<span class=\\"underline-and-line-through\\">[bar\]</span>baz" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["underline",""\]\] "foo<span class=\\"underline-and-line-through\\">b[a\]r</span>baz" queryCommandState("underline") before]
-    expected: FAIL
-
-  [[["underline",""\]\] "foo<span class=\\"underline-and-line-through\\">b[a\]r</span>baz" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["underline",""\]\] "fo[o<u>b\]ar</u>baz" compare innerHTML]
-    expected: FAIL
-
   [[["underline",""\]\] "fo[o<u>b\]ar</u>baz" queryCommandIndeterm("underline") before]
-    expected: FAIL
-
-  [[["underline",""\]\] "fo[o<u>b\]ar</u>baz" queryCommandState("underline") after]
     expected: FAIL
 
   [[["underline",""\]\] "foo<u>ba[r</u>b\]az" compare innerHTML]
     expected: FAIL
 
   [[["underline",""\]\] "foo<u>ba[r</u>b\]az" queryCommandIndeterm("underline") before]
-    expected: FAIL
-
-  [[["underline",""\]\] "foo<u>ba[r</u>b\]az" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "fo[o<u>bar</u>b\]az" compare innerHTML]
@@ -705,86 +435,38 @@
   [[["stylewithcss","true"\],["underline",""\]\] "fo[o<u>bar</u>b\]az" queryCommandState("underline") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["underline",""\]\] "fo[o<u>bar</u>b\]az" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["underline",""\]\] "fo[o<u>bar</u>b\]az" queryCommandIndeterm("underline") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "fo[o<u>bar</u>b\]az" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "foo[<u>b\]ar</u>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "foo[<u>b\]ar</u>baz" queryCommandState("underline") before]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["underline",""\]\] "foo[<u>b\]ar</u>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "foo[<u>b\]ar</u>baz" queryCommandState("underline") before]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "foo<u>ba[r</u>\]baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "foo<u>ba[r</u>\]baz" queryCommandState("underline") before]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["underline",""\]\] "foo<u>ba[r</u>\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "foo<u>ba[r</u>\]baz" queryCommandState("underline") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "foo[<u>bar</u>\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "foo[<u>bar</u>\]baz" queryCommandState("underline") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "foo[<u>bar</u>\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "foo[<u>bar</u>\]baz" queryCommandState("underline") before]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "foo<u>[bar\]</u>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "foo<u>[bar\]</u>baz" queryCommandState("underline") before]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<strike>foo[bar\]baz</strike>" queryCommandState("stylewithcss") before]
     expected: FAIL
 
-  [[["underline",""\]\] "foo<ins>[bar\]</ins>baz" compare innerHTML]
+  [[["underline",""\]\] "foo<span style=\\"text-decoration: underline line-through\\">[bar\]</span>baz" queryCommandState("underline") after]
     expected: FAIL
 
-  [[["underline",""\]\] "<ins>foo[bar\]baz</ins>" compare innerHTML]
+  [[["stylewithcss","true"\],["underline",""\]\] "foo<span style=\\"text-decoration: underline line-through\\">b[a\]r</span>baz" queryCommandState("underline") after]
     expected: FAIL
 
-  [[["underline",""\]\] "<ins>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</ins>" compare innerHTML]
+  [[["stylewithcss","false"\],["underline",""\]\] "foo<span style=\\"text-decoration: underline line-through\\">b[a\]r</span>baz" queryCommandState("underline") after]
     expected: FAIL
 
-  [[["underline",""\]\] "<ins>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</ins>" compare innerHTML]
+  [[["underline",""\]\] "foo<u>ba[r</u>b\]az" queryCommandState("underline") before]
     expected: FAIL
 
-  [[["underline",""\]\] "<ins>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</ins>" compare innerHTML]
-    expected: FAIL
-
-  [[["underline",""\]\] "<ins>foo[b<i>ar\]ba</i>z</ins>" compare innerHTML]
-    expected: FAIL
-
-  [[["underline",""\]\] "foo<span class=\\"underline\\">[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["underline",""\]\] "foo<span class=\\"underline\\">b[a\]r</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["underline",""\]\] "foo<span class=\\"underline-and-line-through\\">[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["underline",""\]\] "foo<span class=\\"underline-and-line-through\\">b[a\]r</span>baz" compare innerHTML]
+  [[["stylewithcss","false"\],["underline",""\]\] "foo<u>ba[r</u>\]baz" queryCommandState("underline") after]
     expected: FAIL


### PR DESCRIPTION
First of all, the effective command value was wrong, since there is no relevant CSS property for the underline command. Instead, we should directly use the text-decoration property. This then allows us to implement reordering of modifiable elements.

We also need to "change the element to a span", which is quite annoying to do. Instead, it mimics what would have happened by moving children and copying attributes.

There are some regressions, but overall this is another big step towards the right track. The regressions look related to tricky edge cases that I am not even sure other browsers handle.

Part of #25005

Testing: WPT