### PR TITLE
api: WebView::animating should only take a reference to self

### DIFF
--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -377,7 +377,7 @@ impl WebView {
     /// transition or is running `requestAnimationFrame` callbacks. This indicates that the
     /// embedding application should be spinning the Servo event loop on regular intervals
     /// in order to trigger animation updates.
-    pub fn animating(self) -> bool {
+    pub fn animating(&self) -> bool {
         self.inner().animating
     }
 


### PR DESCRIPTION
Fixed that `WebView::animating` takes `self` instead of `&self` as argument.

Testing: Unsure how this could be tested for, beyond creating a unit test for each individual function as a sanity check that all parameters are correct. This seems excessive.
Fixes: #44251
