### PR TITLE
script: use &mut JSContext in components/script/body.rs

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -47,7 +47,7 @@ use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::readablestream::{ReadableStream, get_read_promise_bytes, get_read_promise_done};
 use crate::dom::urlsearchparams::URLSearchParams;
 use crate::realms::{AlreadyInRealm, InRealm, enter_auto_realm, enter_realm};
-use crate::script_runtime::{CanGc, JSContext};
+use crate::script_runtime::CanGc;
 use crate::task_source::SendableTaskSource;
 
 /// <https://fetch.spec.whatwg.org/#concept-body-clone>
@@ -208,14 +208,14 @@ impl TransmitBodyConnectHandler {
         if self.source == BodySource::Null {
             let stream = self.stream.clone();
             self.task_source
-                .queue(task!(start_reading_request_body_stream: move || {
+                .queue(task!(start_reading_request_body_stream: move |cx| {
                     // Step 1, Let body be request’s body.
                     let rooted_stream = stream.root();
 
                     // TODO: Step 2, If body is null.
 
                     // Step 3, get a reader for stream.
-                    rooted_stream.acquire_default_reader(CanGc::deprecated_note())
+                    rooted_stream.acquire_default_reader(CanGc::from_cx(cx))
                         .expect("Couldn't acquire a reader for the body stream.");
 
                     // Note: this algorithm continues when the first chunk is requested by `net`.
@@ -683,26 +683,25 @@ pub(crate) enum FetchedData {
 /// `body-fully-read` can be fully implemented, and separated, later,
 /// see #36049.
 pub(crate) fn consume_body<T: BodyMixin + DomObject>(
+    cx: &mut js::context::JSContext,
     object: &T,
     body_type: BodyType,
-    can_gc: CanGc,
 ) -> Rc<Promise> {
     let global = object.global();
-    let cx = GlobalScope::get_cx();
 
     // Enter the realm of the object whose body is being consumed.
     let realm = enter_realm(&*global);
-    let comp = InRealm::Entered(&realm);
+    let _comp = InRealm::Entered(&realm);
 
     // Let promise be a new promise.
     // Note: re-ordered so we can return the promise below.
-    let promise = Promise::new_in_current_realm(comp, can_gc);
+    let promise = Promise::new2(cx, &global);
 
     // If object is unusable, then return a promise rejected with a TypeError.
     if object.is_unusable() {
         promise.reject_error(
             Error::Type(c"The body's stream is disturbed or locked".to_owned()),
-            can_gc,
+            CanGc::from_cx(cx),
         );
         return promise;
     }
@@ -711,14 +710,8 @@ pub(crate) fn consume_body<T: BodyMixin + DomObject>(
         Some(stream) => stream,
         None => {
             // If object’s body is null, then run successSteps with an empty byte sequence.
-            resolve_result_promise(
-                body_type,
-                &promise,
-                object.get_mime_type(can_gc),
-                Vec::with_capacity(0),
-                cx,
-                can_gc,
-            );
+            let mime_type = object.get_mime_type(cx);
+            resolve_result_promise(cx, body_type, &promise, mime_type, Vec::with_capacity(0));
             return promise;
         },
     };
@@ -740,9 +733,9 @@ pub(crate) fn consume_body<T: BodyMixin + DomObject>(
     // original AbortError. This early return rejects with the same [[storedError]] without disturbing the
     // stream, so repeated calls (for example, calling text() twice) keep rejecting with AbortError.
     if stream.is_errored() {
-        rooted!(in(*cx) let mut stored_error = UndefinedValue());
+        rooted!(&in(cx) let mut stored_error = UndefinedValue());
         stream.get_stored_error(stored_error.handle_mut());
-        promise.reject(cx, stored_error.handle(), can_gc);
+        promise.reject(cx.into(), stored_error.handle(), CanGc::from_cx(cx));
         return promise;
     }
 
@@ -750,10 +743,10 @@ pub(crate) fn consume_body<T: BodyMixin + DomObject>(
     // Let reader be the result of getting a reader for body’s stream.
     // If that threw an exception,
     // then run errorSteps with that exception and return.
-    let reader = match stream.acquire_default_reader(can_gc) {
+    let reader = match stream.acquire_default_reader(CanGc::from_cx(cx)) {
         Ok(r) => r,
         Err(e) => {
-            promise.reject_error(e, can_gc);
+            promise.reject_error(e, CanGc::from_cx(cx));
             return promise;
         },
     };
@@ -764,7 +757,7 @@ pub(crate) fn consume_body<T: BodyMixin + DomObject>(
     // Let successSteps given a byte sequence data be to resolve promise
     // with the result of running convertBytesToJSValue with data.
     // If that threw an exception, then run errorSteps with that exception.
-    let mime_type = object.get_mime_type(can_gc);
+    let mime_type = object.get_mime_type(cx);
     let success_promise = promise.clone();
 
     // TODO: https://github.com/servo/servo/pull/44254
@@ -780,12 +773,11 @@ pub(crate) fn consume_body<T: BodyMixin + DomObject>(
         cx,
         Rc::new(move |cx, bytes: &[u8]| {
             resolve_result_promise(
+                cx,
                 body_type,
                 &success_promise,
                 mime_type.clone(),
                 bytes.to_vec(),
-                cx.into(),
-                CanGc::from_cx(cx),
             );
         }),
         Rc::new(move |cx, v| {
@@ -799,28 +791,29 @@ pub(crate) fn consume_body<T: BodyMixin + DomObject>(
 /// The success steps of
 /// <https://fetch.spec.whatwg.org/#concept-body-consume-body>.
 fn resolve_result_promise(
+    cx: &mut js::context::JSContext,
     body_type: BodyType,
     promise: &Promise,
     mime_type: Vec<u8>,
     body: Vec<u8>,
-    cx: JSContext,
-    can_gc: CanGc,
 ) {
-    let pkg_data_results = run_package_data_algorithm(cx, body, body_type, mime_type, can_gc);
+    let pkg_data_results = run_package_data_algorithm(cx, body, body_type, mime_type);
 
     match pkg_data_results {
         Ok(results) => {
             match results {
-                FetchedData::Text(s) => promise.resolve_native(&USVString(s), can_gc),
-                FetchedData::Json(j) => promise.resolve_native(&j, can_gc),
-                FetchedData::BlobData(b) => promise.resolve_native(&b, can_gc),
-                FetchedData::FormData(f) => promise.resolve_native(&f, can_gc),
-                FetchedData::Bytes(b) => promise.resolve_native(&b, can_gc),
-                FetchedData::ArrayBuffer(a) => promise.resolve_native(&a, can_gc),
-                FetchedData::JSException(e) => promise.reject_native(&e.handle(), can_gc),
+                FetchedData::Text(s) => promise.resolve_native(&USVString(s), CanGc::from_cx(cx)),
+                FetchedData::Json(j) => promise.resolve_native(&j, CanGc::from_cx(cx)),
+                FetchedData::BlobData(b) => promise.resolve_native(&b, CanGc::from_cx(cx)),
+                FetchedData::FormData(f) => promise.resolve_native(&f, CanGc::from_cx(cx)),
+                FetchedData::Bytes(b) => promise.resolve_native(&b, CanGc::from_cx(cx)),
+                FetchedData::ArrayBuffer(a) => promise.resolve_native(&a, CanGc::from_cx(cx)),
+                FetchedData::JSException(e) => {
+                    promise.reject_native(&e.handle(), CanGc::from_cx(cx))
+                },
             };
         },
-        Err(err) => promise.reject_error(err, can_gc),
+        Err(err) => promise.reject_error(err, CanGc::from_cx(cx)),
     }
 }
 
@@ -828,22 +821,21 @@ fn resolve_result_promise(
 /// and returns a JavaScript value or throws an exception of
 /// <https://fetch.spec.whatwg.org/#concept-body-consume-body>.
 fn run_package_data_algorithm(
-    cx: JSContext,
+    cx: &mut js::context::JSContext,
     bytes: Vec<u8>,
     body_type: BodyType,
     mime_type: Vec<u8>,
-    can_gc: CanGc,
 ) -> Fallible<FetchedData> {
     let mime = &*mime_type;
-    let in_realm_proof = AlreadyInRealm::assert_for_cx(cx);
-    let global = GlobalScope::from_safe_context(cx, InRealm::Already(&in_realm_proof));
+    let in_realm_proof = AlreadyInRealm::assert_for_cx(cx.into());
+    let global = GlobalScope::from_safe_context(cx.into(), InRealm::Already(&in_realm_proof));
     match body_type {
         BodyType::Text => run_text_data_algorithm(bytes),
         BodyType::Json => run_json_data_algorithm(cx, bytes),
-        BodyType::Blob => run_blob_data_algorithm(&global, bytes, mime, can_gc),
-        BodyType::FormData => run_form_data_algorithm(&global, bytes, mime, can_gc),
-        BodyType::ArrayBuffer => run_array_buffer_data_algorithm(cx, bytes, can_gc),
-        BodyType::Bytes => run_bytes_data_algorithm(cx, bytes, can_gc),
+        BodyType::Blob => run_blob_data_algorithm(cx, &global, bytes, mime),
+        BodyType::FormData => run_form_data_algorithm(cx, &global, bytes, mime),
+        BodyType::ArrayBuffer => run_array_buffer_data_algorithm(cx, bytes),
+        BodyType::Bytes => run_bytes_data_algorithm(cx, bytes),
     }
 }
 
@@ -863,23 +855,26 @@ fn run_text_data_algorithm(bytes: Vec<u8>) -> Fallible<FetchedData> {
 
 #[expect(unsafe_code)]
 /// <https://fetch.spec.whatwg.org/#ref-for-concept-body-consume-body%E2%91%A3>
-fn run_json_data_algorithm(cx: JSContext, bytes: Vec<u8>) -> Fallible<FetchedData> {
+fn run_json_data_algorithm(
+    cx: &mut js::context::JSContext,
+    bytes: Vec<u8>,
+) -> Fallible<FetchedData> {
     // The JSON spec allows implementations to either ignore UTF-8 BOM or treat it as an error.
     // `JS_ParseJSON` treats this as an error, so it is necessary for us to strip it if present.
     //
     // https://datatracker.ietf.org/doc/html/rfc8259#section-8.1
     let json_text = decode_to_utf16_with_bom_removal(&bytes, UTF_8);
-    rooted!(in(*cx) let mut rval = UndefinedValue());
+    rooted!(&in(cx) let mut rval = UndefinedValue());
     unsafe {
         if !JS_ParseJSON(
-            *cx,
+            cx.raw_cx(),
             json_text.as_ptr(),
             json_text.len() as u32,
             rval.handle_mut(),
         ) {
-            rooted!(in(*cx) let mut exception = UndefinedValue());
-            assert!(JS_GetPendingException(*cx, exception.handle_mut()));
-            JS_ClearPendingException(*cx);
+            rooted!(&in(cx) let mut exception = UndefinedValue());
+            assert!(JS_GetPendingException(cx.raw_cx(), exception.handle_mut()));
+            JS_ClearPendingException(cx.raw_cx());
             return Ok(FetchedData::JSException(RootedTraceableBox::from_box(
                 Heap::boxed(exception.get()),
             )));
@@ -891,10 +886,10 @@ fn run_json_data_algorithm(cx: JSContext, bytes: Vec<u8>) -> Fallible<FetchedDat
 
 /// <https://fetch.spec.whatwg.org/#ref-for-concept-body-consume-body%E2%91%A0>
 fn run_blob_data_algorithm(
+    cx: &mut js::context::JSContext,
     root: &GlobalScope,
     bytes: Vec<u8>,
     mime: &[u8],
-    can_gc: CanGc,
 ) -> Fallible<FetchedData> {
     let mime_string = if let Ok(s) = String::from_utf8(mime.to_vec()) {
         s
@@ -904,7 +899,7 @@ fn run_blob_data_algorithm(
     let blob = Blob::new(
         root,
         BlobImpl::new_from_bytes(bytes, normalize_type_string(&mime_string)),
-        can_gc,
+        CanGc::from_cx(cx),
     );
     Ok(FetchedData::BlobData(blob))
 }
@@ -957,11 +952,11 @@ fn content_type_from_headers(headers: &HeaderMap) -> Result<String, Error> {
 }
 
 fn append_form_data_entry_from_part(
+    cx: &mut js::context::JSContext,
     root: &GlobalScope,
     formdata: &FormData,
     headers: &HeaderMap,
     body: Vec<u8>,
-    can_gc: CanGc,
 ) -> Fallible<()> {
     let Some(name) = extract_name_from_content_disposition(headers) else {
         return Ok(());
@@ -980,7 +975,7 @@ fn append_form_data_entry_from_part(
             BlobImpl::new_from_bytes(body, normalize_type_string(&content_type)),
             DOMString::from(filename),
             None,
-            can_gc,
+            CanGc::from_cx(cx),
         );
         let blob = file.upcast::<Blob>();
         formdata.Append_(USVString(name), blob, None);
@@ -994,23 +989,23 @@ fn append_form_data_entry_from_part(
 }
 
 fn append_multipart_nodes(
+    cx: &mut js::context::JSContext,
     root: &GlobalScope,
     formdata: &FormData,
     nodes: Vec<Node>,
-    can_gc: CanGc,
 ) -> Fallible<()> {
     for node in nodes {
         match node {
             Node::Part(part) => {
-                append_form_data_entry_from_part(root, formdata, &part.headers, part.body, can_gc)?;
+                append_form_data_entry_from_part(cx, root, formdata, &part.headers, part.body)?;
             },
             Node::File(file_part) => {
                 let body = fs::read(&file_part.path)
                     .map_err(|_| Error::Type(c"file part could not be read".to_owned()))?;
-                append_form_data_entry_from_part(root, formdata, &file_part.headers, body, can_gc)?;
+                append_form_data_entry_from_part(cx, root, formdata, &file_part.headers, body)?;
             },
             Node::Multipart((_, inner)) => {
-                append_multipart_nodes(root, formdata, inner, can_gc)?;
+                append_multipart_nodes(cx, root, formdata, inner)?;
             },
         }
     }
@@ -1019,10 +1014,10 @@ fn append_multipart_nodes(
 
 /// <https://fetch.spec.whatwg.org/#ref-for-concept-body-consume-body%E2%91%A2>
 fn run_form_data_algorithm(
+    cx: &mut js::context::JSContext,
     root: &GlobalScope,
     bytes: Vec<u8>,
     mime: &[u8],
-    can_gc: CanGc,
 ) -> Fallible<FetchedData> {
     // The formData() method steps are to return the result of running consume body
     // with this and the following steps given a byte sequence bytes:
@@ -1050,7 +1045,7 @@ fn run_form_data_algorithm(
             let closing_boundary = format!("--{}--", boundary.as_str()).into_bytes();
             let trimmed_bytes = bytes.strip_suffix(b"\r\n").unwrap_or(&bytes);
             if trimmed_bytes == closing_boundary {
-                let formdata = FormData::new(None, root, can_gc);
+                let formdata = FormData::new(None, root, CanGc::from_cx(cx));
                 return Ok(FetchedData::FormData(formdata));
             }
         }
@@ -1063,9 +1058,9 @@ fn run_form_data_algorithm(
         // a more detailed parsing specification is to be written. Volunteers welcome.
 
         // Return a new FormData object, appending each entry, resulting from the parsing operation, to its entry list.
-        let formdata = FormData::new(None, root, can_gc);
+        let formdata = FormData::new(None, root, CanGc::from_cx(cx));
 
-        append_multipart_nodes(root, &formdata, nodes, can_gc)?;
+        append_multipart_nodes(cx, root, &formdata, nodes)?;
 
         return Ok(FetchedData::FormData(formdata));
     }
@@ -1076,7 +1071,7 @@ fn run_form_data_algorithm(
         //
         // Return a new FormData object whose entry list is entries.
         let entries = form_urlencoded::parse(&bytes);
-        let formdata = FormData::new(None, root, can_gc);
+        let formdata = FormData::new(None, root, CanGc::from_cx(cx));
         for (k, e) in entries {
             formdata.Append(USVString(k.into_owned()), USVString(e.into_owned()));
         }
@@ -1088,11 +1083,19 @@ fn run_form_data_algorithm(
 }
 
 /// <https://fetch.spec.whatwg.org/#ref-for-concept-body-consume-body%E2%91%A1>
-fn run_bytes_data_algorithm(cx: JSContext, bytes: Vec<u8>, can_gc: CanGc) -> Fallible<FetchedData> {
-    rooted!(in(*cx) let mut array_buffer_ptr = ptr::null_mut::<JSObject>());
+fn run_bytes_data_algorithm(
+    cx: &mut js::context::JSContext,
+    bytes: Vec<u8>,
+) -> Fallible<FetchedData> {
+    rooted!(&in(cx) let mut array_buffer_ptr = ptr::null_mut::<JSObject>());
 
-    create_buffer_source::<Uint8>(cx, &bytes, array_buffer_ptr.handle_mut(), can_gc)
-        .map_err(|_| Error::JSFailed)?;
+    create_buffer_source::<Uint8>(
+        cx.into(),
+        &bytes,
+        array_buffer_ptr.handle_mut(),
+        CanGc::from_cx(cx),
+    )
+    .map_err(|_| Error::JSFailed)?;
 
     let rooted_heap = RootedTraceableBox::from_box(Heap::boxed(array_buffer_ptr.get()));
     Ok(FetchedData::Bytes(rooted_heap))
@@ -1100,14 +1103,18 @@ fn run_bytes_data_algorithm(cx: JSContext, bytes: Vec<u8>, can_gc: CanGc) -> Fal
 
 /// <https://fetch.spec.whatwg.org/#ref-for-concept-body-consume-body>
 pub(crate) fn run_array_buffer_data_algorithm(
-    cx: JSContext,
+    cx: &mut js::context::JSContext,
     bytes: Vec<u8>,
-    can_gc: CanGc,
 ) -> Fallible<FetchedData> {
-    rooted!(in(*cx) let mut array_buffer_ptr = ptr::null_mut::<JSObject>());
+    rooted!(&in(cx) let mut array_buffer_ptr = ptr::null_mut::<JSObject>());
 
-    create_buffer_source::<ArrayBufferU8>(cx, &bytes, array_buffer_ptr.handle_mut(), can_gc)
-        .map_err(|_| Error::JSFailed)?;
+    create_buffer_source::<ArrayBufferU8>(
+        cx.into(),
+        &bytes,
+        array_buffer_ptr.handle_mut(),
+        CanGc::from_cx(cx),
+    )
+    .map_err(|_| Error::JSFailed)?;
 
     let rooted_heap = RootedTraceableBox::from_box(Heap::boxed(array_buffer_ptr.get()));
     Ok(FetchedData::ArrayBuffer(rooted_heap))
@@ -1139,5 +1146,5 @@ pub(crate) trait BodyMixin {
     /// <https://fetch.spec.whatwg.org/#dom-body-body>
     fn body(&self) -> Option<DomRoot<ReadableStream>>;
     /// <https://fetch.spec.whatwg.org/#concept-body-mime-type>
-    fn get_mime_type(&self, can_gc: CanGc) -> Vec<u8>;
+    fn get_mime_type(&self, cx: &mut js::context::JSContext) -> Vec<u8>;
 }

--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -11,11 +11,11 @@ use http::HeaderMap;
 use http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
 use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
 use ipc_channel::router::ROUTER;
-use js::jsapi::{Heap, JS_ClearPendingException, JSObject, Value as JSValue};
+use js::jsapi::{Heap, JSObject, Value as JSValue};
 use js::jsval::{JSVal, UndefinedValue};
 use js::realm::CurrentRealm;
 use js::rust::HandleValue;
-use js::rust::wrappers::{JS_GetPendingException, JS_ParseJSON};
+use js::rust::wrappers2::{JS_ClearPendingException, JS_GetPendingException, JS_ParseJSON};
 use js::typedarray::{ArrayBufferU8, Uint8};
 use mime::{self, Mime};
 use mime_multipart_hyper1::{Node, read_multipart_body};
@@ -46,7 +46,7 @@ use crate::dom::promise::Promise;
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::readablestream::{ReadableStream, get_read_promise_bytes, get_read_promise_done};
 use crate::dom::urlsearchparams::URLSearchParams;
-use crate::realms::{AlreadyInRealm, InRealm, enter_auto_realm, enter_realm};
+use crate::realms::{InRealm, enter_auto_realm};
 use crate::script_runtime::CanGc;
 use crate::task_source::SendableTaskSource;
 
@@ -691,8 +691,7 @@ pub(crate) fn consume_body<T: BodyMixin + DomObject>(
 
     // Enter the realm of the object whose body is being consumed.
     let mut realm = enter_auto_realm(cx, &*global);
-    let cx = &mut realm.current_realm();
-    let _comp = InRealm::Entered(&realm);
+    let cx: &mut _ = &mut realm.current_realm();
 
     // Let promise be a new promise.
     // Note: re-ordered so we can return the promise below.
@@ -868,14 +867,14 @@ fn run_json_data_algorithm(
     rooted!(&in(cx) let mut rval = UndefinedValue());
     unsafe {
         if !JS_ParseJSON(
-            cx.raw_cx(),
+            cx,
             json_text.as_ptr(),
             json_text.len() as u32,
             rval.handle_mut(),
         ) {
             rooted!(&in(cx) let mut exception = UndefinedValue());
-            assert!(JS_GetPendingException(cx.raw_cx(), exception.handle_mut()));
-            JS_ClearPendingException(cx.raw_cx());
+            assert!(JS_GetPendingException(cx, exception.handle_mut()));
+            JS_ClearPendingException(cx);
             return Ok(FetchedData::JSException(RootedTraceableBox::from_box(
                 Heap::boxed(exception.get()),
             )));

--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -828,8 +828,8 @@ fn run_package_data_algorithm(
     mime_type: Vec<u8>,
 ) -> Fallible<FetchedData> {
     let mime = &*mime_type;
-    let in_realm_proof = AlreadyInRealm::assert_for_cx(cx.into());
-    let global = GlobalScope::from_safe_context(cx.into(), InRealm::Already(&in_realm_proof));
+    let realm = CurrentRealm::assert(cx);
+    let global = GlobalScope::from_current_realm(&realm);
     match body_type {
         BodyType::Text => run_text_data_algorithm(bytes),
         BodyType::Json => run_json_data_algorithm(cx, bytes),

--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -696,7 +696,7 @@ pub(crate) fn consume_body<T: BodyMixin + DomObject>(
 
     // Let promise be a new promise.
     // Note: re-ordered so we can return the promise below.
-    let promise = Promise::new2(cx, &global);
+    let promise = Promise::new_in_realm(cx);
 
     // If object is unusable, then return a promise rejected with a TypeError.
     if object.is_unusable() {

--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -690,7 +690,8 @@ pub(crate) fn consume_body<T: BodyMixin + DomObject>(
     let global = object.global();
 
     // Enter the realm of the object whose body is being consumed.
-    let realm = enter_realm(&*global);
+    let mut realm = enter_auto_realm(cx, &*global);
+    let cx = &mut realm.current_realm();
     let _comp = InRealm::Entered(&realm);
 
     // Let promise be a new promise.

--- a/components/script/dom/bindings/buffer_source.rs
+++ b/components/script/dom/bindings/buffer_source.rs
@@ -349,34 +349,44 @@ where
     /// <https://tc39.es/ecma262/#sec-clonearraybuffer>
     pub(crate) fn clone_array_buffer(
         &self,
-        cx: JSContext,
+        cx: &mut js::context::JSContext,
         byte_offset: usize,
         byte_length: usize,
     ) -> Fallible<HeapBufferSource<ArrayBufferU8>> {
         let result = match &self.buffer_source {
             BufferSource::ArrayBufferView(buffer) => {
                 let mut is_shared = false;
-                rooted!(in(*cx) let view_buffer =
-                    unsafe { JS_GetArrayBufferViewBuffer(*cx, buffer.handle().into(), &mut is_shared) });
+                rooted!(&in(cx) let view_buffer =
+                    unsafe { JS_GetArrayBufferViewBuffer(cx.raw_cx(), buffer.handle().into(), &mut is_shared) });
                 debug_assert!(!is_shared);
 
                 unsafe {
-                    ArrayBufferClone(*cx, view_buffer.handle().into(), byte_offset, byte_length)
+                    ArrayBufferClone(
+                        cx.raw_cx(),
+                        view_buffer.handle().into(),
+                        byte_offset,
+                        byte_length,
+                    )
                 }
             },
             BufferSource::ArrayBuffer(buffer) => unsafe {
-                ArrayBufferClone(*cx, buffer.handle().into(), byte_offset, byte_length)
+                ArrayBufferClone(
+                    cx.raw_cx(),
+                    buffer.handle().into(),
+                    byte_offset,
+                    byte_length,
+                )
             },
         };
 
         if result.is_null() {
             // Normalize SpiderMonkey failure: consume pending exception and
             // map it to a DOM Error.
-            rooted!(in(*cx) let mut _ex = UndefinedValue());
+            rooted!(&in(cx) let mut _ex = UndefinedValue());
             unsafe {
                 // If SpiderMonkey set an exception, clear it so callers see a clean cx.
-                if JS_GetPendingException(*cx, _ex.handle_mut().into()) {
-                    JS_ClearPendingException(*cx);
+                if JS_GetPendingException(cx.raw_cx(), _ex.handle_mut().into()) {
+                    JS_ClearPendingException(cx.raw_cx());
                 }
             }
 
@@ -391,7 +401,7 @@ where
     #[expect(unsafe_code)]
     pub(crate) fn clone_as_uint8_array(
         &self,
-        cx: JSContext,
+        cx: &mut js::context::JSContext,
     ) -> Fallible<HeapBufferSource<ArrayBufferViewU8>> {
         match &self.buffer_source {
             BufferSource::ArrayBufferView(buffer) => {
@@ -400,7 +410,7 @@ where
                 assert!(unsafe { JS_IsArrayBufferViewObject(*buffer.handle()) });
 
                 // Assert: ! IsDetachedBuffer(O.[[ViewedArrayBuffer]]) is false.
-                assert!(!self.is_detached_buffer(cx));
+                assert!(!self.is_detached_buffer(cx.into()));
 
                 // Let buffer be ? CloneArrayBuffer(O.[[ViewedArrayBuffer]],
                 // O.[[ByteOffset]], O.[[ByteLength]], %ArrayBuffer%).
@@ -756,7 +766,7 @@ pub(crate) enum Constructor {
 }
 
 pub(crate) fn create_buffer_source_with_constructor(
-    cx: JSContext,
+    cx: &mut js::context::JSContext,
     constructor: &Constructor,
     buffer_source: &HeapBufferSource<ArrayBufferU8>,
     byte_offset: usize,
@@ -766,7 +776,7 @@ pub(crate) fn create_buffer_source_with_constructor(
         BufferSource::ArrayBuffer(heap) => match constructor {
             Constructor::DataView => Ok(HeapBufferSource::new(BufferSource::ArrayBufferView(
                 RootedTraceableBox::from_box(Heap::boxed(unsafe {
-                    JS_NewDataView(*cx, heap.handle().into(), byte_offset, byte_length)
+                    JS_NewDataView(cx.raw_cx(), heap.handle().into(), byte_offset, byte_length)
                 })),
             ))),
             Constructor::Name(name_type) => construct_typed_array(
@@ -785,7 +795,7 @@ pub(crate) fn create_buffer_source_with_constructor(
 
 /// Helper function to construct different TypedArray views
 fn construct_typed_array(
-    cx: JSContext,
+    cx: &mut js::context::JSContext,
     name_type: &Type,
     buffer_source: &HeapBufferSource<ArrayBufferU8>,
     byte_offset: usize,
@@ -796,73 +806,73 @@ fn construct_typed_array(
             let array_view = unsafe {
                 match name_type {
                     Type::Int8 => JS_NewInt8ArrayWithBuffer(
-                        *cx,
+                        cx.raw_cx(),
                         heap.handle().into(),
                         byte_offset,
                         byte_length,
                     ),
                     Type::Uint8 => JS_NewUint8ArrayWithBuffer(
-                        *cx,
+                        cx.raw_cx(),
                         heap.handle().into(),
                         byte_offset,
                         byte_length,
                     ),
                     Type::Uint16 => JS_NewUint16ArrayWithBuffer(
-                        *cx,
+                        cx.raw_cx(),
                         heap.handle().into(),
                         byte_offset,
                         byte_length,
                     ),
                     Type::Int16 => JS_NewInt16ArrayWithBuffer(
-                        *cx,
+                        cx.raw_cx(),
                         heap.handle().into(),
                         byte_offset,
                         byte_length,
                     ),
                     Type::Int32 => JS_NewInt32ArrayWithBuffer(
-                        *cx,
+                        cx.raw_cx(),
                         heap.handle().into(),
                         byte_offset,
                         byte_length,
                     ),
                     Type::Uint32 => JS_NewUint32ArrayWithBuffer(
-                        *cx,
+                        cx.raw_cx(),
                         heap.handle().into(),
                         byte_offset,
                         byte_length,
                     ),
                     Type::Float32 => JS_NewFloat32ArrayWithBuffer(
-                        *cx,
+                        cx.raw_cx(),
                         heap.handle().into(),
                         byte_offset,
                         byte_length,
                     ),
                     Type::Float64 => JS_NewFloat64ArrayWithBuffer(
-                        *cx,
+                        cx.raw_cx(),
                         heap.handle().into(),
                         byte_offset,
                         byte_length,
                     ),
                     Type::Uint8Clamped => JS_NewUint8ClampedArrayWithBuffer(
-                        *cx,
+                        cx.raw_cx(),
                         heap.handle().into(),
                         byte_offset,
                         byte_length,
                     ),
                     Type::BigInt64 => JS_NewBigInt64ArrayWithBuffer(
-                        *cx,
+                        cx.raw_cx(),
                         heap.handle().into(),
                         byte_offset,
                         byte_length,
                     ),
                     Type::BigUint64 => JS_NewBigUint64ArrayWithBuffer(
-                        *cx,
+                        cx.raw_cx(),
                         heap.handle().into(),
                         byte_offset,
                         byte_length,
                     ),
                     Type::Float16 => JS_NewFloat16ArrayWithBuffer(
-                        *cx,
+                        cx.raw_cx(),
                         heap.handle().into(),
                         byte_offset,
                         byte_length,
@@ -884,15 +894,18 @@ fn construct_typed_array(
 }
 
 pub(crate) fn create_array_buffer_with_size(
-    cx: JSContext,
+    cx: &mut js::context::JSContext,
     size: usize,
 ) -> Fallible<HeapBufferSource<ArrayBufferU8>> {
-    let result = unsafe { NewArrayBuffer(*cx, size) };
+    let result = unsafe { NewArrayBuffer(cx.raw_cx(), size) };
     if result.is_null() {
-        rooted!(in(*cx) let mut rval = UndefinedValue());
+        rooted!(&in(cx) let mut rval = UndefinedValue());
         unsafe {
-            assert!(JS_GetPendingException(*cx, rval.handle_mut().into()));
-            JS_ClearPendingException(*cx)
+            assert!(JS_GetPendingException(
+                cx.raw_cx(),
+                rval.handle_mut().into()
+            ));
+            JS_ClearPendingException(cx.raw_cx())
         };
 
         Err(Error::Type(c"can't create array buffer".to_owned()))

--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -400,8 +400,7 @@ impl Request {
                 ));
             }
             // Step 32.2. Set this’s headers’s guard to "request-no-cors".
-            r.Headers(CanGc::from_cx(cx))
-                .set_guard(Guard::RequestNoCors);
+            r.Headers(cx).set_guard(Guard::RequestNoCors);
         }
 
         match headers_copy {
@@ -413,17 +412,16 @@ impl Request {
                 // but an input with headers is given, set request's
                 // headers as the input's Headers.
                 if let RequestInfo::Request(ref input_request) = input {
-                    r.Headers(CanGc::from_cx(cx))
-                        .copy_from_headers(input_request.Headers(CanGc::from_cx(cx)))?;
+                    r.Headers(cx).copy_from_headers(input_request.Headers(cx))?;
                 }
             },
             // Step 33.5. Otherwise, fill this’s headers with headers.
-            Some(headers_copy) => r.Headers(CanGc::from_cx(cx)).fill(Some(headers_copy))?,
+            Some(headers_copy) => r.Headers(cx).fill(Some(headers_copy))?,
         }
 
         // Step 33.5 depending on how we got here
         // Copy the headers list onto the headers of net_traits::Request
-        r.request.borrow_mut().headers = r.Headers(CanGc::from_cx(cx)).get_headers_list();
+        r.request.borrow_mut().headers = r.Headers(cx).get_headers_list();
 
         // Step 34. Let inputBody be input’s request’s body if input is a Request object; otherwise null.
         let input_body = if let RequestInfo::Request(ref mut input_request) = input {
@@ -468,12 +466,12 @@ impl Request {
                 // Step 37.4. If type is non-null and this’s headers’s header list
                 // does not contain `Content-Type`, then append (`Content-Type`, type) to this’s headers.
                 if !r
-                    .Headers(CanGc::from_cx(cx))
+                    .Headers(cx)
                     .Has(ByteString::new(ct_header_name.to_vec()))
                     .unwrap()
                 {
                     let ct_header_val = contents.as_bytes();
-                    r.Headers(CanGc::from_cx(cx)).Append(
+                    r.Headers(cx).Append(
                         ByteString::new(ct_header_name.to_vec()),
                         ByteString::new(ct_header_val.to_vec()),
                     )?;
@@ -544,7 +542,7 @@ impl Request {
     fn clone_from(cx: &mut js::context::JSContext, r: &Request) -> Fallible<DomRoot<Request>> {
         let req = r.request.borrow();
         let url = req.url();
-        let headers_guard = r.Headers(CanGc::from_cx(cx)).get_guard();
+        let headers_guard = r.Headers(cx).get_guard();
 
         // Step 1. Let newRequest be a copy of request, except for its body.
         let mut new_req_inner = req.clone();
@@ -559,10 +557,8 @@ impl Request {
             r_clone.request.borrow_mut().body = Some(body);
         }
 
-        r_clone
-            .Headers(CanGc::from_cx(cx))
-            .copy_from_headers(r.Headers(CanGc::from_cx(cx)))?;
-        r_clone.Headers(CanGc::from_cx(cx)).set_guard(headers_guard);
+        r_clone.Headers(cx).copy_from_headers(r.Headers(cx))?;
+        r_clone.Headers(cx).set_guard(headers_guard);
 
         clone_body_stream_for_dom_body(cx, &r.body_stream, &r_clone.body_stream)?;
 
@@ -637,9 +633,9 @@ impl RequestMethods<crate::DomTypeHolder> for Request {
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-request-headers>
-    fn Headers(&self, can_gc: CanGc) -> DomRoot<Headers> {
+    fn Headers(&self, cx: &mut js::context::JSContext) -> DomRoot<Headers> {
         self.headers
-            .or_init(|| Headers::new(&self.global(), can_gc))
+            .or_init(|| Headers::new(&self.global(), CanGc::from_cx(cx)))
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-request-destination>
@@ -743,33 +739,33 @@ impl RequestMethods<crate::DomTypeHolder> for Request {
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-body-text>
-    fn Text(&self, can_gc: CanGc) -> Rc<Promise> {
-        consume_body(self, BodyType::Text, can_gc)
+    fn Text(&self, cx: &mut js::context::JSContext) -> Rc<Promise> {
+        consume_body(cx, self, BodyType::Text)
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-body-blob>
-    fn Blob(&self, can_gc: CanGc) -> Rc<Promise> {
-        consume_body(self, BodyType::Blob, can_gc)
+    fn Blob(&self, cx: &mut js::context::JSContext) -> Rc<Promise> {
+        consume_body(cx, self, BodyType::Blob)
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-body-formdata>
-    fn FormData(&self, can_gc: CanGc) -> Rc<Promise> {
-        consume_body(self, BodyType::FormData, can_gc)
+    fn FormData(&self, cx: &mut js::context::JSContext) -> Rc<Promise> {
+        consume_body(cx, self, BodyType::FormData)
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-body-json>
-    fn Json(&self, can_gc: CanGc) -> Rc<Promise> {
-        consume_body(self, BodyType::Json, can_gc)
+    fn Json(&self, cx: &mut js::context::JSContext) -> Rc<Promise> {
+        consume_body(cx, self, BodyType::Json)
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-body-arraybuffer>
-    fn ArrayBuffer(&self, can_gc: CanGc) -> Rc<Promise> {
-        consume_body(self, BodyType::ArrayBuffer, can_gc)
+    fn ArrayBuffer(&self, cx: &mut js::context::JSContext) -> Rc<Promise> {
+        consume_body(cx, self, BodyType::ArrayBuffer)
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-body-bytes>
-    fn Bytes(&self, can_gc: CanGc) -> std::rc::Rc<Promise> {
-        consume_body(self, BodyType::Bytes, can_gc)
+    fn Bytes(&self, cx: &mut js::context::JSContext) -> Rc<Promise> {
+        consume_body(cx, self, BodyType::Bytes)
     }
 }
 
@@ -792,8 +788,8 @@ impl BodyMixin for Request {
         self.body_stream.get()
     }
 
-    fn get_mime_type(&self, can_gc: CanGc) -> Vec<u8> {
-        let headers = self.Headers(can_gc);
+    fn get_mime_type(&self, cx: &mut js::context::JSContext) -> Vec<u8> {
+        let headers = self.Headers(cx);
         headers.extract_mime_type()
     }
 }

--- a/components/script/dom/response.rs
+++ b/components/script/dom/response.rs
@@ -139,8 +139,8 @@ impl BodyMixin for Response {
         self.body_stream.get()
     }
 
-    fn get_mime_type(&self, can_gc: CanGc) -> Vec<u8> {
-        let headers = self.Headers(can_gc);
+    fn get_mime_type(&self, cx: &mut js::context::JSContext) -> Vec<u8> {
+        let headers = self.Headers(CanGc::from_cx(cx));
         headers.extract_mime_type()
     }
 }
@@ -378,33 +378,33 @@ impl ResponseMethods<crate::DomTypeHolder> for Response {
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-body-text>
-    fn Text(&self, can_gc: CanGc) -> Rc<Promise> {
-        consume_body(self, BodyType::Text, can_gc)
+    fn Text(&self, cx: &mut js::context::JSContext) -> Rc<Promise> {
+        consume_body(cx, self, BodyType::Text)
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-body-blob>
-    fn Blob(&self, can_gc: CanGc) -> Rc<Promise> {
-        consume_body(self, BodyType::Blob, can_gc)
+    fn Blob(&self, cx: &mut js::context::JSContext) -> Rc<Promise> {
+        consume_body(cx, self, BodyType::Blob)
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-body-formdata>
-    fn FormData(&self, can_gc: CanGc) -> Rc<Promise> {
-        consume_body(self, BodyType::FormData, can_gc)
+    fn FormData(&self, cx: &mut js::context::JSContext) -> Rc<Promise> {
+        consume_body(cx, self, BodyType::FormData)
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-body-json>
-    fn Json(&self, can_gc: CanGc) -> Rc<Promise> {
-        consume_body(self, BodyType::Json, can_gc)
+    fn Json(&self, cx: &mut js::context::JSContext) -> Rc<Promise> {
+        consume_body(cx, self, BodyType::Json)
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-body-arraybuffer>
-    fn ArrayBuffer(&self, can_gc: CanGc) -> Rc<Promise> {
-        consume_body(self, BodyType::ArrayBuffer, can_gc)
+    fn ArrayBuffer(&self, cx: &mut js::context::JSContext) -> Rc<Promise> {
+        consume_body(cx, self, BodyType::ArrayBuffer)
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-body-bytes>
-    fn Bytes(&self, can_gc: CanGc) -> std::rc::Rc<Promise> {
-        consume_body(self, BodyType::Bytes, can_gc)
+    fn Bytes(&self, cx: &mut js::context::JSContext) -> Rc<Promise> {
+        consume_body(cx, self, BodyType::Bytes)
     }
 }
 

--- a/components/script/dom/stream/byteteereadintorequest.rs
+++ b/components/script/dom/stream/byteteereadintorequest.rs
@@ -139,7 +139,7 @@ impl ByteTeeReadIntoRequest {
         // If otherCanceled is false,
         if !other_canceled {
             // Let cloneResult be CloneAsUint8Array(chunk).
-            let clone_result = chunk.clone_as_uint8_array(cx.into());
+            let clone_result = chunk.clone_as_uint8_array(cx);
 
             // If cloneResult is an abrupt completion,
             if let Err(error) = clone_result {

--- a/components/script/dom/stream/byteteereadrequest.rs
+++ b/components/script/dom/stream/byteteereadrequest.rs
@@ -170,7 +170,7 @@ impl ByteTeeReadRequest {
                 HeapBufferSource::<ArrayBufferViewU8>::new(BufferSource::ArrayBufferView(
                     RootedTraceableBox::from_box(Heap::boxed(chunk2.get().to_object())),
                 ));
-            let clone_result = chunk2_source.clone_as_uint8_array(cx.into());
+            let clone_result = chunk2_source.clone_as_uint8_array(cx);
 
             // If cloneResult is an abrupt completion,
             if let Err(error) = clone_result {
@@ -186,7 +186,7 @@ impl ByteTeeReadRequest {
                 HeapBufferSource::<ArrayBufferViewU8>::new(BufferSource::ArrayBufferView(
                     RootedTraceableBox::from_box(Heap::boxed(chunk2.get().to_object())),
                 ));
-            match chunk2_source.clone_as_uint8_array(cx.into()) {
+            match chunk2_source.clone_as_uint8_array(cx) {
                 Ok(clone) => chunk2_view = Some(clone),
                 Err(error) => {
                     handle_clone_error(cx, error);

--- a/components/script/dom/stream/byteteeunderlyingsource.rs
+++ b/components/script/dom/stream/byteteeunderlyingsource.rs
@@ -354,7 +354,7 @@ impl ByteTeeUnderlyingSource {
                     .expect("Branch 1 should be set.")
                     .get_byte_controller();
                 let byob_request = byob_branch_controller
-                    .get_byob_request(cx.into(), CanGc::from_cx(cx))
+                    .get_byob_request(cx)
                     .expect("Byob request should be set.");
 
                 match byob_request {
@@ -399,7 +399,7 @@ impl ByteTeeUnderlyingSource {
                     .expect("Branch 2 should be set.")
                     .get_byte_controller();
                 let byob_request = byob_branch_controller
-                    .get_byob_request(cx.into(), CanGc::from_cx(cx))
+                    .get_byob_request(cx)
                     .expect("Byob request should be set.");
 
                 match byob_request {

--- a/components/script/dom/stream/readablebytestreamcontroller.rs
+++ b/components/script/dom/stream/readablebytestreamcontroller.rs
@@ -35,7 +35,7 @@ use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::stream::readablestream::ReadableStream;
 use crate::dom::stream::readablestreambyobrequest::ReadableStreamBYOBRequest;
 use crate::realms::{InRealm, enter_auto_realm};
-use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
+use crate::script_runtime::CanGc;
 
 /// <https://streams.spec.whatwg.org/#readable-byte-stream-queue-entry>
 #[derive(JSTraceable, MallocSizeOf)]
@@ -360,7 +360,7 @@ impl ReadableByteStreamController {
                     // Let emptyView be ! Construct(ctor, « pullIntoDescriptor’s buffer,
                     // pullIntoDescriptor’s byte offset, 0 »).
                     if let Ok(empty_view) = create_buffer_source_with_constructor(
-                        cx.into(),
+                        cx,
                         &ctor,
                         &pull_into_descriptor.buffer,
                         pull_into_descriptor.byte_offset as usize,
@@ -385,11 +385,11 @@ impl ReadableByteStreamController {
                 if self.queue_total_size.get() > 0.0 {
                     // If ! ReadableByteStreamControllerFillPullIntoDescriptorFromQueue(
                     // controller, pullIntoDescriptor) is true,
-                    if self.fill_pull_into_descriptor_from_queue(cx.into(), &pull_into_descriptor) {
+                    if self.fill_pull_into_descriptor_from_queue(cx, &pull_into_descriptor) {
                         // Let filledView be ! ReadableByteStreamControllerConvertPullIntoDescriptor(
                         // pullIntoDescriptor).
                         if let Ok(filled_view) =
-                            self.convert_pull_into_descriptor(cx.into(), &pull_into_descriptor)
+                            self.convert_pull_into_descriptor(cx, &pull_into_descriptor)
                         {
                             // Perform ! ReadableByteStreamControllerHandleQueueDrain(controller).
                             self.handle_queue_drain(cx);
@@ -629,7 +629,7 @@ impl ReadableByteStreamController {
 
             // Let filledPullIntos be the result of performing
             // ! ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(controller).
-            let filled_pull_intos = self.process_pull_into_descriptors_using_queue(cx.into());
+            let filled_pull_intos = self.process_pull_into_descriptors_using_queue(cx);
 
             // For each filledPullInto of filledPullIntos,
             for filled_pull_into in filled_pull_intos {
@@ -681,7 +681,7 @@ impl ReadableByteStreamController {
 
         // Let filledPullIntos be the result of performing
         // ! ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(controller).
-        let filled_pull_intos = self.process_pull_into_descriptors_using_queue(cx.into());
+        let filled_pull_intos = self.process_pull_into_descriptors_using_queue(cx);
 
         // Perform ! ReadableByteStreamControllerCommitPullIntoDescriptor(controller.[[stream]], pullIntoDescriptor).
         self.commit_pull_into_descriptor(cx, &pull_into_descriptor)
@@ -801,8 +801,7 @@ impl ReadableByteStreamController {
     /// <https://streams.spec.whatwg.org/#abstract-opdef-readablebytestreamcontrollergetbyobrequest>
     pub(crate) fn get_byob_request(
         &self,
-        cx: SafeJSContext,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) -> Fallible<Option<DomRoot<ReadableStreamBYOBRequest>>> {
         // If controller.[[byobRequest]] is null and controller.[[pendingPullIntos]] is not empty,
         let pending_pull_intos = self.pending_pull_intos.borrow();
@@ -826,7 +825,7 @@ impl ReadableByteStreamController {
             .expect("Construct Uint8Array failed");
 
             // Let byobRequest be a new ReadableStreamBYOBRequest.
-            let byob_request = ReadableStreamBYOBRequest::new(&self.global(), can_gc);
+            let byob_request = ReadableStreamBYOBRequest::new(&self.global(), CanGc::from_cx(cx));
 
             // Set byobRequest.[[controller]] to controller.
             byob_request.set_controller(Some(&DomRoot::from_ref(self)));
@@ -1071,7 +1070,7 @@ impl ReadableByteStreamController {
 
                 // Let transferredView be ! Construct(%Uint8Array%, « transferredBuffer, byteOffset, byteLength »).
                 let transferred_view = create_buffer_source_with_constructor(
-                    cx.into(),
+                    cx,
                     &Constructor::Name(Type::Uint8),
                     &transferred_buffer,
                     byte_offset,
@@ -1092,7 +1091,7 @@ impl ReadableByteStreamController {
 
             // Let filledPullIntos be the result of performing !
             // ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(controller).
-            let filled_pull_intos = self.process_pull_into_descriptors_using_queue(cx.into());
+            let filled_pull_intos = self.process_pull_into_descriptors_using_queue(cx);
 
             // For each filledPullInto of filledPullIntos,
             // Perform ! ReadableByteStreamControllerCommitPullIntoDescriptor(stream, filledPullInto).
@@ -1145,7 +1144,7 @@ impl ReadableByteStreamController {
 
         // Let filledView be ! ReadableByteStreamControllerConvertPullIntoDescriptor(pullIntoDescriptor).
         let filled_view = self
-            .convert_pull_into_descriptor(cx.into(), pull_into_descriptor)
+            .convert_pull_into_descriptor(cx, pull_into_descriptor)
             .expect("convert_pull_into_descriptor failed");
 
         rooted!(&in(cx) let mut view_value = UndefinedValue());
@@ -1172,7 +1171,7 @@ impl ReadableByteStreamController {
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-convert-pull-into-descriptor>
     pub(crate) fn convert_pull_into_descriptor(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         pull_into_descriptor: &PullIntoDescriptor,
     ) -> Fallible<HeapBufferSource<ArrayBufferViewU8>> {
         // Let bytesFilled be pullIntoDescriptor’s bytes filled.
@@ -1190,7 +1189,7 @@ impl ReadableByteStreamController {
         // Let buffer be ! TransferArrayBuffer(pullIntoDescriptor’s buffer).
         let buffer = pull_into_descriptor
             .buffer
-            .transfer_array_buffer(cx)
+            .transfer_array_buffer(cx.into())
             .expect("TransferArrayBuffer failed");
 
         // Return ! Construct(pullIntoDescriptor’s view constructor,
@@ -1208,7 +1207,7 @@ impl ReadableByteStreamController {
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-process-pull-into-descriptors-using-queue>
     pub(crate) fn process_pull_into_descriptors_using_queue(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
     ) -> Vec<PullIntoDescriptor> {
         // Assert: controller.[[closeRequested]] is false.
         assert!(!self.close_requested.get());
@@ -1249,7 +1248,7 @@ impl ReadableByteStreamController {
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-fill-pull-into-descriptor-from-queue>
     pub(crate) fn fill_pull_into_descriptor_from_queue(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         pull_into_descriptor: &PullIntoDescriptor,
     ) -> bool {
         // Let maxBytesToCopy be min(controller.[[queueTotalSize]],
@@ -1269,7 +1268,7 @@ impl ReadableByteStreamController {
         let mut ready = false;
 
         // Assert: ! IsDetachedBuffer(pullIntoDescriptor’s buffer) is false.
-        assert!(!pull_into_descriptor.buffer.is_detached_buffer(cx));
+        assert!(!pull_into_descriptor.buffer.is_detached_buffer(cx.into()));
 
         // Assert: pullIntoDescriptor’s bytes filled < pullIntoDescriptor’s minimum fill.
         assert!(pull_into_descriptor.bytes_filled.get() < pull_into_descriptor.minimum_fill);
@@ -1317,7 +1316,7 @@ impl ReadableByteStreamController {
             // Assert: ! CanCopyDataBlockBytes(descriptorBuffer, destStart,
             // queueBuffer, queueByteOffset, bytesToCopy) is true.
             assert!(descriptor_buffer.can_copy_data_block_bytes(
-                cx,
+                cx.into(),
                 dest_start as usize,
                 queue_buffer,
                 queue_byte_offset,
@@ -1327,7 +1326,7 @@ impl ReadableByteStreamController {
             // Perform ! CopyDataBlockBytes(descriptorBuffer.[[ArrayBufferData]], destStart,
             // queueBuffer.[[ArrayBufferData]], queueByteOffset, bytesToCopy).
             descriptor_buffer.copy_data_block_bytes(
-                cx,
+                cx.into(),
                 dest_start as usize,
                 queue_buffer,
                 queue_byte_offset,
@@ -1440,7 +1439,7 @@ impl ReadableByteStreamController {
     ) -> Fallible<()> {
         // Let cloneResult be CloneArrayBuffer(buffer, byteOffset, byteLength, %ArrayBuffer%).
         if let Ok(clone_result) =
-            buffer.clone_array_buffer(cx.into(), byte_offset as usize, byte_length as usize)
+            buffer.clone_array_buffer(cx, byte_offset as usize, byte_length as usize)
         {
             // Perform ! ReadableByteStreamControllerEnqueueChunkToQueue
             // (controller, cloneResult.[[Value]], 0, byteLength).
@@ -1529,7 +1528,7 @@ impl ReadableByteStreamController {
 
         // Let view be ! Construct(%Uint8Array%, « entry’s buffer, entry’s byte offset, entry’s byte length »).
         let view = create_buffer_source_with_constructor(
-            cx.into(),
+            cx,
             &Constructor::Name(Type::Uint8),
             &entry.buffer,
             entry.byte_offset,
@@ -1848,7 +1847,7 @@ impl ReadableByteStreamController {
         if let Some(auto_allocate_chunk_size) = auto_allocate_chunk_size {
             // create_array_buffer_with_size
             // Let buffer be Construct(%ArrayBuffer%, « autoAllocateChunkSize »).
-            match create_array_buffer_with_size(cx.into(), auto_allocate_chunk_size as usize) {
+            match create_array_buffer_with_size(cx, auto_allocate_chunk_size as usize) {
                 Ok(buffer) => {
                     // Let pullIntoDescriptor be a new pull-into descriptor with
                     // buffer buffer.[[Value]]
@@ -1930,11 +1929,10 @@ impl ReadableByteStreamControllerMethods<crate::DomTypeHolder> for ReadableByteS
     /// <https://streams.spec.whatwg.org/#rbs-controller-byob-request>
     fn GetByobRequest(
         &self,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) -> Fallible<Option<DomRoot<ReadableStreamBYOBRequest>>> {
-        let cx = GlobalScope::get_cx();
         // Return ! ReadableByteStreamControllerGetBYOBRequest(this).
-        self.get_byob_request(cx, can_gc)
+        self.get_byob_request(cx)
     }
 
     /// <https://streams.spec.whatwg.org/#rbs-controller-desired-size>

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -825,13 +825,12 @@ DOMInterfaces = {
 },
 
 'Request': {
-    'canGc': ['Headers', 'Text', 'Blob', 'FormData', 'Json', 'ArrayBuffer', 'Clone', 'Bytes'],
-    'cx': ['Clone', 'Constructor'],
+    'cx': ['Constructor', 'Constructor', 'Headers', 'Clone', 'Text', 'Blob', 'FormData', 'Json', 'ArrayBuffer', 'Bytes'],
 },
 
 'Response': {
-    'canGc': ['Text', 'Blob', 'FormData', 'Json', 'ArrayBuffer', 'Headers', 'Bytes'],
-    'cx': ['Clone', 'Constructor', 'CreateFromJson', 'Error', 'Redirect'],
+    'canGc': ['Headers'],
+    'cx': ['Constructor', 'CreateFromJson', 'Clone', 'Error', 'Redirect', 'Text', 'Blob', 'FormData', 'Json', 'ArrayBuffer', 'Bytes'],
 },
 
 'RTCPeerConnection': {
@@ -1093,8 +1092,7 @@ DOMInterfaces = {
 },
 
 "ReadableByteStreamController": {
-    "canGc": ["GetByobRequest"],
-    "cx": ["Close", "Enqueue", "Error"]
+    "cx": ["Enqueue", "Close", "Error", "GetByobRequest"]
 },
 
 "ReadableStreamBYOBRequest": {


### PR DESCRIPTION
Port `components/script/body.rs` to use `&mut JSContext`

Testing: A successful build is enough
Fixes: Part of #42638
