### PR TITLE
webgl: check TexImage3D's input data length

### DIFF
--- a/components/script/dom/webgl/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl/webgl2renderingcontext.rs
@@ -3153,31 +3153,41 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
 
         // TODO: If pixel store parameter constraints are not met, generates an INVALID_OPERATION error.
 
-        // If srcData is null, a buffer of sufficient size initialized to 0 is passed.
         let unpacking_alignment = self.base.texture_unpacking_alignment();
+        let element_size = data_type.element_size();
+        let components_per_element = data_type.components_per_element();
+        let components = format.components();
+        // NOTE: width, height and depth are positive or zero due to validate()
+        let expected_byte_len = if height == 0 {
+            0
+        } else {
+            // We need to be careful here to not count unpack
+            // alignment at the end of the image, otherwise (for
+            // example) passing a single byte for uploading a 1x1x1
+            // GL_ALPHA/GL_UNSIGNED_BYTE texture would throw an error.
+            let cpp = element_size * components / components_per_element;
+            let mut padding_bytes = (cpp * width) % unpacking_alignment;
+            if padding_bytes > 0 {
+                padding_bytes = unpacking_alignment - padding_bytes;
+            }
+            let bytes_per_row = cpp * width + padding_bytes;
+            let bytes_last_row = cpp * width;
+            let bytes_per_image = bytes_per_row * height;
+            let bytes_last_image = bytes_per_row * (height - 1) + bytes_last_row;
+            bytes_per_image * (depth - 1) + bytes_last_image
+        };
+
+        // If srcData is null, a buffer of sufficient size initialized to 0 is passed.
         let buff = match *src_data {
             Some(ref data) => GenericSharedMemory::from_bytes(unsafe { data.as_slice() }),
-            None => {
-                let element_size = data_type.element_size();
-                let components = format.components();
-                let components_per_element = format.components();
-                // FIXME: This is copied from tex_image_2d which is apparently incorrect
-                // NOTE: width and height are positive or zero due to validate()
-                let expected_byte_len = if height == 0 {
-                    0
-                } else {
-                    // We need to be careful here to not count unpack
-                    // alignment at the end of the image, otherwise (for
-                    // example) passing a single byte for uploading a 1x1
-                    // GL_ALPHA/GL_UNSIGNED_BYTE texture would throw an error.
-                    let cpp = element_size * components / components_per_element;
-                    let stride =
-                        (width * cpp + unpacking_alignment - 1) & !(unpacking_alignment - 1);
-                    stride * (height - 1) + width * cpp
-                };
-                GenericSharedMemory::from_bytes(&vec![0u8; expected_byte_len as usize])
-            },
+            None => GenericSharedMemory::from_bytes(&vec![0u8; expected_byte_len as usize]),
         };
+        if buff.len() < expected_byte_len as usize {
+            return {
+                self.base.webgl_error(InvalidOperation);
+                Ok(())
+            };
+        }
         let (alpha_treatment, y_axis_treatment) =
             self.base.get_current_unpack_state(Alpha::NotPremultiplied);
         // If UNPACK_FLIP_Y_WEBGL or UNPACK_PREMULTIPLY_ALPHA_WEBGL is set to true, texImage3D and texSubImage3D

--- a/tests/wpt/webgl/meta/conformance2/textures/misc/tex-3d-size-limit.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/misc/tex-3d-size-limit.html.ini
@@ -1,4 +1,124 @@
 [tex-3d-size-limit.html]
-  expected: CRASH
-  [WebGL test #1]
+  expected: ERROR
+  [WebGL test #3]
+    expected: FAIL
+
+  [WebGL test #4]
+    expected: FAIL
+
+  [WebGL test #5]
+    expected: FAIL
+
+  [WebGL test #6]
+    expected: FAIL
+
+  [WebGL test #7]
+    expected: FAIL
+
+  [WebGL test #8]
+    expected: FAIL
+
+  [WebGL test #9]
+    expected: FAIL
+
+  [WebGL test #10]
+    expected: FAIL
+
+  [WebGL test #11]
+    expected: FAIL
+
+  [WebGL test #12]
+    expected: FAIL
+
+  [WebGL test #13]
+    expected: FAIL
+
+  [WebGL test #14]
+    expected: FAIL
+
+  [WebGL test #15]
+    expected: FAIL
+
+  [WebGL test #16]
+    expected: FAIL
+
+  [WebGL test #17]
+    expected: FAIL
+
+  [WebGL test #18]
+    expected: FAIL
+
+  [WebGL test #19]
+    expected: FAIL
+
+  [WebGL test #20]
+    expected: FAIL
+
+  [WebGL test #21]
+    expected: FAIL
+
+  [WebGL test #22]
+    expected: FAIL
+
+  [WebGL test #23]
+    expected: FAIL
+
+  [WebGL test #24]
+    expected: FAIL
+
+  [WebGL test #25]
+    expected: FAIL
+
+  [WebGL test #26]
+    expected: FAIL
+
+  [WebGL test #27]
+    expected: FAIL
+
+  [WebGL test #28]
+    expected: FAIL
+
+  [WebGL test #29]
+    expected: FAIL
+
+  [WebGL test #30]
+    expected: FAIL
+
+  [WebGL test #31]
+    expected: FAIL
+
+  [WebGL test #32]
+    expected: FAIL
+
+  [WebGL test #33]
+    expected: FAIL
+
+  [WebGL test #34]
+    expected: FAIL
+
+  [WebGL test #35]
+    expected: FAIL
+
+  [WebGL test #36]
+    expected: FAIL
+
+  [WebGL test #37]
+    expected: FAIL
+
+  [WebGL test #38]
+    expected: FAIL
+
+  [WebGL test #39]
+    expected: FAIL
+
+  [WebGL test #40]
+    expected: FAIL
+
+  [WebGL test #41]
+    expected: FAIL
+
+  [WebGL test #44]
+    expected: FAIL
+
+  [WebGL test #89]
     expected: FAIL

--- a/tests/wpt/webgl/meta/conformance2/textures/misc/tex-unpack-params.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/misc/tex-unpack-params.html.ini
@@ -6,9 +6,6 @@
   [WebGL test #10]
     expected: FAIL
 
-  [WebGL test #11]
-    expected: FAIL
-
   [WebGL test #13]
     expected: FAIL
 


### PR DESCRIPTION
tex-3d-size-limit.html currently crashes because we don't check that the input data is large enough, and happily access memory that's not ours if it's not.

The referenced ticket comes from the fact that we don't systematically detect a crash (which makes sense if we're (un)lucky), and this patch eradicates the crash altogether by checking the input buffer size. The size computation is a (partial) port of WPT's computeImageSizes3D JS function.

Fixes: https://github.com/servo/servo/issues/42881
Testing: Some expected failures in wpt/webgl can be removed, including a crash.