### PR TITLE
chore: Remove some clippy complains for 1.95

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -872,15 +872,10 @@ where
             None => self
                 .browsing_context_group_set
                 .values()
-                .filter_map(|bc_group| {
-                    if bc_group
+                .filter(|bc_group| {
+                    bc_group
                         .top_level_browsing_context_set
                         .contains(webview_id)
-                    {
-                        Some(bc_group)
-                    } else {
-                        None
-                    }
                 })
                 .last()
                 .ok_or(

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -871,8 +871,8 @@ where
             },
             None => self
                 .browsing_context_group_set
-                .iter()
-                .filter_map(|(_, bc_group)| {
+                .values()
+                .filter_map(|bc_group| {
                     if bc_group
                         .top_level_browsing_context_set
                         .contains(webview_id)

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -468,14 +468,14 @@ impl TextRun {
         };
         let text_rendering = inherited_text_style.text_rendering;
 
-        // The next current character index within the entire inline formatting context's text.
-        let mut next_character_index = self.character_range.start;
         // The next bytes index of the charcter within the entire inline formatting context's text.
         let mut next_byte_index = self.text_range.start;
 
-        for (character, next_character) in char_iterator {
+        // next_character_index: The next current character index within the entire inline formatting context's text.
+        for (next_character_index, (character, next_character)) in
+            (self.character_range.start..).zip(char_iterator)
+        {
             let current_character_index = next_character_index;
-            next_character_index += 1;
 
             let current_byte_index = next_byte_index;
             next_byte_index += character.len_utf8();

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -651,10 +651,10 @@ impl ImageCacheStore {
                 .remove(&(url.clone(), origin.clone(), *cors_setting))
         {
             if let ImageResponse::Loaded(Image::Raster(image), _) = loaded_image.image_response {
-                if image.id.is_some() {
+                if let Some(id) = image.id {
                     self.paint_api.update_images(
                         self.webview_id.into(),
-                        vec![ImageUpdate::DeleteImage(image.id.unwrap())].into(),
+                        vec![ImageUpdate::DeleteImage(id)].into(),
                     );
                 }
             }
@@ -670,17 +670,19 @@ impl ImageCacheStore {
             .rasterized_vector_images
             .remove(&(*image_id, *device_size))
         {
-            // If there is no corresponding rasterized_vector_image result,
-            // then the vector image is either being rasterized or is in
-            // self.store.key_cache.pending_image_keys. Either way, we need to notify the
-            // KeyCache that it was evicted.
-            if entry.result.is_none() {
+            if let Some(result) = entry.result {
+                if let Some(image_id) = result.id {
+                    self.paint_api.update_images(
+                        self.webview_id.into(),
+                        vec![ImageUpdate::DeleteImage(image_id)].into(),
+                    );
+                }
+            } else {
+                // If there is no corresponding rasterized_vector_image result,
+                // then the vector image is either being rasterized or is in
+                // self.store.key_cache.pending_image_keys. Either way, we need to notify the
+                // KeyCache that it was evicted.
                 self.evict_image_from_keycache(image_id, device_size);
-            } else if let Some(image_id) = entry.result.as_ref().unwrap().id {
-                self.paint_api.update_images(
-                    self.webview_id.into(),
-                    vec![ImageUpdate::DeleteImage(image_id)].into(),
-                );
             }
         }
     }

--- a/components/script/dom/audio/audionode.rs
+++ b/components/script/dom/audio/audionode.rs
@@ -303,17 +303,13 @@ impl AudioNodeMethods<crate::DomTypeHolder> for AudioNode {
                     return Err(Error::IndexSize(None));
                 }
             },
-            EventTargetTypeId::AudioNode(AudioNodeTypeId::PannerNode) => {
-                if value > 2 {
-                    return Err(Error::NotSupported(None));
-                }
+            EventTargetTypeId::AudioNode(AudioNodeTypeId::PannerNode) if value > 2 => {
+                return Err(Error::NotSupported(None));
             },
             EventTargetTypeId::AudioNode(AudioNodeTypeId::AudioScheduledSourceNode(
                 AudioScheduledSourceNodeTypeId::StereoPannerNode,
-            )) => {
-                if value > 2 {
-                    return Err(Error::NotSupported(None));
-                }
+            )) if value > 2 => {
+                return Err(Error::NotSupported(None));
             },
             EventTargetTypeId::AudioNode(AudioNodeTypeId::ChannelMergerNode) => {
                 return Err(Error::InvalidState(None));
@@ -349,10 +345,10 @@ impl AudioNodeMethods<crate::DomTypeHolder> for AudioNode {
         }
 
         match self.upcast::<EventTarget>().type_id() {
-            EventTargetTypeId::AudioNode(AudioNodeTypeId::AudioDestinationNode) => {
-                if self.context.is_offline() {
-                    return Err(Error::InvalidState(None));
-                }
+            EventTargetTypeId::AudioNode(AudioNodeTypeId::AudioDestinationNode)
+                if self.context.is_offline() =>
+            {
+                return Err(Error::InvalidState(None));
             },
             EventTargetTypeId::AudioNode(AudioNodeTypeId::PannerNode) => {
                 if value == ChannelCountMode::Max {
@@ -361,10 +357,8 @@ impl AudioNodeMethods<crate::DomTypeHolder> for AudioNode {
             },
             EventTargetTypeId::AudioNode(AudioNodeTypeId::AudioScheduledSourceNode(
                 AudioScheduledSourceNodeTypeId::StereoPannerNode,
-            )) => {
-                if value == ChannelCountMode::Max {
-                    return Err(Error::NotSupported(None));
-                }
+            )) if value == ChannelCountMode::Max => {
+                return Err(Error::NotSupported(None));
             },
             EventTargetTypeId::AudioNode(AudioNodeTypeId::ChannelMergerNode) => {
                 return Err(Error::InvalidState(None));

--- a/components/script/dom/html/htmlvideoelement.rs
+++ b/components/script/dom/html/htmlvideoelement.rs
@@ -439,7 +439,7 @@ impl FetchResponseListener for PosterFrameFetchContext {
 
         let status_is_ok = metadata
             .as_ref()
-            .map_or(true, |m| m.status.in_range(200..300));
+            .is_none_or(|m| m.status.in_range(200..300));
 
         if !status_is_ok {
             self.cancelled = true;

--- a/components/script/dom/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver.rs
@@ -502,10 +502,8 @@ impl IntersectionObserver {
         // > If the intersection root is an Element, and target is not a descendant of
         // > the intersection root in the containing block chain, skip to step 11.
         match &self.root {
-            Some(ElementOrDocument::Document(document)) => {
-                if document != &target.owner_document() {
-                    return IntersectionObservationOutput::default_skipped();
-                }
+            Some(ElementOrDocument::Document(document)) if document != &target.owner_document() => {
+                return IntersectionObservationOutput::default_skipped();
             },
             Some(ElementOrDocument::Element(element)) => {
                 // To ensure consistency, we also check for elements right now, but we can depend on the

--- a/components/script/dom/radionodelist.rs
+++ b/components/script/dom/radionodelist.rs
@@ -122,12 +122,10 @@ impl RadioNodeListMethods<crate::DomTypeHolder> for RadioNodeList {
                             return;
                         }
                     },
-                    InputType::Radio(_) => {
+                    InputType::Radio(_) if input.Value() == value => {
                         // Step 2
-                        if input.Value() == value {
-                            input.SetChecked(true, can_gc);
-                            return;
-                        }
+                        input.SetChecked(true, can_gc);
+                        return;
                     },
                     _ => {},
                 }

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -1755,15 +1755,12 @@ pub(crate) fn is_field_value(slice: &[u8]) -> bool {
                     false
                 }
             },
-            10 => {
+            10 if prev == PreviousCharacter::CR => {
                 // LF
-                if prev == PreviousCharacter::CR {
-                    prev = PreviousCharacter::LF;
-                    true
-                } else {
-                    false
-                }
+                prev = PreviousCharacter::LF;
+                true
             },
+            10 => false,
             32 => {
                 // SP
                 if prev == PreviousCharacter::LF || prev == PreviousCharacter::SPHT {
@@ -1779,15 +1776,12 @@ pub(crate) fn is_field_value(slice: &[u8]) -> bool {
                     false
                 }
             },
-            9 => {
+            9 if prev == PreviousCharacter::LF || prev == PreviousCharacter::SPHT => {
                 // HT
-                if prev == PreviousCharacter::LF || prev == PreviousCharacter::SPHT {
-                    prev = PreviousCharacter::SPHT;
-                    true
-                } else {
-                    false
-                }
+                prev = PreviousCharacter::SPHT;
+                true
             },
+            9 => false,
             0..=31 | 127 => false, // CTLs
             x if x > 127 => false, // non ASCII
             _ if prev == PreviousCharacter::Other || prev == PreviousCharacter::SPHT => {

--- a/components/storage/indexeddb/mod.rs
+++ b/components/storage/indexeddb/mod.rs
@@ -901,11 +901,10 @@ impl IndexedDBManager {
                                 Some(IndexedDBTxnMode::Readonly) => {
                                     db.running_readonly.remove(&txn);
                                 },
-                                Some(_) => {
-                                    if db.running_readwrite == Some(txn) {
-                                        db.running_readwrite = None;
-                                    }
+                                Some(_) if db.running_readwrite == Some(txn) => {
+                                    db.running_readwrite = None;
                                 },
+                                Some(_) => {},
                                 None => {
                                     // txn might have been aborted/removed; nothing to clear
                                 },

--- a/components/webxr/openxr/mod.rs
+++ b/components/webxr/openxr/mod.rs
@@ -25,12 +25,11 @@ use profile_traits::generic_callback::GenericCallback as ProfileGenericCallback;
 use surfman::{
     Context as SurfmanContext, Device as SurfmanDevice, Error as SurfmanError, SurfaceTexture,
 };
-use webxr_api;
 use webxr_api::util::{self, ClipPlanes};
 use webxr_api::{
-    BaseSpace, Capture, ContextId, DeviceAPI, DiscoveryAPI, Display, Error, Event, EventBuffer,
-    Floor, Frame, GLContexts, InputId, InputSource, LayerGrandManager, LayerId, LayerInit,
-    LayerManager, LayerManagerAPI, LeftEye, Native, Quitter, RightEye, SelectKind,
+    self, BaseSpace, Capture, ContextId, DeviceAPI, DiscoveryAPI, Display, Error, Event,
+    EventBuffer, Floor, Frame, GLContexts, InputId, InputSource, LayerGrandManager, LayerId,
+    LayerInit, LayerManager, LayerManagerAPI, LeftEye, Native, Quitter, RightEye, SelectKind,
     Session as WebXrSession, SessionBuilder, SessionInit, SessionMode, SubImage, SubImages, View,
     ViewerPose, Viewport, Viewports, Views, Visibility,
 };


### PR DESCRIPTION
This removes some complains that clippy will have in 1.95.
As this is mostly just match guards, it doesn't update MSRV.

Testing: This is equivalent exchanges, so current WPT would find anything.
