### PR TITLE
layout: depend on `web_atoms` rather than `html5ever`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8071,7 +8071,6 @@ dependencies = [
  "bitflags 2.11.0",
  "data-url",
  "euclid",
- "html5ever",
  "icu_locid",
  "icu_segmenter",
  "itertools 0.14.0",
@@ -8113,6 +8112,7 @@ dependencies = [
  "unicode-script",
  "unicode_categories",
  "url",
+ "web_atoms",
  "webrender_api",
  "xi-unicode",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,6 +212,7 @@ webdriver = "0.53.0"
 webpki-roots = "1.0"
 webrender = { version = "0.68", features = ["capture"] }
 webrender_api = "0.68"
+web_atoms = "0.2"
 wgpu-core = "26"
 wgpu-types = "26"
 winapi = "0.3"

--- a/components/layout/Cargo.toml
+++ b/components/layout/Cargo.toml
@@ -28,7 +28,7 @@ embedder_traits = { workspace = true }
 euclid = { workspace = true }
 fonts = { workspace = true }
 fonts_traits = { workspace = true }
-html5ever = { workspace = true }
+web_atoms = { workspace = true }
 icu_locid = { workspace = true }
 icu_segmenter = { workspace = true }
 itertools = { workspace = true }

--- a/components/layout/dom.rs
+++ b/components/layout/dom.rs
@@ -5,7 +5,6 @@
 use std::marker::PhantomData;
 
 use atomic_refcell::{AtomicRef, AtomicRefCell, AtomicRefMut};
-use html5ever::{local_name, ns};
 use layout_api::{
     GenericLayoutDataTrait, LayoutDataTrait, LayoutElement, LayoutElementType, LayoutNode,
     LayoutNodeType as ScriptLayoutNodeType, SVGElementData,
@@ -18,6 +17,7 @@ use style::context::SharedStyleContext;
 use style::properties::ComputedValues;
 use style::selector_parser::PseudoElement;
 use style::values::specified::box_::DisplayOutside as StyloDisplayOutside;
+use web_atoms::{local_name, ns};
 
 use crate::cell::{ArcRefCell, WeakRefCell};
 use crate::context::LayoutContext;

--- a/components/layout/dom_traversal.rs
+++ b/components/layout/dom_traversal.rs
@@ -4,7 +4,6 @@
 
 use std::borrow::Cow;
 
-use html5ever::LocalName;
 use layout_api::{
     LayoutElement, LayoutElementType, LayoutNode, LayoutNodeType, PseudoElementChain,
 };
@@ -15,6 +14,7 @@ use style::properties::ComputedValues;
 use style::selector_parser::PseudoElement;
 use style::values::generics::counters::{Content, ContentItem};
 use style::values::specified::Quotes;
+use web_atoms::LocalName;
 
 use crate::context::LayoutContext;
 use crate::dom::{BoxSlot, LayoutBox, NodeExt};

--- a/components/layout/fragment_tree/base_fragment.rs
+++ b/components/layout/fragment_tree/base_fragment.rs
@@ -7,7 +7,6 @@ use std::ops::Deref;
 use app_units::Au;
 use atomic_refcell::AtomicRef;
 use bitflags::bitflags;
-use html5ever::local_name;
 use layout_api::{LayoutElement, LayoutNode, PseudoElementChain, combine_id_with_fragment_type};
 use malloc_size_of::malloc_size_of_is_0;
 use malloc_size_of_derive::MallocSizeOf;
@@ -16,6 +15,7 @@ use servo_arc::Arc as ServoArc;
 use style::dom::OpaqueNode;
 use style::properties::ComputedValues;
 use style::selector_parser::PseudoElement;
+use web_atoms::local_name;
 
 use crate::SharedStyle;
 use crate::dom_traversal::NodeAndStyleInfo;

--- a/components/layout/replaced.rs
+++ b/components/layout/replaced.rs
@@ -6,7 +6,6 @@ use app_units::{Au, MAX_AU};
 use data_url::DataUrl;
 use embedder_traits::ViewportDetails;
 use euclid::{Scale, Size2D};
-use html5ever::local_name;
 use layout_api::{IFrameSize, LayoutElement, LayoutImageDestination, LayoutNode, SVGElementData};
 use malloc_size_of_derive::MallocSizeOf;
 use net_traits::image_cache::{Image, ImageOrMetadataAvailable, VectorImage};
@@ -28,6 +27,7 @@ use style::values::computed::image::Image as ComputedImage;
 use style::values::computed::{Content, Context, ToComputedValue};
 use style::values::generics::counters::{GenericContentItem, GenericContentItems};
 use url::Url;
+use web_atoms::local_name;
 use webrender_api::ImageKey;
 
 use crate::cell::ArcRefCell;


### PR DESCRIPTION
`servo-layout` only depends on `html5ever` for it's atom types which are now split out into the `web_atoms` crate. This switches the dependency to `web_atoms` to remove the unncessary dependency

Testing: This just imports the same types from a different crate. So if it builds, it should work.
