### PR TITLE
release: Build android in production mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -305,7 +305,7 @@ jobs:
     name: Build release (Android)
     uses: ./.github/workflows/android.yml
     with:
-      profile: "release"
+      profile: "production"
     secrets: inherit
 
   build-ohos:


### PR DESCRIPTION
Since https://github.com/servo/servo/pull/44182 production builds for android are now possible in CI.
Let's unify this, since all other platforms already use production. The production build is also ~45MB small, which is a huge reduction compared to the ~159MB our nightly builds have. I didn't investigate further why the difference is that large, but I installed the production version on my phone and didn't spot any obvious issues (on servo.org).

[Mach try android-production](https://github.com/jschwe/servo/actions/runs/24525178123)

Testing: We don't test CI workflows themselves.

