### PR TITLE
servoshell: Remove IndexedDB preference from servo:preferences

### DIFF
--- a/resources/resource_protocol/preferences.html
+++ b/resources/resource_protocol/preferences.html
@@ -52,7 +52,7 @@
       const prefs = {
           "experimental": [],
           "http-cache": ["network_http_cache_disabled"],
-          "more-experimental": ["dom_abort_controller_enabled", "dom_indexeddb_enabled"],
+          "more-experimental": ["dom_abort_controller_enabled"],
           "user-agent": ["user_agent"],
       };
 


### PR DESCRIPTION
Since indexeddb is now part of the experimental features list, we can remove it from the "more experimental" features list.