### PR TITLE
script: Generate custom fields also, for interfaces inheriting from `PerformanceEntry`, from `impl_performance_entry_struct!`

### DIFF
--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -763,7 +763,9 @@ macro_rules! window_event_handlers(
 
 /// DOM struct implementation for simple interfaces inheriting from PerformanceEntry.
 macro_rules! impl_performance_entry_struct(
-    ($binding:ident, $struct:ident, $type:path) => (
+    ($binding:ident, $struct:ident, $type:path,
+        { $( $(#[$attr:meta])* $field_name:ident : $field_type:ty, ),* } // Arguments
+    ) => (
         use servo_base::cross_process_instant::CrossProcessInstant;
         use time::Duration;
 
@@ -778,16 +780,22 @@ macro_rules! impl_performance_entry_struct(
         #[dom_struct]
         pub(crate) struct $struct {
             entry: PerformanceEntry,
+            $( $(#[$attr])* $field_name: $field_type, )*
         }
 
         impl $struct {
-            fn new_inherited(name: DOMString, start_time: CrossProcessInstant, duration: Duration)
-                -> $struct {
+            #[cfg_attr(crown, expect(crown::unrooted_must_root))]
+            fn new_inherited(
+                name: DOMString,
+                start_time: CrossProcessInstant,
+                duration: Duration,
+                $( $field_name: $field_type, )* ) -> $struct {
                 $struct {
                     entry: PerformanceEntry::new_inherited(name,
                                                            $type,
                                                            Some(start_time),
-                                                           duration)
+                                                           duration),
+                    $( $field_name: $field_name, )*
                 }
             }
 
@@ -795,8 +803,15 @@ macro_rules! impl_performance_entry_struct(
             pub(crate) fn new(global: &GlobalScope,
                        name: DOMString,
                        start_time: CrossProcessInstant,
-                       duration: Duration) -> DomRoot<$struct> {
-                let entry = $struct::new_inherited(name, start_time, duration);
+                       duration: Duration,
+                       $( $field_name: $field_type ),*
+                    ) -> DomRoot<$struct> {
+                let entry = $struct::new_inherited(
+                    name,
+                    start_time,
+                    duration,
+                    $( $field_name, )*
+                );
                 reflect_dom_object(Box::new(entry), global, CanGc::deprecated_note())
             }
         }

--- a/components/script/dom/performance/performance.rs
+++ b/components/script/dom/performance/performance.rs
@@ -637,7 +637,7 @@ impl PerformanceMethods<crate::DomTypeHolder> for Performance {
             .get_entries_by_name_and_type(Some(name), entry_type)
     }
 
-    /// <https://w3c.github.io/user -timing/#dom-performance-mark>
+    /// <https://w3c.github.io/user-timing/#dom-performance-mark>
     fn Mark(&self, mark_name: DOMString) -> Fallible<DomRoot<PerformanceMark>> {
         let global = self.global();
         // NOTE: This should happen within the performancemark constructor
@@ -646,17 +646,18 @@ impl PerformanceMethods<crate::DomTypeHolder> for Performance {
         }
 
         // Step 1. Run the PerformanceMark constructor and let entry be the newly created object.
+        // TODO: Implement PerformanceMark constructor steps
         let entry = PerformanceMark::new(
             &global,
             mark_name,
             CrossProcessInstant::now(),
             Duration::ZERO,
+            Default::default(),
         );
 
         // Step 2. Queue a PerformanceEntry entry.
+        // Step 3. Add entry to the performance entry buffer. (This is done in queue_entry itself)
         self.queue_entry(entry.upcast::<PerformanceEntry>());
-
-        // TODO Step 3. Add entry to the performance entry buffer.
 
         // Step 4. Return entry.
         Ok(entry)
@@ -796,10 +797,11 @@ impl PerformanceMethods<crate::DomTypeHolder> for Performance {
             measure_name,
             start_time,
             end_time - start_time,
+            Default::default(),
         );
 
         // Step 10. Queue a PerformanceEntry entry.
-        // Step 11. Add entry to the performance entry buffer.
+        // Step 11. Add entry to the performance entry buffer. (This is done in queue_entry itself)
         self.queue_entry(entry.upcast::<PerformanceEntry>());
 
         // Step 12. Return entry.

--- a/components/script/dom/performance/performancemark.rs
+++ b/components/script/dom/performance/performancemark.rs
@@ -2,4 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-impl_performance_entry_struct!(PerformanceMarkBinding, PerformanceMark, EntryType::Mark);
+use js::jsapi::Heap;
+use js::jsval::JSVal;
+use js::rust::MutableHandleValue;
+
+use crate::dom::bindings::codegen::Bindings::PerformanceMarkBinding::PerformanceMarkMethods;
+use crate::script_runtime::JSContext;
+
+impl_performance_entry_struct!(
+    PerformanceMarkBinding,
+    PerformanceMark, EntryType::Mark,
+    {
+        #[ignore_malloc_size_of = "Defined in rust-mozjs"]
+        detail: Heap<JSVal>,
+    }
+);
+
+impl PerformanceMarkMethods<crate::DomTypeHolder> for PerformanceMark {
+    fn Detail(&self, _cx: JSContext, mut retval: MutableHandleValue) {
+        retval.set(self.detail.get())
+    }
+}

--- a/components/script/dom/performance/performancemeasure.rs
+++ b/components/script/dom/performance/performancemeasure.rs
@@ -2,8 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use js::jsapi::Heap;
+use js::jsval::JSVal;
+use js::rust::MutableHandleValue;
+
+use crate::dom::bindings::codegen::Bindings::PerformanceMeasureBinding::PerformanceMeasureMethods;
+use crate::script_runtime::JSContext;
+
 impl_performance_entry_struct!(
     PerformanceMeasureBinding,
     PerformanceMeasure,
-    EntryType::Measure
+    EntryType::Measure,
+    {
+        #[ignore_malloc_size_of = "Defined in rust-mozjs"]
+        detail: Heap<JSVal>,
+    }
 );
+
+impl PerformanceMeasureMethods<crate::DomTypeHolder> for PerformanceMeasure {
+    fn Detail(&self, _cx: JSContext, mut retval: MutableHandleValue) {
+        retval.set(self.detail.get())
+    }
+}

--- a/components/script_bindings/webidls/PerformanceMark.webidl
+++ b/components/script_bindings/webidls/PerformanceMark.webidl
@@ -8,4 +8,5 @@
 
 [Exposed=(Window,Worker)]
 interface PerformanceMark : PerformanceEntry {
+    readonly attribute any detail;
 };

--- a/components/script_bindings/webidls/PerformanceMeasure.webidl
+++ b/components/script_bindings/webidls/PerformanceMeasure.webidl
@@ -8,4 +8,5 @@
 
 [Exposed=(Window,Worker)]
 interface PerformanceMeasure : PerformanceEntry {
+    readonly attribute any detail;
 };

--- a/tests/wpt/meta/user-timing/idlharness.any.js.ini
+++ b/tests/wpt/meta/user-timing/idlharness.any.js.ini
@@ -5,33 +5,9 @@
   [PerformanceMark interface object length]
     expected: FAIL
 
-  [PerformanceMark interface: attribute detail]
-    expected: FAIL
-
-  [PerformanceMark interface: mark must inherit property "detail" with the proper type]
-    expected: FAIL
-
-  [PerformanceMeasure interface: attribute detail]
-    expected: FAIL
-
-  [PerformanceMeasure interface: measure must inherit property "detail" with the proper type]
-    expected: FAIL
-
 
 [idlharness.any.html]
   [PerformanceMark interface object length]
-    expected: FAIL
-
-  [PerformanceMark interface: attribute detail]
-    expected: FAIL
-
-  [PerformanceMark interface: mark must inherit property "detail" with the proper type]
-    expected: FAIL
-
-  [PerformanceMeasure interface: attribute detail]
-    expected: FAIL
-
-  [PerformanceMeasure interface: measure must inherit property "detail" with the proper type]
     expected: FAIL
 
 

--- a/tests/wpt/meta/user-timing/mark-measure-feature-detection.html.ini
+++ b/tests/wpt/meta/user-timing/mark-measure-feature-detection.html.ini
@@ -1,6 +1,0 @@
-[mark-measure-feature-detection.html]
-  [Test PerformanceMeasure existence and feature detection]
-    expected: FAIL
-
-  [Test PerformanceMark existence and feature detection]
-    expected: FAIL


### PR DESCRIPTION
Add definition for generation of custom fields for interfaces inheriting from PerformanceEntry.

Testing: More WPT Tests Passed
