### PR TITLE
script: Check correct element if text-decoration is effective

### DIFF
--- a/components/script/dom/execcommand/contenteditable/node.rs
+++ b/components/script/dom/execcommand/contenteditable/node.rs
@@ -1281,8 +1281,10 @@ impl Node {
             // set the "text-decoration" property of new parent to "underline".
             CommandName::Underline => {
                 if new_value == "underline" &&
-                    self.effective_command_value(&CommandName::Underline)
-                        .is_some_and(|value| value == "underline")
+                    new_parent
+                        .upcast::<Node>()
+                        .effective_command_value(&CommandName::Underline)
+                        .is_none_or(|value| value != "underline")
                 {
                     CssPropertyName::TextDecorationLine.set_for_element(
                         cx,

--- a/tests/wpt/meta/editing/run/underline.html.ini
+++ b/tests/wpt/meta/editing/run/underline.html.ini
@@ -2,13 +2,7 @@
   [[["stylewithcss","true"\],["underline",""\]\] "<p>[foo</p> <p>bar\]</p>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "<p>[foo</p> <p>bar\]</p>" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<span>[foo</span> <span>bar\]</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<span>[foo</span> <span>bar\]</span>" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","false"\],["underline",""\]\] "<span>[foo</span> <span>bar\]</span>" compare innerHTML]
@@ -17,16 +11,10 @@
   [[["stylewithcss","true"\],["underline",""\]\] "<p>[foo</p><p> <span>bar</span> </p><p>baz\]</p>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "<p>[foo</p><p> <span>bar</span> </p><p>baz\]</p>" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["underline",""\]\] "<p>[foo</p><p> <span>bar</span> </p><p>baz\]</p>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<p>[foo<p><br><p>bar\]" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<p>[foo<p><br><p>bar\]" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","false"\],["underline",""\]\] "<p>[foo<p><br><p>bar\]" compare innerHTML]
@@ -35,61 +23,31 @@
   [[["stylewithcss","true"\],["underline",""\]\] "foo[bar\]baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "foo[bar\]baz" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "foo[bar<b>baz\]qoz</b>quz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "foo[bar<b>baz\]qoz</b>quz" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "foo[bar<i>baz\]qoz</i>quz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "foo[bar<i>baz\]qoz</i>quz" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "{<p><p> <p>foo</p>}" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "{<p><p> <p>foo</p>}" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<table><tbody><tr><td>foo<td>b[a\]r<td>baz</table>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "<table><tbody><tr><td>foo<td>b[a\]r<td>baz</table>" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<table><tbody><tr data-start=1 data-end=2><td>foo<td>bar<td>baz</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<table><tbody><tr data-start=1 data-end=2><td>foo<td>bar<td>baz</table>" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<table><tbody><tr data-start=0 data-end=2><td>foo<td>bar<td>baz</table>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "<table><tbody><tr data-start=0 data-end=2><td>foo<td>bar<td>baz</table>" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<table><tbody data-start=0 data-end=1><tr><td>foo<td>bar<td>baz</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<table><tbody data-start=0 data-end=1><tr><td>foo<td>bar<td>baz</table>" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<table data-start=0 data-end=1><tbody><tr><td>foo<td>bar<td>baz</table>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "<table data-start=0 data-end=1><tbody><tr><td>foo<td>bar<td>baz</table>" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "{<table><tr><td>foo<td>bar<td>baz</table>}" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "{<table><tr><td>foo<td>bar<td>baz</table>}" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "foo<span style=\\"text-decoration: underline\\">[bar\]</span>baz" compare innerHTML]
@@ -134,13 +92,7 @@
   [[["stylewithcss","true"\],["underline",""\]\] "foo<s>[bar\]</s>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "foo<s>[bar\]</s>baz" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "foo<span style=\\"text-decoration: line-through\\">[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "foo<span style=\\"text-decoration: line-through\\">[bar\]</span>baz" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","false"\],["underline",""\]\] "foo<span style=\\"text-decoration: line-through\\">[bar\]</span>baz" compare innerHTML]
@@ -149,43 +101,22 @@
   [[["stylewithcss","true"\],["underline",""\]\] "<s>foo[bar\]baz</s>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "<s>foo[bar\]baz</s>" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<s>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</s>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<s>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</s>" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<s>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</s>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "<s>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</s>" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<s>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</s>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<s>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</s>" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<s>foo[b<i>ar\]ba</i>z</s>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "<s>foo[b<i>ar\]ba</i>z</s>" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<p style=\\"text-decoration: line-through\\">foo[bar\]baz</p>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "<p style=\\"text-decoration: line-through\\">foo[bar\]baz</p>" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "foo<strike>[bar\]</strike>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "foo<strike>[bar\]</strike>baz" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<p>[foo</p> <p>bar\]</p>" queryCommandState("stylewithcss") before]
@@ -204,6 +135,21 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["underline",""\]\] "<u>foo[b<i>ar\]ba</i>z</u>" queryCommandState("underline") after]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["underline",""\]\] "<u>foo[bar\]baz</u>" queryCommandState("underline") after]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["underline",""\]\] "<u>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</u>" queryCommandState("underline") after]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["underline",""\]\] "<u>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</u>" queryCommandState("underline") after]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["underline",""\]\] "<u>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</u>" queryCommandState("underline") after]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["underline",""\]\] "<u>foo[b<i>ar\]ba</i>z</u>" queryCommandState("underline") after]
     expected: FAIL
 
 
@@ -262,6 +208,9 @@
   [[["stylewithcss","false"\],["underline",""\]\] "<u>fo[o</u><ins>b\]ar</ins>" queryCommandState("underline") after]
     expected: FAIL
 
+  [[["stylewithcss","true"\],["underline",""\]\] "<u>fo[o</u><ins>b\]ar</ins>" queryCommandState("underline") after]
+    expected: FAIL
+
 
 [underline.html?1001-2000]
   [[["stylewithcss","false"\],["underline",""\]\] "foo<strike>[bar\]</strike>baz" queryCommandState("underline") after]
@@ -270,67 +219,34 @@
   [[["stylewithcss","true"\],["underline",""\]\] "<strike>foo[bar\]baz</strike>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "<strike>foo[bar\]baz</strike>" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<strike>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</strike>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<strike>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</strike>" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<strike>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</strike>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "<strike>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</strike>" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<strike>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</strike>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<strike>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</strike>" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<strike>foo[b<i>ar\]ba</i>z</strike>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "<strike>foo[b<i>ar\]ba</i>z</strike>" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "foo<del>[bar\]</del>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "foo<del>[bar\]</del>baz" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<del>foo[bar\]baz</del>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "<del>foo[bar\]baz</del>" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<del>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</del>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<del>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</del>" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<del>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</del>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "<del>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</del>" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<del>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</del>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "<del>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</del>" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<del>foo[b<i>ar\]ba</i>z</del>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<del>foo[b<i>ar\]ba</i>z</del>" queryCommandState("underline") after]
     expected: FAIL
 
   [[["underline",""\]\] "foo<span style=\\"text-decoration: underline line-through\\">[bar\]</span>baz" compare innerHTML]
@@ -357,22 +273,13 @@
   [[["stylewithcss","true"\],["underline",""\]\] "foo<u style=\\"text-decoration: line-through\\">[bar\]</u>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "foo<u style=\\"text-decoration: line-through\\">[bar\]</u>baz" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["underline",""\]\] "foo<u style=\\"text-decoration: line-through\\">[bar\]</u>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "foo<u style=\\"text-decoration: line-through\\">b[a\]r</u>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "foo<u style=\\"text-decoration: line-through\\">b[a\]r</u>baz" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "foo<s style=\\"text-decoration: overline\\">[bar\]</s>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "foo<s style=\\"text-decoration: overline\\">[bar\]</s>baz" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","false"\],["underline",""\]\] "foo<s style=\\"text-decoration: overline\\">[bar\]</s>baz" compare innerHTML]
@@ -381,13 +288,7 @@
   [[["stylewithcss","true"\],["underline",""\]\] "foo<s style=\\"text-decoration: overline\\">b[a\]r</s>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "foo<s style=\\"text-decoration: overline\\">b[a\]r</s>baz" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "foo<u style=\\"text-decoration: overline\\">[bar\]</u>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "foo<u style=\\"text-decoration: overline\\">[bar\]</u>baz" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","false"\],["underline",""\]\] "foo<u style=\\"text-decoration: overline\\">[bar\]</u>baz" compare innerHTML]
@@ -396,25 +297,13 @@
   [[["stylewithcss","true"\],["underline",""\]\] "foo<u style=\\"text-decoration: overline\\">b[a\]r</u>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "foo<u style=\\"text-decoration: overline\\">b[a\]r</u>baz" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<p style=\\"text-decoration: overline\\">foo[bar\]baz</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<p style=\\"text-decoration: overline\\">foo[bar\]baz</p>" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "foo<span class=\\"line-through\\">[bar\]</span>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "foo<span class=\\"line-through\\">[bar\]</span>baz" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "foo<span class=\\"line-through\\">b[a\]r</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "foo<span class=\\"line-through\\">b[a\]r</span>baz" queryCommandState("underline") after]
     expected: FAIL
 
   [[["underline",""\]\] "fo[o<u>b\]ar</u>baz" queryCommandIndeterm("underline") before]
@@ -430,9 +319,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "fo[o<u>bar</u>b\]az" queryCommandIndeterm("underline") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "fo[o<u>bar</u>b\]az" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","false"\],["underline",""\]\] "fo[o<u>bar</u>b\]az" queryCommandIndeterm("underline") before]
@@ -469,4 +355,7 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["underline",""\]\] "foo<u>ba[r</u>\]baz" queryCommandState("underline") after]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["underline",""\]\] "foo<u>ba[r</u>\]baz" queryCommandState("underline") after]
     expected: FAIL


### PR DESCRIPTION
Rather than node, we should check `new_parent` for this. Unfortunately some regressions, which have been flip-flopping in recent PRs. That's because underline itself uses its own state to determine what to do. However, this is a net positive PR that also adheres to the spec, so it's another step in the right direction.

Part of #25005

Testing: WPT