### PR TITLE
script: Use encoding_parse_a_url in Location assign

### DIFF
--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -300,10 +300,9 @@ impl LocationMethods<crate::DomTypeHolder> for Location {
     /// <https://html.spec.whatwg.org/multipage/#dom-location-assign>
     fn Assign(&self, cx: &mut JSContext, url: USVString) -> ErrorResult {
         self.setter_common(cx, |_copy_url| {
-            // Step 3: Parse url relative to the entry settings object. If that failed,
+            // Step 3: encoding-parse url relative to the entry settings object. If that failed,
             // throw a "SyntaxError" DOMException.
-            let base_url = self.entry_settings_object().api_base_url();
-            let url = match base_url.join(&url.0) {
+            let url = match self.window.Document().encoding_parse_a_url(&url.0) {
                 Ok(url) => url,
                 Err(e) => return Err(Error::Syntax(Some(format!("Couldn't parse URL: {}", e)))),
             };
@@ -329,8 +328,7 @@ impl LocationMethods<crate::DomTypeHolder> for Location {
         // Step 1: If this Location object's relevant Document is null, then return.
         if self.has_document() {
             // Step 2. Let urlRecord be the result of encoding-parsing a URL given url, relative to the entry settings object.
-            let base_url = self.entry_settings_object().api_base_url();
-            let url = match base_url.join(&url.0) {
+            let url = match self.window.Document().encoding_parse_a_url(&url.0) {
                 Ok(url) => url,
                 // Step 3. If urlRecord is failure, then throw a "SyntaxError" DOMException.
                 Err(e) => return Err(Error::Syntax(Some(format!("Couldn't parse URL: {}", e)))),
@@ -435,8 +433,7 @@ impl LocationMethods<crate::DomTypeHolder> for Location {
         if self.has_document() {
             // Note: no call to self.check_same_origin_domain()
             // Step 2: Let url be the result of encoding-parsing a URL given the given value, relative to the entry settings object.
-            let base_url = self.entry_settings_object().api_base_url();
-            let url = match base_url.join(&value.0) {
+            let url = match self.window.Document().encoding_parse_a_url(&value.0) {
                 Ok(url) => url,
                 // Step 3: If url is failure, then throw a "SyntaxError" DOMException.
                 Err(e) => return Err(Error::Syntax(Some(format!("Couldn't parse URL: {}", e)))),

--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -302,7 +302,7 @@ impl LocationMethods<crate::DomTypeHolder> for Location {
         self.setter_common(cx, |_copy_url| {
             // Step 3: Let urlRecord be the result of encoding-parsing a URL given url, relative to the entry settings object. If that failed,
             // throw a "SyntaxError" DOMException.
-            let url = match self.window.Document().encoding_parse_a_url(&url.0) {
+            let url = match self.entry_settings_object().encoding_parse_a_url(&url.0) {
                 Ok(url) => url,
                 Err(e) => return Err(Error::Syntax(Some(format!("Couldn't parse URL: {}", e)))),
             };

--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -328,7 +328,7 @@ impl LocationMethods<crate::DomTypeHolder> for Location {
         // Step 1: If this Location object's relevant Document is null, then return.
         if self.has_document() {
             // Step 2. Let urlRecord be the result of encoding-parsing a URL given url, relative to the entry settings object.
-            let url = match self.window.Document().encoding_parse_a_url(&url.0) {
+            let url = match self.entry_settings_object().encoding_parse_a_url(&url.0) {
                 Ok(url) => url,
                 // Step 3. If urlRecord is failure, then throw a "SyntaxError" DOMException.
                 Err(e) => return Err(Error::Syntax(Some(format!("Couldn't parse URL: {}", e)))),
@@ -433,7 +433,7 @@ impl LocationMethods<crate::DomTypeHolder> for Location {
         if self.has_document() {
             // Note: no call to self.check_same_origin_domain()
             // Step 2: Let url be the result of encoding-parsing a URL given the given value, relative to the entry settings object.
-            let url = match self.window.Document().encoding_parse_a_url(&value.0) {
+            let url = match self.entry_settings_object().encoding_parse_a_url(&value.0) {
                 Ok(url) => url,
                 // Step 3: If url is failure, then throw a "SyntaxError" DOMException.
                 Err(e) => return Err(Error::Syntax(Some(format!("Couldn't parse URL: {}", e)))),

--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -300,7 +300,7 @@ impl LocationMethods<crate::DomTypeHolder> for Location {
     /// <https://html.spec.whatwg.org/multipage/#dom-location-assign>
     fn Assign(&self, cx: &mut JSContext, url: USVString) -> ErrorResult {
         self.setter_common(cx, |_copy_url| {
-            // Step 3: encoding-parse url relative to the entry settings object. If that failed,
+            // Step 3: Let urlRecord be the result of encoding-parsing a URL given url, relative to the entry settings object. If that failed,
             // throw a "SyntaxError" DOMException.
             let url = match self.window.Document().encoding_parse_a_url(&url.0) {
                 Ok(url) => url,

--- a/tests/wpt/tests/html/browsers/history/the-location-interface/location-encoding-parse.html
+++ b/tests/wpt/tests/html/browsers/history/the-location-interface/location-encoding-parse.html
@@ -9,7 +9,7 @@
 async_test(t => {
   const iframe = document.createElement('iframe');
   iframe.src = 'resources/blank.html';
-  
+
   iframe.onload = t.step_func(() => {
     if (!iframe.contentWindow.location.href.includes('test=')) {
       iframe.contentWindow.location.replace(
@@ -24,7 +24,7 @@ async_test(t => {
       t.done();
     }
   });
-  
+
   document.body.appendChild(iframe);
 }, 'location.replace() should use document encoding (windows-1252)');
 
@@ -32,7 +32,7 @@ async_test(t => {
 async_test(t => {
   const iframe = document.createElement('iframe');
   iframe.src = 'resources/blank.html';
-  
+
   iframe.onload = t.step_func(() => {
     if (!iframe.contentWindow.location.href.includes('assign=')) {
       iframe.contentWindow.location.assign(
@@ -47,7 +47,7 @@ async_test(t => {
       t.done();
     }
   });
-  
+
   document.body.appendChild(iframe);
 }, 'location.assign() should use document encoding (windows-1252)');
 
@@ -55,10 +55,10 @@ async_test(t => {
 async_test(t => {
   const iframe = document.createElement('iframe');
   iframe.src = 'resources/blank.html';
-  
+
   iframe.onload = t.step_func(() => {
     if (!iframe.contentWindow.location.href.includes('href=')) {
-      iframe.contentWindow.location.href = 
+      iframe.contentWindow.location.href =
         iframe.contentWindow.location.href + '?href=\u00DF';
     } else {
       assert_equals(
@@ -69,7 +69,7 @@ async_test(t => {
       t.done();
     }
   });
-  
+
   document.body.appendChild(iframe);
 }, 'location.href setter should use document encoding (windows-1252)');
 </script>

--- a/tests/wpt/tests/html/browsers/history/the-location-interface/location-encoding-parse.html
+++ b/tests/wpt/tests/html/browsers/history/the-location-interface/location-encoding-parse.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<meta charset="windows-1252">
+<title>Location uses encoding-parse a URL</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+// Test for location.replace()
+async_test(t => {
+  const iframe = document.createElement('iframe');
+  iframe.src = 'resources/blank.html';
+  
+  iframe.onload = t.step_func(() => {
+    if (!iframe.contentWindow.location.href.includes('test=')) {
+      iframe.contentWindow.location.replace(
+        iframe.contentWindow.location.href + '?test=\u00DF'
+      );
+    } else {
+      assert_equals(
+        iframe.contentWindow.location.search,
+        '?test=%DF',
+        'URL should use windows-1252 encoding'
+      );
+      t.done();
+    }
+  });
+  
+  document.body.appendChild(iframe);
+}, 'location.replace() should use document encoding (windows-1252)');
+
+// Test for location.assign()
+async_test(t => {
+  const iframe = document.createElement('iframe');
+  iframe.src = 'resources/blank.html';
+  
+  iframe.onload = t.step_func(() => {
+    if (!iframe.contentWindow.location.href.includes('assign=')) {
+      iframe.contentWindow.location.assign(
+        iframe.contentWindow.location.href + '?assign=\u00DF'
+      );
+    } else {
+      assert_equals(
+        iframe.contentWindow.location.search,
+        '?assign=%DF',
+        'URL should use windows-1252 encoding'
+      );
+      t.done();
+    }
+  });
+  
+  document.body.appendChild(iframe);
+}, 'location.assign() should use document encoding (windows-1252)');
+
+// Test for location.href setter
+async_test(t => {
+  const iframe = document.createElement('iframe');
+  iframe.src = 'resources/blank.html';
+  
+  iframe.onload = t.step_func(() => {
+    if (!iframe.contentWindow.location.href.includes('href=')) {
+      iframe.contentWindow.location.href = 
+        iframe.contentWindow.location.href + '?href=\u00DF';
+    } else {
+      assert_equals(
+        iframe.contentWindow.location.search,
+        '?href=%DF',
+        'URL should use windows-1252 encoding'
+      );
+      t.done();
+    }
+  });
+  
+  document.body.appendChild(iframe);
+}, 'location.href setter should use document encoding (windows-1252)');
+</script>
+</body>

--- a/tests/wpt/tests/html/browsers/history/the-location-interface/resources/blank.html
+++ b/tests/wpt/tests/html/browsers/history/the-location-interface/resources/blank.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<meta charset="windows-1252">
+<title>Blank page</title>


### PR DESCRIPTION
Use "encoding-parse a URL" algorithm in Location 
Testing: ./mach test-wpt tests/wpt/tests/html/browsers/history/the-location-interface
Fixes: #43506 
