### PR TITLE
base: Consolidate thread pools

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -327,17 +327,21 @@ pub struct Preferences {
     pub webgl_testing_context_creation_error: bool,
     /// Number of workers per threadpool, if we fail to detect how much
     /// parallelism is available at runtime.
-    pub threadpools_fallback_worker_num: i64,
+    pub threadpools_fallback_worker_num: u64,
     /// Maximum number of workers for the Image Cache thread pool
-    pub threadpools_image_cache_workers_max: i64,
+    pub threadpools_image_cache_workers_max: u64,
     /// Maximum number of workers for the IndexedDB thread pool
-    pub threadpools_indexeddb_workers_max: i64,
+    pub threadpools_indexeddb_workers_max: u64,
     /// Maximum number of workers for the Web Storage thread pool
-    pub threadpools_webstorage_workers_max: i64,
+    pub threadpools_webstorage_workers_max: u64,
     /// Maximum number of workers for the Networking async runtime thread pool
-    pub threadpools_async_runtime_workers_max: i64,
+    pub threadpools_async_runtime_workers_max: u64,
     /// Maximum number of workers for webrender
-    pub threadpools_webrender_workers_max: i64,
+    pub threadpools_webrender_workers_max: u64,
+    /// Enforce a single threadpool for many parts of servo
+    pub threadpools_single_pool: bool,
+    /// Max number the single thread pool is if
+    pub threadpools_single_pool_max: u64,
     /// The user-agent to use for Servo. This can also be set via [`UserAgentPlatform`] in
     /// order to set the value to the default value for the given platform.
     pub user_agent: String,
@@ -508,6 +512,8 @@ impl Preferences {
             threadpools_indexeddb_workers_max: 4,
             threadpools_webstorage_workers_max: 4,
             threadpools_webrender_workers_max: 4,
+            threadpools_single_pool: false,
+            threadpools_single_pool_max: 8,
             webgl_testing_context_creation_error: false,
             user_agent: String::new(),
             viewport_meta_enabled: false,

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -325,23 +325,15 @@ pub struct Preferences {
     /// The background color of shell's viewport. This will be used by OpenGL's `glClearColor`.
     pub shell_background_color_rgba: [f64; 4],
     pub webgl_testing_context_creation_error: bool,
+    /// Maximum number of workers for the main thread pool
+    pub threadpools_workers_max: u64,
     /// Number of workers per threadpool, if we fail to detect how much
     /// parallelism is available at runtime.
     pub threadpools_fallback_worker_num: u64,
-    /// Maximum number of workers for the Image Cache thread pool
-    pub threadpools_image_cache_workers_max: u64,
-    /// Maximum number of workers for the IndexedDB thread pool
-    pub threadpools_indexeddb_workers_max: u64,
-    /// Maximum number of workers for the Web Storage thread pool
-    pub threadpools_webstorage_workers_max: u64,
     /// Maximum number of workers for the Networking async runtime thread pool
     pub threadpools_async_runtime_workers_max: u64,
     /// Maximum number of workers for webrender
     pub threadpools_webrender_workers_max: u64,
-    /// Enforce a single threadpool for many parts of servo
-    pub threadpools_single_pool: bool,
-    /// Max number the single thread pool is if
-    pub threadpools_single_pool_max: u64,
     /// The user-agent to use for Servo. This can also be set via [`UserAgentPlatform`] in
     /// order to set the value to the default value for the given platform.
     pub user_agent: String,
@@ -506,14 +498,10 @@ impl Preferences {
             network_use_webpki_roots: false,
             session_history_max_length: 20,
             shell_background_color_rgba: [1.0, 1.0, 1.0, 1.0],
+            threadpools_workers_max: 4,
             threadpools_async_runtime_workers_max: 6,
             threadpools_fallback_worker_num: 3,
-            threadpools_image_cache_workers_max: 4,
-            threadpools_indexeddb_workers_max: 4,
-            threadpools_webstorage_workers_max: 4,
             threadpools_webrender_workers_max: 4,
-            threadpools_single_pool: false,
-            threadpools_single_pool_max: 8,
             webgl_testing_context_creation_error: false,
             user_agent: String::new(),
             viewport_meta_enabled: false,

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -330,14 +330,14 @@ pub struct Preferences {
     pub shell_background_color_rgba: [f64; 4],
     pub webgl_testing_context_creation_error: bool,
     /// Maximum number of workers for the main thread pool
-    pub threadpools_workers_max: u64,
-    /// Number of workers per threadpool, if we fail to detect how much
+    pub thread_pool_workers_max: u64,
+    /// Number of workers per thread pool, if we fail to detect how much
     /// parallelism is available at runtime.
-    pub threadpools_fallback_worker_num: u64,
-    /// Maximum number of workers for the Networking async runtime thread pool
-    pub threadpools_async_runtime_workers_max: u64,
-    /// Maximum number of workers for webrender
-    pub threadpools_webrender_workers_max: u64,
+    pub thread_pool_fallback_workers: u64,
+    /// Maximum number of workers for the asynchronous networking runtime thread pool
+    pub thread_pool_async_runtime_workers_max: u64,
+    /// Maximum number of workers for WebRender
+    pub thread_pool_webrender_workers_max: u64,
     /// The user-agent to use for Servo. This can also be set via [`UserAgentPlatform`] in
     /// order to set the value to the default value for the given platform.
     pub user_agent: String,
@@ -504,14 +504,14 @@ impl Preferences {
             network_use_webpki_roots: false,
             session_history_max_length: 20,
             shell_background_color_rgba: [1.0, 1.0, 1.0, 1.0],
-            threadpools_workers_max: 4,
-            threadpools_async_runtime_workers_max: 6,
-            threadpools_fallback_worker_num: 3,
-            threadpools_webrender_workers_max: 4,
+            log_filter: String::new(),
+            thread_pool_workers_max: 4,
+            thread_pool_async_runtime_workers_max: 6,
+            thread_pool_fallback_workers: 3,
+            thread_pool_webrender_workers_max: 4,
             webgl_testing_context_creation_error: false,
             user_agent: String::new(),
             viewport_meta_enabled: false,
-            log_filter: String::new(),
         }
     }
 

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -329,23 +329,15 @@ pub struct Preferences {
     /// The background color of shell's viewport. This will be used by OpenGL's `glClearColor`.
     pub shell_background_color_rgba: [f64; 4],
     pub webgl_testing_context_creation_error: bool,
+    /// Maximum number of workers for the main thread pool
+    pub threadpools_workers_max: u64,
     /// Number of workers per threadpool, if we fail to detect how much
     /// parallelism is available at runtime.
     pub threadpools_fallback_worker_num: u64,
-    /// Maximum number of workers for the Image Cache thread pool
-    pub threadpools_image_cache_workers_max: u64,
-    /// Maximum number of workers for the IndexedDB thread pool
-    pub threadpools_indexeddb_workers_max: u64,
-    /// Maximum number of workers for the Web Storage thread pool
-    pub threadpools_webstorage_workers_max: u64,
     /// Maximum number of workers for the Networking async runtime thread pool
     pub threadpools_async_runtime_workers_max: u64,
     /// Maximum number of workers for webrender
     pub threadpools_webrender_workers_max: u64,
-    /// Enforce a single threadpool for many parts of servo
-    pub threadpools_single_pool: bool,
-    /// Max number the single thread pool is if
-    pub threadpools_single_pool_max: u64,
     /// The user-agent to use for Servo. This can also be set via [`UserAgentPlatform`] in
     /// order to set the value to the default value for the given platform.
     pub user_agent: String,
@@ -512,14 +504,10 @@ impl Preferences {
             network_use_webpki_roots: false,
             session_history_max_length: 20,
             shell_background_color_rgba: [1.0, 1.0, 1.0, 1.0],
+            threadpools_workers_max: 4,
             threadpools_async_runtime_workers_max: 6,
             threadpools_fallback_worker_num: 3,
-            threadpools_image_cache_workers_max: 4,
-            threadpools_indexeddb_workers_max: 4,
-            threadpools_webstorage_workers_max: 4,
             threadpools_webrender_workers_max: 4,
-            threadpools_single_pool: false,
-            threadpools_single_pool_max: 8,
             webgl_testing_context_creation_error: false,
             user_agent: String::new(),
             viewport_meta_enabled: false,

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -331,17 +331,21 @@ pub struct Preferences {
     pub webgl_testing_context_creation_error: bool,
     /// Number of workers per threadpool, if we fail to detect how much
     /// parallelism is available at runtime.
-    pub threadpools_fallback_worker_num: i64,
+    pub threadpools_fallback_worker_num: u64,
     /// Maximum number of workers for the Image Cache thread pool
-    pub threadpools_image_cache_workers_max: i64,
+    pub threadpools_image_cache_workers_max: u64,
     /// Maximum number of workers for the IndexedDB thread pool
-    pub threadpools_indexeddb_workers_max: i64,
+    pub threadpools_indexeddb_workers_max: u64,
     /// Maximum number of workers for the Web Storage thread pool
-    pub threadpools_webstorage_workers_max: i64,
+    pub threadpools_webstorage_workers_max: u64,
     /// Maximum number of workers for the Networking async runtime thread pool
-    pub threadpools_async_runtime_workers_max: i64,
+    pub threadpools_async_runtime_workers_max: u64,
     /// Maximum number of workers for webrender
-    pub threadpools_webrender_workers_max: i64,
+    pub threadpools_webrender_workers_max: u64,
+    /// Enforce a single threadpool for many parts of servo
+    pub threadpools_single_pool: bool,
+    /// Max number the single thread pool is if
+    pub threadpools_single_pool_max: u64,
     /// The user-agent to use for Servo. This can also be set via [`UserAgentPlatform`] in
     /// order to set the value to the default value for the given platform.
     pub user_agent: String,
@@ -514,6 +518,8 @@ impl Preferences {
             threadpools_indexeddb_workers_max: 4,
             threadpools_webstorage_workers_max: 4,
             threadpools_webrender_workers_max: 4,
+            threadpools_single_pool: false,
+            threadpools_single_pool_max: 8,
             webgl_testing_context_creation_error: false,
             user_agent: String::new(),
             viewport_meta_enabled: false,

--- a/components/net/async_runtime.rs
+++ b/components/net/async_runtime.rs
@@ -48,8 +48,8 @@ pub fn init_async_runtime() -> Box<dyn AsyncRuntime> {
         .worker_threads(
             thread::available_parallelism()
                 .map(|i| i.get())
-                .unwrap_or(servo_config::pref!(threadpools_fallback_worker_num) as usize)
-                .min(servo_config::pref!(threadpools_async_runtime_workers_max).max(1) as usize),
+                .unwrap_or(servo_config::pref!(thread_pool_fallback_workers) as usize)
+                .min(servo_config::pref!(thread_pool_async_runtime_workers_max).max(1) as usize),
         )
         .enable_io()
         .enable_time()

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -6,8 +6,8 @@ use std::cell::OnceCell;
 use std::cmp::min;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::mem;
 use std::sync::Arc;
-use std::{mem, thread};
 
 use imsz::imsz_from_reader;
 use log::{debug, warn};
@@ -31,7 +31,6 @@ use resvg::usvg::{self, fontdb};
 use rustc_hash::FxHashMap;
 use servo_base::id::{PipelineId, WebViewId};
 use servo_base::threadpool::ThreadPool;
-use servo_config::pref;
 use servo_url::{ImmutableOrigin, ServoUrl};
 use webrender_api::ImageKey as WebRenderImageKey;
 use webrender_api::units::DeviceIntSize;
@@ -731,21 +730,12 @@ pub struct ImageCacheFactoryImpl {
 impl ImageCacheFactoryImpl {
     pub fn new(broken_image_icon_data: Vec<u8>) -> Self {
         debug!("Creating new ImageCacheFactoryImpl");
-
-        // Uses an estimate of the system cpus to decode images
-        // See https://doc.rust-lang.org/stable/std/thread/fn.available_parallelism.html
-        // If no information can be obtained about the system, uses 4 threads as a default
-        let thread_count = thread::available_parallelism()
-            .map(|i| i.get())
-            .unwrap_or(pref!(threadpools_fallback_worker_num) as usize)
-            .min(pref!(threadpools_image_cache_workers_max).max(1) as usize);
-
         let mut fontdb = fontdb::Database::new();
         fontdb.load_system_fonts();
 
         Self {
             broken_image_icon_data: Arc::new(broken_image_icon_data),
-            thread_pool: Arc::new(ThreadPool::new(thread_count, "ImageCache".to_string())),
+            thread_pool: ThreadPool::new(servo_base::threadpool::ThreadPoolType::ImageCache),
             fontdb: Arc::new(fontdb),
         }
     }

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -735,7 +735,7 @@ impl ImageCacheFactoryImpl {
 
         Self {
             broken_image_icon_data: Arc::new(broken_image_icon_data),
-            thread_pool: ThreadPool::new(servo_base::threadpool::ThreadPoolType::ImageCache),
+            thread_pool: ThreadPool::current_threadpool(),
             fontdb: Arc::new(fontdb),
         }
     }

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -737,7 +737,7 @@ impl ImageCacheFactoryImpl {
 
         Self {
             broken_image_icon_data: Arc::new(broken_image_icon_data),
-            thread_pool: ThreadPool::new(servo_base::threadpool::ThreadPoolType::ImageCache),
+            thread_pool: ThreadPool::current_threadpool(),
             fontdb: Arc::new(fontdb),
         }
     }

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -6,8 +6,8 @@ use std::cell::OnceCell;
 use std::cmp::min;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::mem;
 use std::sync::Arc;
-use std::{mem, thread};
 
 use imsz::imsz_from_reader;
 use log::{debug, warn};
@@ -31,7 +31,6 @@ use resvg::usvg::{self, fontdb};
 use rustc_hash::FxHashMap;
 use servo_base::id::{PipelineId, WebViewId};
 use servo_base::threadpool::ThreadPool;
-use servo_config::pref;
 use servo_url::{ImmutableOrigin, ServoUrl};
 use webrender_api::ImageKey as WebRenderImageKey;
 use webrender_api::units::DeviceIntSize;
@@ -733,21 +732,12 @@ pub struct ImageCacheFactoryImpl {
 impl ImageCacheFactoryImpl {
     pub fn new(broken_image_icon_data: Vec<u8>) -> Self {
         debug!("Creating new ImageCacheFactoryImpl");
-
-        // Uses an estimate of the system cpus to decode images
-        // See https://doc.rust-lang.org/stable/std/thread/fn.available_parallelism.html
-        // If no information can be obtained about the system, uses 4 threads as a default
-        let thread_count = thread::available_parallelism()
-            .map(|i| i.get())
-            .unwrap_or(pref!(threadpools_fallback_worker_num) as usize)
-            .min(pref!(threadpools_image_cache_workers_max).max(1) as usize);
-
         let mut fontdb = fontdb::Database::new();
         fontdb.load_system_fonts();
 
         Self {
             broken_image_icon_data: Arc::new(broken_image_icon_data),
-            thread_pool: Arc::new(ThreadPool::new(thread_count, "ImageCache".to_string())),
+            thread_pool: ThreadPool::new(servo_base::threadpool::ThreadPoolType::ImageCache),
             fontdb: Arc::new(fontdb),
         }
     }

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -737,7 +737,7 @@ impl ImageCacheFactoryImpl {
 
         Self {
             broken_image_icon_data: Arc::new(broken_image_icon_data),
-            thread_pool: ThreadPool::current_threadpool(),
+            thread_pool: ThreadPool::global(),
             fontdb: Arc::new(fontdb),
         }
     }

--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -208,8 +208,8 @@ impl Painter {
         };
         let worker_threads = std::thread::available_parallelism()
             .map(|i| i.get())
-            .unwrap_or(pref!(threadpools_fallback_worker_num) as usize)
-            .min(pref!(threadpools_webrender_workers_max).max(1) as usize);
+            .unwrap_or(pref!(thread_pool_fallback_workers) as usize)
+            .min(pref!(thread_pool_webrender_workers_max).max(1) as usize);
         let workers = Some(Arc::new(
             rayon::ThreadPoolBuilder::new()
                 .num_threads(worker_threads)

--- a/components/shared/base/threadpool.rs
+++ b/components/shared/base/threadpool.rs
@@ -2,11 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
 use std::time::Duration;
 
-use log::debug;
+use log::{debug, error};
+use servo_config::{opts, pref};
 
 /// The state of the thread-pool used by CoreResource.
 struct ThreadPoolState {
@@ -50,22 +51,81 @@ impl ThreadPoolState {
     }
 }
 
-/// Threadpool used by Fetch and file operations.
+/// The type of the ThreadPool to spawn.
+pub enum ThreadPoolType {
+    ImageCache,
+    IndexedDB,
+    WebStorage,
+    Test,
+}
+
+/// Threadpools used throughout servo (except layout/stylo and webrender).
 pub struct ThreadPool {
     pool: rayon::ThreadPool,
     state: Arc<Mutex<ThreadPoolState>>,
 }
 
+/// Get number of threads and names for [`ThreadPoolType`].
+fn get_pool_create_information(t: &ThreadPoolType) -> (usize, String) {
+    let max_thread_count = thread::available_parallelism()
+        .map(|i| i.get())
+        .unwrap_or(pref!(threadpools_fallback_worker_num) as usize);
+
+    match t {
+        ThreadPoolType::ImageCache => (
+            max_thread_count.min(pref!(threadpools_image_cache_workers_max).max(1) as usize),
+            "ImageCache".to_owned(),
+        ),
+        ThreadPoolType::IndexedDB => (
+            max_thread_count.min(pref!(threadpools_indexeddb_workers_max).max(1) as usize),
+            "IndexedDB".to_owned(),
+        ),
+        ThreadPoolType::WebStorage => (
+            max_thread_count.min(pref!(threadpools_webstorage_workers_max).max(1) as usize),
+            "WebStorage".to_owned(),
+        ),
+        ThreadPoolType::Test => (1, "TestPool".to_owned()),
+    }
+}
+
+static GLOBAL_THREADPOOL: OnceLock<Arc<ThreadPool>> = OnceLock::new();
+
 impl ThreadPool {
-    pub fn new(num_threads: usize, pool_name: String) -> Self {
-        debug!("Creating new ThreadPool with {num_threads} threads!");
-        let pool = rayon::ThreadPoolBuilder::new()
-            .thread_name(move |i| format!("{pool_name}#{i}"))
-            .num_threads(num_threads)
-            .build()
-            .unwrap();
-        let state = Arc::new(Mutex::new(ThreadPoolState::new()));
-        Self { pool, state }
+    /// Create a new ThreadPool from type.
+    pub fn new(t: ThreadPoolType) -> Arc<Self> {
+        if pref!(threadpools_single_pool) && !opts::get().multiprocess {
+            let pool = GLOBAL_THREADPOOL.get_or_init(|| {
+                let paralellism = thread::available_parallelism()
+                    .map(|i| i.get())
+                    .unwrap_or(pref!(threadpools_fallback_worker_num) as usize)
+                    .min(pref!(threadpools_single_pool_max) as usize);
+                let pool = rayon::ThreadPoolBuilder::new()
+                    .thread_name(move |i| format!("GlobalPool#{i}"))
+                    .num_threads(paralellism)
+                    .build()
+                    .unwrap();
+                Arc::new(Self {
+                    pool,
+                    state: Arc::new(Mutex::new(ThreadPoolState::new())),
+                })
+            });
+            pool.clone()
+        } else {
+            if opts::get().multiprocess {
+                error!(
+                    "Single threadpool and multiprocess are incompatible. Falling back to separate threadpools"
+                );
+            }
+            let (num_threads, pool_name) = get_pool_create_information(&t);
+            debug!("Creating new ThreadPool with {num_threads} threads!");
+            let pool = rayon::ThreadPoolBuilder::new()
+                .thread_name(move |i| format!("{pool_name}#{i}"))
+                .num_threads(num_threads)
+                .build()
+                .unwrap();
+            let state = Arc::new(Mutex::new(ThreadPoolState::new()));
+            Arc::new(Self { pool, state })
+        }
     }
 
     /// Spawn work on the thread-pool, if still active.

--- a/components/shared/base/threadpool.rs
+++ b/components/shared/base/threadpool.rs
@@ -51,22 +51,23 @@ impl ThreadPoolState {
     }
 }
 
-/// Threadpools used throughout servo (except layout/stylo and webrender).
+/// The thread pools used throughout Servo, apart from those used by Layout and WebRender which
+/// are handled separately.
 pub struct ThreadPool {
     pool: rayon::ThreadPool,
     state: Arc<Mutex<ThreadPoolState>>,
 }
 
-static GLOBAL_THREADPOOL: OnceLock<Arc<ThreadPool>> = OnceLock::new();
+static GLOBAL_THREAD_POOL: OnceLock<Arc<ThreadPool>> = OnceLock::new();
 
 impl ThreadPool {
-    /// Gets the current threadpool for the process.
-    pub fn current_threadpool() -> Arc<Self> {
-        let pool = GLOBAL_THREADPOOL.get_or_init(|| {
+    /// Get the global thread pool for the process.
+    pub fn global() -> Arc<Self> {
+        let pool = GLOBAL_THREAD_POOL.get_or_init(|| {
             let paralellism = thread::available_parallelism()
-                .map(|i| i.get())
-                .unwrap_or(pref!(threadpools_fallback_worker_num) as usize)
-                .min(pref!(threadpools_workers_max) as usize);
+                .map(|parallelism| parallelism.get())
+                .unwrap_or(pref!(thread_pool_fallback_workers) as usize)
+                .min(pref!(thread_pool_workers_max) as usize);
             let pool = rayon::ThreadPoolBuilder::new()
                 .thread_name(move |i| format!("GlobalPool#{i}"))
                 .num_threads(paralellism)

--- a/components/shared/base/threadpool.rs
+++ b/components/shared/base/threadpool.rs
@@ -6,8 +6,8 @@ use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
 use std::time::Duration;
 
-use log::{debug, error};
-use servo_config::{opts, pref};
+use log::debug;
+use servo_config::pref;
 
 /// The state of the thread-pool used by CoreResource.
 struct ThreadPoolState {
@@ -51,81 +51,33 @@ impl ThreadPoolState {
     }
 }
 
-/// The type of the ThreadPool to spawn.
-pub enum ThreadPoolType {
-    ImageCache,
-    IndexedDB,
-    WebStorage,
-    Test,
-}
-
 /// Threadpools used throughout servo (except layout/stylo and webrender).
 pub struct ThreadPool {
     pool: rayon::ThreadPool,
     state: Arc<Mutex<ThreadPoolState>>,
 }
 
-/// Get number of threads and names for [`ThreadPoolType`].
-fn get_pool_create_information(t: &ThreadPoolType) -> (usize, String) {
-    let max_thread_count = thread::available_parallelism()
-        .map(|i| i.get())
-        .unwrap_or(pref!(threadpools_fallback_worker_num) as usize);
-
-    match t {
-        ThreadPoolType::ImageCache => (
-            max_thread_count.min(pref!(threadpools_image_cache_workers_max).max(1) as usize),
-            "ImageCache".to_owned(),
-        ),
-        ThreadPoolType::IndexedDB => (
-            max_thread_count.min(pref!(threadpools_indexeddb_workers_max).max(1) as usize),
-            "IndexedDB".to_owned(),
-        ),
-        ThreadPoolType::WebStorage => (
-            max_thread_count.min(pref!(threadpools_webstorage_workers_max).max(1) as usize),
-            "WebStorage".to_owned(),
-        ),
-        ThreadPoolType::Test => (1, "TestPool".to_owned()),
-    }
-}
-
 static GLOBAL_THREADPOOL: OnceLock<Arc<ThreadPool>> = OnceLock::new();
 
 impl ThreadPool {
-    /// Create a new ThreadPool from type.
-    pub fn new(t: ThreadPoolType) -> Arc<Self> {
-        if pref!(threadpools_single_pool) && !opts::get().multiprocess {
-            let pool = GLOBAL_THREADPOOL.get_or_init(|| {
-                let paralellism = thread::available_parallelism()
-                    .map(|i| i.get())
-                    .unwrap_or(pref!(threadpools_fallback_worker_num) as usize)
-                    .min(pref!(threadpools_single_pool_max) as usize);
-                let pool = rayon::ThreadPoolBuilder::new()
-                    .thread_name(move |i| format!("GlobalPool#{i}"))
-                    .num_threads(paralellism)
-                    .build()
-                    .unwrap();
-                Arc::new(Self {
-                    pool,
-                    state: Arc::new(Mutex::new(ThreadPoolState::new())),
-                })
-            });
-            pool.clone()
-        } else {
-            if opts::get().multiprocess {
-                error!(
-                    "Single threadpool and multiprocess are incompatible. Falling back to separate threadpools"
-                );
-            }
-            let (num_threads, pool_name) = get_pool_create_information(&t);
-            debug!("Creating new ThreadPool with {num_threads} threads!");
+    /// Gets the current threadpool for the process.
+    pub fn current_threadpool() -> Arc<Self> {
+        let pool = GLOBAL_THREADPOOL.get_or_init(|| {
+            let paralellism = thread::available_parallelism()
+                .map(|i| i.get())
+                .unwrap_or(pref!(threadpools_fallback_worker_num) as usize)
+                .min(pref!(threadpools_workers_max) as usize);
             let pool = rayon::ThreadPoolBuilder::new()
-                .thread_name(move |i| format!("{pool_name}#{i}"))
-                .num_threads(num_threads)
+                .thread_name(move |i| format!("GlobalPool#{i}"))
+                .num_threads(paralellism)
                 .build()
                 .unwrap();
-            let state = Arc::new(Mutex::new(ThreadPoolState::new()));
-            Arc::new(Self { pool, state })
-        }
+            Arc::new(Self {
+                pool,
+                state: Arc::new(Mutex::new(ThreadPoolState::new())),
+            })
+        });
+        pool.clone()
     }
 
     /// Spawn work on the thread-pool, if still active.

--- a/components/storage/indexeddb/engines/sqlite.rs
+++ b/components/storage/indexeddb/engines/sqlite.rs
@@ -786,7 +786,7 @@ mod tests {
     }
 
     fn get_pool() -> Arc<ThreadPool> {
-        ThreadPool::new(servo_base::threadpool::ThreadPoolType::Test)
+        ThreadPool::current_threadpool()
     }
 
     #[test]

--- a/components/storage/indexeddb/engines/sqlite.rs
+++ b/components/storage/indexeddb/engines/sqlite.rs
@@ -786,7 +786,7 @@ mod tests {
     }
 
     fn get_pool() -> Arc<ThreadPool> {
-        Arc::new(ThreadPool::new(1, "test".to_string()))
+        ThreadPool::new(servo_base::threadpool::ThreadPoolType::Test)
     }
 
     #[test]

--- a/components/storage/indexeddb/engines/sqlite.rs
+++ b/components/storage/indexeddb/engines/sqlite.rs
@@ -773,7 +773,7 @@ mod tests {
     }
 
     fn get_pool() -> Arc<ThreadPool> {
-        Arc::new(ThreadPool::new(1, "test".to_string()))
+        ThreadPool::new(servo_base::threadpool::ThreadPoolType::Test)
     }
 
     fn create_db(

--- a/components/storage/indexeddb/engines/sqlite.rs
+++ b/components/storage/indexeddb/engines/sqlite.rs
@@ -773,7 +773,7 @@ mod tests {
     }
 
     fn get_pool() -> Arc<ThreadPool> {
-        ThreadPool::new(servo_base::threadpool::ThreadPoolType::Test)
+        ThreadPool::current_threadpool()
     }
 
     fn create_db(

--- a/components/storage/indexeddb/engines/sqlite.rs
+++ b/components/storage/indexeddb/engines/sqlite.rs
@@ -773,7 +773,7 @@ mod tests {
     }
 
     fn get_pool() -> Arc<ThreadPool> {
-        ThreadPool::current_threadpool()
+        ThreadPool::global()
     }
 
     fn create_db(

--- a/components/storage/indexeddb/mod.rs
+++ b/components/storage/indexeddb/mod.rs
@@ -832,7 +832,7 @@ impl IndexedDBManager {
             manager_sender,
             idb_base_dir,
             databases: HashMap::new(),
-            thread_pool: ThreadPool::new(servo_base::threadpool::ThreadPoolType::IndexedDB),
+            thread_pool: ThreadPool::current_threadpool(),
             serial_number_counter: 0,
             connection_queues: Default::default(),
             connections: Default::default(),

--- a/components/storage/indexeddb/mod.rs
+++ b/components/storage/indexeddb/mod.rs
@@ -23,7 +23,6 @@ use rusqlite::Error as RusqliteError;
 use rustc_hash::{FxHashMap, FxHashSet};
 use servo_base::generic_channel::{self, GenericReceiver, GenericSender, ReceiveError};
 use servo_base::threadpool::ThreadPool;
-use servo_config::pref;
 use servo_url::origin::ImmutableOrigin;
 use storage_traits::indexeddb::{
     AsyncOperation, BackendError, BackendResult, ConnectionMsg, CreateObjectResult, DatabaseInfo,
@@ -828,20 +827,12 @@ impl IndexedDBManager {
     ) -> IndexedDBManager {
         debug!("New indexedDBManager");
 
-        // Uses an estimate of the system cpus to process IndexedDB transactions
-        // See https://doc.rust-lang.org/stable/std/thread/fn.available_parallelism.html
-        // If no information can be obtained about the system, uses 4 threads as a default
-        let thread_count = thread::available_parallelism()
-            .map(|i| i.get())
-            .unwrap_or(pref!(threadpools_fallback_worker_num) as usize)
-            .min(pref!(threadpools_indexeddb_workers_max).max(1) as usize);
-
         IndexedDBManager {
             port,
             manager_sender,
             idb_base_dir,
             databases: HashMap::new(),
-            thread_pool: Arc::new(ThreadPool::new(thread_count, "IndexedDB".to_string())),
+            thread_pool: ThreadPool::new(servo_base::threadpool::ThreadPoolType::IndexedDB),
             serial_number_counter: 0,
             connection_queues: Default::default(),
             connections: Default::default(),

--- a/components/storage/indexeddb/mod.rs
+++ b/components/storage/indexeddb/mod.rs
@@ -801,7 +801,7 @@ impl IndexedDBManager {
             port,
             manager_sender,
             databases: HashMap::new(),
-            thread_pool: ThreadPool::current_threadpool(),
+            thread_pool: ThreadPool::global(),
             serial_number_counter: 0,
             connection_queues: Default::default(),
             connections: Default::default(),

--- a/components/storage/indexeddb/mod.rs
+++ b/components/storage/indexeddb/mod.rs
@@ -22,7 +22,6 @@ use rusqlite::Error as RusqliteError;
 use rustc_hash::{FxHashMap, FxHashSet};
 use servo_base::generic_channel::{self, GenericReceiver, GenericSender, ReceiveError};
 use servo_base::threadpool::ThreadPool;
-use servo_config::pref;
 use servo_url::origin::ImmutableOrigin;
 use storage_traits::client_storage::StorageProxyMap;
 use storage_traits::indexeddb::{
@@ -798,19 +797,11 @@ impl IndexedDBManager {
     ) -> IndexedDBManager {
         debug!("New indexedDBManager");
 
-        // Uses an estimate of the system cpus to process IndexedDB transactions
-        // See https://doc.rust-lang.org/stable/std/thread/fn.available_parallelism.html
-        // If no information can be obtained about the system, uses 4 threads as a default
-        let thread_count = thread::available_parallelism()
-            .map(|i| i.get())
-            .unwrap_or(pref!(threadpools_fallback_worker_num) as usize)
-            .min(pref!(threadpools_indexeddb_workers_max).max(1) as usize);
-
         IndexedDBManager {
             port,
             manager_sender,
             databases: HashMap::new(),
-            thread_pool: Arc::new(ThreadPool::new(thread_count, "IndexedDB".to_string())),
+            thread_pool: ThreadPool::new(servo_base::threadpool::ThreadPoolType::IndexedDB),
             serial_number_counter: 0,
             connection_queues: Default::default(),
             connections: Default::default(),

--- a/components/storage/indexeddb/mod.rs
+++ b/components/storage/indexeddb/mod.rs
@@ -801,7 +801,7 @@ impl IndexedDBManager {
             port,
             manager_sender,
             databases: HashMap::new(),
-            thread_pool: ThreadPool::new(servo_base::threadpool::ThreadPoolType::IndexedDB),
+            thread_pool: ThreadPool::current_threadpool(),
             serial_number_counter: 0,
             connection_queues: Default::default(),
             connections: Default::default(),

--- a/components/storage/webstorage/mod.rs
+++ b/components/storage/webstorage/mod.rs
@@ -25,7 +25,6 @@ use servo_base::generic_channel::{self, GenericReceiver, GenericSender};
 use servo_base::id::WebViewId;
 use servo_base::threadpool::ThreadPool;
 use servo_base::{read_json_from_file, write_json_to_file};
-use servo_config::pref;
 use servo_url::{ImmutableOrigin, ServoUrl};
 use storage_traits::webstorage_thread::{OriginDescriptor, WebStorageThreadMsg, WebStorageType};
 use uuid::Uuid;
@@ -224,20 +223,13 @@ impl WebStorageManager {
         if let Some(ref config_dir) = config_dir {
             read_json_from_file(&mut local_storage_origins, config_dir, "localstorage.json");
         }
-        // Uses an estimate of the system cpus to process Webstorage transactions
-        // See https://doc.rust-lang.org/stable/std/thread/fn.available_parallelism.html
-        // If no information can be obtained about the system, uses 4 threads as a default
-        let thread_count = thread::available_parallelism()
-            .map(|i| i.get())
-            .unwrap_or(pref!(threadpools_fallback_worker_num) as usize)
-            .min(pref!(threadpools_webstorage_workers_max).max(1) as usize);
         WebStorageManager {
             port,
             session_storage_origins: StorageOrigins::new(),
             local_storage_origins,
             session_data: FxHashMap::default(),
             config_dir,
-            thread_pool: Arc::new(ThreadPool::new(thread_count, "WebStorage".to_string())),
+            thread_pool: ThreadPool::new(servo_base::threadpool::ThreadPoolType::WebStorage),
             environments: FxHashMap::default(),
         }
     }

--- a/components/storage/webstorage/mod.rs
+++ b/components/storage/webstorage/mod.rs
@@ -229,7 +229,7 @@ impl WebStorageManager {
             local_storage_origins,
             session_data: FxHashMap::default(),
             config_dir,
-            thread_pool: ThreadPool::new(servo_base::threadpool::ThreadPoolType::WebStorage),
+            thread_pool: ThreadPool::current_threadpool(),
             environments: FxHashMap::default(),
         }
     }

--- a/components/storage/webstorage/mod.rs
+++ b/components/storage/webstorage/mod.rs
@@ -229,7 +229,7 @@ impl WebStorageManager {
             local_storage_origins,
             session_data: FxHashMap::default(),
             config_dir,
-            thread_pool: ThreadPool::current_threadpool(),
+            thread_pool: ThreadPool::global(),
             environments: FxHashMap::default(),
         }
     }

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -650,11 +650,6 @@ fn parse_arguments_helper(args_without_binary: Args) -> ArgumentParsingResult {
         preferences.js_ion_enabled = false;
     }
 
-    // For embedded systems we want to save threads.
-    if cfg!(target_os = "android") || cfg!(target_env = "ohos") {
-        preferences.threadpools_single_pool = true;
-    }
-
     // Make sure the default window size is not larger than any provided screen size.
     let default_window_size = Size2D::new(1024, 740);
     let default_window_size = cmd_args

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -650,6 +650,11 @@ fn parse_arguments_helper(args_without_binary: Args) -> ArgumentParsingResult {
         preferences.js_ion_enabled = false;
     }
 
+    // For embedded systems we want to save threads.
+    if cfg!(target_os = "android") || cfg!(target_env = "ohos") {
+        preferences.threadpools_single_pool = true;
+    }
+
     // Make sure the default window size is not larger than any provided screen size.
     let default_window_size = Size2D::new(1024, 740);
     let default_window_size = cmd_args

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -656,11 +656,6 @@ fn parse_arguments_helper(args_without_binary: Args) -> ArgumentParsingResult {
         preferences.js_ion_enabled = false;
     }
 
-    // For embedded systems we want to save threads.
-    if cfg!(target_os = "android") || cfg!(target_env = "ohos") {
-        preferences.threadpools_single_pool = true;
-    }
-
     // Make sure the default window size is not larger than any provided screen size.
     let default_window_size = Size2D::new(1024, 740);
     let default_window_size = cmd_args

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -656,6 +656,11 @@ fn parse_arguments_helper(args_without_binary: Args) -> ArgumentParsingResult {
         preferences.js_ion_enabled = false;
     }
 
+    // For embedded systems we want to save threads.
+    if cfg!(target_os = "android") || cfg!(target_env = "ohos") {
+        preferences.threadpools_single_pool = true;
+    }
+
     // Make sure the default window size is not larger than any provided screen size.
     let default_window_size = Size2D::new(1024, 740);
     let default_window_size = cmd_args


### PR DESCRIPTION
Currently servo is starting many thread pools which default to 4 for each. This is currently 12 threads in total for ImageCache, WebStorage and IndexedDB. This is independent of the JS Helper (6), WebRenderWorker (4) Tokio Runtime (6) and various other threads. (All numbers on my machine).

This change consolidates the thread pools for ImageCache, WebStorage and IndexedDB in the single process mode.

Additionally, it moves the creation of new thread pools into base/threadpool.rs to make it easier to adjust depending on `threads::available_parallelism()` in the future.

Testing: We do not have automatic testcases for different preferences so only manual testing was done.
Fixes: Addresses part of #44304
