### PR TITLE
git: Fix CI by removing wrongly commited `FETCH_HEAD`

### DIFF
--- a/.github/workflows/mac-arm64.yml
+++ b/.github/workflows/mac-arm64.yml
@@ -109,9 +109,11 @@ jobs:
       - if: ${{ runner.environment == 'self-hosted' }}
         # Same as `git switch --detach FETCH_HEAD`, but fixes up dirty working
         # trees, in case the runner image was baked with a dirty working tree.
+        # Safeguard: -- means FETCH_HEAD is revision instead of path.
+        # See <https://github.com/servo/servo/pull/44309>
         run: |
           git switch --detach
-          git reset --hard FETCH_HEAD
+          git reset --hard FETCH_HEAD --
 
       - if: runner.environment != 'self-hosted'
         name: Setup Python

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -182,9 +182,11 @@ jobs:
         run: git fetch --depth=1 origin $GITHUB_SHA
       - if: ${{ github.event_name == 'pull_request_target' }}
         run: git fetch --depth=1 origin ${{ github.event.pull_request.head.sha }}
+      # Safeguard: -- means FETCH_HEAD is revision instead of path.
+      # See <https://github.com/servo/servo/pull/44309>
       - run: |
           git switch --detach
-          git reset --hard FETCH_HEAD
+          git reset --hard FETCH_HEAD --
       - name: Adding test files to directory
         run: cp -r support/hitrace-bencher/* support/openharmony/AppScope/resources/resfile/
       - name: Build for aarch64 HarmonyOS


### PR DESCRIPTION
This is somehow introduced in #43617. This is causing CI failure.
For whatever reason, this thing should only be in `.git` folder. But somehow it is at the root?

Also changed `.yml` to avoid ambiguity: we are using revision instead of path.