### PR TITLE
script: Set shorthand text-decoration instead of longhand

### DIFF
--- a/components/script/dom/execcommand/basecommand.rs
+++ b/components/script/dom/execcommand/basecommand.rs
@@ -5,7 +5,7 @@
 use js::context::JSContext;
 use script_bindings::inheritance::Castable;
 use style::properties::PropertyDeclarationId;
-use style::properties::generated::LonghandId;
+use style::properties::generated::{LonghandId, ShorthandId};
 use style::values::specified::text::TextDecorationLine;
 use style_traits::ToCss;
 
@@ -53,6 +53,7 @@ pub(crate) enum CssPropertyName {
     FontSize,
     FontWeight,
     FontStyle,
+    TextDecoration,
     TextDecorationLine,
 }
 
@@ -94,6 +95,7 @@ impl CssPropertyName {
                 },
                 CssPropertyName::FontWeight => style.clone_font_weight().to_css_string(),
                 CssPropertyName::FontStyle => style.clone_font_style().to_css_string(),
+                CssPropertyName::TextDecoration => unreachable!("Should use longhands instead"),
                 CssPropertyName::TextDecorationLine => {
                     let text_decoration_line = style.get_text().text_decoration_line;
                     if text_decoration_line == TextDecorationLine::NONE {
@@ -122,6 +124,13 @@ impl CssPropertyName {
             CssPropertyName::FontSize => LonghandId::FontSize,
             CssPropertyName::FontWeight => LonghandId::FontWeight,
             CssPropertyName::FontStyle => LonghandId::FontStyle,
+            CssPropertyName::TextDecoration => {
+                let mut dest = String::new();
+                style
+                    .shorthand_to_css(ShorthandId::TextDecoration, &mut dest)
+                    .ok()?;
+                return Some(dest.into());
+            },
             CssPropertyName::TextDecorationLine => LonghandId::TextDecorationLine,
         };
         style
@@ -139,6 +148,7 @@ impl CssPropertyName {
             CssPropertyName::FontSize => "font-size",
             CssPropertyName::FontWeight => "font-weight",
             CssPropertyName::FontStyle => "font-style",
+            CssPropertyName::TextDecoration => "text-decoration",
             CssPropertyName::TextDecorationLine => "text-decoration-line",
         }
         .into()

--- a/components/script/dom/execcommand/contenteditable/node.rs
+++ b/components/script/dom/execcommand/contenteditable/node.rs
@@ -1286,7 +1286,7 @@ impl Node {
                         .effective_command_value(&CommandName::Underline)
                         .is_none_or(|value| value != "underline")
                 {
-                    CssPropertyName::TextDecorationLine.set_for_element(
+                    CssPropertyName::TextDecoration.set_for_element(
                         cx,
                         new_parent_html_element,
                         new_value.clone(),

--- a/tests/wpt/meta/editing/run/underline.html.ini
+++ b/tests/wpt/meta/editing/run/underline.html.ini
@@ -1,7 +1,4 @@
 [underline.html?1-1000]
-  [[["stylewithcss","true"\],["underline",""\]\] "<p>[foo</p> <p>bar\]</p>" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<span>[foo</span> <span>bar\]</span>" compare innerHTML]
     expected: FAIL
 
@@ -20,43 +17,10 @@
   [[["stylewithcss","false"\],["underline",""\]\] "<p>[foo<p><br><p>bar\]" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "foo[bar\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "foo[bar<b>baz\]qoz</b>quz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "foo[bar<i>baz\]qoz</i>quz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "{<p><p> <p>foo</p>}" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<table><tbody><tr><td>foo<td>b[a\]r<td>baz</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<table><tbody><tr data-start=1 data-end=2><td>foo<td>bar<td>baz</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<table><tbody><tr data-start=0 data-end=2><td>foo<td>bar<td>baz</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<table><tbody data-start=0 data-end=1><tr><td>foo<td>bar<td>baz</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<table data-start=0 data-end=1><tbody><tr><td>foo<td>bar<td>baz</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "{<table><tr><td>foo<td>bar<td>baz</table>}" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "foo<span style=\\"text-decoration: underline\\">[bar\]</span>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["underline",""\]\] "foo<span style=\\"text-decoration: underline\\">[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<u>foo[bar\]baz</u>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<u>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</u>" compare innerHTML]
@@ -96,24 +60,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["underline",""\]\] "foo<span style=\\"text-decoration: line-through\\">[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<s>foo[bar\]baz</s>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<s>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</s>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<s>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</s>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<s>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</s>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<s>foo[b<i>ar\]ba</i>z</s>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<p style=\\"text-decoration: line-through\\">foo[bar\]baz</p>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "foo<strike>[bar\]</strike>baz" compare innerHTML]
@@ -163,16 +109,10 @@
   [[["underline",""\]\] "fo[o<span style=text-decoration:underline>b\]ar</span>baz" queryCommandIndeterm("underline") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "<ins>fo[o</ins><u>b\]ar</u>" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<ins>fo[o</ins><u>b\]ar</u>" queryCommandIndeterm("underline") after]
     expected: FAIL
 
   [[["stylewithcss","false"\],["underline",""\]\] "<ins>fo[o</ins><u>b\]ar</u>" queryCommandIndeterm("underline") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<u>fo[o</u><ins>b\]ar</ins>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<u>fo[o</u><ins>b\]ar</ins>" queryCommandIndeterm("underline") after]
@@ -216,37 +156,7 @@
   [[["stylewithcss","false"\],["underline",""\]\] "foo<strike>[bar\]</strike>baz" queryCommandState("underline") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "<strike>foo[bar\]baz</strike>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<strike>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</strike>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<strike>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</strike>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<strike>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</strike>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<strike>foo[b<i>ar\]ba</i>z</strike>" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "foo<del>[bar\]</del>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<del>foo[bar\]baz</del>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<del>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</del>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<del>foo[b<span style=\\"color:blue\\" id=foo>ar\]ba</span>z</del>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<del>foo[b<span style=\\"font-size:3em\\">ar\]ba</span>z</del>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<del>foo[b<i>ar\]ba</i>z</del>" compare innerHTML]
     expected: FAIL
 
   [[["underline",""\]\] "foo<span style=\\"text-decoration: underline line-through\\">[bar\]</span>baz" compare innerHTML]
@@ -276,16 +186,10 @@
   [[["stylewithcss","false"\],["underline",""\]\] "foo<u style=\\"text-decoration: line-through\\">[bar\]</u>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "foo<u style=\\"text-decoration: line-through\\">b[a\]r</u>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "foo<s style=\\"text-decoration: overline\\">[bar\]</s>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["underline",""\]\] "foo<s style=\\"text-decoration: overline\\">[bar\]</s>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "foo<s style=\\"text-decoration: overline\\">b[a\]r</s>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "foo<u style=\\"text-decoration: overline\\">[bar\]</u>baz" compare innerHTML]
@@ -294,16 +198,7 @@
   [[["stylewithcss","false"\],["underline",""\]\] "foo<u style=\\"text-decoration: overline\\">[bar\]</u>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "foo<u style=\\"text-decoration: overline\\">b[a\]r</u>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<p style=\\"text-decoration: overline\\">foo[bar\]baz</p>" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "foo<span class=\\"line-through\\">[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "foo<span class=\\"line-through\\">b[a\]r</span>baz" compare innerHTML]
     expected: FAIL
 
   [[["underline",""\]\] "fo[o<u>b\]ar</u>baz" queryCommandIndeterm("underline") before]


### PR DESCRIPTION
The generated HTML was setting `text-decoration-line` whereas it instead should set `text-decoration`.

Part of #25005

Testing: WPT