### PR TITLE
mach: Allow to not install gstreamer dependencies

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -73,7 +73,7 @@ jobs:
         uses: ./.github/actions/apt-mirrors
       - name: Bootstrap dependencies
         timeout-minutes: 30
-        run: sudo apt update && ./mach bootstrap --yes --skip-lints --skip-nextest
+        run: sudo apt update && ./mach bootstrap --yes --skip-lints --skip-nextest --skip-gstreamer-deps
       - name: Setup OpenHarmony SDK
         id: setup_sdk
         uses: openharmony-rs/setup-ohos-sdk@v0.2.4

--- a/python/mach_bootstrap.py
+++ b/python/mach_bootstrap.py
@@ -117,7 +117,8 @@ def bootstrap_command_only(topdir: str) -> int:
         skip_platform = "--skip-platform" in sys.argv
         skip_lints = "--skip-lints" in sys.argv
         skip_nextest = "--skip-nextest" in sys.argv
-        servo.platform.get().bootstrap(force, yes, skip_platform, skip_lints, skip_nextest)
+        skip_gstreamer_deps = "--skip-gstreamer-deps" in sys.argv
+        servo.platform.get().bootstrap(force, yes, skip_platform, skip_lints, skip_nextest, skip_gstreamer_deps)
     except NotImplementedError as exception:
         print(exception)
         return 1

--- a/python/servo/bootstrap_commands.py
+++ b/python/servo/bootstrap_commands.py
@@ -41,6 +41,7 @@ class MachCommands(CommandBase):
     @CommandArgument("--skip-platform", action="store_true", help="Skip platform bootstrapping.")
     @CommandArgument("--skip-lints", action="store_true", help="Skip tool necessary for linting.")
     @CommandArgument("--skip-nextest", action="store_true", help="Skip tool for running Rust tests.")
+    @CommandArgument("--skip-gstreamer-deps", action="store_true", help="Skip gstreamer dependencies.")
     def bootstrap(
         self,
         force: bool = False,
@@ -48,12 +49,13 @@ class MachCommands(CommandBase):
         skip_platform: bool = False,
         skip_lints: bool = False,
         skip_nextest: bool = False,
+        skip_gstreamer_deps: bool = False,
     ) -> int:
         # Note: This entry point isn't actually invoked by ./mach bootstrap.
         # ./mach bootstrap calls mach_bootstrap.bootstrap_command_only so that
         # it can install dependencies without needing mach's dependencies
         try:
-            servo.platform.get().bootstrap(force, yes, skip_platform, skip_lints, skip_nextest)
+            servo.platform.get().bootstrap(force, yes, skip_platform, skip_lints, skip_nextest, skip_gstreamer_deps)
         except NotImplementedError as exception:
             print(exception)
             return 1

--- a/python/servo/platform/base.py
+++ b/python/servo/platform/base.py
@@ -29,7 +29,7 @@ class Base:
     def executable_suffix(self) -> str:
         return ""
 
-    def _platform_bootstrap(self, force: bool, yes: bool) -> bool:
+    def _platform_bootstrap(self, force: bool, yes: bool, skip_gstreamer_deps: bool) -> bool:
         raise NotImplementedError("Bootstrap installation detection not yet available.")
 
     def _platform_bootstrap_gstreamer(self, target: BuildTarget, force: bool, yes: bool) -> bool:
@@ -54,10 +54,18 @@ class Base:
         except FileNotFoundError:
             return False
 
-    def bootstrap(self, force: bool, yes: bool, skip_platform: bool, skip_lints: bool, skip_nextest: bool) -> None:
+    def bootstrap(
+        self,
+        force: bool,
+        yes: bool,
+        skip_platform: bool,
+        skip_lints: bool,
+        skip_nextest: bool,
+        skip_gstreamer_deps: bool,
+    ) -> None:
         installed_something = False
         if not skip_platform:
-            installed_something |= self._platform_bootstrap(force, yes)
+            installed_something |= self._platform_bootstrap(force, yes, skip_gstreamer_deps)
         self.install_rust_toolchain()
         if not skip_nextest:
             installed_something |= self.install_cargo_nextest(force)

--- a/python/servo/platform/linux.py
+++ b/python/servo/platform/linux.py
@@ -26,10 +26,12 @@ def parse_pkg_file(filename: str) -> list[str]:
         return packages
 
 
-def apt_packages() -> list[str]:
+def apt_packages(skip_gstreamer_deps: bool) -> list[str]:
     basepath = os.path.dirname(__file__)
     apt_pkgs: list[str] = []
     for file in os.listdir(os.path.join(basepath, "linux_packages", "apt")):
+        if skip_gstreamer_deps and ("gstreamer" in file) or ("ubuntu" in file):
+            continue
         # Note: For now we also include ubuntu-only packages, since not available packages
         # will be filtered out automatically, since we check which packages are available.
         if file.endswith(".txt") and file.startswith("apt_"):
@@ -70,7 +72,7 @@ class Linux(Base):
         self.is_linux = True
         self.distro = distro.name()
 
-    def _platform_bootstrap(self, force: bool, yes: bool) -> bool:
+    def _platform_bootstrap(self, force: bool, yes: bool, skip_gstreamer_deps: bool) -> bool:
         if self.distro.lower() == "nixos":
             print("NixOS does not need bootstrap, it will automatically enter a nix-shell")
             print("Just run ./mach build")
@@ -110,10 +112,10 @@ class Linux(Base):
             input("Press Enter to continue...")
             return False
 
-        installed_something = self.install_non_gstreamer_dependencies(force, yes)
+        installed_something = self.install_non_gstreamer_dependencies(force, yes, skip_gstreamer_deps)
         return installed_something
 
-    def install_non_gstreamer_dependencies(self, force: bool, yes: bool = False) -> bool:
+    def install_non_gstreamer_dependencies(self, force: bool, yes: bool, skip_gstreamer_deps: bool) -> bool:
         def check_sudo() -> bool:
             if os.geteuid() != 0:  # pyrefly: ignore[missing-attribute]
                 if shutil.which("sudo") is None:
@@ -131,8 +133,12 @@ class Linux(Base):
         pkgs = []
         command = []
         if self.distro in ["Ubuntu", "Debian GNU/Linux", "Raspbian GNU/Linux"]:
+            print("BEFORE INSTALL")
             command = ["apt-get", "install", "-m"]
-            pkgs = apt_packages()
+            pkgs = apt_packages(skip_gstreamer_deps)
+            print("DOING THE TINSTALL")
+            print("PKG" + str(pkgs))
+            print("skip" + str(skip_gstreamer_deps))
 
             # Skip 'clang' if 'clang' binary already exists.
             result = subprocess.run(["which", "clang"], capture_output=True)

--- a/python/servo/platform/linux_packages/apt/apt_common.txt
+++ b/python/servo/platform/linux_packages/apt/apt_common.txt
@@ -1,6 +1,5 @@
 # lines starting with # are comments
 # This file contains the absolute minimum packages required to build Servo on Linux
-
 # Please keep these in sync with the packages in the book, using the instructions in the README.md
 # in this folder.
 build-essential

--- a/python/servo/platform/linux_packages/apt/apt_common.txt
+++ b/python/servo/platform/linux_packages/apt/apt_common.txt
@@ -17,16 +17,6 @@ libfreetype6-dev
 libgl1-mesa-dri
 libgles2-mesa-dev
 libglib2.0-dev
-gstreamer1.0-plugins-good
-gstreamer1.0-plugins-bad
-libgstreamer-plugins-bad1.0-dev
-gstreamer1.0-plugins-ugly
-gstreamer1.0-plugins-base
-libgstreamer-plugins-base1.0-dev
-gstreamer1.0-libav
-libgstrtspserver-1.0-dev
-gstreamer1.0-tools
-libges-1.0-dev
 libharfbuzz-dev
 liblzma-dev
 libudev-dev

--- a/python/servo/platform/linux_packages/apt/apt_gstreamer.txt
+++ b/python/servo/platform/linux_packages/apt/apt_gstreamer.txt
@@ -1,0 +1,10 @@
+gstreamer1.0-plugins-good
+gstreamer1.0-plugins-bad
+libgstreamer-plugins-bad1.0-dev
+gstreamer1.0-plugins-ugly
+gstreamer1.0-plugins-base
+libgstreamer-plugins-base1.0-dev
+gstreamer1.0-libav
+libgstrtspserver-1.0-dev
+gstreamer1.0-tools
+libges-1.0-dev

--- a/python/servo/platform/linux_packages/apt/apt_ubuntu_only.txt
+++ b/python/servo/platform/linux_packages/apt/apt_ubuntu_only.txt
@@ -1,2 +1,3 @@
 # This package does not exist on debian
+# Currently this whole file will be excluded by the --skip_gstreamer_deps flag
 libgstreamer-plugins-good1.0-dev

--- a/python/servo/platform/macos.py
+++ b/python/servo/platform/macos.py
@@ -40,7 +40,7 @@ class MacOS(Base):
         # Servo only supports the official GStreamer distribution on MacOS.
         return not target.is_cross_build() and os.path.exists(GSTREAMER_ROOT)
 
-    def _platform_bootstrap(self, force: bool, yes: bool) -> bool:
+    def _platform_bootstrap(self, force: bool, yes: bool, skip_gstreamer_deps: bool) -> bool:
         installed_something = False
         try:
             brewfile = os.path.join(util.SERVO_ROOT, "support", "macos", "Brewfile")

--- a/python/servo/platform/windows.py
+++ b/python/servo/platform/windows.py
@@ -101,7 +101,7 @@ class Windows(Base):
         else:
             print("done")
 
-    def _platform_bootstrap(self, force: bool, yes: bool) -> bool:
+    def _platform_bootstrap(self, force: bool, yes: bool, skip_gstreamer_deps: bool) -> bool:
         installed_something = self.passive_bootstrap()
         # If `winget` works well in practice, we could switch the default in the future.
         if shutil.which("choco") is not None:


### PR DESCRIPTION
For OHOS we do not need the gstreamer dependencies anymore, so we don't need to install them via ./mach boostrap.

Testing: This functionality does not have any tests. But here is a run https://github.com/Narfinger/servo/actions/runs/24573350745
