### PR TITLE
layout: Fix x/y offset not being set for direct abspos grid children

### DIFF
--- a/components/layout/taffy/layout.rs
+++ b/components/layout/taffy/layout.rs
@@ -541,10 +541,7 @@ impl TaffyContainer {
 
                         let hoisted_box = AbsolutelyPositionedBox::to_hoisted(
                             abs_pos_box.clone(),
-                            PhysicalRect::from_size(PhysicalSize::new(
-                                Au::from_f32_px(output.size.width),
-                                Au::from_f32_px(output.size.height),
-                            )),
+                            content_size,
                             LogicalVec2 {
                                 inline: resolve_alignment(
                                     child.style.clone_align_self().0,

--- a/tests/wpt/meta/css/css-grid/abspos/absolute-positioning-grid-container-parent-001.html.ini
+++ b/tests/wpt/meta/css/css-grid/abspos/absolute-positioning-grid-container-parent-001.html.ini
@@ -1,7 +1,4 @@
 [absolute-positioning-grid-container-parent-001.html]
-  [.container 4]
-    expected: FAIL
-
   [.container 5]
     expected: FAIL
 
@@ -20,8 +17,11 @@
   [.container 7]
     expected: FAIL
 
-  [.container 8]
+  [.container 9]
     expected: FAIL
 
-  [.container 9]
+  [.container 1]
+    expected: FAIL
+
+  [.container 3]
     expected: FAIL

--- a/tests/wpt/meta/css/css-grid/abspos/grid-abspos-staticpos-align-items-center.html.ini
+++ b/tests/wpt/meta/css/css-grid/abspos/grid-abspos-staticpos-align-items-center.html.ini
@@ -1,2 +1,0 @@
-[grid-abspos-staticpos-align-items-center.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/abspos/grid-abspos-staticpos-align-items-end.html.ini
+++ b/tests/wpt/meta/css/css-grid/abspos/grid-abspos-staticpos-align-items-end.html.ini
@@ -1,2 +1,0 @@
-[grid-abspos-staticpos-align-items-end.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/abspos/grid-abspos-staticpos-align-items-flex-end.html.ini
+++ b/tests/wpt/meta/css/css-grid/abspos/grid-abspos-staticpos-align-items-flex-end.html.ini
@@ -1,2 +1,0 @@
-[grid-abspos-staticpos-align-items-flex-end.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/abspos/grid-abspos-staticpos-align-items-self-end.html.ini
+++ b/tests/wpt/meta/css/css-grid/abspos/grid-abspos-staticpos-align-items-self-end.html.ini
@@ -1,2 +1,0 @@
-[grid-abspos-staticpos-align-items-self-end.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/abspos/grid-abspos-staticpos-align-self-center.html.ini
+++ b/tests/wpt/meta/css/css-grid/abspos/grid-abspos-staticpos-align-self-center.html.ini
@@ -1,2 +1,0 @@
-[grid-abspos-staticpos-align-self-center.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/abspos/grid-abspos-staticpos-align-self-end.html.ini
+++ b/tests/wpt/meta/css/css-grid/abspos/grid-abspos-staticpos-align-self-end.html.ini
@@ -1,2 +1,0 @@
-[grid-abspos-staticpos-align-self-end.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/abspos/grid-abspos-staticpos-align-self-flex-end.html.ini
+++ b/tests/wpt/meta/css/css-grid/abspos/grid-abspos-staticpos-align-self-flex-end.html.ini
@@ -1,2 +1,0 @@
-[grid-abspos-staticpos-align-self-flex-end.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/abspos/grid-abspos-staticpos-align-self-self-end.html.ini
+++ b/tests/wpt/meta/css/css-grid/abspos/grid-abspos-staticpos-align-self-self-end.html.ini
@@ -1,2 +1,0 @@
-[grid-abspos-staticpos-align-self-self-end.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/abspos/grid-positioned-items-gaps-001.html.ini
+++ b/tests/wpt/meta/css/css-grid/abspos/grid-positioned-items-gaps-001.html.ini
@@ -1,7 +1,4 @@
 [grid-positioned-items-gaps-001.html]
-  [.grid 1]
-    expected: FAIL
-
   [.grid 3]
     expected: FAIL
 
@@ -117,7 +114,4 @@
     expected: FAIL
 
   [.grid 42]
-    expected: FAIL
-
-  [.grid 43]
     expected: FAIL

--- a/tests/wpt/meta/css/css-grid/abspos/grid-sizing-positioned-items-001.html.ini
+++ b/tests/wpt/meta/css/css-grid/abspos/grid-sizing-positioned-items-001.html.ini
@@ -2,9 +2,6 @@
   [.grid 1]
     expected: FAIL
 
-  [.grid 2]
-    expected: FAIL
-
   [.grid 3]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-grid/abspos/orthogonal-positioned-grid-items-001.html.ini
+++ b/tests/wpt/meta/css/css-grid/abspos/orthogonal-positioned-grid-items-001.html.ini
@@ -1,2 +1,0 @@
-[orthogonal-positioned-grid-items-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/abspos/positioned-grid-items-001.html.ini
+++ b/tests/wpt/meta/css/css-grid/abspos/positioned-grid-items-001.html.ini
@@ -1,2 +1,0 @@
-[positioned-grid-items-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/abspos/positioned-grid-items-020.html.ini
+++ b/tests/wpt/meta/css/css-grid/abspos/positioned-grid-items-020.html.ini
@@ -1,0 +1,2 @@
+[positioned-grid-items-020.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/abspos/positioned-grid-items-021.html.ini
+++ b/tests/wpt/meta/css/css-grid/abspos/positioned-grid-items-021.html.ini
@@ -1,0 +1,2 @@
+[positioned-grid-items-021.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/abspos/positioned-grid-items-024.html.ini
+++ b/tests/wpt/meta/css/css-grid/abspos/positioned-grid-items-024.html.ini
@@ -1,0 +1,2 @@
+[positioned-grid-items-024.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/abspos/positioned-grid-items-negative-indices-001.html.ini
+++ b/tests/wpt/meta/css/css-grid/abspos/positioned-grid-items-negative-indices-001.html.ini
@@ -1,2 +1,0 @@
-[positioned-grid-items-negative-indices-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/abspos/positioned-grid-items-negative-indices-002.html.ini
+++ b/tests/wpt/meta/css/css-grid/abspos/positioned-grid-items-negative-indices-002.html.ini
@@ -1,0 +1,2 @@
+[positioned-grid-items-negative-indices-002.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-001.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-001.html.ini
@@ -1,10 +1,4 @@
 [grid-column-axis-alignment-positioned-items-001.html]
-  [.grid 1]
-    expected: FAIL
-
-  [.grid 2]
-    expected: FAIL
-
   [.grid 3]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-002.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-002.html.ini
@@ -1,10 +1,4 @@
 [grid-column-axis-alignment-positioned-items-002.html]
-  [.grid 1]
-    expected: FAIL
-
-  [.grid 2]
-    expected: FAIL
-
   [.grid 3]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-003.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-003.html.ini
@@ -1,10 +1,4 @@
 [grid-column-axis-alignment-positioned-items-003.html]
-  [.grid 1]
-    expected: FAIL
-
-  [.grid 2]
-    expected: FAIL
-
   [.grid 3]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-004.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-004.html.ini
@@ -1,10 +1,4 @@
 [grid-column-axis-alignment-positioned-items-004.html]
-  [.grid 1]
-    expected: FAIL
-
-  [.grid 2]
-    expected: FAIL
-
   [.grid 3]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-005.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-005.html.ini
@@ -1,10 +1,4 @@
 [grid-column-axis-alignment-positioned-items-005.html]
-  [.grid 1]
-    expected: FAIL
-
-  [.grid 2]
-    expected: FAIL
-
   [.grid 3]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-006.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-006.html.ini
@@ -1,10 +1,4 @@
 [grid-column-axis-alignment-positioned-items-006.html]
-  [.grid 1]
-    expected: FAIL
-
-  [.grid 2]
-    expected: FAIL
-
   [.grid 3]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-007.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-007.html.ini
@@ -1,10 +1,4 @@
 [grid-column-axis-alignment-positioned-items-007.html]
-  [.grid 1]
-    expected: FAIL
-
-  [.grid 2]
-    expected: FAIL
-
   [.grid 3]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-008.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-008.html.ini
@@ -1,10 +1,4 @@
 [grid-column-axis-alignment-positioned-items-008.html]
-  [.grid 1]
-    expected: FAIL
-
-  [.grid 2]
-    expected: FAIL
-
   [.grid 3]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-009.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-009.html.ini
@@ -1,10 +1,4 @@
 [grid-column-axis-alignment-positioned-items-009.html]
-  [.grid 1]
-    expected: FAIL
-
-  [.grid 2]
-    expected: FAIL
-
   [.grid 3]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-010.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-010.html.ini
@@ -1,10 +1,4 @@
 [grid-column-axis-alignment-positioned-items-010.html]
-  [.grid 1]
-    expected: FAIL
-
-  [.grid 2]
-    expected: FAIL
-
   [.grid 3]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-011.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-011.html.ini
@@ -1,10 +1,4 @@
 [grid-column-axis-alignment-positioned-items-011.html]
-  [.grid 1]
-    expected: FAIL
-
-  [.grid 2]
-    expected: FAIL
-
   [.grid 3]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-017.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-column-axis-alignment-positioned-items-017.html.ini
@@ -1,10 +1,4 @@
 [grid-column-axis-alignment-positioned-items-017.html]
-  [.grid 1]
-    expected: FAIL
-
-  [.grid 2]
-    expected: FAIL
-
   [.grid 3]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-001.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-001.html.ini
@@ -1,10 +1,4 @@
 [grid-row-axis-alignment-positioned-items-001.html]
-  [.grid 1]
-    expected: FAIL
-
-  [.grid 2]
-    expected: FAIL
-
   [.grid 3]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-002.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-002.html.ini
@@ -1,7 +1,4 @@
 [grid-row-axis-alignment-positioned-items-002.html]
-  [.grid 1]
-    expected: FAIL
-
   [.grid 2]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-003.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-003.html.ini
@@ -1,7 +1,4 @@
 [grid-row-axis-alignment-positioned-items-003.html]
-  [.grid 1]
-    expected: FAIL
-
   [.grid 2]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-004.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-004.html.ini
@@ -1,7 +1,4 @@
 [grid-row-axis-alignment-positioned-items-004.html]
-  [.grid 1]
-    expected: FAIL
-
   [.grid 2]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-005.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-005.html.ini
@@ -1,7 +1,4 @@
 [grid-row-axis-alignment-positioned-items-005.html]
-  [.grid 1]
-    expected: FAIL
-
   [.grid 2]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-006.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-006.html.ini
@@ -1,10 +1,4 @@
 [grid-row-axis-alignment-positioned-items-006.html]
-  [.grid 1]
-    expected: FAIL
-
-  [.grid 2]
-    expected: FAIL
-
   [.grid 3]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-007.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-007.html.ini
@@ -1,7 +1,4 @@
 [grid-row-axis-alignment-positioned-items-007.html]
-  [.grid 1]
-    expected: FAIL
-
   [.grid 2]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-008.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-008.html.ini
@@ -1,10 +1,4 @@
 [grid-row-axis-alignment-positioned-items-008.html]
-  [.grid 1]
-    expected: FAIL
-
-  [.grid 2]
-    expected: FAIL
-
   [.grid 3]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-009.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-009.html.ini
@@ -1,7 +1,4 @@
 [grid-row-axis-alignment-positioned-items-009.html]
-  [.grid 1]
-    expected: FAIL
-
   [.grid 2]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-012.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-012.html.ini
@@ -2,9 +2,6 @@
   [.grid 1]
     expected: FAIL
 
-  [.grid 2]
-    expected: FAIL
-
   [.grid 3]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-013.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-013.html.ini
@@ -2,9 +2,6 @@
   [.grid 1]
     expected: FAIL
 
-  [.grid 2]
-    expected: FAIL
-
   [.grid 3]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-014.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-014.html.ini
@@ -2,9 +2,6 @@
   [.grid 1]
     expected: FAIL
 
-  [.grid 2]
-    expected: FAIL
-
   [.grid 3]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-017.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-row-axis-alignment-positioned-items-017.html.ini
@@ -1,10 +1,4 @@
 [grid-row-axis-alignment-positioned-items-017.html]
-  [.grid 1]
-    expected: FAIL
-
-  [.grid 2]
-    expected: FAIL
-
   [.grid 3]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-grid/subgrid/line-names-007.html.ini
+++ b/tests/wpt/meta/css/css-grid/subgrid/line-names-007.html.ini
@@ -1,0 +1,2 @@
+[line-names-007.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/cssom/getComputedStyle-insets-grid.html.ini
+++ b/tests/wpt/meta/css/cssom/getComputedStyle-insets-grid.html.ini
@@ -1,0 +1,3 @@
+[getComputedStyle-insets-grid.html]
+  [Position absolute getComputedStyle left (for display: grid)]
+    expected: FAIL


### PR DESCRIPTION
Previously absolutely positioned direct children of a CSS Grid had their position (relative to their parent) hardcoded to (0, 0). This PR changes that to correctly propagate the position computed by Taffy.

Testing: WPT tests.
