### PR TITLE
Android: Fix black screen when exiting menu or resuming activity in lifecycle

### DIFF
--- a/ports/servoshell/egl/app.rs
+++ b/ports/servoshell/egl/app.rs
@@ -664,6 +664,7 @@ impl App {
         {
             warn!("Binding native surface to context failed ({error:?})");
         }
+        embedded_platform_window.request_repaint(&self.window());
         self.spin_event_loop();
     }
 }


### PR DESCRIPTION
We should request repaint for the platform window when `resume_painting` 
or entering [Resumed](https://developer.android.com/guide/components/activities/activity-lifecycle#onresume) state in Android activity lifecycle.

Fixes: #44300
Fixes: #40632
Fixes: #39737
Testing: Manually tested with following video proof

https://github.com/user-attachments/assets/046c045d-12d1-43fa-9387-fc504cc4bfe5

