### PR TITLE
script: Generate more correct HTML for underline command

### DIFF
--- a/components/script/dom/execcommand/contenteditable/element.rs
+++ b/components/script/dom/execcommand/contenteditable/element.rs
@@ -2,18 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use html5ever::local_name;
+use html5ever::{LocalName, local_name};
+use js::context::JSContext;
 use script_bindings::inheritance::Castable;
 use style::attr::AttrValue;
 use style::properties::{LonghandId, PropertyDeclaration, PropertyDeclarationId};
 use style::values::specified::TextDecorationLine;
 use style::values::specified::box_::DisplayOutside;
 
+use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use crate::dom::bindings::inheritance::{ElementTypeId, HTMLElementTypeId, NodeTypeId};
+use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::element::Element;
 use crate::dom::execcommand::basecommand::{CommandName, CssPropertyName};
 use crate::dom::execcommand::commands::fontsize::font_size_to_css_font;
+use crate::dom::execcommand::contenteditable::node::move_preserving_ranges;
 use crate::dom::html::htmlfontelement::HTMLFontElement;
 use crate::dom::node::node::{Node, NodeTraits};
 
@@ -158,6 +162,18 @@ impl Element {
         false
     }
 
+    pub(crate) fn has_empty_style_attribute(&self) -> bool {
+        let style_attribute = self.style_attribute().borrow();
+        style_attribute.as_ref().is_some_and(|declarations| {
+            let document = self.owner_document();
+            let shared_lock = document.style_shared_lock();
+            let read_lock = shared_lock.read();
+            let style = declarations.read_with(&read_lock);
+
+            style.is_empty()
+        })
+    }
+
     /// <https://w3c.github.io/editing/docs/execCommand/#simple-modifiable-element>
     pub(crate) fn is_simple_modifiable_element(&self) -> bool {
         let attrs = self.attrs();
@@ -194,19 +210,10 @@ impl Element {
             // > with exactly one attribute, which is style,
             // > which sets no CSS properties (including invalid or unrecognized properties).
             if attr_count == 1 &&
-                attrs.first().expect("Size is 1").local_name() == &local_name!("style")
+                attrs.first().expect("Size is 1").local_name() == &local_name!("style") &&
+                self.has_empty_style_attribute()
             {
-                let style_attribute = self.style_attribute().borrow();
-                if style_attribute.as_ref().is_some_and(|declarations| {
-                    let document = self.owner_document();
-                    let shared_lock = document.style_shared_lock();
-                    let read_lock = shared_lock.read();
-                    let style = declarations.read_with(&read_lock);
-
-                    style.is_empty()
-                }) {
-                    return true;
-                }
+                return true;
             }
         }
 
@@ -308,5 +315,39 @@ impl Element {
         }
 
         false
+    }
+
+    /// <https://w3c.github.io/editing/docs/execCommand/#set-the-tag-name>
+    pub(crate) fn set_the_tag_name(&self, cx: &mut JSContext, new_name: &str) -> DomRoot<Element> {
+        // Step 1. If element is an HTML element with local name equal to new name, return element.
+        if self.local_name() == &LocalName::from(new_name) {
+            return DomRoot::from_ref(self);
+        }
+        // Step 2. If element's parent is null, return element.
+        let node = self.upcast::<Node>();
+        let Some(parent) = node.GetParentNode() else {
+            return DomRoot::from_ref(self);
+        };
+        // Step 3. Let replacement element be the result of calling createElement(new name) on the ownerDocument of element.
+        let document = node.owner_document();
+        let replacement = document.create_element(cx, new_name);
+        let replacement_node = replacement.upcast::<Node>();
+        // Step 4. Insert replacement element into element's parent immediately before element.
+        if parent
+            .InsertBefore(cx, replacement_node, Some(node))
+            .is_err()
+        {
+            unreachable!("Must always be able to insert");
+        }
+        // Step 5. Copy all attributes of element to replacement element, in order.
+        self.copy_all_attributes_to_other_element(cx, &replacement);
+        // Step 6. While element has children, append the first child of element as the last child of replacement element, preserving ranges.
+        for child in node.children() {
+            move_preserving_ranges(cx, &child, |cx| replacement_node.AppendChild(cx, &child));
+        }
+        // Step 7. Remove element from its parent.
+        node.remove_self(cx);
+        // Step 8. Return replacement element.
+        replacement
     }
 }

--- a/components/script/dom/execcommand/contenteditable/htmlelement.rs
+++ b/components/script/dom/execcommand/contenteditable/htmlelement.rs
@@ -75,10 +75,15 @@ impl HTMLElement {
             // Step 6. If command is "underline", and element has a style attribute that
             // sets "text-decoration" to some value containing "underline", delete "underline" from the value.
             CommandName::Underline => {
-                let property = CssPropertyName::TextDecorationLine;
-                if property.value_for_element(cx, self) == "underline" {
+                // First we need to check if text-decoration is only set to underline. If it is, remove the full
+                // shorthand. If that's not the case, we should only remove underline from the property
+                if CssPropertyName::TextDecoration.value_for_element(cx, self) == "underline" {
+                    CssPropertyName::TextDecoration.remove_from_element(cx, self);
+                } else if CssPropertyName::TextDecorationLine.value_for_element(cx, self) ==
+                    "underline"
+                {
                     // TODO: Only remove underline
-                    property.remove_from_element(cx, self);
+                    CssPropertyName::TextDecorationLine.remove_from_element(cx, self);
                 }
             },
             _ => {},
@@ -87,6 +92,12 @@ impl HTMLElement {
         // unset that property of element.
         if let Some(property) = command.relevant_css_property() {
             property.remove_from_element(cx, self);
+        }
+        // In case we have a completely style attribute, we need to completely remove it.
+        // Otherwise, when you call `innerHTML`, it would generate a `style=""`, which is
+        // not what the tests expect. They expect the whole attribute to be removed.
+        if element.has_empty_style_attribute() {
+            element.remove_attribute_by_name(&local_name!("style"), CanGc::from_cx(cx));
         }
         // Step 8. If element is a font element:
         if self.is::<HTMLFontElement>() {
@@ -120,30 +131,7 @@ impl HTMLElement {
         }
         // Step 11. Set the tag name of element to "span",
         // and return the one-node list consisting of the result.
-        //
-        // Yeah, here we are. The spec makes this look easy, but the way we
-        // model elements, it's not. We can't simply set the `local_name`,
-        // since the struct also must change. Therefore, instead of only
-        // changing the tag name, we perform all necessary changes to make
-        // it seem like we "changed it to a span". To do so, we move all
-        // of its children and copy its attributes, after which we remove
-        // the original node.
-        let document = node.owner_document();
-        let new_span = document.create_element(cx, "span");
-        let new_span_node = new_span.upcast::<Node>();
-        if node_parent
-            .InsertBefore(cx, new_span_node, Some(node))
-            .is_err()
-        {
-            unreachable!("Must always be able to insert");
-        }
-        for child in node.children() {
-            move_preserving_ranges(cx, &child, |cx| new_span_node.AppendChild(cx, &child));
-        }
-
-        element.copy_all_attributes_to_other_element(cx, &new_span);
-
-        node.remove_self(cx);
+        element.set_the_tag_name(cx, "span");
     }
 
     /// There is no specification for this implementation. Instead, it is

--- a/components/script/dom/execcommand/contenteditable/htmlelement.rs
+++ b/components/script/dom/execcommand/contenteditable/htmlelement.rs
@@ -93,7 +93,7 @@ impl HTMLElement {
         if let Some(property) = command.relevant_css_property() {
             property.remove_from_element(cx, self);
         }
-        // In case we have a completely style attribute, we need to completely remove it.
+        // In case we have a completely empty style attribute, we need to completely remove it.
         // Otherwise, when you call `innerHTML`, it would generate a `style=""`, which is
         // not what the tests expect. They expect the whole attribute to be removed.
         if element.has_empty_style_attribute() {

--- a/components/script/dom/execcommand/contenteditable/node.rs
+++ b/components/script/dom/execcommand/contenteditable/node.rs
@@ -654,7 +654,25 @@ where
         // and the last child of new parent is not a br,
         // call createElement("br") on the ownerDocument of new parent
         // and append the result as the last child of new parent.
-        // TODO
+        if !new_parent.is_inline_node() &&
+            new_parent
+                .rev_children()
+                .find(|child| child.is_visible())
+                .is_some_and(|child| child.is_inline_node()) &&
+            node_list
+                .iter()
+                .find(|node| node.is_visible())
+                .is_some_and(|node| node.is_inline_node()) &&
+            new_parent
+                .children()
+                .last()
+                .is_none_or(|last_child| !last_child.is::<HTMLBRElement>())
+        {
+            let new_br_element = new_parent.owner_document().create_element(cx, "br");
+            if new_parent.AppendChild(cx, new_br_element.upcast()).is_err() {
+                unreachable!("Must always be able to append");
+            }
+        }
         // Step 12.2. For each node in node list, append node as the last child of new parent, preserving ranges.
         for node in node_list {
             move_preserving_ranges(cx, &node, |cx| new_parent.AppendChild(cx, &node));
@@ -666,7 +684,32 @@ where
         // and the last member of node list is not a br,
         // call createElement("br") on the ownerDocument of new parent
         // and insert the result as the first child of new parent.
-        // TODO
+        if !new_parent.is_inline_node() &&
+            new_parent
+                .children()
+                .find(|child| child.is_visible())
+                .is_some_and(|child| child.is_inline_node()) &&
+            node_list
+                .iter()
+                .rev()
+                .find(|node| node.is_visible())
+                .is_some_and(|node| node.is_inline_node()) &&
+            node_list
+                .last()
+                .is_none_or(|last_child| !last_child.is::<HTMLBRElement>())
+        {
+            let new_br_element = new_parent.owner_document().create_element(cx, "br");
+            if new_parent
+                .InsertBefore(
+                    cx,
+                    new_br_element.upcast(),
+                    new_parent.GetFirstChild().as_deref(),
+                )
+                .is_err()
+            {
+                unreachable!("Must always be able to append");
+            }
+        }
         // Step 13.2. For each node in node list, in reverse order,
         // insert node as the first child of new parent, preserving ranges.
         let mut before = new_parent.GetFirstChild();

--- a/components/script/dom/execcommand/contenteditable/range.rs
+++ b/components/script/dom/execcommand/contenteditable/range.rs
@@ -105,10 +105,14 @@ impl Range {
             return;
         }
 
-        for child in self
+        // Make sure to keep track of the tree nodes before, since `callback` might modify
+        // the underyling tree and then the iterator would prematurely stop.
+        let children = self
             .CommonAncestorContainer()
             .traverse_preorder(ShadowIncluding::No)
-        {
+            .collect::<Vec<DomRoot<Node>>>();
+
+        for child in children {
             if self.is_effectively_contained_node(&child) {
                 callback(&child);
             }

--- a/tests/wpt/meta/editing/other/removing-inline-style-specified-by-parent-block.tentative.html.ini
+++ b/tests/wpt/meta/editing/other/removing-inline-style-specified-by-parent-block.tentative.html.ini
@@ -1,7 +1,4 @@
 [removing-inline-style-specified-by-parent-block.tentative.html?u]
-  [Disabling style to text, it's applied to the parent block]
-    expected: FAIL
-
 
 [removing-inline-style-specified-by-parent-block.tentative.html?i]
   [Disabling style to text, it's applied to the parent block]

--- a/tests/wpt/meta/editing/run/delete.html.ini
+++ b/tests/wpt/meta/editing/run/delete.html.ini
@@ -1180,18 +1180,6 @@
   [[["stylewithcss","false"\],["defaultparagraphseparator","p"\],["delete",""\]\] "<p>foo<p style=color:brown>[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["defaultparagraphseparator","div"\],["delete",""\]\] "<p style=text-decoration:underline>foo<p>[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["defaultparagraphseparator","div"\],["delete",""\]\] "<p style=text-decoration:underline>foo<p>[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["defaultparagraphseparator","p"\],["delete",""\]\] "<p style=text-decoration:underline>foo<p>[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["defaultparagraphseparator","p"\],["delete",""\]\] "<p style=text-decoration:underline>foo<p>[\]bar" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["defaultparagraphseparator","div"\],["delete",""\]\] "<p style=text-decoration:underline>foo<p style=text-decoration:line-through>[\]bar" compare innerHTML]
     expected: FAIL
 

--- a/tests/wpt/meta/editing/run/fontsize.html.ini
+++ b/tests/wpt/meta/editing/run/fontsize.html.ini
@@ -1,7 +1,4 @@
 [fontsize.html?1-1000]
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<span>[foo</span> <span>bar\]</span>" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<span>[foo</span> <span>bar\]</span>" compare innerHTML]
     expected: FAIL
 
@@ -373,9 +370,6 @@
     expected: FAIL
 
   [[["styleWithCSS","false"\],["fontSize","5"\]\] "<span style=\\"font-size:32px; background-color:rgb(0, 128, 128)\\">ab[c\]</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["fontSize","5"\]\] "<p><span style=\\"font-size:32px; background-color:rgb(0, 128, 128)\\">[abc</span></p><p><span style=\\"font-size:64px; background-color:rgb(128, 128, 0)\\">def\]</span></p>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=2>ba[r</font>b\]az" queryCommandState("stylewithcss") after]

--- a/tests/wpt/meta/editing/run/underline.html.ini
+++ b/tests/wpt/meta/editing/run/underline.html.ini
@@ -2,9 +2,6 @@
   [[["stylewithcss","true"\],["underline",""\]\] "<span>[foo</span> <span>bar\]</span>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["underline",""\]\] "<span>[foo</span> <span>bar\]</span>" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<p>[foo</p><p> <span>bar</span> </p><p>baz\]</p>" compare innerHTML]
     expected: FAIL
 
@@ -45,12 +42,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["underline",""\]\] "<u>foo[b<i>ar\]ba</i>z</u>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<p style=\\"text-decoration: underline\\">foo[bar\]baz</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "<p style=\\"text-decoration: underline\\">foo[bar\]baz</p>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "foo<s>[bar\]</s>baz" compare innerHTML]


### PR DESCRIPTION
This makes further steps to generate the correct HTML. Some tests now have more appropriate HTML, but are not fully passing yet as they require more fixes. I also missed the fact that there is actually an algorithm to set the tag name, which I thought didn't exist. Therefore, also correctly implement that.

Part of #25005

Testing: WPT