### PR TITLE
script: Canonicalization of sanitizer configuration

### DIFF
--- a/components/script/dom/security/sanitizer.rs
+++ b/components/script/dom/security/sanitizer.rs
@@ -444,7 +444,7 @@ impl NameMember for SanitizerElementWithAttributes {
                     SanitizerElementWithAttributes::SanitizerElementNamespaceWithAttributes(
                         SanitizerElementNamespaceWithAttributes {
                             parent: SanitizerElementNamespace {
-                                name: name.clone(),
+                                name: std::mem::take(name),
                                 namespace: namespace.map(DOMString::from),
                             },
                             attributes: None,
@@ -482,7 +482,7 @@ impl NameMember for SanitizerElement {
             SanitizerElement::String(name) => {
                 let new_instance =
                     SanitizerElement::SanitizerElementNamespace(SanitizerElementNamespace {
-                        name: name.clone(),
+                        name: std::mem::take(name),
                         namespace: namespace.map(DOMString::from),
                     });
                 *self = new_instance;
@@ -516,7 +516,7 @@ impl NameMember for SanitizerAttribute {
             SanitizerAttribute::String(name) => {
                 let new_instance =
                     SanitizerAttribute::SanitizerAttributeNamespace(SanitizerAttributeNamespace {
-                        name: name.clone(),
+                        name: std::mem::take(name),
                         namespace: namespace.map(DOMString::from),
                     });
                 *self = new_instance;
@@ -563,7 +563,7 @@ impl AttributeMember for SanitizerElementWithAttributes {
                 *self = SanitizerElementWithAttributes::SanitizerElementNamespaceWithAttributes(
                     SanitizerElementNamespaceWithAttributes {
                         parent: SanitizerElementNamespace {
-                            name: name.clone(),
+                            name: std::mem::take(name),
                             namespace: None,
                         },
                         attributes,
@@ -583,7 +583,7 @@ impl AttributeMember for SanitizerElementWithAttributes {
                 *self = SanitizerElementWithAttributes::SanitizerElementNamespaceWithAttributes(
                     SanitizerElementNamespaceWithAttributes {
                         parent: SanitizerElementNamespace {
-                            name: name.clone(),
+                            name: std::mem::take(name),
                             namespace: None,
                         },
                         attributes: None,

--- a/components/script/dom/security/sanitizer.rs
+++ b/components/script/dom/security/sanitizer.rs
@@ -9,14 +9,15 @@ use js::rust::HandleObject;
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::SanitizerBinding::{
-    SanitizerAttribute, SanitizerAttributeNamespace, SanitizerConfig, SanitizerElementNamespace,
-    SanitizerElementNamespaceWithAttributes, SanitizerElementWithAttributes, SanitizerMethods,
-    SanitizerPresets,
+    SanitizerAttribute, SanitizerAttributeNamespace, SanitizerConfig, SanitizerElement,
+    SanitizerElementNamespace, SanitizerElementNamespaceWithAttributes,
+    SanitizerElementWithAttributes, SanitizerMethods, SanitizerPresets,
 };
 use crate::dom::bindings::codegen::UnionTypes::SanitizerConfigOrSanitizerPresets;
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
 use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::str::DOMString;
 use crate::dom::window::Window;
 
 #[dom_struct]
@@ -51,11 +52,11 @@ impl Sanitizer {
     /// <https://wicg.github.io/sanitizer-api/#sanitizer-set-a-configuration>
     fn set_configuration(
         &self,
-        configuration: SanitizerConfig,
-        _allow_comments_and_data_attributes: bool,
+        mut configuration: SanitizerConfig,
+        allow_comments_pis_and_data_attributes: bool,
     ) -> bool {
-        // TODO:
-        // Step 1. Canonicalize configuration with allowCommentsAndDataAttributes.
+        // Step 1. Canonicalize configuration with allowCommentsPIsAndDataAttributes.
+        configuration.canonicalize(allow_comments_pis_and_data_attributes);
 
         // TODO:
         // Step 2. If configuration is not valid, then return false.
@@ -109,6 +110,491 @@ impl SanitizerMethods<crate::DomTypeHolder> for Sanitizer {
 
         // Step 8. Return config.
         (*config).clone()
+    }
+}
+
+trait SanitizerConfigAlgorithm {
+    /// <https://wicg.github.io/sanitizer-api/#sanitizer-canonicalize-the-configuration>
+    fn canonicalize(&mut self, allow_comments_pis_and_data_attributes: bool);
+}
+
+impl SanitizerConfigAlgorithm for SanitizerConfig {
+    /// <https://wicg.github.io/sanitizer-api/#sanitizer-canonicalize-the-configuration>
+    fn canonicalize(&mut self, allow_comments_pis_and_data_attributes: bool) {
+        // Step 1. If neither configuration["elements"] nor configuration["removeElements"] exist,
+        // then set configuration["removeElements"] to « ».
+        if self.elements.is_none() && self.removeElements.is_none() {
+            self.removeElements = Some(Vec::new());
+        }
+
+        // TODO:
+        // Step 2. If neither configuration["processingInstructions"] nor
+        // configuration["removeProcessingInstructions"] exist:
+        // Step 2.1. If allowCommentsPIsAndDataAttributes is true, then set
+        // configuration["removeProcessingInstructions"] to « ».
+        // Step 2.2. Otherwise, set configuration["processingInstructions"] to « ».
+
+        // Step 3. If neither configuration["attributes"] nor configuration["removeAttributes"]
+        // exist, then set configuration["removeAttributes"] to « ».
+        if self.attributes.is_none() && self.removeAttributes.is_none() {
+            self.removeAttributes = Some(Vec::new());
+        }
+
+        // Step 4. If configuration["elements"] exists:
+        if let Some(elements) = &mut self.elements {
+            // Step 4.1. Let elements be « ».
+            // Step 4.2. For each element of configuration["elements"] do:
+            // Step 4.2.1. Append the result of canonicalize a sanitizer element with attributes
+            // element to elements.
+            // Step 4.3. Set configuration["elements"] to elements.
+            *elements = elements
+                .iter()
+                .cloned()
+                .map(SanitizerElementWithAttributes::canonicalize)
+                .collect();
+        }
+
+        // Step 5. If configuration["removeElements"] exists:
+        if let Some(remove_elements) = &mut self.removeElements {
+            // Step 5.1. Let elements be « ».
+            // Step 5.2. For each element of configuration["removeElements"] do:
+            // Step 5.2.1. Append the result of canonicalize a sanitizer element element to
+            // elements.
+            // Step 5.3. Set configuration["removeElements"] to elements.
+            *remove_elements = remove_elements
+                .iter()
+                .cloned()
+                .map(SanitizerElement::canonicalize)
+                .collect();
+        }
+
+        // Step 6. If configuration["replaceWithChildrenElements"] exists:
+        if let Some(replace_with_children_elements) = &mut self.replaceWithChildrenElements {
+            // Step 6.1. Let elements be « ».
+            // Step 6.2. For each element of configuration["replaceWithChildrenElements"] do:
+            // Step 6.2.1. Append the result of canonicalize a sanitizer element element to
+            // elements.
+            // Step 6.3. Set configuration["replaceWithChildrenElements"] to elements.
+            *replace_with_children_elements = replace_with_children_elements
+                .iter()
+                .cloned()
+                .map(SanitizerElement::canonicalize)
+                .collect();
+        }
+
+        // TODO:
+        // Step 7. If configuration["processingInstructions"] exists:
+        // Step 7.1. Let processingInstructions be « ».
+        // Step 7.2. For each pi of configuration["processingInstructions"]:
+        // Step 7.2.1. Append the result of canonicalize a sanitizer processing instruction pi
+        // to processingInstructions.
+        // Step 7.3. Set configuration["processingInstructions"] to processingInstructions.
+
+        // TODO:
+        // Step 8. If configuration["removeProcessingInstructions"] exists:
+        // Step 8.1. Let processingInstructions be « ».
+        // Step 8.2. For each pi of configuration["removeProcessingInstructions"]:
+        // Step 8.2.1. Append the result of canonicalize a sanitizer processing instruction
+        // pi to processingInstructions.
+        // Step 8.3. Set configuration["removeProcessingInstructions"] to processingInstructions.
+
+        // Step 9. If configuration["attributes"] exists:
+        if let Some(attributes) = &mut self.attributes {
+            // Step 9.1. Let attributes be « ».
+            // Step 9.2. For each attribute of configuration["attributes"] do:
+            // Step 9.2.1. Append the result of canonicalize a sanitizer attribute attribute to
+            // attributes.
+            // Step 9.3. Set configuration["attributes"] to attributes.
+            *attributes = attributes
+                .iter()
+                .cloned()
+                .map(SanitizerAttribute::canonicalize)
+                .collect();
+        }
+
+        // Step 10. If configuration["removeAttributes"] exists:
+        if let Some(remove_attributes) = &mut self.removeAttributes {
+            // Step 10.1. Let attributes be « ».
+            // Step 10.2. For each attribute of configuration["removeAttributes"] do:
+            // Step 10.2.1. Append the result of canonicalize a sanitizer attribute attribute to
+            // attributes.
+            // Step 10.3. Set configuration["removeAttributes"] to attributes.
+            *remove_attributes = remove_attributes
+                .iter()
+                .cloned()
+                .map(SanitizerAttribute::canonicalize)
+                .collect();
+        }
+
+        // Step 11. If configuration["comments"] does not exist, then set configuration["comments"]
+        // to allowCommentsPIsAndDataAttributes.
+        if self.comments.is_none() {
+            self.comments = Some(allow_comments_pis_and_data_attributes);
+        }
+
+        // Step 12. If configuration["attributes"] exists and configuration["dataAttributes"] does
+        // not exist, then set configuration["dataAttributes"] to allowCommentsPIsAndDataAttributes.
+        if self.attributes.is_some() && self.dataAttributes.is_none() {
+            self.dataAttributes = Some(allow_comments_pis_and_data_attributes);
+        }
+    }
+}
+
+trait Canonicalization {
+    /// <https://wicg.github.io/sanitizer-api/#canonicalize-a-sanitizer-element-with-attributes>
+    /// <https://wicg.github.io/sanitizer-api/#canonicalize-a-sanitizer-element>
+    /// <https://wicg.github.io/sanitizer-api/#canonicalize-a-sanitizer-attribute>
+    fn canonicalize(self) -> Self;
+}
+
+impl Canonicalization for SanitizerElementWithAttributes {
+    /// <https://wicg.github.io/sanitizer-api/#canonicalize-a-sanitizer-element-with-attributes>
+    fn canonicalize(self) -> Self {
+        // Step 1. Let result be the result of canonicalize a sanitizer element with element.
+        let parent = match &self {
+            SanitizerElementWithAttributes::String(name) => SanitizerElement::String(name.clone()),
+            SanitizerElementWithAttributes::SanitizerElementNamespaceWithAttributes(dictionary) => {
+                SanitizerElement::SanitizerElementNamespace(SanitizerElementNamespace {
+                    name: dictionary.parent.name.clone(),
+                    namespace: dictionary.parent.namespace.as_ref().cloned(),
+                })
+            },
+        };
+        let canonicalized_parent = parent.canonicalize();
+        let mut result = SanitizerElementWithAttributes::SanitizerElementNamespaceWithAttributes(
+            SanitizerElementNamespaceWithAttributes {
+                parent: SanitizerElementNamespace {
+                    name: canonicalized_parent.name().clone(),
+                    namespace: canonicalized_parent.namespace().cloned(),
+                },
+                attributes: None,
+                removeAttributes: None,
+            },
+        );
+
+        // Step 2. If element is a dictionary:
+        if matches!(
+            self,
+            SanitizerElementWithAttributes::SanitizerElementNamespaceWithAttributes(_)
+        ) {
+            // Step 2.1. If element["attributes"] exists:
+            if let Some(attributes) = self.attributes() {
+                // Step 2.1.1. Let attributes be « ».
+                // Step 2.1.2. For each attribute of element["attributes"]:
+                // Step 2.1.2.1. Append the result of canonicalize a sanitizer attribute with
+                // attribute to attributes.
+                let attributes = attributes
+                    .iter()
+                    .cloned()
+                    .map(|attribute| attribute.canonicalize())
+                    .collect();
+
+                // Step 2.1.3. Set result["attributes"] to attributes.
+                result.set_attributes(Some(attributes));
+            }
+
+            // Step 2.2. If element["removeAttributes"] exists:
+            if let Some(remove_attributes) = self.remove_attributes() {
+                // Step 2.2.1. Let attributes be « ».
+                // Step 2.2.2. For each attribute of element["removeAttributes"]:
+                // Step 2.2.2.1. Append the result of canonicalize a sanitizer attribute with
+                // attribute to attributes.
+                let attributes = remove_attributes
+                    .iter()
+                    .cloned()
+                    .map(|attribute| attribute.canonicalize())
+                    .collect();
+
+                // Step 2.2.3. Set result["removeAttributes"] to attributes.
+                result.set_remove_attributes(Some(attributes));
+            }
+        }
+
+        // Step 3. If neither result["attributes"] nor result["removeAttributes"] exist:
+        if result.attributes().is_none() && result.remove_attributes().is_none() {
+            // Step 3.1. Set result["removeAttributes"] to « ».
+            result.set_remove_attributes(Some(Vec::new()));
+        }
+
+        // Step 4. Return result.
+        result
+    }
+}
+
+impl Canonicalization for SanitizerElement {
+    /// <https://wicg.github.io/sanitizer-api/#canonicalize-a-sanitizer-element>
+    fn canonicalize(self) -> Self {
+        // Return the result of canonicalize a sanitizer name with element and the HTML namespace as
+        // the default namespace.
+        self.canonicalize_name(Some(ns!(html).to_string()))
+    }
+}
+
+impl Canonicalization for SanitizerAttribute {
+    /// <https://wicg.github.io/sanitizer-api/#canonicalize-a-sanitizer-attribute>
+    fn canonicalize(self) -> Self {
+        // Return the result of canonicalize a sanitizer name with attribute and null as the default
+        // namespace.
+        self.canonicalize_name(None)
+    }
+}
+
+trait NameCanonicalization: NameMember {
+    fn new_dictionary(name: DOMString, namespace: Option<DOMString>) -> Self;
+    fn is_string(&self) -> bool;
+    fn is_dictionary(&self) -> bool;
+
+    /// <https://wicg.github.io/sanitizer-api/#canonicalize-a-sanitizer-name>
+    fn canonicalize_name(mut self, default_namespace: Option<String>) -> Self {
+        // Step 1. Assert: name is either a DOMString or a dictionary.
+        assert!(self.is_string() || self.is_dictionary());
+
+        // Step 2. If name is a DOMString, then return «[ "name" → name, "namespace" →
+        // defaultNamespace]».
+        if self.is_string() {
+            return Self::new_dictionary(
+                self.name().clone(),
+                default_namespace.map(DOMString::from),
+            );
+        }
+
+        // Step 3. Assert: name is a dictionary and both name["name"] and name["namespace"] exist.
+        // NOTE: The latter is guaranteed by Rust type system.
+        assert!(self.is_dictionary());
+
+        // Step 4. If name["namespace"] is the empty string, then set it to null.
+        if self
+            .namespace()
+            .is_some_and(|namespace| namespace.str() == "")
+        {
+            self.set_namespace(None);
+        }
+
+        // Step 5. Return «[
+        // "name" → name["name"],
+        // "namespace" → name["namespace"]
+        // ]».
+        Self::new_dictionary(self.name().clone(), self.namespace().cloned())
+    }
+}
+
+impl NameCanonicalization for SanitizerElement {
+    fn new_dictionary(name: DOMString, namespace: Option<DOMString>) -> Self {
+        SanitizerElement::SanitizerElementNamespace(SanitizerElementNamespace { name, namespace })
+    }
+
+    fn is_string(&self) -> bool {
+        matches!(self, SanitizerElement::String(_))
+    }
+
+    fn is_dictionary(&self) -> bool {
+        matches!(self, SanitizerElement::SanitizerElementNamespace(_))
+    }
+}
+
+impl NameCanonicalization for SanitizerAttribute {
+    fn new_dictionary(name: DOMString, namespace: Option<DOMString>) -> Self {
+        SanitizerAttribute::SanitizerAttributeNamespace(SanitizerAttributeNamespace {
+            name,
+            namespace,
+        })
+    }
+
+    fn is_string(&self) -> bool {
+        matches!(self, SanitizerAttribute::String(_))
+    }
+
+    fn is_dictionary(&self) -> bool {
+        matches!(self, SanitizerAttribute::SanitizerAttributeNamespace(_))
+    }
+}
+
+/// Helper functions for accessing the "name" and "namespace" members of
+/// [`SanitizerElementWithAttributes`], [`SanitizerElement`] and [`SanitizerAttribute`].
+trait NameMember: Sized {
+    fn name(&self) -> &DOMString;
+    fn namespace(&self) -> Option<&DOMString>;
+
+    fn set_namespace(&mut self, namespace: Option<&str>);
+}
+
+impl NameMember for SanitizerElementWithAttributes {
+    fn name(&self) -> &DOMString {
+        match self {
+            SanitizerElementWithAttributes::String(name) => name,
+            SanitizerElementWithAttributes::SanitizerElementNamespaceWithAttributes(dictionary) => {
+                &dictionary.parent.name
+            },
+        }
+    }
+
+    fn namespace(&self) -> Option<&DOMString> {
+        match self {
+            SanitizerElementWithAttributes::String(_) => None,
+            SanitizerElementWithAttributes::SanitizerElementNamespaceWithAttributes(dictionary) => {
+                dictionary.parent.namespace.as_ref()
+            },
+        }
+    }
+
+    fn set_namespace(&mut self, namespace: Option<&str>) {
+        match self {
+            SanitizerElementWithAttributes::String(name) => {
+                let new_instance =
+                    SanitizerElementWithAttributes::SanitizerElementNamespaceWithAttributes(
+                        SanitizerElementNamespaceWithAttributes {
+                            parent: SanitizerElementNamespace {
+                                name: name.clone(),
+                                namespace: namespace.map(DOMString::from),
+                            },
+                            attributes: None,
+                            removeAttributes: None,
+                        },
+                    );
+                *self = new_instance;
+            },
+            SanitizerElementWithAttributes::SanitizerElementNamespaceWithAttributes(dictionary) => {
+                dictionary.parent.namespace = namespace.map(DOMString::from);
+            },
+        }
+    }
+}
+
+impl NameMember for SanitizerElement {
+    fn name(&self) -> &DOMString {
+        match self {
+            SanitizerElement::String(name) => name,
+            SanitizerElement::SanitizerElementNamespace(dictionary) => &dictionary.name,
+        }
+    }
+
+    fn namespace(&self) -> Option<&DOMString> {
+        match self {
+            SanitizerElement::String(_) => None,
+            SanitizerElement::SanitizerElementNamespace(dictionary) => {
+                dictionary.namespace.as_ref()
+            },
+        }
+    }
+
+    fn set_namespace(&mut self, namespace: Option<&str>) {
+        match self {
+            SanitizerElement::String(name) => {
+                let new_instance =
+                    SanitizerElement::SanitizerElementNamespace(SanitizerElementNamespace {
+                        name: name.clone(),
+                        namespace: namespace.map(DOMString::from),
+                    });
+                *self = new_instance;
+            },
+            SanitizerElement::SanitizerElementNamespace(dictionary) => {
+                dictionary.namespace = namespace.map(DOMString::from);
+            },
+        }
+    }
+}
+
+impl NameMember for SanitizerAttribute {
+    fn name(&self) -> &DOMString {
+        match self {
+            SanitizerAttribute::String(name) => name,
+            SanitizerAttribute::SanitizerAttributeNamespace(dictionary) => &dictionary.name,
+        }
+    }
+
+    fn namespace(&self) -> Option<&DOMString> {
+        match self {
+            SanitizerAttribute::String(_) => None,
+            SanitizerAttribute::SanitizerAttributeNamespace(dictionary) => {
+                dictionary.namespace.as_ref()
+            },
+        }
+    }
+
+    fn set_namespace(&mut self, namespace: Option<&str>) {
+        match self {
+            SanitizerAttribute::String(name) => {
+                let new_instance =
+                    SanitizerAttribute::SanitizerAttributeNamespace(SanitizerAttributeNamespace {
+                        name: name.clone(),
+                        namespace: namespace.map(DOMString::from),
+                    });
+                *self = new_instance;
+            },
+            SanitizerAttribute::SanitizerAttributeNamespace(dictionary) => {
+                dictionary.namespace = namespace.map(DOMString::from);
+            },
+        }
+    }
+}
+
+/// Helper functions for accessing the "attributes" and "removeAttributes" members of
+/// [`SanitizerElementWithAttributes`].
+trait AttributeMember {
+    fn attributes(&self) -> Option<&Vec<SanitizerAttribute>>;
+    fn remove_attributes(&self) -> Option<&Vec<SanitizerAttribute>>;
+
+    fn set_attributes(&mut self, attributes: Option<Vec<SanitizerAttribute>>);
+    fn set_remove_attributes(&mut self, remove_attributes: Option<Vec<SanitizerAttribute>>);
+}
+
+impl AttributeMember for SanitizerElementWithAttributes {
+    fn attributes(&self) -> Option<&Vec<SanitizerAttribute>> {
+        match self {
+            SanitizerElementWithAttributes::String(_) => None,
+            SanitizerElementWithAttributes::SanitizerElementNamespaceWithAttributes(dictionary) => {
+                dictionary.attributes.as_ref()
+            },
+        }
+    }
+
+    fn remove_attributes(&self) -> Option<&Vec<SanitizerAttribute>> {
+        match self {
+            SanitizerElementWithAttributes::String(_) => None,
+            SanitizerElementWithAttributes::SanitizerElementNamespaceWithAttributes(dictionary) => {
+                dictionary.removeAttributes.as_ref()
+            },
+        }
+    }
+
+    fn set_attributes(&mut self, attributes: Option<Vec<SanitizerAttribute>>) {
+        match self {
+            SanitizerElementWithAttributes::String(name) => {
+                *self = SanitizerElementWithAttributes::SanitizerElementNamespaceWithAttributes(
+                    SanitizerElementNamespaceWithAttributes {
+                        parent: SanitizerElementNamespace {
+                            name: name.clone(),
+                            namespace: None,
+                        },
+                        attributes,
+                        removeAttributes: None,
+                    },
+                );
+            },
+            SanitizerElementWithAttributes::SanitizerElementNamespaceWithAttributes(dictionary) => {
+                dictionary.attributes = attributes;
+            },
+        }
+    }
+
+    fn set_remove_attributes(&mut self, remove_attributes: Option<Vec<SanitizerAttribute>>) {
+        match self {
+            SanitizerElementWithAttributes::String(name) => {
+                *self = SanitizerElementWithAttributes::SanitizerElementNamespaceWithAttributes(
+                    SanitizerElementNamespaceWithAttributes {
+                        parent: SanitizerElementNamespace {
+                            name: name.clone(),
+                            namespace: None,
+                        },
+                        attributes: None,
+                        removeAttributes: remove_attributes,
+                    },
+                );
+            },
+            SanitizerElementWithAttributes::SanitizerElementNamespaceWithAttributes(dictionary) => {
+                dictionary.removeAttributes = remove_attributes;
+            },
+        }
     }
 }
 

--- a/components/script/dom/security/sanitizer.rs
+++ b/components/script/dom/security/sanitizer.rs
@@ -249,23 +249,31 @@ trait Canonicalization {
 
 impl Canonicalization for SanitizerElementWithAttributes {
     /// <https://wicg.github.io/sanitizer-api/#canonicalize-a-sanitizer-element-with-attributes>
-    fn canonicalize(self) -> Self {
+    fn canonicalize(mut self) -> Self {
         // Step 1. Let result be the result of canonicalize a sanitizer element with element.
-        let parent = match &self {
-            SanitizerElementWithAttributes::String(name) => SanitizerElement::String(name.clone()),
+        let parent = match &mut self {
+            SanitizerElementWithAttributes::String(name) => {
+                SanitizerElement::String(std::mem::take(name))
+            },
             SanitizerElementWithAttributes::SanitizerElementNamespaceWithAttributes(dictionary) => {
                 SanitizerElement::SanitizerElementNamespace(SanitizerElementNamespace {
-                    name: dictionary.parent.name.clone(),
-                    namespace: dictionary.parent.namespace.as_ref().cloned(),
+                    name: std::mem::take(&mut dictionary.parent.name),
+                    namespace: dictionary
+                        .parent
+                        .namespace
+                        .as_mut()
+                        .map(|namespace| std::mem::take(namespace)),
                 })
             },
         };
-        let canonicalized_parent = parent.canonicalize();
+        let mut canonicalized_parent = parent.canonicalize();
         let mut result = SanitizerElementWithAttributes::SanitizerElementNamespaceWithAttributes(
             SanitizerElementNamespaceWithAttributes {
                 parent: SanitizerElementNamespace {
-                    name: canonicalized_parent.name().clone(),
-                    namespace: canonicalized_parent.namespace().cloned(),
+                    name: std::mem::take(canonicalized_parent.name_mut()),
+                    namespace: canonicalized_parent
+                        .namespace_mut()
+                        .map(|namespace| std::mem::take(namespace)),
                 },
                 attributes: None,
                 removeAttributes: None,
@@ -353,7 +361,7 @@ trait NameCanonicalization: NameMember {
         // defaultNamespace]».
         if self.is_string() {
             return Self::new_dictionary(
-                self.name().clone(),
+                std::mem::take(self.name_mut()),
                 default_namespace.map(DOMString::from),
             );
         }
@@ -374,7 +382,11 @@ trait NameCanonicalization: NameMember {
         // "name" → name["name"],
         // "namespace" → name["namespace"]
         // ]».
-        Self::new_dictionary(self.name().clone(), self.namespace().cloned())
+        Self::new_dictionary(
+            std::mem::take(self.name_mut()),
+            self.namespace_mut()
+                .map(|namespace| std::mem::take(namespace)),
+        )
     }
 }
 
@@ -413,7 +425,9 @@ impl NameCanonicalization for SanitizerAttribute {
 /// [`SanitizerElementWithAttributes`], [`SanitizerElement`] and [`SanitizerAttribute`].
 trait NameMember: Sized {
     fn name(&self) -> &DOMString;
+    fn name_mut(&mut self) -> &mut DOMString;
     fn namespace(&self) -> Option<&DOMString>;
+    fn namespace_mut(&mut self) -> Option<&mut DOMString>;
 
     fn set_namespace(&mut self, namespace: Option<&str>);
 }
@@ -428,11 +442,29 @@ impl NameMember for SanitizerElementWithAttributes {
         }
     }
 
+    fn name_mut(&mut self) -> &mut DOMString {
+        match self {
+            SanitizerElementWithAttributes::String(name) => name,
+            SanitizerElementWithAttributes::SanitizerElementNamespaceWithAttributes(dictionary) => {
+                &mut dictionary.parent.name
+            },
+        }
+    }
+
     fn namespace(&self) -> Option<&DOMString> {
         match self {
             SanitizerElementWithAttributes::String(_) => None,
             SanitizerElementWithAttributes::SanitizerElementNamespaceWithAttributes(dictionary) => {
                 dictionary.parent.namespace.as_ref()
+            },
+        }
+    }
+
+    fn namespace_mut(&mut self) -> Option<&mut DOMString> {
+        match self {
+            SanitizerElementWithAttributes::String(_) => None,
+            SanitizerElementWithAttributes::SanitizerElementNamespaceWithAttributes(dictionary) => {
+                dictionary.parent.namespace.as_mut()
             },
         }
     }
@@ -468,11 +500,27 @@ impl NameMember for SanitizerElement {
         }
     }
 
+    fn name_mut(&mut self) -> &mut DOMString {
+        match self {
+            SanitizerElement::String(name) => name,
+            SanitizerElement::SanitizerElementNamespace(dictionary) => &mut dictionary.name,
+        }
+    }
+
     fn namespace(&self) -> Option<&DOMString> {
         match self {
             SanitizerElement::String(_) => None,
             SanitizerElement::SanitizerElementNamespace(dictionary) => {
                 dictionary.namespace.as_ref()
+            },
+        }
+    }
+
+    fn namespace_mut(&mut self) -> Option<&mut DOMString> {
+        match self {
+            SanitizerElement::String(_) => None,
+            SanitizerElement::SanitizerElementNamespace(dictionary) => {
+                dictionary.namespace.as_mut()
             },
         }
     }
@@ -502,11 +550,27 @@ impl NameMember for SanitizerAttribute {
         }
     }
 
+    fn name_mut(&mut self) -> &mut DOMString {
+        match self {
+            SanitizerAttribute::String(name) => name,
+            SanitizerAttribute::SanitizerAttributeNamespace(dictionary) => &mut dictionary.name,
+        }
+    }
+
     fn namespace(&self) -> Option<&DOMString> {
         match self {
             SanitizerAttribute::String(_) => None,
             SanitizerAttribute::SanitizerAttributeNamespace(dictionary) => {
                 dictionary.namespace.as_ref()
+            },
+        }
+    }
+
+    fn namespace_mut(&mut self) -> Option<&mut DOMString> {
+        match self {
+            SanitizerAttribute::String(_) => None,
+            SanitizerAttribute::SanitizerAttributeNamespace(dictionary) => {
+                dictionary.namespace.as_mut()
             },
         }
     }

--- a/components/script/dom/security/sanitizer.rs
+++ b/components/script/dom/security/sanitizer.rs
@@ -258,11 +258,7 @@ impl Canonicalization for SanitizerElementWithAttributes {
             SanitizerElementWithAttributes::SanitizerElementNamespaceWithAttributes(dictionary) => {
                 SanitizerElement::SanitizerElementNamespace(SanitizerElementNamespace {
                     name: std::mem::take(&mut dictionary.parent.name),
-                    namespace: dictionary
-                        .parent
-                        .namespace
-                        .as_mut()
-                        .map(|namespace| std::mem::take(namespace)),
+                    namespace: dictionary.parent.namespace.as_mut().map(std::mem::take),
                 })
             },
         };
@@ -271,9 +267,7 @@ impl Canonicalization for SanitizerElementWithAttributes {
             SanitizerElementNamespaceWithAttributes {
                 parent: SanitizerElementNamespace {
                     name: std::mem::take(canonicalized_parent.name_mut()),
-                    namespace: canonicalized_parent
-                        .namespace_mut()
-                        .map(|namespace| std::mem::take(namespace)),
+                    namespace: canonicalized_parent.namespace_mut().map(std::mem::take),
                 },
                 attributes: None,
                 removeAttributes: None,
@@ -384,8 +378,7 @@ trait NameCanonicalization: NameMember {
         // ]».
         Self::new_dictionary(
             std::mem::take(self.name_mut()),
-            self.namespace_mut()
-                .map(|namespace| std::mem::take(namespace)),
+            self.namespace_mut().map(std::mem::take),
         )
     }
 }

--- a/components/script/dom/security/sanitizer.rs
+++ b/components/script/dom/security/sanitizer.rs
@@ -424,7 +424,6 @@ impl NameCanonicalization for SanitizerAttribute {
 /// Helper functions for accessing the "name" and "namespace" members of
 /// [`SanitizerElementWithAttributes`], [`SanitizerElement`] and [`SanitizerAttribute`].
 trait NameMember: Sized {
-    fn name(&self) -> &DOMString;
     fn name_mut(&mut self) -> &mut DOMString;
     fn namespace(&self) -> Option<&DOMString>;
     fn namespace_mut(&mut self) -> Option<&mut DOMString>;
@@ -433,15 +432,6 @@ trait NameMember: Sized {
 }
 
 impl NameMember for SanitizerElementWithAttributes {
-    fn name(&self) -> &DOMString {
-        match self {
-            SanitizerElementWithAttributes::String(name) => name,
-            SanitizerElementWithAttributes::SanitizerElementNamespaceWithAttributes(dictionary) => {
-                &dictionary.parent.name
-            },
-        }
-    }
-
     fn name_mut(&mut self) -> &mut DOMString {
         match self {
             SanitizerElementWithAttributes::String(name) => name,
@@ -493,13 +483,6 @@ impl NameMember for SanitizerElementWithAttributes {
 }
 
 impl NameMember for SanitizerElement {
-    fn name(&self) -> &DOMString {
-        match self {
-            SanitizerElement::String(name) => name,
-            SanitizerElement::SanitizerElementNamespace(dictionary) => &dictionary.name,
-        }
-    }
-
     fn name_mut(&mut self) -> &mut DOMString {
         match self {
             SanitizerElement::String(name) => name,
@@ -543,13 +526,6 @@ impl NameMember for SanitizerElement {
 }
 
 impl NameMember for SanitizerAttribute {
-    fn name(&self) -> &DOMString {
-        match self {
-            SanitizerAttribute::String(name) => name,
-            SanitizerAttribute::SanitizerAttributeNamespace(dictionary) => &dictionary.name,
-        }
-    }
-
     fn name_mut(&mut self) -> &mut DOMString {
         match self {
             SanitizerAttribute::String(name) => name,

--- a/tests/wpt/meta/sanitizer-api/sanitizer-config.tentative.html.ini
+++ b/tests/wpt/meta/sanitizer-api/sanitizer-config.tentative.html.ini
@@ -5,48 +5,6 @@
   [SanitizerConfig dataAttributes field.]
     expected: FAIL
 
-  [SanitizerConfig, normalization: elements: ["div"\]]
-    expected: FAIL
-
-  [SanitizerConfig, normalization: elements: [{"name":"b"}\]]
-    expected: FAIL
-
-  [SanitizerConfig, normalization: elements: [{"name":"b","namespace":null}\]]
-    expected: FAIL
-
-  [SanitizerConfig, normalization: elements: [{"name":"b","namespace":""}\]]
-    expected: FAIL
-
-  [SanitizerConfig, normalization: elements: [{"name":"p","namespace":"http://www.w3.org/1999/xhtml"}\]]
-    expected: FAIL
-
-  [SanitizerConfig, normalization: elements: [{"name":"bla","namespace":"http://fantasy.org/namespace"}\]]
-    expected: FAIL
-
-  [SanitizerConfig, normalization: removeElements: ["div"\]]
-    expected: FAIL
-
-  [SanitizerConfig, normalization: removeElements: [{"name":"b","namespace":""}\]]
-    expected: FAIL
-
-  [SanitizerConfig, normalization: replaceWithChildrenElements: ["div"\]]
-    expected: FAIL
-
-  [SanitizerConfig, normalization: replaceWithChildrenElements: [{"name":"b","namespace":""}\]]
-    expected: FAIL
-
-  [SanitizerConfig, normalization: attributes: ["href"\]]
-    expected: FAIL
-
-  [SanitizerConfig, normalization: attributes: [{"name":"href","namespace":""}\]]
-    expected: FAIL
-
-  [SanitizerConfig, normalization: removeAttributes: ["href"\]]
-    expected: FAIL
-
-  [SanitizerConfig, normalization: removeAttributes: [{"name":"href","namespace":""}\]]
-    expected: FAIL
-
   [Test elements addition.]
     expected: FAIL
 


### PR DESCRIPTION
Implement the canonicalization of sanitizer configuration, along with the canonicalization of element with attributes, element, attribute and name. They are implemented for the `SanitizerConfig`, `SanitizerElementWithAttributes`, `SanitizerElement` and `SanitizerAttribute`, through the `SantiizerConfigAlgorithm`, `Canonicalization` and `NameCanonicalization` trait.

Note that, in the canonicalization of sanitizer configuration, the steps related to processing instructions are marked as TODO. The feature of supporting process instructions has just been added to the specification recently, and the WPT tests are not yet in place. We will add this support once the tests are ready.

`SanitizerElementWithAttributes`, `SanitizerElement` and `SanitizerAttribute` are unions of string and dictionary. This makes accessing its member fields cumbersome. So, the `NameMember` and `AttributeMember` trait are added to provide helper function for them to reduce boilerplate code.

Specification:
- https://wicg.github.io/sanitizer-api/#sanitizer-canonicalize-the-configuration
- https://wicg.github.io/sanitizer-api/#canonicalize-a-sanitizer-element-with-attributes
- https://wicg.github.io/sanitizer-api/#canonicalize-a-sanitizer-element
- https://wicg.github.io/sanitizer-api/#canonicalize-a-sanitizer-attribute
- https://wicg.github.io/sanitizer-api/#canonicalize-a-sanitizer-name

Testing: Covered by WPT tests in `sanitizer-api/` subdirectory.
Fixes: Part of #43948
