### PR TITLE
IndexedDB: Fix intermittent idbdatabase_deleteObjectStore.any.html t test via soft delete flag

### DIFF
--- a/components/storage/indexeddb/engines/sqlite.rs
+++ b/components/storage/indexeddb/engines/sqlite.rs
@@ -378,17 +378,15 @@ impl KvsEngine for SqliteEngine {
             "DELETE FROM object_data WHERE object_store_id = ?",
             params![object_store.id],
         )?;
-        let result = self.connection.execute(
-            "DELETE FROM object_store WHERE id = ?",
+
+        // https://www.w3.org/TR/IndexedDB-3/#dom-idbdatabase-deleteobjectstore
+        // Step 5. Remove store from this's object store set.
+        self.connection.execute(
+            "UPDATE object_store SET deleted = 1 WHERE id = ?",
             params![object_store.id],
         )?;
-        if result == 0 {
-            Err(Error::QueryReturnedNoRows)
-        } else if result > 1 {
-            Err(Error::QueryReturnedMoreThanOneRow)
-        } else {
-            Ok(())
-        }
+
+        Ok(())
     }
 
     fn close_store(&self, _store_name: &str) -> Result<(), Self::Error> {
@@ -629,7 +627,9 @@ impl KvsEngine for SqliteEngine {
     }
 
     fn object_store_names(&self) -> Result<Vec<String>, Self::Error> {
-        let mut stmt = self.connection.prepare("SELECT name FROM object_store")?;
+        let mut stmt = self
+            .connection
+            .prepare("SELECT name FROM object_store WHERE deleted = 0")?;
         stmt.query_map([], |row| row.get(0))?
             .collect::<Result<Vec<_>, _>>()
     }
@@ -935,12 +935,8 @@ mod tests {
         // Delete the store
         db.delete_store("test_store")
             .expect("Failed to delete store");
-        // Try to delete the same store again
-        let result = db.delete_store("test_store");
-        assert!(result.is_err());
-        // Try to delete a non-existing store
-        let result = db.delete_store("test_store");
-        // Should work as per spec
+        // Deleting a non-existent store should fail
+        let result = db.delete_store("nonexistent_store");
         assert!(result.is_err());
     }
 

--- a/components/storage/indexeddb/engines/sqlite/create.rs
+++ b/components/storage/indexeddb/engines/sqlite/create.rs
@@ -22,7 +22,8 @@ create table object_store (
     name           varchar               not null
         unique,
     key_path       varbinary_blob,
-    auto_increment integer default FALSE not null
+    auto_increment integer default FALSE not null,
+    deleted        integer default 0     not null
 );"#;
     conn.execute(OBJECT_STORE, [])?;
 

--- a/components/storage/indexeddb/engines/sqlite/object_store_model.rs
+++ b/components/storage/indexeddb/engines/sqlite/object_store_model.rs
@@ -13,6 +13,7 @@ pub enum Column {
     Name,
     KeyPath,
     AutoIncrement,
+    Deleted,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -21,6 +22,7 @@ pub struct Model {
     pub name: String,
     pub key_path: Option<Vec<u8>>,
     pub auto_increment: i32,
+    pub deleted: i32,
 }
 
 impl TryFrom<&Row<'_>> for Model {
@@ -32,6 +34,7 @@ impl TryFrom<&Row<'_>> for Model {
             name: value.get(1)?,
             key_path: value.get(2)?,
             auto_increment: value.get(3)?,
+            deleted: value.get(4)?,
         })
     }
 }

--- a/tests/wpt/meta/IndexedDB/idbdatabase_deleteObjectStore.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbdatabase_deleteObjectStore.any.js.ini
@@ -1,15 +1,9 @@
 [idbdatabase_deleteObjectStore.any.worker.html]
-  [Deleted object store's name should be removed from database's list. Attempting to use a deleted IDBObjectStore should throw an InvalidStateError]
-    expected: FAIL
-
   [Attempting to access an index that was deleted as part of object store deletion and then recreated using the same object store name should throw a NotFoundError]
     expected: FAIL
 
 
 [idbdatabase_deleteObjectStore.any.html]
-  [Deleted object store's name should be removed from database's list. Attempting to use a deleted IDBObjectStore should throw an InvalidStateError]
-    expected: FAIL
-
   [Attempting to access an index that was deleted as part of object store deletion and then recreated using the same object store name should throw a NotFoundError]
     expected: FAIL
 


### PR DESCRIPTION
Try to Fix intermittent deleteObjectStore test via soft delete flag, use UPDATE SET deleted=1 instead of DELETE to preserve row metadata for in flight async operations.

Testing: /IndexedDB/idbdatabase_deleteObjectStore.any.html test passess. 

Fixes: #43823