### PR TITLE
embedder_traits: Move Wakelock trait to Embedder_traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8876,6 +8876,7 @@ name = "servo-wakelock"
 version = "0.1.0"
 dependencies = [
  "serde",
+ "servo-embedder-traits",
 ]
 
 [[package]]

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -111,8 +111,8 @@ use embedder_traits::{
     GenericEmbedderProxy, InputEvent, InputEventAndId, InputEventOutcome, JSValue,
     JavaScriptEvaluationError, JavaScriptEvaluationId, KeyboardEvent, MediaSessionActionType,
     MediaSessionEvent, MediaSessionPlaybackState, MouseButton, MouseButtonAction, MouseButtonEvent,
-    NewWebViewDetails, PaintHitTestResult, Theme, ViewportDetails, WebDriverCommandMsg,
-    WebDriverLoadStatus, WebDriverScriptCommand,
+    NewWebViewDetails, PaintHitTestResult, Theme, ViewportDetails, WakeLockProvider, WakeLockType,
+    WebDriverCommandMsg, WebDriverLoadStatus, WebDriverScriptCommand,
 };
 use euclid::Size2D;
 use euclid::default::Size2D as UntypedSize2D;
@@ -168,7 +168,6 @@ use servo_constellation_traits::{
     TraversalDirection, UserContentManagerAction, WindowSizeType,
 };
 use servo_url::{Host, ImmutableOrigin, ServoUrl};
-use servo_wakelock::{WakeLockProvider, WakeLockType};
 use storage_traits::StorageThreads;
 use storage_traits::client_storage::ClientStorageThreadMessage;
 use storage_traits::indexeddb::{IndexedDBThreadMsg, SyncOperation};

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -111,7 +111,7 @@ use embedder_traits::{
     GenericEmbedderProxy, InputEvent, InputEventAndId, InputEventOutcome, JSValue,
     JavaScriptEvaluationError, JavaScriptEvaluationId, KeyboardEvent, MediaSessionActionType,
     MediaSessionEvent, MediaSessionPlaybackState, MouseButton, MouseButtonAction, MouseButtonEvent,
-    NewWebViewDetails, PaintHitTestResult, Theme, ViewportDetails, WakeLockProvider, WakeLockType,
+    NewWebViewDetails, PaintHitTestResult, Theme, ViewportDetails, WakeLockDelegate, WakeLockType,
     WebDriverCommandMsg, WebDriverLoadStatus, WebDriverScriptCommand,
 };
 use euclid::Size2D;
@@ -492,7 +492,7 @@ pub struct Constellation<STF, SWF> {
     screen_wake_lock_count: u32,
 
     /// Provider for OS-level screen wake lock acquisition and release.
-    wake_lock_provider: Box<dyn WakeLockProvider>,
+    wake_lock_provider: Box<dyn WakeLockDelegate>,
 
     /// The image bytes associated with the BrokenImageIcon embedder resource.
     /// Read during startup and provided to image caches that are created
@@ -593,7 +593,7 @@ pub struct InitialConstellationState {
     pub async_runtime: Box<dyn AsyncRuntime>,
 
     /// The wake lock provider for acquiring and releasing OS-level screen wake locks.
-    pub wake_lock_provider: Box<dyn WakeLockProvider>,
+    pub wake_lock_provider: Box<dyn WakeLockDelegate>,
 }
 
 /// When we are exiting a pipeline, we can either force exiting or not. A normal exit

--- a/components/script/dom/wakelock/wakelock.rs
+++ b/components/script/dom/wakelock/wakelock.rs
@@ -92,7 +92,7 @@ impl RoutedPromiseListener<AllowOrDeny> for WakeLock {
                 let global = self.global();
                 global.as_window().send_to_constellation(
                     ScriptToConstellationMessage::AcquireWakeLock(
-                        servo_wakelock::WakeLockType::Screen,
+                        embedder_traits::WakeLockType::Screen,
                     ),
                 );
 

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -69,7 +69,7 @@ use servo_geometry::{
 };
 use servo_media::ServoMedia;
 use servo_media::player::context::GlContext;
-use servo_wakelock::NoOpWakeLockProvider;
+use servo_wakelock::DefaultWakeLockDelegate;
 use storage::new_storage_threads;
 use storage_traits::StorageThreads;
 use style::global_style_data::StyleThreadPool;
@@ -1187,7 +1187,7 @@ fn create_constellation(
         wgpu_image_map: paint.webgpu_image_map(),
         async_runtime,
         privileged_urls,
-        wake_lock_provider: Box::new(NoOpWakeLockProvider),
+        wake_lock_provider: Box::new(DefaultWakeLockDelegate),
     };
 
     let layout_factory = Arc::new(LayoutFactoryImpl());

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -12,6 +12,7 @@ use embedder_traits::user_contents::UserContentManagerId;
 use embedder_traits::{
     AnimationState, FocusSequenceNumber, JSValue, JavaScriptEvaluationError,
     JavaScriptEvaluationId, MediaSessionEvent, ScriptToEmbedderChan, Theme, ViewportDetails,
+    WakeLockType,
 };
 use encoding_rs::Encoding;
 use euclid::default::Size2D as UntypedSize2D;
@@ -37,7 +38,6 @@ use servo_base::id::{
 use servo_canvas_traits::canvas::{CanvasId, CanvasMsg};
 use servo_canvas_traits::webgl::WebGLChan;
 use servo_url::{ImmutableOrigin, OriginSnapshot, ServoUrl};
-use servo_wakelock::WakeLockType;
 use storage_traits::StorageThreads;
 use storage_traits::webstorage_thread::WebStorageType;
 use strum::IntoStaticStr;

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -1159,7 +1159,7 @@ pub enum WakeLockType {
 ///
 /// Implementations are responsible for interacting with the OS to prevent
 /// the screen (or other resources) from sleeping while a wake lock is held.
-pub trait WakeLockProvider: Send + Sync {
+pub trait WakeLockDelegate: Send + Sync {
     /// Acquire a wake lock of the given type, preventing the associated
     /// resource from sleeping. Called when the aggregate lock count transitions
     /// from 0 to 1. Returns an error if the OS fails to grant the lock.

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -1148,3 +1148,25 @@ impl UrlRequest {
         self
     }
 }
+
+/// The type of wake lock to acquire or release.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum WakeLockType {
+    Screen,
+}
+
+/// Trait for platform-specific wake lock support.
+///
+/// Implementations are responsible for interacting with the OS to prevent
+/// the screen (or other resources) from sleeping while a wake lock is held.
+pub trait WakeLockProvider: Send + Sync {
+    /// Acquire a wake lock of the given type, preventing the associated
+    /// resource from sleeping. Called when the aggregate lock count transitions
+    /// from 0 to 1. Returns an error if the OS fails to grant the lock.
+    fn acquire(&self, type_: WakeLockType) -> Result<(), Box<dyn std::error::Error>>;
+
+    /// Release a previously acquired wake lock of the given type, allowing
+    /// the resource to sleep. Called when the aggregate lock count transitions
+    /// from N to 0.
+    fn release(&self, type_: WakeLockType) -> Result<(), Box<dyn std::error::Error>>;
+}

--- a/components/wakelock/Cargo.toml
+++ b/components/wakelock/Cargo.toml
@@ -14,4 +14,5 @@ name = "servo_wakelock"
 path = "lib.rs"
 
 [dependencies]
+embedder_traits = { workspace = true }
 serde = { workspace = true }

--- a/components/wakelock/lib.rs
+++ b/components/wakelock/lib.rs
@@ -4,21 +4,21 @@
 
 //! Platform abstraction for the Screen Wake Lock API.
 //!
-//! Defines [`WakeLockProvider`], a trait for acquiring and releasing OS-level
+//! Defines [`WakeLockDelegate`], a trait for acquiring and releasing OS-level
 //! wake locks. Platform-specific implementations will be added in follow-up
-//! work. For now, [`NoOpWakeLockProvider`] is the only implementation and
+//! work. For now, [`DefaultWakeLockDelegate`] is the only implementation and
 //! does nothing.
 //!
 //! <https://w3c.github.io/screen-wake-lock/>
 use std::error::Error;
 
-use embedder_traits::{WakeLockProvider, WakeLockType};
+use embedder_traits::{WakeLockDelegate, WakeLockType};
 
-/// A no-op [`WakeLockProvider`] used when no platform implementation is
+/// A no-op [`WakeLockDelegate`] used when no platform implementation is
 /// available. All operations succeed silently.
-pub struct NoOpWakeLockProvider;
+pub struct DefaultWakeLockDelegate;
 
-impl WakeLockProvider for NoOpWakeLockProvider {
+impl WakeLockDelegate for DefaultWakeLockDelegate {
     fn acquire(&self, _type_: WakeLockType) -> Result<(), Box<dyn Error>> {
         Ok(())
     }

--- a/components/wakelock/lib.rs
+++ b/components/wakelock/lib.rs
@@ -12,29 +12,7 @@
 //! <https://w3c.github.io/screen-wake-lock/>
 use std::error::Error;
 
-use serde::{Deserialize, Serialize};
-
-/// The type of wake lock to acquire or release.
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub enum WakeLockType {
-    Screen,
-}
-
-/// Trait for platform-specific wake lock support.
-///
-/// Implementations are responsible for interacting with the OS to prevent
-/// the screen (or other resources) from sleeping while a wake lock is held.
-pub trait WakeLockProvider: Send + Sync {
-    /// Acquire a wake lock of the given type, preventing the associated
-    /// resource from sleeping. Called when the aggregate lock count transitions
-    /// from 0 to 1. Returns an error if the OS fails to grant the lock.
-    fn acquire(&self, type_: WakeLockType) -> Result<(), Box<dyn Error>>;
-
-    /// Release a previously acquired wake lock of the given type, allowing
-    /// the resource to sleep. Called when the aggregate lock count transitions
-    /// from N to 0.
-    fn release(&self, type_: WakeLockType) -> Result<(), Box<dyn Error>>;
-}
+use embedder_traits::{WakeLockProvider, WakeLockType};
 
 /// A no-op [`WakeLockProvider`] used when no platform implementation is
 /// available. All operations succeed silently.


### PR DESCRIPTION
Moved the Wakelock trait from wakelock to embedder_trait [components/shared/embedder/lib.rs](https://github.com/servo/servo/compare/main...rovertrack:servo:issue-44239?expand=1#diff-71d8f825ba6f796e220d49bc548e9a34783586a5a597edc6311a26e31dbf7020)
Added Required dependency in `components/shared/embedder/lib.rs`
imported the Wakelock trait from `components/shared/embedder/lib.rs` to `components/wakelock/lib.rs`
Added dependency `embedder_trait` [components/wakelock/Cargo.toml](https://github.com/servo/servo/compare/main...rovertrack:servo:issue-44239?expand=1#diff-11c410f6e5a491394348dac2f1402d2b29bdc9d2d1320059d12589eb1feb2504)

Testing: All expected test pass as there is no change in flow of working

Fixes: #44239 
