### PR TITLE
webgl: Update stable test expectations to close intermittent issue

### DIFF
--- a/tests/wpt/webgl/meta/conformance2/textures/misc/tex-3d-size-limit.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/misc/tex-3d-size-limit.html.ini
@@ -105,5 +105,20 @@
   [WebGL test #89]
     expected: FAIL
 
-  [WebGL test #77]
+  [WebGL test #36]
+    expected: FAIL
+
+  [WebGL test #37]
+    expected: FAIL
+
+  [WebGL test #39]
+    expected: FAIL
+
+  [WebGL test #40]
+    expected: FAIL
+
+  [WebGL test #41]
+    expected: FAIL
+
+  [WebGL test #44]
     expected: FAIL


### PR DESCRIPTION
Since 5634eab8cc8, tex-3d-size-limit.html is not crashing anymore, and even though I updated the test expectations and the test is consistently passing locally at that commit, it's now failing some tests that should have failed since the beginning (since there's no associated check in the code).

I'm not sure why things seem to work with the previous test expectations update and will follow-up, but in the meanwhile let's update them.

With this, things seem to be pretty good:
```
$ ./mach test-wpt --dev tests/wpt/webgl/tests/conformance2/textures/misc/tex-3d-size-limit.html --repeat 1000 [...]
web-platform-test
~~~~~~~~~~~~~~~~~
Ran 92000 checks (91000 subtests, 1000 tests)
Expected results: 92000
Unexpected results: 0
OK
```

Testing: Test seems to pass consistently with the updated expectations.
Fixes: https://github.com/servo/servo/issues/44280