### PR TITLE
script: Iterate over correct collections when moving

### DIFF
--- a/components/script/dom/execcommand/contenteditable/element.rs
+++ b/components/script/dom/execcommand/contenteditable/element.rs
@@ -6,7 +6,7 @@ use html5ever::{LocalName, local_name};
 use js::context::JSContext;
 use script_bindings::inheritance::Castable;
 use style::attr::AttrValue;
-use style::properties::{LonghandId, PropertyDeclaration, PropertyDeclarationId};
+use style::properties::{LonghandId, PropertyDeclaration, PropertyDeclarationId, ShorthandId};
 use style::values::specified::TextDecorationLine;
 use style::values::specified::box_::DisplayOutside;
 
@@ -257,22 +257,20 @@ impl Element {
         let read_lock = shared_lock.read();
         let style = declarations.read_with(&read_lock);
 
-        if style.len() != 1 {
-            return false;
-        }
-
         // > It is a b or strong element with exactly one attribute, which is style,
         // > and the style attribute sets exactly one CSS property
         // > (including invalid or unrecognized properties), which is "font-weight".
         if matches!(*self.local_name(), local_name!("b") | local_name!("strong")) {
-            return style.contains(PropertyDeclarationId::Longhand(LonghandId::FontWeight));
+            return style.len() == 1 &&
+                style.contains(PropertyDeclarationId::Longhand(LonghandId::FontWeight));
         }
 
         // > It is an i or em element with exactly one attribute, which is style,
         // > and the style attribute sets exactly one CSS property (including invalid or unrecognized properties),
         // > which is "font-style".
         if matches!(*self.local_name(), local_name!("i") | local_name!("em")) {
-            return style.contains(PropertyDeclarationId::Longhand(LonghandId::FontStyle));
+            return style.len() == 1 &&
+                style.contains(PropertyDeclarationId::Longhand(LonghandId::FontStyle));
         }
 
         let a_font_or_span = matches!(
@@ -290,27 +288,35 @@ impl Element {
             local_name!("s") | local_name!("strike") | local_name!("u")
         );
         if a_font_or_span || s_strike_or_u {
-            if let Some((text_decoration, _)) = style.get(PropertyDeclarationId::Longhand(
-                LonghandId::TextDecorationLine,
-            )) {
-                // > It is an a, font, s, span, strike, or u element with exactly one attribute,
-                // > which is style, and the style attribute sets exactly one CSS property
-                // > (including invalid or unrecognized properties), which is "text-decoration",
-                // > which is set to "line-through" or "underline" or "overline" or "none".
-                return matches!(
-                    text_decoration,
-                    PropertyDeclaration::TextDecorationLine(
-                        TextDecorationLine::LINE_THROUGH |
-                            TextDecorationLine::UNDERLINE |
-                            TextDecorationLine::OVERLINE |
-                            TextDecorationLine::NONE
-                    )
-                );
-            } else {
+            // Note that the shorthand "text-decoration" expands to 3 longhands. Hence we check if the length
+            // is 3 here, instead of 1.
+            if style.len() == 3 &&
+                style
+                    .shorthand_to_css(ShorthandId::TextDecoration, &mut String::new())
+                    .is_ok()
+            {
+                if let Some((text_decoration, _)) = style.get(PropertyDeclarationId::Longhand(
+                    LonghandId::TextDecorationLine,
+                )) {
+                    // > It is an a, font, s, span, strike, or u element with exactly one attribute,
+                    // > which is style, and the style attribute sets exactly one CSS property
+                    // > (including invalid or unrecognized properties), which is "text-decoration",
+                    // > which is set to "line-through" or "underline" or "overline" or "none".
+                    return matches!(
+                        text_decoration,
+                        PropertyDeclaration::TextDecorationLine(
+                            TextDecorationLine::LINE_THROUGH |
+                                TextDecorationLine::UNDERLINE |
+                                TextDecorationLine::OVERLINE |
+                                TextDecorationLine::NONE
+                        )
+                    );
+                }
+            } else if a_font_or_span {
                 // > It is an a, font, or span element with exactly one attribute, which is style,
                 // > and the style attribute sets exactly one CSS property (including invalid or unrecognized properties),
                 // > and that property is not "text-decoration".
-                return a_font_or_span;
+                return style.len() == 1;
             }
         }
 

--- a/components/script/dom/execcommand/contenteditable/node.rs
+++ b/components/script/dom/execcommand/contenteditable/node.rs
@@ -600,7 +600,7 @@ where
     let new_parent = new_parent.or_else(|| {
         node_list
             .last()
-            .and_then(|first| first.GetNextSibling())
+            .and_then(|last| last.GetNextSibling())
             .filter(|next_of_last| next_of_last.is_editable() && sibling_criteria(next_of_last))
     });
     // Step 8. Otherwise, run new parent instructions, and let new parent be the result.
@@ -970,7 +970,9 @@ impl Node {
             let has_command_value = command_value.is_some();
             propagated_value = command_value.or(propagated_value);
             // Step 11.4. Let children be the children of current ancestor.
-            let children = current_ancestor_node.children();
+            let children = current_ancestor_node
+                .children()
+                .collect::<Vec<DomRoot<Node>>>();
             // Step 11.5. If the specified command value of current ancestor for command is not null, clear the value of current ancestor.
             if has_command_value {
                 if let Some(html_element) = current_ancestor.downcast::<HTMLElement>() {
@@ -1165,19 +1167,22 @@ impl Node {
             NodeOrString::Node(DomRoot::from_ref(self)),
             NodeOrString::String("span".to_owned()),
         ) {
-            for child in self.children() {
-                // Step 7.1. Let children be all children of node, omitting any that are Elements whose
-                // specified command value for command is neither null nor equivalent to new value.
-                if let Some(child_element) = child.downcast::<Element>() {
-                    let specified_value = child_element.specified_command_value(command);
-                    if specified_value.is_some() &&
-                        !command.are_equivalent_values(specified_value.as_ref(), Some(new_value))
-                    {
-                        continue;
-                    }
-                }
-                // Step 7.2. Force the value of each node in children,
-                // with command and new value as in this invocation of the algorithm.
+            // Step 7.1. Let children be all children of node, omitting any that are Elements whose
+            // specified command value for command is neither null nor equivalent to new value.
+            let children = self
+                .children()
+                .filter(|child| {
+                    !child.downcast::<Element>().is_some_and(|child_element| {
+                        let specified_value = child_element.specified_command_value(command);
+                        specified_value.is_some() &&
+                            !command
+                                .are_equivalent_values(specified_value.as_ref(), Some(new_value))
+                    })
+                })
+                .collect::<Vec<DomRoot<Node>>>();
+            // Step 7.2. Force the value of each node in children,
+            // with command and new value as in this invocation of the algorithm.
+            for child in children {
                 child.force_the_value(cx, command, Some(new_value));
             }
             // Step 7.3. Abort this algorithm.
@@ -1357,19 +1362,23 @@ impl Node {
             new_parent.remove_self(cx);
             // Step 21.3. Let children be all children of node,
             // omitting any that are Elements whose specified command value for command is neither null nor equivalent to new value.
-            for child in self.children() {
-                if child.downcast::<Element>().is_some_and(|child_element| {
-                    let specified_command_value = child_element.specified_command_value(command);
-                    specified_command_value.is_some() &&
-                        !command.are_equivalent_values(
-                            specified_command_value.as_ref(),
-                            Some(new_value),
-                        )
-                }) {
-                    continue;
-                }
-                // Step 21.4. Force the value of each node in children,
-                // with command and new value as in this invocation of the algorithm.
+            let children = self
+                .children()
+                .filter(|child| {
+                    !child.downcast::<Element>().is_some_and(|child_element| {
+                        let specified_command_value =
+                            child_element.specified_command_value(command);
+                        specified_command_value.is_some() &&
+                            !command.are_equivalent_values(
+                                specified_command_value.as_ref(),
+                                Some(new_value),
+                            )
+                    })
+                })
+                .collect::<Vec<DomRoot<Node>>>();
+            // Step 21.4. Force the value of each node in children,
+            // with command and new value as in this invocation of the algorithm.
+            for child in children {
                 child.force_the_value(cx, command, Some(new_value));
             }
         }

--- a/tests/wpt/meta/editing/run/fontsize.html.ini
+++ b/tests/wpt/meta/editing/run/fontsize.html.ini
@@ -106,12 +106,6 @@
   [[["fontsize","4"\]\] "<font size=+1>foo[bar\]baz</font>" queryCommandValue("fontsize") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=4>foo<font size=1>b[a\]r</font>baz</font>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=4>foo<font size=1>b[a\]r</font>baz</font>" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<span style=\\"font-size: xx-small\\">[bar\]</span>baz" compare innerHTML]
     expected: FAIL
 
@@ -151,13 +145,7 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<span style=\\"font-size: large\\">[bar\]</span>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<span style=\\"font-size: large\\">foo<span style=\\"font-size: xx-small\\">b[a\]r</span>baz</span>" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<span style=\\"font-size: large\\">foo<span style=\\"font-size: xx-small\\">b[a\]r</span>baz</span>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<span style=\\"font-size: large\\">foo<span style=\\"font-size: xx-small\\">b[a\]r</span>baz</span>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<span style=\\"font-size: large\\">foo<span style=\\"font-size: xx-small\\">b[a\]r</span>baz</span>" queryCommandValue("fontsize") before]

--- a/tests/wpt/meta/editing/run/underline.html.ini
+++ b/tests/wpt/meta/editing/run/underline.html.ini
@@ -1,7 +1,4 @@
 [underline.html?1-1000]
-  [[["stylewithcss","true"\],["underline",""\]\] "<span>[foo</span> <span>bar\]</span>" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<p>[foo</p><p> <span>bar</span> </p><p>baz\]</p>" compare innerHTML]
     expected: FAIL
 
@@ -12,12 +9,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["underline",""\]\] "<p>[foo<p><br><p>bar\]" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "foo<span style=\\"text-decoration: underline\\">[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "foo<span style=\\"text-decoration: underline\\">[bar\]</span>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<u>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</u>" compare innerHTML]
@@ -91,12 +82,6 @@
 
 
 [underline.html?2001-last]
-  [[["stylewithcss","false"\],["underline",""\]\] "foo<u>[bar\]</u>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["underline",""\]\] "fo[o<span style=text-decoration:underline>b\]ar</span>baz" compare innerHTML]
-    expected: FAIL
-
   [[["underline",""\]\] "fo[o<span style=text-decoration:underline>b\]ar</span>baz" queryCommandIndeterm("underline") before]
     expected: FAIL
 
@@ -159,18 +144,6 @@
   [[["stylewithcss","false"\],["underline",""\]\] "foo<span style=\\"text-decoration: underline line-through\\">b[a\]r</span>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "foo<s style=\\"text-decoration: underline\\">[bar\]</s>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "foo<s style=\\"text-decoration: underline\\">[bar\]</s>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "foo<s style=\\"text-decoration: underline\\">b[a\]r</s>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "foo<s style=\\"text-decoration: underline\\">b[a\]r</s>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "foo<u style=\\"text-decoration: line-through\\">[bar\]</u>baz" compare innerHTML]
     expected: FAIL
 
@@ -201,28 +174,10 @@
   [[["underline",""\]\] "foo<u>ba[r</u>b\]az" queryCommandIndeterm("underline") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "fo[o<u>bar</u>b\]az" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "fo[o<u>bar</u>b\]az" queryCommandIndeterm("underline") before]
     expected: FAIL
 
   [[["stylewithcss","false"\],["underline",""\]\] "fo[o<u>bar</u>b\]az" queryCommandIndeterm("underline") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "foo[<u>b\]ar</u>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "foo[<u>b\]ar</u>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "foo<u>ba[r</u>\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "foo<u>ba[r</u>\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "foo<u>[bar\]</u>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<strike>foo[bar\]baz</strike>" queryCommandState("stylewithcss") before]
@@ -244,4 +199,10 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "foo<u>ba[r</u>\]baz" queryCommandState("underline") after]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["underline",""\]\] "foo<s style=\\"text-decoration: underline\\">b[a\]r</s>baz" queryCommandState("underline") after]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["underline",""\]\] "foo<s style=\\"text-decoration: underline\\">b[a\]r</s>baz" queryCommandState("underline") after]
     expected: FAIL


### PR DESCRIPTION
Several times, we first need to capture the relevant nodes, perform a step and then iterate over the nodes. Previously, we would iterate over it, but the iterator could have moved, hence we would jump over some nodes.

Instead, capture these beforehand and then iterate over them.

Also fixes the issue where text-decoration wasn't properly checked, since its a shorthand for 3 longhands. And a PropertyDeclarationBlock only has longhands.

The two regressions are for tests that now generate the correct HTML, but their ranges are incorrectly moved from the `a` to the `b`. I went through the relevant algorithms and didn't spot the mistake. To keep on making babysteps towards a full implementation, I will tackle these in a follow-up. These algorithms are already difficult enough to reason about.

Part of #25005

Testing: WPT