### PR TITLE
ci: Set `LLVM_OBJDUMP` env-var when compiling libservo with MSRV in linux

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -289,7 +289,6 @@ jobs:
           # lld seems to use less memory and prevents OOM errors during linking.
           # We can remove this after upgrading to Rust 1.90, where lld will be the default.
           RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
-          MOZJS_FROM_SOURCE: "1"
           LLVM_OBJDUMP: llvm-objdump-14
         run: |
           cargo +${{ steps.msrv.outputs.rust_version }} build -p servo --locked

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -289,6 +289,8 @@ jobs:
           # lld seems to use less memory and prevents OOM errors during linking.
           # We can remove this after upgrading to Rust 1.90, where lld will be the default.
           RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
+          MOZJS_FROM_SOURCE: "1"
+          LLVM_OBJDUMP: llvm-objdump-14
         run: |
           cargo +${{ steps.msrv.outputs.rust_version }} build -p servo --locked
 


### PR DESCRIPTION
[Sometimes](https://github.com/servo/servo/actions/runs/24611835766/job/71967504931#step:10:1076), CI fails to link pre-built archive, and have to build from source. Previously this always fail as llvm-objdump is not found.

Testing: Successful [try run](https://github.com/yezhizhen/servo/actions/runs/24626909297) when building from source.
Fixes: #44351
