### PR TITLE
devtools: Implement blackboxing on breakpoints

### DIFF
--- a/components/default-resources/resources/debugger.js
+++ b/components/default-resources/resources/debugger.js
@@ -7,7 +7,9 @@ const debuggeesToPipelineIds = new Map;
 const debuggeesToWorkerIds = new Map;
 const sourceIdsToScripts = new Map;
 const frameActorsToFrames = new Map;
+const environmentActorsToEnvironments = new Map;
 const environmentsToEnvironmentActors = new Map;
+const blackboxing = new Map;
 let suspendedFrame = null;
 let lastPauseLocation = null;
 
@@ -357,6 +359,11 @@ function handlePauseAndRespond(frame, pauseReason) {
     };
     lastPauseLocation = { line: offsetMetadata.lineNumber, column: offsetMetadata.columnNumber };
 
+    const source = frame.script.source;
+    if (source != null && isBlackBoxed(source.id, frameOffset.line, frameOffset.column)) {
+        return undefined;
+    }
+
     // Notify devtools and enter pause loop. This blocks until Resume.
     pauseAndRespond(
         pipelineId,
@@ -623,3 +630,68 @@ addEventListener("getEnvironment", event => {
     const actor = createEnvironmentActor(frame.environment);
     getEnvironmentResult(actor);
 });
+
+addEventListener("blackbox", event => {
+    if (event.coversFullSource) {
+        // Blackbox the entire source
+        blackboxing.set(event.spidermonkeyId, []);
+    } else {
+        // Blackbox only a part of the source
+        let blackbox = blackboxing.get(event.spidermonkeyId);
+        if (blackbox == undefined) {
+            blackbox = [];
+        }
+
+        blackbox.push({
+            start: event.start(),
+            end: event.end()
+        });
+
+        blackboxing.set(event.spidermonkeyId, blackbox);
+    }
+});
+
+addEventListener("unblackbox", event => {
+    if (event.coversFullSource) {
+        // Unblackbox the entire source
+        blackboxing.delete(event.spidermonkeyId);
+    } else {
+        // Unblackbox an earlier range of the source
+        const array = blackboxing.get(event.spidermonkeyId);
+
+        const start = event.start();
+        const end = event.end();
+        const index = array.findIndex(range => range.start.line === start.line
+                && range.start.column === start.column
+                && range.end.line === end.line
+                && range.end.column === end.column
+        );
+        if (index !== -1) {
+            array.splice(index, 1);
+
+            // Empty arrays represent a fully blackboxed file
+            // Therefore, if we just made the array empty we will need to remove it from the map
+            if (array.length === 0) {
+                blackboxing.delete(event.spidermonkeyId);
+            }
+        }
+    }
+});
+
+function isBlackBoxed(spidermonkeyId, line, column) {
+    const sourceBlackboxing = blackboxing.get(spidermonkeyId);
+
+    if (sourceBlackboxing == undefined) {
+        return false;
+    } else if (sourceBlackboxing.length === 0) {
+        // An empty array represents a fully ignored source
+        return true;
+    }
+
+    for (const range of sourceBlackboxing) {
+        return (range.start.line < line || (range.start.line === line && range.start.column <= column))
+                && (range.end.line > line || (range.end.line === line && range.end.column >= column))
+    }
+
+    return false;
+}

--- a/components/devtools/actors/blackboxing.rs
+++ b/components/devtools/actors/blackboxing.rs
@@ -2,26 +2,105 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use devtools_traits::{BlackboxCoverage, DevtoolScriptControlMsg};
 use malloc_size_of_derive::MallocSizeOf;
+use serde::Deserialize;
 
-use crate::ActorMsg;
-use crate::actor::{Actor, ActorEncode, ActorRegistry};
+use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
+use crate::actors::browsing_context::BrowsingContextActor;
+use crate::actors::thread::ThreadActor;
+use crate::{ActorMsg, EmptyReplyMsg};
+
+/// Used for both 'blackbox' and 'unblackbox' requests
+#[derive(Deserialize)]
+struct BlackboxRequest {
+    range: Vec<BlackboxRange>,
+    url: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct BlackboxRange {
+    start: BlackboxSourceLocation,
+    end: BlackboxSourceLocation,
+}
+
+#[derive(Deserialize, Debug)]
+struct BlackboxSourceLocation {
+    line: u32,
+    column: u32,
+}
 
 #[derive(MallocSizeOf)]
 pub(crate) struct BlackboxingActor {
     name: String,
+    browsing_context_name: String,
 }
 
 impl Actor for BlackboxingActor {
     fn name(&self) -> String {
         self.name.clone()
     }
+
+    fn handle_message(
+        &self,
+        request: crate::protocol::ClientRequest,
+        registry: &ActorRegistry,
+        msg_type: &str,
+        msg: &serde_json::Map<String, serde_json::Value>,
+        _: crate::StreamId,
+    ) -> Result<(), crate::actor::ActorError> {
+        if msg_type != "blackbox" && msg_type != "unblackbox" {
+            return Err(ActorError::UnrecognizedPacketType);
+        }
+
+        let blackbox_request: BlackboxRequest =
+            serde_json::from_value(msg.clone().into()).map_err(|_| ActorError::Internal)?;
+
+        let coverage = match &blackbox_request.range[..] {
+            [] => BlackboxCoverage::Full,
+            [range] => BlackboxCoverage::Partial(
+                (range.start.line, range.start.column),
+                (range.end.line, range.end.column),
+            ),
+            _ => {
+                log::warn!(
+                    "Expected 0 or 1 range elements, got {:?}",
+                    blackbox_request.range
+                );
+                return Err(ActorError::Internal);
+            },
+        };
+
+        let browsing_context_actor =
+            registry.find::<BrowsingContextActor>(&self.browsing_context_name);
+        let thread_actor = registry.find::<ThreadActor>(&browsing_context_actor.thread_name);
+        let source = thread_actor
+            .source_manager
+            .find_source(registry, &blackbox_request.url)
+            .ok_or(ActorError::Internal)?;
+
+        let control_msg = match msg_type {
+            "blackbox" => DevtoolScriptControlMsg::Blackbox(source.spidermonkey_id, coverage),
+            "unblackbox" => DevtoolScriptControlMsg::Unblackbox(source.spidermonkey_id, coverage),
+            _ => unreachable!(),
+        };
+        source
+            .script_sender
+            .send(control_msg)
+            .map_err(|_| ActorError::Internal)?;
+
+        request.reply_final(&EmptyReplyMsg { from: self.name() })?;
+        Ok(())
+    }
 }
 
 impl BlackboxingActor {
-    pub fn register(registry: &ActorRegistry) -> String {
+    pub fn register(registry: &ActorRegistry, browsing_context_name: String) -> String {
         let name = registry.new_name::<Self>();
-        let actor = Self { name: name.clone() };
+        let actor = Self {
+            name: name.clone(),
+            browsing_context_name,
+        };
         registry.register::<Self>(actor);
         name
     }

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -477,7 +477,7 @@ impl WatcherActor {
         let thread_configuration_name = ThreadConfigurationActor::register(registry);
         let breakpoint_list_name =
             BreakpointListActor::register(registry, browsing_context_name.clone());
-        let blackboxing_name = BlackboxingActor::register(registry);
+        let blackboxing_name = BlackboxingActor::register(registry, browsing_context_name.clone());
 
         let name = registry.new_name::<Self>();
         let actor = Self {

--- a/components/script/dom/debugger/debuggerblackboxevent.rs
+++ b/components/script/dom/debugger/debuggerblackboxevent.rs
@@ -1,0 +1,94 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use devtools_traits::BlackboxCoverage;
+use devtools_traits::BlackboxCoverage::{Full, Partial};
+use dom_struct::dom_struct;
+use script_bindings::codegen::GenericBindings::DebuggerBlackboxEventBinding::DebuggerBlackboxEventMethods;
+use script_bindings::reflector::reflect_dom_object;
+
+use crate::dom::bindings::codegen::Bindings::DebuggerGlobalScopeBinding::DebuggerSourceLocation;
+use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::event::Event;
+use crate::dom::types::GlobalScope;
+use crate::script_runtime::CanGc;
+
+#[dom_struct]
+/// Event for Rust → JS calls in [`crate::dom::debugger::DebuggerGlobalScope`].
+pub(crate) struct DebuggerBlackboxEvent {
+    event: Event,
+    spidermonkey_id: u32,
+    covers_full_source: bool,
+
+    // Only relevant if covers_full_source is false
+    start_line: u32,
+    start_column: u32,
+    end_line: u32,
+    end_column: u32,
+}
+
+impl DebuggerBlackboxEvent {
+    pub(crate) fn new(
+        debugger_global: &GlobalScope,
+        spidermonkey_id: u32,
+        coverage: BlackboxCoverage,
+        can_gc: CanGc,
+    ) -> DomRoot<Self> {
+        let result = Box::new(match coverage {
+            Partial((start_line, start_column), (end_line, end_column)) => Self {
+                event: Event::new_inherited(),
+                spidermonkey_id,
+                covers_full_source: false,
+                start_line,
+                start_column,
+                end_line,
+                end_column,
+            },
+            Full => Self {
+                event: Event::new_inherited(),
+                spidermonkey_id,
+                covers_full_source: true,
+                start_line: 0,
+                start_column: 0,
+                end_line: 0,
+                end_column: 0,
+            },
+        });
+
+        let result = reflect_dom_object(result, debugger_global, can_gc);
+        result.event.init_event("blackbox".into(), false, false);
+
+        result
+    }
+}
+
+impl DebuggerBlackboxEventMethods<crate::DomTypeHolder> for DebuggerBlackboxEvent {
+    // check-tidy: no specs after this line
+    fn SpidermonkeyId(&self) -> u32 {
+        self.spidermonkey_id
+    }
+
+    fn CoversFullSource(&self) -> bool {
+        self.covers_full_source
+    }
+
+    fn Start(&self) -> DebuggerSourceLocation {
+        DebuggerSourceLocation {
+            line: self.start_line,
+            column: self.start_column,
+        }
+    }
+
+    fn End(&self) -> DebuggerSourceLocation {
+        DebuggerSourceLocation {
+            line: self.end_line,
+            column: self.end_column,
+        }
+    }
+
+    fn IsTrusted(&self) -> bool {
+        self.event.IsTrusted()
+    }
+}

--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -5,7 +5,8 @@
 use std::cell::RefCell;
 
 use devtools_traits::{
-    DevtoolScriptControlMsg, EvaluateJSReply, ScriptToDevtoolsControlMsg, SourceInfo, WorkerId,
+    BlackboxCoverage, DevtoolScriptControlMsg, EvaluateJSReply, ScriptToDevtoolsControlMsg,
+    SourceInfo, WorkerId,
 };
 use dom_struct::dom_struct;
 use embedder_traits::ScriptToEmbedderChan;
@@ -26,7 +27,7 @@ use crate::dom::bindings::codegen::Bindings::DebuggerEvalEventBinding::GenericBi
 use crate::dom::bindings::codegen::Bindings::DebuggerGetEnvironmentEventBinding::{
     EnvironmentInfo, EnvironmentVariable,
 };
-use crate::dom::bindings::codegen::Bindings::DebuggerGlobalScopeBinding;
+use crate::dom::bindings::codegen::Bindings::DebuggerGlobalScopeBinding::{self};
 use crate::dom::bindings::codegen::Bindings::DebuggerInterruptEventBinding::{
     FrameInfo, FrameOffset, PauseReason,
 };
@@ -41,12 +42,14 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::utils::define_all_exposed_interfaces;
+use crate::dom::debugger::debuggerblackboxevent::DebuggerBlackboxEvent;
 use crate::dom::debugger::debuggerclearbreakpointevent::DebuggerClearBreakpointEvent;
 use crate::dom::debugger::debuggerframeevent::DebuggerFrameEvent;
 use crate::dom::debugger::debuggergetenvironmentevent::DebuggerGetEnvironmentEvent;
 use crate::dom::debugger::debuggerinterruptevent::DebuggerInterruptEvent;
 use crate::dom::debugger::debuggerresumeevent::DebuggerResumeEvent;
 use crate::dom::debugger::debuggersetbreakpointevent::DebuggerSetBreakpointEvent;
+use crate::dom::debugger::debuggerunblackboxevent::DebuggerUnblackboxEvent;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::types::{
     DebuggerAddDebuggeeEvent, DebuggerEvalEvent, DebuggerGetPossibleBreakpointsEvent, Event,
@@ -357,6 +360,42 @@ impl DebuggerGlobalScope {
         assert!(
             event.fire(cx, self.upcast()),
             "Guaranteed by DebuggerClearBreakpointEvent::new"
+        );
+    }
+
+    pub(crate) fn fire_blackbox(
+        &self,
+        cx: &mut JSContext,
+        spidermonkey_id: u32,
+        coverage: BlackboxCoverage,
+    ) {
+        let event = DomRoot::upcast::<Event>(DebuggerBlackboxEvent::new(
+            self.upcast(),
+            spidermonkey_id,
+            coverage,
+            CanGc::from_cx(cx),
+        ));
+        assert!(
+            event.fire(cx, self.upcast()),
+            "Guaranteed by DebuggerBlackboxEvent::new"
+        );
+    }
+
+    pub(crate) fn fire_unblackbox(
+        &self,
+        cx: &mut JSContext,
+        spidermonkey_id: u32,
+        coverage: BlackboxCoverage,
+    ) {
+        let event = DomRoot::upcast::<Event>(DebuggerUnblackboxEvent::new(
+            self.upcast(),
+            spidermonkey_id,
+            coverage,
+            CanGc::from_cx(cx),
+        ));
+        assert!(
+            event.fire(cx, self.upcast()),
+            "Guaranteed by DebuggerUnblackboxEvent::new"
         );
     }
 }

--- a/components/script/dom/debugger/debuggerunblackboxevent.rs
+++ b/components/script/dom/debugger/debuggerunblackboxevent.rs
@@ -1,0 +1,94 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use devtools_traits::BlackboxCoverage;
+use devtools_traits::BlackboxCoverage::{Full, Partial};
+use dom_struct::dom_struct;
+use script_bindings::codegen::GenericBindings::DebuggerUnblackboxEventBinding::DebuggerUnblackboxEventMethods;
+use script_bindings::reflector::reflect_dom_object;
+
+use crate::dom::bindings::codegen::Bindings::DebuggerGlobalScopeBinding::DebuggerSourceLocation;
+use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::event::Event;
+use crate::dom::types::GlobalScope;
+use crate::script_runtime::CanGc;
+
+#[dom_struct]
+/// Event for Rust → JS calls in [`crate::dom::debugger::DebuggerGlobalScope`].
+pub(crate) struct DebuggerUnblackboxEvent {
+    event: Event,
+    spidermonkey_id: u32,
+    covers_full_source: bool,
+
+    // Only relevant if covers_full_source is false
+    start_line: u32,
+    start_column: u32,
+    end_line: u32,
+    end_column: u32,
+}
+
+impl DebuggerUnblackboxEvent {
+    pub(crate) fn new(
+        debugger_global: &GlobalScope,
+        spidermonkey_id: u32,
+        coverage: BlackboxCoverage,
+        can_gc: CanGc,
+    ) -> DomRoot<Self> {
+        let result = Box::new(match coverage {
+            Partial((start_line, start_column), (end_line, end_column)) => Self {
+                event: Event::new_inherited(),
+                spidermonkey_id,
+                covers_full_source: false,
+                start_line,
+                start_column,
+                end_line,
+                end_column,
+            },
+            Full => Self {
+                event: Event::new_inherited(),
+                spidermonkey_id,
+                covers_full_source: true,
+                start_line: 0,
+                start_column: 0,
+                end_line: 0,
+                end_column: 0,
+            },
+        });
+
+        let result = reflect_dom_object(result, debugger_global, can_gc);
+        result.event.init_event("unblackbox".into(), false, false);
+
+        result
+    }
+}
+
+impl DebuggerUnblackboxEventMethods<crate::DomTypeHolder> for DebuggerUnblackboxEvent {
+    // check-tidy: no specs after this line
+    fn SpidermonkeyId(&self) -> u32 {
+        self.spidermonkey_id
+    }
+
+    fn CoversFullSource(&self) -> bool {
+        self.covers_full_source
+    }
+
+    fn Start(&self) -> DebuggerSourceLocation {
+        DebuggerSourceLocation {
+            line: self.start_line,
+            column: self.start_column,
+        }
+    }
+
+    fn End(&self) -> DebuggerSourceLocation {
+        DebuggerSourceLocation {
+            line: self.end_line,
+            column: self.end_column,
+        }
+    }
+
+    fn IsTrusted(&self) -> bool {
+        self.event.IsTrusted()
+    }
+}

--- a/components/script/dom/debugger/mod.rs
+++ b/components/script/dom/debugger/mod.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 pub(crate) mod debuggeradddebuggeeevent;
+pub(crate) mod debuggerblackboxevent;
 pub(crate) mod debuggerclearbreakpointevent;
 pub(crate) mod debuggerevalevent;
 pub(crate) mod debuggerframeevent;
@@ -12,3 +13,4 @@ pub(crate) mod debuggerglobalscope;
 pub(crate) mod debuggerinterruptevent;
 pub(crate) mod debuggerresumeevent;
 pub(crate) mod debuggersetbreakpointevent;
+pub(crate) mod debuggerunblackboxevent;

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2305,6 +2305,14 @@ impl ScriptThread {
                     .fire_resume(cx, resume_limit_type, frame_actor_id);
                 self.debugger_paused.set(false);
             },
+            DevtoolScriptControlMsg::Blackbox(spidermonkey_id, coverage) => {
+                self.debugger_global
+                    .fire_blackbox(cx, spidermonkey_id, coverage);
+            },
+            DevtoolScriptControlMsg::Unblackbox(spidermonkey_id, coverage) => {
+                self.debugger_global
+                    .fire_unblackbox(cx, spidermonkey_id, coverage);
+            },
         }
     }
 

--- a/components/script_bindings/webidls/DebuggerBlackboxEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerBlackboxEvent.webidl
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// This interface is entirely internal to Servo, and should not be accessible to
+// web pages.
+[Exposed=DebuggerGlobalScope]
+interface DebuggerBlackboxEvent : Event {
+    readonly attribute unsigned long spidermonkeyId;
+    readonly attribute boolean coversFullSource;
+};
+
+partial interface DebuggerBlackboxEvent {
+    DebuggerSourceLocation start();
+    DebuggerSourceLocation end();
+};

--- a/components/script_bindings/webidls/DebuggerGlobalScope.webidl
+++ b/components/script_bindings/webidls/DebuggerGlobalScope.webidl
@@ -23,3 +23,8 @@ dictionary PipelineIdInit {
     required unsigned long namespaceId;
     required unsigned long index;
 };
+
+dictionary DebuggerSourceLocation {
+    required unsigned long line;
+    required unsigned long column;
+};

--- a/components/script_bindings/webidls/DebuggerUnblackboxEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerUnblackboxEvent.webidl
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// This interface is entirely internal to Servo, and should not be accessible to
+// web pages.
+[Exposed=DebuggerGlobalScope]
+interface DebuggerUnblackboxEvent : Event {
+    readonly attribute unsigned long spidermonkeyId;
+    readonly attribute boolean coversFullSource;
+};
+
+partial interface DebuggerUnblackboxEvent {
+    DebuggerSourceLocation start();
+    DebuggerSourceLocation end();
+};

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -417,6 +417,14 @@ pub enum DevtoolScriptControlMsg {
     Resume(Option<String>, Option<String>),
     ListFrames(PipelineId, u32, u32, GenericSender<Vec<String>>),
     GetEnvironment(String, GenericSender<String>),
+    Blackbox(u32, BlackboxCoverage),
+    Unblackbox(u32, BlackboxCoverage),
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub enum BlackboxCoverage {
+    Full,
+    Partial((u32, u32), (u32, u32)),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, MallocSizeOf)]

--- a/python/servo/devtools_tests.py
+++ b/python/servo/devtools_tests.py
@@ -118,6 +118,23 @@ def resume_and_wait(client, thread_actor, timeout=3):
     return future.result(timeout)
 
 
+# Wait for a given number of seconds and assert that no pause happens after calling the trigger
+def wait_and_assert_no_pause(client, thread_actor, trigger, duration):
+    future = Future()
+
+    def on_paused(data):
+        future.set_result(data)
+
+    client.add_event_listener(thread_actor, "paused", on_paused)
+    trigger()
+
+    try:
+        data = future.result(duration)
+        raise AssertionError(f"Received unexpected pause: {data}")
+    except TimeoutError:
+        pass
+
+
 @dataclass
 class Devtools:
     client: RDPClient
@@ -1339,6 +1356,120 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
             )
             style_text = reply["text"]["initial"]
             self.assertIn("body { background: green; font-size: small; }", style_text)
+
+    def test_blackboxing_prevents_breakpoint_pause(self):
+        url = f"{self.base_urls[0]}/debugger/loop.html"
+        self.run_servoshell(url=url)
+        with Devtools.connect() as devtools:
+            thread_actor = attach_thread(devtools)
+            source_actor = wait_for_source(devtools, "debugger/loop.html")
+
+            # Get valid breakpoint position
+            positions = devtools.client.send_receive(
+                {"to": source_actor, "type": "getBreakpointPositionsCompressed"}
+            ).get("positions", {})
+            line_str = min(positions.keys(), key=int)
+            line, column = int(line_str), positions[line_str][0]
+
+            # Blackbox the entire source
+            blackboxing_actor = devtools.watcher.get_blackboxing_actor()["blackboxing"]["actor"]
+            devtools.client.send_receive({"to": blackboxing_actor, "type": "blackbox", "range": [], "url": url})
+
+            # Set a breakpoint and confirm that we will not pause
+            def trigger():
+                set_breakpoint(devtools, url, line, column)
+
+            wait_and_assert_no_pause(devtools.client, thread_actor, trigger, duration=1)
+
+    def test_blackboxing_prevents_breakpoint_pause_single_line(self):
+        url = f"{self.base_urls[0]}/debugger/loop.html"
+        self.run_servoshell(url=url)
+        with Devtools.connect() as devtools:
+            thread_actor = attach_thread(devtools)
+            source_actor = wait_for_source(devtools, "debugger/loop.html")
+
+            # Get valid breakpoint position
+            positions = devtools.client.send_receive(
+                {"to": source_actor, "type": "getBreakpointPositionsCompressed"}
+            ).get("positions", {})
+            line_str = min(positions.keys(), key=int)
+            line, column = int(line_str), positions[line_str][0]
+
+            # Blackbox line 4
+            blackboxing_actor = devtools.watcher.get_blackboxing_actor()["blackboxing"]["actor"]
+            devtools.client.send_receive(
+                {
+                    "to": blackboxing_actor,
+                    "type": "blackbox",
+                    "range": [{"start": {"line": 4, "column": 0}, "end": {"line": 4, "column": 15}}],
+                    "url": url,
+                }
+            )
+
+            # Set a breakpoint and confirm that we will not pause
+            def trigger():
+                set_breakpoint(devtools, url, line, column)
+
+            wait_and_assert_no_pause(devtools.client, thread_actor, trigger, duration=1)
+
+    def test_blackboxing_prevents_breakpoint_pause_multiline(self):
+        url = f"{self.base_urls[0]}/debugger/loop.html"
+        self.run_servoshell(url=url)
+        with Devtools.connect() as devtools:
+            thread_actor = attach_thread(devtools)
+            source_actor = wait_for_source(devtools, "debugger/loop.html")
+
+            # Get valid breakpoint position
+            positions = devtools.client.send_receive(
+                {"to": source_actor, "type": "getBreakpointPositionsCompressed"}
+            ).get("positions", {})
+            line_str = min(positions.keys(), key=int)
+            line, column = int(line_str), positions[line_str][0]
+
+            # Blackbox line 4
+            blackboxing_actor = devtools.watcher.get_blackboxing_actor()["blackboxing"]["actor"]
+            devtools.client.send_receive(
+                {
+                    "to": blackboxing_actor,
+                    "type": "blackbox",
+                    "range": [{"start": {"line": 4, "column": 8}, "end": {"line": 5, "column": 30}}],
+                    "url": url,
+                }
+            )
+
+            # Set a breakpoint and confirm that we will not pause
+            def trigger():
+                set_breakpoint(devtools, url, line, column)
+
+            wait_and_assert_no_pause(devtools.client, thread_actor, trigger, duration=1)
+
+    def test_unblackboxing_partial(self):
+        url = f"{self.base_urls[0]}/debugger/loop.html"
+        self.run_servoshell(url=url)
+        with Devtools.connect() as devtools:
+            thread_actor = attach_thread(devtools)
+            source_actor = wait_for_source(devtools, "debugger/loop.html")
+
+            # Get valid breakpoint position
+            positions = devtools.client.send_receive(
+                {"to": source_actor, "type": "getBreakpointPositionsCompressed"}
+            ).get("positions", {})
+            line_str = min(positions.keys(), key=int)
+            line, column = int(line_str), positions[line_str][0]
+
+            # Blackbox line 4
+            blackboxing_actor = devtools.watcher.get_blackboxing_actor()["blackboxing"]["actor"]
+            range = [{"start": {"line": 4, "column": 0}, "end": {"line": 5, "column": 15}}]
+            devtools.client.send_receive({"to": blackboxing_actor, "type": "blackbox", "range": range, "url": url})
+
+            # Then unblackbox it
+            devtools.client.send_receive({"to": blackboxing_actor, "type": "unblackbox", "range": range, "url": url})
+
+            # Set a breakpoint and confirm that we still pause
+            def trigger():
+                set_breakpoint(devtools, f"{self.base_urls[0]}/debugger/loop.html", line, column)
+
+            wait_for_pause(devtools.client, thread_actor, trigger)
 
     # Sets `base_url` and `web_server` and `web_server_thread`.
     @classmethod


### PR DESCRIPTION
This pull request implements support for blackboxing and unblackboxing sources in devtools. In Firefox's client, this is called "ignore" and "unignore" source.

In Firefox <153 there is a bug that causes firefox to send ranges of 0 character length when a whole line is ignored. This works in Firefox because of a bad location check. This PR introduces a correct location check compared to what Firefox used.
For more context, see: https://bugzilla.mozilla.org/show_bug.cgi?id=2036767

Only blackboxing as it relates to breakpoints is within scope of this PR. It is very possible that this code might work for other types of pauses

Testing: Added 4 new Python test cases for blackboxing and unblackboxing sources against breakpoint pauses
Fixes: Part of https://github.com/servo/servo/issues/36027
