### PR TITLE
paint: Add long-press touch context menu

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1597,6 +1597,9 @@ where
             EmbedderToConstellationMessage::SetAccessibilityActive(webview_id, active) => {
                 self.set_accessibility_active(webview_id, active);
             },
+            EmbedderToConstellationMessage::ShowContextMenu(webview_id, event, hit_test) => {
+                self.show_context_menu(webview_id, event, hit_test);
+            },
         }
     }
 
@@ -3205,6 +3208,38 @@ where
             pipeline_id,
             ScriptThreadMessage::SetAccessibilityActive(pipeline_id, active, epoch),
             "Set accessibility active after closure",
+        );
+    }
+
+    fn show_context_menu(
+        &mut self,
+        webview_id: WebViewId,
+        event: InputEventAndId,
+        hit_test_result: PaintHitTestResult,
+    ) {
+        // Get the web view using its ID.
+        let Some(webview) = self.webviews.get_mut(&webview_id) else {
+            warn!("Got context menu event for unknown WebViewId: {webview_id:?}");
+            return;
+        };
+
+        // Get webview's pipeline ID.
+        let Some(pipeline_id) = webview.active_top_level_pipeline_id else {
+            return;
+        };
+
+        // Construct event without any mouse or keyboard modifiers.
+        let constellation_event = ConstellationInputEvent {
+            event,
+            hit_test_result: Some(hit_test_result),
+            active_keyboard_modifiers: Default::default(),
+            pressed_mouse_buttons: Default::default(),
+        };
+
+        self.send_message_to_pipeline(
+            pipeline_id,
+            ScriptThreadMessage::ShowContextMenu(pipeline_id, constellation_event),
+            "Show contet menu after closure",
         );
     }
 

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -84,6 +84,7 @@ mod from_embedder {
                 Self::UserContentManagerAction(..) => target!("UserContentManagerAction"),
                 Self::UpdatePinchZoomInfos(..) => target!("UpdatePinchZoomInfos"),
                 Self::SetAccessibilityActive(..) => target!("SetAccessibilityActive"),
+                Self::ShowContextMenu(..) => target!("ShowContextMenu"),
             }
         }
     }

--- a/components/paint/lib.rs
+++ b/components/paint/lib.rs
@@ -29,6 +29,7 @@ mod pipeline_details;
 mod refresh_driver;
 mod render_notifier;
 mod screenshot;
+mod timer;
 mod touch;
 mod web_content_animation;
 mod webrender_external_images;

--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -60,6 +60,7 @@ use crate::paint::{RepaintReason, WebRenderDebugOption};
 use crate::refresh_driver::{AnimationRefreshDriverObserver, BaseRefreshDriver};
 use crate::render_notifier::RenderNotifier;
 use crate::screenshot::ScreenshotTaker;
+use crate::timer::TimerDriver;
 use crate::web_content_animation::WebContentAnimator;
 use crate::webrender_external_images::WebGLExternalImages;
 use crate::webview_renderer::{PinchZoomResult, ScrollResult, UnknownWebView, WebViewRenderer};
@@ -91,6 +92,9 @@ pub(crate) struct Painter {
 
     /// The [`BaseRefreshDriver`] which manages the painting of `WebView`s during animations.
     refresh_driver: Rc<BaseRefreshDriver>,
+
+    /// Thread for scheduling timer-based callbacks.
+    timer_driver: Rc<TimerDriver>,
 
     /// A [`RefreshDriverObserver`] for WebView content animations.
     animation_refresh_driver_observer: Rc<AnimationRefreshDriverObserver>,
@@ -180,11 +184,11 @@ impl Painter {
         WindowGLContext::initialize_image_handler(&mut external_image_handlers);
 
         let embedder_to_constellation_sender = paint.embedder_to_constellation_sender.clone();
-        let timer_refresh_driver = LazyCell::default();
+        let timer_driver = LazyCell::default();
         let refresh_driver = Rc::new(BaseRefreshDriver::new(
             paint.event_loop_waker.clone_box(),
             rendering_context.refresh_driver(),
-            &timer_refresh_driver,
+            &timer_driver,
         ));
         let animation_refresh_driver_observer = Rc::new(AnimationRefreshDriverObserver::new(
             embedder_to_constellation_sender.clone(),
@@ -262,7 +266,12 @@ impl Painter {
         let gl_version = webrender_gl.get_string(gleam::gl::VERSION);
         info!("Running on {gl_renderer} with OpenGL version {gl_version}");
 
+        let timer_driver = (*timer_driver).clone();
+        let web_content_animator =
+            WebContentAnimator::new(paint.event_loop_waker.clone_box(), timer_driver.clone());
+
         let painter = Painter {
+            timer_driver,
             painter_id,
             embedder_to_constellation_sender,
             webview_renderers: Default::default(),
@@ -280,10 +289,7 @@ impl Painter {
             frame_delayer: Default::default(),
             lcp_calculator: LargestContentfulPaintCalculator::new(),
             animation_image_cache: FxHashMap::default(),
-            web_content_animator: WebContentAnimator::new(
-                paint.event_loop_waker.clone_box(),
-                (*timer_refresh_driver).clone(),
-            ),
+            web_content_animator,
         };
         painter.assert_gl_framebuffer_complete();
         painter.clear_background();
@@ -1219,6 +1225,7 @@ impl Painter {
                 viewport_details,
                 self.embedder_to_constellation_sender.clone(),
                 self.refresh_driver.clone(),
+                self.timer_driver.clone(),
                 self.webrender_document,
             ));
     }

--- a/components/paint/refresh_driver.rs
+++ b/components/paint/refresh_driver.rs
@@ -6,16 +6,14 @@ use std::cell::{Cell, LazyCell, RefCell};
 use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::thread::{self, JoinHandle};
-use std::time::Duration;
 
-use crossbeam_channel::{Sender, select};
+use crossbeam_channel::Sender;
 use embedder_traits::{EventLoopWaker, RefreshDriver};
 use log::warn;
 use servo_constellation_traits::EmbedderToConstellationMessage;
-use timers::{BoxedTimerCallback, TimerEventRequest, TimerScheduler};
 
 use crate::painter::Painter;
+use crate::timer::TimerDriver;
 use crate::webview_renderer::WebViewRenderer;
 
 /// The [`BaseRefreshDriver`] is a "base class" for [`RefreshDriver`] trait
@@ -40,9 +38,9 @@ impl BaseRefreshDriver {
     pub(crate) fn new(
         event_loop_waker: Box<dyn EventLoopWaker>,
         refresh_driver: Option<Rc<dyn RefreshDriver>>,
-        timer_refresh_driver: &LazyCell<Rc<TimerRefreshDriver>>,
+        timer_driver: &LazyCell<Rc<TimerDriver>>,
     ) -> Self {
-        let refresh_driver = refresh_driver.unwrap_or_else(|| (**timer_refresh_driver).clone());
+        let refresh_driver = refresh_driver.unwrap_or_else(|| (**timer_driver).clone());
         Self {
             waiting_for_frame: Arc::new(AtomicBool::new(false)),
             event_loop_waker,
@@ -177,83 +175,5 @@ impl RefreshDriverObserver for AnimationRefreshDriverObserver {
 
         self.animating.set(true);
         true
-    }
-}
-
-enum TimerThreadMessage {
-    Request(TimerEventRequest),
-    Quit,
-}
-
-/// A thread that manages a [`TimerScheduler`] running in the background of the
-/// [`RefreshDriver`]. This is necessary because we need a reliable way of waking up the
-/// embedder's main thread, which may just be sleeping until the `EventLoopWaker` asks it
-/// to wake up.
-///
-/// It would be nice to integrate this somehow into the embedder thread, but it would
-/// require both some communication with the embedder and for all embedders to be well
-/// behave respecting wakeup timeouts -- a bit too much to ask at the moment.
-pub(crate) struct TimerRefreshDriver {
-    sender: Sender<TimerThreadMessage>,
-    join_handle: Option<JoinHandle<()>>,
-}
-
-impl Default for TimerRefreshDriver {
-    fn default() -> Self {
-        let (sender, receiver) = crossbeam_channel::unbounded::<TimerThreadMessage>();
-        let join_handle = thread::Builder::new()
-            .name(String::from("PaintTimerThread"))
-            .spawn(move || {
-                let mut scheduler = TimerScheduler::default();
-
-                loop {
-                    select! {
-                        recv(receiver) -> message => {
-                            match message {
-                                Ok(TimerThreadMessage::Request(request)) => {
-                                    scheduler.schedule_timer(request);
-                                },
-                                _ => return,
-                            }
-                        },
-                        recv(scheduler.wait_channel()) -> _message => {
-                            scheduler.dispatch_completed_timers();
-                        },
-                    };
-                }
-            })
-            .expect("Could not create RefreshDriver timer thread.");
-
-        Self {
-            sender,
-            join_handle: Some(join_handle),
-        }
-    }
-}
-
-impl TimerRefreshDriver {
-    pub(crate) fn queue_timer(&self, duration: Duration, callback: BoxedTimerCallback) {
-        let _ = self
-            .sender
-            .send(TimerThreadMessage::Request(TimerEventRequest {
-                callback,
-                duration,
-            }));
-    }
-}
-
-impl RefreshDriver for TimerRefreshDriver {
-    fn observe_next_frame(&self, new_start_frame_callback: Box<dyn Fn() + Send + 'static>) {
-        const FRAME_DURATION: Duration = Duration::from_millis(1000 / 120);
-        self.queue_timer(FRAME_DURATION, new_start_frame_callback);
-    }
-}
-
-impl Drop for TimerRefreshDriver {
-    fn drop(&mut self) {
-        let _ = self.sender.send(TimerThreadMessage::Quit);
-        if let Some(join_handle) = self.join_handle.take() {
-            let _ = join_handle.join();
-        }
     }
 }

--- a/components/paint/timer.rs
+++ b/components/paint/timer.rs
@@ -1,0 +1,122 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+//! Paint timer thread.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use crossbeam_channel::{Sender, select};
+use embedder_traits::RefreshDriver;
+use timers::{BoxedTimerCallback, TimerEventRequest, TimerScheduler};
+
+/// Thread-based timer driver.
+pub(crate) struct TimerDriver {
+    join_handle: Option<JoinHandle<()>>,
+    sender: Sender<TimerMessage>,
+    next_timer_id: AtomicU32,
+}
+
+impl TimerDriver {
+    pub(crate) fn new() -> Self {
+        let (sender, receiver) = crossbeam_channel::unbounded::<TimerMessage>();
+        let join_handle = thread::Builder::new()
+            .name(String::from("PaintTimerThread"))
+            .spawn(move || {
+                let mut scheduler = TimerScheduler::default();
+                let mut ids = HashMap::new();
+
+                loop {
+                    select! {
+                        recv(receiver) -> message => {
+                            match message {
+                                Ok(TimerMessage::ScheduleTimer(id, request)) => {
+                                    let timer_id = scheduler.schedule_timer(request);
+                                    ids.insert(id, timer_id);
+                                },
+                                Ok(TimerMessage::CancelTimer(id)) => {
+                                    if let Some(timer_id) = ids.get(&id) {
+                                        scheduler.cancel_timer(*timer_id);
+                                    }
+                                },
+                                _ => return,
+                            }
+                        },
+                        recv(scheduler.wait_channel()) -> _message => {
+                            scheduler.dispatch_completed_timers();
+                        },
+                    };
+                }
+            })
+            .expect("Could not create paint timer thread.");
+
+        Self {
+            sender,
+            join_handle: Some(join_handle),
+            next_timer_id: Default::default(),
+        }
+    }
+
+    /// Schedule `callback` to be executed after `duration` has elapsed.
+    pub(crate) fn queue_timer(
+        &self,
+        duration: Duration,
+        callback: BoxedTimerCallback,
+    ) -> PaintTimerId {
+        let timer_id = PaintTimerId(self.next_timer_id.fetch_add(1, Ordering::Relaxed));
+        let event = TimerEventRequest { callback, duration };
+        let message = TimerMessage::ScheduleTimer(timer_id, event);
+        let _ = self.sender.send(message);
+        timer_id
+    }
+
+    /// Cancel an existing timer using its ID.
+    ///
+    /// This will cancel a pending timer callback, assuming the timeout has not elapsed already.
+    pub(crate) fn cancel_timer(&self, timer_id: PaintTimerId) {
+        let _ = self.sender.send(TimerMessage::CancelTimer(timer_id));
+    }
+}
+
+impl Default for TimerDriver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for TimerDriver {
+    fn drop(&mut self) {
+        let _ = self.sender.send(TimerMessage::Quit);
+        if let Some(join_handle) = self.join_handle.take() {
+            let _ = join_handle.join();
+        }
+    }
+}
+
+/// A timer-based refresh driver is necessary, because we need a reliable way of waking up the
+/// embedder's main thread, which may just be sleeping until the `EventLoopWaker` asks it to wake
+/// up.
+///
+/// It would be nice to integrate this somehow into the embedder thread, but it would
+/// require both some communication with the embedder and for all embedders to be well
+/// behave respecting wakeup timeouts -- a bit too much to ask at the moment.
+impl RefreshDriver for TimerDriver {
+    fn observe_next_frame(&self, new_start_frame_callback: Box<dyn Fn() + Send + 'static>) {
+        const FRAME_DURATION: Duration = Duration::from_millis(1000 / 120);
+        self.queue_timer(FRAME_DURATION, new_start_frame_callback);
+    }
+}
+
+/// ID of a timer created by the [`TimerDriver`].
+#[derive(Clone, Copy, Eq, Hash, PartialEq)]
+pub struct PaintTimerId(u32);
+
+/// Message for the [`TimerDriver`] channel.
+enum TimerMessage {
+    ScheduleTimer(PaintTimerId, TimerEventRequest),
+    CancelTimer(PaintTimerId),
+    Quit,
+}

--- a/components/paint/touch.rs
+++ b/components/paint/touch.rs
@@ -4,12 +4,19 @@
 
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 
-use embedder_traits::{InputEventId, PaintHitTestResult, Scroll, TouchEventType, TouchId};
+use crossbeam_channel::Sender;
+use embedder_traits::{
+    InputEventAndId, InputEventId, PaintHitTestResult, Scroll, TouchEventType, TouchId,
+};
 use euclid::{Point2D, Scale, Vector2D};
 use log::{debug, error, warn};
 use rustc_hash::{FxHashMap, FxHashSet};
 use servo_base::id::WebViewId;
+use servo_constellation_traits::EmbedderToConstellationMessage;
 use style_traits::CSSPixel;
 use webrender_api::units::{DevicePixel, DevicePoint, DeviceVector2D};
 
@@ -17,7 +24,19 @@ use self::TouchSequenceState::*;
 use crate::paint::RepaintReason;
 use crate::painter::Painter;
 use crate::refresh_driver::{BaseRefreshDriver, RefreshDriverObserver};
+use crate::timer::{PaintTimerId, TimerDriver};
 use crate::webview_renderer::{ScrollEvent, ScrollZoomEvent, WebViewRenderer};
+
+/// Minimum time before a tap is considered a long-press (touch context menu).
+const LONG_PRESS_DURATION: Duration = Duration::from_millis(500);
+/// Square of the minimum number of `DeviceIndependentPixel` to begin touch scrolling/Pinching.
+const TOUCH_PAN_MIN_SCREEN_PX_SQUARED: f32 = 100.0;
+/// Factor by which the flinging velocity changes on each tick.
+const FLING_SCALING_FACTOR: f32 = 0.95;
+/// Minimum velocity required for transitioning to fling when panning ends.
+const FLING_MIN_SCREEN_PX: f32 = 3.0;
+/// Maximum velocity when flinging.
+const FLING_MAX_SCREEN_PX: f32 = 4000.0;
 
 /// An ID for a sequence of touch events between a `Down` and the `Up` or `Cancel` event.
 /// The ID is the same for all events between `Down` and `Up` or `Cancel`
@@ -40,15 +59,6 @@ impl TouchSequenceId {
     }
 }
 
-/// Minimum number of `DeviceIndependentPixel` to begin touch scrolling/Pinching.
-const TOUCH_PAN_MIN_SCREEN_PX: f32 = 10.0;
-/// Factor by which the flinging velocity changes on each tick.
-const FLING_SCALING_FACTOR: f32 = 0.95;
-/// Minimum velocity required for transitioning to fling when panning ends.
-const FLING_MIN_SCREEN_PX: f32 = 3.0;
-/// Maximum velocity when flinging.
-const FLING_MAX_SCREEN_PX: f32 = 4000.0;
-
 pub struct TouchHandler {
     /// The [`WebViewId`] of the `WebView` this [`TouchHandler`] is associated with.
     webview_id: WebViewId,
@@ -60,6 +70,9 @@ pub struct TouchHandler {
     pub(crate) pending_touch_input_events: RefCell<FxHashMap<InputEventId, PendingTouchInputEvent>>,
     /// Whether or not the [`FlingRefreshDriverObserver`] is currently observing frames for fling.
     observing_frames_for_fling: Cell<bool>,
+    embedder_to_constellation_sender: Sender<EmbedderToConstellationMessage>,
+    /// Thread for scheduling timer-based callbacks.
+    timer_driver: Rc<TimerDriver>,
 }
 
 /// Whether the default move action is allowed or not.
@@ -102,6 +115,7 @@ pub struct TouchSequenceInfo {
     /// - We had a touch move larger than the minimum distance OR
     /// - We had multiple active touchpoints OR
     /// - `preventDefault()` was called in a touch_down or touch_up handler
+    /// - A long-press was triggered
     pub prevent_click: bool,
     /// Whether move is allowed, prevented or the result is still pending.
     /// Once the first move has been processed by script, we can transition to
@@ -117,6 +131,10 @@ pub struct TouchSequenceInfo {
     pending_touch_move_actions: Vec<ScrollZoomEvent>,
     /// Cache for the last touch hit test result.
     hit_test_result_cache: Option<HitTestResultCache>,
+    /// Whether the context menu was opened as a result of this touch sequence.
+    context_menu_opened: Arc<AtomicBool>,
+    /// ID of the pending context menu callback.
+    context_menu_timer: Option<PaintTimerId>,
 }
 
 impl TouchSequenceInfo {
@@ -210,7 +228,11 @@ pub(crate) struct FlingAction {
 }
 
 impl TouchHandler {
-    pub(crate) fn new(webview_id: WebViewId) -> Self {
+    pub(crate) fn new(
+        webview_id: WebViewId,
+        embedder_to_constellation_sender: Sender<EmbedderToConstellationMessage>,
+        timer_driver: Rc<TimerDriver>,
+    ) -> Self {
         let finished_info = TouchSequenceInfo {
             state: TouchSequenceState::Finished,
             active_touch_points: vec![],
@@ -219,6 +241,8 @@ impl TouchHandler {
             prevent_move: TouchMoveAllowed::Pending,
             pending_touch_move_actions: vec![],
             hit_test_result_cache: None,
+            context_menu_opened: Default::default(),
+            context_menu_timer: None,
         };
         // We insert a simulated initial touch sequence, which is already finished,
         // so that we always have one element in the map, which simplifies creating
@@ -226,6 +250,8 @@ impl TouchHandler {
         let mut touch_sequence_map = FxHashMap::default();
         touch_sequence_map.insert(TouchSequenceId::new(), finished_info);
         TouchHandler {
+            embedder_to_constellation_sender,
+            timer_driver,
             webview_id,
             current_sequence_id: TouchSequenceId::new(),
             touch_sequence_map,
@@ -264,6 +290,11 @@ impl TouchHandler {
 
     pub(crate) fn prevent_click(&mut self, sequence_id: TouchSequenceId) {
         if let Some(sequence) = self.touch_sequence_map.get_mut(&sequence_id) {
+            // Cancel context menu timer, since the default touch action was prevented.
+            if let Some(timer_id) = sequence.context_menu_timer.take() {
+                self.timer_driver.cancel_timer(timer_id);
+            }
+
             sequence.prevent_click = true;
         } else {
             warn!("TouchSequenceInfo corresponding to the sequence number has been deleted.");
@@ -343,7 +374,14 @@ impl TouchHandler {
         self.touch_sequence_map.get_mut(&sequence_id)
     }
 
-    pub(crate) fn on_touch_down(&mut self, touch_id: TouchId, point: Point2D<f32, DevicePixel>) {
+    pub(crate) fn on_touch_down(
+        &mut self,
+        touch_id: TouchId,
+        point: Point2D<f32, DevicePixel>,
+        event_and_id: InputEventAndId,
+        hit_test_result: Option<PaintHitTestResult>,
+        scale: Scale<f32, CSSPixel, DevicePixel>,
+    ) {
         // if the current sequence ID does not exist in the map, then it was already handled
         if !self
             .touch_sequence_map
@@ -353,25 +391,51 @@ impl TouchHandler {
         {
             self.current_sequence_id.next();
             debug!("Entered new touch sequence: {:?}", self.current_sequence_id);
+
+            // Schedule timer to open the context menu.
+            let context_menu_opened = Arc::new(AtomicBool::new(false));
+            let context_menu_timer = hit_test_result.map(|hit_test_result| {
+                self.schedule_context_menu_timer(
+                    hit_test_result,
+                    event_and_id,
+                    context_menu_opened.clone(),
+                )
+            });
+
+            // Initialize hit test result cache.
+            let hit_test_result_cache = hit_test_result.map(|value| HitTestResultCache {
+                value,
+                device_pixels_per_page: scale,
+            });
+
             let active_touch_points = vec![TouchPoint::new(touch_id, point)];
             self.touch_sequence_map.insert(
                 self.current_sequence_id,
                 TouchSequenceInfo {
+                    context_menu_opened,
+                    context_menu_timer,
                     state: Touching,
                     active_touch_points,
                     touch_ids_in_move: FxHashSet::default(),
                     prevent_click: false,
                     prevent_move: TouchMoveAllowed::Pending,
                     pending_touch_move_actions: vec![],
-                    hit_test_result_cache: None,
+                    hit_test_result_cache,
                 },
             );
         } else {
             debug!("Touch down in sequence {:?}.", self.current_sequence_id);
+
+            // Ignore new touch points after context menu event has fired.
             let touch_sequence = self.get_current_touch_sequence_mut();
+            if touch_sequence.context_menu_opened.load(Ordering::Relaxed) {
+                return;
+            }
+
             touch_sequence
                 .active_touch_points
                 .push(TouchPoint::new(touch_id, point));
+
             match touch_sequence.active_touch_points.len() {
                 2.. => {
                     touch_sequence.state = MultiTouch;
@@ -380,9 +444,50 @@ impl TouchHandler {
                     unreachable!("Secondary touch_down event with less than 2 fingers active?");
                 },
             }
+
             // Multiple fingers prevent a click.
             touch_sequence.prevent_click = true;
+
+            // Inhibit context menu for sequences with multiple touch points.
+            if let Some(timer_id) = touch_sequence.context_menu_timer.take() {
+                self.timer_driver.cancel_timer(timer_id);
+            }
         }
+    }
+
+    /// Start the timer for opening the context menu.
+    fn schedule_context_menu_timer(
+        &self,
+        hit_test_result: PaintHitTestResult,
+        event_and_id: InputEventAndId,
+        context_menu_opened: Arc<AtomicBool>,
+    ) -> PaintTimerId {
+        let sender = self.embedder_to_constellation_sender.clone();
+        let event_and_id = Cell::new(Some(event_and_id));
+        let webview_id = self.webview_id;
+
+        let callback = Box::new(move || {
+            // Ignore callback after the first invocation.
+            let event_and_id = match event_and_id.replace(None) {
+                Some(event_and_id) => event_and_id,
+                None => return,
+            };
+
+            // Dispatch context menu event to be handled by the script thread.
+            let _ = sender
+                .send(EmbedderToConstellationMessage::ShowContextMenu(
+                    webview_id,
+                    event_and_id,
+                    hit_test_result,
+                ))
+                .inspect_err(|err| warn!("Could not send message to constellation: {err:?}"));
+
+            // Mark touch sequence as having been used to open the context menu.
+            // This is used to inhibit further touch events from firing after the menu was opened.
+            context_menu_opened.store(true, Ordering::Relaxed);
+        });
+
+        self.timer_driver.queue_timer(LONG_PRESS_DURATION, callback)
     }
 
     pub(crate) fn notify_new_frame_start(&mut self) -> Option<FlingAction> {
@@ -443,10 +548,16 @@ impl TouchHandler {
         point: Point2D<f32, DevicePixel>,
         scale: f32,
     ) -> Option<ScrollZoomEvent> {
-        // As `TouchHandler` is per `WebViewRenderer` which is per `WebView` we might get a Touch Sequence Move that
-        // started with a down on a different webview. As the touch_sequence id is only changed on touch_down this
-        // move event gets a touch id which is already cleaned up.
+        // Ignore touch motion after context menu event has fired.
         let touch_sequence = self.try_get_current_touch_sequence_mut()?;
+        if touch_sequence.context_menu_opened.load(Ordering::Relaxed) {
+            return None;
+        }
+
+        // As `TouchHandler` is per `WebViewRenderer` which is per `WebView` we might get a Touch
+        // Sequence Move that started with a down on a different webview. As the touch_sequence id
+        // is only changed on touch_down this move event gets a touch id which is already cleaned
+        // up.
         let idx = match touch_sequence
             .active_touch_points
             .iter_mut()
@@ -458,10 +569,13 @@ impl TouchHandler {
                 return None;
             },
         };
+
         let old_point = touch_sequence.active_touch_points[idx].point;
         let delta = point - old_point;
+        let distance_squared = delta.x.powi(2) + delta.y.powi(2);
         touch_sequence.update_hit_test_result_cache_pointer(delta);
 
+        let mut timer_pending_cancel = None;
         let action = match touch_sequence.touch_count() {
             1 => {
                 if let Panning { ref mut velocity } = touch_sequence.state {
@@ -476,21 +590,21 @@ impl TouchHandler {
                         scroll: Scroll::Delta((-delta).into()),
                         point,
                     }))
-                } else if delta.x.abs() > TOUCH_PAN_MIN_SCREEN_PX * scale ||
-                    delta.y.abs() > TOUCH_PAN_MIN_SCREEN_PX * scale
-                {
+                } else if distance_squared > TOUCH_PAN_MIN_SCREEN_PX_SQUARED * scale {
                     let _span = profile_traits::info_span!(
                         "TouchHandler::ScrollBegin",
                         delta = ?delta,
                     )
                     .entered();
+
                     touch_sequence.state = Panning {
                         velocity: Vector2D::new(delta.x, delta.y),
                     };
-                    // No clicks should be issued after we transitioned to move.
-                    touch_sequence.prevent_click = true;
-                    // update the touch point
                     touch_sequence.active_touch_points[idx].point = point;
+
+                    // Inhibit clicks and context menu after we transitioned to move.
+                    timer_pending_cancel = touch_sequence.context_menu_timer.take();
+                    touch_sequence.prevent_click = true;
 
                     // Scroll offsets are opposite to the direction of finger motion.
                     Some(ScrollZoomEvent::Scroll(ScrollEvent {
@@ -505,8 +619,7 @@ impl TouchHandler {
             },
             2 => {
                 if touch_sequence.state == Pinching ||
-                    delta.x.abs() > TOUCH_PAN_MIN_SCREEN_PX * scale ||
-                    delta.y.abs() > TOUCH_PAN_MIN_SCREEN_PX * scale
+                    distance_squared > TOUCH_PAN_MIN_SCREEN_PX_SQUARED * scale
                 {
                     touch_sequence.state = Pinching;
                     let (d0, _) = touch_sequence.pinch_distance_and_center();
@@ -528,18 +641,26 @@ impl TouchHandler {
                 None
             },
         };
+
         // If the touch action is not `NoAction` and the first move has not been processed,
-        //  set pending_touch_move_action.
+        // set pending_touch_move_action.
         if let Some(action) = action {
             if touch_sequence.prevent_move == TouchMoveAllowed::Pending {
                 touch_sequence.add_pending_touch_move_action(action);
             }
         }
 
+        // Handle context menu timer dismissal.
+        if let Some(timer_id) = timer_pending_cancel {
+            self.timer_driver.cancel_timer(timer_id);
+        }
+
         action
     }
 
     pub(crate) fn on_touch_up(&mut self, touch_id: TouchId, point: Point2D<f32, DevicePixel>) {
+        let current_sequence_id = self.current_sequence_id;
+
         let Some(touch_sequence) = self.try_get_current_touch_sequence_mut() else {
             warn!("Current touch sequence not found");
             return;
@@ -555,6 +676,13 @@ impl TouchHandler {
                 None
             },
         };
+
+        // Ignore touch release after context menu event has fired.
+        if touch_sequence.context_menu_opened.load(Ordering::Relaxed) {
+            touch_sequence.state = Finished;
+            return;
+        }
+
         match touch_sequence.state {
             Touching => {
                 if touch_sequence.prevent_click {
@@ -608,6 +736,7 @@ impl TouchHandler {
                 error!("Touch-up received, but touch handler already in post-touchup state.")
             },
         }
+
         #[cfg(debug_assertions)]
         if touch_sequence.active_touch_points.is_empty() {
             debug_assert!(
@@ -619,8 +748,13 @@ impl TouchHandler {
         debug!(
             "Touch up with remaining active touchpoints: {:?}, in sequence {:?}",
             touch_sequence.active_touch_points.len(),
-            self.current_sequence_id
+            current_sequence_id
         );
+
+        // Ensure context menus aren't fired after touch release.
+        if let Some(timer_id) = touch_sequence.context_menu_timer.take() {
+            self.timer_driver.cancel_timer(timer_id);
+        }
     }
 
     pub(crate) fn on_touch_cancel(&mut self, touch_id: TouchId, _point: Point2D<f32, DevicePixel>) {
@@ -641,8 +775,14 @@ impl TouchHandler {
                 return;
             },
         }
+
         if touch_sequence.active_touch_points.is_empty() {
             touch_sequence.state = Finished;
+        }
+
+        // Cancel pending context menu timers if the touch sequence was cancelled.
+        if let Some(timer_id) = touch_sequence.context_menu_timer.take() {
+            self.timer_driver.cancel_timer(timer_id);
         }
     }
 
@@ -654,7 +794,7 @@ impl TouchHandler {
         sequence
             .hit_test_result_cache
             .as_ref()
-            .map(|cache| Some(cache.value.clone()))?
+            .map(|cache| Some(cache.value))?
     }
 
     pub(crate) fn set_hit_test_result_cache_value(

--- a/components/paint/web_content_animation.rs
+++ b/components/paint/web_content_animation.rs
@@ -14,7 +14,7 @@ use servo_base::id::WebViewId;
 use servo_config::prefs;
 use webrender_api::{ColorF, PropertyBindingKey, PropertyValue};
 
-use crate::refresh_driver::TimerRefreshDriver;
+use crate::timer::TimerDriver;
 use crate::webview_renderer::WebViewRenderer;
 
 /// The amount of the time the caret blinks before ceasing, in order to preserve power. User
@@ -31,7 +31,7 @@ pub(crate) const CARET_BLINK_TIMEOUT: Duration = Duration::from_secs(30);
 /// currently) nor animations due to touch events such as fling.
 pub(crate) struct WebContentAnimator {
     event_loop_waker: Box<dyn EventLoopWaker>,
-    timer_refresh_driver: Rc<TimerRefreshDriver>,
+    timer_driver: Rc<TimerDriver>,
     caret_visible: Cell<bool>,
     timer_scheduled: Cell<bool>,
     need_update: Arc<AtomicBool>,
@@ -40,11 +40,11 @@ pub(crate) struct WebContentAnimator {
 impl WebContentAnimator {
     pub(crate) fn new(
         event_loop_waker: Box<dyn EventLoopWaker>,
-        timer_refresh_driver: Rc<TimerRefreshDriver>,
+        timer_driver: Rc<TimerDriver>,
     ) -> Self {
         Self {
             event_loop_waker,
-            timer_refresh_driver,
+            timer_driver,
             caret_visible: Cell::new(true),
             timer_scheduled: Default::default(),
             need_update: Default::default(),
@@ -62,7 +62,7 @@ impl WebContentAnimator {
 
         let event_loop_waker = self.event_loop_waker.clone();
         let need_update = self.need_update.clone();
-        self.timer_refresh_driver.queue_timer(
+        self.timer_driver.queue_timer(
             caret_blink_time,
             Box::new(move || {
                 need_update.store(true, Ordering::Relaxed);

--- a/components/paint/webview_renderer.rs
+++ b/components/paint/webview_renderer.rs
@@ -36,6 +36,7 @@ use crate::painter::Painter;
 use crate::pinch_zoom::PinchZoom;
 use crate::pipeline_details::PipelineDetails;
 use crate::refresh_driver::BaseRefreshDriver;
+use crate::timer::TimerDriver;
 use crate::touch::{
     PendingTouchInputEvent, TouchHandler, TouchIdMoveTracking, TouchMoveAllowed, TouchSequenceState,
 };
@@ -133,19 +134,27 @@ impl WebViewRenderer {
         viewport_details: ViewportDetails,
         embedder_to_constellation_sender: Sender<EmbedderToConstellationMessage>,
         refresh_driver: Rc<BaseRefreshDriver>,
+        timer_driver: Rc<TimerDriver>,
         webrender_document: DocumentId,
     ) -> Self {
         let hidpi_scale_factor = viewport_details.hidpi_scale_factor;
         let size = viewport_details.size * viewport_details.hidpi_scale_factor;
         let rect = DeviceRect::from_origin_and_size(DevicePoint::origin(), size);
         let webview_id = renderer_webview.id();
+
+        let touch_handler = TouchHandler::new(
+            webview_id,
+            embedder_to_constellation_sender.clone(),
+            timer_driver,
+        );
+
         Self {
+            touch_handler,
             id: webview_id,
             webview: renderer_webview,
             root_pipeline_id: None,
             rect,
             pipelines: Default::default(),
-            touch_handler: TouchHandler::new(webview_id),
             pending_scroll_zoom_events: Default::default(),
             pending_wheel_events: Default::default(),
             page_zoom: DEFAULT_PAGE_ZOOM,
@@ -481,10 +490,25 @@ impl WebViewRenderer {
         event: TouchEvent,
         id: InputEventId,
     ) -> bool {
+        let event_and_id = InputEventAndId {
+            event: InputEvent::Touch(event),
+            id,
+        };
+
         let point = event
             .point
             .as_device_point(self.device_pixels_per_page_pixel());
-        self.touch_handler.on_touch_down(event.touch_id, point);
+
+        let hit_test_result = self.hit_test(render_api, point).into_iter().next();
+        let scale = self.device_pixels_per_page_pixel_not_including_pinch_zoom();
+        self.touch_handler.on_touch_down(
+            event.touch_id,
+            point,
+            event_and_id,
+            hit_test_result,
+            scale,
+        );
+
         self.send_touch_event(render_api, event, id)
     }
 
@@ -893,7 +917,7 @@ impl WebViewRenderer {
                     // scroll matters. That's why this is done here and not as soon as the touch
                     // starts.
                     self.touch_handler.set_hit_test_result_cache_value(
-                        hit_test_result.clone(),
+                        hit_test_result,
                         self.device_pixels_per_page_pixel(),
                     );
                     return Some(ScrollResult {

--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -1059,6 +1059,25 @@ impl DocumentEventHandler {
         }
     }
 
+    /// Try to open the context menu corresponding to an input event.
+    pub(crate) fn show_context_menu(&self, input_event: &ConstellationInputEvent, can_gc: CanGc) {
+        // Hit test at the input event position.
+        let Some(hit_test_result) = self.window.hit_test_from_input_event(input_event) else {
+            return;
+        };
+
+        // Get browser element at the hit test location.
+        let element = hit_test_result
+            .node
+            .inclusive_ancestors(ShadowIncluding::Yes)
+            .find_map(DomRoot::downcast::<Element>);
+        let Some(element) = element else {
+            return;
+        };
+
+        self.maybe_show_context_menu(element.upcast(), &hit_test_result, input_event, can_gc);
+    }
+
     /// <https://www.w3.org/TR/pointerevents4/#maybe-show-context-menu>
     fn maybe_show_context_menu(
         &self,

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -108,6 +108,7 @@ impl MixedMessage {
                 ScriptThreadMessage::DestroyUserContentManager(..) => None,
                 ScriptThreadMessage::UpdatePinchZoomInfos(id, _) => Some(*id),
                 ScriptThreadMessage::SetAccessibilityActive(..) => None,
+                ScriptThreadMessage::ShowContextMenu(..) => None,
                 ScriptThreadMessage::TriggerGarbageCollection => None,
             },
             MixedMessage::FromScript(inner_msg) => match inner_msg {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1979,6 +1979,14 @@ impl ScriptThread {
             ScriptThreadMessage::SetAccessibilityActive(pipeline_id, active, epoch) => {
                 self.set_accessibility_active(pipeline_id, active, epoch);
             },
+            ScriptThreadMessage::ShowContextMenu(pipeline_id, input_event) => {
+                if let Some(document) = self.documents.borrow().find_document(pipeline_id) {
+                    let can_gc = CanGc::from_cx(cx);
+                    document
+                        .event_handler()
+                        .show_context_menu(&input_event, can_gc);
+                }
+            },
             ScriptThreadMessage::TriggerGarbageCollection => unsafe {
                 JS_GC(*GlobalScope::get_cx(), GCReason::API);
             },

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -118,6 +118,8 @@ pub enum EmbedderToConstellationMessage {
     UpdatePinchZoomInfos(PipelineId, PinchZoomInfos),
     /// Activate or deactivate accessibility features for the given `WebView`.
     SetAccessibilityActive(WebViewId, bool),
+    /// Try to open the context menu corresponding to an input event.
+    ShowContextMenu(WebViewId, InputEventAndId, PaintHitTestResult),
 }
 
 pub enum UserContentManagerAction {

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -893,7 +893,7 @@ impl UntrustedNodeAddress {
 }
 
 /// The result of a hit test in `Paint`.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 pub struct PaintHitTestResult {
     /// The pipeline id of the resulting item.
     pub pipeline_id: PipelineId,

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -324,6 +324,8 @@ pub enum ScriptThreadMessage {
     /// may be split across multiple script threads, and the pipelines in a script thread may belong
     /// to multiple webviews. So the simplest approach is to activate it for one pipeline at a time.
     SetAccessibilityActive(PipelineId, bool, Epoch),
+    /// Try to open the context menu corresponding to an input event.
+    ShowContextMenu(PipelineId, ConstellationInputEvent),
     /// Force a garbage collection in this script thread.
     TriggerGarbageCollection,
 }


### PR DESCRIPTION
This adds support for opening the context menu on touch devices, by holding down a single touch point for 500ms.

This is an alternative implementation based on #43725, which moves the touch handling from the script thread to the touch handling in paint.

The timer used to dispatch the context menu callback reuses the `RefreshTimerDriver`, transitioning it into a more general timer driver with its own `timer.rs` module. This seems consistent with its existing use beyond the refresh driver in the animation handling.

The context menu itself is opened by dispatching an event to the constellation, which then forwards that event to the script thread to open the context menu itself.