### PR TITLE
css: Make animation faster, direction-aware and compute initial keyframe correctly; Eliminate Stylo static preference hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7307,7 +7307,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.37.0"
-source = "git+https://github.com/servo/stylo?rev=a556f4cbd15fc289039261661b049a5dc845cd80#a556f4cbd15fc289039261661b049a5dc845cd80"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F354%2Fhead#a965f644f47e6425cd170707564583e81d898372"
 dependencies = [
  "bitflags 2.11.0",
  "cssparser",
@@ -9012,7 +9012,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=a556f4cbd15fc289039261661b049a5dc845cd80#a556f4cbd15fc289039261661b049a5dc845cd80"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F354%2Fhead#a965f644f47e6425cd170707564583e81d898372"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -9423,7 +9423,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.16.0"
-source = "git+https://github.com/servo/stylo?rev=a556f4cbd15fc289039261661b049a5dc845cd80#a556f4cbd15fc289039261661b049a5dc845cd80"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F354%2Fhead#a965f644f47e6425cd170707564583e81d898372"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -9479,7 +9479,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.16.0"
-source = "git+https://github.com/servo/stylo?rev=a556f4cbd15fc289039261661b049a5dc845cd80#a556f4cbd15fc289039261661b049a5dc845cd80"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F354%2Fhead#a965f644f47e6425cd170707564583e81d898372"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -9488,7 +9488,7 @@ dependencies = [
 [[package]]
 name = "stylo_derive"
 version = "0.16.0"
-source = "git+https://github.com/servo/stylo?rev=a556f4cbd15fc289039261661b049a5dc845cd80#a556f4cbd15fc289039261661b049a5dc845cd80"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F354%2Fhead#a965f644f47e6425cd170707564583e81d898372"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -9500,7 +9500,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.16.0"
-source = "git+https://github.com/servo/stylo?rev=a556f4cbd15fc289039261661b049a5dc845cd80#a556f4cbd15fc289039261661b049a5dc845cd80"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F354%2Fhead#a965f644f47e6425cd170707564583e81d898372"
 dependencies = [
  "bitflags 2.11.0",
  "stylo_malloc_size_of",
@@ -9509,7 +9509,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.16.0"
-source = "git+https://github.com/servo/stylo?rev=a556f4cbd15fc289039261661b049a5dc845cd80#a556f4cbd15fc289039261661b049a5dc845cd80"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F354%2Fhead#a965f644f47e6425cd170707564583e81d898372"
 dependencies = [
  "app_units",
  "cssparser",
@@ -9526,12 +9526,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.16.0"
-source = "git+https://github.com/servo/stylo?rev=a556f4cbd15fc289039261661b049a5dc845cd80#a556f4cbd15fc289039261661b049a5dc845cd80"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F354%2Fhead#a965f644f47e6425cd170707564583e81d898372"
 
 [[package]]
 name = "stylo_traits"
 version = "0.16.0"
-source = "git+https://github.com/servo/stylo?rev=a556f4cbd15fc289039261661b049a5dc845cd80#a556f4cbd15fc289039261661b049a5dc845cd80"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F354%2Fhead#a965f644f47e6425cd170707564583e81d898372"
 dependencies = [
  "app_units",
  "bitflags 2.11.0",
@@ -9953,7 +9953,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?rev=a556f4cbd15fc289039261661b049a5dc845cd80#a556f4cbd15fc289039261661b049a5dc845cd80"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F354%2Fhead#a965f644f47e6425cd170707564583e81d898372"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -9966,7 +9966,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=a556f4cbd15fc289039261661b049a5dc845cd80#a556f4cbd15fc289039261661b049a5dc845cd80"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F354%2Fhead#a965f644f47e6425cd170707564583e81d898372"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7270,7 +7270,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.38.0"
-source = "git+https://github.com/servo/stylo?rev=a683655d35822dc231598ac67c9343df33c48c5d#a683655d35822dc231598ac67c9343df33c48c5d"
+source = "git+https://github.com/servo/stylo?rev=f61100772df4b1e7273528b31269ad9d4c49f086#f61100772df4b1e7273528b31269ad9d4c49f086"
 dependencies = [
  "bitflags 2.11.1",
  "cssparser",
@@ -8976,7 +8976,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=a683655d35822dc231598ac67c9343df33c48c5d#a683655d35822dc231598ac67c9343df33c48c5d"
+source = "git+https://github.com/servo/stylo?rev=f61100772df4b1e7273528b31269ad9d4c49f086#f61100772df4b1e7273528b31269ad9d4c49f086"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -9403,7 +9403,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.17.0"
-source = "git+https://github.com/servo/stylo?rev=a683655d35822dc231598ac67c9343df33c48c5d#a683655d35822dc231598ac67c9343df33c48c5d"
+source = "git+https://github.com/servo/stylo?rev=f61100772df4b1e7273528b31269ad9d4c49f086#f61100772df4b1e7273528b31269ad9d4c49f086"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -9459,7 +9459,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.17.0"
-source = "git+https://github.com/servo/stylo?rev=a683655d35822dc231598ac67c9343df33c48c5d#a683655d35822dc231598ac67c9343df33c48c5d"
+source = "git+https://github.com/servo/stylo?rev=f61100772df4b1e7273528b31269ad9d4c49f086#f61100772df4b1e7273528b31269ad9d4c49f086"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -9468,7 +9468,7 @@ dependencies = [
 [[package]]
 name = "stylo_derive"
 version = "0.17.0"
-source = "git+https://github.com/servo/stylo?rev=a683655d35822dc231598ac67c9343df33c48c5d#a683655d35822dc231598ac67c9343df33c48c5d"
+source = "git+https://github.com/servo/stylo?rev=f61100772df4b1e7273528b31269ad9d4c49f086#f61100772df4b1e7273528b31269ad9d4c49f086"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -9480,7 +9480,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.17.0"
-source = "git+https://github.com/servo/stylo?rev=a683655d35822dc231598ac67c9343df33c48c5d#a683655d35822dc231598ac67c9343df33c48c5d"
+source = "git+https://github.com/servo/stylo?rev=f61100772df4b1e7273528b31269ad9d4c49f086#f61100772df4b1e7273528b31269ad9d4c49f086"
 dependencies = [
  "bitflags 2.11.1",
  "stylo_malloc_size_of",
@@ -9489,7 +9489,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.17.0"
-source = "git+https://github.com/servo/stylo?rev=a683655d35822dc231598ac67c9343df33c48c5d#a683655d35822dc231598ac67c9343df33c48c5d"
+source = "git+https://github.com/servo/stylo?rev=f61100772df4b1e7273528b31269ad9d4c49f086#f61100772df4b1e7273528b31269ad9d4c49f086"
 dependencies = [
  "app_units",
  "cssparser",
@@ -9506,12 +9506,15 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.17.0"
-source = "git+https://github.com/servo/stylo?rev=a683655d35822dc231598ac67c9343df33c48c5d#a683655d35822dc231598ac67c9343df33c48c5d"
+source = "git+https://github.com/servo/stylo?rev=f61100772df4b1e7273528b31269ad9d4c49f086#f61100772df4b1e7273528b31269ad9d4c49f086"
+dependencies = [
+ "toml",
+]
 
 [[package]]
 name = "stylo_traits"
 version = "0.17.0"
-source = "git+https://github.com/servo/stylo?rev=a683655d35822dc231598ac67c9343df33c48c5d#a683655d35822dc231598ac67c9343df33c48c5d"
+source = "git+https://github.com/servo/stylo?rev=f61100772df4b1e7273528b31269ad9d4c49f086#f61100772df4b1e7273528b31269ad9d4c49f086"
 dependencies = [
  "app_units",
  "bitflags 2.11.1",
@@ -9932,7 +9935,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.4.0"
-source = "git+https://github.com/servo/stylo?rev=a683655d35822dc231598ac67c9343df33c48c5d#a683655d35822dc231598ac67c9343df33c48c5d"
+source = "git+https://github.com/servo/stylo?rev=f61100772df4b1e7273528b31269ad9d4c49f086#f61100772df4b1e7273528b31269ad9d4c49f086"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -9945,7 +9948,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=a683655d35822dc231598ac67c9343df33c48c5d#a683655d35822dc231598ac67c9343df33c48c5d"
+source = "git+https://github.com/servo/stylo?rev=f61100772df4b1e7273528b31269ad9d4c49f086#f61100772df4b1e7273528b31269ad9d4c49f086"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,12 +162,12 @@ rustls-platform-verifier = "0.6.2"
 sea-query = { version = "=1.0.0-rc.31", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = { version = "=0.8.0-rc.15" }
 sec1 = "0.7"
-selectors = { git = "https://github.com/servo/stylo", rev = "a556f4cbd15fc289039261661b049a5dc845cd80" }
+selectors = { git = "https://github.com/servo/stylo", rev = "refs/pull/354/head" }
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
 serde_json = "1.0"
-servo_arc = { git = "https://github.com/servo/stylo", rev = "a556f4cbd15fc289039261661b049a5dc845cd80" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "refs/pull/354/head" }
 sha1 = "0.10"
 sha2 = "0.10"
 sha3 = "0.10"
@@ -175,12 +175,12 @@ skrifa = "0.37.0"
 smallvec = { version = "1.15", features = ["serde", "union"] }
 string_cache = "0.9"
 strum = { version = "0.28", features = ["derive"] }
-stylo = { git = "https://github.com/servo/stylo", rev = "a556f4cbd15fc289039261661b049a5dc845cd80" }
-stylo_atoms = { git = "https://github.com/servo/stylo", rev = "a556f4cbd15fc289039261661b049a5dc845cd80" }
-stylo_dom = { git = "https://github.com/servo/stylo", rev = "a556f4cbd15fc289039261661b049a5dc845cd80" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "a556f4cbd15fc289039261661b049a5dc845cd80" }
-stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "a556f4cbd15fc289039261661b049a5dc845cd80" }
-stylo_traits = { git = "https://github.com/servo/stylo", rev = "a556f4cbd15fc289039261661b049a5dc845cd80" }
+stylo = { git = "https://github.com/servo/stylo", rev = "refs/pull/354/head" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "refs/pull/354/head" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "refs/pull/354/head" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "refs/pull/354/head" }
+stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "refs/pull/354/head" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "refs/pull/354/head" }
 surfman = { version = "0.12.0", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,12 +162,12 @@ rustls-platform-verifier = "0.7.0"
 sea-query = { version = "=1.0.0-rc.31", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = { version = "=0.8.0-rc.15" }
 sec1 = "0.7"
-selectors = { git = "https://github.com/servo/stylo", rev = "a683655d35822dc231598ac67c9343df33c48c5d" }
+selectors = { git = "https://github.com/servo/stylo", rev = "f61100772df4b1e7273528b31269ad9d4c49f086" }
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
 serde_json = "1.0"
-servo_arc = { git = "https://github.com/servo/stylo", rev = "a683655d35822dc231598ac67c9343df33c48c5d" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "f61100772df4b1e7273528b31269ad9d4c49f086" }
 sha1 = "0.10"
 sha2 = "0.10"
 sha3 = "0.10"
@@ -176,12 +176,12 @@ smallvec = { version = "1.15", features = ["serde", "union"] }
 speexdsp-resampler = "0.1.0"
 string_cache = "0.9"
 strum = { version = "0.28", features = ["derive"] }
-stylo = { git = "https://github.com/servo/stylo", rev = "a683655d35822dc231598ac67c9343df33c48c5d" }
-stylo_atoms = { git = "https://github.com/servo/stylo", rev = "a683655d35822dc231598ac67c9343df33c48c5d" }
-stylo_dom = { git = "https://github.com/servo/stylo", rev = "a683655d35822dc231598ac67c9343df33c48c5d" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "a683655d35822dc231598ac67c9343df33c48c5d" }
-stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "a683655d35822dc231598ac67c9343df33c48c5d" }
-stylo_traits = { git = "https://github.com/servo/stylo", rev = "a683655d35822dc231598ac67c9343df33c48c5d" }
+stylo = { git = "https://github.com/servo/stylo", rev = "f61100772df4b1e7273528b31269ad9d4c49f086" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "f61100772df4b1e7273528b31269ad9d4c49f086" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "f61100772df4b1e7273528b31269ad9d4c49f086" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "f61100772df4b1e7273528b31269ad9d4c49f086" }
+stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "f61100772df4b1e7273528b31269ad9d4c49f086" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "f61100772df4b1e7273528b31269ad9d4c49f086" }
 surfman = { version = "0.12.1", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"

--- a/tests/wpt/meta/css/css-animations/revert-rule-keyframes.html.ini
+++ b/tests/wpt/meta/css/css-animations/revert-rule-keyframes.html.ini
@@ -1,6 +1,0 @@
-[revert-rule-keyframes.html]
-  [revert-rule in keyframes (width)]
-    expected: FAIL
-
-  [revert-rule in keyframes (--x)]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-easing/step-jump-both.html.ini
+++ b/tests/wpt/meta/css/css-easing/step-jump-both.html.ini
@@ -1,3 +1,0 @@
-[step-jump-both.html]
-  [.test 1]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-easing/step-jump-start.html.ini
+++ b/tests/wpt/meta/css/css-easing/step-jump-start.html.ini
@@ -1,3 +1,0 @@
-[step-jump-start.html]
-  [.test 1]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-logical/animation-002.html.ini
+++ b/tests/wpt/meta/css/css-logical/animation-002.html.ini
@@ -3,12 +3,6 @@
   [Logical properties in animations respect the writing-mode]
     expected: FAIL
 
-  [Logical properties are able to override physical properties in @keyframes declaration blocks]
-    expected: FAIL
-
-  [Declaration order is respected amongst logical properties within @keyframes declaration blocks]
-    expected: FAIL
-
   [Animations update when the writing-mode is changed]
     expected: FAIL
 


### PR DESCRIPTION
Stylo PR: https://github.com/servo/stylo/pull/354

This also includes https://github.com/servo/stylo/pull/367 which eliminates static pref hashing

Testing: New passes in existing tests: revert-rule, css-easing, css-logical.
[revert-rule](https://drafts.csswg.org/css-cascade-5/#revert-rule-keyword) seems to be one of latest CSS keywords. I cannot even find it in MDN.

Fixes: #43086

I'm unable to reopen the previous PR #43594.