### PR TITLE
layout: Add placeholders for text carets after finishing a line

### DIFF
--- a/components/layout/flow/inline/inline_box.rs
+++ b/components/layout/flow/inline/inline_box.rs
@@ -2,11 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::sync::Arc;
 use std::vec::IntoIter;
 
 use app_units::Au;
-use fonts::{FontMetrics, FontRef};
+use fonts::FontRef;
 use layout_api::LayoutNode;
 use malloc_size_of_derive::MallocSizeOf;
 use script::layout_dom::ServoLayoutNode;
@@ -221,7 +220,7 @@ impl InlineBoxContainerState {
         containing_block: &ContainingBlock,
         layout_context: &LayoutContext,
         parent_container: &InlineContainerState,
-        font_metrics: Option<Arc<FontMetrics>>,
+        default_font: Option<FontRef>,
     ) -> Self {
         let style = inline_box.base.style.clone();
         let pbm = inline_box
@@ -234,7 +233,7 @@ impl InlineBoxContainerState {
         }
 
         Self {
-            base: InlineContainerState::new(style, flags, Some(parent_container), font_metrics),
+            base: InlineContainerState::new(style, flags, Some(parent_container), default_font),
             identifier: inline_box.identifier,
             base_fragment_info: inline_box.base.base_fragment_info,
             pbm,
@@ -242,10 +241,11 @@ impl InlineBoxContainerState {
     }
 
     pub(super) fn calculate_space_above_baseline(&self) -> Au {
+        let font_metrics = &self.base.font_metrics;
         let (ascent, descent, line_gap) = (
-            self.base.font_metrics.ascent,
-            self.base.font_metrics.descent,
-            self.base.font_metrics.line_gap,
+            font_metrics.ascent,
+            font_metrics.descent,
+            font_metrics.line_gap,
         );
         let leading = line_gap - (ascent + descent);
         leading.scale_by(0.5) + ascent

--- a/components/layout/flow/inline/line.rs
+++ b/components/layout/flow/inline/line.rs
@@ -771,6 +771,13 @@ pub(super) enum LineItem {
 }
 
 impl LineItem {
+    pub(crate) fn is_in_flow_content(&self) -> bool {
+        matches!(
+            self,
+            Self::TextRun(..) | Self::Atomic(..) | Self::BlockLevel(..)
+        )
+    }
+
     fn inline_box_identifier(&self) -> Option<InlineBoxIdentifier> {
         match self {
             LineItem::InlineStartBoxPaddingBorderMargin(identifier) => Some(*identifier),

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -82,7 +82,7 @@ use std::sync::Arc;
 use app_units::{Au, MAX_AU};
 use bitflags::bitflags;
 use construct::InlineFormattingContextBuilder;
-use fonts::{FontMetrics, GlyphStore};
+use fonts::{FontMetrics, FontRef, GlyphStore};
 use icu_locid::LanguageIdentifier;
 use icu_locid::subtags::{Language, language};
 use icu_properties::{self, LineBreak as ICULineBreak};
@@ -129,7 +129,7 @@ use crate::flow::{
 };
 use crate::formatting_contexts::{Baselines, IndependentFormattingContext};
 use crate::fragment_tree::{
-    BoxFragment, CollapsedMargin, Fragment, FragmentFlags, PositioningFragment,
+    BaseFragmentInfo, BoxFragment, CollapsedMargin, Fragment, FragmentFlags, PositioningFragment,
 };
 use crate::geom::{LogicalRect, LogicalSides1D, LogicalVec2, ToLogical};
 use crate::layout_box_base::LayoutBoxBase;
@@ -462,6 +462,16 @@ struct LineUnderConstruction {
 
     /// Whether the current line is for a block-level box.
     for_block_level: bool,
+
+    /// The starting character offset of this line.
+    ///
+    /// This is used to generate empty `TextRunLineItem` to hold text carets on otherwise
+    /// empty lines.
+    ///
+    /// TODO: This is only guaranteed to be accurate for the first line or when the previous line
+    /// ended with a hard line break. Eventually this should be updated during content processing so
+    /// that text carets work outside of text inputs.
+    starting_character_offset: usize,
 }
 
 impl LineUnderConstruction {
@@ -476,6 +486,7 @@ impl LineUnderConstruction {
             placement_among_floats: OnceCell::new(),
             line_items: Vec::new(),
             for_block_level: false,
+            starting_character_offset: 0,
         }
     }
 
@@ -786,6 +797,10 @@ struct InlineContainerState {
     /// is vertical).
     pub baseline_offset: Au,
 
+    /// The primary font used for this container, if one exists. This is the font that is
+    /// used when not falling back.
+    default_font: Option<FontRef>,
+
     /// The font metrics of the non-fallback font for this container.
     font_metrics: Arc<FontMetrics>,
 }
@@ -850,7 +865,11 @@ struct InlineFormattingContextLayout<'layout_data> {
     /// as soon as we encounter the `<br>` the `<span>`'s ending inline borders would be
     /// placed on the second line, because we add those borders in
     /// [`InlineFormattingContextLayout::finish_inline_box()`].
-    linebreak_before_new_content: bool,
+    ///
+    /// If this field is `Some`, a hard line break should be processed before any new content. The
+    /// `usize` stores the character offset of the originating hard line break, which is used to
+    /// generate placeholders for carets on otherwise empty lines.
+    force_line_break_before_new_content: Option<usize>,
 
     /// When a `<br>` element has `clear`, this needs to be applied after the linebreak,
     /// which will be processed *after* the `<br>` element is processed. This member
@@ -934,10 +953,7 @@ impl InlineFormattingContextLayout<'_> {
             containing_block,
             self.layout_context,
             self.current_inline_container_state(),
-            inline_box
-                .default_font
-                .as_ref()
-                .map(|font| font.metrics.clone()),
+            inline_box.default_font.clone(),
         );
 
         self.depends_on_block_constraints |= inline_box
@@ -1028,6 +1044,9 @@ impl InlineFormattingContextLayout<'_> {
     }
 
     fn finish_last_line(&mut self) {
+        // First, process any deferred forced line breaks.
+        self.possibly_flush_deferred_forced_line_break();
+
         // We are at the end of the IFC, and we need to do a few things to make sure that
         // the current segment is committed and that the final line is finished.
         //
@@ -1048,6 +1067,8 @@ impl InlineFormattingContextLayout<'_> {
     /// [`LineItem`]s and turn them into [`Fragment`]s, then reset the
     /// [`InlineFormattingContextLayout`] preparing it for laying out a new line.
     fn finish_current_line_and_reset(&mut self, last_line_or_forced_line_break: bool) {
+        self.possibly_push_empty_text_run_to_line_for_text_caret();
+
         let whitespace_trimmed = self.current_line.trim_trailing_whitespace();
         let (inline_start_position, justification_adjustment) = self
             .calculate_current_line_inline_start_and_justification_adjustment(
@@ -1480,7 +1501,7 @@ impl InlineFormattingContextLayout<'_> {
         inline_would_overflow
     }
 
-    fn defer_forced_line_break(&mut self) {
+    fn defer_forced_line_break_at_character_offset(&mut self, line_break_offset: usize) {
         // If the current portion of the unbreakable segment does not fit on the current line
         // we need to put it on a new line *before* actually triggering the hard line break.
         if !self.unbreakable_segment_fits_on_line() {
@@ -1488,7 +1509,7 @@ impl InlineFormattingContextLayout<'_> {
         }
 
         // Defer the actual line break until we've cleared all ending inline boxes.
-        self.linebreak_before_new_content = true;
+        self.force_line_break_before_new_content = Some(line_break_offset);
 
         // In quirks mode, the line-height isn't automatically added to the line. If we consider a
         // forced line break a kind of preserved white space, quirks mode requires that we add the
@@ -1513,13 +1534,15 @@ impl InlineFormattingContextLayout<'_> {
     }
 
     fn possibly_flush_deferred_forced_line_break(&mut self) {
-        if !self.linebreak_before_new_content {
+        let Some(line_break_character_offset) = self.force_line_break_before_new_content.take()
+        else {
             return;
-        }
+        };
 
         self.commit_current_segment_to_line();
         self.process_line_break(true /* forced_line_break */);
-        self.linebreak_before_new_content = false;
+
+        self.current_line.starting_character_offset = line_break_character_offset + 1;
     }
 
     fn push_line_item_to_unbreakable_segment(&mut self, line_item: LineItem) {
@@ -1606,31 +1629,48 @@ impl InlineFormattingContextLayout<'_> {
         ));
     }
 
-    /// If the current unbreakable line segment is empty and this [`InlineFormattingContext`] has a
-    /// selection, push [`LineItem::TextRun`]. This is used as a placeholder for rendering cursors
-    /// on empty lines.
-    fn possibly_push_empty_text_run_to_unbreakable_segment(
-        &mut self,
-        text_run: &TextRun,
-        info: &Arc<FontAndScriptInfo>,
-        offsets: Option<TextRunOffsets>,
-    ) {
-        if offsets.is_none() || self.current_line_segment.has_content {
+    /// If the current line is empty and this [`InlineFormattingContext`] has a selection, push an
+    /// empty [`LineItem::TextRun`] so that text carets can be placed on otherwise empty lines.
+    fn possibly_push_empty_text_run_to_line_for_text_caret(&mut self) {
+        let line_start_offset = self.current_line.starting_character_offset;
+        let Some(shared_selection) = self.ifc.shared_selection.clone() else {
+            return;
+        };
+        let offsets = TextRunOffsets {
+            shared_selection,
+            character_range: line_start_offset..line_start_offset + 1,
+        };
+
+        // If the last content line item is a text item, then the placeholder for the text caret is not necessary.
+        if self
+            .current_line
+            .line_items
+            .iter()
+            .rev()
+            .find(|line_item| line_item.is_in_flow_content())
+            .is_some_and(|line_item| matches!(line_item, LineItem::TextRun(..)))
+        {
             return;
         }
+
+        let inline_container_state = self.current_inline_container_state();
+        let Some(font) = inline_container_state.default_font.clone() else {
+            return;
+        };
 
         self.push_line_item_to_unbreakable_segment(LineItem::TextRun(
             self.current_inline_box_identifier(),
             TextRunLineItem {
                 text: Default::default(),
-                base_fragment_info: text_run.base_fragment_info,
-                inline_styles: text_run.inline_styles.clone(),
-                info: info.clone(),
-                offsets: offsets.map(Box::new),
+                base_fragment_info: BaseFragmentInfo::anonymous(),
+                inline_styles: self.ifc.shared_inline_styles.clone(),
+                info: Arc::new(FontAndScriptInfo::simple_for_font(font)),
+                offsets: Some(Box::new(offsets)),
                 is_empty_for_text_cursor: true,
             },
         ));
         self.current_line_segment.has_content = true;
+        self.commit_current_segment_to_line();
     }
 
     fn update_unbreakable_segment_for_new_content(
@@ -1939,9 +1979,7 @@ impl InlineFormattingContext {
 
         // It's unfortunate that it isn't possible to get this during IFC text processing, but in
         // that situation the style of the containing block is unknown.
-        let default_font_metrics =
-            get_font_for_first_font_for_style(style, &layout_context.font_context)
-                .map(|font| font.metrics.clone());
+        let default_font = get_font_for_first_font_for_style(style, &layout_context.font_context);
 
         let style_text = containing_block.style.get_inherited_text();
         let mut inline_container_state_flags = InlineContainerStateFlags::empty();
@@ -1970,12 +2008,12 @@ impl InlineFormattingContext {
                 style.to_arc(),
                 inline_container_state_flags,
                 None, /* parent_container */
-                default_font_metrics,
+                default_font,
             ),
             inline_box_state_stack: Vec::new(),
             inline_box_states: Vec::with_capacity(self.inline_boxes.len()),
             current_line_segment: UnbreakableSegmentUnderConstruction::new(),
-            linebreak_before_new_content: false,
+            force_line_break_before_new_content: None,
             deferred_br_clear: Clear::None,
             have_deferred_soft_wrap_opportunity: false,
             depends_on_block_constraints: false,
@@ -2158,17 +2196,23 @@ impl InlineContainerState {
         style: ServoArc<ComputedValues>,
         flags: InlineContainerStateFlags,
         parent_container: Option<&InlineContainerState>,
-        font_metrics: Option<Arc<FontMetrics>>,
+        default_font: Option<FontRef>,
     ) -> Self {
-        let font_metrics = font_metrics.unwrap_or_else(FontMetrics::empty);
+        let font_metrics = default_font
+            .as_ref()
+            .map(|font| font.metrics.clone())
+            .unwrap_or_else(FontMetrics::empty);
         let mut baseline_offset = Au::zero();
-        let mut strut_block_sizes = Self::get_block_sizes_with_style(
-            effective_baseline_shift(&style, parent_container),
-            &style,
-            &font_metrics,
-            &font_metrics,
-            &flags,
-        );
+        let mut strut_block_sizes = {
+            Self::get_block_sizes_with_style(
+                effective_baseline_shift(&style, parent_container),
+                &style,
+                &font_metrics,
+                &font_metrics,
+                &flags,
+            )
+        };
+
         if let Some(parent_container) = parent_container {
             // The baseline offset from `vertical-align` might adjust where our block size contribution is
             // within the line.
@@ -2194,6 +2238,7 @@ impl InlineContainerState {
             nested_strut_block_sizes: nested_block_sizes,
             strut_block_sizes,
             baseline_offset,
+            default_font,
             font_metrics,
         }
     }

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -68,6 +68,23 @@ pub(crate) struct FontAndScriptInfo {
     pub text_rendering: TextRendering,
 }
 
+impl FontAndScriptInfo {
+    /// Creates a minimal [`FontAndScriptInfo`] for a single font, with generic language settings
+    /// and the default shaping configuration. This is only used to generate placeholders for
+    /// text carets on otherwise empty lines.
+    pub(crate) fn simple_for_font(font: FontRef) -> Self {
+        Self {
+            font,
+            script: Script::Common,
+            bidi_level: Level::ltr(),
+            language: Language::UND,
+            letter_spacing: None,
+            word_spacing: None,
+            text_rendering: TextRendering::Auto,
+        }
+    }
+}
+
 impl From<&FontAndScriptInfo> for ShapingOptions {
     fn from(info: &FontAndScriptInfo) -> Self {
         let mut flags = ShapingFlags::empty();
@@ -182,11 +199,8 @@ impl TextRunSegment {
             // see any content. We don't line break immediately, because we'd like to finish processing
             // any ongoing inline boxes before ending the line.
             if run.is_single_preserved_newline() {
-                ifc.possibly_push_empty_text_run_to_unbreakable_segment(
-                    text_run, &self.info, offsets,
-                );
+                ifc.defer_forced_line_break_at_character_offset(character_range_start);
                 character_range_start = new_character_range_end;
-                ifc.defer_forced_line_break();
                 continue;
             }
 

--- a/components/script/dom/document/document_embedder_controls.rs
+++ b/components/script/dom/document/document_embedder_controls.rs
@@ -532,7 +532,7 @@ impl Node {
     fn as_text_input(&self) -> Option<DomRoot<Element>> {
         if let Some(input_element) = self
             .downcast::<HTMLInputElement>()
-            .filter(|input_element| input_element.renders_as_text_input_widget())
+            .filter(|input_element| input_element.is_textual_or_password())
         {
             return Some(DomRoot::from_ref(input_element.upcast::<Element>()));
         }

--- a/components/script/dom/html/input_element/mod.rs
+++ b/components/script/dom/html/input_element/mod.rs
@@ -131,6 +131,10 @@ pub(crate) struct HTMLInputElement {
     htmlelement: HTMLElement,
     input_type: DomRefCell<InputType>,
 
+    /// Whether or not the [`InputType`] for this [`HTMLInputElement`] renders as
+    /// textual input. This is cached so that it can be read during layout.
+    is_textual_or_password: Cell<bool>,
+
     /// <https://html.spec.whatwg.org/multipage/#concept-input-checked-dirty-flag>
     checked_changed: Cell<bool>,
     placeholder: DomRefCell<DOMString>,
@@ -188,6 +192,7 @@ impl HTMLInputElement {
                 document,
             ),
             input_type: DomRefCell::new(InputType::new_text()),
+            is_textual_or_password: Cell::new(true),
             placeholder: DomRefCell::new(DOMString::new()),
             checked_changed: Cell::new(false),
             maxlength: Cell::new(DEFAULT_MAX_LENGTH),
@@ -826,25 +831,8 @@ impl HTMLInputElement {
     }
 
     /// Whether this input type renders as a basic text input widget.
-    ///
-    /// TODO(#38251): This should eventually only include `text`, `password`, `url`, `tel`,
-    /// and `email`, but the others do not yet have a custom shadow DOM implementation.
-    pub(crate) fn renders_as_text_input_widget(&self) -> bool {
-        matches!(
-            *self.input_type(),
-            InputType::Date(_) |
-                InputType::DatetimeLocal(_) |
-                InputType::Email(_) |
-                InputType::Month(_) |
-                InputType::Number(_) |
-                InputType::Password(_) |
-                InputType::Search(_) |
-                InputType::Tel(_) |
-                InputType::Text(_) |
-                InputType::Time(_) |
-                InputType::Url(_) |
-                InputType::Week(_)
-        )
+    pub(crate) fn is_textual_or_password(&self) -> bool {
+        self.is_textual_or_password.get()
     }
 
     fn may_have_embedder_control(&self) -> bool {
@@ -922,6 +910,9 @@ impl<'dom> LayoutDom<'dom, HTMLInputElement> {
     }
 
     pub(crate) fn selection_for_layout(self) -> Option<SharedSelection> {
+        if !self.unsafe_get().is_textual_or_password.get() {
+            return None;
+        }
         Some(self.unsafe_get().shared_selection.clone())
     }
 }
@@ -947,7 +938,7 @@ impl TextControlElement for HTMLInputElement {
     // Types omitted which could theoretically be included if they were
     // rendered as a text control: file
     fn has_selectable_text(&self) -> bool {
-        self.renders_as_text_input_widget() && !self.textinput.borrow().get_content().is_empty()
+        self.is_textual_or_password() && !self.textinput.borrow().get_content().is_empty()
     }
 
     fn has_uncollapsed_selection(&self) -> bool {
@@ -967,7 +958,7 @@ impl TextControlElement for HTMLInputElement {
         let offsets = self.textinput.borrow().sorted_selection_offsets_range();
         let (start, end) = (offsets.start.0, offsets.end.0);
         let range = TextByteRange::new(ByteIndex(start), ByteIndex(end));
-        let enabled = self.renders_as_text_input_widget() && self.upcast::<Element>().focus_state();
+        let enabled = self.is_textual_or_password() && self.upcast::<Element>().focus_state();
 
         let mut shared_selection = self.shared_selection.borrow_mut();
         if range == shared_selection.range && enabled == shared_selection.enabled {
@@ -2008,6 +1999,8 @@ impl VirtualMethods for HTMLInputElement {
 
                         *self.input_type.borrow_mut() =
                             InputType::new_from_atom(attr.value().as_atom());
+                        self.is_textual_or_password
+                            .set(self.input_type().is_textual_or_password());
 
                         let element = self.upcast::<Element>();
                         if self.input_type().is_textual() {
@@ -2074,10 +2067,12 @@ impl VirtualMethods for HTMLInputElement {
                             .as_specific()
                             .signal_type_change(self, CanGc::from_cx(cx));
                         *self.input_type.borrow_mut() = InputType::new_text();
-                        let el = self.upcast::<Element>();
+                        self.is_textual_or_password
+                            .set(self.input_type().is_textual_or_password());
 
-                        let read_write = !(self.ReadOnly() || el.disabled_state());
-                        el.set_read_write_state(read_write);
+                        let element = self.upcast::<Element>();
+                        let read_write = !(self.ReadOnly() || element.disabled_state());
+                        element.set_read_write_state(read_write);
                     },
                 }
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -381,6 +381,19 @@
       {}
      ]
     ],
+    "textarea-caret-following-linebreak-last-line.html": [
+     "d005acd011063307b93d74985f3e414ce66828e4",
+     [
+      null,
+      [
+       [
+        "/_mozilla/appearance/textarea-caret-following-linebreak-last-line-ref.html",
+        "=="
+       ]
+      ],
+      {}
+     ]
+    ],
     "textarea-caret-following-linebreak.html": [
      "55bc06e372e9ce8ad4d62d368a644c1f1cd3ffd9",
      [
@@ -8427,6 +8440,10 @@
     ],
     "textarea-caret-following-linebreak-blank-line-ref.html": [
      "5e70ba743b12012fe3b1116414107cf50ef6a8ab",
+     []
+    ],
+    "textarea-caret-following-linebreak-last-line-ref.html": [
+     "937a6ec58a30b33d4807f5560fd8c60fff250927",
      []
     ],
     "textarea-caret-following-linebreak-ref.html": [

--- a/tests/wpt/mozilla/tests/appearance/textarea-caret-following-linebreak-last-line-ref.html
+++ b/tests/wpt/mozilla/tests/appearance/textarea-caret-following-linebreak-last-line-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+    textarea {
+        caret-animation: manual;
+    }
+    </style>
+</head>
+<body>
+    <textarea cols=50 rows="5">text&#13;&#13;</textarea>
+    <script>
+        const textarea = document.getElementsByTagName('textarea')[0];
+        textarea.setSelectionRange(5, 5);
+        textarea.focus();
+    </script>
+</body>

--- a/tests/wpt/mozilla/tests/appearance/textarea-caret-following-linebreak-last-line.html
+++ b/tests/wpt/mozilla/tests/appearance/textarea-caret-following-linebreak-last-line.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel="match" href="textarea-caret-following-linebreak-last-line-ref.html">
+    <style>
+    textarea {
+        caret-animation: manual;
+    }
+    </style>
+</head>
+<body>
+    <textarea cols=50 rows="5">text&#13;</textarea>
+    <script>
+        const textarea = document.getElementsByTagName('textarea')[0];
+        textarea.setSelectionRange(5, 5);
+        textarea.focus();
+    </script>
+</body>


### PR DESCRIPTION
Instead of readily adding a strut for text carets when processing a line
break, wait until a line is finished. This allows placing a strut on the
final line. In addition to fixing #41338 this will also make it possible
to handle line breaks as a separate kind of text run item so that we can
preserve shaping results between layouts.

In addition, some changes are made in script to ensure that these placeholders
are never placed for non-textual input elements.

Testing: This change adds a Servo-specific WPT test. Caret rendering isn't specified.
Fixes: #41338
