### PR TITLE
storage: use client storage in indexeddb

### DIFF
--- a/components/script/dom/indexeddb/idbfactory.rs
+++ b/components/script/dom/indexeddb/idbfactory.rs
@@ -13,6 +13,7 @@ use script_bindings::inheritance::Castable;
 use servo_base::generic_channel::GenericSend;
 use servo_config::pref;
 use servo_url::origin::ImmutableOrigin;
+use storage_traits::client_storage::{StorageIdentifier, StorageProxyMap, StorageType};
 use storage_traits::indexeddb::{
     BackendResult, ConnectionMsg, DatabaseInfo, IndexedDBThreadMsg, SyncOperation,
 };
@@ -494,6 +495,7 @@ impl IDBFactory {
         name: DOMString,
         version: Option<u64>,
         request: &IDBOpenDBRequest,
+        proxy_map: StorageProxyMap,
     ) -> Result<(), ()> {
         let global = self.global();
         let request_id = request.get_id();
@@ -515,6 +517,7 @@ impl IDBFactory {
             name.to_string(),
             version,
             request.get_id(),
+            proxy_map,
         );
 
         // Note: algo continues in parallel.
@@ -539,18 +542,48 @@ impl IDBFactory {
             })
             .collect();
         let origin = global.origin().immutable().clone();
+        let Ok(proxy_map) = self.obtain_a_local_storage_bottle_map(&global, origin.clone()) else {
+            debug_assert!(false, "Failed to obtain a proxy map.");
+            return;
+        };
         if global
             .storage_threads()
             .send(IndexedDBThreadMsg::Sync(
                 SyncOperation::AbortPendingUpgrades {
                     pending_upgrades,
                     origin,
+                    proxy_map,
                 },
             ))
             .is_err()
         {
             error!("Failed to send SyncOperation::AbortPendingUpgrade");
         }
+    }
+
+    /// The indexeddb call into
+    /// <https://storage.spec.whatwg.org/#obtain-a-local-storage-bottle-map>
+    fn obtain_a_local_storage_bottle_map(
+        &self,
+        global: &GlobalScope,
+        origin: ImmutableOrigin,
+    ) -> Result<StorageProxyMap, Error> {
+        let handle = global.storage_threads().client_storage_handle();
+        let message = handle
+            .obtain_a_storage_bottle_map(
+                StorageType::Local,
+                global.webview_id(),
+                StorageIdentifier::IndexedDB,
+                origin,
+            )
+            .recv();
+        let Ok(response) = message else {
+            return Err(Error::Operation(None));
+        };
+        let Ok(proxy_map) = response else {
+            return Err(Error::Operation(None));
+        };
+        Ok(proxy_map)
     }
 }
 
@@ -573,12 +606,17 @@ impl IDBFactoryMethods<crate::DomTypeHolder> for IDBFactory {
             return Err(Error::Security(None));
         };
 
+        // Note: switching to obtaining a storage bottle map,
+        // as per https://github.com/w3c/IndexedDB/pull/334/
+        let proxy_map =
+            self.obtain_a_local_storage_bottle_map(&global, global.origin().immutable().clone())?;
+
         // Step 4: Let request be a new open request.
         let request = IDBOpenDBRequest::new(&self.global(), CanGc::deprecated_note());
 
         // Step 5: Runs in parallel
         if self
-            .open_database(storage_key, name, version, &request)
+            .open_database(storage_key, name, version, &request, proxy_map)
             .is_err()
         {
             return Err(Error::Operation(None));
@@ -599,12 +637,17 @@ impl IDBFactoryMethods<crate::DomTypeHolder> for IDBFactory {
             return Err(Error::Security(None));
         };
 
+        // Note: switching to obtaining a storage bottle map,
+        // as per https://github.com/w3c/IndexedDB/pull/334/
+        let proxy_map =
+            self.obtain_a_local_storage_bottle_map(&global, global.origin().immutable().clone())?;
+
         // Step 3: Let request be a new open request
         let request = IDBOpenDBRequest::new(&self.global(), CanGc::deprecated_note());
 
         // Step 4: Runs in parallel
         if request
-            .delete_database(storage_key, name.to_string())
+            .delete_database(storage_key, name.to_string(), proxy_map)
             .is_err()
         {
             return Err(Error::Operation(None));

--- a/components/script/dom/indexeddb/idbopendbrequest.rs
+++ b/components/script/dom/indexeddb/idbopendbrequest.rs
@@ -9,6 +9,7 @@ use profile_traits::generic_callback::GenericCallback;
 use script_bindings::conversions::SafeToJSValConvertible;
 use servo_base::generic_channel::GenericSend;
 use servo_url::origin::ImmutableOrigin;
+use storage_traits::client_storage::StorageProxyMap;
 use storage_traits::indexeddb::{BackendResult, IndexedDBThreadMsg, SyncOperation};
 use stylo_atoms::Atom;
 use uuid::Uuid;
@@ -214,6 +215,7 @@ impl IDBOpenDBRequest {
         &self,
         storage_key: ImmutableOrigin,
         name: String,
+        proxy_map: StorageProxyMap,
     ) -> Result<(), ()> {
         let global = self.global();
 
@@ -233,7 +235,7 @@ impl IDBOpenDBRequest {
         .expect("Could not create delete database callback");
 
         let delete_operation =
-            SyncOperation::DeleteDatabase(callback, storage_key, name, self.get_id());
+            SyncOperation::DeleteDatabase(callback, storage_key, name, proxy_map, self.get_id());
 
         if global
             .storage_threads()

--- a/components/shared/storage/client_storage.rs
+++ b/components/shared/storage/client_storage.rs
@@ -5,6 +5,7 @@ use std::ops::{Deref, DerefMut};
 use std::path::PathBuf;
 use std::str::FromStr;
 
+use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
 use servo_base::generic_channel::{
     self, GenericCallback, GenericReceiver, GenericSender, SendResult,
@@ -12,7 +13,7 @@ use servo_base::generic_channel::{
 use servo_base::id::WebViewId;
 use servo_url::ImmutableOrigin;
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub struct ClientStorageThreadHandle {
     sender: GenericSender<ClientStorageThreadMessage>,
 }
@@ -25,7 +26,7 @@ impl ClientStorageThreadHandle {
     pub fn obtain_a_storage_bottle_map(
         &self,
         storage_type: StorageType,
-        webview: WebViewId,
+        webview: Option<WebViewId>,
         storage_identifier: StorageIdentifier,
         origin: ImmutableOrigin,
     ) -> GenericReceiver<Result<StorageProxyMap, String>> {
@@ -45,7 +46,7 @@ impl ClientStorageThreadHandle {
         &self,
         bottle_id: i64,
         name: String,
-    ) -> GenericReceiver<Result<PathBuf, String>> {
+    ) -> GenericReceiver<Result<(PathBuf, bool), String>> {
         let (sender, receiver) = generic_channel::channel().unwrap();
         let message = ClientStorageThreadMessage::CreateDatabase {
             bottle_id,
@@ -106,6 +107,12 @@ impl ClientStorageThreadHandle {
 impl From<ClientStorageThreadHandle> for GenericSender<ClientStorageThreadMessage> {
     fn from(handle: ClientStorageThreadHandle) -> Self {
         handle.sender
+    }
+}
+
+impl From<GenericSender<ClientStorageThreadMessage>> for ClientStorageThreadHandle {
+    fn from(sender: GenericSender<ClientStorageThreadMessage>) -> Self {
+        ClientStorageThreadHandle::new(sender)
     }
 }
 
@@ -212,6 +219,7 @@ pub enum ClientStorageErrorr<T> {
     DatabaseDoesNotExist,
     DirectoryCreationFailed,
     DirectoryDeletionFailed,
+    SessionStorageRequiresWindow,
     Internal(T),
 }
 
@@ -222,7 +230,7 @@ impl<T> From<T> for ClientStorageErrorr<T> {
 }
 
 /// <https://storage.spec.whatwg.org/#storage-proxy-map>
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub struct StorageProxyMap {
     pub bottle_id: i64,
     pub handle: ClientStorageThreadHandle,
@@ -232,7 +240,7 @@ pub struct StorageProxyMap {
 pub enum ClientStorageThreadMessage {
     ObtainBottleMap {
         storage_type: StorageType,
-        webview: WebViewId,
+        webview: Option<WebViewId>,
         storage_identifier: StorageIdentifier,
         origin: ImmutableOrigin,
         sender: GenericSender<Result<StorageProxyMap, String>>,
@@ -240,7 +248,8 @@ pub enum ClientStorageThreadMessage {
     CreateDatabase {
         bottle_id: i64,
         name: String,
-        sender: GenericSender<Result<PathBuf, String>>,
+        /// Boolean stands for "created".
+        sender: GenericSender<Result<(PathBuf, bool), String>>,
     },
     DeleteDatabase {
         bottle_id: i64,

--- a/components/shared/storage/indexeddb.rs
+++ b/components/shared/storage/indexeddb.rs
@@ -15,6 +15,8 @@ use servo_base::generic_channel::GenericSender;
 use servo_url::origin::ImmutableOrigin;
 use uuid::Uuid;
 
+use crate::client_storage::StorageProxyMap;
+
 // TODO Box<dyn Error> is not serializable, fix needs to be found
 pub type DbError = String;
 /// A DbResult wraps any part of a call that has to reach into the backend (in this case sqlite.rs)
@@ -577,13 +579,18 @@ pub enum SyncOperation {
         Option<u64>,
         // The id of the request.
         Uuid,
+        // The Storage proxy map.
+        StorageProxyMap,
     ),
 
     /// Deletes the database
     DeleteDatabase(
         GenericCallback<BackendResult<u64>>,
         ImmutableOrigin,
-        String, // Database
+        // Database name.
+        String,
+        // The Storage proxy map.
+        StorageProxyMap,
         Uuid,
     ),
 
@@ -598,13 +605,7 @@ pub enum SyncOperation {
     AbortPendingUpgrades {
         pending_upgrades: HashMap<String, HashSet<Uuid>>,
         origin: ImmutableOrigin,
-    },
-
-    /// Abort the current pending upgrade.
-    AbortPendingUpgrade {
-        name: String,
-        id: Uuid,
-        origin: ImmutableOrigin,
+        proxy_map: StorageProxyMap,
     },
 
     NotifyEndOfVersionChange {

--- a/components/shared/storage/lib.rs
+++ b/components/shared/storage/lib.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use servo_base::generic_channel::{self, GenericCallback, GenericSend, GenericSender, SendResult};
 use servo_url::ImmutableOrigin;
 
-use crate::client_storage::ClientStorageThreadMessage;
+use crate::client_storage::{ClientStorageThreadHandle, ClientStorageThreadMessage};
 use crate::indexeddb::IndexedDBThreadMsg;
 use crate::webstorage_thread::{OriginDescriptor, WebStorageThreadMsg, WebStorageType};
 
@@ -65,6 +65,10 @@ impl StorageThreads {
     ) -> SendResult {
         self.client_storage_thread
             .send(ClientStorageThreadMessage::Estimate { origin, sender })
+    }
+
+    pub fn client_storage_handle(&self) -> ClientStorageThreadHandle {
+        self.client_storage_thread.clone().into()
     }
 
     // TODO: Consider changing to `webstorage_sites`

--- a/components/storage/client_storage.rs
+++ b/components/storage/client_storage.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 use std::{fs, thread};
 
 use log::warn;
-use rusqlite::{Connection, Transaction};
+use rusqlite::{Connection, OptionalExtension, Transaction};
 use servo_base::generic_channel::{self, GenericReceiver, GenericSender};
 use servo_base::id::{BrowsingContextId, WebViewId};
 use servo_url::ImmutableOrigin;
@@ -29,7 +29,7 @@ trait RegistryEngine {
         &mut self,
         bottle_id: i64,
         name: String,
-    ) -> Result<PathBuf, ClientStorageErrorr<Self::Error>>;
+    ) -> Result<(PathBuf, bool), ClientStorageErrorr<Self::Error>>;
     fn delete_database(
         &mut self,
         bottle_id: i64,
@@ -38,7 +38,7 @@ trait RegistryEngine {
     fn obtain_a_storage_bottle_map(
         &mut self,
         storage_type: StorageType,
-        webview: WebViewId,
+        webview: Option<WebViewId>,
         storage_identifier: StorageIdentifier,
         origin: ImmutableOrigin,
         sender: &GenericSender<ClientStorageThreadMessage>,
@@ -425,8 +425,33 @@ impl RegistryEngine for SqliteEngine {
         &mut self,
         bottle_id: i64,
         name: String,
-    ) -> Result<PathBuf, ClientStorageErrorr<Self::Error>> {
+    ) -> Result<(PathBuf, bool), ClientStorageErrorr<Self::Error>> {
         let tx = self.connection.transaction()?;
+
+        // TODO: combine this into a single query (utilizing WITH and a join).
+        let database_id: i64 = tx
+            .query_row(
+                "INSERT INTO databases (bottle_id, name) VALUES (?1, ?2)
+             ON CONFLICT(bottle_id, name) DO UPDATE SET name = excluded.name
+            RETURNING id;",
+                (bottle_id, name),
+                |row| row.get(0),
+            )
+            .map_err(ClientStorageErrorr::Internal)?;
+
+        let existing_path: Option<String> = tx
+            .query_row(
+                "SELECT path FROM directories WHERE database_id = ?1;",
+                [database_id],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(ClientStorageErrorr::Internal)?;
+
+        if let Some(p) = existing_path {
+            // If it exists, we don't need the transaction anymore
+            return Ok((PathBuf::from(p), false));
+        }
 
         let dir = Uuid::new_v4().to_string();
         let cluster = dir.chars().last().unwrap();
@@ -442,29 +467,17 @@ impl RegistryEngine for SqliteEngine {
             )))
         })?;
 
-        let database_id: i64 = tx
-            .query_row(
-                "INSERT INTO databases (bottle_id, name) VALUES (?1, ?2)
-             ON CONFLICT(bottle_id, name) DO NOTHING
-             RETURNING id;",
-                (bottle_id, name),
-                |row| row.get(0),
-            )
-            .map_err(|e| match e {
-                rusqlite::Error::QueryReturnedNoRows => ClientStorageErrorr::DatabaseAlreadyExists,
-                e => ClientStorageErrorr::Internal(e),
-            })?;
-
         tx.execute(
             "INSERT INTO directories (database_id, path) VALUES (?1, ?2);",
             (database_id, path_str),
-        )?;
+        )
+        .map_err(ClientStorageErrorr::Internal)?;
+
+        tx.commit().map_err(ClientStorageErrorr::Internal)?;
 
         std::fs::create_dir_all(&path).map_err(|_| ClientStorageErrorr::DirectoryCreationFailed)?;
 
-        tx.commit()?;
-
-        Ok(path)
+        Ok((path, true))
     }
 
     /// Delete a database for the indexedDB endpoint.
@@ -497,10 +510,12 @@ impl RegistryEngine for SqliteEngine {
         }
         // Note: directory deleted through SQL cascade.
 
-        // Delete the directory on disk
-        std::fs::remove_dir_all(&path).map_err(|_| ClientStorageErrorr::DirectoryDeletionFailed)?;
-
         tx.commit()?;
+
+        // Delete the directory on disk.
+        // Note: on Windows this needs to be done outside of the transaction,
+        // because the transaction holds a file lock.
+        std::fs::remove_dir_all(&path).map_err(|_| ClientStorageErrorr::DirectoryDeletionFailed)?;
 
         Ok(())
     }
@@ -509,7 +524,7 @@ impl RegistryEngine for SqliteEngine {
     fn obtain_a_storage_bottle_map(
         &mut self,
         storage_type: StorageType,
-        webview: WebViewId,
+        webview: Option<WebViewId>,
         storage_identifier: StorageIdentifier,
         origin: ImmutableOrigin,
         sender: &GenericSender<ClientStorageThreadMessage>,
@@ -523,10 +538,16 @@ impl RegistryEngine for SqliteEngine {
                 ensure_storage_shed(&storage_type, None, &tx)?
             },
             StorageType::Session => {
-                // Step 3. Otherwise:
-                // Step 3.1. Assert: type is "session".
-                // Step 3.2. Set shed to environment’s global object’s associated Document’s node
-                // navigable’s traversable navigable’s storage shed.
+                // Step 3: Otherwise:
+                // Step 3.1: Assert: type is "session".
+                let Some(webview) = webview else {
+                    debug_assert!(false, "Session storage is only available on Window.");
+                    return Err(ClientStorageErrorr::SessionStorageRequiresWindow);
+                };
+
+                // Step 3.2: Set shed to environment’s global object’s associated Document’s
+                // node navigable’s traversable navigable’s storage shed.
+                // Note: using the browsing context of the webview as the traversable navigable.
                 ensure_storage_shed(
                     &storage_type,
                     Some(Into::<BrowsingContextId>::into(webview).to_string()),
@@ -648,11 +669,13 @@ pub trait ClientStorageThreadFactory {
 impl ClientStorageThreadFactory for ClientStorageThreadHandle {
     fn new(config_dir: Option<PathBuf>, temporary_storage: bool) -> ClientStorageThreadHandle {
         let (generic_sender, generic_receiver) = generic_channel::channel().unwrap();
-
+        let mut temp_dir: Option<tempfile::TempDir> = None;
         let base_dir = config_dir
             .unwrap_or_else(|| {
                 let tmp_dir = tempfile::tempdir().unwrap();
-                tmp_dir.path().to_path_buf()
+                let path = tmp_dir.path().to_path_buf();
+                temp_dir = Some(tmp_dir);
+                path
             })
             .join("clientstorage");
         let storage_dir = if temporary_storage {
@@ -667,6 +690,8 @@ impl ClientStorageThreadFactory for ClientStorageThreadHandle {
         thread::Builder::new()
             .name("ClientStorageThread".to_owned())
             .spawn(move || {
+                // Keep temp_dir alive while the thread runs.
+                let _ = temp_dir;
                 let engine = SqliteEngine::new(storage_dir).unwrap_or_else(|error| {
                     warn!("Failed to initialize ClientStorage engine into storage dir: {error:?}");
                     SqliteEngine::memory().unwrap()

--- a/components/storage/indexeddb/engines/mod.rs
+++ b/components/storage/indexeddb/engines/mod.rs
@@ -43,8 +43,6 @@ pub trait KvsEngine: MallocSizeOf {
     #[expect(dead_code)]
     fn close_store(&self, store_name: &str) -> Result<(), Self::Error>;
 
-    fn delete_database(self) -> Result<(), Self::Error>;
-
     fn process_transaction(
         &self,
         transaction: KvsTransaction,

--- a/components/storage/indexeddb/engines/sqlite.rs
+++ b/components/storage/indexeddb/engines/sqlite.rs
@@ -790,7 +790,7 @@ mod tests {
         }
         let tmp_dir = tempfile::tempdir().unwrap();
         let handle: ClientStorageThreadHandle =
-            ClientStorageThreadFactory::new(Some(tmp_dir.path().to_path_buf(), true));
+            ClientStorageThreadFactory::new(Some(tmp_dir.path().to_path_buf()), true);
 
         let storage_proxy_map = handle
             .obtain_a_storage_bottle_map(

--- a/components/storage/indexeddb/engines/sqlite.rs
+++ b/components/storage/indexeddb/engines/sqlite.rs
@@ -4,7 +4,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use log::{error, info, warn};
+use log::{info, warn};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use rusqlite::{Connection, Error, OptionalExtension, params};
 use sea_query::{Condition, Expr, ExprTrait, IntoCondition, SqliteQueryBuilder};
@@ -83,24 +83,12 @@ impl SqliteEngine {
 
     // TODO: intake dual pools
     pub fn new(
-        base_dir: &Path,
+        path: PathBuf,
+        created: bool,
         db_info: &IndexedDBDescription,
         pool: Arc<ThreadPool>,
     ) -> Result<Self, Error> {
-        let mut db_path = PathBuf::new();
-        db_path.push(base_dir);
-        db_path.push(db_info.as_path());
-        let db_parent = db_path.clone();
-        db_path.push("db.sqlite");
-
-        let created_db_path = if !db_path.exists() {
-            std::fs::create_dir_all(db_parent).unwrap();
-            std::fs::File::create(&db_path).unwrap();
-            true
-        } else {
-            false
-        };
-
+        let db_path = path.join("indexeddb.sqlite");
         let connection = Self::init_db(&db_path, db_info)?;
 
         for stmt in DB_PRAGMAS {
@@ -113,7 +101,7 @@ impl SqliteEngine {
             db_path,
             read_pool: pool.clone(),
             write_pool: pool,
-            created_db_path,
+            created_db_path: created,
         })
     }
 
@@ -393,17 +381,6 @@ impl KvsEngine for SqliteEngine {
 
     fn close_store(&self, _store_name: &str) -> Result<(), Self::Error> {
         // TODO: do something
-        Ok(())
-    }
-
-    fn delete_database(self) -> Result<(), Self::Error> {
-        // attempt to close the connection first
-        let _ = self.connection.close();
-        if self.db_path.exists() {
-            if let Err(e) = std::fs::remove_dir_all(self.db_path.parent().unwrap()) {
-                error!("Failed to delete database: {:?}", e);
-            }
-        }
         Ok(())
     }
 
@@ -759,23 +736,33 @@ impl MallocSizeOf for SqliteEngine {
 #[cfg(test)]
 mod tests {
     use std::collections::VecDeque;
+    use std::path::PathBuf;
     use std::sync::Arc;
 
     use profile_traits::generic_callback::GenericCallback;
     use profile_traits::time::ProfilerChan;
     use serde::{Deserialize, Serialize};
     use servo_base::generic_channel::{self, GenericReceiver, GenericSender};
+    use servo_base::id::{PIPELINE_NAMESPACE, PipelineNamespace, PipelineNamespaceId, WebViewId};
     use servo_base::threadpool::ThreadPool;
     use servo_url::ImmutableOrigin;
+    use storage_traits::client_storage::{
+        ClientStorageThreadHandle, StorageIdentifier, StorageProxyMap, StorageType,
+    };
     use storage_traits::indexeddb::{
         AsyncOperation, AsyncReadOnlyOperation, AsyncReadWriteOperation, CreateObjectResult,
         IndexedDBKeyRange, IndexedDBKeyType, IndexedDBTxnMode, KeyPath, PutItemResult,
     };
     use url::Host;
 
+    use crate::ClientStorageThreadFactory;
     use crate::indexeddb::IndexedDBDescription;
     use crate::indexeddb::engines::sqlite::encoding;
     use crate::indexeddb::engines::{KvsEngine, KvsOperation, KvsTransaction, SqliteEngine};
+
+    fn install_test_namespace() {
+        PipelineNamespace::install(PipelineNamespaceId(1));
+    }
 
     fn test_origin() -> ImmutableOrigin {
         ImmutableOrigin::Tuple(
@@ -789,13 +776,48 @@ mod tests {
         Arc::new(ThreadPool::new(1, "test".to_string()))
     }
 
+    fn create_db(
+        db_name: String,
+    ) -> (
+        tempfile::TempDir,
+        PathBuf,
+        bool,
+        StorageProxyMap,
+        ClientStorageThreadHandle,
+    ) {
+        if PIPELINE_NAMESPACE.get().is_none() {
+            install_test_namespace();
+        }
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let handle: ClientStorageThreadHandle =
+            ClientStorageThreadFactory::new(Some(tmp_dir.path().to_path_buf()));
+
+        let storage_proxy_map = handle
+            .obtain_a_storage_bottle_map(
+                StorageType::Local,
+                Some(WebViewId::new(servo_base::id::TEST_PAINTER_ID)),
+                StorageIdentifier::IndexedDB,
+                test_origin(),
+            )
+            .recv()
+            .unwrap()
+            .unwrap();
+        let (path, created) = handle
+            .create_database(storage_proxy_map.bottle_id, db_name)
+            .recv()
+            .unwrap()
+            .unwrap();
+        (tmp_dir, path, created, storage_proxy_map, handle)
+    }
+
     #[test]
     fn test_cycle() {
-        let base_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let (_temp_dir, path, created, proxy_map, handle) = create_db("test_db".to_string());
         let thread_pool = get_pool();
         // Test create
-        let _ = SqliteEngine::new(
-            base_dir.path(),
+        let db = SqliteEngine::new(
+            path.clone(),
+            created,
             &IndexedDBDescription {
                 name: "test_db".to_string(),
                 origin: test_origin(),
@@ -803,9 +825,12 @@ mod tests {
             thread_pool.clone(),
         )
         .unwrap();
+        drop(db);
+
         // Test open
         let db = SqliteEngine::new(
-            base_dir.path(),
+            path,
+            created,
             &IndexedDBDescription {
                 name: "test_db".to_string(),
                 origin: test_origin(),
@@ -818,15 +843,21 @@ mod tests {
         db.set_version(5).unwrap();
         let new_version = db.version().expect("Failed to get new version");
         assert_eq!(new_version, 5);
-        db.delete_database().expect("Failed to delete database");
+        drop(db);
+        handle
+            .delete_database(proxy_map.bottle_id, "test_db".to_string())
+            .recv()
+            .unwrap()
+            .expect("Failed to delete database");
     }
 
     #[test]
     fn test_create_store() {
-        let base_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let (_temp_dir, path, created, _proxy_map, _handle) = create_db("test_db".to_string());
         let thread_pool = get_pool();
         let db = SqliteEngine::new(
-            base_dir.path(),
+            path,
+            created,
             &IndexedDBDescription {
                 name: "test_db".to_string(),
                 origin: test_origin(),
@@ -850,10 +881,11 @@ mod tests {
 
     #[test]
     fn test_create_store_empty_name() {
-        let base_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let (_temp_dir, path, created, _proxy_map, _handle) = create_db("test_db".to_string());
         let thread_pool = get_pool();
         let db = SqliteEngine::new(
-            base_dir.path(),
+            path,
+            created,
             &IndexedDBDescription {
                 name: "test_db".to_string(),
                 origin: test_origin(),
@@ -870,10 +902,11 @@ mod tests {
 
     #[test]
     fn test_injection() {
-        let base_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let (_temp_dir, path, created, _proxy_map, _handle) = create_db("test_db".to_string());
         let thread_pool = get_pool();
         let db = SqliteEngine::new(
-            base_dir.path(),
+            path,
+            created,
             &IndexedDBDescription {
                 name: "test_db".to_string(),
                 origin: test_origin(),
@@ -897,10 +930,11 @@ mod tests {
 
     #[test]
     fn test_key_path() {
-        let base_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let (_temp_dir, path, created, _proxy_map, _handle) = create_db("test_db".to_string());
         let thread_pool = get_pool();
         let db = SqliteEngine::new(
-            base_dir.path(),
+            path,
+            created,
             &IndexedDBDescription {
                 name: "test_db".to_string(),
                 origin: test_origin(),
@@ -919,10 +953,11 @@ mod tests {
 
     #[test]
     fn test_delete_store() {
-        let base_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let (_temp_dir, path, created, _proxy_map, _handle) = create_db("test_db".to_string());
         let thread_pool = get_pool();
         let db = SqliteEngine::new(
-            base_dir.path(),
+            path,
+            created,
             &IndexedDBDescription {
                 name: "test_db".to_string(),
                 origin: test_origin(),
@@ -946,10 +981,11 @@ mod tests {
 
     #[test]
     fn test_delete_store_removes_store_records() {
-        let base_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let (_temp_dir, path, created, _proxy_map, _handle) = create_db("test_db".to_string());
         let thread_pool = get_pool();
         let db = SqliteEngine::new(
-            base_dir.path(),
+            path,
+            created,
             &IndexedDBDescription {
                 name: "test_db".to_string(),
                 origin: test_origin(),
@@ -1015,10 +1051,11 @@ mod tests {
             .expect("Could not construct callback")
         }
 
-        let base_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let (_temp_dir, path, created, _proxy_map, _handle) = create_db("test_db".to_string());
         let thread_pool = get_pool();
         let db = SqliteEngine::new(
-            base_dir.path(),
+            path,
+            created,
             &IndexedDBDescription {
                 name: "test_db".to_string(),
                 origin: test_origin(),
@@ -1187,10 +1224,11 @@ mod tests {
             lower_open: bool,
             upper_open: bool,
         ) -> Vec<i32> {
-            let base_dir = tempfile::tempdir().expect("Failed to create temp dir");
+            let (_temp_dir, path, created, _proxy_map, _handle) = create_db("test_db".to_string());
             let thread_pool = get_pool();
             let db = SqliteEngine::new(
-                base_dir.path(),
+                path,
+                created,
                 &IndexedDBDescription {
                     name: "test_db".to_string(),
                     origin: test_origin(),

--- a/components/storage/indexeddb/engines/sqlite.rs
+++ b/components/storage/indexeddb/engines/sqlite.rs
@@ -790,7 +790,7 @@ mod tests {
         }
         let tmp_dir = tempfile::tempdir().unwrap();
         let handle: ClientStorageThreadHandle =
-            ClientStorageThreadFactory::new(Some(tmp_dir.path().to_path_buf()));
+            ClientStorageThreadFactory::new(Some(tmp_dir.path().to_path_buf(), true));
 
         let storage_proxy_map = handle
             .obtain_a_storage_bottle_map(

--- a/components/storage/indexeddb/mod.rs
+++ b/components/storage/indexeddb/mod.rs
@@ -7,7 +7,6 @@ mod engines;
 use std::borrow::ToOwned;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::thread;
 
@@ -25,6 +24,7 @@ use servo_base::generic_channel::{self, GenericReceiver, GenericSender, ReceiveE
 use servo_base::threadpool::ThreadPool;
 use servo_config::pref;
 use servo_url::origin::ImmutableOrigin;
+use storage_traits::client_storage::StorageProxyMap;
 use storage_traits::indexeddb::{
     AsyncOperation, BackendError, BackendResult, ConnectionMsg, CreateObjectResult, DatabaseInfo,
     DbResult, IndexedDBIndex, IndexedDBObjectStore, IndexedDBThreadMsg, IndexedDBTxnMode, KeyPath,
@@ -36,27 +36,16 @@ use crate::indexeddb::engines::{KvsEngine, KvsOperation, KvsTransaction, SqliteE
 use crate::shared::is_sqlite_disk_full_error;
 
 pub trait IndexedDBThreadFactory {
-    fn new(
-        config_dir: Option<PathBuf>,
-        mem_profiler_chan: MemProfilerChan,
-        reporter_name: String,
-    ) -> Self;
+    fn new(mem_profiler_chan: MemProfilerChan, reporter_name: String) -> Self;
 }
 
 impl IndexedDBThreadFactory for GenericSender<IndexedDBThreadMsg> {
     fn new(
-        config_dir: Option<PathBuf>,
         mem_profiler_chan: MemProfilerChan,
         reporter_name: String,
     ) -> GenericSender<IndexedDBThreadMsg> {
         let (chan, port) = generic_channel::channel().unwrap();
         let chan2 = chan.clone();
-
-        let mut idb_base_dir = PathBuf::new();
-        if let Some(p) = config_dir {
-            idb_base_dir.push(p);
-        }
-        idb_base_dir.push("IndexedDB");
 
         let manager_sender = chan.clone();
 
@@ -64,7 +53,7 @@ impl IndexedDBThreadFactory for GenericSender<IndexedDBThreadMsg> {
             .name("IndexedDBManager".to_owned())
             .spawn(move || {
                 mem_profiler_chan.run_with_memory_reporting(
-                    || IndexedDBManager::new(port, manager_sender, idb_base_dir).start(),
+                    || IndexedDBManager::new(port, manager_sender).start(),
                     reporter_name,
                     chan2,
                     IndexedDBThreadMsg::CollectMemoryReport,
@@ -81,30 +70,6 @@ impl IndexedDBThreadFactory for GenericSender<IndexedDBThreadMsg> {
 pub struct IndexedDBDescription {
     pub origin: ImmutableOrigin,
     pub name: String,
-}
-
-impl IndexedDBDescription {
-    // randomly generated namespace for our purposes
-    const NAMESPACE_SERVO_IDB: &uuid::Uuid = &Uuid::from_bytes([
-        0x37, 0x9e, 0x56, 0xb0, 0x1a, 0x76, 0x44, 0xc2, 0xa0, 0xdb, 0xe2, 0x18, 0xc5, 0xc8, 0xa3,
-        0x5d,
-    ]);
-    // Converts the database description to a folder name where all
-    // data for this database is stored
-    pub(super) fn as_path(&self) -> PathBuf {
-        let mut path = PathBuf::new();
-
-        // uuid v5 is deterministic
-        let origin_uuid = Uuid::new_v5(
-            Self::NAMESPACE_SERVO_IDB,
-            self.origin.ascii_serialization().as_bytes(),
-        );
-        let db_name_uuid = Uuid::new_v5(Self::NAMESPACE_SERVO_IDB, self.name.as_bytes());
-        path.push(origin_uuid.to_string());
-        path.push(db_name_uuid.to_string());
-
-        path
-    }
 }
 
 #[derive(MallocSizeOf)]
@@ -591,13 +556,6 @@ impl<E: KvsEngine> IndexedDBEnvironment<E> {
             .map_err(|err| format!("{err:?}"))
     }
 
-    fn delete_database(self) -> BackendResult<()> {
-        let result = self.engine.delete_database();
-        result
-            .map_err(|err| format!("{err:?}"))
-            .map_err(BackendError::from)
-    }
-
     fn version(&self) -> Result<u64, E::Error> {
         self.engine.version()
     }
@@ -649,6 +607,9 @@ enum OpenRequest {
         pending_versionchange: HashSet<Uuid>,
 
         id: Uuid,
+
+        /// <https://storage.spec.whatwg.org/#storage-proxy-map>
+        proxy_map: StorageProxyMap,
     },
     Delete {
         /// The callback used to send a result to script.
@@ -658,12 +619,15 @@ enum OpenRequest {
 
         /// The name of the database.
         /// Note: will be used when the full spec is implemented.
-        _db_name: String,
+        db_name: String,
 
         /// <https://w3c.github.io/IndexedDB/#request-processed-flag>
         processed: bool,
 
         id: Uuid,
+
+        /// <https://storage.spec.whatwg.org/#storage-proxy-map>
+        proxy_map: StorageProxyMap,
     },
 }
 
@@ -679,12 +643,14 @@ impl OpenRequest {
                 pending_close: _,
                 pending_versionchange: _,
                 id,
+                proxy_map: _,
             } => id,
             OpenRequest::Delete {
                 sender: _,
                 _origin: _,
-                _db_name: _,
+                db_name: _,
                 processed: _,
+                proxy_map: _,
                 id,
             } => id,
         };
@@ -702,12 +668,14 @@ impl OpenRequest {
                 pending_close: _,
                 pending_versionchange: _,
                 id: _,
+                proxy_map: _,
             } => true,
             OpenRequest::Delete {
                 sender: _,
                 _origin: _,
-                _db_name: _,
+                db_name: _,
                 processed: _,
+                proxy_map: _,
                 id: _,
             } => false,
         }
@@ -726,6 +694,7 @@ impl OpenRequest {
                 pending_close,
                 pending_versionchange,
                 id: _,
+                proxy_map: _,
             } => {
                 !processed ||
                     pending_upgrade.is_some() ||
@@ -735,9 +704,10 @@ impl OpenRequest {
             OpenRequest::Delete {
                 sender: _,
                 _origin: _,
-                _db_name: _,
+                db_name: _,
                 processed,
                 id: _,
+                proxy_map: _,
             } => !processed,
         }
     }
@@ -755,6 +725,7 @@ impl OpenRequest {
                 pending_versionchange: _,
                 pending_upgrade,
                 id,
+                proxy_map: _,
             } => {
                 if sender
                     .send(ConnectionMsg::AbortError {
@@ -770,9 +741,10 @@ impl OpenRequest {
             OpenRequest::Delete {
                 sender,
                 _origin: _,
-                _db_name: _,
+                db_name: _,
                 processed: _,
                 id: _,
+                proxy_map: _,
             } => {
                 if sender.send(Err(BackendError::DbNotFound)).is_err() {
                     error!("Failed to send result of database delete to script.");
@@ -803,7 +775,6 @@ struct Connection {
 struct IndexedDBManager {
     port: GenericReceiver<IndexedDBThreadMsg>,
     manager_sender: GenericSender<IndexedDBThreadMsg>,
-    idb_base_dir: PathBuf,
     databases: HashMap<IndexedDBDescription, IndexedDBEnvironment<SqliteEngine>>,
     thread_pool: Arc<ThreadPool>,
 
@@ -824,7 +795,6 @@ impl IndexedDBManager {
     fn new(
         port: GenericReceiver<IndexedDBThreadMsg>,
         manager_sender: GenericSender<IndexedDBThreadMsg>,
-        idb_base_dir: PathBuf,
     ) -> IndexedDBManager {
         debug!("New indexedDBManager");
 
@@ -839,7 +809,6 @@ impl IndexedDBManager {
         IndexedDBManager {
             port,
             manager_sender,
-            idb_base_dir,
             databases: HashMap::new(),
             thread_pool: Arc::new(ThreadPool::new(thread_count, "IndexedDB".to_string())),
             serial_number_counter: 0,
@@ -1033,6 +1002,7 @@ impl IndexedDBManager {
                 pending_close: _,
                 pending_versionchange: _,
                 id,
+                proxy_map: _,
             } = open_request
             else {
                 return;
@@ -1060,7 +1030,7 @@ impl IndexedDBManager {
             return;
         }
 
-        let request_id = {
+        let (request_id, proxy_map, db_name) = {
             let Some(queue) = self.connection_queues.get_mut(&key) else {
                 return debug_assert!(false, "A connection queue should exist.");
             };
@@ -1070,6 +1040,8 @@ impl IndexedDBManager {
             let OpenRequest::Open {
                 pending_upgrade: Some(pending_upgrade),
                 id,
+                proxy_map,
+                db_name,
                 ..
             } = front
             else {
@@ -1078,10 +1050,10 @@ impl IndexedDBManager {
             if pending_upgrade.transaction != txn {
                 return;
             }
-            *id
+            (*id, (*proxy_map).clone(), db_name.clone())
         };
 
-        self.abort_pending_upgrade(name, request_id, origin);
+        self.abort_pending_upgrade(name, request_id, origin, db_name, &proxy_map);
     }
 
     /// Run the next open request in the queue.
@@ -1163,10 +1135,29 @@ impl IndexedDBManager {
     /// placeholder backing store entirely.
     ///
     /// Related: <https://github.com/servo/servo/pull/42998>
-    fn revert_aborted_upgrade(&mut self, key: &IndexedDBDescription, old_version: u64) {
+    fn revert_aborted_upgrade(
+        &mut self,
+        key: &IndexedDBDescription,
+        old_version: u64,
+        db_name: String,
+        proxy_map: &StorageProxyMap,
+    ) {
         if old_version == 0 {
             if let Some(db) = self.databases.remove(key) {
-                let _ = db.delete_database();
+                // Note: ensure db is dropped before deleting directory,
+                // to get around windows file locks.
+                drop(db);
+                let response = proxy_map
+                    .handle
+                    .delete_database(proxy_map.bottle_id, db_name.clone())
+                    .recv();
+                if response.is_err() {
+                    error!("Failed to communicate with client storage.");
+                    return;
+                }
+                if response.unwrap().is_err() {
+                    error!("Failed to delete database {:?}", db_name);
+                }
             }
             return;
         }
@@ -1181,7 +1172,14 @@ impl IndexedDBManager {
     /// Aborting the current upgrade for an origin.
     // https://w3c.github.io/IndexedDB/#abort-an-upgrade-transaction
     /// Note: this only reverts the version at this point.
-    fn abort_pending_upgrade(&mut self, name: String, id: Uuid, origin: ImmutableOrigin) {
+    fn abort_pending_upgrade(
+        &mut self,
+        name: String,
+        id: Uuid,
+        origin: ImmutableOrigin,
+        db_name: String,
+        proxy_map: &StorageProxyMap,
+    ) {
         let key = IndexedDBDescription { name, origin };
         let old = {
             let Some(queue) = self.connection_queues.get_mut(&key) else {
@@ -1202,7 +1200,7 @@ impl IndexedDBManager {
             open_request.abort()
         };
         if let Some(old_version) = old {
-            self.revert_aborted_upgrade(&key, old_version);
+            self.revert_aborted_upgrade(&key, old_version, db_name, proxy_map);
         }
 
         self.remove_connection(&key, &id);
@@ -1217,11 +1215,12 @@ impl IndexedDBManager {
         &mut self,
         pending_upgrades: HashMap<String, HashSet<Uuid>>,
         origin: ImmutableOrigin,
+        proxy_map: StorageProxyMap,
     ) {
         for (name, ids) in pending_upgrades.into_iter() {
             let mut version_to_revert: Option<u64> = None;
             let key = IndexedDBDescription {
-                name,
+                name: name.clone(),
                 origin: origin.clone(),
             };
             for id in ids.iter() {
@@ -1252,7 +1251,7 @@ impl IndexedDBManager {
                 }
             }
             if let Some(version) = version_to_revert {
-                self.revert_aborted_upgrade(&key, version);
+                self.revert_aborted_upgrade(&key, version, name, &proxy_map);
             }
         }
     }
@@ -1265,6 +1264,7 @@ impl IndexedDBManager {
         db_name: String,
         version: Option<u64>,
         id: Uuid,
+        proxy_map: StorageProxyMap,
     ) {
         let key = IndexedDBDescription {
             name: db_name.clone(),
@@ -1279,6 +1279,7 @@ impl IndexedDBManager {
             pending_versionchange: Default::default(),
             pending_upgrade: None,
             id,
+            proxy_map,
         };
         let should_continue = {
             // Step 1: Let queue be the connection queue for storageKey and name.
@@ -1341,6 +1342,7 @@ impl IndexedDBManager {
             pending_close: _,
             pending_versionchange: _,
             pending_upgrade,
+            proxy_map: _,
         } = open_request
         else {
             return;
@@ -1433,6 +1435,7 @@ impl IndexedDBManager {
                 processed: _,
                 pending_versionchange,
                 pending_close,
+                proxy_map: _,
             } = open_request
             else {
                 return debug_assert!(
@@ -1509,6 +1512,7 @@ impl IndexedDBManager {
             pending_upgrade: _pending_upgrade,
             pending_close,
             pending_versionchange,
+            proxy_map,
         } = open_request
         else {
             return debug_assert!(
@@ -1517,7 +1521,6 @@ impl IndexedDBManager {
             );
         };
 
-        let idb_base_dir = self.idb_base_dir.as_path();
         let requested_version = *version;
 
         // Step 4: Let db be the database named name in origin, or null otherwise.
@@ -1531,7 +1534,37 @@ impl IndexedDBManager {
                 // with name name, version 0 (zero), and with no object stores.
                 // If this fails for any reason, return an appropriate error
                 // (e.g. a "QuotaExceededError" or "UnknownError" DOMException).
-                let engine = match SqliteEngine::new(idb_base_dir, &key, self.thread_pool.clone()) {
+                let Ok(response) = proxy_map
+                    .handle
+                    .create_database(proxy_map.bottle_id, db_name.clone())
+                    .recv()
+                else {
+                    if let Err(e) = sender.send(ConnectionMsg::DatabaseError {
+                        id: *id,
+                        name: db_name.clone(),
+                        error: BackendError::DbErr(
+                            "Failed to communicate with client storage.".to_string(),
+                        ),
+                    }) {
+                        debug!("Script exit during indexeddb database open {:?}", e);
+                    }
+                    return;
+                };
+                let (path, created) = match response {
+                    Ok((path, created)) => (path, created),
+                    Err(err) => {
+                        if let Err(e) = sender.send(ConnectionMsg::DatabaseError {
+                            id: *id,
+                            name: db_name.clone(),
+                            error: BackendError::DbErr(format!("{err:?}")),
+                        }) {
+                            debug!("Script exit during indexeddb database open {:?}", e);
+                        }
+                        return;
+                    },
+                };
+                let engine = match SqliteEngine::new(path, created, &key, self.thread_pool.clone())
+                {
                     Ok(engine) => engine,
                     Err(err) => {
                         let error = backend_error_from_sqlite_error(err);
@@ -1691,13 +1724,15 @@ impl IndexedDBManager {
         &mut self,
         key: IndexedDBDescription,
         id: Uuid,
+        proxy_map: StorageProxyMap,
         sender: GenericCallback<BackendResult<u64>>,
     ) {
         let open_request = OpenRequest::Delete {
             sender,
             _origin: key.origin.clone(),
-            _db_name: key.name.clone(),
+            db_name: key.name.clone(),
             processed: false,
+            proxy_map,
             id,
         };
 
@@ -1728,9 +1763,10 @@ impl IndexedDBManager {
         let OpenRequest::Delete {
             sender,
             _origin: _,
-            _db_name: _,
+            db_name,
             processed,
             id: _,
+            proxy_map,
         } = open_request
         else {
             return debug_assert!(
@@ -1739,7 +1775,7 @@ impl IndexedDBManager {
             );
         };
 
-        // Step4: Let db be the database named name in storageKey, if one exists. Otherwise, return 0 (zero).
+        // Step 4: Let db be the database named name in storageKey, if one exists. Otherwise, return 0 (zero).
         let version = if let Some(db) = self.databases.remove(&key) {
             // Step 5: Let openConnections be the set of all connections associated with db.
             // Step6: For each entry of openConnections that does not have its close pending flag set to true,
@@ -1767,20 +1803,39 @@ impl IndexedDBManager {
                 return;
             };
 
+            // Note: ensure db is dropped before deleting directory,
+            // to get around windows file locks.
+            drop(db);
+
             // Step 11: Delete db.
             // If this fails for any reason,
             // return an appropriate error (e.g. a QuotaExceededError, or an "UnknownError" DOMException).
-            if let Err(err) = db.delete_database() {
-                *processed = true;
+            let Ok(response) = proxy_map
+                .handle
+                .delete_database(proxy_map.bottle_id, db_name.clone())
+                .recv()
+            else {
                 if sender
-                    .send(BackendResult::Err(BackendError::DbErr(err.to_string())))
+                    .send(BackendResult::Err(BackendError::DbErr(
+                        "Failed to communicate with client storage.".to_string(),
+                    )))
                     .is_err()
                 {
                     debug!("Script went away during pending database delete.");
                 }
                 return;
             };
-
+            if let Err(err) = response {
+                if sender
+                    .send(BackendResult::Err(BackendError::DbErr(format!(
+                        "Client storage error: {err:?}"
+                    ))))
+                    .is_err()
+                {
+                    debug!("Script went away during pending database delete.");
+                }
+                return;
+            }
             version
         } else {
             0
@@ -1831,6 +1886,7 @@ impl IndexedDBManager {
                 pending_upgrade,
                 pending_versionchange,
                 pending_close,
+                proxy_map: _,
             } = open_request
             {
                 pending_close.remove(&id);
@@ -1923,24 +1979,22 @@ impl IndexedDBManager {
             SyncOperation::CloseDatabase(origin, id, db_name) => {
                 self.close_database(origin, id, db_name);
             },
-            SyncOperation::OpenDatabase(sender, origin, db_name, version, id) => {
-                self.open_a_database_connection(sender, origin, db_name, version, id);
+            SyncOperation::OpenDatabase(sender, origin, db_name, version, id, proxy_map) => {
+                self.open_a_database_connection(sender, origin, db_name, version, id, proxy_map);
             },
             SyncOperation::AbortPendingUpgrades {
                 pending_upgrades,
                 origin,
+                proxy_map,
             } => {
-                self.abort_pending_upgrades(pending_upgrades, origin);
+                self.abort_pending_upgrades(pending_upgrades, origin, proxy_map);
             },
-            SyncOperation::AbortPendingUpgrade { name, id, origin } => {
-                self.abort_pending_upgrade(name, id, origin);
-            },
-            SyncOperation::DeleteDatabase(callback, origin, db_name, id) => {
+            SyncOperation::DeleteDatabase(callback, origin, db_name, proxy_map, id) => {
                 let idb_description = IndexedDBDescription {
                     origin,
                     name: db_name,
                 };
-                self.start_delete_database(idb_description, id, callback);
+                self.start_delete_database(idb_description, id, proxy_map, callback);
             },
             SyncOperation::GetObjectStore(sender, origin, db_name, store_name) => {
                 // FIXME:(arihant2math) Should we error out more aggressively here?

--- a/components/storage/storage_thread.rs
+++ b/components/storage/storage_thread.rs
@@ -22,7 +22,6 @@ fn new_storage_thread_group(
     let client_storage: ClientStorageThreadHandle =
         ClientStorageThreadFactory::new(config_dir.clone(), temporary_storage);
     let idb: GenericSender<IndexedDBThreadMsg> = IndexedDBThreadFactory::new(
-        config_dir.clone(),
         mem_profiler_chan.clone(),
         format!("indexedDB-reporter-{label}"),
     );

--- a/components/storage/tests/client_storage.rs
+++ b/components/storage/tests/client_storage.rs
@@ -5,8 +5,11 @@
 use std::path::PathBuf;
 
 use rusqlite::Connection;
-use servo_base::generic_channel::{self, GenericCallback};
-use servo_base::id::{BrowsingContextId, PipelineNamespace, PipelineNamespaceId, WebViewId};
+use servo_base::generic_channel;
+use servo_base::generic_channel::GenericCallback;
+use servo_base::id::{
+    BrowsingContextId, PIPELINE_NAMESPACE, PipelineNamespace, PipelineNamespaceId, WebViewId,
+};
 use servo_url::ServoUrl;
 use storage::ClientStorageThreadFactory;
 use storage_traits::client_storage::{
@@ -15,7 +18,9 @@ use storage_traits::client_storage::{
 };
 
 fn install_test_namespace() {
-    PipelineNamespace::install(PipelineNamespaceId(1));
+    if PIPELINE_NAMESPACE.get().is_none() {
+        PipelineNamespace::install(PipelineNamespaceId(1));
+    }
 }
 
 fn registry_db_path(tmp_dir: &tempfile::TempDir) -> PathBuf {
@@ -33,7 +38,7 @@ fn open_registry(tmp_dir: &tempfile::TempDir) -> Connection {
 fn obtain_bottle_map(
     handle: &ClientStorageThreadHandle,
     storage_type: StorageType,
-    webview: WebViewId,
+    webview: Option<WebViewId>,
     storage_identifier: StorageIdentifier,
     origin: servo_url::ImmutableOrigin,
 ) -> StorageProxyMap {
@@ -72,7 +77,7 @@ fn test_workflow() {
     let storage_proxy_map = handle
         .obtain_a_storage_bottle_map(
             StorageType::Local,
-            WebViewId::new(servo_base::id::TEST_PAINTER_ID),
+            Some(WebViewId::new(servo_base::id::TEST_PAINTER_ID)),
             StorageIdentifier::IndexedDB,
             url.origin(),
         )
@@ -82,18 +87,21 @@ fn test_workflow() {
 
     // Create a db.
     let receiver = handle.create_database(storage_proxy_map.bottle_id, "test1".to_string());
-    let path = receiver.recv().unwrap().expect("Path should be created");
+    let (path, created) = receiver.recv().unwrap().expect("Path should be created");
+    assert!(created);
 
     assert!(std::fs::read_dir(path.clone()).is_ok());
 
     // Create another db with the same name.
     let receiver = handle.create_database(storage_proxy_map.bottle_id, "test1".to_string());
-    assert!(receiver.recv().unwrap().is_err());
+    let (path, created) = receiver.recv().unwrap().expect("Path should be created");
+    assert!(!created);
 
     // Create another db with a different same.
     let receiver = handle.create_database(storage_proxy_map.bottle_id, "test2".to_string());
-    let yet_another_path = receiver.recv().unwrap().expect("Path should be created");
+    let (yet_another_path, created) = receiver.recv().unwrap().expect("Path should be created");
     assert_ne!(path, yet_another_path);
+    assert!(created);
 
     // Delete the dbs.
     let receiver = handle.delete_database(storage_proxy_map.bottle_id, "test1".to_string());
@@ -107,7 +115,7 @@ fn test_workflow() {
     let second_proxy_map = handle
         .obtain_a_storage_bottle_map(
             StorageType::Local,
-            WebViewId::new(servo_base::id::TEST_PAINTER_ID),
+            Some(WebViewId::new(servo_base::id::TEST_PAINTER_ID)),
             StorageIdentifier::IndexedDB,
             url.origin(),
         )
@@ -131,7 +139,7 @@ fn test_repeated_local_obtain_reuses_same_logical_rows() {
         ClientStorageThreadFactory::new(Some(tmp_dir.path().to_path_buf()), false);
 
     let origin = ServoUrl::parse("https://example.com").unwrap().origin();
-    let webview = WebViewId::new(servo_base::id::TEST_PAINTER_ID);
+    let webview = Some(WebViewId::new(servo_base::id::TEST_PAINTER_ID));
 
     let first = obtain_bottle_map(
         &handle,
@@ -186,8 +194,8 @@ fn test_repeated_session_obtain_reuses_same_logical_rows() {
         ClientStorageThreadFactory::new(Some(tmp_dir.path().to_path_buf()), false);
 
     let origin = ServoUrl::parse("https://example.com").unwrap().origin();
-    let webview = WebViewId::new(servo_base::id::TEST_PAINTER_ID);
-    let browsing_context = Into::<BrowsingContextId>::into(webview).to_string();
+    let webview = Some(WebViewId::new(servo_base::id::TEST_PAINTER_ID));
+    let browsing_context = Into::<BrowsingContextId>::into(webview.clone().unwrap()).to_string();
 
     let first = obtain_bottle_map(
         &handle,
@@ -246,7 +254,7 @@ fn test_local_persistence_and_estimate() {
     let storage_proxy_map = obtain_bottle_map(
         &handle,
         StorageType::Local,
-        webview,
+        Some(webview),
         StorageIdentifier::IndexedDB,
         origin.clone(),
     );
@@ -271,7 +279,7 @@ fn test_local_persistence_and_estimate() {
     handle.persisted(origin.clone(), cb).unwrap();
     assert!(rx.recv().unwrap().unwrap());
 
-    let path = handle
+    let (path, _created) = handle
         .create_database(storage_proxy_map.bottle_id, "estimate".to_string())
         .recv()
         .unwrap()


### PR DESCRIPTION
Use the client storage infra in indexeddb.

Follow-up on https://github.com/servo/servo/pull/43900; the intermittent issues noted at https://github.com/servo/servo/pull/44318 appear to have been caused by using a temp dir, which can be deleted more or less anytime on Linux. This PR introduces a directory named `storage_v1` used in client storage. 

Testing: WPT tests
