### PR TITLE
script: Achieve failure parity with other browsers for underline command

### DIFF
--- a/components/script/dom/execcommand/basecommand.rs
+++ b/components/script/dom/execcommand/basecommand.rs
@@ -170,12 +170,6 @@ impl CssPropertyName {
             .Style(CanGc::from_cx(cx))
             .RemoveProperty(cx, self.property_name());
     }
-
-    pub(crate) fn value_for_element(&self, cx: &mut JSContext, element: &HTMLElement) -> DOMString {
-        element
-            .Style(CanGc::from_cx(cx))
-            .GetPropertyValue(self.property_name())
-    }
 }
 
 #[derive(Clone, Copy, Eq, Hash, MallocSizeOf, PartialEq)]

--- a/components/script/dom/execcommand/contenteditable/htmlelement.rs
+++ b/components/script/dom/execcommand/contenteditable/htmlelement.rs
@@ -6,6 +6,7 @@ use html5ever::local_name;
 use js::context::JSContext;
 use script_bindings::inheritance::Castable;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
+use style::properties::{LonghandId, PropertyDeclarationId, ShorthandId};
 
 use crate::dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLElementBinding::HTMLElementMethods;
@@ -26,6 +27,54 @@ use crate::script_runtime::CanGc;
 impl HTMLElement {
     pub(crate) fn local_name(&self) -> &str {
         self.upcast::<Element>().local_name()
+    }
+
+    fn remove_value_from_text_decoration(&self, cx: &mut JSContext, value: &str) {
+        let element = self.upcast::<Element>();
+        let mut original_value = String::new();
+        let property;
+
+        // Ensure that style borrow is dropped before writing new value for style
+        {
+            let style_attribute = element.style_attribute().borrow();
+            let Some(declarations) = style_attribute.as_ref() else {
+                return;
+            };
+            let document = element.owner_document();
+            let shared_lock = document.style_shared_lock();
+            let read_lock = shared_lock.read();
+            let style = declarations.read_with(&read_lock);
+
+            // First we need to check if text-decoration is set as shorthand.
+            // If that's not the case, we should only remove underline from text-decoration-line
+            if style
+                .shorthand_to_css(ShorthandId::TextDecoration, &mut original_value)
+                .is_ok()
+            {
+                property = CssPropertyName::TextDecoration;
+            } else if let Some((text_decoration, _)) = style.get(PropertyDeclarationId::Longhand(
+                LonghandId::TextDecorationLine,
+            )) {
+                if text_decoration.to_css(&mut original_value).is_ok() {
+                    property = CssPropertyName::TextDecorationLine;
+                } else {
+                    return;
+                }
+            } else {
+                return;
+            }
+        }
+
+        let new_value = original_value
+            .replace(&format!(" {} ", value), " ")
+            .replace(&format!(" {}", value), "")
+            .replace(&format!("{} ", value), "")
+            .replace(value, "");
+        if new_value.is_empty() {
+            property.remove_from_element(cx, self);
+        } else {
+            property.set_for_element(cx, self, new_value.into());
+        }
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#clear-the-value>
@@ -66,25 +115,12 @@ impl HTMLElement {
             // that sets "text-decoration" to some value containing "line-through",
             // delete "line-through" from the value.
             CommandName::Strikethrough => {
-                let property = CssPropertyName::TextDecorationLine;
-                if property.value_for_element(cx, self) == "line-through" {
-                    // TODO: Only remove line-through
-                    property.remove_from_element(cx, self);
-                }
+                self.remove_value_from_text_decoration(cx, "line-through");
             },
             // Step 6. If command is "underline", and element has a style attribute that
             // sets "text-decoration" to some value containing "underline", delete "underline" from the value.
             CommandName::Underline => {
-                // First we need to check if text-decoration is only set to underline. If it is, remove the full
-                // shorthand. If that's not the case, we should only remove underline from the property
-                if CssPropertyName::TextDecoration.value_for_element(cx, self) == "underline" {
-                    CssPropertyName::TextDecoration.remove_from_element(cx, self);
-                } else if CssPropertyName::TextDecorationLine.value_for_element(cx, self) ==
-                    "underline"
-                {
-                    // TODO: Only remove underline
-                    CssPropertyName::TextDecorationLine.remove_from_element(cx, self);
-                }
+                self.remove_value_from_text_decoration(cx, "underline");
             },
             _ => {},
         }

--- a/components/script/dom/execcommand/contenteditable/htmlelement.rs
+++ b/components/script/dom/execcommand/contenteditable/htmlelement.rs
@@ -68,7 +68,7 @@ impl HTMLElement {
         let new_value = original_value
             .replace(&format!(" {value} "), " ")
             .replace(&format!(" {value}"), "")
-            .replace(&format!("{value} "),  "")
+            .replace(&format!("{value} "), "")
             .replace(value, "");
         if new_value.is_empty() {
             property.remove_from_element(cx, self);

--- a/components/script/dom/execcommand/contenteditable/htmlelement.rs
+++ b/components/script/dom/execcommand/contenteditable/htmlelement.rs
@@ -66,9 +66,9 @@ impl HTMLElement {
         }
 
         let new_value = original_value
-            .replace(&format!(" {} ", value), " ")
-            .replace(&format!(" {}", value), "")
-            .replace(&format!("{} ", value), "")
+            .replace(&format!(" {value} "), " ")
+            .replace(&format!(" {value}"), "")
+            .replace(&format!("{value} "),  "")
             .replace(value, "");
         if new_value.is_empty() {
             property.remove_from_element(cx, self);

--- a/components/script/dom/execcommand/contenteditable/node.rs
+++ b/components/script/dom/execcommand/contenteditable/node.rs
@@ -643,7 +643,7 @@ where
             let end_offset = range.end_offset();
 
             if end_container == parent_of_new_parent && end_offset == new_parent.index() {
-                range.set_start(&end_container, end_offset + 1);
+                range.set_end(&end_container, end_offset + 1);
             }
         }
     }

--- a/tests/wpt/meta/editing/run/fontsize.html.ini
+++ b/tests/wpt/meta/editing/run/fontsize.html.ini
@@ -371,3 +371,6 @@
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[<font size=2>b\]ar</font>baz" queryCommandValue("fontsize") after]
     expected: FAIL
+
+  [[["styleWithCSS","false"\],["fontSize","5"\]\] "<p><span style=\\"font-size:32px; background-color:rgb(0, 128, 128)\\">[abc</span></p><p><span style=\\"font-size:64px; background-color:rgb(128, 128, 0)\\">def\]</span></p>" compare innerHTML]
+    expected: FAIL

--- a/tests/wpt/meta/editing/run/fontsize.html.ini
+++ b/tests/wpt/meta/editing/run/fontsize.html.ini
@@ -371,6 +371,3 @@
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[<font size=2>b\]ar</font>baz" queryCommandValue("fontsize") after]
     expected: FAIL
-
-  [[["styleWithCSS","false"\],["fontSize","5"\]\] "<p><span style=\\"font-size:32px; background-color:rgb(0, 128, 128)\\">[abc</span></p><p><span style=\\"font-size:64px; background-color:rgb(128, 128, 0)\\">def\]</span></p>" compare innerHTML]
-    expected: FAIL

--- a/tests/wpt/meta/editing/run/underline.html.ini
+++ b/tests/wpt/meta/editing/run/underline.html.ini
@@ -97,9 +97,6 @@
   [[["stylewithcss","false"\],["underline",""\]\] "<u>fo[o</u><ins>b\]ar</ins>" queryCommandIndeterm("underline") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "abc<span style=\\"text-decoration:line-through overline underline\\">[def\]</span>ghi" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "abc<span style=\\"text-decoration:blink line-through overline\\">[def\]</span>ghi" compare innerHTML]
     expected: FAIL
 
@@ -133,15 +130,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "foo<del>[bar\]</del>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["underline",""\]\] "foo<span style=\\"text-decoration: underline line-through\\">[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "foo<span style=\\"text-decoration: underline line-through\\">b[a\]r</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "foo<span style=\\"text-decoration: underline line-through\\">b[a\]r</span>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "foo<u style=\\"text-decoration: line-through\\">[bar\]</u>baz" compare innerHTML]
@@ -183,15 +171,6 @@
   [[["stylewithcss","true"\],["underline",""\]\] "<strike>foo[bar\]baz</strike>" queryCommandState("stylewithcss") before]
     expected: FAIL
 
-  [[["underline",""\]\] "foo<span style=\\"text-decoration: underline line-through\\">[bar\]</span>baz" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "foo<span style=\\"text-decoration: underline line-through\\">b[a\]r</span>baz" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "foo<span style=\\"text-decoration: underline line-through\\">b[a\]r</span>baz" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["underline",""\]\] "foo<u>ba[r</u>b\]az" queryCommandState("underline") before]
     expected: FAIL
 
@@ -205,4 +184,7 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["underline",""\]\] "foo<s style=\\"text-decoration: underline\\">b[a\]r</s>baz" queryCommandState("underline") after]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["underline",""\]\] "foo<u>ba[r</u>\]baz" compare innerHTML]
     expected: FAIL

--- a/tests/wpt/tests/editing/data/underline.js
+++ b/tests/wpt/tests/editing/data/underline.js
@@ -657,7 +657,7 @@ var browserTests = [
     {"stylewithcss":[false,true,"",false,false,""],"underline":[false,true,"",false,false,""]}],
 ["foo<u>ba[r</u>]baz",
     [["stylewithcss","true"],["underline",""]],
-    "foo<span style=\"text-decoration:underline\">ba</span>[r]baz",
+    "foo<u>ba</u>rbaz",
     [true,true],
     {"stylewithcss":[false,false,"",false,true,""],"underline":[false,true,"",false,false,""]}],
 ["foo<u>ba[r</u>]baz",


### PR DESCRIPTION
With these changes, we now fail the minimum set of tests. That is to say: we don't fail any test that no other browser fails. All test failures therefore match at least 1 other browser.

The one exception is the updated test expectation. That's because all browsers fail this test in the exact same way, hence updating the expectation. We fail it, since I don't know how browsers reach to that point. I think it's related to traversal of the contained children and the order that they are traversed in. Unfortunately my attempts at fixing that have not been fruitful, so leaving that one for now.

Part of #25005

Testing: WPT