### PR TITLE
net: Split ResourceTimings into separate file and create batch attribute setting

### DIFF
--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -32,14 +32,13 @@ use net_traits::request::{
 use net_traits::response::{Response, ResponseBody, ResponseType, TerminationReason};
 use net_traits::{
     FetchTaskTarget, NetworkError, ReferrerPolicy, ResourceAttribute, ResourceFetchTiming,
-    ResourceTimeValue, ResourceTimingType, WebSocketDomAction, WebSocketNetworkEvent,
-    set_default_accept_language,
+    ResourceFetchTimingContainer, ResourceTimeValue, ResourceTimingType, WebSocketDomAction,
+    WebSocketNetworkEvent, set_default_accept_language,
 };
 use parking_lot::Mutex;
 use rustc_hash::FxHashMap;
 use rustls_pki_types::CertificateDer;
 use serde::{Deserialize, Serialize};
-use servo_arc::Arc as ServoArc;
 use servo_base::generic_channel::CallbackSetter;
 use servo_base::id::PipelineId;
 use servo_url::{Host, ServoUrl};
@@ -104,7 +103,7 @@ pub struct FetchContext {
     pub file_token: FileTokenCheck,
     pub request_interceptor: Arc<TokioMutex<RequestInterceptor>>,
     pub cancellation_listener: Arc<CancellationListener>,
-    pub timing: ServoArc<Mutex<ResourceFetchTiming>>,
+    pub timing: ResourceFetchTimingContainer,
     pub protocols: Arc<ProtocolRegistry>,
     pub websocket_chan: Option<Arc<Mutex<WebSocketChannel>>>,
     pub ca_certificates: CACertificates<'static>,
@@ -179,11 +178,10 @@ pub type DoneChannel = Option<(TokioSender<Data>, TokioReceiver<Data>)>;
 pub async fn fetch(request: Request, target: Target<'_>, context: &FetchContext) -> Response {
     // Steps 7,4 of https://w3c.github.io/resource-timing/#processing-model
     // rev order okay since spec says they're equal - https://w3c.github.io/resource-timing/#dfn-starttime
-    {
-        let mut timing_guard = context.timing.lock();
-        timing_guard.set_attribute(ResourceAttribute::FetchStart);
-        timing_guard.set_attribute(ResourceAttribute::StartTime(ResourceTimeValue::FetchStart));
-    }
+    context.timing.set_attributes(&[
+        ResourceAttribute::FetchStart,
+        ResourceAttribute::StartTime(ResourceTimeValue::FetchStart),
+    ]);
     fetch_with_cors_cache(request, &mut CorsCache::default(), target, context).await
 }
 
@@ -554,7 +552,7 @@ pub async fn main_fetch(
             if let Some((response, preload_id)) =
                 fetch_params.preload_response_candidate.response().await
             {
-                response.get_resource_timing().lock().preloaded = true;
+                response.get_resource_timing().inner().preloaded = true;
                 context
                     .preloaded_resources
                     .lock()

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -54,8 +54,8 @@ use net_traits::response::{
 };
 use net_traits::{
     CookieSource, DOCUMENT_ACCEPT_HEADER_VALUE, NetworkError, RedirectEndValue, RedirectStartValue,
-    ReferrerPolicy, ResourceAttribute, ResourceFetchTiming, ResourceTimeValue, TlsSecurityInfo,
-    TlsSecurityState,
+    ReferrerPolicy, ResourceAttribute, ResourceFetchTimingContainer, ResourceTimeValue,
+    TlsSecurityInfo, TlsSecurityState,
 };
 use parking_lot::{Mutex, RwLock};
 use profile_traits::mem::{Report, ReportKind};
@@ -63,7 +63,6 @@ use profile_traits::path;
 #[cfg(feature = "tracing")]
 use profile_traits::trace_span;
 use rustc_hash::FxHashMap;
-use servo_arc::Arc;
 use servo_base::cross_process_instant::CrossProcessInstant;
 use servo_base::generic_channel::GenericSharedMemory;
 use servo_base::id::{BrowsingContextId, HistoryStateId, PipelineId};
@@ -587,18 +586,13 @@ async fn obtain_response(
             )
     };
 
-    context
-        .timing
-        .lock()
-        .set_attribute(ResourceAttribute::DomainLookupStart);
-
     // TODO(#21261) connect_start: set if a persistent connection is *not* used and the last non-redirected
     // fetch passes the timing allow check
     let connect_start = CrossProcessInstant::now();
-    context
-        .timing
-        .lock()
-        .set_attribute(ResourceAttribute::ConnectStart(connect_start));
+    context.timing.set_attributes(&[
+        ResourceAttribute::DomainLookupStart,
+        ResourceAttribute::ConnectStart(connect_start),
+    ]);
 
     // TODO: We currently don't know when the handhhake before the connection is done
     // so our best bet would be to set `secure_connection_start` here when we are currently
@@ -606,7 +600,6 @@ async fn obtain_response(
     if url.scheme() == "https" {
         context
             .timing
-            .lock()
             .set_attribute(ResourceAttribute::SecureConnectionStart);
     }
 
@@ -619,7 +612,6 @@ async fn obtain_response(
     let connect_end = CrossProcessInstant::now();
     context
         .timing
-        .lock()
         .set_attribute(ResourceAttribute::ConnectEnd(connect_end));
 
     let request_id = request_id.map(|v| v.to_owned());
@@ -892,7 +884,6 @@ pub(crate) async fn http_fetch(
         //   secure_connection_start)
         context
             .timing
-            .lock()
             .set_attribute(ResourceAttribute::RequestStart);
 
         // Step 4.3. Set response and internalResponse to the result of
@@ -989,19 +980,18 @@ pub(crate) async fn http_fetch(
     response.return_internal = true;
     context
         .timing
-        .lock()
         .set_attribute(ResourceAttribute::RedirectCount(
             fetch_params.request.redirect_count as u16,
         ));
 
-    response.resource_timing = Arc::clone(&context.timing);
+    response.resource_timing = context.timing.clone();
 
     // Step 6
     response
 }
 
 // Convenience struct that implements Drop, for setting redirectEnd on function return
-struct RedirectEndTimer(Option<Arc<Mutex<ResourceFetchTiming>>>);
+struct RedirectEndTimer(Option<ResourceFetchTimingContainer>);
 
 impl RedirectEndTimer {
     fn neuter(&mut self) {
@@ -1014,8 +1004,7 @@ impl Drop for RedirectEndTimer {
         let RedirectEndTimer(resource_fetch_timing_opt) = self;
 
         resource_fetch_timing_opt.as_ref().map_or((), |t| {
-            t.lock()
-                .set_attribute(ResourceAttribute::RedirectEnd(RedirectEndValue::Zero));
+            t.set_attribute(ResourceAttribute::RedirectEnd(RedirectEndValue::Zero));
         })
     }
 }
@@ -1107,30 +1096,14 @@ pub async fn http_redirect_fetch(
 
     // Step 1 of https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-fetchstart
     // TODO: check origin and timing allow check
-    context
-        .timing
-        .lock()
-        .set_attribute(ResourceAttribute::RedirectStart(
-            RedirectStartValue::FetchStart,
-        ));
-
-    context
-        .timing
-        .lock()
-        .set_attribute(ResourceAttribute::FetchStart);
-
     // start_time should equal redirect_start if nonzero; else fetch_start
-    context
-        .timing
-        .lock()
-        .set_attribute(ResourceAttribute::StartTime(ResourceTimeValue::FetchStart));
-
-    context
-        .timing
-        .lock()
-        .set_attribute(ResourceAttribute::StartTime(
-            ResourceTimeValue::RedirectStart,
-        )); // updates start_time only if redirect_start is nonzero (implying TAO)
+    // updates start_time only if redirect_start is nonzero (implying TAO)
+    context.timing.set_attributes(&[
+        ResourceAttribute::RedirectStart(RedirectStartValue::FetchStart),
+        ResourceAttribute::FetchStart,
+        ResourceAttribute::StartTime(ResourceTimeValue::FetchStart),
+        ResourceAttribute::StartTime(ResourceTimeValue::RedirectStart),
+    ]);
 
     // Step 7: If request’s redirect count is 20, then return a network error.
     if request.redirect_count >= 20 {
@@ -1240,12 +1213,9 @@ pub async fn http_redirect_fetch(
     .await;
 
     // TODO: timing allow check
-    context
-        .timing
-        .lock()
-        .set_attribute(ResourceAttribute::RedirectEnd(
-            RedirectEndValue::ResponseEnd,
-        ));
+    context.timing.set_attribute(ResourceAttribute::RedirectEnd(
+        RedirectEndValue::ResponseEnd,
+    ));
     redirect_end_timer.neuter();
 
     fetch_response
@@ -1890,7 +1860,7 @@ fn cross_origin_resource_policy_check(
 }
 
 // Convenience struct that implements Done, for setting responseEnd on function return
-struct ResponseEndTimer(Option<Arc<Mutex<ResourceFetchTiming>>>);
+struct ResponseEndTimer(Option<ResourceFetchTimingContainer>);
 
 impl ResponseEndTimer {
     fn neuter(&mut self) {
@@ -1903,7 +1873,7 @@ impl Drop for ResponseEndTimer {
         let ResponseEndTimer(resource_fetch_timing_opt) = self;
 
         resource_fetch_timing_opt.as_ref().map_or((), |t| {
-            t.lock().set_attribute(ResourceAttribute::ResponseEnd);
+            t.set_attribute(ResourceAttribute::ResponseEnd);
         })
     }
 }
@@ -2077,10 +2047,10 @@ async fn http_network_fetch(
     });
 
     if !(is_same_origin || req_origin_in_timing_allow || wildcard_present) {
-        context.timing.lock().mark_timing_check_failed();
+        context.timing.inner().mark_timing_check_failed();
     }
 
-    let timing = context.timing.lock().clone();
+    let timing = context.timing.inner().clone();
     let mut response = Response::new(url.clone(), timing);
 
     if let Some(handshake_info) = res.extensions().get::<TlsHandshakeInfo>() {
@@ -2179,9 +2149,7 @@ async fn http_network_fetch(
                     &devtools_request,
                     devtools_chan,
                 );
-                timing_ptr2
-                    .lock()
-                    .set_attribute(ResourceAttribute::ResponseEnd);
+                timing_ptr2.set_attribute(ResourceAttribute::ResponseEnd);
                 let _ = done_sender2.send(Data::Done);
                 future::ready(Ok(()))
             })
@@ -2200,9 +2168,7 @@ async fn http_network_fetch(
                     _ => vec![],
                 };
                 *body = ResponseBody::Done(completed_body);
-                timing_ptr3
-                    .lock()
-                    .set_attribute(ResourceAttribute::ResponseEnd);
+                timing_ptr3.set_attribute(ResourceAttribute::ResponseEnd);
                 let _ = done_sender3.send(Data::Done);
             }),
     );

--- a/components/net/request_interceptor.rs
+++ b/components/net/request_interceptor.rs
@@ -51,7 +51,7 @@ impl RequestInterceptor {
         while let Some(message) = receiver.recv().await {
             match message {
                 WebResourceResponseMsg::Start(webresource_response) => {
-                    let timing = context.timing.lock().clone();
+                    let timing = context.timing.inner().clone();
                     let mut response_override =
                         Response::new(webresource_response.url.into(), timing);
                     response_override.headers = webresource_response.headers;

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -41,7 +41,6 @@ use rustc_hash::FxHashMap;
 use rustls_pki_types::CertificateDer;
 use rustls_pki_types::pem::PemObject;
 use serde::{Deserialize, Serialize};
-use servo_arc::Arc as ServoArc;
 use servo_base::generic_channel::{
     self, CallbackSetter, GenericCallback, GenericReceiver, GenericReceiverSet,
     GenericSelectionResult,
@@ -816,7 +815,7 @@ impl CoreResourceManager {
                 file_token,
                 request_interceptor: Arc::new(TokioMutex::new(request_interceptor)),
                 cancellation_listener,
-                timing: ServoArc::new(Mutex::new(ResourceFetchTiming::new(request.timing_type()))),
+                timing: ResourceFetchTiming::new(request.timing_type()).into(),
                 protocols,
                 websocket_chan: None,
                 ca_certificates,
@@ -908,9 +907,7 @@ impl CoreResourceManager {
                         file_token: FileTokenCheck::NotRequired,
                         request_interceptor: Arc::new(TokioMutex::new(request_interceptor)),
                         cancellation_listener,
-                        timing: ServoArc::new(Mutex::new(ResourceFetchTiming::new(
-                            request.timing_type(),
-                        ))),
+                        timing: ResourceFetchTiming::new(request.timing_type()).into(),
                         protocols: protocols.clone(),
                         websocket_chan: Some(Arc::new(Mutex::new(WebSocketChannel::new(
                             event_sender.clone(),

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -43,8 +43,6 @@ use net_traits::{
     FetchTaskTarget, IncludeSubdomains, NetworkError, ReferrerPolicy, ResourceFetchTiming,
     ResourceTimingType, get_current_locale,
 };
-use parking_lot::Mutex;
-use servo_arc::Arc as ServoArc;
 use servo_base::id::{TEST_PIPELINE_ID, TEST_WEBVIEW_ID};
 use servo_url::{ImmutableOrigin, ServoUrl};
 use tokio::sync::Mutex as TokioMutex;
@@ -777,9 +775,7 @@ fn test_fetch_with_hsts() {
         file_token: FileTokenCheck::NotRequired,
         request_interceptor: Arc::new(TokioMutex::new(RequestInterceptor::new(embedder_proxy))),
         cancellation_listener: Arc::new(Default::default()),
-        timing: ServoArc::new(Mutex::new(ResourceFetchTiming::new(
-            ResourceTimingType::Navigation,
-        ))),
+        timing: ResourceFetchTiming::new(ResourceTimingType::Navigation).into(),
         protocols: Arc::new(ProtocolRegistry::default()),
         websocket_chan: None,
         ca_certificates: CACertificates::Default,
@@ -843,9 +839,7 @@ fn test_load_adds_host_to_hsts_list_when_url_is_https() {
         file_token: FileTokenCheck::NotRequired,
         request_interceptor: Arc::new(TokioMutex::new(RequestInterceptor::new(embedder_proxy))),
         cancellation_listener: Arc::new(Default::default()),
-        timing: ServoArc::new(Mutex::new(ResourceFetchTiming::new(
-            ResourceTimingType::Navigation,
-        ))),
+        timing: ResourceFetchTiming::new(ResourceTimingType::Navigation).into(),
         protocols: Arc::new(ProtocolRegistry::default()),
         websocket_chan: None,
         ca_certificates: CACertificates::Default,
@@ -914,9 +908,7 @@ fn test_fetch_self_signed() {
         file_token: FileTokenCheck::NotRequired,
         request_interceptor: Arc::new(TokioMutex::new(RequestInterceptor::new(embedder_proxy))),
         cancellation_listener: Arc::new(Default::default()),
-        timing: ServoArc::new(Mutex::new(ResourceFetchTiming::new(
-            ResourceTimingType::Navigation,
-        ))),
+        timing: ResourceFetchTiming::new(ResourceTimingType::Navigation).into(),
         protocols: Arc::new(ProtocolRegistry::default()),
         websocket_chan: None,
         ca_certificates: CACertificates::Default,
@@ -1563,9 +1555,7 @@ fn test_fetch_request_intercepted() {
         file_token: FileTokenCheck::NotRequired,
         request_interceptor: Arc::new(TokioMutex::new(RequestInterceptor::new(embedder_proxy))),
         cancellation_listener: Arc::new(Default::default()),
-        timing: ServoArc::new(Mutex::new(ResourceFetchTiming::new(
-            ResourceTimingType::Navigation,
-        ))),
+        timing: ResourceFetchTiming::new(ResourceTimingType::Navigation).into(),
         protocols: Arc::new(ProtocolRegistry::default()),
         websocket_chan: None,
         ca_certificates: CACertificates::Default,

--- a/components/net/tests/main.rs
+++ b/components/net/tests/main.rs
@@ -44,9 +44,8 @@ use net_traits::filemanager_thread::FileTokenCheck;
 use net_traits::request::Request;
 use net_traits::response::Response;
 use net_traits::{FetchTaskTarget, ResourceFetchTiming, ResourceTimingType};
-use parking_lot::{Mutex, RwLock};
+use parking_lot::RwLock;
 use rustc_hash::FxHashMap;
-use servo_arc::Arc as ServoArc;
 use servo_url::{ImmutableOrigin, ServoUrl};
 use tokio::sync::Mutex as TokioMutex;
 
@@ -140,9 +139,7 @@ fn new_fetch_context(
         file_token: FileTokenCheck::NotRequired,
         request_interceptor: Arc::new(TokioMutex::new(RequestInterceptor::new(sender))),
         cancellation_listener: Arc::new(Default::default()),
-        timing: ServoArc::new(Mutex::new(ResourceFetchTiming::new(
-            ResourceTimingType::Navigation,
-        ))),
+        timing: ResourceFetchTiming::new(ResourceTimingType::Navigation).into(),
         protocols: Arc::new(ProtocolRegistry::with_internal_protocols()),
         websocket_chan: None,
         ca_certificates: CACertificates::Default,

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -26,7 +26,6 @@ use request::RequestId;
 use rustc_hash::FxHashMap;
 use rustls_pki_types::CertificateDer;
 use serde::{Deserialize, Serialize};
-use servo_base::cross_process_instant::CrossProcessInstant;
 use servo_base::generic_channel::{
     self, CallbackSetter, GenericCallback, GenericOneshotSender, GenericSend, GenericSender,
     SendResult,
@@ -55,7 +54,12 @@ pub mod policy_container;
 pub mod pub_domains;
 pub mod quality;
 pub mod request;
+pub(crate) mod resource_fetch_timing;
 pub mod response;
+pub use resource_fetch_timing::{
+    RedirectEndValue, RedirectStartValue, ResourceAttribute, ResourceFetchTiming,
+    ResourceFetchTimingContainer, ResourceTimeValue, ResourceTimingType,
+};
 
 /// <https://fetch.spec.whatwg.org/#document-accept-header-value>
 pub const DOCUMENT_ACCEPT_HEADER_VALUE: HeaderValue =
@@ -374,7 +378,7 @@ impl FetchTaskTarget for IpcSender<FetchResponseMsg> {
         let result = response
             .get_network_error()
             .map_or_else(|| Ok(()), |network_error| Err(network_error.clone()));
-        let timing = response.get_resource_timing().lock().clone();
+        let timing = response.get_resource_timing().inner().clone();
 
         let _ = self.send(FetchResponseMsg::ProcessResponseEOF(
             request.id, result, timing,
@@ -959,153 +963,6 @@ pub struct ResourceCorsData {
     pub preflight: bool,
     /// Origin of CORS Request
     pub origin: ServoUrl,
-}
-
-#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
-pub struct ResourceFetchTiming {
-    pub domain_lookup_start: Option<CrossProcessInstant>,
-    pub timing_check_passed: bool,
-    pub timing_type: ResourceTimingType,
-    /// Number of redirects until final resource (currently limited to 20)
-    pub redirect_count: u16,
-    pub request_start: Option<CrossProcessInstant>,
-    pub secure_connection_start: Option<CrossProcessInstant>,
-    pub response_start: Option<CrossProcessInstant>,
-    pub fetch_start: Option<CrossProcessInstant>,
-    pub response_end: Option<CrossProcessInstant>,
-    pub redirect_start: Option<CrossProcessInstant>,
-    pub redirect_end: Option<CrossProcessInstant>,
-    pub connect_start: Option<CrossProcessInstant>,
-    pub connect_end: Option<CrossProcessInstant>,
-    pub start_time: Option<CrossProcessInstant>,
-    pub preloaded: bool,
-}
-
-pub enum RedirectStartValue {
-    Zero,
-    FetchStart,
-}
-
-pub enum RedirectEndValue {
-    Zero,
-    ResponseEnd,
-}
-
-// TODO: refactor existing code to use this enum for setting time attributes
-// suggest using this with all time attributes in the future
-pub enum ResourceTimeValue {
-    Zero,
-    Now,
-    FetchStart,
-    RedirectStart,
-}
-
-pub enum ResourceAttribute {
-    RedirectCount(u16),
-    DomainLookupStart,
-    RequestStart,
-    ResponseStart,
-    RedirectStart(RedirectStartValue),
-    RedirectEnd(RedirectEndValue),
-    FetchStart,
-    ConnectStart(CrossProcessInstant),
-    ConnectEnd(CrossProcessInstant),
-    SecureConnectionStart,
-    ResponseEnd,
-    StartTime(ResourceTimeValue),
-}
-
-#[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
-pub enum ResourceTimingType {
-    Resource,
-    Navigation,
-    Error,
-    None,
-}
-
-impl ResourceFetchTiming {
-    pub fn new(timing_type: ResourceTimingType) -> ResourceFetchTiming {
-        ResourceFetchTiming {
-            timing_type,
-            timing_check_passed: true,
-            domain_lookup_start: None,
-            redirect_count: 0,
-            secure_connection_start: None,
-            request_start: None,
-            response_start: None,
-            fetch_start: None,
-            redirect_start: None,
-            redirect_end: None,
-            connect_start: None,
-            connect_end: None,
-            response_end: None,
-            start_time: None,
-            preloaded: false,
-        }
-    }
-
-    // TODO currently this is being set with precise time ns when it should be time since
-    // time origin (as described in Performance::now)
-    pub fn set_attribute(&mut self, attribute: ResourceAttribute) {
-        let should_attribute_always_be_updated = matches!(
-            attribute,
-            ResourceAttribute::FetchStart |
-                ResourceAttribute::ResponseEnd |
-                ResourceAttribute::StartTime(_)
-        );
-        if !self.timing_check_passed && !should_attribute_always_be_updated {
-            return;
-        }
-        let now = Some(CrossProcessInstant::now());
-        match attribute {
-            ResourceAttribute::DomainLookupStart => self.domain_lookup_start = now,
-            ResourceAttribute::RedirectCount(count) => self.redirect_count = count,
-            ResourceAttribute::RequestStart => self.request_start = now,
-            ResourceAttribute::ResponseStart => self.response_start = now,
-            ResourceAttribute::RedirectStart(val) => match val {
-                RedirectStartValue::Zero => self.redirect_start = None,
-                RedirectStartValue::FetchStart => {
-                    if self.redirect_start.is_none() {
-                        self.redirect_start = self.fetch_start
-                    }
-                },
-            },
-            ResourceAttribute::RedirectEnd(val) => match val {
-                RedirectEndValue::Zero => self.redirect_end = None,
-                RedirectEndValue::ResponseEnd => self.redirect_end = self.response_end,
-            },
-            ResourceAttribute::FetchStart => self.fetch_start = now,
-            ResourceAttribute::ConnectStart(instant) => self.connect_start = Some(instant),
-            ResourceAttribute::ConnectEnd(instant) => self.connect_end = Some(instant),
-            ResourceAttribute::SecureConnectionStart => self.secure_connection_start = now,
-            ResourceAttribute::ResponseEnd => self.response_end = now,
-            ResourceAttribute::StartTime(val) => match val {
-                ResourceTimeValue::RedirectStart
-                    if self.redirect_start.is_none() || !self.timing_check_passed => {},
-                _ => self.start_time = self.get_time_value(val),
-            },
-        }
-    }
-
-    fn get_time_value(&self, time: ResourceTimeValue) -> Option<CrossProcessInstant> {
-        match time {
-            ResourceTimeValue::Zero => None,
-            ResourceTimeValue::Now => Some(CrossProcessInstant::now()),
-            ResourceTimeValue::FetchStart => self.fetch_start,
-            ResourceTimeValue::RedirectStart => self.redirect_start,
-        }
-    }
-
-    pub fn mark_timing_check_failed(&mut self) {
-        self.timing_check_passed = false;
-        self.domain_lookup_start = None;
-        self.redirect_count = 0;
-        self.request_start = None;
-        self.response_start = None;
-        self.redirect_start = None;
-        self.connect_start = None;
-        self.connect_end = None;
-    }
 }
 
 /// Metadata about a loaded resource, such as is obtained from HTTP headers.

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -22,11 +22,12 @@ use tokio::sync::oneshot::Sender as TokioSender;
 use url::Position;
 use uuid::Uuid;
 
+use crate::ReferrerPolicy;
 use crate::blob_url_store::UrlWithBlobClaim;
 use crate::policy_container::{PolicyContainer, RequestPolicyContainer};
 use crate::pub_domains::is_same_site;
+use crate::resource_fetch_timing::ResourceTimingType;
 use crate::response::{HttpsState, RedirectTaint, Response};
-use crate::{ReferrerPolicy, ResourceTimingType};
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, MallocSizeOf, PartialEq, Serialize)]
 /// An id to differentiate one network request from another.

--- a/components/shared/net/resource_fetch_timing.rs
+++ b/components/shared/net/resource_fetch_timing.rs
@@ -1,0 +1,190 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use malloc_size_of_derive::MallocSizeOf;
+use parking_lot::{Mutex, MutexGuard};
+use serde::{Deserialize, Serialize};
+use servo_arc::Arc;
+use servo_base::cross_process_instant::CrossProcessInstant;
+
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
+pub struct ResourceFetchTiming {
+    pub domain_lookup_start: Option<CrossProcessInstant>,
+    pub timing_check_passed: bool,
+    pub timing_type: ResourceTimingType,
+    /// Number of redirects until final resource (currently limited to 20)
+    pub redirect_count: u16,
+    pub request_start: Option<CrossProcessInstant>,
+    pub secure_connection_start: Option<CrossProcessInstant>,
+    pub response_start: Option<CrossProcessInstant>,
+    pub fetch_start: Option<CrossProcessInstant>,
+    pub response_end: Option<CrossProcessInstant>,
+    pub redirect_start: Option<CrossProcessInstant>,
+    pub redirect_end: Option<CrossProcessInstant>,
+    pub connect_start: Option<CrossProcessInstant>,
+    pub connect_end: Option<CrossProcessInstant>,
+    pub start_time: Option<CrossProcessInstant>,
+    pub preloaded: bool,
+}
+
+#[derive(Clone)]
+pub enum RedirectStartValue {
+    Zero,
+    FetchStart,
+}
+
+#[derive(Clone)]
+pub enum RedirectEndValue {
+    Zero,
+    ResponseEnd,
+}
+
+// TODO: refactor existing code to use this enum for setting time attributes
+// suggest using this with all time attributes in the future
+#[derive(Clone)]
+pub enum ResourceTimeValue {
+    Zero,
+    Now,
+    FetchStart,
+    RedirectStart,
+}
+
+#[derive(Clone)]
+pub enum ResourceAttribute {
+    RedirectCount(u16),
+    DomainLookupStart,
+    RequestStart,
+    ResponseStart,
+    RedirectStart(RedirectStartValue),
+    RedirectEnd(RedirectEndValue),
+    FetchStart,
+    ConnectStart(CrossProcessInstant),
+    ConnectEnd(CrossProcessInstant),
+    SecureConnectionStart,
+    ResponseEnd,
+    StartTime(ResourceTimeValue),
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
+pub enum ResourceTimingType {
+    Resource,
+    Navigation,
+    Error,
+    None,
+}
+
+impl ResourceFetchTiming {
+    pub fn new(timing_type: ResourceTimingType) -> ResourceFetchTiming {
+        ResourceFetchTiming {
+            timing_type,
+            timing_check_passed: true,
+            domain_lookup_start: None,
+            redirect_count: 0,
+            secure_connection_start: None,
+            request_start: None,
+            response_start: None,
+            fetch_start: None,
+            redirect_start: None,
+            redirect_end: None,
+            connect_start: None,
+            connect_end: None,
+            response_end: None,
+            start_time: None,
+            preloaded: false,
+        }
+    }
+
+    // TODO currently this is being set with precise time ns when it should be time since
+    // time origin (as described in Performance::now)
+    pub fn set_attribute(&mut self, attribute: ResourceAttribute) {
+        let should_attribute_always_be_updated = matches!(
+            attribute,
+            ResourceAttribute::FetchStart |
+                ResourceAttribute::ResponseEnd |
+                ResourceAttribute::StartTime(_)
+        );
+        if !self.timing_check_passed && !should_attribute_always_be_updated {
+            return;
+        }
+        let now = Some(CrossProcessInstant::now());
+        match attribute {
+            ResourceAttribute::DomainLookupStart => self.domain_lookup_start = now,
+            ResourceAttribute::RedirectCount(count) => self.redirect_count = count,
+            ResourceAttribute::RequestStart => self.request_start = now,
+            ResourceAttribute::ResponseStart => self.response_start = now,
+            ResourceAttribute::RedirectStart(val) => match val {
+                RedirectStartValue::Zero => self.redirect_start = None,
+                RedirectStartValue::FetchStart => {
+                    if self.redirect_start.is_none() {
+                        self.redirect_start = self.fetch_start
+                    }
+                },
+            },
+            ResourceAttribute::RedirectEnd(val) => match val {
+                RedirectEndValue::Zero => self.redirect_end = None,
+                RedirectEndValue::ResponseEnd => self.redirect_end = self.response_end,
+            },
+            ResourceAttribute::FetchStart => self.fetch_start = now,
+            ResourceAttribute::ConnectStart(instant) => self.connect_start = Some(instant),
+            ResourceAttribute::ConnectEnd(instant) => self.connect_end = Some(instant),
+            ResourceAttribute::SecureConnectionStart => self.secure_connection_start = now,
+            ResourceAttribute::ResponseEnd => self.response_end = now,
+            ResourceAttribute::StartTime(val) => match val {
+                ResourceTimeValue::RedirectStart
+                    if self.redirect_start.is_none() || !self.timing_check_passed => {},
+                _ => self.start_time = self.get_time_value(val),
+            },
+        }
+    }
+
+    fn get_time_value(&self, time: ResourceTimeValue) -> Option<CrossProcessInstant> {
+        match time {
+            ResourceTimeValue::Zero => None,
+            ResourceTimeValue::Now => Some(CrossProcessInstant::now()),
+            ResourceTimeValue::FetchStart => self.fetch_start,
+            ResourceTimeValue::RedirectStart => self.redirect_start,
+        }
+    }
+
+    pub fn mark_timing_check_failed(&mut self) {
+        self.timing_check_passed = false;
+        self.domain_lookup_start = None;
+        self.redirect_count = 0;
+        self.request_start = None;
+        self.response_start = None;
+        self.redirect_start = None;
+        self.connect_start = None;
+        self.connect_end = None;
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, MallocSizeOf)]
+/// A simple container of [`ResourceFetchTiming`] to allow easy sharing between threads and allow to set multiple attributes in sequence.
+pub struct ResourceFetchTimingContainer(
+    #[conditional_malloc_size_of] Arc<Mutex<ResourceFetchTiming>>,
+);
+
+impl ResourceFetchTimingContainer {
+    pub fn set_attribute(&self, attribute: ResourceAttribute) {
+        self.0.lock().set_attribute(attribute);
+    }
+
+    /// Set multiple attributes in sequence.
+    pub fn set_attributes(&self, attributes: &[ResourceAttribute]) {
+        let mut inner = self.0.lock();
+        for attribute in attributes {
+            inner.set_attribute(attribute.clone());
+        }
+    }
+
+    pub fn inner(&self) -> MutexGuard<'_, ResourceFetchTiming> {
+        self.0.lock()
+    }
+}
+
+impl From<ResourceFetchTiming> for ResourceFetchTimingContainer {
+    fn from(value: ResourceFetchTiming) -> Self {
+        ResourceFetchTimingContainer(Arc::new(Mutex::new(value)))
+    }
+}

--- a/components/shared/net/response.rs
+++ b/components/shared/net/response.rs
@@ -16,9 +16,10 @@ use servo_url::ServoUrl;
 
 use crate::fetch::headers::extract_mime_type_as_mime;
 use crate::http_status::HttpStatus;
+use crate::resource_fetch_timing::{ResourceFetchTimingContainer, ResourceTimingType};
 use crate::{
     FetchMetadata, FilteredMetadata, Metadata, NetworkError, ReferrerPolicy, ResourceFetchTiming,
-    ResourceTimingType, TlsSecurityInfo,
+    TlsSecurityInfo,
 };
 
 /// [Response type](https://fetch.spec.whatwg.org/#concept-response-type)
@@ -132,8 +133,7 @@ pub struct Response {
     #[conditional_malloc_size_of]
     pub aborted: Arc<AtomicBool>,
     /// track network metrics
-    #[conditional_malloc_size_of]
-    pub resource_timing: Arc<Mutex<ResourceFetchTiming>>,
+    pub resource_timing: ResourceFetchTimingContainer,
 
     /// <https://fetch.spec.whatwg.org/#concept-response-range-requested-flag>
     pub range_requested: bool,
@@ -163,7 +163,7 @@ impl Response {
             internal_response: None,
             return_internal: true,
             aborted: Arc::new(AtomicBool::new(false)),
-            resource_timing: Arc::new(Mutex::new(resource_timing)),
+            resource_timing: resource_timing.into(),
             range_requested: false,
             request_includes_credentials: true,
             redirect_taint: Default::default(),
@@ -198,9 +198,7 @@ impl Response {
             internal_response: None,
             return_internal: true,
             aborted: Arc::new(AtomicBool::new(false)),
-            resource_timing: Arc::new(Mutex::new(ResourceFetchTiming::new(
-                ResourceTimingType::Error,
-            ))),
+            resource_timing: ResourceFetchTiming::new(ResourceTimingType::Error).into(),
             range_requested: false,
             request_includes_credentials: true,
             redirect_taint: Default::default(),
@@ -250,8 +248,8 @@ impl Response {
         }
     }
 
-    pub fn get_resource_timing(&self) -> Arc<Mutex<ResourceFetchTiming>> {
-        Arc::clone(&self.resource_timing)
+    pub fn get_resource_timing(&self) -> &ResourceFetchTimingContainer {
+        &self.resource_timing
     }
 
     /// Convert to a filtered response, of type `filter_type`.


### PR DESCRIPTION
ResourceFetchTimings are set throughout the methods in http_loader.rs. These methods are already very complicated, so having multiple times
`context.timings.lock().set_attribute()` can be quite distracting to understanding.

This introduces ResourceFetchTimingsContainer structure which has the lock inside and allows setting multiple attributes to clean up the code in http_loader.

Testing: This is a refactor and does not change functionality.
