### PR TITLE
layout: Fix grid container stretch alignment inside flex with indefinite height

### DIFF
--- a/components/layout/flexbox/layout.rs
+++ b/components/layout/flexbox/layout.rs
@@ -1822,7 +1822,10 @@ impl FlexItem<'_> {
             // The main size of a flex item is considered to be definite if its flex basis is definite
             // or the flex container has a definite main size.
             // <https://drafts.csswg.org/css-flexbox-1/#definite-sizes>
-            let main_size = if self.flex_base_size_is_definite ||
+            // If the child is a grid container, we need to pass definite size
+            // for align-content: stretch to work.
+            let is_grid = self.box_.independent_formatting_context.is_grid();
+            let main_size = if is_grid || self.flex_base_size_is_definite ||
                 flex_context
                     .container_inner_size_constraint
                     .main

--- a/components/layout/flexbox/layout.rs
+++ b/components/layout/flexbox/layout.rs
@@ -1825,7 +1825,8 @@ impl FlexItem<'_> {
             // If the child is a grid container, we need to pass definite size
             // for align-content: stretch to work.
             let is_grid = self.box_.independent_formatting_context.is_grid();
-            let main_size = if is_grid || self.flex_base_size_is_definite ||
+            let main_size = if is_grid ||
+                self.flex_base_size_is_definite ||
                 flex_context
                     .container_inner_size_constraint
                     .main

--- a/components/layout/flexbox/layout.rs
+++ b/components/layout/flexbox/layout.rs
@@ -1822,8 +1822,11 @@ impl FlexItem<'_> {
             // The main size of a flex item is considered to be definite if its flex basis is definite
             // or the flex container has a definite main size.
             // <https://drafts.csswg.org/css-flexbox-1/#definite-sizes>
-            // If the child is a grid container, we need to pass definite size
-            // for align-content: stretch to work.
+            //
+            // Each grid area’s width and height are considered definite
+            // when laying out the grid items into their respective containing blocks,
+            // after the grid is sized.
+            // <https://drafts.csswg.org/css-grid-1/#layout-algorithm>
             let is_grid = self.box_.independent_formatting_context.is_grid();
             let main_size = if is_grid ||
                 self.flex_base_size_is_definite ||

--- a/components/layout/formatting_contexts.rs
+++ b/components/layout/formatting_contexts.rs
@@ -384,6 +384,14 @@ impl IndependentFormattingContext {
         )
     }
 
+    #[inline]
+    pub(crate) fn is_grid(&self) -> bool {
+        matches!(
+            &self.contents,
+            IndependentFormattingContextContents::Grid(_)
+        )
+    }
+
     #[servo_tracing::instrument(
         name = "IndependentFormattingContext::layout_without_caching",
         skip_all

--- a/components/layout/taffy/stylo_taffy/convert.rs
+++ b/components/layout/taffy/stylo_taffy/convert.rs
@@ -155,7 +155,7 @@ pub fn aspect_ratio(input: stylo::AspectRatio) -> Option<f32> {
 #[inline]
 pub fn content_alignment(input: stylo::ContentDistribution) -> Option<taffy::AlignContent> {
     match input.primary().value() {
-        stylo::AlignFlags::NORMAL => None,
+        stylo::AlignFlags::NORMAL => Some(taffy::AlignContent::Stretch),
         stylo::AlignFlags::AUTO => None,
         stylo::AlignFlags::START => Some(taffy::AlignContent::Start),
         stylo::AlignFlags::END => Some(taffy::AlignContent::End),

--- a/components/layout/taffy/stylo_taffy/convert.rs
+++ b/components/layout/taffy/stylo_taffy/convert.rs
@@ -155,6 +155,8 @@ pub fn aspect_ratio(input: stylo::AspectRatio) -> Option<f32> {
 #[inline]
 pub fn content_alignment(input: stylo::ContentDistribution) -> Option<taffy::AlignContent> {
     match input.primary().value() {
+        // <https://www.w3.org/TR/css-align-3/#distribution-grid>
+        // Normal behaves as stretch for grid containers. 
         stylo::AlignFlags::NORMAL => Some(taffy::AlignContent::Stretch),
         stylo::AlignFlags::AUTO => None,
         stylo::AlignFlags::START => Some(taffy::AlignContent::Start),

--- a/components/layout/taffy/stylo_taffy/convert.rs
+++ b/components/layout/taffy/stylo_taffy/convert.rs
@@ -156,7 +156,7 @@ pub fn aspect_ratio(input: stylo::AspectRatio) -> Option<f32> {
 pub fn content_alignment(input: stylo::ContentDistribution) -> Option<taffy::AlignContent> {
     match input.primary().value() {
         // <https://www.w3.org/TR/css-align-3/#distribution-grid>
-        // Normal behaves as stretch for grid containers. 
+        // Normal behaves as stretch for grid containers.
         stylo::AlignFlags::NORMAL => Some(taffy::AlignContent::Stretch),
         stylo::AlignFlags::AUTO => None,
         stylo::AlignFlags::START => Some(taffy::AlignContent::Start),

--- a/components/layout/taffy/stylo_taffy/convert.rs
+++ b/components/layout/taffy/stylo_taffy/convert.rs
@@ -155,9 +155,7 @@ pub fn aspect_ratio(input: stylo::AspectRatio) -> Option<f32> {
 #[inline]
 pub fn content_alignment(input: stylo::ContentDistribution) -> Option<taffy::AlignContent> {
     match input.primary().value() {
-        // <https://www.w3.org/TR/css-align-3/#distribution-grid>
-        // Normal behaves as stretch for grid containers.
-        stylo::AlignFlags::NORMAL => Some(taffy::AlignContent::Stretch),
+        stylo::AlignFlags::NORMAL => None,
         stylo::AlignFlags::AUTO => None,
         stylo::AlignFlags::START => Some(taffy::AlignContent::Start),
         stylo::AlignFlags::END => Some(taffy::AlignContent::End),

--- a/tests/wpt/meta/css/css-grid/grid-within-flexbox-indefinite.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-within-flexbox-indefinite.html.ini
@@ -1,2 +1,0 @@
-[grid-within-flexbox-indefinite.html]
-  expected: FAIL


### PR DESCRIPTION
There was a related post by @Loirooriol 6 years ago: https://github.com/w3c/csswg-drafts/issues/4852

When a flex item is a grid, passes used main size as definite.

Testing: New passing in `/css/css-grid/grid-within-flexbox-indefinite.html`
Fixes: #44384. Now works same as Firefox/Chrome.