### PR TITLE
script: Enable sequential focus navigation across frame boundaries

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -162,8 +162,8 @@ use servo_constellation_traits::{
     AuxiliaryWebViewCreationRequest, AuxiliaryWebViewCreationResponse, ConstellationInterest,
     DocumentState, EmbedderToConstellationMessage, IFrameLoadInfo, IFrameLoadInfoWithData,
     IFrameSizeMsg, Job, LoadData, LogEntry, MessagePortMsg, NavigationHistoryBehavior,
-    PaintMetricEvent, PortMessageTask, PortTransferInfo, SWManagerMsg, SWManagerSenders,
-    ScreenshotReadinessResponse, ScriptToConstellationMessage, ScrollStateUpdate,
+    PaintMetricEvent, PortMessageTask, PortTransferInfo, RemoteFocusOperation, SWManagerMsg,
+    SWManagerSenders, ScreenshotReadinessResponse, ScriptToConstellationMessage, ScrollStateUpdate,
     ServiceWorkerManagerFactory, ServiceWorkerMsg, StructuredSerializedData, TargetSnapshotParams,
     TraversalDirection, UserContentManagerAction, WindowSizeType,
 };
@@ -1934,8 +1934,12 @@ where
             },
             ScriptToConstellationMessage::FocusRemoteBrowsingContext(
                 focused_browsing_context_id,
+                remote_focus_operation,
             ) => {
-                self.handle_focus_remote_browsing_context(focused_browsing_context_id);
+                self.handle_focus_remote_browsing_context(
+                    focused_browsing_context_id,
+                    remote_focus_operation,
+                );
             },
             ScriptToConstellationMessage::SetThrottledComplete(throttled) => {
                 self.handle_set_throttled_complete(source_pipeline_id, throttled);
@@ -4550,7 +4554,11 @@ where
         self.focus_browsing_context(Some(pipeline_id), focused_browsing_context_id);
     }
 
-    fn handle_focus_remote_browsing_context(&mut self, target: BrowsingContextId) {
+    fn handle_focus_remote_browsing_context(
+        &mut self,
+        target: BrowsingContextId,
+        operation: RemoteFocusOperation,
+    ) {
         let Some(browsing_context) = self.browsing_contexts.get(&target) else {
             return warn!("{target:?} not found for focus message");
         };
@@ -4560,7 +4568,7 @@ where
         };
         if let Err(error) = pipeline
             .event_loop
-            .send(ScriptThreadMessage::FocusDocument(pipeline_id))
+            .send(ScriptThreadMessage::FocusDocument(pipeline_id, operation))
         {
             self.handle_send_error(pipeline_id, error);
         }
@@ -4796,7 +4804,10 @@ where
                 let _ = response_sender.send(is_open);
             },
             WebDriverCommandMsg::FocusBrowsingContext(browsing_context_id) => {
-                self.handle_focus_remote_browsing_context(browsing_context_id);
+                self.handle_focus_remote_browsing_context(
+                    browsing_context_id,
+                    RemoteFocusOperation::Viewport,
+                );
             },
             // TODO: This should use the ScriptThreadMessage::EvaluateJavaScript command
             WebDriverCommandMsg::ScriptCommand(browsing_context_id, cmd) => {

--- a/components/script/dom/dissimilaroriginwindow.rs
+++ b/components/script/dom/dissimilaroriginwindow.rs
@@ -9,7 +9,9 @@ use js::jsval::UndefinedValue;
 use js::rust::{CustomAutoRooter, CustomAutoRooterGuard, HandleValue, MutableHandleValue};
 use net_traits::response::HttpsState;
 use servo_base::id::PipelineId;
-use servo_constellation_traits::{ScriptToConstellationMessage, StructuredSerializedData};
+use servo_constellation_traits::{
+    RemoteFocusOperation, ScriptToConstellationMessage, StructuredSerializedData,
+};
 use servo_url::ServoUrl;
 
 use crate::dom::bindings::codegen::Bindings::DissimilarOriginWindowBinding;
@@ -193,12 +195,12 @@ impl DissimilarOriginWindowMethods<crate::DomTypeHolder> for DissimilarOriginWin
     fn Focus(&self) {
         let browsing_context_id = self.window_proxy.browsing_context_id();
         debug!("Initiating a focus operation for {browsing_context_id:?}");
-        self.globalscope
-            .script_to_constellation_chan()
-            .send(ScriptToConstellationMessage::FocusRemoteBrowsingContext(
+        let _ = self.globalscope.script_to_constellation_chan().send(
+            ScriptToConstellationMessage::FocusRemoteBrowsingContext(
                 browsing_context_id,
-            ))
-            .unwrap();
+                RemoteFocusOperation::Viewport,
+            ),
+        );
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-location>

--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -48,7 +48,9 @@ use script_bindings::str::DOMString;
 use script_traits::ConstellationInputEvent;
 use servo_base::generic_channel::GenericCallback;
 use servo_config::pref;
-use servo_constellation_traits::{KeyboardScroll, ScriptToConstellationMessage};
+use servo_constellation_traits::{
+    KeyboardScroll, ScriptToConstellationMessage, SequentialFocusDirection,
+};
 use style::Atom;
 use style_traits::CSSPixel;
 use webrender_api::ExternalScrollId;
@@ -74,8 +76,8 @@ use crate::dom::pointerevent::{PointerEvent, PointerId};
 use crate::dom::scrolling_box::{ScrollAxisState, ScrollRequirement, ScrollingBoxAxis};
 use crate::dom::types::{
     ClipboardEvent, CompositionEvent, DataTransfer, Element, Event, EventTarget, GlobalScope,
-    HTMLAnchorElement, HTMLElement, HTMLLabelElement, MouseEvent, Touch, TouchEvent, TouchList,
-    WheelEvent, Window,
+    HTMLAnchorElement, HTMLElement, HTMLIFrameElement, HTMLLabelElement, MouseEvent, Touch,
+    TouchEvent, TouchList, WheelEvent, Window,
 };
 use crate::drag_data_store::{DragDataStore, Kind, Mode};
 use crate::realms::enter_realm;
@@ -2012,7 +2014,7 @@ impl DocumentEventHandler {
         self.sequential_focus_navigation(cx, direction);
     }
 
-    /// <<https://html.spec.whatwg.org/multipage/#sequential-focus-navigation:currently-focused-area-of-a-top-level-traversable>
+    /// <https://html.spec.whatwg.org/multipage/#sequential-focus-navigation:currently-focused-area-of-a-top-level-traversable>
     fn sequential_focus_navigation(&self, cx: &mut JSContext, direction: SequentialFocusDirection) {
         // > When the user requests that focus move from the currently focused area of a top-level
         // > traversable to the next or previous focusable area (e.g., as the default action of
@@ -2024,10 +2026,6 @@ impl DocumentEventHandler {
         // > user requested to move focus sequentially from there, or else the top-level traversable
         // > itself, if the user instead requested to move focus from outside the top-level
         // > traversable.
-        //
-        // TODO: We do not yet implement support for doing sequential focus navigation between traversibles
-        // according to the specification, so the implementation is currently adapted to work with a single
-        // traversible.
         //
         // Note: Here `None` represents the current traversible.
         let mut starting_point = self
@@ -2056,6 +2054,23 @@ impl DocumentEventHandler {
         //
         // Note: This is handled by the `direction` argument to this method.
 
+        self.sequential_focus_navigation_loop(
+            cx,
+            starting_point,
+            direction,
+            false, /* allow_focusing_viewport */
+        );
+    }
+
+    /// The inner loop ("Loop") of:
+    /// <https://html.spec.whatwg.org/multipage/#sequential-focus-navigation:currently-focused-area-of-a-top-level-traversable>
+    pub(crate) fn sequential_focus_navigation_loop(
+        &self,
+        cx: &mut JSContext,
+        starting_point: Option<DomRoot<Node>>,
+        direction: SequentialFocusDirection,
+        allow_focusing_viewport: bool,
+    ) {
         // > 4. Loop: Let selection mechanism be "sequential" if starting point is a navigable or if
         // > starting point is in its Document's sequential focus navigation order.
         // > Otherwise, starting point is not in its Document's sequential focus navigation order;
@@ -2073,20 +2088,49 @@ impl DocumentEventHandler {
         // > 6. If candidate is not null, then run the focusing steps for candidate and return.
         if let Some(candidate) = candidate {
             self.focus_and_scroll_to_element_for_key_event(cx, &candidate);
+            // We can't simply run the focusing steps, because:
+            //  1. The focusing steps do not scroll to the element.
+            //  2. When focus shifts to a child navigable (iframe) we have special behavior to reach
+            //     across document boundaries to focus the first focusable element in the iframe.
+            match candidate.downcast::<HTMLIFrameElement>() {
+                Some(iframe_element) => self
+                    .window
+                    .Document()
+                    .focus_handler()
+                    .sequentially_focus_child_iframe_local_or_remote(cx, iframe_element, direction),
+                None => self.focus_and_scroll_to_element_for_key_event(cx, &candidate),
+            }
             return;
         }
 
         // > 7. Otherwise, unset the sequential focus navigation starting point.
         self.sequential_focus_navigation_starting_point.clear();
 
+        // This is not in the specification, but there's a difference between moving focus into
+        // a child `<iframe>` and within a Document. If no suitable focusable area can be found
+        // when moving into an `<iframe>`, we want to focus the `<iframe>`'s viewport itself.
+        if allow_focusing_viewport {
+            self.window
+                .Document()
+                .focus_handler()
+                .focus(cx, FocusableArea::Viewport);
+            return;
+        }
+
         // > 8. If starting point is a top-level traversable, or a focusable area in the top-level
         // > traversable, the user agent should transfer focus to its own controls appropriately (if
         // > any), honouring direction, and then return.
         // TODO: Implement this.
+        if self.window.is_top_level() {
+            return;
+        }
 
         // > 9. Otherwise, starting point is a focusable area in a child navigable. Set starting
         // > point to that child navigable's parent and return to the step labeled loop.
-        // TODO: Implement this.
+        self.window
+            .Document()
+            .focus_handler()
+            .sequentially_focus_parent_local_or_remote(cx, direction);
     }
 
     fn find_element_for_tab_focus_following_element(
@@ -2094,7 +2138,7 @@ impl DocumentEventHandler {
         direction: SequentialFocusDirection,
         starting_point: DomRoot<Node>,
     ) -> Option<DomRoot<Element>> {
-        let root_node = self.window.Document().GetDocumentElement()?;
+        let root_node = self.window.Document();
         let focused_element_tab_index = starting_point
             .downcast::<Element>()
             .and_then(Element::explicitly_set_tab_index)
@@ -2192,7 +2236,7 @@ impl DocumentEventHandler {
         &self,
         direction: SequentialFocusDirection,
     ) -> Option<DomRoot<Element>> {
-        let root_node = self.window.Document().GetDocumentElement()?;
+        let root_node = self.window.Document();
         let mut winning_node_and_tab_index: Option<(DomRoot<Element>, i32)> = None;
         for node in root_node
             .upcast::<Node>()
@@ -2524,17 +2568,6 @@ impl DocumentEventHandler {
             None,
         );
     }
-}
-
-/// <https://html.spec.whatwg.org/multipage/#sequential-focus-direction>
-///
-/// > A sequential focus direction is one of two possible values: "forward", or "backward". They are
-/// > used in the below algorithms to describe the direction in which sequential focus travels at the
-/// > user's request.
-#[derive(Clone, Copy, PartialEq)]
-enum SequentialFocusDirection {
-    Forward,
-    Backward,
 }
 
 fn compare_tab_indices(a: i32, b: i32) -> Ordering {

--- a/components/script/dom/document/focus.rs
+++ b/components/script/dom/document/focus.rs
@@ -7,16 +7,22 @@ use std::cell::{Cell, Ref};
 use bitflags::bitflags;
 use embedder_traits::FocusSequenceNumber;
 use js::context::JSContext;
+use script_bindings::codegen::GenericBindings::HTMLIFrameElementBinding::HTMLIFrameElementMethods;
 use script_bindings::codegen::GenericBindings::ShadowRootBinding::ShadowRootMethods;
+use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
 use script_bindings::inheritance::Castable;
 use script_bindings::root::{Dom, DomRoot};
 use script_bindings::script_runtime::CanGc;
-use servo_constellation_traits::ScriptToConstellationMessage;
+use servo_base::id::BrowsingContextId;
+use servo_constellation_traits::{
+    RemoteFocusOperation, ScriptToConstellationMessage, SequentialFocusDirection,
+};
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::focusevent::FocusEventType;
 use crate::dom::types::{Element, EventTarget, FocusEvent, HTMLElement, HTMLIFrameElement, Window};
 use crate::dom::{Document, Event, EventBubbles, EventCancelable, Node, NodeTraits};
+use crate::realms::enter_realm;
 
 /// The kind of focusable area a [`FocusableArea`] is. A [`FocusableArea`] may be click focusable,
 /// sequentially focusable, or both.
@@ -511,5 +517,88 @@ impl DocumentFocusHandler {
             return;
         }
         self.focus(cx, FocusableArea::Viewport);
+    }
+
+    pub(crate) fn sequentially_focus_child_iframe_local_or_remote(
+        &self,
+        cx: &mut JSContext,
+        iframe_element: &HTMLIFrameElement,
+        direction: SequentialFocusDirection,
+    ) {
+        if let Some(content_document) = iframe_element.GetContentDocument() {
+            // The <iframe> is in the same `ScriptThread` and we have direct access to it. We can
+            // move the focus directly.
+            content_document
+                .focus_handler()
+                .sequential_focus_from_another_document(cx, None, direction);
+        } else if let Some(browsing_context_id) = iframe_element.browsing_context_id() {
+            self.window.send_to_constellation(
+                ScriptToConstellationMessage::FocusRemoteBrowsingContext(
+                    browsing_context_id,
+                    RemoteFocusOperation::Sequential(direction, None),
+                ),
+            );
+        } else {
+            iframe_element
+                .upcast::<Node>()
+                .run_the_focusing_steps(cx, None);
+        }
+    }
+
+    pub(crate) fn sequentially_focus_parent_local_or_remote(
+        &self,
+        cx: &mut JSContext,
+        direction: SequentialFocusDirection,
+    ) {
+        let window_proxy = self.window.window_proxy();
+        if let Some(iframe) = window_proxy.frame_element() {
+            // The parent browsing context is in the same `ScriptThread` and we have direct access
+            // to it. We can move the focus directly.
+            let browsing_context_id = iframe
+                .downcast::<HTMLIFrameElement>()
+                .and_then(|iframe_element| iframe_element.browsing_context_id());
+            iframe
+                .owner_document()
+                .focus_handler()
+                .sequential_focus_from_another_document(cx, browsing_context_id, direction);
+        } else if let Some(browsing_context_id) = window_proxy
+            .parent()
+            .map(|parent| parent.browsing_context_id())
+        {
+            self.window.send_to_constellation(
+                ScriptToConstellationMessage::FocusRemoteBrowsingContext(
+                    browsing_context_id,
+                    RemoteFocusOperation::Sequential(
+                        direction,
+                        Some(window_proxy.browsing_context_id()),
+                    ),
+                ),
+            );
+        }
+    }
+
+    pub(crate) fn sequential_focus_from_another_document(
+        &self,
+        cx: &mut JSContext,
+        browsing_context_id: Option<BrowsingContextId>,
+        direction: SequentialFocusDirection,
+    ) {
+        let _realm = enter_realm(&*self.window);
+        let starting_point = browsing_context_id.and_then(|browsing_context_id| {
+            self.window
+                .Document()
+                .iframes()
+                .get(browsing_context_id)
+                .map(|iframe| DomRoot::from_ref(iframe.element.upcast::<Node>()))
+        });
+        self.window
+            .Document()
+            .event_handler()
+            .sequential_focus_navigation_loop(
+                cx,
+                starting_point,
+                direction,
+                true, /* allow focusing viewport */
+            );
     }
 }

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -80,7 +80,7 @@ impl MixedMessage {
 
                 ScriptThreadMessage::FocusDocumentAsPartOfFocusingSteps(id, ..) => Some(*id),
                 ScriptThreadMessage::UnfocusDocumentAsPartOfFocusingSteps(id, ..) => Some(*id),
-                ScriptThreadMessage::FocusDocument(id) => Some(*id),
+                ScriptThreadMessage::FocusDocument(id, ..) => Some(*id),
                 ScriptThreadMessage::WebDriverScriptCommand(id, ..) => Some(*id),
                 ScriptThreadMessage::TickAllAnimations(..) => None,
                 ScriptThreadMessage::WebFontLoaded(id) => Some(*id),

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -89,9 +89,10 @@ use servo_base::{Epoch, generic_channel};
 use servo_canvas_traits::webgl::WebGLPipeline;
 use servo_config::{opts, pref, prefs};
 use servo_constellation_traits::{
-    LoadData, LoadOrigin, NavigationHistoryBehavior, ScreenshotReadinessResponse,
-    ScriptToConstellationChan, ScriptToConstellationMessage, ScrollStateUpdate,
-    StructuredSerializedData, TargetSnapshotParams, TraversalDirection, WindowSizeType,
+    LoadData, LoadOrigin, NavigationHistoryBehavior, RemoteFocusOperation,
+    ScreenshotReadinessResponse, ScriptToConstellationChan, ScriptToConstellationMessage,
+    ScrollStateUpdate, StructuredSerializedData, TargetSnapshotParams, TraversalDirection,
+    WindowSizeType,
 };
 use servo_url::{ImmutableOrigin, MutableOrigin, OriginSnapshot, ServoUrl};
 use storage_traits::StorageThreads;
@@ -1841,8 +1842,8 @@ impl ScriptThread {
             ScriptThreadMessage::UnfocusDocumentAsPartOfFocusingSteps(pipeline_id, sequence) => {
                 self.handle_unfocus_document_as_part_of_focusing_steps(cx, pipeline_id, sequence);
             },
-            ScriptThreadMessage::FocusDocument(pipeline_id) => {
-                self.handle_focus_document(cx, pipeline_id);
+            ScriptThreadMessage::FocusDocument(pipeline_id, remote_focus_operation) => {
+                self.handle_focus_document(cx, pipeline_id, remote_focus_operation);
             },
             ScriptThreadMessage::WebDriverScriptCommand(pipeline_id, msg) => {
                 self.handle_webdriver_msg(pipeline_id, msg, cx)
@@ -2863,12 +2864,22 @@ impl ScriptThread {
         );
     }
 
-    fn handle_focus_document(&self, cx: &mut js::context::JSContext, pipeline_id: PipelineId) {
+    fn handle_focus_document(
+        &self,
+        cx: &mut js::context::JSContext,
+        pipeline_id: PipelineId,
+        remote_focus_operation: RemoteFocusOperation,
+    ) {
         let Some(document) = self.documents.borrow().find_document(pipeline_id) else {
             warn!("Unknown {pipeline_id:?} for FocusDocument message.");
             return;
         };
-        document.window().Focus(cx);
+        match remote_focus_operation {
+            RemoteFocusOperation::Viewport => document.window().Focus(cx),
+            RemoteFocusOperation::Sequential(direction, iframe_browsing_context_id) => document
+                .focus_handler()
+                .sequential_focus_from_another_document(cx, iframe_browsing_context_id, direction),
+        }
     }
 
     fn handle_unfocus_document_as_part_of_focusing_steps(

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -635,9 +635,13 @@ pub enum ScriptToConstellationMessage {
     /// The second field is a sequence number that the constellation should use
     /// when sending a focus-related message to the sender pipeline next time.
     FocusAncestorBrowsingContextsForFocusingSteps(Option<BrowsingContextId>, FocusSequenceNumber),
-    /// Have the Constellation trigger a remote call to `Focus` on the `Window` of the given
-    /// [`BrowsingContextId`].
-    FocusRemoteBrowsingContext(BrowsingContextId),
+    /// Focus a remote `BrowsingContext` and run the focusing steps. This is used in two situations:
+    /// - When calling the DOM `focus()` API on a remote `Window` as well as from
+    ///   WebDriver. The difference between this and `FocusDocumentAsPartOfFocusingSteps` is that this
+    ///   version actually does run the focusing steps and may result in blur and focus events firing
+    ///   up the frame tree.
+    /// - When doing sequential focus navigation into and out of frames.
+    FocusRemoteBrowsingContext(BrowsingContextId, RemoteFocusOperation),
     /// Get the top-level browsing context info for a given browsing context.
     GetTopForBrowsingContext(BrowsingContextId, GenericSender<Option<WebViewId>>),
     /// Get the browsing context id of the browsing context in which pipeline is
@@ -779,4 +783,25 @@ impl Default for TargetSnapshotParams {
             iframe_element_referrer_policy: ReferrerPolicy::EmptyString,
         }
     }
+}
+
+/// <https://html.spec.whatwg.org/multipage/#sequential-focus-direction>
+///
+/// > A sequential focus direction is one of two possible values: "forward", or "backward". They are
+/// > used in the below algorithms to describe the direction in which sequential focus travels at the
+/// > user's request.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+pub enum SequentialFocusDirection {
+    Forward,
+    Backward,
+}
+
+/// The type of focus operation to do on a remote document.
+#[derive(Deserialize, Serialize)]
+pub enum RemoteFocusOperation {
+    /// Focus the entire viewport of the remote document.
+    Viewport,
+    /// Do sequential focus navigation using the `<iframe>` element with the given
+    /// [`BrowsingContextId`] as the starting point and in the given direction.
+    Sequential(SequentialFocusDirection, Option<BrowsingContextId>),
 }

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -42,8 +42,9 @@ use servo_bluetooth_traits::BluetoothRequest;
 use servo_canvas_traits::webgl::WebGLPipeline;
 use servo_config::prefs::PrefValue;
 use servo_constellation_traits::{
-    KeyboardScroll, LoadData, NavigationHistoryBehavior, ScriptToConstellationSender,
-    ScrollStateUpdate, StructuredSerializedData, TargetSnapshotParams, WindowSizeType,
+    KeyboardScroll, LoadData, NavigationHistoryBehavior, RemoteFocusOperation,
+    ScriptToConstellationSender, ScrollStateUpdate, StructuredSerializedData, TargetSnapshotParams,
+    WindowSizeType,
 };
 use servo_url::{ImmutableOrigin, ServoUrl};
 use storage_traits::StorageThreads;
@@ -235,11 +236,13 @@ pub enum ScriptThreadMessage {
     /// `<iframe>` losing focus. This does not do anything for a top-level `Document`, which can never
     /// lose focus (apart from losing system focus, which is a separate concept).
     UnfocusDocumentAsPartOfFocusingSteps(PipelineId, FocusSequenceNumber),
-    /// Focus a `Document` and run the focusing steps. This is used when calling the DOM `focus()`
-    /// API on a remote `Window` as well as from WebDriver. The difference between this and
-    /// `FocusDocumentAsPartOfFocusingSteps` is that this version actually does run the focusing
-    /// steps and may result in blur and focus events firing up the frame tree.
-    FocusDocument(PipelineId),
+    /// Focus a `Document` and run the focusing steps. This is used in two situations:
+    /// - When calling the DOM `focus()` API on a remote `Window` as well as from
+    ///   WebDriver. The difference between this and `FocusDocumentAsPartOfFocusingSteps` is that this
+    ///   version actually does run the focusing steps and may result in blur and focus events firing
+    ///   up the frame tree.
+    /// - When doing sequential focus navigation into and out of frames.
+    FocusDocument(PipelineId, RemoteFocusOperation),
     /// Passes a webdriver command to the script thread for execution
     WebDriverScriptCommand(PipelineId, WebDriverScriptCommand),
     /// Notifies script thread that all animations are done

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13357,6 +13357,24 @@
       }
      ]
     ],
+    "sequential-focus-navigation-across-documents-001.html": [
+     "40c2ff0e0fd0e85110825c7836eb767880d6dd61",
+     [
+      null,
+      {
+       "testdriver": true
+      }
+     ]
+    ],
+    "sequential-focus-navigation-across-documents-002.html": [
+     "e8ddf03b4fb8247db5426e477386d4e687ae3930",
+     [
+      null,
+      {
+       "testdriver": true
+      }
+     ]
+    ],
     "sequential-focus-navigation-starting-point-001.html": [
      "4fecfba641a3acec0132d1d21fc862e02b182416",
      [

--- a/tests/wpt/mozilla/tests/input-events/sequential-focus-navigation-across-documents-001.html
+++ b/tests/wpt/mozilla/tests/input-events/sequential-focus-navigation-across-documents-001.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<title>Sequential focus navigation works across local iframe boundaries</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+
+<input class="text" id="input1">
+<iframe id="frame" srcdoc="<input id=frameinput1><input id=frameinput2>"></iframe>
+<input class="text" id="input2">
+
+<script>
+promise_test(async test => {
+    let tabKey = "\uE004";
+    let shiftKey = "\uE008";
+
+    input1.focus();
+    assert_equals(document.activeElement, input1);
+
+    await new test_driver.Actions()
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .send();
+    let frameDocument = frame.contentDocument;
+    assert_equals(document.hasFocus(), true);
+    assert_equals(document.activeElement, frame);
+    assert_equals(frameDocument.activeElement, frameDocument.getElementById("frameinput1"));
+
+    await new test_driver.Actions()
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .send();
+    assert_equals(document.hasFocus(), true);
+    assert_equals(document.activeElement, frame);
+    assert_equals(frameDocument.activeElement, frameDocument.getElementById("frameinput2"));
+
+    await new test_driver.Actions()
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .send();
+    assert_equals(document.activeElement, input2);
+    assert_equals(frameDocument.hasFocus(), false);
+
+
+    // Now traverse the sequential focus order backwards.
+    await new test_driver.Actions()
+        .keyDown(shiftKey)
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .keyUp(shiftKey)
+        .send();
+    assert_equals(document.hasFocus(), true);
+    assert_equals(document.activeElement, frame);
+    assert_equals(frameDocument.activeElement, frameDocument.getElementById("frameinput2"));
+
+    await new test_driver.Actions()
+        .keyDown(shiftKey)
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .keyUp(shiftKey)
+        .send();
+    assert_equals(document.hasFocus(), true);
+    assert_equals(document.activeElement, frame);
+    assert_equals(frameDocument.activeElement, frameDocument.getElementById("frameinput1"));
+
+    await new test_driver.Actions()
+        .keyDown(shiftKey)
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .keyUp(shiftKey)
+        .send();
+    assert_equals(document.activeElement, input1);
+    assert_equals(frameDocument.hasFocus(), false);
+
+});
+</script>

--- a/tests/wpt/mozilla/tests/input-events/sequential-focus-navigation-across-documents-002.html
+++ b/tests/wpt/mozilla/tests/input-events/sequential-focus-navigation-across-documents-002.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<title>Sequential focus navigation works across sandboxed iframe boundaries</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+
+<input class="text" id="input1">
+<iframe id="frame" sandbox srcdoc="<input id=frameinput1><input id=frameinput2>"></iframe>
+<input class="text" id="input2">
+
+<script>
+promise_test(async test => {
+    let tabKey = "\uE004";
+    let shiftKey = "\uE008";
+
+    input1.focus();
+    assert_equals(document.activeElement, input1);
+
+    await new test_driver.Actions()
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .send();
+    await new test_driver.Actions()
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .send();
+    await new test_driver.Actions()
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .send();
+
+    assert_equals(document.activeElement, input2);
+
+    // Now traverse the sequential focus order backwards.
+    await new test_driver.Actions()
+        .keyDown(shiftKey)
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .keyUp(shiftKey)
+        .send();
+    await new test_driver.Actions()
+        .keyDown(shiftKey)
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .keyUp(shiftKey)
+        .send();
+    await new test_driver.Actions()
+        .keyDown(shiftKey)
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .keyUp(shiftKey)
+        .send();
+    assert_equals(document.activeElement, input1);
+
+});
+</script>


### PR DESCRIPTION
This change implements support for navigation across both local and
remote frame boundaries during sequential focus navigation. It allows
the user to tab into an iframe and then tab back out again in both
directions.

When the frame is local (in the same `ScriptThread`) the navigation
happens synchronously and without messaging, as this is observable via
JavaScript. When the frame is remote, a message is sent to the
constellation to ensure that the focus shifts asynchronously.

Testing: This change adds two tests for this behavior.
