### PR TITLE
Template for roadmap issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/roadmap.md
+++ b/.github/ISSUE_TEMPLATE/roadmap.md
@@ -1,0 +1,25 @@
+---
+name: Roadmap Issue
+about: Create an issue to track in the Servo roadmap
+title: ''
+labels: B-roadmap
+assignees: ''
+
+---
+
+## Roadmap Issue
+
+**Description:**
+A clear and concise description of the work that will be done.
+
+**Area:** e.g. Layout, Script, Performance, ...
+
+**People:** Who are planning to work on this task.
+
+Leave it blank if it's just something interesting for the project,
+but nobody is planning to work on at the moment.
+
+---
+
+Feel free to add any other comments on the issue after this line.
+


### PR DESCRIPTION
As discussed on [Zulip](https://servo.zulipchat.com/#narrow/channel/263398-general/topic/Roadmap/with/580266351), this is a new template for tracking roadmap issues.

Testing: No needed, just a GitHub issue template.
