### PR TITLE
script: Refactor `HttpsState` move from Document to GlobalScope

### DIFF
--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -13,6 +13,7 @@ use embedder_traits::resources::{self, Resource};
 use js::context::JSContext;
 use js::rust::wrappers2::JS_DefineDebuggerObject;
 use net_traits::ResourceThreads;
+use net_traits::response::HttpsState;
 use profile_traits::{mem, time};
 use servo_base::generic_channel::{GenericCallback, GenericSender, channel};
 use servo_base::id::{Index, PipelineId, PipelineNamespaceId};
@@ -117,6 +118,7 @@ impl DebuggerGlobalScope {
                 None,
                 false,
                 None, // font_context
+                HttpsState::None,
             ),
             devtools_to_script_sender,
             get_possible_breakpoints_result_sender: RefCell::new(None),

--- a/components/script/dom/dissimilaroriginwindow.rs
+++ b/components/script/dom/dissimilaroriginwindow.rs
@@ -7,6 +7,7 @@ use js::context::JSContext;
 use js::jsapi::{Heap, JSObject};
 use js::jsval::UndefinedValue;
 use js::rust::{CustomAutoRooter, CustomAutoRooterGuard, HandleValue, MutableHandleValue};
+use net_traits::response::HttpsState;
 use servo_base::id::PipelineId;
 use servo_constellation_traits::{ScriptToConstellationMessage, StructuredSerializedData};
 use servo_url::ServoUrl;
@@ -69,6 +70,7 @@ impl DissimilarOriginWindow {
                 Some(global_to_clone_from.is_secure_context()),
                 false,
                 global_to_clone_from.font_context().cloned(),
+                HttpsState::None,
             ),
             window_proxy: Dom::from_ref(window_proxy),
             location: Default::default(),

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -42,7 +42,6 @@ use net_traits::pub_domains::is_pub_domain;
 use net_traits::request::{
     InsecureRequestsPolicy, PreloadId, PreloadKey, PreloadedResources, RequestBuilder,
 };
-use net_traits::response::HttpsState;
 use percent_encoding::percent_decode;
 use profile_traits::generic_channel as profile_generic_channel;
 use profile_traits::time::TimerMetadataFrameType;
@@ -438,9 +437,7 @@ pub(crate) struct Document {
     unload_event_start: Cell<Option<CrossProcessInstant>>,
     #[no_trace]
     unload_event_end: Cell<Option<CrossProcessInstant>>,
-    /// <https://html.spec.whatwg.org/multipage/#concept-document-https-state>
-    #[no_trace]
-    https_state: Cell<HttpsState>,
+
     /// The document's origin.
     #[no_trace]
     origin: DomRefCell<MutableOrigin>,
@@ -840,10 +837,6 @@ impl Document {
 
     pub(crate) fn is_xhtml_document(&self) -> bool {
         self.content_type.matches(APPLICATION, "xhtml+xml")
-    }
-
-    pub(crate) fn set_https_state(&self, https_state: HttpsState) {
-        self.https_state.set(https_state);
     }
 
     pub(crate) fn is_fully_active(&self) -> bool {
@@ -3590,7 +3583,6 @@ impl Document {
             load_event_end: Cell::new(Default::default()),
             unload_event_start: Cell::new(Default::default()),
             unload_event_end: Cell::new(Default::default()),
-            https_state: Cell::new(HttpsState::None),
             origin: DomRefCell::new(origin),
             referrer,
             target_element: MutNullableDom::new(None),

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -770,6 +770,7 @@ impl GlobalScope {
         inherited_secure_context: Option<bool>,
         unminify_js: bool,
         font_context: Option<Arc<FontContext>>,
+        initial_https_state: HttpsState,
     ) -> Self {
         Self {
             task_manager: Default::default(),
@@ -808,7 +809,7 @@ impl GlobalScope {
             #[cfg(feature = "webgpu")]
             gpu_devices: DomRefCell::new(HashMapTracedValues::new_fx()),
             frozen_supported_performance_entry_types: CachedFrozenArray::new(),
-            https_state: Cell::new(HttpsState::None),
+            https_state: Cell::new(initial_https_state),
             console_group_stack: DomRefCell::new(Vec::new()),
             console_count_map: Default::default(),
             inherited_secure_context,

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -58,6 +58,7 @@ use net_traits::image_cache::{
     ImageResponse, PendingImageId, PendingImageResponse, RasterizationCompleteResponse,
 };
 use net_traits::request::Referrer;
+use net_traits::response::HttpsState;
 use net_traits::{ResourceFetchTiming, ResourceThreads};
 use num_traits::ToPrimitive;
 use paint_api::{CrossProcessPaintApi, PinchZoomInfos};
@@ -3680,6 +3681,7 @@ impl Window {
         inherited_secure_context: Option<bool>,
         theme: Theme,
         weak_script_thread: Weak<ScriptThread>,
+        initial_https_state: HttpsState,
     ) -> DomRoot<Self> {
         let error_reporter = CSSErrorReporter {
             pipelineid: pipeline_id,
@@ -3705,6 +3707,7 @@ impl Window {
                 inherited_secure_context,
                 unminify_js,
                 Some(font_context),
+                initial_https_state,
             ),
             ongoing_navigation: Default::default(),
             script_chan,

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -23,6 +23,7 @@ use net_traits::policy_container::PolicyContainer;
 use net_traits::request::{
     CredentialsMode, Destination, InsecureRequestsPolicy, ParserMetadata, RequestBuilder, RequestId,
 };
+use net_traits::response::HttpsState;
 use net_traits::{FetchMetadata, Metadata, NetworkError, ReferrerPolicy, ResourceFetchTiming};
 use profile_traits::mem::{ProcessReports, perform_memory_report};
 use servo_base::cross_process_instant::CrossProcessInstant;
@@ -359,6 +360,7 @@ impl WorkerGlobalScope {
                 init.inherited_secure_context,
                 init.unminify_js,
                 font_context,
+                HttpsState::None,
             ),
             microtask_queue: runtime.microtask_queue.clone(),
             worker_id: init.worker_id,

--- a/components/script/dom/workletglobalscope.rs
+++ b/components/script/dom/workletglobalscope.rs
@@ -11,6 +11,7 @@ use dom_struct::dom_struct;
 use embedder_traits::{JavaScriptEvaluationError, ScriptToEmbedderChan};
 use net_traits::ResourceThreads;
 use net_traits::image_cache::ImageCache;
+use net_traits::response::HttpsState;
 use profile_traits::{mem, time};
 use script_traits::Painter;
 use servo_base::generic_channel::{GenericCallback, GenericSender};
@@ -123,6 +124,7 @@ impl WorkletGlobalScope {
                 inherited_secure_context,
                 false,
                 None, // font_context
+                HttpsState::None,
             ),
             base_url,
             to_script_thread_sender: init.to_script_thread_sender.clone(),

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3444,6 +3444,7 @@ impl ScriptThread {
             incomplete.load_data.inherited_secure_context,
             incomplete.theme,
             self.this.clone(),
+            metadata.https_state,
         );
         self.debugger_global.fire_add_debuggee(
             CanGc::from_cx(cx),
@@ -3609,7 +3610,6 @@ impl ScriptThread {
             ),
         );
 
-        document.set_https_state(metadata.https_state);
         document.set_navigation_start(incomplete.navigation_start);
 
         if is_html_document == IsHTMLDocument::NonHTMLDocument {


### PR DESCRIPTION
Refactored `HttpsState` by moving it from `Document` to `GlobalScope`

Testing: `./mach test-wpt tests/wpt/tests/mixed-content/csp.https.window.js` & `./mach test-wpt tests/wpt/tests/fetch/api/request/destination/fetch-destination.https.html` passed locally. `./mach try` failed due to billing issue on my account.
Fixes: #44342