### PR TITLE
layout: Replace SVG base fragment rect conditionally to support `viewBox`

### DIFF
--- a/components/layout/replaced.rs
+++ b/components/layout/replaced.rs
@@ -73,7 +73,6 @@ pub(crate) struct NaturalSizes {
     pub width: Option<Au>,
     pub height: Option<Au>,
     pub ratio: Option<CSSFloat>,
-    pub has_viewbox: bool,
 }
 
 impl NaturalSizes {
@@ -91,7 +90,6 @@ impl NaturalSizes {
             width: Some(Au::from_f32_px(width)),
             height: Some(Au::from_f32_px(height)),
             ratio,
-            has_viewbox: false,
         }
     }
 
@@ -110,7 +108,6 @@ impl NaturalSizes {
             width: None,
             height: None,
             ratio: None,
-            has_viewbox: false,
         }
     }
 }
@@ -144,7 +141,10 @@ pub(crate) enum ReplacedContentKind {
     IFrame(IFrameInfo),
     Canvas(CanvasInfo),
     Video(VideoInfo),
-    SVGElement(Option<VectorImage>),
+    SVGElement {
+        vector_image: Option<VectorImage>,
+        has_viewbox: bool,
+    },
     Audio,
 }
 
@@ -197,7 +197,6 @@ impl ReplacedContents {
                     // See /components/script/resources/media-controls.css
                     height: Some(Au::from_px(40)),
                     ratio: None,
-                    has_viewbox: false,
                 };
                 (ReplacedContentKind::Audio, natural_size)
             } else {
@@ -270,7 +269,6 @@ impl ReplacedContents {
             width: width.map(|w| Au::from_f32_px(w.px())),
             height: height.map(|h| Au::from_f32_px(h.px())),
             ratio,
-            has_viewbox: svg_data.view_box.is_some(),
         };
 
         let svg_source = match svg_data.source {
@@ -306,7 +304,13 @@ impl ReplacedContents {
             _ => unreachable!("SVG element can't contain a raster image."),
         });
 
-        (ReplacedContentKind::SVGElement(vector_image), natural_size)
+        (
+            ReplacedContentKind::SVGElement {
+                vector_image,
+                has_viewbox: svg_data.view_box.is_some(),
+            },
+            natural_size,
+        )
     }
 
     fn from_content_property(node: ServoLayoutNode<'_>, context: &LayoutContext) -> Option<Self> {
@@ -568,12 +572,15 @@ impl ReplacedContents {
                     url: None,
                 }))]
             },
-            ReplacedContentKind::SVGElement(vector_image) => {
+            ReplacedContentKind::SVGElement {
+                vector_image,
+                has_viewbox,
+            } => {
                 let Some(vector_image) = vector_image else {
                     return vec![];
                 };
 
-                if !self.natural_size.has_viewbox {
+                if !has_viewbox {
                     base.rect = PhysicalSize::new(
                         vector_image
                             .metadata

--- a/components/layout/replaced.rs
+++ b/components/layout/replaced.rs
@@ -73,6 +73,7 @@ pub(crate) struct NaturalSizes {
     pub width: Option<Au>,
     pub height: Option<Au>,
     pub ratio: Option<CSSFloat>,
+    pub has_viewbox: bool,
 }
 
 impl NaturalSizes {
@@ -90,6 +91,7 @@ impl NaturalSizes {
             width: Some(Au::from_f32_px(width)),
             height: Some(Au::from_f32_px(height)),
             ratio,
+            has_viewbox: false,
         }
     }
 
@@ -108,6 +110,7 @@ impl NaturalSizes {
             width: None,
             height: None,
             ratio: None,
+            has_viewbox: false,
         }
     }
 }
@@ -194,6 +197,7 @@ impl ReplacedContents {
                     // See /components/script/resources/media-controls.css
                     height: Some(Au::from_px(40)),
                     ratio: None,
+                    has_viewbox: false,
                 };
                 (ReplacedContentKind::Audio, natural_size)
             } else {
@@ -266,6 +270,7 @@ impl ReplacedContents {
             width: width.map(|w| Au::from_f32_px(w.px())),
             height: height.map(|h| Au::from_f32_px(h.px())),
             ratio,
+            has_viewbox: svg_data.view_box.is_some(),
         };
 
         let svg_source = match svg_data.source {
@@ -568,20 +573,21 @@ impl ReplacedContents {
                     return vec![];
                 };
 
-                // TODO: This is incorrect if the SVG has a viewBox.
-                base.rect = PhysicalSize::new(
-                    vector_image
-                        .metadata
-                        .width
-                        .try_into()
-                        .map_or(MAX_AU, Au::from_px),
-                    vector_image
-                        .metadata
-                        .height
-                        .try_into()
-                        .map_or(MAX_AU, Au::from_px),
-                )
-                .into();
+                if !self.natural_size.has_viewbox {
+                    base.rect = PhysicalSize::new(
+                        vector_image
+                            .metadata
+                            .width
+                            .try_into()
+                            .map_or(MAX_AU, Au::from_px),
+                        vector_image
+                            .metadata
+                            .height
+                            .try_into()
+                            .map_or(MAX_AU, Au::from_px),
+                    )
+                    .into();
+                }
 
                 let scale = layout_context.style_context.device_pixel_ratio();
                 let raster_size = Size2D::new(

--- a/tests/wpt/meta/css/CSS2/inline-svg-100-percent-in-body.html.ini
+++ b/tests/wpt/meta/css/CSS2/inline-svg-100-percent-in-body.html.ini
@@ -1,2 +1,0 @@
-[inline-svg-100-percent-in-body.html]
-  expected: FAIL

--- a/tests/wpt/meta/svg/coordinate-systems/viewBox-baseVal-change-invalid.html.ini
+++ b/tests/wpt/meta/svg/coordinate-systems/viewBox-baseVal-change-invalid.html.ini
@@ -1,0 +1,2 @@
+[viewBox-baseVal-change-invalid.html]
+  expected: FAIL

--- a/tests/wpt/meta/svg/coordinate-systems/viewBox-change-repaint-001.html.ini
+++ b/tests/wpt/meta/svg/coordinate-systems/viewBox-change-repaint-001.html.ini
@@ -1,2 +1,0 @@
-[viewBox-change-repaint-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/svg/painting/reftests/non-scaling-stroke-006.html.ini
+++ b/tests/wpt/meta/svg/painting/reftests/non-scaling-stroke-006.html.ini
@@ -1,2 +1,0 @@
-[non-scaling-stroke-006.html]
-  expected: FAIL

--- a/tests/wpt/meta/svg/painting/reftests/small-nested-viewbox.html.ini
+++ b/tests/wpt/meta/svg/painting/reftests/small-nested-viewbox.html.ini
@@ -1,2 +1,0 @@
-[small-nested-viewbox.html]
-  expected: FAIL


### PR DESCRIPTION
As titled.

Testing: Manually tested with multiple real websites with viewbox in svg. 
It looked terrible before, but now looking good!
New passing in WPT.

Partially addresses: #38985