### PR TITLE
media: Switch to workspace dependencies and minor cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5311,11 +5311,10 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.2.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
@@ -8111,7 +8110,6 @@ dependencies = [
 name = "servo-media"
 version = "0.1.0"
 dependencies = [
- "once_cell",
  "servo-media-audio",
  "servo-media-player",
  "servo-media-streams",
@@ -8131,7 +8129,6 @@ dependencies = [
  "num-traits",
  "petgraph",
  "serde",
- "serde_derive",
  "servo-malloc-size-of",
  "servo-media-derive",
  "servo-media-player",
@@ -8202,7 +8199,6 @@ dependencies = [
  "ipc-channel",
  "log",
  "mime",
- "once_cell",
  "servo-media",
  "servo-media-audio",
  "servo-media-gstreamer-render",
@@ -8265,7 +8261,6 @@ dependencies = [
  "ohos-media-sys",
  "ohos-sys-opaque-types",
  "ohos-window-sys",
- "once_cell",
  "rangemap",
  "serde_json",
  "servo-media",
@@ -8284,7 +8279,6 @@ dependencies = [
  "ipc-channel",
  "malloc_size_of_derive",
  "serde",
- "serde_derive",
  "servo-malloc-size-of",
  "servo-media-streams",
  "servo-media-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3527,8 +3527,6 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -3537,6 +3535,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -4843,11 +4846,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "0e0b564323a0fb6d54b864f625ae139de9612e27edb944dda37c109f05aac531"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -12038,6 +12041,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d3a7e2cda3061858987ee2fb028f61695f5ee13f9490d75be6c3900df9a4ea"
 dependencies = [
  "num-traits",
+ "rayon",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ brotli = "8.0.2"
 bytemuck = "1"
 byteorder = "1.5"
 bytes = "1.0"
+byte-slice-cast = "1.2.3"
 cbc = "0.1.2"
 cfg-if = "1.0.4"
 chacha20poly1305 = "0.10"
@@ -114,6 +115,7 @@ js = { package = "mozjs", version = "=0.15.8", default-features = false, feature
 keyboard-types = { version = "0.8.3", features = ["serde", "webdriver"] }
 kurbo = { version = "0.12", features = ["euclid"] }
 libc = "0.2"
+lru = "0.17"
 log = "0.4.29"
 mach2 = "0.6"
 malloc_size_of_derive = "0.1"
@@ -129,6 +131,7 @@ nix = "0.30"
 nom = "8.0.0"
 nom-rfc8288 = "0.4.0"
 num-bigint-dig = "0.8"
+num-complex = "0.4.6"
 num-derive = "0.4.2"
 num-traits = "0.2"
 num_cpus = "1.17.0"
@@ -149,6 +152,7 @@ postcard = { version = "1.1.3", default-features = false, features = ["use-std"]
 proc-macro2 = "1"
 quote = "1"
 rand = "0.9"
+rangemap = "1.7.1"
 raw-window-handle = "0.6"
 rayon = "1"
 read-fonts = "0.35.0"
@@ -171,6 +175,7 @@ servo_arc = { git = "https://github.com/servo/stylo", rev = "a556f4cbd15fc289039
 sha1 = "0.10"
 sha2 = "0.10"
 sha3 = "0.10"
+speexdsp-resampler = "0.1.0"
 skrifa = "0.37.0"
 smallvec = { version = "1.15", features = ["serde", "union"] }
 string_cache = "0.9"
@@ -223,6 +228,7 @@ wio = "0.2"
 wr_malloc_size_of = "0.2.2"
 x25519-dalek = { version = "2.0.1", features = ["static_secrets"] }
 xml5ever = "0.39"
+yuv = { version = "0.8.13", features = ["rayon"] }
 
 ############################################################################################
 ## Workspace-local dependencies

--- a/components/media/audio/Cargo.toml
+++ b/components/media/audio/Cargo.toml
@@ -21,11 +21,11 @@ servo-media-derive = { workspace = true }
 servo-media-player = { workspace = true }
 servo-media-traits = { workspace = true }
 servo-media-streams = { workspace = true }
-smallvec = "1"
-speexdsp-resampler = "0.1.0"
+smallvec = { workspace = true }
+speexdsp-resampler = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
-num-complex = "0.4.6"
+num-complex = { workspace = true }
 
 [dependencies.petgraph]
 version = "0.4.12"

--- a/components/media/audio/Cargo.toml
+++ b/components/media/audio/Cargo.toml
@@ -14,10 +14,9 @@ name = "servo_media_audio"
 path = "lib.rs"
 
 [dependencies]
-euclid = "0.22"
-log = "0.4"
-serde_derive = "1.0.66"
-serde = "1.0.66"
+euclid = { workspace = true }
+log = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 servo-media-derive = { workspace = true }
 servo-media-player = { workspace = true }
 servo-media-traits = { workspace = true }
@@ -26,7 +25,7 @@ smallvec = "1"
 speexdsp-resampler = "0.1.0"
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
-num-complex = "0.2.4"
+num-complex = "0.4.6"
 
 [dependencies.petgraph]
 version = "0.4.12"

--- a/components/media/audio/block.rs
+++ b/components/media/audio/block.rs
@@ -8,6 +8,7 @@ use std::ops::*;
 
 use byte_slice_cast::*;
 use euclid::default::Vector3D;
+use serde::{Deserialize, Serialize};
 use smallvec::{SmallVec, smallvec};
 
 use crate::graph::{PortIndex, PortKind};

--- a/components/media/audio/lib.rs
+++ b/components/media/audio/lib.rs
@@ -3,9 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #[macro_use]
-extern crate serde_derive;
-
-#[macro_use]
 extern crate servo_media_derive;
 
 extern crate servo_media_player as player;

--- a/components/media/backends/gstreamer/Cargo.toml
+++ b/components/media/backends/gstreamer/Cargo.toml
@@ -31,9 +31,8 @@ gstreamer-webrtc = { workspace = true }
 gstreamer-sdp = { workspace = true }
 gstreamer-sys = { workspace = true }
 ipc-channel = { workspace = true }
-log = "0.4"
-mime = "0.3.13"
-once_cell = "1.18.0"
+log = { workspace = true }
+mime = { workspace = true }
 servo-media = { workspace = true }
 servo-media-audio = { workspace = true }
 servo-media-gstreamer-render = { workspace = true }
@@ -41,7 +40,7 @@ servo-media-player = { workspace = true }
 servo-media-streams = { workspace = true }
 servo-media-traits = { workspace = true }
 servo-media-webrtc = { workspace = true }
-url = "2.0"
+url = { workspace = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
 servo-media-gstreamer-render-unix = { workspace = true, features = [

--- a/components/media/backends/gstreamer/Cargo.toml
+++ b/components/media/backends/gstreamer/Cargo.toml
@@ -18,7 +18,7 @@ glx = ["servo-media-gstreamer-render-unix/gl-x11"]
 wayland = ["servo-media-gstreamer-render-unix/gl-wayland"]
 
 [dependencies]
-byte-slice-cast = "1"
+byte-slice-cast = { workspace = true }
 glib = { workspace = true }
 glib-sys = { workspace = true }
 gstreamer = { workspace = true }

--- a/components/media/backends/gstreamer/lib.rs
+++ b/components/media/backends/gstreamer/lib.rs
@@ -20,7 +20,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::mpsc::{self, Sender};
-use std::sync::{Arc, Mutex, Weak};
+use std::sync::{Arc, LazyLock, Mutex, OnceLock, Weak};
 use std::thread;
 use std::vec::Vec;
 
@@ -30,7 +30,6 @@ use ipc_channel::ipc::IpcSender;
 use log::warn;
 use media_stream::GStreamerMediaStream;
 use mime::Mime;
-use once_cell::sync::{Lazy, OnceCell};
 use registry_scanner::GSTREAMER_REGISTRY_SCANNER;
 use servo_media::{Backend, BackendDeInit, BackendInit, MediaInstanceError, SupportsMediaType};
 use servo_media_audio::context::{AudioContext, AudioContextOptions};
@@ -48,10 +47,10 @@ use servo_media_streams::{MediaOutput, MediaSocket, MediaStreamType};
 use servo_media_traits::{BackendMsg, ClientContextId, MediaInstance};
 use servo_media_webrtc::{WebRtcBackend, WebRtcController, WebRtcSignaller};
 
-static BACKEND_BASE_TIME: Lazy<gstreamer::ClockTime> =
-    Lazy::new(|| gstreamer::SystemClock::obtain().time());
+static BACKEND_BASE_TIME: LazyLock<gstreamer::ClockTime> =
+    LazyLock::new(|| gstreamer::SystemClock::obtain().time());
 
-static BACKEND_THREAD: OnceCell<bool> = OnceCell::new();
+static BACKEND_THREAD: OnceLock<bool> = OnceLock::new();
 
 pub type WeakMediaInstance = Weak<Mutex<dyn MediaInstance>>;
 pub type WeakMediaInstanceHashMap = HashMap<ClientContextId, Vec<(usize, WeakMediaInstance)>>;

--- a/components/media/backends/gstreamer/media_stream.rs
+++ b/components/media/backends/gstreamer/media_stream.rs
@@ -3,12 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::any::Any;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
 
 use glib::BoolError;
 use gstreamer;
 use gstreamer::prelude::*;
-use once_cell::sync::Lazy;
 use servo_media_streams::registry::{
     MediaStreamId, get_stream, register_stream, unregister_stream,
 };
@@ -16,14 +15,14 @@ use servo_media_streams::{MediaOutput, MediaSocket, MediaStream, MediaStreamType
 
 use super::BACKEND_BASE_TIME;
 
-pub static RTP_CAPS_OPUS: Lazy<gstreamer::Caps> = Lazy::new(|| {
+pub static RTP_CAPS_OPUS: LazyLock<gstreamer::Caps> = LazyLock::new(|| {
     gstreamer::Caps::builder("application/x-rtp")
         .field("media", "audio")
         .field("encoding-name", "OPUS")
         .build()
 });
 
-pub static RTP_CAPS_VP8: Lazy<gstreamer::Caps> = Lazy::new(|| {
+pub static RTP_CAPS_VP8: LazyLock<gstreamer::Caps> = LazyLock::new(|| {
     gstreamer::Caps::builder("application/x-rtp")
         .field("media", "video")
         .field("encoding-name", "VP8")

--- a/components/media/backends/gstreamer/media_stream_source.rs
+++ b/components/media/backends/gstreamer/media_stream_source.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
 
 use glib::subclass::prelude::*;
 use gstreamer::prelude::*;
@@ -17,7 +17,6 @@ use crate::media_stream::{GStreamerMediaStream, RTP_CAPS_OPUS, RTP_CAPS_VP8};
 
 // Implementation sub-module of the GObject
 mod imp {
-    use std::sync::LazyLock;
 
     use super::*;
 

--- a/components/media/backends/gstreamer/media_stream_source.rs
+++ b/components/media/backends/gstreamer/media_stream_source.rs
@@ -9,7 +9,6 @@ use glib::subclass::prelude::*;
 use gstreamer::prelude::*;
 use gstreamer::subclass::prelude::*;
 use gstreamer_base::UniqueFlowCombiner;
-use once_cell::sync::Lazy;
 use servo_media_player::PlayerError;
 use servo_media_streams::{MediaStream, MediaStreamType};
 use url::Url;
@@ -18,9 +17,11 @@ use crate::media_stream::{GStreamerMediaStream, RTP_CAPS_OPUS, RTP_CAPS_VP8};
 
 // Implementation sub-module of the GObject
 mod imp {
+    use std::sync::LazyLock;
+
     use super::*;
 
-    static AUDIO_SRC_PAD_TEMPLATE: Lazy<gstreamer::PadTemplate> = Lazy::new(|| {
+    static AUDIO_SRC_PAD_TEMPLATE: LazyLock<gstreamer::PadTemplate> = LazyLock::new(|| {
         gstreamer::PadTemplate::new(
             "audio_src",
             gstreamer::PadDirection::Src,
@@ -30,7 +31,7 @@ mod imp {
         .expect("Could not create audio src pad template")
     });
 
-    static VIDEO_SRC_PAD_TEMPLATE: Lazy<gstreamer::PadTemplate> = Lazy::new(|| {
+    static VIDEO_SRC_PAD_TEMPLATE: LazyLock<gstreamer::PadTemplate> = LazyLock::new(|| {
         gstreamer::PadTemplate::new(
             "video_src",
             gstreamer::PadDirection::Src,
@@ -226,7 +227,7 @@ mod imp {
     // corresponding values of the properties.
     impl ObjectImpl for ServoMediaStreamSrc {
         fn properties() -> &'static [glib::ParamSpec] {
-            static PROPERTIES: Lazy<Vec<glib::ParamSpec>> = Lazy::new(|| {
+            static PROPERTIES: LazyLock<Vec<glib::ParamSpec>> = LazyLock::new(|| {
                 vec![
                     // Let playbin3 know we are a live source.
                     glib::ParamSpecBoolean::builder("is-live")
@@ -254,20 +255,21 @@ mod imp {
     // Implementation of gstreamer::Element virtual methods
     impl ElementImpl for ServoMediaStreamSrc {
         fn metadata() -> Option<&'static gstreamer::subclass::ElementMetadata> {
-            static ELEMENT_METADATA: Lazy<gstreamer::subclass::ElementMetadata> = Lazy::new(|| {
-                gstreamer::subclass::ElementMetadata::new(
-                    "Servo Media Stream Source",
-                    "Source/Audio/Video",
-                    "Feed player with media stream data",
-                    "Servo developers",
-                )
-            });
+            static ELEMENT_METADATA: LazyLock<gstreamer::subclass::ElementMetadata> =
+                LazyLock::new(|| {
+                    gstreamer::subclass::ElementMetadata::new(
+                        "Servo Media Stream Source",
+                        "Source/Audio/Video",
+                        "Feed player with media stream data",
+                        "Servo developers",
+                    )
+                });
 
             Some(&*ELEMENT_METADATA)
         }
 
         fn pad_templates() -> &'static [gstreamer::PadTemplate] {
-            static PAD_TEMPLATES: Lazy<Vec<gstreamer::PadTemplate>> = Lazy::new(|| {
+            static PAD_TEMPLATES: LazyLock<Vec<gstreamer::PadTemplate>> = LazyLock::new(|| {
                 // Add pad templates for our audio and video source pads.
                 // These are later used for actually creating the pads and beforehand
                 // already provide information to GStreamer about all possible

--- a/components/media/backends/gstreamer/registry_scanner.rs
+++ b/components/media/backends/gstreamer/registry_scanner.rs
@@ -4,14 +4,13 @@
 
 use std::collections::HashSet;
 use std::str::FromStr;
-
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 
 // The GStreamer registry holds the metadata of the set of plugins available in the host.
 // This scanner is used to lazily analyze the registry and to provide information about
 // the set of supported mime types and codecs that the backend is able to deal with.
-pub static GSTREAMER_REGISTRY_SCANNER: Lazy<GStreamerRegistryScanner> =
-    Lazy::new(GStreamerRegistryScanner::new);
+pub static GSTREAMER_REGISTRY_SCANNER: LazyLock<GStreamerRegistryScanner> =
+    LazyLock::new(GStreamerRegistryScanner::new);
 
 pub struct GStreamerRegistryScanner {
     supported_mime_types: HashSet<&'static str>,

--- a/components/media/backends/gstreamer/source.rs
+++ b/components/media/backends/gstreamer/source.rs
@@ -9,13 +9,14 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use glib::subclass::prelude::*;
 use gstreamer::prelude::*;
 use gstreamer::subclass::prelude::*;
-use once_cell::sync::Lazy;
 use url::Url;
 
 const MAX_SRC_QUEUE_SIZE: u64 = 50 * 1024 * 1024; // 50 MB.
 
 // Implementation sub-module of the GObject
 mod imp {
+    use std::sync::LazyLock;
+
     use super::*;
 
     macro_rules! inner_appsrc_proxy {
@@ -316,20 +317,21 @@ mod imp {
     // Implementation of gstreamer::Element virtual methods
     impl ElementImpl for ServoSrc {
         fn metadata() -> Option<&'static gstreamer::subclass::ElementMetadata> {
-            static ELEMENT_METADATA: Lazy<gstreamer::subclass::ElementMetadata> = Lazy::new(|| {
-                gstreamer::subclass::ElementMetadata::new(
-                    "Servo Media Source",
-                    "Source/Audio/Video",
-                    "Feed player with media data",
-                    "Servo developers",
-                )
-            });
+            static ELEMENT_METADATA: LazyLock<gstreamer::subclass::ElementMetadata> =
+                LazyLock::new(|| {
+                    gstreamer::subclass::ElementMetadata::new(
+                        "Servo Media Source",
+                        "Source/Audio/Video",
+                        "Feed player with media data",
+                        "Servo developers",
+                    )
+                });
 
             Some(&*ELEMENT_METADATA)
         }
 
         fn pad_templates() -> &'static [gstreamer::PadTemplate] {
-            static PAD_TEMPLATES: Lazy<Vec<gstreamer::PadTemplate>> = Lazy::new(|| {
+            static PAD_TEMPLATES: LazyLock<Vec<gstreamer::PadTemplate>> = LazyLock::new(|| {
                 let caps = gstreamer::Caps::new_any();
                 let src_pad_template = gstreamer::PadTemplate::new(
                     "src",

--- a/components/media/backends/ohos/Cargo.toml
+++ b/components/media/backends/ohos/Cargo.toml
@@ -27,10 +27,10 @@ ohos-window-sys = { version = "0.1.3", features = ["api-13"] }
 ohos-sys-opaque-types = { version = "0.1.7" }
 ipc-channel = { workspace = true }
 crossbeam-channel = { workspace = true }
-lru = "0.16.3"
-rangemap = "1.6.0"
+lru = { workspace = true }
+rangemap = { workspace = true }
 libc = { workspace = true }
-yuv = "0.8.11"
+yuv = { workspace = true }
 
 [build-dependencies]
 serde_json.workspace = true

--- a/components/media/backends/ohos/Cargo.toml
+++ b/components/media/backends/ohos/Cargo.toml
@@ -20,9 +20,8 @@ servo-media-player = { workspace = true }
 servo-media-streams = { workspace = true }
 servo-media-traits = { workspace = true }
 servo-media-webrtc = { workspace = true }
-mime = "0.3.13"
-once_cell = "1.18.0"
-log = "0.4"
+mime = { workspace = true }
+log = { workspace = true }
 ohos-media-sys = { version = "0.0.5", features = ["api-21"] }
 ohos-window-sys = { version = "0.1.3", features = ["api-13"] }
 ohos-sys-opaque-types = { version = "0.1.7" }
@@ -30,7 +29,7 @@ ipc-channel = { workspace = true }
 crossbeam-channel = { workspace = true }
 lru = "0.16.3"
 rangemap = "1.6.0"
-libc = "0.2"
+libc = { workspace = true }
 yuv = "0.8.11"
 
 [build-dependencies]

--- a/components/media/backends/ohos/registry_scanner.rs
+++ b/components/media/backends/ohos/registry_scanner.rs
@@ -3,10 +3,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::collections::HashMap;
+use std::sync::LazyLock;
 
-use once_cell::sync::Lazy;
-
-pub static OHOS_REGISTRY_SCANNER: Lazy<OhosRegistryScanner> = Lazy::new(OhosRegistryScanner::new);
+pub static OHOS_REGISTRY_SCANNER: LazyLock<OhosRegistryScanner> =
+    LazyLock::new(OhosRegistryScanner::new);
 
 // Should be a combination of mime/codecs
 // If the type we are matching only contain mime, then we only match the container.

--- a/components/media/player/Cargo.toml
+++ b/components/media/player/Cargo.toml
@@ -14,8 +14,7 @@ name = "servo_media_player"
 path = "lib.rs"
 
 [dependencies]
-serde = "1.0.66"
-serde_derive = "1.0.66"
+serde = { workspace = true, features = ["derive"] }
 ipc-channel = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }

--- a/components/media/player/context.rs
+++ b/components/media/player/context.rs
@@ -12,6 +12,7 @@
 //! trait object to its `player` instance.
 
 use malloc_size_of_derive::MallocSizeOf;
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Serialize, MallocSizeOf)]
 pub enum GlContext {

--- a/components/media/player/lib.rs
+++ b/components/media/player/lib.rs
@@ -6,8 +6,6 @@ use std::ops::Range;
 use std::time::Duration;
 
 pub extern crate ipc_channel;
-#[macro_use]
-extern crate serde_derive;
 extern crate servo_media_streams as streams;
 extern crate servo_media_traits;
 
@@ -17,6 +15,7 @@ pub mod metadata;
 pub mod video;
 
 use ipc_channel::ipc::{self, IpcSender};
+use serde::{Deserialize, Serialize};
 use servo_media_traits::MediaInstance;
 use streams::registry::MediaStreamId;
 

--- a/components/media/player/metadata.rs
+++ b/components/media/player/metadata.rs
@@ -4,6 +4,8 @@
 
 use std::time;
 
+use serde::{Deserialize, Serialize};
+
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct Metadata {
     pub duration: Option<time::Duration>,

--- a/components/media/servo-media-derive/Cargo.toml
+++ b/components/media/servo-media-derive/Cargo.toml
@@ -15,6 +15,6 @@ proc-macro = true
 path = "lib.rs"
 
 [dependencies]
-syn = "2"
-quote = "1"
-proc-macro2 = "1"
+syn = { workspace = true }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }

--- a/components/media/servo-media/Cargo.toml
+++ b/components/media/servo-media/Cargo.toml
@@ -14,7 +14,6 @@ name = "servo_media"
 path = "lib.rs"
 
 [dependencies]
-once_cell = "1.18.0"
 servo-media-audio = { workspace = true }
 servo-media-player = { workspace = true }
 servo-media-streams = { workspace = true }

--- a/components/media/servo-media/lib.rs
+++ b/components/media/servo-media/lib.rs
@@ -8,15 +8,12 @@ pub extern crate servo_media_streams as streams;
 pub extern crate servo_media_traits as traits;
 pub extern crate servo_media_webrtc as webrtc;
 
-extern crate once_cell;
-
 use std::ops::Deref;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
 
 use audio::context::{AudioContext, AudioContextOptions};
 use audio::sink::AudioSinkError;
-use once_cell::sync::OnceCell;
 use player::audio::AudioRenderer;
 use player::context::PlayerGLContext;
 use player::ipc_channel::ipc::IpcSender;
@@ -31,7 +28,7 @@ use webrtc::{WebRtcController, WebRtcSignaller};
 
 pub struct ServoMedia(Box<dyn Backend>);
 
-static INSTANCE: OnceCell<Arc<ServoMedia>> = OnceCell::new();
+static INSTANCE: OnceLock<Arc<ServoMedia>> = OnceLock::new();
 
 pub trait BackendInit {
     fn init() -> Box<dyn Backend>;

--- a/components/media/streams/Cargo.toml
+++ b/components/media/streams/Cargo.toml
@@ -16,4 +16,4 @@ path = "lib.rs"
 [dependencies]
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
-uuid = { version = "1.4", features = ["v4"] }
+uuid = { workspace = true, features = ["v4"] }

--- a/components/media/webrtc/Cargo.toml
+++ b/components/media/webrtc/Cargo.toml
@@ -13,6 +13,6 @@ description.workspace = true
 path = "lib.rs"
 
 [dependencies]
-log = "0.4"
+log = { workspace = true }
 servo-media-streams = { workspace = true }
-uuid = { version = "1.4", features = ["v4"] }
+uuid = { workspace = true, features = ["v4"] }


### PR DESCRIPTION
This PR makes minor cleanup in the media crates:
- Switch dependencies to workspace dependencies if they are already included in the main Cargo.toml
- Switch from crate serde_derive to serde with feature flag derive.
- Switch from the separate crate for OnceCell to the std provided LazyLock.
- Update num_complex

Testing: The only functional changes are either slight version bumps, the replacement to LazyLock which is conservative and the num_complex update which also shouldn't have any behavior changes.
