### PR TITLE
dependabot: Add rustls-webpki related group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,6 +52,11 @@ updates:
     objc2-related:
       patterns:
         - "objc2*"
+    rustls-webpki-related:
+      patterns:
+        - rustls-webpki
+        - webpki-roots
+        - webpki-root-certs
     sea-query-related:
       patterns:
         - "sea-query"


### PR DESCRIPTION
This should make #44415, #44418, #44419 
work in one PR without conflict in the future.

Testing: Will be tested in CI in future rounds of update.