### PR TITLE
script: Add initial implementation of italic command

### DIFF
--- a/components/script/dom/execcommand/basecommand.rs
+++ b/components/script/dom/execcommand/basecommand.rs
@@ -21,6 +21,7 @@ use crate::dom::execcommand::commands::delete::execute_delete_command;
 use crate::dom::execcommand::commands::fontsize::{
     execute_fontsize_command, font_size_loosely_equivalent, value_for_fontsize_command,
 };
+use crate::dom::execcommand::commands::italic::execute_italic_command;
 use crate::dom::execcommand::commands::strikethrough::execute_strikethrough_command;
 use crate::dom::execcommand::commands::stylewithcss::execute_style_with_css_command;
 use crate::dom::execcommand::commands::underline::execute_underline_command;
@@ -230,21 +231,42 @@ impl CommandName {
                 // > True if the CSS styling flag is true, otherwise false.
                 document.css_styling_flag()
             },
-            CommandName::FontSize => {
-                // Font size does not have a state defined for its command
-                false
-            },
             _ => {
-                // https://w3c.github.io/editing/docs/execCommand/#state
-                // > The state of a command is true if it is already in effect,
-                // > in some sense specific to the command.
+                // https://w3c.github.io/editing/docs/execCommand/#inline-formatting-command-definitions
+                // > If a command has inline command activated values defined, its state is true if either
+                // > no formattable node is effectively contained in the active range,
+                // > and the active range's start node's effective command value is one of the given values;
+                // > or if there is at least one formattable node effectively contained in the active range,
+                // > and all of them have an effective command value equal to one of the given values.
+                let inline_command_activated_values = self.inline_command_activated_values();
+                if inline_command_activated_values.is_empty() {
+                    return None;
+                }
                 let selection = document.GetSelection(CanGc::from_cx(cx))?;
                 let active_range = selection.active_range()?;
-                active_range
-                    .first_formattable_contained_node()
-                    .unwrap_or_else(|| active_range.start_container())
-                    .effective_command_value(self)
-                    .is_some()
+                let mut at_least_one_child_is_formattable = false;
+                let mut all_children_have_matching_command_values = true;
+                active_range.for_each_effectively_contained_child(|node| {
+                    if !node.is_formattable() {
+                        return;
+                    }
+                    at_least_one_child_is_formattable = true;
+                    all_children_have_matching_command_values &= node
+                        .effective_command_value(self)
+                        .is_some_and(|effective_value| {
+                            inline_command_activated_values.contains(&&*effective_value.str())
+                        });
+                });
+                if at_least_one_child_is_formattable {
+                    all_children_have_matching_command_values
+                } else {
+                    active_range
+                        .start_container()
+                        .effective_command_value(self)
+                        .is_some_and(|effective_value| {
+                            inline_command_activated_values.contains(&&*effective_value.str())
+                        })
+                }
             },
         })
     }
@@ -373,6 +395,7 @@ impl CommandName {
             },
             CommandName::Delete => execute_delete_command(cx, document, selection),
             CommandName::FontSize => execute_fontsize_command(cx, document, selection, value),
+            CommandName::Italic => execute_italic_command(cx, document, selection),
             CommandName::Strikethrough => execute_strikethrough_command(cx, document, selection),
             CommandName::StyleWithCss => execute_style_with_css_command(document, value),
             CommandName::Underline => execute_underline_command(cx, document, selection),

--- a/components/script/dom/execcommand/commands/italic.rs
+++ b/components/script/dom/execcommand/commands/italic.rs
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use js::context::JSContext;
+
+use crate::dom::document::Document;
+use crate::dom::execcommand::basecommand::CommandName;
+use crate::dom::execcommand::execcommands::DocumentExecCommandSupport;
+use crate::dom::selection::Selection;
+
+/// <https://w3c.github.io/editing/docs/execCommand/#the-italic-command>
+pub(crate) fn execute_italic_command(
+    cx: &mut JSContext,
+    document: &Document,
+    selection: &Selection,
+) -> bool {
+    // > If queryCommandState("italic") returns true, set the selection's value to "normal".
+    // > Otherwise set the selection's value to "italic". Either way, return true.
+    let value = if document.command_state_for_command(cx, "italic".into()) {
+        Some("normal".into())
+    } else {
+        Some("italic".into())
+    };
+    selection.set_the_selection_value(cx, value, CommandName::Italic, document);
+
+    true
+}

--- a/components/script/dom/execcommand/commands/mod.rs
+++ b/components/script/dom/execcommand/commands/mod.rs
@@ -5,6 +5,7 @@
 pub(crate) mod defaultparagraphseparator;
 pub(crate) mod delete;
 pub(crate) mod fontsize;
+pub(crate) mod italic;
 pub(crate) mod strikethrough;
 pub(crate) mod stylewithcss;
 pub(crate) mod underline;

--- a/components/script/dom/execcommand/execcommands.rs
+++ b/components/script/dom/execcommand/execcommands.rs
@@ -120,6 +120,7 @@ impl Document {
             "delete" => CommandName::Delete,
             "defaultparagraphseparator" => CommandName::DefaultParagraphSeparator,
             "fontsize" => CommandName::FontSize,
+            "italic" => CommandName::Italic,
             "strikethrough" => CommandName::Strikethrough,
             "stylewithcss" => CommandName::StyleWithCss,
             "underline" => CommandName::Underline,

--- a/tests/wpt/meta/editing/event.html.ini
+++ b/tests/wpt/meta/editing/event.html.ini
@@ -65,12 +65,6 @@
   [Command hiliteColor, value "green": input event]
     expected: FAIL
 
-  [Command italic, value "": input event]
-    expected: FAIL
-
-  [Command italic, value "quasit": input event]
-    expected: FAIL
-
   [Command removeFormat, value "": input event]
     expected: FAIL
 

--- a/tests/wpt/meta/editing/other/editing-div-outside-body.html.ini
+++ b/tests/wpt/meta/editing/other/editing-div-outside-body.html.ini
@@ -14,9 +14,6 @@
   [Test for execCommand("bold", false, undefined) in "<div>a[b\]c</div>"]
     expected: FAIL
 
-  [Test for execCommand("italic", false, undefined) in "<div>a[b\]c</div>"]
-    expected: FAIL
-
   [Test for execCommand("createLink", false, "another.html") in "<div>a[b\]c</div>"]
     expected: FAIL
 
@@ -41,9 +38,6 @@
     expected: FAIL
 
   [Test for execCommand("bold", false, undefined) in "<div>a[b\]c</div>"]
-    expected: FAIL
-
-  [Test for execCommand("italic", false, undefined) in "<div>a[b\]c</div>"]
     expected: FAIL
 
   [Test for execCommand("createLink", false, "another.html") in "<div>a[b\]c</div>"]
@@ -72,9 +66,6 @@
   [Test for execCommand("bold", false, undefined) in "<div>a[b\]c</div>"]
     expected: FAIL
 
-  [Test for execCommand("italic", false, undefined) in "<div>a[b\]c</div>"]
-    expected: FAIL
-
   [Test for execCommand("createLink", false, "another.html") in "<div>a[b\]c</div>"]
     expected: FAIL
 
@@ -101,9 +92,6 @@
   [Test for execCommand("bold", false, undefined) in "<div>a[b\]c</div>"]
     expected: FAIL
 
-  [Test for execCommand("italic", false, undefined) in "<div>a[b\]c</div>"]
-    expected: FAIL
-
   [Test for execCommand("createLink", false, "another.html") in "<div>a[b\]c</div>"]
     expected: FAIL
 
@@ -128,9 +116,6 @@
     expected: FAIL
 
   [Test for execCommand("bold", false, undefined) in "<div>a[b\]c</div>"]
-    expected: FAIL
-
-  [Test for execCommand("italic", false, undefined) in "<div>a[b\]c</div>"]
     expected: FAIL
 
   [Test for execCommand("createLink", false, "another.html") in "<div>a[b\]c</div>"]

--- a/tests/wpt/meta/editing/other/exec-command-with-text-editor.tentative.html.ini
+++ b/tests/wpt/meta/editing/other/exec-command-with-text-editor.tentative.html.ini
@@ -2,9 +2,6 @@
   [In <input type="password">, execCommand("bold", false, bold), a[b\]c): The command should be supported]
     expected: FAIL
 
-  [In <input type="password">, execCommand("italic", false, null), a[b\]c): The command should be supported]
-    expected: FAIL
-
   [In <input type="password">, execCommand("superscript", false, null), a[b\]c): The command should be supported]
     expected: FAIL
 
@@ -153,9 +150,6 @@
     expected: FAIL
 
   [In <input type="password"> in contenteditable, execCommand("bold", false, bold), a[b\]c): The command should be supported]
-    expected: FAIL
-
-  [In <input type="password"> in contenteditable, execCommand("italic", false, null), a[b\]c): The command should be supported]
     expected: FAIL
 
   [In <input type="password"> in contenteditable, execCommand("superscript", false, null), a[b\]c): The command should be supported]
@@ -434,12 +428,24 @@
   [In <input type="password"> in contenteditable, execCommand("strikethrough", false, null), a[b\]c): input.target should be undefined]
     expected: FAIL
 
+  [In <input type="password"> in contenteditable, execCommand("italic", false, null), a[b\]c): The command should not be enabled]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("italic", false, null), a[b\]c): execCommand() should return false]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("italic", false, null), a[b\]c): should not fire beforeinput event]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("italic", false, null), a[b\]c): input.inputType should be undefined]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("italic", false, null), a[b\]c): input.target should be undefined]
+    expected: FAIL
+
 
 [exec-command-with-text-editor.tentative.html?type=text]
   [In <input type="text">, execCommand("bold", false, bold), a[b\]c): The command should be supported]
-    expected: FAIL
-
-  [In <input type="text">, execCommand("italic", false, null), a[b\]c): The command should be supported]
     expected: FAIL
 
   [In <input type="text">, execCommand("superscript", false, null), a[b\]c): The command should be supported]
@@ -590,9 +596,6 @@
     expected: FAIL
 
   [In <input type="text"> in contenteditable, execCommand("bold", false, bold), a[b\]c): The command should be supported]
-    expected: FAIL
-
-  [In <input type="text"> in contenteditable, execCommand("italic", false, null), a[b\]c): The command should be supported]
     expected: FAIL
 
   [In <input type="text"> in contenteditable, execCommand("superscript", false, null), a[b\]c): The command should be supported]
@@ -871,12 +874,24 @@
   [In <input type="text"> in contenteditable, execCommand("strikethrough", false, null), a[b\]c): input.target should be undefined]
     expected: FAIL
 
+  [In <input type="text"> in contenteditable, execCommand("italic", false, null), a[b\]c): The command should not be enabled]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("italic", false, null), a[b\]c): execCommand() should return false]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("italic", false, null), a[b\]c): should not fire beforeinput event]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("italic", false, null), a[b\]c): input.inputType should be undefined]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("italic", false, null), a[b\]c): input.target should be undefined]
+    expected: FAIL
+
 
 [exec-command-with-text-editor.tentative.html?type=textarea]
   [In <textarea>, execCommand("bold", false, bold), a[b\]c): The command should be supported]
-    expected: FAIL
-
-  [In <textarea>, execCommand("italic", false, null), a[b\]c): The command should be supported]
     expected: FAIL
 
   [In <textarea>, execCommand("superscript", false, null), a[b\]c): The command should be supported]
@@ -1033,9 +1048,6 @@
     expected: FAIL
 
   [In <textarea> in contenteditable, execCommand("bold", false, bold), a[b\]c): The command should be supported]
-    expected: FAIL
-
-  [In <textarea> in contenteditable, execCommand("italic", false, null), a[b\]c): The command should be supported]
     expected: FAIL
 
   [In <textarea> in contenteditable, execCommand("superscript", false, null), a[b\]c): The command should be supported]
@@ -1318,4 +1330,19 @@
     expected: FAIL
 
   [In <textarea> in contenteditable, execCommand("strikethrough", false, null), a[b\]c): input.target should be undefined]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("italic", false, null), a[b\]c): The command should not be enabled]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("italic", false, null), a[b\]c): execCommand() should return false]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("italic", false, null), a[b\]c): should not fire beforeinput event]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("italic", false, null), a[b\]c): input.inputType should be undefined]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("italic", false, null), a[b\]c): input.target should be undefined]
     expected: FAIL

--- a/tests/wpt/meta/editing/other/removing-inline-style-specified-by-parent-block.tentative.html.ini
+++ b/tests/wpt/meta/editing/other/removing-inline-style-specified-by-parent-block.tentative.html.ini
@@ -1,9 +1,6 @@
 [removing-inline-style-specified-by-parent-block.tentative.html?u]
 
 [removing-inline-style-specified-by-parent-block.tentative.html?i]
-  [Disabling style to text, it's applied to the parent block]
-    expected: FAIL
-
   [Disabling style to text, it's applied to the editing host]
     expected: FAIL
 

--- a/tests/wpt/meta/editing/run/italic.html.ini
+++ b/tests/wpt/meta/editing/run/italic.html.ini
@@ -1,1351 +1,238 @@
 [italic.html?1-1000]
-  [[["italic",""\]\] "foo[\]bar": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["italic",""\]\] "foo[\]bar" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<p>[foo</p> <p>bar\]</p>": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<p>[foo</p> <p>bar\]</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<p>[foo</p> <p>bar\]</p>" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "<p>[foo</p> <p>bar\]</p>": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "<p>[foo</p> <p>bar\]</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "<p>[foo</p> <p>bar\]</p>" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<span>[foo</span> <span>bar\]</span>": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<span>[foo</span> <span>bar\]</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<span>[foo</span> <span>bar\]</span>" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "<span>[foo</span> <span>bar\]</span>": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "<span>[foo</span> <span>bar\]</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "<span>[foo</span> <span>bar\]</span>" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<p>[foo</p><p> <span>bar</span> </p><p>baz\]</p>": execCommand("italic", false, "") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["italic",""\]\] "<p>[foo</p><p> <span>bar</span> </p><p>baz\]</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<p>[foo</p><p> <span>bar</span> </p><p>baz\]</p>" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "<p>[foo</p><p> <span>bar</span> </p><p>baz\]</p>": execCommand("italic", false, "") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["italic",""\]\] "<p>[foo</p><p> <span>bar</span> </p><p>baz\]</p>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["italic",""\]\] "<p>[foo</p><p> <span>bar</span> </p><p>baz\]</p>" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<p>[foo<p><br><p>bar\]": execCommand("italic", false, "") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["italic",""\]\] "<p>[foo<p><br><p>bar\]" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<p>[foo<p><br><p>bar\]" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "<p>[foo<p><br><p>bar\]": execCommand("italic", false, "") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["italic",""\]\] "<p>[foo<p><br><p>bar\]" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["italic",""\]\] "<p>[foo<p><br><p>bar\]" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["italic",""\]\] "<b>foo[\]bar</b>": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["italic",""\]\] "<b>foo[\]bar</b>" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["italic",""\]\] "<i>foo[\]bar</i>": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["italic",""\]\] "<i>foo[\]bar</i>" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["italic",""\]\] "<span>foo</span>{}<span>bar</span>": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["italic",""\]\] "<span>foo</span>{}<span>bar</span>" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["italic",""\]\] "<span>foo[</span><span>\]bar</span>": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["italic",""\]\] "<span>foo[</span><span>\]bar</span>" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo[bar\]baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo[bar\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo[bar\]baz" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo[bar\]baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo[bar\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo[bar\]baz" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo[bar<b>baz\]qoz</b>quz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo[bar<b>baz\]qoz</b>quz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo[bar<b>baz\]qoz</b>quz" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo[bar<b>baz\]qoz</b>quz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo[bar<b>baz\]qoz</b>quz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo[bar<b>baz\]qoz</b>quz" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["italic",""\]\] "foo[bar<i>baz\]qoz</i>quz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["italic",""\]\] "foo[bar<i>baz\]qoz</i>quz" compare innerHTML]
-    expected: FAIL
-
   [[["italic",""\]\] "foo[bar<i>baz\]qoz</i>quz" queryCommandIndeterm("italic") before]
-    expected: FAIL
-
-  [[["italic",""\]\] "foo[bar<i>baz\]qoz</i>quz" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "{<p><p> <p>foo</p>}": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "{<p><p> <p>foo</p>}" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "{<p><p> <p>foo</p>}" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "{<p><p> <p>foo</p>}": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "{<p><p> <p>foo</p>}" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "{<p><p> <p>foo</p>}" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<table><tbody><tr><td>foo<td>b[a\]r<td>baz</table>": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<table><tbody><tr><td>foo<td>b[a\]r<td>baz</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<table><tbody><tr><td>foo<td>b[a\]r<td>baz</table>" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "<table><tbody><tr><td>foo<td>b[a\]r<td>baz</table>": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "<table><tbody><tr><td>foo<td>b[a\]r<td>baz</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "<table><tbody><tr><td>foo<td>b[a\]r<td>baz</table>" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<table><tbody><tr data-start=1 data-end=2><td>foo<td>bar<td>baz</table>": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<table><tbody><tr data-start=1 data-end=2><td>foo<td>bar<td>baz</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<table><tbody><tr data-start=1 data-end=2><td>foo<td>bar<td>baz</table>" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "<table><tbody><tr data-start=1 data-end=2><td>foo<td>bar<td>baz</table>": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "<table><tbody><tr data-start=1 data-end=2><td>foo<td>bar<td>baz</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "<table><tbody><tr data-start=1 data-end=2><td>foo<td>bar<td>baz</table>" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<table><tbody><tr data-start=0 data-end=2><td>foo<td>bar<td>baz</table>": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<table><tbody><tr data-start=0 data-end=2><td>foo<td>bar<td>baz</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<table><tbody><tr data-start=0 data-end=2><td>foo<td>bar<td>baz</table>" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "<table><tbody><tr data-start=0 data-end=2><td>foo<td>bar<td>baz</table>": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "<table><tbody><tr data-start=0 data-end=2><td>foo<td>bar<td>baz</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "<table><tbody><tr data-start=0 data-end=2><td>foo<td>bar<td>baz</table>" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<table><tbody data-start=0 data-end=1><tr><td>foo<td>bar<td>baz</table>": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<table><tbody data-start=0 data-end=1><tr><td>foo<td>bar<td>baz</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<table><tbody data-start=0 data-end=1><tr><td>foo<td>bar<td>baz</table>" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "<table><tbody data-start=0 data-end=1><tr><td>foo<td>bar<td>baz</table>": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "<table><tbody data-start=0 data-end=1><tr><td>foo<td>bar<td>baz</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "<table><tbody data-start=0 data-end=1><tr><td>foo<td>bar<td>baz</table>" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<table data-start=0 data-end=1><tbody><tr><td>foo<td>bar<td>baz</table>": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<table data-start=0 data-end=1><tbody><tr><td>foo<td>bar<td>baz</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<table data-start=0 data-end=1><tbody><tr><td>foo<td>bar<td>baz</table>" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "<table data-start=0 data-end=1><tbody><tr><td>foo<td>bar<td>baz</table>": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "<table data-start=0 data-end=1><tbody><tr><td>foo<td>bar<td>baz</table>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "<table data-start=0 data-end=1><tbody><tr><td>foo<td>bar<td>baz</table>" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "{<table><tr><td>foo<td>bar<td>baz</table>}": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "{<table><tr><td>foo<td>bar<td>baz</table>}" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "{<table><tr><td>foo<td>bar<td>baz</table>}" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "{<table><tr><td>foo<td>bar<td>baz</table>}": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "{<table><tr><td>foo<td>bar<td>baz</table>}" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "{<table><tr><td>foo<td>bar<td>baz</table>}" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<address>[bar\]</address>baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<address>[bar\]</address>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<address>[bar\]</address>baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<address>[bar\]</address>baz": execCommand("italic", false, "") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["italic",""\]\] "foo<address>[bar\]</address>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<address>[bar\]</address>baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<cite>[bar\]</cite>baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<cite>[bar\]</cite>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<cite>[bar\]</cite>baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<cite>[bar\]</cite>baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["italic",""\]\] "foo<cite>[bar\]</cite>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<cite>[bar\]</cite>baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<dfn>[bar\]</dfn>baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<dfn>[bar\]</dfn>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<dfn>[bar\]</dfn>baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<dfn>[bar\]</dfn>baz": execCommand("italic", false, "") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["italic",""\]\] "foo<dfn>[bar\]</dfn>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<dfn>[bar\]</dfn>baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["italic",""\]\] "foo<em>[bar\]</em>baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["italic",""\]\] "foo<em>[bar\]</em>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["italic",""\]\] "foo<em>[bar\]</em>baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<var>[bar\]</var>baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<var>[bar\]</var>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<var>[bar\]</var>baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<var>[bar\]</var>baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["italic",""\]\] "foo<var>[bar\]</var>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<var>[bar\]</var>baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo{<address>bar</address>}baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo{<address>bar</address>}baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo{<address>bar</address>}baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo{<address>bar</address>}baz": execCommand("italic", false, "") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["italic",""\]\] "foo{<address>bar</address>}baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["italic",""\]\] "foo{<address>bar</address>}baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo{<cite>bar</cite>}baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo{<cite>bar</cite>}baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo{<cite>bar</cite>}baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo{<cite>bar</cite>}baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["italic",""\]\] "foo{<cite>bar</cite>}baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo{<cite>bar</cite>}baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo{<dfn>bar</dfn>}baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo{<dfn>bar</dfn>}baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo{<dfn>bar</dfn>}baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo{<dfn>bar</dfn>}baz": execCommand("italic", false, "") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["italic",""\]\] "foo{<dfn>bar</dfn>}baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["italic",""\]\] "foo{<dfn>bar</dfn>}baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["italic",""\]\] "foo{<em>bar</em>}baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["italic",""\]\] "foo{<em>bar</em>}baz" compare innerHTML]
-    expected: FAIL
-
-  [[["italic",""\]\] "foo{<em>bar</em>}baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo{<var>bar</var>}baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo{<var>bar</var>}baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo{<var>bar</var>}baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo{<var>bar</var>}baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["italic",""\]\] "foo{<var>bar</var>}baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo{<var>bar</var>}baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<address>b[a\]r</address>baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<address>b[a\]r</address>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<address>b[a\]r</address>baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<address>b[a\]r</address>baz": execCommand("italic", false, "") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["italic",""\]\] "foo<address>b[a\]r</address>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<address>b[a\]r</address>baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<cite>b[a\]r</cite>baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<cite>b[a\]r</cite>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<cite>b[a\]r</cite>baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<cite>b[a\]r</cite>baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["italic",""\]\] "foo<cite>b[a\]r</cite>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<cite>b[a\]r</cite>baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<dfn>b[a\]r</dfn>baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<dfn>b[a\]r</dfn>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<dfn>b[a\]r</dfn>baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<dfn>b[a\]r</dfn>baz": execCommand("italic", false, "") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["italic",""\]\] "foo<dfn>b[a\]r</dfn>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<dfn>b[a\]r</dfn>baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<em>b[a\]r</em>baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["italic",""\]\] "foo<em>b[a\]r</em>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<em>b[a\]r</em>baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<em>b[a\]r</em>baz": execCommand("italic", false, "") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["italic",""\]\] "foo<em>b[a\]r</em>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<em>b[a\]r</em>baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<i>b[a\]r</i>baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<i>b[a\]r</i>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<i>b[a\]r</i>baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<i>b[a\]r</i>baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<i>b[a\]r</i>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<i>b[a\]r</i>baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<var>b[a\]r</var>baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<var>b[a\]r</var>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<var>b[a\]r</var>baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<var>b[a\]r</var>baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["italic",""\]\] "foo<var>b[a\]r</var>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<var>b[a\]r</var>baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "fo[o<address>bar</address>b\]az": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "fo[o<address>bar</address>b\]az" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["italic",""\]\] "fo[o<address>bar</address>b\]az" queryCommandIndeterm("italic") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["italic",""\]\] "fo[o<address>bar</address>b\]az" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "fo[o<address>bar</address>b\]az": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "fo[o<address>bar</address>b\]az" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["italic",""\]\] "fo[o<address>bar</address>b\]az" queryCommandIndeterm("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "fo[o<address>bar</address>b\]az" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "fo[o<cite>bar</cite>b\]az": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "fo[o<cite>bar</cite>b\]az" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["italic",""\]\] "fo[o<cite>bar</cite>b\]az" queryCommandIndeterm("italic") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["italic",""\]\] "fo[o<cite>bar</cite>b\]az" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "fo[o<cite>bar</cite>b\]az": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "fo[o<cite>bar</cite>b\]az" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["italic",""\]\] "fo[o<cite>bar</cite>b\]az" queryCommandIndeterm("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "fo[o<cite>bar</cite>b\]az" queryCommandState("italic") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["italic",""\]\] "<p>[foo</p> <p>bar\]</p>" queryCommandState("stylewithcss") before]
     expected: FAIL
 
+  [[["stylewithcss","true"\],["italic",""\]\] "foo<em>b[a\]r</em>baz" queryCommandState("italic") after]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["italic",""\]\] "foo<em>b[a\]r</em>baz" queryCommandState("italic") after]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["italic",""\]\] "foo<i>b[a\]r</i>baz" queryCommandState("italic") after]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["italic",""\]\] "foo<i>b[a\]r</i>baz" queryCommandState("italic") after]
+    expected: FAIL
+
 
 [italic.html?2001-last]
-  [[["stylewithcss","false"\],["italic",""\]\] "<span style=font-style:italic>fo[o</span><span style=font-style:oblique>b\]ar</span>" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<span style=font-style:oblique>fo[o</span><span style=font-style:italic>b\]ar</span>": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<span style=font-style:oblique>fo[o</span><span style=font-style:italic>b\]ar</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<span style=font-style:oblique>fo[o</span><span style=font-style:italic>b\]ar</span>" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "<span style=font-style:oblique>fo[o</span><span style=font-style:italic>b\]ar</span>": execCommand("italic", false, "") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["italic",""\]\] "<span style=font-style:oblique>fo[o</span><span style=font-style:italic>b\]ar</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "<span style=font-style:oblique>fo[o</span><span style=font-style:italic>b\]ar</span>" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<i>fo[o</i><address>b\]ar</address>": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<i>fo[o</i><address>b\]ar</address>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<i>fo[o</i><address>b\]ar</address>" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "<i>fo[o</i><address>b\]ar</address>": execCommand("italic", false, "") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["italic",""\]\] "<i>fo[o</i><address>b\]ar</address>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["italic",""\]\] "<i>fo[o</i><address>b\]ar</address>" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "{ <span contenteditable=\\"false\\">A</span> ; <span contenteditable=\\"false\\">B</span> ; <span contenteditable=\\"false\\">C</span> }": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "{ <span contenteditable=\\"false\\">A</span> ; <span contenteditable=\\"false\\">B</span> ; <span contenteditable=\\"false\\">C</span> }" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["italic",""\]\] "<span style=font-style:oblique>fo[o</span><span style=font-style:italic>b\]ar</span>" queryCommandState("stylewithcss") before]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["italic",""\]\] "<span style=font-style:italic>fo[o</span><span style=font-style:oblique>b\]ar</span>" queryCommandState("italic") after]
     expected: FAIL
 
 
 [italic.html?1001-2000]
-  [[["stylewithcss","true"\],["italic",""\]\] "fo[o<dfn>bar</dfn>b\]az": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "fo[o<dfn>bar</dfn>b\]az" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["italic",""\]\] "fo[o<dfn>bar</dfn>b\]az" queryCommandIndeterm("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "fo[o<dfn>bar</dfn>b\]az" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "fo[o<dfn>bar</dfn>b\]az": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "fo[o<dfn>bar</dfn>b\]az" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["italic",""\]\] "fo[o<dfn>bar</dfn>b\]az" queryCommandIndeterm("italic") before]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["italic",""\]\] "fo[o<dfn>bar</dfn>b\]az" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "fo[o<em>bar</em>b\]az": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "fo[o<em>bar</em>b\]az" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["italic",""\]\] "fo[o<em>bar</em>b\]az" queryCommandIndeterm("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "fo[o<em>bar</em>b\]az" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "fo[o<em>bar</em>b\]az": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "fo[o<em>bar</em>b\]az" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["italic",""\]\] "fo[o<em>bar</em>b\]az" queryCommandIndeterm("italic") before]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["italic",""\]\] "fo[o<em>bar</em>b\]az" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "fo[o<var>bar</var>b\]az": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "fo[o<var>bar</var>b\]az" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["italic",""\]\] "fo[o<var>bar</var>b\]az" queryCommandIndeterm("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "fo[o<var>bar</var>b\]az" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "fo[o<var>bar</var>b\]az": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "fo[o<var>bar</var>b\]az" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["italic",""\]\] "fo[o<var>bar</var>b\]az" queryCommandIndeterm("italic") before]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["italic",""\]\] "fo[o<var>bar</var>b\]az" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo[<address>bar</address>baz\]": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo[<address>bar</address>baz\]" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["italic",""\]\] "foo[<address>bar</address>baz\]" queryCommandIndeterm("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo[<address>bar</address>baz\]" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo[<address>bar</address>baz\]": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo[<address>bar</address>baz\]" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["italic",""\]\] "foo[<address>bar</address>baz\]" queryCommandIndeterm("italic") before]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["italic",""\]\] "foo[<address>bar</address>baz\]" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo[<cite>bar</cite>baz\]": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo[<cite>bar</cite>baz\]" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["italic",""\]\] "foo[<cite>bar</cite>baz\]" queryCommandIndeterm("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo[<cite>bar</cite>baz\]" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo[<cite>bar</cite>baz\]": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo[<cite>bar</cite>baz\]" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["italic",""\]\] "foo[<cite>bar</cite>baz\]" queryCommandIndeterm("italic") before]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["italic",""\]\] "foo[<cite>bar</cite>baz\]" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo[<dfn>bar</dfn>baz\]": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo[<dfn>bar</dfn>baz\]" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["italic",""\]\] "foo[<dfn>bar</dfn>baz\]" queryCommandIndeterm("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo[<dfn>bar</dfn>baz\]" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo[<dfn>bar</dfn>baz\]": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo[<dfn>bar</dfn>baz\]" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["italic",""\]\] "foo[<dfn>bar</dfn>baz\]" queryCommandIndeterm("italic") before]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["italic",""\]\] "foo[<dfn>bar</dfn>baz\]" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo[<em>bar</em>baz\]": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo[<em>bar</em>baz\]" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["italic",""\]\] "foo[<em>bar</em>baz\]" queryCommandIndeterm("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo[<em>bar</em>baz\]" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo[<em>bar</em>baz\]": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo[<em>bar</em>baz\]" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["italic",""\]\] "foo[<em>bar</em>baz\]" queryCommandIndeterm("italic") before]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["italic",""\]\] "foo[<em>bar</em>baz\]" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo[<i>bar</i>baz\]": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo[<i>bar</i>baz\]" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["italic",""\]\] "foo[<i>bar</i>baz\]" queryCommandIndeterm("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo[<i>bar</i>baz\]" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo[<i>bar</i>baz\]": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo[<i>bar</i>baz\]" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["italic",""\]\] "foo[<i>bar</i>baz\]" queryCommandIndeterm("italic") before]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["italic",""\]\] "foo[<i>bar</i>baz\]" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo[<var>bar</var>baz\]": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo[<var>bar</var>baz\]" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["italic",""\]\] "foo[<var>bar</var>baz\]" queryCommandIndeterm("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo[<var>bar</var>baz\]" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo[<var>bar</var>baz\]": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo[<var>bar</var>baz\]" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["italic",""\]\] "foo[<var>bar</var>baz\]" queryCommandIndeterm("italic") before]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["italic",""\]\] "foo[<var>bar</var>baz\]" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "[foo<address>bar</address>\]baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "[foo<address>bar</address>\]baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["italic",""\]\] "[foo<address>bar</address>\]baz" queryCommandIndeterm("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "[foo<address>bar</address>\]baz" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "[foo<address>bar</address>\]baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "[foo<address>bar</address>\]baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["italic",""\]\] "[foo<address>bar</address>\]baz" queryCommandIndeterm("italic") before]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["italic",""\]\] "[foo<address>bar</address>\]baz" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "[foo<cite>bar</cite>\]baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "[foo<cite>bar</cite>\]baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["italic",""\]\] "[foo<cite>bar</cite>\]baz" queryCommandIndeterm("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "[foo<cite>bar</cite>\]baz" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "[foo<cite>bar</cite>\]baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "[foo<cite>bar</cite>\]baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["italic",""\]\] "[foo<cite>bar</cite>\]baz" queryCommandIndeterm("italic") before]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["italic",""\]\] "[foo<cite>bar</cite>\]baz" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "[foo<dfn>bar</dfn>\]baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "[foo<dfn>bar</dfn>\]baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["italic",""\]\] "[foo<dfn>bar</dfn>\]baz" queryCommandIndeterm("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "[foo<dfn>bar</dfn>\]baz" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "[foo<dfn>bar</dfn>\]baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "[foo<dfn>bar</dfn>\]baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["italic",""\]\] "[foo<dfn>bar</dfn>\]baz" queryCommandIndeterm("italic") before]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["italic",""\]\] "[foo<dfn>bar</dfn>\]baz" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "[foo<em>bar</em>\]baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "[foo<em>bar</em>\]baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["italic",""\]\] "[foo<em>bar</em>\]baz" queryCommandIndeterm("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "[foo<em>bar</em>\]baz" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "[foo<em>bar</em>\]baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "[foo<em>bar</em>\]baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["italic",""\]\] "[foo<em>bar</em>\]baz" queryCommandIndeterm("italic") before]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["italic",""\]\] "[foo<em>bar</em>\]baz" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "[foo<i>bar</i>\]baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "[foo<i>bar</i>\]baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["italic",""\]\] "[foo<i>bar</i>\]baz" queryCommandIndeterm("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "[foo<i>bar</i>\]baz" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "[foo<i>bar</i>\]baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "[foo<i>bar</i>\]baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["italic",""\]\] "[foo<i>bar</i>\]baz" queryCommandIndeterm("italic") before]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["italic",""\]\] "[foo<i>bar</i>\]baz" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "[foo<var>bar</var>\]baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "[foo<var>bar</var>\]baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["italic",""\]\] "[foo<var>bar</var>\]baz" queryCommandIndeterm("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "[foo<var>bar</var>\]baz" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "[foo<var>bar</var>\]baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "[foo<var>bar</var>\]baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["italic",""\]\] "[foo<var>bar</var>\]baz" queryCommandIndeterm("italic") before]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["italic",""\]\] "[foo<var>bar</var>\]baz" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<span style=\\"font-style: italic\\">[bar\]</span>baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<span style=\\"font-style: italic\\">[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<span style=\\"font-style: italic\\">[bar\]</span>baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<span style=\\"font-style: italic\\">[bar\]</span>baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<span style=\\"font-style: italic\\">[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<span style=\\"font-style: italic\\">[bar\]</span>baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<span style=\\"font-style: oblique\\">[bar\]</span>baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<span style=\\"font-style: oblique\\">[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<span style=\\"font-style: oblique\\">[bar\]</span>baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<span style=\\"font-style: oblique\\">[bar\]</span>baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<span style=\\"font-style: oblique\\">[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<span style=\\"font-style: oblique\\">[bar\]</span>baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<span style=\\"font-style: oblique\\">b[a\]r</span>baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<span style=\\"font-style: oblique\\">b[a\]r</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<span style=\\"font-style: oblique\\">b[a\]r</span>baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<span style=\\"font-style: oblique\\">b[a\]r</span>baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["italic",""\]\] "foo<span style=\\"font-style: oblique\\">b[a\]r</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<span style=\\"font-style: oblique\\">b[a\]r</span>baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<i>{<p>foo</p><p>bar</p>}<p>baz</p></i>": execCommand("italic", false, "") return value]
     expected: FAIL
 
   [[["stylewithcss","true"\],["italic",""\]\] "<i>{<p>foo</p><p>bar</p>}<p>baz</p></i>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["italic",""\]\] "<i>{<p>foo</p><p>bar</p>}<p>baz</p></i>" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "<i>{<p>foo</p><p>bar</p>}<p>baz</p></i>": execCommand("italic", false, "") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["italic",""\]\] "<i>{<p>foo</p><p>bar</p>}<p>baz</p></i>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "<i>{<p>foo</p><p>bar</p>}<p>baz</p></i>" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<i><p>foo[<b>bar</b>}</p><p>baz</p></i>": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<i><p>foo[<b>bar</b>}</p><p>baz</p></i>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<i><p>foo[<b>bar</b>}</p><p>baz</p></i>" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "<i><p>foo[<b>bar</b>}</p><p>baz</p></i>": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "<i><p>foo[<b>bar</b>}</p><p>baz</p></i>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "<i><p>foo[<b>bar</b>}</p><p>baz</p></i>" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo [bar <b>baz\] qoz</b> quz sic": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo [bar <b>baz\] qoz</b> quz sic" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo [bar <b>baz\] qoz</b> quz sic" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo [bar <b>baz\] qoz</b> quz sic": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo [bar <b>baz\] qoz</b> quz sic" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo [bar <b>baz\] qoz</b> quz sic" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo bar <b>baz [qoz</b> quz\] sic": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo bar <b>baz [qoz</b> quz\] sic" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo bar <b>baz [qoz</b> quz\] sic" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo bar <b>baz [qoz</b> quz\] sic": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo bar <b>baz [qoz</b> quz\] sic" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo bar <b>baz [qoz</b> quz\] sic" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["italic",""\]\] "foo [bar <i>baz\] qoz</i> quz sic": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["italic",""\]\] "foo [bar <i>baz\] qoz</i> quz sic" compare innerHTML]
     expected: FAIL
 
   [[["italic",""\]\] "foo [bar <i>baz\] qoz</i> quz sic" queryCommandIndeterm("italic") before]
     expected: FAIL
 
-  [[["italic",""\]\] "foo [bar <i>baz\] qoz</i> quz sic" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["italic",""\]\] "foo bar <i>baz [qoz</i> quz\] sic": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["italic",""\]\] "foo bar <i>baz [qoz</i> quz\] sic" compare innerHTML]
-    expected: FAIL
-
   [[["italic",""\]\] "foo bar <i>baz [qoz</i> quz\] sic" queryCommandIndeterm("italic") before]
-    expected: FAIL
-
-  [[["italic",""\]\] "foo bar <i>baz [qoz</i> quz\] sic" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["italic",""\]\] "fo[o<i>b\]ar</i>baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["italic",""\]\] "fo[o<i>b\]ar</i>baz" compare innerHTML]
     expected: FAIL
 
   [[["italic",""\]\] "fo[o<i>b\]ar</i>baz" queryCommandIndeterm("italic") before]
     expected: FAIL
 
-  [[["italic",""\]\] "fo[o<i>b\]ar</i>baz" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["italic",""\]\] "foo<i>ba[r</i>b\]az": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["italic",""\]\] "foo<i>ba[r</i>b\]az" compare innerHTML]
-    expected: FAIL
-
   [[["italic",""\]\] "foo<i>ba[r</i>b\]az" queryCommandIndeterm("italic") before]
-    expected: FAIL
-
-  [[["italic",""\]\] "foo<i>ba[r</i>b\]az" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "fo[o<i>bar</i>b\]az": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "fo[o<i>bar</i>b\]az" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["italic",""\]\] "fo[o<i>bar</i>b\]az" queryCommandIndeterm("italic") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["italic",""\]\] "fo[o<i>bar</i>b\]az" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "fo[o<i>bar</i>b\]az": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "fo[o<i>bar</i>b\]az" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["italic",""\]\] "fo[o<i>bar</i>b\]az" queryCommandIndeterm("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "fo[o<i>bar</i>b\]az" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo[<i>b\]ar</i>baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo[<i>b\]ar</i>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo[<i>b\]ar</i>baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo[<i>b\]ar</i>baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo[<i>b\]ar</i>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo[<i>b\]ar</i>baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<i>ba[r</i>\]baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<i>ba[r</i>\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<i>ba[r</i>\]baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<i>ba[r</i>\]baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<i>ba[r</i>\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<i>ba[r</i>\]baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo[<i>bar</i>\]baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo[<i>bar</i>\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo[<i>bar</i>\]baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo[<i>bar</i>\]baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo[<i>bar</i>\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo[<i>bar</i>\]baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<i>[bar\]</i>baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<i>[bar\]</i>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<i>[bar\]</i>baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<i>[bar\]</i>baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<i>[bar\]</i>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<i>[bar\]</i>baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo{<i>bar</i>}baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo{<i>bar</i>}baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo{<i>bar</i>}baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo{<i>bar</i>}baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo{<i>bar</i>}baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo{<i>bar</i>}baz" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["italic",""\]\] "fo[o<span style=font-style:italic>b\]ar</span>baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["italic",""\]\] "fo[o<span style=font-style:italic>b\]ar</span>baz" compare innerHTML]
     expected: FAIL
 
   [[["italic",""\]\] "fo[o<span style=font-style:italic>b\]ar</span>baz" queryCommandIndeterm("italic") before]
     expected: FAIL
 
-  [[["italic",""\]\] "fo[o<span style=font-style:italic>b\]ar</span>baz" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "fo[o<span style=font-style:oblique>b\]ar</span>baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "fo[o<span style=font-style:oblique>b\]ar</span>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["italic",""\]\] "fo[o<span style=font-style:oblique>b\]ar</span>baz" queryCommandIndeterm("italic") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["italic",""\]\] "fo[o<span style=font-style:oblique>b\]ar</span>baz" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "fo[o<span style=font-style:oblique>b\]ar</span>baz": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "fo[o<span style=font-style:oblique>b\]ar</span>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["italic",""\]\] "fo[o<span style=font-style:oblique>b\]ar</span>baz" queryCommandIndeterm("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "fo[o<span style=font-style:oblique>b\]ar</span>baz" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<span style=font-style:italic>fo[o</span><span style=font-style:oblique>b\]ar</span>": execCommand("italic", false, "") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<span style=font-style:italic>fo[o</span><span style=font-style:oblique>b\]ar</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "<span style=font-style:italic>fo[o</span><span style=font-style:oblique>b\]ar</span>" queryCommandState("italic") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "<span style=font-style:italic>fo[o</span><span style=font-style:oblique>b\]ar</span>": execCommand("italic", false, "") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["italic",""\]\] "<span style=font-style:italic>fo[o</span><span style=font-style:oblique>b\]ar</span>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["italic",""\]\] "fo[o<dfn>bar</dfn>b\]az" queryCommandState("stylewithcss") before]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["italic",""\]\] "foo<span style=\\"font-style: oblique\\">b[a\]r</span>baz" queryCommandState("italic") after]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["italic",""\]\] "foo<span style=\\"font-style: oblique\\">b[a\]r</span>baz" queryCommandState("italic") after]
     expected: FAIL

--- a/tests/wpt/meta/editing/run/multitest.html.ini
+++ b/tests/wpt/meta/editing/run/multitest.html.ini
@@ -1360,25 +1360,13 @@
   [[["bold",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("bold") after]
     expected: FAIL
 
-  [[["italic",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("italic", false, "") return value]
-    expected: FAIL
-
   [[["italic",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
   [[["italic",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["italic",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["italic",""\],["delete",""\]\] "foo[\]bar": execCommand("italic", false, "") return value]
-    expected: FAIL
-
   [[["italic",""\],["delete",""\]\] "foo[\]bar" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["italic",""\],["delete",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("italic", false, "") return value]
     expected: FAIL
 
   [[["italic",""\],["delete",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
@@ -1390,22 +1378,13 @@
   [[["italic",""\],["delete",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("italic") after]
     expected: FAIL
 
-  [[["italic",""\],["formatblock","<div>"\]\] "foo[\]bar": execCommand("italic", false, "") return value]
-    expected: FAIL
-
   [[["italic",""\],["formatblock","<div>"\]\] "foo[\]bar": execCommand("formatblock", false, "<div>") return value]
     expected: FAIL
 
   [[["italic",""\],["formatblock","<div>"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["italic",""\],["formatblock","<div>"\]\] "foo[\]bar" queryCommandState("italic") after]
-    expected: FAIL
-
   [[["italic",""\],["formatblock","<div>"\]\] "foo[\]bar" queryCommandValue("formatblock") after]
-    expected: FAIL
-
-  [[["italic",""\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar": execCommand("italic", false, "") return value]
     expected: FAIL
 
   [[["italic",""\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar": execCommand("formatblock", false, "<div>") return value]
@@ -1417,25 +1396,13 @@
   [[["italic",""\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["italic",""\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("italic") after]
-    expected: FAIL
-
   [[["italic",""\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("formatblock") after]
-    expected: FAIL
-
-  [[["italic",""\],["forwarddelete",""\]\] "foo[\]bar": execCommand("italic", false, "") return value]
     expected: FAIL
 
   [[["italic",""\],["forwarddelete",""\]\] "foo[\]bar": execCommand("forwarddelete", false, "") return value]
     expected: FAIL
 
   [[["italic",""\],["forwarddelete",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["italic",""\],["forwarddelete",""\]\] "foo[\]bar" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["italic",""\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("italic", false, "") return value]
     expected: FAIL
 
   [[["italic",""\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("forwarddelete", false, "") return value]
@@ -1447,22 +1414,10 @@
   [[["italic",""\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["italic",""\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["italic",""\],["indent",""\]\] "foo[\]bar": execCommand("italic", false, "") return value]
-    expected: FAIL
-
   [[["italic",""\],["indent",""\]\] "foo[\]bar": execCommand("indent", false, "") return value]
     expected: FAIL
 
   [[["italic",""\],["indent",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["italic",""\],["indent",""\]\] "foo[\]bar" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["italic",""\],["indent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("italic", false, "") return value]
     expected: FAIL
 
   [[["italic",""\],["indent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("indent", false, "") return value]
@@ -1474,22 +1429,10 @@
   [[["italic",""\],["indent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["italic",""\],["indent",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["italic",""\],["inserthorizontalrule",""\]\] "foo[\]bar": execCommand("italic", false, "") return value]
-    expected: FAIL
-
   [[["italic",""\],["inserthorizontalrule",""\]\] "foo[\]bar": execCommand("inserthorizontalrule", false, "") return value]
     expected: FAIL
 
   [[["italic",""\],["inserthorizontalrule",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["italic",""\],["inserthorizontalrule",""\]\] "foo[\]bar" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["italic",""\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("italic", false, "") return value]
     expected: FAIL
 
   [[["italic",""\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserthorizontalrule", false, "") return value]
@@ -1501,22 +1444,10 @@
   [[["italic",""\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["italic",""\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["italic",""\],["inserthtml","ab<b>c</b>d"\]\] "foo[\]bar": execCommand("italic", false, "") return value]
-    expected: FAIL
-
   [[["italic",""\],["inserthtml","ab<b>c</b>d"\]\] "foo[\]bar": execCommand("inserthtml", false, "ab<b>c</b>d") return value]
     expected: FAIL
 
   [[["italic",""\],["inserthtml","ab<b>c</b>d"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["italic",""\],["inserthtml","ab<b>c</b>d"\]\] "foo[\]bar" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["italic",""\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar": execCommand("italic", false, "") return value]
     expected: FAIL
 
   [[["italic",""\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserthtml", false, "ab<b>c</b>d") return value]
@@ -1528,22 +1459,10 @@
   [[["italic",""\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["italic",""\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["italic",""\],["insertimage","/img/lion.svg"\]\] "foo[\]bar": execCommand("italic", false, "") return value]
-    expected: FAIL
-
   [[["italic",""\],["insertimage","/img/lion.svg"\]\] "foo[\]bar": execCommand("insertimage", false, "/img/lion.svg") return value]
     expected: FAIL
 
   [[["italic",""\],["insertimage","/img/lion.svg"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["italic",""\],["insertimage","/img/lion.svg"\]\] "foo[\]bar" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["italic",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("italic", false, "") return value]
     expected: FAIL
 
   [[["italic",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertimage", false, "/img/lion.svg") return value]
@@ -1555,22 +1474,10 @@
   [[["italic",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["italic",""\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["italic",""\],["insertlinebreak",""\]\] "foo[\]bar": execCommand("italic", false, "") return value]
-    expected: FAIL
-
   [[["italic",""\],["insertlinebreak",""\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
   [[["italic",""\],["insertlinebreak",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["italic",""\],["insertlinebreak",""\]\] "foo[\]bar" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["italic",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("italic", false, "") return value]
     expected: FAIL
 
   [[["italic",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
@@ -1582,25 +1489,13 @@
   [[["italic",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["italic",""\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["italic",""\],["insertorderedlist",""\]\] "foo[\]bar": execCommand("italic", false, "") return value]
-    expected: FAIL
-
   [[["italic",""\],["insertorderedlist",""\]\] "foo[\]bar": execCommand("insertorderedlist", false, "") return value]
     expected: FAIL
 
   [[["italic",""\],["insertorderedlist",""\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["italic",""\],["insertorderedlist",""\]\] "foo[\]bar" queryCommandState("italic") after]
-    expected: FAIL
-
   [[["italic",""\],["insertorderedlist",""\]\] "foo[\]bar" queryCommandState("insertorderedlist") after]
-    expected: FAIL
-
-  [[["italic",""\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("italic", false, "") return value]
     expected: FAIL
 
   [[["italic",""\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertorderedlist", false, "") return value]
@@ -1612,27 +1507,15 @@
   [[["italic",""\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["italic",""\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("italic") after]
-    expected: FAIL
-
   [[["italic",""\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("insertorderedlist") after]
     expected: FAIL
 
 
 [multitest.html?1001-2000]
-  [[["italic",""\],["insertparagraph",""\]\] "foo[\]bar": execCommand("italic", false, "") return value]
-    expected: FAIL
-
   [[["italic",""\],["insertparagraph",""\]\] "foo[\]bar": execCommand("insertparagraph", false, "") return value]
     expected: FAIL
 
   [[["italic",""\],["insertparagraph",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["italic",""\],["insertparagraph",""\]\] "foo[\]bar" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["italic",""\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("italic", false, "") return value]
     expected: FAIL
 
   [[["italic",""\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertparagraph", false, "") return value]
@@ -1644,25 +1527,13 @@
   [[["italic",""\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["italic",""\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["italic",""\],["insertunorderedlist",""\]\] "foo[\]bar": execCommand("italic", false, "") return value]
-    expected: FAIL
-
   [[["italic",""\],["insertunorderedlist",""\]\] "foo[\]bar": execCommand("insertunorderedlist", false, "") return value]
     expected: FAIL
 
   [[["italic",""\],["insertunorderedlist",""\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["italic",""\],["insertunorderedlist",""\]\] "foo[\]bar" queryCommandState("italic") after]
-    expected: FAIL
-
   [[["italic",""\],["insertunorderedlist",""\]\] "foo[\]bar" queryCommandState("insertunorderedlist") after]
-    expected: FAIL
-
-  [[["italic",""\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("italic", false, "") return value]
     expected: FAIL
 
   [[["italic",""\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertunorderedlist", false, "") return value]
@@ -1674,22 +1545,13 @@
   [[["italic",""\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["italic",""\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("italic") after]
-    expected: FAIL
-
   [[["italic",""\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("insertunorderedlist") after]
-    expected: FAIL
-
-  [[["italic",""\],["justifycenter",""\]\] "foo[\]bar": execCommand("italic", false, "") return value]
     expected: FAIL
 
   [[["italic",""\],["justifycenter",""\]\] "foo[\]bar": execCommand("justifycenter", false, "") return value]
     expected: FAIL
 
   [[["italic",""\],["justifycenter",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["italic",""\],["justifycenter",""\]\] "foo[\]bar" queryCommandState("italic") after]
     expected: FAIL
 
   [[["italic",""\],["justifycenter",""\]\] "foo[\]bar" queryCommandValue("justifycenter") before]
@@ -1701,9 +1563,6 @@
   [[["italic",""\],["justifycenter",""\]\] "foo[\]bar" queryCommandValue("justifycenter") after]
     expected: FAIL
 
-  [[["italic",""\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("italic", false, "") return value]
-    expected: FAIL
-
   [[["italic",""\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifycenter", false, "") return value]
     expected: FAIL
 
@@ -1711,9 +1570,6 @@
     expected: FAIL
 
   [[["italic",""\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["italic",""\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("italic") after]
     expected: FAIL
 
   [[["italic",""\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("justifycenter") before]
@@ -1725,16 +1581,10 @@
   [[["italic",""\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("justifycenter") after]
     expected: FAIL
 
-  [[["italic",""\],["justifyfull",""\]\] "foo[\]bar": execCommand("italic", false, "") return value]
-    expected: FAIL
-
   [[["italic",""\],["justifyfull",""\]\] "foo[\]bar": execCommand("justifyfull", false, "") return value]
     expected: FAIL
 
   [[["italic",""\],["justifyfull",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["italic",""\],["justifyfull",""\]\] "foo[\]bar" queryCommandState("italic") after]
     expected: FAIL
 
   [[["italic",""\],["justifyfull",""\]\] "foo[\]bar" queryCommandValue("justifyfull") before]
@@ -1746,9 +1596,6 @@
   [[["italic",""\],["justifyfull",""\]\] "foo[\]bar" queryCommandValue("justifyfull") after]
     expected: FAIL
 
-  [[["italic",""\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("italic", false, "") return value]
-    expected: FAIL
-
   [[["italic",""\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyfull", false, "") return value]
     expected: FAIL
 
@@ -1756,9 +1603,6 @@
     expected: FAIL
 
   [[["italic",""\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["italic",""\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("italic") after]
     expected: FAIL
 
   [[["italic",""\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("justifyfull") before]
@@ -1770,13 +1614,7 @@
   [[["italic",""\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("justifyfull") after]
     expected: FAIL
 
-  [[["italic",""\],["justifyleft",""\]\] "foo[\]bar": execCommand("italic", false, "") return value]
-    expected: FAIL
-
   [[["italic",""\],["justifyleft",""\]\] "foo[\]bar": execCommand("justifyleft", false, "") return value]
-    expected: FAIL
-
-  [[["italic",""\],["justifyleft",""\]\] "foo[\]bar" queryCommandState("italic") after]
     expected: FAIL
 
   [[["italic",""\],["justifyleft",""\]\] "foo[\]bar" queryCommandState("justifyleft") before]
@@ -1791,9 +1629,6 @@
   [[["italic",""\],["justifyleft",""\]\] "foo[\]bar" queryCommandValue("justifyleft") after]
     expected: FAIL
 
-  [[["italic",""\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("italic", false, "") return value]
-    expected: FAIL
-
   [[["italic",""\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyleft", false, "") return value]
     expected: FAIL
 
@@ -1801,9 +1636,6 @@
     expected: FAIL
 
   [[["italic",""\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["italic",""\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("italic") after]
     expected: FAIL
 
   [[["italic",""\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("justifyleft") before]
@@ -1818,16 +1650,10 @@
   [[["italic",""\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("justifyleft") after]
     expected: FAIL
 
-  [[["italic",""\],["justifyright",""\]\] "foo[\]bar": execCommand("italic", false, "") return value]
-    expected: FAIL
-
   [[["italic",""\],["justifyright",""\]\] "foo[\]bar": execCommand("justifyright", false, "") return value]
     expected: FAIL
 
   [[["italic",""\],["justifyright",""\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["italic",""\],["justifyright",""\]\] "foo[\]bar" queryCommandState("italic") after]
     expected: FAIL
 
   [[["italic",""\],["justifyright",""\]\] "foo[\]bar" queryCommandValue("justifyright") before]
@@ -1839,9 +1665,6 @@
   [[["italic",""\],["justifyright",""\]\] "foo[\]bar" queryCommandValue("justifyright") after]
     expected: FAIL
 
-  [[["italic",""\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("italic", false, "") return value]
-    expected: FAIL
-
   [[["italic",""\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyright", false, "") return value]
     expected: FAIL
 
@@ -1849,9 +1672,6 @@
     expected: FAIL
 
   [[["italic",""\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["italic",""\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("italic") after]
     expected: FAIL
 
   [[["italic",""\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("justifyright") before]
@@ -1863,16 +1683,7 @@
   [[["italic",""\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("justifyright") after]
     expected: FAIL
 
-  [[["italic",""\],["outdent",""\]\] "foo[\]bar": execCommand("italic", false, "") return value]
-    expected: FAIL
-
   [[["italic",""\],["outdent",""\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
-    expected: FAIL
-
-  [[["italic",""\],["outdent",""\]\] "foo[\]bar" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["italic",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("italic", false, "") return value]
     expected: FAIL
 
   [[["italic",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
@@ -1882,9 +1693,6 @@
     expected: FAIL
 
   [[["italic",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["italic",""\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("italic") after]
     expected: FAIL
 
   [[["strikethrough",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
@@ -6115,9 +5923,6 @@
   [[["stylewithcss","false"\],["fontsize","4"\],["insertText","a"\]\] "<font size=7>{}<br></font>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["italic",""\],["insertText","a"\]\] "<span style=font-weight:bold>{}<br></span></b>": execCommand("italic", false, "") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["italic",""\],["insertText","a"\]\] "<span style=font-weight:bold>{}<br></span></b>": execCommand("insertText", false, "a") return value]
     expected: FAIL
 
@@ -6328,16 +6133,10 @@
   [[["styleWithCSS","false"\],["bold",""\],["italic",""\],["insertText","b"\]\] "a[\]c": execCommand("bold", false, "") return value]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["bold",""\],["italic",""\],["insertText","b"\]\] "a[\]c": execCommand("italic", false, "") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["bold",""\],["italic",""\],["insertText","b"\]\] "a[\]c": execCommand("insertText", false, "b") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["bold",""\],["italic",""\],["insertText","b"\]\] "a[\]c" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["italic",""\],["bold",""\],["insertText","b"\]\] "a[\]c": execCommand("italic", false, "") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["italic",""\],["bold",""\],["insertText","b"\]\] "a[\]c": execCommand("bold", false, "") return value]
@@ -6352,9 +6151,6 @@
   [[["styleWithCSS","false"\],["bold",""\],["italic",""\],["insertText","b"\]\] "<b>a[\]</b>c": execCommand("bold", false, "") return value]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["bold",""\],["italic",""\],["insertText","b"\]\] "<b>a[\]</b>c": execCommand("italic", false, "") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["bold",""\],["italic",""\],["insertText","b"\]\] "<b>a[\]</b>c": execCommand("insertText", false, "b") return value]
     expected: FAIL
 
@@ -6362,9 +6158,6 @@
     expected: FAIL
 
   [[["styleWithCSS","false"\],["bold",""\],["italic",""\],["insertText","b"\]\] "<i>a[\]</i>c": execCommand("bold", false, "") return value]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["bold",""\],["italic",""\],["insertText","b"\]\] "<i>a[\]</i>c": execCommand("italic", false, "") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["bold",""\],["italic",""\],["insertText","b"\]\] "<i>a[\]</i>c": execCommand("insertText", false, "b") return value]
@@ -6376,9 +6169,6 @@
   [[["styleWithCSS","false"\],["bold",""\],["italic",""\],["insertText","b"\]\] "a[\]<b>c</b>": execCommand("bold", false, "") return value]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["bold",""\],["italic",""\],["insertText","b"\]\] "a[\]<b>c</b>": execCommand("italic", false, "") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["bold",""\],["italic",""\],["insertText","b"\]\] "a[\]<b>c</b>": execCommand("insertText", false, "b") return value]
     expected: FAIL
 
@@ -6386,9 +6176,6 @@
     expected: FAIL
 
   [[["styleWithCSS","false"\],["bold",""\],["italic",""\],["insertText","b"\]\] "a[\]<i>c</i>": execCommand("bold", false, "") return value]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["bold",""\],["italic",""\],["insertText","b"\]\] "a[\]<i>c</i>": execCommand("italic", false, "") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["bold",""\],["italic",""\],["insertText","b"\]\] "a[\]<i>c</i>": execCommand("insertText", false, "b") return value]

--- a/tests/wpt/meta/editing/run/strikethrough.html.ini
+++ b/tests/wpt/meta/editing/run/strikethrough.html.ini
@@ -38,18 +38,6 @@
   [[["stylewithcss","true"\],["strikethrough",""\]\] "foo<s>[bar\]</s>baz" queryCommandState("strikethrough") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["strikethrough",""\]\] "<strike>fo[o</strike><s>b\]ar</s>" queryCommandState("strikethrough") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["strikethrough",""\]\] "<strike>fo[o</strike><s>b\]ar</s>" queryCommandState("strikethrough") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["strikethrough",""\]\] "<s>fo[o</s><del>b\]ar</del>" queryCommandState("strikethrough") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["strikethrough",""\]\] "<s>fo[o</s><del>b\]ar</del>" queryCommandState("strikethrough") after]
-    expected: FAIL
-
 
 [strikethrough.html?1001-2000]
   [[["stylewithcss","true"\],["strikethrough",""\]\] "<strike>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</strike>" compare innerHTML]
@@ -214,13 +202,7 @@
   [[["stylewithcss","false"\],["strikethrough",""\]\] "foo<u style=\\"text-decoration: line-through\\">b[a\]r</u>baz" queryCommandState("strikethrough") after]
     expected: FAIL
 
-  [[["strikethrough",""\]\] "foo<s>ba[r</s>b\]az" queryCommandState("strikethrough") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["strikethrough",""\]\] "foo<s>ba[r</s>\]baz" queryCommandState("strikethrough") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["strikethrough",""\]\] "foo<s>ba[r</s>\]baz" queryCommandState("strikethrough") after]
+  [[["strikethrough",""\]\] "foo<s>ba[r</s>b\]az" compare innerHTML]
     expected: FAIL
 
 

--- a/tests/wpt/meta/editing/run/underline.html.ini
+++ b/tests/wpt/meta/editing/run/underline.html.ini
@@ -118,12 +118,6 @@
   [[["stylewithcss","false"\],["underline",""\]\] "<ins>fo[o</ins><u>b\]ar</u>" queryCommandState("underline") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["underline",""\]\] "<u>fo[o</u><ins>b\]ar</ins>" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<u>fo[o</u><ins>b\]ar</ins>" queryCommandState("underline") after]
-    expected: FAIL
-
 
 [underline.html?1001-2000]
   [[["stylewithcss","false"\],["underline",""\]\] "foo<strike>[bar\]</strike>baz" queryCommandState("underline") after]
@@ -156,9 +150,6 @@
   [[["underline",""\]\] "fo[o<u>b\]ar</u>baz" queryCommandIndeterm("underline") before]
     expected: FAIL
 
-  [[["underline",""\]\] "foo<u>ba[r</u>b\]az" compare innerHTML]
-    expected: FAIL
-
   [[["underline",""\]\] "foo<u>ba[r</u>b\]az" queryCommandIndeterm("underline") before]
     expected: FAIL
 
@@ -169,15 +160,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<strike>foo[bar\]baz</strike>" queryCommandState("stylewithcss") before]
-    expected: FAIL
-
-  [[["underline",""\]\] "foo<u>ba[r</u>b\]az" queryCommandState("underline") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "foo<u>ba[r</u>\]baz" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "foo<u>ba[r</u>\]baz" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "foo<s style=\\"text-decoration: underline\\">b[a\]r</s>baz" queryCommandState("underline") after]


### PR DESCRIPTION
While working on this, I realised that the `current_state`
computation was wrong. Instead, the spec actually clearly
defines what to do, but I hadn't found it yet. The code
now correctly implements state computation and voila, it
also fixes the previous underline issue that I didn't
understand why it would fail.

Part of #25005

Testing: WPT