### PR TITLE
layout: Allow repeatedly adding the same node to AccessibilityUpdate 

### DIFF
--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -11,7 +11,7 @@ use servo_base::Epoch;
 use style::dom::{NodeInfo, OpaqueNode};
 
 struct AccessibilityUpdate {
-    accesskit_update: Option<accesskit::TreeUpdate>,
+    accesskit_update: accesskit::TreeUpdate,
     nodes: FxHashMap<accesskit::NodeId, accesskit::Node>,
 }
 
@@ -32,30 +32,23 @@ pub struct AccessibilityTree {
 impl AccessibilityUpdate {
     fn new(tree: accesskit::Tree, tree_id: accesskit::TreeId) -> Self {
         Self {
-            accesskit_update: Some(accesskit::TreeUpdate {
+            accesskit_update: accesskit::TreeUpdate {
                 nodes: vec![],
                 tree: Some(tree),
                 focus: accesskit::NodeId(1),
                 tree_id,
-            }),
+            },
             nodes: FxHashMap::default(),
         }
     }
 
     fn add(&mut self, node: &AccessibilityNode) {
-        assert!(
-            self.accesskit_update.is_some(),
-            "Tried to use TreeUpdate after finializing"
-        );
         self.nodes.insert(node.id, node.accesskit_node.clone());
     }
 
-    fn finalize(&mut self) -> accesskit::TreeUpdate {
-        let Some(mut accesskit_update) = self.accesskit_update.take() else {
-            panic!("Tried to use TreeUpdate after finializing");
-        };
-        accesskit_update.nodes.extend(self.nodes.drain());
-        accesskit_update
+    fn finalize(mut self) -> accesskit::TreeUpdate {
+        self.accesskit_update.nodes.extend(self.nodes.drain());
+        self.accesskit_update
     }
 }
 

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -29,81 +29,6 @@ pub struct AccessibilityTree {
     epoch: Epoch,
 }
 
-impl AccessibilityUpdate {
-    fn new(tree: accesskit::Tree, tree_id: accesskit::TreeId) -> Self {
-        Self {
-            accesskit_update: accesskit::TreeUpdate {
-                nodes: vec![],
-                tree: Some(tree),
-                focus: accesskit::NodeId(1),
-                tree_id,
-            },
-            nodes: FxHashMap::default(),
-        }
-    }
-
-    fn add(&mut self, node: &AccessibilityNode) {
-        self.nodes.insert(node.id, node.accesskit_node.clone());
-    }
-
-    fn finalize(mut self) -> accesskit::TreeUpdate {
-        self.accesskit_update.nodes.extend(self.nodes.drain());
-        self.accesskit_update
-    }
-}
-
-#[cfg(test)]
-#[test]
-fn test_accessibility_update_add_some_nodes_twice() {
-    let mut update = AccessibilityUpdate::new(
-        accesskit::Tree {
-            root: accesskit::NodeId(2),
-            toolkit_name: None,
-            toolkit_version: None,
-        },
-        accesskit::TreeId::ROOT,
-    );
-    update.add(&AccessibilityNode::new_with_role(
-        accesskit::NodeId(5),
-        Role::Paragraph,
-    ));
-    update.add(&AccessibilityNode::new_with_role(
-        accesskit::NodeId(3),
-        Role::GenericContainer,
-    ));
-    update.add(&AccessibilityNode::new_with_role(
-        accesskit::NodeId(4),
-        Role::Heading,
-    ));
-    update.add(&AccessibilityNode::new_with_role(
-        accesskit::NodeId(4),
-        Role::Heading,
-    ));
-    update.add(&AccessibilityNode::new_with_role(
-        accesskit::NodeId(3),
-        Role::ScrollView,
-    ));
-    let mut tree_update = update.finalize();
-    tree_update.nodes.sort_by_key(|(node_id, _node)| *node_id);
-    assert_eq!(
-        tree_update,
-        accesskit::TreeUpdate {
-            nodes: vec![
-                (accesskit::NodeId(3), accesskit::Node::new(Role::ScrollView)),
-                (accesskit::NodeId(4), accesskit::Node::new(Role::Heading)),
-                (accesskit::NodeId(5), accesskit::Node::new(Role::Paragraph)),
-            ],
-            tree: Some(accesskit::Tree {
-                root: accesskit::NodeId(2),
-                toolkit_name: None,
-                toolkit_version: None
-            }),
-            tree_id: accesskit::TreeId::ROOT,
-            focus: accesskit::NodeId(1),
-        }
-    );
-}
-
 impl AccessibilityTree {
     const ROOT_NODE_ID: accesskit::NodeId = accesskit::NodeId(0);
 
@@ -217,4 +142,79 @@ impl AccessibilityNode {
             accesskit_node: accesskit::Node::new(role),
         }
     }
+}
+
+impl AccessibilityUpdate {
+    fn new(tree: accesskit::Tree, tree_id: accesskit::TreeId) -> Self {
+        Self {
+            accesskit_update: accesskit::TreeUpdate {
+                nodes: vec![],
+                tree: Some(tree),
+                focus: accesskit::NodeId(1),
+                tree_id,
+            },
+            nodes: FxHashMap::default(),
+        }
+    }
+
+    fn add(&mut self, node: &AccessibilityNode) {
+        self.nodes.insert(node.id, node.accesskit_node.clone());
+    }
+
+    fn finalize(mut self) -> accesskit::TreeUpdate {
+        self.accesskit_update.nodes.extend(self.nodes.drain());
+        self.accesskit_update
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn test_accessibility_update_add_some_nodes_twice() {
+    let mut update = AccessibilityUpdate::new(
+        accesskit::Tree {
+            root: accesskit::NodeId(2),
+            toolkit_name: None,
+            toolkit_version: None,
+        },
+        accesskit::TreeId::ROOT,
+    );
+    update.add(&AccessibilityNode::new_with_role(
+        accesskit::NodeId(5),
+        Role::Paragraph,
+    ));
+    update.add(&AccessibilityNode::new_with_role(
+        accesskit::NodeId(3),
+        Role::GenericContainer,
+    ));
+    update.add(&AccessibilityNode::new_with_role(
+        accesskit::NodeId(4),
+        Role::Heading,
+    ));
+    update.add(&AccessibilityNode::new_with_role(
+        accesskit::NodeId(4),
+        Role::Heading,
+    ));
+    update.add(&AccessibilityNode::new_with_role(
+        accesskit::NodeId(3),
+        Role::ScrollView,
+    ));
+    let mut tree_update = update.finalize();
+    tree_update.nodes.sort_by_key(|(node_id, _node)| *node_id);
+    assert_eq!(
+        tree_update,
+        accesskit::TreeUpdate {
+            nodes: vec![
+                (accesskit::NodeId(3), accesskit::Node::new(Role::ScrollView)),
+                (accesskit::NodeId(4), accesskit::Node::new(Role::Heading)),
+                (accesskit::NodeId(5), accesskit::Node::new(Role::Paragraph)),
+            ],
+            tree: Some(accesskit::Tree {
+                root: accesskit::NodeId(2),
+                toolkit_name: None,
+                toolkit_version: None
+            }),
+            tree_id: accesskit::TreeId::ROOT,
+            focus: accesskit::NodeId(1),
+        }
+    );
 }

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -11,7 +11,8 @@ use servo_base::Epoch;
 use style::dom::{NodeInfo, OpaqueNode};
 
 struct AccessibilityUpdate {
-    accesskit_update: accesskit::TreeUpdate,
+    accesskit_update: Option<accesskit::TreeUpdate>,
+    nodes: FxHashMap<accesskit::NodeId, accesskit::Node>,
 }
 
 #[derive(Debug)]
@@ -31,19 +32,30 @@ pub struct AccessibilityTree {
 impl AccessibilityUpdate {
     fn new(tree: accesskit::Tree, tree_id: accesskit::TreeId) -> Self {
         Self {
-            accesskit_update: accesskit::TreeUpdate {
-                nodes: Default::default(),
+            accesskit_update: Some(accesskit::TreeUpdate {
+                nodes: vec![],
                 tree: Some(tree),
                 focus: accesskit::NodeId(1),
                 tree_id,
-            },
+            }),
+            nodes: FxHashMap::default(),
         }
     }
 
     fn add(&mut self, node: &AccessibilityNode) {
-        self.accesskit_update
-            .nodes
-            .push((node.id, node.accesskit_node.clone()));
+        assert!(
+            self.accesskit_update.is_some(),
+            "Tried to use TreeUpdate after finializing"
+        );
+        self.nodes.insert(node.id, node.accesskit_node.clone());
+    }
+
+    fn finalize(&mut self) -> accesskit::TreeUpdate {
+        let Some(mut accesskit_update) = self.accesskit_update.take() else {
+            panic!("Tried to use TreeUpdate after finializing");
+        };
+        accesskit_update.nodes.extend(self.nodes.drain());
+        accesskit_update
     }
 }
 
@@ -89,7 +101,7 @@ impl AccessibilityTree {
         tree_update.add(root_node);
 
         self.update_node_and_children(root_dom_node, &mut tree_update);
-        Some(tree_update.accesskit_update)
+        Some(tree_update.finalize())
     }
 
     fn update_node_and_children(

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -52,6 +52,58 @@ impl AccessibilityUpdate {
     }
 }
 
+#[cfg(test)]
+#[test]
+fn test_accessibility_update_add_some_nodes_twice() {
+    let mut update = AccessibilityUpdate::new(
+        accesskit::Tree {
+            root: accesskit::NodeId(2),
+            toolkit_name: None,
+            toolkit_version: None,
+        },
+        accesskit::TreeId::ROOT,
+    );
+    update.add(&AccessibilityNode::new_with_role(
+        accesskit::NodeId(5),
+        Role::Paragraph,
+    ));
+    update.add(&AccessibilityNode::new_with_role(
+        accesskit::NodeId(3),
+        Role::GenericContainer,
+    ));
+    update.add(&AccessibilityNode::new_with_role(
+        accesskit::NodeId(4),
+        Role::Heading,
+    ));
+    update.add(&AccessibilityNode::new_with_role(
+        accesskit::NodeId(4),
+        Role::Heading,
+    ));
+    update.add(&AccessibilityNode::new_with_role(
+        accesskit::NodeId(3),
+        Role::ScrollView,
+    ));
+    let mut tree_update = update.finalize();
+    tree_update.nodes.sort_by_key(|(node_id, _node)| *node_id);
+    assert_eq!(
+        tree_update,
+        accesskit::TreeUpdate {
+            nodes: vec![
+                (accesskit::NodeId(3), accesskit::Node::new(Role::ScrollView)),
+                (accesskit::NodeId(4), accesskit::Node::new(Role::Heading)),
+                (accesskit::NodeId(5), accesskit::Node::new(Role::Paragraph)),
+            ],
+            tree: Some(accesskit::Tree {
+                root: accesskit::NodeId(2),
+                toolkit_name: None,
+                toolkit_version: None
+            }),
+            tree_id: accesskit::TreeId::ROOT,
+            focus: accesskit::NodeId(1),
+        }
+    );
+}
+
 impl AccessibilityTree {
     const ROOT_NODE_ID: accesskit::NodeId = accesskit::NodeId(0);
 
@@ -155,6 +207,14 @@ impl AccessibilityNode {
         Self {
             id,
             accesskit_node: accesskit::Node::new(Role::Unknown),
+        }
+    }
+
+    #[cfg(test)]
+    fn new_with_role(id: accesskit::NodeId, role: accesskit::Role) -> Self {
+        Self {
+            id,
+            accesskit_node: accesskit::Node::new(role),
         }
     }
 }


### PR DESCRIPTION
This means keeping nodes in a temporary map until the accesskit TreeUpdate is accessed via `finalize()`. After `finalize()` is called, any further attempts to use the object will panic.

Testing: Added a unit test.