### PR TITLE
layout: Accessibility: Compute labels for name-from-content nodes 

### DIFF
--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -1,12 +1,13 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+use std::collections::VecDeque;
 use std::sync::LazyLock;
 
 use accesskit::Role;
 use layout_api::{LayoutElement, LayoutNode, LayoutNodeType};
 use log::trace;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use script::layout_dom::ServoLayoutNode;
 use servo_base::Epoch;
 use style::dom::OpaqueNode;
@@ -68,13 +69,22 @@ impl AccessibilityTree {
         tree_update: &mut AccessibilityUpdate,
     ) -> bool {
         // TODO: read accessibility damage (right now, assume damage is complete)
-        let (node_id, updated) = self.update_node(dom_node);
+        let (node_id, mut updated) = self.update_node(dom_node);
 
         let mut any_descendant_updated = false;
         for dom_child in dom_node.flat_tree_children() {
             // TODO: We actually need to propagate damage within the accessibility tree, rather than
             // assuming it matches the DOM tree, but this will do for now.
             any_descendant_updated |= self.update_node_and_children(&dom_child, tree_update);
+        }
+
+        if any_descendant_updated {
+            let node_ref = self.assert_node_by_id(node_id);
+            let mut node = node_ref.borrow_mut();
+            if let Some(text) = self.label_from_descendants(&node) {
+                node.accesskit_node.set_label(text);
+                updated = true;
+            }
         }
 
         if updated {
@@ -119,6 +129,33 @@ impl AccessibilityTree {
 
         // TODO: only return true if any update actually happened
         (node.id, true)
+    }
+
+    fn label_from_descendants(&self, node: &AccessibilityNode) -> Option<String> {
+        if !NAME_FROM_CONTENTS_ROLES.contains(&node.accesskit_node.role()) {
+            return None;
+        }
+        let mut children: VecDeque<accesskit::NodeId> = VecDeque::default();
+        children.extend(node.accesskit_node.children());
+        let mut text = String::new();
+        while let Some(child_id) = children.pop_front() {
+            let child = self.assert_node_by_id(child_id);
+            let accesskit_node = &child.borrow().accesskit_node;
+            match accesskit_node.role() {
+                Role::TextRun => {
+                    if let Some(child_text) = accesskit_node.value() {
+                        text.push_str(child_text);
+                    }
+                },
+                _ => {
+                    for id in accesskit_node.children().iter().rev() {
+                        children.push_front(*id);
+                    }
+                },
+            }
+        }
+        let text: String = text.trim().to_owned();
+        Some(text)
     }
 
     fn get_or_create_node(
@@ -266,3 +303,6 @@ static HTML_ELEMENT_ROLE_MAPPINGS: LazyLock<FxHashMap<LocalName, Role>> = LazyLo
     .into_iter()
     .collect()
 });
+
+static NAME_FROM_CONTENTS_ROLES: LazyLock<FxHashSet<Role>> =
+    LazyLock::new(|| [(Role::Heading)].into_iter().collect());

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -135,7 +135,7 @@ impl AccessibilityTree {
         if !NAME_FROM_CONTENTS_ROLES.contains(&node.accesskit_node.role()) {
             return None;
         }
-        let mut children = VecDeque::from(node.accesskit_node.children().to_vec());
+        let mut children = VecDeque::from_iter(node.accesskit_node.children().iter().copied());
         let mut text = String::new();
         while let Some(child_id) = children.pop_front() {
             let child = self.assert_node_by_id(child_id);

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -135,8 +135,7 @@ impl AccessibilityTree {
         if !NAME_FROM_CONTENTS_ROLES.contains(&node.accesskit_node.role()) {
             return None;
         }
-        let mut children: VecDeque<accesskit::NodeId> = VecDeque::default();
-        children.extend(node.accesskit_node.children());
+        let mut children = VecDeque::from(node.accesskit_node.children());
         let mut text = String::new();
         while let Some(child_id) = children.pop_front() {
             let child = self.assert_node_by_id(child_id);
@@ -154,8 +153,7 @@ impl AccessibilityTree {
                 },
             }
         }
-        let text: String = text.trim().to_owned();
-        Some(text)
+        Some(text.trim().to_owned())
     }
 
     fn get_or_create_node(
@@ -304,5 +302,6 @@ static HTML_ELEMENT_ROLE_MAPPINGS: LazyLock<FxHashMap<LocalName, Role>> = LazyLo
     .collect()
 });
 
+/// <https://w3c.github.io/aria/#namefromcontent>
 static NAME_FROM_CONTENTS_ROLES: LazyLock<FxHashSet<Role>> =
     LazyLock::new(|| [(Role::Heading)].into_iter().collect());

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -135,7 +135,7 @@ impl AccessibilityTree {
         if !NAME_FROM_CONTENTS_ROLES.contains(&node.accesskit_node.role()) {
             return None;
         }
-        let mut children = VecDeque::from(node.accesskit_node.children());
+        let mut children = VecDeque::from(node.accesskit_node.children().to_vec());
         let mut text = String::new();
         while let Some(child_id) = children.pop_front() {
             let child = self.assert_node_by_id(child_id);

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -258,6 +258,78 @@ fn test_accessibility_basic_mapping() {
     );
 }
 
+#[test]
+fn test_accessibility_basic_name_from_contents() {
+    let servo_test = ServoTest::new_with_builder(|builder| {
+        let mut preferences = Preferences::default();
+        preferences.accessibility_enabled = true;
+        builder.preferences(preferences)
+    });
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .url(Url::parse("data:text/html,<!DOCTYPE html><h1>Servo</h1>").unwrap())
+        .build();
+
+    webview.set_accessibility_active(true);
+
+    let load_webview = webview.clone();
+    servo_test.spin(move || load_webview.load_status() != LoadStatus::Complete);
+
+    let updates = wait_for_min_updates(&servo_test, delegate.clone(), 2);
+    let tree = build_tree(updates);
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let first_child = root
+        .children()
+        .next()
+        .expect("Root web area should have at least one child.");
+    assert_eq!(first_child.role(), Role::Heading);
+    assert_eq!(first_child.label(), Some("Servo".to_owned()));
+}
+
+#[test]
+fn test_accessibility_name_from_contents_subtree() {
+    let servo_test = ServoTest::new_with_builder(|builder| {
+        let mut preferences = Preferences::default();
+        preferences.accessibility_enabled = true;
+        builder.preferences(preferences)
+    });
+    let url = "data:text/html,<!DOCTYPE html>\
+               <h1>Servo aims to empower <code>developers</code> with a <em>lightweight</em>, \
+               <strong>high-performance</strong> alternative for <span>embedding \
+               <span>web technologies</span> in <span>applications</span></span>.</h1>";
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .url(Url::parse(url).unwrap())
+        .build();
+
+    webview.set_accessibility_active(true);
+
+    let load_webview = webview.clone();
+    servo_test.spin(move || load_webview.load_status() != LoadStatus::Complete);
+
+    let updates = wait_for_min_updates(&servo_test, delegate.clone(), 2);
+    let tree = build_tree(updates);
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let heading = root
+        .children()
+        .next()
+        .expect("Root web area should have at least one child.");
+    assert_eq!(heading.role(), Role::Heading);
+    let heading_children: Vec<accesskit_consumer::Node> = heading.children().collect();
+    assert_eq!(heading_children.len(), 9);
+    assert_eq!(
+        heading.label(),
+        Some(
+            "Servo aims to empower developers with a lightweight, high-performance alternative for \
+             embedding web technologies in applications."
+                .to_owned()
+        ),
+        "Heading label should be composed of the text contents of all of its descendant text nodes"
+    );
+}
+
 fn wait_for_min_updates(
     servo_test: &ServoTest,
     delegate: Rc<WebViewDelegateImpl>,


### PR DESCRIPTION
After updating children, we can then walk the text node descendants for [name from content](https://w3c.github.io/aria/#namefromcontent) nodes to compute their labels.

Testing: New tests added in PR.
