### PR TITLE
layout_api: Use a "type bundle" to encapsulate all layout DOM types

### DIFF
--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -10,9 +10,9 @@ use embedder_traits::UntrustedNodeAddress;
 use euclid::{Point2D, Rect, SideOffsets2D, Size2D};
 use itertools::Itertools;
 use layout_api::{
-    AxesOverflow, BoxAreaType, CSSPixelRectIterator, LayoutElement, LayoutElementType, LayoutNode,
-    LayoutNodeType, OffsetParentResponse, PhysicalSides, ScrollContainerQueryFlags,
-    ScrollContainerResponse,
+    AxesOverflow, BoxAreaType, CSSPixelRectIterator, DangerousStyleElementOf, LayoutElement,
+    LayoutElementType, LayoutNode, LayoutNodeType, OffsetParentResponse, PhysicalSides,
+    ScrollContainerQueryFlags, ScrollContainerResponse,
 };
 use paint_api::display_list::ScrollTree;
 use script::layout_dom::ServoLayoutNode;
@@ -1483,7 +1483,7 @@ where
         };
         context
             .stylist
-            .compute_for_declarations::<E::ConcreteDangerousStyleElement>(
+            .compute_for_declarations::<DangerousStyleElementOf<'dom, E::ConcreteTypeBundle>>(
                 &context.guards,
                 parent_style,
                 ServoArc::new(shared_lock.wrap(declarations)),

--- a/components/script/layout_dom/mod.rs
+++ b/components/script/layout_dom/mod.rs
@@ -27,10 +27,24 @@ mod servo_dangerous_style_shadow_root;
 mod servo_layout_element;
 mod servo_layout_node;
 
+use std::marker::PhantomData;
+
 pub use iterators::*;
+use layout_api::LayoutDomTypeBundle;
 pub use servo_dangerous_style_document::*;
 pub use servo_dangerous_style_element::*;
 pub use servo_dangerous_style_node::*;
 pub use servo_dangerous_style_shadow_root::*;
 pub use servo_layout_element::*;
 pub use servo_layout_node::*;
+
+pub struct ServoLayoutDomTypeBundle<'dom> {
+    phantom: PhantomData<&'dom ()>,
+}
+
+impl<'dom> LayoutDomTypeBundle<'dom> for ServoLayoutDomTypeBundle<'dom> {
+    type ConcreteLayoutElement = ServoLayoutElement<'dom>;
+    type ConcreteLayoutNode = ServoLayoutNode<'dom>;
+    type ConcreteDangerousStyleNode = ServoDangerousStyleNode<'dom>;
+    type ConcreteDangerousStyleElement = ServoDangerousStyleElement<'dom>;
+}

--- a/components/script/layout_dom/servo_dangerous_style_element.rs
+++ b/components/script/layout_dom/servo_dangerous_style_element.rs
@@ -54,7 +54,7 @@ use crate::dom::html::htmlslotelement::HTMLSlotElement;
 use crate::dom::node::{Node, NodeFlags};
 use crate::layout_dom::{
     DOMDescendantIterator, ServoDangerousStyleNode, ServoDangerousStyleShadowRoot,
-    ServoLayoutElement, ServoLayoutNode,
+    ServoLayoutDomTypeBundle, ServoLayoutElement, ServoLayoutNode,
 };
 
 /// A wrapper around [`LayoutDom<_, Element>`] to be used with `stylo` and `selectors`.
@@ -81,9 +81,9 @@ impl<'dom> From<LayoutDom<'dom, Element>> for ServoDangerousStyleElement<'dom> {
 }
 
 impl<'dom> DangerousStyleElement<'dom> for ServoDangerousStyleElement<'dom> {
-    type ConcreteLayoutElement = ServoLayoutElement<'dom>;
+    type ConcreteTypeBundle = ServoLayoutDomTypeBundle<'dom>;
 
-    fn layout_element(&self) -> Self::ConcreteLayoutElement {
+    fn layout_element(&self) -> ServoLayoutElement<'dom> {
         self.element.into()
     }
 }

--- a/components/script/layout_dom/servo_dangerous_style_node.rs
+++ b/components/script/layout_dom/servo_dangerous_style_node.rs
@@ -19,7 +19,7 @@ use super::{ServoDangerousStyleDocument, ServoDangerousStyleShadowRoot};
 use crate::dom::bindings::error::Error;
 use crate::dom::bindings::root::LayoutDom;
 use crate::dom::node::{Node, NodeFlags};
-use crate::layout_dom::{ServoDangerousStyleElement, ServoLayoutNode};
+use crate::layout_dom::{ServoDangerousStyleElement, ServoLayoutDomTypeBundle, ServoLayoutNode};
 
 /// A wrapper around [`LayoutDom<_, Node>`] to be used with `stylo` and `selectors`.
 ///
@@ -75,9 +75,9 @@ impl<'dom> From<LayoutDom<'dom, Node>> for ServoDangerousStyleNode<'dom> {
 }
 
 impl<'dom> DangerousStyleNode<'dom> for ServoDangerousStyleNode<'dom> {
-    type ConcreteLayoutNode = ServoLayoutNode<'dom>;
+    type ConcreteTypeBundle = ServoLayoutDomTypeBundle<'dom>;
 
-    fn layout_node(&self) -> Self::ConcreteLayoutNode {
+    fn layout_node(&self) -> ServoLayoutNode<'dom> {
         self.node.into()
     }
 }

--- a/components/script/layout_dom/servo_layout_element.rs
+++ b/components/script/layout_dom/servo_layout_element.rs
@@ -24,7 +24,8 @@ use crate::dom::bindings::root::LayoutDom;
 use crate::dom::element::Element;
 use crate::dom::node::{Node, NodeFlags};
 use crate::layout_dom::{
-    ServoDangerousStyleElement, ServoDangerousStyleShadowRoot, ServoLayoutNode,
+    ServoDangerousStyleElement, ServoDangerousStyleShadowRoot, ServoLayoutDomTypeBundle,
+    ServoLayoutNode,
 };
 
 impl fmt::Debug for LayoutDom<'_, Element> {
@@ -72,8 +73,7 @@ impl<'dom> From<LayoutDom<'dom, Element>> for ServoLayoutElement<'dom> {
 }
 
 impl<'dom> LayoutElement<'dom> for ServoLayoutElement<'dom> {
-    type ConcreteLayoutNode = ServoLayoutNode<'dom>;
-    type ConcreteStyleElement = ServoDangerousStyleElement<'dom>;
+    type ConcreteTypeBundle = ServoLayoutDomTypeBundle<'dom>;
 
     fn with_pseudo(&self, pseudo_element: PseudoElement) -> Option<Self> {
         if pseudo_element.is_eager() &&
@@ -174,7 +174,7 @@ impl<'dom> LayoutElement<'dom> for ServoLayoutElement<'dom> {
                     },
                     PseudoElementCascadeType::Precomputed => context
                         .stylist
-                        .precomputed_values_for_pseudo::<Self::ConcreteStyleElement>(
+                        .precomputed_values_for_pseudo::<ServoDangerousStyleElement<'dom>>(
                         &context.guards,
                         &pseudo_element,
                         Some(base_style),

--- a/components/script/layout_dom/servo_layout_node.rs
+++ b/components/script/layout_dom/servo_layout_node.rs
@@ -28,7 +28,7 @@ use crate::dom::bindings::root::LayoutDom;
 use crate::dom::element::Element;
 use crate::dom::node::{Node, NodeFlags, NodeTypeIdWrapper};
 use crate::layout_dom::{
-    ServoDangerousStyleElement, ServoDangerousStyleNode, ServoLayoutNodeChildrenIterator,
+    ServoDangerousStyleNode, ServoLayoutDomTypeBundle, ServoLayoutNodeChildrenIterator,
 };
 
 impl fmt::Debug for LayoutDom<'_, Node> {
@@ -113,10 +113,7 @@ impl<'dom> From<LayoutDom<'dom, Node>> for ServoLayoutNode<'dom> {
 }
 
 impl<'dom> LayoutNode<'dom> for ServoLayoutNode<'dom> {
-    type ConcreteDangerousStyleNode = ServoDangerousStyleNode<'dom>;
-    type ConcreteDangerousStyleElement = ServoDangerousStyleElement<'dom>;
-    type ConcreteLayoutElement = ServoLayoutElement<'dom>;
-    type ChildIterator = ServoLayoutNodeChildrenIterator<'dom>;
+    type ConcreteTypeBundle = ServoLayoutDomTypeBundle<'dom>;
 
     fn with_pseudo(&self, pseudo_element_type: PseudoElement) -> Option<Self> {
         Some(
@@ -126,7 +123,7 @@ impl<'dom> LayoutNode<'dom> for ServoLayoutNode<'dom> {
         )
     }
 
-    unsafe fn dangerous_style_node(self) -> Self::ConcreteDangerousStyleNode {
+    unsafe fn dangerous_style_node(self) -> ServoDangerousStyleNode<'dom> {
         self.node.into()
     }
 
@@ -224,11 +221,11 @@ impl<'dom> LayoutNode<'dom> for ServoLayoutNode<'dom> {
         }
     }
 
-    fn flat_tree_children(&self) -> LayoutIterator<ServoLayoutNodeChildrenIterator<'dom>> {
+    fn flat_tree_children(&self) -> impl Iterator<Item = Self> {
         LayoutIterator(ServoLayoutNodeChildrenIterator::new_for_flat_tree(*self))
     }
 
-    fn dom_children(&self) -> LayoutIterator<ServoLayoutNodeChildrenIterator<'dom>> {
+    fn dom_children(&self) -> impl Iterator<Item = Self> {
         LayoutIterator(ServoLayoutNodeChildrenIterator::new_for_dom_tree(*self))
     }
 

--- a/components/shared/layout/layout_dom.rs
+++ b/components/shared/layout/layout_dom.rs
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#![deny(missing_docs)]
+
+use crate::{DangerousStyleElement, DangerousStyleNode, LayoutElement, LayoutNode};
+
+/// A trait that holds all the concrete implementations of the Layout DOM traits. This is
+/// useful because it means that other types (specifically the implementation of the `Layout`
+/// trait) can be parameterized over a single type (`LayoutDomTypeBundle`) rather than all of
+/// the various Layout DOM trait implementations.
+pub trait LayoutDomTypeBundle<'dom> {
+    /// The concrete implementation of [`LayoutNode`] from `script`.
+    type ConcreteLayoutNode: LayoutNode<'dom>;
+    /// The concrete implementation of [`LayoutElement`] from `script`.
+    type ConcreteLayoutElement: LayoutElement<'dom>;
+    /// The concrete implementation of [`DangerousStyleNode`] from `script`.
+    type ConcreteDangerousStyleNode: DangerousStyleNode<'dom>;
+    /// The concrete implementation of [`DangerousStyleElement`] from `script`.
+    type ConcreteDangerousStyleElement: DangerousStyleElement<'dom>;
+}
+
+// The type aliases below simplify extracting the concrete types out of the type bundle. It will be
+// possible to simplify this once default associated types have landed and are stable:
+// https://github.com/rust-lang/rust/issues/29661.
+
+/// Type alias to extract `ConcreteLayoutNode` from a `LayoutDomTypeBundle` implementation.
+pub type LayoutNodeOf<'dom, T> = <T as LayoutDomTypeBundle<'dom>>::ConcreteLayoutNode;
+
+/// Type alias to extract `ConcreteLayoutElement` from a `LayoutDomTypeBundle` implementation.
+pub type LayoutElementOf<'dom, T> = <T as LayoutDomTypeBundle<'dom>>::ConcreteLayoutElement;
+
+/// Type alias to extract `ConcreteDangerousStyleNode` from a `LayoutDomTypeBundle` implementation.
+pub type DangerousStyleNodeOf<'dom, T> =
+    <T as LayoutDomTypeBundle<'dom>>::ConcreteDangerousStyleNode;
+
+/// Type alias to extract `ConcreteDangerousStyleElement` from a `LayoutDomTypeBundle` implementation.
+pub type DangerousStyleElementOf<'dom, T> =
+    <T as LayoutDomTypeBundle<'dom>>::ConcreteDangerousStyleElement;

--- a/components/shared/layout/layout_element.rs
+++ b/components/shared/layout/layout_element.rs
@@ -16,7 +16,8 @@ use style::dom::TElement;
 use style::properties::ComputedValues;
 use style::selector_parser::{PseudoElement, SelectorImpl};
 
-use crate::{LayoutDataTrait, LayoutNode, LayoutNodeType, PseudoElementChain, StyleData};
+use crate::layout_dom::{DangerousStyleElementOf, LayoutElementOf, LayoutNodeOf};
+use crate::{LayoutDataTrait, LayoutDomTypeBundle, LayoutNodeType, PseudoElementChain, StyleData};
 
 /// A trait that exposes a DOM element to layout. Implementors of this trait must abide by certain
 /// safety requirements. Layout will only ever access and mutate each element from a single thread
@@ -28,12 +29,8 @@ use crate::{LayoutDataTrait, LayoutNode, LayoutNodeType, PseudoElementChain, Sty
 /// that API is marked as `unsafe` here. In general [`DangerousStyleElement`] should only be used
 /// when interfacing with the `stylo` and `selectors`.
 pub trait LayoutElement<'dom>: Copy + Debug + Send + Sync {
-    /// An associated type that refers to the concrete implementation of [`DangerousStyleElement`]
-    /// implemented in `script`.
-    type ConcreteStyleElement: DangerousStyleElement<'dom>;
-    /// An associated type that refers to the concrete implementation of [`LayoutNode`]
-    /// implemented in `script`.
-    type ConcreteLayoutNode: LayoutNode<'dom>;
+    /// The concrete implementation of [`LayoutDomTypeBundle`] implemented in `script`.
+    type ConcreteTypeBundle: LayoutDomTypeBundle<'dom>;
 
     /// Creates a new `LayoutElement` for the same `LayoutElement`
     /// with a different pseudo-element type.
@@ -53,7 +50,7 @@ pub trait LayoutElement<'dom>: Copy + Debug + Send + Sync {
 
     /// Return this [`LayoutElement`] as a [`LayoutNode`], preserving the internal
     /// pseudo-element chain.
-    fn as_node(&self) -> Self::ConcreteLayoutNode;
+    fn as_node(&self) -> LayoutNodeOf<'dom, Self::ConcreteTypeBundle>;
 
     /// Returns access to a version of this LayoutElement that can be used by stylo
     /// and selectors. This is dangerous as it allows more access to ancestor nodes
@@ -65,7 +62,9 @@ pub trait LayoutElement<'dom>: Copy + Debug + Send + Sync {
     /// This should only ever be called from the main script thread. It is never
     /// okay to explicitly create a node for style while any layout worker threads
     /// are running.
-    unsafe fn dangerous_style_element(self) -> Self::ConcreteStyleElement;
+    unsafe fn dangerous_style_element(
+        self,
+    ) -> DangerousStyleElementOf<'dom, Self::ConcreteTypeBundle>;
 
     /// Initialize this node with empty style and opaque layout data.
     fn initialize_style_and_layout_data<RequestedLayoutDataType: LayoutDataTrait>(&self);
@@ -144,9 +143,8 @@ pub trait LayoutElement<'dom>: Copy + Debug + Send + Sync {
 pub trait DangerousStyleElement<'dom>:
     TElement + ::selectors::Element<Impl = SelectorImpl> + Send + Sync
 {
-    /// The concrete implementation of [`LayoutElement`] implemented in `script`.
-    type ConcreteLayoutElement: LayoutElement<'dom>;
-    /// The concrete implementation of [`LayoutNode`] implemented in `script`.
+    /// The concrete implementation of [`LayoutDomTypeBundle`] implemented in `script`.
+    type ConcreteTypeBundle: LayoutDomTypeBundle<'dom>;
     /// Get a handle to the original "safe" version of this element, a [`LayoutElement`].
-    fn layout_element(&self) -> Self::ConcreteLayoutElement;
+    fn layout_element(&self) -> LayoutElementOf<'dom, Self::ConcreteTypeBundle>;
 }

--- a/components/shared/layout/layout_node.rs
+++ b/components/shared/layout/layout_node.rs
@@ -14,15 +14,15 @@ use servo_arc::Arc;
 use servo_base::id::{BrowsingContextId, PipelineId};
 use servo_url::ServoUrl;
 use style::context::SharedStyleContext;
-use style::dom::{LayoutIterator, NodeInfo, OpaqueNode, TNode};
+use style::dom::{NodeInfo, OpaqueNode, TNode};
 use style::properties::ComputedValues;
 use style::selector_parser::PseudoElement;
 
-use crate::layout_element::{DangerousStyleElement, LayoutElement};
+use crate::layout_dom::{DangerousStyleNodeOf, LayoutElementOf, LayoutNodeOf};
 use crate::pseudo_element_chain::PseudoElementChain;
 use crate::{
-    GenericLayoutData, HTMLCanvasData, HTMLMediaData, LayoutDataTrait, LayoutNodeType,
-    SVGElementData, SharedSelection,
+    GenericLayoutData, HTMLCanvasData, HTMLMediaData, LayoutDataTrait, LayoutDomTypeBundle,
+    LayoutNodeType, SVGElementData, SharedSelection,
 };
 
 /// A trait that exposes a DOM nodes to layout. Implementors of this trait must abide by certain
@@ -35,14 +35,8 @@ use crate::{
 /// that API is marked as `unsafe` here. In general [`DangerousStyleNode`] should only be used
 /// when interfacing with the `stylo` and `selectors`.
 pub trait LayoutNode<'dom>: Copy + Debug + NodeInfo + Send + Sync {
-    /// The concrete implementation of [`DangerousStyleNode`] implemented in `script`.
-    type ConcreteDangerousStyleNode: DangerousStyleNode<'dom>;
-    /// The concrete implementation of [`DangerousStyleElement`] implemented in `script`.
-    type ConcreteDangerousStyleElement: DangerousStyleElement<'dom>;
-    /// The concrete implementation of [`ConcreteLayoutElement`] implemented in `script`.
-    type ConcreteLayoutElement: LayoutElement<'dom>;
-    /// The concrete implementation of [`ChildIterator`] implemented in `script`.
-    type ChildIterator: Iterator<Item = Self> + Sized;
+    /// The concrete implementation of [`LayoutDomTypeBundle`] implemented in `script`.
+    type ConcreteTypeBundle: LayoutDomTypeBundle<'dom>;
 
     /// Creates a new `LayoutNode` for the same `LayoutNode` with a different pseudo-element type.
     ///
@@ -70,7 +64,7 @@ pub trait LayoutNode<'dom>: Copy + Debug + NodeInfo + Send + Sync {
     /// This should only ever be called from the main script thread. It is never
     /// okay to explicitly create a node for style while any layout worker threads
     /// are running.
-    unsafe fn dangerous_style_node(self) -> Self::ConcreteDangerousStyleNode;
+    unsafe fn dangerous_style_node(self) -> DangerousStyleNodeOf<'dom, Self::ConcreteTypeBundle>;
 
     /// Returns access to the DOM parent node of this node. This *does not* take
     /// into account shadow tree children and slottables. For that use
@@ -115,18 +109,18 @@ pub trait LayoutNode<'dom>: Copy + Debug + NodeInfo + Send + Sync {
     /// takes into account shadow tree children and slottables.
     ///
     /// [flat tree]: https://drafts.csswg.org/css-shadow-1/#flat-tree
-    fn flat_tree_children(&self) -> LayoutIterator<Self::ChildIterator>;
+    fn flat_tree_children(&self) -> impl Iterator<Item = Self> + Sized;
 
     /// Returns an iterator over this node's children in the DOM. This
     /// *does not* take shadow roots and assigned slottables into account.
     /// For that use [`Self::flat_tree_children`].
-    fn dom_children(&self) -> LayoutIterator<Self::ChildIterator>;
+    fn dom_children(&self) -> impl Iterator<Item = Self> + Sized;
 
     /// Returns a [`LayoutElement`] if this is an element in the HTML namespace, None otherwise.
-    fn as_html_element(&self) -> Option<Self::ConcreteLayoutElement>;
+    fn as_html_element(&self) -> Option<LayoutElementOf<'dom, Self::ConcreteTypeBundle>>;
 
     /// Returns a [`LayoutElement`] if this is an element.
-    fn as_element(&self) -> Option<Self::ConcreteLayoutElement>;
+    fn as_element(&self) -> Option<LayoutElementOf<'dom, Self::ConcreteTypeBundle>>;
 
     /// Returns the computed style for the given node, properly handling pseudo-elements. For
     /// elements this returns their style and for other nodes, this returns the style of the parent
@@ -236,8 +230,8 @@ pub trait LayoutNode<'dom>: Copy + Debug + NodeInfo + Send + Sync {
 /// If you are not interfacing with `stylo` and `selectors` you *should not* use this
 /// type, unless you know what you are doing.
 pub trait DangerousStyleNode<'dom>: TNode + Sized + NodeInfo + Send + Sync {
-    /// The concrete implementation of [`LayoutNode`] implemented in `script`.
-    type ConcreteLayoutNode: LayoutNode<'dom>;
+    /// The concrete implementation of [`LayoutDomTypeBundle`] implemented in `script`.
+    type ConcreteTypeBundle: LayoutDomTypeBundle<'dom>;
     /// Get a handle to the original "safe" version of this node, a [`LayoutNode`] implementation.
-    fn layout_node(&self) -> Self::ConcreteLayoutNode;
+    fn layout_node(&self) -> LayoutNodeOf<'dom, Self::ConcreteTypeBundle>;
 }

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -9,6 +9,7 @@
 #![deny(unsafe_code)]
 
 mod layout_damage;
+mod layout_dom;
 mod layout_element;
 mod layout_node;
 mod pseudo_element_chain;
@@ -29,6 +30,10 @@ use embedder_traits::{Cursor, ScriptToEmbedderChan, Theme, UntrustedNodeAddress,
 use euclid::{Point2D, Rect};
 use fonts::{FontContext, TextByteRange, WebFontDocumentContext};
 pub use layout_damage::LayoutDamage;
+pub use layout_dom::{
+    DangerousStyleElementOf, DangerousStyleNodeOf, LayoutDomTypeBundle, LayoutElementOf,
+    LayoutNodeOf,
+};
 pub use layout_element::{DangerousStyleElement, LayoutElement};
 pub use layout_node::{DangerousStyleNode, LayoutNode};
 use libc::c_void;


### PR DESCRIPTION
This change creates a new "type bundle" trait, which holds all of the
concrete implementations of the layout DOM types. The benefit here is
that each implementation of a layout DOM type needs a single associated
type. In addition, and most importantly, `Layout` itself only needs to
parameterized over a single type (the concrete type bundle). This will
make parameterizing layout a lot friendlier.

The downside is that extracting the concrete type from the type bundle
is a bit ugly in Rust, so the change also exposes some type aliases to
make this nicer. In the future, default associated types can make
things a bit simpler as well.

Testing: This should not change behavior so no new tests are necessary.
