### PR TITLE
profile: Add instrumentation to startup related functions 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8687,6 +8687,7 @@ dependencies = [
  "servo-script-traits",
  "servo-storage-traits",
  "servo-timers",
+ "servo-tracing",
  "servo-url",
  "servo-wakelock",
  "servo-webgpu-traits",

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1272,7 +1272,7 @@ where
         self.process_manager.register(&mut sel);
 
         let request = {
-            let oper =  {
+            let oper = {
                 let _span = profile_traits::trace_span!("handle_request::select").entered();
                 sel.select()
             };

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1272,10 +1272,12 @@ where
         self.process_manager.register(&mut sel);
 
         let request = {
-            let oper = sel.select();
+            let oper =  {
+                let _span = profile_traits::trace_span!("handle_request::select").entered();
+                sel.select()
+            };
             let index = oper.index();
 
-            let _span = profile_traits::trace_span!("handle_request::select").entered();
             match index {
                 0 => oper
                     .recv(&self.namespace_receiver)
@@ -1349,6 +1351,7 @@ where
         }
     }
 
+    #[servo_tracing::instrument(skip_all)]
     fn handle_request_from_swmanager(&mut self, message: SWManagerMsg) {
         match message {
             SWManagerMsg::PostMessageToClient => {

--- a/components/constellation/process_manager.rs
+++ b/components/constellation/process_manager.rs
@@ -65,6 +65,7 @@ impl ProcessManager {
         receiver
     }
 
+    #[servo_tracing::instrument(skip_all)]
     pub fn remove(&mut self, index: usize) {
         let (mut process, _) = self.processes.swap_remove(index);
         debug!("Removing process pid={}", process.pid());

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -139,6 +139,7 @@ servo-config = { workspace = true }
 servo-constellation-traits = { workspace = true }
 servo-geometry = { workspace = true }
 servo-media = { workspace = true }
+servo-tracing = {workspace = true}
 servo-url = { workspace = true }
 servo-wakelock = { workspace = true }
 servo_arc = { workspace = true }

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -139,7 +139,7 @@ servo-config = { workspace = true }
 servo-constellation-traits = { workspace = true }
 servo-geometry = { workspace = true }
 servo-media = { workspace = true }
-servo-tracing = {workspace = true}
+servo-tracing = { workspace = true }
 servo-url = { workspace = true }
 servo-wakelock = { workspace = true }
 servo_arc = { workspace = true }

--- a/components/script/init.rs
+++ b/components/script/init.rs
@@ -160,6 +160,7 @@ fn jit_forbidden() -> bool {
 }
 
 #[expect(unsafe_code)]
+#[servo_tracing::instrument]
 pub fn init() -> JSEngineSetup {
     if pref!(js_disable_jit) || jit_forbidden() {
         let reason = if pref!(js_disable_jit) {

--- a/components/script/init.rs
+++ b/components/script/init.rs
@@ -160,7 +160,7 @@ fn jit_forbidden() -> bool {
 }
 
 #[expect(unsafe_code)]
-#[servo_tracing::instrument]
+#[servo_tracing::instrument(name = "script::init")]
 pub fn init() -> JSEngineSetup {
     if pref!(js_disable_jit) || jit_forbidden() {
         let reason = if pref!(js_disable_jit) {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -470,6 +470,10 @@ impl ScriptThreadFactory for ScriptThread {
             .name(format!("Script#{script_thread_id}"))
             .stack_size(8 * 1024 * 1024) // 8 MiB stack to be consistent with other browsers.
             .spawn(move || {
+                profile_traits::debug_event!(
+                    "ScriptThread::spawned",
+                    script_thread_id = script_thread_id.to_string()
+                );
                 thread_state::initialize(ThreadState::SCRIPT);
                 PipelineNamespace::install(state.pipeline_namespace_id);
                 ScriptEventLoopId::install(state.id);
@@ -863,6 +867,7 @@ impl ScriptThread {
     }
 
     /// Creates a new script thread.
+    #[servo_tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn new(
         state: InitialScriptState,
         layout_factory: Arc<dyn LayoutFactory>,
@@ -3811,6 +3816,7 @@ impl ScriptThread {
 
     /// Instructs the constellation to fetch the document that will be loaded. Stores the InProgressLoad
     /// argument until a notification is received that the fetch is complete.
+    #[servo_tracing::instrument(skip_all)]
     fn pre_page_load(&self, cx: &mut js::context::JSContext, mut incomplete: InProgressLoad) {
         let url_str = incomplete.load_data.url.as_str();
         if url_str == "about:blank" || incomplete.load_data.js_eval_result.is_some() {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -867,7 +867,7 @@ impl ScriptThread {
     }
 
     /// Creates a new script thread.
-    #[servo_tracing::instrument(level = "debug", skip_all)]
+    #[servo_tracing::instrument(name = "ScripThread::new", level = "debug", skip_all)]
     pub(crate) fn new(
         state: InitialScriptState,
         layout_factory: Arc<dyn LayoutFactory>,

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -63,6 +63,8 @@ pub use servo_config::{opts, pref, prefs};
 pub use servo_geometry::{
     DeviceIndependentIntRect, DeviceIndependentPixel, convert_rect_to_css_pixel,
 };
+#[doc(hidden)]
+pub use servo_tracing;
 pub use servo_url::ServoUrl;
 pub use style::Zero;
 pub use style_traits::CSSPixel;

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -192,6 +192,7 @@ impl ServoInner {
             .and_then(WebView::from_weak_handle)
     }
 
+    #[servo_tracing::instrument(level = "debug", skip_all)]
     fn spin_event_loop(&self) -> bool {
         if self.shutdown_state.get() == ShutdownState::FinishedShuttingDown {
             return false;
@@ -263,6 +264,7 @@ impl ServoInner {
         true
     }
 
+    #[servo_tracing::instrument(level = "debug", skip_all)]
     fn receive_one_message(&self) -> Option<Message> {
         let mut select = crossbeam_channel::Select::new();
         let embedder_receiver_index = select.recv(&self.embedder_receiver);

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -834,7 +834,7 @@ impl Drop for ServoInner {
 pub struct Servo(Rc<ServoInner>);
 
 impl Servo {
-    #[servo_tracing::instrument(skip(builder))]
+    #[servo_tracing::instrument(name = "Servo::new", skip(builder))]
     fn new(builder: ServoBuilder) -> Self {
         // Global configuration options, parsed from the command line.
         let opts = builder.opts.map(|opts| *opts);

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -129,6 +129,7 @@ impl App {
         self.state = AppState::Running(running_state);
     }
 
+    #[servo::servo_tracing::instrument(level = "debug", skip_all)]
     fn create_platform_window(
         &self,
         url: Url,

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -105,6 +105,7 @@ pub struct HeadedWindow {
 }
 
 impl HeadedWindow {
+    #[servo::servo_tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn new(
         servoshell_preferences: &ServoShellPreferences,
         event_loop: &ActiveEventLoop,

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -105,7 +105,7 @@ pub struct HeadedWindow {
 }
 
 impl HeadedWindow {
-    #[servo::servo_tracing::instrument(level = "debug", skip_all)]
+    #[servo::servo_tracing::instrument(level = "debug", name = "HeadedWindow::new", skip_all)]
     pub(crate) fn new(
         servoshell_preferences: &ServoShellPreferences,
         event_loop: &ActiveEventLoop,

--- a/ports/servoshell/desktop/headless_window.rs
+++ b/ports/servoshell/desktop/headless_window.rs
@@ -35,7 +35,7 @@ pub struct HeadlessWindow {
 }
 
 impl HeadlessWindow {
-    #[servo::servo_tracing::instrument(level = "debug", skip_all)]
+    #[servo::servo_tracing::instrument(level = "debug", name = "HeadlessWindow::new", skip_all)]
     pub fn new(servoshell_preferences: &ServoShellPreferences) -> Rc<Self> {
         let size = servoshell_preferences.initial_window_size;
 

--- a/ports/servoshell/desktop/headless_window.rs
+++ b/ports/servoshell/desktop/headless_window.rs
@@ -35,6 +35,7 @@ pub struct HeadlessWindow {
 }
 
 impl HeadlessWindow {
+    #[servo::servo_tracing::instrument(level = "debug", skip_all)]
     pub fn new(servoshell_preferences: &ServoShellPreferences) -> Rc<Self> {
         let size = servoshell_preferences.initial_window_size;
 

--- a/ports/servoshell/egl/app.rs
+++ b/ports/servoshell/egl/app.rs
@@ -277,7 +277,7 @@ pub struct App {
 
 #[expect(unused)]
 impl App {
-    #[servo::servo_tracing::instrument(skip_all)]
+    #[servo::servo_tracing::instrument(skip_all, name = "App::new", level = "info")]
     pub(super) fn new(init: AppInitOptions) -> Rc<Self> {
         let mut servo_builder = ServoBuilder::default()
             .opts(init.opts)

--- a/ports/servoshell/egl/app.rs
+++ b/ports/servoshell/egl/app.rs
@@ -277,6 +277,7 @@ pub struct App {
 
 #[expect(unused)]
 impl App {
+    #[servo::servo_tracing::instrument(skip_all)]
     pub(super) fn new(init: AppInitOptions) -> Rc<Self> {
         let mut servo_builder = ServoBuilder::default()
             .opts(init.opts)

--- a/ports/servoshell/window.rs
+++ b/ports/servoshell/window.rs
@@ -86,6 +86,7 @@ impl ServoShellWindow {
     }
 
     /// Must be called *after* `self` is in `state.windows`, otherwise it will panic.
+    #[servo::servo_tracing::instrument(skip(self, state))]
     pub(crate) fn create_toplevel_webview(&self, state: Rc<RunningAppState>, url: Url) -> WebView {
         let mut webview_builder =
             WebViewBuilder::new(state.servo(), self.platform_window.rendering_context())


### PR DESCRIPTION
Follow-up to #44443.
This helps investigating the cold-start timeline, and could be used
by tooling to A/B compare branches affecting the cold-start time.

Additionally also change the `handle_request::select` span, so that we can see the blocked time (which was probably what was intended), since the actual time spent on recv after select is insignificant.

Testing: Tracing output is not covered by automatic tests.

