### PR TITLE
devtools: Respect SOURCE_DATE_EPOCH for build_id

### DIFF
--- a/components/devtools/build.rs
+++ b/components/devtools/build.rs
@@ -8,13 +8,16 @@ use std::{env, fs};
 use chrono::Local;
 
 fn main() {
+    println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
     let path = Path::new(&env::var_os("OUT_DIR").unwrap()).join("build_id.rs");
-    fs::write(
-        path,
-        format!(
-            "const BUILD_ID: &str = \"{}\";",
-            Local::now().format("%Y%m%d%H%M%S")
-        ),
-    )
-    .unwrap();
+    let timestamp = env::var_os("SOURCE_DATE_EPOCH")
+        .map(|s| {
+            s.to_str()
+                // if SOURCE_DATE_EPOCH is set, but not a valid str fail loudly
+                // instead of falling back.
+                .expect("SOURCE_DATE_EPOCH must be valid utf-8")
+                .to_owned()
+        })
+        .unwrap_or_else(|| Local::now().format("%Y%m%d%H%M%S").to_string());
+    fs::write(path, format!("const BUILD_ID: &str = \"{timestamp}\";",)).unwrap();
 }

--- a/components/devtools/build.rs
+++ b/components/devtools/build.rs
@@ -5,19 +5,29 @@
 use std::path::Path;
 use std::{env, fs};
 
-use chrono::Local;
+use chrono::{TimeZone, Utc};
 
 fn main() {
     println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
+    // Parsing as suggested on <https://reproducible-builds.org/docs/source-date-epoch/>
+    let now = match env::var("SOURCE_DATE_EPOCH") {
+        Ok(val) => Utc
+            .timestamp_opt(
+                val.parse::<i64>()
+                    .expect("SOURCE_DATE_EPOCH should be a valid integer"),
+                0,
+            )
+            .unwrap(),
+        Err(_) => Utc::now(),
+    };
+
+    let build_id = now.format("%Y%m%d%H%M%S").to_string();
+
     let path = Path::new(&env::var_os("OUT_DIR").unwrap()).join("build_id.rs");
-    let timestamp = env::var_os("SOURCE_DATE_EPOCH")
-        .map(|s| {
-            s.to_str()
-                // if SOURCE_DATE_EPOCH is set, but not a valid str fail loudly
-                // instead of falling back.
-                .expect("SOURCE_DATE_EPOCH must be valid utf-8")
-                .to_owned()
-        })
-        .unwrap_or_else(|| Local::now().format("%Y%m%d%H%M%S").to_string());
-    fs::write(path, format!("const BUILD_ID: &str = \"{timestamp}\";",)).unwrap();
+    // The build ID is used in Firefox devtools, `getDateFromBuildID` function:
+    // <https://searchfox.org/firefox-main/rev/be31b3948198286e39a9855e414823cb17b6e94c/devtools/client/shared/remote-debugging/version-checker.js#21-24>
+    // The expected format is: yyyyMMddHHmmss.
+    // The date is than later used to check devtools compatibility:
+    // <https://searchfox.org/firefox-main/rev/be31b3948198286e39a9855e414823cb17b6e94c/devtools/client/shared/remote-debugging/version-checker.js#133-139>
+    fs::write(path, format!("const BUILD_ID: &str = \"{build_id}\";")).unwrap();
 }


### PR DESCRIPTION
We are probably not anywhere close to reproducible builds, but we should try to follow best practices where trivially possible.
See also: https://reproducible-builds.org/docs/source-date-epoch/

Firefox devtools expects the build_id to be provided in a datetime specific format.
This PR also switches the time to UTC instead of `Local`, since there seems to be no clear reason to use Local, and SOURCE_DATE_EPOCH is UTC.

Testing: No functional changes, the devtools build_id is not covered by any tests.
Fixes: #44458
