### PR TITLE
Devtools: Enable Stylesheets Resource and Add Basic Fields to StyleSheetsActor

### DIFF
--- a/components/devtools/actors/stylesheets.rs
+++ b/components/devtools/actors/stylesheets.rs
@@ -10,11 +10,41 @@ use crate::StreamId;
 use crate::actor::{Actor, ActorError, ActorRegistry};
 use crate::protocol::ClientRequest;
 
+/// <https://searchfox.org/mozilla-central/source/devtools/server/actors/resources/stylesheets.js>
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct StyleSheetData {
+    /// Unique identifier for this stylesheet.
+    resource_id: String,
+    /// The URL of the stylesheet. Optional for inline stylesheets.
+    href: Option<String>,
+    /// The URL of the document that owns this stylesheet.
+    node_href: String,
+    /// Whether the stylesheet is disabled.
+    disabled: bool,
+    /// The title of the stylesheet.
+    title: String,
+    /// Whether this is a browser stylesheet.
+    system: bool,
+    /// Whether this stylesheet was created by DevTools.
+    is_new: bool,
+    /// Optional source map URL.
+    source_map_url: Option<String>,
+    /// The index of this stylesheet in the document's stylesheet list.
+    style_sheet_index: i32,
+    // TODO: the following fields will be implemented later once we fetch the stylesheets
+    // constructed: bool,
+    // file_name: Option<String>,
+    // at_rules: Vec<Rule>,
+    // rule_count: u32,
+    // source_map_base_url: String,
+}
+
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct GetStyleSheetsReply {
     from: String,
-    style_sheets: Vec<u32>, // TODO: real JSON structure.
+    style_sheets: Vec<StyleSheetData>,
 }
 
 #[derive(MallocSizeOf)]
@@ -38,6 +68,7 @@ impl Actor for StyleSheetsActor {
             "getStyleSheets" => {
                 let msg = GetStyleSheetsReply {
                     from: self.name(),
+                    // TODO: Fetch actual stylesheets from the script thread.
                     style_sheets: vec![],
                 };
                 request.reply_final(&msg)?

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -84,7 +84,7 @@ impl SessionContext {
                 ("network-event", true),
                 ("network-event-stacktrace", false),
                 ("reflow", true),
-                ("stylesheet", false),
+                ("stylesheet", true),
                 ("source", true),
                 ("thread-state", false),
                 ("server-sent-event", false),
@@ -385,6 +385,17 @@ impl Actor for WatcherActor {
                                     &mut request,
                                 );
                             }
+                        },
+                        "stylesheet" => {
+                            // TODO: Fetch actual stylesheets from the script thread.
+                            // For now, send an empty array.
+                            let empty: Vec<serde_json::Value> = vec![];
+                            browsing_context_actor.resources_array(
+                                empty,
+                                resource.into(),
+                                ResourceArrayType::Available,
+                                &mut request,
+                            );
                         },
                         "network-event" => {},
                         _ => warn!("resource {} not handled yet", resource),


### PR DESCRIPTION
Added basic fields required by firefox remote debugging protocol for stylesheets- `StyleSheetData`
Enabled stylesheets in devtools watcher, made stylesheet request return an empty array for now.

Testing: No change in behaviour and tests 

Fixes: part of #44315
