### PR TITLE
script: Separate concepts of heap buffer sources and rooted heap buffer sources

### DIFF
--- a/components/script/dom/audio/audiobuffer.rs
+++ b/components/script/dom/audio/audiobuffer.rs
@@ -61,6 +61,7 @@ pub(crate) struct AudioBuffer {
 }
 
 impl AudioBuffer {
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new_inherited(
         number_of_channels: u32,
         length: u32,

--- a/components/script/dom/bindings/buffer_source.rs
+++ b/components/script/dom/bindings/buffer_source.rs
@@ -203,7 +203,7 @@ where
             BufferSource::ArrayBufferView(buffer) => unsafe {
                 let mut is_shared = false;
                 rooted!(in (*cx) let view_buffer =
-                         JS_GetArrayBufferViewBuffer(*cx, buffer.handle().into(), &mut is_shared));
+                         JS_GetArrayBufferViewBuffer(*cx, buffer.handle(), &mut is_shared));
 
                 RootedTraceableBox::new(HeapBufferSource::<ArrayBufferU8>::new(
                     BufferSource::ArrayBuffer(Heap::boxed(*view_buffer.handle())),
@@ -225,7 +225,7 @@ where
                     // assert buffer is an ArrayBuffer view
                     assert!(JS_IsArrayBufferViewObject(*buffer.handle()));
                     rooted!(in (*cx) let view_buffer =
-                            JS_GetArrayBufferViewBuffer(*cx, buffer.handle().into(), &mut is_shared));
+                            JS_GetArrayBufferViewBuffer(*cx, buffer.handle(), &mut is_shared));
                     // This buffer is always created unshared
                     debug_assert!(!is_shared);
                     // Detach the ArrayBuffer
@@ -233,7 +233,7 @@ where
                 }
             },
             BufferSource::ArrayBuffer(buffer) => unsafe {
-                DetachArrayBuffer(*cx, Handle::from_raw(buffer.handle().into()))
+                DetachArrayBuffer(*cx, Handle::from_raw(buffer.handle()))
             },
         }
     }
@@ -255,7 +255,7 @@ where
                 unsafe {
                     assert!(JS_IsArrayBufferViewObject(*buffer.handle()));
                     rooted!(in (*cx) let view_buffer =
-                            JS_GetArrayBufferViewBuffer(*cx, buffer.handle().into(), &mut is_shared));
+                            JS_GetArrayBufferViewBuffer(*cx, buffer.handle(), &mut is_shared));
                     debug_assert!(!is_shared);
                     IsDetachedArrayBufferObject(*view_buffer.handle())
                 }
@@ -274,7 +274,7 @@ where
                 unsafe {
                     assert!(JS_IsArrayBufferViewObject(*buffer.handle()));
                     rooted!(in (*cx) let view_buffer =
-                            JS_GetArrayBufferViewBuffer(*cx, buffer.handle().into(), &mut is_shared));
+                            JS_GetArrayBufferViewBuffer(*cx, buffer.handle(), &mut is_shared));
                     debug_assert!(!is_shared);
                     GetArrayBufferByteLength(*view_buffer.handle())
                 }
@@ -356,7 +356,7 @@ where
             BufferSource::ArrayBufferView(buffer) => {
                 let mut is_shared = false;
                 rooted!(&in(cx) let view_buffer =
-                    unsafe { JS_GetArrayBufferViewBuffer(cx.raw_cx(), buffer.handle().into(), &mut is_shared) });
+                    unsafe { JS_GetArrayBufferViewBuffer(cx.raw_cx(), buffer.handle(), &mut is_shared) });
                 debug_assert!(!is_shared);
 
                 unsafe {
@@ -371,7 +371,7 @@ where
             BufferSource::ArrayBuffer(buffer) => unsafe {
                 ArrayBufferClone(
                     cx.raw_cx(),
-                    buffer.handle().into(),
+                    buffer.handle(),
                     byte_offset,
                     byte_length,
                 )
@@ -611,9 +611,9 @@ where
                     BufferSource::ArrayBufferView(from_heap) |
                     BufferSource::ArrayBuffer(from_heap) => ArrayBufferCopyData(
                         *cx,
-                        heap.handle().into(),
+                        heap.handle(),
                         dest_start,
-                        from_heap.handle().into(),
+                        from_heap.handle(),
                         from_byte_offset,
                         bytes_to_copy,
                     ),
@@ -638,7 +638,7 @@ where
         let mut is_defined = false;
         match &self.buffer_source {
             BufferSource::ArrayBufferView(heap) | BufferSource::ArrayBuffer(heap) => unsafe {
-                if !HasDefinedArrayBufferDetachKey(*cx, heap.handle().into(), &mut is_defined) {
+                if !HasDefinedArrayBufferDetachKey(*cx, heap.handle(), &mut is_defined) {
                     return false;
                 }
             },
@@ -665,7 +665,7 @@ where
         // Step 2 (Reordered)
         let buffer_data = match &self.buffer_source {
             BufferSource::ArrayBufferView(buffer) | BufferSource::ArrayBuffer(buffer) => unsafe {
-                StealArrayBufferContents(*cx, buffer.handle().into())
+                StealArrayBufferContents(*cx, buffer.handle())
             },
         };
 
@@ -777,7 +777,7 @@ pub(crate) fn create_buffer_source_with_constructor(
         BufferSource::ArrayBuffer(heap) => match constructor {
             Constructor::DataView => Ok(RootedTraceableBox::new(HeapBufferSource::new(
                 BufferSource::ArrayBufferView(Heap::boxed(unsafe {
-                    JS_NewDataView(cx.raw_cx(), heap.handle().into(), byte_offset, byte_length)
+                    JS_NewDataView(cx.raw_cx(), heap.handle(), byte_offset, byte_length)
                 })),
             ))),
             Constructor::Name(name_type) => construct_typed_array(
@@ -808,73 +808,73 @@ fn construct_typed_array(
                 match name_type {
                     Type::Int8 => JS_NewInt8ArrayWithBuffer(
                         cx.raw_cx(),
-                        heap.handle().into(),
+                        heap.handle(),
                         byte_offset,
                         byte_length,
                     ),
                     Type::Uint8 => JS_NewUint8ArrayWithBuffer(
                         cx.raw_cx(),
-                        heap.handle().into(),
+                        heap.handle(),
                         byte_offset,
                         byte_length,
                     ),
                     Type::Uint16 => JS_NewUint16ArrayWithBuffer(
                         cx.raw_cx(),
-                        heap.handle().into(),
+                        heap.handle(),
                         byte_offset,
                         byte_length,
                     ),
                     Type::Int16 => JS_NewInt16ArrayWithBuffer(
                         cx.raw_cx(),
-                        heap.handle().into(),
+                        heap.handle(),
                         byte_offset,
                         byte_length,
                     ),
                     Type::Int32 => JS_NewInt32ArrayWithBuffer(
                         cx.raw_cx(),
-                        heap.handle().into(),
+                        heap.handle(),
                         byte_offset,
                         byte_length,
                     ),
                     Type::Uint32 => JS_NewUint32ArrayWithBuffer(
                         cx.raw_cx(),
-                        heap.handle().into(),
+                        heap.handle(),
                         byte_offset,
                         byte_length,
                     ),
                     Type::Float32 => JS_NewFloat32ArrayWithBuffer(
                         cx.raw_cx(),
-                        heap.handle().into(),
+                        heap.handle(),
                         byte_offset,
                         byte_length,
                     ),
                     Type::Float64 => JS_NewFloat64ArrayWithBuffer(
                         cx.raw_cx(),
-                        heap.handle().into(),
+                        heap.handle(),
                         byte_offset,
                         byte_length,
                     ),
                     Type::Uint8Clamped => JS_NewUint8ClampedArrayWithBuffer(
                         cx.raw_cx(),
-                        heap.handle().into(),
+                        heap.handle(),
                         byte_offset,
                         byte_length,
                     ),
                     Type::BigInt64 => JS_NewBigInt64ArrayWithBuffer(
                         cx.raw_cx(),
-                        heap.handle().into(),
+                        heap.handle(),
                         byte_offset,
                         byte_length,
                     ),
                     Type::BigUint64 => JS_NewBigUint64ArrayWithBuffer(
                         cx.raw_cx(),
-                        heap.handle().into(),
+                        heap.handle(),
                         byte_offset,
                         byte_length,
                     ),
                     Type::Float16 => JS_NewFloat16ArrayWithBuffer(
                         cx.raw_cx(),
-                        heap.handle().into(),
+                        heap.handle(),
                         byte_offset,
                         byte_length,
                     ),

--- a/components/script/dom/bindings/buffer_source.rs
+++ b/components/script/dom/bindings/buffer_source.rs
@@ -55,25 +55,24 @@ pub(crate) type RootedTypedArray<T> = RootedTraceableBox<TypedArray<T, Box<Heap<
 /// provides a view onto an `ArrayBuffer`.
 ///
 /// See: <https://webidl.spec.whatwg.org/#BufferSource>
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) enum BufferSource {
     /// Represents an `ArrayBufferView` (e.g., `Uint8Array`, `DataView`).
     /// See: <https://webidl.spec.whatwg.org/#ArrayBufferView>
-    ArrayBufferView(RootedTraceableBox<Heap<*mut JSObject>>),
+    ArrayBufferView(Box<Heap<*mut JSObject>>),
 
     /// Represents an `ArrayBuffer`, a fixed-length binary data buffer.
     /// See: <https://webidl.spec.whatwg.org/#idl-ArrayBuffer>
-    ArrayBuffer(RootedTraceableBox<Heap<*mut JSObject>>),
+    ArrayBuffer(Box<Heap<*mut JSObject>>),
 }
 
 impl Clone for BufferSource {
     fn clone(&self) -> Self {
         match self {
             BufferSource::ArrayBufferView(heap) => {
-                BufferSource::ArrayBufferView(RootedTraceableBox::from_box(Heap::boxed(heap.get())))
+                BufferSource::ArrayBufferView(Heap::boxed(heap.get()))
             },
-            BufferSource::ArrayBuffer(heap) => {
-                BufferSource::ArrayBuffer(RootedTraceableBox::from_box(Heap::boxed(heap.get())))
-            },
+            BufferSource::ArrayBuffer(heap) => BufferSource::ArrayBuffer(Heap::boxed(heap.get())),
         }
     }
 }
@@ -82,7 +81,7 @@ pub(crate) fn create_heap_buffer_source_with_length<T>(
     cx: JSContext,
     len: u32,
     can_gc: CanGc,
-) -> Fallible<HeapBufferSource<T>>
+) -> Fallible<RootedTraceableBox<HeapBufferSource<T>>>
 where
     T: TypedArrayElement + TypedArrayElementCreator + 'static,
     T::Element: Clone + Copy,
@@ -94,11 +93,12 @@ where
         return Err(Error::JSFailed);
     }
 
-    Ok(HeapBufferSource::<T>::new(BufferSource::ArrayBufferView(
-        RootedTraceableBox::from_box(Heap::boxed(*array.handle())),
+    Ok(RootedTraceableBox::new(HeapBufferSource::<T>::new(
+        BufferSource::ArrayBufferView(Heap::boxed(*array.handle())),
     )))
 }
 
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct HeapBufferSource<T> {
     buffer_source: BufferSource,
     phantom: PhantomData<T>,
@@ -139,6 +139,7 @@ impl<T> HeapBufferSource<T>
 where
     T: TypedArrayElement,
 {
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new(buffer_source: BufferSource) -> HeapBufferSource<T> {
         HeapBufferSource {
             buffer_source,
@@ -148,17 +149,15 @@ where
 
     pub(crate) fn from_view(
         chunk: CustomAutoRooterGuard<TypedArray<T, *mut JSObject>>,
-    ) -> HeapBufferSource<T> {
-        HeapBufferSource::<T>::new(BufferSource::ArrayBufferView(RootedTraceableBox::from_box(
+    ) -> RootedTraceableBox<HeapBufferSource<T>> {
+        RootedTraceableBox::new(HeapBufferSource::<T>::new(BufferSource::ArrayBufferView(
             Heap::boxed(unsafe { *chunk.underlying_object() }),
         )))
     }
 
     pub(crate) fn default() -> Self {
         HeapBufferSource {
-            buffer_source: BufferSource::ArrayBufferView(RootedTraceableBox::from_box(
-                Heap::boxed(std::ptr::null_mut()),
-            )),
+            buffer_source: BufferSource::ArrayBufferView(Heap::boxed(std::ptr::null_mut())),
             phantom: PhantomData,
         }
     }
@@ -199,15 +198,15 @@ where
     pub(crate) fn get_array_buffer_view_buffer(
         &self,
         cx: JSContext,
-    ) -> HeapBufferSource<ArrayBufferU8> {
+    ) -> RootedTraceableBox<HeapBufferSource<ArrayBufferU8>> {
         match &self.buffer_source {
             BufferSource::ArrayBufferView(buffer) => unsafe {
                 let mut is_shared = false;
                 rooted!(in (*cx) let view_buffer =
                          JS_GetArrayBufferViewBuffer(*cx, buffer.handle().into(), &mut is_shared));
 
-                HeapBufferSource::<ArrayBufferU8>::new(BufferSource::ArrayBuffer(
-                    RootedTraceableBox::from_box(Heap::boxed(*view_buffer.handle())),
+                RootedTraceableBox::new(HeapBufferSource::<ArrayBufferU8>::new(
+                    BufferSource::ArrayBuffer(Heap::boxed(*view_buffer.handle())),
                 ))
             },
             BufferSource::ArrayBuffer(_) => {
@@ -352,7 +351,7 @@ where
         cx: &mut js::context::JSContext,
         byte_offset: usize,
         byte_length: usize,
-    ) -> Fallible<HeapBufferSource<ArrayBufferU8>> {
+    ) -> Fallible<RootedTraceableBox<HeapBufferSource<ArrayBufferU8>>> {
         let result = match &self.buffer_source {
             BufferSource::ArrayBufferView(buffer) => {
                 let mut is_shared = false;
@@ -392,8 +391,10 @@ where
 
             Err(Error::Type(c"can't clone array buffer".to_owned()))
         } else {
-            Ok(HeapBufferSource::<ArrayBufferU8>::new(
-                BufferSource::ArrayBuffer(RootedTraceableBox::from_box(Heap::boxed(result))),
+            Ok(RootedTraceableBox::new(
+                HeapBufferSource::<ArrayBufferU8>::new(BufferSource::ArrayBuffer(Heap::boxed(
+                    result,
+                ))),
             ))
         }
     }
@@ -402,7 +403,7 @@ where
     pub(crate) fn clone_as_uint8_array(
         &self,
         cx: &mut js::context::JSContext,
-    ) -> Fallible<HeapBufferSource<ArrayBufferViewU8>> {
+    ) -> Fallible<RootedTraceableBox<HeapBufferSource<ArrayBufferViewU8>>> {
         match &self.buffer_source {
             BufferSource::ArrayBufferView(buffer) => {
                 // Assert: O is an Object.
@@ -650,7 +651,7 @@ where
     pub(crate) fn transfer_array_buffer(
         &self,
         cx: JSContext,
-    ) -> Fallible<HeapBufferSource<ArrayBufferU8>> {
+    ) -> Fallible<RootedTraceableBox<HeapBufferSource<ArrayBufferU8>>> {
         assert!(self.is_array_buffer_object());
 
         // Assert: ! IsDetachedBuffer(O) is false.
@@ -683,10 +684,10 @@ where
             // Return a new ArrayBuffer object, created in the current Realm,
             // whose [[ArrayBufferData]] internal slot value is arrayBufferData and
             // whose [[ArrayBufferByteLength]] internal slot value is arrayBufferByteLength.
-            Ok(HeapBufferSource::<ArrayBufferU8>::new(
-                BufferSource::ArrayBuffer(RootedTraceableBox::from_box(Heap::boxed(unsafe {
-                    NewArrayBufferWithContents(*cx, buffer_length, buffer_data)
-                }))),
+            Ok(RootedTraceableBox::new(
+                HeapBufferSource::<ArrayBufferU8>::new(BufferSource::ArrayBuffer(Heap::boxed(
+                    unsafe { NewArrayBufferWithContents(*cx, buffer_length, buffer_data) },
+                ))),
             ))
         }
     }
@@ -771,11 +772,11 @@ pub(crate) fn create_buffer_source_with_constructor(
     buffer_source: &HeapBufferSource<ArrayBufferU8>,
     byte_offset: usize,
     byte_length: usize,
-) -> Fallible<HeapBufferSource<ArrayBufferViewU8>> {
+) -> Fallible<RootedTraceableBox<HeapBufferSource<ArrayBufferViewU8>>> {
     match &buffer_source.buffer_source {
         BufferSource::ArrayBuffer(heap) => match constructor {
-            Constructor::DataView => Ok(HeapBufferSource::new(BufferSource::ArrayBufferView(
-                RootedTraceableBox::from_box(Heap::boxed(unsafe {
+            Constructor::DataView => Ok(RootedTraceableBox::new(HeapBufferSource::new(
+                BufferSource::ArrayBufferView(Heap::boxed(unsafe {
                     JS_NewDataView(cx.raw_cx(), heap.handle().into(), byte_offset, byte_length)
                 })),
             ))),
@@ -800,7 +801,7 @@ fn construct_typed_array(
     buffer_source: &HeapBufferSource<ArrayBufferU8>,
     byte_offset: usize,
     byte_length: i64,
-) -> Fallible<HeapBufferSource<ArrayBufferViewU8>> {
+) -> Fallible<RootedTraceableBox<HeapBufferSource<ArrayBufferViewU8>>> {
     match &buffer_source.buffer_source {
         BufferSource::ArrayBuffer(heap) => {
             let array_view = unsafe {
@@ -883,8 +884,8 @@ fn construct_typed_array(
                 }
             };
 
-            Ok(HeapBufferSource::new(BufferSource::ArrayBufferView(
-                RootedTraceableBox::from_box(Heap::boxed(array_view)),
+            Ok(RootedTraceableBox::new(HeapBufferSource::new(
+                BufferSource::ArrayBufferView(Heap::boxed(array_view)),
             )))
         },
         BufferSource::ArrayBufferView(_) => {
@@ -896,7 +897,7 @@ fn construct_typed_array(
 pub(crate) fn create_array_buffer_with_size(
     cx: &mut js::context::JSContext,
     size: usize,
-) -> Fallible<HeapBufferSource<ArrayBufferU8>> {
+) -> Fallible<RootedTraceableBox<HeapBufferSource<ArrayBufferU8>>> {
     let result = unsafe { NewArrayBuffer(cx.raw_cx(), size) };
     if result.is_null() {
         rooted!(&in(cx) let mut rval = UndefinedValue());
@@ -910,8 +911,8 @@ pub(crate) fn create_array_buffer_with_size(
 
         Err(Error::Type(c"can't create array buffer".to_owned()))
     } else {
-        Ok(HeapBufferSource::<ArrayBufferU8>::new(
-            BufferSource::ArrayBuffer(RootedTraceableBox::from_box(Heap::boxed(result))),
+        Ok(RootedTraceableBox::new(
+            HeapBufferSource::<ArrayBufferU8>::new(BufferSource::ArrayBuffer(Heap::boxed(result))),
         ))
     }
 }

--- a/components/script/dom/bindings/buffer_source.rs
+++ b/components/script/dom/bindings/buffer_source.rs
@@ -369,12 +369,7 @@ where
                 }
             },
             BufferSource::ArrayBuffer(buffer) => unsafe {
-                ArrayBufferClone(
-                    cx.raw_cx(),
-                    buffer.handle(),
-                    byte_offset,
-                    byte_length,
-                )
+                ArrayBufferClone(cx.raw_cx(), buffer.handle(), byte_offset, byte_length)
             },
         };
 

--- a/components/script/dom/canvas/imagedata.rs
+++ b/components/script/dom/canvas/imagedata.rs
@@ -149,7 +149,7 @@ impl ImageData {
                 reflector_: Reflector::new(),
                 width,
                 height,
-                data,
+                data: *data.into_box(),
                 pixel_format,
                 color_space,
             }),

--- a/components/script/dom/stream/byteteereadintorequest.rs
+++ b/components/script/dom/stream/byteteereadintorequest.rs
@@ -10,10 +10,12 @@ use js::context::JSContext;
 use js::jsval::UndefinedValue;
 use js::typedarray::ArrayBufferViewU8;
 use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::trace::RootedTraceableBox;
 
 use super::byteteeunderlyingsource::ByteTeePullAlgorithm;
 use crate::dom::bindings::buffer_source::HeapBufferSource;
 use crate::dom::bindings::error::{ErrorToJsval, Fallible};
+use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::globalscope::GlobalScope;
@@ -24,17 +26,17 @@ use crate::microtask::Microtask;
 use crate::script_runtime::CanGc;
 
 #[derive(JSTraceable, MallocSizeOf)]
-#[cfg_attr(crown, expect(crown::unrooted_must_root))]
 pub(crate) struct ByteTeeReadIntoRequestMicrotask {
     #[ignore_malloc_size_of = "mozjs"]
-    chunk: HeapBufferSource<ArrayBufferViewU8>,
-    tee_read_request: Dom<ByteTeeReadIntoRequest>,
+    chunk: RootedTraceableBox<HeapBufferSource<ArrayBufferViewU8>>,
+    tee_read_request: Trusted<ByteTeeReadIntoRequest>,
 }
 
 impl ByteTeeReadIntoRequestMicrotask {
     pub(crate) fn microtask_chunk_steps(&self, cx: &mut JSContext) {
         self.tee_read_request
-            .chunk_steps(self.chunk.clone(), cx)
+            .root()
+            .chunk_steps(&self.chunk, cx)
             .expect("Failed to enqueue chunk");
     }
 }
@@ -97,11 +99,14 @@ impl ByteTeeReadIntoRequest {
         )
     }
 
-    pub(crate) fn enqueue_chunk_steps(&self, chunk: HeapBufferSource<ArrayBufferViewU8>) {
+    pub(crate) fn enqueue_chunk_steps(
+        &self,
+        chunk: RootedTraceableBox<HeapBufferSource<ArrayBufferViewU8>>,
+    ) {
         // Queue a microtask to perform the following steps:
         let byte_tee_read_request_chunk = ByteTeeReadIntoRequestMicrotask {
             chunk,
-            tee_read_request: Dom::from_ref(self),
+            tee_read_request: Trusted::new(self),
         };
 
         self.global()
@@ -114,7 +119,7 @@ impl ByteTeeReadIntoRequest {
     #[allow(clippy::borrowed_box)]
     pub(crate) fn chunk_steps(
         &self,
-        chunk: HeapBufferSource<ArrayBufferViewU8>,
+        chunk: &HeapBufferSource<ArrayBufferViewU8>,
         cx: &mut JSContext,
     ) -> Fallible<()> {
         // Set readAgainForBranch1 to false.
@@ -210,7 +215,7 @@ impl ByteTeeReadIntoRequest {
     pub(crate) fn close_steps(
         &self,
         cx: &mut JSContext,
-        chunk: Option<HeapBufferSource<ArrayBufferViewU8>>,
+        chunk: Option<RootedTraceableBox<HeapBufferSource<ArrayBufferViewU8>>>,
     ) -> Fallible<()> {
         // Set reading to false.
         self.reading.set(false);
@@ -255,7 +260,7 @@ impl ByteTeeReadIntoRequest {
                 // ReadableByteStreamControllerRespondWithNewView(byobBranch.[[controller]], chunk).
                 if !byob_canceled {
                     let byob_branch_controller = self.byob_branch.get_byte_controller();
-                    byob_branch_controller.respond_with_new_view(cx, chunk)?;
+                    byob_branch_controller.respond_with_new_view(cx, &chunk)?;
                 }
 
                 // If otherCanceled is false and otherBranch.[[controller]].[[pendingPullIntos]] is not empty,

--- a/components/script/dom/stream/byteteereadrequest.rs
+++ b/components/script/dom/stream/byteteereadrequest.rs
@@ -153,10 +153,10 @@ impl ByteTeeReadRequest {
 
         // Prepare per branch chunks ahead of the spec enqueue steps.
         let chunk1_view = if !self.canceled_1.get() {
-            Some(HeapBufferSource::<ArrayBufferViewU8>::new(
-                BufferSource::ArrayBufferView(RootedTraceableBox::from_box(Heap::boxed(
-                    chunk1.get().to_object(),
-                ))),
+            Some(RootedTraceableBox::new(
+                HeapBufferSource::<ArrayBufferViewU8>::new(BufferSource::ArrayBufferView(
+                    Heap::boxed(chunk1.get().to_object()),
+                )),
             ))
         } else {
             None
@@ -168,8 +168,8 @@ impl ByteTeeReadRequest {
         if !self.canceled_1.get() && !self.canceled_2.get() {
             // Let cloneResult be CloneAsUint8Array(chunk).
             let chunk2_source =
-                HeapBufferSource::<ArrayBufferViewU8>::new(BufferSource::ArrayBufferView(
-                    RootedTraceableBox::from_box(Heap::boxed(chunk2.get().to_object())),
+                RootedTraceableBox::new(HeapBufferSource::<ArrayBufferViewU8>::new(
+                    BufferSource::ArrayBufferView(Heap::boxed(chunk2.get().to_object())),
                 ));
             let clone_result = chunk2_source.clone_as_uint8_array(cx);
 
@@ -184,8 +184,8 @@ impl ByteTeeReadRequest {
         } else if !self.canceled_2.get() {
             // Only branch2 needs data; clone once for it.
             let chunk2_source =
-                HeapBufferSource::<ArrayBufferViewU8>::new(BufferSource::ArrayBufferView(
-                    RootedTraceableBox::from_box(Heap::boxed(chunk2.get().to_object())),
+                RootedTraceableBox::new(HeapBufferSource::<ArrayBufferViewU8>::new(
+                    BufferSource::ArrayBufferView(Heap::boxed(chunk2.get().to_object())),
                 ));
             match chunk2_source.clone_as_uint8_array(cx) {
                 Ok(clone) => chunk2_view = Some(clone),

--- a/components/script/dom/stream/byteteeunderlyingsource.rs
+++ b/components/script/dom/stream/byteteeunderlyingsource.rs
@@ -235,7 +235,7 @@ impl ByteTeeUnderlyingSource {
     fn pull_with_byob_reader(
         &self,
         cx: &mut JSContext,
-        view: HeapBufferSource<ArrayBufferViewU8>,
+        view: &HeapBufferSource<ArrayBufferViewU8>,
         for_branch2: bool,
         global: &GlobalScope,
     ) {
@@ -369,7 +369,7 @@ impl ByteTeeUnderlyingSource {
                         // Otherwise, perform pullWithBYOBReader, given byobRequest.[[view]] and false.
                         let view = request.get_view();
 
-                        self.pull_with_byob_reader(cx, view, false, &self.stream.global());
+                        self.pull_with_byob_reader(cx, &view, false, &self.stream.global());
                     },
                 }
 
@@ -413,7 +413,7 @@ impl ByteTeeUnderlyingSource {
                         // Otherwise, perform pullWithBYOBReader, given byobRequest.[[view]] and true.
                         let view = request.get_view();
 
-                        self.pull_with_byob_reader(cx, view, true, &self.stream.global());
+                        self.pull_with_byob_reader(cx, &view, true, &self.stream.global());
                     },
                 }
 

--- a/components/script/dom/stream/readablebytestreamcontroller.rs
+++ b/components/script/dom/stream/readablebytestreamcontroller.rs
@@ -40,6 +40,7 @@ use crate::script_runtime::CanGc;
 
 /// <https://streams.spec.whatwg.org/#readable-byte-stream-queue-entry>
 #[derive(JSTraceable, MallocSizeOf)]
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct QueueEntry {
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-queue-entry-buffer>
     #[ignore_malloc_size_of = "HeapBufferSource"]
@@ -52,12 +53,12 @@ pub(crate) struct QueueEntry {
 
 impl QueueEntry {
     pub(crate) fn new(
-        buffer: HeapBufferSource<ArrayBufferU8>,
+        buffer: RootedTraceableBox<HeapBufferSource<ArrayBufferU8>>,
         byte_offset: usize,
         byte_length: usize,
     ) -> QueueEntry {
         QueueEntry {
-            buffer,
+            buffer: *buffer.into_box(),
             byte_offset,
             byte_length,
         }
@@ -74,6 +75,7 @@ pub(crate) enum ReaderType {
 
 /// <https://streams.spec.whatwg.org/#pull-into-descriptor>
 #[derive(Eq, JSTraceable, MallocSizeOf, PartialEq)]
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct PullIntoDescriptor {
     #[ignore_malloc_size_of = "HeapBufferSource"]
     /// <https://streams.spec.whatwg.org/#pull-into-descriptor-buffer>
@@ -267,11 +269,12 @@ impl ReadableByteStreamController {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-pull-into>
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn perform_pull_into(
         &self,
         cx: &mut JSContext,
         read_into_request: &ReadIntoRequest,
-        view: HeapBufferSource<ArrayBufferViewU8>,
+        view: &HeapBufferSource<ArrayBufferViewU8>,
         min: u64,
     ) {
         // Let stream be controller.[[stream]].
@@ -328,7 +331,7 @@ impl ReadableByteStreamController {
                 // reader type  "byob"
                 let buffer_byte_length = buffer.byte_length();
                 let pull_into_descriptor = PullIntoDescriptor {
-                    buffer,
+                    buffer: *buffer.into_box(),
                     buffer_byte_length: buffer_byte_length as u64,
                     byte_offset: byte_offset as u64,
                     byte_length: byte_length as u64,
@@ -501,10 +504,11 @@ impl ReadableByteStreamController {
             }
 
             // Set firstDescriptor’s buffer to ! TransferArrayBuffer(firstDescriptor’s buffer).
-            first_descriptor.buffer = first_descriptor
+            first_descriptor.buffer = *first_descriptor
                 .buffer
                 .transfer_array_buffer(cx.into())
-                .expect("TransferArrayBuffer failed");
+                .expect("TransferArrayBuffer failed")
+                .into_box();
         }
 
         // Perform ? ReadableByteStreamControllerRespondInternal(controller, bytesWritten).
@@ -554,6 +558,7 @@ impl ReadableByteStreamController {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-respond-in-closed-state>
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn respond_in_closed_state(&self, cx: &mut JSContext) -> Fallible<()> {
         let pending_pull_intos = self.pending_pull_intos.borrow();
         let first_descriptor = pending_pull_intos.first().unwrap();
@@ -605,6 +610,7 @@ impl ReadableByteStreamController {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-respond-in-readable-state>
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn respond_in_readable_state(&self, cx: &mut JSContext, bytes_written: u64) -> Fallible<()> {
         let pending_pull_intos = self.pending_pull_intos.borrow();
         let first_descriptor = pending_pull_intos.first().unwrap();
@@ -700,7 +706,7 @@ impl ReadableByteStreamController {
     pub(crate) fn respond_with_new_view(
         &self,
         cx: &mut JSContext,
-        view: HeapBufferSource<ArrayBufferViewU8>,
+        view: &HeapBufferSource<ArrayBufferViewU8>,
     ) -> Fallible<()> {
         let view_byte_length;
         {
@@ -769,9 +775,10 @@ impl ReadableByteStreamController {
             view_byte_length = view.byte_length();
 
             // Set firstDescriptor’s buffer to ? TransferArrayBuffer(view.[[ViewedArrayBuffer]]).
-            first_descriptor.buffer = view
+            first_descriptor.buffer = *view
                 .get_array_buffer_view_buffer(cx.into())
-                .transfer_array_buffer(cx.into())?;
+                .transfer_array_buffer(cx.into())?
+                .into_box();
         }
 
         // Perform ? ReadableByteStreamControllerRespondInternal(controller, viewByteLength).
@@ -968,10 +975,11 @@ impl ReadableByteStreamController {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-enqueue>
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn enqueue(
         &self,
         cx: &mut JSContext,
-        chunk: HeapBufferSource<ArrayBufferViewU8>,
+        chunk: RootedTraceableBox<HeapBufferSource<ArrayBufferViewU8>>,
     ) -> Fallible<()> {
         // Let stream be controller.[[stream]].
         let stream = self.stream.get().unwrap();
@@ -1013,10 +1021,11 @@ impl ReadableByteStreamController {
                 self.invalidate_byob_request();
 
                 // Set firstPendingPullInto’s buffer to ! TransferArrayBuffer(firstPendingPullInto’s buffer).
-                first_descriptor.buffer = first_descriptor
+                first_descriptor.buffer = *first_descriptor
                     .buffer
                     .transfer_array_buffer(cx.into())
-                    .expect("TransferArrayBuffer failed");
+                    .expect("TransferArrayBuffer failed")
+                    .into_box();
 
                 // If firstPendingPullInto’s reader type is "none",
                 if first_descriptor.reader_type.is_none() {
@@ -1172,7 +1181,7 @@ impl ReadableByteStreamController {
         &self,
         cx: &mut js::context::JSContext,
         pull_into_descriptor: &PullIntoDescriptor,
-    ) -> Fallible<HeapBufferSource<ArrayBufferViewU8>> {
+    ) -> Fallible<RootedTraceableBox<HeapBufferSource<ArrayBufferViewU8>>> {
         // Let bytesFilled be pullIntoDescriptor’s bytes filled.
         let bytes_filled = pull_into_descriptor.bytes_filled.get();
 
@@ -1196,7 +1205,7 @@ impl ReadableByteStreamController {
         Ok(create_buffer_source_with_constructor(
             cx,
             &pull_into_descriptor.view_constructor,
-            &buffer,
+            &*buffer,
             pull_into_descriptor.byte_offset as usize,
             (bytes_filled / element_size) as usize,
         )
@@ -1204,6 +1213,7 @@ impl ReadableByteStreamController {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-process-pull-into-descriptors-using-queue>
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn process_pull_into_descriptors_using_queue(
         &self,
         cx: &mut js::context::JSContext,
@@ -1465,9 +1475,10 @@ impl ReadableByteStreamController {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-enqueue-chunk-to-queue>
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn enqueue_chunk_to_queue(
         &self,
-        buffer: HeapBufferSource<ArrayBufferU8>,
+        buffer: RootedTraceableBox<HeapBufferSource<ArrayBufferU8>>,
         byte_offset: usize,
         byte_length: usize,
     ) {
@@ -1504,6 +1515,7 @@ impl ReadableByteStreamController {
     }
 
     /// <https://streams.spec.whatwg.org/#abstract-opdef-readablebytestreamcontrollerfillreadrequestfromqueue>
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn fill_read_request_from_queue(
         &self,
         cx: &mut JSContext,
@@ -1517,6 +1529,7 @@ impl ReadableByteStreamController {
         // Let entry be controller.[[queue]][0].
         // Remove entry from controller.[[queue]].
         let entry = self.remove_entry();
+        //FIXME: use first() and remove afterwards?
 
         // Set controller.[[queueTotalSize]] to controller.[[queueTotalSize]] − entry’s byte length.
         self.queue_total_size
@@ -1756,6 +1769,7 @@ impl ReadableByteStreamController {
     }
 
     // <https://streams.spec.whatwg.org/#abstract-opdef-readablebytestreamcontroller-releasesteps
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn perform_release_steps(&self) -> Fallible<()> {
         // If this.[[pendingPullIntos]] is not empty,
         let mut pending_pull_intos = self.pending_pull_intos.borrow_mut();
@@ -1816,6 +1830,7 @@ impl ReadableByteStreamController {
     }
 
     /// <https://streams.spec.whatwg.org/#rbs-controller-private-pull>
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn perform_pull_steps(&self, cx: &mut JSContext, read_request: &ReadRequest) {
         // Let stream be this.[[stream]].
         let stream = self.stream.get().unwrap();
@@ -1855,7 +1870,7 @@ impl ReadableByteStreamController {
                     // view constructor %Uint8Array%
                     // reader type  "default"
                     let pull_into_descriptor = PullIntoDescriptor {
-                        buffer,
+                        buffer: *buffer.into_box(),
                         buffer_byte_length: auto_allocate_chunk_size,
                         byte_length: auto_allocate_chunk_size,
                         byte_offset: 0,

--- a/components/script/dom/stream/readablebytestreamcontroller.rs
+++ b/components/script/dom/stream/readablebytestreamcontroller.rs
@@ -601,7 +601,7 @@ impl ReadableByteStreamController {
             // For each filledPullInto of filledPullIntos,
             for filled_pull_into in &*filled_pull_intos {
                 // Perform ! ReadableByteStreamControllerCommitPullIntoDescriptor(stream, filledPullInto).
-                self.commit_pull_into_descriptor(cx, &filled_pull_into)
+                self.commit_pull_into_descriptor(cx, filled_pull_into)
                     .expect("commit_pull_into_descriptor failed");
             }
         }
@@ -639,7 +639,7 @@ impl ReadableByteStreamController {
             for filled_pull_into in &*filled_pull_intos {
                 // Perform ! ReadableByteStreamControllerCommitPullIntoDescriptor(controller.[[stream]]
                 // , filledPullInto).
-                self.commit_pull_into_descriptor(cx, &filled_pull_into)
+                self.commit_pull_into_descriptor(cx, filled_pull_into)
                     .expect("commit_pull_into_descriptor failed");
             }
 
@@ -694,7 +694,7 @@ impl ReadableByteStreamController {
         // For each filledPullInto of filledPullIntos,
         for filled_pull_into in &*filled_pull_intos {
             // Perform ! ReadableByteStreamControllerCommitPullIntoDescriptor(controller.[[stream]], filledPullInto).
-            self.commit_pull_into_descriptor(cx, &filled_pull_into)
+            self.commit_pull_into_descriptor(cx, filled_pull_into)
                 .expect("commit_pull_into_descriptor failed");
         }
 
@@ -1102,7 +1102,7 @@ impl ReadableByteStreamController {
             // For each filledPullInto of filledPullIntos,
             // Perform ! ReadableByteStreamControllerCommitPullIntoDescriptor(stream, filledPullInto).
             for filled_pull_into in &*filled_pull_intos {
-                self.commit_pull_into_descriptor(cx, &filled_pull_into)
+                self.commit_pull_into_descriptor(cx, filled_pull_into)
                     .expect("commit_pull_into_descriptor failed");
             }
         } else {
@@ -1203,7 +1203,7 @@ impl ReadableByteStreamController {
         Ok(create_buffer_source_with_constructor(
             cx,
             &pull_into_descriptor.view_constructor,
-            &*buffer,
+            &buffer,
             pull_into_descriptor.byte_offset as usize,
             (bytes_filled / element_size) as usize,
         )

--- a/components/script/dom/stream/readablebytestreamcontroller.rs
+++ b/components/script/dom/stream/readablebytestreamcontroller.rs
@@ -51,6 +51,8 @@ pub(crate) struct QueueEntry {
     byte_length: usize,
 }
 
+impl js::gc::Rootable for QueueEntry {}
+
 impl QueueEntry {
     pub(crate) fn new(
         buffer: RootedTraceableBox<HeapBufferSource<ArrayBufferU8>>,
@@ -97,6 +99,8 @@ pub(crate) struct PullIntoDescriptor {
     /// <https://streams.spec.whatwg.org/#pull-into-descriptor-reader-type>
     reader_type: Option<ReaderType>,
 }
+
+impl js::gc::Rootable for PullIntoDescriptor {}
 
 /// The fulfillment handler for
 /// <https://streams.spec.whatwg.org/#dom-underlyingsource-start>
@@ -269,7 +273,6 @@ impl ReadableByteStreamController {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-pull-into>
-    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn perform_pull_into(
         &self,
         cx: &mut JSContext,
@@ -330,7 +333,7 @@ impl ReadableByteStreamController {
                 // view constructor ctor
                 // reader type  "byob"
                 let buffer_byte_length = buffer.byte_length();
-                let pull_into_descriptor = PullIntoDescriptor {
+                let pull_into_descriptor = RootedTraceableBox::new(PullIntoDescriptor {
                     buffer: *buffer.into_box(),
                     buffer_byte_length: buffer_byte_length as u64,
                     byte_offset: byte_offset as u64,
@@ -340,14 +343,14 @@ impl ReadableByteStreamController {
                     element_size,
                     view_constructor: ctor.clone(),
                     reader_type: Some(ReaderType::Byob),
-                };
+                });
 
                 // If controller.[[pendingPullIntos]] is not empty,
                 {
                     let mut pending_pull_intos = self.pending_pull_intos.borrow_mut();
                     if !pending_pull_intos.is_empty() {
                         // Append pullIntoDescriptor to controller.[[pendingPullIntos]].
-                        pending_pull_intos.push(pull_into_descriptor);
+                        pending_pull_intos.push(*pull_into_descriptor.into_box());
 
                         // Perform ! ReadableStreamAddReadIntoRequest(stream, readIntoRequest).
                         stream.add_read_into_request(read_into_request);
@@ -436,7 +439,7 @@ impl ReadableByteStreamController {
                 {
                     self.pending_pull_intos
                         .borrow_mut()
-                        .push(pull_into_descriptor);
+                        .push(*pull_into_descriptor.into_box());
                 }
                 // Perform ! ReadableStreamAddReadIntoRequest(stream, readIntoRequest).
                 stream.add_read_into_request(read_into_request);
@@ -558,7 +561,6 @@ impl ReadableByteStreamController {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-respond-in-closed-state>
-    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn respond_in_closed_state(&self, cx: &mut JSContext) -> Fallible<()> {
         let pending_pull_intos = self.pending_pull_intos.borrow();
         let first_descriptor = pending_pull_intos.first().unwrap();
@@ -587,19 +589,17 @@ impl ReadableByteStreamController {
         // If ! ReadableStreamHasBYOBReader(stream) is true,
         if stream.has_byob_reader() {
             // Let filledPullIntos be a new empty list.
-            let mut filled_pull_intos = Vec::new();
+            rooted!(&in(cx) let mut filled_pull_intos = Vec::new());
 
             // While filledPullIntos’s size < ! ReadableStreamGetNumReadIntoRequests(stream),
             while filled_pull_intos.len() < stream.get_num_read_into_requests() {
                 // Let pullIntoDescriptor be ! ReadableByteStreamControllerShiftPendingPullInto(controller).
-                let pull_into_descriptor = self.shift_pending_pull_into();
-
                 // Append pullIntoDescriptor to filledPullIntos.
-                filled_pull_intos.push(pull_into_descriptor);
+                filled_pull_intos.push(self.shift_pending_pull_into());
             }
 
             // For each filledPullInto of filledPullIntos,
-            for filled_pull_into in filled_pull_intos {
+            for filled_pull_into in &*filled_pull_intos {
                 // Perform ! ReadableByteStreamControllerCommitPullIntoDescriptor(stream, filledPullInto).
                 self.commit_pull_into_descriptor(cx, &filled_pull_into)
                     .expect("commit_pull_into_descriptor failed");
@@ -610,7 +610,6 @@ impl ReadableByteStreamController {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-respond-in-readable-state>
-    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn respond_in_readable_state(&self, cx: &mut JSContext, bytes_written: u64) -> Fallible<()> {
         let pending_pull_intos = self.pending_pull_intos.borrow();
         let first_descriptor = pending_pull_intos.first().unwrap();
@@ -634,10 +633,10 @@ impl ReadableByteStreamController {
 
             // Let filledPullIntos be the result of performing
             // ! ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(controller).
-            let filled_pull_intos = self.process_pull_into_descriptors_using_queue(cx);
+            rooted!(&in(cx) let filled_pull_intos = self.process_pull_into_descriptors_using_queue(cx));
 
             // For each filledPullInto of filledPullIntos,
-            for filled_pull_into in filled_pull_intos {
+            for filled_pull_into in &*filled_pull_intos {
                 // Perform ! ReadableByteStreamControllerCommitPullIntoDescriptor(controller.[[stream]]
                 // , filledPullInto).
                 self.commit_pull_into_descriptor(cx, &filled_pull_into)
@@ -657,7 +656,7 @@ impl ReadableByteStreamController {
         drop(pending_pull_intos);
 
         // Perform ! ReadableByteStreamControllerShiftPendingPullInto(controller).
-        let pull_into_descriptor = self.shift_pending_pull_into();
+        rooted!(&in(cx) let pull_into_descriptor = self.shift_pending_pull_into());
 
         // Let remainderSize be the remainder after dividing pullIntoDescriptor’s bytes
         // filled by pullIntoDescriptor’s element size.
@@ -686,14 +685,14 @@ impl ReadableByteStreamController {
 
         // Let filledPullIntos be the result of performing
         // ! ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(controller).
-        let filled_pull_intos = self.process_pull_into_descriptors_using_queue(cx);
+        rooted!(&in(cx) let filled_pull_intos = self.process_pull_into_descriptors_using_queue(cx));
 
         // Perform ! ReadableByteStreamControllerCommitPullIntoDescriptor(controller.[[stream]], pullIntoDescriptor).
         self.commit_pull_into_descriptor(cx, &pull_into_descriptor)
             .expect("commit_pull_into_descriptor failed");
 
         // For each filledPullInto of filledPullIntos,
-        for filled_pull_into in filled_pull_intos {
+        for filled_pull_into in &*filled_pull_intos {
             // Perform ! ReadableByteStreamControllerCommitPullIntoDescriptor(controller.[[stream]], filledPullInto).
             self.commit_pull_into_descriptor(cx, &filled_pull_into)
                 .expect("commit_pull_into_descriptor failed");
@@ -975,7 +974,6 @@ impl ReadableByteStreamController {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-enqueue>
-    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn enqueue(
         &self,
         cx: &mut JSContext,
@@ -1099,11 +1097,11 @@ impl ReadableByteStreamController {
 
             // Let filledPullIntos be the result of performing !
             // ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(controller).
-            let filled_pull_intos = self.process_pull_into_descriptors_using_queue(cx);
+            rooted!(&in(cx) let filled_pull_intos = self.process_pull_into_descriptors_using_queue(cx));
 
             // For each filledPullInto of filledPullIntos,
             // Perform ! ReadableByteStreamControllerCommitPullIntoDescriptor(stream, filledPullInto).
-            for filled_pull_into in filled_pull_intos {
+            for filled_pull_into in &*filled_pull_intos {
                 self.commit_pull_into_descriptor(cx, &filled_pull_into)
                     .expect("commit_pull_into_descriptor failed");
             }
@@ -1213,7 +1211,6 @@ impl ReadableByteStreamController {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-process-pull-into-descriptors-using-queue>
-    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn process_pull_into_descriptors_using_queue(
         &self,
         cx: &mut js::context::JSContext,
@@ -1222,7 +1219,7 @@ impl ReadableByteStreamController {
         assert!(!self.close_requested.get());
 
         // Let filledPullIntos be a new empty list.
-        let mut filled_pull_intos = Vec::new();
+        rooted!(&in(cx) let mut filled_pull_intos = Vec::new());
 
         // While controller.[[pendingPullIntos]] is not empty,
         loop {
@@ -1243,15 +1240,13 @@ impl ReadableByteStreamController {
             // If ! ReadableByteStreamControllerFillPullIntoDescriptorFromQueue(controller, pullIntoDescriptor) is true,
             if fill_pull_result {
                 // Perform ! ReadableByteStreamControllerShiftPendingPullInto(controller).
-                let pull_into_descriptor = self.shift_pending_pull_into();
-
                 // Append pullIntoDescriptor to filledPullIntos.
-                filled_pull_intos.push(pull_into_descriptor);
+                filled_pull_intos.push(self.shift_pending_pull_into());
             }
         }
 
         // Return filledPullIntos.
-        filled_pull_intos
+        filled_pull_intos.take()
     }
 
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-fill-pull-into-descriptor-from-queue>
@@ -1475,7 +1470,6 @@ impl ReadableByteStreamController {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-enqueue-chunk-to-queue>
-    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn enqueue_chunk_to_queue(
         &self,
         buffer: RootedTraceableBox<HeapBufferSource<ArrayBufferU8>>,
@@ -1483,10 +1477,10 @@ impl ReadableByteStreamController {
         byte_length: usize,
     ) {
         // Let entry be a new ReadableByteStreamQueueEntry object.
-        let entry = QueueEntry::new(buffer, byte_offset, byte_length);
-
         // Append entry to controller.[[queue]].
-        self.queue.borrow_mut().push_back(entry);
+        self.queue
+            .borrow_mut()
+            .push_back(QueueEntry::new(buffer, byte_offset, byte_length));
 
         // Set controller.[[queueTotalSize]] to controller.[[queueTotalSize]] + byteLength.
         self.queue_total_size
@@ -1515,7 +1509,6 @@ impl ReadableByteStreamController {
     }
 
     /// <https://streams.spec.whatwg.org/#abstract-opdef-readablebytestreamcontrollerfillreadrequestfromqueue>
-    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn fill_read_request_from_queue(
         &self,
         cx: &mut JSContext,
@@ -1528,8 +1521,7 @@ impl ReadableByteStreamController {
 
         // Let entry be controller.[[queue]][0].
         // Remove entry from controller.[[queue]].
-        let entry = self.remove_entry();
-        //FIXME: use first() and remove afterwards?
+        rooted!(&in(cx) let entry = self.remove_entry());
 
         // Set controller.[[queueTotalSize]] to controller.[[queueTotalSize]] − entry’s byte length.
         self.queue_total_size
@@ -1769,20 +1761,19 @@ impl ReadableByteStreamController {
     }
 
     // <https://streams.spec.whatwg.org/#abstract-opdef-readablebytestreamcontroller-releasesteps
-    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn perform_release_steps(&self) -> Fallible<()> {
         // If this.[[pendingPullIntos]] is not empty,
         let mut pending_pull_intos = self.pending_pull_intos.borrow_mut();
         if !pending_pull_intos.is_empty() {
             // Let firstPendingPullInto be this.[[pendingPullIntos]][0].
-            let mut first_pending_pull_into = pending_pull_intos.remove(0);
+            let mut first_pending_pull_into = RootedTraceableBox::new(pending_pull_intos.remove(0));
 
             // Set firstPendingPullInto’s reader type to "none".
             first_pending_pull_into.reader_type = None;
 
             // Set this.[[pendingPullIntos]] to the list « firstPendingPullInto »
             pending_pull_intos.clear();
-            pending_pull_intos.push(first_pending_pull_into);
+            pending_pull_intos.push(*first_pending_pull_into.into_box());
         }
         Ok(())
     }
@@ -1830,7 +1821,6 @@ impl ReadableByteStreamController {
     }
 
     /// <https://streams.spec.whatwg.org/#rbs-controller-private-pull>
-    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn perform_pull_steps(&self, cx: &mut JSContext, read_request: &ReadRequest) {
         // Let stream be this.[[stream]].
         let stream = self.stream.get().unwrap();
@@ -1869,22 +1859,21 @@ impl ReadableByteStreamController {
                     // element size 1
                     // view constructor %Uint8Array%
                     // reader type  "default"
-                    let pull_into_descriptor = PullIntoDescriptor {
-                        buffer: *buffer.into_box(),
-                        buffer_byte_length: auto_allocate_chunk_size,
-                        byte_length: auto_allocate_chunk_size,
-                        byte_offset: 0,
-                        bytes_filled: Cell::new(0),
-                        minimum_fill: 1,
-                        element_size: 1,
-                        view_constructor: Constructor::Name(Type::Uint8),
-                        reader_type: Some(ReaderType::Default),
-                    };
 
                     // Append pullIntoDescriptor to this.[[pendingPullIntos]].
                     self.pending_pull_intos
                         .borrow_mut()
-                        .push(pull_into_descriptor);
+                        .push(PullIntoDescriptor {
+                            buffer: *buffer.into_box(),
+                            buffer_byte_length: auto_allocate_chunk_size,
+                            byte_length: auto_allocate_chunk_size,
+                            byte_offset: 0,
+                            bytes_filled: Cell::new(0),
+                            minimum_fill: 1,
+                            element_size: 1,
+                            view_constructor: Constructor::Name(Type::Uint8),
+                            reader_type: Some(ReaderType::Default),
+                        });
                 },
                 Err(error) => {
                     // If buffer is an abrupt completion,

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -1057,7 +1057,7 @@ impl ReadableStream {
         &self,
         cx: &mut JSContext,
         read_into_request: &ReadIntoRequest,
-        view: HeapBufferSource<ArrayBufferViewU8>,
+        view: &HeapBufferSource<ArrayBufferViewU8>,
         min: u64,
     ) {
         match self.controller.borrow().as_ref() {

--- a/components/script/dom/stream/readablestreambyobreader.rs
+++ b/components/script/dom/stream/readablestreambyobreader.rs
@@ -65,13 +65,11 @@ impl ReadIntoRequest {
             },
             ReadIntoRequest::ByteTee {
                 byte_tee_read_into_request,
-            } => {
-                byte_tee_read_into_request.enqueue_chunk_steps(
-                    HeapBufferSource::<ArrayBufferViewU8>::new(BufferSource::ArrayBufferView(
-                        RootedTraceableBox::from_box(Heap::boxed(chunk.get().to_object())),
-                    )),
-                )
-            },
+            } => byte_tee_read_into_request.enqueue_chunk_steps(RootedTraceableBox::new(
+                HeapBufferSource::<ArrayBufferViewU8>::new(BufferSource::ArrayBufferView(
+                    Heap::boxed(chunk.get().to_object()),
+                )),
+            )),
         }
     }
 
@@ -106,10 +104,10 @@ impl ReadIntoRequest {
                 Some(chunk) => byte_tee_read_into_request
                     .close_steps(
                         cx,
-                        Some(HeapBufferSource::<ArrayBufferViewU8>::new(
-                            BufferSource::ArrayBufferView(RootedTraceableBox::from_box(
-                                Heap::boxed(chunk.get().to_object()),
-                            )),
+                        Some(RootedTraceableBox::new(
+                            HeapBufferSource::<ArrayBufferViewU8>::new(
+                                BufferSource::ArrayBufferView(Heap::boxed(chunk.get().to_object())),
+                            ),
                         )),
                     )
                     .expect("close steps should not fail"),
@@ -322,7 +320,7 @@ impl ReadableStreamBYOBReader {
     pub(crate) fn read(
         &self,
         cx: &mut JSContext,
-        view: HeapBufferSource<ArrayBufferViewU8>,
+        view: &HeapBufferSource<ArrayBufferViewU8>,
         min: u64,
         read_into_request: &ReadIntoRequest,
     ) {
@@ -506,7 +504,7 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
         let read_into_request = ReadIntoRequest::Read(promise.clone());
 
         // Perform ! ReadableStreamBYOBReaderRead(this, view, options["min"], readIntoRequest).
-        self.read(cx, view, min, &read_into_request);
+        self.read(cx, &view, min, &read_into_request);
 
         // Return promise.
         promise

--- a/components/script/dom/stream/readablestreambyobrequest.rs
+++ b/components/script/dom/stream/readablestreambyobrequest.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use std::cell::Ref;
+
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::gc::CustomAutoRooterGuard;
@@ -44,10 +46,13 @@ impl ReadableStreamBYOBRequest {
         self.controller.set(controller);
     }
 
-    pub(crate) fn set_view(&self, view: Option<HeapBufferSource<ArrayBufferViewU8>>) {
+    pub(crate) fn set_view(
+        &self,
+        view: Option<RootedTraceableBox<HeapBufferSource<ArrayBufferViewU8>>>,
+    ) {
         match view {
             Some(view) => {
-                *self.view.borrow_mut() = view;
+                *self.view.borrow_mut() = *view.into_box();
             },
             None => {
                 *self.view.borrow_mut() = HeapBufferSource::<ArrayBufferViewU8>::default();
@@ -55,8 +60,8 @@ impl ReadableStreamBYOBRequest {
         }
     }
 
-    pub(crate) fn get_view(&self) -> HeapBufferSource<ArrayBufferViewU8> {
-        self.view.borrow().clone()
+    pub(crate) fn get_view(&self) -> Ref<'_, HeapBufferSource<ArrayBufferViewU8>> {
+        self.view.borrow()
     }
 }
 
@@ -121,6 +126,6 @@ impl ReadableStreamBYOBRequestMethods<crate::DomTypeHolder> for ReadableStreamBY
         }
 
         // Return ? ReadableByteStreamControllerRespondWithNewView(this.[[controller]], view).
-        controller.respond_with_new_view(cx, view)
+        controller.respond_with_new_view(cx, &view)
     }
 }

--- a/components/script/dom/stream/readablestreambyobrequest.rs
+++ b/components/script/dom/stream/readablestreambyobrequest.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::cell::Ref;
-
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::gc::CustomAutoRooterGuard;
@@ -60,8 +58,8 @@ impl ReadableStreamBYOBRequest {
         }
     }
 
-    pub(crate) fn get_view(&self) -> Ref<'_, HeapBufferSource<ArrayBufferViewU8>> {
-        self.view.borrow()
+    pub(crate) fn get_view(&self) -> RootedTraceableBox<HeapBufferSource<ArrayBufferViewU8>> {
+        RootedTraceableBox::new(self.view.borrow().clone())
     }
 }
 

--- a/components/script_bindings/trace.rs
+++ b/components/script_bindings/trace.rs
@@ -348,6 +348,10 @@ impl<T: JSTraceable + 'static> RootedTraceableBox<T> {
     pub fn from_box(boxed_traceable: Box<T>) -> RootedTraceableBox<T> {
         Self(js::gc::RootedTraceableBox::from_box(boxed_traceable))
     }
+
+    pub fn into_box(self) -> Box<T> {
+        self.0.into_box()
+    }
 }
 
 impl<T> RootedTraceableBox<Heap<T>>


### PR DESCRIPTION
The current implementation of HeapBufferSource contains a RootedTraceableBox to make it easy to move HeapBufferSource values around without violating rules around rooting. However this makes them inappropriate to store inside of DOM type like ImageData, which should only store the `Heap<Value>` without the stack root.

Testing: Fixes many asserting tests in WPT run with --debug-mozjs enabled, but we don't run that in CI yet.
Fixes: #44387
