### PR TITLE
script: Add `ScrollIntoView` steps for `VisualViewport`

### DIFF
--- a/components/paint/paint.rs
+++ b/components/paint/paint.rs
@@ -422,9 +422,9 @@ impl Paint {
                     );
                 }
             },
-            PaintMessage::ScrollViewportByDelta(webview_id, delta) => {
+            PaintMessage::ScrollViewportByDelta(webview_id, delta, scroll_type) => {
                 if let Some(mut painter) = self.maybe_painter_mut(webview_id.into()) {
-                    painter.scroll_viewport_by_delta(webview_id, delta);
+                    painter.scroll_viewport_by_delta(webview_id, delta, scroll_type);
                 }
             },
             PaintMessage::UpdateEpoch {

--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -25,6 +25,7 @@ use paint_api::viewport_description::ViewportDescription;
 use paint_api::{
     ImageUpdate, PipelineExitSource, SendableFrameTree, SerializableDisplayListPayload,
     SerializableImageData, WebRenderExternalImageHandlers, WebRenderImageHandlerType, WebViewTrait,
+    WebViewViewportScrollType,
 };
 use profile_traits::time::{ProfilerCategory, ProfilerChan};
 use profile_traits::time_profile;
@@ -914,11 +915,14 @@ impl Painter {
         &mut self,
         webview_id: WebViewId,
         delta: LayoutVector2D,
+        scroll_type: WebViewViewportScrollType,
     ) {
         let Some(webview_renderer) = self.webview_renderers.get_mut(&webview_id) else {
             return;
         };
-        let (pinch_zoom_result, scroll_results) = webview_renderer.scroll_viewport_by_delta(delta);
+        let (pinch_zoom_result, scroll_results) =
+            webview_renderer.scroll_viewport_by_delta(delta, scroll_type);
+
         self.send_zoom_and_scroll_offset_updates(
             pinch_zoom_result == PinchZoomResult::DidPinchZoom,
             scroll_results,

--- a/components/paint/webview_renderer.rs
+++ b/components/paint/webview_renderer.rs
@@ -19,7 +19,7 @@ use paint_api::display_list::ScrollType;
 use paint_api::viewport_description::{
     DEFAULT_PAGE_ZOOM, MAX_PAGE_ZOOM, MIN_PAGE_ZOOM, ViewportDescription,
 };
-use paint_api::{PipelineExitSource, SendableFrameTree, WebViewTrait};
+use paint_api::{PipelineExitSource, SendableFrameTree, WebViewTrait, WebViewViewportScrollType};
 use rustc_hash::FxHashMap;
 use servo_base::id::{PipelineId, WebViewId};
 use servo_constellation_traits::{
@@ -913,6 +913,7 @@ impl WebViewRenderer {
     pub(crate) fn scroll_viewport_by_delta(
         &mut self,
         delta: LayoutVector2D,
+        scroll_type: WebViewViewportScrollType,
     ) -> (PinchZoomResult, Vec<ScrollResult>) {
         let device_pixels_per_page_pixel = self.device_pixels_per_page_pixel();
         let delta_in_device_pixels = delta.cast_unit() * device_pixels_per_page_pixel;
@@ -925,7 +926,13 @@ impl WebViewRenderer {
             true => PinchZoomResult::DidNotPinchZoom,
             false => PinchZoomResult::DidPinchZoom,
         };
-        if remaining == Vector2D::zero() {
+
+        if pinch_zoom_result == PinchZoomResult::DidPinchZoom {
+            self.send_pinch_zoom_infos_to_script();
+        }
+
+        if scroll_type == WebViewViewportScrollType::PinchZoomOnly || remaining == Vector2D::zero()
+        {
             return (pinch_zoom_result, vec![]);
         }
 
@@ -955,10 +962,6 @@ impl WebViewRenderer {
         };
 
         self.send_scroll_positions_to_layout_for_pipeline(root_pipeline_id, external_scroll_id);
-
-        if pinch_zoom_result == PinchZoomResult::DidPinchZoom {
-            self.send_pinch_zoom_infos_to_script();
-        }
 
         let scroll_result = ScrollResult {
             hit_test_result,

--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -26,6 +26,7 @@ use js::context::JSContext;
 use js::jsapi::JSAutoRealm;
 use keyboard_types::{Code, Key, KeyState, Modifiers, NamedKey};
 use layout_api::{ScrollContainerQueryFlags, node_id_from_scroll_id};
+use paint_api::WebViewViewportScrollType;
 use rustc_hash::FxHashMap;
 use script_bindings::codegen::GenericBindings::DocumentBinding::DocumentMethods;
 use script_bindings::codegen::GenericBindings::ElementBinding::ScrollLogicalPosition;
@@ -2311,9 +2312,11 @@ impl DocumentEventHandler {
         let parent_pipeline = self.window.parent_info();
         if scrolling_box.is_viewport() && parent_pipeline.is_none() {
             let (_, delta) = calculate_current_scroll_offset_and_delta();
-            self.window
-                .paint_api()
-                .scroll_viewport_by_delta(self.window.webview_id(), delta);
+            self.window.paint_api().scroll_viewport_by_delta(
+                self.window.webview_id(),
+                delta,
+                WebViewViewportScrollType::Whole,
+            );
         }
 
         // If this is the viewport and we cannot scroll, try to ask a parent viewport to scroll,

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -929,7 +929,26 @@ impl Element {
             }
         }
 
-        let window_proxy = self.owner_window().window_proxy();
+        let window = self.owner_window();
+
+        // If window is top level then try to scroll into view the visual viewport that is associated
+        // with the window. If there are no visual viewport, then we doesn't need to do anything since
+        // the visual viewport is the same as the layout viewport.
+        if window.is_top_level() {
+            if container.is_none() &&
+                let Some(visual_viewport) = window.get_visual_viewport()
+            {
+                visual_viewport.scroll_target_into_view_with_options(
+                    behavior,
+                    block,
+                    inline,
+                    get_target_rect(),
+                );
+            }
+            return;
+        }
+
+        let window_proxy = window.window_proxy();
         let Some(frame_element) = window_proxy.frame_element() else {
             return;
         };

--- a/components/script/dom/scrolling_box.rs
+++ b/components/script/dom/scrolling_box.rs
@@ -244,7 +244,7 @@ impl ScrollingBox {
 
     /// Step 10 from <https://drafts.csswg.org/cssom-view/#determine-the-scroll-into-view-position>:
     // TODO: we are not considering the coordinate system of the element while deciding the scroll position.
-    fn calculate_scroll_position_one_axis(
+    pub(crate) fn calculate_scroll_position_one_axis(
         state: ScrollAxisState,
         element_start: f32,
         element_end: f32,

--- a/components/script/dom/visualviewport.rs
+++ b/components/script/dom/visualviewport.rs
@@ -4,12 +4,13 @@
 
 use std::cell::Cell;
 
+use app_units::Au;
 use bitflags::bitflags;
 use dom_struct::dom_struct;
-use euclid::{Rect, Scale, Size2D};
-use paint_api::PinchZoomInfos;
+use euclid::{Rect, Scale, Size2D, Vector2D};
+use paint_api::{PinchZoomInfos, WebViewViewportScrollType};
 use script_bindings::codegen::GenericBindings::VisualViewportBinding::VisualViewportMethods;
-use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
+use script_bindings::codegen::GenericBindings::WindowBinding::{ScrollBehavior, WindowMethods};
 use script_bindings::inheritance::Castable;
 use script_bindings::num::Finite;
 use script_bindings::root::{Dom, DomRoot};
@@ -19,6 +20,7 @@ use webrender_api::units::DevicePixel;
 
 use crate::dom::bindings::reflector::reflect_dom_object;
 use crate::dom::eventtarget::EventTarget;
+use crate::dom::scrolling_box::{ScrollAxisState, ScrollingBox};
 use crate::dom::window::Window;
 
 /// <https://drafts.csswg.org/cssom-view/#the-visualviewport-interface>
@@ -120,6 +122,54 @@ impl VisualViewport {
         self.window
             .Document()
             .finish_handle_scroll_event(self.upcast());
+    }
+
+    /// Apply scroll into view algorithm to the [`VisualViewport`]. This essentially implement
+    /// steps 1.3.1 of <https://drafts.csswg.org/cssom-view/#scroll-a-target-into-view>.
+    // TODO: It could be better for `VisualViewport` to be integrated as one of the `ScrollingBox`
+    // types. Thus, moving all of these utilities into `ScrollingBox`. Although we should define
+    // other behavior like keyboard scroll for `VisualViewport`.
+    pub(crate) fn scroll_target_into_view_with_options(
+        &self,
+        _behavior: ScrollBehavior,
+        block: ScrollAxisState,
+        inline: ScrollAxisState,
+        target_rect: Rect<Au, CSSPixel>,
+    ) {
+        let device_pixel_ratio = self.window.device_pixel_ratio();
+        let to_pixel = |value: Au| value.to_nearest_pixel(device_pixel_ratio.0);
+
+        let visual_viewport_rect = self.viewport_rect.get();
+        let target_rect_top_left = target_rect.origin.map(to_pixel) - visual_viewport_rect.origin;
+        let target_rect_bottom_right =
+            target_rect.max().map(to_pixel) - visual_viewport_rect.origin;
+
+        // TODO: Together with the implementation within `ScrollingBox` we are not considering the
+        // writing mode properly for the VisualViewport. From reverse engineering, it should
+        // follow the writing mode of root node.
+        let scroll_position = Vector2D::new(
+            ScrollingBox::calculate_scroll_position_one_axis(
+                inline,
+                target_rect_top_left.x,
+                target_rect_bottom_right.x,
+                visual_viewport_rect.width(),
+                visual_viewport_rect.origin.x,
+            ),
+            ScrollingBox::calculate_scroll_position_one_axis(
+                block,
+                target_rect_top_left.y,
+                target_rect_bottom_right.y,
+                visual_viewport_rect.height(),
+                visual_viewport_rect.origin.y,
+            ),
+        );
+
+        let scroll_delta = scroll_position - visual_viewport_rect.origin.to_vector();
+        self.window.paint_api().scroll_viewport_by_delta(
+            self.window.webview_id(),
+            scroll_delta.cast_unit(),
+            WebViewViewportScrollType::PinchZoomOnly,
+        );
     }
 }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -3191,6 +3191,10 @@ impl Window {
         self.viewport_details.get()
     }
 
+    pub(crate) fn get_visual_viewport(&self) -> Option<DomRoot<VisualViewport>> {
+        self.visual_viewport.get()
+    }
+
     pub(crate) fn get_or_init_visual_viewport(&self, can_gc: CanGc) -> DomRoot<VisualViewport> {
         self.visual_viewport.or_init(|| {
             VisualViewport::new_from_layout_viewport(self, self.viewport_details().size, can_gc)

--- a/components/shared/paint/lib.rs
+++ b/components/shared/paint/lib.rs
@@ -113,10 +113,9 @@ pub enum PaintMessage {
         LayoutVector2D,
         ExternalScrollId,
     ),
-    /// Scroll the WebView's viewport by the given delta. This will also do panning
-    /// in the pinch zoom viewport if possible and the remaining delta will be used
-    /// to scroll the root layer.
-    ScrollViewportByDelta(WebViewId, LayoutVector2D),
+    /// Scroll the WebView's viewport by the given delta. Could be configured to limit
+    /// scroll to panning in the pinch zoom viewport, or with root layer.
+    ScrollViewportByDelta(WebViewId, LayoutVector2D, WebViewViewportScrollType),
     /// Update the rendering epoch of the given `Pipeline`.
     UpdateEpoch {
         /// The [`WebViewId`] that this display list belongs to.
@@ -295,11 +294,17 @@ impl CrossProcessPaintApi {
     ///
     /// Note the value provided here is in `DeviceIndependentPixels` and will first be
     /// converted to `DevicePixels` by the renderer.
-    pub fn scroll_viewport_by_delta(&self, webview_id: WebViewId, delta: LayoutVector2D) {
-        if let Err(error) = self
-            .0
-            .send(PaintMessage::ScrollViewportByDelta(webview_id, delta))
-        {
+    pub fn scroll_viewport_by_delta(
+        &self,
+        webview_id: WebViewId,
+        delta: LayoutVector2D,
+        scroll_type: WebViewViewportScrollType,
+    ) {
+        if let Err(error) = self.0.send(PaintMessage::ScrollViewportByDelta(
+            webview_id,
+            delta,
+            scroll_type,
+        )) {
             warn!("Error scroll viewport: {error}");
         }
     }
@@ -840,4 +845,13 @@ impl PinchZoomInfos {
             rect: Rect::from_size(size),
         }
     }
+}
+
+/// The scroll operation type for [`PaintMessage::ScrollViewportByDelta`].
+#[derive(Deserialize, IntoStaticStr, PartialEq, Serialize)]
+pub enum WebViewViewportScrollType {
+    /// Do pinch zoom panning and the remaining delta will be used to scroll the root layer.
+    Whole,
+    /// Do pinch zoom panning only.
+    PinchZoomOnly,
 }


### PR DESCRIPTION
In the `ScrollIntoView` API, while iterating the scrolling box add a step to scroll the `VisualViewport`. It is included as the last step of the *scroll a target into view* algorithm when we are in the top level `Window` because `PinchZoom` are only applicable to that `Window`.

Additionally, add `WebViewViewportScrollType` enum to the `CrossProcessApi` to provide a method to help with the scrolling of the `VisualViewport`.

Testing: Existing WPTs
Fixes: https://github.com/servo/servo/issues/42903
