### PR TITLE
script: Don't panic when trying to de-activate accessibility

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3723,11 +3723,13 @@ impl ScriptThread {
             return;
         }
 
-        let document = self
-            .documents
-            .borrow()
-            .find_document(pipeline_id)
-            .expect("Got pipeline_id from self.documents");
+        let Some(document) = self.documents.borrow().find_document(pipeline_id) else {
+            if active {
+                error!("Trying to set accessibility active on stale document: {pipeline_id}");
+            }
+            return;
+        };
+
         document
             .window()
             .layout()


### PR DESCRIPTION
When reloading, the pipeline is closed before we get the chance to set accessibility inactive, which we do for pipelines which stick around in the bfcache. We don't need to panic if we're trying to de-activate accessibility and the pipeline is already closed.

Trying to activate accessibility on a closed pipeline is an error we should investigate, but probably also not a panic-worthy condition.

Testing: Not sure how to test this beyond manual testing. Manual testing: run servoshell with `--pref accessibility_enabled` and reload any page.