### PR TITLE
layout: Consider Gaussian blur when computing clip rectangle for `box-shadow` display list item

### DIFF
--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -1902,21 +1902,24 @@ impl<'a> BuilderForBoxFragment<'a> {
             );
             let spread = box_shadow.spread.px();
             let blur = box_shadow.base.blur.px();
-            // Match webrender's `fn add_box_shadow` in box_shadow.rs logic:
-            //
-            // shadow_rect = rect.translate(offset).inflate(spread_amount, spread_amount)
-            // blur_offset = (BLUR_SAMPLE_SCALE * blur).ceil()  (BLUR_SAMPLE_SCALE = 3.0)
-            // dest_rect = shadow_rect.inflate(blur_offset, blur_offset)
-            let spread_amount = match clip_mode {
-                BoxShadowClipMode::Outset => spread,
-                BoxShadowClipMode::Inset => -spread,
+            let clip_rect = match clip_mode {
+                // Inset shadows are always inside the rect.
+                BoxShadowClipMode::Inset => rect,
+                // Match webrender's `fn add_box_shadow` in box_shadow.rs logic:
+                //
+                // shadow_rect = rect.translate(offset).inflate(spread_amount, spread_amount)
+                // blur_offset = (BLUR_SAMPLE_SCALE * blur).ceil()  (BLUR_SAMPLE_SCALE = 3.0)
+                // dest_rect = shadow_rect.inflate(blur_offset, blur_offset)
+                BoxShadowClipMode::Outset => {
+                    let blur_offset = (blur * 3.0).ceil();
+                    let dest_rect = rect
+                        .translate(offset)
+                        .inflate(spread, spread)
+                        .inflate(blur_offset, blur_offset);
+                    rect.union(&dest_rect)
+                },
             };
-            let blur_offset = (blur * 3.0).ceil();
-            let dest_rect = rect
-                .translate(offset)
-                .inflate(spread_amount, spread_amount)
-                .inflate(blur_offset, blur_offset);
-            let common = builder.common_properties(rect.union(&dest_rect), &style);
+            let common = builder.common_properties(clip_rect, &style);
 
             builder.wr().push_box_shadow(
                 &common,

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -1908,10 +1908,10 @@ impl<'a> BuilderForBoxFragment<'a> {
                 // Match webrender's box_shadow.rs Gaussian blur inflation.
                 // (BLUR_SAMPLE_SCALE * blur).ceil(). BLUR_SAMPLE_SCALE is 3.0.
                 BoxShadowClipMode::Outset => {
-                    let blur_offset = (blur * 3.0).ceil();
+                    let extra_size_from_blur = (blur * 3.0).ceil();
                     rect.translate(offset)
                         .inflate(spread, spread)
-                        .inflate(blur_offset, blur_offset)
+                        .inflate(extra_size_from_blur, extra_size_from_blur)
                 },
             };
             let common = builder.common_properties(clip_rect, &style);

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -1902,10 +1902,21 @@ impl<'a> BuilderForBoxFragment<'a> {
             );
             let spread = box_shadow.spread.px();
             let blur = box_shadow.base.blur.px();
-            let shifted = rect.translate(offset);
-            let spread_rect = shifted.inflate(spread, spread);
-            let shadow_rect = spread_rect.inflate(blur, blur);
-            let common = builder.common_properties(rect.union(&shadow_rect), &style);
+            // Match webrender's `fn add_box_shadow` in box_shadow.rs logic:
+            //
+            // shadow_rect = rect.translate(offset).inflate(spread_amount, spread_amount)
+            // blur_offset = (BLUR_SAMPLE_SCALE * blur).ceil()  (BLUR_SAMPLE_SCALE = 3.0)
+            // dest_rect = shadow_rect.inflate(blur_offset, blur_offset)
+            let spread_amount = match clip_mode {
+                BoxShadowClipMode::Outset => spread,
+                BoxShadowClipMode::Inset => -spread,
+            };
+            let blur_offset = (blur * 3.0).ceil();
+            let dest_rect = rect
+                .translate(offset)
+                .inflate(spread_amount, spread_amount)
+                .inflate(blur_offset, blur_offset);
+            let common = builder.common_properties(rect.union(&dest_rect), &style);
 
             builder.wr().push_box_shadow(
                 &common,

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -1905,18 +1905,13 @@ impl<'a> BuilderForBoxFragment<'a> {
             let clip_rect = match clip_mode {
                 // Inset shadows are always inside the rect.
                 BoxShadowClipMode::Inset => rect,
-                // Match webrender's `fn add_box_shadow` in box_shadow.rs logic:
-                //
-                // shadow_rect = rect.translate(offset).inflate(spread_amount, spread_amount)
-                // blur_offset = (BLUR_SAMPLE_SCALE * blur).ceil()  (BLUR_SAMPLE_SCALE = 3.0)
-                // dest_rect = shadow_rect.inflate(blur_offset, blur_offset)
+                // Match webrender's box_shadow.rs Gaussian blur inflation.
+                // (BLUR_SAMPLE_SCALE * blur).ceil(). BLUR_SAMPLE_SCALE is 3.0.
                 BoxShadowClipMode::Outset => {
                     let blur_offset = (blur * 3.0).ceil();
-                    let dest_rect = rect
-                        .translate(offset)
+                    rect.translate(offset)
                         .inflate(spread, spread)
-                        .inflate(blur_offset, blur_offset);
-                    rect.union(&dest_rect)
+                        .inflate(blur_offset, blur_offset)
                 },
             };
             let common = builder.common_properties(clip_rect, &style);
@@ -1924,13 +1919,10 @@ impl<'a> BuilderForBoxFragment<'a> {
             builder.wr().push_box_shadow(
                 &common,
                 rect,
-                LayoutVector2D::new(
-                    box_shadow.base.horizontal.px(),
-                    box_shadow.base.vertical.px(),
-                ),
+                offset,
                 rgba(style.resolve_color(&box_shadow.base.color)),
-                box_shadow.base.blur.px(),
-                box_shadow.spread.px(),
+                blur,
+                spread,
                 self.border_radius,
                 clip_mode,
             );


### PR DESCRIPTION
According to [spec](https://drafts.csswg.org/css-backgrounds/#shadow-blur), the exact algorithm is not defined. 

1. We use a scale consistent with webrender defined in [`fn add_box_shadow`](https://github.com/servo/webrender/blob/e1c924ebad9ffdfe8c8c606aba77eb3f888c396a/webrender/src/box_shadow.rs#L305) of `box_shadow.rs`.
2. For `inset`, we avoid extra computation as it should always be within the original rect anyway.


Testing: Successful [try](https://github.com/servo/servo/actions/runs/24875566269). Manually tested on Android with following image. I don't think it is possible to add a test for this.

| Previously | Now |
| -------- | -------- |
| ![Screenshot_20260424_145355.jpg](https://github.com/user-attachments/assets/f4a933e0-9d9a-4a7f-8371-3e0a737e12a5) | ![Screenshot_20260424_145624.jpg](https://github.com/user-attachments/assets/e97485d5-12ca-41b6-986a-5803673f8116) |

Fixes: #44472.
