### PR TITLE
script: propagate &mut JSContext in DebuggerGlobalScope::fire_add_debugee

### DIFF
--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -156,23 +156,27 @@ impl DebuggerGlobalScope {
 
     pub(crate) fn fire_add_debuggee(
         &self,
-        can_gc: CanGc,
+        cx: &mut JSContext,
         debuggee_global: &GlobalScope,
         debuggee_pipeline_id: PipelineId,
         debuggee_worker_id: Option<WorkerId>,
     ) {
-        let _realm = enter_realm(self);
-        let debuggee_pipeline_id =
-            crate::dom::pipelineid::PipelineId::new(self.upcast(), debuggee_pipeline_id, can_gc);
+        let mut realm = enter_auto_realm(cx, self);
+        let cx = &mut realm;
+        let debuggee_pipeline_id = crate::dom::pipelineid::PipelineId::new(
+            self.upcast(),
+            debuggee_pipeline_id,
+            CanGc::from_cx(cx),
+        );
         let event = DomRoot::upcast::<Event>(DebuggerAddDebuggeeEvent::new(
             self.upcast(),
             debuggee_global,
             &debuggee_pipeline_id,
             debuggee_worker_id.map(|id| id.to_string().into()),
-            can_gc,
+            CanGc::from_cx(cx),
         ));
         assert!(
-            event.fire(self.upcast(), can_gc),
+            event.fire(self.upcast(), CanGc::from_cx(cx)),
             "Guaranteed by DebuggerAddDebuggeeEvent::new"
         );
     }

--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -494,7 +494,7 @@ impl DedicatedWorkerGlobalScope {
                     cx,
                 );
                 debugger_global.fire_add_debuggee(
-                    CanGc::from_cx(cx),
+                    cx,
                     global.upcast(),
                     pipeline_id,
                     Some(worker_id),

--- a/components/script/dom/workers/serviceworkerglobalscope.rs
+++ b/components/script/dom/workers/serviceworkerglobalscope.rs
@@ -399,7 +399,7 @@ impl ServiceWorkerGlobalScope {
 
                 if let Some(debugger_global) = debugger_global.as_deref() {
                     debugger_global.fire_add_debuggee(
-                        CanGc::from_cx(cx),
+                        cx,
                         global_scope,
                         pipeline_id,
                         Some(worker_scope.worker_id()),

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3460,12 +3460,8 @@ impl ScriptThread {
             incomplete.theme,
             self.this.clone(),
         );
-        self.debugger_global.fire_add_debuggee(
-            CanGc::from_cx(cx),
-            window.upcast(),
-            incomplete.pipeline_id,
-            None,
-        );
+        self.debugger_global
+            .fire_add_debuggee(cx, window.upcast(), incomplete.pipeline_id, None);
 
         let mut realm = enter_auto_realm(cx, &*window);
         let cx = &mut realm;


### PR DESCRIPTION
Propagate `&mut JSContext` in `DebuggerGlobalScope::fire_add_debugee`

Testing: Successful build is enough
Fixes: Part of #42638 

Opened to reduces the complexity of #44254 