### PR TITLE
script: propagate &mut JSContext in DebuggerGlobalScope::fire_eval

### DIFF
--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -179,7 +179,7 @@ impl DebuggerGlobalScope {
 
     pub(crate) fn fire_eval(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         code: DOMString,
         debuggee_pipeline_id: PipelineId,
         debuggee_worker_id: Option<WorkerId>,

--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -191,7 +191,7 @@ impl DebuggerGlobalScope {
                 .replace(Some(result_sender))
                 .is_none()
         );
-        let _realm = enter_realm(self);
+        let _realm = enter_auto_realm(cx, self);
         let debuggee_pipeline_id = crate::dom::pipelineid::PipelineId::new(
             self.upcast(),
             debuggee_pipeline_id,

--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -191,7 +191,8 @@ impl DebuggerGlobalScope {
                 .replace(Some(result_sender))
                 .is_none()
         );
-        let _realm = enter_auto_realm(cx, self);
+        let mut realm = enter_auto_realm(cx, self);
+        let cx = &mut realm;
         let debuggee_pipeline_id = crate::dom::pipelineid::PipelineId::new(
             self.upcast(),
             debuggee_pipeline_id,

--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -179,7 +179,7 @@ impl DebuggerGlobalScope {
 
     pub(crate) fn fire_eval(
         &self,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
         code: DOMString,
         debuggee_pipeline_id: PipelineId,
         debuggee_worker_id: Option<WorkerId>,
@@ -192,18 +192,21 @@ impl DebuggerGlobalScope {
                 .is_none()
         );
         let _realm = enter_realm(self);
-        let debuggee_pipeline_id =
-            crate::dom::pipelineid::PipelineId::new(self.upcast(), debuggee_pipeline_id, can_gc);
+        let debuggee_pipeline_id = crate::dom::pipelineid::PipelineId::new(
+            self.upcast(),
+            debuggee_pipeline_id,
+            CanGc::from_cx(cx),
+        );
         let event = DomRoot::upcast::<Event>(DebuggerEvalEvent::new(
             self.upcast(),
             code,
             &debuggee_pipeline_id,
             debuggee_worker_id.map(|id| id.to_string().into()),
             frame_actor_id.map(|id| id.into()),
-            can_gc,
+            CanGc::from_cx(cx),
         ));
         assert!(
-            event.fire(self.upcast(), can_gc),
+            event.fire(self.upcast(), CanGc::from_cx(cx)),
             "Guaranteed by DebuggerEvalEvent::new"
         );
     }

--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -675,7 +675,7 @@ impl DedicatedWorkerGlobalScope {
                 DevtoolScriptControlMsg::WantsLiveNotifications(_pipe_id, _bool_val) => {},
                 DevtoolScriptControlMsg::Eval(code, id, frame_actor_id, reply) => {
                     self.debugger_global.fire_eval(
-                        CanGc::from_cx(cx),
+                        cx,
                         code.into(),
                         id,
                         Some(self.upcast::<WorkerGlobalScope>().worker_id()),

--- a/components/script/dom/workers/serviceworkerglobalscope.rs
+++ b/components/script/dom/workers/serviceworkerglobalscope.rs
@@ -500,7 +500,7 @@ impl ServiceWorkerGlobalScope {
                 DevtoolScriptControlMsg::Eval(code, id, frame_actor_id, reply) => {
                     if let Some(debugger_global) = self.debugger_global.as_deref() {
                         debugger_global.fire_eval(
-                            CanGc::from_cx(cx),
+                            cx,
                             code.into(),
                             id,
                             Some(self.upcast::<WorkerGlobalScope>().worker_id()),

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2237,14 +2237,8 @@ impl ScriptThread {
                 )
             },
             DevtoolScriptControlMsg::Eval(code, id, frame_actor_id, reply) => {
-                self.debugger_global.fire_eval(
-                    CanGc::from_cx(cx),
-                    code.into(),
-                    id,
-                    None,
-                    frame_actor_id,
-                    reply,
-                );
+                self.debugger_global
+                    .fire_eval(cx, code.into(), id, None, frame_actor_id, reply);
             },
             DevtoolScriptControlMsg::GetPossibleBreakpoints(spidermonkey_id, result_sender) => {
                 self.debugger_global.fire_get_possible_breakpoints(


### PR DESCRIPTION
Propagate `&mut JSContext` in `DebuggerGlobalScope::fire_eval`

Testing: Successful build is enough
Fixes: Part of #42638 

Opened to reduces the complexity of #44254 