### PR TITLE
script: propagate &mut JSContext in DebuggerGlobalScope::fire_get_possible_breakpoints

### DIFF
--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -210,7 +210,7 @@ impl DebuggerGlobalScope {
 
     pub(crate) fn fire_get_possible_breakpoints(
         &self,
-        can_gc: CanGc,
+        cx: &mut JSContext,
         spidermonkey_id: u32,
         result_sender: GenericSender<Vec<devtools_traits::RecommendedBreakpointLocation>>,
     ) {
@@ -223,17 +223,17 @@ impl DebuggerGlobalScope {
         let event = DomRoot::upcast::<Event>(DebuggerGetPossibleBreakpointsEvent::new(
             self.upcast(),
             spidermonkey_id,
-            can_gc,
+            CanGc::from_cx(cx),
         ));
         assert!(
-            event.fire(self.upcast(), can_gc),
+            event.fire(self.upcast(), CanGc::from_cx(cx)),
             "Guaranteed by DebuggerGetPossibleBreakpointsEvent::new"
         );
     }
 
     pub(crate) fn fire_set_breakpoint(
         &self,
-        can_gc: CanGc,
+        cx: &mut JSContext,
         spidermonkey_id: u32,
         script_id: u32,
         offset: u32,
@@ -243,10 +243,10 @@ impl DebuggerGlobalScope {
             spidermonkey_id,
             script_id,
             offset,
-            can_gc,
+            CanGc::from_cx(cx),
         ));
         assert!(
-            event.fire(self.upcast(), can_gc),
+            event.fire(self.upcast(), CanGc::from_cx(cx)),
             "Guaranteed by DebuggerSetBreakpointEvent::new"
         );
     }
@@ -290,9 +290,9 @@ impl DebuggerGlobalScope {
 
     pub(crate) fn fire_get_environment(
         &self,
+        cx: &mut JSContext,
         frame_actor_id: String,
         result_sender: GenericSender<String>,
-        can_gc: CanGc,
     ) {
         assert!(
             self.get_environment_result_sender
@@ -303,35 +303,35 @@ impl DebuggerGlobalScope {
         let event = DomRoot::upcast::<Event>(DebuggerGetEnvironmentEvent::new(
             self.upcast(),
             frame_actor_id.into(),
-            can_gc,
+            CanGc::from_cx(cx),
         ));
         assert!(
-            event.fire(self.upcast(), can_gc),
+            event.fire(self.upcast(), CanGc::from_cx(cx)),
             "Guaranteed by DebuggerGetEnvironmentEvent::new"
         );
     }
 
     pub(crate) fn fire_resume(
         &self,
+        cx: &mut JSContext,
         resume_limit_type: Option<String>,
         frame_actor_id: Option<String>,
-        can_gc: CanGc,
     ) {
         let event = DomRoot::upcast::<Event>(DebuggerResumeEvent::new(
             self.upcast(),
             resume_limit_type.map(DOMString::from),
             frame_actor_id.map(DOMString::from),
-            can_gc,
+            CanGc::from_cx(cx),
         ));
         assert!(
-            event.fire(self.upcast(), can_gc),
+            event.fire(self.upcast(), CanGc::from_cx(cx)),
             "Guaranteed by DebuggerResumeEvent::new"
         );
     }
 
     pub(crate) fn fire_clear_breakpoint(
         &self,
-        can_gc: CanGc,
+        cx: &mut JSContext,
         spidermonkey_id: u32,
         script_id: u32,
         offset: u32,
@@ -341,10 +341,10 @@ impl DebuggerGlobalScope {
             spidermonkey_id,
             script_id,
             offset,
-            can_gc,
+            CanGc::from_cx(cx),
         ));
         assert!(
-            event.fire(self.upcast(), can_gc),
+            event.fire(self.upcast(), CanGc::from_cx(cx)),
             "Guaranteed by DebuggerClearBreakpointEvent::new"
         );
     }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2248,26 +2248,18 @@ impl ScriptThread {
             },
             DevtoolScriptControlMsg::GetPossibleBreakpoints(spidermonkey_id, result_sender) => {
                 self.debugger_global.fire_get_possible_breakpoints(
-                    CanGc::from_cx(cx),
+                    cx,
                     spidermonkey_id,
                     result_sender,
                 );
             },
             DevtoolScriptControlMsg::SetBreakpoint(spidermonkey_id, script_id, offset) => {
-                self.debugger_global.fire_set_breakpoint(
-                    CanGc::from_cx(cx),
-                    spidermonkey_id,
-                    script_id,
-                    offset,
-                );
+                self.debugger_global
+                    .fire_set_breakpoint(cx, spidermonkey_id, script_id, offset);
             },
             DevtoolScriptControlMsg::ClearBreakpoint(spidermonkey_id, script_id, offset) => {
-                self.debugger_global.fire_clear_breakpoint(
-                    CanGc::from_cx(cx),
-                    spidermonkey_id,
-                    script_id,
-                    offset,
-                );
+                self.debugger_global
+                    .fire_clear_breakpoint(cx, spidermonkey_id, script_id, offset);
             },
             DevtoolScriptControlMsg::Interrupt => {
                 self.debugger_global.fire_interrupt(CanGc::from_cx(cx));
@@ -2282,18 +2274,12 @@ impl ScriptThread {
                 );
             },
             DevtoolScriptControlMsg::GetEnvironment(frame_actor_id, result_sender) => {
-                self.debugger_global.fire_get_environment(
-                    frame_actor_id,
-                    result_sender,
-                    CanGc::from_cx(cx),
-                );
+                self.debugger_global
+                    .fire_get_environment(cx, frame_actor_id, result_sender);
             },
             DevtoolScriptControlMsg::Resume(resume_limit_type, frame_actor_id) => {
-                self.debugger_global.fire_resume(
-                    resume_limit_type,
-                    frame_actor_id,
-                    CanGc::from_cx(cx),
-                );
+                self.debugger_global
+                    .fire_resume(cx, resume_limit_type, frame_actor_id);
                 self.debugger_paused.set(false);
             },
         }


### PR DESCRIPTION
Propagate `&mut JSContext` in `DebuggerGlobalScope::fire_get_possible_breakpoints` and related call sites.

Testing: Successful build is enough
Fixes: Part of #42638 

Opened to reduces the complexity of #44254 