### PR TITLE
script: propagate &mut JSContext in EventTarget::fire_event_with_params

### DIFF
--- a/components/script/dom/abortsignal.rs
+++ b/components/script/dom/abortsignal.rs
@@ -227,8 +227,7 @@ impl AbortSignal {
         self.abort_algorithms.borrow_mut().clear();
 
         // Step 3. Fire an event named abort at signal.
-        self.upcast::<EventTarget>()
-            .fire_event(atom!("abort"), CanGc::from_cx(cx));
+        self.upcast::<EventTarget>().fire_event(cx, atom!("abort"));
     }
 
     /// <https://dom.spec.whatwg.org/#abortsignal-aborted>

--- a/components/script/dom/audio/audiotracklist.rs
+++ b/components/script/dom/audio/audiotracklist.rs
@@ -93,7 +93,7 @@ impl AudioTrackList {
         let task_source = global.task_manager().media_element_task_source();
         task_source.queue(task!(media_track_change: move |cx| {
             let this = this.root();
-            this.upcast::<EventTarget>().fire_event(atom!("change"), CanGc::from_cx(cx));
+            this.upcast::<EventTarget>().fire_event(cx, atom!("change"));
         }));
     }
 

--- a/components/script/dom/bluetooth/bluetoothdevice.rs
+++ b/components/script/dom/bluetooth/bluetoothdevice.rs
@@ -237,7 +237,7 @@ impl BluetoothDevice {
 
         // Step 8.
         self.upcast::<EventTarget>()
-            .fire_bubbling_event(atom!("gattserverdisconnected"), CanGc::from_cx(cx));
+            .fire_bubbling_event(cx, atom!("gattserverdisconnected"));
     }
 
     // https://webbluetoothcg.github.io/web-bluetooth/#garbage-collect-the-connection

--- a/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
@@ -343,7 +343,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTCharacteristic {
 
                 // Step 5.5.3.
                 self.upcast::<EventTarget>()
-                    .fire_bubbling_event(atom!("characteristicvaluechanged"), CanGc::from_cx(cx));
+                    .fire_bubbling_event(cx, atom!("characteristicvaluechanged"));
 
                 // Step 5.5.4.
                 promise.resolve_native(&value, CanGc::from_cx(cx));

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -901,7 +901,7 @@ impl Document {
                 // Step 4.6.2 Set document's page showing flag to true.
                 document.page_showing.set(true);
                 // Step 4.6.3 Update the visibility state of document to "visible".
-                document.update_visibility_state(DocumentVisibilityState::Visible, CanGc::from_cx(cx));
+                document.update_visibility_state(cx, DocumentVisibilityState::Visible);
                 // Step 4.6.4 Fire a page transition event named pageshow at document's relevant
                 // global object with true.
                 let event = PageTransitionEvent::new(
@@ -1265,7 +1265,11 @@ impl Document {
     }
 
     // https://html.spec.whatwg.org/multipage/#current-document-readiness
-    pub(crate) fn set_ready_state(&self, state: DocumentReadyState, can_gc: CanGc) {
+    pub(crate) fn set_ready_state(
+        &self,
+        cx: &mut js::context::JSContext,
+        state: DocumentReadyState,
+    ) {
         match state {
             DocumentReadyState::Loading => {
                 if self.window().is_top_level() {
@@ -1291,7 +1295,7 @@ impl Document {
         self.ready_state.set(state);
 
         self.upcast::<EventTarget>()
-            .fire_event(atom!("readystatechange"), can_gc);
+            .fire_event(cx, atom!("readystatechange"));
     }
 
     /// Return whether scripting is enabled or not
@@ -1383,7 +1387,7 @@ impl Document {
     }
 
     /// <https://drafts.csswg.org/cssom-view/#document-run-the-scroll-steps>
-    pub(crate) fn run_the_scroll_steps(&self, can_gc: CanGc) {
+    pub(crate) fn run_the_scroll_steps(&self, cx: &mut js::context::JSContext) {
         // Step 1: For each scrolling box `box` that was scrolled:
         //
         // Note: Since scrolling is currently synchronous (no scroll animations /
@@ -1445,7 +1449,7 @@ impl Document {
             // fire an event named type that bubbles at target.
             let event = pending_event.event.clone();
             if pending_event.target.is::<Document>() {
-                pending_event.target.fire_bubbling_event(event, can_gc);
+                pending_event.target.fire_bubbling_event(cx, event);
             }
             // Step 2.2: Otherwise, if type is "scrollsnapchange", then:
             //  ....
@@ -1456,7 +1460,7 @@ impl Document {
             //
             // Step 2.4: Otherwise, fire an event named type at target.
             else {
-                pending_event.target.fire_event(event, can_gc);
+                pending_event.target.fire_event(cx, event);
             }
         }
 
@@ -2050,7 +2054,7 @@ impl Document {
     }
 
     // https://html.spec.whatwg.org/multipage/#unload-a-document
-    pub(crate) fn unload(&self, recursive_flag: bool, can_gc: CanGc) {
+    pub(crate) fn unload(&self, cx: &mut js::context::JSContext, recursive_flag: bool) {
         // TODO: Step 1, increase the event loop's termination nesting level by 1.
         // Step 2
         self.incr_ignore_opens_during_unload_counter();
@@ -2066,14 +2070,14 @@ impl Document {
                 false,                  // bubbles
                 false,                  // cancelable
                 self.salvageable.get(), // persisted
-                can_gc,
+                CanGc::from_cx(cx),
             );
             let event = event.upcast::<Event>();
             event.set_trusted(true);
             self.window
-                .dispatch_event_with_target_override(event, can_gc);
+                .dispatch_event_with_target_override(event, CanGc::from_cx(cx));
             // Step 6 Update the visibility state of oldDocument to "hidden".
-            self.update_visibility_state(DocumentVisibilityState::Hidden, can_gc);
+            self.update_visibility_state(cx, DocumentVisibilityState::Hidden);
         }
         // Step 7
         if !self.fired_unload.get() {
@@ -2082,13 +2086,13 @@ impl Document {
                 atom!("unload"),
                 EventBubbles::Bubbles,
                 EventCancelable::Cancelable,
-                can_gc,
+                CanGc::from_cx(cx),
             );
             event.set_trusted(true);
             let event_target = self.window.upcast::<EventTarget>();
             let has_listeners = event_target.has_listeners_for(&atom!("unload"));
             self.window
-                .dispatch_event_with_target_override(&event, can_gc);
+                .dispatch_event_with_target_override(&event, CanGc::from_cx(cx));
             self.fired_unload.set(true);
             // Step 9
             if has_listeners {
@@ -2105,7 +2109,7 @@ impl Document {
             for iframe in &iframes {
                 // TODO: handle the case of cross origin iframes.
                 let document = iframe.owner_document();
-                document.unload(true, can_gc);
+                document.unload(cx, true);
                 if !document.salvageable() {
                     self.salvageable.set(false);
                 }
@@ -2207,7 +2211,7 @@ impl Document {
                 }
 
                 // Step 9.1. Update the current document readiness to "complete".
-                document.set_ready_state(DocumentReadyState::Complete, CanGc::from_cx(cx));
+                document.set_ready_state(cx,DocumentReadyState::Complete);
 
                 // Step 9.2. If the Document object's browsing context is null, then abort these steps.
                 if document.browsing_context().is_none() {
@@ -2449,30 +2453,28 @@ impl Document {
         self.owner_global()
             .task_manager()
             .dom_manipulation_task_source()
-            .queue(
-                task!(fire_dom_content_loaded_event: move |cx| {
-                let document = document.root();
+            .queue(task!(fire_dom_content_loaded_event: move |cx| {
+            let document = document.root();
 
-                // Step 6.1 Set the Document's load timing info's DOM content loaded event start time
-                // to the current high resolution time given the Document's relevant global object.
-                update_with_current_instant(&document.dom_content_loaded_event_start);
+            // Step 6.1 Set the Document's load timing info's DOM content loaded event start time
+            // to the current high resolution time given the Document's relevant global object.
+            update_with_current_instant(&document.dom_content_loaded_event_start);
 
-                // Step 6.2 Fire an event named DOMContentLoaded at the Document object, with its bubbles
-                // attribute initialized to true.
-                document.upcast::<EventTarget>().fire_bubbling_event(atom!("DOMContentLoaded"), CanGc::from_cx(cx));
+            // Step 6.2 Fire an event named DOMContentLoaded at the Document object, with its bubbles
+            // attribute initialized to true.
+            document.upcast::<EventTarget>().fire_bubbling_event(cx, atom!("DOMContentLoaded"));
 
-                // Step 6.3 Set the Document's load timing info's DOM content loaded event end time to the current
-                // high resolution time given the Document's relevant global object.
-                update_with_current_instant(&document.dom_content_loaded_event_end);
+            // Step 6.3 Set the Document's load timing info's DOM content loaded event end time to the current
+            // high resolution time given the Document's relevant global object.
+            update_with_current_instant(&document.dom_content_loaded_event_end);
 
-                // TODO Step 6.4 Enable the client message queue of the ServiceWorkerContainer object whose associated
-                // service worker client is the Document object's relevant settings object.
+            // TODO Step 6.4 Enable the client message queue of the ServiceWorkerContainer object whose associated
+            // service worker client is the Document object's relevant settings object.
 
-                // TODO Step 6.5 Invoke WebDriver BiDi DOM content loaded with the Document's browsing context, and
-                // a new WebDriver BiDi navigation status whose id is the Document object's during-loading
-                // navigation ID for WebDriver BiDi, status is "pending", and url is the Document object's URL.
-                })
-            );
+            // TODO Step 6.5 Invoke WebDriver BiDi DOM content loaded with the Document's browsing context, and
+            // a new WebDriver BiDi navigation status whose id is the Document object's during-loading
+            // navigation ID for WebDriver BiDi, status is "pending", and url is the Document object's URL.
+            }));
 
         // html parsing has finished - set dom content loaded
         self.interactive_time
@@ -4474,7 +4476,11 @@ impl Document {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#visibility-state>
-    fn update_visibility_state(&self, visibility_state: DocumentVisibilityState, can_gc: CanGc) {
+    fn update_visibility_state(
+        &self,
+        cx: &mut js::context::JSContext,
+        visibility_state: DocumentVisibilityState,
+    ) {
         // Step 1 If document's visibility state equals visibilityState, then return.
         if self.visibility_state.get() == visibility_state {
             return;
@@ -4487,7 +4493,7 @@ impl Document {
             &self.global(),
             visibility_state,
             CrossProcessInstant::now(),
-            can_gc,
+            CanGc::from_cx(cx),
         );
         self.window
             .Performance()
@@ -4518,7 +4524,7 @@ impl Document {
 
         // Step 7 Fire an event named visibilitychange at document, with its bubbles attribute initialized to true.
         self.upcast::<EventTarget>()
-            .fire_bubbling_event(atom!("visibilitychange"), can_gc);
+            .fire_bubbling_event(cx, atom!("visibilitychange"));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#is-initial-about:blank>
@@ -4747,7 +4753,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         // Step 4. Parse HTML from string given document and compliantHTML.
         ServoParser::parse_html_document(&document, Some(compliant_html), url, None, None, cx);
         // Step 5. Return document.
-        document.set_ready_state(DocumentReadyState::Complete, CanGc::from_cx(cx));
+        document.set_ready_state(cx, DocumentReadyState::Complete);
         Ok(document)
     }
 

--- a/components/script/dom/document/document_embedder_controls.rs
+++ b/components/script/dom/document/document_embedder_controls.rs
@@ -219,7 +219,7 @@ impl DocumentEmbedderControls {
                 ControlElement::FileInput(input_element),
                 EmbedderControlResponse::FilePicker(response),
             ) => {
-                input_element.handle_file_picker_response(response, CanGc::from_cx(cx));
+                input_element.handle_file_picker_response(cx, response);
             },
             (
                 ControlElement::ContextMenu(context_menu_nodes),

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -153,7 +153,7 @@ impl DOMParserMethods<crate::DomTypeHolder> for DOMParser {
             },
         };
         // Step 4. Return document.
-        document.set_ready_state(DocumentReadyState::Complete, CanGc::from_cx(cx));
+        document.set_ready_state(cx, DocumentReadyState::Complete);
         Ok(document)
     }
 }

--- a/components/script/dom/event/event.rs
+++ b/components/script/dom/event/event.rs
@@ -1246,11 +1246,11 @@ impl TaskOnce for EventTask {
         let bubbles = self.bubbles;
         let cancelable = self.cancelable;
         target.fire_event_with_params(
+            cx,
             self.name,
             bubbles,
             cancelable,
             EventComposed::NotComposed,
-            CanGc::from_cx(cx),
         );
     }
 }
@@ -1264,7 +1264,7 @@ pub(crate) struct SimpleEventTask {
 impl TaskOnce for SimpleEventTask {
     fn run_once(self, cx: &mut js::context::JSContext) {
         let target = self.target.root();
-        target.fire_event(self.name, CanGc::from_cx(cx));
+        target.fire_event(cx, self.name);
     }
 }
 

--- a/components/script/dom/event/eventtarget.rs
+++ b/components/script/dom/event/eventtarget.rs
@@ -811,61 +811,75 @@ impl EventTarget {
     }
 
     // https://dom.spec.whatwg.org/#concept-event-fire
-    pub(crate) fn fire_event(&self, name: Atom, can_gc: CanGc) -> bool {
+    pub(crate) fn fire_event(&self, cx: &mut js::context::JSContext, name: Atom) -> bool {
         self.fire_event_with_params(
+            cx,
             name,
             EventBubbles::DoesNotBubble,
             EventCancelable::NotCancelable,
             EventComposed::NotComposed,
-            can_gc,
         )
     }
 
     // https://dom.spec.whatwg.org/#concept-event-fire
-    pub(crate) fn fire_bubbling_event(&self, name: Atom, can_gc: CanGc) -> bool {
+    pub(crate) fn fire_bubbling_event(&self, cx: &mut js::context::JSContext, name: Atom) -> bool {
         self.fire_event_with_params(
+            cx,
             name,
             EventBubbles::Bubbles,
             EventCancelable::NotCancelable,
             EventComposed::NotComposed,
-            can_gc,
         )
     }
 
     // https://dom.spec.whatwg.org/#concept-event-fire
-    pub(crate) fn fire_cancelable_event(&self, name: Atom, can_gc: CanGc) -> bool {
+    pub(crate) fn fire_cancelable_event(
+        &self,
+        cx: &mut js::context::JSContext,
+        name: Atom,
+    ) -> bool {
         self.fire_event_with_params(
+            cx,
             name,
             EventBubbles::DoesNotBubble,
             EventCancelable::Cancelable,
             EventComposed::NotComposed,
-            can_gc,
         )
     }
 
     // https://dom.spec.whatwg.org/#concept-event-fire
-    pub(crate) fn fire_bubbling_cancelable_event(&self, name: Atom, can_gc: CanGc) -> bool {
+    pub(crate) fn fire_bubbling_cancelable_event(
+        &self,
+        cx: &mut js::context::JSContext,
+        name: Atom,
+    ) -> bool {
         self.fire_event_with_params(
+            cx,
             name,
             EventBubbles::Bubbles,
             EventCancelable::Cancelable,
             EventComposed::NotComposed,
-            can_gc,
         )
     }
 
     /// <https://dom.spec.whatwg.org/#concept-event-fire>
     pub(crate) fn fire_event_with_params(
         &self,
+        cx: &mut js::context::JSContext,
         name: Atom,
         bubbles: EventBubbles,
         cancelable: EventCancelable,
         composed: EventComposed,
-        can_gc: CanGc,
     ) -> bool {
-        let event = Event::new(&self.global(), name, bubbles, cancelable, can_gc);
+        let event = Event::new(
+            &self.global(),
+            name,
+            bubbles,
+            cancelable,
+            CanGc::from_cx(cx),
+        );
         event.set_composed(composed.into());
-        event.fire(self, can_gc)
+        event.fire(self, CanGc::from_cx(cx))
     }
 
     /// <https://dom.spec.whatwg.org/#dom-eventtarget-addeventlistener>

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -153,7 +153,7 @@ impl EventSourceContext {
                 let event_source = event_source.root();
                 if event_source.ready_state.get() != ReadyState::Closed {
                     event_source.ready_state.set(ReadyState::Open);
-                    event_source.upcast::<EventTarget>().fire_event(atom!("open"), CanGc::from_cx(cx));
+                    event_source.upcast::<EventTarget>().fire_event(cx, atom!("open"));
                 }
             }),
         );
@@ -203,7 +203,7 @@ impl EventSourceContext {
                 event_source.ready_state.set(ReadyState::Connecting);
 
                 // Step 1.3.
-                event_source.upcast::<EventTarget>().fire_event(atom!("error"), CanGc::from_cx(cx));
+                event_source.upcast::<EventTarget>().fire_event(cx, atom!("error"));
 
                 // Step 2.
                 let duration = event_source.reconnection_time.get();
@@ -552,7 +552,7 @@ impl EventSource {
                 let event_source = event_source.root();
                 if event_source.ready_state.get() != ReadyState::Closed {
                     event_source.ready_state.set(ReadyState::Closed);
-                    event_source.upcast::<EventTarget>().fire_event(atom!("error"), CanGc::from_cx(cx));
+                    event_source.upcast::<EventTarget>().fire_event(cx, atom!("error"));
                 }
             }),
         );

--- a/components/script/dom/fullscreen/lib.rs
+++ b/components/script/dom/fullscreen/lib.rs
@@ -311,7 +311,7 @@ impl TaskOnce for ElementPerformFullscreenEnter {
             // TODO(#31866): we should queue this and fire them in update the rendering.
             document
                 .upcast::<EventTarget>()
-                .fire_event(atom!("fullscreenerror"), CanGc::from_cx(cx));
+                .fire_event(cx, atom!("fullscreenerror"));
             promise.reject_error(
                 Error::Type(c"fullscreen is not connected".to_owned()),
                 CanGc::from_cx(cx),
@@ -324,11 +324,11 @@ impl TaskOnce for ElementPerformFullscreenEnter {
         element.set_fullscreen_state(true);
         document.set_fullscreen_element(Some(&element));
         document.upcast::<EventTarget>().fire_event_with_params(
+            cx,
             atom!("fullscreenchange"),
             EventBubbles::Bubbles,
             EventCancelable::NotCancelable,
             EventComposed::Composed,
-            CanGc::from_cx(cx),
         );
 
         // Step 14.
@@ -365,11 +365,11 @@ impl TaskOnce for ElementPerformFullscreenExit {
         element.set_fullscreen_state(false);
         document.set_fullscreen_element(None);
         document.upcast::<EventTarget>().fire_event_with_params(
+            cx,
             atom!("fullscreenchange"),
             EventBubbles::Bubbles,
             EventCancelable::NotCancelable,
             EventComposed::Composed,
-            CanGc::from_cx(cx),
         );
 
         // Step 16

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -995,9 +995,7 @@ impl GlobalScope {
         };
 
         // Fire an event named close at otherPort.
-        dom_port
-            .upcast()
-            .fire_event(atom!("close"), CanGc::from_cx(cx));
+        dom_port.upcast().fire_event(cx, atom!("close"));
 
         let res = self.script_to_constellation_chan().send(
             ScriptToConstellationMessage::DisentanglePorts(port_id, None),
@@ -1060,7 +1058,7 @@ impl GlobalScope {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#disentangle>
-    pub(crate) fn disentangle_port(&self, port: &MessagePort, can_gc: CanGc) {
+    pub(crate) fn disentangle_port(&self, cx: &mut js::context::JSContext, port: &MessagePort) {
         let initiator_port = port.message_port_id();
         // Let otherPort be the MessagePort which initiatorPort was entangled with.
         let Some(other_port) = port.disentangle() else {
@@ -1103,7 +1101,7 @@ impl GlobalScope {
         // Fire an event named close at `otherPort`.
         // Note: done here if the port is managed by the same global as `initialPort`.
         if let Some(dom_port) = dom_port {
-            dom_port.upcast().fire_event(atom!("close"), can_gc);
+            dom_port.upcast().fire_event(cx, atom!("close"));
         }
 
         let chan = self.script_to_constellation_chan().clone();
@@ -1203,9 +1201,7 @@ impl GlobalScope {
             if dom_port.disentangled() {
                 // <https://html.spec.whatwg.org/multipage/#disentangle>
                 // Fire an event named close at otherPort.
-                dom_port
-                    .upcast()
-                    .fire_event(atom!("close"), CanGc::from_cx(cx));
+                dom_port.upcast().fire_event(cx, atom!("close"));
 
                 let res = self.script_to_constellation_chan().send(
                     ScriptToConstellationMessage::DisentanglePorts(*port_id, None),

--- a/components/script/dom/html/htmlbuttonelement.rs
+++ b/components/script/dom/html/htmlbuttonelement.rs
@@ -510,7 +510,7 @@ impl Activatable for HTMLButtonElement {
             // Step 3.2 If element's type attribute is in the Reset Button state, then reset
             // element's form owner and return.
             if button_type == ButtonType::Reset {
-                owner.reset(ResetFrom::NotFromForm, CanGc::from_cx(cx));
+                owner.reset(cx, ResetFrom::NotFromForm);
                 return;
             }
             // Step 3.3 If element's type attribute is in the Auto state, then return.

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -367,8 +367,8 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-form-reset>
-    fn Reset(&self, can_gc: CanGc) {
-        self.reset(ResetFrom::FromForm, can_gc);
+    fn Reset(&self, cx: &mut js::context::JSContext) {
+        self.reset(cx, ResetFrom::FromForm);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-form-elements>
@@ -1230,7 +1230,7 @@ impl HTMLFormElement {
                 // field, with the cancelable attribute initialized to true.
                 let not_canceled = field
                     .upcast::<EventTarget>()
-                    .fire_cancelable_event(atom!("invalid"), CanGc::from_cx(cx));
+                    .fire_cancelable_event(cx, atom!("invalid"));
                 // Step 6.2: If notCanceled is true, then add field to unhandled invalid controls.
                 if not_canceled {
                     return Some(field);
@@ -1379,7 +1379,7 @@ impl HTMLFormElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-form-reset>
-    pub(crate) fn reset(&self, _reset_method_flag: ResetFrom, can_gc: CanGc) {
+    pub(crate) fn reset(&self, cx: &mut js::context::JSContext, _reset_method_flag: ResetFrom) {
         // https://html.spec.whatwg.org/multipage/#locked-for-reset
         if self.marked_for_reset.get() {
             return;
@@ -1392,7 +1392,7 @@ impl HTMLFormElement {
         // with the bubbles and cancelable attributes initialized to true.
         let reset = self
             .upcast::<EventTarget>()
-            .fire_bubbling_cancelable_event(atom!("reset"), can_gc);
+            .fire_bubbling_cancelable_event(cx, atom!("reset"));
         if !reset {
             return;
         }
@@ -1405,7 +1405,7 @@ impl HTMLFormElement {
             .collect();
 
         for child in controls {
-            child.reset(can_gc);
+            child.reset(CanGc::from_cx(cx));
         }
         self.marked_for_reset.set(false);
     }

--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -807,8 +807,7 @@ impl HTMLIFrameElement {
         // TODO 5 Set childDocument's iframe load in progress flag.
 
         // Step 6. Fire an event named load at element.
-        self.upcast::<EventTarget>()
-            .fire_event(atom!("load"), CanGc::from_cx(cx));
+        self.upcast::<EventTarget>().fire_event(cx, atom!("load"));
 
         let blocker = &self.load_blocker;
         LoadBlocker::terminate(blocker, cx);

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -555,18 +555,16 @@ impl HTMLImageElement {
         // Fire image.onload and loadend
         if trigger_image_load {
             // TODO: https://html.spec.whatwg.org/multipage/#fire-a-progress-event-or-event
+            self.upcast::<EventTarget>().fire_event(cx, atom!("load"));
             self.upcast::<EventTarget>()
-                .fire_event(atom!("load"), CanGc::from_cx(cx));
-            self.upcast::<EventTarget>()
-                .fire_event(atom!("loadend"), CanGc::from_cx(cx));
+                .fire_event(cx, atom!("loadend"));
         }
 
         // Fire image.onerror
         if trigger_image_error {
+            self.upcast::<EventTarget>().fire_event(cx, atom!("error"));
             self.upcast::<EventTarget>()
-                .fire_event(atom!("error"), CanGc::from_cx(cx));
-            self.upcast::<EventTarget>()
-                .fire_event(atom!("loadend"), CanGc::from_cx(cx));
+                .fire_event(cx, atom!("loadend"));
         }
     }
 
@@ -1031,7 +1029,7 @@ impl HTMLImageElement {
                     let has_src_attribute = this.upcast::<Element>().has_attribute(&local_name!("src"));
 
                     if has_src_attribute || this.uses_srcset_or_picture() {
-                        this.upcast::<EventTarget>().fire_event(atom!("error"), CanGc::from_cx(cx));
+                        this.upcast::<EventTarget>().fire_event(cx, atom!("error"));
                     }
                 }));
 
@@ -1073,7 +1071,7 @@ impl HTMLImageElement {
                     // Step 13.4.2. If maybe omit events is not set or previousURL is not equal to
                     // selected source, then fire an event named error at the img element.
                     // TODO: Add missing `maybe omit events` flag and previousURL.
-                    this.upcast::<EventTarget>().fire_event(atom!("error"), CanGc::from_cx(cx));
+                    this.upcast::<EventTarget>().fire_event(cx, atom!("error"));
                 }));
 
             // Step 13.5. Return.
@@ -1197,7 +1195,7 @@ impl HTMLImageElement {
                             // Step 7.4.7.3. If maybe omit events is not set or previousURL is not
                             // equal to urlString, then fire an event named load at the img element.
                             // TODO: Add missing `maybe omit events` flag and previousURL.
-                            this.upcast::<EventTarget>().fire_event(atom!("load"), CanGc::from_cx(cx));
+                            this.upcast::<EventTarget>().fire_event(cx, atom!("load"));
                         }));
 
                     // Step 7.4.8. Abort the update the image data algorithm.
@@ -1479,7 +1477,7 @@ impl HTMLImageElement {
                 this.upcast::<Node>().dirty(NodeDamage::Other);
 
                 // Step 16.7. Fire an event named load at the img element.
-                this.upcast::<EventTarget>().fire_event(atom!("load"), CanGc::from_cx(cx));
+                this.upcast::<EventTarget>().fire_event(cx, atom!("load"));
             }));
     }
 

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -935,17 +935,15 @@ impl HTMLLinkElement {
     /// <https://html.spec.whatwg.org/multipage/#link-type-preload:fetch-and-process-the-linked-resource-2>
     pub(crate) fn fire_event_after_response(
         &self,
+        cx: &mut JSContext,
         response: Result<(), NetworkError>,
-        can_gc: CanGc,
     ) {
         // Step 3.1 If response is a network error, fire an event named error at el.
         // Otherwise, fire an event named load at el.
         if response.is_err() {
-            self.upcast::<EventTarget>()
-                .fire_event(atom!("error"), can_gc);
+            self.upcast::<EventTarget>().fire_event(cx, atom!("error"));
         } else {
-            self.upcast::<EventTarget>()
-                .fire_event(atom!("load"), can_gc);
+            self.upcast::<EventTarget>().fire_event(cx, atom!("load"));
         }
     }
 
@@ -1054,8 +1052,7 @@ impl HTMLLinkElement {
                     false => atom!("load"),
                 };
 
-                link.upcast::<EventTarget>()
-                    .fire_event(event, CanGc::from_cx(cx));
+                link.upcast::<EventTarget>().fire_event(cx, event);
             },
         );
     }

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -876,10 +876,10 @@ impl HTMLMediaElement {
 
                     this.fulfill_in_flight_play_promises(|| {
                         // Step 2.3.1. Fire an event named timeupdate at the element.
-                        this.upcast::<EventTarget>().fire_event(atom!("timeupdate"), CanGc::from_cx(cx));
+                        this.upcast::<EventTarget>().fire_event(cx, atom!("timeupdate"));
 
                         // Step 2.3.2. Fire an event named pause at the element.
-                        this.upcast::<EventTarget>().fire_event(atom!("pause"), CanGc::from_cx(cx));
+                        this.upcast::<EventTarget>().fire_event(cx, atom!("pause"));
 
                         // Step 2.3.3. Reject pending play promises with promises and an
                         // "AbortError" DOMException.
@@ -920,7 +920,7 @@ impl HTMLMediaElement {
 
                 this.fulfill_in_flight_play_promises(|| {
                     // Step 2.1. Fire an event named playing at the element.
-                    this.upcast::<EventTarget>().fire_event(atom!("playing"), CanGc::from_cx(cx));
+                    this.upcast::<EventTarget>().fire_event(cx, atom!("playing"));
 
                     // Step 2.2. Resolve pending play promises with promises.
                     // Done after running this closure in `fulfill_in_flight_play_promises`.
@@ -973,7 +973,7 @@ impl HTMLMediaElement {
                                 return;
                             }
 
-                            this.upcast::<EventTarget>().fire_event(atom!("loadeddata"), CanGc::from_cx(cx));
+                            this.upcast::<EventTarget>().fire_event(cx, atom!("loadeddata"));
                             // Once the readyState attribute reaches HAVE_CURRENT_DATA, after the
                             // loadeddata event has been fired, set the element's
                             // delaying-the-load-event flag to false.
@@ -1287,7 +1287,7 @@ impl HTMLMediaElement {
                 }
 
                 let source = trusted_source.root();
-                source.upcast::<EventTarget>().fire_event(atom!("error"), CanGc::from_cx(cx));
+                source.upcast::<EventTarget>().fire_event(cx, atom!("error"));
             }));
 
         // Step 9.children.11. Await a stable state.
@@ -1632,7 +1632,7 @@ impl HTMLMediaElement {
                     this.show_poster.set(true);
 
                     // Step 5. Fire an event named error at the media element.
-                    this.upcast::<EventTarget>().fire_event(atom!("error"), CanGc::from_cx(cx));
+                    this.upcast::<EventTarget>().fire_event(cx, atom!("error"));
 
                     if let Some(ref player) = *this.player.borrow() {
                         if let Err(error) = player.lock().unwrap().stop() {
@@ -1810,7 +1810,7 @@ impl HTMLMediaElement {
                     return;
                 }
 
-                this.upcast::<EventTarget>().fire_event(name, CanGc::from_cx(cx));
+                this.upcast::<EventTarget>().fire_event(cx, name);
             }));
     }
 
@@ -1957,8 +1957,7 @@ impl HTMLMediaElement {
         self.delay_load_event(false, cx);
 
         // Step 5. Fire an event named error at the media element.
-        self.upcast::<EventTarget>()
-            .fire_event(atom!("error"), CanGc::from_cx(cx));
+        self.upcast::<EventTarget>().fire_event(cx, atom!("error"));
 
         // Step 6. Abort the overall resource selection algorithm.
     }
@@ -2300,7 +2299,7 @@ impl HTMLMediaElement {
                 }
 
                 // Step 3.1. Fire an event named timeupdate at the media element.
-                this.upcast::<EventTarget>().fire_event(atom!("timeupdate"), CanGc::from_cx(cx));
+                this.upcast::<EventTarget>().fire_event(cx, atom!("timeupdate"));
 
                 // Step 3.2. If the media element has ended playback, the direction of playback is
                 // forwards, and paused is false, then:
@@ -2311,7 +2310,7 @@ impl HTMLMediaElement {
                     this.paused.set(true);
 
                     // Step 3.2.2. Fire an event named pause at the media element.
-                    this.upcast::<EventTarget>().fire_event(atom!("pause"), CanGc::from_cx(cx));
+                    this.upcast::<EventTarget>().fire_event(cx, atom!("pause"));
 
                     // Step 3.2.3. Take pending play promises and reject pending play promises with
                     // the result and an "AbortError" DOMException.
@@ -2320,7 +2319,7 @@ impl HTMLMediaElement {
                 }
 
                 // Step 3.3. Fire an event named ended at the media element.
-                this.upcast::<EventTarget>().fire_event(atom!("ended"), CanGc::from_cx(cx));
+                this.upcast::<EventTarget>().fire_event(cx, atom!("ended"));
             }));
 
         // <https://html.spec.whatwg.org/multipage/#dom-media-have_current_data>
@@ -3906,7 +3905,7 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
             // Step 1. Fire an event named progress at the media element.
             element
                 .upcast::<EventTarget>()
-                .fire_event(atom!("progress"), CanGc::from_cx(cx));
+                .fire_event(cx, atom!("progress"));
 
             // Step 2. Set the networkState to NETWORK_IDLE and fire an event named suspend at the
             // media element.
@@ -3914,7 +3913,7 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
 
             element
                 .upcast::<EventTarget>()
-                .fire_event(atom!("suspend"), CanGc::from_cx(cx));
+                .fire_event(cx, atom!("suspend"));
         } else if status.is_err() && element.ready_state.get() != ReadyState::HaveNothing {
             // => "If the connection is interrupted after some media data has been received..."
             element.media_data_processing_fatal_steps(MEDIA_ERR_NETWORK, cx);

--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -533,18 +533,17 @@ impl HTMLSelectElement {
                 // Step 2. Fire an event named input at the select element, with the bubbles and composed
                 // attributes initialized to true.
                 this.upcast::<EventTarget>()
-                    .fire_event_with_params(
+                    .fire_event_with_params(cx,
                         atom!("input"),
                         EventBubbles::Bubbles,
                         EventCancelable::NotCancelable,
                         EventComposed::Composed,
-                        CanGc::from_cx(cx),
                     );
 
                 // Step 3. Fire an event named change at the select element, with the bubbles attribute initialized
                 // to true.
                 this.upcast::<EventTarget>()
-                    .fire_bubbling_event(atom!("change"), CanGc::from_cx(cx));
+                    .fire_bubbling_event(cx, atom!("change"));
             }));
     }
 

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -260,12 +260,11 @@ impl HTMLTextAreaElement {
                     // Step 1. Set target's has scheduled selectionchange event to false.
                     this.has_scheduled_selectionchange_event.set(false);
                     // Step 2. If target is an element, fire an event named selectionchange, which bubbles and not cancelable, at target.
-                    this.upcast::<EventTarget>().fire_event_with_params(
+                    this.upcast::<EventTarget>().fire_event_with_params(cx,
                         atom!("selectionchange"),
                         EventBubbles::Bubbles,
                         EventCancelable::NotCancelable,
                         EventComposed::Composed,
-                        CanGc::from_cx(cx),
                     );
                     // Step 3. Otherwise, if target is a document, fire an event named selectionchange,
                     // which does not bubble and not cancelable, at target.

--- a/components/script/dom/html/input_element/checkbox_input_type.rs
+++ b/components/script/dom/html/input_element/checkbox_input_type.rs
@@ -45,16 +45,16 @@ impl SpecificInputType for CheckboxInputType {
         // Step 2: Fire an event named input at the element with the bubbles and composed
         // attributes initialized to true.
         target.fire_event_with_params(
+            cx,
             atom!("input"),
             EventBubbles::Bubbles,
             EventCancelable::NotCancelable,
             EventComposed::Composed,
-            CanGc::from_cx(cx),
         );
 
         // Step 3: Fire an event named change at the element with the bubbles attribute
         // initialized to true.
-        target.fire_bubbling_event(atom!("change"), CanGc::from_cx(cx));
+        target.fire_bubbling_event(cx, atom!("change"));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-input-element:legacy-pre-activation-behavior>

--- a/components/script/dom/html/input_element/file_input_type.rs
+++ b/components/script/dom/html/input_element/file_input_type.rs
@@ -74,9 +74,9 @@ impl FileInputType {
 
     pub(crate) fn handle_file_picker_response(
         &self,
+        cx: &mut js::context::JSContext,
         input: &HTMLInputElement,
         response: Option<Vec<SelectedFile>>,
-        can_gc: CanGc,
     ) {
         let mut files = Vec::new();
 
@@ -107,7 +107,7 @@ impl FileInputType {
         files.extend(
             response_files
                 .into_iter()
-                .map(|file| File::new_from_selected(&window, file, can_gc)),
+                .map(|file| File::new_from_selected(&window, file, CanGc::from_cx(cx))),
         );
 
         // Only use the last file if this isn't a multi-select file input. This could
@@ -119,17 +119,17 @@ impl FileInputType {
                 .unwrap_or_default();
         }
 
-        self.set_files(&FileList::new(&window, files, can_gc));
+        self.set_files(&FileList::new(&window, files, CanGc::from_cx(cx)));
 
         let target = input.upcast::<EventTarget>();
         target.fire_event_with_params(
+            cx,
             atom!("input"),
             EventBubbles::Bubbles,
             EventCancelable::NotCancelable,
             EventComposed::Composed,
-            can_gc,
         );
-        target.fire_bubbling_event(atom!("change"), can_gc);
+        target.fire_bubbling_event(cx, atom!("change"));
     }
 }
 

--- a/components/script/dom/html/input_element/mod.rs
+++ b/components/script/dom/html/input_element/mod.rs
@@ -925,12 +925,11 @@ impl HTMLInputElement {
                     // Step 1. Set target's has scheduled selectionchange event to false.
                     this.has_scheduled_selectionchange_event.set(false);
                     // Step 2. If target is an element, fire an event named selectionchange, which bubbles and not cancelable, at target.
-                    this.upcast::<EventTarget>().fire_event_with_params(
+                    this.upcast::<EventTarget>().fire_event_with_params(cx,
                         atom!("selectionchange"),
                         EventBubbles::Bubbles,
                         EventCancelable::NotCancelable,
                         EventComposed::Composed,
-                        CanGc::from_cx(cx),
                     );
                     // Step 3. Otherwise, if target is a document, fire an event named selectionchange,
                     // which does not bubble and not cancelable, at target.
@@ -1941,11 +1940,11 @@ impl HTMLInputElement {
 
     pub(crate) fn handle_file_picker_response(
         &self,
+        cx: &mut js::context::JSContext,
         response: Option<Vec<SelectedFile>>,
-        can_gc: CanGc,
     ) {
         if let InputType::File(ref file_input_type) = *self.input_type() {
-            file_input_type.handle_file_picker_response(self, response, can_gc)
+            file_input_type.handle_file_picker_response(cx, self, response)
         }
     }
 

--- a/components/script/dom/html/input_element/radio_input_type.rs
+++ b/components/script/dom/html/input_element/radio_input_type.rs
@@ -79,16 +79,16 @@ impl SpecificInputType for RadioInputType {
         // Step 2: Fire an event named input at the element with the bubbles and composed
         // attributes initialized to true.
         target.fire_event_with_params(
+            cx,
             atom!("input"),
             EventBubbles::Bubbles,
             EventCancelable::NotCancelable,
             EventComposed::Composed,
-            CanGc::from_cx(cx),
         );
 
         // Step 3: Fire an event named change at the element with the bubbles attribute
         // initialized to true.
-        target.fire_bubbling_event(atom!("change"), CanGc::from_cx(cx));
+        target.fire_bubbling_event(cx, atom!("change"));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-input-element:legacy-pre-activation-behavior>

--- a/components/script/dom/html/input_element/reset_input_type.rs
+++ b/components/script/dom/html/input_element/reset_input_type.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 use js::context::JSContext;
 use script_bindings::domstring::DOMString;
-use script_bindings::script_runtime::CanGc;
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::event::Event;
@@ -45,7 +44,7 @@ impl SpecificInputType for ResetInputType {
             }
 
             // Step 3: Reset the form owner from the element.
-            form_owner.reset(ResetFrom::NotFromForm, CanGc::from_cx(cx));
+            form_owner.reset(cx, ResetFrom::NotFromForm);
         }
     }
 

--- a/components/script/dom/media/videotracklist.rs
+++ b/components/script/dom/media/videotracklist.rs
@@ -95,9 +95,9 @@ impl VideoTrackList {
         self.global()
             .task_manager()
             .media_element_task_source()
-            .queue(task!(media_track_change: move || {
+            .queue(task!(media_track_change: move |cx| {
                 let this = this.root();
-                this.upcast::<EventTarget>().fire_event(atom!("change"), CanGc::deprecated_note());
+                this.upcast::<EventTarget>().fire_event(cx, atom!("change"));
             }));
     }
 

--- a/components/script/dom/messageport.rs
+++ b/components/script/dom/messageport.rs
@@ -341,7 +341,7 @@ impl MessagePortMethods<crate::DomTypeHolder> for MessagePort {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-messageport-close>
-    fn Close(&self, can_gc: CanGc) {
+    fn Close(&self, cx: &mut JSContext) {
         // Set this's [[Detached]] internal slot value to true.
         self.detached.set(true);
 
@@ -349,7 +349,7 @@ impl MessagePortMethods<crate::DomTypeHolder> for MessagePort {
         global.close_message_port(self.message_port_id());
 
         // If this is entangled, disentangle it.
-        global.disentangle_port(self, can_gc);
+        global.disentangle_port(cx, self);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#handler-messageport-onmessage>

--- a/components/script/dom/performance/performance.rs
+++ b/components/script/dom/performance/performance.rs
@@ -409,13 +409,13 @@ impl Performance {
     }
     // `fire a buffer full event` paragraph of
     /// <https://w3c.github.io/resource-timing/#sec-extensions-performance-interface>
-    fn fire_buffer_full_event(&self, can_gc: CanGc) {
+    fn fire_buffer_full_event(&self, cx: &mut js::context::JSContext) {
         while !self.resource_timing_secondary_entries.borrow().is_empty() {
             let no_of_excess_entries_before = self.resource_timing_secondary_entries.borrow().len();
 
             if !self.can_add_resource_timing_entry() {
                 self.upcast::<EventTarget>()
-                    .fire_event(atom!("resourcetimingbufferfull"), can_gc);
+                    .fire_event(cx, atom!("resourcetimingbufferfull"));
             }
             self.copy_secondary_resource_timing_buffer();
             let no_of_excess_entries_after = self.resource_timing_secondary_entries.borrow().len();
@@ -448,8 +448,8 @@ impl Performance {
             self.global()
                 .task_manager()
                 .performance_timeline_task_source()
-                .queue(task!(fire_a_buffer_full_event: move || {
-                    performance.root().fire_buffer_full_event(CanGc::deprecated_note());
+                .queue(task!(fire_a_buffer_full_event: move |cx| {
+                    performance.root().fire_buffer_full_event(cx);
                 }));
         }
 

--- a/components/script/dom/processingoptions.rs
+++ b/components/script/dom/processingoptions.rs
@@ -37,7 +37,6 @@ use crate::dom::performance::performanceresourcetiming::InitiatorType;
 use crate::dom::types::HTMLLinkElement;
 use crate::fetch::create_a_potential_cors_request;
 use crate::network_listener::{FetchResponseListener, ResourceTimingListener, submit_timing};
-use crate::script_runtime::CanGc;
 
 trait ValueForKeyInLinkHeader {
     fn has_key_in_link_header(&self, key: &str) -> bool;
@@ -532,8 +531,7 @@ impl FetchResponseListener for LinkFetchContext {
         //
         // Part of Prefetch
         if let Some(link) = self.link.as_ref() {
-            link.root()
-                .fire_event_after_response(response_result, CanGc::from_cx(cx));
+            link.root().fire_event_after_response(cx, response_result);
         }
     }
 

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -115,8 +115,8 @@ impl Selection {
 
                     // Step 3. Otherwise, if target is a document, fire an event named selectionchange,
                     // which does not bubble and not cancelable, at target.
-                    this.document.upcast::<EventTarget>().fire_event(atom!("selectionchange"), CanGc::from_cx(cx));
-                })
+                    this.document.upcast::<EventTarget>().fire_event(cx, atom!("selectionchange"));
+                }),
             );
     }
 

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -486,7 +486,7 @@ impl ServoParser {
 
         // Step 2.
         self.document
-            .set_ready_state(DocumentReadyState::Interactive, CanGc::from_cx(cx));
+            .set_ready_state(cx, DocumentReadyState::Interactive);
 
         // Step 3.
         self.tokenizer.end(cx);
@@ -494,7 +494,7 @@ impl ServoParser {
 
         // Step 4.
         self.document
-            .set_ready_state(DocumentReadyState::Complete, CanGc::from_cx(cx));
+            .set_ready_state(cx, DocumentReadyState::Complete);
     }
 
     // https://html.spec.whatwg.org/multipage/#active-parser
@@ -756,7 +756,7 @@ impl ServoParser {
 
         // Step 1.
         self.document
-            .set_ready_state(DocumentReadyState::Interactive, CanGc::from_cx(cx));
+            .set_ready_state(cx, DocumentReadyState::Interactive);
 
         // Step 2.
         self.tokenizer.end(cx);

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -2381,7 +2381,7 @@ impl CrossRealmTransformReadable {
             self.controller.close(CanGc::from_cx(cx));
 
             // Disentangle port.
-            global.disentangle_port(port, CanGc::from_cx(cx));
+            global.disentangle_port(cx, port);
         }
 
         // Otherwise, if type is "error",
@@ -2390,7 +2390,7 @@ impl CrossRealmTransformReadable {
             self.controller.error(value.handle(), CanGc::from_cx(cx));
 
             // Disentangle port.
-            global.disentangle_port(port, CanGc::from_cx(cx));
+            global.disentangle_port(cx, port);
         }
     }
 
@@ -2415,7 +2415,7 @@ impl CrossRealmTransformReadable {
             .error(rooted_error.handle(), CanGc::from_cx(cx));
 
         // Disentangle port.
-        global.disentangle_port(port, CanGc::from_cx(cx));
+        global.disentangle_port(cx, port);
     }
 }
 

--- a/components/script/dom/stream/underlyingsourcecontainer.rs
+++ b/components/script/dom/stream/underlyingsourcecontainer.rs
@@ -159,7 +159,7 @@ impl UnderlyingSourceContainer {
                     port.pack_and_post_message_handling_error("error", reason, CanGc::from_cx(cx));
 
                 // Disentangle port.
-                self.global().disentangle_port(port, CanGc::from_cx(cx));
+                self.global().disentangle_port(cx, port);
 
                 let promise = Promise::new2(cx, &self.global());
 

--- a/components/script/dom/stream/writablestream.rs
+++ b/components/script/dom/stream/writablestream.rs
@@ -1215,7 +1215,7 @@ impl CrossRealmTransformWritable {
             .error_if_needed(cx, rooted_error.handle(), global);
 
         // Disentangle port.
-        global.disentangle_port(port, CanGc::from_cx(cx));
+        global.disentangle_port(cx, port);
     }
 }
 

--- a/components/script/dom/stream/writablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/writablestreamdefaultcontroller.rs
@@ -181,7 +181,7 @@ impl Callback for TransferBackPressurePromiseReaction {
         // If result is an abrupt completion,
         if let Err(error) = result {
             // Disentangle port.
-            global.disentangle_port(&self.port, can_gc);
+            global.disentangle_port(cx, &self.port);
 
             // Return a promise rejected with result.[[Value]].
             self.result_promise.reject_error(error, can_gc);
@@ -628,7 +628,7 @@ impl WritableStreamDefaultController {
                     port.pack_and_post_message_handling_error("error", reason, CanGc::from_cx(cx));
 
                 // Disentangle port.
-                global.disentangle_port(port, CanGc::from_cx(cx));
+                global.disentangle_port(cx, port);
 
                 let promise = Promise::new(global, CanGc::from_cx(cx));
 
@@ -792,7 +792,7 @@ impl WritableStreamDefaultController {
                     .expect("Sending close should not fail.");
 
                 // Disentangle port.
-                global.disentangle_port(port, CanGc::from_cx(cx));
+                global.disentangle_port(cx, port);
 
                 // Return a promise resolved with undefined.
                 Promise::new_resolved(global, cx.into(), (), CanGc::from_cx(cx))

--- a/components/script/dom/validation.rs
+++ b/components/script/dom/validation.rs
@@ -45,7 +45,7 @@ pub(crate) trait Validatable {
         if self.is_instance_validatable() && !self.satisfies_constraints(CanGc::from_cx(cx)) {
             self.as_element()
                 .upcast::<EventTarget>()
-                .fire_cancelable_event(atom!("invalid"), CanGc::from_cx(cx));
+                .fire_cancelable_event(cx, atom!("invalid"));
             false
         } else {
             true
@@ -68,7 +68,7 @@ pub(crate) trait Validatable {
         let report = self
             .as_element()
             .upcast::<EventTarget>()
-            .fire_cancelable_event(atom!("invalid"), CanGc::from_cx(cx));
+            .fire_cancelable_event(cx, atom!("invalid"));
 
         // Step 1.2. If `report` is true, for the element,
         // report the problem, run focusing steps, scroll into view.

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -521,7 +521,7 @@ impl TaskOnce for ConnectionEstablishedTask {
         };
 
         // Step 4.
-        ws.upcast().fire_event(atom!("open"), CanGc::from_cx(cx));
+        ws.upcast().fire_event(cx, atom!("open"));
     }
 }
 
@@ -567,7 +567,7 @@ impl TaskOnce for CloseTask {
 
         // Step 2.
         if self.failed {
-            ws.upcast().fire_event(atom!("error"), CanGc::from_cx(cx));
+            ws.upcast().fire_event(cx, atom!("error"));
         }
 
         // Step 3.

--- a/components/script/dom/webvtt/texttracklist.rs
+++ b/components/script/dom/webvtt/texttracklist.rs
@@ -99,13 +99,13 @@ impl TextTrackList {
     // FIXME(#22314, dlrobertson) allow TextTracks to be
     // removed from the TextTrackList.
     #[expect(dead_code)]
-    pub(crate) fn remove(&self, idx: usize, can_gc: CanGc) {
+    pub(crate) fn remove(&self, cx: &mut js::context::JSContext, idx: usize) {
         if let Some(track) = self.dom_tracks.borrow().get(idx) {
             track.remove_track_list();
         }
         self.dom_tracks.borrow_mut().remove(idx);
         self.upcast::<EventTarget>()
-            .fire_event(atom!("removetrack"), can_gc);
+            .fire_event(cx, atom!("removetrack"));
     }
 }
 

--- a/components/script/dom/webxr/xrsystem.rs
+++ b/components/script/dom/webxr/xrsystem.rs
@@ -319,13 +319,11 @@ impl XRSystem {
         self.global()
             .task_manager()
             .dom_manipulation_task_source()
-            .queue(
-                task!(fire_sessionavailable_event: move || {
-                    // The sessionavailable event indicates user intent to enter an XR session
-                    let xr = xr.root();
-                        let _guard = ScriptThread::user_interacting_guard();
-                        xr.upcast::<EventTarget>().fire_bubbling_event(atom!("sessionavailable"), CanGc::deprecated_note());
-                })
-            );
+            .queue(task!(fire_sessionavailable_event: move |cx| {
+                // The sessionavailable event indicates user intent to enter an XR session
+                let xr = xr.root();
+                    let _guard = ScriptThread::user_interacting_guard();
+                    xr.upcast::<EventTarget>().fire_bubbling_event(cx, atom!("sessionavailable"));
+            }));
     }
 }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -882,7 +882,7 @@ impl Window {
         // Step 3. Append the following session history traversal steps to traversable:
         // TODO
         // Step 3.2. Unload a document and its descendants given traversable's active document, null, and afterAllUnloads.
-        document.unload(false, CanGc::from_cx(cx));
+        document.unload(cx, false);
         // Step 3.1. Let afterAllUnloads be an algorithm step which destroys traversable.
         self.destroy_top_level_traversable(cx);
     }

--- a/components/script/dom/workers/serviceworker.rs
+++ b/components/script/dom/workers/serviceworker.rs
@@ -77,15 +77,15 @@ impl ServiceWorker {
         )
     }
 
-    pub(crate) fn dispatch_simple_error(address: TrustedServiceWorkerAddress, can_gc: CanGc) {
+    pub(crate) fn dispatch_simple_error(cx: &mut JSContext, address: TrustedServiceWorkerAddress) {
         let service_worker = address.root();
-        service_worker.upcast().fire_event(atom!("error"), can_gc);
+        service_worker.upcast().fire_event(cx, atom!("error"));
     }
 
-    pub(crate) fn set_transition_state(&self, state: ServiceWorkerState, can_gc: CanGc) {
+    pub(crate) fn set_transition_state(&self, cx: &mut JSContext, state: ServiceWorkerState) {
         self.state.set(state);
         self.upcast::<EventTarget>()
-            .fire_event(atom!("statechange"), can_gc);
+            .fire_event(cx, atom!("statechange"));
     }
 
     pub(crate) fn get_script_url(&self) -> ServoUrl {
@@ -167,6 +167,6 @@ impl ServiceWorkerMethods<crate::DomTypeHolder> for ServiceWorker {
 impl TaskOnce for SimpleWorkerErrorHandler<ServiceWorker> {
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn run_once(self, cx: &mut JSContext) {
-        ServiceWorker::dispatch_simple_error(self.addr, CanGc::from_cx(cx));
+        ServiceWorker::dispatch_simple_error(cx, self.addr);
     }
 }

--- a/components/script/dom/workers/serviceworkerglobalscope.rs
+++ b/components/script/dom/workers/serviceworkerglobalscope.rs
@@ -545,8 +545,7 @@ impl ServiceWorkerGlobalScope {
                 // TODO XXXcreativcoder This will eventually use a FetchEvent interface to fire event
                 // when we have the Request and Response dom api's implemented
                 // https://w3c.github.io/ServiceWorker/#fetchevent-interface
-                self.upcast::<EventTarget>()
-                    .fire_event(atom!("fetch"), CanGc::from_cx(cx));
+                self.upcast::<EventTarget>().fire_event(cx, atom!("fetch"));
                 let _ = mediator.response_chan.send(None);
             },
             WakeUp => {},

--- a/components/script/dom/workers/worker.rs
+++ b/components/script/dom/workers/worker.rs
@@ -133,9 +133,12 @@ impl Worker {
         }
     }
 
-    pub(crate) fn dispatch_simple_error(address: TrustedWorkerAddress, can_gc: CanGc) {
+    pub(crate) fn dispatch_simple_error(
+        cx: &mut js::context::JSContext,
+        address: TrustedWorkerAddress,
+    ) {
         let worker = address.root();
-        worker.upcast().fire_event(atom!("error"), can_gc);
+        worker.upcast().fire_event(cx, atom!("error"));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-dedicatedworkerglobalscope-postmessage>
@@ -348,6 +351,6 @@ impl WorkerMethods<crate::DomTypeHolder> for Worker {
 impl TaskOnce for SimpleWorkerErrorHandler<Worker> {
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn run_once(self, cx: &mut JSContext) {
-        Worker::dispatch_simple_error(self.addr, CanGc::from_cx(cx));
+        Worker::dispatch_simple_error(cx, self.addr);
     }
 }

--- a/components/script/microtask.rs
+++ b/components/script/microtask.rs
@@ -166,8 +166,7 @@ impl MicrotaskQueue {
                         ScriptThread::invoke_backup_element_queue(cx);
                     },
                     Microtask::NotifyMutationObservers => {
-                        ScriptThread::mutation_observers()
-                            .notify_mutation_observers(CanGc::from_cx(cx));
+                        ScriptThread::mutation_observers().notify_mutation_observers(cx);
                     },
                     Microtask::ReadableStreamByteTeeReadRequest(ref task) => {
                         task.microtask_chunk_steps(cx)

--- a/components/script/script_mutation_observers.rs
+++ b/components/script/script_mutation_observers.rs
@@ -38,7 +38,7 @@ impl ScriptMutationObservers {
     }
 
     /// <https://dom.spec.whatwg.org/#notify-mutation-observers>
-    pub(crate) fn notify_mutation_observers(&self, can_gc: CanGc) {
+    pub(crate) fn notify_mutation_observers(&self, cx: &mut js::context::JSContext) {
         // Step 1. Set the surrounding agent’s mutation observer microtask queued to false.
         self.mutation_observer_microtask_queued.set(false);
 
@@ -70,9 +70,13 @@ impl ScriptMutationObservers {
             // Step 6.4 If records is not empty, then invoke mo’s callback with « records,
             // mo » and "report", and with callback this value mo.
             if !queue.is_empty() {
-                let _ = mo
-                    .callback()
-                    .Call_(&**mo, queue, mo, ExceptionHandling::Report, can_gc);
+                let _ = mo.callback().Call_(
+                    &**mo,
+                    queue,
+                    mo,
+                    ExceptionHandling::Report,
+                    CanGc::from_cx(cx),
+                );
             }
         }
 
@@ -80,7 +84,7 @@ impl ScriptMutationObservers {
         // with its bubbles attribute set to true, at slot.
         for slot in signal_set {
             slot.upcast::<EventTarget>()
-                .fire_event(atom!("slotchange"), can_gc);
+                .fire_event(cx, atom!("slotchange"));
         }
     }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1201,7 +1201,7 @@ impl ScriptThread {
             let resized = document.window().run_the_resize_steps(CanGc::from_cx(cx));
 
             // > 9. For each doc of docs, run the scroll steps for doc.
-            document.run_the_scroll_steps(CanGc::from_cx(cx));
+            document.run_the_scroll_steps(cx);
 
             // Media queries is only relevant when there are resizing.
             if resized {
@@ -1766,7 +1766,7 @@ impl ScriptThread {
                 cx,
             ),
             ScriptThreadMessage::UnloadDocument(pipeline_id) => {
-                self.handle_unload_document(pipeline_id, CanGc::from_cx(cx))
+                self.handle_unload_document(cx, pipeline_id)
             },
             ScriptThreadMessage::ResizeInactive(id, new_size) => {
                 self.handle_resize_inactive_msg(id, new_size)
@@ -2975,10 +2975,10 @@ impl ScriptThread {
         }
     }
 
-    fn handle_unload_document(&self, pipeline_id: PipelineId, can_gc: CanGc) {
+    fn handle_unload_document(&self, cx: &mut js::context::JSContext, pipeline_id: PipelineId) {
         let document = self.documents.borrow().find_document(pipeline_id);
         if let Some(document) = document {
-            document.unload(false, can_gc);
+            document.unload(cx, false);
         }
     }
 
@@ -3543,7 +3543,7 @@ impl ScriptThread {
             document.shared_declarative_refresh_steps(refresh_val.as_bytes());
         }
 
-        document.set_ready_state(DocumentReadyState::Loading, CanGc::from_cx(cx));
+        document.set_ready_state(cx, DocumentReadyState::Loading);
 
         self.documents
             .borrow_mut()

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -46,7 +46,7 @@ use crate::dom::window::CSSErrorReporter;
 use crate::fetch::{RequestWithGlobalScope, create_a_potential_cors_request};
 use crate::messaging::{CommonScriptMsg, MainThreadScriptMsg};
 use crate::network_listener::{self, FetchResponseListener, ResourceTimingListener};
-use crate::script_runtime::{CanGc, ScriptThreadEventCategory};
+use crate::script_runtime::ScriptThreadEventCategory;
 use crate::task_source::TaskSourceName;
 use crate::unminify::{
     BeautifyFileType, create_output_file, create_temp_files, execute_js_beautify,
@@ -319,9 +319,7 @@ impl StylesheetContext {
                 true => atom!("error"),
                 false => atom!("load"),
             };
-            element
-                .upcast::<EventTarget>()
-                .fire_event(event, CanGc::from_cx(cx));
+            element.upcast::<EventTarget>().fire_event(cx, event);
         }
         // Regardless if there are other pending events, we need to unblock
         // rendering for this particular request and signal that the load has finished

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1853,8 +1853,8 @@ fn clear_a_resettable_element(cx: &mut JSContext, element: &Element) -> Result<(
     }
 
     let event_target = element.upcast::<EventTarget>();
-    event_target.fire_bubbling_event(atom!("input"), CanGc::from_cx(cx));
-    event_target.fire_bubbling_event(atom!("change"), CanGc::from_cx(cx));
+    event_target.fire_bubbling_event(cx, atom!("input"));
+    event_target.fire_bubbling_event(cx, atom!("change"));
 
     // Step 5. Run the unfocusing steps for the element.
     html_element.Blur(CanGc::from_cx(cx));
@@ -2003,9 +2003,9 @@ pub(crate) fn handle_element_click(
                     Some(option_element) => {
                         // Steps 8.2 - 8.4
                         let event_target = container.upcast::<EventTarget>();
-                        event_target.fire_event(atom!("mouseover"), CanGc::from_cx(cx));
-                        event_target.fire_event(atom!("mousemove"), CanGc::from_cx(cx));
-                        event_target.fire_event(atom!("mousedown"), CanGc::from_cx(cx));
+                        event_target.fire_event(cx, atom!("mouseover"));
+                        event_target.fire_event(cx, atom!("mousemove"));
+                        event_target.fire_event(cx, atom!("mousedown"));
 
                         // Step 8.5
                         match container.downcast::<HTMLElement>() {
@@ -2023,7 +2023,7 @@ pub(crate) fn handle_element_click(
                         // Step 8.6
                         if !is_disabled(&element) {
                             // Step 8.6.1
-                            event_target.fire_event(atom!("input"), CanGc::from_cx(cx));
+                            event_target.fire_event(cx, atom!("input"));
 
                             // Steps 8.6.2
                             let previous_selectedness = option_element.Selected();
@@ -2043,13 +2043,13 @@ pub(crate) fn handle_element_click(
 
                             // Step 8.6.4
                             if !previous_selectedness {
-                                event_target.fire_event(atom!("change"), CanGc::from_cx(cx));
+                                event_target.fire_event(cx, atom!("change"));
                             }
                         }
 
                         // Steps 8.7 - 8.8
-                        event_target.fire_event(atom!("mouseup"), CanGc::from_cx(cx));
-                        event_target.fire_event(atom!("click"), CanGc::from_cx(cx));
+                        event_target.fire_event(cx, atom!("mouseup"));
+                        event_target.fire_event(cx, atom!("click"));
 
                         Ok(None)
                     },

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -488,8 +488,8 @@ DOMInterfaces = {
 },
 
 'HTMLFormElement': {
-    'canGc': ['Elements', 'IndexedGetter', 'NamedGetter', 'Reset', 'SetRel', 'RelList'],
-    'cx': ['CheckValidity', 'ReportValidity', 'RequestSubmit', 'Submit'],
+    'canGc': ['Elements', 'IndexedGetter', 'NamedGetter', 'SetRel', 'RelList'],
+    'cx': ['CheckValidity', 'ReportValidity', 'RequestSubmit', 'Submit', 'Reset'],
 },
 
 'HTMLFrameSetElement': {
@@ -717,8 +717,8 @@ DOMInterfaces = {
 
 'MessagePort': {
     'weakReferenceable': True,
-    'canGc': ['Close', 'GetOnmessage'],
-    'cx': ['PostMessage', 'PostMessage_', 'SetOnmessage', 'Start']
+    'canGc': ['GetOnmessage'],
+    'cx': ['Close', 'PostMessage', 'PostMessage_', 'SetOnmessage', 'Start']
 },
 
 'MessageEvent': {


### PR DESCRIPTION
Propagate `&mut JSContext` in `EventTarget::fire_event_with_params` and related call sites.

Testing: Successful build is enough
Fixes: Part of #42638 