### PR TITLE
net: Image Cache: Spawn setting image keys on thread pool

### DIFF
--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -407,12 +407,14 @@ enum KeyCacheState {
     PendingBatch,
     /// We have some keys in the cache.
     Ready(Vec<WebRenderImageKey>),
+    /// Currently filling images from the KeyCache. No new keys will be requested.
+    Processing,
 }
 
 impl KeyCacheState {
     fn size(&self) -> usize {
         match self {
-            KeyCacheState::PendingBatch => 0,
+            KeyCacheState::PendingBatch | KeyCacheState::Processing => 0,
             KeyCacheState::Ready(items) => items.len(),
         }
     }
@@ -554,7 +556,7 @@ impl ImageCacheStore {
             return;
         }
         match self.key_cache.cache {
-            KeyCacheState::PendingBatch => {
+            KeyCacheState::PendingBatch | KeyCacheState::Processing => {
                 self.key_cache.images_pending_keys.push_back(pending_image);
             },
             KeyCacheState::Ready(ref mut cache) => match cache.pop() {
@@ -587,7 +589,8 @@ impl ImageCacheStore {
 
     /// Insert received keys into the cache and complete the loading of images.
     fn insert_keys_and_load_images(&mut self, image_keys: Vec<WebRenderImageKey>) {
-        if let KeyCacheState::PendingBatch = self.key_cache.cache {
+        if let KeyCacheState::Processing = self.key_cache.cache {
+            // We can set this now to ready as we have the exclusive write access.
             self.key_cache.cache = KeyCacheState::Ready(image_keys);
             let len = min(
                 self.key_cache.cache.size(),
@@ -601,6 +604,7 @@ impl ImageCacheStore {
             for key in images {
                 self.load_image_with_keycache(key);
             }
+            // It is important to fetch new image keys as we might have missed previous returns.
             if !self.key_cache.images_pending_keys.is_empty() {
                 self.paint_api
                     .generate_image_key_async(self.webview_id, self.pipeline_id);
@@ -1243,9 +1247,19 @@ impl ImageCache for ImageCacheImpl {
         }
     }
 
-    fn fill_key_cache_with_batch_of_keys(&self, image_keys: Vec<WebRenderImageKey>) {
-        let mut store = self.store.lock();
-        store.insert_keys_and_load_images(image_keys);
+    /// This method does not block
+    fn dispatch_fill_key_cache_with_batch_of_keys(&self, image_keys: Vec<WebRenderImageKey>) {
+        // This is safe to do because of the following reason.
+        // The only way this can be in a unwelcome state is the following chain of events
+        // dispatch_fill_key -> get_image_key -> fetch_image_keys -> insert_keys_and_load_images.
+        // However, we ignore all calls for this when the state is set to processing. Returning
+        // the state to anything else enforces that we have the exclusive write access to the KeyCache.
+        self.store.lock().key_cache.cache = KeyCacheState::Processing;
+
+        let store = self.store.clone();
+        self.thread_pool.spawn(move || {
+            store.lock().insert_keys_and_load_images(image_keys);
+        });
     }
 
     fn clear(&self) {

--- a/components/net/tests/image_cache.rs
+++ b/components/net/tests/image_cache.rs
@@ -42,7 +42,7 @@ fn handle_pending_key_requests(cache: &Arc<dyn ImageCache>, receiver: &Receiver<
         let keys: Vec<_> = (0..10)
             .map(|i| ImageKey::new(webrender_api::IdNamespace(42), i as u32))
             .collect();
-        cache.fill_key_cache_with_batch_of_keys(keys);
+        cache.dispatch_fill_key_cache_with_batch_of_keys(keys);
     }
 }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1968,7 +1968,7 @@ impl ScriptThread {
                 if let Some(window) = self.documents.borrow().find_window(pipeline_id) {
                     window
                         .image_cache()
-                        .fill_key_cache_with_batch_of_keys(image_keys);
+                        .dispatch_fill_key_cache_with_batch_of_keys(image_keys);
                 } else {
                     warn!(
                         "Could not find window corresponding to an image cache to send image keys to pipeline {:?}",

--- a/components/shared/net/image_cache.rs
+++ b/components/shared/net/image_cache.rs
@@ -244,7 +244,7 @@ pub trait ImageCache: Sync + Send {
     fn notify_pending_response(&self, id: PendingImageId, action: FetchResponseMsg);
 
     /// Fills the image cache with a batch of keys.
-    fn fill_key_cache_with_batch_of_keys(&self, image_keys: Vec<ImageKey>);
+    fn dispatch_fill_key_cache_with_batch_of_keys(&self, image_keys: Vec<ImageKey>);
 
     /// Clear the image cache.
     fn clear(&self);


### PR DESCRIPTION
This replaces the `fill_key_cache_with_batch_of_keys` with `dispatch_fill_key_cache_with_batch_of_keys` to put it on the already existing thread pool.

`fill_key_cache_with_batch_of_keys` is called from the ScriptThread and calls `set_webrender_image_key` which creates an IpcSharedMemory. For large images this can take a long time.
Offloading it away from the ScriptThread means it has more time for important work.

We additionally add some safeguards around ImageCache to prevent us from requesting new ImageKeys while we are processing them.

Testing: WPT tests will probably not find this implementation issue as it is mostly equivalent code except in the case of data races.
