### PR TITLE
pass &mut JSContext to remove_script_and_layout_blocker

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -3720,19 +3720,17 @@ impl Document {
             .set(self.script_and_layout_blockers.get() + 1);
     }
 
-    #[expect(unsafe_code)]
     /// Terminate the period in which JS or layout is disallowed from running.
     /// If no further blockers remain, any delayed tasks in the queue will
     /// be executed in queue order until the queue is empty.
-    pub(crate) fn remove_script_and_layout_blocker(&self) {
+    pub(crate) fn remove_script_and_layout_blocker(&self, cx: &mut js::context::JSContext) {
         assert!(self.script_and_layout_blockers.get() > 0);
         self.script_and_layout_blockers
             .set(self.script_and_layout_blockers.get() - 1);
         while self.script_and_layout_blockers.get() == 0 && !self.delayed_tasks.borrow().is_empty()
         {
             let task = self.delayed_tasks.borrow_mut().remove(0);
-            let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
-            task.run_box(&mut cx);
+            task.run_box(cx);
         }
     }
 

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -2881,8 +2881,8 @@ impl Node {
             }
         }
 
-        old_doc.remove_script_and_layout_blocker();
-        document.remove_script_and_layout_blocker();
+        old_doc.remove_script_and_layout_blocker(cx);
+        document.remove_script_and_layout_blocker(cx);
     }
 
     /// <https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity>
@@ -3251,8 +3251,8 @@ impl Node {
             }),
         );
 
-        parent_document.remove_script_and_layout_blocker();
-        from_document.remove_script_and_layout_blocker();
+        parent_document.remove_script_and_layout_blocker(cx);
+        from_document.remove_script_and_layout_blocker(cx);
     }
 
     /// <https://dom.spec.whatwg.org/#concept-node-replace-all>
@@ -3303,7 +3303,7 @@ impl Node {
             });
             MutationObserver::queue_a_mutation_record(parent, mutation);
         }
-        parent.owner_doc().remove_script_and_layout_blocker();
+        parent.owner_doc().remove_script_and_layout_blocker(cx);
     }
 
     /// <https://dom.spec.whatwg.org/multipage/#string-replace-all>
@@ -3417,7 +3417,7 @@ impl Node {
             });
             MutationObserver::queue_a_mutation_record(parent, mutation);
         }
-        parent.owner_doc().remove_script_and_layout_blocker();
+        parent.owner_doc().remove_script_and_layout_blocker(cx);
     }
 
     /// <https://dom.spec.whatwg.org/#live-range-pre-remove-steps>


### PR DESCRIPTION
This PR makes the `remove_script_and_layout_blocker` in https://github.com/servo/servo/blob/ee72fca571f27bf8c3c77014d5f450118464c6ce/components/script/dom/document/document.rs#L3727
take `&mut JSContext` as argument, removing the dependency of the previous `temp_cx` being created!

Testing:  No behaviour changes , all tests passes.
Fixes: #44479 
