### PR TITLE
crown: ignore must-root return types

### DIFF
--- a/support/crown/src/unrooted_must_root.rs
+++ b/support/crown/src/unrooted_must_root.rs
@@ -32,7 +32,7 @@ pub fn register(lint_store: &mut LintStore) {
 /// "Incorrect" usage includes:
 ///
 ///  - Not being used in a struct/enum field which is not `#[crown::unrooted_must_root_lint::must_root]` itself
-///  - Not being used as an argument to a function (Except onces named `new` and `new_inherited`)
+///  - Being used as a function argument.
 ///  - Not being bound locally in a `let` statement, assignment, `for` loop, or `match` statement.
 ///
 /// This helps catch most situations where pointers like `JS<T>` are used in a way that they can be invalidated by a
@@ -412,15 +412,6 @@ impl<'tcx> LateLintPass<'tcx> for UnrootedPass {
                         lint.span(arg.span);
                     })
                 }
-            }
-
-            if !in_new_function &&
-                is_unrooted_ty(&self.symbols, cx, sig.output().skip_binder(), false)
-            {
-                cx.lint(UNROOTED_MUST_ROOT, |lint| {
-                    lint.primary_message("Type must be rooted.");
-                    lint.span(decl.output.span());
-                })
             }
         }
 

--- a/support/crown/tests/compile-fail/missing_allow_in_rc.rs
+++ b/support/crown/tests/compile-fail/missing_allow_in_rc.rs
@@ -23,7 +23,6 @@ impl TypeHolderTrait for TypeHolder {
 struct Foo;
 
 fn foo<T: TypeHolderTrait>() -> Rc<T::F> {
-    //~^ ERROR: Type must be rooted. [crown::unrooted_must_root]
     unimplemented!()
 }
 

--- a/support/crown/tests/compile-fail/missing_allow_in_rc.rs
+++ b/support/crown/tests/compile-fail/missing_allow_in_rc.rs
@@ -26,4 +26,9 @@ fn foo<T: TypeHolderTrait>() -> Rc<T::F> {
     unimplemented!()
 }
 
+fn bar<T: TypeHolderTrait>() {
+    let foo = foo::<T>();
+    //~^ ERROR: Expression of type std::rc::Rc
+}
+
 fn main() {}

--- a/support/crown/tests/compile-fail/unrooted_must_root_return_type.rs
+++ b/support/crown/tests/compile-fail/unrooted_must_root_return_type.rs
@@ -7,8 +7,10 @@
 struct Foo(i32);
 
 fn foo2() -> Foo {
-    //~^ ERROR: Type must be rooted
     unimplemented!()
 }
 
-fn main() {}
+fn main() {
+    let foo = foo2();
+    //~^ ERROR: Expression of type Foo must be rooted
+}


### PR DESCRIPTION
Stop the unrooted_must_root lint from reporting must-root types only because they appear in a function return type. Caller-side handling is still checked when the returned value is bound locally without rooting.

Testing: `cargo test` in `support/crown`
Fixes: #44463