### PR TITLE
servo: Add `referrer` and `destination` fields to `WebResourceRequest`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7465,6 +7465,7 @@ dependencies = [
  "accesskit_consumer",
  "arboard",
  "bitflags 2.11.1",
+ "content-security-policy",
  "cookie 0.18.1",
  "crossbeam-channel",
  "dpi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7851,6 +7851,7 @@ version = "0.1.0"
 dependencies = [
  "accesskit",
  "bitflags 2.11.1",
+ "content-security-policy",
  "cookie 0.18.1",
  "crossbeam-channel",
  "euclid",

--- a/components/net/request_interceptor.rs
+++ b/components/net/request_interceptor.rs
@@ -35,6 +35,8 @@ impl RequestInterceptor {
             method: request.method.clone(),
             url: request.url().into_url(),
             headers: request.headers.clone(),
+            destination: request.destination,
+            referrer_url: request.referrer.to_url().map(|url| url.as_url().clone()),
             is_for_main_frame,
             is_redirect: request.redirect_count > 0,
         };

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -166,6 +166,7 @@ servo-media-ohos = { workspace = true }
 
 [dev-dependencies]
 accesskit_consumer = "0.35.0"
+content-security-policy = { workspace = true }
 http = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -182,8 +182,6 @@ struct ServoInner {
     pending_handled_input_events: RefCell<Vec<PendingHandledInputEvent>>,
     /// An [`EventLoopWaker`] used to wake up the main embedder event loop.
     event_loop_waker: Box<dyn EventLoopWaker>,
-    /// Public resource threads, available for embedder-initiated fetches.
-    resource_threads: ResourceThreads,
 }
 
 impl ServoInner {
@@ -964,7 +962,6 @@ impl Servo {
         Servo(Rc::new(ServoInner {
             delegate: RefCell::new(Rc::new(DefaultServoDelegate)),
             paint,
-            resource_threads: public_resource_threads.clone(),
             network_manager: Rc::new(RefCell::new(NetworkManager::new(
                 public_resource_threads.clone(),
                 private_resource_threads.clone(),
@@ -997,10 +994,6 @@ impl Servo {
 
     pub fn set_delegate(&self, delegate: Rc<dyn ServoDelegate>) {
         *self.0.delegate.borrow_mut() = delegate;
-    }
-
-    pub fn resource_threads(&self) -> ResourceThreads {
-        self.0.resource_threads.clone()
     }
 
     /// **EXPERIMENTAL:** Intialize GL accelerated media playback. This currently only works on a limited number

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -182,6 +182,8 @@ struct ServoInner {
     pending_handled_input_events: RefCell<Vec<PendingHandledInputEvent>>,
     /// An [`EventLoopWaker`] used to wake up the main embedder event loop.
     event_loop_waker: Box<dyn EventLoopWaker>,
+    /// Public resource threads, available for embedder-initiated fetches.
+    resource_threads: ResourceThreads,
 }
 
 impl ServoInner {
@@ -962,6 +964,7 @@ impl Servo {
         Servo(Rc::new(ServoInner {
             delegate: RefCell::new(Rc::new(DefaultServoDelegate)),
             paint,
+            resource_threads: public_resource_threads.clone(),
             network_manager: Rc::new(RefCell::new(NetworkManager::new(
                 public_resource_threads.clone(),
                 private_resource_threads.clone(),
@@ -994,6 +997,10 @@ impl Servo {
 
     pub fn set_delegate(&self, delegate: Rc<dyn ServoDelegate>) {
         *self.0.delegate.borrow_mut() = delegate;
+    }
+
+    pub fn resource_threads(&self) -> ResourceThreads {
+        self.0.resource_threads.clone()
     }
 
     /// **EXPERIMENTAL:** Intialize GL accelerated media playback. This currently only works on a limited number

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -1172,7 +1172,7 @@ mod test {
             method: Method::GET,
             headers: HeaderMap::default(),
             url: Url::parse("https://example.com").expect("Guaranteed by argument"),
-            destination: net_traits::request::Destination::Document,
+            destination: content_security_policy::Destination::Document,
             referrer_url: None,
             is_for_main_frame: false,
             is_redirect: false,

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -1172,6 +1172,8 @@ mod test {
             method: Method::GET,
             headers: HeaderMap::default(),
             url: Url::parse("https://example.com").expect("Guaranteed by argument"),
+            destination: net_traits::request::Destination::Document,
+            referrer_url: None,
             is_for_main_frame: false,
             is_redirect: false,
         };

--- a/components/shared/embedder/Cargo.toml
+++ b/components/shared/embedder/Cargo.toml
@@ -19,6 +19,7 @@ gamepad = []
 [dependencies]
 accesskit = { workspace = true }
 bitflags = { workspace = true }
+content-security-policy = { workspace = true }
 cookie = { workspace = true }
 crossbeam-channel = { workspace = true }
 euclid = { workspace = true }

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -22,6 +22,7 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use accesskit::TreeUpdate;
+use content_security_policy::Destination;
 use crossbeam_channel::Sender;
 use euclid::{Box2D, Point2D, Scale, Size2D, Vector2D};
 use http::{HeaderMap, Method, StatusCode};
@@ -652,6 +653,8 @@ pub struct WebResourceRequest {
     )]
     pub headers: HeaderMap,
     pub url: Url,
+    pub destination: Destination,
+    pub referrer_url: Option<Url>,
     pub is_for_main_frame: bool,
     pub is_redirect: bool,
 }


### PR DESCRIPTION
The destination and referrer are useful for some use cases like hooking up adblock-rust. We could also fetch the referrer from the headers but this is more expensive. I also added a way to get access to the resource threads from the Servo api. This allows embedders to use Servo's fetch implementation instead of bringing an external http client.

Testing: updated relevant unit tests

