### PR TITLE
layout: value of <input type=file> now inherits ‘color’ by default

### DIFF
--- a/components/layout/stylesheets/servo.css
+++ b/components/layout/stylesheets/servo.css
@@ -176,7 +176,7 @@ input[type="file"] {
   display: inline-block;
   border: none;
   background: transparent;
-  color: initial;
+  color: inherit;
   padding-inline-end: 0.5em;
 }
 

--- a/components/layout/stylesheets/servo.css
+++ b/components/layout/stylesheets/servo.css
@@ -3,7 +3,7 @@ input[type="hidden"] {
 }
 
 /* Textual inputs */
-input,
+input:not([type="file"]),
 textarea {
   background: white;
   border: solid grey 1px;
@@ -176,7 +176,6 @@ input[type="file"] {
   display: inline-block;
   border: none;
   background: transparent;
-  color: inherit;
   padding-inline-end: 0.5em;
 }
 

--- a/components/layout/stylesheets/servo.css
+++ b/components/layout/stylesheets/servo.css
@@ -174,8 +174,6 @@ input[type="file"]::file-selector-button {
 input[type="file"] {
   cursor: default;
   display: inline-block;
-  border: none;
-  background: transparent;
   padding-inline-end: 0.5em;
 }
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13042,6 +13042,13 @@
       {}
      ]
     ],
+    "input-file-color-inherit.html": [
+     "59df9e84fd7816f942759fbf7c303182b23e03af",
+     [
+      null,
+      {}
+     ]
+    ],
     "matchMedia.html": [
      "45a7ea268b1ebdba69e947b79d675cc9221428d4",
      [

--- a/tests/wpt/mozilla/tests/css/input-file-color-inherit.html
+++ b/tests/wpt/mozilla/tests/css/input-file-color-inherit.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<title>CSS: input[type=file] should inherit 'color' by default</title>
+<link rel="help" href="https://github.com/servo/servo/issues/44427">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  #container { color: rgb(255, 255, 255); }
+</style>
+<div id="container">
+  <input id="inp" type="file">
+</div>
+<script>
+  test(() => {
+    const style = getComputedStyle(inp);
+    assert_equals(style.color, "rgb(255, 255, 255)",
+      "input[type=file] should inherit color from its parent");
+  }, "input[type=file] value part should inherit 'color' by default");
+</script>


### PR DESCRIPTION
Made value of <input type=file> now inherit ‘color’ by default

Testing: `./mach test-wpt tests/wpt/mozilla/tests/css/input-file-color-inherit.html` passes successfully.
Fixes: #44427