### PR TITLE
script: propagate &mut JSContext in FileReader::read

### DIFF
--- a/components/script/dom/file/filereader.rs
+++ b/components/script/dom/file/filereader.rs
@@ -392,18 +392,23 @@ impl FileReaderMethods<crate::DomTypeHolder> for FileReader {
     event_handler!(loadend, GetOnloadend, SetOnloadend);
 
     // https://w3c.github.io/FileAPI/#dfn-readAsArrayBuffer
-    fn ReadAsArrayBuffer(&self, blob: &Blob, can_gc: CanGc) -> ErrorResult {
-        self.read(FileReaderFunction::ArrayBuffer, blob, None, can_gc)
+    fn ReadAsArrayBuffer(&self, cx: &mut js::context::JSContext, blob: &Blob) -> ErrorResult {
+        self.read(cx, FileReaderFunction::ArrayBuffer, blob, None)
     }
 
     // https://w3c.github.io/FileAPI/#dfn-readAsDataURL
-    fn ReadAsDataURL(&self, blob: &Blob, can_gc: CanGc) -> ErrorResult {
-        self.read(FileReaderFunction::DataUrl, blob, None, can_gc)
+    fn ReadAsDataURL(&self, cx: &mut js::context::JSContext, blob: &Blob) -> ErrorResult {
+        self.read(cx, FileReaderFunction::DataUrl, blob, None)
     }
 
     // https://w3c.github.io/FileAPI/#dfn-readAsText
-    fn ReadAsText(&self, blob: &Blob, label: Option<DOMString>, can_gc: CanGc) -> ErrorResult {
-        self.read(FileReaderFunction::Text, blob, label, can_gc)
+    fn ReadAsText(
+        &self,
+        cx: &mut js::context::JSContext,
+        blob: &Blob,
+        label: Option<DOMString>,
+    ) -> ErrorResult {
+        self.read(cx, FileReaderFunction::Text, blob, label)
     }
 
     /// <https://w3c.github.io/FileAPI/#dfn-abort>
@@ -473,11 +478,12 @@ impl FileReader {
     /// <https://w3c.github.io/FileAPI/#readOperation>
     fn read(
         &self,
+        cx: &mut js::context::JSContext,
         function: FileReaderFunction,
         blob: &Blob,
         label: Option<DOMString>,
-        can_gc: CanGc,
     ) -> ErrorResult {
+        let can_gc = CanGc::from_cx(cx);
         let cx = GlobalScope::get_cx();
 
         // If fr’s state is "loading", throw an InvalidStateError DOMException.

--- a/components/script/dom/file/filereader.rs
+++ b/components/script/dom/file/filereader.rs
@@ -483,9 +483,6 @@ impl FileReader {
         blob: &Blob,
         label: Option<DOMString>,
     ) -> ErrorResult {
-        let can_gc = CanGc::from_cx(cx);
-        let cx = GlobalScope::get_cx();
-
         // If fr’s state is "loading", throw an InvalidStateError DOMException.
         if self.ready_state.get() == FileReaderReadyState::Loading {
             return Err(Error::InvalidState(None));
@@ -501,10 +498,10 @@ impl FileReader {
         // See the note below in the error steps.
 
         // Let stream be the result of calling get stream on blob.
-        let stream = blob.get_stream(can_gc);
+        let stream = blob.get_stream(CanGc::from_cx(cx));
 
         // Let reader be the result of getting a reader from stream.
-        let reader = stream.and_then(|s| s.acquire_default_reader(can_gc))?;
+        let reader = stream.and_then(|s| s.acquire_default_reader(CanGc::from_cx(cx)))?;
 
         let type_ = blob.Type();
 
@@ -527,7 +524,7 @@ impl FileReader {
 
         // Read all bytes from stream with reader.
         reader.read_all_bytes(
-            cx,
+            cx.into(),
             Rc::new(move |blob_contents| {
                 let global = filereader_success.global();
                 let task_manager = global.task_manager();
@@ -580,7 +577,7 @@ impl FileReader {
                     DOMErrorName::OperationError,
                 ));
             }),
-            can_gc,
+            CanGc::from_cx(cx),
         );
         Ok(())
     }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -326,7 +326,8 @@ DOMInterfaces = {
 },
 
 'FileReader': {
-    'canGc': ['Abort', 'ReadAsArrayBuffer', 'ReadAsDataURL', 'ReadAsText'],
+    'canGc': ['Abort'],
+    'cx': ['ReadAsArrayBuffer', 'ReadAsDataURL', 'ReadAsText'],
 },
 
 'FileReaderSync': {


### PR DESCRIPTION
Propagate `&mut JSContext` in `FileReader::read` and related call sites.

Testing: Successful build is enough
Fixes: Part of #42638 

Opened to reduces the complexity of #44254 