### PR TITLE
script: propagate &mut JSContext in Activatable::activation_behavior

### DIFF
--- a/components/script/dom/activation.rs
+++ b/components/script/dom/activation.rs
@@ -31,7 +31,12 @@ pub(crate) trait Activatable {
     // https://dom.spec.whatwg.org/#eventtarget-activation-behavior
     // event and target are used only by HTMLAnchorElement, in the case
     // where the target is an <img ismap> so the href gets coordinates appended
-    fn activation_behavior(&self, event: &Event, target: &EventTarget, can_gc: CanGc);
+    fn activation_behavior(
+        &self,
+        cx: &mut js::context::JSContext,
+        event: &Event,
+        target: &EventTarget,
+    );
 
     /// <https://html.spec.whatwg.org/multipage/#concept-selector-active>
     fn enter_formal_activation_state(&self) {

--- a/components/script/dom/event/event.rs
+++ b/components/script/dom/event/event.rs
@@ -315,7 +315,7 @@ impl Event {
         legacy_output_did_listeners_throw: Option<&Cell<bool>>,
         can_gc: CanGc,
     ) -> bool {
-        // TODO https://github.com/servo/servo/issues/43234
+        // TODO https://github.com/servo/servo/issues/44499
         #[allow(unsafe_code)]
         let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
         let cx = &mut cx;

--- a/components/script/dom/event/event.rs
+++ b/components/script/dom/event/event.rs
@@ -315,6 +315,11 @@ impl Event {
         legacy_output_did_listeners_throw: Option<&Cell<bool>>,
         can_gc: CanGc,
     ) -> bool {
+        // TODO https://github.com/servo/servo/issues/43234
+        #[allow(unsafe_code)]
+        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
+        let cx = &mut cx;
+
         // > When a user interaction causes firing of an activation triggering input event in a Document document, the user agent
         // > must perform the following activation notification steps before dispatching the event:
         // <https://html.spec.whatwg.org/multipage/#user-activation-processing-model>
@@ -648,12 +653,12 @@ impl Event {
                 // navigation) should use the element the event was originally fired on.
                 if let Some(node) = original_target.downcast::<Node>() {
                     let vtable = vtable_for(node);
-                    vtable.handle_event(self, can_gc);
+                    vtable.handle_event(cx, self);
                 }
             } else if let Some(target) = self.GetTarget() {
                 if let Some(node) = target.downcast::<Node>() {
                     let vtable = vtable_for(node);
-                    vtable.handle_event(self, can_gc);
+                    vtable.handle_event(cx, self);
                 }
             }
         }
@@ -688,7 +693,7 @@ impl Event {
                 // Step 12.1. If event’s canceled flag is unset, then run activationTarget’s
                 // activation behavior with event.
                 if !self.DefaultPrevented() {
-                    activatable.activation_behavior(self, &target, can_gc);
+                    activatable.activation_behavior(cx, self, &target);
                 }
                 // Step 12.2. Otherwise, if activationTarget has legacy-canceled-activation behavior, then run
                 // activationTarget’s legacy-canceled-activation behavior.

--- a/components/script/dom/html/htmlanchorelement.rs
+++ b/components/script/dom/html/htmlanchorelement.rs
@@ -346,7 +346,12 @@ impl Activatable for HTMLAnchorElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-a-element:activation-behaviour>
-    fn activation_behavior(&self, event: &Event, target: &EventTarget, _: CanGc) {
+    fn activation_behavior(
+        &self,
+        _cx: &mut js::context::JSContext,
+        event: &Event,
+        target: &EventTarget,
+    ) {
         let element = self.as_element();
         let mouse_event = event.downcast::<MouseEvent>().unwrap();
         let mut ismap_suffix = None;

--- a/components/script/dom/html/htmlareaelement.rs
+++ b/components/script/dom/html/htmlareaelement.rs
@@ -528,7 +528,12 @@ impl Activatable for HTMLAreaElement {
         self.as_element().has_attribute(&local_name!("href"))
     }
 
-    fn activation_behavior(&self, _event: &Event, _target: &EventTarget, _can_gc: CanGc) {
+    fn activation_behavior(
+        &self,
+        _cx: &mut js::context::JSContext,
+        _event: &Event,
+        _target: &EventTarget,
+    ) {
         follow_hyperlink(self.as_element(), self.relations.get(), None);
     }
 }

--- a/components/script/dom/html/htmlbuttonelement.rs
+++ b/components/script/dom/html/htmlbuttonelement.rs
@@ -479,7 +479,12 @@ impl Activatable for HTMLButtonElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-button-element:activation-behaviour>
-    fn activation_behavior(&self, event: &Event, target: &EventTarget, can_gc: CanGc) {
+    fn activation_behavior(
+        &self,
+        cx: &mut js::context::JSContext,
+        event: &Event,
+        target: &EventTarget,
+    ) {
         // Step 2. If element's node document is not fully active, then return.
         if !target
             .downcast::<Node>()
@@ -497,14 +502,14 @@ impl Activatable for HTMLButtonElement {
                 owner.submit(
                     SubmittedFrom::NotFromForm,
                     FormSubmitterElement::Button(self),
-                    can_gc,
+                    CanGc::from_cx(cx),
                 );
                 return;
             }
             // Step 3.2 If element's type attribute is in the Reset Button state, then reset
             // element's form owner and return.
             if button_type == ButtonType::Reset {
-                owner.reset(ResetFrom::NotFromForm, can_gc);
+                owner.reset(ResetFrom::NotFromForm, CanGc::from_cx(cx));
                 return;
             }
             // Step 3.3 If element's type attribute is in the Auto state, then return.
@@ -527,7 +532,7 @@ impl Activatable for HTMLButtonElement {
                 parent
                     .downcast::<HTMLInputElement>()
                     .expect("File select button should always be a child of an input element")
-                    .activation_behavior(event, target, can_gc);
+                    .activation_behavior(cx, event, target);
             }
 
             return;
@@ -556,10 +561,10 @@ impl Activatable for HTMLButtonElement {
                 Some(DomRoot::from_ref(self.upcast())),
                 self.upcast::<Element>()
                     .get_string_attribute(&local_name!("command")),
-                can_gc,
+                CanGc::from_cx(cx),
             );
             let event = event.upcast::<Event>();
-            if !event.fire(target.upcast::<EventTarget>(), can_gc) {
+            if !event.fire(target.upcast::<EventTarget>(), CanGc::from_cx(cx)) {
                 return;
             }
             // Step 5.5 If target is not connected, then return.
@@ -574,7 +579,11 @@ impl Activatable for HTMLButtonElement {
             // TODO Steps 5.7, 5.8, 5.9
             // Step 5.10 Otherwise, if this standard defines command steps for target's local name,
             // then run the corresponding command steps given target, element, and command.
-            let _ = vtable_for(target_node).command_steps(DomRoot::from_ref(self), command, can_gc);
+            let _ = vtable_for(target_node).command_steps(
+                DomRoot::from_ref(self),
+                command,
+                CanGc::from_cx(cx),
+            );
         }
         // TODO Step 6 Otherwise, run the popover target attribute activation behavior given element
         // and event's target.

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -1450,7 +1450,12 @@ impl Activatable for HTMLElement {
     }
 
     // Basically used to make the HTMLSummaryElement activatable (which has no IDL definition)
-    fn activation_behavior(&self, _event: &Event, _target: &EventTarget, _can_gc: CanGc) {
+    fn activation_behavior(
+        &self,
+        _cx: &mut js::context::JSContext,
+        _event: &Event,
+        _target: &EventTarget,
+    ) {
         self.summary_activation_behavior();
     }
 }

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -2074,7 +2074,7 @@ impl VirtualMethods for HTMLImageElement {
         }
     }
 
-    fn handle_event(&self, event: &Event, can_gc: CanGc) {
+    fn handle_event(&self, cx: &mut js::context::JSContext, event: &Event) {
         if event.type_() != atom!("click") {
             return;
         }
@@ -2095,7 +2095,9 @@ impl VirtualMethods for HTMLImageElement {
             mouse_event.ClientX().to_f32().unwrap(),
             mouse_event.ClientY().to_f32().unwrap(),
         );
-        let bcr = self.upcast::<Element>().GetBoundingClientRect(can_gc);
+        let bcr = self
+            .upcast::<Element>()
+            .GetBoundingClientRect(CanGc::from_cx(cx));
         let bcr_p = Point2D::new(bcr.X() as f32, bcr.Y() as f32);
 
         // Walk HTMLAreaElements
@@ -2106,7 +2108,7 @@ impl VirtualMethods for HTMLImageElement {
                 None => return,
             };
             if shp.hit_test(&point) {
-                element.activation_behavior(event, self.upcast(), can_gc);
+                element.activation_behavior(cx, event, self.upcast());
                 return;
             }
         }

--- a/components/script/dom/html/htmllabelelement.rs
+++ b/components/script/dom/html/htmllabelelement.rs
@@ -75,9 +75,14 @@ impl Activatable for HTMLLabelElement {
     // at all, we are free to do an implementation-dependent thing;
     // firing a click event is an example, and the precise details of that
     // click event (e.g. isTrusted) are not specified.
-    fn activation_behavior(&self, _event: &Event, _target: &EventTarget, can_gc: CanGc) {
+    fn activation_behavior(
+        &self,
+        cx: &mut js::context::JSContext,
+        _event: &Event,
+        _target: &EventTarget,
+    ) {
         if let Some(e) = self.GetControl() {
-            e.Click(can_gc);
+            e.Click(CanGc::from_cx(cx));
         }
     }
 }

--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -904,8 +904,8 @@ impl VirtualMethods for HTMLSelectElement {
         }
     }
 
-    fn handle_event(&self, event: &Event, can_gc: CanGc) {
-        self.super_type().unwrap().handle_event(event, can_gc);
+    fn handle_event(&self, cx: &mut js::context::JSContext, event: &Event) {
+        self.super_type().unwrap().handle_event(cx, event);
         if let Some(event) = event.downcast::<FocusEvent>() {
             if *event.upcast::<Event>().type_() != *"blur" {
                 self.owner_document()
@@ -976,7 +976,12 @@ impl Activatable for HTMLSelectElement {
         !self.upcast::<Element>().disabled_state()
     }
 
-    fn activation_behavior(&self, event: &Event, _target: &EventTarget, _can_gc: CanGc) {
+    fn activation_behavior(
+        &self,
+        _cx: &mut js::context::JSContext,
+        event: &Event,
+        _target: &EventTarget,
+    ) {
         if !event.IsTrusted() {
             return;
         }

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -734,7 +734,7 @@ impl VirtualMethods for HTMLTextAreaElement {
     }
 
     // copied and modified from htmlinputelement.rs
-    fn handle_event(&self, event: &Event, can_gc: CanGc) {
+    fn handle_event(&self, cx: &mut js::context::JSContext, event: &Event) {
         if let Some(mouse_event) = event.downcast::<MouseEvent>() {
             self.handle_mouse_event(mouse_event);
             event.mark_as_handled();
@@ -743,7 +743,7 @@ impl VirtualMethods for HTMLTextAreaElement {
                 // This can't be inlined, as holding on to textinput.borrow_mut()
                 // during self.implicit_submission will cause a panic.
                 let action = self.textinput.borrow_mut().handle_keydown(keyboard_event);
-                self.handle_key_reaction(action, event, can_gc);
+                self.handle_key_reaction(action, event, CanGc::from_cx(cx));
             }
         } else if event.type_() == atom!("compositionstart") ||
             event.type_() == atom!("compositionupdate") ||
@@ -755,14 +755,14 @@ impl VirtualMethods for HTMLTextAreaElement {
                         .textinput
                         .borrow_mut()
                         .handle_compositionend(compositionevent);
-                    self.handle_key_reaction(action, event, can_gc);
+                    self.handle_key_reaction(action, event, CanGc::from_cx(cx));
                     self.upcast::<Node>().dirty(NodeDamage::Other);
                 } else if event.type_() == atom!("compositionupdate") {
                     let action = self
                         .textinput
                         .borrow_mut()
                         .handle_compositionupdate(compositionevent);
-                    self.handle_key_reaction(action, event, can_gc);
+                    self.handle_key_reaction(action, event, CanGc::from_cx(cx));
                     self.upcast::<Node>().dirty(NodeDamage::Other);
                 }
                 self.maybe_update_shared_selection();
@@ -779,7 +779,7 @@ impl VirtualMethods for HTMLTextAreaElement {
                 self.owner_document().event_handler().fire_clipboard_event(
                     None,
                     ClipboardEventType::Change,
-                    can_gc,
+                    CanGc::from_cx(cx),
                 );
             }
             if flags.contains(ClipboardEventFlags::QueueInputEvent) {
@@ -792,17 +792,17 @@ impl VirtualMethods for HTMLTextAreaElement {
             }
             if !flags.is_empty() {
                 event.mark_as_handled();
-                self.handle_text_content_changed(can_gc);
+                self.handle_text_content_changed(CanGc::from_cx(cx));
             }
         } else if let Some(event) = event.downcast::<FocusEvent>() {
             self.handle_focus_event(event);
         }
 
-        self.validity_state(can_gc)
-            .perform_validation_and_update(ValidationFlags::all(), can_gc);
+        self.validity_state(CanGc::from_cx(cx))
+            .perform_validation_and_update(ValidationFlags::all(), CanGc::from_cx(cx));
 
         if let Some(super_type) = self.super_type() {
-            super_type.handle_event(event, can_gc);
+            super_type.handle_event(cx, event);
         }
     }
 

--- a/components/script/dom/html/input_element/mod.rs
+++ b/components/script/dom/html/input_element/mod.rs
@@ -2489,7 +2489,7 @@ impl Activatable for HTMLInputElement {
     /// <https://html.spec.whatwg.org/multipage/#input-activation-behavior>
     fn activation_behavior(
         &self,
-        _cx: &mut js::context::JSContext,
+        cx: &mut js::context::JSContext,
         event: &Event,
         target: &EventTarget,
     ) {

--- a/components/script/dom/html/input_element/mod.rs
+++ b/components/script/dom/html/input_element/mod.rs
@@ -2497,7 +2497,7 @@ impl Activatable for HTMLInputElement {
             self,
             event,
             target,
-            CanGc::from_cx(_cx),
+            CanGc::from_cx(cx),
         );
     }
 }

--- a/components/script/dom/html/input_element/mod.rs
+++ b/components/script/dom/html/input_element/mod.rs
@@ -2225,7 +2225,7 @@ impl VirtualMethods for HTMLInputElement {
     // Compare:
     // https://w3c.github.io/uievents/#default-action
     /// <https://dom.spec.whatwg.org/#action-versus-occurance>
-    fn handle_event(&self, event: &Event, can_gc: CanGc) {
+    fn handle_event(&self, cx: &mut js::context::JSContext, event: &Event) {
         if let Some(mouse_event) = event.downcast::<MouseEvent>() {
             self.handle_mouse_event(mouse_event);
             event.mark_as_handled();
@@ -2237,7 +2237,7 @@ impl VirtualMethods for HTMLInputElement {
                 // This can't be inlined, as holding on to textinput.borrow_mut()
                 // during self.implicit_submission will cause a panic.
                 let action = self.textinput.borrow_mut().handle_keydown(keyevent);
-                self.handle_key_reaction(action, event, can_gc);
+                self.handle_key_reaction(action, event, CanGc::from_cx(cx));
             }
         } else if (event.type_() == atom!("compositionstart") ||
             event.type_() == atom!("compositionupdate") ||
@@ -2250,7 +2250,7 @@ impl VirtualMethods for HTMLInputElement {
                         .textinput
                         .borrow_mut()
                         .handle_compositionend(compositionevent);
-                    self.handle_key_reaction(action, event, can_gc);
+                    self.handle_key_reaction(action, event, CanGc::from_cx(cx));
                     self.upcast::<Node>().dirty(NodeDamage::Other);
                     self.update_placeholder_shown_state();
                 } else if event.type_() == atom!("compositionupdate") {
@@ -2258,7 +2258,7 @@ impl VirtualMethods for HTMLInputElement {
                         .textinput
                         .borrow_mut()
                         .handle_compositionupdate(compositionevent);
-                    self.handle_key_reaction(action, event, can_gc);
+                    self.handle_key_reaction(action, event, CanGc::from_cx(cx));
                     self.upcast::<Node>().dirty(NodeDamage::Other);
                     self.update_placeholder_shown_state();
                 } else if event.type_() == atom!("compositionstart") {
@@ -2277,7 +2277,7 @@ impl VirtualMethods for HTMLInputElement {
                 self.owner_document().event_handler().fire_clipboard_event(
                     None,
                     ClipboardEventType::Change,
-                    can_gc,
+                    CanGc::from_cx(cx),
                 );
             }
             if flags.contains(ClipboardEventFlags::QueueInputEvent) {
@@ -2296,10 +2296,10 @@ impl VirtualMethods for HTMLInputElement {
             self.handle_focus_event(event)
         }
 
-        self.value_changed(can_gc);
+        self.value_changed(CanGc::from_cx(cx));
 
         if let Some(super_type) = self.super_type() {
-            super_type.handle_event(event, can_gc);
+            super_type.handle_event(cx, event);
         }
     }
 
@@ -2487,10 +2487,18 @@ impl Activatable for HTMLInputElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#input-activation-behavior>
-    fn activation_behavior(&self, event: &Event, target: &EventTarget, can_gc: CanGc) {
-        self.input_type()
-            .as_specific()
-            .activation_behavior(self, event, target, can_gc)
+    fn activation_behavior(
+        &self,
+        _cx: &mut js::context::JSContext,
+        event: &Event,
+        target: &EventTarget,
+    ) {
+        self.input_type().as_specific().activation_behavior(
+            self,
+            event,
+            target,
+            CanGc::from_cx(_cx),
+        );
     }
 }
 

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -4791,7 +4791,7 @@ impl VirtualMethods for Node {
         self.owner_doc().content_and_heritage_changed(self);
     }
 
-    fn handle_event(&self, event: &Event, can_gc: CanGc) {
+    fn handle_event(&self, cx: &mut js::context::JSContext, event: &Event) {
         if event.DefaultPrevented() || event.flags().contains(EventFlags::Handled) {
             return;
         }
@@ -4799,7 +4799,7 @@ impl VirtualMethods for Node {
         if let Some(event) = event.downcast::<KeyboardEvent>() {
             self.owner_document()
                 .event_handler()
-                .run_default_keyboard_event_handler(self, event, can_gc);
+                .run_default_keyboard_event_handler(self, event, CanGc::from_cx(cx));
         }
     }
 }

--- a/components/script/dom/virtualmethods.rs
+++ b/components/script/dom/virtualmethods.rs
@@ -149,9 +149,9 @@ pub(crate) trait VirtualMethods {
     }
 
     /// Called during event dispatch after the bubbling phase completes.
-    fn handle_event(&self, event: &Event, can_gc: CanGc) {
+    fn handle_event(&self, cx: &mut js::context::JSContext, event: &Event) {
         if let Some(s) = self.super_type() {
-            s.handle_event(event, can_gc);
+            s.handle_event(cx, event);
         }
     }
 


### PR DESCRIPTION
Propagate `&mut JSContext` in `Activatable::activation_behavior` and related call sites.

Testing: Successful build is enough
Fixes: Part of #42638 

Opened to reduces the complexity of #44482 