### PR TITLE
script:  move drop implementation to a separate struct from WebGLSync and WebGLTransformFeedback

### DIFF
--- a/components/script/dom/webgl/webglsync.rs
+++ b/components/script/dom/webgl/webglsync.rs
@@ -9,7 +9,6 @@ use script_bindings::weakref::WeakRef;
 use servo_canvas_traits::webgl::{WebGLCommand, WebGLSyncId, webgl_channel};
 
 use crate::dom::bindings::codegen::Bindings::WebGL2RenderingContextBinding::WebGL2RenderingContextConstants as constants;
-use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object};
 use crate::dom::bindings::root::DomRoot;

--- a/components/script/dom/webgl/webglsync.rs
+++ b/components/script/dom/webgl/webglsync.rs
@@ -5,6 +5,7 @@
 use std::cell::Cell;
 
 use dom_struct::dom_struct;
+use script_bindings::weakref::WeakRef;
 use servo_canvas_traits::webgl::{WebGLCommand, WebGLSyncId, webgl_channel};
 
 use crate::dom::bindings::codegen::Bindings::WebGL2RenderingContextBinding::WebGL2RenderingContextConstants as constants;
@@ -14,26 +15,67 @@ use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::webgl::webglobject::WebGLObject;
 use crate::dom::webgl::webglrenderingcontext::{Operation, WebGLRenderingContext};
+use crate::dom::webglrenderingcontext::capture_webgl_backtrace;
 use crate::script_runtime::CanGc;
+
+#[derive(JSTraceable, MallocSizeOf)]
+struct DroppableWebGLSync {
+    context: WeakRef<WebGLRenderingContext>,
+    #[no_trace]
+    sync_id: WebGLSyncId,
+    marked_for_deletion: Cell<bool>,
+}
+
+impl DroppableWebGLSync {
+    fn send_with_fallibility(&self, command: WebGLCommand, fallibility: Operation) {
+        if let Some(root) = self.context.root() {
+            let result = root.sender().send(command, capture_webgl_backtrace());
+            if matches!(fallibility, Operation::Infallible) {
+                result.expect("Operation failed");
+            }
+        }
+    }
+
+    fn delete(&self, operation_fallibility: Operation) {
+        if self.is_valid() {
+            self.marked_for_deletion.set(true);
+            self.send_with_fallibility(
+                WebGLCommand::DeleteSync(self.sync_id),
+                operation_fallibility,
+            );
+        }
+    }
+
+    fn is_valid(&self) -> bool {
+        !self.marked_for_deletion.get()
+    }
+}
+
+impl Drop for DroppableWebGLSync {
+    fn drop(&mut self) {
+        self.delete(Operation::Fallible);
+    }
+}
 
 #[dom_struct(associated_memory)]
 pub(crate) struct WebGLSync {
     webgl_object: WebGLObject,
-    #[no_trace]
-    sync_id: WebGLSyncId,
-    marked_for_deletion: Cell<bool>,
     client_wait_status: Cell<Option<u32>>,
     sync_status: Cell<Option<u32>>,
+    droppable: DroppableWebGLSync,
 }
 
 impl WebGLSync {
     fn new_inherited(context: &WebGLRenderingContext, sync_id: WebGLSyncId) -> Self {
         Self {
             webgl_object: WebGLObject::new_inherited(context),
-            sync_id,
-            marked_for_deletion: Cell::new(false),
             client_wait_status: Cell::new(None),
             sync_status: Cell::new(None),
+            droppable: DroppableWebGLSync {
+                context: WeakRef::new(context),
+                sync_id,
+                marked_for_deletion: Cell::new(false),
+            },
         }
     }
 
@@ -66,7 +108,7 @@ impl WebGLSync {
                     let context = context.root();
                     let (sender, receiver) = webgl_channel().unwrap();
                     context.send_command(WebGLCommand::ClientWaitSync(
-                        this.sync_id,
+                        this.id(),
                         flags,
                         timeout,
                         sender,
@@ -84,13 +126,7 @@ impl WebGLSync {
     }
 
     pub(crate) fn delete(&self, operation_fallibility: Operation) {
-        if self.is_valid() {
-            self.marked_for_deletion.set(true);
-            self.upcast().send_with_fallibility(
-                WebGLCommand::DeleteSync(self.sync_id),
-                operation_fallibility,
-            );
-        }
+        self.droppable.delete(operation_fallibility);
     }
 
     pub(crate) fn get_sync_status(
@@ -106,7 +142,7 @@ impl WebGLSync {
                     let this = this.root();
                     let context = context.root();
                     let (sender, receiver) = webgl_channel().unwrap();
-                    context.send_command(WebGLCommand::GetSyncParameter(this.sync_id, pname, sender));
+                    context.send_command(WebGLCommand::GetSyncParameter(this.id(), pname, sender));
                     this.sync_status.set(Some(receiver.recv().unwrap()));
                 });
                 self.global()
@@ -120,16 +156,10 @@ impl WebGLSync {
     }
 
     pub(crate) fn is_valid(&self) -> bool {
-        !self.marked_for_deletion.get()
+        self.droppable.is_valid()
     }
 
     pub(crate) fn id(&self) -> WebGLSyncId {
-        self.sync_id
-    }
-}
-
-impl Drop for WebGLSync {
-    fn drop(&mut self) {
-        self.delete(Operation::Fallible);
+        self.droppable.sync_id
     }
 }

--- a/components/script/dom/webgl/webgltransformfeedback.rs
+++ b/components/script/dom/webgl/webgltransformfeedback.rs
@@ -8,7 +8,6 @@ use dom_struct::dom_struct;
 use script_bindings::weakref::WeakRef;
 use servo_canvas_traits::webgl::{WebGLCommand, webgl_channel};
 
-use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::webgl::webglobject::WebGLObject;

--- a/components/script/dom/webgl/webgltransformfeedback.rs
+++ b/components/script/dom/webgl/webgltransformfeedback.rs
@@ -5,6 +5,7 @@
 use std::cell::Cell;
 
 use dom_struct::dom_struct;
+use script_bindings::weakref::WeakRef;
 use servo_canvas_traits::webgl::{WebGLCommand, webgl_channel};
 
 use crate::dom::bindings::inheritance::Castable;
@@ -12,27 +13,72 @@ use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::webgl::webglobject::WebGLObject;
 use crate::dom::webgl::webglrenderingcontext::{Operation, WebGLRenderingContext};
+use crate::dom::webglrenderingcontext::capture_webgl_backtrace;
 use crate::script_runtime::CanGc;
+
+#[derive(JSTraceable, MallocSizeOf)]
+struct DroppableWebGLTransformFeedback {
+    context: WeakRef<WebGLRenderingContext>,
+    id: u32,
+    marked_for_deletion: Cell<bool>,
+}
+
+impl DroppableWebGLTransformFeedback {
+    fn send_with_fallibility(&self, command: WebGLCommand, fallibility: Operation) {
+        if let Some(root) = self.context.root() {
+            let result = root.sender().send(command, capture_webgl_backtrace());
+            if matches!(fallibility, Operation::Infallible) {
+                result.expect("Operation failed");
+            }
+        }
+    }
+
+    fn delete(&self, operation_fallibility: Operation) {
+        if self.is_valid() && self.id() != 0 {
+            self.marked_for_deletion.set(true);
+            self.send_with_fallibility(
+                WebGLCommand::DeleteTransformFeedback(self.id()),
+                operation_fallibility,
+            );
+        }
+    }
+
+    fn id(&self) -> u32 {
+        self.id
+    }
+
+    fn is_valid(&self) -> bool {
+        !self.marked_for_deletion.get()
+    }
+}
+
+impl Drop for DroppableWebGLTransformFeedback {
+    fn drop(&mut self) {
+        self.delete(Operation::Fallible);
+    }
+}
 
 #[dom_struct(associated_memory)]
 pub(crate) struct WebGLTransformFeedback {
     webgl_object: WebGLObject,
-    id: u32,
-    marked_for_deletion: Cell<bool>,
     has_been_bound: Cell<bool>,
     is_active: Cell<bool>,
     is_paused: Cell<bool>,
+    droppable: DroppableWebGLTransformFeedback,
 }
 
 impl WebGLTransformFeedback {
     fn new_inherited(context: &WebGLRenderingContext, id: u32) -> Self {
         Self {
             webgl_object: WebGLObject::new_inherited(context),
-            id,
-            marked_for_deletion: Cell::new(false),
             has_been_bound: Cell::new(false),
             is_active: Cell::new(false),
             is_paused: Cell::new(false),
+            droppable: DroppableWebGLTransformFeedback {
+                context: WeakRef::new(context),
+                id,
+                marked_for_deletion: Cell::new(false),
+            },
         }
     }
 
@@ -87,11 +133,11 @@ impl WebGLTransformFeedback {
     }
 
     pub(crate) fn id(&self) -> u32 {
-        self.id
+        self.droppable.id()
     }
 
     pub(crate) fn is_valid(&self) -> bool {
-        !self.marked_for_deletion.get()
+        self.droppable.is_valid()
     }
 
     pub(crate) fn is_active(&self) -> bool {
@@ -103,13 +149,7 @@ impl WebGLTransformFeedback {
     }
 
     pub(crate) fn delete(&self, operation_fallibility: Operation) {
-        if self.is_valid() && self.id() != 0 {
-            self.marked_for_deletion.set(true);
-            self.upcast().send_with_fallibility(
-                WebGLCommand::DeleteTransformFeedback(self.id),
-                operation_fallibility,
-            );
-        }
+        self.droppable.delete(operation_fallibility);
     }
 
     pub(crate) fn set_active(&self, value: bool) {
@@ -122,11 +162,5 @@ impl WebGLTransformFeedback {
         if self.is_valid() && self.is_active() {
             self.is_active.set(value);
         }
-    }
-}
-
-impl Drop for WebGLTransformFeedback {
-    fn drop(&mut self) {
-        self.delete(Operation::Fallible);
     }
 }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -947,10 +947,6 @@ DOMInterfaces = {
     'weakReferenceable': True,
 },
 
-'WebGLSync': {
-    'allowDropImpl': True,
-},
-
 'WebGLTexture': {
     'allowDropImpl': True,
 },

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -951,10 +951,6 @@ DOMInterfaces = {
     'allowDropImpl': True,
 },
 
-'WebGLTransformFeedback': {
-    'allowDropImpl': True,
-},
-
 'Window': {
     'canGc': ['CookieStore', 'FetchLater', 'GetVisualViewport', 'ReportError', 'Screen', 'StructuredClone'],
     'additionalTraits': ['crate::interfaces::WindowHelpers'],


### PR DESCRIPTION
move drop implementation to a separate struct from WebGLSync and WebGLTransformFeedback. Aligned Binding.conf too.

Testing: WebGL tests just cover the cases. No more tests needed.
Fixes: Partially #26488 
