### PR TITLE
Check for empty path in match_def_path

### DIFF
--- a/support/crown/src/common.rs
+++ b/support/crown/src/common.rs
@@ -18,6 +18,9 @@ use rustc_type_ir::Upcast as _;
 /// usage e.g. with
 /// `match_def_path(cx, id, &["core", "option", "Option"])`
 pub fn match_def_path(cx: &LateContext, def_id: DefId, path: &[Symbol]) -> bool {
+    if path.is_empty() {
+        return false;
+    }
     let def_path = cx.tcx.def_path(def_id);
     let krate = &cx.tcx.crate_name(def_path.krate);
     if krate != &path[0] {


### PR DESCRIPTION
Add a check for empty path in match_def_path function.

Previously, match_def_path in support/crown/src/common.rs
would panic if called with an empty path slice due to an
unchecked access of path[0]. This adds an early return of
false when the path is empty, since an empty path can never
match any definition path.

Testing: No automated tests added. This fix handles an 
edge case that cannot occur through normal usage but 
could cause a panic if triggered. The fix is a simple 
guard clause with no logic change to existing behaviour.

:D