### PR TITLE
script: Pass `&mut JSContext` to event handler attributes

### DIFF
--- a/components/script/dom/event/eventtarget.rs
+++ b/components/script/dom/event/eventtarget.rs
@@ -14,6 +14,7 @@ use std::sync::LazyLock;
 use deny_public_fields::DenyPublicFields;
 use devtools_traits::EventListenerInfo;
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::jsapi::JS::CompileFunction;
 use js::jsapi::{JS_GetFunctionObject, SupportUnscopables};
 use js::jsval::JSVal;
@@ -389,14 +390,14 @@ impl EventListeners {
     /// <https://html.spec.whatwg.org/multipage/#getting-the-current-value-of-the-event-handler>
     fn get_inline_listener(
         &self,
+        cx: &mut JSContext,
         owner: &EventTarget,
         ty: &Atom,
-        can_gc: CanGc,
     ) -> Option<CommonEventHandler> {
         for entry in &self.0 {
             if let EventListenerType::Inline(ref inline) = entry.borrow().listener {
                 // Step 1.1-1.8 and Step 2
-                return get_compiled_handler(inline, owner, ty, can_gc);
+                return get_compiled_handler(inline, owner, ty, CanGc::from_cx(cx));
             }
         }
 
@@ -583,11 +584,15 @@ impl EventTarget {
         listener.borrow().passive
     }
 
-    fn get_inline_event_listener(&self, ty: &Atom, can_gc: CanGc) -> Option<CommonEventHandler> {
+    fn get_inline_event_listener(
+        &self,
+        cx: &mut JSContext,
+        ty: &Atom,
+    ) -> Option<CommonEventHandler> {
         let handlers = self.handlers.borrow();
         handlers
             .get(ty)
-            .and_then(|entry| entry.get_inline_listener(self, ty, can_gc))
+            .and_then(|entry| entry.get_inline_listener(cx, self, ty))
     }
 
     /// Store the raw uncompiled event handler for on-demand compilation later.
@@ -745,14 +750,13 @@ impl EventTarget {
     #[expect(unsafe_code)]
     pub(crate) fn set_event_handler_common<T: CallbackContainer<crate::DomTypeHolder>>(
         &self,
+        cx: &mut JSContext,
         ty: &str,
         listener: Option<Rc<T>>,
     ) {
-        let cx = GlobalScope::get_cx();
-
         let event_listener = listener.map(|listener| {
             InlineEventListener::Compiled(CommonEventHandler::EventHandler(unsafe {
-                EventHandlerNonNull::new(cx, listener.callback())
+                EventHandlerNonNull::new(cx.into(), listener.callback())
             }))
         });
         self.set_inline_event_listener(Atom::from(ty), event_listener);
@@ -761,14 +765,13 @@ impl EventTarget {
     #[expect(unsafe_code)]
     pub(crate) fn set_error_event_handler<T: CallbackContainer<crate::DomTypeHolder>>(
         &self,
+        cx: &mut JSContext,
         ty: &str,
         listener: Option<Rc<T>>,
     ) {
-        let cx = GlobalScope::get_cx();
-
         let event_listener = listener.map(|listener| {
             InlineEventListener::Compiled(CommonEventHandler::ErrorEventHandler(unsafe {
-                OnErrorEventHandlerNonNull::new(cx, listener.callback())
+                OnErrorEventHandlerNonNull::new(cx.into(), listener.callback())
             }))
         });
         self.set_inline_event_listener(Atom::from(ty), event_listener);
@@ -777,14 +780,13 @@ impl EventTarget {
     #[expect(unsafe_code)]
     pub(crate) fn set_beforeunload_event_handler<T: CallbackContainer<crate::DomTypeHolder>>(
         &self,
+        cx: &mut JSContext,
         ty: &str,
         listener: Option<Rc<T>>,
     ) {
-        let cx = GlobalScope::get_cx();
-
         let event_listener = listener.map(|listener| {
             InlineEventListener::Compiled(CommonEventHandler::BeforeUnloadEventHandler(unsafe {
-                OnBeforeUnloadEventHandlerNonNull::new(cx, listener.callback())
+                OnBeforeUnloadEventHandlerNonNull::new(cx.into(), listener.callback())
             }))
         });
         self.set_inline_event_listener(Atom::from(ty), event_listener);
@@ -793,14 +795,13 @@ impl EventTarget {
     #[expect(unsafe_code)]
     pub(crate) fn get_event_handler_common<T: CallbackContainer<crate::DomTypeHolder>>(
         &self,
+        cx: &mut JSContext,
         ty: &str,
-        can_gc: CanGc,
     ) -> Option<Rc<T>> {
-        let cx = GlobalScope::get_cx();
-        let listener = self.get_inline_event_listener(&Atom::from(ty), can_gc);
+        let listener = self.get_inline_event_listener(cx, &Atom::from(ty));
         unsafe {
             listener.map(|listener| {
-                CallbackContainer::new(cx, listener.parent().callback_holder().get())
+                CallbackContainer::new(cx.into(), listener.parent().callback_holder().get())
             })
         }
     }

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -200,12 +200,12 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     // https://html.spec.whatwg.org/multipage/#attr-title
     make_getter!(Title, "title");
     // https://html.spec.whatwg.org/multipage/#attr-title
-    make_setter!(SetTitle, "title");
+    make_setter!(cx, SetTitle, "title");
 
     // https://html.spec.whatwg.org/multipage/#attr-lang
     make_getter!(Lang, "lang");
     // https://html.spec.whatwg.org/multipage/#attr-lang
-    make_setter!(SetLang, "lang");
+    make_setter!(cx, SetLang, "lang");
 
     // https://html.spec.whatwg.org/multipage/#the-dir-attribute
     make_enumerated_getter!(
@@ -217,12 +217,12 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     );
 
     // https://html.spec.whatwg.org/multipage/#the-dir-attribute
-    make_setter!(SetDir, "dir");
+    make_setter!(cx, SetDir, "dir");
 
     // https://html.spec.whatwg.org/multipage/#dom-hidden
     make_bool_getter!(Hidden, "hidden");
     // https://html.spec.whatwg.org/multipage/#dom-hidden
-    make_bool_setter!(SetHidden, "hidden");
+    make_bool_setter!(cx, SetHidden, "hidden");
 
     // https://html.spec.whatwg.org/multipage/#globaleventhandlers
     global_event_handlers!(NoOnload);
@@ -233,171 +233,171 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#handler-onerror>
-    fn GetOnerror(&self, can_gc: CanGc) -> Option<Rc<OnErrorEventHandlerNonNull>> {
+    fn GetOnerror(&self, cx: &mut JSContext) -> Option<Rc<OnErrorEventHandlerNonNull>> {
         if self.is_body_or_frameset() {
             let document = self.owner_document();
             if document.has_browsing_context() {
-                document.window().GetOnerror()
+                document.window().GetOnerror(cx)
             } else {
                 None
             }
         } else {
             self.upcast::<EventTarget>()
-                .get_event_handler_common("error", can_gc)
+                .get_event_handler_common(cx, "error")
         }
     }
 
     /// <https://html.spec.whatwg.org/multipage/#handler-onerror>
-    fn SetOnerror(&self, listener: Option<Rc<OnErrorEventHandlerNonNull>>) {
+    fn SetOnerror(&self, cx: &mut JSContext, listener: Option<Rc<OnErrorEventHandlerNonNull>>) {
         if self.is_body_or_frameset() {
             let document = self.owner_document();
             if document.has_browsing_context() {
-                document.window().SetOnerror(listener)
+                document.window().SetOnerror(cx, listener)
             }
         } else {
             // special setter for error
             self.upcast::<EventTarget>()
-                .set_error_event_handler("error", listener)
+                .set_error_event_handler(cx, "error", listener)
         }
     }
 
     /// <https://html.spec.whatwg.org/multipage/#handler-onload>
-    fn GetOnload(&self, can_gc: CanGc) -> Option<Rc<EventHandlerNonNull>> {
+    fn GetOnload(&self, cx: &mut JSContext) -> Option<Rc<EventHandlerNonNull>> {
         if self.is_body_or_frameset() {
             let document = self.owner_document();
             if document.has_browsing_context() {
-                document.window().GetOnload()
+                document.window().GetOnload(cx)
             } else {
                 None
             }
         } else {
             self.upcast::<EventTarget>()
-                .get_event_handler_common("load", can_gc)
+                .get_event_handler_common(cx, "load")
         }
     }
 
     /// <https://html.spec.whatwg.org/multipage/#handler-onload>
-    fn SetOnload(&self, listener: Option<Rc<EventHandlerNonNull>>) {
+    fn SetOnload(&self, cx: &mut JSContext, listener: Option<Rc<EventHandlerNonNull>>) {
         if self.is_body_or_frameset() {
             let document = self.owner_document();
             if document.has_browsing_context() {
-                document.window().SetOnload(listener)
+                document.window().SetOnload(cx, listener)
             }
         } else {
             self.upcast::<EventTarget>()
-                .set_event_handler_common("load", listener)
+                .set_event_handler_common(cx, "load", listener)
         }
     }
 
     /// <https://html.spec.whatwg.org/multipage/#handler-onblur>
-    fn GetOnblur(&self, can_gc: CanGc) -> Option<Rc<EventHandlerNonNull>> {
+    fn GetOnblur(&self, cx: &mut JSContext) -> Option<Rc<EventHandlerNonNull>> {
         if self.is_body_or_frameset() {
             let document = self.owner_document();
             if document.has_browsing_context() {
-                document.window().GetOnblur()
+                document.window().GetOnblur(cx)
             } else {
                 None
             }
         } else {
             self.upcast::<EventTarget>()
-                .get_event_handler_common("blur", can_gc)
+                .get_event_handler_common(cx, "blur")
         }
     }
 
     /// <https://html.spec.whatwg.org/multipage/#handler-onblur>
-    fn SetOnblur(&self, listener: Option<Rc<EventHandlerNonNull>>) {
+    fn SetOnblur(&self, cx: &mut JSContext, listener: Option<Rc<EventHandlerNonNull>>) {
         if self.is_body_or_frameset() {
             let document = self.owner_document();
             if document.has_browsing_context() {
-                document.window().SetOnblur(listener)
+                document.window().SetOnblur(cx, listener)
             }
         } else {
             self.upcast::<EventTarget>()
-                .set_event_handler_common("blur", listener)
+                .set_event_handler_common(cx, "blur", listener)
         }
     }
 
     /// <https://html.spec.whatwg.org/multipage/#handler-onfocus>
-    fn GetOnfocus(&self, can_gc: CanGc) -> Option<Rc<EventHandlerNonNull>> {
+    fn GetOnfocus(&self, cx: &mut JSContext) -> Option<Rc<EventHandlerNonNull>> {
         if self.is_body_or_frameset() {
             let document = self.owner_document();
             if document.has_browsing_context() {
-                document.window().GetOnfocus()
+                document.window().GetOnfocus(cx)
             } else {
                 None
             }
         } else {
             self.upcast::<EventTarget>()
-                .get_event_handler_common("focus", can_gc)
+                .get_event_handler_common(cx, "focus")
         }
     }
 
     /// <https://html.spec.whatwg.org/multipage/#handler-onfocus>
-    fn SetOnfocus(&self, listener: Option<Rc<EventHandlerNonNull>>) {
+    fn SetOnfocus(&self, cx: &mut JSContext, listener: Option<Rc<EventHandlerNonNull>>) {
         if self.is_body_or_frameset() {
             let document = self.owner_document();
             if document.has_browsing_context() {
-                document.window().SetOnfocus(listener)
+                document.window().SetOnfocus(cx, listener)
             }
         } else {
             self.upcast::<EventTarget>()
-                .set_event_handler_common("focus", listener)
+                .set_event_handler_common(cx, "focus", listener)
         }
     }
 
     /// <https://html.spec.whatwg.org/multipage/#handler-onresize>
-    fn GetOnresize(&self, can_gc: CanGc) -> Option<Rc<EventHandlerNonNull>> {
+    fn GetOnresize(&self, cx: &mut JSContext) -> Option<Rc<EventHandlerNonNull>> {
         if self.is_body_or_frameset() {
             let document = self.owner_document();
             if document.has_browsing_context() {
-                document.window().GetOnresize()
+                document.window().GetOnresize(cx)
             } else {
                 None
             }
         } else {
             self.upcast::<EventTarget>()
-                .get_event_handler_common("resize", can_gc)
+                .get_event_handler_common(cx, "resize")
         }
     }
 
     /// <https://html.spec.whatwg.org/multipage/#handler-onresize>
-    fn SetOnresize(&self, listener: Option<Rc<EventHandlerNonNull>>) {
+    fn SetOnresize(&self, cx: &mut JSContext, listener: Option<Rc<EventHandlerNonNull>>) {
         if self.is_body_or_frameset() {
             let document = self.owner_document();
             if document.has_browsing_context() {
-                document.window().SetOnresize(listener)
+                document.window().SetOnresize(cx, listener)
             }
         } else {
             self.upcast::<EventTarget>()
-                .set_event_handler_common("resize", listener)
+                .set_event_handler_common(cx, "resize", listener)
         }
     }
 
     /// <https://html.spec.whatwg.org/multipage/#handler-onscroll>
-    fn GetOnscroll(&self, can_gc: CanGc) -> Option<Rc<EventHandlerNonNull>> {
+    fn GetOnscroll(&self, cx: &mut JSContext) -> Option<Rc<EventHandlerNonNull>> {
         if self.is_body_or_frameset() {
             let document = self.owner_document();
             if document.has_browsing_context() {
-                document.window().GetOnscroll()
+                document.window().GetOnscroll(cx)
             } else {
                 None
             }
         } else {
             self.upcast::<EventTarget>()
-                .get_event_handler_common("scroll", can_gc)
+                .get_event_handler_common(cx, "scroll")
         }
     }
 
     /// <https://html.spec.whatwg.org/multipage/#handler-onscroll>
-    fn SetOnscroll(&self, listener: Option<Rc<EventHandlerNonNull>>) {
+    fn SetOnscroll(&self, cx: &mut JSContext, listener: Option<Rc<EventHandlerNonNull>>) {
         if self.is_body_or_frameset() {
             let document = self.owner_document();
             if document.has_browsing_context() {
-                document.window().SetOnscroll(listener)
+                document.window().SetOnscroll(cx, listener)
             }
         } else {
             self.upcast::<EventTarget>()
-                .set_event_handler_common("scroll", listener)
+                .set_event_handler_common(cx, "scroll", listener)
         }
     }
 
@@ -648,14 +648,14 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-translate>
-    fn SetTranslate(&self, yesno: bool, can_gc: CanGc) {
+    fn SetTranslate(&self, cx: &mut JSContext, yesno: bool) {
         self.as_element().set_string_attribute(
             &html5ever::local_name!("translate"),
             match yesno {
                 true => DOMString::from("yes"),
                 false => DOMString::from("no"),
             },
-            can_gc,
+            CanGc::from_cx(cx),
         );
     }
 
@@ -670,20 +670,24 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     );
 
     /// <https://html.spec.whatwg.org/multipage/#dom-contenteditable>
-    fn SetContentEditable(&self, value: DOMString, can_gc: CanGc) -> ErrorResult {
+    fn SetContentEditable(&self, cx: &mut JSContext, value: DOMString) -> ErrorResult {
         let lower_value = value.to_ascii_lowercase();
         let attr_name = &local_name!("contenteditable");
         match lower_value.as_ref() {
             // > On setting, if the new value is an ASCII case-insensitive match for the string "inherit", then the content attribute must be removed,
             "inherit" => {
-                self.element.remove_attribute_by_name(attr_name, can_gc);
+                self.element
+                    .remove_attribute_by_name(attr_name, CanGc::from_cx(cx));
             },
             // > if the new value is an ASCII case-insensitive match for the string "true", then the content attribute must be set to the string "true",
             // > if the new value is an ASCII case-insensitive match for the string "plaintext-only", then the content attribute must be set to the string "plaintext-only",
             // > if the new value is an ASCII case-insensitive match for the string "false", then the content attribute must be set to the string "false",
             "true" | "false" | "plaintext-only" => {
-                self.element
-                    .set_attribute(attr_name, AttrValue::String(lower_value), can_gc);
+                self.element.set_attribute(
+                    attr_name,
+                    AttrValue::String(lower_value),
+                    CanGc::from_cx(cx),
+                );
             },
             // > and otherwise the attribute setter must throw a "SyntaxError" DOMException.
             _ => return Err(Error::Syntax(None)),
@@ -752,7 +756,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-noncedelement-nonce>
-    fn SetNonce(&self, value: DOMString) {
+    fn SetNonce(&self, _cx: &mut JSContext, value: DOMString) {
         self.as_element()
             .update_nonce_internal_slot(value.to_string())
     }
@@ -763,9 +767,9 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-fe-autofocus>
-    fn SetAutofocus(&self, autofocus: bool, can_gc: CanGc) {
+    fn SetAutofocus(&self, cx: &mut JSContext, autofocus: bool) {
         self.element
-            .set_bool_attribute(&local_name!("autofocus"), autofocus, can_gc);
+            .set_bool_attribute(&local_name!("autofocus"), autofocus, CanGc::from_cx(cx));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-tabindex>
@@ -774,16 +778,16 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-tabindex>
-    fn SetTabIndex(&self, tab_index: i32, can_gc: CanGc) {
+    fn SetTabIndex(&self, cx: &mut JSContext, tab_index: i32) {
         self.element
-            .set_int_attribute(&local_name!("tabindex"), tab_index, can_gc);
+            .set_int_attribute(&local_name!("tabindex"), tab_index, CanGc::from_cx(cx));
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-accesskey
     make_getter!(AccessKey, "accesskey");
 
     // https://html.spec.whatwg.org/multipage/#dom-accesskey
-    make_setter!(SetAccessKey, "accesskey");
+    make_setter!(cx, SetAccessKey, "accesskey");
 
     /// <https://html.spec.whatwg.org/multipage/#dom-accesskeylabel>
     fn AccessKeyLabel(&self) -> DOMString {
@@ -1204,12 +1208,7 @@ impl VirtualMethods for HTMLElement {
         Some(self.as_element() as &dyn VirtualMethods)
     }
 
-    fn attribute_mutated(
-        &self,
-        cx: &mut js::context::JSContext,
-        attr: &Attr,
-        mutation: AttributeMutation,
-    ) {
+    fn attribute_mutated(&self, cx: &mut JSContext, attr: &Attr, mutation: AttributeMutation) {
         self.super_type()
             .unwrap()
             .attribute_mutated(cx, attr, mutation);
@@ -1235,7 +1234,8 @@ impl VirtualMethods for HTMLElement {
                     },
                     // https://html.spec.whatwg.org/multipage/#deactivate-an-event-handler
                     AttributeMutation::Removed => {
-                        evtarget.set_event_handler_common::<EventHandlerNonNull>(event_name, None);
+                        evtarget
+                            .set_event_handler_common::<EventHandlerNonNull>(cx, event_name, None);
                     },
                 }
             },

--- a/components/script/dom/html/input_element/file_input_type.rs
+++ b/components/script/dom/html/input_element/file_input_type.rs
@@ -270,7 +270,7 @@ impl FileInputShadowTree {
         selector_button
             .downcast::<HTMLElement>()
             .expect("This should be guaranteed by the element type used above")
-            .SetTabIndex(-1, CanGc::from_cx(cx));
+            .SetTabIndex(cx, -1);
 
         let _ = shadow_root.AppendChild(cx, selector_button.upcast());
 

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -527,38 +527,37 @@ macro_rules! unsafe_no_jsmanaged_fields(
 /// These are used to generate a event handler which has no special case.
 macro_rules! define_event_handler(
     ($handler: ty, $event_type: ident, $getter: ident, $setter: ident, $setter_fn: ident) => (
-        fn $getter(&self) -> Option<::std::rc::Rc<$handler>> {
+        fn $getter(&self, cx: &mut js::context::JSContext) -> Option<::std::rc::Rc<$handler>> {
             use crate::dom::bindings::inheritance::Castable;
             use crate::dom::eventtarget::EventTarget;
-            use crate::script_runtime::CanGc;
             let eventtarget = self.upcast::<EventTarget>();
-            eventtarget.get_event_handler_common(stringify!($event_type), CanGc::deprecated_note())
+            eventtarget.get_event_handler_common(cx, stringify!($event_type))
         }
 
-        fn $setter(&self, listener: Option<::std::rc::Rc<$handler>>) {
+        fn $setter(&self, cx: &mut js::context::JSContext, listener: Option<::std::rc::Rc<$handler>>) {
             use crate::dom::bindings::inheritance::Castable;
             use crate::dom::eventtarget::EventTarget;
             let eventtarget = self.upcast::<EventTarget>();
-            eventtarget.$setter_fn(stringify!($event_type), listener)
+            eventtarget.$setter_fn(cx, stringify!($event_type), listener)
         }
     )
 );
 
 macro_rules! define_window_owned_event_handler(
     ($handler: ty, $event_type: ident, $getter: ident, $setter: ident) => (
-        fn $getter(&self) -> Option<::std::rc::Rc<$handler>> {
+        fn $getter(&self, cx: &mut js::context::JSContext) -> Option<::std::rc::Rc<$handler>> {
             let document = self.owner_document();
             if document.has_browsing_context() {
-                document.window().$getter()
+                document.window().$getter(cx)
             } else {
                 None
             }
         }
 
-        fn $setter(&self, _cx: &mut js::context::JSContext, listener: Option<::std::rc::Rc<$handler>>) {
+        fn $setter(&self, cx: &mut js::context::JSContext, listener: Option<::std::rc::Rc<$handler>>) {
             let document = self.owner_document();
             if document.has_browsing_context() {
-                document.window().$setter(listener)
+                document.window().$setter(cx, listener)
             }
         }
     )
@@ -582,26 +581,25 @@ macro_rules! event_handler(
 /// only to interested pipelines.
 macro_rules! registered_event_handler(
     ($interest:expr, $event_type: ident, $getter: ident, $setter: ident) => (
-        fn $getter(&self) -> Option<::std::rc::Rc<
+        fn $getter(&self, cx: &mut js::context::JSContext) -> Option<::std::rc::Rc<
             crate::dom::bindings::codegen::Bindings::EventHandlerBinding::EventHandlerNonNull,
         >> {
             use crate::dom::bindings::inheritance::Castable;
             use crate::dom::eventtarget::EventTarget;
-            use crate::script_runtime::CanGc;
             let eventtarget = self.upcast::<EventTarget>();
-            eventtarget.get_event_handler_common(stringify!($event_type), CanGc::deprecated_note())
+            eventtarget.get_event_handler_common(cx, stringify!($event_type))
         }
 
-        fn $setter(&self, listener: Option<::std::rc::Rc<
+        fn $setter(&self, cx: &mut js::context::JSContext, listener: Option<::std::rc::Rc<
             crate::dom::bindings::codegen::Bindings::EventHandlerBinding::EventHandlerNonNull,
         >>) {
             use crate::dom::bindings::inheritance::Castable;
             use crate::dom::bindings::reflector::DomGlobal;
             use crate::dom::eventtarget::EventTarget;
-            let had_handler = self.$getter().is_some();
+            let had_handler = self.$getter(cx).is_some();
             let has_handler = listener.is_some();
             let eventtarget = self.upcast::<EventTarget>();
-            eventtarget.set_event_handler_common(stringify!($event_type), listener);
+            eventtarget.set_event_handler_common(cx, stringify!($event_type), listener);
             if !had_handler && has_handler {
                 self.global().register_interest($interest);
             } else if had_handler && !has_handler {

--- a/components/script/dom/messageport.rs
+++ b/components/script/dom/messageport.rs
@@ -107,9 +107,9 @@ impl MessagePort {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#handler-messageport-onmessage>
-    fn set_onmessage(&self, listener: Option<Rc<EventHandlerNonNull>>) {
+    fn set_onmessage(&self, cx: &mut JSContext, listener: Option<Rc<EventHandlerNonNull>>) {
         let eventtarget = self.upcast::<EventTarget>();
-        eventtarget.set_event_handler_common("message", listener);
+        eventtarget.set_event_handler_common(cx, "message", listener);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#message-port-post-message-steps>
@@ -353,12 +353,12 @@ impl MessagePortMethods<crate::DomTypeHolder> for MessagePort {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#handler-messageport-onmessage>
-    fn GetOnmessage(&self, can_gc: CanGc) -> Option<Rc<EventHandlerNonNull>> {
+    fn GetOnmessage(&self, cx: &mut JSContext) -> Option<Rc<EventHandlerNonNull>> {
         if self.detached.get() {
             return None;
         }
         let eventtarget = self.upcast::<EventTarget>();
-        eventtarget.get_event_handler_common("message", can_gc)
+        eventtarget.get_event_handler_common(cx, "message")
     }
 
     /// <https://html.spec.whatwg.org/multipage/#handler-messageport-onmessage>
@@ -366,7 +366,7 @@ impl MessagePortMethods<crate::DomTypeHolder> for MessagePort {
         if self.detached.get() {
             return;
         }
-        self.set_onmessage(listener);
+        self.set_onmessage(cx, listener);
         // Note: we cannot use the event_handler macro, due to the need to start the port.
         self.global().start_message_port(cx, self.message_port_id());
     }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -466,13 +466,9 @@ DOMInterfaces = {
         'GetOnload',
         'GetOnresize',
         'GetOnscroll',
-        'SetAutofocus',
-        'SetContentEditable',
-        'SetTabIndex',
-        'SetTranslate',
         'Style',
     ],
-    'cx': ['SetInnerText', 'SetOuterText']
+    'implicitCxSetters': True,
 },
 
 'HTMLFieldSetElement': {

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -159,6 +159,12 @@ RUST_KEYWORDS = {
     "yield",
 }
 
+EVENT_HANDLER_CALLBACKS = {
+    "EventHandlerNonNull",
+    "OnErrorEventHandlerNonNull",
+    "OnBeforeUnloadEventHandlerNonNull",
+}
+
 def isIDLType(obj: IDLObject) -> TypeGuard[IDLType]:
     if obj.isType():
         assert isinstance(obj, IDLType)
@@ -4169,6 +4175,16 @@ def needCx(returnType: IDLType | None, arguments: Iterable[IDLArgument | FakeArg
     return max([typeNeedsCx(a.type) for a in arguments] + [typeNeedsCx(returnType, True)]) if considerTypes else Context.No
 
 
+def isEventHandlerCallback(member: IDLAttribute) -> bool:
+    if not member.isAttr():
+        return False
+    if not member.type.isCallback():
+        return False
+    # pyrefly: ignore  # missing-attribute
+    callback = member.type.unroll().callback
+    return callback.identifier.name in EVENT_HANDLER_CALLBACKS
+
+
 class CGCallGenerator(CGThing):
     """
     A class to generate an actual call to a C++ object.  Assumes that the C++
@@ -4185,7 +4201,7 @@ class CGCallGenerator(CGThing):
                  extendedAttributes: list[str],
                  descriptor: Descriptor,
                  nativeMethodName: str,
-                 is_attr: bool,
+                 is_implicit_cx_attribute: bool,
                  static: bool,
                  object: str = "this",
                  hasCEReactions: bool = False
@@ -4214,7 +4230,6 @@ class CGCallGenerator(CGThing):
             args.append(CGGeneric(name))
 
         needsCx = False
-        is_implicit_cx_attribute = descriptor.implicitCxSetters and is_attr and nativeMethodName.startswith('Set')
         match max([needCx(returnType, (a for (a, _) in arguments), True), Context.Cx if is_implicit_cx_attribute else Context.No]):
             case Context.Cx:
                 descriptor.cxMethods.append(nativeMethodName)
@@ -4359,11 +4374,13 @@ class CGPerSignatureCall(CGThing):
                                                           idlNode.identifier.name))
         else:
             hasCEReactions = idlNode.getExtendedAttribute("CEReactions") or False
+            is_event_listener = isinstance(idlNode, IDLAttribute) and isEventHandlerCallback(idlNode)
+            is_implicit_cx_attribute = is_event_listener or descriptor.implicitCxSetters and idlNode.isAttr() and nativeMethodName.startswith('Set')
             cgThings.append(CGCallGenerator(
                 errorResult,
                 self.getArguments(), self.argsPre, returnType,
                 self.extendedAttributes, descriptor, nativeMethodName,
-                idlNode.isAttr(), static, hasCEReactions=hasCEReactions))
+                is_implicit_cx_attribute, static, hasCEReactions=hasCEReactions))
 
         self.cgRoot = CGList(cgThings, "\n")
 
@@ -7099,7 +7116,7 @@ class CGInterfaceTrait(CGThing):
                            attribute_arguments(
                                m.type,
                                cx_no_gc=name in descriptor.cx_no_gcMethods,
-                               cx=name in descriptor.cxMethods,
+                               cx=name in descriptor.cxMethods or isEventHandlerCallback(m),
                                realm=name in descriptor.realmMethods,
                                inRealm=name in descriptor.inRealmMethods,
                                canGc=name in descriptor.canGcMethods,
@@ -7120,7 +7137,7 @@ class CGInterfaceTrait(CGThing):
                                    m.type,
                                    m.type,
                                    cx_no_gc=name in descriptor.cx_no_gcMethods,
-                                   cx=name in descriptor.cxMethods or descriptor.implicitCxSetters,
+                                   cx=name in descriptor.cxMethods or descriptor.implicitCxSetters or isEventHandlerCallback(m),
                                    realm=name in descriptor.realmMethods,
                                    inRealm=name in descriptor.inRealmMethods,
                                    canGc=name in descriptor.canGcMethods,
@@ -9083,7 +9100,6 @@ def process_arg(expr: str, arg: IDLArgument | FakeArgument) -> str:
         expr = f"&{expr}"
     return expr
 
-
 class GlobalGenRoots():
     """
     Roots for global codegen.
@@ -9489,11 +9505,6 @@ impl Clone for TopTypeId {
         """Generate the sorted list of content event handler attribute names
         by inspecting WebIDL definitions for interfaces that inherit from
         HTMLElement or SVGElement."""
-        EVENT_HANDLER_CALLBACKS = {
-            "EventHandlerNonNull",
-            "OnErrorEventHandlerNonNull",
-            "OnBeforeUnloadEventHandlerNonNull",
-        }
 
         handler_names: set[str] = set()
 
@@ -9506,13 +9517,7 @@ impl Clone for TopTypeId {
                 continue
 
             for member in descriptor.interface.members:
-                if not member.isAttr():
-                    continue
-                if not member.type.isCallback():
-                    continue
-                # pyrefly: ignore  # missing-attribute
-                callback = member.type.unroll().callback
-                if callback.identifier.name in EVENT_HANDLER_CALLBACKS:
+                if isEventHandlerCallback(member):
                     handler_names.add(member.identifier.name)
 
         sorted_names = sorted(handler_names)


### PR DESCRIPTION
Use the same event handler detection method to figure out which getters/setters handle events. Add the relevant `cx` to the macro definitions.

Part of #42638

Testing: It compiles