### PR TITLE
script: propagate &mut JSContext in VirtualMethods::command_steps

### DIFF
--- a/components/script/dom/html/htmlbuttonelement.rs
+++ b/components/script/dom/html/htmlbuttonelement.rs
@@ -579,11 +579,7 @@ impl Activatable for HTMLButtonElement {
             // TODO Steps 5.7, 5.8, 5.9
             // Step 5.10 Otherwise, if this standard defines command steps for target's local name,
             // then run the corresponding command steps given target, element, and command.
-            let _ = vtable_for(target_node).command_steps(
-                DomRoot::from_ref(self),
-                command,
-                CanGc::from_cx(cx),
-            );
+            let _ = vtable_for(target_node).command_steps(cx, DomRoot::from_ref(self), command);
         }
         // TODO Step 6 Otherwise, run the popover target attribute activation behavior given element
         // and event's target.

--- a/components/script/dom/html/htmldialogelement.rs
+++ b/components/script/dom/html/htmldialogelement.rs
@@ -385,14 +385,14 @@ impl VirtualMethods for HTMLDialogElement {
     /// <https://html.spec.whatwg.org/multipage/#the-dialog-element:command-steps>
     fn command_steps(
         &self,
+        cx: &mut js::context::JSContext,
         source: DomRoot<HTMLButtonElement>,
         command: CommandState,
-        can_gc: CanGc,
     ) -> bool {
         if self
             .super_type()
             .unwrap()
-            .command_steps(source.clone(), command, can_gc)
+            .command_steps(cx, source.clone(), command)
         {
             return true;
         }
@@ -404,7 +404,11 @@ impl VirtualMethods for HTMLDialogElement {
         // close the dialog element with source's optional value and source.
         if command == CommandState::Close && element.has_attribute(&local_name!("open")) {
             let button_element = DomRoot::from_ref(source.upcast::<Element>());
-            self.close_the_dialog(source.optional_value(), Some(button_element), can_gc);
+            self.close_the_dialog(
+                source.optional_value(),
+                Some(button_element),
+                CanGc::from_cx(cx),
+            );
             return true;
         }
 
@@ -415,7 +419,7 @@ impl VirtualMethods for HTMLDialogElement {
         // then show a modal dialog given element and source.
         if command == CommandState::ShowModal && !element.has_attribute(&local_name!("open")) {
             let button_element = DomRoot::from_ref(source.upcast::<Element>());
-            let _ = self.show_a_modal(Some(button_element), can_gc);
+            let _ = self.show_a_modal(Some(button_element), CanGc::from_cx(cx));
             return true;
         }
 

--- a/components/script/dom/virtualmethods.rs
+++ b/components/script/dom/virtualmethods.rs
@@ -164,12 +164,12 @@ pub(crate) trait VirtualMethods {
     /// <https://html.spec.whatwg.org/multipage/#command-steps>
     fn command_steps(
         &self,
+        cx: &mut js::context::JSContext,
         button: DomRoot<HTMLButtonElement>,
         command: CommandState,
-        can_gc: CanGc,
     ) -> bool {
         self.super_type()
-            .is_some_and(|super_type| super_type.command_steps(button, command, can_gc))
+            .is_some_and(|super_type| super_type.command_steps(cx, button, command))
     }
 
     /// <https://dom.spec.whatwg.org/#concept-node-adopt-ext>


### PR DESCRIPTION
Propagate `&mut JSContext` in `VirtualMethods::command_steps` and related call sites.

Testing: Successful build is enough
Fixes: Part of #42638 