### PR TITLE
script: propagate &mut JSContext in HTMLFormElement::static_validation

### DIFF
--- a/components/script/dom/html/htmlbuttonelement.rs
+++ b/components/script/dom/html/htmlbuttonelement.rs
@@ -501,9 +501,9 @@ impl Activatable for HTMLButtonElement {
             // ..., and return.
             if button_type == ButtonType::Submit {
                 owner.submit(
+                    cx,
                     SubmittedFrom::NotFromForm,
                     FormSubmitterElement::Button(self),
-                    CanGc::from_cx(cx),
                 );
                 return;
             }

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -293,16 +293,20 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
     make_getter!(Rel, "rel");
 
     /// <https://html.spec.whatwg.org/multipage/#the-form-element:concept-form-submit>
-    fn Submit(&self, can_gc: CanGc) {
+    fn Submit(&self, cx: &mut js::context::JSContext) {
         self.submit(
+            cx,
             SubmittedFrom::FromForm,
             FormSubmitterElement::Form(self),
-            can_gc,
         );
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-form-requestsubmit>
-    fn RequestSubmit(&self, submitter: Option<&HTMLElement>, can_gc: CanGc) -> Fallible<()> {
+    fn RequestSubmit(
+        &self,
+        cx: &mut js::context::JSContext,
+        submitter: Option<&HTMLElement>,
+    ) -> Fallible<()> {
         let submitter: FormSubmitterElement = match submitter {
             Some(submitter_element) => {
                 // Step 1.1
@@ -358,7 +362,7 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
             },
         };
         // Step 3
-        self.submit(SubmittedFrom::NotFromForm, submitter, can_gc);
+        self.submit(cx, SubmittedFrom::NotFromForm, submitter);
         Ok(())
     }
 
@@ -654,12 +658,12 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-form-checkvalidity>
     fn CheckValidity(&self, cx: &mut JSContext) -> bool {
-        self.static_validation(CanGc::from_cx(cx)).is_ok()
+        self.static_validation(cx).is_ok()
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-form-reportvalidity>
     fn ReportValidity(&self, cx: &mut JSContext) -> bool {
-        self.interactive_validation(CanGc::from_cx(cx)).is_ok()
+        self.interactive_validation(cx).is_ok()
     }
 }
 
@@ -735,9 +739,9 @@ impl HTMLFormElement {
     /// [Form submission](https://html.spec.whatwg.org/multipage/#concept-form-submit)
     pub(crate) fn submit(
         &self,
+        cx: &mut js::context::JSContext,
         submit_method_flag: SubmittedFrom,
         submitter: FormSubmitterElement,
-        can_gc: CanGc,
     ) {
         // Step 1
         if self.upcast::<Element>().cannot_navigate() {
@@ -769,7 +773,7 @@ impl HTMLFormElement {
             // Step 6.2
             self.firing_submission_events.set(true);
             // Step 6.3
-            if !submitter.no_validate(self) && self.interactive_validation(can_gc).is_err() {
+            if !submitter.no_validate(self) && self.interactive_validation(cx).is_err() {
                 self.firing_submission_events.set(false);
                 return;
             }
@@ -795,10 +799,10 @@ impl HTMLFormElement {
                 true,
                 true,
                 submitter_button.map(DomRoot::from_ref),
-                can_gc,
+                CanGc::from_cx(cx),
             );
             let event = event.upcast::<Event>();
-            event.fire(self.upcast::<EventTarget>(), can_gc);
+            event.fire(self.upcast::<EventTarget>(), CanGc::from_cx(cx));
 
             // Step 6.6
             self.firing_submission_events.set(false);
@@ -816,10 +820,11 @@ impl HTMLFormElement {
         let encoding = self.pick_encoding();
 
         // Step 8
-        let mut form_data = match self.get_form_dataset(Some(submitter), Some(encoding), can_gc) {
-            Some(form_data) => form_data,
-            None => return,
-        };
+        let mut form_data =
+            match self.get_form_dataset(Some(submitter), Some(encoding), CanGc::from_cx(cx)) {
+                Some(form_data) => form_data,
+                None => return,
+            };
 
         // Step 9. If form cannot navigate, then return.
         if self.upcast::<Element>().cannot_navigate() {
@@ -937,7 +942,7 @@ impl HTMLFormElement {
                     encoding,
                     target_window,
                     history_handling,
-                    can_gc,
+                    CanGc::from_cx(cx),
                 );
             },
             // https://html.spec.whatwg.org/multipage/#submit-get-action
@@ -1152,12 +1157,12 @@ impl HTMLFormElement {
 
     /// Interactively validate the constraints of form elements
     /// <https://html.spec.whatwg.org/multipage/#interactively-validate-the-constraints>
-    fn interactive_validation(&self, can_gc: CanGc) -> Result<(), ()> {
+    fn interactive_validation(&self, cx: &mut js::context::JSContext) -> Result<(), ()> {
         // Step 1 - 2: Statically validate the constraints of form,
         // and let `unhandled invalid controls` be the list of elements
         // returned if the result was negative.
         // If the result was positive, then return that result.
-        let unhandled_invalid_controls = match self.static_validation(can_gc) {
+        let unhandled_invalid_controls = match self.static_validation(cx) {
             Ok(()) => return Ok(()),
             Err(err) => err,
         };
@@ -1178,7 +1183,7 @@ impl HTMLFormElement {
                     // some other action that brings the element to the user's attention.
 
                     // Here we run focusing steps and scroll element into view.
-                    html_elem.Focus(&FocusOptions::default(), can_gc);
+                    html_elem.Focus(&FocusOptions::default(), CanGc::from_cx(cx));
                     first = false;
                 }
             }
@@ -1192,7 +1197,10 @@ impl HTMLFormElement {
 
     /// Statitically validate the constraints of form elements
     /// <https://html.spec.whatwg.org/multipage/#statically-validate-the-constraints>
-    fn static_validation(&self, can_gc: CanGc) -> Result<(), Vec<DomRoot<Element>>> {
+    fn static_validation(
+        &self,
+        cx: &mut js::context::JSContext,
+    ) -> Result<(), Vec<DomRoot<Element>>> {
         // Step 1-3
         let invalid_controls = self
             .controls
@@ -1200,7 +1208,7 @@ impl HTMLFormElement {
             .iter()
             .filter_map(|field| {
                 if let Some(element) = field.downcast::<Element>() {
-                    if element.is_invalid(true, can_gc) {
+                    if element.is_invalid(true, CanGc::from_cx(cx)) {
                         Some(DomRoot::from_ref(element))
                     } else {
                         None
@@ -1222,7 +1230,7 @@ impl HTMLFormElement {
                 // field, with the cancelable attribute initialized to true.
                 let not_canceled = field
                     .upcast::<EventTarget>()
-                    .fire_cancelable_event(atom!("invalid"), can_gc);
+                    .fire_cancelable_event(atom!("invalid"), CanGc::from_cx(cx));
                 // Step 6.2: If notCanceled is true, then add field to unhandled invalid controls.
                 if not_canceled {
                     return Some(field);

--- a/components/script/dom/html/input_element/checkbox_input_type.rs
+++ b/components/script/dom/html/input_element/checkbox_input_type.rs
@@ -30,10 +30,10 @@ impl SpecificInputType for CheckboxInputType {
     /// <https://html.spec.whatwg.org/multipage/#checkbox-state-(type=checkbox):input-activation-behavior>
     fn activation_behavior(
         &self,
+        cx: &mut js::context::JSContext,
         input: &HTMLInputElement,
         _event: &Event,
         _target: &EventTarget,
-        can_gc: CanGc,
     ) {
         // Step 1: If the element is not connected, then return.
         if !input.upcast::<Node>().is_connected() {
@@ -49,12 +49,12 @@ impl SpecificInputType for CheckboxInputType {
             EventBubbles::Bubbles,
             EventCancelable::NotCancelable,
             EventComposed::Composed,
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         // Step 3: Fire an event named change at the element with the bubbles attribute
         // initialized to true.
-        target.fire_bubbling_event(atom!("change"), can_gc);
+        target.fire_bubbling_event(atom!("change"), CanGc::from_cx(cx));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-input-element:legacy-pre-activation-behavior>

--- a/components/script/dom/html/input_element/color_input_type.rs
+++ b/components/script/dom/html/input_element/color_input_type.rs
@@ -198,10 +198,10 @@ impl SpecificInputType for ColorInputType {
     /// <https://html.spec.whatwg.org/multipage/#color-state-(type=color):input-activation-behavior>
     fn activation_behavior(
         &self,
+        _cx: &mut js::context::JSContext,
         input: &HTMLInputElement,
         _event: &Event,
         _target: &EventTarget,
-        _can_gc: CanGc,
     ) {
         input.show_the_picker_if_applicable();
     }

--- a/components/script/dom/html/input_element/file_input_type.rs
+++ b/components/script/dom/html/input_element/file_input_type.rs
@@ -163,10 +163,10 @@ impl SpecificInputType for FileInputType {
     /// <https://html.spec.whatwg.org/multipage/#file-upload-state-(type=file):input-activation-behavior>
     fn activation_behavior(
         &self,
+        _cx: &mut js::context::JSContext,
         input: &HTMLInputElement,
         _event: &Event,
         _target: &EventTarget,
-        _can_gc: CanGc,
     ) {
         input.show_the_picker_if_applicable();
     }

--- a/components/script/dom/html/input_element/image_input_type.rs
+++ b/components/script/dom/html/input_element/image_input_type.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 use js::context::JSContext;
-use script_bindings::script_runtime::CanGc;
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::event::Event;
@@ -23,10 +22,10 @@ impl SpecificInputType for ImageInputType {
     /// <https://html.spec.whatwg.org/multipage/#image-button-state-(type=image):input-activation-behavior>
     fn activation_behavior(
         &self,
+        cx: &mut JSContext,
         input: &HTMLInputElement,
         _event: &Event,
         _target: &EventTarget,
-        can_gc: CanGc,
     ) {
         // Step 1: If the element does not have a form owner, then return.
         if let Some(form_owner) = input.form_owner() {
@@ -43,9 +42,9 @@ impl SpecificInputType for ImageInputType {
             // Step 4: Submit the element's form owner from the element with userInvolvement
             // set to event's user navigation involvement.
             form_owner.submit(
+                cx,
                 SubmittedFrom::NotFromForm,
                 FormSubmitterElement::Input(input),
-                can_gc,
             )
         }
     }

--- a/components/script/dom/html/input_element/input_type.rs
+++ b/components/script/dom/html/input_element/input_type.rs
@@ -304,10 +304,10 @@ pub(crate) trait SpecificInputType {
 
     fn activation_behavior(
         &self,
+        _cx: &mut js::context::JSContext,
         _input: &HTMLInputElement,
         _event: &Event,
         _target: &EventTarget,
-        _can_gc: CanGc,
     ) {
     }
 

--- a/components/script/dom/html/input_element/mod.rs
+++ b/components/script/dom/html/input_element/mod.rs
@@ -846,10 +846,15 @@ impl HTMLInputElement {
         matches!(*self.input_type(), InputType::Color(_)) && !el.disabled_state()
     }
 
-    fn handle_key_reaction(&self, action: KeyReaction, event: &Event, can_gc: CanGc) {
+    fn handle_key_reaction(
+        &self,
+        cx: &mut js::context::JSContext,
+        action: KeyReaction,
+        event: &Event,
+    ) {
         match action {
             KeyReaction::TriggerDefaultAction => {
-                self.implicit_submission(can_gc);
+                self.implicit_submission(cx);
                 event.mark_as_handled();
             },
             KeyReaction::DispatchInput(text, is_composing, input_type) => {
@@ -1810,7 +1815,7 @@ impl HTMLInputElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#implicit-submission>
-    fn implicit_submission(&self, can_gc: CanGc) {
+    fn implicit_submission(&self, cx: &mut js::context::JSContext) {
         let doc = self.owner_document();
         let node = doc.upcast::<Node>();
         let owner = self.form_owner();
@@ -1834,7 +1839,10 @@ impl HTMLInputElement {
                     // but we can get here from synthetic keydown events
                     button
                         .upcast::<Node>()
-                        .fire_synthetic_pointer_event_not_trusted(atom!("click"), can_gc);
+                        .fire_synthetic_pointer_event_not_trusted(
+                            atom!("click"),
+                            CanGc::from_cx(cx),
+                        );
                 }
             },
             None => {
@@ -1865,9 +1873,9 @@ impl HTMLInputElement {
                     return;
                 }
                 form.submit(
+                    cx,
                     SubmittedFrom::NotFromForm,
                     FormSubmitterElement::Form(form),
-                    can_gc,
                 );
             },
         }
@@ -2275,7 +2283,7 @@ impl VirtualMethods for HTMLInputElement {
     // Compare:
     // https://w3c.github.io/uievents/#default-action
     /// <https://dom.spec.whatwg.org/#action-versus-occurance>
-    fn handle_event(&self, cx: &mut js::context::JSContext, event: &Event) {
+    fn handle_event(&self, cx: &mut JSContext, event: &Event) {
         if let Some(mouse_event) = event.downcast::<MouseEvent>() {
             self.handle_mouse_event(mouse_event);
             event.mark_as_handled();
@@ -2287,7 +2295,7 @@ impl VirtualMethods for HTMLInputElement {
                 // This can't be inlined, as holding on to textinput.borrow_mut()
                 // during self.implicit_submission will cause a panic.
                 let action = self.textinput.borrow_mut().handle_keydown(keyevent);
-                self.handle_key_reaction(action, event, CanGc::from_cx(cx));
+                self.handle_key_reaction(cx, action, event);
             }
         } else if (event.type_() == atom!("compositionstart") ||
             event.type_() == atom!("compositionupdate") ||
@@ -2300,7 +2308,7 @@ impl VirtualMethods for HTMLInputElement {
                         .textinput
                         .borrow_mut()
                         .handle_compositionend(compositionevent);
-                    self.handle_key_reaction(action, event, CanGc::from_cx(cx));
+                    self.handle_key_reaction(cx, action, event);
                     self.upcast::<Node>().dirty(NodeDamage::Other);
                     self.update_placeholder_shown_state();
                 } else if event.type_() == atom!("compositionupdate") {
@@ -2308,7 +2316,7 @@ impl VirtualMethods for HTMLInputElement {
                         .textinput
                         .borrow_mut()
                         .handle_compositionupdate(compositionevent);
-                    self.handle_key_reaction(action, event, CanGc::from_cx(cx));
+                    self.handle_key_reaction(cx, action, event);
                     self.upcast::<Node>().dirty(NodeDamage::Other);
                     self.update_placeholder_shown_state();
                 } else if event.type_() == atom!("compositionstart") {
@@ -2543,12 +2551,9 @@ impl Activatable for HTMLInputElement {
         event: &Event,
         target: &EventTarget,
     ) {
-        self.input_type().as_specific().activation_behavior(
-            self,
-            event,
-            target,
-            CanGc::from_cx(cx),
-        );
+        self.input_type()
+            .as_specific()
+            .activation_behavior(cx, self, event, target);
     }
 }
 

--- a/components/script/dom/html/input_element/radio_input_type.rs
+++ b/components/script/dom/html/input_element/radio_input_type.rs
@@ -64,10 +64,10 @@ impl SpecificInputType for RadioInputType {
     /// <https://html.spec.whatwg.org/multipage/#radio-button-state-(type=radio):input-activation-behavior>
     fn activation_behavior(
         &self,
+        cx: &mut js::context::JSContext,
         input: &HTMLInputElement,
         _event: &Event,
         _target: &EventTarget,
-        can_gc: CanGc,
     ) {
         // Step 1: If the element is not connected, then return.
         if !input.upcast::<Node>().is_connected() {
@@ -83,12 +83,12 @@ impl SpecificInputType for RadioInputType {
             EventBubbles::Bubbles,
             EventCancelable::NotCancelable,
             EventComposed::Composed,
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         // Step 3: Fire an event named change at the element with the bubbles attribute
         // initialized to true.
-        target.fire_bubbling_event(atom!("change"), can_gc);
+        target.fire_bubbling_event(atom!("change"), CanGc::from_cx(cx));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-input-element:legacy-pre-activation-behavior>

--- a/components/script/dom/html/input_element/reset_input_type.rs
+++ b/components/script/dom/html/input_element/reset_input_type.rs
@@ -30,10 +30,10 @@ impl SpecificInputType for ResetInputType {
     /// <https://html.spec.whatwg.org/multipage/#reset-button-state-(type=reset):input-activation-behavior>
     fn activation_behavior(
         &self,
+        cx: &mut js::context::JSContext,
         input: &HTMLInputElement,
         _event: &Event,
         _target: &EventTarget,
-        can_gc: CanGc,
     ) {
         // Step 1: If the element does not have a form owner, then return.
         if let Some(form_owner) = input.form_owner() {
@@ -45,7 +45,7 @@ impl SpecificInputType for ResetInputType {
             }
 
             // Step 3: Reset the form owner from the element.
-            form_owner.reset(ResetFrom::NotFromForm, can_gc);
+            form_owner.reset(ResetFrom::NotFromForm, CanGc::from_cx(cx));
         }
     }
 

--- a/components/script/dom/html/input_element/submit_input_type.rs
+++ b/components/script/dom/html/input_element/submit_input_type.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 use js::context::JSContext;
 use script_bindings::domstring::DOMString;
-use script_bindings::script_runtime::CanGc;
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::event::Event;
@@ -30,10 +29,10 @@ impl SpecificInputType for SubmitInputType {
     /// <https://html.spec.whatwg.org/multipage/#submit-button-state-(type=submit):input-activation-behavior>
     fn activation_behavior(
         &self,
+        cx: &mut JSContext,
         input: &HTMLInputElement,
         _event: &Event,
         _target: &EventTarget,
-        can_gc: CanGc,
     ) {
         // Step 1: If the element does not have a form owner, then return.
         if let Some(form_owner) = input.form_owner() {
@@ -47,9 +46,9 @@ impl SpecificInputType for SubmitInputType {
             // Step 3: Submit the element's form owner from the element with userInvolvement
             // set to event's user navigation involvement.
             form_owner.submit(
+                cx,
                 SubmittedFrom::NotFromForm,
                 FormSubmitterElement::Input(input),
-                can_gc,
             )
         }
     }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -488,8 +488,8 @@ DOMInterfaces = {
 },
 
 'HTMLFormElement': {
-    'canGc': ['Elements', 'IndexedGetter', 'NamedGetter', 'RequestSubmit', 'Submit', 'Reset', 'SetRel', 'RelList'],
-    'cx': ['CheckValidity', 'ReportValidity'],
+    'canGc': ['Elements', 'IndexedGetter', 'NamedGetter', 'Reset', 'SetRel', 'RelList'],
+    'cx': ['CheckValidity', 'ReportValidity', 'RequestSubmit', 'Submit'],
 },
 
 'HTMLFrameSetElement': {


### PR DESCRIPTION
Propagate `&mut JSContext` in `HTMLFormElement::static_validation` and related call sites.

Testing: Successful build is enough
Fixes: Part of #42638 

Opened to reduces the complexity of #44254 