### PR TITLE
script: propagate &mut JSContext in HTMLDialogElement::show_a_modal

### DIFF
--- a/components/script/dom/html/htmldialogelement.rs
+++ b/components/script/dom/html/htmldialogelement.rs
@@ -62,7 +62,11 @@ impl HTMLDialogElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#show-a-modal-dialog>
-    pub fn show_a_modal(&self, source: Option<DomRoot<Element>>, can_gc: CanGc) -> ErrorResult {
+    pub fn show_a_modal(
+        &self,
+        cx: &mut js::context::JSContext,
+        source: Option<DomRoot<Element>>,
+    ) -> ErrorResult {
         let subject = self.upcast::<Element>();
         // Step 1. If subject has an open attribute and is modal of subject is true, then return.
         if subject.has_attribute(&local_name!("open")) &&
@@ -103,10 +107,10 @@ impl HTMLDialogElement {
             DOMString::from("closed"),
             DOMString::from("open"),
             source.borrow().clone(),
-            can_gc,
+            CanGc::from_cx(cx),
         );
         let event = event.upcast::<Event>();
-        if !event.fire(self.upcast::<EventTarget>(), can_gc) {
+        if !event.fire(self.upcast::<EventTarget>(), CanGc::from_cx(cx)) {
             return Ok(());
         }
 
@@ -126,7 +130,7 @@ impl HTMLDialogElement {
         self.queue_dialog_toggle_event_task("closed", "open", source);
 
         // Step 11. Add an open attribute to subject, whose value is the empty string.
-        subject.set_bool_attribute(&local_name!("open"), true, can_gc);
+        subject.set_bool_attribute(&local_name!("open"), true, CanGc::from_cx(cx));
         subject.set_open_state(true);
 
         // TODO: Step 12. Assert: subject's close watcher is not null.
@@ -157,9 +161,9 @@ impl HTMLDialogElement {
     /// <https://html.spec.whatwg.org/multipage/#close-the-dialog>
     pub fn close_the_dialog(
         &self,
+        cx: &mut js::context::JSContext,
         result: Option<DOMString>,
         source: Option<DomRoot<Element>>,
-        can_gc: CanGc,
     ) {
         let subject = self.upcast::<Element>();
         // Step 1. If subject does not have an open attribute, then return.
@@ -176,10 +180,10 @@ impl HTMLDialogElement {
             DOMString::from("open"),
             DOMString::from("closed"),
             source.borrow().clone(),
-            can_gc,
+            CanGc::from_cx(cx),
         );
         let event = event.upcast::<Event>();
-        event.fire(self.upcast::<EventTarget>(), can_gc);
+        event.fire(self.upcast::<EventTarget>(), CanGc::from_cx(cx));
 
         // Step 3. If subject does not have an open attribute, then return.
         if !subject.has_attribute(&local_name!("open")) {
@@ -190,7 +194,7 @@ impl HTMLDialogElement {
         self.queue_dialog_toggle_event_task("open", "closed", source);
 
         // Step 5. Remove subject's open attribute.
-        subject.remove_attribute(&ns!(), &local_name!("open"), can_gc);
+        subject.remove_attribute(&ns!(), &local_name!("open"), CanGc::from_cx(cx));
         subject.set_open_state(false);
 
         // TODO: Step 6. If is modal of subject is true, then request an element to be removed from the top layer given subject.
@@ -291,7 +295,7 @@ impl HTMLDialogElementMethods<crate::DomTypeHolder> for HTMLDialogElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-dialog-show>
-    fn Show(&self, can_gc: CanGc) -> ErrorResult {
+    fn Show(&self, cx: &mut js::context::JSContext) -> ErrorResult {
         let element = self.upcast::<Element>();
         // Step 1. If this has an open attribute and is modal of this is false, then return.
         if element.has_attribute(&local_name!("open")) &&
@@ -316,10 +320,10 @@ impl HTMLDialogElementMethods<crate::DomTypeHolder> for HTMLDialogElement {
             DOMString::from("closed"),
             DOMString::from("open"),
             None,
-            can_gc,
+            CanGc::from_cx(cx),
         );
         let event = event.upcast::<Event>();
-        if !event.fire(self.upcast::<EventTarget>(), can_gc) {
+        if !event.fire(self.upcast::<EventTarget>(), CanGc::from_cx(cx)) {
             return Ok(());
         }
 
@@ -332,7 +336,7 @@ impl HTMLDialogElementMethods<crate::DomTypeHolder> for HTMLDialogElement {
         self.queue_dialog_toggle_event_task("closed", "open", None);
 
         // Step 6. Add an open attribute to this, whose value is the empty string.
-        element.set_bool_attribute(&local_name!("open"), true, can_gc);
+        element.set_bool_attribute(&local_name!("open"), true, CanGc::from_cx(cx));
         element.set_open_state(true);
 
         // TODO: Step 7. Set this's previously focused element to the focused element.
@@ -353,16 +357,16 @@ impl HTMLDialogElementMethods<crate::DomTypeHolder> for HTMLDialogElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-dialog-showmodal>
-    fn ShowModal(&self, can_gc: CanGc) -> ErrorResult {
+    fn ShowModal(&self, cx: &mut js::context::JSContext) -> ErrorResult {
         // The showModal() method steps are to show a modal dialog given this and null.
-        self.show_a_modal(None, can_gc)
+        self.show_a_modal(cx, None)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-dialog-close>
-    fn Close(&self, return_value: Option<DOMString>, can_gc: CanGc) {
+    fn Close(&self, cx: &mut js::context::JSContext, return_value: Option<DOMString>) {
         // Step 1. If returnValue is not given, then set it to null.
         // Step 2. Close the dialog this with returnValue and null.
-        self.close_the_dialog(return_value, None, can_gc);
+        self.close_the_dialog(cx, return_value, None);
     }
 }
 
@@ -404,11 +408,7 @@ impl VirtualMethods for HTMLDialogElement {
         // close the dialog element with source's optional value and source.
         if command == CommandState::Close && element.has_attribute(&local_name!("open")) {
             let button_element = DomRoot::from_ref(source.upcast::<Element>());
-            self.close_the_dialog(
-                source.optional_value(),
-                Some(button_element),
-                CanGc::from_cx(cx),
-            );
+            self.close_the_dialog(cx, source.optional_value(), Some(button_element));
             return true;
         }
 
@@ -419,7 +419,7 @@ impl VirtualMethods for HTMLDialogElement {
         // then show a modal dialog given element and source.
         if command == CommandState::ShowModal && !element.has_attribute(&local_name!("open")) {
             let button_element = DomRoot::from_ref(source.upcast::<Element>());
-            let _ = self.show_a_modal(Some(button_element), CanGc::from_cx(cx));
+            let _ = self.show_a_modal(cx, Some(button_element));
             return true;
         }
 

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -448,7 +448,7 @@ DOMInterfaces = {
 },
 
 'HTMLDialogElement': {
-    'canGc': ['Close', 'Show', 'ShowModal'],
+    'cx': ['Close', 'Show', 'ShowModal'],
 },
 
 'HTMLDocument': {


### PR DESCRIPTION
Propagate `&mut JSContext` in `HTMLDialogElement::show_a_modal` and related call sites.

Testing: Successful build is enough
Fixes: Part of #42638 