### PR TITLE
script: move drop implementation to a separate struct from WebGLTexture (#26488)

### DIFF
--- a/components/script/dom/webgl/webglframebuffer.rs
+++ b/components/script/dom/webgl/webglframebuffer.rs
@@ -928,11 +928,10 @@ impl WebGLFramebuffer {
         }
     }
 
-    fn with_matching_textures<F>(&self, texture: &WebGLTexture, mut closure: F)
+    fn with_matching_textures_id<F>(&self, tex_id: WebGLTextureId, mut closure: F)
     where
         F: FnMut(&DomRefCell<Option<WebGLFramebufferAttachment>>, u32),
     {
-        let tex_id = texture.id();
         let attachments = [
             (&self.depth, constants::DEPTH_ATTACHMENT),
             (&self.stencil, constants::STENCIL_ATTACHMENT),
@@ -984,13 +983,13 @@ impl WebGLFramebuffer {
         Ok(())
     }
 
-    pub(crate) fn detach_texture(&self, texture: &WebGLTexture) -> WebGLResult<()> {
+    pub(crate) fn detach_texture(&self, tex_id: WebGLTextureId) -> WebGLResult<()> {
         // Opaque framebuffers cannot have their attachments changed
         // https://immersive-web.github.io/webxr/#opaque-framebuffer
         self.validate_transparent()?;
 
         let mut depth_or_stencil_updated = false;
-        self.with_matching_textures(texture, |att, name| {
+        self.with_matching_textures_id(tex_id, |att, name| {
             depth_or_stencil_updated |= INTERESTING_ATTACHMENT_POINTS.contains(&name);
             if let Some(att) = &*att.borrow() {
                 att.detach();
@@ -1013,7 +1012,7 @@ impl WebGLFramebuffer {
     }
 
     pub(crate) fn invalidate_texture(&self, texture: &WebGLTexture) {
-        self.with_matching_textures(texture, |_att, _name| {
+        self.with_matching_textures_id(texture.id(), |_att, _name| {
             self.update_status();
         });
     }

--- a/components/script/dom/webgl/webgltexture.rs
+++ b/components/script/dom/webgl/webgltexture.rs
@@ -9,6 +9,7 @@ use std::cmp;
 
 use dom_struct::dom_struct;
 use script_bindings::reflector::DomObject as _;
+use script_bindings::weakref::WeakRef;
 use servo_canvas_traits::webgl::{
     TexDataType, TexFormat, TexParameter, TexParameterBool, TexParameterInt, WebGLCommand,
     WebGLError, WebGLResult, WebGLTextureId, WebGLVersion, webgl_channel,
@@ -19,13 +20,12 @@ use crate::dom::bindings::codegen::Bindings::EXTTextureFilterAnisotropicBinding:
 use crate::dom::bindings::codegen::Bindings::WebGL2RenderingContextBinding::WebGL2RenderingContextConstants as constants;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object};
-#[cfg(feature = "webxr")]
-use crate::dom::bindings::root::Dom;
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::webgl::validations::types::TexImageTarget;
 use crate::dom::webgl::webglframebuffer::WebGLFramebuffer;
 use crate::dom::webgl::webglobject::WebGLObject;
 use crate::dom::webgl::webglrenderingcontext::{Operation, WebGLRenderingContext};
+use crate::dom::webglrenderingcontext::capture_webgl_backtrace;
 #[cfg(feature = "webxr")]
 use crate::dom::xrsession::XRSession;
 use crate::script_runtime::CanGc;
@@ -43,21 +43,75 @@ pub(crate) enum TexParameterValue {
 enum WebGLTextureOwner {
     WebGL,
     #[cfg(feature = "webxr")]
-    WebXR(Dom<XRSession>),
+    WebXR(WeakRef<XRSession>),
 }
 
 const MAX_LEVEL_COUNT: usize = 31;
 const MAX_FACE_COUNT: usize = 6;
 
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
+#[derive(JSTraceable, MallocSizeOf)]
+struct DroppableWebGLTexture {
+    context: WeakRef<WebGLRenderingContext>,
+    #[no_trace]
+    id: WebGLTextureId,
+    is_deleted: Cell<bool>,
+    owner: WebGLTextureOwner,
+}
+
+impl DroppableWebGLTexture {
+    fn send_with_fallibility(&self, command: WebGLCommand, fallibility: Operation) {
+        if let Some(root) = self.context.root() {
+            let result = root.sender().send(command, capture_webgl_backtrace());
+            if matches!(fallibility, Operation::Infallible) {
+                result.expect("Operation failed");
+            }
+        }
+    }
+
+    fn delete(&self, operation_fallibility: Operation) {
+        if !self.is_deleted.get() {
+            self.is_deleted.set(true);
+
+            /*
+            If a texture object is deleted while its image is attached to one or more attachment
+            points in a currently bound framebuffer, then it is as if FramebufferTexture had been
+            called, with a texture of zero, for each attachment point to which this im-age was
+            attached in that framebuffer. In other words, this texture image is firstdetached from
+            all attachment points in a currently bound framebuffer.
+            - GLES 3.0, 4.4.2.3, "Attaching Texture Images to a Framebuffer"
+            */
+            if let Some(context) = self.context.root() {
+                if let Some(fb) = context.get_draw_framebuffer_slot().get() {
+                    let _ = fb.detach_texture(self.id);
+                }
+                if let Some(fb) = context.get_read_framebuffer_slot().get() {
+                    let _ = fb.detach_texture(self.id);
+                }
+            }
+
+            // We don't delete textures owned by WebXR
+            #[cfg(feature = "webxr")]
+            if let WebGLTextureOwner::WebXR(_) = self.owner {
+                return;
+            }
+
+            self.send_with_fallibility(WebGLCommand::DeleteTexture(self.id), operation_fallibility);
+        }
+    }
+}
+
+impl Drop for DroppableWebGLTexture {
+    fn drop(&mut self) {
+        self.delete(Operation::Fallible);
+    }
+}
+
 #[dom_struct(associated_memory)]
 pub(crate) struct WebGLTexture {
     webgl_object: WebGLObject,
-    #[no_trace]
-    id: WebGLTextureId,
     /// The target to which this texture was bound the first time
     target: Cell<Option<u32>>,
-    is_deleted: Cell<bool>,
-    owner: WebGLTextureOwner,
     /// Stores information about mipmap levels and cubemap faces.
     #[ignore_malloc_size_of = "Arrays are cumbersome"]
     image_info_array: DomRefCell<[Option<ImageInfo>; MAX_LEVEL_COUNT * MAX_FACE_COUNT]>,
@@ -71,6 +125,7 @@ pub(crate) struct WebGLTexture {
     attached_framebuffer: MutNullableDom<WebGLFramebuffer>,
     /// Number of immutable levels.
     immutable_levels: Cell<Option<u32>>,
+    droppable: DroppableWebGLTexture,
 }
 
 impl WebGLTexture {
@@ -81,15 +136,7 @@ impl WebGLTexture {
     ) -> Self {
         Self {
             webgl_object: WebGLObject::new_inherited(context),
-            id,
             target: Cell::new(None),
-            is_deleted: Cell::new(false),
-            #[cfg(feature = "webxr")]
-            owner: owner
-                .map(|session| WebGLTextureOwner::WebXR(Dom::from_ref(session)))
-                .unwrap_or(WebGLTextureOwner::WebGL),
-            #[cfg(not(feature = "webxr"))]
-            owner: WebGLTextureOwner::WebGL,
             immutable_levels: Cell::new(None),
             face_count: Cell::new(0),
             base_mipmap_level: 0,
@@ -97,6 +144,17 @@ impl WebGLTexture {
             mag_filter: Cell::new(constants::LINEAR),
             image_info_array: DomRefCell::new([None; MAX_LEVEL_COUNT * MAX_FACE_COUNT]),
             attached_framebuffer: Default::default(),
+            droppable: DroppableWebGLTexture {
+                context: WeakRef::new(context),
+                id,
+                is_deleted: Cell::new(false),
+                #[cfg(feature = "webxr")]
+                owner: owner
+                    .map(|session| WebGLTextureOwner::WebXR(WeakRef::new(session)))
+                    .unwrap_or(WebGLTextureOwner::WebGL),
+                #[cfg(not(feature = "webxr"))]
+                owner: WebGLTextureOwner::WebGL,
+            },
         }
     }
 
@@ -143,7 +201,7 @@ impl WebGLTexture {
 
 impl WebGLTexture {
     pub(crate) fn id(&self) -> WebGLTextureId {
-        self.id
+        self.droppable.id
     }
 
     // NB: Only valid texture targets come here
@@ -168,7 +226,7 @@ impl WebGLTexture {
         }
 
         self.upcast()
-            .send_command(WebGLCommand::BindTexture(target, Some(self.id)));
+            .send_command(WebGLCommand::BindTexture(target, Some(self.id())));
 
         Ok(())
     }
@@ -240,47 +298,20 @@ impl WebGLTexture {
     }
 
     pub(crate) fn delete(&self, operation_fallibility: Operation) {
-        if !self.is_deleted.get() {
-            self.is_deleted.set(true);
-
-            /*
-            If a texture object is deleted while its image is attached to one or more attachment
-            points in a currently bound framebuffer, then it is as if FramebufferTexture had been
-            called, with a texture of zero, for each attachment point to which this im-age was
-            attached in that framebuffer. In other words, this texture image is firstdetached from
-            all attachment points in a currently bound framebuffer.
-            - GLES 3.0, 4.4.2.3, "Attaching Texture Images to a Framebuffer"
-            */
-            let webgl_object = self.upcast();
-            if let Some(context) = webgl_object.context() {
-                if let Some(fb) = context.get_draw_framebuffer_slot().get() {
-                    let _ = fb.detach_texture(self);
-                }
-                if let Some(fb) = context.get_read_framebuffer_slot().get() {
-                    let _ = fb.detach_texture(self);
-                }
-            }
-
-            // We don't delete textures owned by WebXR
-            #[cfg(feature = "webxr")]
-            if let WebGLTextureOwner::WebXR(_) = self.owner {
-                return;
-            }
-
-            webgl_object
-                .send_with_fallibility(WebGLCommand::DeleteTexture(self.id), operation_fallibility);
-        }
+        self.droppable.delete(operation_fallibility);
     }
 
     pub(crate) fn is_invalid(&self) -> bool {
         // https://immersive-web.github.io/layers/#xrwebglsubimagetype
         #[cfg(feature = "webxr")]
-        if let WebGLTextureOwner::WebXR(ref session) = self.owner {
-            if session.is_outside_raf() {
-                return true;
+        if let WebGLTextureOwner::WebXR(ref session) = self.droppable.owner {
+            if let Some(xr) = session.root() {
+                if xr.is_outside_raf() {
+                    return true;
+                }
             }
         }
-        self.is_deleted.get()
+        self.droppable.is_deleted.get()
     }
 
     pub(crate) fn is_immutable(&self) -> bool {
@@ -602,12 +633,6 @@ impl WebGLTexture {
         self.update_size();
 
         Ok(())
-    }
-}
-
-impl Drop for WebGLTexture {
-    fn drop(&mut self) {
-        self.delete(Operation::Fallible);
     }
 }
 

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -948,10 +948,6 @@ DOMInterfaces = {
     'weakReferenceable': True,
 },
 
-'WebGLTexture': {
-    'allowDropImpl': True,
-},
-
 'Window': {
     'canGc': ['CookieStore', 'FetchLater', 'GetVisualViewport', 'ReportError', 'Screen', 'StructuredClone'],
     'additionalTraits': ['crate::interfaces::WindowHelpers'],
@@ -1046,6 +1042,7 @@ DOMInterfaces = {
 'XRSession': {
     'inRealms': ['RequestReferenceSpace', 'UpdateRenderState', 'UpdateTargetFrameRate'],
     'canGc': ['End', 'RequestReferenceSpace', 'UpdateTargetFrameRate', 'RequestHitTestSource', 'GetSupportedFrameRates', 'EnabledFeatures'],
+    'weakReferenceable': True,
 },
 
 'XRSystem': {


### PR DESCRIPTION
Move the drop logic for WebGLTexture into a new `DroppableWebGLTexture` struct, removing the `allowDropImpl` binding configuration. This also switches WebXR session and rendering context references to `WeakRef` to avoid cycles, and changes `detach_texture` to accept a `WebGLTextureId` directly instead of a `&WebGLTexture` reference.

Testing: WebGLTests should cover the related parts.
Fixes: Partially #26488 
