### PR TITLE
devtools: Implement Style Editor tab

### DIFF
--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -144,7 +144,7 @@ pub(crate) struct BrowsingContextActor {
     css_properties_name: String,
     pub(crate) inspector_name: String,
     reflow_name: String,
-    style_sheets_name: String,
+    pub style_sheets_name: String,
     pub thread_name: String,
     _tab: String,
     // Different pipelines may run on different script threads.
@@ -229,7 +229,8 @@ impl BrowsingContextActor {
 
         let reflow_name = ReflowActor::register(registry);
 
-        let style_sheets_name = StyleSheetsActor::register(registry);
+        let style_sheets_name =
+            StyleSheetsActor::register(registry, script_sender.clone(), name.clone());
 
         let tab_descriptor_name =
             TabDescriptorActor::register(registry, name.clone(), is_top_level_global);

--- a/components/devtools/actors/stylesheets.rs
+++ b/components/devtools/actors/stylesheets.rs
@@ -96,6 +96,7 @@ impl Actor for StyleSheetsActor {
                 };
                 request.reply_final(&msg)?
             },
+            /// TODO: Fix CSS text formatting of external sheets, match same as source.
             "getText" => {
                 let resource_id = msg.get("resourceId").and_then(|v| v.as_str()).unwrap_or("");
                 let index = resource_id
@@ -160,7 +161,7 @@ impl StyleSheetsActor {
                 browsing_context_actor.pipeline_id(),
                 tx,
             ));
-        let style_sheets = rx.recv().unwrap_or_else(|_| vec![]);
+        let style_sheets = rx.recv().unwrap();
         style_sheets
             .into_iter()
             .map(|info| StyleSheetData {

--- a/components/devtools/actors/stylesheets.rs
+++ b/components/devtools/actors/stylesheets.rs
@@ -96,7 +96,7 @@ impl Actor for StyleSheetsActor {
                 };
                 request.reply_final(&msg)?
             },
-            /// TODO: Fix CSS text formatting of external sheets, match same as source.
+            // TODO: Improve CSS text formatting for remote stylesheets to match as source.
             "getText" => {
                 let resource_id = msg.get("resourceId").and_then(|v| v.as_str()).unwrap_or("");
                 let index = resource_id

--- a/components/devtools/actors/stylesheets.rs
+++ b/components/devtools/actors/stylesheets.rs
@@ -1,13 +1,18 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-
+use devtools_traits::DevtoolScriptControlMsg;
+use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
+use servo_base::generic_channel;
+use servo_base::generic_channel::GenericSender;
 
 use crate::StreamId;
 use crate::actor::{Actor, ActorError, ActorRegistry};
+use crate::actors::browsing_context::BrowsingContextActor;
+use crate::actors::long_string::{LongStringActor, LongStringObj};
 use crate::protocol::ClientRequest;
 
 /// <https://searchfox.org/mozilla-central/source/devtools/server/actors/resources/stylesheets.js>
@@ -15,29 +20,36 @@ use crate::protocol::ClientRequest;
 #[serde(rename_all = "camelCase")]
 pub(crate) struct StyleSheetData {
     /// Unique identifier for this stylesheet.
-    resource_id: String,
+    pub(crate) resource_id: String,
+    /// Current browsing context id.
+    pub(crate) browsing_context_id: u32,
     /// The URL of the stylesheet. Optional for inline stylesheets.
-    href: Option<String>,
+    pub(crate) href: Option<String>,
     /// The URL of the document that owns this stylesheet.
-    node_href: String,
+    pub(crate) node_href: String,
     /// Whether the stylesheet is disabled.
-    disabled: bool,
+    pub(crate) disabled: bool,
     /// The title of the stylesheet.
-    title: String,
+    pub(crate) title: Option<String>,
     /// Whether this is a browser stylesheet.
-    system: bool,
+    pub(crate) system: bool,
     /// Whether this stylesheet was created by DevTools.
-    is_new: bool,
+    pub(crate) is_new: bool,
+    /// Optional file name used for local files.
+    pub(crate) file_name: Option<String>,
     /// Optional source map URL.
-    source_map_url: Option<String>,
+    #[serde(rename = "sourceMapURL")]
+    pub(crate) source_map_url: Option<String>,
+    #[serde(rename = "sourceMapBaseURL")]
+    pub(crate) source_map_base_url: Option<String>,
     /// The index of this stylesheet in the document's stylesheet list.
-    style_sheet_index: i32,
-    // TODO: the following fields will be implemented later once we fetch the stylesheets
-    // constructed: bool,
-    // file_name: Option<String>,
-    // at_rules: Vec<Rule>,
-    // rule_count: u32,
-    // source_map_base_url: String,
+    pub(crate) style_sheet_index: i32,
+    /// whether the stylesheet was constructed using Web APIs.
+    pub(crate) constructed: bool,
+    /// Total count of individual CSS rules within that specific stylesheet.
+    pub(crate) rule_count: u32,
+    /// List of media query metadata (ex: @media, @keyframes).
+    pub(crate) at_rules: Vec<String>,
 }
 
 #[derive(Serialize)]
@@ -47,9 +59,18 @@ struct GetStyleSheetsReply {
     style_sheets: Vec<StyleSheetData>,
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct GetTextReply {
+    from: String,
+    text: LongStringObj,
+}
+
 #[derive(MallocSizeOf)]
 pub(crate) struct StyleSheetsActor {
     name: String,
+    script_sender: GenericSender<DevtoolScriptControlMsg>,
+    browsing_context_name: String,
 }
 
 impl Actor for StyleSheetsActor {
@@ -59,21 +80,53 @@ impl Actor for StyleSheetsActor {
     fn handle_message(
         &self,
         request: ClientRequest,
-        _registry: &ActorRegistry,
+        registry: &ActorRegistry,
         msg_type: &str,
-        _msg: &Map<String, Value>,
+        msg: &Map<String, Value>,
         _id: StreamId,
     ) -> Result<(), ActorError> {
+        let browsing_context_actor =
+            registry.find::<BrowsingContextActor>(&self.browsing_context_name);
         match msg_type {
             "getStyleSheets" => {
+                let style_sheets = self.get_stylesheets_data(&browsing_context_actor);
                 let msg = GetStyleSheetsReply {
                     from: self.name(),
-                    // TODO: Fetch actual stylesheets from the script thread.
-                    style_sheets: vec![],
+                    style_sheets,
                 };
                 request.reply_final(&msg)?
             },
-
+            "getText" => {
+                let resource_id = msg.get("resourceId").and_then(|v| v.as_str()).unwrap_or("");
+                let index = resource_id
+                    .split('-')
+                    .next_back()
+                    .unwrap_or("0")
+                    .parse::<i32>()
+                    .unwrap_or(0);
+                let (tx, rx) = generic_channel::channel().unwrap();
+                let _ = self
+                    .script_sender
+                    .send(DevtoolScriptControlMsg::GetStyleSheetText(
+                        browsing_context_actor.pipeline_id(),
+                        index,
+                        tx,
+                    ));
+                let css_text = rx
+                    .recv()
+                    .map_err(|_| ActorError::Internal)?
+                    .unwrap_or_else(|| {
+                        warn!("Stylesheet fetched without text content");
+                        "Error fetching CSS text".to_string()
+                    });
+                let long_string_name = LongStringActor::register(registry, css_text);
+                let long_string_actor = registry.find::<LongStringActor>(&long_string_name);
+                let msg = GetTextReply {
+                    from: self.name(),
+                    text: long_string_actor.long_string_obj(),
+                };
+                request.reply_final(&msg)?
+            },
             _ => return Err(ActorError::UnrecognizedPacketType),
         };
         Ok(())
@@ -81,10 +134,59 @@ impl Actor for StyleSheetsActor {
 }
 
 impl StyleSheetsActor {
-    pub fn register(registry: &ActorRegistry) -> String {
+    pub fn register(
+        registry: &ActorRegistry,
+        script_sender: GenericSender<DevtoolScriptControlMsg>,
+        browsing_context_name: String,
+    ) -> String {
         let name = registry.new_name::<Self>();
-        let actor = StyleSheetsActor { name: name.clone() };
+        let actor = StyleSheetsActor {
+            name: name.clone(),
+            script_sender,
+            browsing_context_name,
+        };
         registry.register::<Self>(actor);
         name
+    }
+
+    pub(crate) fn get_stylesheets_data(
+        &self,
+        browsing_context_actor: &BrowsingContextActor,
+    ) -> Vec<StyleSheetData> {
+        let (tx, rx) = generic_channel::channel().unwrap();
+        let _ = self
+            .script_sender
+            .send(DevtoolScriptControlMsg::GetStyleSheets(
+                browsing_context_actor.pipeline_id(),
+                tx,
+            ));
+        let style_sheets = rx.recv().unwrap_or_else(|_| vec![]);
+        style_sheets
+            .into_iter()
+            .map(|info| StyleSheetData {
+                resource_id: format!(
+                    "{}-{}",
+                    browsing_context_actor.browsing_context_id.value(),
+                    info.style_sheet_index
+                ),
+                browsing_context_id: browsing_context_actor.browsing_context_id.value(),
+                href: info.href.clone(),
+                node_href: browsing_context_actor.url.borrow().clone(),
+                disabled: info.disabled,
+                title: (!info.title.is_empty()).then_some(info.title),
+                system: info.system,
+                is_new: false,
+                file_name: None,
+                source_map_url: Some("".to_string()),
+                source_map_base_url: Some(
+                    info.href
+                        .unwrap_or_else(|| browsing_context_actor.url.borrow().clone()),
+                ),
+                style_sheet_index: info.style_sheet_index,
+                constructed: false,
+                rule_count: info.rule_count,
+                at_rules: vec![], // TODO: Populate with media query metadata for the Style Editor sidebar.
+            })
+            .collect()
     }
 }

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -29,6 +29,7 @@ use crate::actors::blackboxing::BlackboxingActor;
 use crate::actors::browsing_context::{BrowsingContextActor, BrowsingContextActorMsg};
 use crate::actors::console::ConsoleActor;
 use crate::actors::root::RootActor;
+use crate::actors::stylesheets::StyleSheetsActor;
 use crate::actors::watcher::target_configuration::{
     TargetConfigurationActor, TargetConfigurationActorMsg,
 };
@@ -387,11 +388,11 @@ impl Actor for WatcherActor {
                             }
                         },
                         "stylesheet" => {
-                            // TODO: Fetch actual stylesheets from the script thread.
-                            // For now, send an empty array.
-                            let empty: Vec<serde_json::Value> = vec![];
+                            let stylesheets_actor = registry.find::<StyleSheetsActor>(
+                                &browsing_context_actor.style_sheets_name,
+                            );
                             browsing_context_actor.resources_array(
-                                empty,
+                                stylesheets_actor.get_stylesheets_data(&browsing_context_actor),
                                 resource.into(),
                                 ResourceArrayType::Available,
                                 &mut request,

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -388,11 +388,11 @@ impl Actor for WatcherActor {
                             }
                         },
                         "stylesheet" => {
-                            let stylesheets_actor = registry.find::<StyleSheetsActor>(
+                            let style_sheets_actor = registry.find::<StyleSheetsActor>(
                                 &browsing_context_actor.style_sheets_name,
                             );
                             browsing_context_actor.resources_array(
-                                stylesheets_actor.get_stylesheets_data(&browsing_context_actor),
+                                style_sheets_actor.get_stylesheets_data(&browsing_context_actor),
                                 resource.into(),
                                 ResourceArrayType::Available,
                                 &mut request,

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -276,7 +276,7 @@ pub(crate) fn handle_get_stylesheet_text(
         }
 
         // For styles which are not inline, Reconstruct the CSS from rules.
-        let rules = stylesheet.GetCssRules(cx).ok()?;
+        let rules = stylesheet.rulelist(cx);
         let mut css_text = String::new();
         for i in 0..rules.Length() {
             if let Some(rule) = rules.Item(cx, i) {

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -8,17 +8,20 @@ use std::str;
 
 use devtools_traits::{
     AncestorData, AttrModification, AutoMargins, ComputedNodeLayout, CssDatabaseProperty,
-    EventListenerInfo, MatchedRule, NodeInfo, NodeStyle, RuleModification, TimelineMarker,
-    TimelineMarkerType,
+    EventListenerInfo, MatchedRule, NodeInfo, NodeStyle, RuleModification, StyleSheetInfo,
+    TimelineMarker, TimelineMarkerType,
 };
 use js::context::JSContext;
 use markup5ever::{LocalName, ns};
 use rustc_hash::FxHashMap;
+use script_bindings::codegen::GenericBindings::CSSRuleBinding::CSSRuleMethods;
+use script_bindings::codegen::GenericBindings::NodeBinding::NodeMethods;
 use script_bindings::root::Dom;
 use servo_base::generic_channel::GenericSender;
 use servo_base::id::PipelineId;
 use servo_config::pref;
 use style::attr::AttrValue;
+use style::stylesheets::Origin;
 
 use crate::document_collection::DocumentCollection;
 use crate::dom::bindings::codegen::Bindings::CSSGroupingRuleBinding::CSSGroupingRuleMethods;
@@ -224,6 +227,66 @@ pub(crate) fn handle_get_document_element(
         })
         .map(|element| element.upcast::<Node>().summarize(cx));
     reply.send(info).unwrap();
+}
+
+pub(crate) fn handle_get_stylesheets(
+    documents: &DocumentCollection,
+    pipeline: PipelineId,
+    reply: GenericSender<Vec<StyleSheetInfo>>,
+) {
+    let mut stylesheets = vec![];
+    if let Some(document) = documents.find_document(pipeline) {
+        let node = document.upcast::<Node>();
+        for i in 0..node.stylesheet_list_owner().stylesheet_count() {
+            if let Some(s) = node.stylesheet_list_owner().stylesheet_at(i) {
+                stylesheets.push(StyleSheetInfo {
+                    href: s.href().map(|h| h.to_string()),
+                    disabled: s.disabled(),
+                    title: s.title().to_string(),
+                    style_sheet_index: i as i32,
+                    system: s.origin() == Origin::UserAgent,
+                    rule_count: s.get_rule_count(),
+                });
+            }
+        }
+    }
+    reply.send(stylesheets).unwrap();
+}
+
+pub(crate) fn handle_get_stylesheet_text(
+    cx: &mut JSContext,
+    documents: &DocumentCollection,
+    pipeline: PipelineId,
+    index: i32,
+    reply: GenericSender<Option<String>>,
+) {
+    let text = (|| {
+        let document = documents.find_document(pipeline)?;
+        let stylesheet = document
+            .upcast::<Node>()
+            .stylesheet_list_owner()
+            .stylesheet_at(index as usize)?;
+
+        // For inline, Prefer the original "authored" source from the owner node (e.g., <style> tag).
+        if let Some(node) = stylesheet.owner_node() {
+            let text = node.upcast::<Node>().GetTextContent().unwrap_or_default();
+            if !text.is_empty() {
+                return Some(text.to_string());
+            }
+        }
+
+        // For styles which are not inline, Reconstruct the CSS from rules.
+        let rules = stylesheet.GetCssRules(cx).ok()?;
+        let mut css_text = String::new();
+        for i in 0..rules.Length() {
+            if let Some(rule) = rules.Item(cx, i) {
+                css_text.push_str(&rule.CssText().to_string());
+                css_text.push('\n');
+            }
+        }
+        Some(css_text)
+    })();
+    reply.send(text).unwrap();
 }
 
 pub(crate) fn handle_get_children(

--- a/components/script/dom/css/cssstylesheet.rs
+++ b/components/script/dom/css/cssstylesheet.rs
@@ -9,6 +9,7 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::realm::CurrentRealm;
 use js::rust::HandleObject;
+use script_bindings::codegen::GenericBindings::StyleSheetBinding::StyleSheetMethods;
 use script_bindings::inheritance::Castable;
 use script_bindings::root::Dom;
 use servo_arc::Arc;
@@ -172,6 +173,29 @@ impl CSSStyleSheet {
 
     pub(crate) fn disabled(&self) -> bool {
         self.style_stylesheet.borrow().disabled()
+    }
+
+    pub(crate) fn href(&self) -> Option<DOMString> {
+        self.upcast::<StyleSheet>().GetHref()
+    }
+
+    pub(crate) fn title(&self) -> DOMString {
+        self.upcast::<StyleSheet>().GetTitle().unwrap_or_default()
+    }
+
+    pub(crate) fn get_rule_count(&self) -> u32 {
+        let sheet = self.style_stylesheet.borrow();
+        let guard = sheet.shared_lock.read();
+        sheet.contents(&guard).rules.read_with(&guard).0.len() as u32
+    }
+
+    pub(crate) fn origin(&self) -> Origin {
+        let guard = self.style_shared_lock.read();
+        self.style_stylesheet()
+            .clone()
+            .contents
+            .read_with(&guard)
+            .origin
     }
 
     pub(crate) fn owner_node(&self) -> Option<DomRoot<Element>> {

--- a/components/script/dom/css/cssstylesheet.rs
+++ b/components/script/dom/css/cssstylesheet.rs
@@ -157,7 +157,7 @@ impl CSSStyleSheet {
         )
     }
 
-    fn rulelist(&self, cx: &mut JSContext) -> DomRoot<CSSRuleList> {
+    pub(crate) fn rulelist(&self, cx: &mut JSContext) -> DomRoot<CSSRuleList> {
         self.rule_list.or_init(|| {
             let sheet = self.style_stylesheet.borrow();
             let guard = sheet.shared_lock.read();

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2128,6 +2128,12 @@ impl ScriptThread {
                     reply,
                 )
             },
+            DevtoolScriptControlMsg::GetStyleSheets(id, reply) => {
+                devtools::handle_get_stylesheets(&documents, id, reply);
+            },
+            DevtoolScriptControlMsg::GetStyleSheetText(id, index, reply) => {
+                devtools::handle_get_stylesheet_text(cx, &documents, id, index, reply);
+            },
             DevtoolScriptControlMsg::GetChildren(id, node_id, reply) => {
                 devtools::handle_get_children(cx, &self.devtools_state, id, &node_id, reply)
             },

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -345,6 +345,10 @@ pub enum DevtoolScriptControlMsg {
         MatchedRule,
         GenericSender<Option<Vec<NodeStyle>>>,
     ),
+    /// Retrieve the list of stylesheets for the given pipeline and node.
+    GetStyleSheets(PipelineId, GenericSender<Vec<StyleSheetInfo>>),
+    /// Retrieve the actual CSS text for the stylesheet with the given node ID and index.
+    GetStyleSheetText(PipelineId, i32, GenericSender<Option<String>>),
     /// Retrieves the CSS selectors for the given node. A selector is comprised of the text
     /// of the selector and the id of the stylesheet that contains it.
     GetSelectors(PipelineId, String, GenericSender<Option<Vec<MatchedRule>>>),
@@ -622,6 +626,16 @@ pub struct EnvironmentInfo {
     pub scope_kind: Option<String>,
     pub function_display_name: Option<String>,
     pub binding_variables: Vec<PropertyDescriptor>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct StyleSheetInfo {
+    pub href: Option<String>,
+    pub disabled: bool,
+    pub title: String,
+    pub style_sheet_index: i32,
+    pub system: bool,
+    pub rule_count: u32,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/python/servo/devtools_tests.py
+++ b/python/servo/devtools_tests.py
@@ -1250,6 +1250,91 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
 
                 done.result(1)
 
+    def test_stylesheet_inline(self):
+        self.run_servoshell(url=f"{self.base_urls[0]}/stylesheets/inline_style.html")
+        with Devtools.connect() as devtools:
+            done = Future()
+            stylesheets_data = []
+
+            def on_resource(data):
+                for [resource_type, resources] in data["array"]:
+                    if resource_type == "stylesheet":
+                        stylesheets_data.extend(resources)
+                        done.set_result(None)
+
+            devtools.client.add_event_listener(
+                devtools.targets[0]["actor"],
+                Events.Watcher.RESOURCES_AVAILABLE_ARRAY,
+                on_resource,
+            )
+            devtools.watcher.watch_resources([Resources.STYLESHEET])
+            done.result(1)
+
+            # Inline sheets won't have href.
+            inline_sheet = stylesheets_data[0]
+            self.assertIsNone(inline_sheet.get("href"))
+            self.assertEqual(inline_sheet["ruleCount"], 2)
+            self.assertFalse(inline_sheet["system"])
+            self.assertFalse(inline_sheet["disabled"])
+
+    def test_stylesheet_linked(self):
+        self.run_servoshell(url=f"{self.base_urls[0]}/stylesheets/linked_style.html")
+        with Devtools.connect() as devtools:
+            done = Future()
+            stylesheets_data = []
+
+            def on_resource(data):
+                for [resource_type, resources] in data["array"]:
+                    if resource_type == "stylesheet":
+                        stylesheets_data.extend(resources)
+                        done.set_result(None)
+
+            devtools.client.add_event_listener(
+                devtools.targets[0]["actor"],
+                Events.Watcher.RESOURCES_AVAILABLE_ARRAY,
+                on_resource,
+            )
+            devtools.watcher.watch_resources([Resources.STYLESHEET])
+            done.result(1)
+
+            # Linked sheets have linked css as href.
+            linked_sheet = stylesheets_data[0]
+            self.assertEqual(f"{self.base_urls[0]}/stylesheets/styles.css", linked_sheet["href"])
+            self.assertFalse(linked_sheet["system"])
+            self.assertEqual(linked_sheet["ruleCount"], 1)
+            self.assertFalse(linked_sheet["disabled"])
+
+    def test_stylesheet_content(self):
+        self.run_servoshell(url=f"{self.base_urls[0]}/stylesheets/linked_style.html")
+        with Devtools.connect() as devtools:
+            founded_resources = []
+            done = Future()
+
+            def on_resource(data):
+                for [resource_type, resources] in data["array"]:
+                    if resource_type == "stylesheet":
+                        founded_resources.extend(resources)
+                        done.set_result(None)
+
+            devtools.client.add_event_listener(
+                devtools.targets[0]["actor"],
+                Events.Watcher.RESOURCES_AVAILABLE_ARRAY,
+                on_resource,
+            )
+            devtools.watcher.watch_resources([Resources.STYLESHEET])
+            done.result(1)
+
+            # Test getText by sending the resource id.
+            reply = devtools.client.send_receive(
+                {
+                    "to": devtools.targets[0]["styleSheetsActor"],
+                    "type": "getText",
+                    "resourceId": founded_resources[0]["resourceId"],
+                }
+            )
+            style_text = reply["text"]["initial"]
+            self.assertIn("body { background: green; font-size: small; }", style_text)
+
     # Sets `base_url` and `web_server` and `web_server_thread`.
     @classmethod
     def setUpClass(cls):

--- a/python/servo/devtools_tests/stylesheets/inline_style.html
+++ b/python/servo/devtools_tests/stylesheets/inline_style.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<style>
+    body { background: red; }
+    h1 { color: blue; }
+</style>
+<h1>Hello</h1>

--- a/python/servo/devtools_tests/stylesheets/linked_style.html
+++ b/python/servo/devtools_tests/stylesheets/linked_style.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<link rel="stylesheet" href="styles.css">

--- a/python/servo/devtools_tests/stylesheets/styles.css
+++ b/python/servo/devtools_tests/stylesheets/styles.css
@@ -1,0 +1,4 @@
+body {
+    background: green;
+    font-size: small;
+}


### PR DESCRIPTION
This PR focuses on forwarding the stylesheets and CSS text to the devtools.
watcher gets request for resource-available it registers in `StyleSheetActor` and gets the stylesheets.
`StyleSheetActor` asks the `script_thread` for stylesheets for the current document in the pipeline sends back to `StyleSheetActor` which is sent over for the response.
when the request comes for the CSS text which is a `getText` request it takes in resource id and the stylesheet index, for each stylesheets it check if it is inline it sends it unchanged, if its not inline it reconstruct it according to the `CSSRules` either of them are sent over the protocol to the devtools client and it shows up in the style editor.
Added tests for stylesheets resources and stylesheets CSS text content.

Testing: ./mach test-devtools test_stylesheet
Part of: #44315
