### PR TITLE
script: propagate &mut JSContext in ExtendableMessageEvent::dispatch_error

### DIFF
--- a/components/script/dom/event/extendablemessageevent.rs
+++ b/components/script/dom/event/extendablemessageevent.rs
@@ -144,7 +144,11 @@ impl ExtendableMessageEvent {
             .fire(target, can_gc);
     }
 
-    pub(crate) fn dispatch_error(target: &EventTarget, scope: &GlobalScope, can_gc: CanGc) {
+    pub(crate) fn dispatch_error(
+        cx: &mut js::context::JSContext,
+        target: &EventTarget,
+        scope: &GlobalScope,
+    ) {
         let init = ExtendableMessageEventBinding::ExtendableMessageEventInit::empty();
         let ExtendableMsgEvent = ExtendableMessageEvent::new(
             scope,
@@ -155,9 +159,11 @@ impl ExtendableMessageEvent {
             init.origin.clone(),
             init.lastEventId.clone(),
             init.ports.clone(),
-            can_gc,
+            CanGc::from_cx(cx),
         );
-        ExtendableMsgEvent.upcast::<Event>().fire(target, can_gc);
+        ExtendableMsgEvent
+            .upcast::<Event>()
+            .fire(target, CanGc::from_cx(cx));
     }
 }
 

--- a/components/script/dom/workers/serviceworkerglobalscope.rs
+++ b/components/script/dom/workers/serviceworkerglobalscope.rs
@@ -531,11 +531,7 @@ impl ServiceWorkerGlobalScope {
                         CanGc::from_cx(cx),
                     );
                 } else {
-                    ExtendableMessageEvent::dispatch_error(
-                        target,
-                        scope.upcast(),
-                        CanGc::from_cx(cx),
-                    );
+                    ExtendableMessageEvent::dispatch_error(cx, target, scope.upcast());
                 }
             },
             CommonWorker(WorkerScriptMsg::Common(msg)) => {


### PR DESCRIPTION
Propagate `&mut JSContext` in `ExtendableMessageEvent::dispatch_error` and related call sites.

Testing: Successful build is enough
Fixes: Part of #42638 