### PR TITLE
script: propagate &mut JSContext in Extractable::extract

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -483,9 +483,9 @@ impl ExtractedBody {
 pub(crate) trait Extractable {
     fn extract(
         &self,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         keep_alive: bool,
-        can_gc: CanGc,
     ) -> Fallible<ExtractedBody>;
 }
 
@@ -493,19 +493,19 @@ impl Extractable for BodyInit {
     /// <https://fetch.spec.whatwg.org/#concept-bodyinit-extract>
     fn extract(
         &self,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         keep_alive: bool,
-        can_gc: CanGc,
     ) -> Fallible<ExtractedBody> {
         match self {
-            BodyInit::String(s) => s.extract(global, keep_alive, can_gc),
-            BodyInit::URLSearchParams(usp) => usp.extract(global, keep_alive, can_gc),
-            BodyInit::Blob(b) => b.extract(global, keep_alive, can_gc),
-            BodyInit::FormData(formdata) => formdata.extract(global, keep_alive, can_gc),
+            BodyInit::String(s) => s.extract(cx, global, keep_alive),
+            BodyInit::URLSearchParams(usp) => usp.extract(cx, global, keep_alive),
+            BodyInit::Blob(b) => b.extract(cx, global, keep_alive),
+            BodyInit::FormData(formdata) => formdata.extract(cx, global, keep_alive),
             BodyInit::ArrayBuffer(typedarray) => {
                 let bytes = typedarray.to_vec();
                 let total_bytes = bytes.len();
-                let stream = ReadableStream::new_from_bytes(global, bytes, can_gc)?;
+                let stream = ReadableStream::new_from_bytes(global, bytes, CanGc::from_cx(cx))?;
                 Ok(ExtractedBody {
                     stream,
                     total_bytes: Some(total_bytes),
@@ -516,7 +516,7 @@ impl Extractable for BodyInit {
             BodyInit::ArrayBufferView(typedarray) => {
                 let bytes = typedarray.to_vec();
                 let total_bytes = bytes.len();
-                let stream = ReadableStream::new_from_bytes(global, bytes, can_gc)?;
+                let stream = ReadableStream::new_from_bytes(global, bytes, CanGc::from_cx(cx))?;
                 Ok(ExtractedBody {
                     stream,
                     total_bytes: Some(total_bytes),
@@ -552,13 +552,13 @@ impl Extractable for BodyInit {
 impl Extractable for Vec<u8> {
     fn extract(
         &self,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         _keep_alive: bool,
-        can_gc: CanGc,
     ) -> Fallible<ExtractedBody> {
         let bytes = self.clone();
         let total_bytes = self.len();
-        let stream = ReadableStream::new_from_bytes(global, bytes, can_gc)?;
+        let stream = ReadableStream::new_from_bytes(global, bytes, CanGc::from_cx(cx))?;
         Ok(ExtractedBody {
             stream,
             total_bytes: Some(total_bytes),
@@ -572,9 +572,9 @@ impl Extractable for Vec<u8> {
 impl Extractable for Blob {
     fn extract(
         &self,
+        cx: &mut js::context::JSContext,
         _global: &GlobalScope,
         _keep_alive: bool,
-        can_gc: CanGc,
     ) -> Fallible<ExtractedBody> {
         let blob_type = self.Type();
         let content_type = if blob_type.is_empty() {
@@ -583,7 +583,7 @@ impl Extractable for Blob {
             Some(blob_type)
         };
         let total_bytes = self.Size() as usize;
-        let stream = self.get_stream(can_gc)?;
+        let stream = self.get_stream(CanGc::from_cx(cx))?;
         Ok(ExtractedBody {
             stream,
             total_bytes: Some(total_bytes),
@@ -596,14 +596,14 @@ impl Extractable for Blob {
 impl Extractable for DOMString {
     fn extract(
         &self,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         _keep_alive: bool,
-        can_gc: CanGc,
     ) -> Fallible<ExtractedBody> {
         let bytes = self.as_bytes().to_owned();
         let total_bytes = bytes.len();
         let content_type = Some(DOMString::from("text/plain;charset=UTF-8"));
-        let stream = ReadableStream::new_from_bytes(global, bytes, can_gc)?;
+        let stream = ReadableStream::new_from_bytes(global, bytes, CanGc::from_cx(cx))?;
         Ok(ExtractedBody {
             stream,
             total_bytes: Some(total_bytes),
@@ -616,9 +616,9 @@ impl Extractable for DOMString {
 impl Extractable for FormData {
     fn extract(
         &self,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         _keep_alive: bool,
-        can_gc: CanGc,
     ) -> Fallible<ExtractedBody> {
         let boundary = generate_boundary();
         let bytes = encode_multipart_form_data(&mut self.datums(), boundary.clone(), UTF_8);
@@ -627,7 +627,7 @@ impl Extractable for FormData {
             "multipart/form-data; boundary={}",
             boundary
         )));
-        let stream = ReadableStream::new_from_bytes(global, bytes, can_gc)?;
+        let stream = ReadableStream::new_from_bytes(global, bytes, CanGc::from_cx(cx))?;
         Ok(ExtractedBody {
             stream,
             total_bytes: Some(total_bytes),
@@ -640,16 +640,16 @@ impl Extractable for FormData {
 impl Extractable for URLSearchParams {
     fn extract(
         &self,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         _keep_alive: bool,
-        can_gc: CanGc,
     ) -> Fallible<ExtractedBody> {
         let bytes = self.serialize_utf8().into_bytes();
         let total_bytes = bytes.len();
         let content_type = Some(DOMString::from(
             "application/x-www-form-urlencoded;charset=UTF-8",
         ));
-        let stream = ReadableStream::new_from_bytes(global, bytes, can_gc)?;
+        let stream = ReadableStream::new_from_bytes(global, bytes, CanGc::from_cx(cx))?;
         Ok(ExtractedBody {
             stream,
             total_bytes: Some(total_bytes),

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -936,13 +936,13 @@ impl HTMLFormElement {
             ("http", FormMethod::Post) | ("https", FormMethod::Post) => {
                 load_data.method = Method::POST;
                 self.submit_entity_body(
+                    cx,
                     &mut form_data,
                     load_data,
                     enctype,
                     encoding,
                     target_window,
                     history_handling,
-                    CanGc::from_cx(cx),
                 );
             },
             // https://html.spec.whatwg.org/multipage/#submit-get-action
@@ -990,13 +990,13 @@ impl HTMLFormElement {
     #[allow(clippy::too_many_arguments)]
     fn submit_entity_body(
         &self,
+        cx: &mut js::context::JSContext,
         form_data: &mut [FormDatum],
         mut load_data: LoadData,
         enctype: FormEncType,
         encoding: &'static Encoding,
         target: &Window,
         history_handling: NavigationHistoryBehavior,
-        can_gc: CanGc,
     ) {
         let boundary = generate_boundary();
         let bytes = match enctype {
@@ -1034,7 +1034,7 @@ impl HTMLFormElement {
         let global = self.global();
 
         let request_body = bytes
-            .extract(&global, false, can_gc)
+            .extract(cx, &global, false)
             .expect("Couldn't extract body.")
             .into_net_request_body()
             .0;

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -488,7 +488,12 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
     }
 
     /// <https://w3c.github.io/beacon/#sec-processing-model>
-    fn SendBeacon(&self, url: USVString, data: Option<BodyInit>, can_gc: CanGc) -> Fallible<bool> {
+    fn SendBeacon(
+        &self,
+        cx: &mut js::context::JSContext,
+        url: USVString,
+        data: Option<BodyInit>,
+    ) -> Fallible<bool> {
         let global = self.global();
         // Step 1. Set base to this's relevant settings object's API base URL.
         let base = global.api_base_url();
@@ -514,7 +519,7 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
         if let Some(data) = data {
             // Step 6.1. Set transmittedData and contentType to the result of extracting data's byte stream
             // with the keepalive flag set.
-            let extracted_body = data.extract(&global, true, can_gc)?;
+            let extracted_body = data.extract(cx, &global, true)?;
             // Step 6.2. If the amount of data that can be queued to be sent by keepalive enabled requests
             // is exceeded by the size of transmittedData (as defined in HTTP-network-or-cache fetch),
             // set the return value to false and terminate these steps.

--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -95,9 +95,9 @@ impl Request {
 
     // https://fetch.spec.whatwg.org/#dom-request
     pub(crate) fn constructor(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         mut input: RequestInfo,
         init: &RequestInit,
     ) -> Fallible<DomRoot<Request>> {
@@ -344,7 +344,7 @@ impl Request {
         // TODO
 
         // Step 28. Set this’s request to request.
-        let r = Request::from_net_request(global, proto, request, can_gc);
+        let r = Request::from_net_request(global, proto, request, CanGc::from_cx(cx));
 
         // Step 29. Let signals be « signal » if signal is non-null; otherwise « ».
         let signals = signal.map_or(vec![], |s| vec![s]);
@@ -352,7 +352,9 @@ impl Request {
         // abort signal from signals, using AbortSignal and this’s relevant realm.
         r.signal
             .set(Some(&AbortSignal::create_dependent_abort_signal(
-                signals, global, can_gc,
+                signals,
+                global,
+                CanGc::from_cx(cx),
             )));
 
         // Step 31. Set this’s headers to a new Headers object with this’s relevant realm,
@@ -361,7 +363,7 @@ impl Request {
         // "or_init" looks unclear here, but it always enters the block since r
         // hasn't had any other way to initialize its headers
         r.headers
-            .or_init(|| Headers::for_request(&r.global(), can_gc));
+            .or_init(|| Headers::for_request(&r.global(), CanGc::from_cx(cx)));
 
         // Step 33. If init is not empty, then:
         //
@@ -398,7 +400,8 @@ impl Request {
                 ));
             }
             // Step 32.2. Set this’s headers’s guard to "request-no-cors".
-            r.Headers(can_gc).set_guard(Guard::RequestNoCors);
+            r.Headers(CanGc::from_cx(cx))
+                .set_guard(Guard::RequestNoCors);
         }
 
         match headers_copy {
@@ -410,17 +413,17 @@ impl Request {
                 // but an input with headers is given, set request's
                 // headers as the input's Headers.
                 if let RequestInfo::Request(ref input_request) = input {
-                    r.Headers(can_gc)
-                        .copy_from_headers(input_request.Headers(can_gc))?;
+                    r.Headers(CanGc::from_cx(cx))
+                        .copy_from_headers(input_request.Headers(CanGc::from_cx(cx)))?;
                 }
             },
             // Step 33.5. Otherwise, fill this’s headers with headers.
-            Some(headers_copy) => r.Headers(can_gc).fill(Some(headers_copy))?,
+            Some(headers_copy) => r.Headers(CanGc::from_cx(cx)).fill(Some(headers_copy))?,
         }
 
         // Step 33.5 depending on how we got here
         // Copy the headers list onto the headers of net_traits::Request
-        r.request.borrow_mut().headers = r.Headers(can_gc).get_headers_list();
+        r.request.borrow_mut().headers = r.Headers(CanGc::from_cx(cx)).get_headers_list();
 
         // Step 34. Let inputBody be input’s request’s body if input is a Request object; otherwise null.
         let input_body = if let RequestInfo::Request(ref mut input_request) = input {
@@ -457,7 +460,7 @@ impl Request {
         if let Some(Some(ref input_init_body)) = init.body {
             // Step 37.1. Let bodyWithType be the result of extracting init["body"], with keepalive set to request’s keepalive.
             let mut body_with_type =
-                input_init_body.extract(global, r.request.borrow().keep_alive, can_gc)?;
+                input_init_body.extract(cx, global, r.request.borrow().keep_alive)?;
 
             // Step 37.3. Let type be bodyWithType’s type.
             if let Some(contents) = body_with_type.content_type.take() {
@@ -465,12 +468,12 @@ impl Request {
                 // Step 37.4. If type is non-null and this’s headers’s header list
                 // does not contain `Content-Type`, then append (`Content-Type`, type) to this’s headers.
                 if !r
-                    .Headers(can_gc)
+                    .Headers(CanGc::from_cx(cx))
                     .Has(ByteString::new(ct_header_name.to_vec()))
                     .unwrap()
                 {
                     let ct_header_val = contents.as_bytes();
-                    r.Headers(can_gc).Append(
+                    r.Headers(CanGc::from_cx(cx)).Append(
                         ByteString::new(ct_header_name.to_vec()),
                         ByteString::new(ct_header_val.to_vec()),
                     )?;
@@ -612,13 +615,13 @@ fn includes_credentials(input: &ServoUrl) -> bool {
 impl RequestMethods<crate::DomTypeHolder> for Request {
     /// <https://fetch.spec.whatwg.org/#dom-request>
     fn Constructor(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         input: RequestInfo,
         init: RootedTraceableBox<RequestInit>,
     ) -> Fallible<DomRoot<Request>> {
-        Self::constructor(global, proto, can_gc, input, &init)
+        Self::constructor(cx, global, proto, input, &init)
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-request-method>

--- a/components/script/dom/response.rs
+++ b/components/script/dom/response.rs
@@ -34,7 +34,7 @@ use crate::dom::headers::{Guard, Headers, is_obs_text, is_vchar};
 use crate::dom::promise::Promise;
 use crate::dom::stream::readablestream::ReadableStream;
 use crate::dom::stream::underlyingsourcecontainer::UnderlyingSourceType;
-use crate::script_runtime::{CanGc, JSContext, StreamConsumer};
+use crate::script_runtime::{CanGc, StreamConsumer};
 
 #[dom_struct]
 pub(crate) struct Response {
@@ -169,32 +169,34 @@ fn is_null_body_status(status: u16) -> bool {
 impl ResponseMethods<crate::DomTypeHolder> for Response {
     /// <https://fetch.spec.whatwg.org/#dom-response>
     fn Constructor(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         body_init: Option<BodyInit>,
         init: &ResponseBinding::ResponseInit,
     ) -> Fallible<DomRoot<Response>> {
         // 1. Set this’s response to a new response.
         // Our Response/Body types don't actually hold onto an internal fetch Response.
-        let response = Response::new_with_proto(global, proto, can_gc);
+        let response = Response::new_with_proto(global, proto, CanGc::from_cx(cx));
         if body_init.is_some() {
             response.is_body_empty.set(false);
         }
 
         // 2. Set this’s headers to a new Headers object with this’s relevant realm,
         // whose header list is this’s response’s header list and guard is "response".
-        response.Headers(can_gc).set_guard(Guard::Response);
+        response
+            .Headers(CanGc::from_cx(cx))
+            .set_guard(Guard::Response);
 
         // 3. Let bodyWithType be null.
         // 4. If body is non-null, then set bodyWithType to the result of extracting body.
         let body_with_type = match body_init {
-            Some(body) => Some(body.extract(global, false, can_gc)?),
+            Some(body) => Some(body.extract(cx, global, false)?),
             None => None,
         };
 
         // 5. Perform *initialize a response* given this, init, and bodyWithType.
-        initialize_response(global, can_gc, body_with_type, init, response)
+        initialize_response(global, CanGc::from_cx(cx), body_with_type, init, response)
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-response-error>
@@ -252,29 +254,30 @@ impl ResponseMethods<crate::DomTypeHolder> for Response {
 
     /// <https://fetch.spec.whatwg.org/#dom-response-json>
     fn CreateFromJson(
-        cx: JSContext,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         data: HandleValue,
         init: &ResponseBinding::ResponseInit,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<Response>> {
         // 1. Let bytes the result of running serialize a JavaScript value to JSON bytes on data.
-        let json_str = serialize_jsval_to_json_utf8(cx, data)?;
+        let json_str = serialize_jsval_to_json_utf8(cx.into(), data)?;
 
         // 2. Let body be the result of extracting bytes
         // The spec's definition of JSON bytes is a UTF-8 encoding so using a DOMString here handles
         // the encoding part.
         let body_init = BodyInit::String(json_str);
-        let mut body = body_init.extract(global, false, can_gc)?;
+        let mut body = body_init.extract(cx, global, false)?;
 
         // 3. Let responseObject be the result of creating a Response object, given a new response,
         // "response", and the current realm.
-        let response = Response::new(global, can_gc);
-        response.Headers(can_gc).set_guard(Guard::Response);
+        let response = Response::new(global, CanGc::from_cx(cx));
+        response
+            .Headers(CanGc::from_cx(cx))
+            .set_guard(Guard::Response);
 
         // 4. Perform initialize a response given responseObject, init, and (body, "application/json").
         body.content_type = Some("application/json".into());
-        initialize_response(global, can_gc, Some(body), init, response)
+        initialize_response(global, CanGc::from_cx(cx), Some(body), init, response)
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-response-type>

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2167,11 +2167,11 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     /// <https://fetch.spec.whatwg.org/#dom-window-fetchlater>
     fn FetchLater(
         &self,
+        cx: &mut js::context::JSContext,
         input: RequestInfo,
         init: RootedTraceableBox<DeferredRequestInit>,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<FetchLaterResult>> {
-        fetch::FetchLater(self, input, init, can_gc)
+        fetch::FetchLater(cx, self, input, init)
     }
 
     #[cfg(feature = "bluetooth")]

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -591,7 +591,7 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
             },
             Some(DocumentOrXMLHttpRequestBodyInit::Blob(ref b)) => {
                 let extracted_body = b
-                    .extract(&self.global(), false, can_gc)
+                    .extract(cx, &self.global(), false)
                     .expect("Couldn't extract body.");
                 if !extracted_body.in_memory() && self.sync.get() {
                     warn!("Sync XHR with not in-memory Blob as body not supported");
@@ -602,16 +602,16 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
             },
             Some(DocumentOrXMLHttpRequestBodyInit::FormData(ref formdata)) => Some(
                 formdata
-                    .extract(&self.global(), false, can_gc)
+                    .extract(cx, &self.global(), false)
                     .expect("Couldn't extract body."),
             ),
             Some(DocumentOrXMLHttpRequestBodyInit::String(ref str)) => Some(
-                str.extract(&self.global(), false, can_gc)
+                str.extract(cx, &self.global(), false)
                     .expect("Couldn't extract body."),
             ),
             Some(DocumentOrXMLHttpRequestBodyInit::URLSearchParams(ref urlsp)) => Some(
                 urlsp
-                    .extract(&self.global(), false, can_gc)
+                    .extract(cx, &self.global(), false)
                     .expect("Couldn't extract body."),
             ),
             Some(DocumentOrXMLHttpRequestBodyInit::ArrayBuffer(ref typedarray)) => {

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -226,7 +226,7 @@ pub(crate) fn Fetch(
 
     // Step 2. Let requestObject be the result of invoking the initial value of Request as constructor
     //         with input and init as arguments. If this throws an exception, reject p with it and return p.
-    let request_object = match Request::Constructor(global, None, CanGc::from_cx(cx), input, init) {
+    let request_object = match Request::Constructor(cx, global, None, input, init) {
         Err(e) => {
             response.error_stream(e.clone(), CanGc::from_cx(cx));
             promise.reject_error(e, CanGc::from_cx(cx));
@@ -350,25 +350,28 @@ fn queue_deferred_fetch(
 /// <https://fetch.spec.whatwg.org/#dom-window-fetchlater>
 #[expect(non_snake_case, unsafe_code)]
 pub(crate) fn FetchLater(
+    cx: &mut js::context::JSContext,
     window: &Window,
     input: RequestInfo,
     init: RootedTraceableBox<DeferredRequestInit>,
-    can_gc: CanGc,
 ) -> Fallible<DomRoot<FetchLaterResult>> {
     let global_scope = window.upcast();
     let document = window.Document();
     // Step 1. Let requestObject be the result of invoking the initial value
     // of Request as constructor with input and init as arguments.
-    let request_object = Request::constructor(global_scope, None, can_gc, input, &init.parent)?;
+    let request_object = Request::constructor(cx, global_scope, None, input, &init.parent)?;
     // Step 2. If requestObject’s signal is aborted, then throw signal’s abort reason.
     let signal = request_object.Signal();
     if signal.aborted() {
-        let cx = GlobalScope::get_cx();
-        rooted!(in(*cx) let mut abort_reason = UndefinedValue());
-        signal.Reason(cx, abort_reason.handle_mut());
+        rooted!(&in(cx) let mut abort_reason = UndefinedValue());
+        signal.Reason(cx.into(), abort_reason.handle_mut());
         unsafe {
-            assert!(!JS_IsExceptionPending(*cx));
-            JS_SetPendingException(*cx, abort_reason.handle(), ExceptionStackBehavior::Capture);
+            assert!(!JS_IsExceptionPending(cx.raw_cx()));
+            JS_SetPendingException(
+                cx.raw_cx(),
+                abort_reason.handle(),
+                ExceptionStackBehavior::Capture,
+            );
         }
         return Err(Error::JSFailed);
     }
@@ -421,7 +424,11 @@ pub(crate) fn FetchLater(
     // Step 14. Add the following abort steps to requestObject’s signal: Set deferredRecord’s invoke state to "aborted".
     signal.add(&AbortAlgorithm::FetchLater(deferred_record_id));
     // Step 15. Return a new FetchLaterResult whose activated getter steps are to return activated.
-    Ok(FetchLaterResult::new(window, deferred_record_id, can_gc))
+    Ok(FetchLaterResult::new(
+        window,
+        deferred_record_id,
+        CanGc::from_cx(cx),
+    ))
 }
 
 /// <https://fetch.spec.whatwg.org/#deferred-fetch-record-invoke-state>

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -740,8 +740,8 @@ DOMInterfaces = {
 
 'Navigator': {
     'inRealms': ['GetVRDisplays'],
-    'canGc': ['Languages', 'SendBeacon', 'UserActivation'],
-    'cx': ['Clipboard', 'Storage', 'WakeLock'],
+    'canGc': ['Languages', 'UserActivation'],
+    'cx': ['Clipboard', 'SendBeacon', 'Storage', 'WakeLock'],
 },
 
 'WakeLock': {
@@ -808,10 +808,12 @@ DOMInterfaces = {
 
 'Request': {
     'canGc': ['Headers', 'Text', 'Blob', 'FormData', 'Json', 'ArrayBuffer', 'Clone', 'Bytes'],
+    'cx': ['Constructor'],
 },
 
 'Response': {
-    'canGc': ['Error', 'Redirect', 'Clone', 'CreateFromJson', 'Text', 'Blob', 'FormData', 'Json', 'ArrayBuffer', 'Headers', 'Bytes'],
+    'canGc': ['Error', 'Redirect', 'Clone', 'Text', 'Blob', 'FormData', 'Json', 'ArrayBuffer', 'Headers', 'Bytes'],
+    'cx': ['Constructor', 'CreateFromJson'],
 },
 
 'RTCPeerConnection': {
@@ -953,11 +955,12 @@ DOMInterfaces = {
 },
 
 'Window': {
-    'canGc': ['CookieStore', 'FetchLater', 'GetVisualViewport', 'ReportError', 'Screen', 'StructuredClone'],
+    'canGc': ['CookieStore', 'GetVisualViewport', 'ReportError', 'Screen', 'StructuredClone'],
     'additionalTraits': ['crate::interfaces::WindowHelpers'],
     'realm': ['CreateImageBitmap', 'CreateImageBitmap_', 'WebdriverCallback', 'GetOpener', 'Fetch'],
     'cx': [
         'Focus',
+        'FetchLater',
         'GetLocalStorage',
         'GetSessionStorage',
         'Location',


### PR DESCRIPTION
Propagate `&mut JSContext` in `Extractable::extract` and related call sites.

Testing: Successful build is enough
Fixes: Part of #42638 

Opened to reduces the complexity of #44254 