### PR TITLE
script: propagate &mut JSContext in MessageEvent::dispatch_error

### DIFF
--- a/components/script/dom/event/messageevent.rs
+++ b/components/script/dom/event/messageevent.rs
@@ -222,7 +222,11 @@ impl MessageEvent {
         messageevent.upcast::<Event>().fire(target, can_gc);
     }
 
-    pub(crate) fn dispatch_error(target: &EventTarget, scope: &GlobalScope, can_gc: CanGc) {
+    pub(crate) fn dispatch_error(
+        cx: &mut js::context::JSContext,
+        target: &EventTarget,
+        scope: &GlobalScope,
+    ) {
         let init = MessageEventBinding::MessageEventInit::empty();
         let messageevent = MessageEvent::new(
             scope,
@@ -234,9 +238,11 @@ impl MessageEvent {
             init.source.as_ref(),
             init.lastEventId.clone(),
             init.ports.clone(),
-            can_gc,
+            CanGc::from_cx(cx),
         );
-        messageevent.upcast::<Event>().fire(target, can_gc);
+        messageevent
+            .upcast::<Event>()
+            .fire(target, CanGc::from_cx(cx));
     }
 }
 

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -1361,7 +1361,7 @@ impl GlobalScope {
                                     return;
                                 }
 
-                                rooted!(&in() let mut message = UndefinedValue());
+                                rooted!(&in(cx) let mut message = UndefinedValue());
 
                                 // Step 10.3 StructuredDeserialize(serialized, targetRealm).
                                 if let Ok(ports) = structuredclone::read(&global, data, message.handle_mut(), CanGc::from_cx(cx)) {

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -1361,7 +1361,7 @@ impl GlobalScope {
                                     return;
                                 }
 
-                                rooted!(in(*GlobalScope::get_cx()) let mut message = UndefinedValue());
+                                rooted!(&in() let mut message = UndefinedValue());
 
                                 // Step 10.3 StructuredDeserialize(serialized, targetRealm).
                                 if let Ok(ports) = structuredclone::read(&global, data, message.handle_mut(), CanGc::from_cx(cx)) {

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -1377,7 +1377,7 @@ impl GlobalScope {
                                     );
                                 } else {
                                     // Step 10.3, fire an event named messageerror at destination.
-                                    MessageEvent::dispatch_error(cx, destination.upcast(), &global, );
+                                    MessageEvent::dispatch_error(cx, destination.upcast(), &global);
                                 }
                             })
                         );

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -1377,7 +1377,7 @@ impl GlobalScope {
                                     );
                                 } else {
                                     // Step 10.3, fire an event named messageerror at destination.
-                                    MessageEvent::dispatch_error(destination.upcast(), &global, CanGc::from_cx(cx));
+                                    MessageEvent::dispatch_error(cx, destination.upcast(), &global, );
                                 }
                             })
                         );
@@ -1569,7 +1569,7 @@ impl GlobalScope {
                     // If this throws an exception, catch it,
                     // fire an event named messageerror at messageEventTarget,
                     // using MessageEvent, and then return.
-                    MessageEvent::dispatch_error(message_event_target, self, CanGc::from_cx(cx));
+                    MessageEvent::dispatch_error(cx, message_event_target, self);
                 }
             });
         }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -10,6 +10,7 @@ use std::collections::{HashMap, HashSet};
 use std::default::Default;
 use std::ffi::c_void;
 use std::io::{Write, stderr, stdout};
+use std::ptr::NonNull;
 use std::rc::{Rc, Weak};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -33,11 +34,9 @@ use euclid::{Point2D, Rect, Scale, Size2D, Vector2D};
 use fonts::{CspViolationHandler, FontContext, NetworkTimingHandler, WebFontDocumentContext};
 use js::context::JSContext;
 use js::glue::DumpJSStack;
-use js::jsapi::{
-    GCReason, Heap, JS_GC, JSAutoRealm, JSContext as RawJSContext, JSObject, JSPROP_ENUMERATE,
-};
+use js::jsapi::{GCReason, Heap, JS_GC, JSContext as RawJSContext, JSObject, JSPROP_ENUMERATE};
 use js::jsval::{NullValue, UndefinedValue};
-use js::realm::CurrentRealm;
+use js::realm::{AutoRealm, CurrentRealm};
 use js::rust::wrappers::JS_DefineProperty;
 use js::rust::{
     CustomAutoRooter, CustomAutoRooterGuard, HandleObject, HandleValue, MutableHandleObject,
@@ -3873,7 +3872,7 @@ impl Window {
     ) {
         let this = Trusted::new(self);
         let source = Trusted::new(source);
-        let task = task!(post_serialised_message: move || {
+        let task = task!(post_serialised_message: move |cx| {
             let this = this.root();
             let source = source.root();
             let document = this.Document();
@@ -3886,10 +3885,9 @@ impl Window {
             }
 
             // Steps 7.2.-7.5.
-            let cx = this.get_cx();
             let obj = this.reflector().get_jsobject();
-            let _ac = JSAutoRealm::new(*cx, obj.get());
-            rooted!(in(*cx) let mut message_clone = UndefinedValue());
+            let mut realm = AutoRealm::new(cx, NonNull::new(obj.get()).unwrap());
+            rooted!(&in(*realm) let mut message_clone = UndefinedValue());
             if let Ok(ports) = structuredclone::read(this.upcast(), data, message_clone.handle_mut(), CanGc::deprecated_note()) {
                 // Step 7.6, 7.7
                 MessageEvent::dispatch_jsval(
@@ -3904,9 +3902,9 @@ impl Window {
             } else {
                 // Step 4, fire messageerror.
                 MessageEvent::dispatch_error(
+                    &mut realm,
                     this.upcast(),
                     this.upcast(),
-                    CanGc::deprecated_note()
                 );
             }
         });

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -3903,7 +3903,7 @@ impl Window {
             } else {
                 // Step 4, fire messageerror.
                 MessageEvent::dispatch_error(
-                    &mut realm,
+                    cx,
                     this.upcast(),
                     this.upcast(),
                 );

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -3887,7 +3887,8 @@ impl Window {
             // Steps 7.2.-7.5.
             let obj = this.reflector().get_jsobject();
             let mut realm = AutoRealm::new(cx, NonNull::new(obj.get()).unwrap());
-            rooted!(&in(*realm) let mut message_clone = UndefinedValue());
+            let cx = &mut *realm;
+            rooted!(&in(cx) let mut message_clone = UndefinedValue());
             if let Ok(ports) = structuredclone::read(this.upcast(), data, message_clone.handle_mut(), CanGc::deprecated_note()) {
                 // Step 7.6, 7.7
                 MessageEvent::dispatch_jsval(

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -3889,7 +3889,7 @@ impl Window {
             let mut realm = AutoRealm::new(cx, NonNull::new(obj.get()).unwrap());
             let cx = &mut *realm;
             rooted!(&in(cx) let mut message_clone = UndefinedValue());
-            if let Ok(ports) = structuredclone::read(this.upcast(), data, message_clone.handle_mut(), CanGc::deprecated_note()) {
+            if let Ok(ports) = structuredclone::read(this.upcast(), data, message_clone.handle_mut(), CanGc::from_cx(cx)) {
                 // Step 7.6, 7.7
                 MessageEvent::dispatch_jsval(
                     this.upcast(),

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -3898,7 +3898,7 @@ impl Window {
                     Some(&source_origin.ascii_serialization()),
                     Some(&*source),
                     ports,
-                    CanGc::deprecated_note()
+                    CanGc::from_cx(cx),
                 );
             } else {
                 // Step 4, fire messageerror.

--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -56,7 +56,7 @@ use crate::dom::webgpu::identityhub::IdentityHub;
 use crate::dom::worker::{TrustedWorkerAddress, Worker};
 use crate::dom::workerglobalscope::{ScriptFetchContext, WorkerGlobalScope};
 use crate::messaging::{CommonScriptMsg, ScriptEventLoopReceiver, ScriptEventLoopSender};
-use crate::realms::enter_realm;
+use crate::realms::enter_auto_realm;
 use crate::script_module::{ModuleFetchClient, fetch_a_module_worker_script_graph};
 use crate::script_runtime::ScriptThreadEventCategory::WorkerEvent;
 use crate::script_runtime::{CanGc, Runtime, ThreadSafeJSContext};

--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -632,7 +632,8 @@ impl DedicatedWorkerGlobalScope {
     fn dispatch_message_event(&self, cx: &mut JSContext, msg: MessageData) {
         let scope = self.upcast::<WorkerGlobalScope>();
         let target = self.upcast();
-        let _ac = enter_realm(self);
+        let mut realm = enter_auto_realm(cx, self);
+        let cx = &mut realm;
         rooted!(&in(cx) let mut message = UndefinedValue());
         if let Ok(ports) = structuredclone::read(
             scope.upcast(),

--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -619,24 +619,27 @@ impl DedicatedWorkerGlobalScope {
         )
     }
 
-    pub(crate) fn fire_queued_messages(&self, can_gc: CanGc) {
+    pub(crate) fn fire_queued_messages(&self, cx: &mut JSContext) {
         let queue: Vec<_> = self.queued_worker_tasks.borrow_mut().drain(..).collect();
         for msg in queue {
             if self.upcast::<WorkerGlobalScope>().is_closing() {
                 return;
             }
-            self.dispatch_message_event(msg, can_gc);
+            self.dispatch_message_event(cx, msg);
         }
     }
 
-    fn dispatch_message_event(&self, msg: MessageData, can_gc: CanGc) {
+    fn dispatch_message_event(&self, cx: &mut JSContext, msg: MessageData) {
         let scope = self.upcast::<WorkerGlobalScope>();
         let target = self.upcast();
         let _ac = enter_realm(self);
-        rooted!(in(*scope.get_cx()) let mut message = UndefinedValue());
-        if let Ok(ports) =
-            structuredclone::read(scope.upcast(), *msg.data, message.handle_mut(), can_gc)
-        {
+        rooted!(&in(cx) let mut message = UndefinedValue());
+        if let Ok(ports) = structuredclone::read(
+            scope.upcast(),
+            *msg.data,
+            message.handle_mut(),
+            CanGc::from_cx(cx),
+        ) {
             MessageEvent::dispatch_jsval(
                 target,
                 scope.upcast(),
@@ -644,10 +647,10 @@ impl DedicatedWorkerGlobalScope {
                 Some(&msg.origin.ascii_serialization()),
                 None,
                 ports,
-                can_gc,
+                CanGc::from_cx(cx),
             );
         } else {
-            MessageEvent::dispatch_error(target, scope.upcast(), can_gc);
+            MessageEvent::dispatch_error(cx, target, scope.upcast());
         }
     }
 
@@ -655,7 +658,7 @@ impl DedicatedWorkerGlobalScope {
         match msg {
             WorkerScriptMsg::DOMMessage(message_data) => {
                 if self.upcast::<WorkerGlobalScope>().is_execution_ready() {
-                    self.dispatch_message_event(message_data, CanGc::from_cx(cx));
+                    self.dispatch_message_event(cx, message_data);
                 } else {
                     self.queued_worker_tasks.borrow_mut().push(message_data);
                 }

--- a/components/script/dom/workers/worker.rs
+++ b/components/script/dom/workers/worker.rs
@@ -129,7 +129,7 @@ impl Worker {
             );
         } else {
             // Step 4 of the "port post message steps" of the implicit messageport, fire messageerror.
-            MessageEvent::dispatch_error(target, &global, CanGc::from_cx(cx));
+            MessageEvent::dispatch_error(cx, target, &global);
         }
     }
 

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -444,11 +444,6 @@ impl WorkerGlobalScope {
         self.devtools_receiver.as_ref()
     }
 
-    #[expect(unsafe_code, unused)]
-    pub(crate) fn get_cx(&self) -> JSContext {
-        unsafe { JSContext::from_ptr(js::rust::Runtime::get().unwrap().as_ptr()) }
-    }
-
     pub(crate) fn is_closing(&self) -> bool {
         self.closing.load(Ordering::SeqCst)
     }

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -444,7 +444,7 @@ impl WorkerGlobalScope {
         self.devtools_receiver.as_ref()
     }
 
-    #[expect(unsafe_code)]
+    #[expect(unsafe_code, unused)]
     pub(crate) fn get_cx(&self) -> JSContext {
         unsafe { JSContext::from_ptr(js::rust::Runtime::get().unwrap().as_ptr()) }
     }
@@ -634,7 +634,7 @@ impl WorkerGlobalScope {
                 _ => unreachable!(),
             }
             if let Some(dedicated) = self.downcast::<DedicatedWorkerGlobalScope>() {
-                dedicated.fire_queued_messages(CanGc::from_cx(cx));
+                dedicated.fire_queued_messages(cx);
             }
         }
     }


### PR DESCRIPTION
Propagate `&mut JSContext` in `MessageEvent::dispatch_error` and related call sites.

Testing: Successful build is enough
Fixes: Part of #42638 