### PR TITLE
script: Add the "sequential" navigation mechanism for tab navigation

### DIFF
--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -62,7 +62,9 @@ use crate::dom::bindings::root::MutNullableDom;
 use crate::dom::bindings::trace::NoTrace;
 use crate::dom::clipboardevent::ClipboardEventType;
 use crate::dom::document::FireMouseEventType;
-use crate::dom::document::focus::FocusableArea;
+use crate::dom::document::focus::{
+    FocusableArea, SequentialFocusNavigationMechanism, SequentialFocusNavigationSearch,
+};
 use crate::dom::event::{EventBubbles, EventCancelable, EventComposed, EventFlags};
 #[cfg(feature = "gamepad")]
 use crate::dom::gamepad::gamepad::{Gamepad, contains_user_gesture};
@@ -2053,7 +2055,6 @@ impl DocumentEventHandler {
         // > the user requested the previous control.
         //
         // Note: This is handled by the `direction` argument to this method.
-
         self.sequential_focus_navigation_loop(
             cx,
             starting_point,
@@ -2075,15 +2076,35 @@ impl DocumentEventHandler {
         // > starting point is in its Document's sequential focus navigation order.
         // > Otherwise, starting point is not in its Document's sequential focus navigation order;
         // > let selection mechanism be "DOM".
-        // TODO: Implement this.
+        let starting_point_is_navigable = starting_point
+            .as_ref()
+            .is_none_or(|starting_point| starting_point.is::<HTMLIFrameElement>());
+        let selection_mechanism = starting_point
+            .as_ref()
+            .and_then(|node| node.downcast::<Element>())
+            .filter(|element| element.is_sequentially_focusable())
+            .map(|element| {
+                SequentialFocusNavigationMechanism::Sequential(
+                    element.explicitly_set_tab_index().unwrap_or_default(),
+                )
+            })
+            .unwrap_or_else(|| {
+                if starting_point_is_navigable {
+                    SequentialFocusNavigationMechanism::Navigable
+                } else {
+                    SequentialFocusNavigationMechanism::Dom
+                }
+            });
 
         // > 5. Let candidate be the result of running the sequential navigation search algorithm
         // > with starting point, direction, and selection mechanism.
-        let candidate = starting_point
-            .map(|starting_point| {
-                self.find_element_for_tab_focus_following_element(direction, starting_point)
-            })
-            .unwrap_or_else(|| self.find_first_tab_focusable_element(direction));
+        let candidate = SequentialFocusNavigationSearch::new(
+            self.window.as_rooted(),
+            direction,
+            selection_mechanism,
+            starting_point,
+        )
+        .search();
 
         // > 6. If candidate is not null, then run the focusing steps for candidate and return.
         if let Some(candidate) = candidate {
@@ -2131,168 +2152,6 @@ impl DocumentEventHandler {
             .Document()
             .focus_handler()
             .sequentially_focus_parent_local_or_remote(cx, direction);
-    }
-
-    fn find_element_for_tab_focus_following_element(
-        &self,
-        direction: SequentialFocusDirection,
-        starting_point: DomRoot<Node>,
-    ) -> Option<DomRoot<Element>> {
-        let root_node = self.window.Document();
-        let focused_element_tab_index = starting_point
-            .downcast::<Element>()
-            .and_then(Element::explicitly_set_tab_index)
-            .unwrap_or_default();
-        let mut winning_node_and_tab_index: Option<(DomRoot<Element>, i32)> = None;
-        let mut saw_focused_element = false;
-
-        for node in root_node
-            .upcast::<Node>()
-            .traverse_preorder(ShadowIncluding::Yes)
-        {
-            if node == starting_point {
-                saw_focused_element = true;
-                continue;
-            }
-
-            let Some(candidate_element) = DomRoot::downcast::<Element>(node) else {
-                continue;
-            };
-            if !candidate_element.is_sequentially_focusable() {
-                continue;
-            }
-
-            let candidate_element_tab_index = candidate_element
-                .explicitly_set_tab_index()
-                .unwrap_or_default();
-            let ordering =
-                compare_tab_indices(focused_element_tab_index, candidate_element_tab_index);
-            match direction {
-                SequentialFocusDirection::Forward => {
-                    // If moving forward the first element with equal tab index after the current
-                    // element is the winner.
-                    if saw_focused_element && ordering == Ordering::Equal {
-                        return Some(candidate_element);
-                    }
-                    // If the candidate element does not have a lesser tab index, then discard it.
-                    if ordering != Ordering::Less {
-                        continue;
-                    }
-                    let Some((_, winning_tab_index)) = winning_node_and_tab_index else {
-                        // If this candidate has a tab index which is one greater than the current
-                        // tab index, then we know it is the winner, because we give precedence to
-                        // elements earlier in the DOM.
-                        if candidate_element_tab_index == focused_element_tab_index + 1 {
-                            return Some(candidate_element);
-                        }
-
-                        winning_node_and_tab_index =
-                            Some((candidate_element, candidate_element_tab_index));
-                        continue;
-                    };
-                    // If the candidate element has a lesser tab index than than the current winner,
-                    // then it becomes the winner.
-                    if compare_tab_indices(candidate_element_tab_index, winning_tab_index) ==
-                        Ordering::Less
-                    {
-                        winning_node_and_tab_index =
-                            Some((candidate_element, candidate_element_tab_index))
-                    }
-                },
-                SequentialFocusDirection::Backward => {
-                    // If moving backward the last element with an equal tab index that precedes
-                    // the focused element in the DOM is the winner.
-                    if !saw_focused_element && ordering == Ordering::Equal {
-                        winning_node_and_tab_index =
-                            Some((candidate_element, candidate_element_tab_index));
-                        continue;
-                    }
-                    // If the candidate does not have a greater tab index, then discard it.
-                    if ordering != Ordering::Greater {
-                        continue;
-                    }
-                    let Some((_, winning_tab_index)) = winning_node_and_tab_index else {
-                        winning_node_and_tab_index =
-                            Some((candidate_element, candidate_element_tab_index));
-                        continue;
-                    };
-                    // If the candidate element's tab index is not less than the current winner,
-                    // then it becomes the new winner. This means that when the tab indices are
-                    // equal, we give preference to the last one in DOM order.
-                    if compare_tab_indices(candidate_element_tab_index, winning_tab_index) !=
-                        Ordering::Less
-                    {
-                        winning_node_and_tab_index =
-                            Some((candidate_element, candidate_element_tab_index))
-                    }
-                },
-            }
-        }
-
-        Some(winning_node_and_tab_index?.0)
-    }
-
-    fn find_first_tab_focusable_element(
-        &self,
-        direction: SequentialFocusDirection,
-    ) -> Option<DomRoot<Element>> {
-        let root_node = self.window.Document();
-        let mut winning_node_and_tab_index: Option<(DomRoot<Element>, i32)> = None;
-        for node in root_node
-            .upcast::<Node>()
-            .traverse_preorder(ShadowIncluding::Yes)
-        {
-            let Some(candidate_element) = DomRoot::downcast::<Element>(node) else {
-                continue;
-            };
-            if !candidate_element.is_sequentially_focusable() {
-                continue;
-            }
-
-            let candidate_element_tab_index = candidate_element
-                .explicitly_set_tab_index()
-                .unwrap_or_default();
-            match direction {
-                SequentialFocusDirection::Forward => {
-                    // We can immediately return the first time we find an element with the lowest
-                    // possible tab index (1). We are guaranteed not to find any lower tab index
-                    // and all other equal tab indices are later in the DOM.
-                    if candidate_element_tab_index == 1 {
-                        return Some(candidate_element);
-                    }
-
-                    // Only promote a candidate to the current winner if it has a lesser tab
-                    // index than the current winner or there is currently no winer.
-                    if winning_node_and_tab_index
-                        .as_ref()
-                        .is_none_or(|(_, winning_tab_index)| {
-                            compare_tab_indices(candidate_element_tab_index, *winning_tab_index) ==
-                                Ordering::Less
-                        })
-                    {
-                        winning_node_and_tab_index =
-                            Some((candidate_element, candidate_element_tab_index));
-                    }
-                },
-                SequentialFocusDirection::Backward => {
-                    // Only promote a candidate to winner if it has tab index equal to or
-                    // greater than the winner's tab index. This gives precedence to elements
-                    // later in the DOM.
-                    if winning_node_and_tab_index
-                        .as_ref()
-                        .is_none_or(|(_, winning_tab_index)| {
-                            compare_tab_indices(candidate_element_tab_index, *winning_tab_index) !=
-                                Ordering::Less
-                        })
-                    {
-                        winning_node_and_tab_index =
-                            Some((candidate_element, candidate_element_tab_index));
-                    }
-                },
-            }
-        }
-
-        Some(winning_node_and_tab_index?.0)
     }
 
     pub(crate) fn do_keyboard_scroll(&self, scroll: KeyboardScroll) {

--- a/components/script/dom/document/focus.rs
+++ b/components/script/dom/document/focus.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cell::{Cell, Ref};
+use std::cmp::Ordering;
 
 use bitflags::bitflags;
 use embedder_traits::FocusSequenceNumber;
@@ -21,7 +22,9 @@ use servo_constellation_traits::{
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::focusevent::FocusEventType;
 use crate::dom::types::{Element, EventTarget, FocusEvent, HTMLElement, HTMLIFrameElement, Window};
-use crate::dom::{Document, Event, EventBubbles, EventCancelable, Node, NodeTraits};
+use crate::dom::{
+    Document, Event, EventBubbles, EventCancelable, Node, NodeTraits, ShadowIncluding,
+};
 use crate::realms::enter_realm;
 
 /// The kind of focusable area a [`FocusableArea`] is. A [`FocusableArea`] may be click focusable,
@@ -600,5 +603,278 @@ impl DocumentFocusHandler {
                 direction,
                 true, /* allow focusing viewport */
             );
+    }
+}
+
+/// <https://html.spec.whatwg.org/multipage/#selection-mechanism>
+///
+/// This also incorporates the case where the starting point is a navigable
+/// as that is a distinct set of behaviors from the two kinds of mechanisms
+/// listed in the specification.
+pub(crate) enum SequentialFocusNavigationMechanism {
+    Dom,
+    Sequential(i32 /* focused_element_tab_index */),
+    Navigable,
+}
+
+enum Continue {
+    Yes,
+    No,
+}
+
+pub(crate) struct SequentialFocusNavigationSearch {
+    window: DomRoot<Window>,
+    direction: SequentialFocusDirection,
+    mechanism: SequentialFocusNavigationMechanism,
+    starting_point: Option<DomRoot<Node>>,
+    current_winner: Option<(DomRoot<Element>, i32)>,
+    passed_starting_point: bool,
+}
+
+impl SequentialFocusNavigationSearch {
+    pub(crate) fn new(
+        window: DomRoot<Window>,
+        direction: SequentialFocusDirection,
+        mechanism: SequentialFocusNavigationMechanism,
+        starting_point: Option<DomRoot<Node>>,
+    ) -> Self {
+        // If there's no starting point, the starting point is actually the root element, which
+        // we always have passed.
+        let passed_starting_point = starting_point.is_none();
+        Self {
+            window,
+            direction,
+            mechanism,
+            starting_point,
+            current_winner: Default::default(),
+            passed_starting_point,
+        }
+    }
+
+    pub(crate) fn search(mut self) -> Option<DomRoot<Element>> {
+        for node in self
+            .window
+            .Document()
+            .upcast::<Node>()
+            .traverse_preorder(ShadowIncluding::Yes)
+        {
+            // Never keep the focus on the same node.
+            if Some(&*node) == self.starting_point.as_deref() {
+                self.passed_starting_point = true;
+                continue;
+            }
+
+            let Some(candidate_element) = node.downcast::<Element>() else {
+                continue;
+            };
+
+            if !candidate_element.is_sequentially_focusable() {
+                continue;
+            }
+
+            let result = match self.mechanism {
+                SequentialFocusNavigationMechanism::Dom => {
+                    self.process_element_for_dom_traversal(candidate_element)
+                },
+                SequentialFocusNavigationMechanism::Sequential(focused_element_tab_index) => self
+                    .process_element_for_sequential_traversal(
+                        candidate_element,
+                        focused_element_tab_index,
+                    ),
+                SequentialFocusNavigationMechanism::Navigable => {
+                    self.process_element_for_navigable_starting_point_traversal(candidate_element)
+                },
+            };
+
+            if matches!(result, Continue::No) {
+                break;
+            }
+        }
+
+        Some(self.current_winner?.0)
+    }
+
+    fn select_new_winner(&mut self, element: &Element, element_tab_index: i32) {
+        self.current_winner = Some((DomRoot::from_ref(element), element_tab_index));
+    }
+
+    fn process_element_for_dom_traversal(&mut self, candidate_element: &Element) -> Continue {
+        match self.direction {
+            // direction is "forward"
+            // > Let candidate be the first suitable sequentially focusable area after starting point,
+            // > in starting point's Document's sequential focus navigation order, if any; or else
+            // > null
+            SequentialFocusDirection::Forward if self.passed_starting_point => {
+                self.select_new_winner(
+                    candidate_element,
+                    candidate_element
+                        .explicitly_set_tab_index()
+                        .unwrap_or_default(),
+                );
+                Continue::No
+            },
+            // If searching forward, do not consider anything until passing the starting point.
+            SequentialFocusDirection::Forward => Continue::Yes,
+            // direction is "backward"
+            // > Let candidate be the last suitable sequentially focusable area before starting
+            // > point, in starting point's Document's sequential focus navigation order, if any; or
+            // > else null
+            SequentialFocusDirection::Backward if !self.passed_starting_point => {
+                self.select_new_winner(
+                    candidate_element,
+                    candidate_element
+                        .explicitly_set_tab_index()
+                        .unwrap_or_default(),
+                );
+                Continue::Yes
+            },
+            // There is no possible winner after the starting point when searching backward.
+            SequentialFocusDirection::Backward => Continue::No,
+        }
+    }
+
+    fn process_element_for_navigable_starting_point_traversal(
+        &mut self,
+        candidate_element: &Element,
+    ) -> Continue {
+        let candidate_element_tab_index = candidate_element
+            .explicitly_set_tab_index()
+            .unwrap_or_default();
+
+        let Some((_, winning_tab_index)) = self.current_winner else {
+            self.select_new_winner(candidate_element, candidate_element_tab_index);
+            return Continue::Yes;
+        };
+
+        let candidate_and_current_winner_ordering =
+            compare_tab_indices(candidate_element_tab_index, winning_tab_index);
+        match self.direction {
+            // direction is "forward"
+            // > Let candidate be the first suitable sequentially focusable area in starting point's
+            // > active document, if any; or else null
+            //
+            // There's an ambiguity in the specification here. In this case it says to choose
+            // the "first suitable sequentially focusable area" It's possible to interpret this
+            // as the first in DOM order, but browsers seem to agree to following tab index
+            // order instead.
+            //
+            // Pick the lowest, prioritizing the earlier node when equal.
+            SequentialFocusDirection::Forward
+                if candidate_and_current_winner_ordering == Ordering::Less =>
+            {
+                self.select_new_winner(candidate_element, candidate_element_tab_index);
+            },
+            // direction is "backward"
+            // > Let candidate be the last suitable sequentially focusable area in starting point's
+            // > active document, if any; or else null
+            //
+            // There's an ambiguity in the specification here. In this case it says to choose
+            // the "last suitable sequentially focusable area" It's possible to interpret this
+            // as the first in DOM order, but browsers seem to agree to following tab index
+            // order instead.
+            //
+            // Pick the highest, prioritizing the later node when equal.
+            SequentialFocusDirection::Backward
+                if candidate_and_current_winner_ordering != Ordering::Less =>
+            {
+                self.select_new_winner(candidate_element, candidate_element_tab_index);
+            },
+            _ => {},
+        }
+        Continue::Yes
+    }
+
+    fn process_element_for_sequential_traversal(
+        &mut self,
+        candidate_element: &Element,
+        focused_element_tab_index: i32,
+    ) -> Continue {
+        let candidate_element_tab_index = candidate_element
+            .explicitly_set_tab_index()
+            .unwrap_or_default();
+        let candidate_and_focused_ordering =
+            compare_tab_indices(candidate_element_tab_index, focused_element_tab_index);
+        match self.direction {
+            SequentialFocusDirection::Forward => {
+                // If moving forward the first element with equal tab index after the current
+                // element is the winner.
+                if self.passed_starting_point && candidate_and_focused_ordering == Ordering::Equal {
+                    self.select_new_winner(candidate_element, candidate_element_tab_index);
+                    return Continue::No;
+                }
+                // If the candidate element does not have a greater tab index, then discard it.
+                if candidate_and_focused_ordering != Ordering::Greater {
+                    return Continue::Yes;
+                }
+                let Some((_, winning_tab_index)) = self.current_winner else {
+                    // If this candidate has a tab index which is one greater than the current
+                    // tab index, then we know it is the winner, because we give precedence to
+                    // elements earlier in the DOM.
+                    if candidate_element_tab_index == focused_element_tab_index + 1 {
+                        self.select_new_winner(candidate_element, candidate_element_tab_index);
+                        return Continue::No;
+                    }
+
+                    self.select_new_winner(candidate_element, candidate_element_tab_index);
+                    return Continue::Yes;
+                };
+
+                // If the candidate element has a lesser tab index than the current winner,
+                // then it becomes the winner.
+                if compare_tab_indices(candidate_element_tab_index, winning_tab_index) ==
+                    Ordering::Less
+                {
+                    self.select_new_winner(candidate_element, candidate_element_tab_index);
+                }
+                Continue::Yes
+            },
+            SequentialFocusDirection::Backward => {
+                // If moving backward the last element with an equal tab index that precedes
+                // the focused element in the DOM is the winner.
+                if !self.passed_starting_point && candidate_and_focused_ordering == Ordering::Equal
+                {
+                    self.select_new_winner(candidate_element, candidate_element_tab_index);
+                    return Continue::Yes;
+                }
+                // If the candidate does not have a lesser tab index, then discard it.
+                if candidate_and_focused_ordering != Ordering::Less {
+                    return Continue::Yes;
+                }
+                let Some((_, winning_tab_index)) = self.current_winner else {
+                    self.select_new_winner(candidate_element, candidate_element_tab_index);
+                    return Continue::Yes;
+                };
+                // If the candidate element's tab index is not less than the current winner,
+                // then it becomes the new winner. This means that when the tab indices are
+                // equal, we give preference to the last one in DOM order.
+                if compare_tab_indices(candidate_element_tab_index, winning_tab_index) !=
+                    Ordering::Less
+                {
+                    self.select_new_winner(candidate_element, candidate_element_tab_index);
+                }
+                Continue::Yes
+            },
+        }
+    }
+}
+
+/// Compare two tab indices according to <https://html.spec.whatwg.org/multipage/#tabindex-value>.
+///
+/// `Ordering::Less`: The index should come before the other in sequential focus order.
+/// `Ordering::Equal`: The two indices should be processed in DOM order, respecting focus direction
+/// and focus scopes.
+/// `Ordering::Greater`: The index should come after the other in sequential focus order.
+///
+/// Note that a tabindex of 0 should come after all others, which is essentially why we need this
+/// function.
+fn compare_tab_indices(a: i32, b: i32) -> Ordering {
+    if a == b {
+        Ordering::Equal
+    } else if a == 0 {
+        Ordering::Greater
+    } else if b == 0 {
+        Ordering::Less
+    } else {
+        a.cmp(&b)
     }
 }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13375,6 +13375,60 @@
       }
      ]
     ],
+    "sequential-focus-navigation-across-documents-003.html": [
+     "16937fbd8fb9e92663e35c23611250960dd36e81",
+     [
+      null,
+      {
+       "testdriver": true
+      }
+     ]
+    ],
+    "sequential-focus-navigation-across-documents-004.html": [
+     "eebef72b924b09856e06d1369478fbcbe0e1ba2b",
+     [
+      null,
+      {
+       "testdriver": true
+      }
+     ]
+    ],
+    "sequential-focus-navigation-from-document-001.html": [
+     "a91b350c0e9a1fcf839376e2d8a275e39e45db16",
+     [
+      null,
+      {
+       "testdriver": true
+      }
+     ]
+    ],
+    "sequential-focus-navigation-from-document-002.html": [
+     "908174b1d645d9c95f466170a56640a1a691c31d",
+     [
+      null,
+      {
+       "testdriver": true
+      }
+     ]
+    ],
+    "sequential-focus-navigation-non-sequentially-focusable-starting-point-001.html": [
+     "741f66651c6bbf653ba5c7b2914fbb737a87fe71",
+     [
+      null,
+      {
+       "testdriver": true
+      }
+     ]
+    ],
+    "sequential-focus-navigation-non-sequentially-focusable-starting-point-002.html": [
+     "6179f03e1280e0d73d4a6a694d7453b2b4514490",
+     [
+      null,
+      {
+       "testdriver": true
+      }
+     ]
+    ],
     "sequential-focus-navigation-starting-point-001.html": [
      "4fecfba641a3acec0132d1d21fc862e02b182416",
      [

--- a/tests/wpt/mozilla/tests/input-events/sequential-focus-navigation-across-documents-003.html
+++ b/tests/wpt/mozilla/tests/input-events/sequential-focus-navigation-across-documents-003.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<title>Sequential focus navigation works across local iframe boundaries and respects tabindex</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+
+<input class="text" id="input1">
+<iframe id="frame" srcdoc="<input id=frameinput1 tabindex=2><input id=frameinput2 tabindex=1>"></iframe>
+<input class="text" id="input2">
+
+<script>
+promise_test(async test => {
+    let tabKey = "\uE004";
+    let shiftKey = "\uE008";
+
+    input1.focus();
+    assert_equals(document.activeElement, input1);
+
+    await new test_driver.Actions()
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .send();
+    let frameDocument = frame.contentDocument;
+    assert_equals(document.hasFocus(), true);
+    assert_equals(document.activeElement, frame);
+    assert_equals(frameDocument.activeElement, frameDocument.getElementById("frameinput2"));
+
+    await new test_driver.Actions()
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .send();
+    assert_equals(document.hasFocus(), true);
+    assert_equals(document.activeElement, frame);
+    assert_equals(frameDocument.activeElement, frameDocument.getElementById("frameinput1"));
+
+    await new test_driver.Actions()
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .send();
+    assert_equals(document.activeElement, input2);
+    assert_equals(frameDocument.hasFocus(), false);
+
+    // Now traverse the sequential focus order backwards.
+    await new test_driver.Actions()
+        .keyDown(shiftKey)
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .keyUp(shiftKey)
+        .send();
+    assert_equals(document.hasFocus(), true);
+    assert_equals(document.activeElement, frame);
+    assert_equals(frameDocument.activeElement, frameDocument.getElementById("frameinput1"));
+
+    await new test_driver.Actions()
+        .keyDown(shiftKey)
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .keyUp(shiftKey)
+        .send();
+    assert_equals(document.hasFocus(), true);
+    assert_equals(document.activeElement, frame);
+    assert_equals(frameDocument.activeElement, frameDocument.getElementById("frameinput2"));
+
+    await new test_driver.Actions()
+        .keyDown(shiftKey)
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .keyUp(shiftKey)
+        .send();
+    assert_equals(document.activeElement, input1);
+    assert_equals(frameDocument.hasFocus(), false);
+
+});
+</script>

--- a/tests/wpt/mozilla/tests/input-events/sequential-focus-navigation-across-documents-004.html
+++ b/tests/wpt/mozilla/tests/input-events/sequential-focus-navigation-across-documents-004.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<title>Sequential focus navigation works across local iframe boundaries with no sequentially focusable element</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+
+<input class="text" id="input1">
+<iframe id="frame" srcdoc="<input id=frameinput1 tabindex=-1>"></iframe>
+<input class="text" id="input2">
+
+<script>
+promise_test(async test => {
+    let tabKey = "\uE004";
+    let shiftKey = "\uE008";
+
+    let frameDocument = frame.contentDocument;
+
+    input1.focus();
+    assert_equals(document.hasFocus(), true);
+    assert_equals(frameDocument.hasFocus(), false);
+    assert_equals(document.activeElement, input1);
+    assert_equals(frameDocument.activeElement, frameDocument.body);
+
+    await new test_driver.Actions()
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .send();
+    assert_equals(document.hasFocus(), true);
+    assert_equals(frameDocument.hasFocus(), true);
+    assert_equals(document.activeElement, frame);
+    assert_equals(frameDocument.activeElement, frameDocument.body);
+
+    await new test_driver.Actions()
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .send();
+    assert_equals(document.hasFocus(), true);
+    assert_equals(frameDocument.hasFocus(), false);
+    assert_equals(document.activeElement, input2);
+    assert_equals(frameDocument.activeElement, frameDocument.body);
+
+
+    // Now traverse the sequential focus order backwards.
+    await new test_driver.Actions()
+        .keyDown(shiftKey)
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .keyUp(shiftKey)
+        .send();
+    assert_equals(document.hasFocus(), true);
+    assert_equals(frameDocument.hasFocus(), true);
+    assert_equals(document.activeElement, frame);
+    assert_equals(frameDocument.activeElement, frameDocument.body);
+
+    await new test_driver.Actions()
+        .keyDown(shiftKey)
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .keyUp(shiftKey)
+        .send();
+    assert_equals(document.hasFocus(), true);
+    assert_equals(frameDocument.hasFocus(), false);
+    assert_equals(document.activeElement, input1);
+    assert_equals(frameDocument.activeElement, frameDocument.body);
+
+});
+</script>

--- a/tests/wpt/mozilla/tests/input-events/sequential-focus-navigation-from-document-001.html
+++ b/tests/wpt/mozilla/tests/input-events/sequential-focus-navigation-from-document-001.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<title>Sequential focus navigation works when starting from viewport</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+
+<input class="text" tabindex=1 id="input1">
+<input class="text" tabindex=2 id="input2">
+<input class="text" tabindex=3 id="input3">
+
+<script>
+promise_test(async test => {
+    let tabKey = "\uE004";
+    let shiftKey = "\uE008";
+
+    window.focus();
+    assert_equals(document.activeElement, document.body);
+
+    await new test_driver.Actions()
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .send();
+    assert_equals(document.activeElement, input1);
+
+    await new test_driver.Actions()
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .send();
+    assert_equals(document.activeElement, input2);
+
+    await new test_driver.Actions()
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .send();
+    assert_equals(document.activeElement, input3);
+
+    // Now traverse the sequential focus order backwards.
+    await new test_driver.Actions()
+        .keyDown(shiftKey)
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .keyUp(shiftKey)
+        .send();
+    assert_equals(document.activeElement, input2);
+
+    await new test_driver.Actions()
+        .keyDown(shiftKey)
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .keyUp(shiftKey)
+        .send();
+    assert_equals(document.activeElement, input1);
+});
+</script>

--- a/tests/wpt/mozilla/tests/input-events/sequential-focus-navigation-from-document-002.html
+++ b/tests/wpt/mozilla/tests/input-events/sequential-focus-navigation-from-document-002.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<title>Sequential focus navigation starting from viewport operates in DOM order</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+
+<input class="text" tabindex=2 id="input1">
+<input class="text" tabindex=1 id="input2">
+<input class="text" tabindex=3 id="input3">
+
+<script>
+promise_test(async test => {
+    let tabKey = "\uE004";
+    let shiftKey = "\uE008";
+
+    window.focus();
+    assert_equals(document.activeElement, document.body);
+
+    await new test_driver.Actions()
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .send();
+    // There's an ambiguity in the specification here. In this case it says to choose
+    // "Let candidate be the first suitable sequentially focusable area in starting point's
+    // active document, if any; or else null." It's perhaps possible to interpret this as
+    // the first in DOM order, but browsers seem to agree to following tabindex order instead.
+    assert_equals(document.activeElement, input2);
+
+    await new test_driver.Actions()
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .send();
+    assert_equals(document.activeElement, input1);
+
+    await new test_driver.Actions()
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .send();
+    assert_equals(document.activeElement, input3);
+
+    // Now traverse the sequential focus order backwards.
+    await new test_driver.Actions()
+        .keyDown(shiftKey)
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .keyUp(shiftKey)
+        .send();
+    assert_equals(document.activeElement, input1);
+
+    await new test_driver.Actions()
+        .keyDown(shiftKey)
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .keyUp(shiftKey)
+        .send();
+    assert_equals(document.activeElement, input2);
+});
+</script>

--- a/tests/wpt/mozilla/tests/input-events/sequential-focus-navigation-non-sequentially-focusable-starting-point-001.html
+++ b/tests/wpt/mozilla/tests/input-events/sequential-focus-navigation-non-sequentially-focusable-starting-point-001.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<title>Sequential focus navigation starting non-sequentially focusable element</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+
+<input class="text" tabindex=1 id="input1">
+<input class="text" tabindex=100 id="input2">
+<input class="text" tabindex=-1 id="input3">
+<input class="text" tabindex=100 id="input4">
+<input class="text" tabindex=1 id="input5">
+
+<script>
+promise_test(async test => {
+    let tabKey = "\uE004";
+    let shiftKey = "\uE008";
+
+    input3.focus();
+    assert_equals(document.activeElement, input3);
+
+    await new test_driver.Actions()
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .send();
+
+    // Tab index is ignored when starting from non-sequentially focusable element.
+    assert_equals(document.activeElement, input4);
+
+    input3.focus();
+    assert_equals(document.activeElement, input3);
+
+    await new test_driver.Actions()
+        .keyDown(shiftKey)
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .keyUp(shiftKey)
+        .send();
+
+    // Tab index is ignored when starting from non-sequentially focusable element.
+    assert_equals(document.activeElement, input2);
+});
+</script>

--- a/tests/wpt/mozilla/tests/input-events/sequential-focus-navigation-non-sequentially-focusable-starting-point-002.html
+++ b/tests/wpt/mozilla/tests/input-events/sequential-focus-navigation-non-sequentially-focusable-starting-point-002.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<title>Sequential focus navigation starting from a non-sequentially focusable element</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+
+<input class="text" tabindex=1 id="input1">
+<input class="text" tabindex=100 id="input2">
+<input class="text" tabindex=1 id="input3">
+<input class="text" tabindex=100 id="input4">
+<input class="text" tabindex=1 id="input5">
+
+<script>
+promise_test(async test => {
+    let tabKey = "\uE004";
+    let shiftKey = "\uE008";
+
+    input3.focus();
+    assert_equals(document.activeElement, input3);
+
+    // input3 has a tab index set so sequential focus should respect the sequential focus order.
+    await new test_driver.Actions()
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .send();
+    assert_equals(document.activeElement, input5);
+
+    input3.focus();
+    assert_equals(document.activeElement, input3);
+
+    // After making input3 non-sequentially focusable, sequential focus navigation should follow
+    // DOM order.
+    input3.tabIndex = "-1";
+    await new test_driver.Actions()
+        .keyDown(tabKey)
+        .keyUp(tabKey)
+        .send();
+    assert_equals(document.activeElement, input4);
+});
+</script>


### PR DESCRIPTION
This change aligns Servo with the HTML specification's concept of the
*navigation mechanism*, which determines the behavior of picking a
candidate element during sequential focus navigation. The previous,
somewhat duplicated, code is adapted to match the specification. What this
means in practice is that when you press the tab key when a
non-sequentially focusable element is focused, tabindex is ignored and
DOM order takes precedence.

Testing: A new Servo-specific WPT test is added for this behavior.
