### PR TITLE
script: Turn on `implicitCxSetters` for all elements

### DIFF
--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -1936,19 +1936,19 @@ impl DocumentEventHandler {
 
     pub(crate) fn run_default_keyboard_event_handler(
         &self,
+        cx: &mut js::context::JSContext,
         node: &Node,
         event: &KeyboardEvent,
-        can_gc: CanGc,
     ) {
         if event.upcast::<Event>().type_() != atom!("keydown") {
             return;
         }
 
-        if self.maybe_dispatch_simulated_click(node, event, can_gc) {
+        if self.maybe_dispatch_simulated_click(node, event, CanGc::from_cx(cx)) {
             return;
         }
 
-        if self.maybe_handle_accesskey(event, can_gc) {
+        if self.maybe_handle_accesskey(cx, event) {
             return;
         }
 
@@ -1976,7 +1976,7 @@ impl DocumentEventHandler {
                 // > If the key is the Tab key, the default action MUST be to shift the document focus
                 // > from the currently focused element (if any) to the new focused element, as
                 // > described in Focus Event Types
-                self.sequential_focus_navigation_via_keyboard_event(event, can_gc);
+                self.sequential_focus_navigation_via_keyboard_event(event, CanGc::from_cx(cx));
                 return;
             },
             _ => return,
@@ -2445,7 +2445,11 @@ impl DocumentEventHandler {
             .or_insert(Dom::from_ref(element));
     }
 
-    fn maybe_handle_accesskey(&self, event: &KeyboardEvent, can_gc: CanGc) -> bool {
+    fn maybe_handle_accesskey(
+        &self,
+        cx: &mut js::context::JSContext,
+        event: &KeyboardEvent,
+    ) -> bool {
         #[cfg(target_os = "macos")]
         let access_key_modifiers = Modifiers::CONTROL | Modifiers::ALT;
         #[cfg(not(target_os = "macos"))]
@@ -2499,8 +2503,8 @@ impl DocumentEventHandler {
 
         // This behavior is unspecified, but all browsers do this. When activating the element it is
         // focused and scrolled into view.
-        self.focus_and_scroll_to_element_for_key_event(html_element.upcast(), can_gc);
-        command.perform_action(can_gc);
+        self.focus_and_scroll_to_element_for_key_event(html_element.upcast(), CanGc::from_cx(cx));
+        command.perform_action(cx);
         true
     }
 

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -2783,8 +2783,8 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-element-id>
-    fn SetId(&self, id: DOMString, can_gc: CanGc) {
-        self.set_atomic_attribute(&local_name!("id"), id, can_gc);
+    fn SetId(&self, cx: &mut JSContext, id: DOMString) {
+        self.set_atomic_attribute(&local_name!("id"), id, CanGc::from_cx(cx));
     }
 
     /// <https://dom.spec.whatwg.org/#dom-element-classname>
@@ -2793,8 +2793,8 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-element-classname>
-    fn SetClassName(&self, class: DOMString, can_gc: CanGc) {
-        self.set_tokenlist_attribute(&local_name!("class"), class, can_gc);
+    fn SetClassName(&self, cx: &mut JSContext, class: DOMString) {
+        self.set_tokenlist_attribute(&local_name!("class"), class, CanGc::from_cx(cx));
     }
 
     /// <https://dom.spec.whatwg.org/#dom-element-classlist>
@@ -3192,7 +3192,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
 
     // https://drafts.csswg.org/cssom-view/#dom-element-scrolltop
     // TODO(stevennovaryo): Need to update the scroll API to follow the spec since it is quite outdated.
-    fn SetScrollTop(&self, y_: f64) {
+    fn SetScrollTop(&self, _cx: &mut JSContext, y_: f64) {
         let behavior = ScrollBehavior::Auto;
 
         // Step 1, 2
@@ -3288,7 +3288,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     }
 
     /// <https://drafts.csswg.org/cssom-view/#dom-element-scrollleft>
-    fn SetScrollLeft(&self, x: f64) {
+    fn SetScrollLeft(&self, _cx: &mut JSContext, x: f64) {
         let behavior = ScrollBehavior::Auto;
 
         // Step 1, 2

--- a/components/script/dom/html/htmldetailselement.rs
+++ b/components/script/dom/html/htmldetailselement.rs
@@ -159,8 +159,8 @@ impl HTMLDetailsElement {
         )
     }
 
-    pub(crate) fn toggle(&self) {
-        self.SetOpen(!self.Open());
+    pub(crate) fn toggle(&self, cx: &mut JSContext) {
+        self.SetOpen(cx, !self.Open());
     }
 
     fn shadow_tree(&self, cx: &mut JSContext) -> Ref<'_, ShadowTree> {
@@ -303,6 +303,7 @@ impl HTMLDetailsElement {
     /// <https://html.spec.whatwg.org/multipage/#ensure-details-exclusivity-by-closing-other-elements-if-needed>
     fn ensure_details_exclusivity(
         &self,
+        cx: &mut js::context::JSContext,
         conflict_resolution_behaviour: ExclusivityConflictResolution,
     ) {
         // NOTE: This method implements two spec algorithms that are very similar to each other, distinguished by the
@@ -370,9 +371,9 @@ impl HTMLDetailsElement {
             // Step 4.1.2 Break.
             // NOTE: We don't bother to assert here and don't need to "break" since we're not in a loop.
             match conflict_resolution_behaviour {
-                ExclusivityConflictResolution::CloseThisElement => self.SetOpen(false),
+                ExclusivityConflictResolution::CloseThisElement => self.SetOpen(cx, false),
                 ExclusivityConflictResolution::CloseExistingOpenElement => {
-                    other_open_member.SetOpen(false)
+                    other_open_member.SetOpen(cx, false)
                 },
             }
         }
@@ -447,7 +448,7 @@ impl VirtualMethods for HTMLDetailsElement {
                 }
             }
 
-            self.ensure_details_exclusivity(ExclusivityConflictResolution::CloseThisElement);
+            self.ensure_details_exclusivity(cx, ExclusivityConflictResolution::CloseThisElement);
         }
         // Step 3. If localName is open, then:
         else if attr.local_name() == &local_name!("open") {
@@ -492,6 +493,7 @@ impl VirtualMethods for HTMLDetailsElement {
             };
             if was_previously_closed && self.Open() {
                 self.ensure_details_exclusivity(
+                    cx,
                     ExclusivityConflictResolution::CloseExistingOpenElement,
                 );
             }
@@ -531,7 +533,7 @@ impl VirtualMethods for HTMLDetailsElement {
         }
 
         // Step 1. Ensure details exclusivity by closing the given element if needed given insertedNode.
-        self.ensure_details_exclusivity(ExclusivityConflictResolution::CloseThisElement);
+        self.ensure_details_exclusivity(cx, ExclusivityConflictResolution::CloseThisElement);
     }
 
     fn unbind_from_tree(&self, cx: &mut js::context::JSContext, context: &UnbindContext) {

--- a/components/script/dom/html/htmldialogelement.rs
+++ b/components/script/dom/html/htmldialogelement.rs
@@ -5,6 +5,7 @@ use std::borrow::Borrow;
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, local_name, ns};
+use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::error::{Error, ErrorResult};
 use stylo_dom::ElementState;
@@ -290,7 +291,7 @@ impl HTMLDialogElementMethods<crate::DomTypeHolder> for HTMLDialogElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-dialog-returnvalue>
-    fn SetReturnValue(&self, return_value: DOMString) {
+    fn SetReturnValue(&self, _cx: &mut JSContext, return_value: DOMString) {
         *self.return_value.borrow_mut() = return_value;
     }
 

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -987,7 +987,7 @@ impl HTMLElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#the-summary-element:activation-behaviour
-    pub(crate) fn summary_activation_behavior(&self) {
+    pub(crate) fn summary_activation_behavior(&self, cx: &mut js::context::JSContext) {
         debug_assert!(self.as_element().local_name() == &local_name!("summary"));
 
         // Step 1. If this summary element is not the summary for its parent details, then return.
@@ -1008,7 +1008,7 @@ impl HTMLElement {
 
         // Step 3. If the open attribute is present on parent, then remove it.
         // Otherwise, set parent's open attribute to the empty string.
-        parent.toggle();
+        parent.toggle(cx);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#summary-for-its-parent-details>
@@ -1452,11 +1452,11 @@ impl Activatable for HTMLElement {
     // Basically used to make the HTMLSummaryElement activatable (which has no IDL definition)
     fn activation_behavior(
         &self,
-        _cx: &mut js::context::JSContext,
+        cx: &mut js::context::JSContext,
         _event: &Event,
         _target: &EventTarget,
     ) {
-        self.summary_activation_behavior();
+        self.summary_activation_behavior(cx);
     }
 }
 

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -255,8 +255,8 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-fs-encoding>
-    fn SetEncoding(&self, value: DOMString) {
-        self.SetEnctype(value)
+    fn SetEncoding(&self, cx: &mut JSContext, value: DOMString) {
+        self.SetEnctype(cx, value)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-fs-method
@@ -504,9 +504,12 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-a-rel>
-    fn SetRel(&self, rel: DOMString, can_gc: CanGc) {
-        self.upcast::<Element>()
-            .set_tokenlist_attribute(&local_name!("rel"), rel, can_gc);
+    fn SetRel(&self, cx: &mut JSContext, rel: DOMString) {
+        self.upcast::<Element>().set_tokenlist_attribute(
+            &local_name!("rel"),
+            rel,
+            CanGc::from_cx(cx),
+        );
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-a-rellist>

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -1766,13 +1766,13 @@ impl HTMLImageElementMethods<crate::DomTypeHolder> for HTMLImageElement {
 
         // Step 3. If width is given, then set an attribute value for img using "width" and width.
         if let Some(w) = width {
-            image.SetWidth(w);
+            image.SetWidth(cx, w);
         }
 
         // Step 4. If height is given, then set an attribute value for img using "height" and
         // height.
         if let Some(h) = height {
-            image.SetHeight(h);
+            image.SetHeight(cx, h);
         }
 
         // Step 5. Return img.

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -1126,9 +1126,12 @@ impl HTMLLinkElementMethods<crate::DomTypeHolder> for HTMLLinkElement {
     make_getter!(Rel, "rel");
 
     /// <https://html.spec.whatwg.org/multipage/#dom-link-rel>
-    fn SetRel(&self, rel: DOMString, can_gc: CanGc) {
-        self.upcast::<Element>()
-            .set_tokenlist_attribute(&local_name!("rel"), rel, can_gc);
+    fn SetRel(&self, cx: &mut JSContext, rel: DOMString) {
+        self.upcast::<Element>().set_tokenlist_attribute(
+            &local_name!("rel"),
+            rel,
+            CanGc::from_cx(cx),
+        );
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-link-as

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -3013,7 +3013,7 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-media-muted>
-    fn SetMuted(&self, value: bool) {
+    fn SetMuted(&self, _cx: &mut JSContext, value: bool) {
         if self.muted.get() == value {
             return;
         }
@@ -3145,7 +3145,7 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-media-defaultplaybackrate>
-    fn SetDefaultPlaybackRate(&self, value: Finite<f64>) -> ErrorResult {
+    fn SetDefaultPlaybackRate(&self, _cx: &mut JSContext, value: Finite<f64>) -> ErrorResult {
         // If the given value is not supported by the user agent, then throw a "NotSupportedError"
         // DOMException.
         let min_allowed = -64.0;
@@ -3173,7 +3173,7 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-media-playbackrate>
-    fn SetPlaybackRate(&self, value: Finite<f64>) -> ErrorResult {
+    fn SetPlaybackRate(&self, _cx: &mut JSContext, value: Finite<f64>) -> ErrorResult {
         // The attribute is mutable: on setting, the user agent must follow these steps:
 
         // Step 1. If the given value is not supported by the user agent, then throw a
@@ -3228,7 +3228,7 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-media-currenttime>
-    fn SetCurrentTime(&self, time: Finite<f64>) {
+    fn SetCurrentTime(&self, _cx: &mut JSContext, time: Finite<f64>) {
         if self.ready_state.get() == ReadyState::HaveNothing {
             self.default_playback_start_position.set(*time);
         } else {
@@ -3333,7 +3333,7 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-media-volume>
-    fn SetVolume(&self, value: Finite<f64>) -> ErrorResult {
+    fn SetVolume(&self, _cx: &mut JSContext, value: Finite<f64>) -> ErrorResult {
         // If the new value is outside the range 0.0 to 1.0 inclusive, then, on setting, an
         // "IndexSizeError" DOMException must be thrown instead.
         let minimum_volume = 0.0;
@@ -3393,7 +3393,7 @@ impl VirtualMethods for HTMLMediaElement {
                     AttributeMutationReason::ByCloning | AttributeMutationReason::ByParser,
                 ) = mutation
                 {
-                    self.SetMuted(true);
+                    self.SetMuted(cx, true);
                 }
             },
             local_name!("src") => {

--- a/components/script/dom/html/htmlmeterelement.rs
+++ b/components/script/dom/html/htmlmeterelement.rs
@@ -186,11 +186,14 @@ impl HTMLMeterElementMethods<crate::DomTypeHolder> for HTMLMeterElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-meter-value>
-    fn SetValue(&self, value: Finite<f64>, can_gc: CanGc) {
+    fn SetValue(&self, cx: &mut js::context::JSContext, value: Finite<f64>) {
         let mut string_value = DOMString::from((*value).to_string());
         string_value.set_best_representation_of_the_floating_point_number();
-        self.upcast::<Element>()
-            .set_string_attribute(&local_name!("value"), string_value, can_gc);
+        self.upcast::<Element>().set_string_attribute(
+            &local_name!("value"),
+            string_value,
+            CanGc::from_cx(cx),
+        );
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-meter-minimum>
@@ -204,11 +207,14 @@ impl HTMLMeterElementMethods<crate::DomTypeHolder> for HTMLMeterElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-meter-min>
-    fn SetMin(&self, value: Finite<f64>, can_gc: CanGc) {
+    fn SetMin(&self, cx: &mut js::context::JSContext, value: Finite<f64>) {
         let mut string_value = DOMString::from((*value).to_string());
         string_value.set_best_representation_of_the_floating_point_number();
-        self.upcast::<Element>()
-            .set_string_attribute(&local_name!("min"), string_value, can_gc);
+        self.upcast::<Element>().set_string_attribute(
+            &local_name!("min"),
+            string_value,
+            CanGc::from_cx(cx),
+        );
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-meter-maximum>
@@ -223,11 +229,14 @@ impl HTMLMeterElementMethods<crate::DomTypeHolder> for HTMLMeterElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-meter-maximum>
-    fn SetMax(&self, value: Finite<f64>, can_gc: CanGc) {
+    fn SetMax(&self, cx: &mut js::context::JSContext, value: Finite<f64>) {
         let mut string_value = DOMString::from((*value).to_string());
         string_value.set_best_representation_of_the_floating_point_number();
-        self.upcast::<Element>()
-            .set_string_attribute(&local_name!("max"), string_value, can_gc);
+        self.upcast::<Element>().set_string_attribute(
+            &local_name!("max"),
+            string_value,
+            CanGc::from_cx(cx),
+        );
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-meter-low>
@@ -246,11 +255,14 @@ impl HTMLMeterElementMethods<crate::DomTypeHolder> for HTMLMeterElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-meter-low>
-    fn SetLow(&self, value: Finite<f64>, can_gc: CanGc) {
+    fn SetLow(&self, cx: &mut js::context::JSContext, value: Finite<f64>) {
         let mut string_value = DOMString::from((*value).to_string());
         string_value.set_best_representation_of_the_floating_point_number();
-        self.upcast::<Element>()
-            .set_string_attribute(&local_name!("low"), string_value, can_gc);
+        self.upcast::<Element>().set_string_attribute(
+            &local_name!("low"),
+            string_value,
+            CanGc::from_cx(cx),
+        );
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-meter-high>
@@ -273,11 +285,14 @@ impl HTMLMeterElementMethods<crate::DomTypeHolder> for HTMLMeterElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-meter-high>
-    fn SetHigh(&self, value: Finite<f64>, can_gc: CanGc) {
+    fn SetHigh(&self, cx: &mut js::context::JSContext, value: Finite<f64>) {
         let mut string_value = DOMString::from((*value).to_string());
         string_value.set_best_representation_of_the_floating_point_number();
-        self.upcast::<Element>()
-            .set_string_attribute(&local_name!("high"), string_value, can_gc);
+        self.upcast::<Element>().set_string_attribute(
+            &local_name!("high"),
+            string_value,
+            CanGc::from_cx(cx),
+        );
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-meter-optimum>
@@ -296,13 +311,13 @@ impl HTMLMeterElementMethods<crate::DomTypeHolder> for HTMLMeterElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-meter-optimum>
-    fn SetOptimum(&self, value: Finite<f64>, can_gc: CanGc) {
+    fn SetOptimum(&self, cx: &mut js::context::JSContext, value: Finite<f64>) {
         let mut string_value = DOMString::from((*value).to_string());
         string_value.set_best_representation_of_the_floating_point_number();
         self.upcast::<Element>().set_string_attribute(
             &local_name!("optimum"),
             string_value,
-            can_gc,
+            CanGc::from_cx(cx),
         );
     }
 }

--- a/components/script/dom/html/htmloptionelement.rs
+++ b/components/script/dom/html/htmloptionelement.rs
@@ -273,10 +273,10 @@ impl HTMLOptionElementMethods<crate::DomTypeHolder> for HTMLOptionElement {
         }
 
         if let Some(val) = value {
-            option.SetValue(val)
+            option.SetValue(cx, val)
         }
 
-        option.SetDefaultSelected(default_selected);
+        option.SetDefaultSelected(cx, default_selected);
         option.set_selectedness(selected);
         option.update_select_validity(CanGc::from_cx(cx));
         Ok(option)
@@ -374,11 +374,11 @@ impl HTMLOptionElementMethods<crate::DomTypeHolder> for HTMLOptionElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-option-selected>
-    fn SetSelected(&self, selected: bool, can_gc: CanGc) {
+    fn SetSelected(&self, cx: &mut JSContext, selected: bool) {
         self.dirtiness.set(true);
         self.set_selectedness(selected);
         self.pick_if_selected_and_reset();
-        self.update_select_validity(can_gc);
+        self.update_select_validity(CanGc::from_cx(cx));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-option-index>

--- a/components/script/dom/html/htmlprogresselement.rs
+++ b/components/script/dom/html/htmlprogresselement.rs
@@ -85,7 +85,7 @@ impl HTMLProgressElement {
         );
 
         // FIXME: This should use ::-moz-progress-bar
-        progress_bar.SetId("-servo-progress-bar".into(), CanGc::from_cx(cx));
+        progress_bar.SetId(cx, "-servo-progress-bar".into());
         root.upcast::<Node>()
             .AppendChild(cx, progress_bar.upcast::<Node>())
             .unwrap();
@@ -146,14 +146,14 @@ impl HTMLProgressElementMethods<crate::DomTypeHolder> for HTMLProgressElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-progress-value>
-    fn SetValue(&self, new_val: Finite<f64>, can_gc: CanGc) {
+    fn SetValue(&self, cx: &mut JSContext, new_val: Finite<f64>) {
         if *new_val >= 0.0 {
             let mut string_value = DOMString::from((*new_val).to_string());
             string_value.set_best_representation_of_the_floating_point_number();
             self.upcast::<Element>().set_string_attribute(
                 &local_name!("value"),
                 string_value,
-                can_gc,
+                CanGc::from_cx(cx),
             );
         }
     }
@@ -176,14 +176,14 @@ impl HTMLProgressElementMethods<crate::DomTypeHolder> for HTMLProgressElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-progress-max>
-    fn SetMax(&self, new_val: Finite<f64>, can_gc: CanGc) {
+    fn SetMax(&self, cx: &mut JSContext, new_val: Finite<f64>) {
         if *new_val > 0.0 {
             let mut string_value = DOMString::from((*new_val).to_string());
             string_value.set_best_representation_of_the_floating_point_number();
             self.upcast::<Element>().set_string_attribute(
                 &local_name!("max"),
                 string_value,
-                can_gc,
+                CanGc::from_cx(cx),
             );
         }
     }

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -1363,10 +1363,13 @@ impl HTMLScriptElementMethods<crate::DomTypeHolder> for HTMLScriptElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-script-async>
-    fn SetAsync(&self, value: bool, can_gc: CanGc) {
+    fn SetAsync(&self, cx: &mut JSContext, value: bool) {
         self.non_blocking.set(false);
-        self.upcast::<Element>()
-            .set_bool_attribute(&local_name!("async"), value, can_gc);
+        self.upcast::<Element>().set_bool_attribute(
+            &local_name!("async"),
+            value,
+            CanGc::from_cx(cx),
+        );
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-script-defer

--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -712,7 +712,7 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-select-value>
-    fn SetValue(&self, value: DOMString, can_gc: CanGc) {
+    fn SetValue(&self, cx: &mut JSContext, value: DOMString) {
         let mut opt_iter = self.list_of_options();
         // Reset until we find an <option> with a matching value
         for opt in opt_iter.by_ref() {
@@ -728,8 +728,8 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
             opt.set_selectedness(false);
         }
 
-        self.validity_state(can_gc)
-            .perform_validation_and_update(ValidationFlags::VALUE_MISSING, can_gc);
+        self.validity_state(CanGc::from_cx(cx))
+            .perform_validation_and_update(ValidationFlags::VALUE_MISSING, CanGc::from_cx(cx));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-select-selectedindex>

--- a/components/script/dom/html/htmlstyleelement.rs
+++ b/components/script/dom/html/htmlstyleelement.rs
@@ -462,7 +462,7 @@ impl HTMLStyleElementMethods<crate::DomTypeHolder> for HTMLStyleElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-style-disabled>
-    fn SetDisabled(&self, value: bool) {
+    fn SetDisabled(&self, _cx: &mut js::context::JSContext, value: bool) {
         if let Some(sheet) = self.get_cssom_stylesheet() {
             sheet.set_disabled(value);
         }

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -440,7 +440,7 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea-value>
-    fn SetValue(&self, value: DOMString, can_gc: CanGc) {
+    fn SetValue(&self, cx: &mut JSContext, value: DOMString) {
         // Step 1: Let oldAPIValue be this element's API value.
         let old_api_value = self.Value();
 
@@ -456,7 +456,7 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
         // "none".
         if old_api_value != self.Value() {
             self.textinput.borrow_mut().clear_selection_to_end();
-            self.handle_text_content_changed(can_gc);
+            self.handle_text_content_changed(CanGc::from_cx(cx));
         }
     }
 
@@ -479,7 +479,7 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectionstart>
-    fn SetSelectionStart(&self, start: Option<u32>) -> ErrorResult {
+    fn SetSelectionStart(&self, _cx: &mut JSContext, start: Option<u32>) -> ErrorResult {
         self.selection()
             .set_dom_start(start.map(Utf16CodeUnitLength::from))
     }
@@ -490,7 +490,7 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectionend>
-    fn SetSelectionEnd(&self, end: Option<u32>) -> ErrorResult {
+    fn SetSelectionEnd(&self, _cx: &mut JSContext, end: Option<u32>) -> ErrorResult {
         self.selection()
             .set_dom_end(end.map(Utf16CodeUnitLength::from))
     }
@@ -501,7 +501,11 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectiondirection>
-    fn SetSelectionDirection(&self, direction: Option<DOMString>) -> ErrorResult {
+    fn SetSelectionDirection(
+        &self,
+        _cx: &mut JSContext,
+        direction: Option<DOMString>,
+    ) -> ErrorResult {
         self.selection().set_dom_direction(direction)
     }
 

--- a/components/script/dom/html/input_element/checkbox_input_type.rs
+++ b/components/script/dom/html/input_element/checkbox_input_type.rs
@@ -64,7 +64,7 @@ impl SpecificInputType for CheckboxInputType {
     ) -> Option<InputActivationState> {
         let was_checked = input.Checked();
         let was_indeterminate = input.Indeterminate();
-        input.SetIndeterminate(false);
+        input.SetIndeterminate(cx, false);
         input.SetChecked(cx, !was_checked);
         Some(InputActivationState {
             checked: was_checked,
@@ -82,7 +82,7 @@ impl SpecificInputType for CheckboxInputType {
         input: &HTMLInputElement,
         cache: InputActivationState,
     ) {
-        input.SetIndeterminate(cache.indeterminate);
+        input.SetIndeterminate(cx, cache.indeterminate);
         input.SetChecked(cx, cache.checked);
     }
 

--- a/components/script/dom/html/input_element/mod.rs
+++ b/components/script/dom/html/input_element/mod.rs
@@ -1090,7 +1090,7 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-input-files>
-    fn SetFiles(&self, files: Option<&FileList>) {
+    fn SetFiles(&self, _cx: &mut js::context::JSContext, files: Option<&FileList>) {
         if let Some(files) = files {
             self.input_type().as_specific().set_files(files)
         }
@@ -1446,7 +1446,7 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-input-indeterminate>
-    fn SetIndeterminate(&self, val: bool) {
+    fn SetIndeterminate(&self, _cx: &mut JSContext, val: bool) {
         self.upcast::<Element>()
             .set_state(ElementState::INDETERMINATE, val)
     }
@@ -1479,7 +1479,7 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectionstart>
-    fn SetSelectionStart(&self, start: Option<u32>) -> ErrorResult {
+    fn SetSelectionStart(&self, _cx: &mut JSContext, start: Option<u32>) -> ErrorResult {
         self.selection()
             .set_dom_start(start.map(Utf16CodeUnitLength::from))
     }
@@ -1490,7 +1490,7 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectionend>
-    fn SetSelectionEnd(&self, end: Option<u32>) -> ErrorResult {
+    fn SetSelectionEnd(&self, _cx: &mut JSContext, end: Option<u32>) -> ErrorResult {
         self.selection()
             .set_dom_end(end.map(Utf16CodeUnitLength::from))
     }
@@ -1501,7 +1501,11 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectiondirection>
-    fn SetSelectionDirection(&self, direction: Option<DOMString>) -> ErrorResult {
+    fn SetSelectionDirection(
+        &self,
+        _cx: &mut JSContext,
+        direction: Option<DOMString>,
+    ) -> ErrorResult {
         self.selection().set_dom_direction(direction)
     }
 

--- a/components/script/dom/html/interactive_element_command.rs
+++ b/components/script/dom/html/interactive_element_command.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use js::context::JSContext;
 use script_bindings::codegen::GenericBindings::HTMLButtonElementBinding::HTMLButtonElementMethods;
 use script_bindings::codegen::GenericBindings::HTMLElementBinding::HTMLElementMethods;
 use script_bindings::codegen::GenericBindings::HTMLInputElementBinding::HTMLInputElementMethods;
@@ -153,7 +154,7 @@ impl InteractiveElementCommand {
         html_element.Hidden()
     }
 
-    pub(crate) fn perform_action(&self, can_gc: CanGc) {
+    pub(crate) fn perform_action(&self, cx: &mut JSContext) {
         match self {
             // <https://html.spec.whatwg.org/multipage#using-the-a-element-to-define-a-command>
             // > The Action of the command is to fire a click event at the element.
@@ -161,33 +162,33 @@ impl InteractiveElementCommand {
             // > Firing a click event at target means firing a synthetic pointer event named click at target.
             InteractiveElementCommand::Anchor(anchor_element) => anchor_element
                 .upcast::<Node>()
-                .fire_synthetic_pointer_event_not_trusted(atom!("click"), can_gc),
+                .fire_synthetic_pointer_event_not_trusted(atom!("click"), CanGc::from_cx(cx)),
             // <https://html.spec.whatwg.org/multipage/#using-the-button-element-to-define-a-command>
             // > The Label, Access Key, Hidden State, and Action facets of the command are
             // > determined as for a elements (see the previous section).
             InteractiveElementCommand::Button(button_element) => button_element
                 .upcast::<Node>()
-                .fire_synthetic_pointer_event_not_trusted(atom!("click"), can_gc),
+                .fire_synthetic_pointer_event_not_trusted(atom!("click"), CanGc::from_cx(cx)),
             // <https://html.spec.whatwg.org/multipage/#using-the-input-element-to-define-a-command>
             // > The Action of the command is to fire a click event at the element.
             InteractiveElementCommand::Input(input_element) => input_element
                 .upcast::<Node>()
-                .fire_synthetic_pointer_event_not_trusted(atom!("click"), can_gc),
+                .fire_synthetic_pointer_event_not_trusted(atom!("click"), CanGc::from_cx(cx)),
             // <https://html.spec.whatwg.org/multipage/#using-the-option-element-to-define-a-command>
             // > If the option's nearest ancestor select element has a multiple attribute, the
             // > Action of the command is to toggle the option element. Otherwise, the Action is to
             // > pick the option element.
             // Note: setSelected takes care of whether or not the owner has the `multiple` attribute.
             InteractiveElementCommand::Option(option_element) => {
-                option_element.SetSelected(true, can_gc)
+                option_element.SetSelected(cx, true)
             },
             // > The Action of the command is to run the following steps:
             // >  1. Run the focusing steps for the element.
             // >  2. Fire a click event at the element.
             InteractiveElementCommand::HTMLElement(html_element) => {
                 let node: &Node = html_element.upcast();
-                node.run_the_focusing_steps(None, can_gc);
-                node.fire_synthetic_pointer_event_not_trusted(atom!("click"), can_gc);
+                node.run_the_focusing_steps(None, CanGc::from_cx(cx));
+                node.fire_synthetic_pointer_event_not_trusted(atom!("click"), CanGc::from_cx(cx));
             },
         }
     }

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -29,7 +29,7 @@ macro_rules! make_bool_getter(
 #[macro_export]
 macro_rules! make_limited_int_setter(
     ($attr:ident, $htmlname:tt, $default:expr) => (
-        fn $attr(&self, value: i32) -> $crate::dom::bindings::error::ErrorResult {
+        fn $attr(&self, cx: &mut js::context::JSContext, value: i32) -> $crate::dom::bindings::error::ErrorResult {
             use $crate::dom::bindings::inheritance::Castable;
             use $crate::dom::element::Element;
             use $crate::script_runtime::CanGc;
@@ -41,7 +41,7 @@ macro_rules! make_limited_int_setter(
             };
 
             let element = self.upcast::<Element>();
-            element.set_int_attribute(&html5ever::local_name!($htmlname), value, CanGc::deprecated_note());
+            element.set_int_attribute(&html5ever::local_name!($htmlname), value, CanGc::from_cx(cx));
             Ok(())
         }
     );
@@ -117,8 +117,8 @@ macro_rules! make_url_setter_inner(
 #[macro_export]
 macro_rules! make_url_setter(
     ( $attr:ident, $htmlname:tt ) => (
-        fn $attr(&self, value: USVString) {
-            make_url_setter_inner!(self, value, $htmlname, CanGc::deprecated_note());
+        fn $attr(&self, cx: &mut js::context::JSContext, value: USVString) {
+            make_url_setter_inner!(self, value, $htmlname, CanGc::from_cx(cx));
         }
     );
     ( $cx:ident, $attr:ident, $htmlname:tt ) => (
@@ -288,8 +288,8 @@ macro_rules! make_setter_inner(
 #[macro_export]
 macro_rules! make_setter(
     ( $attr:ident, $htmlname:tt ) => (
-        fn $attr(&self, value: DOMString) {
-            make_setter_inner!(self, value, $htmlname, CanGc::deprecated_note());
+        fn $attr(&self, cx: &mut js::context::JSContext, value: DOMString) {
+            make_setter_inner!(self, value, $htmlname, CanGc::from_cx(cx));
         }
     );
     ( $cx:ident, $attr:ident, $htmlname:tt ) => (
@@ -312,8 +312,8 @@ macro_rules! make_bool_setter_inner(
 #[macro_export]
 macro_rules! make_bool_setter(
     ( $attr:ident, $htmlname:tt ) => (
-        fn $attr(&self, value: bool) {
-            make_bool_setter_inner!(self, value, $htmlname, CanGc::deprecated_note());
+        fn $attr(&self, cx: &mut js::context::JSContext, value: bool) {
+            make_bool_setter_inner!(self, value, $htmlname, CanGc::from_cx(cx));
         }
     );
     ( $cx:ident, $attr:ident, $htmlname:tt ) => (
@@ -326,7 +326,7 @@ macro_rules! make_bool_setter(
 #[macro_export]
 macro_rules! make_uint_setter(
     ($attr:ident, $htmlname:tt, $default:expr) => (
-        fn $attr(&self, value: u32) {
+        fn $attr(&self, cx: &mut js::context::JSContext, value: u32) {
             use $crate::dom::bindings::inheritance::Castable;
             use $crate::dom::element::Element;
             use $crate::dom::values::UNSIGNED_LONG_MAX;
@@ -337,7 +337,7 @@ macro_rules! make_uint_setter(
                 value
             };
             let element = self.upcast::<Element>();
-            element.set_uint_attribute(&html5ever::local_name!($htmlname), value, CanGc::deprecated_note())
+            element.set_uint_attribute(&html5ever::local_name!($htmlname), value, CanGc::from_cx(cx))
         }
     );
     ($attr:ident, $htmlname:tt) => {
@@ -368,7 +368,7 @@ macro_rules! make_clamped_uint_setter(
 #[macro_export]
 macro_rules! make_limited_uint_setter(
     ($attr:ident, $htmlname:tt, $default:expr) => (
-        fn $attr(&self, value: u32) -> $crate::dom::bindings::error::ErrorResult {
+        fn $attr(&self, cx: &mut js::context::JSContext, value: u32) -> $crate::dom::bindings::error::ErrorResult {
             use $crate::dom::bindings::inheritance::Castable;
             use $crate::dom::element::Element;
             use $crate::dom::values::UNSIGNED_LONG_MAX;
@@ -381,7 +381,7 @@ macro_rules! make_limited_uint_setter(
                 value
             };
             let element = self.upcast::<Element>();
-            element.set_uint_attribute(&html5ever::local_name!($htmlname), value, CanGc::deprecated_note());
+            element.set_uint_attribute(&html5ever::local_name!($htmlname), value, CanGc::from_cx(cx));
             Ok(())
         }
     );
@@ -400,8 +400,8 @@ macro_rules! make_atomic_setter_inner(
 #[macro_export]
 macro_rules! make_atomic_setter(
     ( $attr:ident, $htmlname:tt ) => (
-        fn $attr(&self, value: DOMString) {
-            make_atomic_setter_inner!(self, value, $htmlname, CanGc::deprecated_note());
+        fn $attr(&self, cx: &mut js::context::JSContext, value: DOMString) {
+            make_atomic_setter_inner!(self, value, $htmlname, CanGc::from_cx(cx));
         }
     );
     ( $cx:ident, $attr:ident, $htmlname:tt ) => (
@@ -484,7 +484,7 @@ macro_rules! make_dimension_uint_getter(
 #[macro_export]
 macro_rules! make_dimension_uint_setter(
     ($attr:ident, $htmlname:tt, $default:expr) => (
-        fn $attr(&self, value: u32) {
+        fn $attr(&self, cx: &mut js::context::JSContext, value: u32) {
             use $crate::dom::bindings::inheritance::Castable;
             use $crate::dom::element::Element;
             use $crate::dom::values::UNSIGNED_LONG_MAX;
@@ -496,7 +496,7 @@ macro_rules! make_dimension_uint_setter(
                 value
             };
             let value = AttrValue::from_dimension(value.to_string());
-            element.set_attribute(&html5ever::local_name!($htmlname), value, CanGc::deprecated_note())
+            element.set_attribute(&html5ever::local_name!($htmlname), value, CanGc::from_cx(cx))
         }
     );
     ($attr:ident, $htmlname:tt) => {

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -4799,7 +4799,7 @@ impl VirtualMethods for Node {
         if let Some(event) = event.downcast::<KeyboardEvent>() {
             self.owner_document()
                 .event_handler()
-                .run_default_keyboard_event_handler(self, event, CanGc::from_cx(cx));
+                .run_default_keyboard_event_handler(cx, self, event);
         }
     }
 }

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1169,7 +1169,7 @@ impl ParserContext {
                 None,
             );
             let img = DomRoot::downcast::<HTMLImageElement>(img).unwrap();
-            img.SetSrc(USVString(self.url.to_string()));
+            img.SetSrc(cx, USVString(self.url.to_string()));
             DomRoot::upcast::<Node>(img)
         } else if mime_type.type_() == mime::AUDIO {
             let audio = Element::create(
@@ -1182,8 +1182,8 @@ impl ParserContext {
                 None,
             );
             let audio = DomRoot::downcast::<HTMLMediaElement>(audio).unwrap();
-            audio.SetControls(true);
-            audio.SetSrc(USVString(self.url.to_string()));
+            audio.SetControls(cx, true);
+            audio.SetSrc(cx, USVString(self.url.to_string()));
             DomRoot::upcast::<Node>(audio)
         } else {
             let video = Element::create(
@@ -1196,8 +1196,8 @@ impl ParserContext {
                 None,
             );
             let video = DomRoot::downcast::<HTMLMediaElement>(video).unwrap();
-            video.SetControls(true);
-            video.SetSrc(USVString(self.url.to_string()));
+            video.SetControls(cx, true);
+            video.SetSrc(cx, USVString(self.url.to_string()));
             DomRoot::upcast::<Node>(video)
         };
         // Step 4. Append an element host element for the media, as described below, to the body element.

--- a/components/script/dom/svg/svgelement.rs
+++ b/components/script/dom/svg/svgelement.rs
@@ -4,6 +4,7 @@
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, local_name, ns};
+use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::codegen::GenericBindings::ElementBinding::ScrollLogicalPosition;
 use script_bindings::codegen::GenericBindings::WindowBinding::ScrollBehavior;
@@ -126,7 +127,7 @@ impl SVGElementMethods<crate::DomTypeHolder> for SVGElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-noncedelement-nonce>
-    fn SetNonce(&self, value: DOMString) {
+    fn SetNonce(&self, _cx: &mut JSContext, value: DOMString) {
         self.as_element()
             .update_nonce_internal_slot(value.to_string())
     }
@@ -137,9 +138,9 @@ impl SVGElementMethods<crate::DomTypeHolder> for SVGElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-fe-autofocus>
-    fn SetAutofocus(&self, autofocus: bool, can_gc: CanGc) {
+    fn SetAutofocus(&self, cx: &mut JSContext, autofocus: bool) {
         self.element
-            .set_bool_attribute(&local_name!("autofocus"), autofocus, can_gc);
+            .set_bool_attribute(&local_name!("autofocus"), autofocus, CanGc::from_cx(cx));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-focus>
@@ -199,8 +200,8 @@ impl SVGElementMethods<crate::DomTypeHolder> for SVGElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-tabindex>
-    fn SetTabIndex(&self, tab_index: i32, can_gc: CanGc) {
+    fn SetTabIndex(&self, cx: &mut JSContext, tab_index: i32) {
         self.element
-            .set_int_attribute(&local_name!("tabindex"), tab_index, can_gc);
+            .set_int_attribute(&local_name!("tabindex"), tab_index, CanGc::from_cx(cx));
     }
 }

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -2032,13 +2032,10 @@ pub(crate) fn handle_element_click(
                             match container.downcast::<HTMLSelectElement>() {
                                 Some(select_element) => {
                                     if select_element.Multiple() {
-                                        option_element.SetSelected(
-                                            !option_element.Selected(),
-                                            CanGc::from_cx(cx),
-                                        );
+                                        option_element.SetSelected(cx, !option_element.Selected());
                                     }
                                 },
-                                None => option_element.SetSelected(true, CanGc::from_cx(cx)),
+                                None => option_element.SetSelected(cx, true),
                             }
 
                             // Step 8.6.4

--- a/components/script_bindings/codegen/configuration.py
+++ b/components/script_bindings/codegen/configuration.py
@@ -301,7 +301,6 @@ class Descriptor(DescriptorProvider):
         self.weakReferenceable = desc.get('weakReferenceable', False)
         self.useSystemCompartment = desc.get('useSystemCompartment', False)
         self.allowDropImpl = desc.get('allowDropImpl', False)
-        self.implicitCxSetters = desc.get('implicitCxSetters', False)
 
         # If we're concrete, we need to crawl our ancestor interfaces and mark
         # them as having a concrete descendant.
@@ -429,6 +428,7 @@ class Descriptor(DescriptorProvider):
         self.prototypeDepth = len(self.prototypeChain) - 1
         config.maxProtoChainLength = max(config.maxProtoChainLength,
                                          len(self.prototypeChain))
+        self.implicitCxSetters = desc.get('implicitCxSetters', "Element" in self.prototypeChain)
 
     def maybeGetSuperModule(self) -> str | None:
         """


### PR DESCRIPTION
With this change, now all attribute macros receive a `cx`. This is one of the final steps
to migrating the `set_X_attribute` methods to receive `cx`.

There are very few setters that don't require a `cx`. However, those are so unique, that
they simply ignore using the argument.

Part of #42812

Testing: It compiles