### PR TITLE
script: Replace some usage of children() with children_unrooted() in script/dom/execcommand

### DIFF
--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -244,7 +244,7 @@ pub(crate) fn handle_get_children(
     let mut pipeline_state = state.mut_pipeline_state_for(pipeline).unwrap();
 
     let inline: Vec<_> = parent
-        .children()
+        .children_unrooted(cx.no_gc())
         .map(|child| {
             let window = child.owner_window();
             let Some(elem) = child.downcast::<Element>() else {

--- a/components/script/dom/bindings/root.rs
+++ b/components/script/dom/bindings/root.rs
@@ -279,9 +279,9 @@ impl<'a, T: Castable> UnrootedDom<'a, T> {
     }
 }
 
-impl<'a, T: DomObject> PartialEq<Root<Dom<T>>> for UnrootedDom<'a, T> {
-    fn eq(&self, other: &Root<Dom<T>>) -> bool {
-        self.inner == Dom::from_ref(&**other)
+impl<'a, T: DomObject> PartialEq<&T> for UnrootedDom<'a, T> {
+    fn eq(&self, other: &&T) -> bool {
+        self.inner == Dom::from_ref(*other)
     }
 }
 

--- a/components/script/dom/bindings/root.rs
+++ b/components/script/dom/bindings/root.rs
@@ -279,6 +279,12 @@ impl<'a, T: Castable> UnrootedDom<'a, T> {
     }
 }
 
+impl<'a, T: DomObject> PartialEq<Root<Dom<T>>> for UnrootedDom<'a, T> {
+    fn eq(&self, other: &Root<Dom<T>>) -> bool {
+        self.inner == Dom::from_ref(&**other)
+    }
+}
+
 /// A holder that provides interior mutability for GC-managed values such as
 /// `Dom<T>`, with nullability represented by an enclosing Option wrapper.
 /// Essentially a `Cell<Option<Dom<T>>>`, but safer.

--- a/components/script/dom/execcommand/commands/delete.rs
+++ b/components/script/dom/execcommand/commands/delete.rs
@@ -208,7 +208,7 @@ pub(crate) fn execute_delete_command(
         );
         let child = start_node
             .children_unrooted(cx.no_gc())
-            .nth(offset as usize - 1)
+            .nth(start_offset as usize - 1)
             .map(|node| node.as_rooted());
         if let Some(child) = child {
             if child.is_editable() && child.is_invisible() {

--- a/components/script/dom/execcommand/commands/delete.rs
+++ b/components/script/dom/execcommand/commands/delete.rs
@@ -299,7 +299,7 @@ pub(crate) fn execute_delete_command(
         }
         let child = start_node
             .children_unrooted(cx.no_gc())
-            .nth(offset as usize - 1)
+            .nth(start_offset as usize - 1)
             .map(|node| node.as_rooted());
         let Some(child) = child else {
             break;

--- a/components/script/dom/execcommand/commands/delete.rs
+++ b/components/script/dom/execcommand/commands/delete.rs
@@ -64,7 +64,11 @@ pub(crate) fn execute_delete_command(
         // Step 4.2. Otherwise, if node has a child with index offset − 1 and that child is an editable invisible node,
         // remove that child from node, then subtract one from offset.
         if offset > 0 {
-            if let Some(child) = node.children().nth(offset as usize - 1) {
+            let child = node
+                .children_unrooted(&cx)
+                .nth(offset as usize - 1)
+                .map(|node| node.as_rooted());
+            if let Some(child) = child {
                 if child.is_editable() && child.is_invisible() {
                     child.remove_self(cx);
                     offset -= 1;
@@ -80,7 +84,11 @@ pub(crate) fn execute_delete_command(
             continue;
         }
         if offset > 0 {
-            if let Some(child) = node.children().nth(offset as usize - 1) {
+            let child = node
+                .children_unrooted(&cx)
+                .nth(offset as usize - 1)
+                .map(|node| node.as_rooted());
+            if let Some(child) = child {
                 // Step 4.4. Otherwise, if node has a child with index offset − 1 and that child is an editable a,
                 // remove that child from node, preserving its descendants. Then return true.
                 if child.is_editable() && child.is::<HTMLAnchorElement>() {
@@ -108,7 +116,7 @@ pub(crate) fn execute_delete_command(
     if (node.is::<Text>() && offset != 0) ||
         (offset > 0 &&
             node.is_block_node() &&
-            node.children()
+            node.children_unrooted(cx.no_gc())
                 .nth(offset as usize - 1)
                 .is_some_and(|child| {
                     child.is::<HTMLBRElement>() ||
@@ -198,7 +206,11 @@ pub(crate) fn execute_delete_command(
             start_offset > 0,
             "Must always have a start_offset greater than one"
         );
-        if let Some(child) = start_node.children().nth(start_offset as usize - 1) {
+        let child = start_node
+            .children_unrooted(&cx)
+            .nth(offset as usize - 1)
+            .map(|node| node.as_rooted());
+        if let Some(child) = child {
             if child.is_editable() && child.is_invisible() {
                 child.remove_self(cx);
                 start_offset -= 1;
@@ -214,7 +226,7 @@ pub(crate) fn execute_delete_command(
 
     // Step 11. If the child of start node with index start offset is a table, return true.
     if start_node
-        .children()
+        .children_unrooted(&cx)
         .nth(start_offset as usize)
         .is_some_and(|child| child.is::<HTMLTableElement>())
     {
@@ -229,7 +241,7 @@ pub(crate) fn execute_delete_command(
     if offset == 0 &&
         (start_offset > 0 &&
             start_node
-                .children()
+                .children_unrooted(&cx)
                 .nth(start_offset as usize - 1)
                 .is_some_and(|child| {
                     child.is::<HTMLHRElement>() ||
@@ -285,7 +297,11 @@ pub(crate) fn execute_delete_command(
         if start_offset == 0 {
             break;
         }
-        let Some(child) = start_node.children().nth(start_offset as usize - 1) else {
+        let child = start_node
+            .children_unrooted(&cx)
+            .nth(offset as usize - 1)
+            .map(|node| node.as_rooted());
+        let Some(child) = child else {
             break;
         };
         // Step 16.1. If start node's child with index start offset minus one

--- a/components/script/dom/execcommand/commands/delete.rs
+++ b/components/script/dom/execcommand/commands/delete.rs
@@ -65,7 +65,7 @@ pub(crate) fn execute_delete_command(
         // remove that child from node, then subtract one from offset.
         if offset > 0 {
             let child = node
-                .children_unrooted(&cx)
+                .children_unrooted(cx.no_gc())
                 .nth(offset as usize - 1)
                 .map(|node| node.as_rooted());
             if let Some(child) = child {
@@ -85,7 +85,7 @@ pub(crate) fn execute_delete_command(
         }
         if offset > 0 {
             let child = node
-                .children_unrooted(&cx)
+                .children_unrooted(cx.no_gc())
                 .nth(offset as usize - 1)
                 .map(|node| node.as_rooted());
             if let Some(child) = child {
@@ -207,7 +207,7 @@ pub(crate) fn execute_delete_command(
             "Must always have a start_offset greater than one"
         );
         let child = start_node
-            .children_unrooted(&cx)
+            .children_unrooted(cx.no_gc())
             .nth(offset as usize - 1)
             .map(|node| node.as_rooted());
         if let Some(child) = child {
@@ -226,7 +226,7 @@ pub(crate) fn execute_delete_command(
 
     // Step 11. If the child of start node with index start offset is a table, return true.
     if start_node
-        .children_unrooted(&cx)
+        .children_unrooted(cx.no_gc())
         .nth(start_offset as usize)
         .is_some_and(|child| child.is::<HTMLTableElement>())
     {
@@ -241,7 +241,7 @@ pub(crate) fn execute_delete_command(
     if offset == 0 &&
         (start_offset > 0 &&
             start_node
-                .children_unrooted(&cx)
+                .children_unrooted(cx.no_gc())
                 .nth(start_offset as usize - 1)
                 .is_some_and(|child| {
                     child.is::<HTMLHRElement>() ||
@@ -298,7 +298,7 @@ pub(crate) fn execute_delete_command(
             break;
         }
         let child = start_node
-            .children_unrooted(&cx)
+            .children_unrooted(cx.no_gc())
             .nth(offset as usize - 1)
             .map(|node| node.as_rooted());
         let Some(child) = child else {

--- a/components/script/dom/execcommand/contenteditable/node.rs
+++ b/components/script/dom/execcommand/contenteditable/node.rs
@@ -664,7 +664,7 @@ where
                 .find(|node| node.is_visible())
                 .is_some_and(|node| node.is_inline_node()) &&
             new_parent
-                .children()
+                .children_unrooted(&cx)
                 .last()
                 .is_none_or(|last_child| !last_child.is::<HTMLBRElement>())
         {
@@ -686,7 +686,7 @@ where
         // and insert the result as the first child of new parent.
         if !new_parent.is_inline_node() &&
             new_parent
-                .children()
+                .children_unrooted(&cx)
                 .find(|child| child.is_visible())
                 .is_some_and(|child| child.is_inline_node()) &&
             node_list
@@ -732,7 +732,11 @@ where
             // and new parent's last child is not a br, call createElement("br") on the ownerDocument
             // of new parent and append the result as the last child of new parent.
             if !new_parent.is_inline_node() {
-                if let Some(last_child_of_new_parent) = new_parent.children().last() {
+                let child = new_parent
+                    .children_unrooted(&cx)
+                    .last()
+                    .map(|node| node.as_rooted());
+                if let Some(last_child_of_new_parent) = child {
                     if last_child_of_new_parent.is_inline_node() &&
                         !last_child_of_new_parent.is::<HTMLBRElement>() &&
                         next_of_new_parent

--- a/components/script/dom/execcommand/contenteditable/node.rs
+++ b/components/script/dom/execcommand/contenteditable/node.rs
@@ -664,7 +664,7 @@ where
                 .find(|node| node.is_visible())
                 .is_some_and(|node| node.is_inline_node()) &&
             new_parent
-                .children_unrooted(&cx)
+                .children_unrooted(cx.no_gc())
                 .last()
                 .is_none_or(|last_child| !last_child.is::<HTMLBRElement>())
         {
@@ -686,7 +686,7 @@ where
         // and insert the result as the first child of new parent.
         if !new_parent.is_inline_node() &&
             new_parent
-                .children_unrooted(&cx)
+                .children_unrooted(cx.no_gc())
                 .find(|child| child.is_visible())
                 .is_some_and(|child| child.is_inline_node()) &&
             node_list
@@ -733,7 +733,7 @@ where
             // of new parent and append the result as the last child of new parent.
             if !new_parent.is_inline_node() {
                 let child = new_parent
-                    .children_unrooted(&cx)
+                    .children_unrooted(cx.no_gc())
                     .last()
                     .map(|node| node.as_rooted());
                 if let Some(last_child_of_new_parent) = child {

--- a/components/script/dom/execcommand/contenteditable/selection.rs
+++ b/components/script/dom/execcommand/contenteditable/selection.rs
@@ -410,7 +410,7 @@ impl Selection {
             // call createElement("br") on the context object and append the result as the last child of parent.
             if parent.block_node_of().is_some_and(|block_node| {
                 block_node
-                    .children_unrooted(&cx)
+                    .children_unrooted(cx.no_gc())
                     .all(|child| child.is_invisible())
             }) && parent.is_editable_or_editing_host()
             {
@@ -514,7 +514,7 @@ impl Selection {
             // Step 32.2. While reference node is not a child of start block, set reference node to its parent.
             loop {
                 if start_block
-                    .children_unrooted(&cx)
+                    .children_unrooted(cx.no_gc())
                     .all(|child| child != reference_node)
                 {
                     reference_node = reference_node

--- a/components/script/dom/execcommand/contenteditable/selection.rs
+++ b/components/script/dom/execcommand/contenteditable/selection.rs
@@ -515,7 +515,7 @@ impl Selection {
             loop {
                 if start_block
                     .children_unrooted(cx.no_gc())
-                    .all(|child| child != reference_node)
+                    .all(|child| child != &reference_node)
                 {
                     reference_node = reference_node
                         .GetParentNode()

--- a/components/script/dom/execcommand/contenteditable/selection.rs
+++ b/components/script/dom/execcommand/contenteditable/selection.rs
@@ -408,10 +408,11 @@ impl Selection {
             node.remove_self(cx);
             // Step 25.3. If the block node of parent has no visible children, and parent is editable or an editing host,
             // call createElement("br") on the context object and append the result as the last child of parent.
-            if parent
-                .block_node_of()
-                .is_some_and(|block_node| block_node.children().all(|child| child.is_invisible())) &&
-                parent.is_editable_or_editing_host()
+            if parent.block_node_of().is_some_and(|block_node| {
+                block_node
+                    .children_unrooted(&cx)
+                    .all(|child| child.is_invisible())
+            }) && parent.is_editable_or_editing_host()
             {
                 let br = context_object.create_element(cx, "br");
                 if parent.AppendChild(cx, br.upcast()).is_err() {
@@ -512,7 +513,10 @@ impl Selection {
             let mut reference_node = end_block.clone();
             // Step 32.2. While reference node is not a child of start block, set reference node to its parent.
             loop {
-                if start_block.children().all(|child| child != reference_node) {
+                if start_block
+                    .children_unrooted(&cx)
+                    .all(|child| child != *reference_node)
+                {
                     reference_node = reference_node
                         .GetParentNode()
                         .expect("Must always have a parent, at least start_block");

--- a/components/script/dom/execcommand/contenteditable/selection.rs
+++ b/components/script/dom/execcommand/contenteditable/selection.rs
@@ -515,7 +515,7 @@ impl Selection {
             loop {
                 if start_block
                     .children_unrooted(&cx)
-                    .all(|child| child != *reference_node)
+                    .all(|child| child != reference_node)
                 {
                     reference_node = reference_node
                         .GetParentNode()

--- a/components/script/dom/html/htmlfieldsetelement.rs
+++ b/components/script/dom/html/htmlfieldsetelement.rs
@@ -182,7 +182,7 @@ impl VirtualMethods for HTMLFieldSetElement {
                 element.set_disabled_state(disabled_state);
                 element.set_enabled_state(!disabled_state);
                 let mut found_legend = false;
-                let children = node.children().filter(|node| {
+                let children = node.children_unrooted(&cx).filter(|node| {
                     if found_legend {
                         true
                     } else if node.is::<HTMLLegendElement>() {

--- a/components/script/dom/html/htmlfieldsetelement.rs
+++ b/components/script/dom/html/htmlfieldsetelement.rs
@@ -182,7 +182,7 @@ impl VirtualMethods for HTMLFieldSetElement {
                 element.set_disabled_state(disabled_state);
                 element.set_enabled_state(!disabled_state);
                 let mut found_legend = false;
-                let children = node.children_unrooted(&cx).filter(|node| {
+                let children = node.children_unrooted(cx.no_gc()).filter(|node| {
                     if found_legend {
                         true
                     } else if node.is::<HTMLLegendElement>() {

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -72,7 +72,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::DomGlobal;
-use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
+use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom, UnrootedDom};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::blob::Blob;
 use crate::dom::csp::{GlobalCspReporting, Violation};
@@ -1103,13 +1103,13 @@ impl HTMLMediaElement {
             Mode::Attribute((**attribute.value()).to_owned())
         } else if let Some(source) = self
             .upcast::<Node>()
-            .children()
-            .find_map(DomRoot::downcast::<HTMLSourceElement>)
+            .children_unrooted(&cx)
+            .find_map(UnrootedDom::downcast::<HTMLSourceElement>)
         {
             // Otherwise, if the media element does not have an assigned media provider object and
             // does not have a src attribute, but does have a source element child, then let mode be
             // children and let candidate be the first such source element child in tree order.
-            Mode::Children(source)
+            Mode::Children(source.as_rooted())
         } else {
             // Otherwise, the media element has no assigned media provider object and has neither a
             // src attribute nor a source element child:

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -1103,7 +1103,7 @@ impl HTMLMediaElement {
             Mode::Attribute((**attribute.value()).to_owned())
         } else if let Some(source) = self
             .upcast::<Node>()
-            .children_unrooted(&cx)
+            .children_unrooted(cx.no_gc())
             .find_map(UnrootedDom::downcast::<HTMLSourceElement>)
         {
             // Otherwise, if the media element does not have an assigned media provider object and


### PR DESCRIPTION
This replaces some usages of children() with children_unrooted() for more efficiency in execcommand, htmlfieldsetelement and htmlmediaelement.

We also implement PartialEq<Root<Dom<T>>> for UnrootedDom<'_,T>.

Safety is enforced by taking a &JSContext.

Testing: Compilation is the test for these changes.
