### PR TITLE
backport: Fix advisories for webpki and thin-vec and adjust unit test cookie expiry time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7110,9 +7110,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -10886,18 +10886,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9694,9 +9694,9 @@ dependencies = [
 
 [[package]]
 name = "thin-vec"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144f754d318415ac792f9d69fc87abbbfc043ce2ef041c60f16ad828f638717d"
+checksum = "259cdf8ed4e4aca6f1e9d011e10bd53f524a2d0637d7b28450f6c64ac298c4c6"
 
 [[package]]
 name = "thiserror"

--- a/components/net/tests/cookie.rs
+++ b/components/net/tests/cookie.rs
@@ -393,7 +393,7 @@ fn test_cookie_eviction_expired() {
         );
         vec.push(st);
     }
-    vec.push("foo=bar; Secure; expires=Sun, 18-Apr-2027 21:06:29 GMT".to_owned());
+    vec.push("foo=bar; Secure; expires=Sun, 18-Apr-2127 21:06:29 GMT".to_owned());
     let r = add_retrieve_cookies(
         "https://home.example.org:8888/cookie-parser?0001",
         &vec,
@@ -407,13 +407,13 @@ fn test_cookie_eviction_all_secure_one_nonsecure() {
     let mut vec = Vec::new();
     for i in 1..5 {
         let st = format!(
-            "extra{}=bar; Secure; expires=Sun, 18-Apr-2026 21:06:29 GMT",
+            "extra{}=bar; Secure; expires=Sun, 18-Apr-2126 21:06:29 GMT",
             i
         );
         vec.push(st);
     }
-    vec.push("foo=bar; expires=Sun, 18-Apr-2026 21:06:29 GMT".to_owned());
-    vec.push("foo2=bar; Secure; expires=Sun, 18-Apr-2028 21:06:29 GMT".to_owned());
+    vec.push("foo=bar; expires=Sun, 18-Apr-2126 21:06:29 GMT".to_owned());
+    vec.push("foo2=bar; Secure; expires=Sun, 18-Apr-2128 21:06:29 GMT".to_owned());
     let r = add_retrieve_cookies(
         "https://home.example.org:8888/cookie-parser?0001",
         &vec,
@@ -430,12 +430,12 @@ fn test_cookie_eviction_all_secure_new_nonsecure() {
     let mut vec = Vec::new();
     for i in 1..6 {
         let st = format!(
-            "extra{}=bar; Secure; expires=Sun, 18-Apr-2026 21:06:29 GMT",
+            "extra{}=bar; Secure; expires=Sun, 18-Apr-2126 21:06:29 GMT",
             i
         );
         vec.push(st);
     }
-    vec.push("foo=bar; expires=Sun, 18-Apr-2077 21:06:29 GMT".to_owned());
+    vec.push("foo=bar; expires=Sun, 18-Apr-2177 21:06:29 GMT".to_owned());
     let r = add_retrieve_cookies(
         "https://home.example.org:8888/cookie-parser?0001",
         &vec,
@@ -451,10 +451,10 @@ fn test_cookie_eviction_all_secure_new_nonsecure() {
 fn test_cookie_eviction_all_nonsecure_new_secure() {
     let mut vec = Vec::new();
     for i in 1..6 {
-        let st = format!("extra{}=bar; expires=Sun, 18-Apr-2026 21:06:29 GMT", i);
+        let st = format!("extra{}=bar; expires=Sun, 18-Apr-2126 21:06:29 GMT", i);
         vec.push(st);
     }
-    vec.push("foo=bar; Secure; expires=Sun, 18-Apr-2077 21:06:29 GMT".to_owned());
+    vec.push("foo=bar; Secure; expires=Sun, 18-Apr-2177 21:06:29 GMT".to_owned());
     let r = add_retrieve_cookies(
         "https://home.example.org:8888/cookie-parser?0001",
         &vec,
@@ -470,10 +470,10 @@ fn test_cookie_eviction_all_nonsecure_new_secure() {
 fn test_cookie_eviction_all_nonsecure_new_nonsecure() {
     let mut vec = Vec::new();
     for i in 1..6 {
-        let st = format!("extra{}=bar; expires=Sun, 18-Apr-2026 21:06:29 GMT", i);
+        let st = format!("extra{}=bar; expires=Sun, 18-Apr-2126 21:06:29 GMT", i);
         vec.push(st);
     }
-    vec.push("foo=bar; expires=Sun, 18-Apr-2077 21:06:29 GMT".to_owned());
+    vec.push("foo=bar; expires=Sun, 18-Apr-2177 21:06:29 GMT".to_owned());
     let r = add_retrieve_cookies(
         "https://home.example.org:8888/cookie-parser?0001",
         &vec,


### PR DESCRIPTION
This PR targets the release/v0.1 branch.

Update think-vec to 0.2.16:

This fixes https://rustsec.org/advisories/RUSTSEC-2026-0103.html.
by backporting da6aaf7eb9ae369000f6e568975c899ce4f18c40
and 5eb2ffc623e03775e550c452411fc9f85a10c1a0.

--------------------------------------

Update webpki dependency group:

This backports the following dependency upgrade commits:

- 7007dc43461a0c487155311e1057c42eb45466d0
- d995e909768959acc81eb05c95b31b7ac515dba9
- c75eea95c3fe02257743a23ab36b21ee10ae78c9

This fixes:

- https://rustsec.org/advisories/RUSTSEC-2026-0098
- https://rustsec.org/advisories/RUSTSEC-2026-0099.html
- https://rustsec.org/advisories/RUSTSEC-2026-0104.html

------------------------------------------

net: Update test cookie expiration dates:

Cherry-pick c66690e64bd860f45d5726ff6e19442a18bd9d46, which is required to fix
failing unit-tests, which had a hardcoded expiration time.

Testing: Dependency upgrade, no API changes, covered by existing tests.

