### PR TITLE
layout: Keep all trailing whitespace after unparented table-levels

### DIFF
--- a/components/layout/flow/construct.rs
+++ b/components/layout/flow/construct.rs
@@ -320,12 +320,13 @@ impl<'dom, 'style> BlockContainerBuilder<'dom, 'style> {
         // creation of an inline table. It requires the parent to be an inline box.
         let inline_table = self.currently_processing_inline_box();
 
-        let contents: Vec<AnonymousTableContent<'dom>> =
+        let mut contents: Vec<AnonymousTableContent<'dom>> =
             self.anonymous_table_content.drain(..).collect();
-        let last_text = match contents.last() {
-            Some(AnonymousTableContent::Text(info, text)) => Some((info.clone(), text.clone())),
-            _ => None,
-        };
+        let last_element_index = contents
+            .iter()
+            .rposition(|content| matches!(content, AnonymousTableContent::Element { .. }))
+            .expect("Anonymous table contents should include some table-level element");
+        let trailing_contents = contents.split_off(last_element_index + 1);
 
         let (table_info, ifc) =
             Table::construct_anonymous(self.context, self.info, contents, self.propagated_data);
@@ -350,7 +351,7 @@ impl<'dom, 'style> BlockContainerBuilder<'dom, 'style> {
             });
         }
 
-        // If the last element in the anonymous table content is whitespace, that
+        // If the anonymous table contents end with trailing whitespace, that
         // whitespace doesn't actually belong to the table. It should be processed outside
         // ie become a space between the anonymous table and the rest of the block
         // content. Anonymous tables are really only constructed around internal table
@@ -359,8 +360,13 @@ impl<'dom, 'style> BlockContainerBuilder<'dom, 'style> {
         //
         // See https://drafts.csswg.org/css-tables/#fixup-algorithm sections "Remove
         // irrelevant boxes" and "Generate missing parents."
-        if let Some((info, text)) = last_text {
-            self.handle_text(&info, text);
+        for content in trailing_contents {
+            match content {
+                AnonymousTableContent::Text(info, text) => self.handle_text(&info, text),
+                AnonymousTableContent::Element { .. } => {
+                    unreachable!("All elements were placed inside the table")
+                },
+            }
         }
     }
 }

--- a/tests/wpt/tests/css/CSS2/tables/table-anonymous-objects-214.html
+++ b/tests/wpt/tests/css/CSS2/tables/table-anonymous-objects-214.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>CSS Test: Anonymous table objects</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes">
+<link rel="help" href="https://github.com/servo/servo/issues/44549">
+<link rel="match" href="../../reference/ref-filled-green-200px-square.html">
+<meta assert="An anonymous table box parent is generated around the table-cell.
+  This table doesn't include any of the spaces that follow the table-cell.">
+
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+#red {
+  position: absolute;
+  width: 200px;
+  height: 200px;
+  background: red;
+  z-index: -1;
+}
+#test {
+  white-space: pre;
+  font: 200px / 1 Ahem;
+  color: green;
+  margin-left: -4ch;
+}
+#cell {
+  display: table-cell;
+}
+</style>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div id="red"></div>
+<div id="test"><div id="cell"></div></div>
+<script src="/common/reftest-wait.js"></script>
+<script>
+document.getElementById("test").append("   ", " ", "X");
+document.fonts.ready.then(takeScreenshot);
+</script>
+</html>


### PR DESCRIPTION
A sequence of table-level boxes gets wrapped inside an anonymous table box. This includes interleaved spaces (which table layout will skip), but not trailing spaces, which need to be kept after the table.

We were only keeping the last such whitespace node, but it's possible to have more than one whitespace node. So this patch keeps all nodes after the last table-level element.

Testing: Adding new WPT
Fixes: #44549
