### PR TITLE
layout: Handle `display: contents` in all `TraversalHandler`

### DIFF
--- a/components/layout/dom_traversal.rs
+++ b/components/layout/dom_traversal.rs
@@ -97,10 +97,10 @@ pub(super) trait TraversalHandler<'dom> {
     );
 
     /// Notify the handler that we are about to recurse into a `display: contents` element.
-    fn enter_display_contents(&mut self, _: SharedInlineStyles) {}
+    fn enter_display_contents(&mut self, _: SharedInlineStyles);
 
     /// Notify the handler that we have finished a `display: contents` element.
-    fn leave_display_contents(&mut self) {}
+    fn leave_display_contents(&mut self);
 }
 
 fn traverse_children_of<'dom>(

--- a/components/layout/flow/construct.rs
+++ b/components/layout/flow/construct.rs
@@ -328,8 +328,13 @@ impl<'dom, 'style> BlockContainerBuilder<'dom, 'style> {
             .expect("Anonymous table contents should include some table-level element");
         let trailing_contents = contents.split_off(last_element_index + 1);
 
-        let (table_info, ifc) =
-            Table::construct_anonymous(self.context, self.info, contents, self.propagated_data);
+        let (table_info, ifc) = Table::construct_anonymous(
+            self.context,
+            self,
+            self.info,
+            contents,
+            self.propagated_data,
+        );
 
         if inline_table {
             self.ensure_inline_formatting_context_builder()
@@ -363,6 +368,10 @@ impl<'dom, 'style> BlockContainerBuilder<'dom, 'style> {
         for content in trailing_contents {
             match content {
                 AnonymousTableContent::Text(info, text) => self.handle_text(&info, text),
+                AnonymousTableContent::EnterDisplayContents(styles) => {
+                    self.enter_display_contents(styles)
+                },
+                AnonymousTableContent::LeaveDisplayContents => self.leave_display_contents(),
                 AnonymousTableContent::Element { .. } => {
                     unreachable!("All elements were placed inside the table")
                 },
@@ -439,6 +448,11 @@ impl<'dom> TraversalHandler<'dom> for BlockContainerBuilder<'dom, '_> {
     }
 
     fn enter_display_contents(&mut self, styles: SharedInlineStyles) {
+        if !self.anonymous_table_content.is_empty() {
+            self.anonymous_table_content
+                .push(AnonymousTableContent::EnterDisplayContents(styles));
+            return;
+        }
         self.display_contents_shared_styles.push(styles.clone());
         if let Some(builder) = self.inline_formatting_context_builder.as_mut() {
             builder.enter_display_contents(styles);
@@ -446,6 +460,11 @@ impl<'dom> TraversalHandler<'dom> for BlockContainerBuilder<'dom, '_> {
     }
 
     fn leave_display_contents(&mut self) {
+        if !self.anonymous_table_content.is_empty() {
+            self.anonymous_table_content
+                .push(AnonymousTableContent::LeaveDisplayContents);
+            return;
+        }
         self.display_contents_shared_styles.pop();
         if let Some(builder) = self.inline_formatting_context_builder.as_mut() {
             builder.leave_display_contents();

--- a/components/layout/table/construct.rs
+++ b/components/layout/table/construct.rs
@@ -22,6 +22,7 @@ use crate::cell::ArcRefCell;
 use crate::context::LayoutContext;
 use crate::dom::{BoxSlot, LayoutBox, NodeExt};
 use crate::dom_traversal::{Contents, NodeAndStyleInfo, NonReplacedContents, TraversalHandler};
+use crate::flow::inline::SharedInlineStyles;
 use crate::flow::{BlockContainerBuilder, BlockFormattingContext};
 use crate::formatting_contexts::{
     IndependentFormattingContext, IndependentFormattingContextContents,
@@ -50,6 +51,8 @@ impl ResolvedSlotAndLocation<'_> {
 
 pub(crate) enum AnonymousTableContent<'dom> {
     Text(NodeAndStyleInfo<'dom>, Cow<'dom, str>),
+    EnterDisplayContents(SharedInlineStyles),
+    LeaveDisplayContents,
     Element {
         info: NodeAndStyleInfo<'dom>,
         display: DisplayGeneratingBox,
@@ -63,6 +66,7 @@ impl AnonymousTableContent<'_> {
         match self {
             Self::Element { .. } => false,
             Self::Text(_, text) => text.chars().all(char_is_whitespace),
+            Self::EnterDisplayContents(_) | Self::LeaveDisplayContents => true,
         }
     }
 
@@ -86,6 +90,7 @@ impl Table {
 
     pub(crate) fn construct_anonymous<'dom>(
         context: &LayoutContext,
+        parent: &mut impl TraversalHandler<'dom>,
         parent_info: &NodeAndStyleInfo<'dom>,
         contents: Vec<AnonymousTableContent<'dom>>,
         propagated_data: PropagatedBoxTreeData,
@@ -112,6 +117,13 @@ impl Table {
                     // We only collect that whitespace in case we need to re-emit trailing whitespace
                     // after we've added our anonymous table.
                 },
+                // Since the table builder skips text, we don't have to handle `display: contents` there.
+                // But we need to handle it for the parent builder, because it may contain trailing
+                // whitespace which won't be placed inside the table.
+                AnonymousTableContent::EnterDisplayContents(styles) => {
+                    parent.enter_display_contents(styles)
+                },
+                AnonymousTableContent::LeaveDisplayContents => parent.leave_display_contents(),
             }
         }
 
@@ -707,6 +719,10 @@ impl<'style, 'dom> TableBuilderTraversal<'style, 'dom> {
                 AnonymousTableContent::Text(info, text) => {
                     row_builder.handle_text(&info, text);
                 },
+                AnonymousTableContent::EnterDisplayContents(styles) => {
+                    row_builder.enter_display_contents(styles)
+                },
+                AnonymousTableContent::LeaveDisplayContents => row_builder.leave_display_contents(),
             }
         }
 
@@ -742,6 +758,16 @@ impl<'dom> TraversalHandler<'dom> for TableBuilderTraversal<'_, 'dom> {
     fn handle_text(&mut self, info: &NodeAndStyleInfo<'dom>, text: Cow<'dom, str>) {
         self.current_anonymous_row_content
             .push(AnonymousTableContent::Text(info.clone(), text));
+    }
+
+    fn enter_display_contents(&mut self, styles: SharedInlineStyles) {
+        self.current_anonymous_row_content
+            .push(AnonymousTableContent::EnterDisplayContents(styles));
+    }
+
+    fn leave_display_contents(&mut self) {
+        self.current_anonymous_row_content
+            .push(AnonymousTableContent::LeaveDisplayContents);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#forming-a-table>
@@ -985,6 +1011,10 @@ impl<'style, 'builder, 'dom, 'a> TableRowGroupBuilder<'style, 'builder, 'dom, 'a
                 AnonymousTableContent::Text(info, text) => {
                     row_builder.handle_text(&info, text);
                 },
+                AnonymousTableContent::EnterDisplayContents(styles) => {
+                    row_builder.enter_display_contents(styles)
+                },
+                AnonymousTableContent::LeaveDisplayContents => row_builder.leave_display_contents(),
             }
         }
 
@@ -1010,6 +1040,16 @@ impl<'dom> TraversalHandler<'dom> for TableRowGroupBuilder<'_, '_, 'dom, '_> {
     fn handle_text(&mut self, info: &NodeAndStyleInfo<'dom>, text: Cow<'dom, str>) {
         self.current_anonymous_row_content
             .push(AnonymousTableContent::Text(info.clone(), text));
+    }
+
+    fn enter_display_contents(&mut self, styles: SharedInlineStyles) {
+        self.current_anonymous_row_content
+            .push(AnonymousTableContent::EnterDisplayContents(styles));
+    }
+
+    fn leave_display_contents(&mut self) {
+        self.current_anonymous_row_content
+            .push(AnonymousTableContent::LeaveDisplayContents);
     }
 
     fn handle_element(
@@ -1118,6 +1158,10 @@ impl<'style, 'builder, 'dom, 'a> TableRowBuilder<'style, 'builder, 'dom, 'a> {
                 AnonymousTableContent::Text(info, text) => {
                     builder.handle_text(&info, text);
                 },
+                AnonymousTableContent::EnterDisplayContents(styles) => {
+                    builder.enter_display_contents(styles)
+                },
+                AnonymousTableContent::LeaveDisplayContents => builder.leave_display_contents(),
             }
         }
 
@@ -1150,6 +1194,16 @@ impl<'dom> TraversalHandler<'dom> for TableRowBuilder<'_, '_, 'dom, '_> {
     fn handle_text(&mut self, info: &NodeAndStyleInfo<'dom>, text: Cow<'dom, str>) {
         self.current_anonymous_cell_content
             .push(AnonymousTableContent::Text(info.clone(), text));
+    }
+
+    fn enter_display_contents(&mut self, styles: SharedInlineStyles) {
+        self.current_anonymous_cell_content
+            .push(AnonymousTableContent::EnterDisplayContents(styles));
+    }
+
+    fn leave_display_contents(&mut self) {
+        self.current_anonymous_cell_content
+            .push(AnonymousTableContent::LeaveDisplayContents);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#algorithm-for-processing-rows>
@@ -1248,6 +1302,8 @@ struct TableColumnGroupBuilder {
 
 impl<'dom> TraversalHandler<'dom> for TableColumnGroupBuilder {
     fn handle_text(&mut self, _info: &NodeAndStyleInfo<'dom>, _text: Cow<'dom, str>) {}
+    fn enter_display_contents(&mut self, _: SharedInlineStyles) {}
+    fn leave_display_contents(&mut self) {}
     fn handle_element(
         &mut self,
         info: &NodeAndStyleInfo<'dom>,

--- a/tests/wpt/meta/css/css-display/display-contents-dynamic-table-001-inline.html.ini
+++ b/tests/wpt/meta/css/css-display/display-contents-dynamic-table-001-inline.html.ini
@@ -1,2 +1,0 @@
-[display-contents-dynamic-table-001-inline.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-display/display-contents-dynamic-table-001-none.html.ini
+++ b/tests/wpt/meta/css/css-display/display-contents-dynamic-table-001-none.html.ini
@@ -1,2 +1,0 @@
-[display-contents-dynamic-table-001-none.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-display/display-contents-dynamic-table-002-inline.html.ini
+++ b/tests/wpt/meta/css/css-display/display-contents-dynamic-table-002-inline.html.ini
@@ -1,2 +1,0 @@
-[display-contents-dynamic-table-002-inline.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-display/display-contents-dynamic-table-002-none.html.ini
+++ b/tests/wpt/meta/css/css-display/display-contents-dynamic-table-002-none.html.ini
@@ -1,2 +1,0 @@
-[display-contents-dynamic-table-002-none.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-display/display-contents-table-001.html.ini
+++ b/tests/wpt/meta/css/css-display/display-contents-table-001.html.ini
@@ -1,2 +1,0 @@
-[display-contents-table-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-display/display-contents-table-002.html.ini
+++ b/tests/wpt/meta/css/css-display/display-contents-table-002.html.ini
@@ -1,2 +1,0 @@
-[display-contents-table-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-display/display-contents-td-001.html.ini
+++ b/tests/wpt/meta/css/css-display/display-contents-td-001.html.ini
@@ -1,0 +1,2 @@
+[display-contents-td-001.html]
+  expected: FAIL

--- a/tests/wpt/tests/css/css-display/display-contents-table-003.html
+++ b/tests/wpt/tests/css/css-display/display-contents-table-003.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<meta charset="utf-8">
+<title>CSS Test: CSS display:contents in table layout</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="help" href="https://github.com/servo/servo/issues/42070">
+<link rel="match" href="../reference/ref-filled-green-200px-square.html">
+
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+div { color: red; font: 40px / 1 Ahem; }
+span { display: contents; color: green; }
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div style="display: table"><span>XXXXX</span></div>
+<div style="display: table-caption"><span>XXXXX</span></div>
+<div style="display: table-row-group"><span>XXXXX</span></div>
+<div style="display: table-row"><span>XXXXX</span></div>
+<div style="display: table-cell"><span>XXXXX</span></div>
+
+<script src="/common/reftest-wait.js"></script>
+<script>
+document.fonts.ready.then(takeScreenshot);
+</script>
+</html>


### PR DESCRIPTION
The `TraversalHandler` trait defined the methods that handle elements with `display: contents` using a default implementation that was no-op. Therefore, it was easy for types implementing the trait to forget to handle `display: contents` correctly.

This patch removes the default implementation, and adds the missing implementations for `TableRowBuilder`, `TableRowGroupBuilder`, `TableColumnGroupBuilder` and `TableBuilderTraversal`.

Testing: 6 existing tests pass, and adding a new one. There is one new failure, because we lack `font-kerning: none`.
Fixes: #42070
