### PR TITLE
ohos: Add linker version script

### DIFF
--- a/ports/servoshell/build.rs
+++ b/ports/servoshell/build.rs
@@ -46,6 +46,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Note: We can't use `#[cfg(windows)]`, since that would check the host platform
     // and not the target platform
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
+    let target_env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap();
 
     if target_os == "windows" {
         #[cfg(windows)]
@@ -90,6 +91,28 @@ fn main() -> Result<(), Box<dyn Error>> {
     // linker to locate them. See `man dyld` for more info.
     if target_os == "macos" {
         println!("cargo:rustc-link-arg=-Wl,-rpath,@executable_path/lib/");
+    }
+
+    // On OpenHarmony, libservoshell.so is loaded by ArkTS as a NAPI module.
+    // Passing a version script allows us to inform the linker about required
+    // symbol visibility (only one), which improves stripping of unused sections.
+    if target_env == "ohos" {
+        let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")?;
+        let version_script = Path::new(&manifest_dir)
+            .join("platform")
+            .join("openharmony")
+            .join("libservoshell.ver");
+        let version_script_str = version_script.to_str().expect("utf-8");
+        assert!(
+            version_script.exists(),
+            "Expected version script to exist at path `{version_script_str}`"
+        );
+        println!("cargo:rerun-if-changed={version_script_str}");
+        // Using `rustc-link-arg-cdylib` causes a false-positive warning:
+        // https://github.com/rust-lang/cargo/issues/16487
+        // We work around this by just using the unconditional link-arg, which
+        // should be fine, since we always build servo as a cdylib on OpenHarmony.
+        println!("cargo:rustc-link-arg=-Wl,--version-script={version_script_str}");
     }
     Ok(())
 }

--- a/ports/servoshell/build.rs
+++ b/ports/servoshell/build.rs
@@ -102,7 +102,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             .join("platform")
             .join("openharmony")
             .join("libservoshell.ver");
-        let version_script_str = version_script.to_str().expect("utf-8");
+        let version_script_str = version_script.to_str().expect("Expected UTF-8 text");
         assert!(
             version_script.exists(),
             "Expected version script to exist at path `{version_script_str}`"

--- a/ports/servoshell/platform/openharmony/libservoshell.ver
+++ b/ports/servoshell/platform/openharmony/libservoshell.ver
@@ -1,0 +1,13 @@
+# Linker version script for libservoshell.so on OpenHarmony.
+#
+# The shared library is loaded by ArkTS as a NAPI module. The only symbol the
+# OpenHarmony NAPI runtime needs to resolve via the dynamic symbol table is
+# `napi_register_module_v1`, which is provided by the `napi-ohos` crate.
+#
+# See https://sourceware.org/binutils/docs/ld/VERSION.html for more information.
+{
+    global:
+        napi_register_module_v1;
+    local:
+        *;
+};


### PR DESCRIPTION
With production-stripped, the binary size is 87MB (locally) after this change, compared to 91MB before (according to bencher.dev). We don't use the version script for any versioning, simply to adjust the symbol visibility and hide all symbols we don't need, which improves pruning of code that is never used.
All `#[napi]` annotated functions are registered indirectly via `napi_register_module_v1` and don't need public visibility.

Testing: Covered by existing HarmonyOS runtime tests in CI.

