### PR TITLE
script: pass `&mut JSContext` to `UnderlyingSourceContainer::call_start_algorithm`

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -52,9 +52,9 @@ use crate::task_source::SendableTaskSource;
 
 /// <https://fetch.spec.whatwg.org/#concept-body-clone>
 pub(crate) fn clone_body_stream_for_dom_body(
+    cx: &mut js::context::JSContext,
     original_body_stream: &MutNullableDom<ReadableStream>,
     cloned_body_stream: &MutNullableDom<ReadableStream>,
-    can_gc: CanGc,
 ) -> Fallible<()> {
     // To clone a body *body*, run these steps:
 
@@ -63,7 +63,7 @@ pub(crate) fn clone_body_stream_for_dom_body(
     };
 
     // step 1. Let « out1, out2 » be the result of teeing body’s stream.
-    let branches = stream.tee(true, can_gc)?;
+    let branches = stream.tee(cx, true)?;
     let out1 = &*branches[0];
     let out2 = &*branches[1];
 
@@ -505,7 +505,7 @@ impl Extractable for BodyInit {
             BodyInit::ArrayBuffer(typedarray) => {
                 let bytes = typedarray.to_vec();
                 let total_bytes = bytes.len();
-                let stream = ReadableStream::new_from_bytes(global, bytes, CanGc::from_cx(cx))?;
+                let stream = ReadableStream::new_from_bytes(cx, global, bytes)?;
                 Ok(ExtractedBody {
                     stream,
                     total_bytes: Some(total_bytes),
@@ -516,7 +516,7 @@ impl Extractable for BodyInit {
             BodyInit::ArrayBufferView(typedarray) => {
                 let bytes = typedarray.to_vec();
                 let total_bytes = bytes.len();
-                let stream = ReadableStream::new_from_bytes(global, bytes, CanGc::from_cx(cx))?;
+                let stream = ReadableStream::new_from_bytes(cx, global, bytes)?;
                 Ok(ExtractedBody {
                     stream,
                     total_bytes: Some(total_bytes),
@@ -558,7 +558,7 @@ impl Extractable for Vec<u8> {
     ) -> Fallible<ExtractedBody> {
         let bytes = self.clone();
         let total_bytes = self.len();
-        let stream = ReadableStream::new_from_bytes(global, bytes, CanGc::from_cx(cx))?;
+        let stream = ReadableStream::new_from_bytes(cx, global, bytes)?;
         Ok(ExtractedBody {
             stream,
             total_bytes: Some(total_bytes),
@@ -583,7 +583,7 @@ impl Extractable for Blob {
             Some(blob_type)
         };
         let total_bytes = self.Size() as usize;
-        let stream = self.get_stream(CanGc::from_cx(cx))?;
+        let stream = self.get_stream(cx)?;
         Ok(ExtractedBody {
             stream,
             total_bytes: Some(total_bytes),
@@ -603,7 +603,7 @@ impl Extractable for DOMString {
         let bytes = self.as_bytes().to_owned();
         let total_bytes = bytes.len();
         let content_type = Some(DOMString::from("text/plain;charset=UTF-8"));
-        let stream = ReadableStream::new_from_bytes(global, bytes, CanGc::from_cx(cx))?;
+        let stream = ReadableStream::new_from_bytes(cx, global, bytes)?;
         Ok(ExtractedBody {
             stream,
             total_bytes: Some(total_bytes),
@@ -627,7 +627,7 @@ impl Extractable for FormData {
             "multipart/form-data; boundary={}",
             boundary
         )));
-        let stream = ReadableStream::new_from_bytes(global, bytes, CanGc::from_cx(cx))?;
+        let stream = ReadableStream::new_from_bytes(cx, global, bytes)?;
         Ok(ExtractedBody {
             stream,
             total_bytes: Some(total_bytes),
@@ -649,7 +649,7 @@ impl Extractable for URLSearchParams {
         let content_type = Some(DOMString::from(
             "application/x-www-form-urlencoded;charset=UTF-8",
         ));
-        let stream = ReadableStream::new_from_bytes(global, bytes, CanGc::from_cx(cx))?;
+        let stream = ReadableStream::new_from_bytes(cx, global, bytes)?;
         Ok(ExtractedBody {
             stream,
             total_bytes: Some(total_bytes),

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -32,7 +32,6 @@ use crate::dom::bindings::structuredclone::StructuredData;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 use crate::dom::stream::readablestream::ReadableStream;
-use crate::realms::InRealm;
 use crate::script_runtime::CanGc;
 
 /// <https://w3c.github.io/FileAPI/#dfn-Blob>
@@ -104,8 +103,11 @@ impl Blob {
     }
 
     /// <https://w3c.github.io/FileAPI/#blob-get-stream>
-    pub(crate) fn get_stream(&self, can_gc: CanGc) -> Fallible<DomRoot<ReadableStream>> {
-        self.global().get_blob_stream(&self.blob_id, can_gc)
+    pub(crate) fn get_stream(
+        &self,
+        cx: &mut js::context::JSContext,
+    ) -> Fallible<DomRoot<ReadableStream>> {
+        self.global().get_blob_stream(cx, &self.blob_id)
     }
 }
 
@@ -212,7 +214,7 @@ impl BlobMethods<crate::DomTypeHolder> for Blob {
 
     // <https://w3c.github.io/FileAPI/#blob-get-stream>
     fn Stream(&self, cx: &mut js::context::JSContext) -> Fallible<DomRoot<ReadableStream>> {
-        self.get_stream(CanGc::from_cx(cx))
+        self.get_stream(cx)
     }
 
     /// <https://w3c.github.io/FileAPI/#slice-method-algo>
@@ -266,19 +268,18 @@ impl BlobMethods<crate::DomTypeHolder> for Blob {
     }
 
     /// <https://w3c.github.io/FileAPI/#arraybuffer-method-algo>
-    fn ArrayBuffer(&self, in_realm: InRealm, can_gc: CanGc) -> Rc<Promise> {
-        let cx = GlobalScope::get_cx();
-        let promise = Promise::new_in_current_realm(in_realm, can_gc);
+    fn ArrayBuffer(&self, cx: &mut CurrentRealm) -> Rc<Promise> {
+        let promise = Promise::new_in_realm(cx);
 
         // 1. Let stream be the result of calling get stream on this.
-        let stream = self.get_stream(can_gc);
+        let stream = self.get_stream(cx);
 
         // 2. Let reader be the result of getting a reader from stream.
         //    If that threw an exception, return a new promise rejected with that exception.
-        let reader = match stream.and_then(|s| s.acquire_default_reader(can_gc)) {
+        let reader = match stream.and_then(|s| s.acquire_default_reader(CanGc::from_cx(cx))) {
             Ok(reader) => reader,
             Err(error) => {
-                promise.reject_error(error, can_gc);
+                promise.reject_error(error, CanGc::from_cx(cx));
                 return promise;
             },
         };
@@ -287,8 +288,9 @@ impl BlobMethods<crate::DomTypeHolder> for Blob {
         let success_promise = promise.clone();
         let failure_promise = promise.clone();
         reader.read_all_bytes(
-            cx,
+            cx.into(),
             Rc::new(move |bytes| {
+                let cx = GlobalScope::get_cx();
                 rooted!(in(*cx) let mut js_object = ptr::null_mut::<JSObject>());
                 // 4. Return the result of transforming promise by a fulfillment handler that returns a new
                 //    [ArrayBuffer]
@@ -296,34 +298,33 @@ impl BlobMethods<crate::DomTypeHolder> for Blob {
                     cx,
                     bytes,
                     js_object.handle_mut(),
-                    can_gc,
+                    CanGc::deprecated_note(),
                 )
                 .expect("Converting input to ArrayBufferU8 should never fail");
-                success_promise.resolve_native(&array_buffer, can_gc);
+                success_promise.resolve_native(&array_buffer, CanGc::deprecated_note());
             }),
             Rc::new(move |cx, value| {
-                failure_promise.reject(cx, value, can_gc);
+                failure_promise.reject(cx, value, CanGc::deprecated_note());
             }),
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         promise
     }
 
     /// <https://w3c.github.io/FileAPI/#dom-blob-bytes>
-    fn Bytes(&self, in_realm: InRealm, can_gc: CanGc) -> Rc<Promise> {
-        let cx = GlobalScope::get_cx();
-        let p = Promise::new_in_current_realm(in_realm, can_gc);
+    fn Bytes(&self, cx: &mut CurrentRealm) -> Rc<Promise> {
+        let p = Promise::new_in_realm(cx);
 
         // 1. Let stream be the result of calling get stream on this.
-        let stream = self.get_stream(can_gc);
+        let stream = self.get_stream(cx);
 
         // 2. Let reader be the result of getting a reader from stream.
         //    If that threw an exception, return a new promise rejected with that exception.
-        let reader = match stream.and_then(|s| s.acquire_default_reader(can_gc)) {
+        let reader = match stream.and_then(|s| s.acquire_default_reader(CanGc::from_cx(cx))) {
             Ok(r) => r,
             Err(e) => {
-                p.reject_error(e, can_gc);
+                p.reject_error(e, CanGc::from_cx(cx));
                 return p;
             },
         };
@@ -332,17 +333,23 @@ impl BlobMethods<crate::DomTypeHolder> for Blob {
         let p_success = p.clone();
         let p_failure = p.clone();
         reader.read_all_bytes(
-            cx,
+            cx.into(),
             Rc::new(move |bytes| {
+                let cx = GlobalScope::get_cx();
                 rooted!(in(*cx) let mut js_object = ptr::null_mut::<JSObject>());
-                let arr = create_buffer_source::<Uint8>(cx, bytes, js_object.handle_mut(), can_gc)
-                    .expect("Converting input to uint8 array should never fail");
-                p_success.resolve_native(&arr, can_gc);
+                let arr = create_buffer_source::<Uint8>(
+                    cx,
+                    bytes,
+                    js_object.handle_mut(),
+                    CanGc::deprecated_note(),
+                )
+                .expect("Converting input to uint8 array should never fail");
+                p_success.resolve_native(&arr, CanGc::deprecated_note());
             }),
             Rc::new(move |cx, v| {
-                p_failure.reject(cx, v, can_gc);
+                p_failure.reject(cx, v, CanGc::deprecated_note());
             }),
-            can_gc,
+            CanGc::from_cx(cx),
         );
         p
     }

--- a/components/script/dom/file/filereader.rs
+++ b/components/script/dom/file/filereader.rs
@@ -498,7 +498,7 @@ impl FileReader {
         // See the note below in the error steps.
 
         // Let stream be the result of calling get stream on blob.
-        let stream = blob.get_stream(CanGc::from_cx(cx));
+        let stream = blob.get_stream(cx);
 
         // Let reader be the result of getting a reader from stream.
         let reader = stream.and_then(|s| s.acquire_default_reader(CanGc::from_cx(cx)))?;

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2183,21 +2183,21 @@ impl GlobalScope {
     /// <https://w3c.github.io/FileAPI/#blob-get-stream>
     pub(crate) fn get_blob_stream(
         &self,
+        cx: &mut js::context::JSContext,
         blob_id: &BlobId,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<ReadableStream>> {
         let (file_id, size) = match self.get_blob_bytes_or_file_id(blob_id) {
             BlobResult::Bytes(bytes) => {
                 // If we have all the bytes in memory, queue them and close the stream.
-                return ReadableStream::new_from_bytes(self, bytes, can_gc);
+                return ReadableStream::new_from_bytes(cx, self, bytes);
             },
             BlobResult::File(id, size) => (id, size),
         };
 
         let stream = ReadableStream::new_with_external_underlying_source(
+            cx,
             self,
             UnderlyingSourceType::Blob(size),
-            can_gc,
         )?;
 
         let recv = self.send_msg(file_id);

--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -541,16 +541,16 @@ impl Request {
     }
 
     /// <https://fetch.spec.whatwg.org/#concept-request-clone>
-    fn clone_from(r: &Request, can_gc: CanGc) -> Fallible<DomRoot<Request>> {
+    fn clone_from(cx: &mut js::context::JSContext, r: &Request) -> Fallible<DomRoot<Request>> {
         let req = r.request.borrow();
         let url = req.url();
-        let headers_guard = r.Headers(can_gc).get_guard();
+        let headers_guard = r.Headers(CanGc::from_cx(cx)).get_guard();
 
         // Step 1. Let newRequest be a copy of request, except for its body.
         let mut new_req_inner = req.clone();
         let body = new_req_inner.body.take();
 
-        let r_clone = Request::new(&r.global(), None, url, can_gc);
+        let r_clone = Request::new(&r.global(), None, url, CanGc::from_cx(cx));
         *r_clone.request.borrow_mut() = new_req_inner;
 
         // Step 2. If request’s body is non-null, set newRequest’s body
@@ -560,11 +560,11 @@ impl Request {
         }
 
         r_clone
-            .Headers(can_gc)
-            .copy_from_headers(r.Headers(can_gc))?;
-        r_clone.Headers(can_gc).set_guard(headers_guard);
+            .Headers(CanGc::from_cx(cx))
+            .copy_from_headers(r.Headers(CanGc::from_cx(cx)))?;
+        r_clone.Headers(CanGc::from_cx(cx)).set_guard(headers_guard);
 
-        clone_body_stream_for_dom_body(&r.body_stream, &r_clone.body_stream, can_gc)?;
+        clone_body_stream_for_dom_body(cx, &r.body_stream, &r_clone.body_stream)?;
 
         // Step 3. Return newRequest.
         Ok(r_clone)
@@ -716,20 +716,23 @@ impl RequestMethods<crate::DomTypeHolder> for Request {
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-request-clone>
-    fn Clone(&self, can_gc: CanGc) -> Fallible<DomRoot<Request>> {
+    fn Clone(&self, cx: &mut js::context::JSContext) -> Fallible<DomRoot<Request>> {
         // Step 1. If this is unusable, then throw a TypeError.
         if self.is_unusable() {
             return Err(Error::Type(c"Request is unusable".to_owned()));
         }
 
         // Step 2. Let clonedRequest be the result of cloning this’s request.
-        let cloned_request = Request::clone_from(self, can_gc)?;
+        let cloned_request = Request::clone_from(cx, self)?;
         // Step 3. Assert: this’s signal is non-null.
         let signal = self.signal.get().expect("Should always be initialized");
         // Step 4. Let clonedSignal be the result of creating a dependent
         // abort signal from « this’s signal », using AbortSignal and this’s relevant realm.
-        let cloned_signal =
-            AbortSignal::create_dependent_abort_signal(vec![signal], &self.global(), can_gc);
+        let cloned_signal = AbortSignal::create_dependent_abort_signal(
+            vec![signal],
+            &self.global(),
+            CanGc::from_cx(cx),
+        );
         // Step 5. Let clonedRequestObject be the result of creating a Request object,
         // given clonedRequest, this’s headers’s guard, clonedSignal and this’s relevant realm.
         //

--- a/components/script/dom/response.rs
+++ b/components/script/dom/response.rs
@@ -26,7 +26,7 @@ use crate::dom::bindings::codegen::Bindings::ResponseBinding::{
 };
 use crate::dom::bindings::codegen::Bindings::XMLHttpRequestBinding::BodyInit;
 use crate::dom::bindings::error::{Error, Fallible};
-use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object_with_proto};
+use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object_with_proto_and_cx};
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::str::{ByteString, USVString, serialize_jsval_to_json_utf8};
 use crate::dom::globalscope::GlobalScope;
@@ -63,11 +63,11 @@ pub(crate) struct Response {
 }
 
 impl Response {
-    pub(crate) fn new_inherited(global: &GlobalScope, can_gc: CanGc) -> Response {
+    pub(crate) fn new_inherited(cx: &mut js::context::JSContext, global: &GlobalScope) -> Response {
         let stream = ReadableStream::new_with_external_underlying_source(
+            cx,
             global,
             UnderlyingSourceType::FetchResponse,
-            can_gc,
         )
         .expect("Failed to create ReadableStream with external underlying source");
         Response {
@@ -86,20 +86,20 @@ impl Response {
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-response>
-    pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<Response> {
-        Self::new_with_proto(global, None, can_gc)
+    pub(crate) fn new(cx: &mut js::context::JSContext, global: &GlobalScope) -> DomRoot<Response> {
+        Self::new_with_proto(cx, global, None)
     }
 
     fn new_with_proto(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<Response> {
-        reflect_dom_object_with_proto(
-            Box::new(Response::new_inherited(global, can_gc)),
+        reflect_dom_object_with_proto_and_cx(
+            Box::new(Response::new_inherited(cx, global)),
             global,
             proto,
-            can_gc,
+            cx,
         )
     }
 
@@ -177,7 +177,7 @@ impl ResponseMethods<crate::DomTypeHolder> for Response {
     ) -> Fallible<DomRoot<Response>> {
         // 1. Set this’s response to a new response.
         // Our Response/Body types don't actually hold onto an internal fetch Response.
-        let response = Response::new_with_proto(global, proto, CanGc::from_cx(cx));
+        let response = Response::new_with_proto(cx, global, proto);
         if body_init.is_some() {
             response.is_body_empty.set(false);
         }
@@ -196,24 +196,26 @@ impl ResponseMethods<crate::DomTypeHolder> for Response {
         };
 
         // 5. Perform *initialize a response* given this, init, and bodyWithType.
-        initialize_response(global, CanGc::from_cx(cx), body_with_type, init, response)
+        initialize_response(cx, global, body_with_type, init, response)
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-response-error>
-    fn Error(global: &GlobalScope, can_gc: CanGc) -> DomRoot<Response> {
-        let response = Response::new(global, can_gc);
+    fn Error(cx: &mut js::context::JSContext, global: &GlobalScope) -> DomRoot<Response> {
+        let response = Response::new(cx, global);
         *response.response_type.borrow_mut() = DOMResponseType::Error;
-        response.Headers(can_gc).set_guard(Guard::Immutable);
+        response
+            .Headers(CanGc::from_cx(cx))
+            .set_guard(Guard::Immutable);
         *response.status.borrow_mut() = HttpStatus::new_error();
         response
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-response-redirect>
     fn Redirect(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         url: USVString,
         status: u16,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<Response>> {
         // Step 1
         let base_url = global.api_base_url();
@@ -232,7 +234,7 @@ impl ResponseMethods<crate::DomTypeHolder> for Response {
 
         // Step 4
         // see Step 4 continued
-        let response = Response::new(global, can_gc);
+        let response = Response::new(cx, global);
 
         // Step 5
         *response.status.borrow_mut() = HttpStatus::new_raw(status, vec![]);
@@ -241,12 +243,14 @@ impl ResponseMethods<crate::DomTypeHolder> for Response {
         let url_bytestring =
             ByteString::from_str(url.as_str()).unwrap_or(ByteString::new(b"".to_vec()));
         response
-            .Headers(can_gc)
+            .Headers(CanGc::from_cx(cx))
             .Set(ByteString::new(b"Location".to_vec()), url_bytestring)?;
 
         // Step 4 continued
         // Headers Guard is set to Immutable here to prevent error in Step 6
-        response.Headers(can_gc).set_guard(Guard::Immutable);
+        response
+            .Headers(CanGc::from_cx(cx))
+            .set_guard(Guard::Immutable);
 
         // Step 7
         Ok(response)
@@ -270,14 +274,14 @@ impl ResponseMethods<crate::DomTypeHolder> for Response {
 
         // 3. Let responseObject be the result of creating a Response object, given a new response,
         // "response", and the current realm.
-        let response = Response::new(global, CanGc::from_cx(cx));
+        let response = Response::new(cx, global);
         response
             .Headers(CanGc::from_cx(cx))
             .set_guard(Guard::Response);
 
         // 4. Perform initialize a response given responseObject, init, and (body, "application/json").
         body.content_type = Some("application/json".into());
-        initialize_response(global, CanGc::from_cx(cx), Some(body), init, response)
+        initialize_response(cx, global, Some(body), init, response)
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-response-type>
@@ -327,20 +331,20 @@ impl ResponseMethods<crate::DomTypeHolder> for Response {
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-response-clone>
-    fn Clone(&self, can_gc: CanGc) -> Fallible<DomRoot<Response>> {
+    fn Clone(&self, cx: &mut js::context::JSContext) -> Fallible<DomRoot<Response>> {
         // Step 1. If this is unusable, then throw a TypeError.
         if self.is_unusable() {
             return Err(Error::Type(c"cannot clone a disturbed response".to_owned()));
         }
 
         // Step 2. Let clonedResponse be the result of cloning this’s response.
-        let new_response = Response::new(&self.global(), can_gc);
+        let new_response = Response::new(cx, &self.global());
         new_response
-            .Headers(can_gc)
-            .copy_from_headers(self.Headers(can_gc))?;
+            .Headers(CanGc::from_cx(cx))
+            .copy_from_headers(self.Headers(CanGc::from_cx(cx)))?;
         new_response
-            .Headers(can_gc)
-            .set_guard(self.Headers(can_gc).get_guard());
+            .Headers(CanGc::from_cx(cx))
+            .set_guard(self.Headers(CanGc::from_cx(cx)).get_guard());
 
         *new_response.response_type.borrow_mut() = *self.response_type.borrow();
         new_response
@@ -356,7 +360,7 @@ impl ResponseMethods<crate::DomTypeHolder> for Response {
 
         // Step 3. Return the result of creating a Response object,
         // given clonedResponse, this’s headers’s guard, and this’s relevant realm.
-        clone_body_stream_for_dom_body(&self.body_stream, &new_response.body_stream, can_gc)?;
+        clone_body_stream_for_dom_body(cx, &self.body_stream, &new_response.body_stream)?;
         // The cloned response must not receive network chunks directly; it is fed via the tee branch.
         new_response.fetch_body_stream.set(None);
 
@@ -406,8 +410,8 @@ impl ResponseMethods<crate::DomTypeHolder> for Response {
 
 /// <https://fetch.spec.whatwg.org/#initialize-a-response>
 fn initialize_response(
+    cx: &mut js::context::JSContext,
     global: &GlobalScope,
-    can_gc: CanGc,
     body: Option<ExtractedBody>,
     init: &ResponseBinding::ResponseInit,
     response: DomRoot<Response>,
@@ -437,7 +441,7 @@ fn initialize_response(
     // 5. If init["headers"] exists, then fill response’s headers with init["headers"].
     if let Some(ref headers_member) = init.headers {
         response
-            .Headers(can_gc)
+            .Headers(CanGc::from_cx(cx))
             .fill(Some(headers_member.clone()))?;
     }
 
@@ -459,11 +463,11 @@ fn initialize_response(
         // then append (`Content-Type`, body’s type) to response’s header list.
         if let Some(content_type_contents) = &body.content_type {
             if !response
-                .Headers(can_gc)
+                .Headers(CanGc::from_cx(cx))
                 .Has(ByteString::new(b"Content-Type".to_vec()))
                 .unwrap()
             {
-                response.Headers(can_gc).Append(
+                response.Headers(CanGc::from_cx(cx)).Append(
                     ByteString::new(b"Content-Type".to_vec()),
                     ByteString::new(content_type_contents.as_bytes().to_vec()),
                 )?;
@@ -473,7 +477,7 @@ fn initialize_response(
         // Reset FetchResponse to an in-memory stream with empty byte sequence here for
         // no-init-body case. This is because the Response/Body types here do not hold onto a
         // fetch Response object.
-        let stream = ReadableStream::new_from_bytes(global, Vec::with_capacity(0), can_gc)?;
+        let stream = ReadableStream::new_from_bytes(cx, global, Vec::with_capacity(0))?;
         response.body_stream.set(Some(&*stream));
         response.fetch_body_stream.set(Some(&*stream));
     }

--- a/components/script/dom/stream/readablebytestreamcontroller.rs
+++ b/components/script/dom/stream/readablebytestreamcontroller.rs
@@ -33,7 +33,7 @@ use crate::dom::promise::Promise;
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::stream::readablestream::ReadableStream;
 use crate::dom::stream::readablestreambyobrequest::ReadableStreamBYOBRequest;
-use crate::realms::{InRealm, enter_realm};
+use crate::realms::{InRealm, enter_auto_realm, enter_realm};
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 
 /// <https://streams.spec.whatwg.org/#readable-byte-stream-queue-entry>
@@ -1701,9 +1701,9 @@ impl ReadableByteStreamController {
     /// <https://streams.spec.whatwg.org/#set-up-readable-byte-stream-controller>
     pub(crate) fn setup(
         &self,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         stream: DomRoot<ReadableStream>,
-        can_gc: CanGc,
     ) -> Fallible<()> {
         // Assert: stream.[[controller]] is undefined.
         stream.assert_no_controller();
@@ -1746,13 +1746,16 @@ impl ReadableByteStreamController {
             // Let startResult be the result of performing startAlgorithm. (This might throw an exception.)
             let start_result = underlying_source
                 .call_start_algorithm(
+                    cx,
                     Controller::ReadableByteStreamController(rooted_byte_controller.clone()),
-                    can_gc,
                 )
                 .unwrap_or_else(|| {
-                    let promise = Promise::new(global, can_gc);
-                    promise.resolve_native(&(), can_gc);
-                    Ok(promise)
+                    Ok(Promise::new_resolved(
+                        global,
+                        cx.into(),
+                        (),
+                        CanGc::from_cx(cx),
+                    ))
                 });
 
             // Let startPromise be a promise resolved with startResult.
@@ -1767,11 +1770,13 @@ impl ReadableByteStreamController {
                 Some(Box::new(StartAlgorithmRejectionHandler {
                     controller: Dom::from_ref(&rooted_byte_controller),
                 })),
-                can_gc,
+                CanGc::from_cx(cx),
             );
-            let realm = enter_realm(global);
-            let comp = InRealm::Entered(&realm);
-            start_promise.append_native_handler(&handler, comp, can_gc);
+            let mut realm = enter_auto_realm(cx, global);
+            let cx = &mut realm.current_realm();
+            let in_realm_proof = cx.into();
+            let comp = InRealm::Already(&in_realm_proof);
+            start_promise.append_native_handler(&handler, comp, CanGc::from_cx(cx));
         };
 
         Ok(())

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -852,25 +852,27 @@ impl PartialEq for ReaderType {
 /// <https://streams.spec.whatwg.org/#create-readable-stream>
 #[cfg_attr(crown, expect(crown::unrooted_must_root))]
 pub(crate) fn create_readable_stream(
+    cx: &mut js::context::JSContext,
     global: &GlobalScope,
     underlying_source_type: UnderlyingSourceType,
     queuing_strategy: Option<Rc<QueuingStrategySize>>,
     high_water_mark: Option<f64>,
-    can_gc: CanGc,
 ) -> DomRoot<ReadableStream> {
     // If highWaterMark was not passed, set it to 1.
     let high_water_mark = high_water_mark.unwrap_or(1.0);
 
     // If sizeAlgorithm was not passed, set it to an algorithm that returns 1.
-    let size_algorithm =
-        queuing_strategy.unwrap_or(extract_size_algorithm(&QueuingStrategy::empty(), can_gc));
+    let size_algorithm = queuing_strategy.unwrap_or(extract_size_algorithm(
+        &QueuingStrategy::empty(),
+        CanGc::from_cx(cx),
+    ));
 
     // Assert: ! IsNonNegativeNumber(highWaterMark) is true.
     assert!(high_water_mark >= 0.0);
 
     // Let stream be a new ReadableStream.
     // Perform ! InitializeReadableStream(stream).
-    let stream = ReadableStream::new_with_proto(global, None, can_gc);
+    let stream = ReadableStream::new_with_proto(global, None, CanGc::from_cx(cx));
 
     // Let controller be a new ReadableStreamDefaultController.
     let controller = ReadableStreamDefaultController::new(
@@ -878,13 +880,13 @@ pub(crate) fn create_readable_stream(
         underlying_source_type,
         high_water_mark,
         size_algorithm,
-        can_gc,
+        CanGc::from_cx(cx),
     );
 
     // Perform ? SetUpReadableStreamDefaultController(stream, controller, startAlgorithm,
     // pullAlgorithm, cancelAlgorithm, highWaterMark, sizeAlgorithm).
     controller
-        .setup(stream.clone(), can_gc)
+        .setup(cx, stream.clone())
         .expect("Setup of default controller cannot fail");
 
     // Return stream.
@@ -893,21 +895,22 @@ pub(crate) fn create_readable_stream(
 
 /// <https://streams.spec.whatwg.org/#abstract-opdef-createreadablebytestream>
 #[cfg_attr(crown, expect(crown::unrooted_must_root))]
-pub(crate) fn readable_byte_stream_tee(
+fn readable_byte_stream_tee(
+    cx: &mut js::context::JSContext,
     global: &GlobalScope,
     underlying_source_type: UnderlyingSourceType,
-    can_gc: CanGc,
 ) -> DomRoot<ReadableStream> {
     // Let stream be a new ReadableStream.
     // Perform ! InitializeReadableStream(stream).
-    let tee_stream = ReadableStream::new_with_proto(global, None, can_gc);
+    let tee_stream = ReadableStream::new_with_proto(global, None, CanGc::from_cx(cx));
 
     // Let controller be a new ReadableByteStreamController.
-    let controller = ReadableByteStreamController::new(underlying_source_type, 0.0, global, can_gc);
+    let controller =
+        ReadableByteStreamController::new(underlying_source_type, 0.0, global, CanGc::from_cx(cx));
 
     // Perform ? SetUpReadableByteStreamController(stream, controller, startAlgorithm, pullAlgorithm, cancelAlgorithm, 0, undefined).
     controller
-        .setup(global, tee_stream.clone(), can_gc)
+        .setup(cx, global, tee_stream.clone())
         .expect("Setup of byte stream controller cannot fail");
 
     // Return stream.
@@ -988,17 +991,17 @@ impl ReadableStream {
 
     /// Build a stream backed by a Rust source that has already been read into memory.
     pub(crate) fn new_from_bytes(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         bytes: Vec<u8>,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<ReadableStream>> {
         let stream = ReadableStream::new_with_external_underlying_source(
+            cx,
             global,
             UnderlyingSourceType::Memory(bytes.len()),
-            can_gc,
         )?;
-        stream.enqueue_native(bytes, can_gc);
-        stream.controller_close_native(can_gc);
+        stream.enqueue_native(bytes, CanGc::from_cx(cx));
+        stream.controller_close_native(CanGc::from_cx(cx));
         Ok(stream)
     }
 
@@ -1006,20 +1009,20 @@ impl ReadableStream {
     /// Note: external sources are always paired with a default controller.
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new_with_external_underlying_source(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         source: UnderlyingSourceType,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<ReadableStream>> {
         assert!(source.is_native());
-        let stream = ReadableStream::new_with_proto(global, None, can_gc);
+        let stream = ReadableStream::new_with_proto(global, None, CanGc::from_cx(cx));
         let controller = ReadableStreamDefaultController::new(
             global,
             source,
             1.0,
-            extract_size_algorithm(&QueuingStrategy::empty(), can_gc),
-            can_gc,
+            extract_size_algorithm(&QueuingStrategy::empty(), CanGc::from_cx(cx)),
+            CanGc::from_cx(cx),
         );
-        controller.setup(stream.clone(), can_gc)?;
+        controller.setup(cx, stream.clone())?;
         Ok(stream)
     }
 
@@ -1658,12 +1661,12 @@ impl ReadableStream {
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     /// <https://streams.spec.whatwg.org/#abstract-opdef-readablebytestreamtee>
-    fn byte_tee(&self, can_gc: CanGc) -> Fallible<Vec<DomRoot<ReadableStream>>> {
+    fn byte_tee(&self, cx: &mut js::context::JSContext) -> Fallible<Vec<DomRoot<ReadableStream>>> {
         // Assert: stream implements ReadableStream.
         // Assert: stream.[[controller]] implements ReadableByteStreamController.
 
         // Let reader be ? AcquireReadableStreamDefaultReader(stream).
-        let reader = self.acquire_default_reader(can_gc)?;
+        let reader = self.acquire_default_reader(CanGc::from_cx(cx))?;
         let reader = Rc::new(RefCell::new(ReaderType::Default(MutNullableDom::new(
             Some(&reader),
         ))));
@@ -1690,7 +1693,7 @@ impl ReadableStream {
         let reason_2 = Rc::new(Heap::boxed(UndefinedValue()));
 
         // Let cancelPromise be a new promise.
-        let cancel_promise = Promise::new(&self.global(), can_gc);
+        let cancel_promise = Promise::new2(cx, &self.global());
         let reader_version = Rc::new(Cell::new(0));
 
         let byte_tee_source_1 = ByteTeeUnderlyingSource::new(
@@ -1707,7 +1710,7 @@ impl ReadableStream {
             reader_version.clone(),
             ByteTeeCancelAlgorithm::Cancel1Algorithm,
             ByteTeePullAlgorithm::Pull1Algorithm,
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         let byte_tee_source_2 = ByteTeeUnderlyingSource::new(
@@ -1724,30 +1727,30 @@ impl ReadableStream {
             reader_version,
             ByteTeeCancelAlgorithm::Cancel2Algorithm,
             ByteTeePullAlgorithm::Pull2Algorithm,
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         // Set branch1 to ! CreateReadableByteStream(startAlgorithm, pull1Algorithm, cancel1Algorithm).
         let branch_1 = readable_byte_stream_tee(
+            cx,
             &self.global(),
             UnderlyingSourceType::TeeByte(Dom::from_ref(&byte_tee_source_1)),
-            can_gc,
         );
         byte_tee_source_1.set_branch_1(&branch_1);
         byte_tee_source_2.set_branch_1(&branch_1);
 
         // Set branch2 to ! CreateReadableByteStream(startAlgorithm, pull2Algorithm, cancel2Algorithm).
         let branch_2 = readable_byte_stream_tee(
+            cx,
             &self.global(),
             UnderlyingSourceType::TeeByte(Dom::from_ref(&byte_tee_source_2)),
-            can_gc,
         );
         byte_tee_source_1.set_branch_2(&branch_2);
         byte_tee_source_2.set_branch_2(&branch_2);
 
         // Perform forwardReaderError, given reader.
-        byte_tee_source_1.forward_reader_error(reader.clone(), can_gc);
-        byte_tee_source_2.forward_reader_error(reader, can_gc);
+        byte_tee_source_1.forward_reader_error(reader.clone(), CanGc::from_cx(cx));
+        byte_tee_source_2.forward_reader_error(reader, CanGc::from_cx(cx));
 
         // Return « branch1, branch2 ».
         Ok(vec![branch_1, branch_2])
@@ -1757,8 +1760,8 @@ impl ReadableStream {
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn default_tee(
         &self,
+        cx: &mut js::context::JSContext,
         clone_for_branch_2: bool,
-        can_gc: CanGc,
     ) -> Fallible<Vec<DomRoot<ReadableStream>>> {
         // Assert: stream implements ReadableStream.
 
@@ -1766,7 +1769,7 @@ impl ReadableStream {
         let clone_for_branch_2 = Rc::new(Cell::new(clone_for_branch_2));
 
         // Let reader be ? AcquireReadableStreamDefaultReader(stream).
-        let reader = self.acquire_default_reader(can_gc)?;
+        let reader = self.acquire_default_reader(CanGc::from_cx(cx))?;
 
         // Let reading be false.
         let reading = Rc::new(Cell::new(false));
@@ -1782,7 +1785,7 @@ impl ReadableStream {
         // Let reason2 be undefined.
         let reason_2 = Rc::new(Heap::boxed(UndefinedValue()));
         // Let cancelPromise be a new promise.
-        let cancel_promise = Promise::new(&self.global(), can_gc);
+        let cancel_promise = Promise::new2(cx, &self.global());
 
         let tee_source_1 = DefaultTeeUnderlyingSource::new(
             &reader,
@@ -1796,7 +1799,7 @@ impl ReadableStream {
             reason_2.clone(),
             cancel_promise.clone(),
             DefaultTeeCancelAlgorithm::Cancel1Algorithm,
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         let underlying_source_type_branch_1 =
@@ -1814,7 +1817,7 @@ impl ReadableStream {
             reason_2,
             cancel_promise.clone(),
             DefaultTeeCancelAlgorithm::Cancel2Algorithm,
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         let underlying_source_type_branch_2 =
@@ -1822,22 +1825,22 @@ impl ReadableStream {
 
         // Set branch_1 to ! CreateReadableStream(startAlgorithm, pullAlgorithm, cancel1Algorithm).
         let branch_1 = create_readable_stream(
+            cx,
             &self.global(),
             underlying_source_type_branch_1,
             None,
             None,
-            can_gc,
         );
         tee_source_1.set_branch_1(&branch_1);
         tee_source_2.set_branch_1(&branch_1);
 
         // Set branch_2 to ! CreateReadableStream(startAlgorithm, pullAlgorithm, cancel2Algorithm).
         let branch_2 = create_readable_stream(
+            cx,
             &self.global(),
             underlying_source_type_branch_2,
             None,
             None,
-            can_gc,
         );
         tee_source_1.set_branch_2(&branch_2);
         tee_source_2.set_branch_2(&branch_2);
@@ -1849,7 +1852,7 @@ impl ReadableStream {
             canceled_1,
             canceled_2,
             cancel_promise,
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         // Return « branch_1, branch_2 ».
@@ -1960,8 +1963,8 @@ impl ReadableStream {
     /// <https://streams.spec.whatwg.org/#readable-stream-tee>
     pub(crate) fn tee(
         &self,
+        cx: &mut js::context::JSContext,
         clone_for_branch_2: bool,
-        can_gc: CanGc,
     ) -> Fallible<Vec<DomRoot<ReadableStream>>> {
         // Assert: stream implements ReadableStream.
         // Assert: cloneForBranch2 is a boolean.
@@ -1969,12 +1972,12 @@ impl ReadableStream {
         match self.controller.borrow().as_ref() {
             Some(ControllerType::Default(_)) => {
                 // Return ? ReadableStreamDefaultTee(stream, cloneForBranch2).
-                self.default_tee(clone_for_branch_2, can_gc)
+                self.default_tee(cx, clone_for_branch_2)
             },
             Some(ControllerType::Byte(_)) => {
                 // If stream.[[controller]] implements ReadableByteStreamController,
                 // return ? ReadableByteStreamTee(stream).
-                self.byte_tee(can_gc)
+                self.byte_tee(cx)
             },
             None => {
                 unreachable!("Stream should have a controller.");
@@ -1983,14 +1986,14 @@ impl ReadableStream {
     }
 
     /// <https://streams.spec.whatwg.org/#set-up-readable-byte-stream-controller-from-underlying-source>
-    pub(crate) fn set_up_byte_controller(
+    fn set_up_byte_controller(
         &self,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         underlying_source_dict: JsUnderlyingSource,
         underlying_source_handle: SafeHandleObject,
         stream: DomRoot<ReadableStream>,
         strategy_hwm: f64,
-        can_gc: CanGc,
     ) -> Fallible<()> {
         // Let pullAlgorithm be an algorithm that returns a promise resolved with undefined.
         // Let cancelAlgorithm be an algorithm that returns a promise resolved with undefined.
@@ -2015,7 +2018,7 @@ impl ReadableStream {
             UnderlyingSourceType::Js(underlying_source_dict, Heap::default()),
             strategy_hwm,
             global,
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         // Note: this must be done before `setup`,
@@ -2024,7 +2027,7 @@ impl ReadableStream {
 
         // Perform ? SetUpReadableByteStreamController(stream, controller, startAlgorithm,
         // pullAlgorithm, cancelAlgorithm, highWaterMark, autoAllocateChunkSize).
-        controller.setup(global, stream, can_gc)
+        controller.setup(cx, global, stream)
     }
 
     /// <https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformreadable>
@@ -2066,7 +2069,7 @@ impl ReadableStream {
 
         // Perform ! SetUpReadableStreamDefaultController
         controller
-            .setup(DomRoot::from_ref(self), CanGc::from_cx(cx))
+            .setup(cx, DomRoot::from_ref(self))
             .expect("Setting up controller for transfer cannot fail.");
     }
 }
@@ -2074,20 +2077,19 @@ impl ReadableStream {
 impl ReadableStreamMethods<crate::DomTypeHolder> for ReadableStream {
     /// <https://streams.spec.whatwg.org/#rs-constructor>
     fn Constructor(
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         proto: Option<SafeHandleObject>,
-        can_gc: CanGc,
         underlying_source: Option<*mut JSObject>,
         strategy: &QueuingStrategy,
     ) -> Fallible<DomRoot<Self>> {
         // If underlyingSource is missing, set it to null.
-        rooted!(in(*cx) let underlying_source_obj = underlying_source.unwrap_or(ptr::null_mut()));
+        rooted!(&in(cx) let underlying_source_obj = underlying_source.unwrap_or(ptr::null_mut()));
         // Let underlyingSourceDict be underlyingSource,
         // converted to an IDL value of type UnderlyingSource.
         let underlying_source_dict = if !underlying_source_obj.is_null() {
-            rooted!(in(*cx) let obj_val = ObjectValue(underlying_source_obj.get()));
-            match JsUnderlyingSource::new(cx, obj_val.handle(), can_gc) {
+            rooted!(&in(cx) let obj_val = ObjectValue(underlying_source_obj.get()));
+            match JsUnderlyingSource::new(cx.into(), obj_val.handle(), CanGc::from_cx(cx)) {
                 Ok(ConversionResult::Success(val)) => val,
                 Ok(ConversionResult::Failure(error)) => {
                     return Err(Error::Type(error.into_owned()));
@@ -2101,7 +2103,7 @@ impl ReadableStreamMethods<crate::DomTypeHolder> for ReadableStream {
         };
 
         // Perform ! InitializeReadableStream(this).
-        let stream = ReadableStream::new_with_proto(global, proto, can_gc);
+        let stream = ReadableStream::new_with_proto(global, proto, CanGc::from_cx(cx));
 
         if underlying_source_dict.type_.is_some() {
             // If strategy["size"] exists, throw a RangeError exception.
@@ -2117,26 +2119,26 @@ impl ReadableStreamMethods<crate::DomTypeHolder> for ReadableStream {
             // Perform ? SetUpReadableByteStreamControllerFromUnderlyingSource(this,
             // underlyingSource, underlyingSourceDict, highWaterMark).
             stream.set_up_byte_controller(
+                cx,
                 global,
                 underlying_source_dict,
                 underlying_source_obj.handle(),
                 stream.clone(),
                 strategy_hwm,
-                can_gc,
             )?;
         } else {
             // Let highWaterMark be ? ExtractHighWaterMark(strategy, 1).
             let high_water_mark = extract_high_water_mark(strategy, 1.0)?;
 
             // Let sizeAlgorithm be ! ExtractSizeAlgorithm(strategy).
-            let size_algorithm = extract_size_algorithm(strategy, can_gc);
+            let size_algorithm = extract_size_algorithm(strategy, CanGc::from_cx(cx));
 
             let controller = ReadableStreamDefaultController::new(
                 global,
                 UnderlyingSourceType::Js(underlying_source_dict, Heap::default()),
                 high_water_mark,
                 size_algorithm,
-                can_gc,
+                CanGc::from_cx(cx),
             );
 
             // Note: this must be done before `setup`,
@@ -2144,7 +2146,7 @@ impl ReadableStreamMethods<crate::DomTypeHolder> for ReadableStream {
             controller.set_underlying_source_this_object(underlying_source_obj.handle());
 
             // Perform ? SetUpReadableStreamDefaultControllerFromUnderlyingSource
-            controller.setup(stream.clone(), can_gc)?;
+            controller.setup(cx, stream.clone())?;
         };
 
         Ok(stream)
@@ -2195,9 +2197,9 @@ impl ReadableStreamMethods<crate::DomTypeHolder> for ReadableStream {
     }
 
     /// <https://streams.spec.whatwg.org/#rs-tee>
-    fn Tee(&self, can_gc: CanGc) -> Fallible<Vec<DomRoot<ReadableStream>>> {
+    fn Tee(&self, cx: &mut js::context::JSContext) -> Fallible<Vec<DomRoot<ReadableStream>>> {
         // Return ? ReadableStreamTee(this, false).
-        self.tee(false, can_gc)
+        self.tee(cx, false)
     }
 
     /// <https://streams.spec.whatwg.org/#rs-pipe-to>

--- a/components/script/dom/stream/readablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/readablestreamdefaultcontroller.rs
@@ -33,7 +33,7 @@ use crate::dom::stream::readablestreamdefaultreader::ReadRequest;
 use crate::dom::stream::underlyingsourcecontainer::{
     UnderlyingSourceContainer, UnderlyingSourceType,
 };
-use crate::realms::{InRealm, enter_realm};
+use crate::realms::{InRealm, enter_auto_realm, enter_realm};
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 
 /// The fulfillment handler for
@@ -395,8 +395,8 @@ impl ReadableStreamDefaultController {
     /// <https://streams.spec.whatwg.org/#set-up-readable-stream-default-controller>
     pub(crate) fn setup(
         &self,
+        cx: &mut js::context::JSContext,
         stream: DomRoot<ReadableStream>,
-        can_gc: CanGc,
     ) -> Result<(), Error> {
         // Assert: stream.[[controller]] is undefined
         stream.assert_no_controller();
@@ -425,12 +425,11 @@ impl ReadableStreamDefaultController {
             // Let startResult be the result of performing startAlgorithm. (This might throw an exception.)
             let start_result = underlying_source
                 .call_start_algorithm(
+                    cx,
                     Controller::ReadableStreamDefaultController(rooted_default_controller.clone()),
-                    can_gc,
                 )
                 .unwrap_or_else(|| {
-                    let promise = Promise::new(global, can_gc);
-                    promise.resolve_native(&(), can_gc);
+                    let promise = Promise::new_resolved(global, cx.into(), (), CanGc::from_cx(cx));
                     Ok(promise)
                 });
 
@@ -446,11 +445,13 @@ impl ReadableStreamDefaultController {
                 Some(Box::new(StartAlgorithmRejectionHandler {
                     controller: Dom::from_ref(&rooted_default_controller),
                 })),
-                can_gc,
+                CanGc::from_cx(cx),
             );
-            let realm = enter_realm(global);
-            let comp = InRealm::Entered(&realm);
-            start_promise.append_native_handler(&handler, comp, can_gc);
+            let mut realm = enter_auto_realm(cx, global);
+            let cx = &mut realm.current_realm();
+            let in_realm_proof = cx.into();
+            let comp = InRealm::Already(&in_realm_proof);
+            start_promise.append_native_handler(&handler, comp, CanGc::from_cx(cx));
         };
 
         Ok(())

--- a/components/script/dom/stream/transformstream.rs
+++ b/components/script/dom/stream/transformstream.rs
@@ -562,11 +562,11 @@ impl TransformStream {
         // cancelAlgorithm, readableHighWaterMark, readableSizeAlgorithm).
 
         let readable = create_readable_stream(
+            cx,
             global,
             UnderlyingSourceType::Transform(Dom::from_ref(self), start_promise),
             Some(readable_size_algorithm),
             Some(readable_high_water_mark),
-            CanGc::from_cx(cx),
         );
         self.readable.set(Some(&readable));
 

--- a/components/script/dom/stream/underlyingsourcecontainer.rs
+++ b/components/script/dom/stream/underlyingsourcecontainer.rs
@@ -246,22 +246,21 @@ impl UnderlyingSourceContainer {
     #[expect(unsafe_code)]
     pub(crate) fn call_start_algorithm(
         &self,
+        cx: &mut js::context::JSContext,
         controller: Controller,
-        can_gc: CanGc,
     ) -> Option<Result<Rc<Promise>, Error>> {
         match &self.underlying_source_type {
             UnderlyingSourceType::Js(source, this_obj) => {
                 if let Some(start) = &source.start {
-                    let cx = GlobalScope::get_cx();
-                    rooted!(in(*cx) let mut result_object = ptr::null_mut::<JSObject>());
-                    rooted!(in(*cx) let mut result: JSVal);
+                    rooted!(&in(cx) let mut result_object = ptr::null_mut::<JSObject>());
+                    rooted!(&in(cx) let mut result: JSVal);
                     unsafe {
                         if let Err(error) = start.Call_(
                             &SafeHandle::from_raw(this_obj.handle()),
                             controller,
                             result.handle_mut(),
                             ExceptionHandling::Rethrow,
-                            can_gc,
+                            CanGc::from_cx(cx),
                         ) {
                             return Some(Err(error));
                         }
@@ -275,11 +274,14 @@ impl UnderlyingSourceContainer {
                         }
                     };
                     let promise = if is_promise {
-                        Promise::new_with_js_promise(result_object.handle(), cx)
+                        Promise::new_with_js_promise(result_object.handle(), cx.into())
                     } else {
-                        let promise = Promise::new(&self.global(), can_gc);
-                        promise.resolve_native(&result.get(), can_gc);
-                        promise
+                        Promise::new_resolved(
+                            &self.global(),
+                            cx.into(),
+                            result.get(),
+                            CanGc::from_cx(cx),
+                        )
                     };
                     return Some(Ok(promise));
                 }

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -557,7 +557,6 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
         cx: &mut js::context::JSContext,
         data: Option<DocumentOrXMLHttpRequestBodyInit>,
     ) -> ErrorResult {
-        let can_gc = CanGc::from_cx(cx);
         // Step 1. If this’s state is not opened, then throw an "InvalidStateError" DOMException.
         // Step 2. If this’s send() flag is set, then throw an "InvalidStateError" DOMException.
         if self.ready_state.get() != XMLHttpRequestState::Opened || self.send_flag.get() {
@@ -581,7 +580,7 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
                 };
                 let total_bytes = bytes.len();
                 let global = self.global();
-                let stream = ReadableStream::new_from_bytes(&global, bytes, can_gc)?;
+                let stream = ReadableStream::new_from_bytes(cx, &global, bytes)?;
                 Some(ExtractedBody {
                     stream,
                     total_bytes: Some(total_bytes),
@@ -618,7 +617,7 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
                 let bytes = typedarray.to_vec();
                 let total_bytes = bytes.len();
                 let global = self.global();
-                let stream = ReadableStream::new_from_bytes(&global, bytes, can_gc)?;
+                let stream = ReadableStream::new_from_bytes(cx, &global, bytes)?;
                 Some(ExtractedBody {
                     stream,
                     total_bytes: Some(total_bytes),
@@ -630,7 +629,7 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
                 let bytes = typedarray.to_vec();
                 let total_bytes = bytes.len();
                 let global = self.global();
-                let stream = ReadableStream::new_from_bytes(&global, bytes, can_gc)?;
+                let stream = ReadableStream::new_from_bytes(cx, &global, bytes)?;
                 Some(ExtractedBody {
                     stream,
                     total_bytes: Some(total_bytes),

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -219,7 +219,7 @@ pub(crate) fn Fetch(
 
     // Step 7. Let responseObject be null.
     // NOTE: We do initialize the object earlier earlier so we can use it to track errors
-    let response = Response::new(global, CanGc::from_cx(cx));
+    let response = Response::new(cx, global);
     response
         .Headers(CanGc::from_cx(cx))
         .set_guard(Guard::Immutable);

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -48,9 +48,7 @@ DOMInterfaces = {
 
 'Blob': {
     'weakReferenceable': True,
-    'canGc': ['ArrayBuffer', 'Bytes'],
-    'inRealms': ['Bytes', 'ArrayBuffer'],
-    'realm': ['Text'],
+    'realm': ['ArrayBuffer', 'Bytes', 'Text'],
     'cx': ['Stream', 'Slice', 'Constructor']
 },
 
@@ -819,12 +817,12 @@ DOMInterfaces = {
 
 'Request': {
     'canGc': ['Headers', 'Text', 'Blob', 'FormData', 'Json', 'ArrayBuffer', 'Clone', 'Bytes'],
-    'cx': ['Constructor'],
+    'cx': ['Clone', 'Constructor'],
 },
 
 'Response': {
-    'canGc': ['Error', 'Redirect', 'Clone', 'Text', 'Blob', 'FormData', 'Json', 'ArrayBuffer', 'Headers', 'Bytes'],
-    'cx': ['Constructor', 'CreateFromJson'],
+    'canGc': ['Text', 'Blob', 'FormData', 'Json', 'ArrayBuffer', 'Headers', 'Bytes'],
+    'cx': ['Clone', 'Constructor', 'CreateFromJson', 'Error', 'Redirect'],
 },
 
 'RTCPeerConnection': {
@@ -1076,9 +1074,9 @@ DOMInterfaces = {
 },
 
 'ReadableStream': {
-    'canGc': ['GetReader', 'Tee'],
+    'canGc': ['GetReader'],
     'realm': ['PipeTo', 'PipeThrough'],
-    'cx': ['Cancel']
+    'cx': ['Cancel', 'Constructor', 'Tee']
 },
 
 "ReadableStreamDefaultController": {


### PR DESCRIPTION
Pass `&mut JSContext` to more stream code, a couple of `CanGc::deprecated_note()` are needed until `ReadAllBytesSuccessSteps` signature is modified to accept `&mut JSContext`.

Testing: It compiles
Part of #40600
