### PR TITLE
script: Propagate &mut JSContext to `HTMLElement::Focus/Blur`

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -1205,7 +1205,7 @@ impl Document {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#scroll-to-the-fragment-identifier>
-    pub(crate) fn scroll_to_the_fragment(&self, fragment: &str, can_gc: CanGc) {
+    pub(crate) fn scroll_to_the_fragment(&self, cx: &mut js::context::JSContext, fragment: &str) {
         // Step 1. If document's indicated part is null, then set document's target element to null.
         //
         // > For an HTML document document, its indicated part is the result of
@@ -1247,7 +1247,7 @@ impl Document {
 
         // Step 3.6. Run the focusing steps for target, with the Document's viewport as the fallback
         // target.
-        indicated_part.run_the_focusing_steps(Some(FocusableArea::Viewport), can_gc);
+        indicated_part.run_the_focusing_steps(cx, Some(FocusableArea::Viewport));
 
         // Step 3.7. Move the sequential focus navigation starting point to target.
         self.event_handler()
@@ -2270,7 +2270,7 @@ impl Document {
                 // TODO
 
                 if let Some(fragment) = document.url().fragment() {
-                    document.scroll_to_the_fragment(fragment, CanGc::from_cx(cx));
+                    document.scroll_to_the_fragment(cx, fragment);
                 }
             }));
 

--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -926,7 +926,7 @@ impl DocumentEventHandler {
                     self.window
                         .Document()
                         .focus_handler()
-                        .focus(node.find_click_focusable_area(), CanGc::from_cx(cx));
+                        .focus(cx, node.find_click_focusable_area());
                 }
 
                 // Step 9. If mbutton is the secondary mouse button, then
@@ -1444,9 +1444,7 @@ impl DocumentEventHandler {
         let document = self.window.Document();
         let composition_event = match event {
             ImeEvent::Dismissed => {
-                document
-                    .focus_handler()
-                    .focus(FocusableArea::Viewport, CanGc::from_cx(cx));
+                document.focus_handler().focus(cx, FocusableArea::Viewport);
                 return Default::default();
             },
             ImeEvent::Composition(composition_event) => composition_event,
@@ -1976,7 +1974,7 @@ impl DocumentEventHandler {
                 // > If the key is the Tab key, the default action MUST be to shift the document focus
                 // > from the currently focused element (if any) to the new focused element, as
                 // > described in Focus Event Types
-                self.sequential_focus_navigation_via_keyboard_event(event, CanGc::from_cx(cx));
+                self.sequential_focus_navigation_via_keyboard_event(cx, event);
                 return;
             },
             _ => return,
@@ -2000,18 +1998,22 @@ impl DocumentEventHandler {
             .filter(|node| node.is_connected())
     }
 
-    fn sequential_focus_navigation_via_keyboard_event(&self, event: &KeyboardEvent, can_gc: CanGc) {
+    fn sequential_focus_navigation_via_keyboard_event(
+        &self,
+        cx: &mut JSContext,
+        event: &KeyboardEvent,
+    ) {
         let direction = if event.modifiers().contains(Modifiers::SHIFT) {
             SequentialFocusDirection::Backward
         } else {
             SequentialFocusDirection::Forward
         };
 
-        self.sequential_focus_navigation(direction, can_gc);
+        self.sequential_focus_navigation(cx, direction);
     }
 
     /// <<https://html.spec.whatwg.org/multipage/#sequential-focus-navigation:currently-focused-area-of-a-top-level-traversable>
-    fn sequential_focus_navigation(&self, direction: SequentialFocusDirection, can_gc: CanGc) {
+    fn sequential_focus_navigation(&self, cx: &mut JSContext, direction: SequentialFocusDirection) {
         // > When the user requests that focus move from the currently focused area of a top-level
         // > traversable to the next or previous focusable area (e.g., as the default action of
         // > pressing the tab key), or when the user requests that focus sequentially move to a
@@ -2070,7 +2072,7 @@ impl DocumentEventHandler {
 
         // > 6. If candidate is not null, then run the focusing steps for candidate and return.
         if let Some(candidate) = candidate {
-            self.focus_and_scroll_to_element_for_key_event(&candidate, can_gc);
+            self.focus_and_scroll_to_element_for_key_event(cx, &candidate);
             return;
         }
 
@@ -2503,15 +2505,13 @@ impl DocumentEventHandler {
 
         // This behavior is unspecified, but all browsers do this. When activating the element it is
         // focused and scrolled into view.
-        self.focus_and_scroll_to_element_for_key_event(html_element.upcast(), CanGc::from_cx(cx));
+        self.focus_and_scroll_to_element_for_key_event(cx, html_element.upcast());
         command.perform_action(cx);
         true
     }
 
-    fn focus_and_scroll_to_element_for_key_event(&self, element: &Element, can_gc: CanGc) {
-        element
-            .upcast::<Node>()
-            .run_the_focusing_steps(None, can_gc);
+    fn focus_and_scroll_to_element_for_key_event(&self, cx: &mut JSContext, element: &Element) {
+        element.upcast::<Node>().run_the_focusing_steps(cx, None);
         let scroll_axis = ScrollAxisState {
             position: ScrollLogicalPosition::Center,
             requirement: ScrollRequirement::IfNotVisible,

--- a/components/script/dom/document/focus.rs
+++ b/components/script/dom/document/focus.rs
@@ -6,6 +6,7 @@ use std::cell::{Cell, Ref};
 
 use bitflags::bitflags;
 use embedder_traits::FocusSequenceNumber;
+use js::context::JSContext;
 use script_bindings::codegen::GenericBindings::ShadowRootBinding::ShadowRootMethods;
 use script_bindings::inheritance::Castable;
 use script_bindings::root::{Dom, DomRoot};
@@ -241,10 +242,10 @@ impl DocumentFocusHandler {
 
     /// Reassign the focus context to the element that last requested focus during this
     /// transaction, or the document if no elements requested it.
-    pub(crate) fn focus(&self, new_focus_target: FocusableArea, can_gc: CanGc) {
+    pub(crate) fn focus(&self, cx: &mut JSContext, new_focus_target: FocusableArea) {
         let old_focus_chain = self.current_focus_chain();
         let new_focus_chain = new_focus_target.focus_chain();
-        self.focus_update_steps(new_focus_chain, old_focus_chain, &new_focus_target, can_gc);
+        self.focus_update_steps(cx, new_focus_chain, old_focus_chain, &new_focus_target);
 
         // Advertise the change in the focus chain.
         // <https://html.spec.whatwg.org/multipage/#focus-chain>
@@ -292,10 +293,10 @@ impl DocumentFocusHandler {
     /// <https://html.spec.whatwg.org/multipage/#focus-update-steps>
     pub(crate) fn focus_update_steps(
         &self,
+        cx: &mut JSContext,
         mut new_focus_chain: Vec<FocusableArea>,
         mut old_focus_chain: Vec<FocusableArea>,
         new_focus_target: &FocusableArea,
-        can_gc: CanGc,
     ) {
         let new_focus_chain_was_empty = new_focus_chain.is_empty();
 
@@ -379,10 +380,10 @@ impl DocumentFocusHandler {
             // blur event target, with related blur target as the related target.
             if let Some(blur_event_target) = blur_event_target {
                 self.fire_focus_event(
+                    cx,
                     FocusEventType::Blur,
                     blur_event_target,
                     related_blur_target,
-                    can_gc,
                 );
             }
         }
@@ -395,7 +396,7 @@ impl DocumentFocusHandler {
                 .element()
                 .and_then(|element| element.downcast::<HTMLElement>())
             {
-                html_element.handle_focus_state_for_contenteditable(can_gc);
+                html_element.handle_focus_state_for_contenteditable(cx);
             }
         }
 
@@ -457,10 +458,10 @@ impl DocumentFocusHandler {
             // focus event target, with related focus target as the related target.
             if let Some(focus_event_target) = focus_event_target {
                 self.fire_focus_event(
+                    cx,
                     FocusEventType::Focus,
                     focus_event_target,
                     related_focus_target,
-                    can_gc,
                 );
             }
         }
@@ -469,10 +470,10 @@ impl DocumentFocusHandler {
     /// <https://html.spec.whatwg.org/multipage/#fire-a-focus-event>
     pub(crate) fn fire_focus_event(
         &self,
+        cx: &mut JSContext,
         focus_event_type: FocusEventType,
         event_target: &EventTarget,
         related_target: Option<&EventTarget>,
-        can_gc: CanGc,
     ) {
         let event_name = match focus_event_type {
             FocusEventType::Focus => "focus".into(),
@@ -487,11 +488,11 @@ impl DocumentFocusHandler {
             Some(&self.window),
             0i32,
             related_target,
-            can_gc,
+            CanGc::from_cx(cx),
         );
         let event = event.upcast::<Event>();
         event.set_trusted(true);
-        event.fire(event_target, can_gc);
+        event.fire(event_target, CanGc::from_cx(cx));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#focus-fixup-rule>
@@ -500,7 +501,7 @@ impl DocumentFocusHandler {
     /// > focus changed during ongoing navigation to false.
     ///
     /// TODO: Handle the "focus changed during ongoing navigation" flag.
-    pub(crate) fn perform_focus_fixup_rule(&self, can_gc: CanGc) {
+    pub(crate) fn perform_focus_fixup_rule(&self, cx: &mut JSContext) {
         if self
             .focused_area
             .borrow()
@@ -509,6 +510,6 @@ impl DocumentFocusHandler {
         {
             return;
         }
-        self.focus(FocusableArea::Viewport, can_gc);
+        self.focus(cx, FocusableArea::Viewport);
     }
 }

--- a/components/script/dom/execcommand/contenteditable/htmlelement.rs
+++ b/components/script/dom/execcommand/contenteditable/htmlelement.rs
@@ -173,17 +173,17 @@ impl HTMLElement {
     /// There is no specification for this implementation. Instead, it is
     /// reverse-engineered based on the WPT test
     /// /selection/contenteditable/initial-selection-on-focus.tentative.html
-    pub(crate) fn handle_focus_state_for_contenteditable(&self, can_gc: CanGc) {
+    pub(crate) fn handle_focus_state_for_contenteditable(&self, cx: &mut JSContext) {
         if !self.is_editing_host() {
             return;
         }
         let document = self.owner_document();
-        let Some(selection) = document.GetSelection(can_gc) else {
+        let Some(selection) = document.GetSelection(CanGc::from_cx(cx)) else {
             return;
         };
         let range = self
             .upcast::<Element>()
-            .ensure_contenteditable_selection_range(&document, can_gc);
+            .ensure_contenteditable_selection_range(&document, CanGc::from_cx(cx));
         // If the current range is already associated with this contenteditable
         // element, then we shouldn't do anything. This is important when focus
         // is lost and regained, but selection was changed beforehand. In that

--- a/components/script/dom/history.rs
+++ b/components/script/dom/history.rs
@@ -87,9 +87,9 @@ impl History {
     /// Steps 5-16
     pub(crate) fn activate_state(
         &self,
+        cx: &mut JSContext,
         state_id: Option<HistoryStateId>,
         url: ServoUrl,
-        can_gc: CanGc,
     ) {
         // Steps 5
         let document = self.window.Document();
@@ -101,7 +101,7 @@ impl History {
 
         // Step 8
         if let Some(fragment) = url.fragment() {
-            document.scroll_to_the_fragment(fragment, can_gc);
+            document.scroll_to_the_fragment(cx, fragment);
         }
 
         // Step 11
@@ -132,7 +132,7 @@ impl History {
                     self.window.as_global_scope(),
                     data,
                     state.handle_mut(),
-                    can_gc,
+                    CanGc::from_cx(cx),
                 )
                 .is_err()
                 {
@@ -152,7 +152,7 @@ impl History {
                 self.window.upcast::<EventTarget>(),
                 &self.window,
                 self.state.as_handle_value(),
-                can_gc,
+                CanGc::from_cx(cx),
             );
         }
 
@@ -165,11 +165,11 @@ impl History {
                 false,
                 old_url.into_string(),
                 url.into_string(),
-                can_gc,
+                CanGc::from_cx(cx),
             );
             event
                 .upcast::<Event>()
-                .fire(self.window.upcast::<EventTarget>(), can_gc);
+                .fire(self.window.upcast::<EventTarget>(), CanGc::from_cx(cx));
         }
     }
 

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -458,12 +458,12 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-focus>
-    fn Focus(&self, options: &FocusOptions, can_gc: CanGc) {
+    fn Focus(&self, cx: &mut JSContext, options: &FocusOptions) {
         // 1. If the allow focus steps given this's node document return false, then return.
         // TODO: Implement this.
 
         // 2. Run the focusing steps for this.
-        if !self.upcast::<Node>().run_the_focusing_steps(None, can_gc) {
+        if !self.upcast::<Node>().run_the_focusing_steps(cx, None) {
             // The specification seems to imply we should scroll into view even if this element
             // is not a focusable area. No browser does this, so we return early in that case.
             // See https://github.com/whatwg/html/issues/12231.
@@ -492,7 +492,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-blur>
-    fn Blur(&self, can_gc: CanGc) {
+    fn Blur(&self, cx: &mut JSContext) {
         // TODO: Run the unfocusing steps. Focus the top-level document, not
         //       the current document.
         if !self.as_element().focus_state() {
@@ -501,7 +501,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
         // <https://html.spec.whatwg.org/multipage/#unfocusing-steps>
         self.owner_document()
             .focus_handler()
-            .focus(FocusableArea::Viewport, can_gc);
+            .focus(cx, FocusableArea::Viewport);
     }
 
     /// <https://drafts.csswg.org/cssom-view/#dom-htmlelement-scrollparent>

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -1186,7 +1186,7 @@ impl HTMLFormElement {
                     // some other action that brings the element to the user's attention.
 
                     // Here we run focusing steps and scroll element into view.
-                    html_elem.Focus(&FocusOptions::default(), CanGc::from_cx(cx));
+                    html_elem.Focus(cx, &FocusOptions::default());
                     first = false;
                 }
             }

--- a/components/script/dom/html/interactive_element_command.rs
+++ b/components/script/dom/html/interactive_element_command.rs
@@ -187,7 +187,7 @@ impl InteractiveElementCommand {
             // >  2. Fire a click event at the element.
             InteractiveElementCommand::HTMLElement(html_element) => {
                 let node: &Node = html_element.upcast();
-                node.run_the_focusing_steps(None, CanGc::from_cx(cx));
+                node.run_the_focusing_steps(cx, None);
                 node.fire_synthetic_pointer_event_not_trusted(atom!("click"), CanGc::from_cx(cx));
             },
         }

--- a/components/script/dom/node/focus.rs
+++ b/components/script/dom/node/focus.rs
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use js::context::JSContext;
 use script_bindings::codegen::GenericBindings::ShadowRootBinding::ShadowRootMethods;
 use script_bindings::inheritance::Castable;
 use script_bindings::root::DomRoot;
-use script_bindings::script_runtime::CanGc;
 
 use crate::dom::document::focus::{FocusableArea, FocusableAreaKind};
 use crate::dom::types::{Element, HTMLDialogElement, HTMLIFrameElement};
@@ -205,8 +205,8 @@ impl Node {
     /// Return `true` if anything was focused or `false` otherwise.
     pub(crate) fn run_the_focusing_steps(
         &self,
+        cx: &mut JSContext,
         fallback_target: Option<FocusableArea>,
-        can_gc: CanGc,
     ) -> bool {
         // > 1. If new focus target is not a focusable area, then set new focus target to the result
         // >    of getting the focusable area for new focus target, given focus trigger if it was
@@ -232,7 +232,7 @@ impl Node {
         // TODO: Handle all of these steps by converting the focus transaction code to follow
         // the HTML focus specification.
         let document = self.owner_document();
-        document.focus_handler().focus(focusable_area, can_gc);
+        document.focus_handler().focus(cx, focusable_area);
         true
     }
 }

--- a/components/script/dom/svg/svgelement.rs
+++ b/components/script/dom/svg/svgelement.rs
@@ -149,10 +149,7 @@ impl SVGElementMethods<crate::DomTypeHolder> for SVGElement {
         // TODO: Implement this.
 
         // 2. Run the focusing steps for this.
-        if !self
-            .upcast::<Node>()
-            .run_the_focusing_steps(None, CanGc::from_cx(cx))
-        {
+        if !self.upcast::<Node>().run_the_focusing_steps(cx, None) {
             // The specification seems to imply we should scroll into view even if this element
             // is not a focusable area. No browser does this, so we return early in that case.
             // See https://github.com/whatwg/html/issues/12231.
@@ -191,7 +188,7 @@ impl SVGElementMethods<crate::DomTypeHolder> for SVGElement {
         // <https://html.spec.whatwg.org/multipage/#unfocusing-steps>
         self.owner_document()
             .focus_handler()
-            .focus(FocusableArea::Viewport, CanGc::from_cx(cx));
+            .focus(cx, FocusableArea::Viewport);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-tabindex>

--- a/components/script/dom/validation.rs
+++ b/components/script/dom/validation.rs
@@ -80,7 +80,7 @@ pub(crate) trait Validatable {
             );
             if let Some(html_elem) = self.as_element().downcast::<HTMLElement>() {
                 // Run focusing steps and scroll into view.
-                html_elem.Focus(&FocusOptions::default(), CanGc::from_cx(cx));
+                html_elem.Focus(cx, &FocusOptions::default());
             }
         }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1298,9 +1298,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
         // TODO: Implement this.
 
         // Step 4. Run the focusing steps with current.
-        document
-            .focus_handler()
-            .focus(FocusableArea::Viewport, CanGc::from_cx(cx));
+        document.focus_handler().focus(cx, FocusableArea::Viewport);
 
         // Step 5. If current is a top-level traversable, user agents are encouraged to trigger some
         // sort of notification to indicate to the user that the page is attempting to gain focus.

--- a/components/script/navigation.rs
+++ b/components/script/navigation.rs
@@ -350,7 +350,7 @@ fn navigate_to_fragment(
     let Some(fragment) = url.fragment() else {
         unreachable!("Must always have a fragment");
     };
-    doc.scroll_to_the_fragment(fragment, CanGc::from_cx(cx));
+    doc.scroll_to_the_fragment(cx, fragment);
     // Step 16. Let traversable be navigable's traversable navigable.
     // TODO
     // Step 17. Append the following session history synchronous navigation steps involving navigable to traversable:

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1252,9 +1252,7 @@ impl ScriptThread {
             // > For each doc of docs, if the focused area of doc is not a focusable area, then run the
             // > focusing steps for doc's viewport, and set doc's relevant global object's navigation API's
             // > focus changed during ongoing navigation to false.
-            document
-                .focus_handler()
-                .perform_focus_fixup_rule(CanGc::from_cx(cx));
+            document.focus_handler().perform_focus_fixup_rule(cx);
 
             // TODO: Perform pending transition operations from
             // https://drafts.csswg.org/css-view-transitions/#perform-pending-transition-operations.
@@ -1824,13 +1822,9 @@ impl ScriptThread {
                 reason,
                 cx,
             ),
-            ScriptThreadMessage::UpdateHistoryState(pipeline_id, history_state_id, url) => self
-                .handle_update_history_state_msg(
-                    pipeline_id,
-                    history_state_id,
-                    url,
-                    CanGc::from_cx(cx),
-                ),
+            ScriptThreadMessage::UpdateHistoryState(pipeline_id, history_state_id, url) => {
+                self.handle_update_history_state_msg(cx, pipeline_id, history_state_id, url)
+            },
             ScriptThreadMessage::RemoveHistoryStates(pipeline_id, history_states) => {
                 self.handle_remove_history_states(pipeline_id, history_states)
             },
@@ -2862,10 +2856,10 @@ impl ScriptThread {
             .unwrap_or(FocusableArea::Viewport);
 
         focus_handler.focus_update_steps(
+            cx,
             focusable_area.focus_chain(),
             focus_handler.current_focus_chain(),
             &focusable_area,
-            CanGc::from_cx(cx),
         );
     }
 
@@ -2907,10 +2901,10 @@ impl ScriptThread {
         }
 
         focus_handler.focus_update_steps(
+            cx,
             vec![],
             focus_handler.current_focus_chain(),
             &FocusableArea::Viewport,
-            CanGc::from_cx(cx),
         );
     }
 
@@ -3020,17 +3014,15 @@ impl ScriptThread {
 
     fn handle_update_history_state_msg(
         &self,
+        cx: &mut js::context::JSContext,
         pipeline_id: PipelineId,
         history_state_id: Option<HistoryStateId>,
         url: ServoUrl,
-        can_gc: CanGc,
     ) {
         let Some(window) = self.documents.borrow().find_window(pipeline_id) else {
             return warn!("update history state after pipeline {pipeline_id} closed.",);
         };
-        window
-            .History()
-            .activate_state(history_state_id, url, can_gc);
+        window.History().activate_state(cx, history_state_id, url);
     }
 
     fn handle_remove_history_states(

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1291,10 +1291,10 @@ pub(crate) fn handle_will_send_keys(
 
         if !element.is_active_element() {
             html_element.Focus(
+                cx,
                 &FocusOptions {
                     preventScroll: true,
                 },
-                CanGc::from_cx(cx),
             );
         } else {
             element_has_focus = element.focus_state();
@@ -1837,10 +1837,10 @@ fn clear_a_resettable_element(cx: &mut JSContext, element: &Element) -> Result<(
 
     // Step 3. Invoke the focusing steps for the element.
     html_element.Focus(
+        cx,
         &FocusOptions {
             preventScroll: true,
         },
-        CanGc::from_cx(cx),
     );
 
     // Step 4. Run clear algorithm for element.
@@ -1857,7 +1857,7 @@ fn clear_a_resettable_element(cx: &mut JSContext, element: &Element) -> Result<(
     event_target.fire_bubbling_event(cx, atom!("change"));
 
     // Step 5. Run the unfocusing steps for the element.
-    html_element.Blur(CanGc::from_cx(cx));
+    html_element.Blur(cx);
 
     Ok(())
 }
@@ -2011,10 +2011,10 @@ pub(crate) fn handle_element_click(
                         match container.downcast::<HTMLElement>() {
                             Some(html_element) => {
                                 html_element.Focus(
+                                    cx,
                                     &FocusOptions {
                                         preventScroll: true,
                                     },
-                                    CanGc::from_cx(cx),
                                 );
                             },
                             None => return Err(ErrorStatus::UnknownError),

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -470,10 +470,8 @@ DOMInterfaces = {
 'HTMLElement': {
     'canGc': [
         'AttachInternals',
-        'Blur',
         'Click',
         'Dataset',
-        'Focus',
         'GetOnblur',
         'GetOnerror',
         'GetOnfocus',
@@ -481,6 +479,10 @@ DOMInterfaces = {
         'GetOnresize',
         'GetOnscroll',
         'Style',
+    ],
+    'cx': [
+        'Blur',
+        'Focus',
     ],
     'implicitCxSetters': True,
 },


### PR DESCRIPTION
Part of https://github.com/servo/servo/issues/42638
Testing: It compiles
Fixes: #44557
Unblocks: #44558