### PR TITLE
script: propagate &mut JSContext to VirtualMethods::moving_steps #43044

### DIFF
--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -1423,19 +1423,19 @@ impl VirtualMethods for HTMLElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-trees:html-element-moving-steps>
-    fn moving_steps(&self, context: &MoveContext, can_gc: CanGc) {
+    fn moving_steps(&self, cx: &mut JSContext, context: &MoveContext) {
         // Step 1. If movedNode is an element whose namespace is the HTML namespace, and this
         // standard defines HTML element moving steps for movedNode's local name, then run the
         // corresponding HTML element moving steps given movedNode.
         if let Some(super_type) = self.super_type() {
-            super_type.moving_steps(context, can_gc);
+            super_type.moving_steps(cx, context);
         }
 
         // Step 2. If movedNode is a form-associated element with a non-null form owner and
         // movedNode and its form owner are no longer in the same tree, then reset the form owner of
         // movedNode.
         if let Some(form_control) = self.element.as_maybe_form_control() {
-            form_control.moving_steps(can_gc)
+            form_control.moving_steps(cx)
         }
     }
 }

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -1874,14 +1874,14 @@ pub(crate) trait FormControl: DomObject<ReflectorType = ()> + NodeTraits {
         }
     }
 
-    fn moving_steps(&self, can_gc: CanGc) {
+    fn moving_steps(&self, cx: &mut JSContext) {
         // If movedNode is a form-associated element with a non-null form owner and movedNode and
         // its form owner are no longer in the same tree, then reset the form owner of movedNode.
         let same_subtree = self
             .form_owner()
             .is_none_or(|form| self.to_element().is_in_same_home_subtree(&*form));
         if !same_subtree {
-            self.reset_form_owner(can_gc)
+            self.reset_form_owner(CanGc::from_cx(cx))
         }
     }
 

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -30,7 +30,6 @@ use num_traits::ToPrimitive;
 use pixels::{CorsStatus, ImageMetadata, Snapshot};
 use regex::Regex;
 use rustc_hash::FxHashSet;
-use script_bindings::script_runtime::temp_cx;
 use servo_url::ServoUrl;
 use servo_url::origin::MutableOrigin;
 use style::attr::{AttrValue, LengthOrPercentageOrAuto, parse_unsigned_integer};
@@ -2145,14 +2144,10 @@ impl VirtualMethods for HTMLImageElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage#the-img-element:html-element-moving-steps>
-    #[expect(unsafe_code)]
     fn moving_steps(&self, cx: &mut JSContext, context: &MoveContext) {
         if let Some(super_type) = self.super_type() {
             super_type.moving_steps(cx, context);
         }
-        // TODO: https://github.com/servo/servo/issues/43044
-        let mut cx = unsafe { temp_cx() };
-        let cx = &mut cx;
 
         // Step 1. If oldParent is a picture element, then, count this as a relevant mutation for movedNode.
         if let Some(old_parent) = context.old_parent {

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -2146,9 +2146,9 @@ impl VirtualMethods for HTMLImageElement {
 
     /// <https://html.spec.whatwg.org/multipage#the-img-element:html-element-moving-steps>
     #[expect(unsafe_code)]
-    fn moving_steps(&self, context: &MoveContext, can_gc: CanGc) {
+    fn moving_steps(&self, cx: &mut JSContext, context: &MoveContext) {
         if let Some(super_type) = self.super_type() {
-            super_type.moving_steps(context, can_gc);
+            super_type.moving_steps(cx, context);
         }
         // TODO: https://github.com/servo/servo/issues/43044
         let mut cx = unsafe { temp_cx() };

--- a/components/script/dom/html/htmloptionelement.rs
+++ b/components/script/dom/html/htmloptionelement.rs
@@ -515,9 +515,9 @@ impl VirtualMethods for HTMLOptionElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-option-element:html-element-moving-steps>
-    fn moving_steps(&self, context: &MoveContext, can_gc: CanGc) {
+    fn moving_steps(&self, cx: &mut JSContext, context: &MoveContext) {
         if let Some(super_type) = self.super_type() {
-            super_type.moving_steps(context, can_gc);
+            super_type.moving_steps(cx, context);
         }
 
         // The option HTML element moving steps, given movedNode and oldParent, are to run update an
@@ -529,8 +529,8 @@ impl VirtualMethods for HTMLOptionElement {
                 .find_map(DomRoot::downcast::<HTMLSelectElement>)
             {
                 select
-                    .validity_state(can_gc)
-                    .perform_validation_and_update(ValidationFlags::all(), can_gc);
+                    .validity_state(CanGc::from_cx(cx))
+                    .perform_validation_and_update(ValidationFlags::all(), CanGc::from_cx(cx));
                 select.ask_for_reset();
             }
 
@@ -544,6 +544,6 @@ impl VirtualMethods for HTMLOptionElement {
         element.check_parent_disabled_state_for_option();
 
         self.pick_if_selected_and_reset();
-        self.update_select_validity(can_gc);
+        self.update_select_validity(CanGc::from_cx(cx));
     }
 }

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -1518,10 +1518,10 @@ impl Node {
             // inclusiveDescendant and oldParent.
             // Otherwise, run the moving steps with inclusiveDescendant and null.
             if descendant.deref() == node {
-                vtable_for(&descendant).moving_steps(&context, CanGc::from_cx(cx));
+                vtable_for(&descendant).moving_steps(cx, &context);
             } else {
                 context.old_parent = None;
-                vtable_for(&descendant).moving_steps(&context, CanGc::from_cx(cx));
+                vtable_for(&descendant).moving_steps(cx, &context);
             }
 
             // Step 24.2. If inclusiveDescendant is custom and newParent is connected,
@@ -4772,9 +4772,9 @@ impl VirtualMethods for Node {
         }
     }
 
-    fn moving_steps(&self, context: &MoveContext, can_gc: CanGc) {
+    fn moving_steps(&self, cx: &mut JSContext, context: &MoveContext) {
         if let Some(super_type) = self.super_type() {
-            super_type.moving_steps(context, can_gc);
+            super_type.moving_steps(cx, context);
         }
 
         // Ranges should only drain to the parent from inclusive non-shadow

--- a/components/script/dom/virtualmethods.rs
+++ b/components/script/dom/virtualmethods.rs
@@ -5,7 +5,6 @@
 use html5ever::LocalName;
 use js::context::JSContext;
 use script_bindings::root::DomRoot;
-use script_bindings::script_runtime::CanGc;
 use style::attr::AttrValue;
 
 use crate::dom::attr::Attr;

--- a/components/script/dom/virtualmethods.rs
+++ b/components/script/dom/virtualmethods.rs
@@ -119,9 +119,9 @@ pub(crate) trait VirtualMethods {
     }
 
     /// <https://dom.spec.whatwg.org/#concept-node-move-ext>
-    fn moving_steps(&self, context: &MoveContext, can_gc: CanGc) {
+    fn moving_steps(&self, cx: &mut JSContext, context: &MoveContext) {
         if let Some(s) = self.super_type() {
-            s.moving_steps(context, can_gc);
+            s.moving_steps(cx, context);
         }
     }
 


### PR DESCRIPTION
Propagate `&mut JSContext` in `VirtualMethods::moving_steps` and these call sites:
- `HTMLElements::`
- `HTMLFormElements::`
- `HTMLImageElements::`
- `HTMLOptionElement::`
- `Node::`

Testing: Successful build, fmt, test-tidy
Fixes: #43044 