### PR TITLE
script: Ignore pipeline update messages if the relevant iframe is not expecting it

### DIFF
--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -629,12 +629,15 @@ impl HTMLIFrameElement {
         }
     }
 
+    /// Returns true if the contained pipeline was updated, false otherwise.
+    /// This can occur if the iframe's nested browsing context has changed
+    /// since the asynchronous update was started.
     pub(crate) fn update_pipeline_id(
         &self,
         new_pipeline_id: PipelineId,
         reason: UpdatePipelineIdReason,
         cx: &mut JSContext,
-    ) {
+    ) -> bool {
         // For all updates except the one for the initial blank document,
         // we need to set the flag back to false because the navigation is complete,
         // because the goal is to, when a navigation is pending, to skip the async load
@@ -645,7 +648,7 @@ impl HTMLIFrameElement {
         if self.pending_pipeline_id.get() != Some(new_pipeline_id) &&
             reason == UpdatePipelineIdReason::Navigation
         {
-            return;
+            return false;
         }
 
         self.pipeline_id.set(Some(new_pipeline_id));
@@ -658,6 +661,7 @@ impl HTMLIFrameElement {
         }
 
         self.upcast::<Node>().dirty(NodeDamage::Other);
+        true
     }
 
     fn new_inherited(

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2989,27 +2989,31 @@ impl ScriptThread {
             .documents
             .borrow()
             .find_iframe(parent_pipeline_id, browsing_context_id);
-        if let Some(frame_element) = frame_element {
-            frame_element.update_pipeline_id(new_pipeline_id, reason, cx);
-        }
+        let Some(frame_element) = frame_element else {
+            return;
+        };
+        if !frame_element.update_pipeline_id(new_pipeline_id, reason, cx) {
+            return;
+        };
 
-        if let Some(window) = self.documents.borrow().find_window(new_pipeline_id) {
-            // Ensure that the state of any local window proxies accurately reflects
-            // the new pipeline.
-            let _ = self.window_proxies.local_window_proxy(
-                cx,
-                &self.senders,
-                &self.documents,
-                &window,
-                browsing_context_id,
-                webview_id,
-                Some(parent_pipeline_id),
-                // Any local window proxy has already been created, so there
-                // is no need to pass along existing opener information that
-                // will be discarded.
-                None,
-            );
-        }
+        let Some(window) = self.documents.borrow().find_window(new_pipeline_id) else {
+            return;
+        };
+        // Ensure that the state of any local window proxies accurately reflects
+        // the new pipeline.
+        let _ = self.window_proxies.local_window_proxy(
+            cx,
+            &self.senders,
+            &self.documents,
+            &window,
+            browsing_context_id,
+            webview_id,
+            Some(parent_pipeline_id),
+            // Any local window proxy has already been created, so there
+            // is no need to pass along existing opener information that
+            // will be discarded.
+            None,
+        );
     }
 
     fn handle_update_history_state_msg(


### PR DESCRIPTION
When an iframe has a new browsing context and an update pipeline message arrives for the old context, we would skip updating the iframe's state but still update the window proxy for the old iframe window object. Because we eagerly clear window proxy data for browsing contexts that are removed, this would create a new window proxy and try to update the window proxy field for the old global object, but SpiderMonkey does not think that's a good idea and asserts.

Testing: Fixes a large number of assertions in WPT with debug-mozjs enabled. We don't run this configuration in CI yet.
Fixes: #44043
