### PR TITLE
script: Port `GetClientRects` & `GetBoundingClientRect` to safe JS wrapper for `Range`&`Element`

### DIFF
--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -520,7 +520,7 @@ pub(crate) fn handle_get_layout(
         .downcast::<Element>()
         .expect("should be getting layout of element");
 
-    let rect = element.GetBoundingClientRect(CanGc::from_cx(cx));
+    let rect = element.GetBoundingClientRect(cx);
     let width = rect.Width() as f32;
     let height = rect.Height() as f32;
 

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -3074,7 +3074,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     }
 
     /// <https://drafts.csswg.org/cssom-view/#dom-element-getclientrects>
-    fn GetClientRects(&self, can_gc: CanGc) -> DomRoot<DOMRectList> {
+    fn GetClientRects(&self, cx: &mut JSContext) -> DomRoot<DOMRectList> {
         let win = self.owner_window();
         let raw_rects = self.upcast::<Node>().border_boxes();
         let rects: Vec<DomRoot<DOMRect>> = raw_rects
@@ -3085,15 +3085,15 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
                     rect.origin.y.to_f64_px(),
                     rect.size.width.to_f64_px(),
                     rect.size.height.to_f64_px(),
-                    can_gc,
+                    CanGc::from_cx(cx),
                 )
             })
             .collect();
-        DOMRectList::new(&win, rects, can_gc)
+        DOMRectList::new(&win, rects, CanGc::from_cx(cx))
     }
 
     /// <https://drafts.csswg.org/cssom-view/#dom-element-getboundingclientrect>
-    fn GetBoundingClientRect(&self, can_gc: CanGc) -> DomRoot<DOMRect> {
+    fn GetBoundingClientRect(&self, cx: &mut JSContext) -> DomRoot<DOMRect> {
         let win = self.owner_window();
         let rect = self.upcast::<Node>().border_box().unwrap_or_default();
         debug_assert!(rect.size.width.to_f64_px() >= 0.0 && rect.size.height.to_f64_px() >= 0.0);
@@ -3103,7 +3103,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
             rect.origin.y.to_f64_px(),
             rect.size.width.to_f64_px(),
             rect.size.height.to_f64_px(),
-            can_gc,
+            CanGc::from_cx(cx),
         )
     }
 

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -2092,9 +2092,7 @@ impl VirtualMethods for HTMLImageElement {
             mouse_event.ClientX().to_f32().unwrap(),
             mouse_event.ClientY().to_f32().unwrap(),
         );
-        let bcr = self
-            .upcast::<Element>()
-            .GetBoundingClientRect(CanGc::from_cx(cx));
+        let bcr = self.upcast::<Element>().GetBoundingClientRect(cx);
         let bcr_p = Point2D::new(bcr.X() as f32, bcr.Y() as f32);
 
         // Walk HTMLAreaElements

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -530,7 +530,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-range-clonerange>
-    fn CloneRange(&self, can_gc: CanGc) -> DomRoot<Range> {
+    fn CloneRange(&self, cx: &mut JSContext) -> DomRoot<Range> {
         let start_node = self.start_container();
         let owner_doc = start_node.owner_doc();
         Range::new(
@@ -539,7 +539,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
             self.start_offset(),
             &self.end_container(),
             self.end_offset(),
-            can_gc,
+            CanGc::from_cx(cx),
         )
     }
 
@@ -1190,7 +1190,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
     }
 
     /// <https://drafts.csswg.org/cssom-view/#dom-range-getclientrects>
-    fn GetClientRects(&self, can_gc: CanGc) -> DomRoot<DOMRectList> {
+    fn GetClientRects(&self, cx: &mut JSContext) -> DomRoot<DOMRectList> {
         let start = self.start_container();
         let window = start.owner_window();
 
@@ -1203,16 +1203,16 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
                     rect.origin.y.to_f64_px(),
                     rect.size.width.to_f64_px(),
                     rect.size.height.to_f64_px(),
-                    can_gc,
+                    CanGc::from_cx(cx),
                 )
             })
             .collect();
 
-        DOMRectList::new(&window, client_rects, can_gc)
+        DOMRectList::new(&window, client_rects, CanGc::from_cx(cx))
     }
 
     /// <https://drafts.csswg.org/cssom-view/#dom-range-getboundingclientrect>
-    fn GetBoundingClientRect(&self, can_gc: CanGc) -> DomRoot<DOMRect> {
+    fn GetBoundingClientRect(&self, cx: &mut JSContext) -> DomRoot<DOMRect> {
         let window = self.start_container().owner_window();
 
         // Step 1. Let list be the result of invoking getClientRects() on the same range this method was invoked on.
@@ -1230,7 +1230,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
             bounding_rect.origin.y.to_f64_px(),
             bounding_rect.size.width.to_f64_px(),
             bounding_rect.size.height.to_f64_px(),
-            can_gc,
+            CanGc::from_cx(cx),
         )
     }
 }

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -727,7 +727,7 @@ fn get_element_in_view_center_point(cx: &mut JSContext, element: &Element) -> Op
     let doc = element.owner_document();
     // Step 1: Let rectangle be the first element of the DOMRect sequence
     // returned by calling getClientRects() on element.
-    element.GetClientRects(CanGc::from_cx(cx)).first().map(|rectangle| {
+    element.GetClientRects(cx).first().map(|rectangle| {
         let x = rectangle.X();
         let y = rectangle.Y();
         let width = rectangle.Width();
@@ -1604,7 +1604,7 @@ pub(crate) fn handle_get_rect(
                 // Step 4-5
                 // We pass the rect instead of element so we don't have to
                 // call `GetBoundingClientRect` twice.
-                let rect = element.GetBoundingClientRect(CanGc::from_cx(cx));
+                let rect = element.GetBoundingClientRect(cx);
                 let (x, y) = calculate_absolute_position(documents, &pipeline, &rect)?;
 
                 // Step 6-7
@@ -1629,7 +1629,7 @@ pub(crate) fn handle_scroll_and_get_bounding_client_rect(
             get_known_element(documents, pipeline, element_id).map(|element| {
                 scroll_into_view(cx, &element, documents, &pipeline);
 
-                let rect = element.GetBoundingClientRect(CanGc::from_cx(cx));
+                let rect = element.GetBoundingClientRect(cx);
                 Rect::new(
                     Point2D::new(rect.X() as f32, rect.Y() as f32),
                     Size2D::new(rect.Width() as f32, rect.Height() as f32),

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -315,8 +315,8 @@ DOMInterfaces = {
 },
 
 'Element': {
-    'cx': ['GetHTML', 'GetInnerHTML', 'GetOuterHTML', 'SetHTMLUnsafe', 'SetInnerHTML', 'SetOuterHTML', 'InsertAdjacentHTML', 'ToggleAttribute', 'SetAttribute', 'SetAttributeNS', 'SetAttributeNode', 'SetAttributeNodeNS', 'RemoveAttributeNS', 'RemoveAttributeNode', 'SetRole', 'SetAriaAtomic', 'SetAriaAutoComplete', 'SetAriaBrailleLabel', 'SetAriaBrailleRoleDescription', 'SetAriaBusy', 'SetAriaChecked', 'SetAriaColCount', 'SetAriaColIndex', 'SetAriaColIndexText', 'SetAriaColSpan', 'SetAriaCurrent', 'SetAriaDescription', 'SetAriaDisabled', 'SetAriaExpanded', 'SetAriaHasPopup', 'SetAriaHidden', 'SetAriaInvalid', 'SetAriaKeyShortcuts', 'SetAriaLabel', 'SetAriaLevel', 'SetAriaLive', 'SetAriaModal', 'SetAriaMultiLine', 'SetAriaMultiSelectable', 'SetAriaOrientation', 'SetAriaPlaceholder', 'SetAriaPosInSet', 'SetAriaPressed','SetAriaReadOnly', 'SetAriaRelevant', 'SetAriaRequired', 'SetAriaRoleDescription', 'SetAriaRowCount', 'SetAriaRowIndex', 'SetAriaRowIndexText', 'SetAriaRowSpan', 'SetAriaSelected', 'SetAriaSetSize','SetAriaSort', 'SetAriaValueMax', 'SetAriaValueMin', 'SetAriaValueNow', 'SetAriaValueText', 'ReplaceWith', 'MoveBefore', 'InsertAdjacentElement', 'InsertAdjacentText', 'Before', 'After', 'Prepend', 'Remove', 'ReplaceChildren', 'Append', 'AttachShadow', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'Children'],
-    'canGc': ['GetClientRects', 'GetBoundingClientRect', 'SetId','SetClassName', 'RequestFullscreen', 'ClassList', 'Attributes', 'RemoveAttribute'],
+    'cx': ['GetHTML', 'GetInnerHTML', 'GetOuterHTML', 'SetHTMLUnsafe', 'SetInnerHTML', 'SetOuterHTML', 'InsertAdjacentHTML', 'ToggleAttribute', 'SetAttribute', 'SetAttributeNS', 'SetAttributeNode', 'SetAttributeNodeNS', 'RemoveAttributeNS', 'RemoveAttributeNode', 'SetRole', 'SetAriaAtomic', 'SetAriaAutoComplete', 'SetAriaBrailleLabel', 'SetAriaBrailleRoleDescription', 'SetAriaBusy', 'SetAriaChecked', 'SetAriaColCount', 'SetAriaColIndex', 'SetAriaColIndexText', 'SetAriaColSpan', 'SetAriaCurrent', 'SetAriaDescription', 'SetAriaDisabled', 'SetAriaExpanded', 'SetAriaHasPopup', 'SetAriaHidden', 'SetAriaInvalid', 'SetAriaKeyShortcuts', 'SetAriaLabel', 'SetAriaLevel', 'SetAriaLive', 'SetAriaModal', 'SetAriaMultiLine', 'SetAriaMultiSelectable', 'SetAriaOrientation', 'SetAriaPlaceholder', 'SetAriaPosInSet', 'SetAriaPressed','SetAriaReadOnly', 'SetAriaRelevant', 'SetAriaRequired', 'SetAriaRoleDescription', 'SetAriaRowCount', 'SetAriaRowIndex', 'SetAriaRowIndexText', 'SetAriaRowSpan', 'SetAriaSelected', 'SetAriaSetSize','SetAriaSort', 'SetAriaValueMax', 'SetAriaValueMin', 'SetAriaValueNow', 'SetAriaValueText', 'ReplaceWith', 'MoveBefore', 'InsertAdjacentElement', 'InsertAdjacentText', 'Before', 'After', 'Prepend', 'Remove', 'ReplaceChildren', 'Append', 'AttachShadow', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'Children', 'GetClientRects', 'GetBoundingClientRect'],
+    'canGc': ['SetId','SetClassName', 'RequestFullscreen', 'ClassList', 'Attributes', 'RemoveAttribute'],
 },
 
 'ElementInternals': {
@@ -813,9 +813,8 @@ DOMInterfaces = {
 },
 
 'Range': {
-    'canGc': ['CloneRange', 'GetClientRects', 'GetBoundingClientRect'],
     'weakReferenceable': True,
-    'cx': ['CloneContents', 'CreateContextualFragment', 'DeleteContents', 'ExtractContents', 'InsertNode', 'SurroundContents'],
+    'cx': ['CloneContents', 'CloneRange', 'CreateContextualFragment', 'DeleteContents', 'ExtractContents', 'GetBoundingClientRect', 'GetClientRects', 'InsertNode', 'SurroundContents'],
 },
 
 'Request': {


### PR DESCRIPTION
Part of #42638

Testing: It compiles.