### PR TITLE
script: Fix name of non-replaceable sanitizer elements

### DIFF
--- a/components/script/dom/security/sanitizer.rs
+++ b/components/script/dom/security/sanitizer.rs
@@ -1946,7 +1946,7 @@ fn built_in_non_replaceable_elements_list() -> Vec<SanitizerElement> {
             namespace: Some(ns!(svg).to_string().into()),
         }),
         SanitizerElement::SanitizerElementNamespace(SanitizerElementNamespace {
-            name: "mathml".into(),
+            name: "math".into(),
             namespace: Some(ns!(mathml).to_string().into()),
         }),
     ]

--- a/tests/wpt/meta/sanitizer-api/sanitizer-config.tentative.html.ini
+++ b/tests/wpt/meta/sanitizer-api/sanitizer-config.tentative.html.ini
@@ -10,6 +10,3 @@
 
   [Test attribute removal.]
     expected: FAIL
-
-  [config[replaceWithChildrenElements\] should not allow non-replaceable elements]
-    expected: FAIL

--- a/tests/wpt/meta/sanitizer-api/sanitizer-modifiers.tentative.html.ini
+++ b/tests/wpt/meta/sanitizer-api/sanitizer-modifiers.tentative.html.ini
@@ -28,6 +28,3 @@
 
   [sanitizer.removeAttribute() with global removeAttributes and element's removeAttributes]
     expected: FAIL
-
-  [sanitizer.replaceElementWithChildren() does not allow non-replaceable elements.]
-    expected: FAIL


### PR DESCRIPTION
The third item of the *built-in non-replaceable elements list* of the Sanitizer API should have the name "math". We wrongly use "mathml" in our code. This patch fixes this typo.

Specification of *built-in non-replaceable elements list*: https://wicg.github.io/sanitizer-api/#built-in-non-replaceable-elements-list

Testing: Covered by WPT tests in `sanitizer-api/sanitizer-config.tentative.html` and `sanitizer-api/sanitizer-modifiers.tentative.html`.