### PR TITLE
script: Propagate `&mut JSContext` to `UnderlyingSourceContainer::call_pull_algorithm`

### DIFF
--- a/components/script/dom/stream/byteteereadintorequest.rs
+++ b/components/script/dom/stream/byteteereadintorequest.rs
@@ -6,6 +6,7 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::jsval::UndefinedValue;
 use js::typedarray::ArrayBufferViewU8;
 
@@ -30,7 +31,7 @@ pub(crate) struct ByteTeeReadIntoRequestMicrotask {
 }
 
 impl ByteTeeReadIntoRequestMicrotask {
-    pub(crate) fn microtask_chunk_steps(&self, cx: &mut js::context::JSContext) {
+    pub(crate) fn microtask_chunk_steps(&self, cx: &mut JSContext) {
         self.tee_read_request
             .chunk_steps(self.chunk.clone(), cx)
             .expect("Failed to enqueue chunk");
@@ -113,7 +114,7 @@ impl ByteTeeReadIntoRequest {
     pub(crate) fn chunk_steps(
         &self,
         chunk: HeapBufferSource<ArrayBufferViewU8>,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
     ) -> Fallible<()> {
         // Set readAgainForBranch1 to false.
         self.read_again_for_branch_1.set(false);
@@ -207,7 +208,7 @@ impl ByteTeeReadIntoRequest {
     /// <https://streams.spec.whatwg.org/#ref-for-read-into-request-close-steps%E2%91%A1>
     pub(crate) fn close_steps(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         chunk: Option<HeapBufferSource<ArrayBufferViewU8>>,
     ) -> Fallible<()> {
         // Set reading to false.
@@ -282,7 +283,7 @@ impl ByteTeeReadIntoRequest {
 
     pub(crate) fn pull_algorithm(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         byte_tee_pull_algorithm: Option<ByteTeePullAlgorithm>,
     ) {
         self.tee_underlying_source

--- a/components/script/dom/stream/byteteereadrequest.rs
+++ b/components/script/dom/stream/byteteereadrequest.rs
@@ -6,6 +6,7 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::jsapi::Heap;
 use js::jsval::{JSVal, UndefinedValue};
 use js::typedarray::ArrayBufferViewU8;
@@ -33,7 +34,7 @@ pub(crate) struct ByteTeeReadRequestMicrotask {
 }
 
 impl ByteTeeReadRequestMicrotask {
-    pub(crate) fn microtask_chunk_steps(&self, cx: &mut js::context::JSContext) {
+    pub(crate) fn microtask_chunk_steps(&self, cx: &mut JSContext) {
         self.tee_read_request
             .chunk_steps(&self.chunk, cx)
             .expect("ByteTeeReadRequestMicrotask::microtask_chunk_steps failed");
@@ -115,11 +116,7 @@ impl ByteTeeReadRequest {
 
     /// <https://streams.spec.whatwg.org/#ref-for-read-request-chunk-steps%E2%91%A3>
     #[allow(clippy::borrowed_box)]
-    pub(crate) fn chunk_steps(
-        &self,
-        chunk: &Box<Heap<JSVal>>,
-        cx: &mut js::context::JSContext,
-    ) -> Fallible<()> {
+    pub(crate) fn chunk_steps(&self, chunk: &Box<Heap<JSVal>>, cx: &mut JSContext) -> Fallible<()> {
         // Set readAgainForBranch1 to false.
         self.read_again_for_branch_1.set(false);
 
@@ -131,7 +128,7 @@ impl ByteTeeReadRequest {
         let chunk2 = chunk;
 
         // Helper to surface clone failures exactly once
-        let handle_clone_error = |cx: &mut js::context::JSContext, error: Error| {
+        let handle_clone_error = |cx: &mut JSContext, error: Error| {
             rooted!(&in(cx) let mut error_value = UndefinedValue());
             error.to_jsval(
                 cx.into(),
@@ -225,7 +222,7 @@ impl ByteTeeReadRequest {
     }
 
     /// <https://streams.spec.whatwg.org/#ref-for-read-request-close-steps%E2%91%A2>
-    pub(crate) fn close_steps(&self, cx: &mut js::context::JSContext) -> Fallible<()> {
+    pub(crate) fn close_steps(&self, cx: &mut JSContext) -> Fallible<()> {
         let branch_1_controller = self.branch_1.get_byte_controller();
         let branch_2_controller = self.branch_2.get_byte_controller();
 
@@ -270,7 +267,7 @@ impl ByteTeeReadRequest {
 
     pub(crate) fn pull_algorithm(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         byte_tee_pull_algorithm: Option<ByteTeePullAlgorithm>,
     ) {
         self.tee_underlying_source

--- a/components/script/dom/stream/byteteeunderlyingsource.rs
+++ b/components/script/dom/stream/byteteeunderlyingsource.rs
@@ -6,8 +6,9 @@ use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::jsapi::{HandleValueArray, Heap, NewArrayObject, Value};
-use js::jsval::{ObjectValue, UndefinedValue};
+use js::jsval::ObjectValue;
 use js::rust::HandleValue as SafeHandleValue;
 use js::typedarray::ArrayBufferViewU8;
 
@@ -163,11 +164,7 @@ impl ByteTeeUnderlyingSource {
         }
     }
 
-    pub(crate) fn pull_with_default_reader(
-        &self,
-        cx: &mut js::context::JSContext,
-        global: &GlobalScope,
-    ) -> Fallible<()> {
+    fn pull_with_default_reader(&self, cx: &mut JSContext, global: &GlobalScope) -> Fallible<()> {
         let mut reader = self.reader.borrow_mut();
         match &*reader {
             ReaderType::BYOB(byte_reader) => {
@@ -233,9 +230,9 @@ impl ByteTeeUnderlyingSource {
         Ok(())
     }
 
-    pub(crate) fn pull_with_byob_reader(
+    fn pull_with_byob_reader(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         view: HeapBufferSource<ArrayBufferViewU8>,
         for_branch2: bool,
         global: &GlobalScope,
@@ -326,7 +323,7 @@ impl ByteTeeUnderlyingSource {
     /// Let pullAlgorithm be the following steps:
     pub(crate) fn pull_algorithm(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         byte_tee_pull_algorithm: Option<ByteTeePullAlgorithm>,
     ) -> Rc<Promise> {
         let pull_algorithm =
@@ -339,11 +336,10 @@ impl ByteTeeUnderlyingSource {
                     // Set readAgainForBranch1 to true.
                     self.read_again_for_branch_1.set(true);
                     // Return a promise resolved with undefined.
-                    rooted!(&in(cx) let mut rval = UndefinedValue());
                     return Promise::new_resolved(
                         &self.stream.global(),
                         cx.into(),
-                        rval.handle(),
+                        (),
                         CanGc::from_cx(cx),
                     );
                 }
@@ -376,13 +372,7 @@ impl ByteTeeUnderlyingSource {
                 }
 
                 // Return a promise resolved with undefined.
-                rooted!(&in(cx) let mut rval = UndefinedValue());
-                Promise::new_resolved(
-                    &self.stream.global(),
-                    cx.into(),
-                    rval.handle(),
-                    CanGc::from_cx(cx),
-                )
+                Promise::new_resolved(&self.stream.global(), cx.into(), (), CanGc::from_cx(cx))
             },
             ByteTeePullAlgorithm::Pull2Algorithm => {
                 // If reading is true,
@@ -391,11 +381,10 @@ impl ByteTeeUnderlyingSource {
                     self.read_again_for_branch_2.set(true);
 
                     // Return a promise resolved with undefined.
-                    rooted!(&in(cx) let mut rval = UndefinedValue());
                     return Promise::new_resolved(
                         &self.stream.global(),
                         cx.into(),
-                        rval.handle(),
+                        (),
                         CanGc::from_cx(cx),
                     );
                 }
@@ -427,13 +416,7 @@ impl ByteTeeUnderlyingSource {
                 }
 
                 // Return a promise resolved with undefined.
-                rooted!(&in(cx) let mut rval = UndefinedValue());
-                Promise::new_resolved(
-                    &self.stream.global(),
-                    cx.into(),
-                    rval.handle(),
-                    CanGc::from_cx(cx),
-                )
+                Promise::new_resolved(&self.stream.global(), cx.into(), (), CanGc::from_cx(cx))
             },
         }
     }
@@ -444,7 +427,7 @@ impl ByteTeeUnderlyingSource {
     /// Let cancel2Algorithm be the following steps, taking a reason argument
     pub(crate) fn cancel_algorithm(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         reason: SafeHandleValue,
     ) -> Option<Result<Rc<Promise>, Error>> {
         match self.tee_cancel_algorithm {
@@ -481,7 +464,7 @@ impl ByteTeeUnderlyingSource {
     }
 
     #[expect(unsafe_code)]
-    fn resolve_cancel_promise(&self, cx: &mut js::context::JSContext) {
+    fn resolve_cancel_promise(&self, cx: &mut JSContext) {
         // Let compositeReason be ! CreateArrayFromList(« reason_1, reason_2 »).
         rooted_vec!(let mut reasons_values);
         reasons_values.push(self.reason_1.get());

--- a/components/script/dom/stream/defaultteereadrequest.rs
+++ b/components/script/dom/stream/defaultteereadrequest.rs
@@ -6,6 +6,7 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::jsapi::Heap;
 use js::jsval::{JSVal, UndefinedValue};
 use js::realm::AutoRealm;
@@ -32,7 +33,7 @@ pub(crate) struct DefaultTeeReadRequestMicrotask {
 }
 
 impl MicrotaskRunnable for DefaultTeeReadRequestMicrotask {
-    fn handler(&self, cx: &mut js::context::JSContext) {
+    fn handler(&self, cx: &mut JSContext) {
         self.tee_read_request.chunk_steps(cx, &self.chunk);
     }
 
@@ -99,7 +100,7 @@ impl DefaultTeeReadRequest {
     /// <https://streams.spec.whatwg.org/#readable-stream-cancel>
     pub(crate) fn stream_cancel(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         reason: SafeHandleValue,
     ) {
@@ -121,7 +122,7 @@ impl DefaultTeeReadRequest {
     }
     /// <https://streams.spec.whatwg.org/#ref-for-read-request-chunk-steps%E2%91%A2>
     #[expect(clippy::borrowed_box)]
-    pub(crate) fn chunk_steps(&self, cx: &mut js::context::JSContext, chunk: &Box<Heap<JSVal>>) {
+    pub(crate) fn chunk_steps(&self, cx: &mut JSContext, chunk: &Box<Heap<JSVal>>) {
         let global = &self.stream.global();
         // Set readAgain to false.
         self.read_again.set(false);
@@ -186,7 +187,7 @@ impl DefaultTeeReadRequest {
         }
     }
     /// <https://streams.spec.whatwg.org/#read-request-close-steps>
-    pub(crate) fn close_steps(&self, cx: &mut js::context::JSContext) {
+    pub(crate) fn close_steps(&self, cx: &mut JSContext) {
         // Set reading to false.
         self.reading.set(false);
         // If canceled_1 is false, perform ! ReadableStreamDefaultControllerClose(branch_1.[[controller]]).
@@ -211,7 +212,7 @@ impl DefaultTeeReadRequest {
     /// <https://streams.spec.whatwg.org/#readable-stream-default-controller-enqueue>
     fn readable_stream_default_controller_enqueue(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         stream: &ReadableStream,
         chunk: SafeHandleValue,
     ) {
@@ -225,7 +226,7 @@ impl DefaultTeeReadRequest {
     /// <https://streams.spec.whatwg.org/#readable-stream-default-controller-close>
     fn readable_stream_default_controller_close(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         stream: &ReadableStream,
     ) {
         stream.get_default_controller().close(cx);
@@ -235,14 +236,14 @@ impl DefaultTeeReadRequest {
     /// <https://streams.spec.whatwg.org/#readable-stream-default-controller-error>
     fn readable_stream_default_controller_error(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         stream: &ReadableStream,
         error: SafeHandleValue,
     ) {
         stream.get_default_controller().error(cx, error);
     }
 
-    pub(crate) fn pull_algorithm(&self, cx: &mut js::context::JSContext) {
+    pub(crate) fn pull_algorithm(&self, cx: &mut JSContext) {
         self.tee_underlying_source.pull_algorithm(cx);
     }
 }

--- a/components/script/dom/stream/defaultteeunderlyingsource.rs
+++ b/components/script/dom/stream/defaultteeunderlyingsource.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::jsapi::{HandleValueArray, Heap, NewArrayObject, Value};
-use js::jsval::{ObjectValue, UndefinedValue};
+use js::jsval::ObjectValue;
 use js::rust::HandleValue as SafeHandleValue;
 
 use crate::dom::bindings::error::Error;
@@ -110,13 +110,7 @@ impl DefaultTeeUnderlyingSource {
             // Set readAgain to true.
             self.read_again.set(true);
             // Return a promise resolved with undefined.
-            rooted!(&in(cx) let mut rval = UndefinedValue());
-            return Promise::new_resolved(
-                &self.stream.global(),
-                cx.into(),
-                rval.handle(),
-                CanGc::from_cx(cx),
-            );
+            return Promise::new_resolved(&self.stream.global(), cx.into(), (), CanGc::from_cx(cx));
         }
 
         // Set reading to true.
@@ -146,13 +140,7 @@ impl DefaultTeeUnderlyingSource {
         self.reader.read(cx, &read_request);
 
         // Return a promise resolved with undefined.
-        rooted!(&in(cx) let mut rval = UndefinedValue());
-        Promise::new_resolved(
-            &self.stream.global(),
-            cx.into(),
-            rval.handle(),
-            CanGc::from_cx(cx),
-        )
+        Promise::new_resolved(&self.stream.global(), cx.into(), (), CanGc::from_cx(cx))
     }
 
     /// <https://streams.spec.whatwg.org/#abstract-opdef-readablestreamdefaulttee>

--- a/components/script/dom/stream/readablebytestreamcontroller.rs
+++ b/components/script/dom/stream/readablebytestreamcontroller.rs
@@ -8,6 +8,7 @@ use std::collections::VecDeque;
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::jsapi::{Heap, Type};
 use js::jsval::UndefinedValue;
 use js::realm::CurrentRealm;
@@ -33,7 +34,7 @@ use crate::dom::promise::Promise;
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::stream::readablestream::ReadableStream;
 use crate::dom::stream::readablestreambyobrequest::ReadableStreamBYOBRequest;
-use crate::realms::{InRealm, enter_auto_realm, enter_realm};
+use crate::realms::{InRealm, enter_auto_realm};
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 
 /// <https://streams.spec.whatwg.org/#readable-byte-stream-queue-entry>
@@ -269,7 +270,7 @@ impl ReadableByteStreamController {
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-pull-into>
     pub(crate) fn perform_pull_into(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         read_into_request: &ReadIntoRequest,
         view: HeapBufferSource<ArrayBufferViewU8>,
         min: u64,
@@ -460,11 +461,7 @@ impl ReadableByteStreamController {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-respond>
-    pub(crate) fn respond(
-        &self,
-        cx: &mut js::context::JSContext,
-        bytes_written: u64,
-    ) -> Fallible<()> {
+    pub(crate) fn respond(&self, cx: &mut JSContext, bytes_written: u64) -> Fallible<()> {
         {
             // Assert: controller.[[pendingPullIntos]] is not empty.
             let mut pending_pull_intos = self.pending_pull_intos.borrow_mut();
@@ -516,11 +513,7 @@ impl ReadableByteStreamController {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-respond-internal>
-    pub(crate) fn respond_internal(
-        &self,
-        cx: &mut js::context::JSContext,
-        bytes_written: u64,
-    ) -> Fallible<()> {
+    fn respond_internal(&self, cx: &mut JSContext, bytes_written: u64) -> Fallible<()> {
         {
             // Let firstDescriptor be controller.[[pendingPullIntos]][0].
             let pending_pull_intos = self.pending_pull_intos.borrow();
@@ -562,7 +555,7 @@ impl ReadableByteStreamController {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-respond-in-closed-state>
-    pub(crate) fn respond_in_closed_state(&self, cx: &mut js::context::JSContext) -> Fallible<()> {
+    fn respond_in_closed_state(&self, cx: &mut JSContext) -> Fallible<()> {
         let pending_pull_intos = self.pending_pull_intos.borrow();
         let first_descriptor = pending_pull_intos.first().unwrap();
 
@@ -613,11 +606,7 @@ impl ReadableByteStreamController {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-respond-in-readable-state>
-    pub(crate) fn respond_in_readable_state(
-        &self,
-        cx: &mut js::context::JSContext,
-        bytes_written: u64,
-    ) -> Fallible<()> {
+    fn respond_in_readable_state(&self, cx: &mut JSContext, bytes_written: u64) -> Fallible<()> {
         let pending_pull_intos = self.pending_pull_intos.borrow();
         let first_descriptor = pending_pull_intos.first().unwrap();
 
@@ -711,7 +700,7 @@ impl ReadableByteStreamController {
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-respond-with-new-view>
     pub(crate) fn respond_with_new_view(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         view: HeapBufferSource<ArrayBufferViewU8>,
     ) -> Fallible<()> {
         let view_byte_length;
@@ -854,7 +843,7 @@ impl ReadableByteStreamController {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-close>
-    pub(crate) fn close(&self, cx: &mut js::context::JSContext) -> Fallible<()> {
+    pub(crate) fn close(&self, cx: &mut JSContext) -> Fallible<()> {
         // Let stream be controller.[[stream]].
         let stream = self.stream.get().unwrap();
 
@@ -916,7 +905,7 @@ impl ReadableByteStreamController {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-error>
-    pub(crate) fn error(&self, cx: &mut js::context::JSContext, e: SafeHandleValue) {
+    pub(crate) fn error(&self, cx: &mut JSContext, e: SafeHandleValue) {
         // Let stream be controller.[[stream]].
         let stream = self.stream.get().unwrap();
 
@@ -983,7 +972,7 @@ impl ReadableByteStreamController {
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-enqueue>
     pub(crate) fn enqueue(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         chunk: HeapBufferSource<ArrayBufferViewU8>,
     ) -> Fallible<()> {
         // Let stream be controller.[[stream]].
@@ -1127,9 +1116,9 @@ impl ReadableByteStreamController {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-commit-pull-into-descriptor>
-    pub(crate) fn commit_pull_into_descriptor(
+    fn commit_pull_into_descriptor(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         pull_into_descriptor: &PullIntoDescriptor,
     ) -> Fallible<()> {
         // Assert: stream.[[state]] is not "errored".
@@ -1411,10 +1400,7 @@ impl ReadableByteStreamController {
     }
 
     /// <https://streams.spec.whatwg.org/#abstract-opdef-readablebytestreamcontrollerenqueuedetachedpullintotoqueue>
-    pub(crate) fn enqueue_detached_pull_into_to_queue(
-        &self,
-        cx: &mut js::context::JSContext,
-    ) -> Fallible<()> {
+    pub(crate) fn enqueue_detached_pull_into_to_queue(&self, cx: &mut JSContext) -> Fallible<()> {
         // first_descriptor: &PullIntoDescriptor,
         let pending_pull_intos = self.pending_pull_intos.borrow();
         let first_descriptor = pending_pull_intos.first().unwrap();
@@ -1447,7 +1433,7 @@ impl ReadableByteStreamController {
     /// <https://streams.spec.whatwg.org/#abstract-opdef-readablebytestreamcontrollerenqueueclonedchunktoqueue>
     pub(crate) fn enqueue_cloned_chunk_to_queue(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         buffer: &HeapBufferSource<ArrayBufferU8>,
         byte_offset: u64,
         byte_length: u64,
@@ -1510,10 +1496,7 @@ impl ReadableByteStreamController {
     }
 
     /// <https://streams.spec.whatwg.org/#abstract-opdef-readablebytestreamcontrollerprocessreadrequestsusingqueue>
-    pub(crate) fn process_read_requests_using_queue(
-        &self,
-        cx: &mut js::context::JSContext,
-    ) -> Fallible<()> {
+    pub(crate) fn process_read_requests_using_queue(&self, cx: &mut JSContext) -> Fallible<()> {
         // Let reader be controller.[[stream]].[[reader]].
         // Assert: reader implements ReadableStreamDefaultReader.
         let reader = self.stream.get().unwrap().get_default_reader();
@@ -1525,7 +1508,7 @@ impl ReadableByteStreamController {
     /// <https://streams.spec.whatwg.org/#abstract-opdef-readablebytestreamcontrollerfillreadrequestfromqueue>
     pub(crate) fn fill_read_request_from_queue(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         read_request: &ReadRequest,
     ) -> Fallible<()> {
         // Assert: controller.[[queueTotalSize]] > 0.
@@ -1566,7 +1549,7 @@ impl ReadableByteStreamController {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-handle-queue-drain>
-    pub(crate) fn handle_queue_drain(&self, cx: &mut js::context::JSContext) {
+    pub(crate) fn handle_queue_drain(&self, cx: &mut JSContext) {
         // Assert: controller.[[stream]].[[state]] is "readable".
         assert!(self.stream.get().unwrap().is_readable());
 
@@ -1584,7 +1567,7 @@ impl ReadableByteStreamController {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-call-pull-if-needed>
-    pub(crate) fn call_pull_if_needed(&self, cx: &mut js::context::JSContext) {
+    fn call_pull_if_needed(&self, cx: &mut JSContext) {
         // Let shouldPull be ! ReadableByteStreamControllerShouldCallPull(controller).
         let should_pull = self.should_call_pull();
         // If shouldPull is false, return.
@@ -1625,27 +1608,22 @@ impl ReadableByteStreamController {
                 CanGc::from_cx(cx),
             );
 
-            let realm = enter_realm(&*global);
-            let comp = InRealm::Entered(&realm);
+            let mut realm = enter_auto_realm(cx, &*global);
+            let cx = &mut realm.current_realm();
+            let in_realm_proof = cx.into();
+            let comp = InRealm::Already(&in_realm_proof);
+
             let result = underlying_source
                 .call_pull_algorithm(cx, controller)
                 .unwrap_or_else(|| {
-                    let promise = Promise::new2(cx, &global);
-                    promise.resolve_native(&(), CanGc::from_cx(cx));
+                    let promise = Promise::new_resolved(&global, cx.into(), (), CanGc::from_cx(cx));
                     Ok(promise)
                 });
             let promise = result.unwrap_or_else(|error| {
                 rooted!(&in(cx) let mut rval = UndefinedValue());
                 // TODO: check if `self.global()` is the right globalscope.
-                error.to_jsval(
-                    cx.into(),
-                    &self.global(),
-                    rval.handle_mut(),
-                    CanGc::from_cx(cx),
-                );
-                let promise = Promise::new2(cx, &global);
-                promise.reject_native(&rval.handle(), CanGc::from_cx(cx));
-                promise
+                error.to_jsval(cx.into(), &global, rval.handle_mut(), CanGc::from_cx(cx));
+                Promise::new_rejected(&global, cx.into(), rval.handle(), CanGc::from_cx(cx))
             });
             promise.append_native_handler(&handler, comp, CanGc::from_cx(cx));
         }
@@ -1702,7 +1680,7 @@ impl ReadableByteStreamController {
     /// <https://streams.spec.whatwg.org/#set-up-readable-byte-stream-controller>
     pub(crate) fn setup(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         stream: DomRoot<ReadableStream>,
     ) -> Fallible<()> {
@@ -1804,7 +1782,7 @@ impl ReadableByteStreamController {
     /// <https://streams.spec.whatwg.org/#rbs-controller-private-cancel>
     pub(crate) fn perform_cancel_steps(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         reason: SafeHandleValue,
     ) -> Rc<Promise> {
@@ -1844,11 +1822,7 @@ impl ReadableByteStreamController {
     }
 
     /// <https://streams.spec.whatwg.org/#rbs-controller-private-pull>
-    pub(crate) fn perform_pull_steps(
-        &self,
-        cx: &mut js::context::JSContext,
-        read_request: &ReadRequest,
-    ) {
+    pub(crate) fn perform_pull_steps(&self, cx: &mut JSContext, read_request: &ReadRequest) {
         // Let stream be this.[[stream]].
         let stream = self.stream.get().unwrap();
 
@@ -1970,7 +1944,7 @@ impl ReadableByteStreamControllerMethods<crate::DomTypeHolder> for ReadableByteS
     }
 
     /// <https://streams.spec.whatwg.org/#rbs-controller-close>
-    fn Close(&self, cx: &mut js::context::JSContext) -> Fallible<()> {
+    fn Close(&self, cx: &mut JSContext) -> Fallible<()> {
         // If this.[[closeRequested]] is true, throw a TypeError exception.
         if self.close_requested.get() {
             return Err(Error::Type(c"closeRequested is true".to_owned()));
@@ -1988,7 +1962,7 @@ impl ReadableByteStreamControllerMethods<crate::DomTypeHolder> for ReadableByteS
     /// <https://streams.spec.whatwg.org/#rbs-controller-enqueue>
     fn Enqueue(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         chunk: js::gc::CustomAutoRooterGuard<js::typedarray::ArrayBufferView>,
     ) -> Fallible<()> {
         let chunk = HeapBufferSource::<ArrayBufferViewU8>::from_view(chunk);
@@ -2020,7 +1994,7 @@ impl ReadableByteStreamControllerMethods<crate::DomTypeHolder> for ReadableByteS
     }
 
     /// <https://streams.spec.whatwg.org/#rbs-controller-error>
-    fn Error(&self, cx: &mut js::context::JSContext, e: SafeHandleValue) -> Fallible<()> {
+    fn Error(&self, cx: &mut JSContext, e: SafeHandleValue) -> Fallible<()> {
         // Perform ! ReadableByteStreamControllerError(this, e).
         self.error(cx, e);
         Ok(())

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -11,6 +11,7 @@ use servo_base::generic_channel::GenericSharedMemory;
 use servo_base::id::{MessagePortId, MessagePortIndex};
 use servo_constellation_traits::MessagePortImpl;
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::jsapi::{Heap, JSObject};
 use js::jsval::{JSVal, ObjectValue, UndefinedValue};
 use js::realm::CurrentRealm;
@@ -60,7 +61,7 @@ use crate::dom::stream::underlyingsourcecontainer::UnderlyingSourceType;
 use crate::dom::stream::writablestreamdefaultwriter::WritableStreamDefaultWriter;
 use script_bindings::codegen::GenericBindings::MessagePortBinding::MessagePortMethods;
 use crate::dom::messageport::MessagePort;
-use crate::realms::{enter_realm, InRealm, enter_auto_realm};
+use crate::realms::{InRealm, enter_auto_realm};
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::bindings::transferable::Transferable;
@@ -426,7 +427,7 @@ impl PipeTo {
     #[expect(unsafe_code)]
     fn write_chunk(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         chunk: SafeHandleValue,
     ) -> bool {
@@ -741,7 +742,7 @@ impl PipeTo {
     }
 
     /// <https://streams.spec.whatwg.org/#rs-pipeTo-finalize>
-    fn finalize(&self, cx: &mut js::context::JSContext, global: &GlobalScope) {
+    fn finalize(&self, cx: &mut JSContext, global: &GlobalScope) {
         *self.state.borrow_mut() = PipeToState::Finalized;
 
         // Perform ! WritableStreamDefaultWriterRelease(writer).
@@ -852,7 +853,7 @@ impl PartialEq for ReaderType {
 /// <https://streams.spec.whatwg.org/#create-readable-stream>
 #[cfg_attr(crown, expect(crown::unrooted_must_root))]
 pub(crate) fn create_readable_stream(
-    cx: &mut js::context::JSContext,
+    cx: &mut JSContext,
     global: &GlobalScope,
     underlying_source_type: UnderlyingSourceType,
     queuing_strategy: Option<Rc<QueuingStrategySize>>,
@@ -896,7 +897,7 @@ pub(crate) fn create_readable_stream(
 /// <https://streams.spec.whatwg.org/#abstract-opdef-createreadablebytestream>
 #[cfg_attr(crown, expect(crown::unrooted_must_root))]
 fn readable_byte_stream_tee(
-    cx: &mut js::context::JSContext,
+    cx: &mut JSContext,
     global: &GlobalScope,
     underlying_source_type: UnderlyingSourceType,
 ) -> DomRoot<ReadableStream> {
@@ -991,7 +992,7 @@ impl ReadableStream {
 
     /// Build a stream backed by a Rust source that has already been read into memory.
     pub(crate) fn new_from_bytes(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         bytes: Vec<u8>,
     ) -> Fallible<DomRoot<ReadableStream>> {
@@ -1009,7 +1010,7 @@ impl ReadableStream {
     /// Note: external sources are always paired with a default controller.
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new_with_external_underlying_source(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         source: UnderlyingSourceType,
     ) -> Fallible<DomRoot<ReadableStream>> {
@@ -1048,11 +1049,7 @@ impl ReadableStream {
     /// Call into the pull steps of the controller,
     /// as part of
     /// <https://streams.spec.whatwg.org/#readable-stream-default-reader-read>
-    pub(crate) fn perform_pull_steps(
-        &self,
-        cx: &mut js::context::JSContext,
-        read_request: &ReadRequest,
-    ) {
+    pub(crate) fn perform_pull_steps(&self, cx: &mut JSContext, read_request: &ReadRequest) {
         match self.controller.borrow().as_ref() {
             Some(ControllerType::Default(controller)) => controller
                 .get()
@@ -1073,7 +1070,7 @@ impl ReadableStream {
     /// <https://streams.spec.whatwg.org/#readable-stream-byob-reader-read>
     pub(crate) fn perform_pull_into(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         read_into_request: &ReadIntoRequest,
         view: HeapBufferSource<ArrayBufferViewU8>,
         min: u64,
@@ -1136,7 +1133,7 @@ impl ReadableStream {
 
     /// Endpoint to enqueue chunks directly from Rust.
     /// Note: in other use cases this call happens via the controller.
-    pub(crate) fn enqueue_native(&self, cx: &mut js::context::JSContext, bytes: Vec<u8>) {
+    pub(crate) fn enqueue_native(&self, cx: &mut JSContext, bytes: Vec<u8>) {
         match self.controller.borrow().as_ref() {
             Some(ControllerType::Default(controller)) => controller
                 .get()
@@ -1151,7 +1148,7 @@ impl ReadableStream {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-stream-error>
-    pub(crate) fn error(&self, cx: &mut js::context::JSContext, e: SafeHandleValue) {
+    pub(crate) fn error(&self, cx: &mut JSContext, e: SafeHandleValue) {
         // Assert: stream.[[state]] is "readable".
         assert!(self.is_readable());
 
@@ -1200,7 +1197,7 @@ impl ReadableStream {
 
     /// <https://streams.spec.whatwg.org/#readable-stream-error>
     /// Note: in other use cases this call happens via the controller.
-    pub(crate) fn error_native(&self, cx: &mut js::context::JSContext, error: Error) {
+    pub(crate) fn error_native(&self, cx: &mut JSContext, error: Error) {
         rooted!(&in(cx) let mut error_val = UndefinedValue());
         error.to_jsval(
             cx.into(),
@@ -1213,7 +1210,7 @@ impl ReadableStream {
 
     /// Call into the controller's `Close` method.
     /// <https://streams.spec.whatwg.org/#readable-stream-default-controller-close>
-    pub(crate) fn controller_close_native(&self, cx: &mut js::context::JSContext) {
+    pub(crate) fn controller_close_native(&self, cx: &mut JSContext) {
         match self.controller.borrow().as_ref() {
             Some(ControllerType::Default(controller)) => {
                 let _ = controller
@@ -1329,7 +1326,7 @@ impl ReadableStream {
     /// and before `stop_reading`.
     /// Native call to
     /// <https://streams.spec.whatwg.org/#readable-stream-default-reader-read>
-    pub(crate) fn read_a_chunk(&self, cx: &mut js::context::JSContext) -> Rc<Promise> {
+    pub(crate) fn read_a_chunk(&self, cx: &mut JSContext) -> Rc<Promise> {
         match self.reader.borrow().as_ref() {
             Some(ReaderType::Default(reader)) => {
                 let Some(reader) = reader.get() else {
@@ -1349,7 +1346,7 @@ impl ReadableStream {
     /// must be done after `start_reading`.
     /// Native call to
     /// <https://streams.spec.whatwg.org/#abstract-opdef-readablestreamdefaultreaderrelease>
-    pub(crate) fn stop_reading(&self, cx: &mut js::context::JSContext) {
+    pub(crate) fn stop_reading(&self, cx: &mut JSContext) {
         let reader_ref = self.reader.borrow();
 
         match reader_ref.as_ref() {
@@ -1456,7 +1453,7 @@ impl ReadableStream {
     /// <https://streams.spec.whatwg.org/#readable-stream-fulfill-read-request>
     pub(crate) fn fulfill_read_request(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         chunk: SafeHandleValue,
         done: bool,
     ) {
@@ -1496,7 +1493,7 @@ impl ReadableStream {
     /// <https://streams.spec.whatwg.org/#readable-stream-fulfill-read-into-request>
     pub(crate) fn fulfill_read_into_request(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         chunk: SafeHandleValue,
         done: bool,
     ) {
@@ -1539,7 +1536,7 @@ impl ReadableStream {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-stream-close>
-    pub(crate) fn close(&self, cx: &mut js::context::JSContext) {
+    pub(crate) fn close(&self, cx: &mut JSContext) {
         // Assert: stream.[[state]] is "readable".
         assert!(self.is_readable());
         // Set stream.[[state]] to "closed".
@@ -1583,7 +1580,7 @@ impl ReadableStream {
     /// <https://streams.spec.whatwg.org/#readable-stream-cancel>
     pub(crate) fn cancel(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         reason: SafeHandleValue,
     ) -> Rc<Promise> {
@@ -1652,8 +1649,10 @@ impl ReadableStream {
             Some(rejection_handler),
             CanGc::from_cx(cx),
         );
-        let realm = enter_realm(&*global);
-        let comp = InRealm::Entered(&realm);
+        let mut realm = enter_auto_realm(cx, &*global);
+        let cx = &mut realm.current_realm();
+
+        let comp = InRealm::Already(&cx.into());
         source_cancel_promise.append_native_handler(&handler, comp, CanGc::from_cx(cx));
 
         // Return the result of reacting to sourceCancelPromise
@@ -1668,7 +1667,7 @@ impl ReadableStream {
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     /// <https://streams.spec.whatwg.org/#abstract-opdef-readablebytestreamtee>
-    fn byte_tee(&self, cx: &mut js::context::JSContext) -> Fallible<Vec<DomRoot<ReadableStream>>> {
+    fn byte_tee(&self, cx: &mut JSContext) -> Fallible<Vec<DomRoot<ReadableStream>>> {
         // Assert: stream implements ReadableStream.
         // Assert: stream.[[controller]] implements ReadableByteStreamController.
 
@@ -1767,7 +1766,7 @@ impl ReadableStream {
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn default_tee(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         clone_for_branch_2: bool,
     ) -> Fallible<Vec<DomRoot<ReadableStream>>> {
         // Assert: stream implements ReadableStream.
@@ -1970,7 +1969,7 @@ impl ReadableStream {
     /// <https://streams.spec.whatwg.org/#readable-stream-tee>
     pub(crate) fn tee(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         clone_for_branch_2: bool,
     ) -> Fallible<Vec<DomRoot<ReadableStream>>> {
         // Assert: stream implements ReadableStream.
@@ -1995,7 +1994,7 @@ impl ReadableStream {
     /// <https://streams.spec.whatwg.org/#set-up-readable-byte-stream-controller-from-underlying-source>
     fn set_up_byte_controller(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         underlying_source_dict: JsUnderlyingSource,
         underlying_source_handle: SafeHandleObject,
@@ -2040,7 +2039,7 @@ impl ReadableStream {
     /// <https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformreadable>
     pub(crate) fn setup_cross_realm_transform_readable(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         port: &MessagePort,
     ) {
         let port_id = port.message_port_id();
@@ -2084,7 +2083,7 @@ impl ReadableStream {
 impl ReadableStreamMethods<crate::DomTypeHolder> for ReadableStream {
     /// <https://streams.spec.whatwg.org/#rs-constructor>
     fn Constructor(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<SafeHandleObject>,
         underlying_source: Option<*mut JSObject>,
@@ -2165,7 +2164,7 @@ impl ReadableStreamMethods<crate::DomTypeHolder> for ReadableStream {
     }
 
     /// <https://streams.spec.whatwg.org/#rs-cancel>
-    fn Cancel(&self, cx: &mut js::context::JSContext, reason: SafeHandleValue) -> Rc<Promise> {
+    fn Cancel(&self, cx: &mut JSContext, reason: SafeHandleValue) -> Rc<Promise> {
         let global = self.global();
         if self.is_locked() {
             // If ! IsReadableStreamLocked(this) is true,
@@ -2204,7 +2203,7 @@ impl ReadableStreamMethods<crate::DomTypeHolder> for ReadableStream {
     }
 
     /// <https://streams.spec.whatwg.org/#rs-tee>
-    fn Tee(&self, cx: &mut js::context::JSContext) -> Fallible<Vec<DomRoot<ReadableStream>>> {
+    fn Tee(&self, cx: &mut JSContext) -> Fallible<Vec<DomRoot<ReadableStream>>> {
         // Return ? ReadableStreamTee(this, false).
         self.tee(cx, false)
     }
@@ -2507,10 +2506,7 @@ impl Transferable for ReadableStream {
     type Data = MessagePortImpl;
 
     /// <https://streams.spec.whatwg.org/#ref-for-transfer-steps>
-    fn transfer(
-        &self,
-        cx: &mut js::context::JSContext,
-    ) -> Fallible<(MessagePortId, MessagePortImpl)> {
+    fn transfer(&self, cx: &mut JSContext) -> Fallible<(MessagePortId, MessagePortImpl)> {
         // Step 1. If ! IsReadableStreamLocked(value) is true, throw a
         // "DataCloneError" DOMException.
         if self.is_locked() {
@@ -2551,7 +2547,7 @@ impl Transferable for ReadableStream {
 
     /// <https://streams.spec.whatwg.org/#ref-for-transfer-receiving-steps>
     fn transfer_receive(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         owner: &GlobalScope,
         id: MessagePortId,
         port_impl: MessagePortImpl,

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -1651,8 +1651,8 @@ impl ReadableStream {
         );
         let mut realm = enter_auto_realm(cx, &*global);
         let cx = &mut realm.current_realm();
-
-        let comp = InRealm::Already(&cx.into());
+        let in_realm_proof = cx.into();
+        let comp = InRealm::Already(&in_realm_proof);
         source_cancel_promise.append_native_handler(&handler, comp, CanGc::from_cx(cx));
 
         // Return the result of reacting to sourceCancelPromise

--- a/components/script/dom/stream/readablestreambyobreader.rs
+++ b/components/script/dom/stream/readablestreambyobreader.rs
@@ -8,6 +8,7 @@ use std::mem;
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::gc::CustomAutoRooterGuard;
 use js::jsapi::Heap;
 use js::jsval::{JSVal, UndefinedValue};
@@ -76,11 +77,7 @@ impl ReadIntoRequest {
     }
 
     /// <https://streams.spec.whatwg.org/#ref-for-read-into-request-close-steps%E2%91%A0>
-    pub fn close_steps(
-        &self,
-        cx: &mut js::context::JSContext,
-        chunk: Option<RootedTraceableBox<Heap<JSVal>>>,
-    ) {
+    pub fn close_steps(&self, cx: &mut JSContext, chunk: Option<RootedTraceableBox<Heap<JSVal>>>) {
         match self {
             ReadIntoRequest::Read(promise) => match chunk {
                 // close steps, given chunk
@@ -305,7 +302,7 @@ impl ReadableStreamBYOBReader {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-stream-cancel>
-    pub(crate) fn cancel(&self, cx: &mut js::context::JSContext) {
+    pub(crate) fn cancel(&self, cx: &mut JSContext) {
         // If reader is not undefined and reader implements ReadableStreamBYOBReader,
         // Let readIntoRequests be reader.[[readIntoRequests]].
         let mut read_into_requests = self.take_read_into_requests();
@@ -325,7 +322,7 @@ impl ReadableStreamBYOBReader {
     /// <https://streams.spec.whatwg.org/#readable-stream-byob-reader-read>
     pub(crate) fn read(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         view: HeapBufferSource<ArrayBufferViewU8>,
         min: u64,
         read_into_request: &ReadIntoRequest,
@@ -423,7 +420,7 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
     /// <https://streams.spec.whatwg.org/#byob-reader-read>
     fn Read(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         view: CustomAutoRooterGuard<ArrayBufferView>,
         options: &ReadableStreamBYOBReaderReadOptions,
     ) -> Rc<Promise> {
@@ -533,7 +530,7 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
     }
 
     /// <https://streams.spec.whatwg.org/#generic-reader-cancel>
-    fn Cancel(&self, cx: &mut js::context::JSContext, reason: SafeHandleValue) -> Rc<Promise> {
+    fn Cancel(&self, cx: &mut JSContext, reason: SafeHandleValue) -> Rc<Promise> {
         self.generic_cancel(cx, &self.global(), reason)
     }
 }

--- a/components/script/dom/stream/readablestreambyobrequest.rs
+++ b/components/script/dom/stream/readablestreambyobrequest.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::gc::CustomAutoRooterGuard;
 use js::typedarray::{ArrayBufferView, ArrayBufferViewU8};
 use script_bindings::trace::RootedTraceableBox;
@@ -70,7 +71,7 @@ impl ReadableStreamBYOBRequestMethods<crate::DomTypeHolder> for ReadableStreamBY
     }
 
     /// <https://streams.spec.whatwg.org/#rs-byob-request-respond>
-    fn Respond(&self, cx: &mut js::context::JSContext, bytes_written: u64) -> Fallible<()> {
+    fn Respond(&self, cx: &mut JSContext, bytes_written: u64) -> Fallible<()> {
         // If this.[[controller]] is undefined, throw a TypeError exception.
         let controller = if let Some(controller) = self.controller.get() {
             controller
@@ -102,7 +103,7 @@ impl ReadableStreamBYOBRequestMethods<crate::DomTypeHolder> for ReadableStreamBY
     /// <https://streams.spec.whatwg.org/#rs-byob-request-respond-with-new-view>
     fn RespondWithNewView(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         view: CustomAutoRooterGuard<ArrayBufferView>,
     ) -> Fallible<()> {
         let view = HeapBufferSource::<ArrayBufferViewU8>::from_view(view);

--- a/components/script/dom/stream/readablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/readablestreamdefaultcontroller.rs
@@ -8,6 +8,7 @@ use std::ptr;
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::jsapi::{Heap, JSObject};
 use js::jsval::{JSVal, UndefinedValue};
 use js::realm::CurrentRealm;
@@ -33,7 +34,7 @@ use crate::dom::stream::readablestreamdefaultreader::ReadRequest;
 use crate::dom::stream::underlyingsourcecontainer::{
     UnderlyingSourceContainer, UnderlyingSourceType,
 };
-use crate::realms::{InRealm, enter_auto_realm, enter_realm};
+use crate::realms::{InRealm, enter_auto_realm};
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 
 /// The fulfillment handler for
@@ -391,7 +392,7 @@ impl ReadableStreamDefaultController {
     /// <https://streams.spec.whatwg.org/#set-up-readable-stream-default-controller>
     pub(crate) fn setup(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         stream: DomRoot<ReadableStream>,
     ) -> Result<(), Error> {
         // Assert: stream.[[controller]] is undefined
@@ -503,7 +504,7 @@ impl ReadableStreamDefaultController {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-stream-default-controller-call-pull-if-needed>
-    fn call_pull_if_needed(&self, cx: &mut js::context::JSContext) {
+    fn call_pull_if_needed(&self, cx: &mut JSContext) {
         // Let shouldPull be ! ReadableStreamDefaultControllerShouldCallPull(controller).
         // If shouldPull is false, return.
         if !self.should_call_pull() {
@@ -542,35 +543,30 @@ impl ReadableStreamDefaultController {
             CanGc::from_cx(cx),
         );
 
-        let realm = enter_realm(&*global);
-        let comp = InRealm::Entered(&realm);
+        let mut realm = enter_auto_realm(cx, &*global);
+        let cx = &mut realm.current_realm();
+
         let result = underlying_source
             .call_pull_algorithm(cx, controller)
             .unwrap_or_else(|| {
-                let promise = Promise::new2(cx, &global);
-                promise.resolve_native(&(), CanGc::from_cx(cx));
+                let promise = Promise::new_resolved(&global, cx.into(), (), CanGc::from_cx(cx));
                 Ok(promise)
             });
         let promise = result.unwrap_or_else(|error| {
             rooted!(&in(cx) let mut rval = UndefinedValue());
             // TODO: check if `self.global()` is the right globalscope.
-            error.to_jsval(
-                cx.into(),
-                &self.global(),
-                rval.handle_mut(),
-                CanGc::from_cx(cx),
-            );
-            let promise = Promise::new2(cx, &global);
-            promise.reject_native(&rval.handle(), CanGc::from_cx(cx));
-            promise
+            error.to_jsval(cx.into(), &global, rval.handle_mut(), CanGc::from_cx(cx));
+            Promise::new_rejected(&global, cx.into(), rval.handle(), CanGc::from_cx(cx))
         });
+
+        let comp = InRealm::Already(&cx.into());
         promise.append_native_handler(&handler, comp, CanGc::from_cx(cx));
     }
 
     /// <https://streams.spec.whatwg.org/#rs-default-controller-private-cancel>
     pub(crate) fn perform_cancel_steps(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         reason: SafeHandleValue,
     ) -> Rc<Promise> {
@@ -606,11 +602,7 @@ impl ReadableStreamDefaultController {
     }
 
     /// <https://streams.spec.whatwg.org/#rs-default-controller-private-pull>
-    pub(crate) fn perform_pull_steps(
-        &self,
-        cx: &mut js::context::JSContext,
-        read_request: &ReadRequest,
-    ) {
+    pub(crate) fn perform_pull_steps(&self, cx: &mut JSContext, read_request: &ReadRequest) {
         // Let stream be this.[[stream]].
         // Note: the spec does not assert that there is a stream.
         let Some(stream) = self.stream.get() else {
@@ -654,11 +646,7 @@ impl ReadableStreamDefaultController {
 
     /// <https://streams.spec.whatwg.org/#readable-stream-default-controller-enqueue>
     #[expect(unsafe_code)]
-    pub(crate) fn enqueue(
-        &self,
-        cx: &mut js::context::JSContext,
-        chunk: SafeHandleValue,
-    ) -> Result<(), Error> {
+    pub(crate) fn enqueue(&self, cx: &mut JSContext, chunk: SafeHandleValue) -> Result<(), Error> {
         // If ! ReadableStreamDefaultControllerCanCloseOrEnqueue(controller) is false, return.
         if !self.can_close_or_enqueue() {
             return Ok(());
@@ -748,7 +736,7 @@ impl ReadableStreamDefaultController {
 
     /// Native call to
     /// <https://streams.spec.whatwg.org/#readable-stream-default-controller-enqueue>
-    pub(crate) fn enqueue_native(&self, cx: &mut js::context::JSContext, chunk: Vec<u8>) {
+    pub(crate) fn enqueue_native(&self, cx: &mut JSContext, chunk: Vec<u8>) {
         let stream = self
             .stream
             .get()
@@ -796,7 +784,7 @@ impl ReadableStreamDefaultController {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-stream-default-controller-close>
-    pub(crate) fn close(&self, cx: &mut js::context::JSContext) {
+    pub(crate) fn close(&self, cx: &mut JSContext) {
         // If ! ReadableStreamDefaultControllerCanCloseOrEnqueue(controller) is false, return.
         if !self.can_close_or_enqueue() {
             return;
@@ -853,7 +841,7 @@ impl ReadableStreamDefaultController {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-stream-default-controller-error>
-    pub(crate) fn error(&self, cx: &mut js::context::JSContext, e: SafeHandleValue) {
+    pub(crate) fn error(&self, cx: &mut JSContext, e: SafeHandleValue) {
         let Some(stream) = self.stream.get() else {
             return;
         };
@@ -889,7 +877,7 @@ impl ReadableStreamDefaultControllerMethods<crate::DomTypeHolder>
     }
 
     /// <https://streams.spec.whatwg.org/#rs-default-controller-close>
-    fn Close(&self, cx: &mut js::context::JSContext) -> Fallible<()> {
+    fn Close(&self, cx: &mut JSContext) -> Fallible<()> {
         if !self.can_close_or_enqueue() {
             // If ! ReadableStreamDefaultControllerCanCloseOrEnqueue(this) is false,
             // throw a TypeError exception.
@@ -903,7 +891,7 @@ impl ReadableStreamDefaultControllerMethods<crate::DomTypeHolder>
     }
 
     /// <https://streams.spec.whatwg.org/#rs-default-controller-enqueue>
-    fn Enqueue(&self, cx: &mut js::context::JSContext, chunk: SafeHandleValue) -> Fallible<()> {
+    fn Enqueue(&self, cx: &mut JSContext, chunk: SafeHandleValue) -> Fallible<()> {
         // If ! ReadableStreamDefaultControllerCanCloseOrEnqueue(this) is false, throw a TypeError exception.
         if !self.can_close_or_enqueue() {
             return Err(Error::Type(c"Stream cannot be enqueued to.".to_owned()));
@@ -914,7 +902,7 @@ impl ReadableStreamDefaultControllerMethods<crate::DomTypeHolder>
     }
 
     /// <https://streams.spec.whatwg.org/#rs-default-controller-error>
-    fn Error(&self, cx: &mut js::context::JSContext, e: SafeHandleValue) -> Fallible<()> {
+    fn Error(&self, cx: &mut JSContext, e: SafeHandleValue) -> Fallible<()> {
         self.error(cx, e);
         Ok(())
     }

--- a/components/script/dom/stream/readablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/readablestreamdefaultcontroller.rs
@@ -559,7 +559,8 @@ impl ReadableStreamDefaultController {
             Promise::new_rejected(&global, cx.into(), rval.handle(), CanGc::from_cx(cx))
         });
 
-        let comp = InRealm::Already(&cx.into());
+        let in_realm_proof = cx.into();
+        let comp = InRealm::Already(&in_realm_proof);
         promise.append_native_handler(&handler, comp, CanGc::from_cx(cx));
     }
 

--- a/components/script/dom/stream/transformstream.rs
+++ b/components/script/dom/stream/transformstream.rs
@@ -7,6 +7,7 @@ use std::ptr::{self};
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::jsapi::{Heap, IsPromiseObject, JSObject};
 use js::jsval::{JSVal, ObjectValue, UndefinedValue};
 use js::realm::CurrentRealm;
@@ -42,8 +43,8 @@ use crate::dom::stream::underlyingsourcecontainer::UnderlyingSourceType;
 use crate::dom::stream::writablestream::create_writable_stream;
 use crate::dom::stream::writablestreamdefaultcontroller::UnderlyingSinkType;
 use crate::dom::types::{PromiseNativeHandler, TransformStreamDefaultController, WritableStream};
-use crate::realms::{enter_auto_realm, enter_realm};
-use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
+use crate::realms::enter_auto_realm;
+use crate::script_runtime::CanGc;
 
 impl js::gc::Rootable for TransformBackPressureChangePromiseFulfillment {}
 
@@ -443,7 +444,7 @@ impl TransformStream {
     /// <https://streams.spec.whatwg.org/#transformstream-set-up>
     pub(crate) fn set_up(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         transformer_type: TransformerType,
     ) -> Fallible<()> {
@@ -514,7 +515,7 @@ impl TransformStream {
     #[expect(clippy::too_many_arguments)]
     fn initialize(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         start_promise: Rc<Promise>,
         writable_high_water_mark: f64,
@@ -659,7 +660,7 @@ impl TransformStream {
     /// <https://streams.spec.whatwg.org/#transform-stream-default-sink-write-algorithm>
     pub(crate) fn transform_stream_default_sink_write_algorithm(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         chunk: SafeHandleValue,
     ) -> Fallible<Rc<Promise>> {
@@ -713,10 +714,9 @@ impl TransformStream {
     /// <https://streams.spec.whatwg.org/#transform-stream-default-sink-abort-algorithm>
     pub(crate) fn transform_stream_default_sink_abort_algorithm(
         &self,
-        cx: SafeJSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         reason: SafeHandleValue,
-        can_gc: CanGc,
     ) -> Fallible<Rc<Promise>> {
         // Let controller be stream.[[controller]].
         let controller = self.controller.get().expect("controller is not set");
@@ -730,10 +730,10 @@ impl TransformStream {
         let readable = self.readable.get().expect("readable stream is not set");
 
         // Let controller.[[finishPromise]] be a new promise.
-        controller.set_finish_promise(Promise::new(global, can_gc));
+        controller.set_finish_promise(Promise::new2(cx, global));
 
         // Let cancelPromise be the result of performing controller.[[cancelAlgorithm]], passing reason.
-        let cancel_promise = controller.perform_cancel(cx, global, reason, can_gc)?;
+        let cancel_promise = controller.perform_cancel(cx, global, reason)?;
 
         // Perform ! TransformStreamDefaultControllerClearAlgorithms(controller).
         controller.clear_algorithms();
@@ -750,11 +750,13 @@ impl TransformStream {
                 readable: Dom::from_ref(&readable),
                 controller: Dom::from_ref(&controller),
             })),
-            can_gc,
+            CanGc::from_cx(cx),
         );
-        let realm = enter_realm(global);
-        let comp = InRealm::Entered(&realm);
-        cancel_promise.append_native_handler(&handler, comp, can_gc);
+        let mut realm = enter_auto_realm(cx, global);
+        let cx = &mut realm.current_realm();
+
+        let comp = InRealm::Already(&cx.into());
+        cancel_promise.append_native_handler(&handler, comp, CanGc::from_cx(cx));
 
         // Return controller.[[finishPromise]].
         let finish_promise = controller
@@ -766,7 +768,7 @@ impl TransformStream {
     /// <https://streams.spec.whatwg.org/#transform-stream-default-sink-close-algorithm>
     pub(crate) fn transform_stream_default_sink_close_algorithm(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
     ) -> Fallible<Rc<Promise>> {
         // Let controller be stream.[[controller]].
@@ -824,10 +826,9 @@ impl TransformStream {
     /// <https://streams.spec.whatwg.org/#transform-stream-default-source-cancel>
     pub(crate) fn transform_stream_default_source_cancel(
         &self,
-        cx: SafeJSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         reason: SafeHandleValue,
-        can_gc: CanGc,
     ) -> Fallible<Rc<Promise>> {
         // Let controller be stream.[[controller]].
         let controller = self
@@ -847,10 +848,10 @@ impl TransformStream {
             .ok_or(Error::Type(c"writable stream is not set".to_owned()))?;
 
         // Let controller.[[finishPromise]] be a new promise.
-        controller.set_finish_promise(Promise::new(global, can_gc));
+        controller.set_finish_promise(Promise::new2(cx, global));
 
         // Let cancelPromise be the result of performing controller.[[cancelAlgorithm]], passing reason.
-        let cancel_promise = controller.perform_cancel(cx, global, reason, can_gc)?;
+        let cancel_promise = controller.perform_cancel(cx, global, reason)?;
 
         // Perform ! TransformStreamDefaultControllerClearAlgorithms(controller).
         controller.clear_algorithms();
@@ -869,16 +870,18 @@ impl TransformStream {
                 controller: Dom::from_ref(&controller),
                 stream: Dom::from_ref(self),
             })),
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         // Return controller.[[finishPromise]].
         let finish_promise = controller
             .get_finish_promise()
             .expect("finish promise is not set");
-        let realm = enter_realm(global);
-        let comp = InRealm::Entered(&realm);
-        cancel_promise.append_native_handler(&handler, comp, can_gc);
+        let mut realm = enter_auto_realm(cx, global);
+        let cx = &mut realm.current_realm();
+
+        let comp = InRealm::Already(&cx.into());
+        cancel_promise.append_native_handler(&handler, comp, CanGc::from_cx(cx));
         Ok(finish_promise)
     }
 
@@ -908,7 +911,7 @@ impl TransformStream {
     /// <https://streams.spec.whatwg.org/#transform-stream-error-writable-and-unblock-write>
     pub(crate) fn error_writable_and_unblock_write(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         error: SafeHandleValue,
     ) {
@@ -933,12 +936,7 @@ impl TransformStream {
     }
 
     /// <https://streams.spec.whatwg.org/#transform-stream-error>
-    pub(crate) fn error(
-        &self,
-        cx: &mut js::context::JSContext,
-        global: &GlobalScope,
-        error: SafeHandleValue,
-    ) {
+    pub(crate) fn error(&self, cx: &mut JSContext, global: &GlobalScope, error: SafeHandleValue) {
         // Perform ! ReadableStreamDefaultControllerError(stream.[[readable]].[[controller]], e).
         self.get_readable()
             .get_default_controller()
@@ -953,7 +951,7 @@ impl TransformStreamMethods<crate::DomTypeHolder> for TransformStream {
     /// <https://streams.spec.whatwg.org/#ts-constructor>
     #[expect(unsafe_code)]
     fn Constructor(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<SafeHandleObject>,
         transformer: Option<*mut JSObject>,
@@ -1081,10 +1079,7 @@ impl Transferable for TransformStream {
     type Data = TransformStreamData;
 
     /// <https://streams.spec.whatwg.org/#ref-for-transfer-steps②>
-    fn transfer(
-        &self,
-        cx: &mut js::context::JSContext,
-    ) -> Fallible<(MessagePortId, TransformStreamData)> {
+    fn transfer(&self, cx: &mut JSContext) -> Fallible<(MessagePortId, TransformStreamData)> {
         let global = self.global();
         let mut realm = enter_auto_realm(cx, &*global);
         let mut realm = realm.current_realm();
@@ -1147,7 +1142,7 @@ impl Transferable for TransformStream {
 
     /// <https://streams.spec.whatwg.org/#ref-for-transfer-receiving-steps②>
     fn transfer_receive(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         owner: &GlobalScope,
         _id: MessagePortId,
         data: TransformStreamData,

--- a/components/script/dom/stream/transformstream.rs
+++ b/components/script/dom/stream/transformstream.rs
@@ -754,8 +754,8 @@ impl TransformStream {
         );
         let mut realm = enter_auto_realm(cx, global);
         let cx = &mut realm.current_realm();
-
-        let comp = InRealm::Already(&cx.into());
+        let in_realm_proof = cx.into();
+        let comp = InRealm::Already(&in_realm_proof);
         cancel_promise.append_native_handler(&handler, comp, CanGc::from_cx(cx));
 
         // Return controller.[[finishPromise]].
@@ -879,8 +879,8 @@ impl TransformStream {
             .expect("finish promise is not set");
         let mut realm = enter_auto_realm(cx, global);
         let cx = &mut realm.current_realm();
-
-        let comp = InRealm::Already(&cx.into());
+        let in_realm_proof = cx.into();
+        let comp = InRealm::Already(&in_realm_proof);
         cancel_promise.append_native_handler(&handler, comp, CanGc::from_cx(cx));
         Ok(finish_promise)
     }

--- a/components/script/dom/stream/transformstreamdefaultcontroller.rs
+++ b/components/script/dom/stream/transformstreamdefaultcontroller.rs
@@ -6,6 +6,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::jsapi::{
     ExceptionStackBehavior, Heap, JS_IsExceptionPending, JS_SetPendingException, JSObject,
 };
@@ -38,7 +39,7 @@ use crate::dom::promise::Promise;
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::types::{DecompressionStream, TransformStream};
 use crate::realms::{InRealm, enter_auto_realm};
-use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
+use crate::script_runtime::CanGc;
 
 impl js::gc::Rootable for TransformTransformPromiseRejection {}
 
@@ -175,7 +176,7 @@ impl TransformStreamDefaultController {
     /// <https://streams.spec.whatwg.org/#transform-stream-default-controller-perform-transform>
     pub(crate) fn transform_stream_default_controller_perform_transform(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         chunk: SafeHandleValue,
     ) -> Fallible<Rc<Promise>> {
@@ -204,7 +205,7 @@ impl TransformStreamDefaultController {
 
     pub(crate) fn perform_transform(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         chunk: SafeHandleValue,
     ) -> Fallible<Rc<Promise>> {
@@ -362,10 +363,9 @@ impl TransformStreamDefaultController {
 
     pub(crate) fn perform_cancel(
         &self,
-        cx: SafeJSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         chunk: SafeHandleValue,
-        can_gc: CanGc,
     ) -> Fallible<Rc<Promise>> {
         let result = match &self.transformer_type {
             // <https://streams.spec.whatwg.org/#set-up-transform-stream-default-controller-from-transformer>
@@ -381,22 +381,22 @@ impl TransformStreamDefaultController {
                 // callback this value transformer.
                 let algo = cancel.borrow().clone();
                 if let Some(cancel) = algo {
-                    rooted!(in(*cx) let this_object = transform_obj.get());
+                    rooted!(&in(cx) let this_object = transform_obj.get());
                     cancel
                         .Call_(
                             &this_object.handle(),
                             chunk,
                             ExceptionHandling::Rethrow,
-                            can_gc,
+                            CanGc::from_cx(cx),
                         )
                         .unwrap_or_else(|e| {
-                            let p = Promise::new(global, can_gc);
-                            p.reject_error(e, can_gc);
+                            let p = Promise::new2(cx, global);
+                            p.reject_error(e, CanGc::from_cx(cx));
                             p
                         })
                 } else {
                     // Step 4. Let cancelAlgorithm be an algorithm which returns a promise resolved with undefined.
-                    Promise::new_resolved(global, cx, (), can_gc)
+                    Promise::new_resolved(global, cx.into(), (), CanGc::from_cx(cx))
                 }
             },
             TransformerType::Decoder(_) => {
@@ -408,7 +408,7 @@ impl TransformStreamDefaultController {
                 // Step 7.2 If result is a Promise, then return result.
                 // Note: Not applicable.
                 // Step 7.3 Return a promise resolved with undefined.
-                Promise::new_resolved(global, cx, (), can_gc)
+                Promise::new_resolved(global, cx.into(), (), CanGc::from_cx(cx))
             },
             TransformerType::Encoder(_) => {
                 // <https://streams.spec.whatwg.org/#transformstream-set-up>
@@ -419,7 +419,7 @@ impl TransformStreamDefaultController {
                 // Step 7.2 If result is a Promise, then return result.
                 // Note: Not applicable.
                 // Step 7.3 Return a promise resolved with undefined.
-                Promise::new_resolved(global, cx, (), can_gc)
+                Promise::new_resolved(global, cx.into(), (), CanGc::from_cx(cx))
             },
             TransformerType::Compressor(_) => {
                 // <https://streams.spec.whatwg.org/#transformstream-set-up>
@@ -430,7 +430,7 @@ impl TransformStreamDefaultController {
                 // Step 7.2 If result is a Promise, then return result.
                 // Note: Not applicable.
                 // Step 7.3 Return a promise resolved with undefined.
-                Promise::new_resolved(global, cx, (), can_gc)
+                Promise::new_resolved(global, cx.into(), (), CanGc::from_cx(cx))
             },
             TransformerType::Decompressor(_) => {
                 // <https://streams.spec.whatwg.org/#transformstream-set-up>
@@ -441,7 +441,7 @@ impl TransformStreamDefaultController {
                 // Step 7.2 If result is a Promise, then return result.
                 // Note: Not applicable.
                 // Step 7.3 Return a promise resolved with undefined.
-                Promise::new_resolved(global, cx, (), can_gc)
+                Promise::new_resolved(global, cx.into(), (), CanGc::from_cx(cx))
             },
         };
 
@@ -450,7 +450,7 @@ impl TransformStreamDefaultController {
 
     pub(crate) fn perform_flush(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
     ) -> Fallible<Rc<Promise>> {
         let result = match &self.transformer_type {
@@ -590,7 +590,7 @@ impl TransformStreamDefaultController {
     #[expect(unsafe_code)]
     pub(crate) fn enqueue(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         chunk: SafeHandleValue,
     ) -> Fallible<()> {
@@ -653,12 +653,7 @@ impl TransformStreamDefaultController {
     }
 
     /// <https://streams.spec.whatwg.org/#transform-stream-default-controller-error>
-    pub(crate) fn error(
-        &self,
-        cx: &mut js::context::JSContext,
-        global: &GlobalScope,
-        reason: SafeHandleValue,
-    ) {
+    pub(crate) fn error(&self, cx: &mut JSContext, global: &GlobalScope, reason: SafeHandleValue) {
         // Perform ! TransformStreamError(controller.[[stream]], e).
         self.stream
             .get()
@@ -687,7 +682,7 @@ impl TransformStreamDefaultController {
     }
 
     /// <https://streams.spec.whatwg.org/#transform-stream-default-controller-terminate>
-    fn terminate(&self, cx: &mut js::context::JSContext, global: &GlobalScope) {
+    fn terminate(&self, cx: &mut JSContext, global: &GlobalScope) {
         // Let stream be controller.[[stream]].
         let stream = self.stream.get().expect("stream is null");
 
@@ -731,20 +726,20 @@ impl TransformStreamDefaultControllerMethods<crate::DomTypeHolder>
     }
 
     /// <https://streams.spec.whatwg.org/#ts-default-controller-enqueue>
-    fn Enqueue(&self, cx: &mut js::context::JSContext, chunk: SafeHandleValue) -> Fallible<()> {
+    fn Enqueue(&self, cx: &mut JSContext, chunk: SafeHandleValue) -> Fallible<()> {
         // Perform ? TransformStreamDefaultControllerEnqueue(this, chunk).
         self.enqueue(cx, &self.global(), chunk)
     }
 
     /// <https://streams.spec.whatwg.org/#ts-default-controller-error>
-    fn Error(&self, cx: &mut js::context::JSContext, reason: SafeHandleValue) -> Fallible<()> {
+    fn Error(&self, cx: &mut JSContext, reason: SafeHandleValue) -> Fallible<()> {
         // Perform ? TransformStreamDefaultControllerError(this, e).
         self.error(cx, &self.global(), reason);
         Ok(())
     }
 
     /// <https://streams.spec.whatwg.org/#ts-default-controller-terminate>
-    fn Terminate(&self, cx: &mut js::context::JSContext) -> Fallible<()> {
+    fn Terminate(&self, cx: &mut JSContext) -> Fallible<()> {
         // Perform ? TransformStreamDefaultControllerTerminate(this).
         self.terminate(cx, &self.global());
         Ok(())

--- a/components/script/dom/stream/underlyingsourcecontainer.rs
+++ b/components/script/dom/stream/underlyingsourcecontainer.rs
@@ -6,6 +6,7 @@ use std::ptr;
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::jsapi::{Heap, IsPromiseObject, JSObject};
 use js::jsval::{JSVal, UndefinedValue};
 use js::rust::{Handle as SafeHandle, HandleObject, HandleValue as SafeHandleValue, IntoHandle};
@@ -118,7 +119,7 @@ impl UnderlyingSourceContainer {
     #[expect(unsafe_code)]
     pub(crate) fn call_cancel_algorithm(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         reason: SafeHandleValue,
     ) -> Option<Result<Rc<Promise>, Error>> {
@@ -143,12 +144,7 @@ impl UnderlyingSourceContainer {
             },
             UnderlyingSourceType::Transform(stream, _) => {
                 // Return ! TransformStreamDefaultSourceCancelAlgorithm(stream, reason).
-                Some(stream.transform_stream_default_source_cancel(
-                    cx.into(),
-                    global,
-                    reason,
-                    CanGc::from_cx(cx),
-                ))
+                Some(stream.transform_stream_default_source_cancel(cx, global, reason))
             },
             UnderlyingSourceType::Transfer(port) => {
                 // Let cancelAlgorithm be the following steps, taking a reason argument:
@@ -185,7 +181,7 @@ impl UnderlyingSourceContainer {
     #[expect(unsafe_code)]
     pub(crate) fn call_pull_algorithm(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         controller: Controller,
     ) -> Option<Result<Rc<Promise>, Error>> {
         match &self.underlying_source_type {
@@ -217,8 +213,8 @@ impl UnderlyingSourceContainer {
                     .expect("Sending pull should not fail.");
 
                 // Return a promise resolved with undefined.
-                let promise = Promise::new2(cx, &self.global());
-                promise.resolve_native(&(), CanGc::from_cx(cx));
+                let promise =
+                    Promise::new_resolved(&self.global(), cx.into(), (), CanGc::from_cx(cx));
                 Some(Ok(promise))
             },
             UnderlyingSourceType::TeeByte(tee_underlyin_source) => {
@@ -246,7 +242,7 @@ impl UnderlyingSourceContainer {
     #[expect(unsafe_code)]
     pub(crate) fn call_start_algorithm(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         controller: Controller,
     ) -> Option<Result<Rc<Promise>, Error>> {
         match &self.underlying_source_type {

--- a/components/script/dom/stream/writablestream.rs
+++ b/components/script/dom/stream/writablestream.rs
@@ -9,6 +9,7 @@ use std::ptr::{self};
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::jsapi::{Heap, JSObject};
 use js::jsval::{JSVal, ObjectValue, UndefinedValue};
 use js::realm::CurrentRealm;
@@ -252,7 +253,7 @@ impl WritableStream {
     }
 
     /// <https://streams.spec.whatwg.org/#writable-stream-finish-erroring>
-    pub(crate) fn finish_erroring(&self, cx: &mut js::context::JSContext, global: &GlobalScope) {
+    pub(crate) fn finish_erroring(&self, cx: &mut JSContext, global: &GlobalScope) {
         // Assert: stream.[[state]] is "erroring".
         assert!(self.is_erroring());
 
@@ -341,7 +342,7 @@ impl WritableStream {
     }
 
     /// <https://streams.spec.whatwg.org/#writable-stream-reject-close-and-closed-promise-if-needed>
-    fn reject_close_and_closed_promise_if_needed(&self, cx: &mut js::context::JSContext) {
+    fn reject_close_and_closed_promise_if_needed(&self, cx: &mut JSContext) {
         // Assert: stream.[[state]] is "errored".
         assert!(self.is_errored());
 
@@ -397,7 +398,7 @@ impl WritableStream {
     /// <https://streams.spec.whatwg.org/#writable-stream-start-erroring>
     pub(crate) fn start_erroring(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         error: SafeHandleValue,
     ) {
@@ -435,7 +436,7 @@ impl WritableStream {
     /// <https://streams.spec.whatwg.org/#writable-stream-deal-with-rejection>
     pub(crate) fn deal_with_rejection(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         error: SafeHandleValue,
     ) {
@@ -547,7 +548,7 @@ impl WritableStream {
     /// <https://streams.spec.whatwg.org/#writable-stream-finish-in-flight-close-with-error>
     pub(crate) fn finish_in_flight_close_with_error(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         error: SafeHandleValue,
     ) {
@@ -584,7 +585,7 @@ impl WritableStream {
     /// <https://streams.spec.whatwg.org/#writable-stream-finish-in-flight-write-with-error>
     pub(crate) fn finish_in_flight_write_with_error(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         error: SafeHandleValue,
     ) {
@@ -736,11 +737,7 @@ impl WritableStream {
     }
 
     /// <https://streams.spec.whatwg.org/#writable-stream-close>
-    pub(crate) fn close(
-        &self,
-        cx: &mut js::context::JSContext,
-        global: &GlobalScope,
-    ) -> Rc<Promise> {
+    pub(crate) fn close(&self, cx: &mut JSContext, global: &GlobalScope) -> Rc<Promise> {
         // Let state be stream.[[state]].
         // If state is "closed" or "errored",
         if self.is_closed() || self.is_errored() {
@@ -867,7 +864,7 @@ impl WritableStream {
     /// <https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformwritable>
     pub(crate) fn setup_cross_realm_transform_writable(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         port: &MessagePort,
     ) {
         let port_id = port.message_port_id();
@@ -921,7 +918,7 @@ impl WritableStream {
     #[allow(clippy::too_many_arguments)]
     fn setup_from_underlying_sink(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         stream: &WritableStream,
         underlying_sink_obj: SafeHandleObject,
@@ -979,7 +976,7 @@ impl WritableStream {
 /// <https://streams.spec.whatwg.org/#create-writable-stream>
 #[cfg_attr(crown, expect(crown::unrooted_must_root))]
 pub(crate) fn create_writable_stream(
-    cx: &mut js::context::JSContext,
+    cx: &mut JSContext,
     global: &GlobalScope,
     writable_high_water_mark: f64,
     writable_size_algorithm: Rc<QueuingStrategySize>,
@@ -1012,7 +1009,7 @@ pub(crate) fn create_writable_stream(
 impl WritableStreamMethods<crate::DomTypeHolder> for WritableStream {
     /// <https://streams.spec.whatwg.org/#ws-constructor>
     fn Constructor(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<SafeHandleObject>,
         underlying_sink: Option<*mut JSObject>,
@@ -1225,10 +1222,7 @@ impl Transferable for WritableStream {
     type Data = MessagePortImpl;
 
     /// <https://streams.spec.whatwg.org/#ref-for-transfer-steps①>
-    fn transfer(
-        &self,
-        cx: &mut js::context::JSContext,
-    ) -> Fallible<(MessagePortId, MessagePortImpl)> {
+    fn transfer(&self, cx: &mut JSContext) -> Fallible<(MessagePortId, MessagePortImpl)> {
         // Step 1. If ! IsWritableStreamLocked(value) is true, throw a
         // "DataCloneError" DOMException.
         if self.is_locked() {
@@ -1269,7 +1263,7 @@ impl Transferable for WritableStream {
 
     /// <https://streams.spec.whatwg.org/#ref-for-transfer-receiving-steps①>
     fn transfer_receive(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         owner: &GlobalScope,
         id: MessagePortId,
         port_impl: MessagePortImpl,

--- a/components/script/dom/stream/writablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/writablestreamdefaultcontroller.rs
@@ -7,6 +7,7 @@ use std::ptr;
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::jsapi::{Heap, IsPromiseObject, JSObject};
 use js::jsval::{JSVal, UndefinedValue};
 use js::realm::CurrentRealm;
@@ -30,7 +31,7 @@ use crate::dom::readablestreamdefaultcontroller::{EnqueuedValue, QueueWithSizes,
 use crate::dom::stream::writablestream::WritableStream;
 use crate::dom::types::{AbortController, AbortSignal, TransformStream};
 use crate::realms::{InRealm, enter_auto_realm};
-use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
+use crate::script_runtime::CanGc;
 
 impl js::gc::Rootable for CloseAlgorithmFulfillmentHandler {}
 
@@ -442,7 +443,7 @@ impl WritableStreamDefaultController {
     /// <https://streams.spec.whatwg.org/#set-up-writable-stream-default-controller>
     pub(crate) fn setup(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         stream: &WritableStream,
     ) -> Result<(), Error> {
@@ -484,7 +485,7 @@ impl WritableStreamDefaultController {
 
         // Let startResult be the result of performing startAlgorithm. (This may throw an exception.)
         // Let startPromise be a promise resolved with startResult.
-        let start_promise = self.start_algorithm(cx.into(), global, CanGc::from_cx(cx))?;
+        let start_promise = self.start_algorithm(cx, global)?;
 
         let rooted_default_controller = DomRoot::from_ref(self);
 
@@ -515,7 +516,7 @@ impl WritableStreamDefaultController {
     }
 
     /// <https://streams.spec.whatwg.org/#writable-stream-default-controller-close>
-    pub(crate) fn close(&self, cx: &mut js::context::JSContext, global: &GlobalScope) {
+    pub(crate) fn close(&self, cx: &mut JSContext, global: &GlobalScope) {
         // Perform ! EnqueueValueWithSize(controller, close sentinel, 0).
         self.queue
             .enqueue_value_with_size(EnqueuedValue::CloseSentinel)
@@ -525,12 +526,7 @@ impl WritableStreamDefaultController {
     }
 
     #[expect(unsafe_code)]
-    fn start_algorithm(
-        &self,
-        cx: SafeJSContext,
-        global: &GlobalScope,
-        can_gc: CanGc,
-    ) -> Fallible<Rc<Promise>> {
+    fn start_algorithm(&self, cx: &mut JSContext, global: &GlobalScope) -> Fallible<Rc<Promise>> {
         match &self.underlying_sink_type {
             UnderlyingSinkType::Js {
                 start,
@@ -540,15 +536,15 @@ impl WritableStreamDefaultController {
             } => {
                 let algo = start.borrow().clone();
                 let start_promise = if let Some(start) = algo {
-                    rooted!(in(*cx) let mut result_object = ptr::null_mut::<JSObject>());
-                    rooted!(in(*cx) let mut result: JSVal);
-                    rooted!(in(*cx) let this_object = self.underlying_sink_obj.get());
+                    rooted!(&in(cx) let mut result_object = ptr::null_mut::<JSObject>());
+                    rooted!(&in(cx) let mut result: JSVal);
+                    rooted!(&in(cx) let this_object = self.underlying_sink_obj.get());
                     start.Call_(
                         &this_object.handle(),
                         self,
                         result.handle_mut(),
                         ExceptionHandling::Rethrow,
-                        can_gc,
+                        CanGc::from_cx(cx),
                     )?;
                     let is_promise = unsafe {
                         if result.is_object() {
@@ -559,20 +555,25 @@ impl WritableStreamDefaultController {
                         }
                     };
                     if is_promise {
-                        Promise::new_with_js_promise(result_object.handle(), cx)
+                        Promise::new_with_js_promise(result_object.handle(), cx.into())
                     } else {
-                        Promise::new_resolved(global, cx, result.get(), can_gc)
+                        Promise::new_resolved(global, cx.into(), result.get(), CanGc::from_cx(cx))
                     }
                 } else {
                     // Let startAlgorithm be an algorithm that returns undefined.
-                    Promise::new_resolved(global, cx, (), can_gc)
+                    Promise::new_resolved(global, cx.into(), (), CanGc::from_cx(cx))
                 };
 
                 Ok(start_promise)
             },
             UnderlyingSinkType::Transfer { .. } => {
                 // Let startAlgorithm be an algorithm that returns undefined.
-                Ok(Promise::new_resolved(global, cx, (), can_gc))
+                Ok(Promise::new_resolved(
+                    global,
+                    cx.into(),
+                    (),
+                    CanGc::from_cx(cx),
+                ))
             },
             UnderlyingSinkType::Transform(_, start_promise) => {
                 // Let startAlgorithm be an algorithm that returns startPromise.
@@ -584,7 +585,7 @@ impl WritableStreamDefaultController {
     /// <https://streams.spec.whatwg.org/#ref-for-abstract-opdef-writablestreamcontroller-abortsteps>
     pub(crate) fn abort_steps(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         reason: SafeHandleValue,
     ) -> Rc<Promise> {
@@ -644,12 +645,7 @@ impl WritableStreamDefaultController {
             UnderlyingSinkType::Transform(stream, _) => {
                 // Return ! TransformStreamDefaultSinkAbortAlgorithm(stream, reason).
                 stream
-                    .transform_stream_default_sink_abort_algorithm(
-                        cx.into(),
-                        global,
-                        reason,
-                        CanGc::from_cx(cx),
-                    )
+                    .transform_stream_default_sink_abort_algorithm(cx, global, reason)
                     .expect("Transform stream default sink abort algorithm should not fail.")
             },
         };
@@ -663,7 +659,7 @@ impl WritableStreamDefaultController {
     /// <https://streams.spec.whatwg.org/#writablestreamdefaultcontroller-writealgorithm>
     fn call_write_algorithm(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         chunk: SafeHandleValue,
         global: &GlobalScope,
     ) -> Rc<Promise> {
@@ -747,11 +743,7 @@ impl WritableStreamDefaultController {
     }
 
     /// <https://streams.spec.whatwg.org/#writablestreamdefaultcontroller-closealgorithm>
-    fn call_close_algorithm(
-        &self,
-        cx: &mut js::context::JSContext,
-        global: &GlobalScope,
-    ) -> Rc<Promise> {
+    fn call_close_algorithm(&self, cx: &mut JSContext, global: &GlobalScope) -> Rc<Promise> {
         match &self.underlying_sink_type {
             UnderlyingSinkType::Js {
                 abort: _,
@@ -807,7 +799,7 @@ impl WritableStreamDefaultController {
     }
 
     /// <https://streams.spec.whatwg.org/#writable-stream-default-controller-process-close>
-    pub(crate) fn process_close(&self, cx: &mut js::context::JSContext, global: &GlobalScope) {
+    pub(crate) fn process_close(&self, cx: &mut JSContext, global: &GlobalScope) {
         // Let stream be controller.[[stream]].
         let Some(stream) = self.stream.get() else {
             unreachable!("Controller should have a stream");
@@ -854,7 +846,7 @@ impl WritableStreamDefaultController {
     }
 
     /// <https://streams.spec.whatwg.org/#writable-stream-default-controller-advance-queue-if-needed>
-    fn advance_queue_if_needed(&self, cx: &mut js::context::JSContext, global: &GlobalScope) {
+    fn advance_queue_if_needed(&self, cx: &mut JSContext, global: &GlobalScope) {
         // Let stream be controller.[[stream]].
         let Some(stream) = self.stream.get() else {
             unreachable!("Controller should have a stream");
@@ -911,12 +903,7 @@ impl WritableStreamDefaultController {
     }
 
     /// <https://streams.spec.whatwg.org/#writable-stream-default-controller-process-write>
-    fn process_write(
-        &self,
-        cx: &mut js::context::JSContext,
-        chunk: SafeHandleValue,
-        global: &GlobalScope,
-    ) {
+    fn process_write(&self, cx: &mut JSContext, chunk: SafeHandleValue, global: &GlobalScope) {
         // Let stream be controller.[[stream]].
         let Some(stream) = self.stream.get() else {
             unreachable!("Controller should have a stream");
@@ -971,7 +958,7 @@ impl WritableStreamDefaultController {
     /// <https://streams.spec.whatwg.org/#writable-stream-default-controller-get-chunk-size>
     pub(crate) fn get_chunk_size(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         chunk: SafeHandleValue,
     ) -> f64 {
@@ -1017,7 +1004,7 @@ impl WritableStreamDefaultController {
     /// <https://streams.spec.whatwg.org/#writable-stream-default-controller-write>
     pub(crate) fn write(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         chunk: SafeHandleValue,
         chunk_size: f64,
@@ -1068,7 +1055,7 @@ impl WritableStreamDefaultController {
     /// <https://streams.spec.whatwg.org/#writable-stream-default-controller-error-if-needed>
     pub(crate) fn error_if_needed(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         error: SafeHandleValue,
         global: &GlobalScope,
     ) {
@@ -1087,7 +1074,7 @@ impl WritableStreamDefaultController {
     /// <https://streams.spec.whatwg.org/#writable-stream-default-controller-error>
     fn error(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         stream: &WritableStream,
         e: SafeHandleValue,
         global: &GlobalScope,

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1093,7 +1093,7 @@ DOMInterfaces = {
 
 "ReadableByteStreamController": {
     "canGc": ["GetByobRequest"],
-    "cx": ["Enqueue", "Close", "Error"]
+    "cx": ["Close", "Enqueue", "Error"]
 },
 
 "ReadableStreamBYOBRequest": {


### PR DESCRIPTION
Changes extracted from [call-setup-cx](https://github.com/Gae24/servo/tree/call-setup-cx) to minimize PR size.

Testing: It compiles
Part of #40600
