### PR TITLE
ci: Use linker wrapper to limit concurrency

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -360,6 +360,7 @@ jobs:
         env:
           NEXTEST_RETRIES: 2 # https://github.com/servo/servo/issues/30683
           LANG: en-US
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: "${{github.workspace}}/support/linux/linker-wrapper.sh"
         run: |
           ./mach test-unit --code-coverage \
               --profile=coverage \

--- a/support/linux/linker-wrapper.sh
+++ b/support/linux/linker-wrapper.sh
@@ -4,8 +4,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-set -euo pipefail
-
 # This is a linker wrapper script that is intended to run on Linux CI systems,
 # and serialize linker invocations by rustc to avoid out of memory issues.
 # We assume that `clang` is in PATH and the linker driver. Rustc chooses `cc`
@@ -17,6 +15,10 @@ set -euo pipefail
 # to this script via another environment variable, perhaps via mach.
 # Maybe it could make sense to integrate this wrapper into mach, to also prevent OOM errors
 # during local development.
+
+set -o errexit
+set -o nounset
+set -o pipefail
 
 real_linker_driver=clang
 

--- a/support/linux/linker-wrapper.sh
+++ b/support/linux/linker-wrapper.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+set -euo pipefail
+
+# This is a linker wrapper script that is intended to run on Linux CI systems,
+# and serialize linker invocations by rustc to avoid out of memory issues.
+# We assume that `clang` is in PATH and the linker driver. Rustc chooses `cc`
+# by default.
+# The wrapper can be used in CI by setting the following environment variabel:
+# CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: $GITHUB_WORKSPACE/support/linux/linker-wrapper.sh
+#
+# If future usecases require a custom linker driver, we could pass the real linker through
+# to this script via another environment variable, perhaps via mach.
+# Maybe it could make sense to integrate this wrapper into mach, to also prevent OOM errors
+# during local development.
+
+real_linker_driver=clang
+
+if ! command -v flock >/dev/null 2>&1; then
+    echo "linker-wrapper.sh: Error: flock is required to manage concurrency" >&2
+    echo "linker-wrapper.sh: Invoking the linker without managing concurrency" >&2
+    # Todo: Testing only, flock should be available, but lets be sure.
+    exit 1
+    # "${real_linker_driver}" "$@"
+fi
+
+lock_file="${TMPDIR:-/tmp}/servo-linker.lock"
+lock_fd=""
+
+cleanup() {
+    if [[ -n "${lock_fd}" ]]; then
+        exec {lock_fd}>&-
+    fi
+}
+
+trap cleanup EXIT
+
+# This opens $lock_file for writing, and puts the fd into lock_fd
+exec {lock_fd}>"${lock_file}"
+
+if flock "${lock_fd}"; then
+    "${real_linker_driver}" "$@"
+    exit $?
+else
+  echo "linker-wrapper.sh: Failed to flock ${lock_file}." >&2
+  exit 1
+fi


### PR DESCRIPTION
To avoid out of memory kills during linking, control the link concurrency in CI coverage unit-tests on Linux using `flock` and a simple bash linker wrapper script.

[mach try linux-coverage in a fork (github hosted)](https://github.com/jschwe/servo/actions/runs/25099375441/job/73544287553)
[mach try linux-coverage on self-hosted](https://github.com/servo/servo/actions/runs/25100097183/job/73546859758)

Testing: This is a CI modification. 
Fixes: #44330
