### PR TITLE
fonts: Rename `GlyphStore` to `ShapedText`

### DIFF
--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -41,7 +41,7 @@ use crate::platform::font_list::fallback_font_families;
 use crate::{
     EmojiPresentationPreference, FallbackFontSelectionOptions, FontContext, FontData,
     FontDataAndIndex, FontDataError, FontIdentifier, FontTemplateDescriptor, FontTemplateRef,
-    FontTemplateRefMethods, GlyphId, GlyphStore, LocalFontIdentifier, ShapedGlyph, Shaper,
+    FontTemplateRefMethods, GlyphId, LocalFontIdentifier, ShapedGlyph, ShapedText, Shaper,
 };
 
 pub(crate) const GPOS: Tag = Tag::new(b"GPOS");
@@ -199,7 +199,7 @@ impl FontMetrics {
 struct CachedShapeData {
     glyph_advances: HashMap<GlyphId, FractionalPixel>,
     glyph_indices: HashMap<char, Option<GlyphId>>,
-    shaped_text: HashMap<ShapeCacheEntry, Arc<GlyphStore>>,
+    shaped_text: HashMap<ShapeCacheEntry, Arc<ShapedText>>,
 }
 
 impl malloc_size_of::MallocSizeOf for CachedShapeData {
@@ -418,7 +418,7 @@ struct ShapeCacheEntry {
 }
 
 impl Font {
-    pub fn shape_text(&self, text: &str, options: &ShapingOptions) -> Arc<GlyphStore> {
+    pub fn shape_text(&self, text: &str, options: &ShapingOptions) -> Arc<ShapedText> {
         let lookup_key = ShapeCacheEntry {
             text: text.to_owned(),
             options: *options,
@@ -469,8 +469,8 @@ impl Font {
     }
 
     /// Fast path for ASCII text that only needs simple horizontal LTR kerning.
-    fn shape_text_fast(&self, text: &str, options: &ShapingOptions) -> GlyphStore {
-        let mut glyph_store = GlyphStore::new(text.len(), options);
+    fn shape_text_fast(&self, text: &str, options: &ShapingOptions) -> ShapedText {
+        let mut glyph_store = ShapedText::new(text.len(), options);
         let mut prev_glyph_id = None;
         for (string_byte_offset, byte) in text.bytes().enumerate() {
             let character = byte as char;

--- a/components/fonts/glyph.rs
+++ b/components/fonts/glyph.rs
@@ -20,9 +20,8 @@ use crate::{GlyphShapingResult, ShapedGlyph, ShapingFlags, ShapingOptions};
 /// In the common case (reasonable glyph advances, no offsets from the font em-box, and one glyph
 /// per character), we pack glyph advance, glyph id, and some flags into a single u32.
 ///
-/// In the uncommon case (multiple glyphs per unicode character, large glyph index/advance, or
-/// glyph offsets), we pack the glyph count into GlyphEntry, and store the other glyph information
-/// in DetailedGlyphStore.
+/// In the uncommon case (multiple glyphs per unicode character, large glyph index/advance, or glyph
+/// offsets), we create a DetailedGlyphEntry for the glyph and pack its index into the GlyphEntry.
 #[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
 pub struct GlyphEntry {
     value: u32,
@@ -140,10 +139,8 @@ pub struct DetailedGlyphEntry {
     is_word_separator: bool,
 }
 
-// This enum is a proxy that's provided to GlyphStore clients when iterating
+// This enum is a proxy that's provided to ShapedText clients when iterating
 // through glyphs (either for a particular TextRun offset, or all glyphs).
-// Rather than eagerly assembling and copying glyph data, it only retrieves
-// values as they are needed from the GlyphStore, using provided offsets.
 #[derive(Clone, Copy)]
 pub enum GlyphInfo<'a> {
     Simple(&'a GlyphEntry),
@@ -200,7 +197,7 @@ impl GlyphInfo<'_> {
 /// stored as pointers into the `detail_store`.
 ///
 /// ~~~ascii
-/// +- GlyphStore --------------------------------+
+/// +- ShapedText --------------------------------+
 /// |               +---+---+---+---+---+---+---+ |
 /// | entry_buffer: |   | s |   | s |   | s | s | |  d = detailed
 /// |               +-|-+---+-|-+---+-|-+---+---+ |  s = simple
@@ -213,10 +210,10 @@ impl GlyphInfo<'_> {
 /// +---------------------------------------------+
 /// ~~~
 #[derive(Clone, Deserialize, MallocSizeOf, Serialize)]
-pub struct GlyphStore {
+pub struct ShapedText {
     // TODO(pcwalton): Allocation of this buffer is expensive. Consider a small-vector
     // optimization.
-    /// A collection of [`GlyphEntry`]s within the [`GlyphStore`]. Each [`GlyphEntry`]
+    /// A collection of [`GlyphEntry`]s within the [`ShapedText`]. Each [`GlyphEntry`]
     /// maybe simple or detailed. When detailed, there will be a corresponding entry
     /// in [`Self::detailed_glyphs`].
     glyphs: Vec<GlyphEntry>,
@@ -228,7 +225,7 @@ pub struct GlyphStore {
     /// A cache of the advance of the entire glyph store.
     total_advance: Au,
 
-    /// The number of characters that correspond to the glyphs in this [`GlyphStore`]
+    /// The number of characters that correspond to the glyphs in this [`ShapedText`]
     total_characters: usize,
 
     /// A cache of the number of word separators in the entire glyph store.
@@ -243,12 +240,12 @@ pub struct GlyphStore {
     /// but that may not be the case with `white-space: break-spaces`.
     ends_with_whitespace: bool,
 
-    /// Whether or not this [`GlyphStore`] has right-to-left text, which has implications
+    /// Whether or not this [`ShapedText`] has right-to-left text, which has implications
     /// about the order of the glyphs in the store.
     is_rtl: bool,
 }
 
-impl GlyphStore {
+impl ShapedText {
     /// Initializes the glyph store with the given capacity, but doesn't actually add any glyphs.
     ///
     /// Use the `add_*` methods to store glyph data.
@@ -270,7 +267,7 @@ impl GlyphStore {
     }
 
     /// This constructor turns shaping output from HarfBuzz into a glyph run to be
-    /// used by layout. The idea here is that we add each glyph to the [`GlyphStore`]
+    /// used by layout. The idea here is that we add each glyph to the [`ShapedText`]
     /// and track to which characters from the original string each glyph
     /// corresponds. HarfBuzz will either give us glyphs that correspond to
     /// characters left-to-right or right-to-left. Each character can produce
@@ -297,7 +294,7 @@ impl GlyphStore {
         };
 
         let mut previous_character_offset = None;
-        let mut glyph_store = GlyphStore::new(shaped_glyph_data.len(), options);
+        let mut glyph_store = ShapedText::new(shaped_glyph_data.len(), options);
         for mut shaped_glyph in shaped_glyph_data.iter() {
             // The glyph "cluster" (HarfBuzz terminology) is the byte offset in the string that
             // this glyph corresponds to. More than one glyph can share a cluster.
@@ -358,45 +355,45 @@ impl GlyphStore {
         self.total_advance
     }
 
-    /// Return the number of glyphs stored in this [`GlyphStore`].
+    /// Return the number of glyphs stored in this [`ShapedText`].
     #[inline]
     pub fn len(&self) -> usize {
         self.glyphs.len()
     }
 
-    /// Whether or not this [`GlyphStore`] has any glyphs.
+    /// Whether or not this [`ShapedText`] has any glyphs.
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.glyphs.is_empty()
     }
 
     /// The number of characters (`char`) from the original string that produced this
-    /// [`GlyphStore`].
+    /// [`ShapedText`].
     #[inline]
     pub fn character_count(&self) -> usize {
         self.total_characters
     }
 
-    /// Whether or not this [`GlyphStore`] is entirely whitepsace.
+    /// Whether or not this [`ShapedText`] is entirely white space.
     #[inline]
     pub fn is_whitespace(&self) -> bool {
         self.is_whitespace
     }
 
-    /// Whether or not this [`GlyphStore`] ends with whitespace.
+    /// Whether or not this [`ShapedText`] ends with whitespace.
     #[inline]
     pub fn ends_with_whitespace(&self) -> bool {
         self.ends_with_whitespace
     }
 
-    /// The number of word separators in this [`GlyphStore`].
+    /// The number of word separators in this [`ShapedText`].
     #[inline]
     pub fn total_word_separators(&self) -> usize {
         self.total_word_separators
     }
 
-    /// The number of characters that were consumed to produce this [`GlyphStore`]. Some
-    /// characters correpond to more than one glyph and some glyphs correspond to more than
+    /// The number of characters that were consumed to produce this [`ShapedText`]. Some
+    /// characters correspond to more than one glyph and some glyphs correspond to more than
     /// one character.
     #[inline]
     pub fn total_characters(&self) -> usize {
@@ -478,7 +475,7 @@ impl GlyphStore {
         self.add_detailed_glyph(shaped_glyph, None, 0);
     }
 
-    /// If the last glyph added to this [`GlyphStore`] was a simple glyph, convert it to a
+    /// If the last glyph added to this [`ShapedText`] was a simple glyph, convert it to a
     /// detailed one. In either case, return the index into [`Self::detailed_glyphs`] for
     /// the most recently added glyph.
     fn ensure_last_glyph_is_detailed(&mut self) -> usize {
@@ -563,9 +560,9 @@ fn character_is_word_separator(character: char) -> bool {
     is_word_separator
 }
 
-impl fmt::Debug for GlyphStore {
+impl fmt::Debug for ShapedText {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        writeln!(formatter, "GlyphStore:")?;
+        writeln!(formatter, "ShapedText:")?;
         for entry in self.glyphs.iter() {
             if entry.is_simple() {
                 writeln!(

--- a/components/fonts/lib.rs
+++ b/components/fonts/lib.rs
@@ -27,7 +27,7 @@ pub use font_context::{
 pub use font_store::FontTemplates;
 pub use fonts_traits::*;
 pub(crate) use glyph::*;
-pub use glyph::{GlyphInfo, GlyphStore};
+pub use glyph::{GlyphInfo, ShapedText};
 use icu_locid::subtags::Language;
 pub use platform::font_list::fallback_font_families;
 pub(crate) use shapers::*;

--- a/components/fonts/shapers/harfbuzz.rs
+++ b/components/fonts/shapers/harfbuzz.rs
@@ -32,7 +32,7 @@ use read_fonts::types::Tag;
 use super::{GlyphShapingResult, ShapedGlyph, unicode_script_to_iso15924_tag};
 use crate::platform::font::FontTable;
 use crate::{
-    BASE, Font, FontBaseline, FontTableMethods, GlyphId, GlyphStore, KERN, LIGA, ShapingFlags,
+    BASE, Font, FontBaseline, FontTableMethods, GlyphId, KERN, LIGA, ShapedText, ShapingFlags,
     ShapingOptions, fixed_to_float, float_to_fixed,
 };
 
@@ -306,8 +306,8 @@ impl Shaper {
         }
     }
 
-    pub(crate) fn shape_text(&self, text: &str, options: &ShapingOptions) -> GlyphStore {
-        GlyphStore::with_shaped_glyph_data(text, options, &self.shaped_glyph_data(text, options))
+    pub(crate) fn shape_text(&self, text: &str, options: &ShapingOptions) -> ShapedText {
+        ShapedText::with_shaped_glyph_data(text, options, &self.shaped_glyph_data(text, options))
     }
 
     pub(crate) fn baseline(&self) -> Option<FontBaseline> {

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use app_units::{AU_PER_PX, Au};
 use clip::{Clip, ClipId};
 use euclid::{Box2D, Point2D, Rect, Scale, SideOffsets2D, Size2D, UnknownUnit, Vector2D};
-use fonts::GlyphStore;
+use fonts::ShapedText;
 use gradient::WebRenderGradient;
 use layout_api::ReflowStatistics;
 use net_traits::image_cache::Image as CachedImage;
@@ -1941,7 +1941,7 @@ fn rgba(color: AbsoluteColor) -> wr::ColorF {
 }
 
 fn glyphs(
-    glyph_runs: &[Arc<GlyphStore>],
+    glyph_runs: &[Arc<ShapedText>],
     mut baseline_origin: PhysicalPoint<Au>,
     justification_adjustment: Au,
     include_whitespace: bool,

--- a/components/layout/flow/inline/line.rs
+++ b/components/layout/flow/inline/line.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use app_units::Au;
 use bitflags::bitflags;
-use fonts::GlyphStore;
+use fonts::ShapedText;
 use itertools::Either;
 use layout_api::SharedSelection;
 use malloc_size_of_derive::MallocSizeOf;
@@ -846,7 +846,7 @@ pub(super) struct TextRunLineItem {
     pub info: Arc<FontAndScriptInfo>,
     pub base_fragment_info: BaseFragmentInfo,
     pub inline_styles: SharedInlineStyles,
-    pub text: Vec<std::sync::Arc<GlyphStore>>,
+    pub text: Vec<std::sync::Arc<ShapedText>>,
     /// When necessary, this field store the [`TextRunOffsets`] for a particular
     /// [`TextRunLineItem`]. This is currently only used inside of text inputs.
     pub offsets: Option<Box<TextRunOffsets>>,
@@ -917,7 +917,7 @@ impl TextRunLineItem {
     pub(crate) fn merge_if_possible(
         &mut self,
         new_info: &Arc<FontAndScriptInfo>,
-        new_glyph_store: &Arc<GlyphStore>,
+        new_glyph_store: &Arc<ShapedText>,
         new_offsets: &Option<TextRunOffsets>,
         new_inline_styles: &SharedInlineStyles,
     ) -> bool {

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -83,7 +83,7 @@ use app_units::{Au, MAX_AU};
 use atomic_refcell::AtomicRef;
 use bitflags::bitflags;
 use construct::InlineFormattingContextBuilder;
-use fonts::{FontMetrics, FontRef, GlyphStore};
+use fonts::{FontMetrics, FontRef, ShapedText};
 use icu_locid::LanguageIdentifier;
 use icu_locid::subtags::{Language, language};
 use icu_properties::{self, LineBreak as ICULineBreak};
@@ -1561,7 +1561,7 @@ impl InlineFormattingContextLayout<'_> {
 
     fn push_glyph_store_to_unbreakable_segment(
         &mut self,
-        glyph_store: Arc<GlyphStore>,
+        glyph_store: Arc<ShapedText>,
         text_run: &TextRun,
         info: &Arc<FontAndScriptInfo>,
         offsets: Option<TextRunOffsets>,

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -7,7 +7,7 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use app_units::Au;
-use fonts::{FontContext, FontRef, GlyphStore, ShapingFlags, ShapingOptions};
+use fonts::{FontContext, FontRef, ShapedText, ShapingFlags, ShapingOptions};
 use icu_locid::subtags::Language;
 use icu_properties::{self, LineBreak};
 use log::warn;
@@ -135,7 +135,7 @@ pub(crate) struct TextRunSegment {
 
     /// The shaped runs within this segment.
     #[conditional_malloc_size_of]
-    pub runs: Vec<Arc<GlyphStore>>,
+    pub runs: Vec<Arc<ShapedText>>,
 }
 
 impl TextRunSegment {

--- a/components/layout/fragment_tree/fragment.rs
+++ b/components/layout/fragment_tree/fragment.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use app_units::Au;
 use atomic_refcell::{AtomicRef, AtomicRefMut};
 use euclid::{Point2D, Rect, Size2D};
-use fonts::{FontMetrics, GlyphStore};
+use fonts::{FontMetrics, ShapedText};
 use layout_api::BoxAreaType;
 use malloc_size_of_derive::MallocSizeOf;
 use servo_base::id::PipelineId;
@@ -71,7 +71,7 @@ pub(crate) struct TextFragment {
     pub font_metrics: Arc<FontMetrics>,
     pub font_key: FontInstanceKey,
     #[conditional_malloc_size_of]
-    pub glyphs: Vec<Arc<GlyphStore>>,
+    pub glyphs: Vec<Arc<ShapedText>>,
     /// Extra space to add for each justification opportunity.
     pub justification_adjustment: Au,
     /// When necessary, this field store the [`TextRunOffsets`] for a particular


### PR DESCRIPTION
The new name better represents what this struct holds and opens the way
for creating a `ShapedTextSlice` or `ShapedTextView`.

Testing: This is just a rename so shoul be covered by existing tests.
