### PR TITLE
script: Guarantee zeroizing of secret in `Vec<u8>` stored in `CryptoKey`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8726,6 +8726,7 @@ dependencies = [
  "wgpu-types",
  "x25519-dalek",
  "xml5ever",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -229,6 +229,7 @@ wr_malloc_size_of = "0.2.2"
 x25519-dalek = { version = "2.0.1", features = ["static_secrets"] }
 xml5ever = "0.39"
 yuv = { version = "0.8.13", features = ["rayon"] }
+zeroize = "1.8"
 
 ############################################################################################
 ## Workspace-local dependencies

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -175,6 +175,7 @@ wgpu-types = { workspace = true, optional = true }
 x25519-dalek = { workspace = true }
 xml5ever = { workspace = true }
 xpath = { workspace = true }
+zeroize = { workspace = true }
 
 [target.'cfg(not(target_os = "ios"))'.dependencies]
 mozangle = { workspace = true }

--- a/components/script/dom/webcrypto/cryptokey.rs
+++ b/components/script/dom/webcrypto/cryptokey.rs
@@ -9,6 +9,7 @@ use dom_struct::dom_struct;
 use js::jsapi::{Heap, JSObject, Value};
 use malloc_size_of::MallocSizeOf;
 use script_bindings::conversions::SafeToJSValConvertible;
+use zeroize::Zeroizing;
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::{
@@ -25,7 +26,11 @@ pub(crate) enum CryptoKeyOrCryptoKeyPair {
     CryptoKeyPair(CryptoKeyPair),
 }
 
-/// The underlying cryptographic data this key represents
+/// The underlying cryptographic data this key represents.
+///
+/// Please make sure the inner types for secret variants implement the `zeroize::ZeroizeOnDrop`
+/// trait, which signifies that the type will call `Zeroize::zeroize` on `Drop` to securely erase
+/// the secret from memory.
 pub(crate) enum Handle {
     RsaPrivateKey(rsa::RsaPrivateKey),
     RsaPublicKey(rsa::RsaPublicKey),
@@ -35,16 +40,16 @@ pub(crate) enum Handle {
     P256PublicKey(p256::PublicKey),
     P384PublicKey(p384::PublicKey),
     P521PublicKey(p521::PublicKey),
-    Ed25519PrivateKey(Vec<u8>),
+    Ed25519PrivateKey(Zeroizing<Vec<u8>>),
     Ed25519PublicKey(Vec<u8>),
     X25519PrivateKey(x25519_dalek::StaticSecret),
     X25519PublicKey(x25519_dalek::PublicKey),
     Aes128Key(aes::cipher::crypto_common::Key<aes::Aes128>),
     Aes192Key(aes::cipher::crypto_common::Key<aes::Aes192>),
     Aes256Key(aes::cipher::crypto_common::Key<aes::Aes256>),
-    HkdfSecret(Vec<u8>),
-    Pbkdf2(Vec<u8>),
-    Hmac(Vec<u8>),
+    HkdfSecret(Zeroizing<Vec<u8>>),
+    Pbkdf2(Zeroizing<Vec<u8>>),
+    Hmac(Zeroizing<Vec<u8>>),
     MlKem512PrivateKey((ml_kem::B32, ml_kem::B32)),
     MlKem768PrivateKey((ml_kem::B32, ml_kem::B32)),
     MlKem1024PrivateKey((ml_kem::B32, ml_kem::B32)),
@@ -60,7 +65,7 @@ pub(crate) enum Handle {
     MlDsa65PublicKey(Box<ml_dsa::EncodedVerifyingKey<ml_dsa::MlDsa65>>),
     MlDsa87PublicKey(Box<ml_dsa::EncodedVerifyingKey<ml_dsa::MlDsa87>>),
     ChaCha20Poly1305Key(chacha20poly1305::Key),
-    Argon2Password(Vec<u8>),
+    Argon2Password(Zeroizing<Vec<u8>>),
 }
 
 /// <https://w3c.github.io/webcrypto/#cryptokey-interface>

--- a/components/script/dom/webcrypto/subtlecrypto/argon2_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/argon2_operation.rs
@@ -177,7 +177,7 @@ pub(crate) fn import_key(
         extractable,
         KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
         usages,
-        Handle::Argon2Password(key_data.to_vec()),
+        Handle::Argon2Password(key_data.to_vec().into()),
     );
 
     // Step 10. Return key.

--- a/components/script/dom/webcrypto/subtlecrypto/ed25519_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ed25519_operation.rs
@@ -154,7 +154,7 @@ pub(crate) fn generate_key(
             .filter(|&usage| *usage == KeyUsage::Sign)
             .cloned()
             .collect(),
-        Handle::Ed25519PrivateKey(seed),
+        Handle::Ed25519PrivateKey(seed.into()),
     );
 
     // Step 16. Let result be a new CryptoKeyPair dictionary.
@@ -287,7 +287,7 @@ pub(crate) fn import_key(
                 extractable,
                 KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
                 usages,
-                Handle::Ed25519PrivateKey(curve_private_key),
+                Handle::Ed25519PrivateKey(curve_private_key.into()),
             )
         },
         // If format is "jwk":
@@ -388,7 +388,7 @@ pub(crate) fn import_key(
                     extractable,
                     KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
                     usages,
-                    Handle::Ed25519PrivateKey(d),
+                    Handle::Ed25519PrivateKey(d.into()),
                 )
             }
             // Otherwise:

--- a/components/script/dom/webcrypto/subtlecrypto/hkdf_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/hkdf_operation.rs
@@ -128,7 +128,7 @@ pub(crate) fn import_key(
             extractable,
             KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
             usages,
-            Handle::HkdfSecret(key_data.to_vec()),
+            Handle::HkdfSecret(key_data.to_vec().into()),
         );
 
         // Step 2.8. Return key.

--- a/components/script/dom/webcrypto/subtlecrypto/hmac_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/hmac_operation.rs
@@ -160,7 +160,7 @@ pub(crate) fn generate_key(
         extractable,
         KeyAlgorithmAndDerivatives::HmacKeyAlgorithm(algorithm),
         usages,
-        Handle::Hmac(key_data),
+        Handle::Hmac(key_data.into()),
     );
 
     // Step 16. Return key.
@@ -360,7 +360,7 @@ pub(crate) fn import_key(
         extractable,
         KeyAlgorithmAndDerivatives::HmacKeyAlgorithm(algorithm),
         usages,
-        Handle::Hmac(truncated_data),
+        Handle::Hmac(truncated_data.into()),
     );
 
     // Step 15. Return key.

--- a/components/script/dom/webcrypto/subtlecrypto/pbkdf2_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/pbkdf2_operation.rs
@@ -120,7 +120,7 @@ pub(crate) fn import_key(
         extractable,
         KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
         usages,
-        Handle::Pbkdf2(key_data.to_vec()),
+        Handle::Pbkdf2(key_data.to_vec().into()),
     );
 
     // Step 9. Return key.


### PR DESCRIPTION
Replace `Vec<u8>` with `Zeroizing<Vec<u8>>` for secret variants in the enum `dom::cryptokey::Handle`.

The wrapper `zeroize::Zeroizing` implements `zeroize::ZeroizeOnDrop`, which securely erase the secret from memory on `Drop`. It also guarantees the operation will not be "optimized away" by the compiler.

Testing: Hardening. No behavioral changes.
Fixes: Part of #44586
