### PR TITLE
Update uv.lock for #44591

### DIFF
--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -55,6 +55,7 @@ from WebIDL import (
     IDLUnresolvedIdentifier,
     IDLMaplikeOrSetlikeOrIterableBase,
     IDLConstructor,
+    IDLObjectWithIdentifier,
 )
 
 from configuration import (
@@ -684,11 +685,15 @@ class CGMethodCall(CGThing):
 
 
 def dictionaryHasSequenceMember(dictionary: IDLDictionary) -> bool:
-    return (any(typeIsSequenceOrHasSequenceMember(m.type) for m in
-                dictionary.members)
-            or (dictionary.parent
-                # pyrefly: ignore  # bad-argument-type
-                and dictionaryHasSequenceMember(dictionary.parent)))
+    for member in dictionary.members:
+        if typeIsSequenceOrHasSequenceMember(member.type):
+            return True
+
+    if dictionary.parent:
+        # pyrefly: ignore  # bad-argument-type
+        return dictionaryHasSequenceMember(dictionary.parent)
+
+    return False
 
 
 def typeIsSequenceOrHasSequenceMember(type: IDLType) -> bool:
@@ -4424,7 +4429,7 @@ class CGSwitch(CGList):
     Each case is a CGCase.  The default is a CGThing for the body of
     the default case, if any.
     """
-    def __init__(self, expression: str, cases: list[CGThing], default: CGThing | None = None) -> None:
+    def __init__(self, expression: str, cases: list[CGCase], default: CGThing | None = None) -> None:
         CGList.__init__(self, [CGIndenter(c) for c in cases], "\n")
         self.prepend(CGWrapper(CGGeneric(expression),
                                pre="match ", post=" {"))
@@ -5615,7 +5620,7 @@ class CGUnionConversionStruct(CGThing):
     def from_jsval(self) -> CGWrapper:
         memberTypes = cast(list[IDLType], self.type.flatMemberTypes)
         names = []
-        conversions = []
+        conversions: list[CGThing] = []
 
         def get_name(memberType: IDLType) -> str:
             if self.type.isGeckoInterface():
@@ -6103,7 +6108,9 @@ class CGClass(CGThing):
         result += ' {\n'
 
         if self.bases:
-            self.members = [ClassMember("parent", self.bases[0].name, "pub")] + self.members
+            parent_name = self.bases[0].name
+            assert parent_name is not None
+            self.members = [ClassMember("parent", parent_name, "pub")] + self.members
 
         result += CGIndenter(CGGeneric(self.extradeclarations),
                              len(self.indent)).define()
@@ -7194,7 +7201,7 @@ class CGInterfaceTrait(CGThing):
                 return False
             return functools.reduce((lambda x, y: x or y[1] == '*mut RawJSContext'), arguments, False)
 
-        methods = []
+        methods: list[CGThing] = []
         exposureSet = list(descriptor.interface.exposureSet)
         exposedGlobal = "GlobalScope" if len(exposureSet) > 1 else exposureSet[0]
         hasLength = False
@@ -7385,7 +7392,7 @@ class CGDescriptor(CGThing):
                 return f'{name} as {descriptor.name}{name}'
             return name
 
-        cgThings = []
+        cgThings: list[CGThing] = []
 
         defaultToJSONMethod = None
         unscopableNames = []
@@ -7554,26 +7561,28 @@ class CGDescriptor(CGThing):
 
         cgThings.append(CGInitStatics(descriptor))
 
-        cgThings = CGList(cgThings, '\n')
+        cgRoot: CGThing = CGList(cgThings, '\n')
 
         # Add imports
         # These are inside the generated module
-        cgThings = CGImports(cgThings, descriptors=[descriptor], callbacks=[],
-                             dictionaries=[], enums=[], typedefs=[], imports=[
+        cgRoot = CGImports(cgRoot, descriptors=[descriptor], callbacks=[],
+                           dictionaries=[], enums=[], typedefs=[], imports=[
             'crate::import::module::*',
         ], config=config)
 
-        cgThings = CGWrapper(CGNamespace(toBindingNamespace(descriptor.name),
-                                         cgThings, public=True),
-                             post='\n')
+        cgRoot = CGWrapper(CGNamespace(toBindingNamespace(descriptor.name),
+                                       cgRoot, public=True),
+                           post='\n')
 
         if reexports:
             reexports = ', '.join([reexportedName(name) for name in reexports])
             namespace = toBindingNamespace(descriptor.name)
-            cgThings = CGList([CGGeneric(f'pub use self::{namespace}::{{{reexports}}};'),
-                               cgThings], '\n')
+            cgRoot = CGList([
+                CGGeneric(f'pub use self::{namespace}::{{{reexports}}};'),
+                cgRoot
+            ], '\n')
 
-        self.cgRoot = cgThings
+        self.cgRoot = cgRoot
 
     def define(self) -> str:
         return self.cgRoot.define()
@@ -8396,7 +8405,7 @@ def argument_type(descriptorProvider: DescriptorProvider,
 
 def method_arguments(descriptorProvider: DescriptorProvider,
                      returnType: IDLType,
-                     arguments: list[IDLArgument],
+                     arguments: Iterable[IDLArgument | FakeArgument],
                      passJSBits: bool = True,
                      trailing: tuple[str, str] | None = None,
                      cx_no_gc: bool = False,
@@ -8455,8 +8464,15 @@ def return_type(descriptorProvider: DescriptorProvider, rettype: IDLType, infall
 
 
 class CGNativeMember(ClassMethod):
-    def __init__(self, descriptorProvider: DescriptorProvider, member: IDLMethod, name: str, signature: tuple[IDLType, list[IDLArgument]], extendedAttrs: dict[str, Any],
-                 breakAfter: bool = True, passJSBitsAsNeeded: bool = True, visibility: str = "public",
+    def __init__(self,
+                 descriptorProvider: DescriptorProvider,
+                 member: IDLMethod | IDLAttribute | FakeMember,
+                 name: str,
+                 signature: tuple[IDLType, list[IDLArgument | FakeArgument]],
+                 extendedAttrs: dict[str, Any],
+                 breakAfter: bool = True,
+                 passJSBitsAsNeeded: bool = True,
+                 visibility: str = "public",
                  unsafe: bool = False) -> None:
         """
         If passJSBitsAsNeeded is false, we don't automatically pass in a
@@ -8484,7 +8500,7 @@ class CGNativeMember(ClassMethod):
         typeDecl = return_type(self.descriptorProvider, type, infallible)
         return typeDecl
 
-    def getArgs(self, returnType: IDLType, argList: list[IDLArgument]) -> list[Argument]:
+    def getArgs(self, returnType: IDLType, argList: list[IDLArgument | FakeArgument]) -> list[Argument]:
         return [Argument(arg[1], arg[0]) for arg in method_arguments(self.descriptorProvider,
                                                                      returnType,
                                                                      argList,
@@ -8492,7 +8508,7 @@ class CGNativeMember(ClassMethod):
 
 
 class CGCallback(CGClass):
-    def __init__(self, idlObject: IDLCallback, descriptorProvider: DescriptorProvider, baseName: str, methods: list[CallbackMethod]) -> None:
+    def __init__(self, idlObject: IDLObjectWithIdentifier, descriptorProvider: DescriptorProvider, baseName: str, methods: Iterable[CallbackMethod]) -> None:
         self.baseName = baseName
         self._deps = idlObject.getDeps()
         name = idlObject.identifier.name
@@ -8502,7 +8518,7 @@ class CGCallback(CGClass):
         # CGNativeMember infrastructure, but that infrastructure can't deal
         # with templates and most especially template arguments.  So just
         # cheat and have CallbackMember compute all those things for us.
-        realMethods = []
+        realMethods: list[CallbackMethod | ClassMethod] = []
         for method in methods:
             if not method.needThisHandling:
                 realMethods.append(method)
@@ -8659,7 +8675,7 @@ class FakeMember():
 
 
 class CallbackMember(CGNativeMember):
-    def __init__(self, sig: tuple[IDLType, list[IDLArgument]], name: str, descriptorProvider: DescriptorProvider, needThisHandling: bool) -> None:
+    def __init__(self, sig: tuple[IDLType, list[IDLArgument | FakeArgument]], name: str, descriptorProvider: DescriptorProvider, needThisHandling: bool) -> None:
         """
         needThisHandling is True if we need to be able to accept a specified
         thisObj, False otherwise.
@@ -8770,7 +8786,7 @@ class CallbackMember(CGNativeMember):
         # And slap them together.
         return CGList(argConversionsCG, "\n\n").define() + "\n\n"
 
-    def getArgConversion(self, i: int, arg: IDLArgument) -> str:
+    def getArgConversion(self, i: int, arg: IDLArgument | FakeArgument) -> str:
         argval = arg.identifier.name
 
         if arg.variadic:
@@ -8802,7 +8818,7 @@ class CallbackMember(CGNativeMember):
             )
         return conversion
 
-    def getArgs(self, returnType: IDLType, argList: list[IDLArgument]) -> list[Argument]:
+    def getArgs(self, returnType: IDLType, argList: list[IDLArgument | FakeArgument]) -> list[Argument]:
         args = CGNativeMember.getArgs(self, returnType, argList)
         if not self.needThisHandling:
             # Since we don't need this handling, we're the actual method that
@@ -8844,7 +8860,7 @@ class CallbackMember(CGNativeMember):
 
 
 class CallbackMethod(CallbackMember):
-    def __init__(self, sig: tuple[IDLType, list[IDLArgument]], name: str, descriptorProvider: DescriptorProvider, needThisHandling: bool) -> None:
+    def __init__(self, sig: tuple[IDLType, list[IDLArgument | FakeArgument]], name: str, descriptorProvider: DescriptorProvider, needThisHandling: bool) -> None:
         CallbackMember.__init__(self, sig, name, descriptorProvider,
                                 needThisHandling)
 
@@ -8910,7 +8926,7 @@ class CallbackOperationBase(CallbackMethod):
     """
     Common class for implementing various callback operations.
     """
-    def __init__(self, signature: tuple[IDLType, list[IDLArgument]], jsName: str, nativeName: str, descriptor: Descriptor, singleOperation: bool) -> None:
+    def __init__(self, signature: tuple[IDLType, list[IDLArgument | FakeArgument]], jsName: str, nativeName: str, descriptor: Descriptor, singleOperation: bool) -> None:
         self.singleOperation = singleOperation
         self.methodName = jsName
         CallbackMethod.__init__(self, signature, nativeName, descriptor, singleOperation)
@@ -8985,7 +9001,8 @@ class CGMaplikeOrSetlikeMethodGenerator(CGGeneric):
         """
         # like iterables are implemented seperatly as we are actually implementing them
         if methodName in ["keys", "values", "entries", "forEach"]:
-            CGIterableMethodGenerator.__init__(self, descriptor, likeable, methodName)
+            cgIterableMethod = CGIterableMethodGenerator(descriptor, likeable, methodName)
+            CGGeneric.__init__(self, cgIterableMethod.define())
         elif methodName in ["size", "clear"]:  # zero arguments
             CGGeneric.__init__(self, fill(
                 """

--- a/components/script_bindings/codegen/configuration.py
+++ b/components/script_bindings/codegen/configuration.py
@@ -259,6 +259,7 @@ class Descriptor(DescriptorProvider):
             prefix = ""
 
         typeName = desc.get('nativeType', nativeTypeDefault)
+        assert isinstance(typeName, str)
 
         spiderMonkeyInterface = desc.get('spiderMonkeyInterface', False)
 
@@ -573,6 +574,7 @@ def getTypesFromDictionary(dictionary: IDLWrapperType | IDLDictionary) -> list[I
     types = []
     curDict = dictionary
     while curDict:
+        assert isinstance(curDict, IDLDictionary)
         types.extend([getUnwrappedType(m.type) for m in curDict.members])
         curDict = curDict.parent
     return types

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -217,7 +217,7 @@ class MachCommands(CommandBase):
             # On the Mac, set a lovely icon. This makes it easier to pick out the Servo binary in tools
             # like Instruments.app.
             try:
-                import Cocoa  # pyrefly: ignore[import-error]
+                import Cocoa  # pyrefly: ignore[missing-import]
 
                 icon_path = path.join(self.get_top_dir(), "resources", "servo_1024.png")
                 icon = Cocoa.NSImage.alloc().initWithContentsOfFile_(icon_path)

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -26,7 +26,7 @@ from enum import Enum
 from glob import glob
 from os import path
 from subprocess import CompletedProcess
-from typing import Any, Optional, Union, LiteralString, cast, List
+from typing import Any, Optional, Union, cast, List
 from collections.abc import Generator, Callable
 
 import toml
@@ -53,15 +53,19 @@ class BuildType:
     kind: Kind
     profile: str
 
+    @staticmethod
     def dev() -> BuildType:
         return BuildType(BuildType.Kind.DEV, "debug")
 
+    @staticmethod
     def release() -> BuildType:
         return BuildType(BuildType.Kind.RELEASE, "release")
 
+    @staticmethod
     def prod() -> BuildType:
         return BuildType(BuildType.Kind.CUSTOM, "production")
 
+    @staticmethod
     def custom(profile: str) -> BuildType:
         return BuildType(BuildType.Kind.CUSTOM, profile)
 
@@ -88,6 +92,7 @@ class BuildType:
     def as_cargo_arg(self) -> List[str]:
         return ["--profile", self.profile]
 
+    @staticmethod
     def from_string(profile: str) -> BuildType:
         if profile == "dev":
             return BuildType.dev()
@@ -812,14 +817,14 @@ class CommandBase(object):
 
         return call(["cargo", command] + args + cargo_args, env=env, verbose=verbose)
 
-    def android_adb_path(self, env: dict[str, Any]) -> LiteralString:
+    def android_adb_path(self, env: dict[str, Any]) -> str:
         if "ANDROID_SDK_ROOT" in env:
             sdk_adb = path.join(env["ANDROID_SDK_ROOT"], "platform-tools", "adb")
             if path.exists(sdk_adb):
                 return sdk_adb
         return "adb"
 
-    def android_emulator_path(self, env: dict[str, Any]) -> LiteralString:
+    def android_emulator_path(self, env: dict[str, Any]) -> str:
         if "ANDROID_SDK_ROOT" in env:
             sdk_adb = path.join(env["ANDROID_SDK_ROOT"], "emulator", "emulator")
             if path.exists(sdk_adb):

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -485,6 +485,9 @@ class PackageCommands(CommandBase):
         elif is_windows():
             pkg_path = path.join(path.dirname(binary_path), "msi", "Servo.msi")
             exec_command = ["msiexec", "/i", pkg_path]
+        else:
+            print('install command not supported for the current target')
+            return 1
 
         if not path.exists(pkg_path):
             print("Servo package not found. Packaging servo...")

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -486,7 +486,7 @@ class PackageCommands(CommandBase):
             pkg_path = path.join(path.dirname(binary_path), "msi", "Servo.msi")
             exec_command = ["msiexec", "/i", pkg_path]
         else:
-            print('install command not supported for the current target')
+            print("install command not supported for the current target")
             return 1
 
         if not path.exists(pkg_path):

--- a/python/servo/platform/build_target.py
+++ b/python/servo/platform/build_target.py
@@ -455,39 +455,39 @@ class OpenHarmonyTarget(CrossBuildTarget):
             env["RUSTFLAGS"] += " -Zexternal-clangrt"
             san_compile_flags.append("-fno-omit-frame-pointer")
 
-        # On OpenHarmony we add some additional flags when asan is enabled
-        if sanitizer.is_asan():
-            libasan_so_path = libclang_arch.joinpath("libclang_rt.asan.so")
-            libasan_preinit_path = libclang_arch.joinpath("libclang_rt.asan-preinit.a")
-            if not libasan_so_path.exists():
-                raise RuntimeError(f"Couldn't find ASAN runtime library at {libasan_so_path}")
-            link_args.extend(
-                [
-                    "-fsanitize=address",
-                    "--rtlib=compiler-rt",
-                    "-shared-libasan",
-                    str(libasan_so_path),
-                    "-Wl,--whole-archive",
-                    "-Wl," + str(libasan_preinit_path),
-                    "-Wl,--no-whole-archive",
-                ]
-            )
+            # On OpenHarmony we add some additional flags when asan is enabled
+            if sanitizer.is_asan():
+                libasan_so_path = libclang_arch.joinpath("libclang_rt.asan.so")
+                libasan_preinit_path = libclang_arch.joinpath("libclang_rt.asan-preinit.a")
+                if not libasan_so_path.exists():
+                    raise RuntimeError(f"Couldn't find ASAN runtime library at {libasan_so_path}")
+                link_args.extend(
+                    [
+                        "-fsanitize=address",
+                        "--rtlib=compiler-rt",
+                        "-shared-libasan",
+                        str(libasan_so_path),
+                        "-Wl,--whole-archive",
+                        "-Wl," + str(libasan_preinit_path),
+                        "-Wl,--no-whole-archive",
+                    ]
+                )
 
-            san_compile_flags.extend(["-fsanitize=address", "-shared-libasan", "-fsanitize-recover=address"])
+                san_compile_flags.extend(["-fsanitize=address", "-shared-libasan", "-fsanitize-recover=address"])
 
-            arch_asan_ignore_list = lib_clang_version_dir.joinpath("share", "asan_ignorelist.txt")
-            if arch_asan_ignore_list.exists():
-                san_compile_flags.append("-fsanitize-system-ignorelist=" + str(arch_asan_ignore_list))
-            else:
-                print(f"Warning: Couldn't find system ASAN ignorelist at `{arch_asan_ignore_list}`")
-        elif sanitizer.is_tsan():
-            libtsan_so_path = libclang_arch.joinpath("libclang_rt.tsan.so")
-            builtins_path = libclang_arch.joinpath("libclang_rt.builtins.a")
+                arch_asan_ignore_list = lib_clang_version_dir.joinpath("share", "asan_ignorelist.txt")
+                if arch_asan_ignore_list.exists():
+                    san_compile_flags.append("-fsanitize-system-ignorelist=" + str(arch_asan_ignore_list))
+                else:
+                    print(f"Warning: Couldn't find system ASAN ignorelist at `{arch_asan_ignore_list}`")
+            elif sanitizer.is_tsan():
+                libtsan_so_path = libclang_arch.joinpath("libclang_rt.tsan.so")
+                builtins_path = libclang_arch.joinpath("libclang_rt.builtins.a")
 
-            link_args.extend(
-                ["-fsanitize=thread", "--rtlib=compiler-rt", "-shared-libsan", str(libtsan_so_path), str(builtins_path)]
-            )
-            san_compile_flags.append("-shared-libsan")
+                link_args.extend(
+                    ["-fsanitize=thread", "--rtlib=compiler-rt", "-shared-libsan", str(libtsan_so_path), str(builtins_path)]
+                )
+                san_compile_flags.append("-shared-libsan")
 
         link_args = [f"-Clink-arg={arg}" for arg in link_args]
         env["RUSTFLAGS"] += " " + " ".join(link_args)

--- a/python/servo/platform/build_target.py
+++ b/python/servo/platform/build_target.py
@@ -485,7 +485,13 @@ class OpenHarmonyTarget(CrossBuildTarget):
                 builtins_path = libclang_arch.joinpath("libclang_rt.builtins.a")
 
                 link_args.extend(
-                    ["-fsanitize=thread", "--rtlib=compiler-rt", "-shared-libsan", str(libtsan_so_path), str(builtins_path)]
+                    [
+                        "-fsanitize=thread",
+                        "--rtlib=compiler-rt",
+                        "-shared-libsan",
+                        str(libtsan_so_path),
+                        str(builtins_path),
+                    ]
                 )
                 san_compile_flags.append("-shared-libsan")
 

--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -145,7 +145,7 @@ class PostBuildCommands(CommandBase):
             if usb:
                 args += ["-d"]
             shell = subprocess.Popen(args + ["shell"], stdin=subprocess.PIPE)
-            shell.communicate("\n".join(script) + "\n")
+            shell.communicate(("\n".join(script) + "\n").encode())
             return shell.wait()
 
         args = [servo_binary]

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -957,7 +957,7 @@ def parse_config(config_file: dict[str, Any]) -> None:
         # FIXME: Temporarily ignoring this since the type signature for
         # `normalize_paths` must use a constrained type variable for this to
         # typecheck but Pyrefly doesn't handle that correctly (but mypy does).
-        # pyrefly: ignore[bad-argument-type]
+        # pyrefly: ignore[unsupported-operation]
         config["check_ext"][normalize_paths(path)] = exts
 
     # Add list of blocked packages

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -473,7 +473,16 @@ def run_python_type_checker() -> Iterator[tuple[str, int, str]]:
         pass
     else:
         for error in errors:
-            diagnostic = PyreflyDiagnostic(**error)
+            diagnostic = PyreflyDiagnostic(
+                line=error['line'],
+                column=error['column'],
+                stop_line=error['stop_line'],
+                stop_column=error['stop_column'],
+                path=error['path'],
+                code=error['code'],
+                name=error['name'],
+                description=error['description'],
+                concise_description=error['concise_description'])
             yield relative_path(diagnostic.path), diagnostic.line, diagnostic.concise_description
 
 

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -474,15 +474,16 @@ def run_python_type_checker() -> Iterator[tuple[str, int, str]]:
     else:
         for error in errors:
             diagnostic = PyreflyDiagnostic(
-                line=error['line'],
-                column=error['column'],
-                stop_line=error['stop_line'],
-                stop_column=error['stop_column'],
-                path=error['path'],
-                code=error['code'],
-                name=error['name'],
-                description=error['description'],
-                concise_description=error['concise_description'])
+                line=error["line"],
+                column=error["column"],
+                stop_line=error["stop_line"],
+                stop_column=error["stop_column"],
+                path=error["path"],
+                code=error["code"],
+                name=error["name"],
+                description=error["description"],
+                concise_description=error["concise_description"],
+            )
             yield relative_path(diagnostic.path), diagnostic.line, diagnostic.concise_description
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1498,18 +1498,19 @@ wheels = [
 
 [[package]]
 name = "pyrefly"
-version = "0.23.1"
+version = "0.63.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e5/69/8f068f86cc15f5b0c51aada12aa6871cda1eacbcecc34e844b490014d135/pyrefly-0.23.1.tar.gz", hash = "sha256:7032d97dfdf885e8309e9d78bd70b332649544e1f36905082f703e133f575aaa", size = 1106563, upload-time = "2025-07-08T21:16:31.181Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/66/c3e6c3963fe6bb40b0199745ce6cd5772253ec0a4edfe6db63a646f9d007/pyrefly-0.63.1.tar.gz", hash = "sha256:6819eb0857f5fcaef463ad58778e4121cb8c7c5a974a4739c8aa867e1ef16980", size = 5574619, upload-time = "2026-04-29T05:59:52.521Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d6/7ba06a447a022f564c400f50fc428d0bcc6582518fe86126a4b21b85f6dc/pyrefly-0.23.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:a25506700f179004438221aa50aa107f70dc52d08ee538150ef1c3789544f921", size = 5996702, upload-time = "2025-07-08T21:16:17.377Z" },
-    { url = "https://files.pythonhosted.org/packages/58/d7/6985b5d2f96fb4b98bff88ed103510af8381399ece619666e67d48d3e276/pyrefly-0.23.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5307f3184b69effbb867be07c09a0181347b76b1723f3ed246030fb253dde4f2", size = 5564161, upload-time = "2025-07-08T21:16:19.108Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/fb/7b6709bf2869e9d1d4929b3acaf68777c5acf2a458a4a64e88d45b40f96b/pyrefly-0.23.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f59e2c0cf65d1f10e9a0b9c7de63c677a17c3634d60bfa3a3426cd0184e73b4", size = 5771362, upload-time = "2025-07-08T21:16:20.753Z" },
-    { url = "https://files.pythonhosted.org/packages/af/36/8474aad6c30ad93e7d19c457af87298daf54a63ed39d5ebbc828372a40d0/pyrefly-0.23.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2cd03be65aa0b527e29855a42354641f612885587cb40e6ae8bb91b739a4fca6", size = 6470799, upload-time = "2025-07-08T21:16:22.444Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/b1/dfc9e5de5ef21d801522909ef9d7dbeb559997dad6cf1afee46dd7f664db/pyrefly-0.23.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:93d841cb1cd5164407482cb30b09fc25ceaa113809d7715e454dd3cd47faf140", size = 6238136, upload-time = "2025-07-08T21:16:24.013Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/d3/cb59a94e44d06946b301fd3a10b8944ccc4dbd5de4176370adc665a5c7c6/pyrefly-0.23.1-py3-none-win32.whl", hash = "sha256:b077ba0c832a3994e5f457066bd391eaecbfd2332e15beb4dd42658e39371d93", size = 5756476, upload-time = "2025-07-08T21:16:25.866Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/05/04c55202fd079d1142dd3b37b8eddd694fe5efaa334111a67fda4ab5c176/pyrefly-0.23.1-py3-none-win_amd64.whl", hash = "sha256:c6f621d22e528904b9253bd378b45e475f2b4e0e43bf85088654383ec42b98c8", size = 6143869, upload-time = "2025-07-08T21:16:27.533Z" },
-    { url = "https://files.pythonhosted.org/packages/33/03/3a82631943792d9a23457f235af58700a9e139efb7ecd83d5e0cad9161bb/pyrefly-0.23.1-py3-none-win_arm64.whl", hash = "sha256:e567ad4e1001040cfca7418b1bc2ec21c4c6f96fd1102e848ad8ced0bd5dcdb7", size = 5779868, upload-time = "2025-07-08T21:16:29.259Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/7b/52a34bd3dde4c1b6cf8e8cf8bcbb0fa52b868df2ab07220e130c87877376/pyrefly-0.63.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:1bc37f4fe8c3e50f6718bcb1c6cae475e5e24197f6fe8042c3d6ca3d8f2e10da", size = 13102494, upload-time = "2026-04-29T05:59:27.558Z" },
+    { url = "https://files.pythonhosted.org/packages/60/e0/2ac0c3e003ba6c855e4775536485c75b18e1aaf5e18e966a033751436416/pyrefly-0.63.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:712733b7c4344644eafa827de88a36e697a1aa282f913da89d3ad26e7dcc2dc2", size = 12597372, upload-time = "2026-04-29T05:59:30.434Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/07/1bb6354ccd7ccca2706fc00cfde952c2e18383a47f0cb5417347df836b7f/pyrefly-0.63.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e6cbba7aedc266be0e6a69305e9caa53b3b4bab190bde046ce37a895af5c20a0", size = 36494119, upload-time = "2026-04-29T05:59:33.813Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f5/9c243090872ad3c1f690c782df900468630ad139a0fb309a1185e6838dc7/pyrefly-0.63.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d6a99c4acd7ff8418a15f39dd402d8f9bf7d640a8a2536f7a1b34ef7e1b1167c", size = 39262905, upload-time = "2026-04-29T05:59:36.609Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ef/33918f3b5d04e34f8ad7a5d0de493c5d32a93b183b58c7e785571854b608/pyrefly-0.63.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6b6490de58b1ec9fe99aa1fbaf0759079a916c0fb75d345439ba2a427aaebc1a", size = 37446668, upload-time = "2026-04-29T05:59:39.549Z" },
+    { url = "https://files.pythonhosted.org/packages/15/d5/f0c9e6938c3f1231405ee77045b2b51c349d1a6aa84ba8717f4829f64bbc/pyrefly-0.63.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d53ec1f8711b24b1e992309b978b219daf2335201f26acafa86f14fbb81804ec", size = 42061281, upload-time = "2026-04-29T05:59:42.56Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/0c/ca7d4f2bc3c17dac9c3da9956d8baa5c4fe4c4e4996ead9b55273b0ee20a/pyrefly-0.63.1-py3-none-win32.whl", hash = "sha256:a9a45d3fc563f02cdca4681e899a775561bd71e923d6ac4a8979d93d7c2aff2a", size = 12086212, upload-time = "2026-04-29T05:59:45.021Z" },
+    { url = "https://files.pythonhosted.org/packages/97/b5/1f6373e1fcefca3414baeed4209ecab2f4beb7849a2508517d73e78034ce/pyrefly-0.63.1-py3-none-win_amd64.whl", hash = "sha256:c6470a8eedae0e46d94667fd958cd008f9c2599aa3e6f2f43b6f4e6e87863cc3", size = 12934616, upload-time = "2026-04-29T05:59:48.146Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/ab/116efd46872f88cec697133d0430ce28affcc7247ebdff71429422a3a42b/pyrefly-0.63.1-py3-none-win_arm64.whl", hash = "sha256:b54b068a77341bc50604fb9bd4d0cf37fb74c09fb92344645c596813cc53950a", size = 12434930, upload-time = "2026-04-29T05:59:50.462Z" },
 ]
 
 [[package]]
@@ -1815,7 +1816,7 @@ requires-dist = [
     { name = "ply", specifier = "==3.8" },
     { name = "pycodestyle", marker = "python_full_version >= '3.9'", specifier = "==2.11.1" },
     { name = "pyflakes", marker = "python_full_version >= '3.9'", specifier = "==3.1.0" },
-    { name = "pyrefly", specifier = "==0.23.1" },
+    { name = "pyrefly", specifier = "==0.63.1" },
     { name = "pyyaml", specifier = "==6.0.1" },
     { name = "redo", specifier = "==3.0.0" },
     { name = "requests" },


### PR DESCRIPTION
#44591 bumps pyrefly to 0.63.1, but uv.lock still lists pyrefly 0.23.1. as a result, when mach runs `uv run --frozen`, we still try to install the old version of pyrefly, which fails on FreeBSD (#44589).

this patch updates uv.lock by running `uv lock`, on a Linux machine. for some reason, if i run `uv lock` on a FreeBSD machine, uv just removes pyrefly from uv.lock, which is probably not what we want.

Testing: tested manually on FreeBSD (it takes an eternity to build pyrefly though!)