### PR TITLE
script: propagate &mut JSContext in ReadableStreamDefaultReader::read_all_bytes

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -320,16 +320,14 @@ impl js::gc::Rootable for TransmitBodyPromiseHandler {}
 impl Callback for TransmitBodyPromiseHandler {
     /// Step 5 of <https://fetch.spec.whatwg.org/#concept-request-transmit-body>
     fn callback(&self, cx: &mut CurrentRealm, v: HandleValue) {
-        let can_gc = CanGc::from_cx(cx);
         let _realm = InRealm::Already(&cx.into());
-        let cx = cx.into();
-        let is_done = match get_read_promise_done(cx, &v, can_gc) {
+        let is_done = match get_read_promise_done(cx.into(), &v, CanGc::from_cx(cx)) {
             Ok(is_done) => is_done,
             Err(_) => {
                 // Step 5.5, the "otherwise" steps.
                 // TODO: terminate fetch.
                 let _ = self.control_sender.send(BodyChunkRequest::Done);
-                return self.stream.stop_reading(can_gc);
+                return self.stream.stop_reading(cx);
             },
         };
 
@@ -337,15 +335,15 @@ impl Callback for TransmitBodyPromiseHandler {
             // Step 5.3, the "done" steps.
             // TODO: queue a fetch task on request to process request end-of-body.
             let _ = self.control_sender.send(BodyChunkRequest::Done);
-            return self.stream.stop_reading(can_gc);
+            return self.stream.stop_reading(cx);
         }
 
-        let chunk = match get_read_promise_bytes(cx, &v, can_gc) {
+        let chunk = match get_read_promise_bytes(cx.into(), &v, CanGc::from_cx(cx)) {
             Ok(chunk) => chunk,
             Err(_) => {
                 // Step 5.5, the "otherwise" steps.
                 let _ = self.control_sender.send(BodyChunkRequest::Error);
-                return self.stream.stop_reading(can_gc);
+                return self.stream.stop_reading(cx);
             },
         };
 
@@ -379,7 +377,7 @@ impl Callback for TransmitBodyPromiseRejectionHandler {
     fn callback(&self, cx: &mut CurrentRealm, _v: HandleValue) {
         // Step 5.4, the "rejection" steps.
         let _ = self.control_sender.send(BodyChunkRequest::Error);
-        self.stream.stop_reading(CanGc::from_cx(cx));
+        self.stream.stop_reading(cx);
     }
 }
 
@@ -769,26 +767,30 @@ pub(crate) fn consume_body<T: BodyMixin + DomObject>(
     let mime_type = object.get_mime_type(can_gc);
     let success_promise = promise.clone();
 
+    // TODO: https://github.com/servo/servo/pull/44254
+    #[allow(unsafe_code)]
+    let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
+    let cx = &mut cx;
+
     // Read all bytes from reader, given successSteps and errorSteps.
     // Note: spec uses an intermediary concept of `fully_read`,
     // which seems useful when invoking fetch from other places.
     // TODO: #36049
     reader.read_all_bytes(
         cx,
-        Rc::new(move |bytes: &[u8]| {
+        Rc::new(move |cx, bytes: &[u8]| {
             resolve_result_promise(
                 body_type,
                 &success_promise,
                 mime_type.clone(),
                 bytes.to_vec(),
-                cx,
-                can_gc,
+                cx.into(),
+                CanGc::from_cx(cx),
             );
         }),
         Rc::new(move |cx, v| {
-            error_promise.reject(cx, v, can_gc);
+            error_promise.reject(cx.into(), v, CanGc::from_cx(cx));
         }),
-        can_gc,
     );
 
     promise

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -288,25 +288,23 @@ impl BlobMethods<crate::DomTypeHolder> for Blob {
         let success_promise = promise.clone();
         let failure_promise = promise.clone();
         reader.read_all_bytes(
-            cx.into(),
-            Rc::new(move |bytes| {
-                let cx = GlobalScope::get_cx();
-                rooted!(in(*cx) let mut js_object = ptr::null_mut::<JSObject>());
+            cx,
+            Rc::new(move |cx, bytes| {
+                rooted!(&in(cx) let mut js_object = ptr::null_mut::<JSObject>());
                 // 4. Return the result of transforming promise by a fulfillment handler that returns a new
                 //    [ArrayBuffer]
                 let array_buffer = create_buffer_source::<ArrayBufferU8>(
-                    cx,
+                    cx.into(),
                     bytes,
                     js_object.handle_mut(),
-                    CanGc::deprecated_note(),
+                    CanGc::from_cx(cx),
                 )
                 .expect("Converting input to ArrayBufferU8 should never fail");
-                success_promise.resolve_native(&array_buffer, CanGc::deprecated_note());
+                success_promise.resolve_native(&array_buffer, CanGc::from_cx(cx));
             }),
             Rc::new(move |cx, value| {
-                failure_promise.reject(cx, value, CanGc::deprecated_note());
+                failure_promise.reject(cx.into(), value, CanGc::from_cx(cx));
             }),
-            CanGc::from_cx(cx),
         );
 
         promise
@@ -333,23 +331,21 @@ impl BlobMethods<crate::DomTypeHolder> for Blob {
         let p_success = p.clone();
         let p_failure = p.clone();
         reader.read_all_bytes(
-            cx.into(),
-            Rc::new(move |bytes| {
-                let cx = GlobalScope::get_cx();
-                rooted!(in(*cx) let mut js_object = ptr::null_mut::<JSObject>());
+            cx,
+            Rc::new(move |cx, bytes| {
+                rooted!(&in(cx) let mut js_object = ptr::null_mut::<JSObject>());
                 let arr = create_buffer_source::<Uint8>(
-                    cx,
+                    cx.into(),
                     bytes,
                     js_object.handle_mut(),
-                    CanGc::deprecated_note(),
+                    CanGc::from_cx(cx),
                 )
                 .expect("Converting input to uint8 array should never fail");
-                p_success.resolve_native(&arr, CanGc::deprecated_note());
+                p_success.resolve_native(&arr, CanGc::from_cx(cx));
             }),
             Rc::new(move |cx, v| {
-                p_failure.reject(cx, v, CanGc::deprecated_note());
+                p_failure.reject(cx.into(), v, CanGc::from_cx(cx));
             }),
-            CanGc::from_cx(cx),
         );
         p
     }

--- a/components/script/dom/file/filereader.rs
+++ b/components/script/dom/file/filereader.rs
@@ -524,8 +524,8 @@ impl FileReader {
 
         // Read all bytes from stream with reader.
         reader.read_all_bytes(
-            cx.into(),
-            Rc::new(move |blob_contents| {
+            cx,
+            Rc::new(move |_cx, blob_contents| {
                 let global = filereader_success.global();
                 let task_manager = global.task_manager();
                 let task_source = task_manager.file_reading_task_source();
@@ -577,7 +577,6 @@ impl FileReader {
                     DOMErrorName::OperationError,
                 ));
             }),
-            CanGc::from_cx(cx),
         );
         Ok(())
     }

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -633,17 +633,17 @@ fn stream_handle_incoming(
 ) {
     match bytes {
         Ok(b) => {
-            stream.enqueue_native(b, CanGc::from_cx(cx));
+            stream.enqueue_native(cx, b);
         },
         Err(e) => {
-            stream.error_native(e, CanGc::from_cx(cx));
+            stream.error_native(cx, e);
         },
     }
 }
 
 /// Callback used to close streams as part of FileListener.
 fn stream_handle_eof(cx: &mut js::context::JSContext, stream: &ReadableStream) {
-    stream.controller_close_native(CanGc::from_cx(cx));
+    stream.controller_close_native(cx);
 }
 
 impl FileListener {

--- a/components/script/dom/response.rs
+++ b/components/script/dom/response.rs
@@ -103,9 +103,9 @@ impl Response {
         )
     }
 
-    pub(crate) fn error_stream(&self, error: Error, can_gc: CanGc) {
+    pub(crate) fn error_stream(&self, cx: &mut js::context::JSContext, error: Error) {
         if let Some(body) = self.fetch_body_stream.get() {
-            body.error_native(error, can_gc);
+            body.error_native(cx, error);
         }
     }
 
@@ -548,19 +548,19 @@ impl Response {
         *self.stream_consumer.borrow_mut() = sc;
     }
 
-    pub(crate) fn stream_chunk(&self, chunk: Vec<u8>, can_gc: CanGc) {
+    pub(crate) fn stream_chunk(&self, cx: &mut js::context::JSContext, chunk: Vec<u8>) {
         self.is_body_empty.set(false);
         // Note, are these two actually mutually exclusive?
         if let Some(stream_consumer) = self.stream_consumer.borrow().as_ref() {
             stream_consumer.consume_chunk(chunk.as_slice());
         } else if let Some(body) = self.fetch_body_stream.get() {
-            body.enqueue_native(chunk, can_gc);
+            body.enqueue_native(cx, chunk);
         }
     }
 
-    pub(crate) fn finish(&self, can_gc: CanGc) {
+    pub(crate) fn finish(&self, cx: &mut js::context::JSContext) {
         if let Some(body) = self.fetch_body_stream.get() {
-            body.controller_close_native(can_gc);
+            body.controller_close_native(cx);
         }
         let stream_consumer = self.stream_consumer.borrow_mut().take();
         if let Some(stream_consumer) = stream_consumer {

--- a/components/script/dom/stream/byteteereadintorequest.rs
+++ b/components/script/dom/stream/byteteereadintorequest.rs
@@ -152,11 +152,11 @@ impl ByteTeeReadIntoRequest {
 
                 // Perform ! ReadableByteStreamControllerError(byobBranch.[[controller]], cloneResult.[[Value]]).
                 let byob_branch_controller = self.byob_branch.get_byte_controller();
-                byob_branch_controller.error(error_value.handle(), CanGc::from_cx(cx));
+                byob_branch_controller.error(cx, error_value.handle());
 
                 // Perform ! ReadableByteStreamControllerError(otherBranch.[[controller]], cloneResult.[[Value]]).
                 let other_branch_controller = self.other_branch.get_byte_controller();
-                other_branch_controller.error(error_value.handle(), CanGc::from_cx(cx));
+                other_branch_controller.error(cx, error_value.handle());
 
                 // Resolve cancelPromise with ! ReadableStreamCancel(stream, cloneResult.[[Value]]).
                 let cancel_result =
@@ -175,11 +175,7 @@ impl ByteTeeReadIntoRequest {
                 // ReadableByteStreamControllerRespondWithNewView(byobBranch.[[controller]], chunk).
                 if !byob_canceled {
                     let byob_branch_controller = self.byob_branch.get_byte_controller();
-                    byob_branch_controller.respond_with_new_view(
-                        cx.into(),
-                        chunk,
-                        CanGc::from_cx(cx),
-                    )?;
+                    byob_branch_controller.respond_with_new_view(cx, chunk)?;
                 }
 
                 // Perform ! ReadableByteStreamControllerEnqueue(otherBranch.[[controller]], clonedChunk).
@@ -191,7 +187,7 @@ impl ByteTeeReadIntoRequest {
             // ! ReadableByteStreamControllerRespondWithNewView(byobBranch.[[controller]], chunk).
 
             let byob_branch_controller = self.byob_branch.get_byte_controller();
-            byob_branch_controller.respond_with_new_view(cx.into(), chunk, CanGc::from_cx(cx))?;
+            byob_branch_controller.respond_with_new_view(cx, chunk)?;
         }
 
         // Set reading to false.
@@ -211,11 +207,9 @@ impl ByteTeeReadIntoRequest {
     /// <https://streams.spec.whatwg.org/#ref-for-read-into-request-close-steps%E2%91%A1>
     pub(crate) fn close_steps(
         &self,
+        cx: &mut js::context::JSContext,
         chunk: Option<HeapBufferSource<ArrayBufferViewU8>>,
-        can_gc: CanGc,
     ) -> Fallible<()> {
-        let cx = GlobalScope::get_cx();
-
         // Set reading to false.
         self.reading.set(false);
 
@@ -236,13 +230,13 @@ impl ByteTeeReadIntoRequest {
         // If byobCanceled is false, perform ! ReadableByteStreamControllerClose(byobBranch.[[controller]]).
         if !byob_canceled {
             let byob_branch_controller = self.byob_branch.get_byte_controller();
-            byob_branch_controller.close(cx, can_gc)?;
+            byob_branch_controller.close(cx)?;
         }
 
         // If otherCanceled is false, perform ! ReadableByteStreamControllerClose(otherBranch.[[controller]]).
         if !other_canceled {
             let other_branch_controller = self.other_branch.get_byte_controller();
-            other_branch_controller.close(cx, can_gc)?;
+            other_branch_controller.close(cx)?;
         }
 
         // If chunk is not undefined,
@@ -259,7 +253,7 @@ impl ByteTeeReadIntoRequest {
                 // ReadableByteStreamControllerRespondWithNewView(byobBranch.[[controller]], chunk).
                 if !byob_canceled {
                     let byob_branch_controller = self.byob_branch.get_byte_controller();
-                    byob_branch_controller.respond_with_new_view(cx, chunk, can_gc)?;
+                    byob_branch_controller.respond_with_new_view(cx, chunk)?;
                 }
 
                 // If otherCanceled is false and otherBranch.[[controller]].[[pendingPullIntos]] is not empty,
@@ -267,7 +261,7 @@ impl ByteTeeReadIntoRequest {
                 if !other_canceled {
                     let other_branch_controller = self.other_branch.get_byte_controller();
                     if other_branch_controller.get_pending_pull_intos_size() > 0 {
-                        other_branch_controller.respond(cx, 0, can_gc)?;
+                        other_branch_controller.respond(cx, 0)?;
                     }
                 }
             }
@@ -275,7 +269,7 @@ impl ByteTeeReadIntoRequest {
 
         // If byobCanceled is false or otherCanceled is false, resolve cancelPromise with undefined.
         if !byob_canceled || !other_canceled {
-            self.cancel_promise.resolve_native(&(), can_gc);
+            self.cancel_promise.resolve_native(&(), CanGc::from_cx(cx));
         }
 
         Ok(())
@@ -292,6 +286,6 @@ impl ByteTeeReadIntoRequest {
         byte_tee_pull_algorithm: Option<ByteTeePullAlgorithm>,
     ) {
         self.tee_underlying_source
-            .pull_algorithm(byte_tee_pull_algorithm, CanGc::from_cx(cx));
+            .pull_algorithm(cx, byte_tee_pull_algorithm);
     }
 }

--- a/components/script/dom/stream/byteteereadrequest.rs
+++ b/components/script/dom/stream/byteteereadrequest.rs
@@ -143,8 +143,8 @@ impl ByteTeeReadRequest {
             let branch_1_controller = self.branch_1.get_byte_controller();
             let branch_2_controller = self.branch_2.get_byte_controller();
 
-            branch_1_controller.error(error_value.handle(), CanGc::from_cx(cx));
-            branch_2_controller.error(error_value.handle(), CanGc::from_cx(cx));
+            branch_1_controller.error(cx, error_value.handle());
+            branch_2_controller.error(cx, error_value.handle());
 
             let cancel_result = self
                 .stream
@@ -225,8 +225,7 @@ impl ByteTeeReadRequest {
     }
 
     /// <https://streams.spec.whatwg.org/#ref-for-read-request-close-steps%E2%91%A2>
-    pub(crate) fn close_steps(&self, can_gc: CanGc) -> Fallible<()> {
-        let cx = GlobalScope::get_cx();
+    pub(crate) fn close_steps(&self, cx: &mut js::context::JSContext) -> Fallible<()> {
         let branch_1_controller = self.branch_1.get_byte_controller();
         let branch_2_controller = self.branch_2.get_byte_controller();
 
@@ -235,29 +234,29 @@ impl ByteTeeReadRequest {
 
         // If canceled1 is false, perform ! ReadableByteStreamControllerClose(branch1.[[controller]]).
         if !self.canceled_1.get() {
-            branch_1_controller.close(cx, can_gc)?;
+            branch_1_controller.close(cx)?;
         }
 
         // If canceled2 is false, perform ! ReadableByteStreamControllerClose(branch2.[[controller]]).
         if !self.canceled_2.get() {
-            branch_2_controller.close(cx, can_gc)?;
+            branch_2_controller.close(cx)?;
         }
 
         // If branch1.[[controller]].[[pendingPullIntos]] is not empty,
         // perform ! ReadableByteStreamControllerRespond(branch1.[[controller]], 0).
         if branch_1_controller.get_pending_pull_intos_size() > 0 {
-            branch_1_controller.respond(cx, 0, can_gc)?;
+            branch_1_controller.respond(cx, 0)?;
         }
 
         // If branch2.[[controller]].[[pendingPullIntos]] is not empty,
         // perform ! ReadableByteStreamControllerRespond(branch2.[[controller]], 0).
         if branch_2_controller.get_pending_pull_intos_size() > 0 {
-            branch_2_controller.respond(cx, 0, can_gc)?;
+            branch_2_controller.respond(cx, 0)?;
         }
 
         // If canceled1 is false or canceled2 is false, resolve cancelPromise with undefined.
         if !self.canceled_1.get() || !self.canceled_2.get() {
-            self.cancel_promise.resolve_native(&(), can_gc);
+            self.cancel_promise.resolve_native(&(), CanGc::from_cx(cx));
         }
 
         Ok(())
@@ -275,6 +274,6 @@ impl ByteTeeReadRequest {
         byte_tee_pull_algorithm: Option<ByteTeePullAlgorithm>,
     ) {
         self.tee_underlying_source
-            .pull_algorithm(byte_tee_pull_algorithm, CanGc::from_cx(cx));
+            .pull_algorithm(cx, byte_tee_pull_algorithm);
     }
 }

--- a/components/script/dom/stream/byteteeunderlyingsource.rs
+++ b/components/script/dom/stream/byteteeunderlyingsource.rs
@@ -23,7 +23,7 @@ use crate::dom::promise::Promise;
 use crate::dom::stream::byteteereadrequest::ByteTeeReadRequest;
 use crate::dom::stream::readablestreamdefaultreader::ReadRequest;
 use crate::dom::types::ReadableStream;
-use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
+use crate::script_runtime::CanGc;
 
 #[derive(JSTraceable, MallocSizeOf)]
 pub(crate) enum ByteTeeCancelAlgorithm {
@@ -165,9 +165,8 @@ impl ByteTeeUnderlyingSource {
 
     pub(crate) fn pull_with_default_reader(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
-        can_gc: CanGc,
     ) -> Fallible<()> {
         let mut reader = self.reader.borrow_mut();
         match &*reader {
@@ -185,12 +184,12 @@ impl ByteTeeUnderlyingSource {
                 byte_reader
                     .get()
                     .expect("Reader should be set.")
-                    .release(can_gc)?;
+                    .release(CanGc::from_cx(cx))?;
 
                 // Acquire default reader.
                 let default_reader = self
                     .stream
-                    .acquire_default_reader(can_gc)
+                    .acquire_default_reader(CanGc::from_cx(cx))
                     .expect("AcquireReadableStreamDefaultReader should not fail");
 
                 *reader = ReaderType::Default(MutNullableDom::new(Some(&default_reader)));
@@ -199,10 +198,10 @@ impl ByteTeeUnderlyingSource {
                 drop(reader);
 
                 // Attach error forwarding for the new reader.
-                self.forward_reader_error(self.reader.clone(), can_gc);
+                self.forward_reader_error(self.reader.clone(), CanGc::from_cx(cx));
 
                 // IMPORTANT: now actually perform the pull we were asked to do.
-                return self.pull_with_default_reader(cx, global, can_gc);
+                return self.pull_with_default_reader(cx, global);
             },
             ReaderType::Default(reader) => {
                 let byte_tee_read_request = ByteTeeReadRequest::new(
@@ -217,7 +216,7 @@ impl ByteTeeUnderlyingSource {
                     self.cancel_promise.clone(),
                     self,
                     global,
-                    can_gc,
+                    CanGc::from_cx(cx),
                 );
 
                 let read_request = ReadRequest::ByteTee {
@@ -227,7 +226,7 @@ impl ByteTeeUnderlyingSource {
                 reader
                     .get()
                     .expect("Reader should be set.")
-                    .read(cx, &read_request, can_gc);
+                    .read(cx, &read_request);
             },
         }
 
@@ -236,11 +235,10 @@ impl ByteTeeUnderlyingSource {
 
     pub(crate) fn pull_with_byob_reader(
         &self,
+        cx: &mut js::context::JSContext,
         view: HeapBufferSource<ArrayBufferViewU8>,
         for_branch2: bool,
-        cx: SafeJSContext,
         global: &GlobalScope,
-        can_gc: CanGc,
     ) {
         let mut reader = self.reader.borrow_mut();
         match &*reader {
@@ -273,7 +271,7 @@ impl ByteTeeUnderlyingSource {
                     self.cancel_promise.clone(),
                     self,
                     global,
-                    can_gc,
+                    CanGc::from_cx(cx),
                 );
 
                 let read_into_request = ReadIntoRequest::ByteTee {
@@ -281,13 +279,10 @@ impl ByteTeeUnderlyingSource {
                 };
 
                 // Perform ! ReadableStreamBYOBReaderRead(reader, view, 1, readIntoRequest).
-                reader.get().expect("Reader should be set.").read(
-                    cx,
-                    view,
-                    1,
-                    &read_into_request,
-                    can_gc,
-                );
+                reader
+                    .get()
+                    .expect("Reader should be set.")
+                    .read(cx, view, 1, &read_into_request);
             },
             ReaderType::Default(default_reader) => {
                 // If reader implements ReadableStreamDefaultReader,
@@ -304,13 +299,13 @@ impl ByteTeeUnderlyingSource {
                 default_reader
                     .get()
                     .expect("Reader should be set.")
-                    .release(can_gc)
+                    .release(cx)
                     .expect("Release should be successful.");
 
                 // Set reader to ! AcquireReadableStreamBYOBReader(stream).
                 let byob_reader = self
                     .stream
-                    .acquire_byob_reader(can_gc)
+                    .acquire_byob_reader(CanGc::from_cx(cx))
                     .expect("Reader should be set.");
 
                 *reader = ReaderType::BYOB(MutNullableDom::new(Some(&byob_reader)));
@@ -320,10 +315,10 @@ impl ByteTeeUnderlyingSource {
                 drop(reader);
 
                 // Perform forwardReaderError, given reader.
-                self.forward_reader_error(self.reader.clone(), can_gc);
+                self.forward_reader_error(self.reader.clone(), CanGc::from_cx(cx));
 
                 // Retry the pull using the BYOB reader we just acquired.
-                self.pull_with_byob_reader(view, for_branch2, cx, global, can_gc);
+                self.pull_with_byob_reader(cx, view, for_branch2, global);
             },
         }
     }
@@ -331,11 +326,9 @@ impl ByteTeeUnderlyingSource {
     /// Let pullAlgorithm be the following steps:
     pub(crate) fn pull_algorithm(
         &self,
+        cx: &mut js::context::JSContext,
         byte_tee_pull_algorithm: Option<ByteTeePullAlgorithm>,
-        can_gc: CanGc,
     ) -> Rc<Promise> {
-        let cx = GlobalScope::get_cx();
-
         let pull_algorithm =
             byte_tee_pull_algorithm.unwrap_or(self.byte_tee_pull_algorithm.clone());
 
@@ -346,8 +339,13 @@ impl ByteTeeUnderlyingSource {
                     // Set readAgainForBranch1 to true.
                     self.read_again_for_branch_1.set(true);
                     // Return a promise resolved with undefined.
-                    rooted!(in(*cx) let mut rval = UndefinedValue());
-                    return Promise::new_resolved(&self.stream.global(), cx, rval.handle(), can_gc);
+                    rooted!(&in(cx) let mut rval = UndefinedValue());
+                    return Promise::new_resolved(
+                        &self.stream.global(),
+                        cx.into(),
+                        rval.handle(),
+                        CanGc::from_cx(cx),
+                    );
                 }
 
                 // Set reading to true.
@@ -360,26 +358,31 @@ impl ByteTeeUnderlyingSource {
                     .expect("Branch 1 should be set.")
                     .get_byte_controller();
                 let byob_request = byob_branch_controller
-                    .get_byob_request(cx, can_gc)
+                    .get_byob_request(cx.into(), CanGc::from_cx(cx))
                     .expect("Byob request should be set.");
 
                 match byob_request {
                     // If byobRequest is null, perform pullWithDefaultReader.
                     None => {
-                        self.pull_with_default_reader(cx, &self.stream.global(), can_gc)
+                        self.pull_with_default_reader(cx, &self.stream.global())
                             .expect("Pull with default reader should be successful.");
                     },
                     Some(request) => {
                         // Otherwise, perform pullWithBYOBReader, given byobRequest.[[view]] and false.
                         let view = request.get_view();
 
-                        self.pull_with_byob_reader(view, false, cx, &self.stream.global(), can_gc);
+                        self.pull_with_byob_reader(cx, view, false, &self.stream.global());
                     },
                 }
 
                 // Return a promise resolved with undefined.
-                rooted!(in(*cx) let mut rval = UndefinedValue());
-                Promise::new_resolved(&self.stream.global(), cx, rval.handle(), can_gc)
+                rooted!(&in(cx) let mut rval = UndefinedValue());
+                Promise::new_resolved(
+                    &self.stream.global(),
+                    cx.into(),
+                    rval.handle(),
+                    CanGc::from_cx(cx),
+                )
             },
             ByteTeePullAlgorithm::Pull2Algorithm => {
                 // If reading is true,
@@ -388,8 +391,13 @@ impl ByteTeeUnderlyingSource {
                     self.read_again_for_branch_2.set(true);
 
                     // Return a promise resolved with undefined.
-                    rooted!(in(*cx) let mut rval = UndefinedValue());
-                    return Promise::new_resolved(&self.stream.global(), cx, rval.handle(), can_gc);
+                    rooted!(&in(cx) let mut rval = UndefinedValue());
+                    return Promise::new_resolved(
+                        &self.stream.global(),
+                        cx.into(),
+                        rval.handle(),
+                        CanGc::from_cx(cx),
+                    );
                 }
 
                 // Set reading to true.
@@ -402,25 +410,30 @@ impl ByteTeeUnderlyingSource {
                     .expect("Branch 2 should be set.")
                     .get_byte_controller();
                 let byob_request = byob_branch_controller
-                    .get_byob_request(cx, can_gc)
+                    .get_byob_request(cx.into(), CanGc::from_cx(cx))
                     .expect("Byob request should be set.");
 
                 match byob_request {
                     None => {
-                        self.pull_with_default_reader(cx, &self.stream.global(), can_gc)
+                        self.pull_with_default_reader(cx, &self.stream.global())
                             .expect("Pull with default reader should be successful.");
                     },
                     Some(request) => {
                         // Otherwise, perform pullWithBYOBReader, given byobRequest.[[view]] and true.
                         let view = request.get_view();
 
-                        self.pull_with_byob_reader(view, true, cx, &self.stream.global(), can_gc);
+                        self.pull_with_byob_reader(cx, view, true, &self.stream.global());
                     },
                 }
 
                 // Return a promise resolved with undefined.
-                rooted!(in(*cx) let mut rval = UndefinedValue());
-                Promise::new_resolved(&self.stream.global(), cx, rval.handle(), can_gc)
+                rooted!(&in(cx) let mut rval = UndefinedValue());
+                Promise::new_resolved(
+                    &self.stream.global(),
+                    cx.into(),
+                    rval.handle(),
+                    CanGc::from_cx(cx),
+                )
             },
         }
     }

--- a/components/script/dom/stream/defaultteereadrequest.rs
+++ b/components/script/dom/stream/defaultteereadrequest.rs
@@ -142,16 +142,16 @@ impl DefaultTeeReadRequest {
             {
                 // Perform ! ReadableStreamDefaultControllerError(branch_1.[[controller]], cloneResult.[[Value]]).
                 self.readable_stream_default_controller_error(
+                    cx,
                     &self.branch_1,
                     clone_result.handle(),
-                    CanGc::from_cx(cx),
                 );
 
                 // Perform ! ReadableStreamDefaultControllerError(branch_2.[[controller]], cloneResult.[[Value]]).
                 self.readable_stream_default_controller_error(
+                    cx,
                     &self.branch_2,
                     clone_result.handle(),
-                    CanGc::from_cx(cx),
                 );
                 // Resolve cancelPromise with ! ReadableStreamCancel(stream, cloneResult.[[Value]]).
                 self.stream_cancel(cx, global, clone_result.handle());
@@ -186,20 +186,20 @@ impl DefaultTeeReadRequest {
         }
     }
     /// <https://streams.spec.whatwg.org/#read-request-close-steps>
-    pub(crate) fn close_steps(&self, can_gc: CanGc) {
+    pub(crate) fn close_steps(&self, cx: &mut js::context::JSContext) {
         // Set reading to false.
         self.reading.set(false);
         // If canceled_1 is false, perform ! ReadableStreamDefaultControllerClose(branch_1.[[controller]]).
         if !self.canceled_1.get() {
-            self.readable_stream_default_controller_close(&self.branch_1, can_gc);
+            self.readable_stream_default_controller_close(cx, &self.branch_1);
         }
         // If canceled_2 is false, perform ! ReadableStreamDefaultControllerClose(branch_2.[[controller]]).
         if !self.canceled_2.get() {
-            self.readable_stream_default_controller_close(&self.branch_2, can_gc);
+            self.readable_stream_default_controller_close(cx, &self.branch_2);
         }
         // If canceled_1 is false or canceled_2 is false, resolve cancelPromise with undefined.
         if !self.canceled_1.get() || !self.canceled_2.get() {
-            self.cancel_promise.resolve_native(&(), can_gc);
+            self.cancel_promise.resolve_native(&(), CanGc::from_cx(cx));
         }
     }
     /// <https://streams.spec.whatwg.org/#read-request-error-steps>
@@ -223,23 +223,26 @@ impl DefaultTeeReadRequest {
 
     /// Call into close of the default controller of a stream,
     /// <https://streams.spec.whatwg.org/#readable-stream-default-controller-close>
-    fn readable_stream_default_controller_close(&self, stream: &ReadableStream, can_gc: CanGc) {
-        stream.get_default_controller().close(can_gc);
+    fn readable_stream_default_controller_close(
+        &self,
+        cx: &mut js::context::JSContext,
+        stream: &ReadableStream,
+    ) {
+        stream.get_default_controller().close(cx);
     }
 
     /// Call into error of the default controller of stream,
     /// <https://streams.spec.whatwg.org/#readable-stream-default-controller-error>
     fn readable_stream_default_controller_error(
         &self,
+        cx: &mut js::context::JSContext,
         stream: &ReadableStream,
         error: SafeHandleValue,
-        can_gc: CanGc,
     ) {
-        stream.get_default_controller().error(error, can_gc);
+        stream.get_default_controller().error(cx, error);
     }
 
     pub(crate) fn pull_algorithm(&self, cx: &mut js::context::JSContext) {
-        self.tee_underlying_source
-            .pull_algorithm(CanGc::from_cx(cx));
+        self.tee_underlying_source.pull_algorithm(cx);
     }
 }

--- a/components/script/dom/stream/defaultteeunderlyingsource.rs
+++ b/components/script/dom/stream/defaultteeunderlyingsource.rs
@@ -104,15 +104,19 @@ impl DefaultTeeUnderlyingSource {
 
     /// <https://streams.spec.whatwg.org/#abstract-opdef-readablestreamdefaulttee>
     /// Let pullAlgorithm be the following steps:
-    pub(crate) fn pull_algorithm(&self, can_gc: CanGc) -> Rc<Promise> {
-        let cx = GlobalScope::get_cx();
+    pub(crate) fn pull_algorithm(&self, cx: &mut js::context::JSContext) -> Rc<Promise> {
         // If reading is true,
         if self.reading.get() {
             // Set readAgain to true.
             self.read_again.set(true);
             // Return a promise resolved with undefined.
-            rooted!(in(*cx) let mut rval = UndefinedValue());
-            return Promise::new_resolved(&self.stream.global(), cx, rval.handle(), can_gc);
+            rooted!(&in(cx) let mut rval = UndefinedValue());
+            return Promise::new_resolved(
+                &self.stream.global(),
+                cx.into(),
+                rval.handle(),
+                CanGc::from_cx(cx),
+            );
         }
 
         // Set reading to true.
@@ -130,7 +134,7 @@ impl DefaultTeeUnderlyingSource {
             self.clone_for_branch_2.clone(),
             self.cancel_promise.clone(),
             self,
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         // Rooting: the tee read request is rooted above.
@@ -139,11 +143,16 @@ impl DefaultTeeUnderlyingSource {
         };
 
         // Perform ! ReadableStreamDefaultReaderRead(reader, readRequest).
-        self.reader.read(cx, &read_request, can_gc);
+        self.reader.read(cx, &read_request);
 
         // Return a promise resolved with undefined.
-        rooted!(in(*cx) let mut rval = UndefinedValue());
-        Promise::new_resolved(&self.stream.global(), cx, rval.handle(), can_gc)
+        rooted!(&in(cx) let mut rval = UndefinedValue());
+        Promise::new_resolved(
+            &self.stream.global(),
+            cx.into(),
+            rval.handle(),
+            CanGc::from_cx(cx),
+        )
     }
 
     /// <https://streams.spec.whatwg.org/#abstract-opdef-readablestreamdefaulttee>

--- a/components/script/dom/stream/readablebytestreamcontroller.rs
+++ b/components/script/dom/stream/readablebytestreamcontroller.rs
@@ -106,7 +106,6 @@ impl Callback for StartAlgorithmFulfillmentHandler {
     /// Continuation of <https://streams.spec.whatwg.org/#set-up-readable-byte-stream-controller>
     /// Upon fulfillment of startPromise,
     fn callback(&self, cx: &mut CurrentRealm, _v: HandleValue) {
-        let can_gc = CanGc::from_cx(cx);
         // Set controller.[[started]] to true.
         self.controller.started.set(true);
 
@@ -117,7 +116,7 @@ impl Callback for StartAlgorithmFulfillmentHandler {
         assert!(!self.controller.pull_again.get());
 
         // Perform ! ReadableByteStreamControllerCallPullIfNeeded(controller).
-        self.controller.call_pull_if_needed(can_gc);
+        self.controller.call_pull_if_needed(cx);
     }
 }
 
@@ -133,9 +132,8 @@ impl Callback for StartAlgorithmRejectionHandler {
     /// Continuation of <https://streams.spec.whatwg.org/#set-up-readable-byte-stream-controller>
     /// Upon rejection of startPromise with reason r,
     fn callback(&self, cx: &mut CurrentRealm, v: HandleValue) {
-        let can_gc = CanGc::from_cx(cx);
         // Perform ! ReadableByteStreamControllerError(controller, r).
-        self.controller.error(v, can_gc);
+        self.controller.error(cx, v);
     }
 }
 
@@ -151,7 +149,6 @@ impl Callback for PullAlgorithmFulfillmentHandler {
     /// Continuation of <https://streams.spec.whatwg.org/#readable-byte-stream-controller-call-pull-if-needed>
     /// Upon fulfillment of pullPromise
     fn callback(&self, cx: &mut CurrentRealm, _v: HandleValue) {
-        let can_gc = CanGc::from_cx(cx);
         // Set controller.[[pulling]] to false.
         self.controller.pulling.set(false);
 
@@ -161,7 +158,7 @@ impl Callback for PullAlgorithmFulfillmentHandler {
             self.controller.pull_again.set(false);
 
             // Perform ! ReadableByteStreamControllerCallPullIfNeeded(controller).
-            self.controller.call_pull_if_needed(can_gc);
+            self.controller.call_pull_if_needed(cx);
         }
     }
 }
@@ -178,9 +175,8 @@ impl Callback for PullAlgorithmRejectionHandler {
     /// Continuation of <https://streams.spec.whatwg.org/#readable-stream-byte-controller-call-pull-if-needed>
     /// Upon rejection of pullPromise with reason e.
     fn callback(&self, cx: &mut CurrentRealm, v: HandleValue) {
-        let can_gc = CanGc::from_cx(cx);
         // Perform ! ReadableByteStreamControllerError(controller, e).
-        self.controller.error(v, can_gc);
+        self.controller.error(cx, v);
     }
 }
 
@@ -273,11 +269,10 @@ impl ReadableByteStreamController {
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-pull-into>
     pub(crate) fn perform_pull_into(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         read_into_request: &ReadIntoRequest,
         view: HeapBufferSource<ArrayBufferViewU8>,
         min: u64,
-        can_gc: CanGc,
     ) {
         // Let stream be controller.[[stream]].
         let stream = self.stream.get().unwrap();
@@ -316,8 +311,8 @@ impl ReadableByteStreamController {
 
         // Let bufferResult be TransferArrayBuffer(view.[[ViewedArrayBuffer]]).
         match view
-            .get_array_buffer_view_buffer(cx)
-            .transfer_array_buffer(cx)
+            .get_array_buffer_view_buffer(cx.into())
+            .transfer_array_buffer(cx.into())
         {
             Ok(buffer) => {
                 // Let buffer be bufferResult.[[Value]].
@@ -364,7 +359,7 @@ impl ReadableByteStreamController {
                     // Let emptyView be ! Construct(ctor, « pullIntoDescriptor’s buffer,
                     // pullIntoDescriptor’s byte offset, 0 »).
                     if let Ok(empty_view) = create_buffer_source_with_constructor(
-                        cx,
+                        cx.into(),
                         &ctor,
                         &pull_into_descriptor.buffer,
                         pull_into_descriptor.byte_offset as usize,
@@ -372,11 +367,11 @@ impl ReadableByteStreamController {
                     ) {
                         // Perform readIntoRequest’s close steps, given emptyView.
                         let result = RootedTraceableBox::new(Heap::default());
-                        rooted!(in(*cx) let mut view_value = UndefinedValue());
-                        empty_view.get_buffer_view_value(cx, view_value.handle_mut());
+                        rooted!(&in(cx) let mut view_value = UndefinedValue());
+                        empty_view.get_buffer_view_value(cx.into(), view_value.handle_mut());
                         result.set(*view_value);
 
-                        read_into_request.close_steps(Some(result), can_gc);
+                        read_into_request.close_steps(cx, Some(result));
 
                         // Return.
                         return;
@@ -389,21 +384,21 @@ impl ReadableByteStreamController {
                 if self.queue_total_size.get() > 0.0 {
                     // If ! ReadableByteStreamControllerFillPullIntoDescriptorFromQueue(
                     // controller, pullIntoDescriptor) is true,
-                    if self.fill_pull_into_descriptor_from_queue(cx, &pull_into_descriptor) {
+                    if self.fill_pull_into_descriptor_from_queue(cx.into(), &pull_into_descriptor) {
                         // Let filledView be ! ReadableByteStreamControllerConvertPullIntoDescriptor(
                         // pullIntoDescriptor).
                         if let Ok(filled_view) =
-                            self.convert_pull_into_descriptor(cx, &pull_into_descriptor)
+                            self.convert_pull_into_descriptor(cx.into(), &pull_into_descriptor)
                         {
                             // Perform ! ReadableByteStreamControllerHandleQueueDrain(controller).
-                            self.handle_queue_drain(can_gc);
+                            self.handle_queue_drain(cx);
 
                             // Perform readIntoRequest’s chunk steps, given filledView.
                             let result = RootedTraceableBox::new(Heap::default());
-                            rooted!(in(*cx) let mut view_value = UndefinedValue());
-                            filled_view.get_buffer_view_value(cx, view_value.handle_mut());
+                            rooted!(&in(cx) let mut view_value = UndefinedValue());
+                            filled_view.get_buffer_view_value(cx.into(), view_value.handle_mut());
                             result.set(*view_value);
-                            read_into_request.chunk_steps(result, can_gc);
+                            read_into_request.chunk_steps(result, CanGc::from_cx(cx));
 
                             // Return.
                             return;
@@ -415,19 +410,19 @@ impl ReadableByteStreamController {
                     // If controller.[[closeRequested]] is true,
                     if self.close_requested.get() {
                         // Let e be a new TypeError exception.
-                        rooted!(in(*cx) let mut error = UndefinedValue());
+                        rooted!(&in(cx) let mut error = UndefinedValue());
                         Error::Type(c"close requested".to_owned()).to_jsval(
-                            cx,
+                            cx.into(),
                             &self.global(),
                             error.handle_mut(),
-                            can_gc,
+                            CanGc::from_cx(cx),
                         );
 
                         // Perform ! ReadableByteStreamControllerError(controller, e).
-                        self.error(error.handle(), can_gc);
+                        self.error(cx, error.handle());
 
                         // Perform readIntoRequest’s error steps, given e.
-                        read_into_request.error_steps(error.handle(), can_gc);
+                        read_into_request.error_steps(error.handle(), CanGc::from_cx(cx));
 
                         // Return.
                         return;
@@ -444,15 +439,20 @@ impl ReadableByteStreamController {
                 stream.add_read_into_request(read_into_request);
 
                 // Perform ! ReadableByteStreamControllerCallPullIfNeeded(controller).
-                self.call_pull_if_needed(can_gc);
+                self.call_pull_if_needed(cx);
             },
             Err(error) => {
                 // If bufferResult is an abrupt completion,
 
                 // Perform readIntoRequest’s error steps, given bufferResult.[[Value]].
-                rooted!(in(*cx) let mut rval = UndefinedValue());
-                error.to_jsval(cx, &self.global(), rval.handle_mut(), can_gc);
-                read_into_request.error_steps(rval.handle(), can_gc);
+                rooted!(&in(cx) let mut rval = UndefinedValue());
+                error.to_jsval(
+                    cx.into(),
+                    &self.global(),
+                    rval.handle_mut(),
+                    CanGc::from_cx(cx),
+                );
+                read_into_request.error_steps(rval.handle(), CanGc::from_cx(cx));
 
                 // Return.
             },
@@ -462,9 +462,8 @@ impl ReadableByteStreamController {
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-respond>
     pub(crate) fn respond(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         bytes_written: u64,
-        can_gc: CanGc,
     ) -> Fallible<()> {
         {
             // Assert: controller.[[pendingPullIntos]] is not empty.
@@ -508,20 +507,19 @@ impl ReadableByteStreamController {
             // Set firstDescriptor’s buffer to ! TransferArrayBuffer(firstDescriptor’s buffer).
             first_descriptor.buffer = first_descriptor
                 .buffer
-                .transfer_array_buffer(cx)
+                .transfer_array_buffer(cx.into())
                 .expect("TransferArrayBuffer failed");
         }
 
         // Perform ? ReadableByteStreamControllerRespondInternal(controller, bytesWritten).
-        self.respond_internal(cx, bytes_written, can_gc)
+        self.respond_internal(cx, bytes_written)
     }
 
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-respond-internal>
     pub(crate) fn respond_internal(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         bytes_written: u64,
-        can_gc: CanGc,
     ) -> Fallible<()> {
         {
             // Let firstDescriptor be controller.[[pendingPullIntos]][0].
@@ -529,7 +527,7 @@ impl ReadableByteStreamController {
             let first_descriptor = pending_pull_intos.first().unwrap();
 
             // Assert: ! CanTransferArrayBuffer(firstDescriptor’s buffer) is true
-            assert!(first_descriptor.buffer.can_transfer_array_buffer(cx));
+            assert!(first_descriptor.buffer.can_transfer_array_buffer(cx.into()));
         }
 
         // Perform ! ReadableByteStreamControllerInvalidateBYOBRequest(controller).
@@ -544,7 +542,7 @@ impl ReadableByteStreamController {
             assert_eq!(bytes_written, 0);
 
             // Perform ! ReadableByteStreamControllerRespondInClosedState(controller, firstDescriptor).
-            self.respond_in_closed_state(cx, can_gc)
+            self.respond_in_closed_state(cx)
                 .expect("respond_in_closed_state failed");
         } else {
             // Assert: state is "readable".
@@ -554,17 +552,17 @@ impl ReadableByteStreamController {
             assert!(bytes_written > 0);
 
             // Perform ? ReadableByteStreamControllerRespondInReadableState(controller, bytesWritten, firstDescriptor).
-            self.respond_in_readable_state(cx, bytes_written, can_gc)?;
+            self.respond_in_readable_state(cx, bytes_written)?;
         }
 
         // Perform ! ReadableByteStreamControllerCallPullIfNeeded(controller).
-        self.call_pull_if_needed(can_gc);
+        self.call_pull_if_needed(cx);
 
         Ok(())
     }
 
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-respond-in-closed-state>
-    pub(crate) fn respond_in_closed_state(&self, cx: SafeJSContext, can_gc: CanGc) -> Fallible<()> {
+    pub(crate) fn respond_in_closed_state(&self, cx: &mut js::context::JSContext) -> Fallible<()> {
         let pending_pull_intos = self.pending_pull_intos.borrow();
         let first_descriptor = pending_pull_intos.first().unwrap();
 
@@ -606,7 +604,7 @@ impl ReadableByteStreamController {
             // For each filledPullInto of filledPullIntos,
             for filled_pull_into in filled_pull_intos {
                 // Perform ! ReadableByteStreamControllerCommitPullIntoDescriptor(stream, filledPullInto).
-                self.commit_pull_into_descriptor(cx, &filled_pull_into, can_gc)
+                self.commit_pull_into_descriptor(cx, &filled_pull_into)
                     .expect("commit_pull_into_descriptor failed");
             }
         }
@@ -617,9 +615,8 @@ impl ReadableByteStreamController {
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-respond-in-readable-state>
     pub(crate) fn respond_in_readable_state(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         bytes_written: u64,
-        can_gc: CanGc,
     ) -> Fallible<()> {
         let pending_pull_intos = self.pending_pull_intos.borrow();
         let first_descriptor = pending_pull_intos.first().unwrap();
@@ -639,17 +636,17 @@ impl ReadableByteStreamController {
             drop(pending_pull_intos);
 
             // Perform ? ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue(controller, pullIntoDescriptor).
-            self.enqueue_detached_pull_into_to_queue(cx, can_gc)?;
+            self.enqueue_detached_pull_into_to_queue(cx)?;
 
             // Let filledPullIntos be the result of performing
             // ! ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(controller).
-            let filled_pull_intos = self.process_pull_into_descriptors_using_queue(cx);
+            let filled_pull_intos = self.process_pull_into_descriptors_using_queue(cx.into());
 
             // For each filledPullInto of filledPullIntos,
             for filled_pull_into in filled_pull_intos {
                 // Perform ! ReadableByteStreamControllerCommitPullIntoDescriptor(controller.[[stream]]
                 // , filledPullInto).
-                self.commit_pull_into_descriptor(cx, &filled_pull_into, can_gc)
+                self.commit_pull_into_descriptor(cx, &filled_pull_into)
                     .expect("commit_pull_into_descriptor failed");
             }
 
@@ -685,7 +682,6 @@ impl ReadableByteStreamController {
                 &pull_into_descriptor.buffer,
                 end - remainder_size,
                 remainder_size,
-                can_gc,
             )?;
         }
 
@@ -696,16 +692,16 @@ impl ReadableByteStreamController {
 
         // Let filledPullIntos be the result of performing
         // ! ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(controller).
-        let filled_pull_intos = self.process_pull_into_descriptors_using_queue(cx);
+        let filled_pull_intos = self.process_pull_into_descriptors_using_queue(cx.into());
 
         // Perform ! ReadableByteStreamControllerCommitPullIntoDescriptor(controller.[[stream]], pullIntoDescriptor).
-        self.commit_pull_into_descriptor(cx, &pull_into_descriptor, can_gc)
+        self.commit_pull_into_descriptor(cx, &pull_into_descriptor)
             .expect("commit_pull_into_descriptor failed");
 
         // For each filledPullInto of filledPullIntos,
         for filled_pull_into in filled_pull_intos {
             // Perform ! ReadableByteStreamControllerCommitPullIntoDescriptor(controller.[[stream]], filledPullInto).
-            self.commit_pull_into_descriptor(cx, &filled_pull_into, can_gc)
+            self.commit_pull_into_descriptor(cx, &filled_pull_into)
                 .expect("commit_pull_into_descriptor failed");
         }
 
@@ -715,9 +711,8 @@ impl ReadableByteStreamController {
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-respond-with-new-view>
     pub(crate) fn respond_with_new_view(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         view: HeapBufferSource<ArrayBufferViewU8>,
-        can_gc: CanGc,
     ) -> Fallible<()> {
         let view_byte_length;
         {
@@ -726,7 +721,7 @@ impl ReadableByteStreamController {
             assert!(!pending_pull_intos.is_empty());
 
             // Assert: ! IsDetachedBuffer(view.[[ViewedArrayBuffer]]) is false.
-            assert!(!view.is_detached_buffer(cx));
+            assert!(!view.is_detached_buffer(cx.into()));
 
             // Let firstDescriptor be controller.[[pendingPullIntos]][0].
             let first_descriptor = pending_pull_intos.first_mut().unwrap();
@@ -764,7 +759,7 @@ impl ReadableByteStreamController {
             // If firstDescriptor’s buffer byte length is not view.[[ViewedArrayBuffer]].[[ByteLength]],
             // throw a RangeError exception.
             if first_descriptor.buffer_byte_length !=
-                (view.viewed_buffer_array_byte_length(cx) as u64)
+                (view.viewed_buffer_array_byte_length(cx.into()) as u64)
             {
                 return Err(Error::Range(
                 c"firstDescriptor's buffer byte length is not view viewed buffer array byte length"
@@ -787,12 +782,12 @@ impl ReadableByteStreamController {
 
             // Set firstDescriptor’s buffer to ? TransferArrayBuffer(view.[[ViewedArrayBuffer]]).
             first_descriptor.buffer = view
-                .get_array_buffer_view_buffer(cx)
-                .transfer_array_buffer(cx)?;
+                .get_array_buffer_view_buffer(cx.into())
+                .transfer_array_buffer(cx.into())?;
         }
 
         // Perform ? ReadableByteStreamControllerRespondInternal(controller, viewByteLength).
-        self.respond_internal(cx, view_byte_length as u64, can_gc)
+        self.respond_internal(cx, view_byte_length as u64)
     }
 
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-get-desired-size>
@@ -859,7 +854,7 @@ impl ReadableByteStreamController {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-close>
-    pub(crate) fn close(&self, cx: SafeJSContext, can_gc: CanGc) -> Fallible<()> {
+    pub(crate) fn close(&self, cx: &mut js::context::JSContext) -> Fallible<()> {
         // Let stream be controller.[[stream]].
         let stream = self.stream.get().unwrap();
 
@@ -898,10 +893,14 @@ impl ReadableByteStreamController {
                 );
 
                 // Perform ! ReadableByteStreamControllerError(controller, e).
-                rooted!(in(*cx) let mut error = UndefinedValue());
-                e.clone()
-                    .to_jsval(cx, &self.global(), error.handle_mut(), can_gc);
-                self.error(error.handle(), can_gc);
+                rooted!(&in(cx) let mut error = UndefinedValue());
+                e.clone().to_jsval(
+                    cx.into(),
+                    &self.global(),
+                    error.handle_mut(),
+                    CanGc::from_cx(cx),
+                );
+                self.error(cx, error.handle());
 
                 // Throw e.
                 return Err(e);
@@ -912,12 +911,12 @@ impl ReadableByteStreamController {
         self.clear_algorithms();
 
         // Perform ! ReadableStreamClose(stream).
-        stream.close(can_gc);
+        stream.close(cx);
         Ok(())
     }
 
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-error>
-    pub(crate) fn error(&self, e: SafeHandleValue, can_gc: CanGc) {
+    pub(crate) fn error(&self, cx: &mut js::context::JSContext, e: SafeHandleValue) {
         // Let stream be controller.[[stream]].
         let stream = self.stream.get().unwrap();
 
@@ -936,7 +935,7 @@ impl ReadableByteStreamController {
         self.clear_algorithms();
 
         // Perform ! ReadableStreamError(stream, e).
-        stream.error(e, can_gc);
+        stream.error(cx, e);
     }
 
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-clear-algorithms>
@@ -1039,7 +1038,7 @@ impl ReadableByteStreamController {
 
                     // perform ? ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue(
                     // controller, firstPendingPullInto).
-                    self.enqueue_detached_pull_into_to_queue(cx.into(), CanGc::from_cx(cx))?;
+                    self.enqueue_detached_pull_into_to_queue(cx)?;
                 }
             }
         }
@@ -1094,7 +1093,7 @@ impl ReadableByteStreamController {
                 // Perform ! ReadableStreamFulfillReadRequest(stream, transferredView, false).
                 rooted!(&in(cx) let mut view_value = UndefinedValue());
                 transferred_view.get_buffer_view_value(cx.into(), view_value.handle_mut());
-                stream.fulfill_read_request(view_value.handle(), false, CanGc::from_cx(cx));
+                stream.fulfill_read_request(cx, view_value.handle(), false);
             }
             // Otherwise, if ! ReadableStreamHasBYOBReader(stream) is true,
         } else if stream.has_byob_reader() {
@@ -1109,7 +1108,7 @@ impl ReadableByteStreamController {
             // For each filledPullInto of filledPullIntos,
             // Perform ! ReadableByteStreamControllerCommitPullIntoDescriptor(stream, filledPullInto).
             for filled_pull_into in filled_pull_intos {
-                self.commit_pull_into_descriptor(cx.into(), &filled_pull_into, CanGc::from_cx(cx))
+                self.commit_pull_into_descriptor(cx, &filled_pull_into)
                     .expect("commit_pull_into_descriptor failed");
             }
         } else {
@@ -1122,7 +1121,7 @@ impl ReadableByteStreamController {
         }
 
         // Perform ! ReadableByteStreamControllerCallPullIfNeeded(controller).
-        self.call_pull_if_needed(CanGc::from_cx(cx));
+        self.call_pull_if_needed(cx);
 
         Ok(())
     }
@@ -1130,9 +1129,8 @@ impl ReadableByteStreamController {
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-commit-pull-into-descriptor>
     pub(crate) fn commit_pull_into_descriptor(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         pull_into_descriptor: &PullIntoDescriptor,
-        can_gc: CanGc,
     ) -> Fallible<()> {
         // Assert: stream.[[state]] is not "errored".
         let stream = self.stream.get().unwrap();
@@ -1158,17 +1156,17 @@ impl ReadableByteStreamController {
 
         // Let filledView be ! ReadableByteStreamControllerConvertPullIntoDescriptor(pullIntoDescriptor).
         let filled_view = self
-            .convert_pull_into_descriptor(cx, pull_into_descriptor)
+            .convert_pull_into_descriptor(cx.into(), pull_into_descriptor)
             .expect("convert_pull_into_descriptor failed");
 
-        rooted!(in(*cx) let mut view_value = UndefinedValue());
-        filled_view.get_buffer_view_value(cx, view_value.handle_mut());
+        rooted!(&in(cx) let mut view_value = UndefinedValue());
+        filled_view.get_buffer_view_value(cx.into(), view_value.handle_mut());
 
         // If pullIntoDescriptor’s reader type is "default",
         if matches!(pull_into_descriptor.reader_type, Some(ReaderType::Default)) {
             // Perform ! ReadableStreamFulfillReadRequest(stream, filledView, done).
 
-            stream.fulfill_read_request(view_value.handle(), done, can_gc);
+            stream.fulfill_read_request(cx, view_value.handle(), done);
         } else {
             // Assert: pullIntoDescriptor’s reader type is "byob".
             assert!(matches!(
@@ -1177,7 +1175,7 @@ impl ReadableByteStreamController {
             ));
 
             // Perform ! ReadableStreamFulfillReadIntoRequest(stream, filledView, done).
-            stream.fulfill_read_into_request(view_value.handle(), done, can_gc);
+            stream.fulfill_read_into_request(cx, view_value.handle(), done);
         }
         Ok(())
     }
@@ -1415,8 +1413,7 @@ impl ReadableByteStreamController {
     /// <https://streams.spec.whatwg.org/#abstract-opdef-readablebytestreamcontrollerenqueuedetachedpullintotoqueue>
     pub(crate) fn enqueue_detached_pull_into_to_queue(
         &self,
-        cx: SafeJSContext,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) -> Fallible<()> {
         // first_descriptor: &PullIntoDescriptor,
         let pending_pull_intos = self.pending_pull_intos.borrow();
@@ -1435,7 +1432,6 @@ impl ReadableByteStreamController {
                 &first_descriptor.buffer,
                 first_descriptor.byte_offset,
                 first_descriptor.bytes_filled.get(),
-                can_gc,
             )?;
         }
 
@@ -1451,15 +1447,14 @@ impl ReadableByteStreamController {
     /// <https://streams.spec.whatwg.org/#abstract-opdef-readablebytestreamcontrollerenqueueclonedchunktoqueue>
     pub(crate) fn enqueue_cloned_chunk_to_queue(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         buffer: &HeapBufferSource<ArrayBufferU8>,
         byte_offset: u64,
         byte_length: u64,
-        can_gc: CanGc,
     ) -> Fallible<()> {
         // Let cloneResult be CloneArrayBuffer(buffer, byteOffset, byteLength, %ArrayBuffer%).
         if let Ok(clone_result) =
-            buffer.clone_array_buffer(cx, byte_offset as usize, byte_length as usize)
+            buffer.clone_array_buffer(cx.into(), byte_offset as usize, byte_length as usize)
         {
             // Perform ! ReadableByteStreamControllerEnqueueChunkToQueue
             // (controller, cloneResult.[[Value]], 0, byteLength).
@@ -1470,12 +1465,15 @@ impl ReadableByteStreamController {
             // If cloneResult is an abrupt completion,
 
             // Perform ! ReadableByteStreamControllerError(controller, cloneResult.[[Value]]).
-            rooted!(in(*cx) let mut rval = UndefinedValue());
+            rooted!(&in(cx) let mut rval = UndefinedValue());
             let error = Error::Type(c"can not clone array buffer".to_owned());
-            error
-                .clone()
-                .to_jsval(cx, &self.global(), rval.handle_mut(), can_gc);
-            self.error(rval.handle(), can_gc);
+            error.clone().to_jsval(
+                cx.into(),
+                &self.global(),
+                rval.handle_mut(),
+                CanGc::from_cx(cx),
+            );
+            self.error(cx, rval.handle());
 
             // Return cloneResult.
             Err(error)
@@ -1527,9 +1525,8 @@ impl ReadableByteStreamController {
     /// <https://streams.spec.whatwg.org/#abstract-opdef-readablebytestreamcontrollerfillreadrequestfromqueue>
     pub(crate) fn fill_read_request_from_queue(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         read_request: &ReadRequest,
-        can_gc: CanGc,
     ) -> Fallible<()> {
         // Assert: controller.[[queueTotalSize]] > 0.
         assert!(self.queue_total_size.get() > 0.0);
@@ -1545,11 +1542,11 @@ impl ReadableByteStreamController {
             .set(self.queue_total_size.get() - entry.byte_length as f64);
 
         // Perform ! ReadableByteStreamControllerHandleQueueDrain(controller).
-        self.handle_queue_drain(can_gc);
+        self.handle_queue_drain(cx);
 
         // Let view be ! Construct(%Uint8Array%, « entry’s buffer, entry’s byte offset, entry’s byte length »).
         let view = create_buffer_source_with_constructor(
-            cx,
+            cx.into(),
             &Constructor::Name(Type::Uint8),
             &entry.buffer,
             entry.byte_offset,
@@ -1559,17 +1556,17 @@ impl ReadableByteStreamController {
 
         // Perform readRequest’s chunk steps, given view.
         let result = RootedTraceableBox::new(Heap::default());
-        rooted!(in(*cx) let mut view_value = UndefinedValue());
-        view.get_buffer_view_value(cx, view_value.handle_mut());
+        rooted!(&in(cx) let mut view_value = UndefinedValue());
+        view.get_buffer_view_value(cx.into(), view_value.handle_mut());
         result.set(*view_value);
 
-        read_request.chunk_steps(result, &self.global(), can_gc);
+        read_request.chunk_steps(cx, result, &self.global());
 
         Ok(())
     }
 
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-handle-queue-drain>
-    pub(crate) fn handle_queue_drain(&self, can_gc: CanGc) {
+    pub(crate) fn handle_queue_drain(&self, cx: &mut js::context::JSContext) {
         // Assert: controller.[[stream]].[[state]] is "readable".
         assert!(self.stream.get().unwrap().is_readable());
 
@@ -1579,15 +1576,15 @@ impl ReadableByteStreamController {
             self.clear_algorithms();
 
             // Perform ! ReadableStreamClose(controller.[[stream]]).
-            self.stream.get().unwrap().close(can_gc);
+            self.stream.get().unwrap().close(cx);
         } else {
             // Perform ! ReadableByteStreamControllerCallPullIfNeeded(controller).
-            self.call_pull_if_needed(can_gc);
+            self.call_pull_if_needed(cx);
         }
     }
 
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-call-pull-if-needed>
-    pub(crate) fn call_pull_if_needed(&self, can_gc: CanGc) {
+    pub(crate) fn call_pull_if_needed(&self, cx: &mut js::context::JSContext) {
         // Let shouldPull be ! ReadableByteStreamControllerShouldCallPull(controller).
         let should_pull = self.should_call_pull();
         // If shouldPull is false, return.
@@ -1625,28 +1622,32 @@ impl ReadableByteStreamController {
                 Some(Box::new(PullAlgorithmRejectionHandler {
                     controller: Dom::from_ref(&rooted_controller),
                 })),
-                can_gc,
+                CanGc::from_cx(cx),
             );
 
             let realm = enter_realm(&*global);
             let comp = InRealm::Entered(&realm);
             let result = underlying_source
-                .call_pull_algorithm(controller, can_gc)
+                .call_pull_algorithm(cx, controller)
                 .unwrap_or_else(|| {
-                    let promise = Promise::new(&global, can_gc);
-                    promise.resolve_native(&(), can_gc);
+                    let promise = Promise::new2(cx, &global);
+                    promise.resolve_native(&(), CanGc::from_cx(cx));
                     Ok(promise)
                 });
             let promise = result.unwrap_or_else(|error| {
-                let cx = GlobalScope::get_cx();
-                rooted!(in(*cx) let mut rval = UndefinedValue());
+                rooted!(&in(cx) let mut rval = UndefinedValue());
                 // TODO: check if `self.global()` is the right globalscope.
-                error.to_jsval(cx, &self.global(), rval.handle_mut(), can_gc);
-                let promise = Promise::new(&global, can_gc);
-                promise.reject_native(&rval.handle(), can_gc);
+                error.to_jsval(
+                    cx.into(),
+                    &self.global(),
+                    rval.handle_mut(),
+                    CanGc::from_cx(cx),
+                );
+                let promise = Promise::new2(cx, &global);
+                promise.reject_native(&rval.handle(), CanGc::from_cx(cx));
                 promise
             });
-            promise.append_native_handler(&handler, comp, can_gc);
+            promise.append_native_handler(&handler, comp, CanGc::from_cx(cx));
         }
     }
 
@@ -1845,9 +1846,8 @@ impl ReadableByteStreamController {
     /// <https://streams.spec.whatwg.org/#rbs-controller-private-pull>
     pub(crate) fn perform_pull_steps(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         read_request: &ReadRequest,
-        can_gc: CanGc,
     ) {
         // Let stream be this.[[stream]].
         let stream = self.stream.get().unwrap();
@@ -1861,7 +1861,7 @@ impl ReadableByteStreamController {
             assert_eq!(stream.get_num_read_requests(), 0);
 
             // Perform ! ReadableByteStreamControllerFillReadRequestFromQueue(this, readRequest).
-            let _ = self.fill_read_request_from_queue(cx, read_request, can_gc);
+            let _ = self.fill_read_request_from_queue(cx, read_request);
 
             // Return.
             return;
@@ -1874,7 +1874,7 @@ impl ReadableByteStreamController {
         if let Some(auto_allocate_chunk_size) = auto_allocate_chunk_size {
             // create_array_buffer_with_size
             // Let buffer be Construct(%ArrayBuffer%, « autoAllocateChunkSize »).
-            match create_array_buffer_with_size(cx, auto_allocate_chunk_size as usize) {
+            match create_array_buffer_with_size(cx.into(), auto_allocate_chunk_size as usize) {
                 Ok(buffer) => {
                     // Let pullIntoDescriptor be a new pull-into descriptor with
                     // buffer buffer.[[Value]]
@@ -1907,9 +1907,14 @@ impl ReadableByteStreamController {
                     // If buffer is an abrupt completion,
                     // Perform readRequest’s error steps, given buffer.[[Value]].
 
-                    rooted!(in(*cx) let mut rval = UndefinedValue());
-                    error.to_jsval(cx, &self.global(), rval.handle_mut(), can_gc);
-                    read_request.error_steps(rval.handle(), can_gc);
+                    rooted!(&in(cx) let mut rval = UndefinedValue());
+                    error.to_jsval(
+                        cx.into(),
+                        &self.global(),
+                        rval.handle_mut(),
+                        CanGc::from_cx(cx),
+                    );
+                    read_request.error_steps(cx, rval.handle());
 
                     // Return.
                     return;
@@ -1921,7 +1926,7 @@ impl ReadableByteStreamController {
         stream.add_read_request(read_request);
 
         // Perform ! ReadableByteStreamControllerCallPullIfNeeded(this).
-        self.call_pull_if_needed(can_gc);
+        self.call_pull_if_needed(cx);
     }
 
     /// Setting the JS object after the heap has settled down.
@@ -1965,8 +1970,7 @@ impl ReadableByteStreamControllerMethods<crate::DomTypeHolder> for ReadableByteS
     }
 
     /// <https://streams.spec.whatwg.org/#rbs-controller-close>
-    fn Close(&self, can_gc: CanGc) -> Fallible<()> {
-        let cx = GlobalScope::get_cx();
+    fn Close(&self, cx: &mut js::context::JSContext) -> Fallible<()> {
         // If this.[[closeRequested]] is true, throw a TypeError exception.
         if self.close_requested.get() {
             return Err(Error::Type(c"closeRequested is true".to_owned()));
@@ -1978,7 +1982,7 @@ impl ReadableByteStreamControllerMethods<crate::DomTypeHolder> for ReadableByteS
         }
 
         // Perform ? ReadableByteStreamControllerClose(this).
-        self.close(cx, can_gc)
+        self.close(cx)
     }
 
     /// <https://streams.spec.whatwg.org/#rbs-controller-enqueue>
@@ -2018,7 +2022,7 @@ impl ReadableByteStreamControllerMethods<crate::DomTypeHolder> for ReadableByteS
     /// <https://streams.spec.whatwg.org/#rbs-controller-error>
     fn Error(&self, cx: &mut js::context::JSContext, e: SafeHandleValue) -> Fallible<()> {
         // Perform ! ReadableByteStreamControllerError(this, e).
-        self.error(e, CanGc::from_cx(cx));
+        self.error(cx, e);
         Ok(())
     }
 }

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -753,7 +753,7 @@ impl PipeTo {
 
         // Otherwise, perform ! ReadableStreamDefaultReaderRelease(reader).
         self.reader
-            .release(CanGc::from_cx(cx))
+            .release(cx)
             .expect("Releasing the reader should not fail");
 
         // If signal is not undefined, remove abortAlgorithm from signal.
@@ -1000,8 +1000,8 @@ impl ReadableStream {
             global,
             UnderlyingSourceType::Memory(bytes.len()),
         )?;
-        stream.enqueue_native(bytes, CanGc::from_cx(cx));
-        stream.controller_close_native(CanGc::from_cx(cx));
+        stream.enqueue_native(cx, bytes);
+        stream.controller_close_native(cx);
         Ok(stream)
     }
 
@@ -1050,19 +1050,18 @@ impl ReadableStream {
     /// <https://streams.spec.whatwg.org/#readable-stream-default-reader-read>
     pub(crate) fn perform_pull_steps(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         read_request: &ReadRequest,
-        can_gc: CanGc,
     ) {
         match self.controller.borrow().as_ref() {
             Some(ControllerType::Default(controller)) => controller
                 .get()
                 .expect("Stream should have controller.")
-                .perform_pull_steps(read_request, can_gc),
+                .perform_pull_steps(cx, read_request),
             Some(ControllerType::Byte(controller)) => controller
                 .get()
                 .expect("Stream should have controller.")
-                .perform_pull_steps(cx, read_request, can_gc),
+                .perform_pull_steps(cx, read_request),
             None => {
                 unreachable!("Stream does not have a controller.");
             },
@@ -1074,17 +1073,16 @@ impl ReadableStream {
     /// <https://streams.spec.whatwg.org/#readable-stream-byob-reader-read>
     pub(crate) fn perform_pull_into(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         read_into_request: &ReadIntoRequest,
         view: HeapBufferSource<ArrayBufferViewU8>,
         min: u64,
-        can_gc: CanGc,
     ) {
         match self.controller.borrow().as_ref() {
             Some(ControllerType::Byte(controller)) => controller
                 .get()
                 .expect("Stream should have controller.")
-                .perform_pull_into(cx, read_into_request, view, min, can_gc),
+                .perform_pull_into(cx, read_into_request, view, min),
             _ => {
                 unreachable!(
                     "Pulling a chunk from a stream with a default controller using a BYOB reader"
@@ -1138,12 +1136,12 @@ impl ReadableStream {
 
     /// Endpoint to enqueue chunks directly from Rust.
     /// Note: in other use cases this call happens via the controller.
-    pub(crate) fn enqueue_native(&self, bytes: Vec<u8>, can_gc: CanGc) {
+    pub(crate) fn enqueue_native(&self, cx: &mut js::context::JSContext, bytes: Vec<u8>) {
         match self.controller.borrow().as_ref() {
             Some(ControllerType::Default(controller)) => controller
                 .get()
                 .expect("Stream should have controller.")
-                .enqueue_native(bytes, can_gc),
+                .enqueue_native(cx, bytes),
             _ => {
                 unreachable!(
                     "Enqueueing chunk to a stream from Rust on other than default controller"
@@ -1153,7 +1151,7 @@ impl ReadableStream {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-stream-error>
-    pub(crate) fn error(&self, e: SafeHandleValue, can_gc: CanGc) {
+    pub(crate) fn error(&self, cx: &mut js::context::JSContext, e: SafeHandleValue) {
         // Assert: stream.[[state]] is "readable".
         assert!(self.is_readable());
 
@@ -1175,7 +1173,7 @@ impl ReadableStream {
 
         if let Some(reader) = default_reader {
             // Perform ! ReadableStreamDefaultReaderErrorReadRequests(reader, e).
-            reader.error(e, can_gc);
+            reader.error(cx, e);
             return;
         }
 
@@ -1189,7 +1187,7 @@ impl ReadableStream {
 
         if let Some(reader) = byob_reader {
             // Perform ! ReadableStreamBYOBReaderErrorReadIntoRequests(reader, e).
-            reader.error_read_into_requests(e, can_gc);
+            reader.error_read_into_requests(e, CanGc::from_cx(cx));
         }
 
         // If reader is undefined, return.
@@ -1202,22 +1200,26 @@ impl ReadableStream {
 
     /// <https://streams.spec.whatwg.org/#readable-stream-error>
     /// Note: in other use cases this call happens via the controller.
-    pub(crate) fn error_native(&self, error: Error, can_gc: CanGc) {
-        let cx = GlobalScope::get_cx();
-        rooted!(in(*cx) let mut error_val = UndefinedValue());
-        error.to_jsval(cx, &self.global(), error_val.handle_mut(), can_gc);
-        self.error(error_val.handle(), can_gc);
+    pub(crate) fn error_native(&self, cx: &mut js::context::JSContext, error: Error) {
+        rooted!(&in(cx) let mut error_val = UndefinedValue());
+        error.to_jsval(
+            cx.into(),
+            &self.global(),
+            error_val.handle_mut(),
+            CanGc::from_cx(cx),
+        );
+        self.error(cx, error_val.handle());
     }
 
     /// Call into the controller's `Close` method.
     /// <https://streams.spec.whatwg.org/#readable-stream-default-controller-close>
-    pub(crate) fn controller_close_native(&self, can_gc: CanGc) {
+    pub(crate) fn controller_close_native(&self, cx: &mut js::context::JSContext) {
         match self.controller.borrow().as_ref() {
             Some(ControllerType::Default(controller)) => {
                 let _ = controller
                     .get()
                     .expect("Stream should have controller.")
-                    .Close(can_gc);
+                    .Close(cx);
             },
             _ => {
                 unreachable!("Native closing is only done on default controllers.")
@@ -1347,7 +1349,7 @@ impl ReadableStream {
     /// must be done after `start_reading`.
     /// Native call to
     /// <https://streams.spec.whatwg.org/#abstract-opdef-readablestreamdefaultreaderrelease>
-    pub(crate) fn stop_reading(&self, can_gc: CanGc) {
+    pub(crate) fn stop_reading(&self, cx: &mut js::context::JSContext) {
         let reader_ref = self.reader.borrow();
 
         match reader_ref.as_ref() {
@@ -1357,7 +1359,7 @@ impl ReadableStream {
                 };
 
                 drop(reader_ref);
-                reader.release(can_gc).expect("Reader release cannot fail.");
+                reader.release(cx).expect("Reader release cannot fail.");
             },
             _ => {
                 unreachable!("Native stop reading can only be done with a default reader.")
@@ -1452,7 +1454,12 @@ impl ReadableStream {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-stream-fulfill-read-request>
-    pub(crate) fn fulfill_read_request(&self, chunk: SafeHandleValue, done: bool, can_gc: CanGc) {
+    pub(crate) fn fulfill_read_request(
+        &self,
+        cx: &mut js::context::JSContext,
+        chunk: SafeHandleValue,
+        done: bool,
+    ) {
         // step 1 - Assert: ! ReadableStreamHasDefaultReader(stream) is true.
         assert!(self.has_default_reader());
 
@@ -1470,12 +1477,12 @@ impl ReadableStream {
 
                 if done {
                     // step 6 - If done is true, perform readRequest’s close steps.
-                    request.close_steps(can_gc);
+                    request.close_steps(cx);
                 } else {
                     // step 7 - Otherwise, perform readRequest’s chunk steps, given chunk.
                     let result = RootedTraceableBox::new(Heap::default());
                     result.set(*chunk);
-                    request.chunk_steps(result, &self.global(), can_gc);
+                    request.chunk_steps(cx, result, &self.global());
                 }
             },
             _ => {
@@ -1489,9 +1496,9 @@ impl ReadableStream {
     /// <https://streams.spec.whatwg.org/#readable-stream-fulfill-read-into-request>
     pub(crate) fn fulfill_read_into_request(
         &self,
+        cx: &mut js::context::JSContext,
         chunk: SafeHandleValue,
         done: bool,
-        can_gc: CanGc,
     ) {
         // Assert: ! ReadableStreamHasBYOBReader(stream) is true.
         assert!(self.has_byob_reader());
@@ -1516,11 +1523,11 @@ impl ReadableStream {
                 let result = RootedTraceableBox::new(Heap::default());
                 if done {
                     result.set(*chunk);
-                    read_into_request.close_steps(Some(result), can_gc);
+                    read_into_request.close_steps(cx, Some(result));
                 } else {
                     // Otherwise, perform readIntoRequest’s chunk steps, given chunk.
                     result.set(*chunk);
-                    read_into_request.chunk_steps(result, can_gc);
+                    read_into_request.chunk_steps(result, CanGc::from_cx(cx));
                 }
             },
             _ => {
@@ -1532,7 +1539,7 @@ impl ReadableStream {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-stream-close>
-    pub(crate) fn close(&self, can_gc: CanGc) {
+    pub(crate) fn close(&self, cx: &mut js::context::JSContext) {
         // Assert: stream.[[state]] is "readable".
         assert!(self.is_readable());
         // Set stream.[[state]] to "closed".
@@ -1552,7 +1559,7 @@ impl ReadableStream {
 
         if let Some(reader) = default_reader {
             // steps 5 & 6 for a default reader
-            reader.close(can_gc);
+            reader.close(cx);
             return;
         }
 
@@ -1567,7 +1574,7 @@ impl ReadableStream {
 
         if let Some(reader) = byob_reader {
             // steps 5 & 6 for a BYOB reader
-            reader.close(can_gc);
+            reader.close(CanGc::from_cx(cx));
         }
 
         // If reader is undefined, return.
@@ -1597,7 +1604,7 @@ impl ReadableStream {
             return promise;
         }
         // Perform ! ReadableStreamClose(stream).
-        self.close(CanGc::from_cx(cx));
+        self.close(cx);
 
         // If reader is not undefined and reader implements ReadableStreamBYOBReader,
         let byob_reader = {
@@ -1610,7 +1617,7 @@ impl ReadableStream {
 
         if let Some(reader) = byob_reader {
             // step 6.1, 6.2 & 6.3 of https://streams.spec.whatwg.org/#readable-stream-cancel
-            reader.cancel(CanGc::from_cx(cx));
+            reader.cancel(cx);
         }
 
         // Let sourceCancelPromise be ! stream.[[controller]].[[CancelSteps]](reason).
@@ -2380,7 +2387,7 @@ impl CrossRealmTransformReadable {
         // Otherwise, if type is "close",
         if type_string == "close" {
             // Perform ! ReadableStreamDefaultControllerClose(controller).
-            self.controller.close(CanGc::from_cx(cx));
+            self.controller.close(cx);
 
             // Disentangle port.
             global.disentangle_port(cx, port);
@@ -2389,7 +2396,7 @@ impl CrossRealmTransformReadable {
         // Otherwise, if type is "error",
         if type_string == "error" {
             // Perform ! ReadableStreamDefaultControllerError(controller, value).
-            self.controller.error(value.handle(), CanGc::from_cx(cx));
+            self.controller.error(cx, value.handle());
 
             // Disentangle port.
             global.disentangle_port(cx, port);
@@ -2413,8 +2420,7 @@ impl CrossRealmTransformReadable {
         port.cross_realm_transform_send_error(rooted_error.handle(), CanGc::from_cx(cx));
 
         // Perform ! ReadableStreamDefaultControllerError(controller, error).
-        self.controller
-            .error(rooted_error.handle(), CanGc::from_cx(cx));
+        self.controller.error(cx, rooted_error.handle());
 
         // Disentangle port.
         global.disentangle_port(cx, port);

--- a/components/script/dom/stream/readablestreambyobreader.rs
+++ b/components/script/dom/stream/readablestreambyobreader.rs
@@ -36,7 +36,7 @@ use crate::dom::promise::Promise;
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::stream::readablestream::ReadableStream;
 use crate::realms::{InRealm, enter_realm};
-use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
+use crate::script_runtime::CanGc;
 
 /// <https://streams.spec.whatwg.org/#read-into-request>
 #[derive(Clone, JSTraceable, MallocSizeOf)]
@@ -76,7 +76,11 @@ impl ReadIntoRequest {
     }
 
     /// <https://streams.spec.whatwg.org/#ref-for-read-into-request-close-steps%E2%91%A0>
-    pub fn close_steps(&self, chunk: Option<RootedTraceableBox<Heap<JSVal>>>, can_gc: CanGc) {
+    pub fn close_steps(
+        &self,
+        cx: &mut js::context::JSContext,
+        chunk: Option<RootedTraceableBox<Heap<JSVal>>>,
+    ) {
         match self {
             ReadIntoRequest::Read(promise) => match chunk {
                 // close steps, given chunk
@@ -86,7 +90,7 @@ impl ReadIntoRequest {
                         done: Some(true),
                         value: chunk,
                     },
-                    can_gc,
+                    CanGc::from_cx(cx),
                 ),
                 None => {
                     let result = RootedTraceableBox::new(Heap::default());
@@ -96,7 +100,7 @@ impl ReadIntoRequest {
                             done: Some(true),
                             value: result,
                         },
-                        can_gc,
+                        CanGc::from_cx(cx),
                     );
                 },
             },
@@ -105,16 +109,16 @@ impl ReadIntoRequest {
             } => match chunk {
                 Some(chunk) => byte_tee_read_into_request
                     .close_steps(
+                        cx,
                         Some(HeapBufferSource::<ArrayBufferViewU8>::new(
                             BufferSource::ArrayBufferView(RootedTraceableBox::from_box(
                                 Heap::boxed(chunk.get().to_object()),
                             )),
                         )),
-                        can_gc,
                     )
                     .expect("close steps should not fail"),
                 None => byte_tee_read_into_request
-                    .close_steps(None, can_gc)
+                    .close_steps(cx, None)
                     .expect("close steps should not fail"),
             },
         }
@@ -159,21 +163,20 @@ impl Callback for ByteTeeClosedPromiseRejectionHandler {
     /// Continuation of <https://streams.spec.whatwg.org/#abstract-opdef-readablebytestreamtee>
     /// Upon rejection of `reader.closedPromise` with reason `r``,
     fn callback(&self, cx: &mut CurrentRealm, v: SafeHandleValue) {
-        let can_gc = CanGc::from_cx(cx);
         // If thisReader is not reader, return.
         if self.reader_version.get() != self.expected_version {
             return;
         }
 
         // Perform ! ReadableByteStreamControllerError(branch1.[[controller]], r).
-        self.branch_1_controller.error(v, can_gc);
+        self.branch_1_controller.error(cx, v);
 
         // Perform ! ReadableByteStreamControllerError(branch2.[[controller]], r).
-        self.branch_2_controller.error(v, can_gc);
+        self.branch_2_controller.error(cx, v);
 
         // If canceled1 is false or canceled2 is false, resolve cancelPromise with undefined.
         if !self.canceled_1.get() || !self.canceled_2.get() {
-            self.cancel_promise.resolve_native(&(), can_gc);
+            self.cancel_promise.resolve_native(&(), CanGc::from_cx(cx));
         }
     }
 }
@@ -302,7 +305,7 @@ impl ReadableStreamBYOBReader {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-stream-cancel>
-    pub(crate) fn cancel(&self, can_gc: CanGc) {
+    pub(crate) fn cancel(&self, cx: &mut js::context::JSContext) {
         // If reader is not undefined and reader implements ReadableStreamBYOBReader,
         // Let readIntoRequests be reader.[[readIntoRequests]].
         let mut read_into_requests = self.take_read_into_requests();
@@ -310,7 +313,7 @@ impl ReadableStreamBYOBReader {
         // Perform readIntoRequest’s close steps, given undefined.
         for request in read_into_requests.drain(0..) {
             // Perform readIntoRequest’s close steps, given undefined.
-            request.close_steps(None, can_gc);
+            request.close_steps(cx, None);
         }
     }
 
@@ -322,11 +325,10 @@ impl ReadableStreamBYOBReader {
     /// <https://streams.spec.whatwg.org/#readable-stream-byob-reader-read>
     pub(crate) fn read(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         view: HeapBufferSource<ArrayBufferViewU8>,
         min: u64,
         read_into_request: &ReadIntoRequest,
-        can_gc: CanGc,
     ) {
         // Let stream be reader.[[stream]].
 
@@ -339,15 +341,14 @@ impl ReadableStreamBYOBReader {
         stream.set_is_disturbed(true);
         // If stream.[[state]] is "errored", perform readIntoRequest’s error steps given stream.[[storedError]].
         if stream.is_errored() {
-            let cx = GlobalScope::get_cx();
-            rooted!(in(*cx) let mut error = UndefinedValue());
+            rooted!(&in(cx) let mut error = UndefinedValue());
             stream.get_stored_error(error.handle_mut());
 
-            read_into_request.error_steps(error.handle(), can_gc);
+            read_into_request.error_steps(error.handle(), CanGc::from_cx(cx));
         } else {
             // Otherwise,
             // perform ! ReadableByteStreamControllerPullInto(stream.[[controller]], view, min, readIntoRequest).
-            stream.perform_pull_into(cx, read_into_request, view, min, can_gc);
+            stream.perform_pull_into(cx, read_into_request, view, min);
         }
     }
 
@@ -509,7 +510,7 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
         let read_into_request = ReadIntoRequest::Read(promise.clone());
 
         // Perform ! ReadableStreamBYOBReaderRead(this, view, options["min"], readIntoRequest).
-        self.read(cx.into(), view, min, &read_into_request, CanGc::from_cx(cx));
+        self.read(cx, view, min, &read_into_request);
 
         // Return promise.
         promise

--- a/components/script/dom/stream/readablestreambyobrequest.rs
+++ b/components/script/dom/stream/readablestreambyobrequest.rs
@@ -70,9 +70,7 @@ impl ReadableStreamBYOBRequestMethods<crate::DomTypeHolder> for ReadableStreamBY
     }
 
     /// <https://streams.spec.whatwg.org/#rs-byob-request-respond>
-    fn Respond(&self, bytes_written: u64, can_gc: CanGc) -> Fallible<()> {
-        let cx = GlobalScope::get_cx();
-
+    fn Respond(&self, cx: &mut js::context::JSContext, bytes_written: u64) -> Fallible<()> {
         // If this.[[controller]] is undefined, throw a TypeError exception.
         let controller = if let Some(controller) = self.controller.get() {
             controller
@@ -83,7 +81,10 @@ impl ReadableStreamBYOBRequestMethods<crate::DomTypeHolder> for ReadableStreamBY
         {
             let view = self.view.borrow();
             // If ! IsDetachedBuffer(this.[[view]].[[ArrayBuffer]]) is true, throw a TypeError exception.
-            if view.get_array_buffer_view_buffer(cx).is_detached_buffer(cx) {
+            if view
+                .get_array_buffer_view_buffer(cx.into())
+                .is_detached_buffer(cx.into())
+            {
                 return Err(Error::Type(c"buffer is detached".to_owned()));
             }
 
@@ -91,20 +92,19 @@ impl ReadableStreamBYOBRequestMethods<crate::DomTypeHolder> for ReadableStreamBY
             assert!(view.byte_length() > 0);
 
             // Assert: this.[[view]].[[ViewedArrayBuffer]].[[ByteLength]] > 0.
-            assert!(view.viewed_buffer_array_byte_length(cx) > 0);
+            assert!(view.viewed_buffer_array_byte_length(cx.into()) > 0);
         }
 
         // Perform ? ReadableByteStreamControllerRespond(this.[[controller]], bytesWritten).
-        controller.respond(cx, bytes_written, can_gc)
+        controller.respond(cx, bytes_written)
     }
 
     /// <https://streams.spec.whatwg.org/#rs-byob-request-respond-with-new-view>
     fn RespondWithNewView(
         &self,
+        cx: &mut js::context::JSContext,
         view: CustomAutoRooterGuard<ArrayBufferView>,
-        can_gc: CanGc,
     ) -> Fallible<()> {
-        let cx = GlobalScope::get_cx();
         let view = HeapBufferSource::<ArrayBufferViewU8>::from_view(view);
 
         // If this.[[controller]] is undefined, throw a TypeError exception.
@@ -115,11 +115,11 @@ impl ReadableStreamBYOBRequestMethods<crate::DomTypeHolder> for ReadableStreamBY
         };
 
         // If ! IsDetachedBuffer(view.[[ViewedArrayBuffer]]) is true, throw a TypeError exception.
-        if view.is_detached_buffer(cx) {
+        if view.is_detached_buffer(cx.into()) {
             return Err(Error::Type(c"buffer is detached".to_owned()));
         }
 
         // Return ? ReadableByteStreamControllerRespondWithNewView(this.[[controller]], view).
-        controller.respond_with_new_view(cx, view, can_gc)
+        controller.respond_with_new_view(cx, view)
     }
 }

--- a/components/script/dom/stream/readablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/readablestreamdefaultcontroller.rs
@@ -48,7 +48,6 @@ impl Callback for PullAlgorithmFulfillmentHandler {
     /// Continuation of <https://streams.spec.whatwg.org/#readable-stream-default-controller-call-pull-if-needed>
     /// Upon fulfillment of pullPromise
     fn callback(&self, cx: &mut CurrentRealm, _v: HandleValue) {
-        let can_gc = CanGc::from_cx(cx);
         // Set controller.[[pulling]] to false.
         self.controller.pulling.set(false);
 
@@ -58,7 +57,7 @@ impl Callback for PullAlgorithmFulfillmentHandler {
             self.controller.pull_again.set(false);
 
             // Perform ! ReadableStreamDefaultControllerCallPullIfNeeded(controller).
-            self.controller.call_pull_if_needed(can_gc);
+            self.controller.call_pull_if_needed(cx);
         }
     }
 }
@@ -75,9 +74,8 @@ impl Callback for PullAlgorithmRejectionHandler {
     /// Continuation of <https://streams.spec.whatwg.org/#readable-stream-default-controller-call-pull-if-needed>
     /// Upon rejection of pullPromise with reason e.
     fn callback(&self, cx: &mut CurrentRealm, v: HandleValue) {
-        let can_gc = CanGc::from_cx(cx);
         // Perform ! ReadableStreamDefaultControllerError(controller, e).
-        self.controller.error(v, can_gc);
+        self.controller.error(cx, v);
     }
 }
 
@@ -93,12 +91,11 @@ impl Callback for StartAlgorithmFulfillmentHandler {
     /// Continuation of <https://streams.spec.whatwg.org/#set-up-readable-stream-default-controller>
     /// Upon fulfillment of startPromise,
     fn callback(&self, cx: &mut CurrentRealm, _v: HandleValue) {
-        let can_gc = CanGc::from_cx(cx);
         // Set controller.[[started]] to true.
         self.controller.started.set(true);
 
         // Perform ! ReadableStreamDefaultControllerCallPullIfNeeded(controller).
-        self.controller.call_pull_if_needed(can_gc);
+        self.controller.call_pull_if_needed(cx);
     }
 }
 
@@ -114,9 +111,8 @@ impl Callback for StartAlgorithmRejectionHandler {
     /// Continuation of <https://streams.spec.whatwg.org/#set-up-readable-stream-default-controller>
     /// Upon rejection of startPromise with reason r,
     fn callback(&self, cx: &mut CurrentRealm, v: HandleValue) {
-        let can_gc = CanGc::from_cx(cx);
         // Perform ! ReadableStreamDefaultControllerError(controller, r).
-        self.controller.error(v, can_gc);
+        self.controller.error(cx, v);
     }
 }
 
@@ -507,7 +503,7 @@ impl ReadableStreamDefaultController {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-stream-default-controller-call-pull-if-needed>
-    fn call_pull_if_needed(&self, can_gc: CanGc) {
+    fn call_pull_if_needed(&self, cx: &mut js::context::JSContext) {
         // Let shouldPull be ! ReadableStreamDefaultControllerShouldCallPull(controller).
         // If shouldPull is false, return.
         if !self.should_call_pull() {
@@ -543,28 +539,32 @@ impl ReadableStreamDefaultController {
             Some(Box::new(PullAlgorithmRejectionHandler {
                 controller: Dom::from_ref(&rooted_default_controller),
             })),
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         let realm = enter_realm(&*global);
         let comp = InRealm::Entered(&realm);
         let result = underlying_source
-            .call_pull_algorithm(controller, can_gc)
+            .call_pull_algorithm(cx, controller)
             .unwrap_or_else(|| {
-                let promise = Promise::new(&global, can_gc);
-                promise.resolve_native(&(), can_gc);
+                let promise = Promise::new2(cx, &global);
+                promise.resolve_native(&(), CanGc::from_cx(cx));
                 Ok(promise)
             });
         let promise = result.unwrap_or_else(|error| {
-            let cx = GlobalScope::get_cx();
-            rooted!(in(*cx) let mut rval = UndefinedValue());
+            rooted!(&in(cx) let mut rval = UndefinedValue());
             // TODO: check if `self.global()` is the right globalscope.
-            error.to_jsval(cx, &self.global(), rval.handle_mut(), can_gc);
-            let promise = Promise::new(&global, can_gc);
-            promise.reject_native(&rval.handle(), can_gc);
+            error.to_jsval(
+                cx.into(),
+                &self.global(),
+                rval.handle_mut(),
+                CanGc::from_cx(cx),
+            );
+            let promise = Promise::new2(cx, &global);
+            promise.reject_native(&rval.handle(), CanGc::from_cx(cx));
             promise
         });
-        promise.append_native_handler(&handler, comp, can_gc);
+        promise.append_native_handler(&handler, comp, CanGc::from_cx(cx));
     }
 
     /// <https://streams.spec.whatwg.org/#rs-default-controller-private-cancel>
@@ -606,7 +606,11 @@ impl ReadableStreamDefaultController {
     }
 
     /// <https://streams.spec.whatwg.org/#rs-default-controller-private-pull>
-    pub(crate) fn perform_pull_steps(&self, read_request: &ReadRequest, can_gc: CanGc) {
+    pub(crate) fn perform_pull_steps(
+        &self,
+        cx: &mut js::context::JSContext,
+        read_request: &ReadRequest,
+    ) {
         // Let stream be this.[[stream]].
         // Note: the spec does not assert that there is a stream.
         let Some(stream) = self.stream.get() else {
@@ -615,10 +619,9 @@ impl ReadableStreamDefaultController {
 
         // if queue contains bytes, perform chunk steps.
         if !self.queue.is_empty() {
-            let cx = GlobalScope::get_cx();
-            rooted!(in(*cx) let mut rval = UndefinedValue());
+            rooted!(&in(cx) let mut rval = UndefinedValue());
             let result = RootedTraceableBox::new(Heap::default());
-            self.dequeue_value(cx, rval.handle_mut(), can_gc);
+            self.dequeue_value(cx.into(), rval.handle_mut(), CanGc::from_cx(cx));
             result.set(*rval);
 
             // If this.[[closeRequested]] is true and this.[[queue]] is empty
@@ -627,19 +630,19 @@ impl ReadableStreamDefaultController {
                 self.clear_algorithms();
 
                 // Perform ! ReadableStreamClose(stream).
-                stream.close(can_gc);
+                stream.close(cx);
             } else {
                 // Otherwise, perform ! ReadableStreamDefaultControllerCallPullIfNeeded(this).
-                self.call_pull_if_needed(can_gc);
+                self.call_pull_if_needed(cx);
             }
             // Perform readRequest’s chunk steps, given chunk.
-            read_request.chunk_steps(result, &self.global(), can_gc);
+            read_request.chunk_steps(cx, result, &self.global());
         } else {
             // Perform ! ReadableStreamAddReadRequest(stream, readRequest).
             stream.add_read_request(read_request);
 
             // Perform ! ReadableStreamDefaultControllerCallPullIfNeeded(this).
-            self.call_pull_if_needed(can_gc);
+            self.call_pull_if_needed(cx);
         }
     }
 
@@ -670,7 +673,7 @@ impl ReadableStreamDefaultController {
         // and ! ReadableStreamGetNumReadRequests(stream) > 0,
         // perform ! ReadableStreamFulfillReadRequest(stream, chunk, false).
         if stream.is_locked() && stream.get_num_read_requests() > 0 {
-            stream.fulfill_read_request(chunk, false, CanGc::from_cx(cx));
+            stream.fulfill_read_request(cx, chunk, false);
         } else {
             // Otherwise,
             // Let result be the result of performing controller.[[strategySizeAlgorithm]],
@@ -694,7 +697,7 @@ impl ReadableStreamDefaultController {
                         unsafe { assert!(JS_GetPendingException(cx, rval.handle_mut())) };
 
                         // Perform ! ReadableStreamDefaultControllerError(controller, result.[[Value]]).
-                        self.error(rval.handle(), CanGc::from_cx(cx));
+                        self.error(cx, rval.handle());
 
                         // Return result.
                         // Note: we need to return a type error, because no exception is pending.
@@ -727,7 +730,7 @@ impl ReadableStreamDefaultController {
                     unsafe { assert!(JS_GetPendingException(cx, rval.handle_mut())) };
 
                     // Perform ! ReadableStreamDefaultControllerError(controller, enqueueResult.[[Value]]).
-                    self.error(rval.handle(), CanGc::from_cx(cx));
+                    self.error(cx, rval.handle());
 
                     // Return enqueueResult.
                     // Note: because we threw the exception above,
@@ -738,23 +741,26 @@ impl ReadableStreamDefaultController {
         }
 
         // Perform ! ReadableStreamDefaultControllerCallPullIfNeeded(controller).
-        self.call_pull_if_needed(CanGc::from_cx(cx));
+        self.call_pull_if_needed(cx);
 
         Ok(())
     }
 
     /// Native call to
     /// <https://streams.spec.whatwg.org/#readable-stream-default-controller-enqueue>
-    pub(crate) fn enqueue_native(&self, chunk: Vec<u8>, can_gc: CanGc) {
+    pub(crate) fn enqueue_native(&self, cx: &mut js::context::JSContext, chunk: Vec<u8>) {
         let stream = self
             .stream
             .get()
             .expect("Controller must have a stream when a chunk is enqueued.");
         if stream.is_locked() && stream.get_num_read_requests() > 0 {
-            let cx = GlobalScope::get_cx();
-            rooted!(in(*cx) let mut rval = UndefinedValue());
-            EnqueuedValue::Native(chunk.into_boxed_slice()).to_jsval(cx, rval.handle_mut(), can_gc);
-            stream.fulfill_read_request(rval.handle(), false, can_gc);
+            rooted!(&in(cx) let mut rval = UndefinedValue());
+            EnqueuedValue::Native(chunk.into_boxed_slice()).to_jsval(
+                cx.into(),
+                rval.handle_mut(),
+                CanGc::from_cx(cx),
+            );
+            stream.fulfill_read_request(cx, rval.handle(), false);
         } else {
             self.queue
                 .enqueue_value_with_size(EnqueuedValue::Native(chunk.into_boxed_slice()))
@@ -790,7 +796,7 @@ impl ReadableStreamDefaultController {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-stream-default-controller-close>
-    pub(crate) fn close(&self, can_gc: CanGc) {
+    pub(crate) fn close(&self, cx: &mut js::context::JSContext) {
         // If ! ReadableStreamDefaultControllerCanCloseOrEnqueue(controller) is false, return.
         if !self.can_close_or_enqueue() {
             return;
@@ -808,7 +814,7 @@ impl ReadableStreamDefaultController {
             self.clear_algorithms();
 
             // Perform ! ReadableStreamClose(stream).
-            stream.close(can_gc);
+            stream.close(cx);
         }
     }
 
@@ -847,7 +853,7 @@ impl ReadableStreamDefaultController {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-stream-default-controller-error>
-    pub(crate) fn error(&self, e: SafeHandleValue, can_gc: CanGc) {
+    pub(crate) fn error(&self, cx: &mut js::context::JSContext, e: SafeHandleValue) {
         let Some(stream) = self.stream.get() else {
             return;
         };
@@ -863,7 +869,7 @@ impl ReadableStreamDefaultController {
         // Perform ! ReadableStreamDefaultControllerClearAlgorithms(controller).
         self.clear_algorithms();
 
-        stream.error(e, can_gc);
+        stream.error(cx, e);
     }
 
     /// <https://streams.spec.whatwg.org/#rs-default-controller-has-backpressure>
@@ -883,7 +889,7 @@ impl ReadableStreamDefaultControllerMethods<crate::DomTypeHolder>
     }
 
     /// <https://streams.spec.whatwg.org/#rs-default-controller-close>
-    fn Close(&self, can_gc: CanGc) -> Fallible<()> {
+    fn Close(&self, cx: &mut js::context::JSContext) -> Fallible<()> {
         if !self.can_close_or_enqueue() {
             // If ! ReadableStreamDefaultControllerCanCloseOrEnqueue(this) is false,
             // throw a TypeError exception.
@@ -891,7 +897,7 @@ impl ReadableStreamDefaultControllerMethods<crate::DomTypeHolder>
         }
 
         // Perform ! ReadableStreamDefaultControllerClose(this).
-        self.close(can_gc);
+        self.close(cx);
 
         Ok(())
     }
@@ -909,7 +915,7 @@ impl ReadableStreamDefaultControllerMethods<crate::DomTypeHolder>
 
     /// <https://streams.spec.whatwg.org/#rs-default-controller-error>
     fn Error(&self, cx: &mut js::context::JSContext, e: SafeHandleValue) -> Fallible<()> {
-        self.error(e, CanGc::from_cx(cx));
+        self.error(cx, e);
         Ok(())
     }
 }

--- a/components/script/dom/stream/readablestreamdefaultreader.rs
+++ b/components/script/dom/stream/readablestreamdefaultreader.rs
@@ -33,10 +33,10 @@ use crate::dom::stream::defaultteereadrequest::DefaultTeeReadRequest;
 use crate::dom::stream::readablestreamgenericreader::ReadableStreamGenericReader;
 use crate::dom::types::ReadableStreamDefaultController;
 use crate::realms::{InRealm, enter_realm};
-use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
+use crate::script_runtime::CanGc;
 
-type ReadAllBytesSuccessSteps = dyn Fn(&[u8]);
-type ReadAllBytesFailureSteps = dyn Fn(SafeJSContext, SafeHandleValue);
+type ReadAllBytesSuccessSteps = dyn Fn(&mut js::context::JSContext, &[u8]);
+type ReadAllBytesFailureSteps = dyn Fn(&mut js::context::JSContext, SafeHandleValue);
 
 impl js::gc::Rootable for ContinueReadMicrotask {}
 
@@ -54,20 +54,18 @@ struct ContinueReadMicrotask {
 
 impl Callback for ContinueReadMicrotask {
     fn callback(&self, cx: &mut CurrentRealm, _v: SafeHandleValue) {
-        let can_gc = CanGc::from_cx(cx);
         // https://streams.spec.whatwg.org/#ref-for-read-loop%E2%91%A0
         // Note: continuing the read-loop from inside a micro-task to break recursion.
-        self.reader.read(cx.into(), &self.request, can_gc);
+        self.reader.read(cx, &self.request);
     }
 }
 
 /// <https://streams.spec.whatwg.org/#read-loop>
 fn read_loop(
+    cx: &mut js::context::JSContext,
     reader: &ReadableStreamDefaultReader,
-    cx: SafeJSContext,
     success_steps: Rc<ReadAllBytesSuccessSteps>,
     failure_steps: Rc<ReadAllBytesFailureSteps>,
-    can_gc: CanGc,
 ) {
     // For the purposes of the above algorithm, to read-loop given reader,
     // bytes, successSteps, and failureSteps:
@@ -80,7 +78,7 @@ fn read_loop(
         bytes: Rc::new(DomRefCell::new(Vec::new())),
     };
     // Step 2 .Perform ! ReadableStreamDefaultReaderRead(reader, readRequest).
-    reader.read(cx, &req, can_gc);
+    reader.read(cx, &req);
 }
 
 /// <https://streams.spec.whatwg.org/#read-request>
@@ -114,9 +112,9 @@ impl ReadRequest {
     /// <https://streams.spec.whatwg.org/#read-request-chunk-steps>
     pub(crate) fn chunk_steps(
         &self,
+        cx: &mut js::context::JSContext,
         chunk: RootedTraceableBox<Heap<JSVal>>,
         global: &GlobalScope,
-        can_gc: CanGc,
     ) {
         match self {
             ReadRequest::Read(promise) => {
@@ -127,7 +125,7 @@ impl ReadRequest {
                         done: Some(false),
                         value: chunk,
                     },
-                    can_gc,
+                    CanGc::from_cx(cx),
                 );
             },
             ReadRequest::DefaultTee { tee_read_request } => {
@@ -145,10 +143,9 @@ impl ReadRequest {
                 bytes,
             } => {
                 // Spec: chunk steps, given chunk
-                let cx = GlobalScope::get_cx();
                 let global = reader.global();
 
-                match bytes_from_chunk_jsval(cx, &chunk, can_gc) {
+                match bytes_from_chunk_jsval(cx.into(), &chunk, CanGc::from_cx(cx)) {
                     Ok(vec) => {
                         // Step 2. Append the bytes represented by chunk to bytes.
                         bytes.borrow_mut().extend_from_slice(&vec);
@@ -156,8 +153,8 @@ impl ReadRequest {
                         // Step 3. Read-loop given reader, bytes, successSteps, and failureSteps.
                         // Spec note: Avoid direct recursion; queue into a microtask.
                         // Resolving the promise will queue a microtask to call into the native handler.
-                        let tick = Promise::new(&global, can_gc);
-                        tick.resolve_native(&(), can_gc);
+                        let tick = Promise::new(&global, CanGc::from_cx(cx));
+                        tick.resolve_native(&(), CanGc::from_cx(cx));
 
                         let handler = PromiseNativeHandler::new(
                             &global,
@@ -166,17 +163,17 @@ impl ReadRequest {
                                 request: self.clone(),
                             })),
                             None,
-                            can_gc,
+                            CanGc::from_cx(cx),
                         );
 
                         let realm = enter_realm(&*global);
                         let comp = InRealm::Entered(&realm);
-                        tick.append_native_handler(&handler, comp, can_gc);
+                        tick.append_native_handler(&handler, comp, CanGc::from_cx(cx));
                     },
                     Err(err) => {
                         // Step 1. If chunk is not a Uint8Array object, call failureSteps with a TypeError and abort.
-                        rooted!(in(*cx) let mut v = UndefinedValue());
-                        err.to_jsval(cx, &global, v.handle_mut(), can_gc);
+                        rooted!(&in(cx) let mut v = UndefinedValue());
+                        err.to_jsval(cx.into(), &global, v.handle_mut(), CanGc::from_cx(cx));
                         (failure_steps)(cx, v.handle());
                     },
                 }
@@ -185,7 +182,7 @@ impl ReadRequest {
     }
 
     /// <https://streams.spec.whatwg.org/#read-request-close-steps>
-    pub(crate) fn close_steps(&self, can_gc: CanGc) {
+    pub(crate) fn close_steps(&self, cx: &mut js::context::JSContext) {
         match self {
             ReadRequest::Read(promise) => {
                 // close steps
@@ -197,17 +194,17 @@ impl ReadRequest {
                         done: Some(true),
                         value: result,
                     },
-                    can_gc,
+                    CanGc::from_cx(cx),
                 );
             },
             ReadRequest::DefaultTee { tee_read_request } => {
-                tee_read_request.close_steps(can_gc);
+                tee_read_request.close_steps(cx);
             },
             ReadRequest::ByteTee {
                 byte_tee_read_request,
             } => {
                 byte_tee_read_request
-                    .close_steps(can_gc)
+                    .close_steps(cx)
                     .expect("ByteTeeReadRequest close steps should not fail");
             },
             ReadRequest::ReadLoop {
@@ -217,22 +214,22 @@ impl ReadRequest {
                 ..
             } => {
                 // Step 1. Call successSteps with bytes.
-                (success_steps)(&bytes.borrow());
+                (success_steps)(cx, &bytes.borrow());
 
                 reader
-                    .release(can_gc)
+                    .release(cx)
                     .expect("Releasing the read-all-bytes reader should succeed");
             },
         }
     }
 
     /// <https://streams.spec.whatwg.org/#read-request-error-steps>
-    pub(crate) fn error_steps(&self, e: SafeHandleValue, can_gc: CanGc) {
+    pub(crate) fn error_steps(&self, cx: &mut js::context::JSContext, e: SafeHandleValue) {
         match self {
             ReadRequest::Read(promise) => {
                 // error steps, given e
                 // Reject promise with e.
-                promise.reject_native(&e, can_gc)
+                promise.reject_native(&e, CanGc::from_cx(cx))
             },
             ReadRequest::DefaultTee { tee_read_request } => {
                 tee_read_request.error_steps();
@@ -248,11 +245,10 @@ impl ReadRequest {
                 ..
             } => {
                 // Step 1. Call failureSteps with e.
-                let cx = GlobalScope::get_cx();
                 (failure_steps)(cx, e);
 
                 reader
-                    .release(can_gc)
+                    .release(cx)
                     .expect("Releasing the read-all-bytes reader should succeed");
             },
         }
@@ -281,21 +277,20 @@ impl Callback for ByteTeeClosedPromiseRejectionHandler {
     /// Continuation of <https://streams.spec.whatwg.org/#abstract-opdef-readablebytestreamtee>
     /// Upon rejection of reader.[[closedPromise]] with reason r,
     fn callback(&self, cx: &mut CurrentRealm, v: SafeHandleValue) {
-        let can_gc = CanGc::from_cx(cx);
         // If thisReader is not the current `reader`, return.
         if self.reader_version.get() != self.expected_version {
             return;
         }
 
         // Perform ! ReadableByteStreamControllerError(branch1.[[controller]], r).
-        self.branch_1_controller.error(v, can_gc);
+        self.branch_1_controller.error(cx, v);
 
         // Perform ! ReadableByteStreamControllerError(branch2.[[controller]], r).
-        self.branch_2_controller.error(v, can_gc);
+        self.branch_2_controller.error(cx, v);
 
         // If canceled1 is false or canceled2 is false, resolve cancelPromise with undefined.
         if !self.canceled_1.get() || !self.canceled_2.get() {
-            self.cancel_promise.resolve_native(&(), can_gc);
+            self.cancel_promise.resolve_native(&(), CanGc::from_cx(cx));
         }
     }
 }
@@ -319,15 +314,14 @@ impl Callback for DefaultTeeClosedPromiseRejectionHandler {
     /// Continuation of <https://streams.spec.whatwg.org/#abstract-opdef-readablestreamdefaulttee>
     /// Upon rejection of reader.[[closedPromise]] with reason r,
     fn callback(&self, cx: &mut CurrentRealm, v: SafeHandleValue) {
-        let can_gc = CanGc::from_cx(cx);
         // Perform ! ReadableStreamDefaultControllerError(branch_1.[[controller]], r).
-        self.branch_1_controller.error(v, can_gc);
+        self.branch_1_controller.error(cx, v);
         // Perform ! ReadableStreamDefaultControllerError(branch_2.[[controller]], r).
-        self.branch_2_controller.error(v, can_gc);
+        self.branch_2_controller.error(cx, v);
 
         // If canceled_1 is false or canceled_2 is false, resolve cancelPromise with undefined.
         if !self.canceled_1.get() || !self.canceled_2.get() {
-            self.cancel_promise.resolve_native(&(), can_gc);
+            self.cancel_promise.resolve_native(&(), CanGc::from_cx(cx));
         }
     }
 }
@@ -400,9 +394,11 @@ impl ReadableStreamDefaultReader {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-stream-close>
-    pub(crate) fn close(&self, can_gc: CanGc) {
+    pub(crate) fn close(&self, cx: &mut js::context::JSContext) {
         // Resolve reader.[[closedPromise]] with undefined.
-        self.closed_promise.borrow().resolve_native(&(), can_gc);
+        self.closed_promise
+            .borrow()
+            .resolve_native(&(), CanGc::from_cx(cx));
         // If reader implements ReadableStreamDefaultReader,
         // Let readRequests be reader.[[readRequests]].
         let mut read_requests = self.take_read_requests();
@@ -410,7 +406,7 @@ impl ReadableStreamDefaultReader {
         // For each readRequest of readRequests,
         for request in read_requests.drain(0..) {
             // Perform readRequest’s close steps.
-            request.close_steps(can_gc);
+            request.close_steps(cx);
         }
     }
 
@@ -427,15 +423,17 @@ impl ReadableStreamDefaultReader {
     }
 
     /// <https://streams.spec.whatwg.org/#readable-stream-error>
-    pub(crate) fn error(&self, e: SafeHandleValue, can_gc: CanGc) {
+    pub(crate) fn error(&self, cx: &mut js::context::JSContext, e: SafeHandleValue) {
         // Reject reader.[[closedPromise]] with e.
-        self.closed_promise.borrow().reject_native(&e, can_gc);
+        self.closed_promise
+            .borrow()
+            .reject_native(&e, CanGc::from_cx(cx));
 
         // Set reader.[[closedPromise]].[[PromiseIsHandled]] to true.
         self.closed_promise.borrow().set_promise_is_handled();
 
         // Perform ! ReadableStreamDefaultReaderErrorReadRequests(reader, e).
-        self.error_read_requests(e, can_gc);
+        self.error_read_requests(cx, e);
     }
 
     /// The removal steps of <https://streams.spec.whatwg.org/#readable-stream-fulfill-read-request>
@@ -447,22 +445,21 @@ impl ReadableStreamDefaultReader {
     }
 
     /// <https://streams.spec.whatwg.org/#abstract-opdef-readablestreamdefaultreaderrelease>
-    pub(crate) fn release(&self, can_gc: CanGc) -> Fallible<()> {
+    pub(crate) fn release(&self, cx: &mut js::context::JSContext) -> Fallible<()> {
         // Perform ! ReadableStreamReaderGenericRelease(reader).
-        self.generic_release(can_gc)
+        self.generic_release(CanGc::from_cx(cx))
             .expect("Generic release failed");
         // Let e be a new TypeError exception.
-        let cx = GlobalScope::get_cx();
-        rooted!(in(*cx) let mut error = UndefinedValue());
+        rooted!(&in(cx) let mut error = UndefinedValue());
         Error::Type(c"Reader is released".to_owned()).to_jsval(
-            cx,
+            cx.into(),
             &self.global(),
             error.handle_mut(),
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         // Perform ! ReadableStreamDefaultReaderErrorReadRequests(reader, e).
-        self.error_read_requests(error.handle(), can_gc);
+        self.error_read_requests(cx, error.handle());
         Ok(())
     }
 
@@ -471,18 +468,18 @@ impl ReadableStreamDefaultReader {
     }
 
     /// <https://streams.spec.whatwg.org/#abstract-opdef-readablestreamdefaultreadererrorreadrequests>
-    fn error_read_requests(&self, rval: SafeHandleValue, can_gc: CanGc) {
+    fn error_read_requests(&self, cx: &mut js::context::JSContext, rval: SafeHandleValue) {
         // step 1
         let mut read_requests = self.take_read_requests();
 
         // step 2 & 3
         for request in read_requests.drain(0..) {
-            request.error_steps(rval, can_gc);
+            request.error_steps(cx, rval);
         }
     }
 
     /// <https://streams.spec.whatwg.org/#readable-stream-default-reader-read>
-    pub(crate) fn read(&self, cx: SafeJSContext, read_request: &ReadRequest, can_gc: CanGc) {
+    pub(crate) fn read(&self, cx: &mut js::context::JSContext, read_request: &ReadRequest) {
         // Let stream be reader.[[stream]].
 
         // Assert: stream is not undefined.
@@ -494,20 +491,19 @@ impl ReadableStreamDefaultReader {
         stream.set_is_disturbed(true);
         // If stream.[[state]] is "closed", perform readRequest’s close steps.
         if stream.is_closed() {
-            read_request.close_steps(can_gc);
+            read_request.close_steps(cx);
         } else if stream.is_errored() {
             // Otherwise, if stream.[[state]] is "errored",
             // perform readRequest’s error steps given stream.[[storedError]].
-            let cx = GlobalScope::get_cx();
-            rooted!(in(*cx) let mut error = UndefinedValue());
+            rooted!(&in(cx) let mut error = UndefinedValue());
             stream.get_stored_error(error.handle_mut());
-            read_request.error_steps(error.handle(), can_gc);
+            read_request.error_steps(cx, error.handle());
         } else {
             // Otherwise
             // Assert: stream.[[state]] is "readable".
             assert!(stream.is_readable());
             // Perform ! stream.[[controller]].[[PullSteps]](readRequest).
-            stream.perform_pull_steps(cx, read_request, can_gc);
+            stream.perform_pull_steps(cx, read_request);
         }
     }
 
@@ -592,16 +588,15 @@ impl ReadableStreamDefaultReader {
     /// <https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-all-bytes>
     pub(crate) fn read_all_bytes(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         success_steps: Rc<ReadAllBytesSuccessSteps>,
         failure_steps: Rc<ReadAllBytesFailureSteps>,
-        can_gc: CanGc,
     ) {
         // To read all bytes from a ReadableStreamDefaultReader reader,
         // given successSteps, which is an algorithm accepting a byte sequence,
         // and failureSteps, which is an algorithm accepting a JavaScript value:
         // read-loop given reader, a new byte sequence, successSteps, and failureSteps.
-        read_loop(self, cx, success_steps, failure_steps, can_gc);
+        read_loop(cx, self, success_steps, failure_steps);
     }
 
     /// step 3 of <https://streams.spec.whatwg.org/#abstract-opdef-readablebytestreamcontrollerprocessreadrequestsusingqueue>
@@ -623,7 +618,7 @@ impl ReadableStreamDefaultReader {
 
             // Perform ! ReadableByteStreamControllerFillReadRequestFromQueue(controller, readRequest).
             controller
-                .fill_read_request_from_queue(cx.into(), &read_request, CanGc::from_cx(cx))
+                .fill_read_request_from_queue(cx, &read_request)
                 .expect("Fill read request from queue failed");
         }
         Ok(())
@@ -683,21 +678,21 @@ impl ReadableStreamDefaultReaderMethods<crate::DomTypeHolder> for ReadableStream
         let read_request = ReadRequest::Read(promise.clone());
 
         // Perform ! ReadableStreamDefaultReaderRead(this, readRequest).
-        self.read(cx.into(), &read_request, CanGc::from_cx(cx));
+        self.read(cx, &read_request);
 
         // Return promise.
         promise
     }
 
     /// <https://streams.spec.whatwg.org/#default-reader-release-lock>
-    fn ReleaseLock(&self, can_gc: CanGc) -> Fallible<()> {
+    fn ReleaseLock(&self, cx: &mut js::context::JSContext) -> Fallible<()> {
         if self.stream.get().is_none() {
             // Step 1: If this.[[stream]] is undefined, return.
             return Ok(());
         }
 
         // Step 2: Perform !ReadableStreamDefaultReaderRelease(this).
-        self.release(can_gc)
+        self.release(cx)
     }
 
     /// <https://streams.spec.whatwg.org/#generic-reader-closed>

--- a/components/script/dom/stream/transformstream.rs
+++ b/components/script/dom/stream/transformstream.rs
@@ -181,30 +181,28 @@ struct CancelPromiseFulfillment {
 impl Callback for CancelPromiseFulfillment {
     /// Reacting to backpressureChangePromise with the following fulfillment steps:
     fn callback(&self, cx: &mut CurrentRealm, _v: SafeHandleValue) {
-        let can_gc = CanGc::from_cx(cx);
-        let cx: SafeJSContext = cx.into();
         // If readable.[[state]] is "errored", reject controller.[[finishPromise]] with readable.[[storedError]].
         if self.readable.is_errored() {
-            rooted!(in(*cx) let mut error = UndefinedValue());
+            rooted!(&in(cx) let mut error = UndefinedValue());
             self.readable.get_stored_error(error.handle_mut());
             self.controller
                 .get_finish_promise()
                 .expect("finish promise is not set")
-                .reject_native(&error.handle(), can_gc);
+                .reject_native(&error.handle(), CanGc::from_cx(cx));
         } else {
             // Otherwise:
             // Perform ! ReadableStreamDefaultControllerError(readable.[[controller]], reason).
-            rooted!(in(*cx) let mut reason = UndefinedValue());
+            rooted!(&in(cx) let mut reason = UndefinedValue());
             reason.set(self.reason.get());
             self.readable
                 .get_default_controller()
-                .error(reason.handle(), can_gc);
+                .error(cx, reason.handle());
 
             // Resolve controller.[[finishPromise]] with undefined.
             self.controller
                 .get_finish_promise()
                 .expect("finish promise is not set")
-                .resolve_native(&(), can_gc);
+                .resolve_native(&(), CanGc::from_cx(cx));
         }
     }
 }
@@ -223,16 +221,14 @@ struct CancelPromiseRejection {
 impl Callback for CancelPromiseRejection {
     /// Reacting to backpressureChangePromise with the following fulfillment steps:
     fn callback(&self, cx: &mut CurrentRealm, v: SafeHandleValue) {
-        let can_gc = CanGc::from_cx(cx);
-        let cx: SafeJSContext = cx.into();
         // Perform ! ReadableStreamDefaultControllerError(readable.[[controller]], r).
-        self.readable.get_default_controller().error(v, can_gc);
+        self.readable.get_default_controller().error(cx, v);
 
         // Reject controller.[[finishPromise]] with r.
         self.controller
             .get_finish_promise()
             .expect("finish promise is not set")
-            .reject(cx, v, can_gc);
+            .reject(cx.into(), v, CanGc::from_cx(cx));
     }
 }
 
@@ -330,8 +326,6 @@ struct FlushPromiseFulfillment {
 impl Callback for FlushPromiseFulfillment {
     /// Reacting to flushpromise with the following fulfillment steps:
     fn callback(&self, cx: &mut CurrentRealm, _v: SafeHandleValue) {
-        let can_gc = CanGc::from_cx(cx);
-        let cx: SafeJSContext = cx.into();
         // If flushPromise was fulfilled, then:
         let finish_promise = self
             .controller
@@ -340,16 +334,16 @@ impl Callback for FlushPromiseFulfillment {
 
         // If readable.[[state]] is "errored", reject controller.[[finishPromise]] with readable.[[storedError]].
         if self.readable.is_errored() {
-            rooted!(in(*cx) let mut error = UndefinedValue());
+            rooted!(&in(cx) let mut error = UndefinedValue());
             self.readable.get_stored_error(error.handle_mut());
-            finish_promise.reject(cx, error.handle(), can_gc);
+            finish_promise.reject(cx.into(), error.handle(), CanGc::from_cx(cx));
         } else {
             // Otherwise:
             // Perform ! ReadableStreamDefaultControllerClose(readable.[[controller]]).
-            self.readable.get_default_controller().close(can_gc);
+            self.readable.get_default_controller().close(cx);
 
             // Resolve controller.[[finishPromise]] with undefined.
-            finish_promise.resolve_native(&(), can_gc);
+            finish_promise.resolve_native(&(), CanGc::from_cx(cx));
         }
     }
 }
@@ -368,17 +362,15 @@ struct FlushPromiseRejection {
 impl Callback for FlushPromiseRejection {
     /// Reacting to flushpromise with the following fulfillment steps:
     fn callback(&self, cx: &mut CurrentRealm, v: SafeHandleValue) {
-        let can_gc = CanGc::from_cx(cx);
-        let cx: SafeJSContext = cx.into();
         // If flushPromise was rejected with reason r, then:
         // Perform ! ReadableStreamDefaultControllerError(readable.[[controller]], r).
-        self.readable.get_default_controller().error(v, can_gc);
+        self.readable.get_default_controller().error(cx, v);
 
         // Reject controller.[[finishPromise]] with r.
         self.controller
             .get_finish_promise()
             .expect("finish promise is not set")
-            .reject(cx, v, can_gc);
+            .reject(cx.into(), v, CanGc::from_cx(cx));
     }
 }
 
@@ -950,7 +942,7 @@ impl TransformStream {
         // Perform ! ReadableStreamDefaultControllerError(stream.[[readable]].[[controller]], e).
         self.get_readable()
             .get_default_controller()
-            .error(error, CanGc::from_cx(cx));
+            .error(cx, error);
 
         // Perform ! TransformStreamErrorWritableAndUnblockWrite(stream, e).
         self.error_writable_and_unblock_write(cx, global, error);

--- a/components/script/dom/stream/transformstreamdefaultcontroller.rs
+++ b/components/script/dom/stream/transformstreamdefaultcontroller.rs
@@ -696,7 +696,7 @@ impl TransformStreamDefaultController {
         let readable_controller = readable.get_default_controller();
 
         // Perform ! ReadableStreamDefaultControllerClose(readableController).
-        readable_controller.close(CanGc::from_cx(cx));
+        readable_controller.close(cx);
 
         // Let error be a TypeError exception indicating that the stream has been terminated.
         let error = Error::Type(c"stream has been terminated".to_owned());

--- a/components/script/dom/stream/underlyingsourcecontainer.rs
+++ b/components/script/dom/stream/underlyingsourcecontainer.rs
@@ -185,8 +185,8 @@ impl UnderlyingSourceContainer {
     #[expect(unsafe_code)]
     pub(crate) fn call_pull_algorithm(
         &self,
+        cx: &mut js::context::JSContext,
         controller: Controller,
-        can_gc: CanGc,
     ) -> Option<Result<Rc<Promise>, Error>> {
         match &self.underlying_source_type {
             UnderlyingSourceType::Js(source, this_obj) => {
@@ -196,7 +196,7 @@ impl UnderlyingSourceContainer {
                             &SafeHandle::from_raw(this_obj.handle()),
                             controller,
                             ExceptionHandling::Rethrow,
-                            can_gc,
+                            CanGc::from_cx(cx),
                         )
                     };
                     return Some(result);
@@ -205,32 +205,32 @@ impl UnderlyingSourceContainer {
             },
             UnderlyingSourceType::Tee(tee_underlying_source) => {
                 // Call the pull algorithm for the appropriate branch.
-                Some(Ok(tee_underlying_source.pull_algorithm(can_gc)))
+                Some(Ok(tee_underlying_source.pull_algorithm(cx)))
             },
             UnderlyingSourceType::Transfer(port) => {
                 // Let pullAlgorithm be the following steps:
                 // from <https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformreadable
 
-                let cx = GlobalScope::get_cx();
-
                 // Perform ! PackAndPostMessage(port, "pull", undefined).
-                rooted!(in(*cx) let mut value = UndefinedValue());
-                port.pack_and_post_message("pull", value.handle(), can_gc)
+                rooted!(&in(cx) let mut value = UndefinedValue());
+                port.pack_and_post_message("pull", value.handle(), CanGc::from_cx(cx))
                     .expect("Sending pull should not fail.");
 
                 // Return a promise resolved with undefined.
-                let promise = Promise::new(&self.global(), can_gc);
-                promise.resolve_native(&(), can_gc);
+                let promise = Promise::new2(cx, &self.global());
+                promise.resolve_native(&(), CanGc::from_cx(cx));
                 Some(Ok(promise))
             },
             UnderlyingSourceType::TeeByte(tee_underlyin_source) => {
                 // Call the pull algorithm for the appropriate branch.
-                Some(Ok(tee_underlyin_source.pull_algorithm(None, can_gc)))
+                Some(Ok(tee_underlyin_source.pull_algorithm(cx, None)))
             },
             // Note: other source type have no pull steps for now.
             UnderlyingSourceType::Transform(stream, _) => {
                 // Return ! TransformStreamDefaultSourcePullAlgorithm(stream).
-                Some(stream.transform_stream_default_source_pull(&self.global(), can_gc))
+                Some(
+                    stream.transform_stream_default_source_pull(&self.global(), CanGc::from_cx(cx)),
+                )
             },
             _ => None,
         }

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -201,7 +201,7 @@ fn abort_fetch_call(
     // Step 5. If response’s body is non-null and is readable, then error response’s body with error.
     if let Some(body) = response.body() {
         if body.is_readable() {
-            body.error(abort_reason, CanGc::from_cx(cx));
+            body.error(cx, abort_reason);
         }
     }
 }
@@ -228,7 +228,7 @@ pub(crate) fn Fetch(
     //         with input and init as arguments. If this throws an exception, reject p with it and return p.
     let request_object = match Request::Constructor(cx, global, None, input, init) {
         Err(e) => {
-            response.error_stream(e.clone(), CanGc::from_cx(cx));
+            response.error_stream(cx, e.clone());
             promise.reject_error(e, CanGc::from_cx(cx));
             return promise;
         },
@@ -573,10 +573,7 @@ impl FetchResponseListener for FetchContext {
                 self.fetch_promise = Some(TrustedPromise::new(promise));
                 let response = self.response_object.root();
                 response.set_type(DOMResponseType::Error, CanGc::from_cx(cx));
-                response.error_stream(
-                    Error::Type(c"Network error occurred".to_owned()),
-                    CanGc::from_cx(cx),
-                );
+                response.error_stream(cx, Error::Type(c"Network error occurred".to_owned()));
                 return;
             },
             // Step 12.4. Set responseObject to the result of creating a Response object,
@@ -635,7 +632,7 @@ impl FetchResponseListener for FetchContext {
         chunk: Vec<u8>,
     ) {
         let response = self.response_object.root();
-        response.stream_chunk(chunk, CanGc::from_cx(cx));
+        response.stream_chunk(cx, chunk);
     }
 
     fn process_response_eof(
@@ -649,13 +646,10 @@ impl FetchResponseListener for FetchContext {
         let _ac = enter_realm(&*response_object);
         if let Err(ref error) = response {
             if *error == NetworkError::DecompressionError {
-                response_object.error_stream(
-                    Error::Type(c"Network error occurred".to_owned()),
-                    CanGc::from_cx(cx),
-                );
+                response_object.error_stream(cx, Error::Type(c"Network error occurred".to_owned()));
             }
         }
-        response_object.finish(CanGc::from_cx(cx));
+        response_object.finish(cx);
         // TODO
         // ... trailerObject is not supported in Servo yet.
 

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1084,17 +1084,16 @@ DOMInterfaces = {
 },
 
 "ReadableStreamDefaultController": {
-    "canGc": ["Close"],
-    "cx": ["Enqueue", "Error"]
+    "cx": ["Close", "Enqueue", "Error"]
 },
 
 "ReadableByteStreamController": {
-    "canGc": ["GetByobRequest", "Close"],
-    "cx": ["Enqueue", "Error"]
+    "canGc": ["GetByobRequest"],
+    "cx": ["Enqueue", "Close", "Error"]
 },
 
 "ReadableStreamBYOBRequest": {
-    "canGc": ["Respond", "RespondWithNewView"]
+    "cx": ["Respond", "RespondWithNewView"]
 },
 
 "ReadableStreamBYOBReader": {
@@ -1103,8 +1102,7 @@ DOMInterfaces = {
 },
 
 "ReadableStreamDefaultReader": {
-    "canGc": ["ReleaseLock"],
-    "cx": ["Read", "Cancel"]
+    "cx": ["Read", "Cancel", "ReleaseLock"]
 },
 
 'ResizeObserverEntry': {


### PR DESCRIPTION
Propagate `&mut JSContext` in `ReadableStreamDefaultReader::read_all_bytes` and related call sites.

Testing: Successful build is enough
Fixes: Part of #42638 

Opened to reduces the complexity of #44254 