### PR TITLE
script: propagate &mut JSContext in IDBOpenDBRequest::dispatch_success

### DIFF
--- a/components/script/dom/indexeddb/idbfactory.rs
+++ b/components/script/dom/indexeddb/idbfactory.rs
@@ -301,11 +301,11 @@ impl IDBFactory {
                 // https://w3c.github.io/IndexedDB/#upgrade-transaction-steps
                 // Step 3. Set transaction’s scope to connection’s object store set.
                 let connection = request.get_or_init_connection(
+                    cx,
                     &self.global(),
                     name.clone(),
                     version,
                     upgraded,
-                    CanGc::from_cx(cx),
                 );
                 connection.set_object_store_names_from_backend(object_store_names);
 
@@ -313,7 +313,7 @@ impl IDBFactory {
                 // set request’s result to result,
                 // set request’s done flag,
                 // and fire an event named success at request.
-                request.dispatch_success(name, version, upgraded, CanGc::from_cx(cx));
+                request.dispatch_success(cx, name, version, upgraded);
             },
             ConnectionMsg::Upgrade {
                 name,
@@ -332,13 +332,7 @@ impl IDBFactory {
                     );
                 };
 
-                let connection = request.get_or_init_connection(
-                    &global,
-                    name,
-                    version,
-                    false,
-                    CanGc::from_cx(cx),
-                );
+                let connection = request.get_or_init_connection(cx, &global, name, version, false);
                 // https://w3c.github.io/IndexedDB/#upgrade-transaction-steps
                 // Step 3. Set transaction’s scope to connection’s object store set.
                 connection.set_object_store_names_from_backend(object_store_names);
@@ -375,13 +369,8 @@ impl IDBFactory {
                         "There should be a request to handle ConnectionMsg::VersionChange."
                     );
                 };
-                let connection = request.get_or_init_connection(
-                    &global,
-                    name.clone(),
-                    version,
-                    false,
-                    CanGc::from_cx(cx),
-                );
+                let connection =
+                    request.get_or_init_connection(cx, &global, name.clone(), version, false);
 
                 // Step 10.2: fire a version change event named versionchange at entry with db’s version and version.
                 connection.dispatch_versionchange(old_version, Some(version), CanGc::from_cx(cx));

--- a/components/script/dom/indexeddb/idbopendbrequest.rs
+++ b/components/script/dom/indexeddb/idbopendbrequest.rs
@@ -28,7 +28,7 @@ use crate::dom::indexeddb::idbrequest::IDBRequest;
 use crate::dom::indexeddb::idbtransaction::IDBTransaction;
 use crate::dom::indexeddb::idbversionchangeevent::IDBVersionChangeEvent;
 use crate::indexeddb::map_backend_error_to_dom_error;
-use crate::realms::enter_realm;
+use crate::realms::enter_auto_realm;
 use crate::script_runtime::CanGc;
 
 #[derive(Clone)]

--- a/components/script/dom/indexeddb/idbopendbrequest.rs
+++ b/components/script/dom/indexeddb/idbopendbrequest.rs
@@ -126,15 +126,21 @@ impl IDBOpenDBRequest {
 
     pub(crate) fn get_or_init_connection(
         &self,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         name: String,
         version: u64,
         upgraded: bool,
-        can_gc: CanGc,
     ) -> DomRoot<IDBDatabase> {
         self.pending_connection.or_init(|| {
             debug_assert!(!upgraded, "A connection should exist for the upgraded db.");
-            IDBDatabase::new(global, name.into(), self.get_id(), version, can_gc)
+            IDBDatabase::new(
+                global,
+                name.into(),
+                self.get_id(),
+                version,
+                CanGc::from_cx(cx),
+            )
         })
     }
 
@@ -271,15 +277,20 @@ impl IDBOpenDBRequest {
         matches
     }
 
-    pub fn dispatch_success(&self, name: String, version: u64, upgraded: bool, can_gc: CanGc) {
+    pub fn dispatch_success(
+        &self,
+        cx: &mut js::context::JSContext,
+        name: String,
+        version: u64,
+        upgraded: bool,
+    ) {
         let global = self.global();
-        let result = self.get_or_init_connection(&global, name, version, upgraded, can_gc);
+        let result = self.get_or_init_connection(cx, &global, name, version, upgraded);
         self.idbrequest.set_ready_state_done();
-        let cx = GlobalScope::get_cx();
 
         let _ac = enter_realm(&*result);
-        rooted!(in(*cx) let mut result_val = UndefinedValue());
-        result.safe_to_jsval(cx, result_val.handle_mut(), CanGc::deprecated_note());
+        rooted!(&in(cx) let mut result_val = UndefinedValue());
+        result.safe_to_jsval(cx.into(), result_val.handle_mut(), CanGc::from_cx(cx));
         self.set_result(result_val.handle());
 
         let event = Event::new(
@@ -287,9 +298,9 @@ impl IDBOpenDBRequest {
             Atom::from("success"),
             EventBubbles::DoesNotBubble,
             EventCancelable::NotCancelable,
-            CanGc::deprecated_note(),
+            CanGc::from_cx(cx),
         );
-        event.fire(self.upcast(), CanGc::deprecated_note());
+        event.fire(self.upcast(), CanGc::from_cx(cx));
     }
 
     /// <https://w3c.github.io/IndexedDB/#eventdef-idbopendbrequest-blocked>

--- a/components/script/dom/indexeddb/idbopendbrequest.rs
+++ b/components/script/dom/indexeddb/idbopendbrequest.rs
@@ -288,7 +288,8 @@ impl IDBOpenDBRequest {
         let result = self.get_or_init_connection(cx, &global, name, version, upgraded);
         self.idbrequest.set_ready_state_done();
 
-        let _ac = enter_realm(&*result);
+        let mut realm = enter_auto_realm(cx, &*result);
+        let cx = &mut realm.current_realm();
         rooted!(&in(cx) let mut result_val = UndefinedValue());
         result.safe_to_jsval(cx.into(), result_val.handle_mut(), CanGc::from_cx(cx));
         self.set_result(result_val.handle());

--- a/components/script/dom/indexeddb/idbopendbrequest.rs
+++ b/components/script/dom/indexeddb/idbopendbrequest.rs
@@ -57,7 +57,8 @@ impl OpenRequestListener {
 
         rooted!(&in(cx) let mut rval = UndefinedValue());
 
-        let _ac = enter_realm(&*open_request);
+        let mut realm = enter_auto_realm(cx, &*open_request);
+        let cx = &mut realm.current_realm();
 
         match result {
             Ok(version) => {

--- a/components/script/dom/indexeddb/idbopendbrequest.rs
+++ b/components/script/dom/indexeddb/idbopendbrequest.rs
@@ -39,7 +39,7 @@ struct OpenRequestListener {
 impl OpenRequestListener {
     /// The continuation of the parallel steps of
     /// <https://www.w3.org/TR/IndexedDB/#dom-idbfactory-deletedatabase>
-    fn handle_delete_db(&self, result: BackendResult<u64>, can_gc: CanGc) {
+    fn handle_delete_db(&self, cx: &mut js::context::JSContext, result: BackendResult<u64>) {
         // Step 4.1: Let result be the result of deleting a database, with storageKey, name, and request.
         // Note: done with the `result` argument.
 
@@ -55,8 +55,7 @@ impl OpenRequestListener {
         // Note: setting the done flag here as it is done in both branches below.
         open_request.idbrequest.set_ready_state_done();
 
-        let cx = GlobalScope::get_cx();
-        rooted!(in(*cx) let mut rval = UndefinedValue());
+        rooted!(&in(cx) let mut rval = UndefinedValue());
 
         let _ac = enter_realm(&*open_request);
 
@@ -73,7 +72,7 @@ impl OpenRequestListener {
                     Atom::from("success"),
                     version,
                     None,
-                    can_gc,
+                    CanGc::from_cx(cx),
                 );
             },
             Err(err) => {
@@ -84,15 +83,15 @@ impl OpenRequestListener {
                 // and fire an event named error at request
                 // with its bubbles and cancelable attributes initialized to true.
                 let error = map_backend_error_to_dom_error(err);
-                open_request.set_error(Some(error), can_gc);
+                open_request.set_error(Some(error), CanGc::from_cx(cx));
                 let event = Event::new(
                     &global,
                     Atom::from("error"),
                     EventBubbles::Bubbles,
                     EventCancelable::Cancelable,
-                    can_gc,
+                    CanGc::from_cx(cx),
                 );
-                event.fire(open_request.upcast(), can_gc);
+                event.fire(open_request.upcast(), CanGc::from_cx(cx));
             },
         }
     }
@@ -226,8 +225,8 @@ impl IDBOpenDBRequest {
         };
         let callback = GenericCallback::new(global.time_profiler_chan().clone(), move |message| {
             let response_listener = response_listener.clone();
-            task_source.queue(task!(request_callback: move || {
-                response_listener.handle_delete_db(message.unwrap(), CanGc::deprecated_note());
+            task_source.queue(task!(request_callback: move |cx| {
+                response_listener.handle_delete_db(cx, message.unwrap());
             }))
         })
         .expect("Could not create delete database callback");


### PR DESCRIPTION
Propagate `&mut JSContext` in `IDBOpenDBRequest::dispatch_success` and related call sites.

Testing: Successful build is enough
Fixes: Part of #42638 