### PR TITLE
script: propagate &mut JSContext in Window::run_resize_steps_for_layout_viewport

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -3347,7 +3347,7 @@ impl Window {
     /// <https://drafts.csswg.org/cssom-view/#document-run-the-resize-steps>
     ///
     /// Handle the pending viewport resize.
-    fn run_resize_steps_for_layout_viewport(&self, can_gc: CanGc) -> bool {
+    fn run_resize_steps_for_layout_viewport(&self, cx: &mut js::context::JSContext) -> bool {
         let Some((new_size, size_type)) = self.take_unhandled_resize_event() else {
             return false;
         };
@@ -3386,9 +3386,11 @@ impl Window {
                 Some(self),
                 0i32,
                 0u32,
-                can_gc,
+                CanGc::from_cx(cx),
             );
-            uievent.upcast::<Event>().fire(self.upcast(), can_gc);
+            uievent
+                .upcast::<Event>()
+                .fire(self.upcast(), CanGc::from_cx(cx));
         }
 
         true
@@ -3398,11 +3400,11 @@ impl Window {
     /// <https://drafts.csswg.org/cssom-view/#document-run-the-resize-steps>
     ///
     /// Returns true if there were any pending viewport resize events.
-    pub(crate) fn run_the_resize_steps(&self, can_gc: CanGc) -> bool {
-        let layout_viewport_resized = self.run_resize_steps_for_layout_viewport(can_gc);
+    pub(crate) fn run_the_resize_steps(&self, cx: &mut js::context::JSContext) -> bool {
+        let layout_viewport_resized = self.run_resize_steps_for_layout_viewport(cx);
 
         if self.has_changed_visual_viewport_dimension.get() {
-            let visual_viewport = self.get_or_init_visual_viewport(can_gc);
+            let visual_viewport = self.get_or_init_visual_viewport(CanGc::from_cx(cx));
 
             let uievent = UIEvent::new(
                 self,
@@ -3412,11 +3414,11 @@ impl Window {
                 Some(self),
                 0i32,
                 0u32,
-                can_gc,
+                CanGc::from_cx(cx),
             );
             uievent
                 .upcast::<Event>()
-                .fire(visual_viewport.upcast(), can_gc);
+                .fire(visual_viewport.upcast(), CanGc::from_cx(cx));
 
             self.has_changed_visual_viewport_dimension.set(false);
         }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1199,7 +1199,7 @@ impl ScriptThread {
             self.process_pending_input_events(cx, *pipeline_id);
 
             // > 8. For each doc of docs, run the resize steps for doc. [CSSOMVIEW]
-            let resized = document.window().run_the_resize_steps(CanGc::from_cx(cx));
+            let resized = document.window().run_the_resize_steps(cx);
 
             // > 9. For each doc of docs, run the scroll steps for doc.
             document.run_the_scroll_steps(cx);


### PR DESCRIPTION
Propagate `&mut JSContext` in `Window::run_resize_steps_for_layout_viewport` and related call sites.

Testing: Successful build is enough
Fixes: Part of #42638 