### PR TITLE
script: Fix "RefCell already borrowed" for DOMString in DataTransfer.getData

### DIFF
--- a/components/script/dom/datatransfer/datatransfer.rs
+++ b/components/script/dom/datatransfer/datatransfer.rs
@@ -188,15 +188,19 @@ impl DataTransferMethods<crate::DomTypeHolder> for DataTransfer {
         // Step 4 Let convert-to-URL be false.
         let mut convert_to_url = false;
 
-        let type_ = match_domstring_ascii!(format,
-            // Step 5 If format equals "text", change it to "text/plain".
-            "text" => DOMString::from("text/plain"),
-            // Step 6 If format equals "url", change it to "text/uri-list" and set convert-to-URL to true.
-            "url" => {
-                convert_to_url = true;
-                DOMString::from("text/uri-list")
-            },
-            _ => format.clone(),);
+        let type_ = 'match_format: {
+            match_domstring_ascii!(format,
+                // Step 5 If format equals "text", change it to "text/plain".
+                "text" => break 'match_format DOMString::from("text/plain"),
+                // Step 6 If format equals "url", change it to "text/uri-list" and set convert-to-URL to true.
+                "url" => {
+                    convert_to_url = true;
+                    break 'match_format  DOMString::from("text/uri-list")
+                },
+                _ => {},
+            );
+            format.clone()
+        };
 
         let data = data_store.find_matching_text(&type_);
 

--- a/components/script/dom/datatransfer/datatransfer.rs
+++ b/components/script/dom/datatransfer/datatransfer.rs
@@ -188,17 +188,19 @@ impl DataTransferMethods<crate::DomTypeHolder> for DataTransfer {
         // Step 4 Let convert-to-URL be false.
         let mut convert_to_url = false;
 
-        let type_ = 'match_format: {
-            match_domstring_ascii!(format,
-                // Step 5 If format equals "text", change it to "text/plain".
-                "text" => break 'match_format DOMString::from("text/plain"),
-                // Step 6 If format equals "url", change it to "text/uri-list" and set convert-to-URL to true.
-                "url" => {
-                    convert_to_url = true;
-                    break 'match_format  DOMString::from("text/uri-list")
-                },
-                _ => {},
-            );
+        let type_override = match_domstring_ascii!(format,
+            // Step 5 If format equals "text", change it to "text/plain".
+            "text" => Some("text/plain"),
+            // Step 6 If format equals "url", change it to "text/uri-list" and set convert-to-URL to true.
+            "url" => {
+                convert_to_url = true;
+                Some("text/uri-list")
+            },
+            _ => None,
+        );
+        let type_ = if let Some(t) = type_override {
+            DOMString::from(t)
+        } else {
             format.clone()
         };
 

--- a/components/script/dom/datatransfer/datatransfer.rs
+++ b/components/script/dom/datatransfer/datatransfer.rs
@@ -190,19 +190,16 @@ impl DataTransferMethods<crate::DomTypeHolder> for DataTransfer {
 
         let type_override = match_domstring_ascii!(format,
             // Step 5 If format equals "text", change it to "text/plain".
-            "text" => Some("text/plain"),
+            "text" => Some(DOMString::from("text/plain")),
             // Step 6 If format equals "url", change it to "text/uri-list" and set convert-to-URL to true.
             "url" => {
                 convert_to_url = true;
-                Some("text/uri-list")
+                Some(DOMString::from("text/uri-list"))
             },
             _ => None,
         );
-        let type_ = if let Some(t) = type_override {
-            DOMString::from(t)
-        } else {
-            format.clone()
-        };
+        // Clone outside of `match_domstring_ascii!` to avoid "RefCell already borrowed" panic
+        let type_ = type_override.unwrap_or_else(|| format.clone());
 
         let data = data_store.find_matching_text(&type_);
 

--- a/components/script_bindings/domstring.rs
+++ b/components/script_bindings/domstring.rs
@@ -918,6 +918,9 @@ macro_rules! match_domstring_ascii_inner {
 /// );
 /// assert_eq!(value, 3);
 /// ```
+///
+/// The `RefCell` inside `DOMString` is borrowed for the duration of the `match`,
+/// so the string cannot be accessed again inside a `match` arm.
 #[macro_export]
 macro_rules! match_domstring_ascii {
     ($input:expr, $($tail:tt)*) => {

--- a/tests/wpt/tests/html/editing/dnd/crashtests/DataTransfer-getData-RefCell-already-borrowed.html
+++ b/tests/wpt/tests/html/editing/dnd/crashtests/DataTransfer-getData-RefCell-already-borrowed.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/44599">
+<script>(new DataTransfer()).getData("");</script>


### PR DESCRIPTION
`match_domstring_ascii!` presumably borrows that RefCell, and `.clone()` borrows it again.

Testing: adding a new crashtest
Fixes: https://github.com/servo/servo/issues/44599
