### PR TITLE
layout: Add `ShapedTextSlice` and use it for line break opportunities

### DIFF
--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -364,10 +364,6 @@ impl Font {
 bitflags! {
     #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
     pub struct ShapingFlags: u8 {
-        /// Set if the text is entirely whitespace.
-        const IS_WHITESPACE_SHAPING_FLAG = 1 << 0;
-        /// Set if the text ends with whitespace.
-        const ENDS_WITH_WHITESPACE_SHAPING_FLAG = 1 << 1;
         /// Set if we are to ignore ligatures.
         const IGNORE_LIGATURES_SHAPING_FLAG = 1 << 2;
         /// Set if we are to disable kerning.
@@ -470,7 +466,7 @@ impl Font {
 
     /// Fast path for ASCII text that only needs simple horizontal LTR kerning.
     fn shape_text_fast(&self, text: &str, options: &ShapingOptions) -> ShapedText {
-        let mut glyph_store = ShapedText::new(text.len(), options);
+        let mut glyph_store = ShapedText::new(text.len(), false /* is_rtl */);
         let mut prev_glyph_id = None;
         for (string_byte_offset, byte) in text.bytes().enumerate() {
             let character = byte as char;

--- a/components/fonts/glyph.rs
+++ b/components/fonts/glyph.rs
@@ -3,6 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::fmt;
+use std::ops::Range;
+use std::sync::Arc;
 use std::vec::Vec;
 
 use app_units::Au;
@@ -13,7 +15,7 @@ use log::{debug, error};
 use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
 
-use crate::{GlyphShapingResult, ShapedGlyph, ShapingFlags, ShapingOptions};
+use crate::{GlyphShapingResult, ShapedGlyph, ShapingOptions};
 
 /// GlyphEntry is a port of Gecko's CompressedGlyph scheme for storing glyph data compactly.
 ///
@@ -226,19 +228,11 @@ pub struct ShapedText {
     total_advance: Au,
 
     /// The number of characters that correspond to the glyphs in this [`ShapedText`]
-    total_characters: usize,
+    character_count: usize,
 
     /// A cache of the number of word separators in the entire glyph store.
     /// See <https://drafts.csswg.org/css-text/#word-separator>.
     total_word_separators: usize,
-
-    /// Whether or not this glyph store contains only glyphs for whitespace.
-    is_whitespace: bool,
-
-    /// Whether or not this glyph store ends with whitespace glyphs.
-    /// Typically whitespace glyphs are placed in a separate store,
-    /// but that may not be the case with `white-space: break-spaces`.
-    ends_with_whitespace: bool,
 
     /// Whether or not this [`ShapedText`] has right-to-left text, which has implications
     /// about the order of the glyphs in the store.
@@ -249,20 +243,14 @@ impl ShapedText {
     /// Initializes the glyph store with the given capacity, but doesn't actually add any glyphs.
     ///
     /// Use the `add_*` methods to store glyph data.
-    pub(crate) fn new(length: usize, options: &ShapingOptions) -> Self {
+    pub(crate) fn new(length: usize, is_rtl: bool) -> Self {
         Self {
             glyphs: Vec::with_capacity(length),
             detailed_glyphs: Default::default(),
             total_advance: Au::zero(),
-            total_characters: 0,
+            character_count: 0,
             total_word_separators: 0,
-            is_whitespace: options
-                .flags
-                .contains(ShapingFlags::IS_WHITESPACE_SHAPING_FLAG),
-            ends_with_whitespace: options
-                .flags
-                .contains(ShapingFlags::ENDS_WITH_WHITESPACE_SHAPING_FLAG),
-            is_rtl: options.flags.contains(ShapingFlags::RTL_FLAG),
+            is_rtl,
         }
     }
 
@@ -294,7 +282,7 @@ impl ShapedText {
         };
 
         let mut previous_character_offset = None;
-        let mut glyph_store = ShapedText::new(shaped_glyph_data.len(), options);
+        let mut glyph_store = ShapedText::new(shaped_glyph_data.len(), shaped_run_is_rtl);
         for mut shaped_glyph in shaped_glyph_data.iter() {
             // The glyph "cluster" (HarfBuzz terminology) is the byte offset in the string that
             // this glyph corresponds to. More than one glyph can share a cluster.
@@ -350,54 +338,10 @@ impl ShapedText {
         glyph_store
     }
 
-    #[inline]
-    pub fn total_advance(&self) -> Au {
-        self.total_advance
-    }
-
     /// Return the number of glyphs stored in this [`ShapedText`].
     #[inline]
-    pub fn len(&self) -> usize {
+    pub fn glyph_count(&self) -> usize {
         self.glyphs.len()
-    }
-
-    /// Whether or not this [`ShapedText`] has any glyphs.
-    #[inline]
-    pub fn is_empty(&self) -> bool {
-        self.glyphs.is_empty()
-    }
-
-    /// The number of characters (`char`) from the original string that produced this
-    /// [`ShapedText`].
-    #[inline]
-    pub fn character_count(&self) -> usize {
-        self.total_characters
-    }
-
-    /// Whether or not this [`ShapedText`] is entirely white space.
-    #[inline]
-    pub fn is_whitespace(&self) -> bool {
-        self.is_whitespace
-    }
-
-    /// Whether or not this [`ShapedText`] ends with whitespace.
-    #[inline]
-    pub fn ends_with_whitespace(&self) -> bool {
-        self.ends_with_whitespace
-    }
-
-    /// The number of word separators in this [`ShapedText`].
-    #[inline]
-    pub fn total_word_separators(&self) -> usize {
-        self.total_word_separators
-    }
-
-    /// The number of characters that were consumed to produce this [`ShapedText`]. Some
-    /// characters correspond to more than one glyph and some glyphs correspond to more than
-    /// one character.
-    #[inline]
-    pub fn total_characters(&self) -> usize {
-        self.total_characters
     }
 
     /// Adds glyph that corresponds to a single character (as far we know) in the originating string.
@@ -414,7 +358,7 @@ impl ShapedText {
             simple_glyph_entry.set_char_is_word_separator();
         }
 
-        self.total_characters += 1;
+        self.character_count += 1;
         self.total_advance += glyph.advance;
         self.glyphs.push(simple_glyph_entry)
     }
@@ -430,7 +374,7 @@ impl ShapedText {
             self.total_word_separators += 1;
         }
 
-        self.total_characters += character_count;
+        self.character_count += character_count;
         self.total_advance += shaped_glyph.advance;
         self.detailed_glyphs.push(DetailedGlyphEntry {
             id: shaped_glyph.glyph_id,
@@ -450,7 +394,7 @@ impl ShapedText {
             .get_mut(detailed_glyph_index)
             .expect("GlyphEntry should have valid index to detailed glyph");
         detailed_glyph.character_count += 1;
-        self.total_characters += 1;
+        self.character_count += 1;
     }
 
     fn add_glyph_for_current_character(
@@ -500,8 +444,15 @@ impl ShapedText {
         detailed_glyph_index
     }
 
-    pub fn glyphs(&self) -> impl Iterator<Item = GlyphInfo<'_>> + use<'_> {
-        self.glyphs.iter().map(|entry| {
+    pub fn glyphs(&self) -> impl DoubleEndedIterator<Item = GlyphInfo<'_>> + use<'_> {
+        self.glyph_slice(0..self.glyphs.len())
+    }
+
+    fn glyph_slice(
+        &self,
+        glyph_range: Range<usize>,
+    ) -> impl DoubleEndedIterator<Item = GlyphInfo<'_>> + use<'_> {
+        self.glyphs[glyph_range].iter().map(|entry| {
             if entry.is_simple() {
                 GlyphInfo::Simple(entry)
             } else {
@@ -582,5 +533,179 @@ impl fmt::Debug for ShapedText {
             }
         }
         Ok(())
+    }
+}
+
+/// A slice of a [`ShapedText`] which allows having different views into a shaped
+/// text run. This is used for splitting up shaped text during layout, without
+/// duplicating the entire run.
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
+pub struct ShapedTextSlice {
+    /// The [`ShapedText`] that this [`ShapedTextSlice`] refers to.
+    #[conditional_malloc_size_of]
+    shaped_text: Arc<ShapedText>,
+
+    /// The range of glyphs within the [`ShapedText`] that this [`ShapedTextSlice`] represents.
+    glyph_range: Range<usize>,
+
+    /// A cache of the advance of the entire [`ShapedTextSlice`].
+    total_advance: Au,
+
+    /// The number of characters that correspond to the glyphs in this [`ShapedTextSlice`]
+    character_count: usize,
+
+    /// A precomputed count of the number of word separators in the entire [`ShapedTextSlice`]. See
+    /// <https://drafts.csswg.org/css-text/#word-separator>.
+    total_word_separators: usize,
+
+    /// Whether or not this [`ShapedTextSlice`] is entirely whitespace.
+    is_whitespace: bool,
+
+    /// Whether or not this [`ShapedTextSlice`] ends with whitespace glyphs.
+    /// Typically whitespace glyphs are placed in a separate slice,
+    /// but that may not be the case with `white-space: break-spaces`.
+    ends_with_whitespace: bool,
+}
+
+impl ShapedTextSlice {
+    /// Return the number of glyphs represented by this [`ShapedTextSlice`].
+    #[inline]
+    pub fn glyph_count(&self) -> usize {
+        self.glyph_range.len()
+    }
+
+    /// The number of characters that were consumed to produce this [`ShapedTextSlice`]. Some
+    /// characters correspond to more than one glyph and some glyphs correspond to more than
+    /// one character.
+    #[inline]
+    pub fn character_count(&self) -> usize {
+        self.character_count
+    }
+
+    /// The total advance of the characters represented by this [`ShapedTextSlice`].
+    #[inline]
+    pub fn total_advance(&self) -> Au {
+        self.total_advance
+    }
+
+    /// The number of word separators in this [`ShapedTextSlice`].
+    #[inline]
+    pub fn total_word_separators(&self) -> usize {
+        self.total_word_separators
+    }
+
+    /// Whether or not this [`ShapedTextSlice`] is entirely whitespace.
+    #[inline]
+    pub fn is_whitespace(&self) -> bool {
+        self.is_whitespace
+    }
+
+    /// Whether or not this [`ShapedTextSlice`] ends with whitespace.
+    #[inline]
+    pub fn ends_with_whitespace(&self) -> bool {
+        self.ends_with_whitespace
+    }
+
+    /// An iterator over the glyphs represented by this [`ShapedTextSlice`].
+    pub fn glyphs(&self) -> impl DoubleEndedIterator<Item = GlyphInfo<'_>> + use<'_> {
+        self.shaped_text.glyph_slice(self.glyph_range.clone())
+    }
+}
+
+/// A data structure used to efficiently slice up a [`ShapedText`] into [`ShapedTextSlice`]s.
+pub struct ShapedTextSlicer {
+    current_glyph_offset: usize,
+    shaped_text: Arc<ShapedText>,
+}
+
+impl ShapedTextSlicer {
+    pub fn new(shaped_text: Arc<ShapedText>) -> Self {
+        let current_glyph_offset = if shaped_text.is_rtl {
+            shaped_text.glyph_count()
+        } else {
+            0
+        };
+
+        Self {
+            current_glyph_offset,
+            shaped_text,
+        }
+    }
+
+    /// Given a desired character count, consume that number of characters worth
+    /// of glyphs from the [`ShapedText`] of this [`ShapedTextSlicer`]. In addition,
+    /// tag the resulting [`ShapedTextSlice`] with the given whitespace-related
+    /// properties.
+    pub fn slice_for_character_count(
+        &mut self,
+        desired_character_count: usize,
+        is_whitespace: bool,
+        ends_with_whitespace: bool,
+    ) -> Arc<ShapedTextSlice> {
+        let mut glyph_count = 0;
+        let mut character_count = 0;
+        let mut total_word_separators = 0;
+        let mut total_advance = Au::zero();
+
+        // In `ShapedText` glyphs are stored in physical left-to-right order, which means that the
+        // indices of the characters that they represent might decrease. Since we want to consume
+        // characters in memory order, we may need to walk the glyphs in the `ShapedText` from right
+        // to left.
+        let iterator = if self.shaped_text.is_rtl {
+            Either::Left(
+                self.shaped_text
+                    .glyph_slice(0..self.current_glyph_offset)
+                    .rev(),
+            )
+        } else {
+            Either::Right(
+                self.shaped_text
+                    .glyph_slice(self.current_glyph_offset..self.shaped_text.glyph_count()),
+            )
+        };
+
+        for glyph in iterator {
+            // When one character produces multiple glyphs, only the first glyph has a character
+            // count of one and the rest have a character count of 0. This checks the potential
+            // total before accumulating a glyph, which allows merging glyphs with a 0 character
+            // count into the slice with the first glyph.
+            let glyph_character_count = glyph.character_count();
+            if character_count + glyph_character_count > desired_character_count {
+                break;
+            }
+
+            glyph_count += 1;
+            character_count += glyph_character_count;
+            total_advance += glyph.advance();
+            if glyph.char_is_word_separator() {
+                total_word_separators += 1;
+            }
+        }
+
+        let (new_glyph_offset, glyph_range) = if self.shaped_text.is_rtl {
+            assert!(self.current_glyph_offset >= glyph_count);
+            let new_glyph_offset = self.current_glyph_offset - glyph_count;
+            (
+                new_glyph_offset,
+                new_glyph_offset..self.current_glyph_offset,
+            )
+        } else {
+            let new_glyph_offset = self.current_glyph_offset + glyph_count;
+            (
+                new_glyph_offset,
+                self.current_glyph_offset..new_glyph_offset,
+            )
+        };
+
+        self.current_glyph_offset = new_glyph_offset;
+        Arc::new(ShapedTextSlice {
+            shaped_text: self.shaped_text.clone(),
+            glyph_range,
+            total_advance,
+            character_count,
+            is_whitespace,
+            ends_with_whitespace,
+            total_word_separators,
+        })
     }
 }

--- a/components/fonts/lib.rs
+++ b/components/fonts/lib.rs
@@ -27,7 +27,7 @@ pub use font_context::{
 pub use font_store::FontTemplates;
 pub use fonts_traits::*;
 pub(crate) use glyph::*;
-pub use glyph::{GlyphInfo, ShapedText};
+pub use glyph::{GlyphInfo, ShapedText, ShapedTextSlice, ShapedTextSlicer};
 use icu_locid::subtags::Language;
 pub use platform::font_list::fallback_font_families;
 pub(crate) use shapers::*;

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use app_units::{AU_PER_PX, Au};
 use clip::{Clip, ClipId};
 use euclid::{Box2D, Point2D, Rect, Scale, SideOffsets2D, Size2D, UnknownUnit, Vector2D};
-use fonts::ShapedText;
+use fonts::ShapedTextSlice;
 use gradient::WebRenderGradient;
 use layout_api::ReflowStatistics;
 use net_traits::image_cache::Image as CachedImage;
@@ -1050,7 +1050,7 @@ impl Fragment {
         let mut start_advance = None;
         let mut end_advance = None;
         for glyph_store in fragment.glyphs.iter() {
-            let glyph_store_character_count = glyph_store.total_characters();
+            let glyph_store_character_count = glyph_store.character_count();
             if current_character_index + glyph_store_character_count <
                 shared_selection.character_range.start
             {
@@ -1941,7 +1941,7 @@ fn rgba(color: AbsoluteColor) -> wr::ColorF {
 }
 
 fn glyphs(
-    glyph_runs: &[Arc<ShapedText>],
+    shaped_text_slices: &[Arc<ShapedTextSlice>],
     mut baseline_origin: PhysicalPoint<Au>,
     justification_adjustment: Au,
     include_whitespace: bool,
@@ -1949,9 +1949,9 @@ fn glyphs(
     let mut glyphs = vec![];
     let mut largest_advance = Au::zero();
 
-    for run in glyph_runs {
-        for glyph in run.glyphs() {
-            if !run.is_whitespace() || include_whitespace {
+    for shaped_text_slice in shaped_text_slices {
+        for glyph in shaped_text_slice.glyphs() {
+            if !shaped_text_slice.is_whitespace() || include_whitespace {
                 let glyph_offset = glyph.offset().unwrap_or(Point2D::zero());
                 let point = LayoutPoint::new(
                     baseline_origin.x.to_f32_px() + glyph_offset.x.to_f32_px(),

--- a/components/layout/flow/inline/line.rs
+++ b/components/layout/flow/inline/line.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use app_units::Au;
 use bitflags::bitflags;
-use fonts::ShapedText;
+use fonts::ShapedTextSlice;
 use itertools::Either;
 use layout_api::SharedSelection;
 use malloc_size_of_derive::MallocSizeOf;
@@ -545,9 +545,9 @@ impl LineItemLayout<'_, '_> {
         let mut inline_advance = text_item
             .text
             .iter()
-            .map(|glyph_store| {
-                number_of_justification_opportunities += glyph_store.total_word_separators();
-                glyph_store.total_advance()
+            .map(|shaped_text_slice| {
+                number_of_justification_opportunities += shaped_text_slice.total_word_separators();
+                shaped_text_slice.total_advance()
             })
             .sum();
 
@@ -846,7 +846,7 @@ pub(super) struct TextRunLineItem {
     pub info: Arc<FontAndScriptInfo>,
     pub base_fragment_info: BaseFragmentInfo,
     pub inline_styles: SharedInlineStyles,
-    pub text: Vec<std::sync::Arc<ShapedText>>,
+    pub text: Vec<Arc<ShapedTextSlice>>,
     /// When necessary, this field store the [`TextRunOffsets`] for a particular
     /// [`TextRunLineItem`]. This is currently only used inside of text inputs.
     pub offsets: Option<Box<TextRunOffsets>>,
@@ -917,7 +917,7 @@ impl TextRunLineItem {
     pub(crate) fn merge_if_possible(
         &mut self,
         new_info: &Arc<FontAndScriptInfo>,
-        new_glyph_store: &Arc<ShapedText>,
+        new_glyph_store: &Arc<ShapedTextSlice>,
         new_offsets: &Option<TextRunOffsets>,
         new_inline_styles: &SharedInlineStyles,
     ) -> bool {

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -83,7 +83,7 @@ use app_units::{Au, MAX_AU};
 use atomic_refcell::AtomicRef;
 use bitflags::bitflags;
 use construct::InlineFormattingContextBuilder;
-use fonts::{FontMetrics, FontRef, ShapedText};
+use fonts::{FontMetrics, FontRef, ShapedTextSlice};
 use icu_locid::LanguageIdentifier;
 use icu_locid::subtags::{Language, language};
 use icu_properties::{self, LineBreak as ICULineBreak};
@@ -529,7 +529,7 @@ impl LineUnderConstruction {
                     text_run
                         .text
                         .iter()
-                        .map(|glyph_store| glyph_store.total_word_separators())
+                        .map(|shaped_text_slice| shaped_text_slice.total_word_separators())
                         .sum::<usize>(),
                 ),
                 _ => None,
@@ -1561,7 +1561,7 @@ impl InlineFormattingContextLayout<'_> {
 
     fn push_glyph_store_to_unbreakable_segment(
         &mut self,
-        glyph_store: Arc<ShapedText>,
+        glyph_store: Arc<ShapedTextSlice>,
         text_run: &TextRun,
         info: &Arc<FontAndScriptInfo>,
         offsets: Option<TextRunOffsets>,

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -7,7 +7,9 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use app_units::Au;
-use fonts::{FontContext, FontRef, ShapedText, ShapingFlags, ShapingOptions};
+use fonts::{
+    FontContext, FontRef, ShapedTextSlice, ShapedTextSlicer, ShapingFlags, ShapingOptions,
+};
 use icu_locid::subtags::Language;
 use icu_properties::{self, LineBreak};
 use log::warn;
@@ -145,7 +147,7 @@ pub(crate) struct TextRunSegment {
 
     /// The shaped runs within this segment.
     #[conditional_malloc_size_of]
-    pub runs: Vec<Arc<ShapedText>>,
+    pub runs: Vec<Arc<ShapedTextSlice>>,
 }
 
 impl TextRunSegment {
@@ -233,19 +235,6 @@ impl TextRunSegment {
         }
     }
 
-    fn shape_and_push_range(
-        &mut self,
-        range: &Range<usize>,
-        formatting_context_text: &str,
-        options: &ShapingOptions,
-    ) {
-        self.runs.push(
-            self.info
-                .font
-                .shape_text(&formatting_context_text[range.clone()], options),
-        );
-    }
-
     /// Shape the text of this [`TextRunSegment`], first finding "words" for the shaper by processing
     /// the linebreaks found in the owning [`super::InlineFormattingContext`]. Linebreaks are filtered,
     /// based on the style of the parent inline box.
@@ -255,14 +244,19 @@ impl TextRunSegment {
         formatting_context_text: &str,
         linebreaker: &mut LineBreaker,
     ) {
-        let options: ShapingOptions = (&*self.info).into();
-
         // Gather the linebreaks that apply to this segment from the inline formatting context's collection
         // of line breaks. Also add a simulated break at the end of the segment in order to ensure the final
         // piece of text is processed.
         let range = self.byte_range.clone();
         let linebreaks = linebreaker.advance_to_linebreaks_in_range(self.byte_range.clone());
         let linebreak_iter = linebreaks.iter().chain(std::iter::once(&range.end));
+
+        let options: ShapingOptions = (&*self.info).into();
+        let mut shaped_text_slicer = ShapedTextSlicer::new(
+            self.info
+                .font
+                .shape_text(&formatting_context_text[range.clone()], &options),
+        );
 
         self.runs.clear();
         self.runs.reserve(linebreaks.len());
@@ -275,7 +269,6 @@ impl TextRunSegment {
 
         let mut last_slice = self.byte_range.start..self.byte_range.start;
         for break_index in linebreak_iter {
-            let mut options = options;
             if *break_index == self.byte_range.start {
                 self.break_at_start = true;
                 continue;
@@ -289,6 +282,7 @@ impl TextRunSegment {
             let mut whitespace = slice.end..slice.end;
             let rev_char_indices = word.char_indices().rev().peekable();
 
+            let mut non_whitespace_slice_ends_with_whitespace = false;
             let mut ends_with_whitespace = false;
             if let Some((first_white_space_index, first_white_space_character)) = rev_char_indices
                 .take_while(|&(_, character)| char_is_whitespace(character))
@@ -306,9 +300,7 @@ impl TextRunSegment {
                     !can_break_anywhere
                 {
                     whitespace.start += first_white_space_character.len_utf8();
-                    options
-                        .flags
-                        .insert(ShapingFlags::ENDS_WITH_WHITESPACE_SHAPING_FLAG);
+                    non_whitespace_slice_ends_with_whitespace = true;
                 }
 
                 slice.end = whitespace.start;
@@ -329,34 +321,36 @@ impl TextRunSegment {
 
             // Push the non-whitespace part of the range.
             if !slice.is_empty() {
-                self.shape_and_push_range(&slice, formatting_context_text, &options);
+                let character_count = formatting_context_text[slice].chars().count();
+                self.runs.push(shaped_text_slicer.slice_for_character_count(
+                    character_count,
+                    false, /* is_whitespace */
+                    non_whitespace_slice_ends_with_whitespace,
+                ));
             }
 
             if whitespace.is_empty() {
                 continue;
             }
 
-            options.flags.insert(
-                ShapingFlags::IS_WHITESPACE_SHAPING_FLAG |
-                    ShapingFlags::ENDS_WITH_WHITESPACE_SHAPING_FLAG,
-            );
-
             // If `white-space-collapse: break-spaces` is active, insert a line breaking opportunity
             // between each white space character in the white space that we trimmed off.
             if text_style.white_space_collapse == WhiteSpaceCollapse::BreakSpaces {
-                let start_index = whitespace.start;
-                for (index, character) in formatting_context_text[whitespace].char_indices() {
-                    let index = start_index + index;
-                    self.shape_and_push_range(
-                        &(index..index + character.len_utf8()),
-                        formatting_context_text,
-                        &options,
-                    );
+                for _ in formatting_context_text[whitespace].chars() {
+                    self.runs.push(shaped_text_slicer.slice_for_character_count(
+                        1, true, /* is_whitespace */
+                        true, /* ends_with_whitespace */
+                    ));
                 }
                 continue;
             }
 
-            self.shape_and_push_range(&whitespace, formatting_context_text, &options);
+            let character_count = formatting_context_text[whitespace].chars().count();
+            self.runs.push(shaped_text_slicer.slice_for_character_count(
+                character_count,
+                true, /* is_whitespace */
+                true, /* ends_with_whitespace */
+            ));
         }
     }
 }

--- a/components/layout/fragment_tree/fragment.rs
+++ b/components/layout/fragment_tree/fragment.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use app_units::Au;
 use atomic_refcell::{AtomicRef, AtomicRefMut};
 use euclid::{Point2D, Rect, Size2D};
-use fonts::{FontMetrics, ShapedText};
+use fonts::{FontMetrics, ShapedTextSlice};
 use layout_api::BoxAreaType;
 use malloc_size_of_derive::MallocSizeOf;
 use servo_base::id::PipelineId;
@@ -71,7 +71,7 @@ pub(crate) struct TextFragment {
     pub font_metrics: Arc<FontMetrics>,
     pub font_key: FontInstanceKey,
     #[conditional_malloc_size_of]
-    pub glyphs: Vec<Arc<ShapedText>>,
+    pub glyphs: Vec<Arc<ShapedTextSlice>>,
     /// Extra space to add for each justification opportunity.
     pub justification_adjustment: Au,
     /// When necessary, this field store the [`TextRunOffsets`] for a particular
@@ -363,7 +363,7 @@ impl TextFragment {
             "Text num_glyphs={} box={:?}",
             self.glyphs
                 .iter()
-                .map(|glyph_store| glyph_store.len())
+                .map(|shaped_text_slice| shaped_text_slice.glyph_count())
                 .sum::<usize>(),
             self.base.rect
         ));

--- a/tests/wpt/meta/css/css-fonts/cjk-kerning.html.ini
+++ b/tests/wpt/meta/css/css-fonts/cjk-kerning.html.ini
@@ -1,6 +1,6 @@
 [cjk-kerning.html]
-  [expected mismatch: .kernOFF .cjk vs .kernON .cjk]
+  [expected mismatch: .paltOFFkernON .cjk vs .paltONkernON .cjk]
     expected: FAIL
 
-  [expected mismatch: .paltOFFkernON .cjk vs .paltONkernON .cjk]
+  [expected match: .default .cjk vs .kernOFF .cjk]
     expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-break/line-break-shaping-001.html.ini
+++ b/tests/wpt/meta/css/css-text/line-break/line-break-shaping-001.html.ini
@@ -1,2 +1,0 @@
-[line-break-shaping-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/word-break/word-break-break-all-004.html.ini
+++ b/tests/wpt/meta/css/css-text/word-break/word-break-break-all-004.html.ini
@@ -1,2 +1,0 @@
-[word-break-break-all-004.html]
-  expected: FAIL


### PR DESCRIPTION
This change makes it so that line breaking does not create separate
`ShapedText` runs, but instead produces "slices" of those runs after
shaping. This should improve shaping results as text is now shaped
together. In addition memory usage should be reduced as a
`ShapedTextSlice` is smaller than `ShapedText`.

The ultimate goal of this work is to move line breaking to fragment
tree layout, reduce the cost and memory usage of storing line break
opportunities, and allow for more flexible line breaking to support
things like `word-break: break-all` and `line-break: anywhere`.

Testing:  This change improves the results of two WPT tests. This is
due to the fact that text is now shaped together, regardless of where
line breaking opportunities are. Particularly for Arabic, this improves
shaping for things like `line-break: anywhere`. Another test `cjk-kerning.html`
shows one new subtest pass and one new subtest failure. The rendering
results were wrong before (as each gylph in the string was shaped
separately). No browsers passes all these tests and we do not support
the `font-feature-settings` CSS property. Overall, rendering is improved.