### PR TITLE
Upgrade to Stylo with user-select property enabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7312,7 +7312,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.37.0"
-source = "git+https://github.com/servo/stylo?rev=bfa746c957ce12bf12936e118b78a806d9ae0d66#bfa746c957ce12bf12936e118b78a806d9ae0d66"
+source = "git+https://github.com/servo/stylo?rev=fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe#fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe"
 dependencies = [
  "bitflags 2.11.1",
  "cssparser",
@@ -9016,7 +9016,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=bfa746c957ce12bf12936e118b78a806d9ae0d66#bfa746c957ce12bf12936e118b78a806d9ae0d66"
+source = "git+https://github.com/servo/stylo?rev=fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe#fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -9443,7 +9443,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.16.0"
-source = "git+https://github.com/servo/stylo?rev=bfa746c957ce12bf12936e118b78a806d9ae0d66#bfa746c957ce12bf12936e118b78a806d9ae0d66"
+source = "git+https://github.com/servo/stylo?rev=fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe#fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -9499,7 +9499,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.16.0"
-source = "git+https://github.com/servo/stylo?rev=bfa746c957ce12bf12936e118b78a806d9ae0d66#bfa746c957ce12bf12936e118b78a806d9ae0d66"
+source = "git+https://github.com/servo/stylo?rev=fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe#fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -9508,7 +9508,7 @@ dependencies = [
 [[package]]
 name = "stylo_derive"
 version = "0.16.0"
-source = "git+https://github.com/servo/stylo?rev=bfa746c957ce12bf12936e118b78a806d9ae0d66#bfa746c957ce12bf12936e118b78a806d9ae0d66"
+source = "git+https://github.com/servo/stylo?rev=fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe#fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -9520,7 +9520,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.16.0"
-source = "git+https://github.com/servo/stylo?rev=bfa746c957ce12bf12936e118b78a806d9ae0d66#bfa746c957ce12bf12936e118b78a806d9ae0d66"
+source = "git+https://github.com/servo/stylo?rev=fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe#fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe"
 dependencies = [
  "bitflags 2.11.1",
  "stylo_malloc_size_of",
@@ -9529,7 +9529,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.16.0"
-source = "git+https://github.com/servo/stylo?rev=bfa746c957ce12bf12936e118b78a806d9ae0d66#bfa746c957ce12bf12936e118b78a806d9ae0d66"
+source = "git+https://github.com/servo/stylo?rev=fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe#fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe"
 dependencies = [
  "app_units",
  "cssparser",
@@ -9546,12 +9546,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.16.0"
-source = "git+https://github.com/servo/stylo?rev=bfa746c957ce12bf12936e118b78a806d9ae0d66#bfa746c957ce12bf12936e118b78a806d9ae0d66"
+source = "git+https://github.com/servo/stylo?rev=fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe#fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe"
 
 [[package]]
 name = "stylo_traits"
 version = "0.16.0"
-source = "git+https://github.com/servo/stylo?rev=bfa746c957ce12bf12936e118b78a806d9ae0d66#bfa746c957ce12bf12936e118b78a806d9ae0d66"
+source = "git+https://github.com/servo/stylo?rev=fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe#fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe"
 dependencies = [
  "app_units",
  "bitflags 2.11.1",
@@ -9973,7 +9973,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?rev=bfa746c957ce12bf12936e118b78a806d9ae0d66#bfa746c957ce12bf12936e118b78a806d9ae0d66"
+source = "git+https://github.com/servo/stylo?rev=fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe#fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -9986,7 +9986,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=bfa746c957ce12bf12936e118b78a806d9ae0d66#bfa746c957ce12bf12936e118b78a806d9ae0d66"
+source = "git+https://github.com/servo/stylo?rev=fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe#fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,12 +166,12 @@ rustls-platform-verifier = "0.7.0"
 sea-query = { version = "=1.0.0-rc.31", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = { version = "=0.8.0-rc.15" }
 sec1 = "0.7"
-selectors = { git = "https://github.com/servo/stylo", rev = "bfa746c957ce12bf12936e118b78a806d9ae0d66" }
+selectors = { git = "https://github.com/servo/stylo", rev = "fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe" }
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
 serde_json = "1.0"
-servo_arc = { git = "https://github.com/servo/stylo", rev = "bfa746c957ce12bf12936e118b78a806d9ae0d66" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe" }
 sha1 = "0.10"
 sha2 = "0.10"
 sha3 = "0.10"
@@ -180,12 +180,12 @@ skrifa = "0.37.0"
 smallvec = { version = "1.15", features = ["serde", "union"] }
 string_cache = "0.9"
 strum = { version = "0.28", features = ["derive"] }
-stylo = { git = "https://github.com/servo/stylo", rev = "bfa746c957ce12bf12936e118b78a806d9ae0d66" }
-stylo_atoms = { git = "https://github.com/servo/stylo", rev = "bfa746c957ce12bf12936e118b78a806d9ae0d66" }
-stylo_dom = { git = "https://github.com/servo/stylo", rev = "bfa746c957ce12bf12936e118b78a806d9ae0d66" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "bfa746c957ce12bf12936e118b78a806d9ae0d66" }
-stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "bfa746c957ce12bf12936e118b78a806d9ae0d66" }
-stylo_traits = { git = "https://github.com/servo/stylo", rev = "bfa746c957ce12bf12936e118b78a806d9ae0d66" }
+stylo = { git = "https://github.com/servo/stylo", rev = "fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe" }
+stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe" }
 surfman = { version = "0.12.0", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"


### PR DESCRIPTION
Upgrades Stylo to latest main which includes https://github.com/servo/stylo/pull/356

`user-select` is now compiled, but still disabled behind a runtime preference.

Testing: No expected behaviour changes, so covered by existing tests
