### PR TITLE
script_bindings: Port `call_setup` to use `&mut JSContext`

### DIFF
--- a/components/script/dom/audio/baseaudiocontext.rs
+++ b/components/script/dom/audio/baseaudiocontext.rs
@@ -549,7 +549,7 @@ impl BaseAudioContextMethods<crate::DomTypeHolder> for BaseAudioContext {
                         assert!(resolvers.contains_key(&uuid_));
                         let resolver = resolvers.remove(&uuid_).unwrap();
                         if let Some(callback) = resolver.success_callback {
-                            let _ = callback.Call__(&buffer, ExceptionHandling::Report, CanGc::from_cx(cx));
+                            let _ = callback.Call__(cx, &buffer, ExceptionHandling::Report);
                         }
                         resolver.promise.resolve_native(&buffer, CanGc::from_cx(cx));
                     }));
@@ -561,9 +561,12 @@ impl BaseAudioContextMethods<crate::DomTypeHolder> for BaseAudioContext {
                         assert!(resolvers.contains_key(&uuid));
                         let resolver = resolvers.remove(&uuid).unwrap();
                         if let Some(callback) = resolver.error_callback {
-                            let _ = callback.Call__(
-                                &DOMException::new(&this.global(), DOMErrorName::DataCloneError, CanGc::from_cx(cx)),
-                                ExceptionHandling::Report, CanGc::from_cx(cx));
+                            let exception = DOMException::new(
+                                &this.global(),
+                                DOMErrorName::DataCloneError,
+                                CanGc::from_cx(cx)
+                            );
+                            let _ = callback.Call__(cx, &exception, ExceptionHandling::Report);
                         }
                         let error = cformat!("Audio decode error {:?}", error);
                         resolver.promise.reject_error(Error::Type(error), CanGc::from_cx(cx));

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -1093,11 +1093,11 @@ impl CustomElementReaction {
                 let arguments = arguments.iter().map(|arg| arg.as_handle_value()).collect();
                 rooted!(&in(cx) let mut value: JSVal);
                 let _ = callback.Call_(
+                    cx,
                     element,
                     arguments,
                     value.handle_mut(),
                     ExceptionHandling::Report,
-                    CanGc::from_cx(cx),
                 );
             },
         }

--- a/components/script/dom/datatransfer/datatransferitem.rs
+++ b/components/script/dom/datatransfer/datatransferitem.rs
@@ -20,7 +20,6 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::file::File;
 use crate::dom::globalscope::GlobalScope;
 use crate::drag_data_store::{DragDataStore, Kind, Mode};
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct DataTransferItem {
@@ -127,7 +126,7 @@ impl DataTransferItemMethods<crate::DomTypeHolder> for DataTransferItem {
                     let maybe_index = this.root().pending_callbacks.borrow().iter().position(|val| val.id == id);
                     if let Some(index) = maybe_index {
                         let callback = this.root().pending_callbacks.borrow_mut().swap_remove(index).callback;
-                        let _ = callback.Call__(DOMString::from(string), ExceptionHandling::Report, CanGc::from_cx(cx));
+                        let _ = callback.Call__(cx, DOMString::from(string), ExceptionHandling::Report);
                     }
                 }));
         }

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -28,6 +28,7 @@ use encoding_rs::{Encoding, UTF_8};
 use fonts::WebFontDocumentContext;
 use html5ever::{LocalName, Namespace, QualName, local_name, ns};
 use hyper_serde::Serde;
+use js::realm::CurrentRealm;
 use js::rust::{HandleObject, HandleValue, MutableHandleValue};
 use layout_api::{
     PendingRestyle, ReflowGoal, ReflowPhasesRun, ReflowStatistics, RestyleReason,
@@ -196,7 +197,6 @@ use crate::image_animation::ImageAnimationManager;
 use crate::mime::{APPLICATION, CHARSET};
 use crate::navigation::navigate;
 use crate::network_listener::{FetchResponseListener, NetworkListener};
-use crate::realms::enter_realm;
 use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 use crate::stylesheet_set::StylesheetSetRef;
@@ -1687,9 +1687,7 @@ impl Document {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#run-the-animation-frame-callbacks>
-    pub(crate) fn run_the_animation_frame_callbacks(&self, can_gc: CanGc) {
-        let _realm = enter_realm(self);
-
+    pub(crate) fn run_the_animation_frame_callbacks(&self, cx: &mut CurrentRealm) {
         self.running_animation_callbacks.set(true);
         let timing = self.global().performance().Now();
 
@@ -1697,7 +1695,7 @@ impl Document {
         for _ in 0..num_callbacks {
             let (_, maybe_callback) = self.animation_frame_list.borrow_mut().pop_front().unwrap();
             if let Some(callback) = maybe_callback {
-                callback.call(self, *timing, can_gc);
+                callback.call(cx, self, *timing);
             }
         }
         self.running_animation_callbacks.set(false);
@@ -3024,7 +3022,7 @@ impl Document {
     #[expect(clippy::redundant_iter_cloned)]
     pub(crate) fn broadcast_active_resize_observations(
         &self,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) -> ResizeObservationDepth {
         let mut shallowest = ResizeObservationDepth::max();
         // Breaking potential re-borrow cycle on `resize_observers`:
@@ -3038,7 +3036,7 @@ impl Document {
             .map(|obs| DomRoot::from_ref(&*obs))
             .collect();
         for observer in iterator {
-            observer.broadcast_active_resize_observations(&mut shallowest, can_gc);
+            observer.broadcast_active_resize_observations(cx, &mut shallowest);
         }
         shallowest
     }
@@ -3167,7 +3165,7 @@ impl Document {
     }
 
     /// <https://w3c.github.io/IntersectionObserver/#notify-intersection-observers-algo>
-    pub(crate) fn notify_intersection_observers(&self, can_gc: CanGc) {
+    pub(crate) fn notify_intersection_observers(&self, cx: &mut js::context::JSContext) {
         // Step 1
         // > Set document’s IntersectionObserverTaskQueued flag to false.
         self.intersection_observer_task_queued.set(false);
@@ -3182,7 +3180,7 @@ impl Document {
         // > For each IntersectionObserver object observer in notify list, run these steps:
         for intersection_observer in notify_list.iter() {
             // Step 3.1-3.5
-            intersection_observer.invoke_callback_if_necessary(can_gc);
+            intersection_observer.invoke_callback_if_necessary(cx);
         }
     }
 
@@ -3206,7 +3204,7 @@ impl Document {
             .task_manager()
             .intersection_observer_task_source()
             .queue(task!(notify_intersection_observers: move |cx| {
-                document.root().notify_intersection_observers(CanGc::from_cx(cx));
+                document.root().notify_intersection_observers(cx);
             }));
     }
 
@@ -4347,7 +4345,7 @@ impl Document {
     }
 
     /// An implementation of <https://drafts.csswg.org/web-animations-1/#update-animations-and-send-events>.
-    pub(crate) fn update_animations_and_send_events(&self, cx: &mut js::context::JSContext) {
+    pub(crate) fn update_animations_and_send_events(&self, cx: &mut CurrentRealm) {
         // Only update the time if it isn't being managed by a test.
         if !self.layout_animations_test_enabled {
             self.timeline.update(self.window());
@@ -4368,7 +4366,6 @@ impl Document {
         self.window().perform_a_microtask_checkpoint(cx);
 
         // Steps 4 through 7 occur inside `send_pending_events().`
-        let _realm = enter_realm(self);
         self.animations().send_pending_events(self.window(), cx);
     }
 
@@ -6338,7 +6335,7 @@ pub(crate) enum AnimationFrameCallback {
 }
 
 impl AnimationFrameCallback {
-    fn call(&self, document: &Document, now: f64, can_gc: CanGc) {
+    fn call(&self, cx: &mut js::context::JSContext, document: &Document, now: f64) {
         match *self {
             AnimationFrameCallback::DevtoolsFramerateTick { ref actor_name } => {
                 let msg = ScriptToDevtoolsControlMsg::FramerateTick(actor_name.clone(), now);
@@ -6348,7 +6345,7 @@ impl AnimationFrameCallback {
             AnimationFrameCallback::FrameRequestCallback { ref callback } => {
                 // TODO(jdm): The spec says that any exceptions should be suppressed:
                 // https://github.com/servo/servo/issues/6928
-                let _ = callback.Call__(Finite::wrap(now), ExceptionHandling::Report, can_gc);
+                let _ = callback.Call__(cx, Finite::wrap(now), ExceptionHandling::Report);
             },
         }
     }

--- a/components/script/dom/event/event.rs
+++ b/components/script/dom/event/event.rs
@@ -9,6 +9,7 @@ use bitflags::bitflags;
 use devtools_traits::{TimelineMarker, TimelineMarkerType};
 use dom_struct::dom_struct;
 use embedder_traits::InputEventResult;
+use js::context::JSContext;
 use js::rust::HandleObject;
 use keyboard_types::{Key, NamedKey};
 use script_bindings::codegen::GenericBindings::PointerEventBinding::PointerEventMethods;
@@ -308,15 +309,15 @@ impl Event {
         )
     }
 
+    #[expect(unsafe_code)]
     fn dispatch_inner(
         &self,
         target: &EventTarget,
         legacy_target_override: bool,
         legacy_output_did_listeners_throw: Option<&Cell<bool>>,
-        can_gc: CanGc,
+        _can_gc: CanGc,
     ) -> bool {
         // TODO https://github.com/servo/servo/issues/44499
-        #[allow(unsafe_code)]
         let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
         let cx = &mut cx;
 
@@ -590,13 +591,13 @@ impl Event {
 
                 // Step 6.13.3. Invoke with struct, event, "capturing", and legacyOutputDidListenersThrowFlag if given.
                 invoke(
+                    cx,
                     segment,
                     index,
                     self,
                     ListenerPhase::Capturing,
                     timeline_window.as_deref(),
                     legacy_output_did_listeners_throw,
-                    can_gc,
                 )
             }
 
@@ -620,13 +621,13 @@ impl Event {
 
                 // Step 6.14.3. Invoke with struct, event, "bubbling", and legacyOutputDidListenersThrowFlag if given.
                 invoke(
+                    cx,
                     segment,
                     index,
                     self,
                     ListenerPhase::Bubbling,
                     timeline_window.as_deref(),
                     legacy_output_did_listeners_throw,
-                    can_gc,
                 );
             }
         }
@@ -1241,7 +1242,7 @@ pub(crate) struct EventTask {
 }
 
 impl TaskOnce for EventTask {
-    fn run_once(self, cx: &mut js::context::JSContext) {
+    fn run_once(self, cx: &mut JSContext) {
         let target = self.target.root();
         let bubbles = self.bubbles;
         let cancelable = self.cancelable;
@@ -1262,7 +1263,7 @@ pub(crate) struct SimpleEventTask {
 }
 
 impl TaskOnce for SimpleEventTask {
-    fn run_once(self, cx: &mut js::context::JSContext) {
+    fn run_once(self, cx: &mut JSContext) {
         let target = self.target.root();
         target.fire_event(cx, self.name);
     }
@@ -1270,13 +1271,13 @@ impl TaskOnce for SimpleEventTask {
 
 /// <https://dom.spec.whatwg.org/#concept-event-listener-invoke>
 fn invoke(
+    cx: &mut JSContext,
     segment: &EventPathSegment,
     segment_index_in_path: usize,
     event: &Event,
     phase: ListenerPhase,
     timeline_window: Option<&Window>,
     legacy_output_did_listeners_throw: Option<&Cell<bool>>,
-    can_gc: CanGc,
 ) {
     // Step 1. Set event’s target to the shadow-adjusted target of the last struct in event’s path,
     // that is either struct or preceding struct, whose shadow-adjusted target is non-null.
@@ -1311,13 +1312,13 @@ fn invoke(
     // Step 8. Let found be the result of running inner invoke with event, listeners, phase,
     // invocationTargetInShadowTree, and legacyOutputDidListenersThrowFlag if given.
     let found = inner_invoke(
+        cx,
         event,
         &listeners,
         phase,
         invocation_target_in_shadow_tree,
         timeline_window,
         legacy_output_did_listeners_throw,
-        can_gc,
     );
 
     // Step 9. If found is false and event’s isTrusted attribute is true:
@@ -1341,13 +1342,13 @@ fn invoke(
         // Step 9.3 Inner invoke with event, listeners, phase, invocationTargetInShadowTree,
         // and legacyOutputDidListenersThrowFlag if given.
         inner_invoke(
+            cx,
             event,
             &listeners,
             phase,
             invocation_target_in_shadow_tree,
             timeline_window,
             legacy_output_did_listeners_throw,
-            can_gc,
         );
 
         // Step 9.4 Set event’s type attribute value to originalEventType.
@@ -1357,13 +1358,13 @@ fn invoke(
 
 /// <https://dom.spec.whatwg.org/#concept-event-listener-inner-invoke>
 fn inner_invoke(
+    cx: &mut JSContext,
     event: &Event,
     listeners: &EventListeners,
     phase: ListenerPhase,
     invocation_target_in_shadow_tree: bool,
     timeline_window: Option<&Window>,
     legacy_output_did_listeners_throw: Option<&Cell<bool>>,
-    can_gc: CanGc,
 ) -> bool {
     // Step 1. Let found be false.
     let mut found = false;
@@ -1395,11 +1396,11 @@ fn inner_invoke(
             event_target.remove_listener(&event.type_(), listener);
         }
 
-        let Some(compiled_listener) =
-            listener
-                .borrow()
-                .get_compiled_listener(&event_target, &event.type_(), can_gc)
-        else {
+        let Some(compiled_listener) = listener.borrow().get_compiled_listener(
+            &event_target,
+            &event.type_(),
+            CanGc::from_cx(cx),
+        ) else {
             continue;
         };
 
@@ -1431,7 +1432,7 @@ fn inner_invoke(
         //     Step 2.10.2 Set legacyOutputDidListenersThrowFlag if given.
         let marker = TimelineMarker::start("DOMEvent".to_owned());
         if compiled_listener
-            .call_or_handle_event(&event_target, event, ExceptionHandling::Report, can_gc)
+            .call_or_handle_event(cx, &event_target, event, ExceptionHandling::Report)
             .is_err()
         {
             if let Some(flag) = legacy_output_did_listeners_throw {

--- a/components/script/dom/event/eventtarget.rs
+++ b/components/script/dom/event/eventtarget.rs
@@ -207,26 +207,26 @@ impl CompiledEventListener {
     // https://html.spec.whatwg.org/multipage/#the-event-handler-processing-algorithm
     pub(crate) fn call_or_handle_event(
         &self,
+        cx: &mut JSContext,
         object: &EventTarget,
         event: &Event,
         exception_handle: ExceptionHandling,
-        can_gc: CanGc,
     ) -> Fallible<()> {
         // Step 3
         match *self {
             CompiledEventListener::Listener(ref listener) => {
-                listener.HandleEvent_(object, event, exception_handle, can_gc)
+                listener.HandleEvent_(cx, object, event, exception_handle)
             },
             CompiledEventListener::Handler(ref handler) => {
                 match *handler {
                     CommonEventHandler::ErrorEventHandler(ref handler) => {
                         if let Some(event) = event.downcast::<ErrorEvent>() {
                             if object.is::<Window>() || object.is::<WorkerGlobalScope>() {
-                                let cx = GlobalScope::get_cx();
-                                rooted!(in(*cx) let mut error: JSVal);
-                                event.Error(cx, error.handle_mut());
-                                rooted!(in(*cx) let mut rooted_return_value: JSVal);
+                                rooted!(&in(cx) let mut error: JSVal);
+                                event.Error(cx.into(), error.handle_mut());
+                                rooted!(&in(cx) let mut rooted_return_value: JSVal);
                                 let return_value = handler.Call_(
+                                    cx,
                                     object,
                                     EventOrString::String(event.Message()),
                                     Some(event.Filename()),
@@ -235,7 +235,6 @@ impl CompiledEventListener {
                                     Some(error.handle()),
                                     rooted_return_value.handle_mut(),
                                     exception_handle,
-                                    can_gc,
                                 );
                                 // Step 4
                                 if let Ok(()) = return_value {
@@ -249,8 +248,9 @@ impl CompiledEventListener {
                             }
                         }
 
-                        rooted!(in(*GlobalScope::get_cx()) let mut rooted_return_value: JSVal);
+                        rooted!(&in(cx) let mut rooted_return_value: JSVal);
                         handler.Call_(
+                            cx,
                             object,
                             EventOrString::Event(DomRoot::from_ref(event)),
                             None,
@@ -259,7 +259,6 @@ impl CompiledEventListener {
                             None,
                             rooted_return_value.handle_mut(),
                             exception_handle,
-                            can_gc,
                         )
                     },
 
@@ -267,10 +266,10 @@ impl CompiledEventListener {
                         if let Some(event) = event.downcast::<BeforeUnloadEvent>() {
                             // Step 5
                             match handler.Call_(
+                                cx,
                                 object,
                                 event.upcast::<Event>(),
                                 exception_handle,
-                                can_gc,
                             ) {
                                 Ok(value) => {
                                     let rv = event.ReturnValue();
@@ -287,20 +286,19 @@ impl CompiledEventListener {
                         } else {
                             // Step 5, "Otherwise" clause
                             handler
-                                .Call_(object, event.upcast::<Event>(), exception_handle, can_gc)
+                                .Call_(cx, object, event.upcast::<Event>(), exception_handle)
                                 .map(|_| ())
                         }
                     },
 
                     CommonEventHandler::EventHandler(ref handler) => {
-                        let cx = GlobalScope::get_cx();
-                        rooted!(in(*cx) let mut rooted_return_value: JSVal);
+                        rooted!(&in(cx) let mut rooted_return_value: JSVal);
                         match handler.Call_(
+                            cx,
                             object,
                             event,
                             rooted_return_value.handle_mut(),
                             exception_handle,
-                            can_gc,
                         ) {
                             Ok(()) => {
                                 let value = rooted_return_value.handle();

--- a/components/script/dom/geolocation/geolocation.rs
+++ b/components/script/dom/geolocation/geolocation.rs
@@ -5,6 +5,7 @@ use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::gc::HandleValue;
 use js::jsapi::IsCallable;
 use rustc_hash::FxHashSet;
@@ -75,11 +76,11 @@ impl Geolocation {
     /// <https://www.w3.org/TR/geolocation/#dfn-request-a-position>
     fn request_position(
         &self,
+        cx: &mut JSContext,
         _success_callback: Rc<PositionCallback<DomTypeHolder>>,
         error_callback: Option<Rc<PositionErrorCallback<DomTypeHolder>>>,
         _options: &PositionOptions,
         watch_id: Option<u32>,
-        can_gc: CanGc,
     ) -> Fallible<()> {
         // Step 1. Let watchIDs be geolocation's [[watchIDs]].
         // Step 2. Let document be the geolocation's relevant global object's associated Document.
@@ -92,16 +93,12 @@ impl Geolocation {
             }
             // Step 3.2. Call back with error passing errorCallback and PERMISSION_DENIED.
             if let Some(error_callback) = error_callback {
-                error_callback.Call_(
-                    self,
-                    &GeolocationPositionError::permission_denied(
-                        &self.global(),
-                        DOMString::from("User denied Geolocation".to_string()),
-                        can_gc,
-                    ),
-                    ExceptionHandling::Report,
-                    can_gc,
-                )?;
+                let position_error = GeolocationPositionError::permission_denied(
+                    &self.global(),
+                    DOMString::from("User denied Geolocation".to_string()),
+                    CanGc::from_cx(cx),
+                );
+                error_callback.Call_(cx, self, &position_error, ExceptionHandling::Report)?;
             }
             // Step 3.3 Terminate this algorithm.
             return Ok(());
@@ -114,16 +111,12 @@ impl Geolocation {
             }
             // Step 4.2. Call back with error passing errorCallback and PERMISSION_DENIED.
             if let Some(error_callback) = error_callback {
-                error_callback.Call_(
-                    self,
-                    &GeolocationPositionError::permission_denied(
-                        &self.global(),
-                        DOMString::from("Insecure context for Geolocation".to_string()),
-                        can_gc,
-                    ),
-                    ExceptionHandling::Report,
-                    can_gc,
-                )?;
+                let position_error = GeolocationPositionError::permission_denied(
+                    &self.global(),
+                    DOMString::from("Insecure context for Geolocation".to_string()),
+                    CanGc::from_cx(cx),
+                );
+                error_callback.Call_(cx, self, &position_error, ExceptionHandling::Report)?;
             }
             // Step 4.3 Terminate this algorithm.
             return Ok(());
@@ -139,59 +132,49 @@ impl GeolocationMethods<DomTypeHolder> for Geolocation {
     /// <https://www.w3.org/TR/geolocation/#dom-geolocation-getcurrentposition>
     fn GetCurrentPosition(
         &self,
-        context: SafeJSContext,
+        cx: &mut JSContext,
         success_callback: Rc<PositionCallback<DomTypeHolder>>,
         error_callback: HandleValue,
         options: &PositionOptions,
-        can_gc: CanGc,
     ) -> Fallible<()> {
-        let error_callback = cast_error_callback(context, error_callback)?;
+        let error_callback = cast_error_callback(cx.into(), error_callback)?;
         // Step 1. If this's relevant global object's associated Document is not fully active:
         if !self.global().as_window().Document().is_active() {
             // Step 1.1 Call back with error errorCallback and POSITION_UNAVAILABLE.
             if let Some(error_callback) = error_callback {
-                error_callback.Call_(
-                    self,
-                    &GeolocationPositionError::position_unavailable(
-                        &self.global(),
-                        DOMString::from("Document is not fully active".to_string()),
-                        can_gc,
-                    ),
-                    ExceptionHandling::Report,
-                    can_gc,
-                )?;
+                let position_error = GeolocationPositionError::position_unavailable(
+                    &self.global(),
+                    DOMString::from("Document is not fully active".to_string()),
+                    CanGc::from_cx(cx),
+                );
+                error_callback.Call_(cx, self, &position_error, ExceptionHandling::Report)?;
             }
             // Step 1.2 Terminate this algorithm.
             return Ok(());
         }
         // Step 2. Request a position passing this, successCallback, errorCallback, and options.
-        self.request_position(success_callback, error_callback, options, None, can_gc)
+        self.request_position(cx, success_callback, error_callback, options, None)
     }
 
     /// <https://www.w3.org/TR/geolocation/#watchposition-method>
     fn WatchPosition(
         &self,
-        context: SafeJSContext,
+        cx: &mut JSContext,
         success_callback: Rc<PositionCallback<DomTypeHolder>>,
         error_callback: HandleValue,
         options: &PositionOptions,
-        can_gc: CanGc,
     ) -> Fallible<i32> {
-        let error_callback = cast_error_callback(context, error_callback)?;
+        let error_callback = cast_error_callback(cx.into(), error_callback)?;
         // Step 1. If this's relevant global object's associated Document is not fully active:
         if !self.global().as_window().Document().is_active() {
             // Step 1.1 Call back with error errorCallback and POSITION_UNAVAILABLE.
             if let Some(error_callback) = error_callback {
-                error_callback.Call_(
-                    self,
-                    &GeolocationPositionError::position_unavailable(
-                        &self.global(),
-                        DOMString::from("Document is not fully active".to_string()),
-                        can_gc,
-                    ),
-                    ExceptionHandling::Report,
-                    can_gc,
-                )?;
+                let position_error = GeolocationPositionError::position_unavailable(
+                    &self.global(),
+                    DOMString::from("Document is not fully active".to_string()),
+                    CanGc::from_cx(cx),
+                );
+                error_callback.Call_(cx, self, &position_error, ExceptionHandling::Report)?;
             }
             // Step 1.2 Return 0.
             return Ok(0);
@@ -203,11 +186,11 @@ impl GeolocationMethods<DomTypeHolder> for Geolocation {
         self.watch_ids.borrow_mut().insert(watch_id);
         // Step 4. Request a position passing this, successCallback, errorCallback, options, and watchId.
         self.request_position(
+            cx,
             success_callback,
             error_callback,
             options,
             Some(watch_id),
-            can_gc,
         )?;
         // Step 5. Return watchId.
         Ok(watch_id as i32)

--- a/components/script/dom/html/htmlcanvaselement.rs
+++ b/components/script/dom/html/htmlcanvaselement.rs
@@ -594,7 +594,7 @@ impl HTMLCanvasElementMethods<crate::DomTypeHolder> for HTMLCanvasElement {
                 };
 
                 let Some(mut snapshot) = result else {
-                    let _ = callback.Call__(None, ExceptionHandling::Report, CanGc::from_cx(cx));
+                    let _ = callback.Call__(cx, None, ExceptionHandling::Report);
                     return;
                 };
 
@@ -618,7 +618,7 @@ impl HTMLCanvasElementMethods<crate::DomTypeHolder> for HTMLCanvasElement {
                 };
 
                 // Step 4.2.2: Invoke callback with « result » and "report".
-                let _ = callback.Call__(result, ExceptionHandling::Report, CanGc::from_cx(cx));
+                let _ = callback.Call__(cx, result, ExceptionHandling::Report);
             }));
 
         Ok(())

--- a/components/script/dom/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver.rs
@@ -365,7 +365,7 @@ impl IntersectionObserver {
     }
 
     /// Step 3.1-3.5 of <https://w3c.github.io/IntersectionObserver/#notify-intersection-observers-algo>
-    pub(crate) fn invoke_callback_if_necessary(&self, can_gc: CanGc) {
+    pub(crate) fn invoke_callback_if_necessary(&self, cx: &mut js::context::JSContext) {
         // Step 1
         // > If observer’s internal [[QueuedEntries]] slot is empty, continue.
         if self.queued_entries.borrow().is_empty() {
@@ -382,13 +382,9 @@ impl IntersectionObserver {
             .collect();
 
         // Step 4-5
-        let _ = self.callback.Call_(
-            self,
-            queued_entries,
-            self,
-            ExceptionHandling::Report,
-            can_gc,
-        );
+        let _ = self
+            .callback
+            .Call_(cx, self, queued_entries, self, ExceptionHandling::Report);
     }
 
     /// Connect the observer itself into owner doc if it is unconnected.

--- a/components/script/dom/media/mediasession.rs
+++ b/components/script/dom/media/mediasession.rs
@@ -80,10 +80,7 @@ impl MediaSession {
         debug!("Handle media session action {:?}", action);
 
         if let Some(handler) = self.action_handlers.borrow().get(&action) {
-            if handler
-                .Call__(ExceptionHandling::Report, CanGc::from_cx(cx))
-                .is_err()
-            {
+            if handler.Call__(cx, ExceptionHandling::Report).is_err() {
                 warn!("Error calling MediaSessionActionHandler callback");
             }
             return;

--- a/components/script/dom/node/nodeiterator.rs
+++ b/components/script/dom/node/nodeiterator.rs
@@ -217,7 +217,7 @@ impl NodeIterator {
                 // Step 5.
                 self.active.set(true);
                 // Step 6.
-                let result = callback.AcceptNode_(self, node, Rethrow, CanGc::from_cx(cx));
+                let result = callback.AcceptNode_(cx, self, node, Rethrow);
                 // Step 7.
                 self.active.set(false);
                 // Step 8.

--- a/components/script/dom/notification.rs
+++ b/components/script/dom/notification.rs
@@ -427,7 +427,7 @@ impl NotificationMethods<crate::DomTypeHolder> for Notification {
                 // Step 3.2.1: If deprecatedCallback is given,
                 //             then invoke deprecatedCallback with « permissionState » and "report".
                 if let Some(callback) = global.remove_notification_permission_request_callback(uuid_) {
-                    let _ = callback.Call__(notification_permission, ExceptionHandling::Report, CanGc::from_cx(cx));
+                    let _ = callback.Call__(cx, notification_permission, ExceptionHandling::Report);
                 }
 
                 // Step 3.2.2: Resolve promise with permissionState.

--- a/components/script/dom/performance/performance.rs
+++ b/components/script/dom/performance/performance.rs
@@ -260,8 +260,8 @@ impl Performance {
                 self.global()
                     .task_manager()
                     .performance_timeline_task_source()
-                    .queue(task!(notify_performance_observers: move || {
-                        owner.root().notify_observers();
+                    .queue(task!(notify_performance_observers: move |cx| {
+                        owner.root().notify_observers(cx);
                     }));
             }
         }
@@ -345,8 +345,8 @@ impl Performance {
         self.global()
             .task_manager()
             .performance_timeline_task_source()
-            .queue(task!(notify_performance_observers: move || {
-                owner.root().notify_observers();
+            .queue(task!(notify_performance_observers: move |cx| {
+                owner.root().notify_observers(cx);
             }));
 
         Some(entry_last_index)
@@ -356,7 +356,7 @@ impl Performance {
     ///
     /// Algorithm spec (step 7):
     /// <https://w3c.github.io/performance-timeline/#queue-a-performanceentry>
-    pub(crate) fn notify_observers(&self) {
+    fn notify_observers(&self, cx: &mut JSContext) {
         // Step 7.1.
         self.pending_notification_observers_task.set(false);
 
@@ -374,7 +374,7 @@ impl Performance {
 
         // Step 7.3.
         for o in observers.iter() {
-            o.notify(CanGc::deprecated_note());
+            o.notify(cx);
         }
     }
 

--- a/components/script/dom/performance/performanceobserver.rs
+++ b/components/script/dom/performance/performanceobserver.rs
@@ -81,20 +81,20 @@ impl PerformanceObserver {
 
     /// Trigger performance observer callback with the list of performance entries
     /// buffered since the last callback call.
-    pub(crate) fn notify(&self, can_gc: CanGc) {
+    pub(crate) fn notify(&self, cx: &mut js::context::JSContext) {
         if self.entries.borrow().is_empty() {
             return;
         }
         let entry_list = PerformanceEntryList::new(self.entries.borrow_mut().drain(..).collect());
         let observer_entry_list =
-            PerformanceObserverEntryList::new(&self.global(), entry_list, can_gc);
+            PerformanceObserverEntryList::new(&self.global(), entry_list, CanGc::from_cx(cx));
         // using self both as thisArg and as the second formal argument
         let _ = self.callback.Call_(
+            cx,
             self,
             &observer_entry_list,
             self,
             ExceptionHandling::Report,
-            can_gc,
         );
     }
 

--- a/components/script/dom/reporting/reportingobserver.rs
+++ b/components/script/dom/reporting/reportingobserver.rs
@@ -7,6 +7,7 @@ use std::rc::Rc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::match_domstring_ascii;
 use script_bindings::str::DOMString;
@@ -108,8 +109,9 @@ impl ReportingObserver {
             // with a copy of global’s registered reporting observer list.
             let observers_global = Trusted::new(&*global);
             global.task_manager().dom_manipulation_task_source().queue(
-                task!(notify_reporting_observers: move || {
+                task!(notify_reporting_observers: move |cx| {
                     Self::invoke_reporting_observers_with_notify_list(
+                        cx,
                         observers_global.root().registered_reporting_observers()
                     );
                 }),
@@ -134,7 +136,10 @@ impl ReportingObserver {
     }
 
     /// <https://w3c.github.io/reporting/#invoke-observers>
-    fn invoke_reporting_observers_with_notify_list(notify_list: Vec<DomRoot<ReportingObserver>>) {
+    fn invoke_reporting_observers_with_notify_list(
+        cx: &mut JSContext,
+        notify_list: Vec<DomRoot<ReportingObserver>>,
+    ) {
         // Step 1. For each ReportingObserver observer in notify list:
         for observer in notify_list.iter() {
             // Step 1.1. If observer’s report queue is empty, then continue.
@@ -147,11 +152,11 @@ impl ReportingObserver {
             // Step 1.4. Invoke observer’s callback with « reports, observer » and "report",
             // and with observer as the callback this value.
             let _ = observer.callback.Call_(
+                cx,
                 &**observer,
                 reports,
                 observer,
                 ExceptionHandling::Report,
-                CanGc::deprecated_note(),
             );
         }
     }

--- a/components/script/dom/resizeobserver/resizeobserver.rs
+++ b/components/script/dom/resizeobserver/resizeobserver.rs
@@ -9,6 +9,7 @@ use dom_struct::dom_struct;
 use euclid::num::Zero;
 use euclid::{Rect, Size2D};
 use html5ever::ns;
+use js::context::JSContext;
 use js::rust::HandleObject;
 use layout_api::BoxAreaType;
 use style_traits::CSSPixel;
@@ -115,8 +116,8 @@ impl ResizeObserver {
     /// Step 2 of <https://drafts.csswg.org/resize-observer/#broadcast-active-resize-observations>
     pub(crate) fn broadcast_active_resize_observations(
         &self,
+        cx: &mut JSContext,
         shallowest_target_depth: &mut ResizeObservationDepth,
-        can_gc: CanGc,
     ) {
         // Step 2.1 If observer.[[activeTargets]] slot is empty, continue.
         // NOTE: Due to the way we implement the activeTarges internal slot we can't easily
@@ -135,8 +136,12 @@ impl ResizeObserver {
             has_active_observation_targets = true;
 
             let window = target.owner_window();
-            let entry =
-                create_and_populate_a_resizeobserverentry(&window, target, observation, can_gc);
+            let entry = create_and_populate_a_resizeobserverentry(
+                &window,
+                target,
+                observation,
+                CanGc::from_cx(cx),
+            );
             entries.push(entry);
             observation.state = ObservationState::Done;
 
@@ -153,7 +158,7 @@ impl ResizeObserver {
         // Step 2.4 Invoke observer.[[callback]] with entries.
         let _ = self
             .callback
-            .Call_(self, entries, self, ExceptionHandling::Report, can_gc);
+            .Call_(cx, self, entries, self, ExceptionHandling::Report);
 
         // Step 2.5 Clear observer.[[activeTargets]].
         // NOTE: The observation state was modified in Step 2.2

--- a/components/script/dom/stream/readablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/readablestreamdefaultcontroller.rs
@@ -675,8 +675,7 @@ impl ReadableStreamDefaultController {
             let size = if let Some(strategy_size) = strategy_size {
                 // Note: the Rethrow exception handling is necessary,
                 // otherwise returning JSFailed will panic because no exception is pending.
-                let result =
-                    strategy_size.Call__(chunk, ExceptionHandling::Rethrow, CanGc::from_cx(cx));
+                let result = strategy_size.Call__(cx, chunk, ExceptionHandling::Rethrow);
                 match result {
                     // Let chunkSize be result.[[Value]].
                     Ok(size) => size,

--- a/components/script/dom/stream/transformstream.rs
+++ b/components/script/dom/stream/transformstream.rs
@@ -1032,11 +1032,11 @@ impl TransformStreamMethods<crate::DomTypeHolder> for TransformStream {
             rooted!(&in(cx) let mut result: JSVal);
             rooted!(&in(cx) let this_object = transformer_obj.get());
             start.Call_(
+                cx,
                 &this_object.handle(),
                 &stream.get_controller(),
                 result.handle_mut(),
                 ExceptionHandling::Rethrow,
-                CanGc::from_cx(cx),
             )?;
             let is_promise = unsafe {
                 if result.is_object() {

--- a/components/script/dom/stream/transformstreamdefaultcontroller.rs
+++ b/components/script/dom/stream/transformstreamdefaultcontroller.rs
@@ -226,11 +226,11 @@ impl TransformStreamDefaultController {
                     rooted!(&in(cx) let this_object = transform_obj.get());
                     transform
                         .Call_(
+                            cx,
                             &this_object.handle(),
                             chunk,
                             self,
                             ExceptionHandling::Rethrow,
-                            CanGc::from_cx(cx),
                         )
                         .unwrap_or_else(|e| {
                             let p = Promise::new2(cx, global);
@@ -383,12 +383,7 @@ impl TransformStreamDefaultController {
                 if let Some(cancel) = algo {
                     rooted!(&in(cx) let this_object = transform_obj.get());
                     cancel
-                        .Call_(
-                            &this_object.handle(),
-                            chunk,
-                            ExceptionHandling::Rethrow,
-                            CanGc::from_cx(cx),
-                        )
+                        .Call_(cx, &this_object.handle(), chunk, ExceptionHandling::Rethrow)
                         .unwrap_or_else(|e| {
                             let p = Promise::new2(cx, global);
                             p.reject_error(e, CanGc::from_cx(cx));
@@ -468,12 +463,7 @@ impl TransformStreamDefaultController {
                 if let Some(flush) = algo {
                     rooted!(&in(cx) let this_object = transform_obj.get());
                     flush
-                        .Call_(
-                            &this_object.handle(),
-                            self,
-                            ExceptionHandling::Rethrow,
-                            CanGc::from_cx(cx),
-                        )
+                        .Call_(cx, &this_object.handle(), self, ExceptionHandling::Rethrow)
                         .unwrap_or_else(|e| {
                             let p = Promise::new2(cx, global);
                             p.reject_error(e, CanGc::from_cx(cx));

--- a/components/script/dom/stream/underlyingsourcecontainer.rs
+++ b/components/script/dom/stream/underlyingsourcecontainer.rs
@@ -128,10 +128,10 @@ impl UnderlyingSourceContainer {
                 if let Some(algo) = &source.cancel {
                     let result = unsafe {
                         algo.Call_(
+                            cx,
                             &SafeHandle::from_raw(this_obj.handle()),
                             Some(reason),
                             ExceptionHandling::Rethrow,
-                            CanGc::from_cx(cx),
                         )
                     };
                     return Some(result);
@@ -189,10 +189,10 @@ impl UnderlyingSourceContainer {
                 if let Some(algo) = &source.pull {
                     let result = unsafe {
                         algo.Call_(
+                            cx,
                             &SafeHandle::from_raw(this_obj.handle()),
                             controller,
                             ExceptionHandling::Rethrow,
-                            CanGc::from_cx(cx),
                         )
                     };
                     return Some(result);
@@ -252,11 +252,11 @@ impl UnderlyingSourceContainer {
                     rooted!(&in(cx) let mut result: JSVal);
                     unsafe {
                         if let Err(error) = start.Call_(
+                            cx,
                             &SafeHandle::from_raw(this_obj.handle()),
                             controller,
                             result.handle_mut(),
                             ExceptionHandling::Rethrow,
-                            CanGc::from_cx(cx),
                         ) {
                             return Some(Err(error));
                         }

--- a/components/script/dom/stream/writablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/writablestreamdefaultcontroller.rs
@@ -540,11 +540,11 @@ impl WritableStreamDefaultController {
                     rooted!(&in(cx) let mut result: JSVal);
                     rooted!(&in(cx) let this_object = self.underlying_sink_obj.get());
                     start.Call_(
+                        cx,
                         &this_object.handle(),
                         self,
                         result.handle_mut(),
                         ExceptionHandling::Rethrow,
-                        CanGc::from_cx(cx),
                     )?;
                     let is_promise = unsafe {
                         if result.is_object() {
@@ -601,10 +601,10 @@ impl WritableStreamDefaultController {
                 // Let result be the result of performing this.[[abortAlgorithm]], passing reason.
                 let result = if let Some(algo) = algo {
                     algo.Call_(
+                        cx,
                         &this_object.handle(),
                         Some(reason),
                         ExceptionHandling::Rethrow,
-                        CanGc::from_cx(cx),
                     )
                 } else {
                     Ok(Promise::new_resolved(
@@ -674,11 +674,11 @@ impl WritableStreamDefaultController {
                 let algo = write.borrow().clone();
                 let result = if let Some(algo) = algo {
                     algo.Call_(
+                        cx,
                         &this_object.handle(),
                         chunk,
                         self,
                         ExceptionHandling::Rethrow,
-                        CanGc::from_cx(cx),
                     )
                 } else {
                     Ok(Promise::new_resolved(
@@ -755,11 +755,7 @@ impl WritableStreamDefaultController {
                 this_object.set(self.underlying_sink_obj.get());
                 let algo = close.borrow().clone();
                 let result = if let Some(algo) = algo {
-                    algo.Call_(
-                        &this_object.handle(),
-                        ExceptionHandling::Rethrow,
-                        CanGc::from_cx(cx),
-                    )
+                    algo.Call_(cx, &this_object.handle(), ExceptionHandling::Rethrow)
                 } else {
                     Ok(Promise::new_resolved(
                         global,
@@ -976,7 +972,7 @@ impl WritableStreamDefaultController {
 
         // Let returnValue be the result of performing controller.[[strategySizeAlgorithm]],
         // passing in chunk, and interpreting the result as a completion record.
-        let result = strategy_size.Call__(chunk, ExceptionHandling::Rethrow, CanGc::from_cx(cx));
+        let result = strategy_size.Call__(cx, chunk, ExceptionHandling::Rethrow);
 
         match result {
             // Let chunkSize be result.[[Value]].

--- a/components/script/dom/testing/testbinding.rs
+++ b/components/script/dom/testing/testbinding.rs
@@ -1086,11 +1086,10 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
         }
         impl Callback for SimpleHandler {
             fn callback(&self, cx: &mut CurrentRealm, v: HandleValue) {
-                let can_gc = CanGc::from_cx(cx);
                 let global = GlobalScope::from_current_realm(cx);
                 let _ = self
                     .handler
-                    .Call_(&*global, v, ExceptionHandling::Report, can_gc);
+                    .Call_(cx, &*global, v, ExceptionHandling::Report);
             }
         }
     }

--- a/components/script/dom/treewalker.rs
+++ b/components/script/dom/treewalker.rs
@@ -465,7 +465,7 @@ impl TreeWalker {
                 // Step 5.
                 self.active.set(true);
                 // Step 6.
-                let result = callback.AcceptNode_(self, node, Rethrow, CanGc::from_cx(cx));
+                let result = callback.AcceptNode_(cx, self, node, Rethrow);
                 // Step 7.
                 self.active.set(false);
                 // Step 8.

--- a/components/script/dom/trustedtypes/trustedtypepolicy.rs
+++ b/components/script/dom/trustedtypes/trustedtypepolicy.rs
@@ -25,7 +25,6 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::trustedtypes::trustedhtml::TrustedHTML;
 use crate::dom::trustedtypes::trustedscript::TrustedScript;
 use crate::dom::trustedtypes::trustedscripturl::TrustedScriptURL;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct TrustedTypePolicy {
@@ -114,12 +113,7 @@ impl TrustedTypePolicy {
                     // Step 4: Let policyValue be the result of invoking function with value as a first argument,
                     // items of arguments as subsequent arguments, and callback **this** value set to undefined,
                     // rethrowing any exceptions.
-                    callback.Call__(
-                        input,
-                        arguments,
-                        ExceptionHandling::Rethrow,
-                        CanGc::from_cx(cx),
-                    )
+                    callback.Call__(cx, input, arguments, ExceptionHandling::Rethrow)
                 },
             },
             TrustedType::TrustedScript => match &self.create_script {
@@ -130,12 +124,7 @@ impl TrustedTypePolicy {
                     // Step 4: Let policyValue be the result of invoking function with value as a first argument,
                     // items of arguments as subsequent arguments, and callback **this** value set to undefined,
                     // rethrowing any exceptions.
-                    callback.Call__(
-                        input,
-                        arguments,
-                        ExceptionHandling::Rethrow,
-                        CanGc::from_cx(cx),
-                    )
+                    callback.Call__(cx, input, arguments, ExceptionHandling::Rethrow)
                 },
             },
             TrustedType::TrustedScriptURL => match &self.create_script_url {
@@ -147,12 +136,7 @@ impl TrustedTypePolicy {
                     // items of arguments as subsequent arguments, and callback **this** value set to undefined,
                     // rethrowing any exceptions.
                     callback
-                        .Call__(
-                            input,
-                            arguments,
-                            ExceptionHandling::Rethrow,
-                            CanGc::from_cx(cx),
-                        )
+                        .Call__(cx, input, arguments, ExceptionHandling::Rethrow)
                         .map(|result| result.map(DOMString::from))
                 },
             },

--- a/components/script/dom/webxr/xrsession.rs
+++ b/components/script/dom/webxr/xrsession.rs
@@ -213,8 +213,8 @@ impl XRSession {
                 let frame: Frame = message.unwrap();
                 let time = CrossProcessInstant::now();
                 let this = this.clone();
-                task_source.queue(task!(xr_raf_callback: move || {
-                    this.root().raf_callback(frame, time, CanGc::deprecated_note());
+                task_source.queue(task!(xr_raf_callback: move |cx| {
+                    this.root().raf_callback(cx, frame, time);
                 }));
             }),
         );
@@ -414,7 +414,12 @@ impl XRSession {
     }
 
     /// <https://immersive-web.github.io/webxr/#xr-animation-frame>
-    fn raf_callback(&self, mut frame: Frame, time: CrossProcessInstant, can_gc: CanGc) {
+    fn raf_callback(
+        &self,
+        cx: &mut js::context::JSContext,
+        mut frame: Frame,
+        time: CrossProcessInstant,
+    ) {
         debug!("WebXR RAF callback {:?}", frame);
 
         // Step 1-2 happen in the xebxr device thread
@@ -434,7 +439,7 @@ impl XRSession {
 
         // TODO: how does this fit the webxr spec?
         for event in frame.events.drain(..) {
-            self.handle_frame_event(event, can_gc);
+            self.handle_frame_event(event, CanGc::from_cx(cx));
         }
 
         // Step 4
@@ -466,12 +471,7 @@ impl XRSession {
         }
 
         let time = self.global().performance().to_dom_high_res_time_stamp(time);
-        let frame = XRFrame::new(
-            self.global().as_window(),
-            self,
-            frame,
-            CanGc::deprecated_note(),
-        );
+        let frame = XRFrame::new(self.global().as_window(), self, frame, CanGc::from_cx(cx));
 
         // Step 8-9
         frame.set_active(true);
@@ -489,7 +489,7 @@ impl XRSession {
         for i in 0..len {
             let callback = self.current_raf_callback_list.borrow()[i].1.clone();
             if let Some(callback) = callback {
-                let _ = callback.Call__(time, &frame, ExceptionHandling::Report, can_gc);
+                let _ = callback.Call__(cx, time, &frame, ExceptionHandling::Report);
             }
         }
         self.outside_raf.set(true);

--- a/components/script/dom/webxr/xrtest.rs
+++ b/components/script/dom/webxr/xrtest.rs
@@ -9,6 +9,7 @@
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::jsval::JSVal;
 use profile_traits::generic_callback::GenericCallback as ProfileGenericCallback;
 use servo_base::generic_channel::GenericSender;
@@ -176,15 +177,10 @@ impl XRTestMethods<crate::DomTypeHolder> for XRTest {
     }
 
     /// <https://github.com/immersive-web/webxr-test-api/blob/master/explainer.md>
-    fn SimulateUserActivation(&self, f: Rc<Function>, can_gc: CanGc) {
+    fn SimulateUserActivation(&self, cx: &mut JSContext, f: Rc<Function>) {
         let _guard = ScriptThread::user_interacting_guard();
-        rooted!(in(*GlobalScope::get_cx()) let mut value: JSVal);
-        let _ = f.Call__(
-            vec![],
-            value.handle_mut(),
-            ExceptionHandling::Rethrow,
-            can_gc,
-        );
+        rooted!(&in(cx) let mut value: JSVal);
+        let _ = f.Call__(cx, vec![], value.handle_mut(), ExceptionHandling::Rethrow);
     }
 
     /// <https://github.com/immersive-web/webxr-test-api/blob/master/explainer.md>

--- a/components/script/microtask.rs
+++ b/components/script/microtask.rs
@@ -27,7 +27,7 @@ use crate::dom::stream::byteteereadintorequest::ByteTeeReadIntoRequestMicrotask;
 use crate::dom::stream::byteteereadrequest::ByteTeeReadRequestMicrotask;
 use crate::dom::stream::defaultteereadrequest::DefaultTeeReadRequestMicrotask;
 use crate::realms::enter_auto_realm;
-use crate::script_runtime::{CanGc, JSContext, notify_about_rejected_promises};
+use crate::script_runtime::{JSContext, notify_about_rejected_promises};
 use crate::script_thread::ScriptThread;
 
 /// A collection of microtasks in FIFO order.
@@ -124,22 +124,14 @@ impl MicrotaskQueue {
                             let _guard = ScriptThread::user_interacting_guard();
                             let mut realm = enter_auto_realm(cx, &*target);
                             let cx = &mut realm;
-                            let _ = job.callback.Call_(
-                                &*target,
-                                ExceptionHandling::Report,
-                                CanGc::from_cx(cx),
-                            );
+                            let _ = job.callback.Call_(cx, &*target, ExceptionHandling::Report);
                         }
                     },
                     Microtask::User(ref job) => {
                         if let Some(target) = target_provider(job.pipeline) {
                             let mut realm = enter_auto_realm(cx, &*target);
                             let cx = &mut realm;
-                            let _ = job.callback.Call_(
-                                &*target,
-                                ExceptionHandling::Report,
-                                CanGc::from_cx(cx),
-                            );
+                            let _ = job.callback.Call_(cx, &*target, ExceptionHandling::Report);
                         }
                     },
                     Microtask::MediaElement(ref task) => {

--- a/components/script/script_mutation_observers.rs
+++ b/components/script/script_mutation_observers.rs
@@ -5,10 +5,10 @@
 use std::cell::Cell;
 use std::rc::Rc;
 
+use js::context::JSContext;
 use script_bindings::callback::ExceptionHandling;
 use script_bindings::inheritance::Castable;
 use script_bindings::root::{Dom, DomRoot};
-use script_bindings::script_runtime::CanGc;
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::types::{EventTarget, HTMLSlotElement, MutationObserver, MutationRecord};
@@ -38,7 +38,7 @@ impl ScriptMutationObservers {
     }
 
     /// <https://dom.spec.whatwg.org/#notify-mutation-observers>
-    pub(crate) fn notify_mutation_observers(&self, cx: &mut js::context::JSContext) {
+    pub(crate) fn notify_mutation_observers(&self, cx: &mut JSContext) {
         // Step 1. Set the surrounding agent’s mutation observer microtask queued to false.
         self.mutation_observer_microtask_queued.set(false);
 
@@ -70,13 +70,9 @@ impl ScriptMutationObservers {
             // Step 6.4 If records is not empty, then invoke mo’s callback with « records,
             // mo » and "report", and with callback this value mo.
             if !queue.is_empty() {
-                let _ = mo.callback().Call_(
-                    &**mo,
-                    queue,
-                    mo,
-                    ExceptionHandling::Report,
-                    CanGc::from_cx(cx),
-                );
+                let _ = mo
+                    .callback()
+                    .Call_(cx, &**mo, queue, mo, ExceptionHandling::Report);
             }
         }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1216,6 +1216,9 @@ impl ScriptThread {
                 document.react_to_environment_changes()
             }
 
+            let mut realm = enter_auto_realm(cx, &*document);
+            let cx = &mut realm.current_realm();
+
             // > 11. For each doc of docs, update animations and send events for doc, passing
             // > in relative high resolution time given frameTimestamp and doc's relevant
             // > global object as the timestamp [WEBANIMATIONS]
@@ -1230,14 +1233,13 @@ impl ScriptThread {
             // > 14. For each doc of docs, run the animation frame callbacks for doc, passing
             // > in the relative high resolution time given frameTimestamp and doc's
             // > relevant global object as the timestamp.
-            document.run_the_animation_frame_callbacks(CanGc::from_cx(cx));
+            document.run_the_animation_frame_callbacks(cx);
 
             // Run the resize observer steps.
-            let _realm = enter_realm(&*document);
             let mut depth = Default::default();
             while document.gather_active_resize_observations_at_depth(&depth) {
                 // Note: this will reflow the doc.
-                depth = document.broadcast_active_resize_observations(CanGc::from_cx(cx));
+                depth = document.broadcast_active_resize_observations(cx);
             }
 
             if document.has_skipped_resize_observations() {

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -41,7 +41,7 @@ use crate::dom::trustedtypes::trustedscript::TrustedScript;
 use crate::dom::types::{Window, WorkerGlobalScope};
 use crate::dom::xmlhttprequest::XHRTimeoutCallback;
 use crate::script_module::ScriptFetchOptions;
-use crate::script_runtime::{CanGc, IntroductionType};
+use crate::script_runtime::IntroductionType;
 use crate::script_thread::ScriptThread;
 use crate::task_source::SendableTaskSource;
 
@@ -825,13 +825,7 @@ impl JsTimerTask {
             InternalTimerCallback::FunctionTimerCallback(ref function, ref arguments) => {
                 let arguments = self.collect_heap_args(arguments);
                 rooted!(&in(cx) let mut value: JSVal);
-                let _ = function.Call_(
-                    this,
-                    arguments,
-                    value.handle_mut(),
-                    Report,
-                    CanGc::from_cx(cx),
-                );
+                let _ = function.Call_(cx, this, arguments, value.handle_mut(), Report);
             },
         };
 

--- a/components/script/xpath.rs
+++ b/components/script/xpath.rs
@@ -14,7 +14,6 @@ use script_bindings::callback::ExceptionHandling;
 use script_bindings::codegen::GenericBindings::AttrBinding::AttrMethods;
 use script_bindings::codegen::GenericBindings::NodeBinding::{GetRootNodeOptions, NodeMethods};
 use script_bindings::root::Dom;
-use script_bindings::script_runtime::CanGc;
 use script_bindings::str::DOMString;
 use style::Atom;
 use style::dom::OpaqueNode;
@@ -273,13 +272,13 @@ impl xpath::Attribute for XPathWrapper<DomRoot<Attr>> {
 }
 
 impl xpath::NamespaceResolver for XPathWrapper<Rc<XPathNSResolver>> {
+    #[expect(unsafe_code)]
     fn resolve_namespace_prefix(&self, prefix: &str) -> Option<String> {
+        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
+        let cx = &mut cx;
+
         self.0
-            .LookupNamespaceURI__(
-                Some(DOMString::from(prefix)),
-                ExceptionHandling::Report,
-                CanGc::deprecated_note(),
-            )
+            .LookupNamespaceURI__(cx, Some(DOMString::from(prefix)), ExceptionHandling::Report)
             .ok()
             .flatten()
             .map(String::from)

--- a/components/script_bindings/callback.rs
+++ b/components/script_bindings/callback.rs
@@ -8,18 +8,16 @@ use std::default::Default;
 use std::ffi::CStr;
 use std::rc::Rc;
 
-use js::jsapi::{
-    AddRawValueRoot, EnterRealm, Heap, IsCallable, JSObject, LeaveRealm, RemoveRawValueRoot,
-};
+use js::jsapi::{AddRawValueRoot, Heap, IsCallable, JSObject, RemoveRawValueRoot};
 use js::jsval::{JSVal, NullValue, ObjectValue, UndefinedValue};
-use js::rust::wrappers::{JS_GetProperty, JS_WrapObject};
+use js::rust::wrappers2::{EnterRealm, JS_GetProperty, JS_WrapObject, LeaveRealm};
 use js::rust::{HandleObject, MutableHandleValue, Runtime};
 
 use crate::codegen::GenericBindings::WindowBinding::Window_Binding::WindowMethods;
 use crate::error::{Error, Fallible};
 use crate::inheritance::Castable;
 use crate::interfaces::{DocumentHelpers, DomHelpers, GlobalScopeHelpers};
-use crate::realms::{InRealm, enter_realm};
+use crate::realms::{InRealm, enter_auto_realm};
 use crate::reflector::DomObject;
 use crate::root::Dom;
 use crate::script_runtime::{CanGc, JSContext};
@@ -210,11 +208,15 @@ impl<D: DomTypes> CallbackInterface<D> {
 
     /// Returns the property with the given `name`, if it is a callable object,
     /// or an error otherwise.
-    pub fn get_callable_property(&self, cx: JSContext, name: &CStr) -> Fallible<JSVal> {
-        rooted!(in(*cx) let mut callable = UndefinedValue());
-        rooted!(in(*cx) let obj = self.callback_holder().get());
+    pub fn get_callable_property(
+        &self,
+        cx: &mut js::context::JSContext,
+        name: &CStr,
+    ) -> Fallible<JSVal> {
+        rooted!(&in(cx) let mut callable = UndefinedValue());
+        rooted!(&in(cx) let obj = self.callback_holder().get());
         unsafe {
-            if !JS_GetProperty(*cx, obj.handle(), name.as_ptr(), callable.handle_mut()) {
+            if !JS_GetProperty(cx, obj.handle(), name.as_ptr(), callable.handle_mut()) {
                 return Err(Error::JSFailed);
             }
 
@@ -231,11 +233,11 @@ impl<D: DomTypes> CallbackInterface<D> {
 
 /// Wraps the reflector for `p` into the realm of `cx`.
 pub(crate) fn wrap_call_this_value<T: ThisReflector>(
-    cx: JSContext,
+    cx: &mut js::context::JSContext,
     p: &T,
     mut rval: MutableHandleValue,
 ) -> bool {
-    rooted!(in(*cx) let mut obj = p.jsobject());
+    rooted!(&in(cx) let mut obj = p.jsobject());
 
     if obj.is_null() {
         rval.set(NullValue());
@@ -243,7 +245,7 @@ pub(crate) fn wrap_call_this_value<T: ThisReflector>(
     }
 
     unsafe {
-        if !JS_WrapObject(*cx, obj.handle_mut()) {
+        if !JS_WrapObject(cx, obj.handle_mut()) {
             return false;
         }
     }
@@ -256,9 +258,10 @@ pub(crate) fn wrap_call_this_value<T: ThisReflector>(
 ///
 /// <https://webidl.spec.whatwg.org/#es-invoking-callback-functions>
 pub fn call_setup<D: DomTypes, T: CallbackContainer<D>, R>(
+    cx: &mut js::context::JSContext,
     callback: &T,
     handling: ExceptionHandling,
-    f: impl FnOnce(JSContext) -> R,
+    f: impl FnOnce(&mut js::context::JSContext) -> R,
 ) -> R {
     // The global for reporting exceptions. This is the global object of the
     // (possibly wrapped) callback object.
@@ -266,24 +269,28 @@ pub fn call_setup<D: DomTypes, T: CallbackContainer<D>, R>(
     if let Some(window) = global.downcast::<D::Window>() {
         window.Document().ensure_safe_to_run_script_or_layout();
     }
-    let cx = D::GlobalScope::get_cx();
 
     let global = &global;
 
     // Step 8: Prepare to run script with relevant settings.
     run_a_script::<D, R>(global, move || {
         let actual_callback = || {
-            let old_realm = unsafe { EnterRealm(*cx, callback.callback()) };
+            let old_realm = unsafe { EnterRealm(cx, callback.callback()) };
             let result = f(cx);
             unsafe {
-                LeaveRealm(*cx, old_realm);
+                LeaveRealm(cx, old_realm);
             }
             if handling == ExceptionHandling::Report {
-                let ar = enter_realm::<D>(&**global);
+                let mut realm = enter_auto_realm::<D>(cx, &**global);
+                let cx = &mut realm.current_realm();
+
+                let in_realm_proof = cx.into();
+                let in_realm = InRealm::Already(&in_realm_proof);
+
                 <D as DomHelpers<D>>::report_pending_exception(
-                    cx,
-                    InRealm::Entered(&ar),
-                    CanGc::deprecated_note(),
+                    cx.into(),
+                    in_realm,
+                    CanGc::from_cx(cx),
                 );
             }
             result

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -366,7 +366,7 @@ DOMInterfaces = {
 },
 
 'Geolocation': {
-    'canGc': ['GetCurrentPosition', 'WatchPosition'],
+    'cx': ['GetCurrentPosition', 'WatchPosition'],
 },
 
 'GlobalScope': {
@@ -1074,7 +1074,8 @@ DOMInterfaces = {
 },
 
 'XRTest': {
-    'canGc': ['SimulateDeviceConnection', 'DisconnectAllDevices', 'SimulateUserActivation'],
+    'canGc': ['SimulateDeviceConnection', 'DisconnectAllDevices'],
+    'cx': ['SimulateUserActivation']
 },
 
 'XRView': {

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -8537,7 +8537,7 @@ class CGCallback(CGClass):
         args = args[2:]
         # Record the names of all the arguments, so we can use them when we call
         # the private method.
-        argnames = [arg.name for arg in args] + ["can_gc"]
+        argnames = [arg.name for arg in args]
         argnamesWithThis = ["cx", "thisValue.handle()"] + argnames
         argnamesWithoutThis = ["cx", "HandleValue::undefined()"] + argnames
         # Now that we've recorded the argnames for our call to our private
@@ -8546,12 +8546,14 @@ class CGCallback(CGClass):
         args.append(Argument("ExceptionHandling", "aExceptionHandling",
                              "ReportExceptions"))
 
-        args.append(Argument("CanGc", "can_gc"))
-        method.args.append(Argument("CanGc", "can_gc"))
-
         # And now insert our template argument.
         argsWithoutThis = list(args)
         args.insert(0, Argument("&T", "thisObj"))
+
+        # And the cx argument
+        method.args[0].argType = "&mut JSContext"
+        args.insert(0, Argument("&mut JSContext", "cx"))
+        argsWithoutThis.insert(0, Argument("&mut JSContext", "cx"))
 
         # And the self argument
         method.args.insert(0, Argument(None, "&self"))
@@ -8559,8 +8561,8 @@ class CGCallback(CGClass):
         argsWithoutThis.insert(0, Argument(None, "&self"))
 
         bodyWithThis = (
-            "call_setup(self, aExceptionHandling, |cx| {\n"
-            "    rooted!(in(*cx) let mut thisValue: JSVal);\n"
+            "call_setup(cx, self, aExceptionHandling, |cx| {\n"
+            "    rooted!(&in(cx) let mut thisValue: JSVal);\n"
             "    let wrap_result = wrap_call_this_value(cx, thisObj, thisValue.handle_mut());\n"
             "    if !wrap_result {\n"
             "        return Err(JSFailed);\n"
@@ -8568,7 +8570,7 @@ class CGCallback(CGClass):
             f"    unsafe {{ self.{method.name}({', '.join(argnamesWithThis)}) }}"
             "})")
         bodyWithoutThis = (
-            "call_setup(self, aExceptionHandling, |cx| {\n"
+            "call_setup(cx, self, aExceptionHandling, |cx| {\n"
             f"    unsafe {{ self.{method.name}({', '.join(argnamesWithoutThis)}) }}"
             "})")
         return [ClassMethod(f'{method.name}_', method.returnType, args,


### PR DESCRIPTION
Callback methods have now access to `&mut JSContext`, an additional `temp_cx` was needed for `XPath` trait.

Testing: It compiles
Part of #42638
