### PR TITLE
layout: fix UA stylesheet for `<input type="radio"/>`

### DIFF
--- a/components/layout/stylesheets/servo.css
+++ b/components/layout/stylesheets/servo.css
@@ -328,9 +328,9 @@ input[type="checkbox"]:indeterminate::before {
 input[type="radio"] {
   display: inline-block;
 
-  /* TODO: According to https://wpt.fyi/results/css/css-grid/stretch-grid-item-radio-input.html?label=experimental&label=master&aligned,
+  /* TODO: According to https://wpt.fyi/results/css/css-grid/stretch-grid-item-radio-input.html,
     Radio buttons should be able to grow / shrink depending of the width/height of the input element. These values should probably
-    be changed once `aspect-ratio` has been supported for non-replaced elementss.
+    be changed once `aspect-ratio` has been supported for non-replaced elements.
   */
   min-height: 14px;
   min-width: 14px;

--- a/components/layout/stylesheets/servo.css
+++ b/components/layout/stylesheets/servo.css
@@ -10,6 +10,10 @@ textarea {
   color: black;
 }
 
+input[type="radio"] {
+  border: none;
+}
+
 textarea {
     padding: 2px;
 }
@@ -40,6 +44,10 @@ textarea:disabled {
   cursor: unset;
   color: grey;
   border-color: lightgrey;
+}
+
+input[type="radio"]:disabled {
+  border: none;
 }
 
 /* FIXME(#36982): Use `display: block; align-content: center` instead of flex. */
@@ -150,7 +158,8 @@ input[type="color"]:focus,
 input[type="range"]:focus,
 input[type="reset"]:focus,
 input[type="submit"]:focus,
-input[type="file"]:focus::file-selector-button {
+input[type="file"]:focus::file-selector-button,
+input[type="radio"]:focus {
   outline: none;
 }
 
@@ -261,7 +270,6 @@ input[type="range"]:disabled::slider-thumb {
 /* Checkbox and radio button inputs */
 input[type="checkbox"],
 input[type="radio"] {
-  border: 1px solid grey;
   margin-inline: 4px 2px;
 
   /* Offset the outline a bit so that it doesn't just make the rounded border thicker. */
@@ -271,8 +279,11 @@ input[type="radio"] {
   position: relative;
 }
 
-input[type="checkbox"]:disabled,
-input[type="radio"]:disabled {
+input[type="checkbox"] {
+  border: 1px solid grey;
+}
+
+input[type="checkbox"]:disabled {
   border-color: lightgrey;
 }
 
@@ -316,21 +327,34 @@ input[type="checkbox"]:indeterminate::before {
 
 input[type="radio"] {
   display: inline-block;
-  border-radius: 50%;
 
   /* Radio buttons do not grow or shrink with their surrounding font size. */
-  min-height: 14px;
-  min-width: 14px;
-  max-height: 14px;
-  max-width: 14px;
-  height: 14px;
-  width: 14px;
-
-  /* Offset the outline a bit so that it doesn't just make the rounded border thicker. */
-  outline-offset: 0.4px;
+  min-height: 10px;
+  min-width: 10px;
+  max-height: 100%;
+  max-width: 100%;
+  height: 10px;
+  width: 10px;
 }
 
 input[type="radio"]::before {
+  content: "";
+  background: transparent;
+
+  /* Ring have a fixed size regardless of the text surrounding them. */
+  width: 10px;
+  height: 10px;
+
+  /* Center the bullet in the containing block. */
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  border: 2px solid grey;
+  border-radius: 50%;
+}
+
+input[type="radio"]::after {
   content: "";
   background: transparent;
 
@@ -346,11 +370,11 @@ input[type="radio"]::before {
   border-radius: 50%;
 }
 
-input[type="radio"]:checked::before {
+input[type="radio"]:checked::after {
   background: black;
 }
 
-input[type="radio"]:checked:disabled::before {
+input[type="radio"]:checked:disabled::after {
   background: grey;
 }
 

--- a/components/layout/stylesheets/servo.css
+++ b/components/layout/stylesheets/servo.css
@@ -328,20 +328,23 @@ input[type="checkbox"]:indeterminate::before {
 input[type="radio"] {
   display: inline-block;
 
-  /* Radio buttons do not grow or shrink with their surrounding font size. */
-  min-height: 10px;
-  min-width: 10px;
-  max-height: 100%;
-  max-width: 100%;
-  height: 10px;
-  width: 10px;
+  /* TODO: According to https://wpt.fyi/results/css/css-grid/stretch-grid-item-radio-input.html?label=experimental&label=master&aligned,
+    Radio buttons should be able to grow / shrink depending of the width/height of the input element. These values should probably
+    be changed once `aspect-ratio` has been supported for non-replaced elementss.
+  */
+  min-height: 14px;
+  min-width: 14px;
+  height: 14px;
+  width: 14px;
 }
 
+/* This creates the ring of the radio input */
 input[type="radio"]::before {
   content: "";
   background: transparent;
 
-  /* Ring have a fixed size regardless of the text surrounding them. */
+  /* TODO:  The ring should be able to grow & shrink according to min(width, height). 
+  However, this is currently not possible to be implemented as `aspect-ratio` hasn't been supported for non-replaced elements. */
   width: 10px;
   height: 10px;
 
@@ -354,11 +357,13 @@ input[type="radio"]::before {
   border-radius: 50%;
 }
 
+/* This creates the bullet of the radio input */
 input[type="radio"]::after {
   content: "";
   background: transparent;
 
-  /* Bullets have a fixed size regardless of the text surrounding them. */
+  /* TODO:  The bullet should be able to grow & shrink according to min(width, height). 
+  However, this is currently not possible to be implemented as `aspect-ratio` hasn't been supported for non-replaced elements. */
   width: 8px;
   height: 8px;
 

--- a/components/layout/stylesheets/servo.css
+++ b/components/layout/stylesheets/servo.css
@@ -329,8 +329,9 @@ input[type="radio"] {
   display: inline-block;
 
   /* TODO: According to https://wpt.fyi/results/css/css-grid/stretch-grid-item-radio-input.html,
-    Radio buttons should be able to grow / shrink depending of the width/height of the input element. These values should probably
-    be changed once `aspect-ratio` has been supported for non-replaced elements.
+     radio buttons should be able to grow / shrink depending of the width/height of the input 
+     element. These values should probably be changed once `aspect-ratio` has been supported
+     for non-replaced elements.
   */
   min-height: 14px;
   min-width: 14px;
@@ -338,13 +339,15 @@ input[type="radio"] {
   width: 14px;
 }
 
-/* This creates the ring of the radio input */
+/* This creates the ring of the radio input. TODO: It might be better to add a UA shadow tree instead of using pseudo elements. */
 input[type="radio"]::before {
   content: "";
   background: transparent;
 
-  /* TODO:  The ring should be able to grow & shrink according to min(width, height). 
-  However, this is currently not possible to be implemented as `aspect-ratio` hasn't been supported for non-replaced elements. */
+  /* TODO: The ring should be able to grow & shrink according to min(width, height). 
+    However, this is currently not possible to be implemented as `aspect-ratio` hasn't
+    been supported for non-replaced elements.
+  */
   width: 10px;
   height: 10px;
 
@@ -357,7 +360,7 @@ input[type="radio"]::before {
   border-radius: 50%;
 }
 
-/* This creates the bullet of the radio input */
+/* This creates the bullet of the radio input. TODO: It might be better to add a UA shadow tree instead of using pseudo elements.*/
 input[type="radio"]::after {
   content: "";
   background: transparent;

--- a/tests/wpt/meta/css/css-grid/stretch-grid-item-radio-input.html.ini
+++ b/tests/wpt/meta/css/css-grid/stretch-grid-item-radio-input.html.ini
@@ -1,0 +1,2 @@
+[stretch-grid-item-radio-input.html]
+  expected: FAIL

--- a/tests/wpt/meta/html/rendering/widgets/baseline-alignment-and-overflow.tentative.html.ini
+++ b/tests/wpt/meta/html/rendering/widgets/baseline-alignment-and-overflow.tentative.html.ini
@@ -20,9 +20,6 @@
   [<input type="radio" style="overflow: scroll; appearance: auto;">]
     expected: FAIL
 
-  [<input type="radio" style="overflow: visible; appearance: none;">]
-    expected: FAIL
-
   [<input type="file" style="overflow: visible; appearance: auto;">]
     expected: FAIL
 
@@ -105,10 +102,4 @@
     expected: FAIL
 
   [<input type="checkbox" style="overflow: scroll; appearance: none;">]
-    expected: FAIL
-
-  [<input type="radio" style="overflow: hidden; appearance: none;">]
-    expected: FAIL
-
-  [<input type="radio" style="overflow: scroll; appearance: none;">]
     expected: FAIL

--- a/tests/wpt/tests/html/rendering/widgets/input-radio-with-width-attribute.html
+++ b/tests/wpt/tests/html/rendering/widgets/input-radio-with-width-attribute.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>HTML Widget Test</title>
+<link rel="author" title="Richard Tjokroutomo href="mailto:richard.tjokro2@gmail.com">
+<link rel="match" href="reference/white-space-intrinsic-size-022-ref.html">
+<meta name="assert" content="The width of the <input type='radio'> should respect the 'width' attribute if specified.">
+
+<script src="/resources/check-layout-th.js"></script>
+<div>
+    <input type="radio" style="width: 100px;" data-expected-width="100"/>
+</div>
+<div>
+    <input type="radio" style="width: 200px;" data-expected-width="200"/>
+</div>
+

--- a/tests/wpt/tests/html/rendering/widgets/input-radio-with-width-attribute.html
+++ b/tests/wpt/tests/html/rendering/widgets/input-radio-with-width-attribute.html
@@ -2,8 +2,7 @@
 <meta charset="UTF-8">
 <title>HTML Widget Test</title>
 <link rel="author" title="Richard Tjokroutomo href="mailto:richard.tjokro2@gmail.com">
-<link rel="match" href="reference/white-space-intrinsic-size-022-ref.html">
-<meta name="assert" content="The width of the <input type='radio'> should respect the 'width' attribute if specified.">
+<meta name="assert" content="The width of the <input type='radio'> should respect the 'width' property if specified.">
 
 <script src="/resources/check-layout-th.js"></script>
 <div>


### PR DESCRIPTION
Fix Servo's UA styling for `<input type="radio"/>` to allow Servo to render the `width` of `<input type="radio"/>` if specified by user.

Test case:
```html
<span style="border-style: solid;">
    <input type="radio" style="width: 180px;"/>
</span>
```
---

Before:
<img width="84" height="56" alt="image" src="https://github.com/user-attachments/assets/79552781-a13e-4aa1-b484-198582f97cb8" />

After:
<img width="245" height="48" alt="image" src="https://github.com/user-attachments/assets/6fd1a9dc-9611-43d9-a7b6-8c95eb689a89" />

---
On Chrome:
<img width="281" height="56" alt="image" src="https://github.com/user-attachments/assets/bda3d374-1468-4de5-ae41-e03d55c4e31b" />

---

Additionally, the radio will toggle if the user click on any area within the border (even outside the radio circle). This is also how Chrome behaves. 

Testing: Added 1 new WPT test.
Fixes: #44619 
