### PR TITLE
Port methods calling fire event

### DIFF
--- a/components/script/animations.rs
+++ b/components/script/animations.rs
@@ -475,7 +475,7 @@ impl Animations {
 
     /// An implementation of the final steps of
     /// <https://drafts.csswg.org/web-animations-1/#update-animations-and-send-events>.
-    pub(crate) fn send_pending_events(&self, window: &Window, can_gc: CanGc) {
+    pub(crate) fn send_pending_events(&self, window: &Window, cx: &mut js::context::JSContext) {
         // > 4. Let events to dispatch be a copy of doc’s pending animation event queue.
         // > 5. Clear doc’s pending animation event queue.
         //
@@ -542,9 +542,9 @@ impl Animations {
                     elapsedTime: elapsed_time,
                     pseudoElement: pseudo_element,
                 };
-                TransitionEvent::new(&window, event_atom, &event_init, can_gc)
+                TransitionEvent::new(&window, event_atom, &event_init, CanGc::from_cx(cx))
                     .upcast::<Event>()
-                    .fire(node.upcast(), can_gc);
+                    .fire(node.upcast(), CanGc::from_cx(cx));
             } else {
                 let event_init = AnimationEventInit {
                     parent,
@@ -552,9 +552,9 @@ impl Animations {
                     elapsedTime: elapsed_time,
                     pseudoElement: pseudo_element,
                 };
-                AnimationEvent::new(&window, event_atom, &event_init, can_gc)
+                AnimationEvent::new(&window, event_atom, &event_init, CanGc::from_cx(cx))
                     .upcast::<Event>()
-                    .fire(node.upcast(), can_gc);
+                    .fire(node.upcast(), CanGc::from_cx(cx));
             }
         }
 

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -4369,8 +4369,7 @@ impl Document {
 
         // Steps 4 through 7 occur inside `send_pending_events().`
         let _realm = enter_realm(self);
-        self.animations()
-            .send_pending_events(self.window(), CanGc::from_cx(cx));
+        self.animations().send_pending_events(self.window(), cx);
     }
 
     pub(crate) fn image_animation_manager(&self) -> Ref<'_, ImageAnimationManager> {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -190,7 +190,7 @@ use crate::layout_image::fetch_image_for_layout;
 use crate::messaging::{MainThreadScriptMsg, ScriptEventLoopReceiver, ScriptEventLoopSender};
 use crate::microtask::{Microtask, UserMicrotask};
 use crate::network_listener::{ResourceTimingListener, submit_timing};
-use crate::realms::enter_realm;
+use crate::realms::{enter_auto_realm, enter_realm};
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext, Runtime};
 use crate::script_thread::ScriptThread;
 use crate::script_window_proxies::ScriptWindowProxies;
@@ -3428,10 +3428,14 @@ impl Window {
 
     /// Evaluate media query lists and report changes
     /// <https://drafts.csswg.org/cssom-view/#evaluate-media-queries-and-report-changes>
-    pub(crate) fn evaluate_media_queries_and_report_changes(&self, can_gc: CanGc) {
-        let _realm = enter_realm(self);
-
+    pub(crate) fn evaluate_media_queries_and_report_changes(
+        &self,
+        cx: &mut js::context::JSContext,
+    ) {
+        let mut realm = enter_auto_realm(cx, self);
+        let cx = &mut realm.current_realm();
         rooted_vec!(let mut mql_list);
+
         self.media_query_lists.for_each(|mql| {
             if let MediaQueryListMatchState::Changed = mql.evaluate_changes() {
                 // Recording list of changed Media Queries
@@ -3447,11 +3451,11 @@ impl Window {
                 false,
                 mql.Media(),
                 mql.Matches(),
-                can_gc,
+                CanGc::from_cx(cx),
             );
             event
                 .upcast::<Event>()
-                .fire(mql.upcast::<EventTarget>(), can_gc);
+                .fire(mql.upcast::<EventTarget>(), CanGc::from_cx(cx));
         }
     }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1209,7 +1209,7 @@ impl ScriptThread {
                 // 10. For each doc of docs, evaluate media queries and report changes for doc.
                 document
                     .window()
-                    .evaluate_media_queries_and_report_changes(CanGc::from_cx(cx));
+                    .evaluate_media_queries_and_report_changes(cx);
 
                 // https://html.spec.whatwg.org/multipage/#img-environment-changes
                 // As per the spec, this can be run at any time.


### PR DESCRIPTION
Propagate `&mut JSContext` in some of the methods calling fire event and related call sites.

Testing: Successful build is enough
Fixes: Part of #42638 