### PR TITLE
fonts: Remove unused import of euclid::num::Zero in tests.

### DIFF
--- a/components/fonts/tests/font.rs
+++ b/components/fonts/tests/font.rs
@@ -7,7 +7,6 @@ use std::io::Read;
 use std::path::PathBuf;
 
 use app_units::Au;
-use euclid::num::Zero;
 use fonts::platform::font::PlatformFont;
 use fonts::{
     Font, FontData, FontDescriptor, FontIdentifier, FontTemplate, FontTemplateRef,


### PR DESCRIPTION
Remove unused import of `euclid::num::Zero` in components/fonts/tests/font.rs
that causes a compiler warning when building unit tests.

Testing: No tests needed for removing an unused import.
Fixes: #44611
