### PR TITLE
script: Introduce argument version of UnderlyingSourceType to remove rooting requirements.

### DIFF
--- a/components/script/dom/stream/readablebytestreamcontroller.rs
+++ b/components/script/dom/stream/readablebytestreamcontroller.rs
@@ -216,7 +216,6 @@ pub(crate) struct ReadableByteStreamController {
 }
 
 impl ReadableByteStreamController {
-    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn new_inherited(
         underlying_source_type: UnderlyingSourceType,
         strategy_hwm: f64,
@@ -243,7 +242,6 @@ impl ReadableByteStreamController {
         }
     }
 
-    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new(
         underlying_source_type: UnderlyingSourceType,
         strategy_hwm: f64,

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -851,7 +851,6 @@ impl PartialEq for ReaderType {
 }
 
 /// <https://streams.spec.whatwg.org/#create-readable-stream>
-#[cfg_attr(crown, expect(crown::unrooted_must_root))]
 pub(crate) fn create_readable_stream(
     cx: &mut JSContext,
     global: &GlobalScope,
@@ -895,7 +894,6 @@ pub(crate) fn create_readable_stream(
 }
 
 /// <https://streams.spec.whatwg.org/#abstract-opdef-createreadablebytestream>
-#[cfg_attr(crown, expect(crown::unrooted_must_root))]
 fn readable_byte_stream_tee(
     cx: &mut JSContext,
     global: &GlobalScope,
@@ -1008,7 +1006,6 @@ impl ReadableStream {
 
     /// Build a stream backed by a Rust underlying source.
     /// Note: external sources are always paired with a default controller.
-    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new_with_external_underlying_source(
         cx: &mut JSContext,
         global: &GlobalScope,
@@ -1740,7 +1737,7 @@ impl ReadableStream {
         let branch_1 = readable_byte_stream_tee(
             cx,
             &self.global(),
-            UnderlyingSourceType::TeeByte(Dom::from_ref(&byte_tee_source_1)),
+            UnderlyingSourceType::TeeByte(&byte_tee_source_1),
         );
         byte_tee_source_1.set_branch_1(&branch_1);
         byte_tee_source_2.set_branch_1(&branch_1);
@@ -1749,7 +1746,7 @@ impl ReadableStream {
         let branch_2 = readable_byte_stream_tee(
             cx,
             &self.global(),
-            UnderlyingSourceType::TeeByte(Dom::from_ref(&byte_tee_source_2)),
+            UnderlyingSourceType::TeeByte(&byte_tee_source_2),
         );
         byte_tee_source_1.set_branch_2(&branch_2);
         byte_tee_source_2.set_branch_2(&branch_2);
@@ -1808,8 +1805,7 @@ impl ReadableStream {
             CanGc::from_cx(cx),
         );
 
-        let underlying_source_type_branch_1 =
-            UnderlyingSourceType::Tee(Dom::from_ref(&tee_source_1));
+        let underlying_source_type_branch_1 = UnderlyingSourceType::Tee(&tee_source_1);
 
         let tee_source_2 = DefaultTeeUnderlyingSource::new(
             &reader,
@@ -1826,8 +1822,7 @@ impl ReadableStream {
             CanGc::from_cx(cx),
         );
 
-        let underlying_source_type_branch_2 =
-            UnderlyingSourceType::Tee(Dom::from_ref(&tee_source_2));
+        let underlying_source_type_branch_2 = UnderlyingSourceType::Tee(&tee_source_2);
 
         // Set branch_1 to ! CreateReadableStream(startAlgorithm, pullAlgorithm, cancel1Algorithm).
         let branch_1 = create_readable_stream(
@@ -2021,7 +2016,7 @@ impl ReadableStream {
         }
 
         let controller = ReadableByteStreamController::new(
-            UnderlyingSourceType::Js(underlying_source_dict, Heap::default()),
+            UnderlyingSourceType::Js(underlying_source_dict),
             strategy_hwm,
             global,
             CanGc::from_cx(cx),
@@ -2057,7 +2052,7 @@ impl ReadableStream {
         // Let controller be a new ReadableStreamDefaultController.
         let controller = ReadableStreamDefaultController::new(
             &self.global(),
-            UnderlyingSourceType::Transfer(Dom::from_ref(port)),
+            UnderlyingSourceType::Transfer(port),
             0.,
             size_algorithm,
             CanGc::from_cx(cx),
@@ -2141,7 +2136,7 @@ impl ReadableStreamMethods<crate::DomTypeHolder> for ReadableStream {
 
             let controller = ReadableStreamDefaultController::new(
                 global,
-                UnderlyingSourceType::Js(underlying_source_dict, Heap::default()),
+                UnderlyingSourceType::Js(underlying_source_dict),
                 high_water_mark,
                 size_algorithm,
                 CanGc::from_cx(cx),

--- a/components/script/dom/stream/readablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/readablestreamdefaultcontroller.rs
@@ -342,7 +342,6 @@ pub(crate) struct ReadableStreamDefaultController {
 }
 
 impl ReadableStreamDefaultController {
-    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn new_inherited(
         global: &GlobalScope,
         underlying_source_type: UnderlyingSourceType,
@@ -368,7 +367,6 @@ impl ReadableStreamDefaultController {
         }
     }
 
-    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new(
         global: &GlobalScope,
         underlying_source: UnderlyingSourceType,

--- a/components/script/dom/stream/transformstream.rs
+++ b/components/script/dom/stream/transformstream.rs
@@ -557,7 +557,7 @@ impl TransformStream {
         let readable = create_readable_stream(
             cx,
             global,
-            UnderlyingSourceType::Transform(Dom::from_ref(self), start_promise),
+            UnderlyingSourceType::Transform(self, start_promise),
             Some(readable_size_algorithm),
             Some(readable_high_water_mark),
         );

--- a/components/script/dom/stream/underlyingsourcecontainer.rs
+++ b/components/script/dom/stream/underlyingsourcecontainer.rs
@@ -25,13 +25,52 @@ use crate::dom::stream::defaultteeunderlyingsource::DefaultTeeUnderlyingSource;
 use crate::dom::stream::transformstream::TransformStream;
 use crate::script_runtime::CanGc;
 
+/// A variation of [UnderlyingSourceType] used for storing state within UnderlyingContainer.
+/// All variants have identical meanings to [UnderlyingSourceType].
+#[derive(JSTraceable)]
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
+enum UnderlyingSource {
+    Memory(usize),
+    Blob(usize),
+    FetchResponse,
+    Js(JsUnderlyingSource, Heap<*mut JSObject>),
+    Tee(Dom<DefaultTeeUnderlyingSource>),
+    Transfer(Dom<MessagePort>),
+    Transform(Dom<TransformStream>, Rc<Promise>),
+    TeeByte(Dom<ByteTeeUnderlyingSource>),
+}
+
+impl UnderlyingSource {
+    /// Does the source have all data in memory?
+    fn in_memory(&self) -> bool {
+        matches!(self, UnderlyingSource::Memory(_))
+    }
+}
+
+impl From<UnderlyingSourceType<'_>> for UnderlyingSource {
+    fn from(underlying_source_type: UnderlyingSourceType<'_>) -> Self {
+        match underlying_source_type {
+            UnderlyingSourceType::Memory(size) => UnderlyingSource::Memory(size),
+            UnderlyingSourceType::Blob(size) => UnderlyingSource::Blob(size),
+            UnderlyingSourceType::FetchResponse => UnderlyingSource::FetchResponse,
+            UnderlyingSourceType::Js(source) => UnderlyingSource::Js(source, Heap::default()),
+            UnderlyingSourceType::Tee(source) => UnderlyingSource::Tee(Dom::from_ref(source)),
+            UnderlyingSourceType::Transfer(port) => UnderlyingSource::Transfer(Dom::from_ref(port)),
+            UnderlyingSourceType::Transform(stream, promise) => {
+                UnderlyingSource::Transform(Dom::from_ref(stream), promise)
+            },
+            UnderlyingSourceType::TeeByte(source) => {
+                UnderlyingSource::TeeByte(Dom::from_ref(source))
+            },
+        }
+    }
+}
+
 /// <https://streams.spec.whatwg.org/#underlying-source-api>
 /// The `Js` variant corresponds to
 /// the JavaScript object representing the underlying source.
 /// The other variants are native sources in Rust.
-#[derive(JSTraceable)]
-#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
-pub(crate) enum UnderlyingSourceType {
+pub(crate) enum UnderlyingSourceType<'a> {
     /// Facilitate partial integration with sources
     /// that are currently read into memory.
     Memory(usize),
@@ -41,20 +80,20 @@ pub(crate) enum UnderlyingSourceType {
     FetchResponse,
     /// A struct representing a JS object as underlying source,
     /// and the actual JS object for use as `thisArg` in callbacks.
-    Js(JsUnderlyingSource, Heap<*mut JSObject>),
+    Js(JsUnderlyingSource),
     /// Tee
-    Tee(Dom<DefaultTeeUnderlyingSource>),
+    Tee(&'a DefaultTeeUnderlyingSource),
     /// Transfer, with the port used in some of the algorithms.
-    Transfer(Dom<MessagePort>),
+    Transfer(&'a MessagePort),
     /// A struct representing a JS object as underlying source,
     /// and the actual JS object for use as `thisArg` in callbacks.
     /// This is used for the `TransformStream` API.
-    Transform(Dom<TransformStream>, Rc<Promise>),
-    // Tee Byte
-    TeeByte(Dom<ByteTeeUnderlyingSource>),
+    Transform(&'a TransformStream, Rc<Promise>),
+    /// Tee Byte
+    TeeByte(&'a ByteTeeUnderlyingSource),
 }
 
-impl UnderlyingSourceType {
+impl UnderlyingSourceType<'_> {
     /// Is the source backed by a Rust native source?
     pub(crate) fn is_native(&self) -> bool {
         matches!(
@@ -65,11 +104,6 @@ impl UnderlyingSourceType {
                 UnderlyingSourceType::Transfer(_)
         )
     }
-
-    /// Does the source have all data in memory?
-    pub(crate) fn in_memory(&self) -> bool {
-        matches!(self, UnderlyingSourceType::Memory(_))
-    }
 }
 
 /// Wrapper around the underlying source.
@@ -77,19 +111,17 @@ impl UnderlyingSourceType {
 pub(crate) struct UnderlyingSourceContainer {
     reflector_: Reflector,
     #[ignore_malloc_size_of = "JsUnderlyingSource implemented in SM."]
-    underlying_source_type: UnderlyingSourceType,
+    underlying_source_type: UnderlyingSource,
 }
 
 impl UnderlyingSourceContainer {
-    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn new_inherited(underlying_source_type: UnderlyingSourceType) -> UnderlyingSourceContainer {
         UnderlyingSourceContainer {
             reflector_: Reflector::new(),
-            underlying_source_type,
+            underlying_source_type: underlying_source_type.into(),
         }
     }
 
-    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new(
         global: &GlobalScope,
         underlying_source_type: UnderlyingSourceType,
@@ -110,7 +142,7 @@ impl UnderlyingSourceContainer {
 
     /// Setting the JS object after the heap has settled down.
     pub(crate) fn set_underlying_source_this_object(&self, object: HandleObject) {
-        if let UnderlyingSourceType::Js(_source, this_obj) = &self.underlying_source_type {
+        if let UnderlyingSource::Js(_source, this_obj) = &self.underlying_source_type {
             this_obj.set(*object);
         }
     }
@@ -124,7 +156,7 @@ impl UnderlyingSourceContainer {
         reason: SafeHandleValue,
     ) -> Option<Result<Rc<Promise>, Error>> {
         match &self.underlying_source_type {
-            UnderlyingSourceType::Js(source, this_obj) => {
+            UnderlyingSource::Js(source, this_obj) => {
                 if let Some(algo) = &source.cancel {
                     let result = unsafe {
                         algo.Call_(
@@ -138,15 +170,15 @@ impl UnderlyingSourceContainer {
                 }
                 None
             },
-            UnderlyingSourceType::Tee(tee_underlying_source) => {
+            UnderlyingSource::Tee(tee_underlying_source) => {
                 // Call the cancel algorithm for the appropriate branch.
                 tee_underlying_source.cancel_algorithm(cx, global, reason)
             },
-            UnderlyingSourceType::Transform(stream, _) => {
+            UnderlyingSource::Transform(stream, _) => {
                 // Return ! TransformStreamDefaultSourceCancelAlgorithm(stream, reason).
                 Some(stream.transform_stream_default_source_cancel(cx, global, reason))
             },
-            UnderlyingSourceType::Transfer(port) => {
+            UnderlyingSource::Transfer(port) => {
                 // Let cancelAlgorithm be the following steps, taking a reason argument:
                 // from <https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformreadable
 
@@ -169,7 +201,7 @@ impl UnderlyingSourceContainer {
                 }
                 Some(Ok(promise))
             },
-            UnderlyingSourceType::TeeByte(tee_underlyin_source) => {
+            UnderlyingSource::TeeByte(tee_underlyin_source) => {
                 // Call the cancel algorithm for the appropriate branch.
                 tee_underlyin_source.cancel_algorithm(cx, reason)
             },
@@ -185,7 +217,7 @@ impl UnderlyingSourceContainer {
         controller: Controller,
     ) -> Option<Result<Rc<Promise>, Error>> {
         match &self.underlying_source_type {
-            UnderlyingSourceType::Js(source, this_obj) => {
+            UnderlyingSource::Js(source, this_obj) => {
                 if let Some(algo) = &source.pull {
                     let result = unsafe {
                         algo.Call_(
@@ -199,11 +231,11 @@ impl UnderlyingSourceContainer {
                 }
                 None
             },
-            UnderlyingSourceType::Tee(tee_underlying_source) => {
+            UnderlyingSource::Tee(tee_underlying_source) => {
                 // Call the pull algorithm for the appropriate branch.
                 Some(Ok(tee_underlying_source.pull_algorithm(cx)))
             },
-            UnderlyingSourceType::Transfer(port) => {
+            UnderlyingSource::Transfer(port) => {
                 // Let pullAlgorithm be the following steps:
                 // from <https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformreadable
 
@@ -217,12 +249,12 @@ impl UnderlyingSourceContainer {
                     Promise::new_resolved(&self.global(), cx.into(), (), CanGc::from_cx(cx));
                 Some(Ok(promise))
             },
-            UnderlyingSourceType::TeeByte(tee_underlyin_source) => {
+            UnderlyingSource::TeeByte(tee_underlyin_source) => {
                 // Call the pull algorithm for the appropriate branch.
                 Some(Ok(tee_underlyin_source.pull_algorithm(cx, None)))
             },
             // Note: other source type have no pull steps for now.
-            UnderlyingSourceType::Transform(stream, _) => {
+            UnderlyingSource::Transform(stream, _) => {
                 // Return ! TransformStreamDefaultSourcePullAlgorithm(stream).
                 Some(
                     stream.transform_stream_default_source_pull(&self.global(), CanGc::from_cx(cx)),
@@ -246,7 +278,7 @@ impl UnderlyingSourceContainer {
         controller: Controller,
     ) -> Option<Result<Rc<Promise>, Error>> {
         match &self.underlying_source_type {
-            UnderlyingSourceType::Js(source, this_obj) => {
+            UnderlyingSource::Js(source, this_obj) => {
                 if let Some(start) = &source.start {
                     rooted!(&in(cx) let mut result_object = ptr::null_mut::<JSObject>());
                     rooted!(&in(cx) let mut result: JSVal);
@@ -283,16 +315,16 @@ impl UnderlyingSourceContainer {
                 }
                 None
             },
-            UnderlyingSourceType::Tee(_) => {
+            UnderlyingSource::Tee(_) => {
                 // Let startAlgorithm be an algorithm that returns undefined.
                 None
             },
-            UnderlyingSourceType::Transfer(_) => {
+            UnderlyingSource::Transfer(_) => {
                 // Let startAlgorithm be an algorithm that returns undefined.
                 // from <https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformreadable
                 None
             },
-            UnderlyingSourceType::Transform(_, start_promise) => {
+            UnderlyingSource::Transform(_, start_promise) => {
                 // Let startAlgorithm be an algorithm that returns startPromise.
                 Some(Ok(start_promise.clone()))
             },
@@ -303,7 +335,7 @@ impl UnderlyingSourceContainer {
     /// <https://streams.spec.whatwg.org/#dom-underlyingsource-autoallocatechunksize>
     pub(crate) fn auto_allocate_chunk_size(&self) -> Option<u64> {
         match &self.underlying_source_type {
-            UnderlyingSourceType::Js(source, _) => source.autoAllocateChunkSize,
+            UnderlyingSource::Js(source, _) => source.autoAllocateChunkSize,
             _ => None,
         }
     }


### PR DESCRIPTION
The UnderlyingSourceType contains members that need to be rooted, which is fine when it's used as a member of a DOM object. However, we also use it as an argument for the constructor, which requires adding a lot of rooting analysis exceptions that could hide other issues. By splitting these responsibilities we make the code simpler to read and remove the rooting analysis exceptions.

Testing: Existing stream tests cover this refactoring.