### PR TITLE
release: Bump version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1822,7 +1822,7 @@ dependencies = [
 
 [[package]]
 name = "deny_public_fields_tests"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "servo-deny-public-fields",
 ]
@@ -4893,7 +4893,7 @@ dependencies = [
 
 [[package]]
 name = "malloc_size_of_tests"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "servo-malloc-size-of",
  "servo_arc",
@@ -6510,7 +6510,7 @@ dependencies = [
 
 [[package]]
 name = "profile_tests"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ipc-channel",
  "servo-config",
@@ -7215,7 +7215,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "script_tests"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "encoding_rs",
  "euclid",
@@ -7450,7 +7450,7 @@ dependencies = [
 
 [[package]]
 name = "servo"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -7529,7 +7529,7 @@ dependencies = [
 
 [[package]]
 name = "servo-allocator"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "backtrace",
  "libc",
@@ -7542,7 +7542,7 @@ dependencies = [
 
 [[package]]
 name = "servo-background-hang-monitor"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "backtrace",
  "crossbeam-channel",
@@ -7559,7 +7559,7 @@ dependencies = [
 
 [[package]]
 name = "servo-background-hang-monitor-api"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "servo-base",
@@ -7567,7 +7567,7 @@ dependencies = [
 
 [[package]]
 name = "servo-base"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "accesskit",
  "crossbeam-channel",
@@ -7591,7 +7591,7 @@ dependencies = [
 
 [[package]]
 name = "servo-bluetooth"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bitflags 2.11.1",
  "blurmock",
@@ -7609,7 +7609,7 @@ dependencies = [
 
 [[package]]
 name = "servo-bluetooth-traits"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "regex",
  "serde",
@@ -7619,7 +7619,7 @@ dependencies = [
 
 [[package]]
 name = "servo-canvas"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bytemuck",
  "crossbeam-channel",
@@ -7647,7 +7647,7 @@ dependencies = [
 
 [[package]]
 name = "servo-canvas-traits"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "crossbeam-channel",
  "euclid",
@@ -7667,7 +7667,7 @@ dependencies = [
 
 [[package]]
 name = "servo-config"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -7677,7 +7677,7 @@ dependencies = [
 
 [[package]]
 name = "servo-config-macro"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7687,7 +7687,7 @@ dependencies = [
 
 [[package]]
 name = "servo-constellation"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "accesskit",
  "backtrace",
@@ -7735,7 +7735,7 @@ dependencies = [
 
 [[package]]
 name = "servo-constellation-traits"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64 0.22.1",
  "content-security-policy",
@@ -7771,14 +7771,14 @@ dependencies = [
 
 [[package]]
 name = "servo-default-resources"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "servo-embedder-traits",
 ]
 
 [[package]]
 name = "servo-deny-public-fields"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "syn",
  "synstructure",
@@ -7786,7 +7786,7 @@ dependencies = [
 
 [[package]]
 name = "servo-devtools"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "atomic_refcell",
  "base64 0.22.1",
@@ -7814,7 +7814,7 @@ dependencies = [
 
 [[package]]
 name = "servo-devtools-traits"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "http 1.4.0",
  "malloc_size_of_derive",
@@ -7830,7 +7830,7 @@ dependencies = [
 
 [[package]]
 name = "servo-dom-struct"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7839,7 +7839,7 @@ dependencies = [
 
 [[package]]
 name = "servo-embedder-traits"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "accesskit",
  "bitflags 2.11.1",
@@ -7872,7 +7872,7 @@ dependencies = [
 
 [[package]]
 name = "servo-fonts"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "app_units",
  "bitflags 2.11.1",
@@ -7927,7 +7927,7 @@ dependencies = [
 
 [[package]]
 name = "servo-fonts-traits"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "atomic_refcell",
  "dwrote",
@@ -7950,7 +7950,7 @@ dependencies = [
 
 [[package]]
 name = "servo-geometry"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "app_units",
  "euclid",
@@ -7962,7 +7962,7 @@ dependencies = [
 
 [[package]]
 name = "servo-hyper-serde"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cookie 0.18.1",
  "headers",
@@ -7977,7 +7977,7 @@ dependencies = [
 
 [[package]]
 name = "servo-jstraceable-derive"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -7986,7 +7986,7 @@ dependencies = [
 
 [[package]]
 name = "servo-layout"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "accesskit",
  "app_units",
@@ -8042,7 +8042,7 @@ dependencies = [
 
 [[package]]
 name = "servo-layout-api"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "app_units",
  "atomic_refcell",
@@ -8074,7 +8074,7 @@ dependencies = [
 
 [[package]]
 name = "servo-malloc-size-of"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "accountable-refcell",
  "app_units",
@@ -8116,7 +8116,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "servo-media-audio",
  "servo-media-player",
@@ -8127,7 +8127,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-audio"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "byte-slice-cast",
  "euclid",
@@ -8148,7 +8148,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-auto"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "servo-media-dummy",
  "servo-media-gstreamer",
@@ -8156,7 +8156,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-derive"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8165,7 +8165,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-dummy"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ipc-channel",
  "servo-media",
@@ -8178,7 +8178,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-examples"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "euclid",
  "rand 0.9.2",
@@ -8190,7 +8190,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-gstreamer"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "byte-slice-cast",
  "glib",
@@ -8221,7 +8221,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-gstreamer-render"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "gstreamer",
  "gstreamer-video",
@@ -8230,7 +8230,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-gstreamer-render-android"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "glib",
  "gstreamer",
@@ -8243,7 +8243,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-gstreamer-render-unix"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "glib",
  "gstreamer",
@@ -8258,7 +8258,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-ohos"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "crossbeam-channel",
  "ipc-channel",
@@ -8282,7 +8282,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-player"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ipc-channel",
  "malloc_size_of_derive",
@@ -8294,7 +8294,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-streams"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "malloc_size_of_derive",
  "servo-malloc-size-of",
@@ -8303,7 +8303,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-thread"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "euclid",
  "ipc-channel",
@@ -8320,7 +8320,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-traits"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "malloc_size_of_derive",
  "servo-malloc-size-of",
@@ -8328,7 +8328,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-webrtc"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "log",
  "servo-media-streams",
@@ -8337,7 +8337,7 @@ dependencies = [
 
 [[package]]
 name = "servo-metrics"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "malloc_size_of_derive",
  "servo-base",
@@ -8351,7 +8351,7 @@ dependencies = [
 
 [[package]]
 name = "servo-net"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-compression",
  "async-recursion",
@@ -8424,7 +8424,7 @@ dependencies = [
 
 [[package]]
 name = "servo-net-traits"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "content-security-policy",
  "cookie 0.18.1",
@@ -8464,7 +8464,7 @@ dependencies = [
 
 [[package]]
 name = "servo-paint"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bitflags 2.11.1",
  "crossbeam-channel",
@@ -8504,7 +8504,7 @@ dependencies = [
 
 [[package]]
 name = "servo-paint-api"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bitflags 2.11.1",
  "crossbeam-channel",
@@ -8539,7 +8539,7 @@ dependencies = [
 
 [[package]]
 name = "servo-pixels"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "criterion",
  "euclid",
@@ -8554,7 +8554,7 @@ dependencies = [
 
 [[package]]
 name = "servo-profile"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "libc",
  "log",
@@ -8572,7 +8572,7 @@ dependencies = [
 
 [[package]]
 name = "servo-profile-traits"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "crossbeam-channel",
  "ipc-channel",
@@ -8588,7 +8588,7 @@ dependencies = [
 
 [[package]]
 name = "servo-script"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "accountable-refcell",
  "aes",
@@ -8731,7 +8731,7 @@ dependencies = [
 
 [[package]]
 name = "servo-script-bindings"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bitflags 2.11.1",
  "crossbeam-channel",
@@ -8770,7 +8770,7 @@ dependencies = [
 
 [[package]]
 name = "servo-script-traits"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "accesskit",
  "crossbeam-channel",
@@ -8805,7 +8805,7 @@ dependencies = [
 
 [[package]]
 name = "servo-storage"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "libc",
  "log",
@@ -8832,7 +8832,7 @@ dependencies = [
 
 [[package]]
 name = "servo-storage-traits"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "malloc_size_of_derive",
  "serde",
@@ -8845,7 +8845,7 @@ dependencies = [
 
 [[package]]
 name = "servo-timers"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "crossbeam-channel",
  "malloc_size_of_derive",
@@ -8854,7 +8854,7 @@ dependencies = [
 
 [[package]]
 name = "servo-tracing"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -8864,7 +8864,7 @@ dependencies = [
 
 [[package]]
 name = "servo-url"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "encoding_rs",
  "malloc_size_of_derive",
@@ -8877,7 +8877,7 @@ dependencies = [
 
 [[package]]
 name = "servo-wakelock"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "servo-embedder-traits",
@@ -8885,7 +8885,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webdriver-server"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -8916,7 +8916,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webgl"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -8940,7 +8940,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webgpu"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "arrayvec",
  "euclid",
@@ -8958,7 +8958,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webgpu-traits"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "arrayvec",
  "malloc_size_of_derive",
@@ -8973,7 +8973,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webxr"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "crossbeam-channel",
  "euclid",
@@ -8991,7 +8991,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webxr-api"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "euclid",
  "ipc-channel",
@@ -9006,7 +9006,7 @@ dependencies = [
 
 [[package]]
 name = "servo-xpath"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "log",
  "malloc_size_of_derive",
@@ -9025,7 +9025,7 @@ dependencies = [
 
 [[package]]
 name = "servoshell"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "accesskit",
  "android_logger",
@@ -9425,7 +9425,7 @@ dependencies = [
 
 [[package]]
 name = "style_tests"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "app_units",
  "cssparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ default-members = ["ports/servoshell"]
 exclude = [".cargo", "support/crown"]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 authors = ["The Servo Project Developers"]
 repository = "https://github.com/servo/servo"
 # A generic description for packages that don't have a meaningful description yet.
@@ -238,72 +238,72 @@ zeroize = "1.8"
 # be listed here, between the `Begin` and `End` comments, so that we can easily find and
 # update the version requirements when bumping the workspace version.
 # Begin workspace-version dependencies - Don't change this comment, we grep for it in scripts!
-deny_public_fields = { package = "servo-deny-public-fields", version = "0.1.0", path = "components/deny_public_fields" }
-devtools = { package = "servo-devtools", version = "0.1.0", path = "components/devtools" }
-devtools_traits = { package = "servo-devtools-traits", version = "0.1.0", path = "components/shared/devtools" }
-dom_struct = { package = "servo-dom-struct", version = "0.1.0", path = "components/dom_struct" }
-embedder_traits = { package = "servo-embedder-traits", version = "0.1.0", path = "components/shared/embedder" }
-fonts = { package = "servo-fonts", version = "0.1.0", path = "components/fonts" }
-fonts_traits = { package = "servo-fonts-traits", version = "0.1.0", path = "components/shared/fonts" }
-hyper_serde = { package = "servo-hyper-serde", version = "0.1.0", path = "components/hyper_serde" }
-jstraceable_derive = { package = "servo-jstraceable-derive", version = "0.1.0", path = "components/jstraceable_derive" }
-layout = { package = "servo-layout", version = "0.1.0", path = "components/layout" }
-layout_api = { package = "servo-layout-api", version = "0.1.0", path = "components/shared/layout" }
-malloc_size_of = { package = "servo-malloc-size-of", version = "0.1.0", path = "components/malloc_size_of" }
-media = { package = "servo-media-thread", version = "0.1.0", path = "components/media/media-thread" }
-metrics = { package = "servo-metrics", version = "0.1.0", path = "components/metrics" }
-net = { package = "servo-net", version = "0.1.0", path = "components/net" }
-net_traits = { package = "servo-net-traits", version = "0.1.0", path = "components/shared/net" }
-paint = { package = "servo-paint", version = "0.1.0", path = "components/paint" }
-paint_api = { package = "servo-paint-api", version = "0.1.0", path = "components/shared/paint" }
-pixels = { package = "servo-pixels", version = "0.1.0", path = "components/pixels" }
-profile = { package = "servo-profile", version = "0.1.0", path = "components/profile" }
-profile_traits = { package = "servo-profile-traits", version = "0.1.0", path = "components/shared/profile" }
-script = { package = "servo-script", version = "0.1.0", path = "components/script" }
-script_bindings = { package = "servo-script-bindings", version = "0.1.0", path = "components/script_bindings" }
-script_traits = { package = "servo-script-traits", version = "0.1.0", path = "components/shared/script" }
-servo = { version = "0.1.0", path = "components/servo", default-features = false }
-servo-allocator = { version = "0.1.0", path = "components/allocator" }
-servo-background-hang-monitor = { version = "0.1.0", path = "components/background_hang_monitor" }
-servo-background-hang-monitor-api = { version = "0.1.0", path = "components/shared/background_hang_monitor" }
-servo-base = { version = "0.1.0", path = "components/shared/base" }
-servo-bluetooth = { version = "0.1.0", path = "components/bluetooth" }
-servo-bluetooth-traits = { version = "0.1.0", path = "components/shared/bluetooth" }
-servo-canvas = { version = "0.1.0", path = "components/canvas" }
-servo-canvas-traits = { version = "0.1.0", path = "components/shared/canvas" }
-servo-config = { version = "0.1.0", path = "components/config" }
-servo-config-macro = { version = "0.1.0", path = "components/config/macro" }
-servo-constellation = { version = "0.1.0", path = "components/constellation" }
-servo-constellation-traits = { version = "0.1.0", path = "components/shared/constellation" }
-servo-default-resources = { version = "0.1.0", path = "components/default-resources" }
-servo-geometry = { version = "0.1.0", path = "components/geometry" }
-servo-media = { version = "0.1.0", path = "components/media/servo-media" }
-servo-media-audio = { version = "0.1.0", path = "components/media/audio" }
-servo-media-auto = { version = "0.1.0", path = "components/media/backends/auto" }
-servo-media-derive = { version = "0.1.0", path = "components/media/servo-media-derive" }
-servo-media-dummy = { version = "0.1.0", path = "components/media/backends/dummy" }
-servo-media-gstreamer = { version = "0.1.0", path = "components/media/backends/gstreamer" }
-servo-media-gstreamer-render = { version = "0.1.0", path = "components/media/backends/gstreamer/render" }
-servo-media-gstreamer-render-android = { version = "0.1.0", path = "components/media/backends/gstreamer/render-android" }
-servo-media-gstreamer-render-unix = { version = "0.1.0", path = "components/media/backends/gstreamer/render-unix" }
-servo-media-ohos = { version = "0.1.0", path = "components/media/backends/ohos" }
-servo-media-player = { version = "0.1.0", path = "components/media/player" }
-servo-media-streams = { version = "0.1.0", path = "components/media/streams" }
-servo-media-traits = { version = "0.1.0", path = "components/media/traits" }
-servo-media-webrtc = { version = "0.1.0", path = "components/media/webrtc" }
-servo-tracing = { version = "0.1.0", path = "components/servo_tracing" }
-servo-url = { version = "0.1.0", path = "components/url" }
-servo-wakelock = { version = "0.1.0", path = "components/wakelock" }
-storage = { package = "servo-storage", version = "0.1.0", path = "components/storage" }
-storage_traits = { package = "servo-storage-traits", version = "0.1.0", path = "components/shared/storage" }
-timers = { package = "servo-timers", version = "0.1.0", path = "components/timers" }
-webdriver_server = { package = "servo-webdriver-server", version = "0.1.0", path = "components/webdriver_server" }
-webgl = { package = "servo-webgl", version = "0.1.0", path = "components/webgl", default-features = false }
-webgpu = { package = "servo-webgpu", version = "0.1.0", path = "components/webgpu" }
-webgpu_traits = { package = "servo-webgpu-traits", version = "0.1.0", path = "components/shared/webgpu" }
-webxr = { package = "servo-webxr", version = "0.1.0", path = "components/webxr" }
-webxr-api = { package = "servo-webxr-api", version = "0.1.0", path = "components/shared/webxr" }
-xpath = { package = "servo-xpath", version = "0.1.0", path = "components/xpath" }
+deny_public_fields = { package = "servo-deny-public-fields", version = "0.2.0", path = "components/deny_public_fields" }
+devtools = { package = "servo-devtools", version = "0.2.0", path = "components/devtools" }
+devtools_traits = { package = "servo-devtools-traits", version = "0.2.0", path = "components/shared/devtools" }
+dom_struct = { package = "servo-dom-struct", version = "0.2.0", path = "components/dom_struct" }
+embedder_traits = { package = "servo-embedder-traits", version = "0.2.0", path = "components/shared/embedder" }
+fonts = { package = "servo-fonts", version = "0.2.0", path = "components/fonts" }
+fonts_traits = { package = "servo-fonts-traits", version = "0.2.0", path = "components/shared/fonts" }
+hyper_serde = { package = "servo-hyper-serde", version = "0.2.0", path = "components/hyper_serde" }
+jstraceable_derive = { package = "servo-jstraceable-derive", version = "0.2.0", path = "components/jstraceable_derive" }
+layout = { package = "servo-layout", version = "0.2.0", path = "components/layout" }
+layout_api = { package = "servo-layout-api", version = "0.2.0", path = "components/shared/layout" }
+malloc_size_of = { package = "servo-malloc-size-of", version = "0.2.0", path = "components/malloc_size_of" }
+media = { package = "servo-media-thread", version = "0.2.0", path = "components/media/media-thread" }
+metrics = { package = "servo-metrics", version = "0.2.0", path = "components/metrics" }
+net = { package = "servo-net", version = "0.2.0", path = "components/net" }
+net_traits = { package = "servo-net-traits", version = "0.2.0", path = "components/shared/net" }
+paint = { package = "servo-paint", version = "0.2.0", path = "components/paint" }
+paint_api = { package = "servo-paint-api", version = "0.2.0", path = "components/shared/paint" }
+pixels = { package = "servo-pixels", version = "0.2.0", path = "components/pixels" }
+profile = { package = "servo-profile", version = "0.2.0", path = "components/profile" }
+profile_traits = { package = "servo-profile-traits", version = "0.2.0", path = "components/shared/profile" }
+script = { package = "servo-script", version = "0.2.0", path = "components/script" }
+script_bindings = { package = "servo-script-bindings", version = "0.2.0", path = "components/script_bindings" }
+script_traits = { package = "servo-script-traits", version = "0.2.0", path = "components/shared/script" }
+servo = { version = "0.2.0", path = "components/servo", default-features = false }
+servo-allocator = { version = "0.2.0", path = "components/allocator" }
+servo-background-hang-monitor = { version = "0.2.0", path = "components/background_hang_monitor" }
+servo-background-hang-monitor-api = { version = "0.2.0", path = "components/shared/background_hang_monitor" }
+servo-base = { version = "0.2.0", path = "components/shared/base" }
+servo-bluetooth = { version = "0.2.0", path = "components/bluetooth" }
+servo-bluetooth-traits = { version = "0.2.0", path = "components/shared/bluetooth" }
+servo-canvas = { version = "0.2.0", path = "components/canvas" }
+servo-canvas-traits = { version = "0.2.0", path = "components/shared/canvas" }
+servo-config = { version = "0.2.0", path = "components/config" }
+servo-config-macro = { version = "0.2.0", path = "components/config/macro" }
+servo-constellation = { version = "0.2.0", path = "components/constellation" }
+servo-constellation-traits = { version = "0.2.0", path = "components/shared/constellation" }
+servo-default-resources = { version = "0.2.0", path = "components/default-resources" }
+servo-geometry = { version = "0.2.0", path = "components/geometry" }
+servo-media = { version = "0.2.0", path = "components/media/servo-media" }
+servo-media-audio = { version = "0.2.0", path = "components/media/audio" }
+servo-media-auto = { version = "0.2.0", path = "components/media/backends/auto" }
+servo-media-derive = { version = "0.2.0", path = "components/media/servo-media-derive" }
+servo-media-dummy = { version = "0.2.0", path = "components/media/backends/dummy" }
+servo-media-gstreamer = { version = "0.2.0", path = "components/media/backends/gstreamer" }
+servo-media-gstreamer-render = { version = "0.2.0", path = "components/media/backends/gstreamer/render" }
+servo-media-gstreamer-render-android = { version = "0.2.0", path = "components/media/backends/gstreamer/render-android" }
+servo-media-gstreamer-render-unix = { version = "0.2.0", path = "components/media/backends/gstreamer/render-unix" }
+servo-media-ohos = { version = "0.2.0", path = "components/media/backends/ohos" }
+servo-media-player = { version = "0.2.0", path = "components/media/player" }
+servo-media-streams = { version = "0.2.0", path = "components/media/streams" }
+servo-media-traits = { version = "0.2.0", path = "components/media/traits" }
+servo-media-webrtc = { version = "0.2.0", path = "components/media/webrtc" }
+servo-tracing = { version = "0.2.0", path = "components/servo_tracing" }
+servo-url = { version = "0.2.0", path = "components/url" }
+servo-wakelock = { version = "0.2.0", path = "components/wakelock" }
+storage = { package = "servo-storage", version = "0.2.0", path = "components/storage" }
+storage_traits = { package = "servo-storage-traits", version = "0.2.0", path = "components/shared/storage" }
+timers = { package = "servo-timers", version = "0.2.0", path = "components/timers" }
+webdriver_server = { package = "servo-webdriver-server", version = "0.2.0", path = "components/webdriver_server" }
+webgl = { package = "servo-webgl", version = "0.2.0", path = "components/webgl", default-features = false }
+webgpu = { package = "servo-webgpu", version = "0.2.0", path = "components/webgpu" }
+webgpu_traits = { package = "servo-webgpu-traits", version = "0.2.0", path = "components/shared/webgpu" }
+webxr = { package = "servo-webxr", version = "0.2.0", path = "components/webxr" }
+webxr-api = { package = "servo-webxr-api", version = "0.2.0", path = "components/shared/webxr" }
+xpath = { package = "servo-xpath", version = "0.2.0", path = "components/xpath" }
 # End workspace-version dependencies - Don't change this comment, we grep for it in scripts!
 
 # RSA key generation could be very slow without compilation

--- a/ports/servoshell/platform/macos/Info.plist
+++ b/ports/servoshell/platform/macos/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.0</string>
+	<string>0.2.0</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>NSPrincipalClass</key>

--- a/ports/servoshell/platform/windows/servoshell.exe.manifest
+++ b/ports/servoshell/platform/windows/servoshell.exe.manifest
@@ -4,7 +4,7 @@
           xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
   <assemblyIdentity type="win32"
                     name="servo.ServoShell"
-                    version="0.1.0.0"/>
+                    version="0.2.0.0"/>
 
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>

--- a/resources/resource_protocol/license.html
+++ b/resources/resource_protocol/license.html
@@ -1337,6 +1337,7 @@
                         <li><a href=" https://github.com/hsivonen/encoding_rs ">encoding_rs 0.8.35</a></li>
                         <li><a href=" https://github.com/linebender/kurbo ">kurbo 0.11.3</a></li>
                         <li><a href=" https://github.com/linebender/kurbo ">kurbo 0.12.0</a></li>
+                        <li><a href=" https://github.com/linebender/kurbo ">kurbo 0.13.0</a></li>
                         <li><a href=" https://github.com/paritytech/nohash-hasher ">nohash-hasher 0.2.0</a></li>
                         <li><a href=" https://github.com/Ralith/openxrs ">openxr-sys 0.12.0</a></li>
                         <li><a href=" https://github.com/nvzqz/static-assertions-rs ">static_assertions 1.1.0</a></li>
@@ -1784,10 +1785,11 @@ Software.
             </li>
             <li class="license">
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/linebender/peniko ">peniko 0.5.0</a>
-                    </p>
+                    <h4>Used by:</h4>
+                    <ul class="license-used-by">
+                        <li><a href=" https://github.com/linebender/peniko ">peniko 0.5.0</a></li>
+                        <li><a href=" https://github.com/linebender/peniko ">peniko 0.6.0</a></li>
+                    </ul>
                 <pre class="license-text">
                                  Apache License
                            Version 2.0, January 2004
@@ -1991,6 +1993,205 @@ Software.
    See the License for the specific language governing permissions and
    limitations under the License.
    </pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                    <p>
+                        Used by
+                            <a href=" https://github.com/jeffparsons/rangemap ">rangemap 1.7.1</a>
+                    </p>
+                <pre class="license-text">
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      &quot;control&quot; means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      &quot;Source&quot; form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      &quot;Object&quot; form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      &quot;Work&quot; shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      &quot;Contribution&quot; shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2019-2022 Jeff Parsons, and [contributors](https://github.com/jeffparsons/rangemap/contributors)
+
+   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+</pre>
             </li>
             <li class="license">
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
@@ -2227,42 +2428,22 @@ Software.
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows-strings 0.1.0</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows-strings 0.4.2</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows-strings 0.5.1</a></li>
-                        <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.45.0</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.52.0</a></li>
-                        <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.59.0</a></li>
-                        <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.60.2</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.61.2</a></li>
-                        <li><a href=" https://github.com/microsoft/windows-rs ">windows-targets 0.42.2</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows-targets 0.52.6</a></li>
-                        <li><a href=" https://github.com/microsoft/windows-rs ">windows-targets 0.53.5</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows-threading 0.1.0</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows-threading 0.2.1</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows 0.58.0</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows 0.61.3</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows 0.62.2</a></li>
-                        <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_gnullvm 0.42.2</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_gnullvm 0.52.6</a></li>
-                        <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_gnullvm 0.53.1</a></li>
-                        <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_msvc 0.42.2</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_msvc 0.52.6</a></li>
-                        <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_msvc 0.53.1</a></li>
-                        <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_gnu 0.42.2</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_gnu 0.52.6</a></li>
-                        <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_gnu 0.53.1</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_gnullvm 0.52.6</a></li>
-                        <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_gnullvm 0.53.1</a></li>
-                        <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_msvc 0.42.2</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_msvc 0.52.6</a></li>
-                        <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_msvc 0.53.1</a></li>
-                        <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnu 0.42.2</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnu 0.52.6</a></li>
-                        <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnu 0.53.1</a></li>
-                        <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnullvm 0.42.2</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnullvm 0.52.6</a></li>
-                        <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnullvm 0.53.1</a></li>
-                        <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_msvc 0.42.2</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_msvc 0.52.6</a></li>
-                        <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_msvc 0.53.1</a></li>
                     </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -3307,15 +3488,225 @@ Software.
             </li>
             <li class="license">
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
+                    <p>
+                        Used by
+                            <a href=" https://github.com/awxkee/yuvutils-rs ">yuv 0.8.14</a>
+                    </p>
+                <pre class="license-text">                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      &quot;control&quot; means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      &quot;Source&quot; form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      &quot;Object&quot; form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      &quot;Work&quot; shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      &quot;Contribution&quot; shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
+      replaced with your own identifying information. (Don&#x27;t include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same &quot;printed page&quot; as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2024 Radzivon Bartoshyk
+
+   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/bholley/atomic_refcell ">atomic_refcell 0.1.13</a></li>
+                        <li><a href=" https://github.com/mozilla/atomic_refcell ">atomic_refcell 0.1.14</a></li>
                         <li><a href=" https://github.com/enarx/ciborium ">ciborium-io 0.2.2</a></li>
                         <li><a href=" https://github.com/enarx/ciborium ">ciborium-ll 0.2.2</a></li>
                         <li><a href=" https://github.com/enarx/ciborium ">ciborium 0.2.2</a></li>
                         <li><a href=" https://github.com/brendanzab/codespan ">codespan-reporting 0.12.0</a></li>
-                        <li><a href=" https://github.com/kornelski/imgref ">imgref 1.12.0</a></li>
-                        <li><a href=" https://github.com/rustls/rustls-platform-verifier ">rustls-platform-verifier 0.6.2</a></li>
+                        <li><a href=" https://github.com/kornelski/imgref ">imgref 1.12.1</a></li>
+                        <li><a href=" https://github.com/rustls/rustls-platform-verifier ">rustls-platform-verifier 0.7.0</a></li>
+                        <li><a href=" https://github.com/Voultapher/self_cell ">self_cell 1.2.2</a></li>
                         <li><a href=" https://github.com/1Password/sys-locale ">sys-locale 0.3.2</a></li>
                     </ul>
                 <pre class="license-text">                                 Apache License
@@ -3950,7 +4341,7 @@ Software.
                         <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-query 1.1.5</a></li>
                         <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-wincon 3.0.11</a></li>
                         <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle 1.0.14</a></li>
-                        <li><a href=" https://github.com/clap-rs/clap ">clap 4.6.0</a></li>
+                        <li><a href=" https://github.com/clap-rs/clap ">clap 4.6.1</a></li>
                         <li><a href=" https://github.com/clap-rs/clap ">clap_builder 4.6.0</a></li>
                         <li><a href=" https://github.com/clap-rs/clap ">clap_lex 1.1.0</a></li>
                         <li><a href=" https://github.com/jamesmunns/cobs.rs ">cobs 0.3.0</a></li>
@@ -4607,7 +4998,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/paholg/typenum ">typenum 1.19.0</a>
+                            <a href=" https://github.com/paholg/typenum ">typenum 1.20.0</a>
                     </p>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -5427,215 +5818,6 @@ APPENDIX: How to apply the Apache License to your work.
    identification within third-party archives.
 
 Copyright 2017 quininer kel
-
-Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/rust-lang-nursery/pin-utils ">pin-utils 0.1.0</a>
-                    </p>
-                <pre class="license-text">                              Apache License
-                        Version 2.0, January 2004
-                     http://www.apache.org/licenses/
-
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-1. Definitions.
-
-   &quot;License&quot; shall mean the terms and conditions for use, reproduction,
-   and distribution as defined by Sections 1 through 9 of this document.
-
-   &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-   the copyright owner that is granting the License.
-
-   &quot;Legal Entity&quot; shall mean the union of the acting entity and all
-   other entities that control, are controlled by, or are under common
-   control with that entity. For the purposes of this definition,
-   &quot;control&quot; means (i) the power, direct or indirect, to cause the
-   direction or management of such entity, whether by contract or
-   otherwise, or (ii) ownership of fifty percent (50%) or more of the
-   outstanding shares, or (iii) beneficial ownership of such entity.
-
-   &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-   exercising permissions granted by this License.
-
-   &quot;Source&quot; form shall mean the preferred form for making modifications,
-   including but not limited to software source code, documentation
-   source, and configuration files.
-
-   &quot;Object&quot; form shall mean any form resulting from mechanical
-   transformation or translation of a Source form, including but
-   not limited to compiled object code, generated documentation,
-   and conversions to other media types.
-
-   &quot;Work&quot; shall mean the work of authorship, whether in Source or
-   Object form, made available under the License, as indicated by a
-   copyright notice that is included in or attached to the work
-   (an example is provided in the Appendix below).
-
-   &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-   form, that is based on (or derived from) the Work and for which the
-   editorial revisions, annotations, elaborations, or other modifications
-   represent, as a whole, an original work of authorship. For the purposes
-   of this License, Derivative Works shall not include works that remain
-   separable from, or merely link (or bind by name) to the interfaces of,
-   the Work and Derivative Works thereof.
-
-   &quot;Contribution&quot; shall mean any work of authorship, including
-   the original version of the Work and any modifications or additions
-   to that Work or Derivative Works thereof, that is intentionally
-   submitted to Licensor for inclusion in the Work by the copyright owner
-   or by an individual or Legal Entity authorized to submit on behalf of
-   the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-   means any form of electronic, verbal, or written communication sent
-   to the Licensor or its representatives, including but not limited to
-   communication on electronic mailing lists, source code control systems,
-   and issue tracking systems that are managed by, or on behalf of, the
-   Licensor for the purpose of discussing and improving the Work, but
-   excluding communication that is conspicuously marked or otherwise
-   designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-   &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-   on behalf of whom a Contribution has been received by Licensor and
-   subsequently incorporated within the Work.
-
-2. Grant of Copyright License. Subject to the terms and conditions of
-   this License, each Contributor hereby grants to You a perpetual,
-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-   copyright license to reproduce, prepare Derivative Works of,
-   publicly display, publicly perform, sublicense, and distribute the
-   Work and such Derivative Works in Source or Object form.
-
-3. Grant of Patent License. Subject to the terms and conditions of
-   this License, each Contributor hereby grants to You a perpetual,
-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-   (except as stated in this section) patent license to make, have made,
-   use, offer to sell, sell, import, and otherwise transfer the Work,
-   where such license applies only to those patent claims licensable
-   by such Contributor that are necessarily infringed by their
-   Contribution(s) alone or by combination of their Contribution(s)
-   with the Work to which such Contribution(s) was submitted. If You
-   institute patent litigation against any entity (including a
-   cross-claim or counterclaim in a lawsuit) alleging that the Work
-   or a Contribution incorporated within the Work constitutes direct
-   or contributory patent infringement, then any patent licenses
-   granted to You under this License for that Work shall terminate
-   as of the date such litigation is filed.
-
-4. Redistribution. You may reproduce and distribute copies of the
-   Work or Derivative Works thereof in any medium, with or without
-   modifications, and in Source or Object form, provided that You
-   meet the following conditions:
-
-   (a) You must give any other recipients of the Work or
-       Derivative Works a copy of this License; and
-
-   (b) You must cause any modified files to carry prominent notices
-       stating that You changed the files; and
-
-   (c) You must retain, in the Source form of any Derivative Works
-       that You distribute, all copyright, patent, trademark, and
-       attribution notices from the Source form of the Work,
-       excluding those notices that do not pertain to any part of
-       the Derivative Works; and
-
-   (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-       distribution, then any Derivative Works that You distribute must
-       include a readable copy of the attribution notices contained
-       within such NOTICE file, excluding those notices that do not
-       pertain to any part of the Derivative Works, in at least one
-       of the following places: within a NOTICE text file distributed
-       as part of the Derivative Works; within the Source form or
-       documentation, if provided along with the Derivative Works; or,
-       within a display generated by the Derivative Works, if and
-       wherever such third-party notices normally appear. The contents
-       of the NOTICE file are for informational purposes only and
-       do not modify the License. You may add Your own attribution
-       notices within Derivative Works that You distribute, alongside
-       or as an addendum to the NOTICE text from the Work, provided
-       that such additional attribution notices cannot be construed
-       as modifying the License.
-
-   You may add Your own copyright statement to Your modifications and
-   may provide additional or different license terms and conditions
-   for use, reproduction, or distribution of Your modifications, or
-   for any such Derivative Works as a whole, provided Your use,
-   reproduction, and distribution of the Work otherwise complies with
-   the conditions stated in this License.
-
-5. Submission of Contributions. Unless You explicitly state otherwise,
-   any Contribution intentionally submitted for inclusion in the Work
-   by You to the Licensor shall be under the terms and conditions of
-   this License, without any additional terms or conditions.
-   Notwithstanding the above, nothing herein shall supersede or modify
-   the terms of any separate license agreement you may have executed
-   with Licensor regarding such Contributions.
-
-6. Trademarks. This License does not grant permission to use the trade
-   names, trademarks, service marks, or product names of the Licensor,
-   except as required for reasonable and customary use in describing the
-   origin of the Work and reproducing the content of the NOTICE file.
-
-7. Disclaimer of Warranty. Unless required by applicable law or
-   agreed to in writing, Licensor provides the Work (and each
-   Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-   implied, including, without limitation, any warranties or conditions
-   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-   PARTICULAR PURPOSE. You are solely responsible for determining the
-   appropriateness of using or redistributing the Work and assume any
-   risks associated with Your exercise of permissions under this License.
-
-8. Limitation of Liability. In no event and under no legal theory,
-   whether in tort (including negligence), contract, or otherwise,
-   unless required by applicable law (such as deliberate and grossly
-   negligent acts) or agreed to in writing, shall any Contributor be
-   liable to You for damages, including any direct, indirect, special,
-   incidental, or consequential damages of any character arising as a
-   result of this License or out of the use or inability to use the
-   Work (including but not limited to damages for loss of goodwill,
-   work stoppage, computer failure or malfunction, or any and all
-   other commercial damages or losses), even if such Contributor
-   has been advised of the possibility of such damages.
-
-9. Accepting Warranty or Additional Liability. While redistributing
-   the Work or Derivative Works thereof, You may choose to offer,
-   and charge a fee for, acceptance of support, warranty, indemnity,
-   or other liability obligations and/or rights consistent with this
-   License. However, in accepting such obligations, You may act only
-   on Your own behalf and on Your sole responsibility, not on behalf
-   of any other Contributor, and only if You agree to indemnify,
-   defend, and hold each Contributor harmless for any liability
-   incurred by, or claims asserted against, such Contributor by reason
-   of your accepting any such warranty or additional liability.
-
-END OF TERMS AND CONDITIONS
-
-APPENDIX: How to apply the Apache License to your work.
-
-   To apply the Apache License to your work, attach the following
-   boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
-   replaced with your own identifying information. (Don&#x27;t include
-   the brackets!)  The text should be enclosed in the appropriate
-   comment syntax for the file format. We also recommend that a
-   file or class name and description of purpose be included on the
-   same &quot;printed page&quot; as the copyright notice for easier
-   identification within third-party archives.
-
-Copyright 2018 The pin-utils authors
 
 Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
 you may not use this file except in compliance with the License.
@@ -6703,7 +6885,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/rustls/pki-types ">rustls-pki-types 1.14.0</a>
+                            <a href=" https://github.com/rustls/pki-types ">rustls-pki-types 1.14.1</a>
                     </p>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -7543,40 +7725,42 @@ limitations under the License.</pre>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/servo/stylo ">servo_arc 0.4.3</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_malloc_size_of 0.14.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-malloc-size-of 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_malloc_size_of 0.16.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-malloc-size-of 0.2.0</a></li>
                         <li><a href=" https://github.com/gimli-rs/addr2line ">addr2line 0.25.1</a></li>
                         <li><a href=" https://github.com/tkaitchuck/ahash ">ahash 0.8.12</a></li>
                         <li><a href=" https://github.com/rust-fuzz/arbitrary/ ">arbitrary 1.4.2</a></li>
-                        <li><a href=" https://github.com/vorner/arc-swap ">arc-swap 1.9.0</a></li>
+                        <li><a href=" https://github.com/vorner/arc-swap ">arc-swap 1.9.1</a></li>
                         <li><a href=" https://github.com/bluss/arrayvec ">arrayvec 0.7.6</a></li>
                         <li><a href=" https://github.com/smol-rs/async-channel ">async-channel 2.5.0</a></li>
+                        <li><a href=" https://github.com/Nullus157/async-compression ">async-compression 0.4.42</a></li>
                         <li><a href=" https://github.com/smol-rs/async-executor ">async-executor 1.14.0</a></li>
                         <li><a href=" https://github.com/smol-rs/async-io ">async-io 2.6.0</a></li>
                         <li><a href=" https://github.com/smol-rs/async-lock ">async-lock 3.4.2</a></li>
                         <li><a href=" https://github.com/smol-rs/async-process ">async-process 2.5.0</a></li>
-                        <li><a href=" https://github.com/smol-rs/async-signal ">async-signal 0.2.13</a></li>
+                        <li><a href=" https://github.com/smol-rs/async-signal ">async-signal 0.2.14</a></li>
                         <li><a href=" https://github.com/smol-rs/async-task ">async-task 4.7.1</a></li>
                         <li><a href=" https://github.com/smol-rs/atomic-waker ">atomic-waker 1.1.2</a></li>
                         <li><a href=" https://github.com/cuviper/autocfg ">autocfg 1.5.0</a></li>
                         <li><a href=" https://github.com/rust-lang/backtrace-rs ">backtrace 0.3.76</a></li>
                         <li><a href=" https://github.com/marshallpierce/rust-base64 ">base64 0.12.3</a></li>
-                        <li><a href=" https://github.com/marshallpierce/rust-base64 ">base64 0.21.7</a></li>
                         <li><a href=" https://github.com/marshallpierce/rust-base64 ">base64 0.22.1</a></li>
                         <li><a href=" https://github.com/bitflags/bitflags ">bitflags 1.3.2</a></li>
-                        <li><a href=" https://github.com/bitflags/bitflags ">bitflags 2.11.0</a></li>
+                        <li><a href=" https://github.com/bitflags/bitflags ">bitflags 2.11.1</a></li>
                         <li><a href=" https://github.com/tuffy/bitstream-io ">bitstream-io 2.6.0</a></li>
                         <li><a href=" https://github.com/smol-rs/blocking ">blocking 1.6.2</a></li>
-                        <li><a href=" https://github.com/pacak/bpaf ">bpaf 0.9.24</a></li>
+                        <li><a href=" https://github.com/pacak/bpaf ">bpaf 0.9.25</a></li>
                         <li><a href=" https://github.com/pacak/bpaf ">bpaf_derive 0.5.23</a></li>
                         <li><a href=" https://github.com/mikedilger/buf-read-ext ">buf-read-ext 0.4.0</a></li>
                         <li><a href=" https://github.com/fitzgen/bumpalo ">bumpalo 3.20.2</a></li>
                         <li><a href=" https://github.com/japaric/cast.rs ">cast 0.3.0</a></li>
-                        <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.2.58</a></li>
+                        <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.2.61</a></li>
                         <li><a href=" https://github.com/jethrogb/rust-cexpr ">cexpr 0.6.0</a></li>
                         <li><a href=" https://github.com/rust-lang/cfg-if ">cfg-if 1.0.4</a></li>
                         <li><a href=" https://github.com/servo/cgl-rs ">cgl 0.3.2</a></li>
                         <li><a href=" https://github.com/rust-lang/cmake-rs ">cmake 0.1.58</a></li>
+                        <li><a href=" https://github.com/Nullus157/async-compression ">compression-codecs 0.4.38</a></li>
+                        <li><a href=" https://github.com/Nullus157/async-compression ">compression-core 0.4.32</a></li>
                         <li><a href=" https://github.com/smol-rs/concurrent-queue ">concurrent-queue 2.5.0</a></li>
                         <li><a href=" https://github.com/servo/core-foundation-rs ">core-foundation-sys 0.8.7</a></li>
                         <li><a href=" https://github.com/servo/core-foundation-rs ">core-foundation 0.10.1</a></li>
@@ -7600,7 +7784,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/servo/euclid ">euclid 0.22.14</a></li>
                         <li><a href=" https://github.com/smol-rs/event-listener-strategy ">event-listener-strategy 0.5.4</a></li>
                         <li><a href=" https://github.com/smol-rs/event-listener ">event-listener 5.4.1</a></li>
-                        <li><a href=" https://github.com/smol-rs/fastrand ">fastrand 2.3.0</a></li>
+                        <li><a href=" https://github.com/smol-rs/fastrand ">fastrand 2.4.1</a></li>
                         <li><a href=" https://github.com/alexcrichton/filetime ">filetime 0.2.27</a></li>
                         <li><a href=" https://github.com/rust-lang/cc-rs ">find-msvc-tools 0.1.9</a></li>
                         <li><a href=" https://github.com/bluss/fixedbitset ">fixedbitset 0.1.9</a></li>
@@ -7626,29 +7810,29 @@ limitations under the License.</pre>
                         <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer 0.25.1</a></li>
                         <li><a href=" https://github.com/servo/rust-harfbuzz ">harfbuzz-sys 0.6.1</a></li>
                         <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.15.5</a></li>
-                        <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.16.0</a></li>
+                        <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.16.1</a></li>
+                        <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.17.0</a></li>
                         <li><a href=" https://github.com/withoutboats/heck ">heck 0.4.1</a></li>
                         <li><a href=" https://github.com/withoutboats/heck ">heck 0.5.0</a></li>
                         <li><a href=" https://github.com/hermit-os/hermit-rs ">hermit-abi 0.5.2</a></li>
                         <li><a href=" https://github.com/servo/html5ever ">html5ever 0.39.0</a></li>
                         <li><a href=" https://github.com/seanmonstar/httparse ">httparse 1.10.1</a></li>
-                        <li><a href=" https://github.com/rustls/hyper-rustls ">hyper-rustls 0.27.7</a></li>
+                        <li><a href=" https://github.com/rustls/hyper-rustls ">hyper-rustls 0.27.9</a></li>
                         <li><a href=" https://github.com/servo/rust-url/ ">idna 1.1.0</a></li>
                         <li><a href=" https://github.com/hsivonen/idna_adapter ">idna_adapter 1.2.0</a></li>
-                        <li><a href=" https://github.com/indexmap-rs/indexmap ">indexmap 2.11.4</a></li>
+                        <li><a href=" https://github.com/indexmap-rs/indexmap ">indexmap 2.14.0</a></li>
                         <li><a href=" https://github.com/servo/ipc-channel ">ipc-channel 0.21.0</a></li>
                         <li><a href=" https://github.com/rust-itertools/itertools ">itertools 0.10.5</a></li>
                         <li><a href=" https://github.com/rust-itertools/itertools ">itertools 0.12.1</a></li>
                         <li><a href=" https://github.com/rust-itertools/itertools ">itertools 0.14.0</a></li>
-                        <li><a href=" https://github.com/jni-rs/jni-rs ">jni 0.21.1</a></li>
                         <li><a href=" https://github.com/rust-lang/jobserver-rs ">jobserver 0.1.34</a></li>
                         <li><a href=" https://github.com/image-rs/jpeg-decoder ">jpeg-decoder 0.3.2</a></li>
-                        <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys ">js-sys 0.3.82</a></li>
+                        <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys ">js-sys 0.3.94</a></li>
                         <li><a href=" https://github.com/timothee-haudebourg/khronos-egl ">khronos-egl 6.0.0</a></li>
                         <li><a href=" https://github.com/rust-lang-nursery/lazy-static.rs ">lazy_static 1.5.0</a></li>
                         <li><a href=" https://github.com/rust-fuzz/libfuzzer ">libfuzzer-sys 0.4.12</a></li>
-                        <li><a href=" https://github.com/rust-lang/libz-sys ">libz-sys 1.1.25</a></li>
-                        <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys 0.11.0</a></li>
+                        <li><a href=" https://github.com/rust-lang/libz-sys ">libz-sys 1.1.28</a></li>
+                        <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys 0.12.1</a></li>
                         <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys 0.4.15</a></li>
                         <li><a href=" https://github.com/Amanieu/parking_lot ">lock_api 0.4.14</a></li>
                         <li><a href=" https://github.com/rust-lang/log ">log 0.4.29</a></li>
@@ -7659,7 +7843,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/hyperium/mime ">mime 0.3.17</a></li>
                         <li><a href=" https://github.com/dignifiedquire/num-bigint ">num-bigint-dig 0.8.6</a></li>
                         <li><a href=" https://github.com/rust-num/num-bigint ">num-bigint 0.4.6</a></li>
-                        <li><a href=" https://github.com/rust-num/num-complex ">num-complex 0.2.4</a></li>
+                        <li><a href=" https://github.com/rust-num/num-complex ">num-complex 0.4.6</a></li>
                         <li><a href=" https://github.com/rust-num/num-derive ">num-derive 0.4.2</a></li>
                         <li><a href=" https://github.com/rust-num/num-integer ">num-integer 0.1.46</a></li>
                         <li><a href=" https://github.com/rust-num/num-iter ">num-iter 0.1.45</a></li>
@@ -7680,13 +7864,13 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/servo/rust-url/ ">percent-encoding 2.3.2</a></li>
                         <li><a href=" https://github.com/bluss/petgraph ">petgraph 0.4.13</a></li>
                         <li><a href=" https://github.com/smol-rs/piper ">piper 0.2.5</a></li>
-                        <li><a href=" https://github.com/rust-lang/pkg-config-rs ">pkg-config 0.3.32</a></li>
+                        <li><a href=" https://github.com/rust-lang/pkg-config-rs ">pkg-config 0.3.33</a></li>
                         <li><a href=" https://github.com/randomites/plain ">plain 0.2.3</a></li>
                         <li><a href=" https://github.com/image-rs/image-png ">png 0.17.16</a></li>
                         <li><a href=" https://github.com/smol-rs/polling ">polling 3.11.0</a></li>
                         <li><a href=" https://github.com/jamesmunns/postcard ">postcard 1.1.3</a></li>
                         <li><a href=" https://github.com/rayon-rs/rayon ">rayon-core 1.13.0</a></li>
-                        <li><a href=" https://github.com/rayon-rs/rayon ">rayon 1.11.0</a></li>
+                        <li><a href=" https://github.com/rayon-rs/rayon ">rayon 1.12.0</a></li>
                         <li><a href=" https://github.com/rust-lang/regex ">regex-automata 0.4.13</a></li>
                         <li><a href=" https://github.com/rust-lang/regex ">regex-syntax 0.8.10</a></li>
                         <li><a href=" https://github.com/rust-lang/regex ">regex 1.12.3</a></li>
@@ -7696,25 +7880,24 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/rust-lang-nursery/rustc-hash ">rustc-hash 1.1.0</a></li>
                         <li><a href=" https://github.com/djc/rustc-version-rs ">rustc_version 0.4.1</a></li>
                         <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 0.38.44</a></li>
-                        <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 1.1.2</a></li>
+                        <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 1.1.4</a></li>
                         <li><a href=" https://github.com/rustls/rustls-native-certs ">rustls-native-certs 0.8.3</a></li>
-                        <li><a href=" https://github.com/rustls/rustls ">rustls 0.23.37</a></li>
+                        <li><a href=" https://github.com/rustls/rustls ">rustls 0.23.40</a></li>
                         <li><a href=" https://github.com/alexcrichton/scoped-tls ">scoped-tls 1.0.1</a></li>
                         <li><a href=" https://github.com/bluss/scopeguard ">scopeguard 1.2.0</a></li>
                         <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework-sys 2.17.0</a></li>
                         <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework 3.7.0</a></li>
-                        <li><a href=" https://github.com/adjivas/sig ">sig 1.0.0</a></li>
                         <li><a href=" https://github.com/vorner/signal-hook ">signal-hook-registry 1.4.8</a></li>
+                        <li><a href=" https://github.com/seancroach/simd_cesu8 ">simd_cesu8 1.1.1</a></li>
                         <li><a href=" https://github.com/linebender/simplecss ">simplecss 0.2.2</a></li>
                         <li><a href=" https://github.com/servo/smallbitvec ">smallbitvec 2.6.0</a></li>
                         <li><a href=" https://github.com/servo/rust-smallvec ">smallvec 1.15.1</a></li>
                         <li><a href=" https://github.com/rust-analyzer/smol_str ">smol_str 0.2.2</a></li>
-                        <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.5.10</a></li>
-                        <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.6.1</a></li>
+                        <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.6.3</a></li>
                         <li><a href=" https://github.com/storyyeller/stable_deref_trait ">stable_deref_trait 1.2.1</a></li>
                         <li><a href=" https://github.com/servo/string-cache ">string_cache 0.9.0</a></li>
                         <li><a href=" https://github.com/servo/string-cache ">string_cache_codegen 0.6.1</a></li>
-                        <li><a href=" https://github.com/servo/surfman ">surfman 0.11.0</a></li>
+                        <li><a href=" https://github.com/servo/surfman ">surfman 0.12.0</a></li>
                         <li><a href=" https://github.com/linebender/svgtypes ">svgtypes 0.15.3</a></li>
                         <li><a href=" https://github.com/gdesmott/system-deps ">system-deps 6.2.2</a></li>
                         <li><a href=" https://github.com/gdesmott/system-deps ">system-deps 7.0.5</a></li>
@@ -7736,17 +7919,17 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/RazrFalcon/unicode-vo ">unicode-vo 0.1.0</a></li>
                         <li><a href=" https://github.com/unicode-rs/unicode-width ">unicode-width 0.2.2</a></li>
                         <li><a href=" https://github.com/servo/rust-url ">url 2.5.8</a></li>
-                        <li><a href=" https://github.com/uuid-rs/uuid ">uuid 1.23.0</a></li>
+                        <li><a href=" https://github.com/uuid-rs/uuid ">uuid 1.23.1</a></li>
                         <li><a href=" https://github.com/SergioBenitez/version_check ">version_check 0.9.5</a></li>
                         <li><a href=" https://github.com/bytecodealliance/wasi ">wasi 0.11.1+wasi-snapshot-preview1</a></li>
                         <li><a href=" https://github.com/bytecodealliance/wasi ">wasi 0.9.0+wasi-snapshot-preview1</a></li>
-                        <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/futures ">wasm-bindgen-futures 0.4.55</a></li>
-                        <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro-support ">wasm-bindgen-macro-support 0.2.105</a></li>
-                        <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro ">wasm-bindgen-macro 0.2.105</a></li>
-                        <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared ">wasm-bindgen-shared 0.2.105</a></li>
-                        <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen ">wasm-bindgen 0.2.105</a></li>
-                        <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys ">web-sys 0.3.82</a></li>
-                        <li><a href=" https://github.com/servo/html5ever ">web_atoms 0.2.3</a></li>
+                        <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/futures ">wasm-bindgen-futures 0.4.67</a></li>
+                        <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro-support ">wasm-bindgen-macro-support 0.2.117</a></li>
+                        <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro ">wasm-bindgen-macro 0.2.117</a></li>
+                        <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared ">wasm-bindgen-shared 0.2.117</a></li>
+                        <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen ">wasm-bindgen 0.2.117</a></li>
+                        <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys ">web-sys 0.3.94</a></li>
+                        <li><a href=" https://github.com/servo/html5ever ">web_atoms 0.2.4</a></li>
                         <li><a href=" https://github.com/bytecodealliance/wit-bindgen ">wit-bindgen 0.51.0</a></li>
                         <li><a href=" https://crates.io/crates/wr_malloc_size_of ">wr_malloc_size_of 0.2.2</a></li>
                         <li><a href=" https://github.com/Stebalien/xattr ">xattr 1.6.1</a></li>
@@ -10098,10 +10281,11 @@ limitations under the License.
             </li>
             <li class="license">
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/grovesNL/glow ">glow 0.16.0</a>
-                    </p>
+                    <h4>Used by:</h4>
+                    <ul class="license-used-by">
+                        <li><a href=" https://github.com/grovesNL/glow ">glow 0.16.0</a></li>
+                        <li><a href=" https://github.com/grovesNL/glow ">glow 0.17.0</a></li>
+                    </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
                      http://www.apache.org/licenses/
@@ -10746,8 +10930,11 @@ limitations under the License.
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/googlefonts/fontations ">font-types 0.10.1</a></li>
+                        <li><a href=" https://github.com/googlefonts/fontations ">font-types 0.11.2</a></li>
                         <li><a href=" https://github.com/googlefonts/fontations ">read-fonts 0.35.0</a></li>
+                        <li><a href=" https://github.com/googlefonts/fontations ">read-fonts 0.37.0</a></li>
                         <li><a href=" https://github.com/googlefonts/fontations ">skrifa 0.37.0</a></li>
+                        <li><a href=" https://github.com/googlefonts/fontations ">skrifa 0.40.0</a></li>
                     </ul>
                 <pre class="license-text">Apache License
 
@@ -12360,13 +12547,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/emilk/egui ">ecolor 0.33.3</a></li>
-                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/egui-winit ">egui-winit 0.33.3</a></li>
-                        <li><a href=" https://github.com/emilk/egui ">egui 0.33.3</a></li>
-                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/emath ">emath 0.33.3</a></li>
-                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/epaint ">epaint 0.33.3</a></li>
-                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/epaint_default_fonts ">epaint_default_fonts 0.33.3</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-hyper-serde 0.13.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-hyper-serde 0.2.0</a></li>
                         <li><a href=" https://github.com/alexheretic/ab-glyph ">ab_glyph 0.2.32</a></li>
                         <li><a href=" https://github.com/alexheretic/ab-glyph ">ab_glyph_rasterizer 0.1.10</a></li>
                         <li><a href=" https://github.com/AccessKit/accesskit ">accesskit 0.24.0</a></li>
@@ -12377,19 +12558,15 @@ limitations under the License.
                         <li><a href=" https://github.com/AccessKit/accesskit ">accesskit_windows 0.32.1</a></li>
                         <li><a href=" https://github.com/AccessKit/accesskit ">accesskit_winit 0.32.2</a></li>
                         <li><a href=" https://github.com/zakarumych/allocator-api2 ">allocator-api2 0.2.21</a></li>
-                        <li><a href=" https://github.com/rust-mobile/android-activity ">android-activity 0.6.0</a></li>
+                        <li><a href=" https://github.com/rust-mobile/android-activity ">android-activity 0.6.1</a></li>
                         <li><a href=" https://github.com/nical/android_system_properties ">android_system_properties 0.1.5</a></li>
                         <li><a href=" https://github.com/zrzka/anes-rs ">anes 0.1.6</a></li>
                         <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.102</a></li>
                         <li><a href=" https://github.com/1Password/arboard ">arboard 3.6.1</a></li>
-                        <li><a href=" https://github.com/Nullus157/async-compression ">async-compression 0.4.41</a></li>
                         <li><a href=" https://github.com/dtolnay/async-trait ">async-trait 0.1.89</a></li>
-                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.39.1</a></li>
+                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.40.0</a></li>
                         <li><a href=" https://github.com/jrmuizel/build-parallel ">build-parallel 0.1.2</a></li>
-                        <li><a href=" https://github.com/emk/cesu8-rs ">cesu8 1.1.0</a></li>
                         <li><a href=" https://github.com/linebender/color ">color 0.3.2</a></li>
-                        <li><a href=" https://github.com/Nullus157/async-compression ">compression-codecs 0.4.37</a></li>
-                        <li><a href=" https://github.com/Nullus157/async-compression ">compression-core 0.4.31</a></li>
                         <li><a href=" https://github.com/soc/directories-rs ">directories 6.0.0</a></li>
                         <li><a href=" https://github.com/dirs-dev/dirs-sys-rs ">dirs-sys 0.5.0</a></li>
                         <li><a href=" https://github.com/soc/dirs-rs ">dirs 6.0.0</a></li>
@@ -12397,8 +12574,14 @@ limitations under the License.
                         <li><a href=" https://github.com/slint-ui/document-features ">document-features 0.2.12</a></li>
                         <li><a href=" https://github.com/dtolnay/dtoa ">dtoa 1.0.11</a></li>
                         <li><a href=" https://gitlab.com/kornelski/dunce ">dunce 1.0.5</a></li>
-                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/egui_glow ">egui_glow 0.33.3</a></li>
+                        <li><a href=" https://github.com/emilk/egui ">ecolor 0.34.1</a></li>
+                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/egui-winit ">egui-winit 0.34.1</a></li>
+                        <li><a href=" https://github.com/emilk/egui ">egui 0.34.1</a></li>
+                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/egui_glow ">egui_glow 0.34.1</a></li>
+                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/emath ">emath 0.34.1</a></li>
                         <li><a href=" https://github.com/dtolnay/enumn ">enumn 0.1.14</a></li>
+                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/epaint ">epaint 0.34.1</a></li>
+                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/epaint_default_fonts ">epaint_default_fonts 0.34.1</a></li>
                         <li><a href=" https://github.com/nical/etagere ">etagere 0.2.15</a></li>
                         <li><a href=" https://github.com/image-rs/fdeflate ">fdeflate 0.3.7</a></li>
                         <li><a href=" https://github.com/linebender/fearless_simd ">fearless_simd 0.3.0</a></li>
@@ -12419,10 +12602,12 @@ limitations under the License.
                         <li><a href=" https://github.com/dtolnay/inherent ">inherent 1.0.13</a></li>
                         <li><a href=" https://github.com/dtolnay/inventory ">inventory 0.3.24</a></li>
                         <li><a href=" https://github.com/dtolnay/itoa ">itoa 1.0.18</a></li>
+                        <li><a href=" https://github.com/jni-rs/jni-rs ">jni-macros 0.22.4</a></li>
                         <li><a href=" https://github.com/jni-rs/jni-sys ">jni-sys-macros 0.4.1</a></li>
+                        <li><a href=" https://github.com/jni-rs/jni-rs ">jni 0.22.4</a></li>
                         <li><a href=" https://github.com/RustCrypto/traits/tree/master/kem ">kem 0.3.0-pre.0</a></li>
                         <li><a href=" https://github.com/brendanzab/gl-rs/ ">khronos_api 3.1.0</a></li>
-                        <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.183</a></li>
+                        <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.186</a></li>
                         <li><a href=" https://github.com/linebender/raw_resource_handle ">linebender_resource_handle 0.1.1</a></li>
                         <li><a href=" https://github.com/LukasKalbertodt/litrs ">litrs 1.0.0</a></li>
                         <li><a href=" https://github.com/JohnTitor/mach2 ">mach2 0.6.0</a></li>
@@ -12443,23 +12628,26 @@ limitations under the License.
                         <li><a href=" https://github.com/madsmtm/objc2 ">objc2-io-surface 0.3.2</a></li>
                         <li><a href=" https://github.com/madsmtm/objc2 ">objc2-metal 0.3.2</a></li>
                         <li><a href=" https://github.com/madsmtm/objc2 ">objc2-quartz-core 0.3.2</a></li>
+                        <li><a href=" https://github.com/madsmtm/objc2 ">objc2-ui-kit 0.3.2</a></li>
                         <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-abilitykit-sys 0.1.5</a></li>
                         <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-deviceinfo-sys 0.1.6</a></li>
                         <li><a href=" https://github.com/openharmony-rs/ohos-deviceinfo ">ohos-deviceinfo 0.1.0</a></li>
                         <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-ime-sys 0.2.3</a></li>
                         <li><a href=" https://github.com/openharmony-rs/ohos-ime ">ohos-ime 0.4.2</a></li>
+                        <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-media-sys 0.0.5</a></li>
                         <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-sys-opaque-types 0.1.9</a></li>
                         <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-vsync-sys 0.1.5</a></li>
                         <li><a href=" https://github.com/openharmony-rs/ohos-vsync ">ohos-vsync 0.1.3</a></li>
                         <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-window-manager-sys 0.1.3</a></li>
+                        <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-window-sys 0.1.6</a></li>
                         <li><a href=" https://github.com/Ralith/openxrs ">openxr 0.20.0</a></li>
                         <li><a href=" https://github.com/alexheretic/owned-ttf-parser ">owned_ttf_parser 0.25.1</a></li>
                         <li><a href=" https://github.com/dtolnay/paste ">paste 1.0.15</a></li>
-                        <li><a href=" https://github.com/as1100k/pastey ">pastey 0.2.1</a></li>
+                        <li><a href=" https://github.com/as1100k/pastey ">pastey 0.2.2</a></li>
                         <li><a href=" https://github.com/taiki-e/pin-project ">pin-project-internal 1.1.11</a></li>
                         <li><a href=" https://github.com/taiki-e/pin-project-lite ">pin-project-lite 0.2.17</a></li>
                         <li><a href=" https://github.com/taiki-e/pin-project ">pin-project 1.1.11</a></li>
-                        <li><a href=" https://github.com/taiki-e/portable-atomic-util ">portable-atomic-util 0.2.6</a></li>
+                        <li><a href=" https://github.com/taiki-e/portable-atomic-util ">portable-atomic-util 0.2.7</a></li>
                         <li><a href=" https://github.com/taiki-e/portable-atomic ">portable-atomic 1.13.1</a></li>
                         <li><a href=" https://github.com/dtolnay/prettyplease ">prettyplease 0.2.37</a></li>
                         <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2 1.0.106</a></li>
@@ -12480,7 +12668,7 @@ limitations under the License.
                         <li><a href=" https://github.com/dtolnay/ryu ">ryu 1.0.23</a></li>
                         <li><a href=" https://github.com/SeaQL/sea-query ">sea-query-derive 1.0.0-rc.12</a></li>
                         <li><a href=" https://github.com/SeaQL/sea-query ">sea-query-rusqlite 0.8.0-rc.15</a></li>
-                        <li><a href=" https://github.com/dtolnay/semver ">semver 1.0.27</a></li>
+                        <li><a href=" https://github.com/dtolnay/semver ">semver 1.0.28</a></li>
                         <li><a href=" https://github.com/serde-rs/serde ">serde 1.0.228</a></li>
                         <li><a href=" https://github.com/serde-rs/bytes ">serde_bytes 0.11.19</a></li>
                         <li><a href=" https://github.com/serde-rs/serde ">serde_core 1.0.228</a></li>
@@ -12490,12 +12678,13 @@ limitations under the License.
                         <li><a href=" https://github.com/serde-rs/test ">serde_test 1.0.177</a></li>
                         <li><a href=" https://github.com/nox/serde_urlencoded ">serde_urlencoded 0.7.1</a></li>
                         <li><a href=" https://github.com/comex/rust-shlex ">shlex 1.3.0</a></li>
+                        <li><a href=" https://github.com/rusticstuff/simdutf8 ">simdutf8 0.1.5</a></li>
                         <li><a href=" https://github.com/jedisct1/rust-siphash ">siphasher 1.0.2</a></li>
                         <li><a href=" https://github.com/gfx-rs/rspirv ">spirv 0.3.0+sdk-1.3.268.0</a></li>
                         <li><a href=" https://github.com/nical/rust_debug ">svg_fmt 0.4.5</a></li>
                         <li><a href=" https://github.com/dtolnay/syn ">syn 2.0.117</a></li>
                         <li><a href=" https://github.com/Actyx/sync_wrapper ">sync_wrapper 1.0.2</a></li>
-                        <li><a href=" https://github.com/gankra/thin-vec ">thin-vec 0.2.14</a></li>
+                        <li><a href=" https://github.com/mozilla/thin-vec ">thin-vec 0.2.18</a></li>
                         <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl 1.0.69</a></li>
                         <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl 2.0.18</a></li>
                         <li><a href=" https://github.com/dtolnay/thiserror ">thiserror 1.0.69</a></li>
@@ -12513,7 +12702,9 @@ limitations under the License.
                         <li><a href=" https://github.com/SimonSapin/rust-utf8 ">utf-8 0.7.6</a></li>
                         <li><a href=" https://github.com/alacritty/vte ">utf8parse 0.2.2</a></li>
                         <li><a href=" https://github.com/linebender/vello ">vello_common 0.0.4</a></li>
+                        <li><a href=" https://github.com/linebender/vello ">vello_common 0.0.6</a></li>
                         <li><a href=" https://github.com/linebender/vello ">vello_cpu 0.0.4</a></li>
+                        <li><a href=" https://github.com/linebender/vello ">vello_cpu 0.0.6</a></li>
                         <li><a href=" https://github.com/bytecodealliance/wasi-rs ">wasip2 1.0.2+wasi-0.2.9</a></li>
                         <li><a href=" https://github.com/bytecodealliance/wasi-rs ">wasip3 0.4.0+wasi-0.3.0-rc-2026-01-06</a></li>
                         <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-core-deps-apple 26.0.0</a></li>
@@ -12525,7 +12716,6 @@ limitations under the License.
                         <li><a href=" https://github.com/retep998/winapi-rs ">winapi-i686-pc-windows-gnu 0.4.0</a></li>
                         <li><a href=" https://github.com/retep998/winapi-rs ">winapi-x86_64-pc-windows-gnu 0.4.0</a></li>
                         <li><a href=" https://github.com/openharmony-rs/ohos-sys ">xcomponent-sys 0.3.5</a></li>
-                        <li><a href=" https://github.com/google/xi-editor ">xi-unicode 0.3.0</a></li>
                         <li><a href=" https://github.com/gyscos/zstd-rs ">zstd-safe 7.2.4</a></li>
                         <li><a href=" https://github.com/gyscos/zstd-rs ">zstd-sys 2.0.16+zstd.1.5.7</a></li>
                         <li><a href=" https://crates.io/crates/zune-core ">zune-core 0.4.12</a></li>
@@ -13345,9 +13535,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/servo/servo ">servo-script-bindings 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-script-bindings 0.2.0</a></li>
                         <li><a href=" https://github.com/dropbox/rust-alloc-no-stdlib ">alloc-stdlib 0.2.2</a></li>
-                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.39.1</a></li>
+                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.40.0</a></li>
                         <li><a href=" https://github.com/dropbox/rust-brotli ">brotli 8.0.2</a></li>
                         <li><a href=" https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek ">curve25519-dalek 4.1.3</a></li>
                         <li><a href=" https://github.com/mitsuhiko/sha1-smol ">sha1_smol 1.0.1</a></li>
@@ -13621,8 +13811,8 @@ express Statement of Purpose.
                 <h3 id="CDLA-Permissive-2.0">Community Data License Agreement Permissive 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/rustls/webpki-roots ">webpki-root-certs 1.0.6</a></li>
-                        <li><a href=" https://github.com/rustls/webpki-roots ">webpki-roots 1.0.6</a></li>
+                        <li><a href=" https://github.com/rustls/webpki-roots ">webpki-root-certs 1.0.7</a></li>
+                        <li><a href=" https://github.com/rustls/webpki-roots ">webpki-roots 1.0.7</a></li>
                     </ul>
                 <pre class="license-text"># Community Data License Agreement - Permissive - Version 2.0
 
@@ -13774,7 +13964,7 @@ THIS SOFTWARE.
                 <h3 id="ISC">ISC License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/rustls/webpki ">rustls-webpki 0.103.10</a>
+                            <a href=" https://github.com/rustls/webpki ">rustls-webpki 0.103.13</a>
                     </p>
                 <pre class="license-text">Except as otherwise noted, this project is licensed under the following
 (ISC-style) terms:
@@ -13801,8 +13991,8 @@ third-party/chromium/LICENSE.
                 <h3 id="ISC">ISC License</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-rs 1.16.2</a></li>
-                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.39.1</a></li>
+                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-rs 1.16.3</a></li>
+                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.40.0</a></li>
                     </ul>
                 <pre class="license-text">ISC License:
 
@@ -14012,35 +14202,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             </li>
             <li class="license">
                 <h3 id="MIT">MIT License</h3>
-                    <h4>Used by:</h4>
-                    <ul class="license-used-by">
-                        <li><a href=" https://github.com/hyperium/headers ">headers-core 0.2.0</a></li>
-                        <li><a href=" https://github.com/hyperium/headers ">headers 0.3.9</a></li>
-                    </ul>
-                <pre class="license-text">Copyright (c) 2014-2019 Sean McArthur
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
                             <a href=" https://github.com/mikedilger/float-cmp ">float-cmp 0.9.0</a>
@@ -14064,33 +14225,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/hyperium/hyper ">hyper 0.14.32</a>
-                    </p>
-                <pre class="license-text">Copyright (c) 2014-2021 Sean McArthur
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
 </pre>
             </li>
             <li class="license">
@@ -14125,33 +14259,6 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/hyperium/hyper ">hyper 1.8.1</a>
-                    </p>
-                <pre class="license-text">Copyright (c) 2014-2025 Sean McArthur
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                    <p>
-                        Used by
                             <a href=" https://github.com/hyperium/headers ">headers 0.4.1</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2014-2025 Sean McArthur
@@ -14174,6 +14281,33 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                    <p>
+                        Used by
+                            <a href=" https://github.com/hyperium/hyper ">hyper 1.9.0</a>
+                    </p>
+                <pre class="license-text">Copyright (c) 2014-2026 Sean McArthur
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 </pre>
             </li>
             <li class="license">
@@ -14209,11 +14343,11 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/smithay/wayland-rs ">wayland-backend 0.3.15</a></li>
-                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-client 0.31.13</a></li>
-                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-cursor 0.31.13</a></li>
-                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-protocols-plasma 0.3.11</a></li>
-                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-protocols-wlr 0.3.11</a></li>
-                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-protocols 0.32.11</a></li>
+                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-client 0.31.14</a></li>
+                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-cursor 0.31.14</a></li>
+                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-protocols-plasma 0.3.12</a></li>
+                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-protocols-wlr 0.3.12</a></li>
+                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-protocols 0.32.12</a></li>
                         <li><a href=" https://github.com/smithay/wayland-rs ">wayland-scanner 0.31.10</a></li>
                         <li><a href=" https://github.com/smithay/wayland-rs ">wayland-sys 0.31.11</a></li>
                     </ul>
@@ -14429,11 +14563,10 @@ SOFTWARE.
             </li>
             <li class="license">
                 <h3 id="MIT">MIT License</h3>
-                    <h4>Used by:</h4>
-                    <ul class="license-used-by">
-                        <li><a href=" https://github.com/hyperium/h2 ">h2 0.3.27</a></li>
-                        <li><a href=" https://github.com/hyperium/h2 ">h2 0.4.12</a></li>
-                    </ul>
+                    <p>
+                        Used by
+                            <a href=" https://github.com/hyperium/h2 ">h2 0.4.13</a>
+                    </p>
                 <pre class="license-text">Copyright (c) 2017 h2 authors
 
 Permission is hereby granted, free of charge, to any
@@ -14606,34 +14739,6 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/seanmonstar/warp ">warp 0.3.7</a>
-                    </p>
-                <pre class="license-text">Copyright (c) 2018-2020 Sean McArthur
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                    <p>
-                        Used by
                             <a href=" https://github.com/seanmonstar/try-lock ">try-lock 0.2.5</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2018-2023 Sean McArthur
@@ -14663,42 +14768,37 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/tokio-rs/slab ">slab 0.4.12</a>
+                            <a href=" https://github.com/seanmonstar/warp ">warp 0.4.2</a>
                     </p>
-                <pre class="license-text">Copyright (c) 2019 Carl Lerche
+                <pre class="license-text">Copyright (c) 2018-2025 Sean McArthur
 
-Permission is hereby granted, free of charge, to any
-person obtaining a copy of this software and associated
-documentation files (the &quot;Software&quot;), to deal in the
-Software without restriction, including without
-limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software
-is furnished to do so, subject to the following
-conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice
-shall be included in all copies or substantial portions
-of the Software.
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
 </pre>
             </li>
             <li class="license">
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/hyperium/http-body ">http-body 0.4.6</a>
+                            <a href=" https://github.com/tokio-rs/slab ">slab 0.4.12</a>
                     </p>
-                <pre class="license-text">Copyright (c) 2019 Hyper Contributors
+                <pre class="license-text">Copyright (c) 2019 Carl Lerche
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated
@@ -15000,12 +15100,12 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus 5.14.0</a></li>
-                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus_macros 5.14.0</a></li>
-                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus_names 4.3.1</a></li>
-                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus_xml 5.1.0</a></li>
-                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zvariant 5.10.0</a></li>
-                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zvariant_derive 5.10.0</a></li>
+                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus 5.15.0</a></li>
+                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus_macros 5.15.0</a></li>
+                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus_names 4.3.2</a></li>
+                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus_xml 5.1.1</a></li>
+                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zvariant 5.10.1</a></li>
+                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zvariant_derive 5.10.1</a></li>
                     </ul>
                 <pre class="license-text">Copyright (c) 2024 Zeeshan Ali Khan &amp; zbus contributors
 
@@ -15103,9 +15203,9 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRES
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/jannistpl/egui-file-dialog ">egui-file-dialog 0.12.0</a>
+                            <a href=" https://github.com/jannistpl/egui-file-dialog ">egui-file-dialog 0.13.0</a>
                     </p>
-                <pre class="license-text">Copyright 2024 - 2025 Jannis Teipel &lt;jannistpl@gmail.com&gt;
+                <pre class="license-text">Copyright 2024 - 2026 Jannis Teipel &lt;jannistpl@gmail.com&gt;
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
@@ -15118,7 +15218,7 @@ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR I
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/jamienicol/glslopt-rs ">glslopt 0.1.12</a>
+                            <a href=" https://github.com/jamienicol/glslopt-rs ">glslopt 0.1.14</a>
                     </p>
                 <pre class="license-text">GLSL Optimizer is licensed according to the terms of the MIT license:
 
@@ -15142,6 +15242,34 @@ BRIAN PAUL BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
 AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 </pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                    <p>
+                        Used by
+                            <a href=" https://github.com/jeromefroe/lru-rs.git ">lru 0.17.0</a>
+                    </p>
+                <pre class="license-text">MIT License
+
+Copyright (c) 2016 Jerome Froelich
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.</pre>
             </li>
             <li class="license">
                 <h3 id="MIT">MIT License</h3>
@@ -15442,7 +15570,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/tokio-rs/tokio ">tokio-macros 2.6.1</a>
+                            <a href=" https://github.com/tokio-rs/tokio ">tokio-macros 2.7.0</a>
                     </p>
                 <pre class="license-text">MIT License
 
@@ -15692,7 +15820,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://gitlab.redox-os.org/redox-os/libredox.git ">libredox 0.1.15</a>
+                            <a href=" https://gitlab.redox-os.org/redox-os/libredox.git ">libredox 0.1.16</a>
                     </p>
                 <pre class="license-text">MIT License
 
@@ -15833,7 +15961,7 @@ SOFTWARE.</pre>
                         <li><a href=" https://github.com/plotters-rs/plotters.git ">plotters-svg 0.3.7</a></li>
                         <li><a href=" https://github.com/plotters-rs/plotters ">plotters 0.3.7</a></li>
                         <li><a href=" https://github.com/lu-zero/simd_helpers ">simd_helpers 0.1.0</a></li>
-                        <li><a href=" https://github.com/DioxusLabs/taffy ">taffy 0.10.0</a></li>
+                        <li><a href=" https://github.com/DioxusLabs/taffy ">taffy 0.10.1</a></li>
                         <li><a href=" https://github.com/reem/rust-void.git ">void 1.0.2</a></li>
                     </ul>
                 <pre class="license-text">MIT License
@@ -15891,7 +16019,7 @@ SOFTWARE.
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/tokio-rs/tokio ">tokio-stream 0.1.18</a></li>
                         <li><a href=" https://github.com/tokio-rs/tokio ">tokio-util 0.7.18</a></li>
-                        <li><a href=" https://github.com/tokio-rs/tokio ">tokio 1.50.0</a></li>
+                        <li><a href=" https://github.com/tokio-rs/tokio ">tokio 1.52.1</a></li>
                     </ul>
                 <pre class="license-text">MIT License
 
@@ -15978,7 +16106,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/becheran/grid ">grid 1.0.0</a>
+                            <a href=" https://github.com/becheran/grid ">grid 1.0.1</a>
                     </p>
                 <pre class="license-text">MIT License
 
@@ -16051,7 +16179,7 @@ SOFTWARE.
                         <li><a href=" https://github.com/luukvanderduim/zbus-lockstep ">zbus-lockstep-macros 0.5.2</a></li>
                         <li><a href=" https://github.com/luukvanderduim/zbus-lockstep ">zbus-lockstep 0.5.2</a></li>
                         <li><a href=" https://github.com/dtolnay/zmij ">zmij 1.0.21</a></li>
-                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zvariant_utils 3.3.0</a></li>
+                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zvariant_utils 3.3.1</a></li>
                     </ul>
                 <pre class="license-text">Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated
@@ -16080,10 +16208,11 @@ DEALINGS IN THE SOFTWARE.
             </li>
             <li class="license">
                 <h3 id="MIT">MIT License</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/winnow-rs/winnow ">winnow 0.7.15</a>
-                    </p>
+                    <h4>Used by:</h4>
+                    <ul class="license-used-by">
+                        <li><a href=" https://github.com/winnow-rs/winnow ">winnow 0.7.15</a></li>
+                        <li><a href=" https://github.com/winnow-rs/winnow ">winnow 1.0.2</a></li>
+                    </ul>
                 <pre class="license-text">Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
 &quot;Software&quot;), to deal in the Software without restriction, including
@@ -16111,7 +16240,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                         <li><a href=" https://github.com/gtk-rs/gtk-rs-core ">gio-sys 0.22.0</a></li>
                         <li><a href=" https://github.com/gtk-rs/gtk-rs-core ">glib-macros 0.22.2</a></li>
                         <li><a href=" https://github.com/gtk-rs/gtk-rs-core ">glib-sys 0.22.3</a></li>
-                        <li><a href=" https://github.com/gtk-rs/gtk-rs-core ">glib 0.22.3</a></li>
+                        <li><a href=" https://github.com/gtk-rs/gtk-rs-core ">glib 0.22.4</a></li>
                         <li><a href=" https://github.com/gtk-rs/gtk-rs-core ">gobject-sys 0.22.0</a></li>
                     </ul>
                 <pre class="license-text">Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -16262,7 +16391,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                         <li><a href=" https://github.com/image-rs/byteorder-lite ">byteorder-lite 0.1.0</a></li>
                         <li><a href=" https://github.com/BurntSushi/byteorder ">byteorder 1.5.0</a></li>
                         <li><a href=" https://github.com/BurntSushi/fst ">fst 0.4.7</a></li>
-                        <li><a href=" https://github.com/BurntSushi/jiff ">jiff 0.2.23</a></li>
+                        <li><a href=" https://github.com/BurntSushi/jiff ">jiff 0.2.24</a></li>
                         <li><a href=" https://github.com/BurntSushi/memchr ">memchr 2.8.0</a></li>
                         <li><a href=" https://github.com/BurntSushi/quickcheck ">quickcheck 1.1.0</a></li>
                         <li><a href=" https://github.com/BurntSushi/walkdir ">walkdir 2.5.0</a></li>
@@ -16323,7 +16452,7 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/GuillaumeGomez/sysinfo ">sysinfo 0.37.2</a>
+                            <a href=" https://github.com/GuillaumeGomez/sysinfo ">sysinfo 0.38.4</a>
                     </p>
                 <pre class="license-text">The MIT License (MIT)
 
@@ -16383,7 +16512,7 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://gitlab.redox-os.org/redox-os/orbclient ">orbclient 0.3.51</a>
+                            <a href=" https://gitlab.redox-os.org/redox-os/orbclient ">orbclient 0.3.53</a>
                     </p>
                 <pre class="license-text">The MIT License (MIT)
 
@@ -16412,7 +16541,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/ia0/data-encoding ">data-encoding 2.10.0</a>
+                            <a href=" https://github.com/ia0/data-encoding ">data-encoding 2.11.0</a>
                     </p>
                 <pre class="license-text">The MIT License (MIT)
 
@@ -16442,7 +16571,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.39.1</a>
+                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.40.0</a>
                     </p>
                 <pre class="license-text">The MIT License (MIT)
 
@@ -16901,11 +17030,10 @@ SOFTWARE.</pre>
             </li>
             <li class="license">
                 <h3 id="MIT">MIT License</h3>
-                    <h4>Used by:</h4>
-                    <ul class="license-used-by">
-                        <li><a href=" https://github.com/tafia/quick-xml ">quick-xml 0.38.4</a></li>
-                        <li><a href=" https://github.com/tafia/quick-xml ">quick-xml 0.39.2</a></li>
-                    </ul>
+                    <p>
+                        Used by
+                            <a href=" https://github.com/tafia/quick-xml ">quick-xml 0.39.2</a>
+                    </p>
                 <pre class="license-text">The MIT License (MIT)
 
 Copyright (c) 2016 Johann Tuffe
@@ -18862,87 +18990,89 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                 <h3 id="MPL-2.0">Mozilla Public License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/servo/stylo ">stylo 0.14.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">selectors 0.36.1</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_atoms 0.14.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_derive 0.14.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_dom 0.14.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_static_prefs 0.14.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_traits 0.14.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo 0.16.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">selectors 0.37.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_atoms 0.16.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_derive 0.16.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_dom 0.16.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_static_prefs 0.16.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_traits 0.16.0</a></li>
                         <li><a href=" https://github.com/servo/stylo ">to_shmem 0.3.0</a></li>
                         <li><a href=" https://github.com/servo/stylo ">to_shmem_derive 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-allocator 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-background-hang-monitor 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-bluetooth 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-canvas 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-config 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-config-macro 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-constellation 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-default-resources 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-deny-public-fields 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-devtools 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-dom-struct 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-fonts 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-geometry 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-jstraceable-derive 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-layout 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-audio 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-auto 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-dummy 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer-render 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer-render-android 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer-render-unix 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-examples 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-thread 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-player 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-derive 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-streams 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-traits 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-webrtc 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-metrics 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-net 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-paint 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-pixels 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-profile 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-script 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-script-bindings 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-tracing 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-background-hang-monitor-api 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-base 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-bluetooth-traits 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-canvas-traits 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-constellation-traits 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-devtools-traits 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-embedder-traits 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-fonts-traits 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-layout-api 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-net-traits 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-paint-api 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-profile-traits 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-script-traits 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-storage-traits 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-webgpu-traits 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-webxr-api 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-storage 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-timers 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-url 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-webdriver-server 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-webgl 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-webgpu 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-webxr 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-xpath 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servoshell 0.1.0</a></li>
-                        <li><a href=" https://crates.io/crates/deny_public_fields_tests ">deny_public_fields_tests 0.1.0</a></li>
-                        <li><a href=" https://crates.io/crates/malloc_size_of_tests ">malloc_size_of_tests 0.1.0</a></li>
-                        <li><a href=" https://crates.io/crates/profile_tests ">profile_tests 0.1.0</a></li>
-                        <li><a href=" https://crates.io/crates/script_tests ">script_tests 0.1.0</a></li>
-                        <li><a href=" https://crates.io/crates/style_tests ">style_tests 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-allocator 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-background-hang-monitor 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-bluetooth 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-canvas 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-config 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-config-macro 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-constellation 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-default-resources 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-deny-public-fields 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-devtools 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-dom-struct 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-fonts 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-geometry 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-jstraceable-derive 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-layout 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-audio 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-auto 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-dummy 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer-render 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer-render-android 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer-render-unix 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-ohos 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-examples 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-thread 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-player 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-derive 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-streams 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-traits 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-webrtc 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-metrics 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-net 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-paint 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-pixels 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-profile 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-script 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-script-bindings 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-tracing 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-background-hang-monitor-api 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-base 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-bluetooth-traits 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-canvas-traits 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-constellation-traits 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-devtools-traits 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-embedder-traits 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-fonts-traits 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-layout-api 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-net-traits 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-paint-api 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-profile-traits 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-script-traits 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-storage-traits 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webgpu-traits 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webxr-api 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-storage 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-timers 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-url 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-wakelock 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webdriver-server 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webgl 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webgpu 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webxr 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-xpath 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servoshell 0.2.0</a></li>
+                        <li><a href=" https://crates.io/crates/deny_public_fields_tests ">deny_public_fields_tests 0.2.0</a></li>
+                        <li><a href=" https://crates.io/crates/malloc_size_of_tests ">malloc_size_of_tests 0.2.0</a></li>
+                        <li><a href=" https://crates.io/crates/profile_tests ">profile_tests 0.2.0</a></li>
+                        <li><a href=" https://crates.io/crates/script_tests ">script_tests 0.2.0</a></li>
+                        <li><a href=" https://crates.io/crates/style_tests ">style_tests 0.2.0</a></li>
                         <li><a href=" https://github.com/servo/app_units ">app_units 0.7.8</a></li>
                         <li><a href=" https://github.com/servo/dwrote-rs ">dwrote 0.11.5</a></li>
-                        <li><a href=" https://github.com/servo/mozjs/ ">mozjs_sys 0.140.8-2</a></li>
+                        <li><a href=" https://github.com/servo/mozjs/ ">mozjs_sys 0.140.10-1</a></li>
                         <li><a href=" https://github.com/soc/option-ext.git ">option-ext 0.2.0</a></li>
                         <li><a href=" https://hg.mozilla.org/mozilla-central/file/tip/testing/webdriver ">webdriver 0.53.0</a></li>
                         <li><a href=" https://github.com/servo/webrender ">webrender 0.68.0</a></li>
@@ -19329,7 +19459,7 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                 <h3 id="MPL-2.0">Mozilla Public License 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/servo/mozjs/ ">mozjs 0.15.7</a>
+                            <a href=" https://github.com/servo/mozjs/ ">mozjs 0.15.11</a>
                     </p>
                 <pre class="license-text">Mozilla Public License Version 2.0
 &#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;
@@ -19734,7 +19864,7 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRES
                 <h3 id="OFL-1.1">SIL Open Font License 1.1</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/emilk/egui/tree/main/crates/epaint_default_fonts ">epaint_default_fonts 0.33.3</a>
+                            <a href=" https://github.com/emilk/egui/tree/main/crates/epaint_default_fonts ">epaint_default_fonts 0.34.1</a>
                     </p>
                 <pre class="license-text">This Font Software is licensed under the SIL Open Font License,
 Version 1.1.
@@ -19834,7 +19964,7 @@ OTHER DEALINGS IN THE FONT SOFTWARE.
                 <h3 id="Ubuntu-font-1.0">Ubuntu Font Licence v1.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/emilk/egui/tree/main/crates/epaint_default_fonts ">epaint_default_fonts 0.33.3</a>
+                            <a href=" https://github.com/emilk/egui/tree/main/crates/epaint_default_fonts ">epaint_default_fonts 0.34.1</a>
                     </p>
                 <pre class="license-text">-------------------------------
 UBUNTU FONT LICENCE Version 1.0
@@ -20006,8 +20136,8 @@ authorization of the copyright holder.
                         <li><a href=" https://github.com/unicode-org/icu4x ">writeable 0.5.5</a></li>
                         <li><a href=" https://github.com/unicode-org/icu4x ">yoke-derive 0.7.5</a></li>
                         <li><a href=" https://github.com/unicode-org/icu4x ">yoke 0.7.5</a></li>
-                        <li><a href=" https://github.com/unicode-org/icu4x ">zerofrom-derive 0.1.6</a></li>
-                        <li><a href=" https://github.com/unicode-org/icu4x ">zerofrom 0.1.6</a></li>
+                        <li><a href=" https://github.com/unicode-org/icu4x ">zerofrom-derive 0.1.7</a></li>
+                        <li><a href=" https://github.com/unicode-org/icu4x ">zerofrom 0.1.7</a></li>
                         <li><a href=" https://github.com/unicode-org/icu4x ">zerovec-derive 0.10.3</a></li>
                         <li><a href=" https://github.com/unicode-org/icu4x ">zerovec 0.10.4</a></li>
                     </ul>

--- a/support/android/apk/servoapp/build.gradle.kts
+++ b/support/android/apk/servoapp/build.gradle.kts
@@ -17,7 +17,7 @@ android {
         minSdk = 30
         targetSdk = 34
         versionCode = generatedVersionCode
-        versionName = "0.1.0"
+        versionName = "0.2.0"
     }
 
     compileOptions {

--- a/support/openharmony/entry/oh-package.json5
+++ b/support/openharmony/entry/oh-package.json5
@@ -5,7 +5,7 @@
   "name": "servoshell",
   "description": "Please describe the basic information.",
   "main": "",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "dependencies": {
     "libservoshell.so": "file:./src/main/cpp/types/libentry"
   }

--- a/support/openharmony/oh-package.json5
+++ b/support/openharmony/oh-package.json5
@@ -8,6 +8,6 @@
   "name": "servoshell",
   "description": "Servo browser shell",
   "main": "",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "dependencies": {}
 }

--- a/support/windows/servoshell.wxs.mako
+++ b/support/windows/servoshell.wxs.mako
@@ -6,7 +6,7 @@
            UpgradeCode="060cd15d-eab1-4614-b438-3988e3efdcf1"
            Language="1033"
            Codepage="1252"
-           Version="0.1.0">
+           Version="0.2.0">
     <Package Id="*"
              Keywords="Installer"
              Description="Servo Tech Demo Installer"


### PR DESCRIPTION
In preperation for the monthly (April) release, bump the version number to 0.2.0.
Note: 0.1.x is reserved for the LTS version, and for regular releases we anyway don't perform analysis of semver compatibility yet, which would be required to make a semver compatible release.

Testing: No functional changes.
