### PR TITLE
script: Port `HTMLFormControlsCollection` & `HTMLFormElement` to &mut JSContext

### DIFF
--- a/components/script/dom/html/htmlformcontrolscollection.rs
+++ b/components/script/dom/html/htmlformcontrolscollection.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::HTMLCollectionBinding::HTMLCollectionMethods;
@@ -10,7 +11,7 @@ use crate::dom::bindings::codegen::Bindings::HTMLFormControlsCollectionBinding::
 use crate::dom::bindings::codegen::Bindings::NodeBinding::{GetRootNodeOptions, NodeMethods};
 use crate::dom::bindings::codegen::UnionTypes::RadioNodeListOrElement;
 use crate::dom::bindings::inheritance::Castable;
-use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object};
+use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object_with_cx};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::element::Element;
@@ -19,7 +20,6 @@ use crate::dom::html::htmlformelement::HTMLFormElement;
 use crate::dom::node::Node;
 use crate::dom::radionodelist::RadioNodeList;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLFormControlsCollection {
@@ -42,15 +42,15 @@ impl HTMLFormControlsCollection {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         form: &HTMLFormElement,
         filter: Box<dyn CollectionFilter + 'static>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLFormControlsCollection> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(HTMLFormControlsCollection::new_inherited(form, filter)),
             window,
-            can_gc,
+            cx,
         )
     }
 }
@@ -64,7 +64,7 @@ impl HTMLFormControlsCollectionMethods<crate::DomTypeHolder> for HTMLFormControl
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-htmlformcontrolscollection-nameditem>
-    fn NamedItem(&self, name: DOMString, can_gc: CanGc) -> Option<RadioNodeListOrElement> {
+    fn NamedItem(&self, cx: &mut JSContext, name: DOMString) -> Option<RadioNodeListOrElement> {
         // Step 1
         if name.is_empty() {
             return None;
@@ -95,9 +95,7 @@ impl HTMLFormControlsCollectionMethods<crate::DomTypeHolder> for HTMLFormControl
                 // specifically HTMLFormElement::Elements(),
                 // and the collection filter excludes image inputs.
                 Some(RadioNodeListOrElement::RadioNodeList(
-                    RadioNodeList::new_controls_except_image_inputs(
-                        window, &self.form, &name, can_gc,
-                    ),
+                    RadioNodeList::new_controls_except_image_inputs(cx, window, &self.form, &name),
                 ))
             }
         // Step 3
@@ -107,8 +105,8 @@ impl HTMLFormControlsCollectionMethods<crate::DomTypeHolder> for HTMLFormControl
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-htmlformcontrolscollection-nameditem>
-    fn NamedGetter(&self, name: DOMString, can_gc: CanGc) -> Option<RadioNodeListOrElement> {
-        self.NamedItem(name, can_gc)
+    fn NamedGetter(&self, cx: &mut JSContext, name: DOMString) -> Option<RadioNodeListOrElement> {
+        self.NamedItem(cx, name)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-htmlformcontrolscollection-interface:supported-property-names>

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -372,7 +372,7 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-form-elements>
-    fn Elements(&self, can_gc: CanGc) -> DomRoot<HTMLFormControlsCollection> {
+    fn Elements(&self, cx: &mut JSContext) -> DomRoot<HTMLFormControlsCollection> {
         #[derive(JSTraceable, MallocSizeOf)]
         struct ElementsFilter {
             form: DomRoot<HTMLFormElement>,
@@ -435,35 +435,38 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
                 form: DomRoot::from_ref(self),
             });
             let window = self.owner_window();
-            HTMLFormControlsCollection::new(&window, self, filter, can_gc)
+            HTMLFormControlsCollection::new(cx, &window, self, filter)
         }))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-form-length>
+    #[expect(unsafe_code)]
     fn Length(&self) -> u32 {
-        self.Elements(CanGc::deprecated_note()).Length()
+        // TODO https://github.com/servo/servo/issues/43234
+        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
+        self.Elements(&mut cx).Length()
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-form-item>
-    fn IndexedGetter(&self, index: u32, can_gc: CanGc) -> Option<DomRoot<Element>> {
-        let elements = self.Elements(can_gc);
+    fn IndexedGetter(&self, cx: &mut JSContext, index: u32) -> Option<DomRoot<Element>> {
+        let elements = self.Elements(cx);
         elements.IndexedGetter(index)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-form-element%3Adetermine-the-value-of-a-named-property>
-    fn NamedGetter(&self, name: DOMString, can_gc: CanGc) -> Option<RadioNodeListOrElement> {
+    fn NamedGetter(&self, cx: &mut JSContext, name: DOMString) -> Option<RadioNodeListOrElement> {
         let window = self.owner_window();
 
         let name = Atom::from(name);
 
         // Step 1
         let mut candidates =
-            RadioNodeList::new_controls_except_image_inputs(&window, self, &name, can_gc);
+            RadioNodeList::new_controls_except_image_inputs(cx, &window, self, &name);
         let mut candidates_length = candidates.Length();
 
         // Step 2
         if candidates_length == 0 {
-            candidates = RadioNodeList::new_images(&window, self, &name, can_gc);
+            candidates = RadioNodeList::new_images(cx, &window, self, &name);
             candidates_length = candidates.Length();
         }
 
@@ -510,7 +513,7 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-a-rellist>
-    fn RelList(&self, can_gc: CanGc) -> DomRoot<DOMTokenList> {
+    fn RelList(&self, cx: &mut JSContext) -> DomRoot<DOMTokenList> {
         self.rel_list.or_init(|| {
             DOMTokenList::new(
                 self.upcast(),
@@ -520,7 +523,7 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
                     Atom::from("noreferrer"),
                     Atom::from("opener"),
                 ]),
-                can_gc,
+                CanGc::from_cx(cx),
             )
         })
     }
@@ -1470,7 +1473,7 @@ impl Element {
 
     #[expect(unsafe_code)]
     pub(crate) fn reset(&self, _can_gc: CanGc) {
-        // TODO https://github.com/servo/servo/issues/43235
+        // TODO https://github.com/servo/servo/issues/44652
         let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
         let cx = &mut cx;
 

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -440,11 +440,8 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-form-length>
-    #[expect(unsafe_code)]
-    fn Length(&self) -> u32 {
-        // TODO https://github.com/servo/servo/issues/43234
-        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
-        self.Elements(&mut cx).Length()
+    fn Length(&self, cx: &mut JSContext) -> u32 {
+        self.Elements(cx).Length()
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-form-item>

--- a/components/script/dom/radionodelist.rs
+++ b/components/script/dom/radionodelist.rs
@@ -10,7 +10,7 @@ use crate::dom::bindings::codegen::Bindings::HTMLInputElementBinding::HTMLInputE
 use crate::dom::bindings::codegen::Bindings::NodeListBinding::NodeListMethods;
 use crate::dom::bindings::codegen::Bindings::RadioNodeListBinding::RadioNodeListMethods;
 use crate::dom::bindings::inheritance::Castable;
-use crate::dom::bindings::reflector::reflect_dom_object;
+use crate::dom::bindings::reflector::reflect_dom_object_with_cx;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::html::htmlformelement::HTMLFormElement;
@@ -19,7 +19,6 @@ use crate::dom::input_element::input_type::InputType;
 use crate::dom::node::Node;
 use crate::dom::nodelist::{NodeList, NodeListType, RadioList, RadioListMode};
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct RadioNodeList {
@@ -36,44 +35,44 @@ impl RadioNodeList {
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         list_type: NodeListType,
-        can_gc: CanGc,
     ) -> DomRoot<RadioNodeList> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(RadioNodeList::new_inherited(list_type)),
             window,
-            can_gc,
+            cx,
         )
     }
 
     pub(crate) fn new_controls_except_image_inputs(
+        cx: &mut JSContext,
         window: &Window,
         form: &HTMLFormElement,
         name: &Atom,
-        can_gc: CanGc,
     ) -> DomRoot<RadioNodeList> {
         RadioNodeList::new(
+            cx,
             window,
             NodeListType::Radio(RadioList::new(
                 form,
                 RadioListMode::ControlsExceptImageInputs,
                 name.clone(),
             )),
-            can_gc,
         )
     }
 
     pub(crate) fn new_images(
+        cx: &mut JSContext,
         window: &Window,
         form: &HTMLFormElement,
         name: &Atom,
-        can_gc: CanGc,
     ) -> DomRoot<RadioNodeList> {
         RadioNodeList::new(
+            cx,
             window,
             NodeListType::Radio(RadioList::new(form, RadioListMode::Images, name.clone())),
-            can_gc,
         )
     }
 }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -496,12 +496,11 @@ DOMInterfaces = {
 },
 
 'HTMLFormControlsCollection': {
-    'canGc': ['NamedGetter', 'NamedItem'],
+    'cx': ['NamedGetter', 'NamedItem'],
 },
 
 'HTMLFormElement': {
-    'canGc': ['Elements', 'IndexedGetter', 'NamedGetter', 'SetRel', 'RelList'],
-    'cx': ['CheckValidity', 'ReportValidity', 'RequestSubmit', 'Submit', 'Reset'],
+    'cx': ['CheckValidity', 'ReportValidity', 'RequestSubmit', 'Submit', 'Reset', 'Elements', 'IndexedGetter', 'NamedGetter', 'SetRel', 'RelList'],
 },
 
 'HTMLFrameSetElement': {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -500,7 +500,7 @@ DOMInterfaces = {
 },
 
 'HTMLFormElement': {
-    'cx': ['CheckValidity', 'ReportValidity', 'RequestSubmit', 'Submit', 'Reset', 'Elements', 'IndexedGetter', 'NamedGetter', 'SetRel', 'RelList'],
+    'cx': ['CheckValidity', 'ReportValidity', 'RequestSubmit', 'Submit', 'Reset', 'Elements', 'IndexedGetter', 'Length', 'NamedGetter', 'SetRel', 'RelList'],
 },
 
 'HTMLFrameSetElement': {

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -6579,9 +6579,13 @@ class CGDOMJSProxyHandler_ownPropertyKeys(CGAbstractExternMethod):
                 """)
 
         if self.descriptor.operations['IndexedGetter']:
+            if "Length" in self.descriptor.cxMethods:
+                length_call = "(*unwrapped_proxy).Length(cx)"
+            else:
+                length_call = "(*unwrapped_proxy).Length()"
             body += dedent(
                 """
-                for i in 0..(*unwrapped_proxy).Length() {
+                for i in 0..""" + length_call + """ {
                     rooted!(&in(cx) let mut rooted_jsid: jsid);
                     int_to_jsid(i as i32, rooted_jsid.handle_mut());
                     AppendToIdVector(props, rooted_jsid.handle());
@@ -6654,9 +6658,13 @@ class CGDOMJSProxyHandler_getOwnEnumerablePropertyKeys(CGAbstractExternMethod):
                 """)
 
         if self.descriptor.operations['IndexedGetter']:
+            if "Length" in self.descriptor.cxMethods:
+                length_call = "(*unwrapped_proxy).Length(cx)"
+            else:
+                length_call = "(*unwrapped_proxy).Length()"
             body += dedent(
                 """
-                for i in 0..(*unwrapped_proxy).Length() {
+                for i in 0..""" + length_call + """ {
                     rooted!(&in(cx) let mut rooted_jsid: jsid);
                     int_to_jsid(i as i32, rooted_jsid.handle_mut());
                     AppendToIdVector(props, rooted_jsid.handle());


### PR DESCRIPTION
Part of #42638

Testing: It compiles.
Closes: #44405.
Fixes #44652