### PR TITLE
Add two error messages to customElements.define

### DIFF
--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -427,7 +427,10 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
         // Step 3. If this's custom element definition set contains an item with name name,
         // then throw a "NotSupportedError" DOMException.
         if self.definitions.borrow().contains_key(&name) {
-            return Err(Error::NotSupported(None));
+            return Err(Error::NotSupported(Some(format!(
+                "{} has already been defined as a custom element",
+                name
+            ))));
         }
 
         // Step 4. If this's custom element definition set contains an

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -418,7 +418,10 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
 
         // Step 2. If name is not a valid custom element name, then throw a "SyntaxError" DOMException.
         if !is_valid_custom_element_name(&name) {
-            return Err(Error::Syntax(None));
+            return Err(Error::Syntax(Some(format!(
+                "{} name is not a valid custom element name",
+                name
+            ))));
         }
 
         // Step 3. If this's custom element definition set contains an item with name name,


### PR DESCRIPTION
Provided an error message for two scenarios:

- When the custom element name is invalid
- When the custom element name has already been registered.

Testing: Verified the behavior manually in devtools (`./mach run --devtools=6080)
Fixes: Part of #40756
