### PR TITLE
script: propagate &mut JSContext in GlobalScope::report_an_error

### DIFF
--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -38,7 +38,7 @@ use crate::dom::bindings::str::USVString;
 use crate::dom::domexception::{DOMErrorName, DOMException};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::types::QuotaExceededError;
-use crate::realms::InRealm;
+use crate::realms::{InRealm, enter_auto_realm};
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 
 #[cfg(feature = "js_backtrace")]
@@ -347,14 +347,18 @@ impl ErrorInfo {
 }
 
 /// Report a pending exception, thereby clearing it.
-pub(crate) fn report_pending_exception(cx: SafeJSContext, realm: InRealm, can_gc: CanGc) {
-    rooted!(in(*cx) let mut value = UndefinedValue());
-    if let Some(error_info) = error_info_from_pending_exception(cx, value.handle_mut(), can_gc) {
-        GlobalScope::from_safe_context(cx, realm).report_an_error(
-            error_info,
-            value.handle(),
-            can_gc,
-        );
+pub(crate) fn report_pending_exception(cx: &mut js::context::JSContext) {
+    let realm = CurrentRealm::assert(cx);
+    let global = GlobalScope::from_current_realm(&realm);
+
+    let mut realm = enter_auto_realm(cx, &*global);
+    let cx = &mut realm.current_realm();
+
+    rooted!(&in(cx) let mut value = UndefinedValue());
+    if let Some(error_info) =
+        error_info_from_pending_exception(cx.into(), value.handle_mut(), CanGc::from_cx(cx))
+    {
+        global.report_an_error(cx, error_info, value.handle());
     }
 }
 
@@ -429,9 +433,9 @@ pub(crate) fn take_and_report_pending_exception_for_api(
 
     let return_value = javascript_error_info_from_error_info(cx, &error_info, value.handle());
     GlobalScope::from_safe_context(cx.into(), in_realm).report_an_error(
+        cx,
         error_info,
         value.handle(),
-        CanGc::from_cx(cx),
     );
 
     Some(return_value)

--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -347,13 +347,8 @@ impl ErrorInfo {
 }
 
 /// Report a pending exception, thereby clearing it.
-pub(crate) fn report_pending_exception(cx: &mut js::context::JSContext) {
-    let realm = CurrentRealm::assert(cx);
-    let global = GlobalScope::from_current_realm(&realm);
-
-    let mut realm = enter_auto_realm(cx, &*global);
-    let cx = &mut realm.current_realm();
-
+pub(crate) fn report_pending_exception(cx: &mut CurrentRealm) {
+    let global = GlobalScope::from_current_realm(&cx);
     rooted!(&in(cx) let mut value = UndefinedValue());
     if let Some(error_info) =
         error_info_from_pending_exception(cx.into(), value.handle_mut(), CanGc::from_cx(cx))

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -29,7 +29,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::settings_stack;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::windowproxy::WindowProxyHandler;
-use crate::realms::InRealm;
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 use crate::script_thread::ScriptThread;
 
@@ -196,7 +195,7 @@ impl DomHelpers<crate::DomTypeHolder> for crate::DomTypeHolder {
         reflect_dom_object(obj, global, can_gc)
     }
 
-    fn report_pending_exception(cx: SafeJSContext, realm: InRealm, can_gc: CanGc) {
-        report_pending_exception(cx, realm, can_gc)
+    fn report_pending_exception(cx: &mut js::context::JSContext) {
+        report_pending_exception(cx)
     }
 }

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -195,7 +195,7 @@ impl DomHelpers<crate::DomTypeHolder> for crate::DomTypeHolder {
         reflect_dom_object(obj, global, can_gc)
     }
 
-    fn report_pending_exception(cx: &mut js::context::JSContext) {
+    fn report_pending_exception(cx: &mut CurrentRealm) {
         report_pending_exception(cx)
     }
 }

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -34,8 +34,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::workerglobalscope::WorkerGlobalScope;
-use crate::realms::{AlreadyInRealm, InRealm};
-use crate::script_runtime::{CanGc, JSContext};
+use crate::script_runtime::JSContext;
 
 /// The maximum object depth logged by console methods.
 const MAX_LOG_DEPTH: usize = 10;
@@ -230,12 +229,10 @@ fn console_argument_from_handle_value(
     match inner(cx, handle_value, seen) {
         Ok(arg) => arg,
         Err(()) => {
-            let in_realm_proof = AlreadyInRealm::assert_for_cx(cx);
-            report_pending_exception(
-                cx,
-                InRealm::Already(&in_realm_proof),
-                CanGc::deprecated_note(),
-            );
+            #[allow(unsafe_code)]
+            let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
+            let cx = &mut cx;
+            report_pending_exception(cx);
             DebuggerValue::StringValue("<error>".into())
         },
     }

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -18,6 +18,7 @@ use js::jsapi::{
     JS_ValueToFunction, PropertyDescriptor,
 };
 use js::jsval::{Int32Value, UndefinedValue};
+use js::realm::CurrentRealm;
 use js::rust::wrappers::{
     GetArrayLength, GetBuiltinClass, GetPropertyKeys, JS_GetOwnPropertyDescriptorById,
     JS_GetPropertyById, JS_IdToValue, JS_Stringify, JS_ValueToSource,
@@ -82,18 +83,17 @@ impl Console {
     }
 
     fn method(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         level: ConsoleLogLevel,
         messages: Vec<HandleValue>,
         include_stacktrace: IncludeStackTrace,
     ) {
-        let cx = GlobalScope::get_cx();
-
         // If the first argument is a string, apply sprintf-style substitutions per the
         // WHATWG Console spec formatter. The result is a single formatted string followed
         // by any arguments that were not consumed by a substitution specifier.
         let (arguments, embedder_msg) = if !messages.is_empty() && messages[0].is_string() {
-            let (formatted, consumed) = apply_sprintf_substitutions(cx, &messages);
+            let (formatted, consumed) = apply_sprintf_substitutions(cx.into(), &messages);
             let remaining = &messages[consumed..];
 
             let mut arguments: Vec<DebuggerValue> =
@@ -121,8 +121,9 @@ impl Console {
             (arguments, stringify_handle_values(&messages))
         };
 
+        #[allow(unsafe_code)]
         let stacktrace = (include_stacktrace == IncludeStackTrace::Yes)
-            .then_some(get_js_stack(*GlobalScope::get_cx()));
+            .then_some(get_js_stack(unsafe { cx.raw_cx() }));
         let console_message = Self::build_message(level.clone(), arguments, stacktrace);
 
         Console::send_to_devtools(global, console_message);
@@ -170,20 +171,21 @@ unsafe fn handle_value_to_string(cx: *mut jsapi::JSContext, value: HandleValue) 
     }
 }
 
+#[expect(unsafe_code)]
 fn console_argument_from_handle_value(
-    cx: JSContext,
+    cx: &mut js::context::JSContext,
     handle_value: HandleValue,
     seen: &mut Vec<u64>,
 ) -> DebuggerValue {
     #[expect(unsafe_code)]
     fn inner(
-        cx: JSContext,
+        cx: &mut js::context::JSContext,
         handle_value: HandleValue,
         seen: &mut Vec<u64>,
     ) -> Result<DebuggerValue, ()> {
         if handle_value.is_string() {
             let js_string = ptr::NonNull::new(handle_value.to_string()).unwrap();
-            let dom_string = unsafe { jsstr_to_string(*cx, js_string) };
+            let dom_string = unsafe { jsstr_to_string(cx.raw_cx(), js_string) };
             return Ok(DebuggerValue::StringValue(dom_string));
         }
 
@@ -229,9 +231,9 @@ fn console_argument_from_handle_value(
     match inner(cx, handle_value, seen) {
         Ok(arg) => arg,
         Err(()) => {
-            #[allow(unsafe_code)]
-            let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
-            let cx = &mut cx;
+            let mut realm = CurrentRealm::assert(cx);
+            let cx = &mut realm;
+
             report_pending_exception(cx);
             DebuggerValue::StringValue("<error>".into())
         },
@@ -240,13 +242,13 @@ fn console_argument_from_handle_value(
 
 #[expect(unsafe_code)]
 fn console_object_from_handle_value(
-    cx: JSContext,
+    cx: &mut js::context::JSContext,
     handle_value: HandleValue,
     seen: &mut Vec<u64>,
 ) -> Option<(String, ObjectPreview)> {
-    rooted!(in(*cx) let object = handle_value.to_object());
+    rooted!(&in(cx) let object = handle_value.to_object());
     let mut object_class = ESClass::Other;
-    if !unsafe { GetBuiltinClass(*cx, object.handle(), &mut object_class as *mut _) } {
+    if !unsafe { GetBuiltinClass(cx.raw_cx(), object.handle(), &mut object_class as *mut _) } {
         return None;
     }
     if object_class != ESClass::Object &&
@@ -258,10 +260,10 @@ fn console_object_from_handle_value(
 
     let mut own_properties = Vec::new();
     let mut items: Vec<(i32, DebuggerValue)> = Vec::new();
-    let mut ids = unsafe { IdVector::new(*cx) };
+    let mut ids = unsafe { IdVector::new(cx.raw_cx()) };
     if !unsafe {
         GetPropertyKeys(
-            *cx,
+            cx.raw_cx(),
             object.handle(),
             jsapi::JSITER_OWNONLY | jsapi::JSITER_SYMBOLS | jsapi::JSITER_HIDDEN,
             ids.handle_mut(),
@@ -271,13 +273,13 @@ fn console_object_from_handle_value(
     }
 
     for id in ids.iter() {
-        rooted!(in(*cx) let id = *id);
-        rooted!(in(*cx) let mut descriptor = PropertyDescriptor::default());
+        rooted!(&in(cx) let id = *id);
+        rooted!(&in(cx) let mut descriptor = PropertyDescriptor::default());
 
         let mut is_none = false;
         if !unsafe {
             JS_GetOwnPropertyDescriptorById(
-                *cx,
+                cx.raw_cx(),
                 object.handle(),
                 id.handle(),
                 descriptor.handle_mut(),
@@ -287,9 +289,15 @@ fn console_object_from_handle_value(
             return None;
         }
 
-        rooted!(in(*cx) let mut property = UndefinedValue());
-        if !unsafe { JS_GetPropertyById(*cx, object.handle(), id.handle(), property.handle_mut()) }
-        {
+        rooted!(&in(cx) let mut property = UndefinedValue());
+        if !unsafe {
+            JS_GetPropertyById(
+                cx.raw_cx(),
+                object.handle(),
+                id.handle(),
+                property.handle_mut(),
+            )
+        } {
             return None;
         }
 
@@ -301,16 +309,16 @@ fn console_object_from_handle_value(
         }
 
         let key = if id.is_string() {
-            rooted!(in(*cx) let mut key_value = UndefinedValue());
+            rooted!(&in(cx) let mut key_value = UndefinedValue());
             let raw_id: jsapi::HandleId = id.handle().into();
-            if !unsafe { JS_IdToValue(*cx, *raw_id.ptr, key_value.handle_mut()) } {
+            if !unsafe { JS_IdToValue(cx.raw_cx(), *raw_id.ptr, key_value.handle_mut()) } {
                 continue;
             }
-            rooted!(in(*cx) let js_string = key_value.to_string());
+            rooted!(&in(cx) let js_string = key_value.to_string());
             let Some(js_string) = NonNull::new(js_string.get()) else {
                 continue;
             };
-            unsafe { jsstr_to_string(*cx, js_string) }
+            unsafe { jsstr_to_string(cx.raw_cx(), js_string) }
         } else {
             continue;
         };
@@ -328,7 +336,7 @@ fn console_object_from_handle_value(
     let (class, kind, function, array_length, items) = match object_class {
         ESClass::Array => {
             let mut len = 0u32;
-            if !unsafe { GetArrayLength(*cx, object.handle(), &mut len) } {
+            if !unsafe { GetArrayLength(cx.raw_cx(), object.handle(), &mut len) } {
                 return None;
             }
             items.sort_by_key(|(index, _)| *index);
@@ -342,18 +350,23 @@ fn console_object_from_handle_value(
             )
         },
         ESClass::Function => {
-            rooted!(in(*cx) let fun = unsafe { JS_ValueToFunction(*cx, handle_value.into()) });
-            rooted!(in(*cx) let mut name = std::ptr::null_mut::<jsapi::JSString>());
-            rooted!(in(*cx) let mut display_name = std::ptr::null_mut::<jsapi::JSString>());
+            rooted!(&in(cx) let fun = unsafe { JS_ValueToFunction(cx.raw_cx(), handle_value.into()) });
+            rooted!(&in(cx) let mut name = std::ptr::null_mut::<jsapi::JSString>());
+            rooted!(&in(cx) let mut display_name = std::ptr::null_mut::<jsapi::JSString>());
             let arity;
             unsafe {
-                JS_GetFunctionId(*cx, fun.handle().into(), name.handle_mut().into());
-                JS_GetFunctionDisplayId(*cx, fun.handle().into(), display_name.handle_mut().into());
+                JS_GetFunctionId(cx.raw_cx(), fun.handle().into(), name.handle_mut().into());
+                JS_GetFunctionDisplayId(
+                    cx.raw_cx(),
+                    fun.handle().into(),
+                    display_name.handle_mut().into(),
+                );
                 arity = JS_GetFunctionArity(fun.get());
             }
-            let name = ptr::NonNull::new(*name).map(|name| unsafe { jsstr_to_string(*cx, name) });
+            let name =
+                ptr::NonNull::new(*name).map(|name| unsafe { jsstr_to_string(cx.raw_cx(), name) });
             let display_name = ptr::NonNull::new(*display_name)
-                .map(|display_name| unsafe { jsstr_to_string(*cx, display_name) });
+                .map(|display_name| unsafe { jsstr_to_string(cx.raw_cx(), display_name) });
 
             // TODO: We should get the actual argument names from the function
             // It's not trivial since we can't access the debugger API here
@@ -700,8 +713,9 @@ enum IncludeStackTrace {
 
 impl consoleMethods<crate::DomTypeHolder> for Console {
     /// <https://developer.mozilla.org/en-US/docs/Web/API/Console/log>
-    fn Log(_cx: JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
+    fn Log(cx: &mut js::context::JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
         Console::method(
+            cx,
             global,
             ConsoleLogLevel::Log,
             messages,
@@ -724,8 +738,9 @@ impl consoleMethods<crate::DomTypeHolder> for Console {
     }
 
     /// <https://developer.mozilla.org/en-US/docs/Web/API/Console>
-    fn Debug(_cx: JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
+    fn Debug(cx: &mut js::context::JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
         Console::method(
+            cx,
             global,
             ConsoleLogLevel::Debug,
             messages,
@@ -734,8 +749,9 @@ impl consoleMethods<crate::DomTypeHolder> for Console {
     }
 
     /// <https://developer.mozilla.org/en-US/docs/Web/API/Console/info>
-    fn Info(_cx: JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
+    fn Info(cx: &mut js::context::JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
         Console::method(
+            cx,
             global,
             ConsoleLogLevel::Info,
             messages,
@@ -744,8 +760,9 @@ impl consoleMethods<crate::DomTypeHolder> for Console {
     }
 
     /// <https://developer.mozilla.org/en-US/docs/Web/API/Console/warn>
-    fn Warn(_cx: JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
+    fn Warn(cx: &mut js::context::JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
         Console::method(
+            cx,
             global,
             ConsoleLogLevel::Warn,
             messages,
@@ -754,8 +771,9 @@ impl consoleMethods<crate::DomTypeHolder> for Console {
     }
 
     /// <https://developer.mozilla.org/en-US/docs/Web/API/Console/error>
-    fn Error(_cx: JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
+    fn Error(cx: &mut js::context::JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
         Console::method(
+            cx,
             global,
             ConsoleLogLevel::Error,
             messages,
@@ -764,8 +782,9 @@ impl consoleMethods<crate::DomTypeHolder> for Console {
     }
 
     /// <https://console.spec.whatwg.org/#trace>
-    fn Trace(_cx: JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
+    fn Trace(cx: &mut js::context::JSContext, global: &GlobalScope, messages: Vec<HandleValue>) {
         Console::method(
+            cx,
             global,
             ConsoleLogLevel::Trace,
             messages,

--- a/components/script/dom/create.rs
+++ b/components/script/dom/create.rs
@@ -89,7 +89,7 @@ use crate::dom::htmlmarqueeelement::HTMLMarqueeElement;
 use crate::dom::svg::svgelement::SVGElement;
 use crate::dom::svg::svgimageelement::SVGImageElement;
 use crate::dom::svg::svgsvgelement::SVGSVGElement;
-use crate::realms::{InRealm, enter_auto_realm};
+use crate::realms::enter_auto_realm;
 use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 
@@ -192,13 +192,10 @@ fn create_html_element(
                             let mut realm = enter_auto_realm(cx, &*global);
                             let cx = &mut realm.current_realm();
 
-                            let in_realm_proof = cx.into();
-                            let in_realm = InRealm::Already(&in_realm_proof);
-
                             // Substep 1. Report exception for definition’s constructor’s corresponding
                             // JavaScript object’s associated realm’s global object.
                             throw_dom_exception(cx.into(), &global, error, CanGc::from_cx(cx));
-                            report_pending_exception(cx.into(), in_realm, CanGc::from_cx(cx));
+                            report_pending_exception(cx);
 
                             // Substep 2. Set result to the result of creating an element internal given document,
                             // HTMLUnknownElement, localName, the HTML namespace, prefix, "failed", null, and registry.

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -931,11 +931,8 @@ pub(crate) fn upgrade_element(
         let mut realm = enter_auto_realm(cx, &*global);
         let cx = &mut realm.current_realm();
 
-        let in_realm_proof = cx.into();
-        let in_realm = InRealm::Already(&in_realm_proof);
-
         throw_dom_exception(cx.into(), &global, error, CanGc::from_cx(cx));
-        report_pending_exception(cx.into(), in_realm, CanGc::from_cx(cx));
+        report_pending_exception(cx);
 
         return;
     }

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -3050,14 +3050,14 @@ impl Document {
     }
 
     /// <https://drafts.csswg.org/resize-observer/#deliver-resize-loop-error-notification>
-    pub(crate) fn deliver_resize_loop_error_notification(&self, can_gc: CanGc) {
+    pub(crate) fn deliver_resize_loop_error_notification(&self, cx: &mut js::context::JSContext) {
         let error_info: ErrorInfo = crate::dom::bindings::error::ErrorInfo {
             message: "ResizeObserver loop completed with undelivered notifications.".to_string(),
             ..Default::default()
         };
         self.window
             .as_global_scope()
-            .report_an_error(error_info, HandleValue::null(), can_gc);
+            .report_an_error(cx, error_info, HandleValue::null());
     }
 
     pub(crate) fn status_code(&self) -> Option<u16> {

--- a/components/script/dom/event/event.rs
+++ b/components/script/dom/event/event.rs
@@ -1396,11 +1396,11 @@ fn inner_invoke(
             event_target.remove_listener(&event.type_(), listener);
         }
 
-        let Some(compiled_listener) = listener.borrow().get_compiled_listener(
-            &event_target,
-            &event.type_(),
-            CanGc::from_cx(cx),
-        ) else {
+        let Some(compiled_listener) =
+            listener
+                .borrow()
+                .get_compiled_listener(cx, &event_target, &event.type_())
+        else {
             continue;
         };
 

--- a/components/script/dom/event/eventtarget.rs
+++ b/components/script/dom/event/eventtarget.rs
@@ -73,7 +73,7 @@ use crate::dom::shadowroot::ShadowRoot;
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::dom::window::Window;
 use crate::dom::workerglobalscope::WorkerGlobalScope;
-use crate::realms::{InRealm, enter_realm};
+use crate::realms::enter_realm;
 use crate::script_runtime::CanGc;
 
 /// <https://html.spec.whatwg.org/multipage/#event-handler-content-attributes>
@@ -133,10 +133,10 @@ enum InlineEventListener {
 /// raw source if necessary.
 /// <https://html.spec.whatwg.org/multipage/#getting-the-current-value-of-the-event-handler>
 fn get_compiled_handler(
+    cx: &mut js::context::JSContext,
     inline_listener: &RefCell<InlineEventListener>,
     owner: &EventTarget,
     ty: &Atom,
-    can_gc: CanGc,
 ) -> Option<CommonEventHandler> {
     let listener = mem::replace(
         &mut *inline_listener.borrow_mut(),
@@ -145,7 +145,7 @@ fn get_compiled_handler(
     let compiled = match listener {
         InlineEventListener::Null => None,
         InlineEventListener::Uncompiled(handler) => {
-            owner.get_compiled_event_handler(handler, ty, can_gc)
+            owner.get_compiled_event_handler(cx, handler, ty)
         },
         InlineEventListener::Compiled(handler) => Some(handler),
     };
@@ -164,13 +164,13 @@ enum EventListenerType {
 impl EventListenerType {
     fn get_compiled_listener(
         &self,
+        cx: &mut js::context::JSContext,
         owner: &EventTarget,
         ty: &Atom,
-        can_gc: CanGc,
     ) -> Option<CompiledEventListener> {
         match *self {
             EventListenerType::Inline(ref inline) => {
-                get_compiled_handler(inline, owner, ty, can_gc).map(CompiledEventListener::Handler)
+                get_compiled_handler(cx, inline, owner, ty).map(CompiledEventListener::Handler)
             },
             EventListenerType::Additive(ref listener) => {
                 Some(CompiledEventListener::Listener(listener.clone()))
@@ -351,11 +351,11 @@ impl EventListenerEntry {
     /// <https://html.spec.whatwg.org/multipage/#getting-the-current-value-of-the-event-handler>
     pub(crate) fn get_compiled_listener(
         &self,
+        cx: &mut js::context::JSContext,
         owner: &EventTarget,
         ty: &Atom,
-        can_gc: CanGc,
     ) -> Option<CompiledEventListener> {
-        self.listener.get_compiled_listener(owner, ty, can_gc)
+        self.listener.get_compiled_listener(cx, owner, ty)
     }
 }
 
@@ -395,7 +395,7 @@ impl EventListeners {
         for entry in &self.0 {
             if let EventListenerType::Inline(ref inline) = entry.borrow().listener {
                 // Step 1.1-1.8 and Step 2
-                return get_compiled_handler(inline, owner, ty, CanGc::from_cx(cx));
+                return get_compiled_handler(cx, inline, owner, ty);
             }
         }
 
@@ -637,9 +637,9 @@ impl EventTarget {
     #[expect(unsafe_code)]
     fn get_compiled_event_handler(
         &self,
+        cx: &mut js::context::JSContext,
         handler: InternalRawUncompiledHandler,
         ty: &Atom,
-        can_gc: CanGc,
     ) -> Option<CommonEventHandler> {
         // Step 3.1
         let element = self.downcast::<Element>();
@@ -689,12 +689,13 @@ impl EventTarget {
         let is_error = ty == &atom!("error") && self.is::<Window>();
         let args = if is_error { ERROR_ARG_NAMES } else { ARG_NAMES };
 
-        let cx = GlobalScope::get_cx();
         let url = cformat!("{}", handler.url);
-        let options = unsafe { CompileOptionsWrapper::new_raw(*cx, url, handler.line as u32) };
+        let options =
+            unsafe { CompileOptionsWrapper::new_raw(cx.raw_cx(), url, handler.line as u32) };
 
         // Step 3.9, subsection Scope steps 1-6
-        let scopechain = js::rust::EnvironmentChain::new(*cx, SupportUnscopables::Yes);
+        let scopechain =
+            js::rust::EnvironmentChain::new(unsafe { cx.raw_cx() }, SupportUnscopables::Yes);
 
         if let Some(element) = element {
             scopechain.append(document.reflector().get_jsobject().get());
@@ -704,9 +705,9 @@ impl EventTarget {
             scopechain.append(element.reflector().get_jsobject().get());
         }
 
-        rooted!(in(*cx) let mut handler = unsafe {
+        rooted!(&in(cx) let mut handler = unsafe {
             CompileFunction(
-                *cx,
+                cx.raw_cx(),
                 scopechain.get(),
                 options.ptr,
                 name.as_ptr(),
@@ -717,8 +718,7 @@ impl EventTarget {
         });
         if handler.get().is_null() {
             // Step 3.7
-            let ar = enter_realm(self);
-            report_pending_exception(cx, InRealm::Entered(&ar), can_gc);
+            report_pending_exception(cx);
             return None;
         }
 
@@ -732,15 +732,15 @@ impl EventTarget {
         // Step 1.14
         if is_error {
             Some(CommonEventHandler::ErrorEventHandler(unsafe {
-                OnErrorEventHandlerNonNull::new(cx, funobj)
+                OnErrorEventHandlerNonNull::new(cx.into(), funobj)
             }))
         } else if ty == &atom!("beforeunload") {
             Some(CommonEventHandler::BeforeUnloadEventHandler(unsafe {
-                OnBeforeUnloadEventHandlerNonNull::new(cx, funobj)
+                OnBeforeUnloadEventHandlerNonNull::new(cx.into(), funobj)
             }))
         } else {
             Some(CommonEventHandler::EventHandler(unsafe {
-                EventHandlerNonNull::new(cx, funobj)
+                EventHandlerNonNull::new(cx.into(), funobj)
             }))
         }
     }

--- a/components/script/dom/event/eventtarget.rs
+++ b/components/script/dom/event/eventtarget.rs
@@ -73,7 +73,7 @@ use crate::dom::shadowroot::ShadowRoot;
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::dom::window::Window;
 use crate::dom::workerglobalscope::WorkerGlobalScope;
-use crate::realms::enter_realm;
+use crate::realms::enter_auto_realm;
 use crate::script_runtime::CanGc;
 
 /// <https://html.spec.whatwg.org/multipage/#event-handler-content-attributes>
@@ -670,8 +670,12 @@ impl EventTarget {
         // source text, we handle parse errors later
 
         // Step 3.8 TODO: settings objects not implemented
-        let window = document.window();
-        let _ac = enter_realm(window);
+
+        let window = &mut document.window();
+        let global = window.global();
+
+        let mut realm = enter_auto_realm(cx, &*global);
+        let cx = &mut realm.current_realm();
 
         // Step 3.9
 

--- a/components/script/dom/global_scope_script_execution.rs
+++ b/components/script/dom/global_scope_script_execution.rs
@@ -29,11 +29,10 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
-use crate::realms::{InRealm, enter_auto_realm};
+use crate::realms::enter_auto_realm;
 use crate::script_module::{
     ModuleScript, ModuleSource, ModuleTree, RethrowError, ScriptFetchOptions,
 };
-use crate::script_runtime::CanGc;
 use crate::unminify::unminify_js;
 
 /// <https://html.spec.whatwg.org/multipage/#classic-script>
@@ -209,10 +208,8 @@ impl GlobalScope {
                     },
                     // Step 8.3. Otherwise, rethrow errors is false. Perform the following steps:
                     _ => {
-                        let in_realm_proof = cx.into();
-                        let in_realm = InRealm::Already(&in_realm_proof);
                         // Report an exception given by evaluationStatus.[[Value]] for script's settings object's global object.
-                        report_pending_exception(cx.into(), in_realm, CanGc::from_cx(cx));
+                        report_pending_exception(cx);
 
                         // Return evaluationStatus.
                         return Err(Error::JSFailed);

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2742,7 +2742,7 @@ impl GlobalScope {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#report-an-exception>
-    pub(crate) fn report_an_exception(&self, cx: SafeJSContext, error: HandleValue, can_gc: CanGc) {
+    pub(crate) fn report_an_exception(&self, cx: &mut js::context::JSContext, error: HandleValue) {
         // Step 1. Let notHandled be true.
         //
         // Handled in `report_an_error`
@@ -2753,17 +2753,26 @@ impl GlobalScope {
         // Step 4. If script is a classic script and script's muted errors is true, then set errorInfo[error] to null,
         // errorInfo[message] to "Script error.", errorInfo[filename] to the empty string,
         // errorInfo[lineno] to 0, and errorInfo[colno] to 0.
-        let error_info = crate::dom::bindings::error::ErrorInfo::from_value(error, cx, can_gc);
+        let error_info = crate::dom::bindings::error::ErrorInfo::from_value(
+            error,
+            cx.into(),
+            CanGc::from_cx(cx),
+        );
         // Step 5. If omitError is true, then set errorInfo[error] to null.
         //
         // `omitError` defaults to `false`
 
         // Steps 6-7
-        self.report_an_error(error_info, error, can_gc);
+        self.report_an_error(cx, error_info, error);
     }
 
     /// Steps 6-7 of <https://html.spec.whatwg.org/multipage/#report-an-exception>
-    pub(crate) fn report_an_error(&self, error_info: ErrorInfo, value: HandleValue, can_gc: CanGc) {
+    pub(crate) fn report_an_error(
+        &self,
+        cx: &mut js::context::JSContext,
+        error_info: ErrorInfo,
+        value: HandleValue,
+    ) {
         #[cfg(feature = "js_backtrace")]
         LAST_EXCEPTION_BACKTRACE.with(|backtrace| {
             if let Some((js_backtrace, rust_backtrace)) = backtrace.borrow_mut().take() {
@@ -2797,12 +2806,12 @@ impl GlobalScope {
             error_info.lineno,
             error_info.column,
             value,
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         let not_handled = event
             .upcast::<Event>()
-            .fire(self.upcast::<EventTarget>(), can_gc);
+            .fire(self.upcast::<EventTarget>(), CanGc::from_cx(cx));
 
         // Step 6.3. Set global's in error reporting mode to false.
         self.in_error_reporting_mode.set(false);
@@ -2903,9 +2912,6 @@ impl GlobalScope {
         introduction_type: Option<&'static CStr>,
         rval: Option<MutableHandleValue>,
     ) -> Result<(), JavaScriptEvaluationError> {
-        let in_realm_proof = cx.into();
-        let in_realm = InRealm::Already(&in_realm_proof);
-
         run_a_script::<DomTypeHolder, _>(self, || {
             let url = self.api_base_url();
             let fetch_options = ScriptFetchOptions::default_classic_script();
@@ -2925,7 +2931,7 @@ impl GlobalScope {
 
             let Some(script) = NonNull::new(*compiled_script) else {
                 debug!("error compiling Dom string");
-                report_pending_exception(cx.into(), in_realm, CanGc::from_cx(cx));
+                report_pending_exception(cx);
                 return Err(JavaScriptEvaluationError::CompilationFailure);
             };
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1538,9 +1538,8 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-reporterror>
-    fn ReportError(&self, cx: SafeJSContext, error: HandleValue, can_gc: CanGc) {
-        self.as_global_scope()
-            .report_an_exception(cx, error, can_gc);
+    fn ReportError(&self, cx: &mut js::context::JSContext, error: HandleValue) {
+        self.as_global_scope().report_an_exception(cx, error);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-navigator>

--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -697,7 +697,7 @@ impl DedicatedWorkerGlobalScope {
         // Step 7.2.1. Let workerObject be the Worker object associated with global.
         let worker = self.worker.borrow().as_ref().unwrap().clone();
         let pipeline_id = self.upcast::<GlobalScope>().pipeline_id();
-        let task = Box::new(task!(forward_error_to_worker_object: move || {
+        let task = Box::new(task!(forward_error_to_worker_object: move |cx| {
             let worker = worker.root();
             let global = worker.global();
 
@@ -713,12 +713,12 @@ impl DedicatedWorkerGlobalScope {
                 error_info.lineno,
                 error_info.column,
                 HandleValue::null(),
-                CanGc::deprecated_note(),
+                CanGc::from_cx(cx),
             );
 
             // Step 7.2.3. If notHandled is true, then report exception for workerObject's relevant global object with omitError set to true.
-            if event.upcast::<Event>().fire(worker.upcast::<EventTarget>(), CanGc::deprecated_note()) {
-                global.report_an_error(error_info, HandleValue::null(), CanGc::deprecated_note());
+            if event.upcast::<Event>().fire(worker.upcast::<EventTarget>(), CanGc::from_cx(cx)) {
+                global.report_an_error(cx, error_info, HandleValue::null(),);
             }
         }));
         self.parent_event_loop_sender

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -836,9 +836,8 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-reporterror>
-    fn ReportError(&self, cx: JSContext, error: HandleValue, can_gc: CanGc) {
-        self.upcast::<GlobalScope>()
-            .report_an_exception(cx, error, can_gc);
+    fn ReportError(&self, cx: &mut js::context::JSContext, error: HandleValue) {
+        self.upcast::<GlobalScope>().report_an_exception(cx, error);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-windowbase64-btoa>

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -471,13 +471,10 @@ impl ModuleTree {
             let mut realm = enter_auto_realm(cx, global);
             let cx = &mut realm.current_realm();
 
-            let in_realm_proof = cx.into();
-            let in_realm = InRealm::Already(&in_realm_proof);
-
             unsafe {
                 JS_SetPendingException(cx, exception.handle(), ExceptionStackBehavior::Capture);
             }
-            report_pending_exception(cx.into(), in_realm, CanGc::from_cx(cx));
+            report_pending_exception(cx);
         }
     }
 

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -93,7 +93,7 @@ use crate::dom::response::Response;
 use crate::dom::trustedtypes::trustedscript::TrustedScript;
 use crate::messaging::{CommonScriptMsg, ScriptEventLoopSender};
 use crate::microtask::{EnqueuedPromiseCallback, Microtask, MicrotaskQueue};
-use crate::realms::{AlreadyInRealm, InRealm, enter_realm};
+use crate::realms::{AlreadyInRealm, InRealm, enter_auto_realm, enter_realm};
 use crate::script_module::EnsureModuleHooksInitialized;
 use crate::task_source::TaskSourceName;
 use crate::{DomTypeHolder, ScriptThread};
@@ -1447,13 +1447,18 @@ unsafe extern "C" fn invoke_script_environment_preparer(
     global: HandleObject,
     closure: *mut ScriptEnvironmentPreparer_Closure,
 ) {
-    let cx = GlobalScope::get_cx();
     let global = unsafe { GlobalScope::from_object(global.get()) };
-    let ar = enter_realm(&*global);
+
+    // TODO: clean this up with proper cx: &mut js::context::JSContext
+    let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
+    let cx = &mut cx;
+
+    let mut realm = enter_auto_realm(cx, &*global);
+    let cx = &mut realm.current_realm();
 
     run_a_script::<DomTypeHolder, _>(&global, || {
-        if unsafe { !RunScriptEnvironmentPreparerClosure(*cx, closure) } {
-            report_pending_exception(cx, InRealm::Entered(&ar), CanGc::deprecated_note());
+        if unsafe { !RunScriptEnvironmentPreparerClosure(cx.raw_cx(), closure) } {
+            report_pending_exception(cx);
         };
     });
 }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1243,7 +1243,7 @@ impl ScriptThread {
             }
 
             if document.has_skipped_resize_observations() {
-                document.deliver_resize_loop_error_notification(CanGc::from_cx(cx));
+                document.deliver_resize_loop_error_notification(cx);
                 // Ensure that another turn of the event loop occurs to process
                 // the skipped observations.
                 document.add_rendering_update_reason(

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -89,7 +89,7 @@ use crate::dom::types::ShadowRoot;
 use crate::dom::validitystate::ValidationFlags;
 use crate::dom::window::Window;
 use crate::dom::xmlserializer::XMLSerializer;
-use crate::realms::{InRealm, enter_auto_realm, enter_realm};
+use crate::realms::{enter_auto_realm, enter_realm};
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 use crate::script_thread::ScriptThread;
 
@@ -375,11 +375,8 @@ pub(crate) fn jsval_to_webdriver(
         let mut seen = HashSet::new();
         let result = jsval_to_webdriver_inner(cx.into(), global_scope, val, &mut seen);
 
-        let in_realm_proof = cx.into();
-        let in_realm = InRealm::Already(&in_realm_proof);
-
         if result.is_err() {
-            report_pending_exception(cx.into(), in_realm, CanGc::from_cx(cx));
+            report_pending_exception(cx);
         }
         result
     })

--- a/components/script_bindings/callback.rs
+++ b/components/script_bindings/callback.rs
@@ -17,10 +17,10 @@ use crate::codegen::GenericBindings::WindowBinding::Window_Binding::WindowMethod
 use crate::error::{Error, Fallible};
 use crate::inheritance::Castable;
 use crate::interfaces::{DocumentHelpers, DomHelpers, GlobalScopeHelpers};
-use crate::realms::{InRealm, enter_auto_realm};
+use crate::realms::enter_auto_realm;
 use crate::reflector::DomObject;
 use crate::root::Dom;
-use crate::script_runtime::{CanGc, JSContext};
+use crate::script_runtime::JSContext;
 use crate::settings_stack::{run_a_callback, run_a_script};
 use crate::{DomTypes, cformat};
 
@@ -284,14 +284,7 @@ pub fn call_setup<D: DomTypes, T: CallbackContainer<D>, R>(
                 let mut realm = enter_auto_realm::<D>(cx, &**global);
                 let cx = &mut realm.current_realm();
 
-                let in_realm_proof = cx.into();
-                let in_realm = InRealm::Already(&in_realm_proof);
-
-                <D as DomHelpers<D>>::report_pending_exception(
-                    cx.into(),
-                    in_realm,
-                    CanGc::from_cx(cx),
-                );
+                <D as DomHelpers<D>>::report_pending_exception(cx);
             }
             result
         };

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -109,6 +109,10 @@ DOMInterfaces = {
     'realm': ['GetType']
 },
 
+'Console': {
+    'cx': ['Log', 'Clear', 'Debug', 'Info', 'Warn', 'Error', 'Trace']
+},
+
 'Comment': {
     'cx': ['Constructor']
 },

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -969,10 +969,11 @@ DOMInterfaces = {
 },
 
 'Window': {
-    'canGc': ['CookieStore', 'GetVisualViewport', 'ReportError', 'Screen'],
+    'canGc': ['CookieStore', 'GetVisualViewport', 'Screen'],
     'additionalTraits': ['crate::interfaces::WindowHelpers'],
     'realm': ['CreateImageBitmap', 'CreateImageBitmap_', 'WebdriverCallback', 'GetOpener', 'Fetch'],
     'cx': [
+        'ReportError',
         'Focus',
         'FetchLater',
         'GetLocalStorage',
@@ -1009,8 +1010,7 @@ DOMInterfaces = {
 },
 
 'WorkerGlobalScope': {
-    'cx': ['ImportScripts', 'SetInterval', 'SetTimeout', 'TrustedTypes', 'StructuredClone'],
-    'canGc': ['ReportError'],
+    'cx': ['ImportScripts', 'SetInterval', 'SetTimeout', 'TrustedTypes', 'StructuredClone', 'ReportError'],
     'realm': ['CreateImageBitmap', 'CreateImageBitmap_', 'Fetch'],
 },
 

--- a/components/script_bindings/interfaces.rs
+++ b/components/script_bindings/interfaces.rs
@@ -61,7 +61,7 @@ pub trait DomHelpers<D: DomTypes> {
         T: DomObject + DomObjectWrap<D>,
         U: DerivedFrom<D::GlobalScope>;
 
-    fn report_pending_exception(cx: &mut js::context::JSContext);
+    fn report_pending_exception(cx: &mut CurrentRealm);
 }
 
 /// Operations that must be invoked from the generated bindings.

--- a/components/script_bindings/interfaces.rs
+++ b/components/script_bindings/interfaces.rs
@@ -61,7 +61,7 @@ pub trait DomHelpers<D: DomTypes> {
         T: DomObject + DomObjectWrap<D>,
         U: DerivedFrom<D::GlobalScope>;
 
-    fn report_pending_exception(cx: JSContext, realm: InRealm, can_gc: CanGc);
+    fn report_pending_exception(cx: &mut js::context::JSContext);
 }
 
 /// Operations that must be invoked from the generated bindings.


### PR DESCRIPTION
Propagate `&mut JSContext` in `GlobalScope::report_an_error` and related call sites.

Testing: Successful build is enough
Fixes: Part of #42638 
