### PR TITLE
script: Remove unnecessary Box inside of Rc.

### DIFF
--- a/components/script/dom/stream/byteteeunderlyingsource.rs
+++ b/components/script/dom/stream/byteteeunderlyingsource.rs
@@ -58,11 +58,9 @@ pub(crate) struct ByteTeeUnderlyingSource {
     #[conditional_malloc_size_of]
     canceled_2: Rc<Cell<bool>>,
     #[ignore_malloc_size_of = "Mozjs"]
-    #[allow(clippy::redundant_allocation)]
-    reason_1: Rc<Box<Heap<Value>>>,
+    reason_1: Rc<Heap<Value>>,
     #[ignore_malloc_size_of = "Mozjs"]
-    #[allow(clippy::redundant_allocation)]
-    reason_2: Rc<Box<Heap<Value>>>,
+    reason_2: Rc<Heap<Value>>,
     #[conditional_malloc_size_of]
     cancel_promise: Rc<Promise>,
     #[conditional_malloc_size_of]
@@ -73,7 +71,6 @@ pub(crate) struct ByteTeeUnderlyingSource {
 
 impl ByteTeeUnderlyingSource {
     #[allow(clippy::too_many_arguments)]
-    #[allow(clippy::redundant_allocation)]
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new(
         reader: Rc<RefCell<ReaderType>>,
@@ -83,8 +80,8 @@ impl ByteTeeUnderlyingSource {
         read_again_for_branch_2: Rc<Cell<bool>>,
         canceled_1: Rc<Cell<bool>>,
         canceled_2: Rc<Cell<bool>>,
-        reason_1: Rc<Box<Heap<Value>>>,
-        reason_2: Rc<Box<Heap<Value>>>,
+        reason_1: Rc<Heap<Value>>,
+        reason_2: Rc<Heap<Value>>,
         cancel_promise: Rc<Promise>,
         reader_version: Rc<Cell<u64>>,
         tee_cancel_algorithm: ByteTeeCancelAlgorithm,

--- a/components/script/dom/stream/defaultteeunderlyingsource.rs
+++ b/components/script/dom/stream/defaultteeunderlyingsource.rs
@@ -45,11 +45,9 @@ pub(crate) struct DefaultTeeUnderlyingSource {
     #[conditional_malloc_size_of]
     clone_for_branch_2: Rc<Cell<bool>>,
     #[ignore_malloc_size_of = "mozjs"]
-    #[expect(clippy::redundant_allocation)]
-    reason_1: Rc<Box<Heap<Value>>>,
+    reason_1: Rc<Heap<Value>>,
     #[ignore_malloc_size_of = "mozjs"]
-    #[expect(clippy::redundant_allocation)]
-    reason_2: Rc<Box<Heap<Value>>>,
+    reason_2: Rc<Heap<Value>>,
     #[conditional_malloc_size_of]
     cancel_promise: Rc<Promise>,
     tee_cancel_algorithm: DefaultTeeCancelAlgorithm,
@@ -57,7 +55,7 @@ pub(crate) struct DefaultTeeUnderlyingSource {
 
 impl DefaultTeeUnderlyingSource {
     #[expect(clippy::too_many_arguments)]
-    #[expect(clippy::redundant_allocation)]
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new(
         reader: &ReadableStreamDefaultReader,
         stream: &ReadableStream,
@@ -66,8 +64,8 @@ impl DefaultTeeUnderlyingSource {
         canceled_1: Rc<Cell<bool>>,
         canceled_2: Rc<Cell<bool>>,
         clone_for_branch_2: Rc<Cell<bool>>,
-        reason_1: Rc<Box<Heap<Value>>>,
-        reason_2: Rc<Box<Heap<Value>>>,
+        reason_1: Rc<Heap<Value>>,
+        reason_2: Rc<Heap<Value>>,
         cancel_promise: Rc<Promise>,
         tee_cancel_algorithm: DefaultTeeCancelAlgorithm,
         can_gc: CanGc,

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -1693,10 +1693,10 @@ impl ReadableStream {
         let canceled_2 = Rc::new(Cell::new(false));
 
         // Let reason1 be undefined.
-        let reason_1 = Rc::new(Heap::boxed(UndefinedValue()));
+        let reason_1 = Rc::new(Heap::default());
 
         // Let reason2 be undefined.
-        let reason_2 = Rc::new(Heap::boxed(UndefinedValue()));
+        let reason_2 = Rc::new(Heap::default());
 
         // Let cancelPromise be a new promise.
         let cancel_promise = Promise::new2(cx, &self.global());
@@ -1787,9 +1787,9 @@ impl ReadableStream {
         let canceled_2 = Rc::new(Cell::new(false));
 
         // Let reason1 be undefined.
-        let reason_1 = Rc::new(Heap::boxed(UndefinedValue()));
+        let reason_1 = Rc::new(Heap::default());
         // Let reason2 be undefined.
-        let reason_2 = Rc::new(Heap::boxed(UndefinedValue()));
+        let reason_2 = Rc::new(Heap::default());
         // Let cancelPromise be a new promise.
         let cancel_promise = Promise::new2(cx, &self.global());
 


### PR DESCRIPTION
The `Box<Heap<...>>` pattern exists because it's easiest to use and initialize Heap correctly when it's immediately placed inside of a stable heap allocation. `Rc<Heap<...>>` serves the same purpose, so we can avoid the redundant allocation and clean up some clippy exceptions.

Testing: Existing streams tests cover this code.