### PR TITLE
Port debugger global scope fire interrupt

### DIFF
--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -274,11 +274,11 @@ impl DebuggerGlobalScope {
 
     pub(crate) fn fire_list_frames(
         &self,
+        cx: &mut js::context::JSContext,
         pipeline_id: PipelineId,
         start: u32,
         count: u32,
         result_sender: GenericSender<Vec<String>>,
-        can_gc: CanGc,
     ) {
         assert!(
             self.get_list_frame_result_sender
@@ -287,16 +287,16 @@ impl DebuggerGlobalScope {
         );
         let _realm = enter_realm(self);
         let pipeline_id =
-            crate::dom::pipelineid::PipelineId::new(self.upcast(), pipeline_id, can_gc);
+            crate::dom::pipelineid::PipelineId::new(self.upcast(), pipeline_id, CanGc::from_cx(cx));
         let event = DomRoot::upcast::<Event>(DebuggerFrameEvent::new(
             self.upcast(),
             &pipeline_id,
             start,
             count,
-            can_gc,
+            CanGc::from_cx(cx),
         ));
         assert!(
-            event.fire(self.upcast(), can_gc),
+            event.fire(self.upcast(), CanGc::from_cx(cx)),
             "Guaranteed by DebuggerFrameEvent::new"
         );
     }

--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -261,10 +261,13 @@ impl DebuggerGlobalScope {
         );
     }
 
-    pub(crate) fn fire_interrupt(&self, can_gc: CanGc) {
-        let event = DomRoot::upcast::<Event>(DebuggerInterruptEvent::new(self.upcast(), can_gc));
+    pub(crate) fn fire_interrupt(&self, cx: &mut js::context::JSContext) {
+        let event = DomRoot::upcast::<Event>(DebuggerInterruptEvent::new(
+            self.upcast(),
+            CanGc::from_cx(cx),
+        ));
         assert!(
-            event.fire(self.upcast(), can_gc),
+            event.fire(self.upcast(), CanGc::from_cx(cx)),
             "Guaranteed by DebuggerInterruptEvent::new"
         );
     }

--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -936,12 +936,7 @@ impl DocumentEventHandler {
                 // Step 9. If mbutton is the secondary mouse button, then
                 // Maybe show context menu with native, target.
                 if let MouseButton::Right = event.button {
-                    self.maybe_show_context_menu(
-                        node.upcast(),
-                        &hit_test_result,
-                        input_event,
-                        CanGc::from_cx(cx),
-                    );
+                    self.maybe_show_context_menu(cx, node.upcast(), &hit_test_result, input_event);
                 }
             },
             // https://w3c.github.io/pointerevents/#dfn-handle-native-mouse-up
@@ -1068,10 +1063,10 @@ impl DocumentEventHandler {
     /// <https://www.w3.org/TR/pointerevents4/#maybe-show-context-menu>
     fn maybe_show_context_menu(
         &self,
+        cx: &mut js::context::JSContext,
         target: &EventTarget,
         hit_test_result: &HitTestResult,
         input_event: &ConstellationInputEvent,
-        can_gc: CanGc,
     ) {
         // <https://w3c.github.io/pointerevents/#contextmenu>
         let menu_event = PointerEvent::new(
@@ -1105,12 +1100,14 @@ impl DocumentEventHandler {
             true,                     // is_primary
             vec![],                   // coalesced_events
             vec![],                   // predicted_events
-            can_gc,
+            CanGc::from_cx(cx),
         );
         menu_event.upcast::<Event>().set_composed(true);
 
         // Step 3. Let result = dispatch menuevent at target.
-        let result = menu_event.upcast::<Event>().fire(target, can_gc);
+        let result = menu_event
+            .upcast::<Event>()
+            .fire(target, CanGc::from_cx(cx));
 
         // Step 4. If result is true, then show the UA context menu
         if result {

--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -1197,6 +1197,7 @@ impl DocumentEventHandler {
 
             // Fire pointerenter hierarchically (from topmost ancestor to target)
             self.fire_pointer_event_for_touch(
+                cx,
                 &element,
                 &pointer_touch,
                 pointer_id,
@@ -1204,7 +1205,6 @@ impl DocumentEventHandler {
                 is_primary,
                 input_event,
                 &hit_test_result,
-                CanGc::from_cx(cx),
             );
         }
 
@@ -1245,6 +1245,7 @@ impl DocumentEventHandler {
 
             // Fire pointerleave hierarchically (from target to topmost ancestor)
             self.fire_pointer_event_for_touch(
+                cx,
                 &element,
                 &pointer_touch,
                 pointer_id,
@@ -1252,7 +1253,6 @@ impl DocumentEventHandler {
                 is_primary,
                 input_event,
                 &hit_test_result,
-                CanGc::from_cx(cx),
             );
         }
 
@@ -2287,6 +2287,7 @@ impl DocumentEventHandler {
     #[allow(clippy::too_many_arguments)]
     fn fire_pointer_event_for_touch(
         &self,
+        cx: &mut js::context::JSContext,
         target_element: &Element,
         touch: &Touch,
         pointer_id: i32,
@@ -2294,7 +2295,6 @@ impl DocumentEventHandler {
         is_primary: bool,
         input_event: &ConstellationInputEvent,
         hit_test_result: &HitTestResult,
-        can_gc: CanGc,
     ) {
         // Collect ancestors from target to root
         let mut targets: Vec<DomRoot<Node>> = vec![];
@@ -2318,11 +2318,11 @@ impl DocumentEventHandler {
                 input_event.active_keyboard_modifiers,
                 false,
                 Some(hit_test_result.point_in_node),
-                can_gc,
+                CanGc::from_cx(cx),
             );
             pointer_event
                 .upcast::<Event>()
-                .fire(target.upcast(), can_gc);
+                .fire(target.upcast(), CanGc::from_cx(cx));
         }
     }
 

--- a/components/script/dom/event/extendablemessageevent.rs
+++ b/components/script/dom/event/extendablemessageevent.rs
@@ -122,11 +122,11 @@ impl ExtendableMessageEvent {
 #[expect(non_snake_case)]
 impl ExtendableMessageEvent {
     pub(crate) fn dispatch_jsval(
+        cx: &mut js::context::JSContext,
         target: &EventTarget,
         scope: &GlobalScope,
         message: HandleValue,
         ports: Vec<DomRoot<MessagePort>>,
-        can_gc: CanGc,
     ) {
         let Extendablemessageevent = ExtendableMessageEvent::new(
             scope,
@@ -137,11 +137,11 @@ impl ExtendableMessageEvent {
             DOMString::new(),
             DOMString::new(),
             ports,
-            can_gc,
+            CanGc::from_cx(cx),
         );
         Extendablemessageevent
             .upcast::<Event>()
-            .fire(target, can_gc);
+            .fire(target, CanGc::from_cx(cx));
     }
 
     pub(crate) fn dispatch_error(

--- a/components/script/dom/workers/serviceworkerglobalscope.rs
+++ b/components/script/dom/workers/serviceworkerglobalscope.rs
@@ -524,11 +524,11 @@ impl ServiceWorkerGlobalScope {
                     CanGc::from_cx(cx),
                 ) {
                     ExtendableMessageEvent::dispatch_jsval(
+                        cx,
                         target,
                         scope.upcast(),
                         message.handle(),
                         ports,
-                        CanGc::from_cx(cx),
                     );
                 } else {
                     ExtendableMessageEvent::dispatch_error(cx, target, scope.upcast());

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2262,13 +2262,8 @@ impl ScriptThread {
                 self.debugger_global.fire_interrupt(cx);
             },
             DevtoolScriptControlMsg::ListFrames(pipeline_id, start, count, result_sender) => {
-                self.debugger_global.fire_list_frames(
-                    pipeline_id,
-                    start,
-                    count,
-                    result_sender,
-                    CanGc::from_cx(cx),
-                );
+                self.debugger_global
+                    .fire_list_frames(cx, pipeline_id, start, count, result_sender);
             },
             DevtoolScriptControlMsg::GetEnvironment(frame_actor_id, result_sender) => {
                 self.debugger_global

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2259,7 +2259,7 @@ impl ScriptThread {
                     .fire_clear_breakpoint(cx, spidermonkey_id, script_id, offset);
             },
             DevtoolScriptControlMsg::Interrupt => {
-                self.debugger_global.fire_interrupt(CanGc::from_cx(cx));
+                self.debugger_global.fire_interrupt(cx);
             },
             DevtoolScriptControlMsg::ListFrames(pipeline_id, start, count, result_sender) => {
                 self.debugger_global.fire_list_frames(


### PR DESCRIPTION
Propagate `&mut JSContext` in `DebuggerGlobalScope::fire_interrupt` and related call sites.

Testing: Successful build is enough
Fixes: Part of #42638 