### PR TITLE
script: Pass `&mut JSContext` to most attribute modification methods

### DIFF
--- a/components/script/dom/css/cssstyledeclaration.rs
+++ b/components/script/dom/css/cssstyledeclaration.rs
@@ -62,7 +62,7 @@ pub(crate) enum CSSStyleOwner {
 impl CSSStyleOwner {
     // Mutate the declaration block associated to this style owner, and
     // optionally indicate if it has changed (assumed to be true).
-    fn mutate_associated_block<F, R>(&self, f: F, can_gc: CanGc) -> R
+    fn mutate_associated_block<F, R>(&self, cx: &mut JSContext, f: F) -> R
     where
         F: FnOnce(&mut PropertyDeclarationBlock, &mut bool) -> R,
     {
@@ -110,7 +110,7 @@ impl CSSStyleOwner {
                         el.set_attribute(
                             &local_name!("style"),
                             AttrValue::Declaration(serialization, pdb),
-                            can_gc,
+                            CanGc::from_cx(cx),
                         );
                     }
                 } else {
@@ -358,66 +358,63 @@ impl CSSStyleDeclaration {
             },
         };
         let base_url = UrlExtraData(self.owner.base_url().get_arc());
-        self.owner.mutate_associated_block(
-            |pdb, changed| {
-                // Step 3. If value is the empty string, invoke removeProperty()
-                // with property as argument and return.
-                if value.is_empty() {
-                    *changed = remove_property(pdb, &id);
+        self.owner.mutate_associated_block(cx, |pdb, changed| {
+            // Step 3. If value is the empty string, invoke removeProperty()
+            // with property as argument and return.
+            if value.is_empty() {
+                *changed = remove_property(pdb, &id);
+                return Ok(());
+            }
+
+            // Step 4. If priority is not the empty string and is not an ASCII case-insensitive
+            // match for the string "important", then return.
+            let importance = match &*priority.str() {
+                "" => Importance::Normal,
+                p if p.eq_ignore_ascii_case("important") => Importance::Important,
+                _ => {
+                    *changed = false;
                     return Ok(());
-                }
+                },
+            };
 
-                // Step 4. If priority is not the empty string and is not an ASCII case-insensitive
-                // match for the string "important", then return.
-                let importance = match &*priority.str() {
-                    "" => Importance::Normal,
-                    p if p.eq_ignore_ascii_case("important") => Importance::Important,
-                    _ => {
-                        *changed = false;
-                        return Ok(());
-                    },
-                };
+            // Step 5
+            let window = self.owner.window();
+            let quirks_mode = window.Document().quirks_mode();
+            let mut declarations = SourcePropertyDeclaration::default();
+            let result = parse_one_declaration_into(
+                &mut declarations,
+                id,
+                &value.str(),
+                Origin::Author,
+                &base_url,
+                Some(window.css_error_reporter()),
+                ParsingMode::DEFAULT,
+                quirks_mode,
+                CssRuleType::Style,
+            );
 
-                // Step 5
-                let window = self.owner.window();
-                let quirks_mode = window.Document().quirks_mode();
-                let mut declarations = SourcePropertyDeclaration::default();
-                let result = parse_one_declaration_into(
-                    &mut declarations,
-                    id,
-                    &value.str(),
-                    Origin::Author,
-                    &base_url,
-                    Some(window.css_error_reporter()),
-                    ParsingMode::DEFAULT,
-                    quirks_mode,
-                    CssRuleType::Style,
-                );
-
-                // Step 6
-                match result {
-                    Ok(()) => {},
-                    Err(_) => {
-                        *changed = false;
-                        return Ok(());
-                    },
-                }
-
-                let mut updates = Default::default();
-                *changed = pdb.prepare_for_update(&declarations, importance, &mut updates);
-
-                if !*changed {
+            // Step 6
+            match result {
+                Ok(()) => {},
+                Err(_) => {
+                    *changed = false;
                     return Ok(());
-                }
+                },
+            }
 
-                // Step 7
-                // Step 8
-                pdb.update(declarations.drain(), importance, &mut updates);
+            let mut updates = Default::default();
+            *changed = pdb.prepare_for_update(&declarations, importance, &mut updates);
 
-                Ok(())
-            },
-            CanGc::from_cx(cx),
-        )
+            if !*changed {
+                return Ok(());
+            }
+
+            // Step 7
+            // Step 8
+            pdb.update(declarations.drain(), importance, &mut updates);
+
+            Ok(())
+        })
     }
 }
 
@@ -533,13 +530,10 @@ impl CSSStyleDeclarationMethods<crate::DomTypeHolder> for CSSStyleDeclaration {
         };
 
         let mut string = String::new();
-        self.owner.mutate_associated_block(
-            |pdb, changed| {
-                pdb.property_value_to_css(&id, &mut string).unwrap();
-                *changed = remove_property(pdb, &id);
-            },
-            CanGc::from_cx(cx),
-        );
+        self.owner.mutate_associated_block(cx, |pdb, changed| {
+            pdb.property_value_to_css(&id, &mut string).unwrap();
+            *changed = remove_property(pdb, &id);
+        });
 
         // Step 6
         Ok(DOMString::from(string))
@@ -601,19 +595,16 @@ impl CSSStyleDeclarationMethods<crate::DomTypeHolder> for CSSStyleDeclaration {
 
         let quirks_mode = window.Document().quirks_mode();
         let base_url = UrlExtraData(self.owner.base_url().get_arc());
-        self.owner.mutate_associated_block(
-            |pdb, _changed| {
-                // Step 3
-                *pdb = parse_style_attribute(
-                    &value.str(),
-                    &base_url,
-                    Some(window.css_error_reporter()),
-                    quirks_mode,
-                    CssRuleType::Style,
-                );
-            },
-            CanGc::from_cx(cx),
-        );
+        self.owner.mutate_associated_block(cx, |pdb, _changed| {
+            // Step 3
+            *pdb = parse_style_attribute(
+                &value.str(),
+                &base_url,
+                Some(window.css_error_reporter()),
+                quirks_mode,
+                CssRuleType::Style,
+            );
+        });
 
         Ok(())
     }

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -1555,14 +1555,14 @@ impl Document {
 
     pub(crate) fn set_body_attribute(
         &self,
+        cx: &mut js::context::JSContext,
         local_name: &LocalName,
         value: DOMString,
-        can_gc: CanGc,
     ) {
         if let Some(ref body) = self.GetBody().filter(|elem| elem.is_body_element()) {
             let body = body.upcast::<Element>();
             let value = body.parse_attribute(&ns!(), local_name, value);
-            body.set_attribute(local_name, value, can_gc);
+            body.set_attribute(local_name, value, CanGc::from_cx(cx));
         }
     }
 
@@ -5698,8 +5698,8 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-document-bgcolor>
-    fn SetBgColor(&self, value: DOMString, can_gc: CanGc) {
-        self.set_body_attribute(&local_name!("bgcolor"), value, can_gc)
+    fn SetBgColor(&self, cx: &mut js::context::JSContext, value: DOMString) {
+        self.set_body_attribute(cx, &local_name!("bgcolor"), value)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-document-fgcolor>
@@ -5708,8 +5708,8 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-document-fgcolor>
-    fn SetFgColor(&self, value: DOMString, can_gc: CanGc) {
-        self.set_body_attribute(&local_name!("text"), value, can_gc)
+    fn SetFgColor(&self, cx: &mut js::context::JSContext, value: DOMString) {
+        self.set_body_attribute(cx, &local_name!("text"), value)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-tree-accessors:dom-document-nameditem-filter>

--- a/components/script/dom/domstringmap.rs
+++ b/components/script/dom/domstringmap.rs
@@ -145,7 +145,7 @@ impl DOMStringMapMethods<crate::DomTypeHolder> for DOMStringMap {
         let name = to_snake_case(&name, false).expect("Must always succeed");
         // Step 3. Remove an attribute by name given name and the DOMStringMap's associated element.
         self.as_element()
-            .remove_attribute(&ns!(), &LocalName::from(name), CanGc::from_cx(cx));
+            .remove_attribute(cx, &ns!(), &LocalName::from(name));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-domstringmap-setitem>

--- a/components/script/dom/element/attributes.rs
+++ b/components/script/dom/element/attributes.rs
@@ -53,7 +53,7 @@ impl Element {
         if value {
             self.set_string_attribute(cx, local_name, DOMString::new());
         } else {
-            self.remove_attribute(&ns!(), local_name, CanGc::from_cx(cx));
+            self.remove_attribute(cx, &ns!(), local_name);
         }
     }
 
@@ -144,7 +144,7 @@ impl Element {
                 self.set_string_attribute(cx, local_name, val);
             },
             None => {
-                self.remove_attribute(&ns!(), local_name, CanGc::from_cx(cx));
+                self.remove_attribute(cx, &ns!(), local_name);
             },
         }
     }
@@ -236,7 +236,7 @@ impl Element {
     /// <https://dom.spec.whatwg.org/#concept-node-clone>
     pub(crate) fn copy_all_attributes_to_other_element(
         &self,
-        cx: &mut JSContext,
+        _cx: &mut JSContext,
         target_element: &Element,
     ) {
         // Step 2.5. For each attribute of node’s attribute list:
@@ -251,7 +251,6 @@ impl Element {
                 attr.namespace().clone(),
                 attr.prefix().cloned(),
                 AttributeMutationReason::ByCloning,
-                CanGc::from_cx(cx),
             );
         }
     }

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -321,7 +321,7 @@ impl Element {
     }
 
     pub(crate) fn new(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         local_name: LocalName,
         namespace: Namespace,
         prefix: Option<Prefix>,
@@ -1885,7 +1885,6 @@ impl Element {
         namespace: Namespace,
         prefix: Option<Prefix>,
         reason: AttributeMutationReason,
-        can_gc: CanGc,
     ) {
         // TODO: https://github.com/servo/servo/issues/42812
         let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
@@ -1900,7 +1899,7 @@ impl Element {
             prefix,
             Some(self),
         );
-        self.push_attribute(&attr, reason, can_gc);
+        self.push_attribute(cx, &attr, reason);
     }
 
     /// <https://dom.spec.whatwg.org/#handle-attribute-changes>
@@ -1980,9 +1979,9 @@ impl Element {
     /// <https://dom.spec.whatwg.org/#concept-element-attributes-append>
     pub(crate) fn push_attribute(
         &self,
+        cx: &mut JSContext,
         attr: &Attr,
         reason: AttributeMutationReason,
-        can_gc: CanGc,
     ) {
         // Step 2. Set attribute’s element to element.
         //
@@ -1999,7 +1998,7 @@ impl Element {
         //
         // Put on a separate line to avoid double borrow
         let new_value = DOMString::from(&**attr.value());
-        self.handle_attribute_changes(attr, None, Some(new_value), reason, can_gc);
+        self.handle_attribute_changes(attr, None, Some(new_value), reason, CanGc::from_cx(cx));
     }
 
     /// This is the inner logic for:
@@ -2057,10 +2056,10 @@ impl Element {
 
     pub(crate) fn set_attribute_from_parser(
         &self,
+        _cx: &mut JSContext,
         qname: QualName,
         value: DOMString,
         prefix: Option<Prefix>,
-        can_gc: CanGc,
     ) {
         // Don't set if the attribute already exists, so we can handle add_attrs_if_missing
         if self
@@ -2087,7 +2086,6 @@ impl Element {
             qname.ns,
             prefix,
             AttributeMutationReason::ByParser,
-            can_gc,
         );
     }
 
@@ -2112,7 +2110,7 @@ impl Element {
 
     pub(crate) fn set_attribute_with_namespace(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         local_name: LocalName,
         value: AttrValue,
         name: LocalName,
@@ -2167,7 +2165,6 @@ impl Element {
                 namespace,
                 prefix,
                 AttributeMutationReason::Directly,
-                can_gc,
             );
         };
     }
@@ -2187,14 +2184,13 @@ impl Element {
 
     pub(crate) fn remove_attribute(
         &self,
+        cx: &mut JSContext,
         namespace: &Namespace,
         local_name: &LocalName,
-        can_gc: CanGc,
     ) -> Option<DomRoot<Attr>> {
-        self.remove_first_matching_attribute(
-            |attr| attr.namespace() == namespace && attr.local_name() == local_name,
-            can_gc,
-        )
+        self.remove_first_matching_attribute(cx, |attr| {
+            attr.namespace() == namespace && attr.local_name() == local_name
+        })
     }
 
     pub(crate) fn remove_attribute_by_name(
@@ -2202,11 +2198,15 @@ impl Element {
         cx: &mut JSContext,
         name: &LocalName,
     ) -> Option<DomRoot<Attr>> {
-        self.remove_first_matching_attribute(|attr| attr.name() == name, CanGc::from_cx(cx))
+        self.remove_first_matching_attribute(cx, |attr| attr.name() == name)
     }
 
     /// <https://dom.spec.whatwg.org/#concept-element-attributes-remove>
-    fn remove_first_matching_attribute<F>(&self, find: F, can_gc: CanGc) -> Option<DomRoot<Attr>>
+    fn remove_first_matching_attribute<F>(
+        &self,
+        cx: &mut JSContext,
+        find: F,
+    ) -> Option<DomRoot<Attr>>
     where
         F: Fn(&Attr) -> bool,
     {
@@ -2225,7 +2225,7 @@ impl Element {
                 Some(&attr.value()),
                 None,
                 AttributeMutationReason::Directly,
-                can_gc,
+                CanGc::from_cx(cx),
             );
 
             attr
@@ -2323,7 +2323,7 @@ impl Element {
     /// <https://dom.spec.whatwg.org/#concept-element-attributes-replace>
     fn set_attribute_node(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         attr: &Attr,
     ) -> Fallible<Option<DomRoot<Attr>>> {
         // Step 1. Let verifiedValue be the result of calling
@@ -2402,7 +2402,7 @@ impl Element {
             // Step 7. Otherwise, append attr to element.
             attr.set_owner(Some(self));
             attr.upcast::<Node>().set_owner_doc(&self.node.owner_doc());
-            self.push_attribute(attr, AttributeMutationReason::Directly, CanGc::from_cx(cx));
+            self.push_attribute(cx, attr, AttributeMutationReason::Directly);
 
             None
         };
@@ -2575,7 +2575,7 @@ impl Element {
     pub(crate) fn parse_fragment(
         &self,
         markup: DOMString,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
     ) -> Fallible<DomRoot<DocumentFragment>> {
         // Steps 1-2.
         // TODO(#11995): XML case.
@@ -2665,7 +2665,7 @@ impl Element {
         }))
     }
 
-    pub(crate) fn outer_html(&self, cx: &mut js::context::JSContext) -> Fallible<DOMString> {
+    pub(crate) fn outer_html(&self, cx: &mut JSContext) -> Fallible<DOMString> {
         match self.GetOuterHTML(cx)? {
             TrustedHTMLOrNullIsEmptyString::NullIsEmptyString(str) => Ok(str),
             TrustedHTMLOrNullIsEmptyString::TrustedHTML(_) => unreachable!(),
@@ -2858,7 +2858,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     /// <https://dom.spec.whatwg.org/#dom-element-toggleattribute>
     fn ToggleAttribute(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         name: DOMString,
         force: Option<bool>,
     ) -> Fallible<bool> {
@@ -2907,7 +2907,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     /// <https://dom.spec.whatwg.org/#dom-element-setattribute>
     fn SetAttribute(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         name: DOMString,
         value: TrustedTypeOrString,
     ) -> ErrorResult {
@@ -2954,7 +2954,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     /// <https://dom.spec.whatwg.org/#dom-element-setattributens>
     fn SetAttributeNS(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         namespace: Option<DOMString>,
         qualified_name: DOMString,
         value: TrustedTypeOrString,
@@ -2987,25 +2987,21 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-element-setattributenode>
-    fn SetAttributeNode(
-        &self,
-        cx: &mut js::context::JSContext,
-        attr: &Attr,
-    ) -> Fallible<Option<DomRoot<Attr>>> {
+    fn SetAttributeNode(&self, cx: &mut JSContext, attr: &Attr) -> Fallible<Option<DomRoot<Attr>>> {
         self.set_attribute_node(cx, attr)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-element-setattributenodens>
     fn SetAttributeNodeNS(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         attr: &Attr,
     ) -> Fallible<Option<DomRoot<Attr>>> {
         self.set_attribute_node(cx, attr)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-element-removeattribute>
-    fn RemoveAttribute(&self, cx: &mut js::context::JSContext, name: DOMString) {
+    fn RemoveAttribute(&self, cx: &mut JSContext, name: DOMString) {
         let name = self.parsed_name(name);
         self.remove_attribute_by_name(cx, &name);
     }
@@ -3013,22 +3009,18 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     /// <https://dom.spec.whatwg.org/#dom-element-removeattributens>
     fn RemoveAttributeNS(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         namespace: Option<DOMString>,
         local_name: DOMString,
     ) {
         let namespace = namespace_from_domstring(namespace);
         let local_name = LocalName::from(local_name);
-        self.remove_attribute(&namespace, &local_name, CanGc::from_cx(cx));
+        self.remove_attribute(cx, &namespace, &local_name);
     }
 
     /// <https://dom.spec.whatwg.org/#dom-element-removeattributenode>
-    fn RemoveAttributeNode(
-        &self,
-        cx: &mut js::context::JSContext,
-        attr: &Attr,
-    ) -> Fallible<DomRoot<Attr>> {
-        self.remove_first_matching_attribute(|a| a == attr, CanGc::from_cx(cx))
+    fn RemoveAttributeNode(&self, cx: &mut JSContext, attr: &Attr) -> Fallible<DomRoot<Attr>> {
+        self.remove_first_matching_attribute(cx, |a| a == attr)
             .ok_or(Error::NotFound(None))
     }
 
@@ -3045,7 +3037,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     /// <https://dom.spec.whatwg.org/#dom-element-getelementsbytagname>
     fn GetElementsByTagName(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         localname: DOMString,
     ) -> DomRoot<HTMLCollection> {
         let window = self.owner_window();
@@ -3055,7 +3047,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     /// <https://dom.spec.whatwg.org/#dom-element-getelementsbytagnamens>
     fn GetElementsByTagNameNS(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         maybe_ns: Option<DOMString>,
         localname: DOMString,
     ) -> DomRoot<HTMLCollection> {
@@ -3066,7 +3058,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     /// <https://dom.spec.whatwg.org/#dom-element-getelementsbyclassname>
     fn GetElementsByClassName(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         classes: DOMString,
     ) -> DomRoot<HTMLCollection> {
         let window = self.owner_window();
@@ -3430,11 +3422,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-element-sethtmlunsafe>
-    fn SetHTMLUnsafe(
-        &self,
-        cx: &mut js::context::JSContext,
-        html: TrustedHTMLOrString,
-    ) -> ErrorResult {
+    fn SetHTMLUnsafe(&self, cx: &mut JSContext, html: TrustedHTMLOrString) -> ErrorResult {
         // Step 1. Let compliantHTML be the result of invoking the
         // Get Trusted Type compliant string algorithm with TrustedHTML,
         // this's relevant global object, html, "Element setHTMLUnsafe", and "script".
@@ -3457,7 +3445,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-element-gethtml>
-    fn GetHTML(&self, cx: &mut js::context::JSContext, options: &GetHTMLOptions) -> DOMString {
+    fn GetHTML(&self, cx: &mut JSContext, options: &GetHTMLOptions) -> DOMString {
         // > Element's getHTML(options) method steps are to return the result of HTML fragment serialization
         // > algorithm with this, options["serializableShadowRoots"], and options["shadowRoots"].
         self.upcast::<Node>().html_serialize(
@@ -3469,10 +3457,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-element-innerhtml>
-    fn GetInnerHTML(
-        &self,
-        cx: &mut js::context::JSContext,
-    ) -> Fallible<TrustedHTMLOrNullIsEmptyString> {
+    fn GetInnerHTML(&self, cx: &mut JSContext) -> Fallible<TrustedHTMLOrNullIsEmptyString> {
         let qname = QualName::new(
             self.prefix().clone(),
             self.namespace().clone(),
@@ -3495,7 +3480,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     /// <https://html.spec.whatwg.org/multipage/#dom-element-innerhtml>
     fn SetInnerHTML(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         value: TrustedHTMLOrNullIsEmptyString,
     ) -> ErrorResult {
         // Step 1: Let compliantString be the result of invoking the
@@ -3539,10 +3524,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-element-outerhtml>
-    fn GetOuterHTML(
-        &self,
-        cx: &mut js::context::JSContext,
-    ) -> Fallible<TrustedHTMLOrNullIsEmptyString> {
+    fn GetOuterHTML(&self, cx: &mut JSContext) -> Fallible<TrustedHTMLOrNullIsEmptyString> {
         // FIXME: This should use the fragment serialization algorithm, which takes
         // care of distinguishing between html/xml documents
         let result = if self.owner_document().is_html_document() {
@@ -3558,7 +3540,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     /// <https://html.spec.whatwg.org/multipage/#dom-element-outerhtml>
     fn SetOuterHTML(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         value: TrustedHTMLOrNullIsEmptyString,
     ) -> ErrorResult {
         // Step 1: Let compliantString be the result of invoking the
@@ -3626,7 +3608,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-parentnode-children>
-    fn Children(&self, cx: &mut js::context::JSContext) -> DomRoot<HTMLCollection> {
+    fn Children(&self, cx: &mut JSContext) -> DomRoot<HTMLCollection> {
         let window = self.owner_window();
         HTMLCollection::children(cx, &window, self.upcast())
     }
@@ -4303,12 +4285,7 @@ impl VirtualMethods for Element {
             .attribute_affects_presentational_hints(attr)
     }
 
-    fn attribute_mutated(
-        &self,
-        cx: &mut js::context::JSContext,
-        attr: &Attr,
-        mutation: AttributeMutation,
-    ) {
+    fn attribute_mutated(&self, cx: &mut JSContext, attr: &Attr, mutation: AttributeMutation) {
         self.super_type()
             .unwrap()
             .attribute_mutated(cx, attr, mutation);
@@ -4585,7 +4562,7 @@ impl VirtualMethods for Element {
         }
     }
 
-    fn post_connection_steps(&self, cx: &mut js::context::JSContext) {
+    fn post_connection_steps(&self, cx: &mut JSContext) {
         if let Some(s) = self.super_type() {
             s.post_connection_steps(cx);
         }
@@ -5058,7 +5035,7 @@ pub(crate) fn set_cross_origin_attribute(
     match value {
         Some(val) => element.set_string_attribute(cx, &local_name!("crossorigin"), val),
         None => {
-            element.remove_attribute(&ns!(), &local_name!("crossorigin"), CanGc::from_cx(cx));
+            element.remove_attribute(cx, &ns!(), &local_name!("crossorigin"));
         },
     }
 }

--- a/components/script/dom/html/htmldialogelement.rs
+++ b/components/script/dom/html/htmldialogelement.rs
@@ -195,7 +195,7 @@ impl HTMLDialogElement {
         self.queue_dialog_toggle_event_task("open", "closed", source);
 
         // Step 5. Remove subject's open attribute.
-        subject.remove_attribute(&ns!(), &local_name!("open"), CanGc::from_cx(cx));
+        subject.remove_attribute(cx, &ns!(), &local_name!("open"));
         subject.set_open_state(false);
 
         // TODO: Step 6. If is modal of subject is true, then request an element to be removed from the top layer given subject.

--- a/components/script/dom/namednodemap.rs
+++ b/components/script/dom/namednodemap.rs
@@ -105,7 +105,7 @@ impl NamedNodeMapMethods<crate::DomTypeHolder> for NamedNodeMap {
     ) -> Fallible<DomRoot<Attr>> {
         let ns = namespace_from_domstring(namespace);
         self.owner
-            .remove_attribute(&ns, &LocalName::from(local_name), CanGc::from_cx(cx))
+            .remove_attribute(cx, &ns, &LocalName::from(local_name))
             .ok_or(Error::NotFound(None))
     }
 

--- a/components/script/dom/servoparser/async_html.rs
+++ b/components/script/dom/servoparser/async_html.rs
@@ -548,10 +548,10 @@ impl Tokenizer {
                     .expect("tried to set attrs on non-Element in HTML parsing");
                 for attr in attrs {
                     elem.set_attribute_from_parser(
+                        cx,
                         attr.name,
                         DOMString::from(attr.value),
                         None,
-                        CanGc::from_cx(cx),
                     );
                 }
             },

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1869,16 +1869,21 @@ impl TreeSink for Sink {
             .expect("Appending failed");
     }
 
+    #[expect(unsafe_code)]
     fn add_attrs_if_missing(&self, target: &Dom<Node>, attrs: Vec<Attribute>) {
+        // TODO: https://github.com/servo/servo/issues/42839
+        let mut cx = unsafe { temp_cx() };
+        let cx = &mut cx;
+
         let elem = target
             .downcast::<Element>()
             .expect("tried to set attrs on non-Element in HTML parsing");
         for attr in attrs {
             elem.set_attribute_from_parser(
+                cx,
                 attr.name,
                 DOMString::from(String::from(attr.value)),
                 None,
-                CanGc::deprecated_note(),
             );
         }
     }
@@ -2044,7 +2049,7 @@ fn create_element_for_token(
 
     // Step 11. Append each attribute in the given token to element.
     for attr in attrs {
-        element.set_attribute_from_parser(attr.name, attr.value, None, CanGc::from_cx(cx));
+        element.set_attribute_from_parser(cx, attr.name, attr.value, None);
     }
 
     // Record if the tokenizer saw duplicate attributes on this element,

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -210,7 +210,7 @@ DOMInterfaces = {
 
 'Document': {
     'additionalTraits': ["crate::interfaces::DocumentHelpers"],
-    'canGc': ['CreateRange', 'SetBgColor', 'SetFgColor', 'Fonts', 'ExitFullscreen', 'CreateExpression', 'CreateNSResolver', 'Evaluate', 'StyleSheets', 'Implementation', 'CreateNodeIterator', 'GetElementsByName', 'AdoptedStyleSheets', 'SetAdoptedStyleSheets'],
+    'canGc': ['CreateRange', 'Fonts', 'ExitFullscreen', 'CreateExpression', 'CreateNSResolver', 'Evaluate', 'StyleSheets', 'Implementation', 'CreateNodeIterator', 'GetElementsByName', 'AdoptedStyleSheets', 'SetAdoptedStyleSheets'],
     'cx': [
         'AdoptNode',
         'Append',
@@ -256,6 +256,8 @@ DOMInterfaces = {
         'Children',
         'GetSelection',
         'NamedGetter',
+        'SetBgColor',
+        'SetFgColor',
     ],
 },
 


### PR DESCRIPTION
One of the final preparation PR's to pass cx to `set_attribute`.

Part of #42812

Testing: It compiles