### PR TITLE
script: Propagate &mut JSContext through event dispatch.

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -917,7 +917,7 @@ impl Document {
                 );
                 let event = event.upcast::<Event>();
                 event.set_trusted(true);
-                window.dispatch_event_with_target_override(event, CanGc::from_cx(cx));
+                window.dispatch_event_with_target_override(cx, event);
             }))
     }
 
@@ -1993,8 +1993,8 @@ impl Document {
     /// <https://html.spec.whatwg.org/multipage/#checking-if-unloading-is-canceled>
     pub(crate) fn check_if_unloading_is_cancelled(
         &self,
+        cx: &mut js::context::JSContext,
         recursive_flag: bool,
-        can_gc: CanGc,
     ) -> bool {
         // TODO: Step 1, increase the event loop's termination nesting level by 1.
         // Step 2
@@ -2005,14 +2005,13 @@ impl Document {
             atom!("beforeunload"),
             EventBubbles::Bubbles,
             EventCancelable::Cancelable,
-            can_gc,
+            CanGc::from_cx(cx),
         );
         let event = beforeunload_event.upcast::<Event>();
         event.set_trusted(true);
         let event_target = self.window.upcast::<EventTarget>();
         let has_listeners = event_target.has_listeners_for(&atom!("beforeunload"));
-        self.window
-            .dispatch_event_with_target_override(event, can_gc);
+        self.window.dispatch_event_with_target_override(cx, event);
         // TODO: Step 6, decrease the event loop's termination nesting level by 1.
         // Step 7
         if has_listeners {
@@ -2040,7 +2039,7 @@ impl Document {
             for iframe in &iframes {
                 // TODO: handle the case of cross origin iframes.
                 let document = iframe.owner_document();
-                can_unload = document.check_if_unloading_is_cancelled(true, can_gc);
+                can_unload = document.check_if_unloading_is_cancelled(cx, true);
                 if !document.salvageable() {
                     self.salvageable.set(false);
                 }
@@ -2075,8 +2074,7 @@ impl Document {
             );
             let event = event.upcast::<Event>();
             event.set_trusted(true);
-            self.window
-                .dispatch_event_with_target_override(event, CanGc::from_cx(cx));
+            self.window.dispatch_event_with_target_override(cx, event);
             // Step 6 Update the visibility state of oldDocument to "hidden".
             self.update_visibility_state(cx, DocumentVisibilityState::Hidden);
         }
@@ -2092,8 +2090,7 @@ impl Document {
             event.set_trusted(true);
             let event_target = self.window.upcast::<EventTarget>();
             let has_listeners = event_target.has_listeners_for(&atom!("unload"));
-            self.window
-                .dispatch_event_with_target_override(&event, CanGc::from_cx(cx));
+            self.window.dispatch_event_with_target_override(cx, &event);
             self.fired_unload.set(true);
             // Step 9
             if has_listeners {
@@ -2232,7 +2229,7 @@ impl Document {
                 );
                 load_event.set_trusted(true);
                 debug!("About to dispatch load for {:?}", document.url());
-                window.dispatch_event_with_target_override(&load_event, CanGc::from_cx(cx));
+                window.dispatch_event_with_target_override(cx, &load_event);
 
                 // Step 9.6. Invoke WebDriver BiDi load complete with the Document's browsing context,
                 // and a new WebDriver BiDi navigation status whose id is the Document object's during-loading navigation ID

--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -686,13 +686,11 @@ impl DocumentEventHandler {
             mouse_over_event
                 .to_pointer_hover_event("pointerover", CanGc::from_cx(cx))
                 .upcast::<Event>()
-                .dispatch(new_target.upcast(), false, CanGc::from_cx(cx));
+                .dispatch(cx, new_target.upcast(), false);
 
-            mouse_over_event.upcast::<Event>().dispatch(
-                new_target.upcast(),
-                false,
-                CanGc::from_cx(cx),
-            );
+            mouse_over_event
+                .upcast::<Event>()
+                .dispatch(cx, new_target.upcast(), false);
 
             let moving_from =
                 old_hover_target.map(|old_target| DomRoot::from_ref(old_target.upcast::<Node>()));
@@ -924,11 +922,9 @@ impl DocumentEventHandler {
                 self.mouse_buttons_down.set(mouse_buttons_down + 1);
 
                 // Step 7. Let result = dispatch event at target
-                let result = mouse_event.upcast::<Event>().dispatch(
-                    node.upcast(),
-                    false,
-                    CanGc::from_cx(cx),
-                );
+                let result = mouse_event
+                    .upcast::<Event>()
+                    .dispatch(cx, node.upcast(), false);
 
                 // Step 8. If result is true and target is a focusable area
                 // that is click focusable, then Run the focusing steps at target.
@@ -976,7 +972,7 @@ impl DocumentEventHandler {
                 // Step 7. dispatch event at target.
                 mouse_event
                     .upcast::<Event>()
-                    .dispatch(node.upcast(), false, CanGc::from_cx(cx));
+                    .dispatch(cx, node.upcast(), false);
 
                 // Click counts should still work for other buttons even though they
                 // do not trigger "click" and "dblclick" events, so we increment
@@ -1046,7 +1042,7 @@ impl DocumentEventHandler {
             click_count,
         )
         .upcast::<Event>()
-        .dispatch(element.upcast(), false, CanGc::from_cx(cx));
+        .dispatch(cx, element.upcast(), false);
         element.set_click_in_progress(false);
 
         // The firing of "dbclick" events is dependent on the platform, so we have
@@ -1069,7 +1065,7 @@ impl DocumentEventHandler {
                 2,
             )
             .upcast::<Event>()
-            .dispatch(element.upcast(), false, CanGc::from_cx(cx));
+            .dispatch(cx, element.upcast(), false);
         }
     }
 
@@ -1707,8 +1703,7 @@ impl DocumentEventHandler {
         }
 
         // Step 2 Fire a clipboard event
-        let clipboard_event =
-            self.fire_clipboard_event(element.clone(), clipboard_event_type, CanGc::from_cx(cx));
+        let clipboard_event = self.fire_clipboard_event(cx, element.clone(), clipboard_event_type);
 
         // Step 3 If a script doesn't call preventDefault()
         // the event will be handled inside target's VirtualMethods::handle_event
@@ -1741,7 +1736,7 @@ impl DocumentEventHandler {
                     }
 
                     // Step 4.2 Fire a clipboard event named clipboardchange
-                    self.fire_clipboard_event(element, ClipboardEventType::Change, CanGc::from_cx(cx));
+                    self.fire_clipboard_event(cx, element, ClipboardEventType::Change);
                 },
                 // Step 4.1 Return false.
                 // Note: This function deviates from the specification a bit by returning
@@ -1759,9 +1754,9 @@ impl DocumentEventHandler {
     /// <https://www.w3.org/TR/clipboard-apis/#fire-a-clipboard-event>
     pub(crate) fn fire_clipboard_event(
         &self,
+        cx: &mut JSContext,
         target: Option<DomRoot<Element>>,
         clipboard_event_type: ClipboardEventType,
-        can_gc: CanGc,
     ) -> DomRoot<ClipboardEvent> {
         let clipboard_event = ClipboardEvent::new(
             &self.window,
@@ -1770,7 +1765,7 @@ impl DocumentEventHandler {
             EventBubbles::Bubbles,
             EventCancelable::Cancelable,
             None,
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         // Step 1 Let clear_was_called be false
@@ -1831,7 +1826,7 @@ impl DocumentEventHandler {
         let clipboard_event_data = DataTransfer::new(
             &self.window,
             Rc::new(RefCell::new(Some(drag_data_store))),
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         // Step 8
@@ -1845,7 +1840,7 @@ impl DocumentEventHandler {
         event.set_composed(true);
 
         // Step 11
-        event.dispatch(&target, false, can_gc);
+        event.dispatch(cx, &target, false);
 
         DomRoot::from(clipboard_event)
     }
@@ -1922,9 +1917,9 @@ impl DocumentEventHandler {
     /// > type is supported by the user agent.
     pub(crate) fn maybe_dispatch_simulated_click(
         &self,
+        cx: &mut JSContext,
         node: &Node,
         event: &KeyboardEvent,
-        can_gc: CanGc,
     ) -> bool {
         if event.key() != Key::Named(NamedKey::Enter) && event.original_code() != Some(Code::Space)
         {
@@ -1942,7 +1937,7 @@ impl DocumentEventHandler {
             return false;
         }
 
-        node.fire_synthetic_pointer_event_not_trusted(atom!("click"), can_gc);
+        node.fire_synthetic_pointer_event_not_trusted(cx, atom!("click"));
         true
     }
 
@@ -1956,7 +1951,7 @@ impl DocumentEventHandler {
             return;
         }
 
-        if self.maybe_dispatch_simulated_click(node, event, CanGc::from_cx(cx)) {
+        if self.maybe_dispatch_simulated_click(cx, node, event) {
             return;
         }
 

--- a/components/script/dom/event/event.rs
+++ b/components/script/dom/event/event.rs
@@ -287,40 +287,35 @@ impl Event {
     /// <https://dom.spec.whatwg.org/#concept-event-dispatch>
     pub(crate) fn dispatch(
         &self,
+        cx: &mut JSContext,
         target: &EventTarget,
         legacy_target_override: bool,
-        can_gc: CanGc,
     ) -> bool {
-        self.dispatch_inner(target, legacy_target_override, None, can_gc)
+        self.dispatch_inner(cx, target, legacy_target_override, None)
     }
 
     pub(crate) fn dispatch_with_legacy_output_did_listeners_throw(
         &self,
+        cx: &mut JSContext,
         target: &EventTarget,
         legacy_target_override: bool,
         legacy_output_did_listeners_throw: &Cell<bool>,
-        can_gc: CanGc,
     ) -> bool {
         self.dispatch_inner(
+            cx,
             target,
             legacy_target_override,
             Some(legacy_output_did_listeners_throw),
-            can_gc,
         )
     }
 
-    #[expect(unsafe_code)]
     fn dispatch_inner(
         &self,
+        cx: &mut JSContext,
         target: &EventTarget,
         legacy_target_override: bool,
         legacy_output_did_listeners_throw: Option<&Cell<bool>>,
-        _can_gc: CanGc,
     ) -> bool {
-        // TODO https://github.com/servo/servo/issues/44499
-        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
-        let cx = &mut cx;
-
         // > When a user interaction causes firing of an activation triggering input event in a Document document, the user agent
         // > must perform the following activation notification steps before dispatching the event:
         // <https://html.spec.whatwg.org/multipage/#user-activation-processing-model>
@@ -770,24 +765,35 @@ impl Event {
     }
 
     /// <https://dom.spec.whatwg.org/#firing-events>
-    pub(crate) fn fire(&self, target: &EventTarget, can_gc: CanGc) -> bool {
+    #[expect(unsafe_code)]
+    pub(crate) fn fire(&self, target: &EventTarget, _can_gc: CanGc) -> bool {
         self.set_trusted(true);
 
-        target.dispatch_event(self, can_gc)
+        // TODO https://github.com/servo/servo/issues/44499
+        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
+        let cx = &mut cx;
+
+        target.dispatch_event(cx, self)
+    }
+
+    pub(crate) fn fire_with_cx(&self, cx: &mut JSContext, target: &EventTarget) -> bool {
+        self.set_trusted(true);
+
+        target.dispatch_event(cx, self)
     }
 
     pub(crate) fn fire_with_legacy_output_did_listeners_throw(
         &self,
+        cx: &mut JSContext,
         target: &EventTarget,
         legacy_output_did_listeners_throw: &Cell<bool>,
-        can_gc: CanGc,
     ) -> bool {
         self.set_trusted(true);
         self.dispatch_with_legacy_output_did_listeners_throw(
+            cx,
             target,
             false,
             legacy_output_did_listeners_throw,
-            can_gc,
         )
     }
 

--- a/components/script/dom/event/event.rs
+++ b/components/script/dom/event/event.rs
@@ -1396,11 +1396,11 @@ fn inner_invoke(
             event_target.remove_listener(&event.type_(), listener);
         }
 
-        let Some(compiled_listener) = listener.borrow().get_compiled_listener(
-            &event_target,
-            &event.type_(),
-            CanGc::from_cx(cx),
-        ) else {
+        let Some(compiled_listener) =
+            listener
+                .borrow()
+                .get_compiled_listener(cx, &event_target, &event.type_())
+        else {
             continue;
         };
 

--- a/components/script/dom/event/eventtarget.rs
+++ b/components/script/dom/event/eventtarget.rs
@@ -475,8 +475,8 @@ impl EventTarget {
             .map_or(EventListeners(vec![]), |listeners| listeners.clone())
     }
 
-    pub(crate) fn dispatch_event(&self, event: &Event, can_gc: CanGc) -> bool {
-        event.dispatch(self, false, can_gc)
+    pub(crate) fn dispatch_event(&self, cx: &mut JSContext, event: &Event) -> bool {
+        event.dispatch(cx, self, false)
     }
 
     pub(crate) fn remove_all_listeners(&self) {
@@ -1108,12 +1108,12 @@ impl EventTargetMethods<crate::DomTypeHolder> for EventTarget {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-eventtarget-dispatchevent>
-    fn DispatchEvent(&self, event: &Event, can_gc: CanGc) -> Fallible<bool> {
+    fn DispatchEvent(&self, cx: &mut JSContext, event: &Event) -> Fallible<bool> {
         if event.dispatching() || !event.initialized() {
             return Err(Error::InvalidState(None));
         }
         event.set_trusted(false);
-        Ok(self.dispatch_event(event, can_gc))
+        Ok(self.dispatch_event(cx, event))
     }
 }
 

--- a/components/script/dom/event/eventtarget.rs
+++ b/components/script/dom/event/eventtarget.rs
@@ -15,9 +15,9 @@ use deny_public_fields::DenyPublicFields;
 use devtools_traits::EventListenerInfo;
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use js::jsapi::JS::CompileFunction;
 use js::jsapi::{JS_GetFunctionObject, SupportUnscopables};
 use js::jsval::JSVal;
+use js::rust::wrappers2::CompileFunction;
 use js::rust::{CompileOptionsWrapper, HandleObject, transform_u16_to_source_text};
 use libc::c_char;
 use rustc_hash::{FxBuildHasher, FxHashSet};
@@ -133,10 +133,10 @@ enum InlineEventListener {
 /// raw source if necessary.
 /// <https://html.spec.whatwg.org/multipage/#getting-the-current-value-of-the-event-handler>
 fn get_compiled_handler(
+    cx: &mut JSContext,
     inline_listener: &RefCell<InlineEventListener>,
     owner: &EventTarget,
     ty: &Atom,
-    can_gc: CanGc,
 ) -> Option<CommonEventHandler> {
     let listener = mem::replace(
         &mut *inline_listener.borrow_mut(),
@@ -145,7 +145,7 @@ fn get_compiled_handler(
     let compiled = match listener {
         InlineEventListener::Null => None,
         InlineEventListener::Uncompiled(handler) => {
-            owner.get_compiled_event_handler(handler, ty, can_gc)
+            owner.get_compiled_event_handler(cx, handler, ty)
         },
         InlineEventListener::Compiled(handler) => Some(handler),
     };
@@ -164,13 +164,13 @@ enum EventListenerType {
 impl EventListenerType {
     fn get_compiled_listener(
         &self,
+        cx: &mut JSContext,
         owner: &EventTarget,
         ty: &Atom,
-        can_gc: CanGc,
     ) -> Option<CompiledEventListener> {
         match *self {
             EventListenerType::Inline(ref inline) => {
-                get_compiled_handler(inline, owner, ty, can_gc).map(CompiledEventListener::Handler)
+                get_compiled_handler(cx, inline, owner, ty).map(CompiledEventListener::Handler)
             },
             EventListenerType::Additive(ref listener) => {
                 Some(CompiledEventListener::Listener(listener.clone()))
@@ -351,11 +351,11 @@ impl EventListenerEntry {
     /// <https://html.spec.whatwg.org/multipage/#getting-the-current-value-of-the-event-handler>
     pub(crate) fn get_compiled_listener(
         &self,
+        cx: &mut JSContext,
         owner: &EventTarget,
         ty: &Atom,
-        can_gc: CanGc,
     ) -> Option<CompiledEventListener> {
-        self.listener.get_compiled_listener(owner, ty, can_gc)
+        self.listener.get_compiled_listener(cx, owner, ty)
     }
 }
 
@@ -395,7 +395,7 @@ impl EventListeners {
         for entry in &self.0 {
             if let EventListenerType::Inline(ref inline) = entry.borrow().listener {
                 // Step 1.1-1.8 and Step 2
-                return get_compiled_handler(inline, owner, ty, CanGc::from_cx(cx));
+                return get_compiled_handler(cx, inline, owner, ty);
             }
         }
 
@@ -632,14 +632,12 @@ impl EventTarget {
 
     // https://html.spec.whatwg.org/multipage/#getting-the-current-value-of-the-event-handler
     // step 3
-    // While the CanGc argument appears unused, it reflects the fact that the CompileFunction
-    // API call can trigger a GC operation.
     #[expect(unsafe_code)]
     fn get_compiled_event_handler(
         &self,
+        cx: &mut JSContext,
         handler: InternalRawUncompiledHandler,
         ty: &Atom,
-        can_gc: CanGc,
     ) -> Option<CommonEventHandler> {
         // Step 3.1
         let element = self.downcast::<Element>();
@@ -689,12 +687,13 @@ impl EventTarget {
         let is_error = ty == &atom!("error") && self.is::<Window>();
         let args = if is_error { ERROR_ARG_NAMES } else { ARG_NAMES };
 
-        let cx = GlobalScope::get_cx();
         let url = cformat!("{}", handler.url);
-        let options = unsafe { CompileOptionsWrapper::new_raw(*cx, url, handler.line as u32) };
+        let options =
+            unsafe { CompileOptionsWrapper::new_raw(cx.raw_cx(), url, handler.line as u32) };
 
         // Step 3.9, subsection Scope steps 1-6
-        let scopechain = js::rust::EnvironmentChain::new(*cx, SupportUnscopables::Yes);
+        let scopechain =
+            js::rust::EnvironmentChain::new(unsafe { cx.raw_cx() }, SupportUnscopables::Yes);
 
         if let Some(element) = element {
             scopechain.append(document.reflector().get_jsobject().get());
@@ -704,9 +703,9 @@ impl EventTarget {
             scopechain.append(element.reflector().get_jsobject().get());
         }
 
-        rooted!(in(*cx) let mut handler = unsafe {
+        rooted!(&in(cx) let mut handler = unsafe {
             CompileFunction(
-                *cx,
+                cx,
                 scopechain.get(),
                 options.ptr,
                 name.as_ptr(),
@@ -718,7 +717,7 @@ impl EventTarget {
         if handler.get().is_null() {
             // Step 3.7
             let ar = enter_realm(self);
-            report_pending_exception(cx, InRealm::Entered(&ar), can_gc);
+            report_pending_exception(cx.into(), InRealm::Entered(&ar), CanGc::from_cx(cx));
             return None;
         }
 
@@ -732,15 +731,15 @@ impl EventTarget {
         // Step 1.14
         if is_error {
             Some(CommonEventHandler::ErrorEventHandler(unsafe {
-                OnErrorEventHandlerNonNull::new(cx, funobj)
+                OnErrorEventHandlerNonNull::new(cx.into(), funobj)
             }))
         } else if ty == &atom!("beforeunload") {
             Some(CommonEventHandler::BeforeUnloadEventHandler(unsafe {
-                OnBeforeUnloadEventHandlerNonNull::new(cx, funobj)
+                OnBeforeUnloadEventHandlerNonNull::new(cx.into(), funobj)
             }))
         } else {
             Some(CommonEventHandler::EventHandler(unsafe {
-                EventHandlerNonNull::new(cx, funobj)
+                EventHandlerNonNull::new(cx.into(), funobj)
             }))
         }
     }

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -442,7 +442,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-click>
-    fn Click(&self, can_gc: CanGc) {
+    fn Click(&self, cx: &mut JSContext) {
         let element = self.as_element();
         if element.disabled_state() {
             return;
@@ -453,7 +453,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
         element.set_click_in_progress(true);
 
         self.upcast::<Node>()
-            .fire_synthetic_pointer_event_not_trusted(atom!("click"), can_gc);
+            .fire_synthetic_pointer_event_not_trusted(cx, atom!("click"));
         element.set_click_in_progress(false);
     }
 

--- a/components/script/dom/html/htmllabelelement.rs
+++ b/components/script/dom/html/htmllabelelement.rs
@@ -82,7 +82,7 @@ impl Activatable for HTMLLabelElement {
         _target: &EventTarget,
     ) {
         if let Some(e) = self.GetControl() {
-            e.Click(CanGc::from_cx(cx));
+            e.Click(cx);
         }
     }
 }

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -1219,7 +1219,7 @@ impl HTMLScriptElement {
             EventCancelable::NotCancelable,
             CanGc::from_cx(cx),
         );
-        event.fire(self.upcast(), CanGc::from_cx(cx))
+        event.fire_with_cx(cx, self.upcast())
     }
 
     fn text(&self) -> DOMString {

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -831,9 +831,9 @@ impl VirtualMethods for HTMLTextAreaElement {
             let flags = reaction.flags;
             if flags.contains(ClipboardEventFlags::FireClipboardChangedEvent) {
                 self.owner_document().event_handler().fire_clipboard_event(
+                    cx,
                     None,
                     ClipboardEventType::Change,
-                    CanGc::from_cx(cx),
                 );
             }
             if flags.contains(ClipboardEventFlags::QueueInputEvent) {

--- a/components/script/dom/html/input_element/mod.rs
+++ b/components/script/dom/html/input_element/mod.rs
@@ -1837,10 +1837,7 @@ impl HTMLInputElement {
                     // but we can get here from synthetic keydown events
                     button
                         .upcast::<Node>()
-                        .fire_synthetic_pointer_event_not_trusted(
-                            atom!("click"),
-                            CanGc::from_cx(cx),
-                        );
+                        .fire_synthetic_pointer_event_not_trusted(cx, atom!("click"));
                 }
             },
             None => {
@@ -2327,9 +2324,9 @@ impl VirtualMethods for HTMLInputElement {
             let flags = reaction.flags;
             if flags.contains(ClipboardEventFlags::FireClipboardChangedEvent) {
                 self.owner_document().event_handler().fire_clipboard_event(
+                    cx,
                     None,
                     ClipboardEventType::Change,
-                    CanGc::from_cx(cx),
                 );
             }
             if flags.contains(ClipboardEventFlags::QueueInputEvent) {

--- a/components/script/dom/html/interactive_element_command.rs
+++ b/components/script/dom/html/interactive_element_command.rs
@@ -11,7 +11,6 @@ use script_bindings::codegen::GenericBindings::HTMLSelectElementBinding::HTMLSel
 use script_bindings::codegen::GenericBindings::NodeBinding::NodeMethods;
 use script_bindings::inheritance::Castable;
 use script_bindings::root::DomRoot;
-use script_bindings::script_runtime::CanGc;
 
 use crate::dom::node::{Node, NodeTraits, ShadowIncluding};
 use crate::dom::types::{
@@ -162,18 +161,18 @@ impl InteractiveElementCommand {
             // > Firing a click event at target means firing a synthetic pointer event named click at target.
             InteractiveElementCommand::Anchor(anchor_element) => anchor_element
                 .upcast::<Node>()
-                .fire_synthetic_pointer_event_not_trusted(atom!("click"), CanGc::from_cx(cx)),
+                .fire_synthetic_pointer_event_not_trusted(cx, atom!("click")),
             // <https://html.spec.whatwg.org/multipage/#using-the-button-element-to-define-a-command>
             // > The Label, Access Key, Hidden State, and Action facets of the command are
             // > determined as for a elements (see the previous section).
             InteractiveElementCommand::Button(button_element) => button_element
                 .upcast::<Node>()
-                .fire_synthetic_pointer_event_not_trusted(atom!("click"), CanGc::from_cx(cx)),
+                .fire_synthetic_pointer_event_not_trusted(cx, atom!("click")),
             // <https://html.spec.whatwg.org/multipage/#using-the-input-element-to-define-a-command>
             // > The Action of the command is to fire a click event at the element.
             InteractiveElementCommand::Input(input_element) => input_element
                 .upcast::<Node>()
-                .fire_synthetic_pointer_event_not_trusted(atom!("click"), CanGc::from_cx(cx)),
+                .fire_synthetic_pointer_event_not_trusted(cx, atom!("click")),
             // <https://html.spec.whatwg.org/multipage/#using-the-option-element-to-define-a-command>
             // > If the option's nearest ancestor select element has a multiple attribute, the
             // > Action of the command is to toggle the option element. Otherwise, the Action is to
@@ -188,7 +187,7 @@ impl InteractiveElementCommand {
             InteractiveElementCommand::HTMLElement(html_element) => {
                 let node: &Node = html_element.upcast();
                 node.run_the_focusing_steps(cx, None);
-                node.fire_synthetic_pointer_event_not_trusted(atom!("click"), CanGc::from_cx(cx));
+                node.fire_synthetic_pointer_event_not_trusted(cx, atom!("click"));
             },
         }
     }

--- a/components/script/dom/indexeddb/idbdatabase.rs
+++ b/components/script/dom/indexeddb/idbdatabase.rs
@@ -153,18 +153,18 @@ impl IDBDatabase {
     /// <https://w3c.github.io/IndexedDB/#eventdef-idbdatabase-versionchange>
     pub fn dispatch_versionchange(
         &self,
+        cx: &mut JSContext,
         old_version: u64,
         new_version: Option<u64>,
-        can_gc: CanGc,
     ) {
         let global = self.global();
         let _ = IDBVersionChangeEvent::fire_version_change_event(
+            cx,
             &global,
             self.upcast(),
             Atom::from("versionchange"),
             old_version,
             new_version,
-            can_gc,
         );
     }
 }

--- a/components/script/dom/indexeddb/idbfactory.rs
+++ b/components/script/dom/indexeddb/idbfactory.rs
@@ -337,13 +337,7 @@ impl IDBFactory {
                 // https://w3c.github.io/IndexedDB/#upgrade-transaction-steps
                 // Step 3. Set transaction’s scope to connection’s object store set.
                 connection.set_object_store_names_from_backend(object_store_names);
-                request.upgrade_db_version(
-                    &connection,
-                    old_version,
-                    version,
-                    transaction,
-                    CanGc::from_cx(cx),
-                );
+                request.upgrade_db_version(cx, &connection, old_version, version, transaction);
             },
             ConnectionMsg::VersionError { name, id } => {
                 // Step 2.1 If result is an error, see dispatch_error().
@@ -374,7 +368,7 @@ impl IDBFactory {
                     request.get_or_init_connection(cx, &global, name.clone(), version, false);
 
                 // Step 10.2: fire a version change event named versionchange at entry with db’s version and version.
-                connection.dispatch_versionchange(old_version, Some(version), CanGc::from_cx(cx));
+                connection.dispatch_versionchange(cx, old_version, Some(version));
 
                 // Step 10.3: Wait for all of the events to be fired.
                 // Note: backend is at this step; sending a message to continue algo there.
@@ -406,7 +400,7 @@ impl IDBFactory {
                 };
 
                 // Step 10.4: fire a version change event named blocked at request with db’s version and version.
-                request.dispatch_blocked(old_version, Some(version), CanGc::from_cx(cx));
+                request.dispatch_blocked(cx, old_version, Some(version));
             },
             ConnectionMsg::TxnMaybeCommit { db_name, txn } => {
                 let factory = Trusted::new(self);

--- a/components/script/dom/indexeddb/idbopendbrequest.rs
+++ b/components/script/dom/indexeddb/idbopendbrequest.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::jsval::UndefinedValue;
 use js::rust::HandleValue;
 use profile_traits::generic_callback::GenericCallback;
@@ -40,7 +41,7 @@ struct OpenRequestListener {
 impl OpenRequestListener {
     /// The continuation of the parallel steps of
     /// <https://www.w3.org/TR/IndexedDB/#dom-idbfactory-deletedatabase>
-    fn handle_delete_db(&self, cx: &mut js::context::JSContext, result: BackendResult<u64>) {
+    fn handle_delete_db(&self, cx: &mut JSContext, result: BackendResult<u64>) {
         // Step 4.1: Let result be the result of deleting a database, with storageKey, name, and request.
         // Note: done with the `result` argument.
 
@@ -69,12 +70,12 @@ impl OpenRequestListener {
                 // and fire a version change event named success at request with result and null.
                 open_request.set_result(rval.handle());
                 let _ = IDBVersionChangeEvent::fire_version_change_event(
+                    cx,
                     &global,
                     open_request.upcast(),
                     Atom::from("success"),
                     version,
                     None,
-                    CanGc::from_cx(cx),
                 );
             },
             Err(err) => {
@@ -128,7 +129,7 @@ impl IDBOpenDBRequest {
 
     pub(crate) fn get_or_init_connection(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         name: String,
         version: u64,
@@ -151,14 +152,13 @@ impl IDBOpenDBRequest {
     /// The below are the steps in the task.
     pub(crate) fn upgrade_db_version(
         &self,
+        cx: &mut JSContext,
         connection: &IDBDatabase,
         old_version: u64,
         version: u64,
         transaction: u64,
-        can_gc: CanGc,
     ) {
         let global = self.global();
-        let cx = GlobalScope::get_cx();
 
         let transaction = IDBTransaction::new_with_serial(
             &global,
@@ -167,15 +167,15 @@ impl IDBOpenDBRequest {
             IDBTransactionDurability::Default,
             &connection.object_stores(),
             transaction,
-            can_gc,
+            CanGc::from_cx(cx),
         );
         transaction.set_versionchange_old_version(old_version);
         connection.set_transaction(&transaction);
         // This task runs Step 10.4 later, so keep the transaction inactive until then.
         transaction.set_active_flag(false);
 
-        rooted!(in(*cx) let mut connection_val = UndefinedValue());
-        connection.safe_to_jsval(cx, connection_val.handle_mut(), can_gc);
+        rooted!(&in(cx) let mut connection_val = UndefinedValue());
+        connection.safe_to_jsval(cx.into(), connection_val.handle_mut(), CanGc::from_cx(cx));
 
         // Step 10.1: Set request’s result to connection.
         self.idbrequest.set_result(connection_val.handle());
@@ -192,12 +192,12 @@ impl IDBOpenDBRequest {
         // Step 10.5: Let didThrow be the result of firing a version change event
         // named upgradeneeded at request with old version and version.
         let did_throw = IDBVersionChangeEvent::fire_version_change_event(
+            cx,
             &global,
             self.upcast(),
             Atom::from("upgradeneeded"),
             old_version,
             Some(version),
-            can_gc,
         );
 
         // Step 10.6: If transaction’s state is active, then:
@@ -208,7 +208,7 @@ impl IDBOpenDBRequest {
             // Step 10.6.2: If didThrow is true, run abort a transaction with
             // transaction and a newly created "AbortError" DOMException.
             if did_throw {
-                transaction.initiate_abort(Error::Abort(None), can_gc);
+                transaction.initiate_abort(Error::Abort(None), CanGc::from_cx(cx));
                 transaction.request_backend_abort();
             } else {
                 // The upgrade transaction auto-commits once inactive and quiescent.
@@ -280,13 +280,7 @@ impl IDBOpenDBRequest {
         matches
     }
 
-    pub fn dispatch_success(
-        &self,
-        cx: &mut js::context::JSContext,
-        name: String,
-        version: u64,
-        upgraded: bool,
-    ) {
+    pub fn dispatch_success(&self, cx: &mut JSContext, name: String, version: u64, upgraded: bool) {
         let global = self.global();
         let result = self.get_or_init_connection(cx, &global, name, version, upgraded);
         self.idbrequest.set_ready_state_done();
@@ -304,19 +298,19 @@ impl IDBOpenDBRequest {
             EventCancelable::NotCancelable,
             CanGc::from_cx(cx),
         );
-        event.fire(self.upcast(), CanGc::from_cx(cx));
+        event.fire_with_cx(cx, self.upcast());
     }
 
     /// <https://w3c.github.io/IndexedDB/#eventdef-idbopendbrequest-blocked>
-    pub fn dispatch_blocked(&self, old_version: u64, new_version: Option<u64>, can_gc: CanGc) {
+    pub fn dispatch_blocked(&self, cx: &mut JSContext, old_version: u64, new_version: Option<u64>) {
         let global = self.global();
         let _ = IDBVersionChangeEvent::fire_version_change_event(
+            cx,
             &global,
             self.upcast(),
             Atom::from("blocked"),
             old_version,
             new_version,
-            can_gc,
         );
     }
 }

--- a/components/script/dom/indexeddb/idbrequest.rs
+++ b/components/script/dom/indexeddb/idbrequest.rs
@@ -292,9 +292,9 @@ impl RequestListener {
             event
                 .upcast::<Event>()
                 .fire_with_legacy_output_did_listeners_throw(
+                    cx,
                     request.upcast(),
                     &did_listeners_throw,
-                    CanGc::from_cx(cx),
                 );
             // Step 8: If transaction’s state is active, then:
             if transaction.is_active() {
@@ -371,9 +371,9 @@ impl RequestListener {
         let default_not_prevented = event
             .upcast::<Event>()
             .fire_with_legacy_output_did_listeners_throw(
+                cx,
                 request.upcast(),
                 &did_listeners_throw,
-                CanGc::from_cx(cx),
             );
         // Step 8: If transaction’s state is active, then:
         if transaction.is_active() {

--- a/components/script/dom/indexeddb/idbversionchangeevent.rs
+++ b/components/script/dom/indexeddb/idbversionchangeevent.rs
@@ -5,6 +5,7 @@
 use std::cell::Cell;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -87,12 +88,12 @@ impl IDBVersionChangeEvent {
 
     /// <https://w3c.github.io/IndexedDB/#fire-a-version-change-event>
     pub(crate) fn fire_version_change_event(
+        cx: &mut JSContext,
         global: &GlobalScope,
         target: &EventTarget,
         event_type: Atom,
         old_version: u64,
         new_version: Option<u64>,
-        can_gc: CanGc,
     ) -> bool {
         // Step 1: Let event be the result of creating an event using IDBVersionChangeEvent.
         // Step 2: Set event’s type attribute to e.
@@ -106,7 +107,7 @@ impl IDBVersionChangeEvent {
             EventCancelable::NotCancelable,
             old_version,
             new_version,
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         // Step 6: Let legacyOutputDidListenersThrowFlag be false.
@@ -115,9 +116,9 @@ impl IDBVersionChangeEvent {
         let _ = event
             .upcast::<Event>()
             .fire_with_legacy_output_did_listeners_throw(
+                cx,
                 target,
                 &legacy_output_did_listeners_throw,
-                can_gc,
             );
         // Step 8: Return legacyOutputDidListenersThrowFlag.
         legacy_output_did_listeners_throw.get()

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -561,7 +561,11 @@ impl Node {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#fire-a-synthetic-pointer-event>
-    pub(crate) fn fire_synthetic_pointer_event_not_trusted(&self, event_type: Atom, can_gc: CanGc) {
+    pub(crate) fn fire_synthetic_pointer_event_not_trusted(
+        &self,
+        cx: &mut JSContext,
+        event_type: Atom,
+    ) {
         // Spec says the choice of which global to create the pointer event
         // on is not well-defined,
         // and refers to heycam/webidl#135
@@ -597,7 +601,7 @@ impl Node {
             false,                              // is_primary
             vec![],                             // coalesced_events
             vec![],                             // predicted_events
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         // Step 4. Set event's composed flag.
@@ -610,7 +614,7 @@ impl Node {
 
         pointer_event
             .upcast::<Event>()
-            .dispatch(self.upcast::<EventTarget>(), false, can_gc);
+            .dispatch(cx, self.upcast::<EventTarget>(), false);
     }
 
     pub(crate) fn parent_directionality(&self) -> String {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -801,8 +801,8 @@ impl Window {
     }
 
     // see note at https://dom.spec.whatwg.org/#concept-event-dispatch step 2
-    pub(crate) fn dispatch_event_with_target_override(&self, event: &Event, can_gc: CanGc) {
-        event.dispatch(self.upcast(), true, can_gc);
+    pub(crate) fn dispatch_event_with_target_override(&self, cx: &mut JSContext, event: &Event) {
+        event.dispatch(cx, self.upcast(), true);
     }
 
     pub(crate) fn font_context(&self) -> &Arc<FontContext> {
@@ -875,7 +875,7 @@ impl Window {
         //
         // Implemented by passing `false` into the method below
         // Step 2. If the result of checking if unloading is canceled for toUnload is not "continue", then return.
-        if !document.check_if_unloading_is_cancelled(false, CanGc::from_cx(cx)) {
+        if !document.check_if_unloading_is_cancelled(cx, false) {
             return;
         }
         // Step 3. Append the following session history traversal steps to traversable:

--- a/components/script/dom/workers/serviceworkerglobalscope.rs
+++ b/components/script/dom/workers/serviceworkerglobalscope.rs
@@ -458,10 +458,7 @@ impl ServiceWorkerGlobalScope {
                     );
                     _ = global_scope.run_a_classic_script(&mut realm, script, RethrowErrors::No);
                     let in_realm_proof = (&mut realm).into();
-                    global.dispatch_activate(
-                        CanGc::from_cx(&mut realm),
-                        InRealm::Already(&in_realm_proof),
-                    );
+                    global.dispatch_activate(&mut realm, InRealm::Already(&in_realm_proof));
                 }
 
                 let reporter_name = format!("service-worker-reporter-{}", random::<u64>());
@@ -552,10 +549,10 @@ impl ServiceWorkerGlobalScope {
         ScriptEventLoopSender::ServiceWorker(self.own_sender.clone())
     }
 
-    fn dispatch_activate(&self, can_gc: CanGc, _realm: InRealm) {
-        let event = ExtendableEvent::new(self, atom!("activate"), false, false, can_gc);
+    fn dispatch_activate(&self, cx: &mut js::context::JSContext, _realm: InRealm) {
+        let event = ExtendableEvent::new(self, atom!("activate"), false, false, CanGc::from_cx(cx));
         let event = (*event).upcast::<Event>();
-        self.upcast::<EventTarget>().dispatch_event(event, can_gc);
+        self.upcast::<EventTarget>().dispatch_event(cx, event);
     }
 }
 

--- a/components/script/navigation.rs
+++ b/components/script/navigation.rs
@@ -46,7 +46,6 @@ use crate::dom::window::Window;
 use crate::dom::windowproxy::WindowProxy;
 use crate::fetch::FetchCanceller;
 use crate::messaging::MainThreadScriptMsg;
-use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 
 #[derive(Clone)]
@@ -498,7 +497,7 @@ pub(crate) fn navigate(
 
     // Step 23.1. Let unloadPromptCanceled be the result of checking if unloading
     // is canceled for navigable's active document's inclusive descendant navigables.
-    let unload_prompt_canceled = doc.check_if_unloading_is_cancelled(false, CanGc::from_cx(cx));
+    let unload_prompt_canceled = doc.check_if_unloading_is_cancelled(cx, false);
     // Step 23.2. If unloadPromptCanceled is not "continue",
     // or navigable's ongoing navigation is no longer navigationId:
     //

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -331,7 +331,7 @@ DOMInterfaces = {
 },
 
 'EventTarget': {
-    'canGc': ['DispatchEvent'],
+    'cx': ['DispatchEvent'],
 },
 
 'ExtendableMessageEvent': {
@@ -470,7 +470,6 @@ DOMInterfaces = {
 'HTMLElement': {
     'canGc': [
         'AttachInternals',
-        'Click',
         'Dataset',
         'GetOnblur',
         'GetOnerror',
@@ -482,6 +481,7 @@ DOMInterfaces = {
     ],
     'cx': [
         'Blur',
+        'Click',
         'Focus',
     ],
     'implicitCxSetters': True,


### PR DESCRIPTION
This work adds a new `Event::fire_with_cx` method to support incrementally porting uses of `Event::fire`.

Testing: Existing tests are sufficient.
Fixes: Part of #42638
