### PR TITLE
script: Properly fire `pointerup` events

### DIFF
--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -177,9 +177,10 @@ pub(crate) struct DocumentEventHandler {
     click_counting_info: DomRefCell<ClickCountingInfo>,
     #[no_trace]
     last_mouse_button_down_point: Cell<Option<Point2D<f32, CSSPixel>>>,
-    /// The number of currently down buttons, used to decide which kind
-    /// of pointer event to dispatch on MouseDown/MouseUp.
-    down_button_count: Cell<u32>,
+    /// The number of mouse buttons currently being pressed. This is used to ensure
+    /// that `pointerup` and `pointerdown` events are only sent when transitioning from
+    /// having no mouse buttons pressed to having any and vice-versa.
+    mouse_buttons_down: Cell<u32>,
     /// The element that is currently hovered by the cursor.
     current_hover_target: MutNullableDom<Element>,
     /// The element that was most recently clicked.
@@ -217,7 +218,7 @@ impl DocumentEventHandler {
             coalesced_wheel_event_ids: Default::default(),
             click_counting_info: Default::default(),
             last_mouse_button_down_point: Default::default(),
-            down_button_count: Cell::new(0),
+            mouse_buttons_down: Cell::new(0),
             current_hover_target: Default::default(),
             most_recently_clicked_element: Default::default(),
             most_recent_mousemove_point: Default::default(),
@@ -883,7 +884,7 @@ impl DocumentEventHandler {
                 .reset_click_count_if_necessary(event.button, hit_test_result.point_in_frame);
         }
 
-        let dom_event = DomRoot::upcast::<Event>(MouseEvent::for_platform_button_event(
+        let mouse_event = MouseEvent::for_platform_button_event(
             cx,
             mouse_event_type,
             event,
@@ -892,7 +893,7 @@ impl DocumentEventHandler {
             &hit_test_result,
             input_event.active_keyboard_modifiers,
             self.click_counting_info.borrow().count + 1,
-        ));
+        );
 
         match event.action {
             MouseButtonAction::Down => {
@@ -900,26 +901,34 @@ impl DocumentEventHandler {
                     .set(Some(hit_test_result.point_in_frame));
 
                 // Step 6. Dispatch pointerdown event.
-                let down_button_count = self.down_button_count.get();
-
-                let event_type = if down_button_count == 0 {
-                    "pointerdown"
+                let mouse_buttons_down = self.mouse_buttons_down.get();
+                let pointer_event_name = if mouse_buttons_down == 0 {
+                    // From <https://w3c.github.io/pointerevents/#dfn-pointerdown>
+                    // > The user agent MUST fire a pointer event named pointerdown when a pointer enters
+                    // > the active buttons state. For mouse, this is when the device transitions from no
+                    // > buttons depressed to at least one button depressed.
+                    "pointerdown".into()
                 } else {
-                    "pointermove"
+                    // From <https://w3c.github.io/pointerevents/#dfn-pointermove>:
+                    // > The user agent MUST fire a pointer event named pointermove when a pointer
+                    // > changes any properties that don't fire pointerdown or pointerup events. This
+                    // > includes any changes to coordinates, pressure, tangential pressure, tilt, twist,
+                    // > contact geometry (width and height) or chorded buttons.
+                    "pointermove".into()
                 };
-                let pointer_event = dom_event
-                    .downcast::<MouseEvent>()
-                    .unwrap()
-                    .to_pointer_event(event_type.into(), CanGc::from_cx(cx));
-
-                pointer_event
+                mouse_event
+                    .to_pointer_event(pointer_event_name, CanGc::from_cx(cx))
                     .upcast::<Event>()
                     .fire(node.upcast(), CanGc::from_cx(cx));
 
-                self.down_button_count.set(down_button_count + 1);
+                self.mouse_buttons_down.set(mouse_buttons_down + 1);
 
                 // Step 7. Let result = dispatch event at target
-                let result = dom_event.dispatch(node.upcast(), false, CanGc::from_cx(cx));
+                let result = mouse_event.upcast::<Event>().dispatch(
+                    node.upcast(),
+                    false,
+                    CanGc::from_cx(cx),
+                );
 
                 // Step 8. If result is true and target is a focusable area
                 // that is click focusable, then Run the focusing steps at target.
@@ -947,28 +956,32 @@ impl DocumentEventHandler {
             // https://w3c.github.io/pointerevents/#dfn-handle-native-mouse-up
             MouseButtonAction::Up => {
                 // Step 6. Dispatch pointerup event.
-                let down_button_count = self.down_button_count.get();
-
-                if down_button_count > 0 {
-                    self.down_button_count.set(down_button_count - 1);
-                }
-
-                let event_type = if down_button_count == 0 {
-                    "pointerup"
+                let mouse_buttons_down = self.mouse_buttons_down.get();
+                let pointer_event_name = if mouse_buttons_down == 1 {
+                    // From <https://w3c.github.io/pointerevents/#dfn-pointerup>:
+                    // > The user agent MUST fire a pointer event named pointerup when a pointer leaves
+                    // > the active buttons state. For mouse, this is when the device transitions from at
+                    // > least one button depressed to no buttons depressed.
+                    "pointerup".into()
                 } else {
-                    "pointermove"
+                    // From <https://w3c.github.io/pointerevents/#dfn-pointermove>:
+                    // > The user agent MUST fire a pointer event named pointermove when a pointer
+                    // > changes any properties that don't fire pointerdown or pointerup events. This
+                    // > includes any changes to coordinates, pressure, tangential pressure, tilt, twist,
+                    // > contact geometry (width and height) or chorded buttons.
+                    "pointermove".into()
                 };
-                let pointer_event = dom_event
-                    .downcast::<MouseEvent>()
-                    .unwrap()
-                    .to_pointer_event(event_type.into(), CanGc::from_cx(cx));
-
-                pointer_event
+                mouse_event
+                    .to_pointer_event(pointer_event_name, CanGc::from_cx(cx))
                     .upcast::<Event>()
                     .fire(node.upcast(), CanGc::from_cx(cx));
+                self.mouse_buttons_down
+                    .set(mouse_buttons_down.saturating_sub(1));
 
                 // Step 7. dispatch event at target.
-                dom_event.dispatch(node.upcast(), false, CanGc::from_cx(cx));
+                mouse_event
+                    .upcast::<Event>()
+                    .dispatch(node.upcast(), false, CanGc::from_cx(cx));
 
                 // Click counts should still work for other buttons even though they
                 // do not trigger "click" and "dblclick" events, so we increment

--- a/tests/wpt/meta/dom/events/pointer-event-document-move.html.ini
+++ b/tests/wpt/meta/dom/events/pointer-event-document-move.html.ini
@@ -1,3 +1,0 @@
-[pointer-event-document-move.html]
-  [Moving a node to new document should move the registered event listeners together]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/disabled-elements/disabled-event-dispatch.tentative.html.ini
+++ b/tests/wpt/meta/html/semantics/disabled-elements/disabled-event-dispatch.tentative.html.ini
@@ -17,12 +17,6 @@
   [Testing pointerdown events when clicking disabled my-control.]
     expected: FAIL
 
-  [Testing pointerup events when clicking child of disabled button.]
-    expected: FAIL
-
-  [Testing pointerup events when clicking child of disabled my-control.]
-    expected: FAIL
-
   [Testing pointerup events when clicking disabled button.]
     expected: FAIL
 

--- a/tests/wpt/meta/html/semantics/disabled-elements/event-propagate-disabled.tentative.html.ini
+++ b/tests/wpt/meta/html/semantics/disabled-elements/event-propagate-disabled.tentative.html.ini
@@ -1,7 +1,4 @@
 [event-propagate-disabled.tentative.html]
-  [Trusted click on <input>, observed from <input>]
-    expected: FAIL
-
   [Trusted click on <input>, observed from <body>]
     expected: FAIL
 
@@ -14,13 +11,7 @@
   [Trusted click on <select disabled="">\n    <!-- <option> can't be clicked as it doesn't have its own painting area -->\n    <option>foo</option>\n  </select>, observed from <body>]
     expected: FAIL
 
-  [Trusted click on <fieldset disabled="">Text</fieldset>, observed from <fieldset>]
-    expected: FAIL
-
   [Trusted click on <fieldset disabled="">Text</fieldset>, observed from <body>]
-    expected: FAIL
-
-  [Trusted click on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <span>]
     expected: FAIL
 
   [Trusted click on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <fieldset>]
@@ -30,9 +21,6 @@
     expected: FAIL
 
   [Trusted click on <button disabled="">Text</button>, observed from <button>]
-    expected: FAIL
-
-  [Trusted click on <button disabled=""><span class="target">Span</span></button>, observed from <span>]
     expected: FAIL
 
   [Trusted click on <button disabled=""><span class="target">Span</span></button>, observed from <button>]

--- a/tests/wpt/meta/html/user-activation/activation-trigger-pointerevent.html.ini
+++ b/tests/wpt/meta/html/user-activation/activation-trigger-pointerevent.html.ini
@@ -1,8 +1,4 @@
 [activation-trigger-pointerevent.html?mouse]
-  expected: TIMEOUT
-  [Activation through mouse pointerevent click]
-    expected: TIMEOUT
-
 
 [activation-trigger-pointerevent.html?touch]
   [Activation through touch pointerevent click]

--- a/tests/wpt/meta/pointerevents/bugs/events_after_lostpointercapture_remove_setcapture_node.html.ini
+++ b/tests/wpt/meta/pointerevents/bugs/events_after_lostpointercapture_remove_setcapture_node.html.ini
@@ -1,4 +1,4 @@
 [events_after_lostpointercapture_remove_setcapture_node.html]
   expected: ERROR
   [setPointerCapture target removed by lostpointercapture]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/pointerevents/coalesced_events_attributes_on_redispatch.https.html.ini
+++ b/tests/wpt/meta/pointerevents/coalesced_events_attributes_on_redispatch.https.html.ini
@@ -1,7 +1,6 @@
 [coalesced_events_attributes_on_redispatch.https.html?mouse]
-  expected: TIMEOUT
   [Coalesced list in pointerdown/move/up events]
-    expected: TIMEOUT
+    expected: FAIL
 
 
 [coalesced_events_attributes_on_redispatch.https.html?pen]

--- a/tests/wpt/meta/pointerevents/compat/pointerevent_compat-mouse-events-when-removing-nodes.html.ini
+++ b/tests/wpt/meta/pointerevents/compat/pointerevent_compat-mouse-events-when-removing-nodes.html.ini
@@ -1,7 +1,4 @@
 [pointerevent_compat-mouse-events-when-removing-nodes.html]
-  [Compat mouse events with no node removal]
-    expected: FAIL
-
   [Compat mouse events with node removal on pointermove]
     expected: FAIL
 

--- a/tests/wpt/meta/pointerevents/compat/pointerevent_mouse-on-object.html.ini
+++ b/tests/wpt/meta/pointerevents/compat/pointerevent_mouse-on-object.html.ini
@@ -1,6 +1,3 @@
 [pointerevent_mouse-on-object.html]
-  [Normal click event sequence within object]
-    expected: FAIL
-
   [Click and drag outside of object event sequence]
     expected: FAIL

--- a/tests/wpt/meta/pointerevents/compat/pointerevent_mouse-pointer-on-scrollbar.html.ini
+++ b/tests/wpt/meta/pointerevents/compat/pointerevent_mouse-pointer-on-scrollbar.html.ini
@@ -1,7 +1,3 @@
 [pointerevent_mouse-pointer-on-scrollbar.html]
-  expected: TIMEOUT
   [Test point (103,175.66666666666666) is on the scrollbar]
     expected: FAIL
-
-  [Verifies that pointerup/down are fired correctly for corresponding mouse events on the scollbar.]
-    expected: TIMEOUT

--- a/tests/wpt/meta/pointerevents/compat/pointerevent_mouse-pointer-preventdefault.html.ini
+++ b/tests/wpt/meta/pointerevents/compat/pointerevent_mouse-pointer-preventdefault.html.ini
@@ -1,21 +1,3 @@
 [pointerevent_mouse-pointer-preventdefault.html]
   [Effect of canceling pointerdown on compat mouse events]
     expected: FAIL
-
-  [Effect of canceling pointermove on compat mouse events]
-    expected: FAIL
-
-  [Effect of canceling pointerup on compat mouse events]
-    expected: FAIL
-
-  [Effect of canceling pointerenter on compat mouse events]
-    expected: FAIL
-
-  [Effect of canceling pointerleave on compat mouse events]
-    expected: FAIL
-
-  [Effect of canceling pointerover on compat mouse events]
-    expected: FAIL
-
-  [Effect of canceling pointerout on compat mouse events]
-    expected: FAIL

--- a/tests/wpt/meta/pointerevents/compat/pointerevent_mouse-pointer-updown-events.html.ini
+++ b/tests/wpt/meta/pointerevents/compat/pointerevent_mouse-pointer-updown-events.html.ini
@@ -1,4 +1,0 @@
-[pointerevent_mouse-pointer-updown-events.html]
-  expected: TIMEOUT
-  [pointerup/down events are fired correctly for corresponding mouse events]
-    expected: TIMEOUT

--- a/tests/wpt/meta/pointerevents/pointerevent_after_target_appended.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_after_target_appended.html.ini
@@ -25,9 +25,6 @@
   [pointer events from mouse received before/after child attached at pointerdown]
     expected: FAIL
 
-  [pointer events from mouse received before/after child attached at pointerup]
-    expected: FAIL
-
   [pointer events from mouse received before/after child moved at pointerdown]
     expected: FAIL
 
@@ -35,9 +32,6 @@
     expected: FAIL
 
   [mouse events from mouse received before/after child attached at mousedown]
-    expected: FAIL
-
-  [mouse events from mouse received before/after child attached at mouseup]
     expected: FAIL
 
   [mouse events from mouse received before/after child moved at mousedown]

--- a/tests/wpt/meta/pointerevents/pointerevent_attributes.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_attributes.html.ini
@@ -80,9 +80,6 @@
   [Test pointer events in an iframe]
     expected: FAIL
 
-  [Main-frame attribute test.]
-    expected: FAIL
-
   [Inner-frame attribute test.]
     expected: FAIL
 
@@ -107,9 +104,6 @@
     expected: FAIL
 
   [Test pointer events in an iframe]
-    expected: FAIL
-
-  [Main-frame attribute test.]
     expected: FAIL
 
   [Inner-frame attribute test.]

--- a/tests/wpt/meta/pointerevents/pointerevent_attributes.optional.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_attributes.optional.html.ini
@@ -99,9 +99,6 @@
 
 
 [pointerevent_attributes.optional.html?mouse-right]
-  [Main-frame attribute test.]
-    expected: FAIL
-
   [Inner-frame attribute test.]
     expected: FAIL
 
@@ -139,6 +136,12 @@
     expected: PRECONDITION_FAILED
 
   [Main-frame mouse pointerleave.toElement value is null]
+    expected: PRECONDITION_FAILED
+
+  [Main-frame mouse pointerup.fromElement value is null]
+    expected: PRECONDITION_FAILED
+
+  [Main-frame mouse pointerup.toElement value is null]
     expected: PRECONDITION_FAILED
 
 
@@ -202,9 +205,6 @@
 
 
 [pointerevent_attributes.optional.html?mouse]
-  [Main-frame attribute test.]
-    expected: FAIL
-
   [Inner-frame attribute test.]
     expected: FAIL
 
@@ -242,4 +242,10 @@
     expected: PRECONDITION_FAILED
 
   [Main-frame mouse pointerleave.toElement value is null]
+    expected: PRECONDITION_FAILED
+
+  [Main-frame mouse pointerup.fromElement value is null]
+    expected: PRECONDITION_FAILED
+
+  [Main-frame mouse pointerup.toElement value is null]
     expected: PRECONDITION_FAILED

--- a/tests/wpt/meta/pointerevents/pointerevent_boundary_events_in_capturing.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_boundary_events_in_capturing.html.ini
@@ -7,7 +7,7 @@
 [pointerevent_boundary_events_in_capturing.html?mouse]
   expected: ERROR
   [Boundary events around pointer capture and release]
-    expected: TIMEOUT
+    expected: FAIL
 
 
 [pointerevent_boundary_events_in_capturing.html?touch]

--- a/tests/wpt/meta/pointerevents/pointerevent_capture_suppressing_mouse.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_capture_suppressing_mouse.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_capture_suppressing_mouse.html]
   expected: ERROR
   [Test pointer capture.]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_click_during_capture.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_click_during_capture.html.ini
@@ -1,8 +1,5 @@
 [pointerevent_click_during_capture.html?mouse-click]
   expected: ERROR
-  [pointerdown/up at child1, no capture]
-    expected: FAIL
-
   [pointerdown/up at child1, capture at child1]
     expected: FAIL
 

--- a/tests/wpt/meta/pointerevents/pointerevent_click_during_parent_capture.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_click_during_parent_capture.html.ini
@@ -45,12 +45,12 @@
   [Test in the iframe: all expected events should be fired]
     expected: FAIL
 
+  [Test in the topmost document: "pointerup" event should be fired on expected target]
+    expected: FAIL
+
 
 [pointerevent_click_during_parent_capture.html?pointerType=mouse&preventDefault=]
   expected: ERROR
-  [Test in the topmost document: all expected events should be fired]
-    expected: FAIL
-
   [Test in the topmost document: "mouseup" event should be fired on expected target]
     expected: FAIL
 
@@ -58,4 +58,7 @@
     expected: FAIL
 
   [Test in the iframe: all expected events should be fired]
+    expected: FAIL
+
+  [Test in the topmost document: "pointerup" event should be fired on expected target]
     expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_click_is_a_pointerevent.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_click_is_a_pointerevent.html.ini
@@ -25,13 +25,10 @@
 [pointerevent_click_is_a_pointerevent.html?mouse]
   expected: TIMEOUT
   [click using mouse is a PointerEvent with correct properties]
-    expected: TIMEOUT
+    expected: FAIL
 
   [click using mouse is a PointerEvent with correct properties when no other PointerEvent listeners are present]
-    expected: NOTRUN
-
-  [click using mouse is a PointerEvent with correct properties using non-pointing device]
-    expected: NOTRUN
+    expected: FAIL
 
   [click using mouse is a PointerEvent with correct properties in a subframe]
-    expected: NOTRUN
+    expected: TIMEOUT

--- a/tests/wpt/meta/pointerevents/pointerevent_lostpointercapture_remove_setcapture_node.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_lostpointercapture_remove_setcapture_node.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_lostpointercapture_remove_setcapture_node.html]
   expected: ERROR
   [setPointerCapture target removed by lostpointercapture]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_mouse_pointercapture_inactivate_pointer.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_mouse_pointercapture_inactivate_pointer.html.ini
@@ -1,7 +1,2 @@
 [pointerevent_mouse_pointercapture_inactivate_pointer.html]
   expected: ERROR
-  [setPointerCapture: pointer active in outer frame, set capture to inner frame]
-    expected: TIMEOUT
-
-  [setPointerCapture: pointer active in inner frame, set capture to outer frame]
-    expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_pointerId_scope.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_pointerId_scope.html.ini
@@ -1,4 +1,3 @@
 [pointerevent_pointerId_scope.html]
-  expected: TIMEOUT
   [pointerId of an active pointer is the same across same origin frames]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_pointermove_isprimary_same_as_pointerdown.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_pointermove_isprimary_same_as_pointerdown.html.ini
@@ -1,8 +1,4 @@
 [pointerevent_pointermove_isprimary_same_as_pointerdown.html?mouse]
-  expected: TIMEOUT
-  [pointermove has same isPrimary as last pointerdown]
-    expected: TIMEOUT
-
 
 [pointerevent_pointermove_isprimary_same_as_pointerdown.html?touch]
   [pointermove has same isPrimary as last pointerdown]

--- a/tests/wpt/meta/pointerevents/pointerevent_pointermove_on_chorded_mouse_button.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_pointermove_on_chorded_mouse_button.html.ini
@@ -1,4 +1,3 @@
 [pointerevent_pointermove_on_chorded_mouse_button.html]
-  expected: TIMEOUT
   [pointermove events received for button state changes]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_pointerrawupdate.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_pointerrawupdate.html.ini
@@ -1,7 +1,0 @@
-[pointerevent_pointerrawupdate.html]
-  expected: TIMEOUT
-  [pointerrawupdate event is not fired]
-    expected: TIMEOUT
-
-  [onpointerrawupdate is not exposed]
-    expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_pointerrawupdate.https.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_pointerrawupdate.https.html.ini
@@ -1,7 +1,6 @@
 [pointerevent_pointerrawupdate.https.html]
-  expected: TIMEOUT
   [pointerrawupdate event is fired]
-    expected: TIMEOUT
+    expected: FAIL
 
   [onpointerrawupdate is exposed]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_range_input.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_range_input.html.ini
@@ -1,19 +1,9 @@
 [pointerevent_range_input.html?mouse]
-  expected: TIMEOUT
   [Horizontal drag on a horizontal slider.]
-    expected: TIMEOUT
-
-  [Vertical drag on a horizontal slider.]
-    expected: NOTRUN
-
-  [Vertical drag on a horizontal slider with touch-action:none.]
-    expected: NOTRUN
+    expected: FAIL
 
   [Vertical drag on a vertical slider.]
-    expected: NOTRUN
-
-  [Horizontal drag on a vertical slider.]
-    expected: NOTRUN
+    expected: FAIL
 
 
 [pointerevent_range_input.html?touch]

--- a/tests/wpt/meta/pointerevents/pointerevent_releasepointercapture_pointerup_mouse.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_releasepointercapture_pointerup_mouse.html.ini
@@ -1,2 +1,4 @@
 [pointerevent_releasepointercapture_pointerup_mouse.html]
   expected: TIMEOUT
+  [target0.releasePointerCapture should not throw]
+    expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_releasepointercapture_release_right_after_capture.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_releasepointercapture_release_right_after_capture.html.ini
@@ -6,5 +6,3 @@
 
 [pointerevent_releasepointercapture_release_right_after_capture.html?mouse]
   expected: ERROR
-  [Release pointer capture right after setpointercapture]
-    expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_setpointercapture_pointerup_mouse.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_setpointercapture_pointerup_mouse.html.ini
@@ -1,2 +1,3 @@
 [pointerevent_setpointercapture_pointerup_mouse.html]
-  expected: TIMEOUT
+  [target0.setPointerCapture should not throw]
+    expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerlock/pointerevent_pointermove_on_chorded_mouse_button_when_locked.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerlock/pointerevent_pointermove_on_chorded_mouse_button_when_locked.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_pointermove_on_chorded_mouse_button_when_locked.html]
-  expected: TIMEOUT
+  expected: ERROR
   [pointer locked pointermove events received for button state changes]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerup_after_pointerdown_target_removed.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerup_after_pointerdown_target_removed.html.ini
@@ -1,6 +1,10 @@
 [pointerup_after_pointerdown_target_removed.html?mouse]
-  [pointerup event from mouse fired after pointerdown target is removed]
+
+[pointerup_after_pointerdown_target_removed.html?pen]
+  [pointerup event from pen fired after pointerdown target is removed]
     expected: FAIL
 
 
-[pointerup_after_pointerdown_target_removed.html?pen]
+[pointerup_after_pointerdown_target_removed.html?touch]
+  [pointerup event from touch fired after pointerdown target is removed]
+    expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerup_button_value_matches_corresponding_pointerdown.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerup_button_value_matches_corresponding_pointerdown.html.ini
@@ -1,4 +1,0 @@
-[pointerup_button_value_matches_corresponding_pointerdown.html]
-  expected: TIMEOUT
-  [Test that the 'button' property of a pointerup event matches the 'button' property of the corresponding pointerdown event]
-    expected: TIMEOUT


### PR DESCRIPTION
The code that determined whether it was appropriate to fire `pointerup`
events had a bug which meant that they were never fired. This change
fixes it and improves documentation, variable naming, and avoids a
couple `unwrap`s.

Testing: This improves quite a few tests and subtests, with a single new
failing subtest. This is expected because the feature it is testing (resetting
the button tracking for pointer events when the target is removed from the DOM)
is not implemented.
Fixes: #38435
