### PR TITLE
script: Pass `&mut JSContext` to `handle_attribute_changes`

### DIFF
--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -704,9 +704,9 @@ pub(crate) fn handle_modify_attribute(
         match modification.new_value {
             Some(string) => {
                 elem.set_attribute(
+                    cx,
                     &LocalName::from(modification.attribute_name),
                     AttrValue::String(string),
-                    CanGc::from_cx(cx),
                 );
             },
             None => elem.RemoveAttribute(cx, DOMString::from(modification.attribute_name)),

--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -23,7 +23,6 @@ use crate::dom::document::Document;
 use crate::dom::element::Element;
 use crate::dom::node::{Node, NodeTraits};
 use crate::dom::trustedtypes::trustedtypepolicyfactory::TrustedTypePolicyFactory;
-use crate::script_runtime::CanGc;
 
 // https://dom.spec.whatwg.org/#interface-attr
 #[dom_struct]
@@ -129,7 +128,7 @@ impl AttrMethods<crate::DomTypeHolder> for Attr {
             if let Some(owner) = self.owner() {
                 // Step 2.4. Change attribute to verifiedValue.
                 let value = owner.parse_attribute(self.namespace(), self.local_name(), value);
-                owner.change_attribute(self, value, CanGc::from_cx(cx));
+                owner.change_attribute(cx, self, value);
             } else {
                 // Step 2.3. If attribute’s element is null, then set attribute’s value to verifiedValue, and return.
                 self.set_value(value);

--- a/components/script/dom/css/cssstyledeclaration.rs
+++ b/components/script/dom/css/cssstyledeclaration.rs
@@ -108,9 +108,9 @@ impl CSSStyleOwner {
                         let mut serialization = String::new();
                         pdb.read_with(&guard).to_css(&mut serialization).unwrap();
                         el.set_attribute(
+                            cx,
                             &local_name!("style"),
                             AttrValue::Declaration(serialization, pdb),
-                            CanGc::from_cx(cx),
                         );
                     }
                 } else {

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -1562,7 +1562,7 @@ impl Document {
         if let Some(ref body) = self.GetBody().filter(|elem| elem.is_body_element()) {
             let body = body.upcast::<Element>();
             let value = body.parse_attribute(&ns!(), local_name, value);
-            body.set_attribute(local_name, value, CanGc::from_cx(cx));
+            body.set_attribute(cx, local_name, value);
         }
     }
 

--- a/components/script/dom/element/attributes.rs
+++ b/components/script/dom/element/attributes.rs
@@ -15,7 +15,6 @@ use crate::dom::bindings::root::Dom;
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::element::{AttributeMutationReason, Element};
 use crate::dom::node::NodeTraits;
-use crate::script_runtime::CanGc;
 
 impl Element {
     pub(crate) fn get_int_attribute(&self, local_name: &LocalName, default: i32) -> i32 {
@@ -34,11 +33,7 @@ impl Element {
         local_name: &LocalName,
         value: DOMString,
     ) {
-        self.set_attribute(
-            local_name,
-            AttrValue::from_atomic(value.into()),
-            CanGc::from_cx(cx),
-        );
+        self.set_attribute(cx, local_name, AttrValue::from_atomic(value.into()));
     }
 
     pub(crate) fn set_bool_attribute(
@@ -74,11 +69,7 @@ impl Element {
         local_name: &LocalName,
         value: USVString,
     ) {
-        self.set_attribute(
-            local_name,
-            AttrValue::String(value.to_string()),
-            CanGc::from_cx(cx),
-        );
+        self.set_attribute(cx, local_name, AttrValue::String(value.to_string()));
     }
 
     pub(crate) fn get_trusted_type_url_attribute(
@@ -111,11 +102,7 @@ impl Element {
         local_name: &LocalName,
         value: DOMString,
     ) {
-        self.set_attribute(
-            local_name,
-            AttrValue::String(value.into()),
-            CanGc::from_cx(cx),
-        );
+        self.set_attribute(cx, local_name, AttrValue::String(value.into()));
     }
 
     /// Used for string attribute reflections where absence of the attribute returns `null`,
@@ -162,9 +149,9 @@ impl Element {
         value: DOMString,
     ) {
         self.set_attribute(
+            cx,
             local_name,
             AttrValue::from_serialized_tokenlist(value.into()),
-            CanGc::from_cx(cx),
         );
     }
 
@@ -174,19 +161,11 @@ impl Element {
         local_name: &LocalName,
         tokens: Vec<Atom>,
     ) {
-        self.set_attribute(
-            local_name,
-            AttrValue::from_atomic_tokens(tokens),
-            CanGc::from_cx(cx),
-        );
+        self.set_attribute(cx, local_name, AttrValue::from_atomic_tokens(tokens));
     }
 
     pub(crate) fn set_int_attribute(&self, cx: &mut JSContext, local_name: &LocalName, value: i32) {
-        self.set_attribute(
-            local_name,
-            AttrValue::Int(value.to_string(), value),
-            CanGc::from_cx(cx),
-        );
+        self.set_attribute(cx, local_name, AttrValue::Int(value.to_string(), value));
     }
 
     pub(crate) fn get_uint_attribute(&self, local_name: &LocalName, default: u32) -> u32 {
@@ -205,11 +184,7 @@ impl Element {
         local_name: &LocalName,
         value: u32,
     ) {
-        self.set_attribute(
-            local_name,
-            AttrValue::UInt(value.to_string(), value),
-            CanGc::from_cx(cx),
-        );
+        self.set_attribute(cx, local_name, AttrValue::UInt(value.to_string(), value));
     }
 
     /// Ensure that for styles, we clone the already-parsed property declaration block.
@@ -236,7 +211,7 @@ impl Element {
     /// <https://dom.spec.whatwg.org/#concept-node-clone>
     pub(crate) fn copy_all_attributes_to_other_element(
         &self,
-        _cx: &mut JSContext,
+        cx: &mut JSContext,
         target_element: &Element,
     ) {
         // Step 2.5. For each attribute of node’s attribute list:
@@ -245,6 +220,7 @@ impl Element {
             let new_value = self.compute_attribute_value_with_style_fast_path(attr);
             // Step 2.5.2. Append copyAttribute to copy.
             target_element.push_new_attribute(
+                cx,
                 attr.local_name().clone(),
                 new_value,
                 attr.name().clone(),

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -1875,10 +1875,10 @@ impl Element {
         }
     }
 
-    #[expect(unsafe_code)]
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn push_new_attribute(
         &self,
+        cx: &mut JSContext,
         local_name: LocalName,
         value: AttrValue,
         name: LocalName,
@@ -1886,9 +1886,6 @@ impl Element {
         prefix: Option<Prefix>,
         reason: AttributeMutationReason,
     ) {
-        // TODO: https://github.com/servo/servo/issues/42812
-        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
-        let cx = &mut cx;
         let attr = Attr::new(
             cx,
             &self.node.owner_doc(),
@@ -1903,19 +1900,14 @@ impl Element {
     }
 
     /// <https://dom.spec.whatwg.org/#handle-attribute-changes>
-    #[expect(unsafe_code)]
     fn handle_attribute_changes(
         &self,
+        cx: &mut JSContext,
         attr: &Attr,
         old_value: Option<&AttrValue>,
         new_value: Option<DOMString>,
         reason: AttributeMutationReason,
-        _can_gc: CanGc,
     ) {
-        // TODO: https://github.com/servo/servo/issues/42812
-        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
-        let cx = &mut cx;
-
         let old_value_string = old_value.map(|old_value| DOMString::from(&**old_value));
         // Step 1. Queue a mutation record of "attributes" for element with attribute’s local name,
         // attribute’s namespace, oldValue, « », « », null, and null.
@@ -1955,7 +1947,7 @@ impl Element {
     }
 
     /// <https://dom.spec.whatwg.org/#concept-element-attributes-change>
-    pub(crate) fn change_attribute(&self, attr: &Attr, mut value: AttrValue, can_gc: CanGc) {
+    pub(crate) fn change_attribute(&self, cx: &mut JSContext, attr: &Attr, mut value: AttrValue) {
         // Step 1. Let oldValue be attribute’s value.
         //
         // Clone to avoid double borrow
@@ -1968,11 +1960,11 @@ impl Element {
         // Put on a separate line to avoid double borrow
         let new_value = DOMString::from(&**attr.value());
         self.handle_attribute_changes(
+            cx,
             attr,
             Some(old_value),
             Some(new_value),
             AttributeMutationReason::Directly,
-            can_gc,
         );
     }
 
@@ -1998,7 +1990,7 @@ impl Element {
         //
         // Put on a separate line to avoid double borrow
         let new_value = DOMString::from(&**attr.value());
-        self.handle_attribute_changes(attr, None, Some(new_value), reason, CanGc::from_cx(cx));
+        self.handle_attribute_changes(cx, attr, None, Some(new_value), reason);
     }
 
     /// This is the inner logic for:
@@ -2056,7 +2048,7 @@ impl Element {
 
     pub(crate) fn set_attribute_from_parser(
         &self,
-        _cx: &mut JSContext,
+        cx: &mut JSContext,
         qname: QualName,
         value: DOMString,
         prefix: Option<Prefix>,
@@ -2080,6 +2072,7 @@ impl Element {
         };
         let value = self.parse_attribute(&qname.ns, &qname.local, value);
         self.push_new_attribute(
+            cx,
             qname.local,
             value,
             name,
@@ -2089,7 +2082,7 @@ impl Element {
         );
     }
 
-    pub(crate) fn set_attribute(&self, name: &LocalName, value: AttrValue, can_gc: CanGc) {
+    pub(crate) fn set_attribute(&self, cx: &mut JSContext, name: &LocalName, value: AttrValue) {
         debug_assert_eq!(
             *name,
             name.to_ascii_lowercase(),
@@ -2098,13 +2091,13 @@ impl Element {
         debug_assert!(!name.contains(':'));
 
         self.set_first_matching_attribute(
+            cx,
             name.clone(),
             value,
             name.clone(),
             ns!(),
             None,
             |attr| attr.local_name() == name,
-            can_gc,
         );
     }
 
@@ -2118,13 +2111,13 @@ impl Element {
         prefix: Option<Prefix>,
     ) {
         self.set_first_matching_attribute(
+            cx,
             local_name.clone(),
             value,
             name,
             namespace.clone(),
             prefix,
             |attr| *attr.local_name() == local_name && *attr.namespace() == namespace,
-            CanGc::from_cx(cx),
         );
     }
 
@@ -2132,13 +2125,13 @@ impl Element {
     #[allow(clippy::too_many_arguments)]
     fn set_first_matching_attribute<F>(
         &self,
+        cx: &mut JSContext,
         local_name: LocalName,
         value: AttrValue,
         name: LocalName,
         namespace: Namespace,
         prefix: Option<Prefix>,
         find: F,
-        can_gc: CanGc,
     ) where
         F: Fn(&Attr) -> bool,
     {
@@ -2152,13 +2145,14 @@ impl Element {
         if let Some(attr) = attr {
             // Step 3. Change attribute to value.
             self.will_mutate_attr(&attr);
-            self.change_attribute(&attr, value, can_gc);
+            self.change_attribute(cx, &attr, value);
         } else {
             // Step 2. If attribute is null, create an attribute whose namespace is namespace,
             // namespace prefix is prefix, local name is localName, value is value,
             // and node document is element’s node document,
             // then append this attribute to element, and then return.
             self.push_new_attribute(
+                cx,
                 local_name,
                 value,
                 name,
@@ -2221,11 +2215,11 @@ impl Element {
             attr.set_owner(None);
             // Step 4. Handle attribute changes for attribute with element, attribute’s value, and null.
             self.handle_attribute_changes(
+                cx,
                 &attr,
                 Some(&attr.value()),
                 None,
                 AttributeMutationReason::Directly,
-                CanGc::from_cx(cx),
             );
 
             attr
@@ -2390,11 +2384,11 @@ impl Element {
             old_attr.set_owner(None);
             // Step 6. Handle attribute changes for oldAttribute with element, oldAttribute’s value, and newAttribute’s value.
             self.handle_attribute_changes(
+                cx,
                 attr,
                 Some(&old_attr.value()),
                 Some(verified_value),
                 AttributeMutationReason::Directly,
-                CanGc::from_cx(cx),
             );
 
             Some(old_attr)
@@ -2879,13 +2873,13 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
                 // Step 4.1.
                 None | Some(true) => {
                     self.set_first_matching_attribute(
+                        cx,
                         name.clone(),
                         AttrValue::String(String::new()),
                         name.clone(),
                         ns!(),
                         None,
                         |attr| *attr.name() == name,
-                        CanGc::from_cx(cx),
                     );
                     Ok(true)
                 },
@@ -2940,13 +2934,13 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         // Step 6. Change attribute to verifiedValue.
         let value = self.parse_attribute(&ns!(), &name, value);
         self.set_first_matching_attribute(
+            cx,
             name.clone(),
             value,
             name.clone(),
             ns!(),
             None,
             |attr| *attr.name() == name,
-            CanGc::from_cx(cx),
         );
         Ok(())
     }

--- a/components/script/dom/html/htmlaudioelement.rs
+++ b/components/script/dom/html/htmlaudioelement.rs
@@ -18,7 +18,6 @@ use crate::dom::element::{CustomElementCreationMode, Element, ElementCreator};
 use crate::dom::html::htmlmediaelement::HTMLMediaElement;
 use crate::dom::node::Node;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLAudioElement {
@@ -79,20 +78,16 @@ impl HTMLAudioElementMethods<crate::DomTypeHolder> for HTMLAudioElement {
 
         // Step 3. Set an attribute value for audio using "preload" and "auto".
         audio.set_attribute(
+            cx,
             &local_name!("preload"),
             AttrValue::String("auto".to_owned()),
-            CanGc::from_cx(cx),
         );
 
         // Step 4. If src is given, then set an attribute value for audio using "src" and src. (This
         // will cause the user agent to invoke the object's resource selection algorithm before
         // returning).
         if let Some(s) = src {
-            audio.set_attribute(
-                &local_name!("src"),
-                AttrValue::String(s.into()),
-                CanGc::from_cx(cx),
-            );
+            audio.set_attribute(cx, &local_name!("src"), AttrValue::String(s.into()));
         }
 
         // Step 5. Return audio.

--- a/components/script/dom/html/htmlbodyelement.rs
+++ b/components/script/dom/html/htmlbodyelement.rs
@@ -22,7 +22,6 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::{BindContext, Node, NodeTraits};
 use crate::dom::virtualmethods::VirtualMethods;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLBodyElement {
@@ -76,11 +75,8 @@ impl HTMLBodyElementMethods<crate::DomTypeHolder> for HTMLBodyElement {
     fn SetBackground(&self, cx: &mut JSContext, input: DOMString) {
         let value =
             AttrValue::from_resolved_url(&self.owner_document().base_url().get_arc(), input.into());
-        self.upcast::<Element>().set_attribute(
-            &local_name!("background"),
-            value,
-            CanGc::from_cx(cx),
-        );
+        self.upcast::<Element>()
+            .set_attribute(cx, &local_name!("background"), value);
     }
 
     // https://html.spec.whatwg.org/multipage/#windoweventhandlers

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -682,11 +682,8 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
             // > if the new value is an ASCII case-insensitive match for the string "plaintext-only", then the content attribute must be set to the string "plaintext-only",
             // > if the new value is an ASCII case-insensitive match for the string "false", then the content attribute must be set to the string "false",
             "true" | "false" | "plaintext-only" => {
-                self.element.set_attribute(
-                    attr_name,
-                    AttrValue::String(lower_value),
-                    CanGc::from_cx(cx),
-                );
+                self.element
+                    .set_attribute(cx, attr_name, AttrValue::String(lower_value));
             },
             // > and otherwise the attribute setter must throw a "SyntaxError" DOMException.
             _ => return Err(Error::Syntax(None)),

--- a/components/script/dom/html/htmlfontelement.rs
+++ b/components/script/dom/html/htmlfontelement.rs
@@ -25,7 +25,6 @@ use crate::dom::element::Element;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::Node;
 use crate::dom::virtualmethods::VirtualMethods;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLFontElement {
@@ -109,7 +108,7 @@ impl HTMLFontElementMethods<crate::DomTypeHolder> for HTMLFontElement {
     /// <https://html.spec.whatwg.org/multipage/#dom-font-size>
     fn SetSize(&self, cx: &mut JSContext, value: DOMString) {
         let element = self.upcast::<Element>();
-        element.set_attribute(&local_name!("size"), parse_size(&value), CanGc::from_cx(cx));
+        element.set_attribute(cx, &local_name!("size"), parse_size(&value));
     }
 }
 

--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -965,9 +965,9 @@ impl HTMLIFrameElementMethods<crate::DomTypeHolder> for HTMLIFrameElement {
         )?;
         // Step 2: Set an attribute value given this, srcdoc's local name, and compliantString.
         element.set_attribute(
+            cx,
             &local_name!("srcdoc"),
             AttrValue::String(value.str().to_owned()),
-            CanGc::from_cx(cx),
         );
         Ok(())
     }

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -1337,11 +1337,7 @@ impl HTMLScriptElementMethods<crate::DomTypeHolder> for HTMLScriptElement {
             value,
             &format!("HTMLScriptElement {}", local_name),
         )?;
-        element.set_attribute(
-            local_name,
-            AttrValue::String(value.str().to_owned()),
-            CanGc::from_cx(cx),
-        );
+        element.set_attribute(cx, local_name, AttrValue::String(value.str().to_owned()));
         Ok(())
     }
 

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -409,10 +409,9 @@ macro_rules! make_legacy_color_setter(
             use $crate::dom::bindings::inheritance::Castable;
             use $crate::dom::element::Element;
             use style::attr::AttrValue;
-            use $crate::script_runtime::CanGc;
             let element = self.upcast::<Element>();
             let value = AttrValue::from_legacy_color(value.into());
-            element.set_attribute(&html5ever::local_name!($htmlname), value, CanGc::from_cx(cx))
+            element.set_attribute(cx, &html5ever::local_name!($htmlname), value)
         }
     );
 );
@@ -423,10 +422,9 @@ macro_rules! make_dimension_setter(
         fn $attr(&self, cx: &mut js::context::JSContext, value: DOMString) {
             use $crate::dom::bindings::inheritance::Castable;
             use $crate::dom::element::Element;
-            use $crate::script_runtime::CanGc;
             let element = self.upcast::<Element>();
             let value = AttrValue::from_dimension(value.into());
-            element.set_attribute(&html5ever::local_name!($htmlname), value, CanGc::from_cx(cx))
+            element.set_attribute(cx, &html5ever::local_name!($htmlname), value)
         }
     );
 );
@@ -437,10 +435,9 @@ macro_rules! make_nonzero_dimension_setter(
         fn $attr(&self, cx: &mut js::context::JSContext, value: DOMString) {
             use $crate::dom::bindings::inheritance::Castable;
             use $crate::dom::element::Element;
-            use $crate::script_runtime::CanGc;
             let element = self.upcast::<Element>();
             let value = AttrValue::from_nonzero_dimension(value.into());
-            element.set_attribute(&html5ever::local_name!($htmlname), value, CanGc::from_cx(cx))
+            element.set_attribute(cx, &html5ever::local_name!($htmlname), value)
         }
     );
 );
@@ -479,7 +476,6 @@ macro_rules! make_dimension_uint_setter(
             use $crate::dom::bindings::inheritance::Castable;
             use $crate::dom::element::Element;
             use $crate::dom::values::UNSIGNED_LONG_MAX;
-            use $crate::script_runtime::CanGc;
             let element = self.upcast::<Element>();
             let value = if value > UNSIGNED_LONG_MAX {
                 $default
@@ -487,7 +483,7 @@ macro_rules! make_dimension_uint_setter(
                 value
             };
             let value = AttrValue::from_dimension(value.to_string());
-            element.set_attribute(&html5ever::local_name!($htmlname), value, CanGc::from_cx(cx))
+            element.set_attribute(cx, &html5ever::local_name!($htmlname), value)
         }
     );
     ($attr:ident, $htmlname:tt) => {


### PR DESCRIPTION
This finishes the migration for all DOM attribute code to pass in `cx`.

Fixes #42812

Testing: It compiles