### PR TITLE
Pass `redirectEnd` to document and expose it to PerformanceMark

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -493,6 +493,9 @@ pub(crate) struct Document {
     /// <https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-redirectstart>
     #[no_trace]
     redirect_start: Cell<Option<CrossProcessInstant>>,
+    /// <https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-redirectend>
+    #[no_trace]
+    redirect_end: Cell<Option<CrossProcessInstant>>,
     /// Number of outstanding requests to prevent JS or layout from running.
     script_and_layout_blockers: Cell<u32>,
     /// List of tasks to execute as soon as last script/layout blocker is removed.
@@ -3606,6 +3609,7 @@ impl Document {
             responsive_images: Default::default(),
             redirect_count: Cell::new(0),
             redirect_start: Cell::new(None),
+            redirect_end: Cell::new(None),
             completely_loaded: Cell::new(false),
             script_and_layout_blockers: Cell::new(0),
             delayed_tasks: Default::default(),
@@ -3868,6 +3872,14 @@ impl Document {
 
     pub(crate) fn set_redirect_start(&self, time: Option<CrossProcessInstant>) {
         self.redirect_start.set(time)
+    }
+
+    pub(crate) fn get_redirect_end(&self) -> Option<CrossProcessInstant> {
+        self.redirect_end.get()
+    }
+
+    pub(crate) fn set_redirect_end(&self, time: Option<CrossProcessInstant>) {
+        self.redirect_end.set(time)
     }
 
     pub(crate) fn elements_by_name_count(&self, name: &DOMString) -> u32 {

--- a/components/script/dom/performance/performance.rs
+++ b/components/script/dom/performance/performance.rs
@@ -504,6 +504,7 @@ impl Performance {
             "loadEventStart" => document.get_load_event_start(),
             "loadEventEnd" => document.get_load_event_end(),
             "redirectStart" => document.get_redirect_start(),
+            "redirectEnd" => document.get_redirect_end(),
             other => {
                 if cfg!(debug_assertions) {
                     unreachable!("{other:?} is not the name of a timestamp");
@@ -544,7 +545,8 @@ impl Performance {
                         "domComplete" |
                         "loadEventStart" |
                         "loadEventEnd" |
-                        "redirectStart"
+                        "redirectStart" |
+                        "redirectEnd"
                 ) {
                     self.convert_a_name_to_a_timestamp(&name.str())
                 }

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1543,6 +1543,7 @@ impl FetchResponseListener for ParserContext {
         if status.is_ok() {
             parser.document.set_redirect_count(timing.redirect_count);
             parser.document.set_redirect_start(timing.redirect_start);
+            parser.document.set_redirect_end(timing.redirect_end);
         }
 
         parser.last_chunk_received.set(true);

--- a/tests/wpt/meta/user-timing/measure-exceptions.html.ini
+++ b/tests/wpt/meta/user-timing/measure-exceptions.html.ini
@@ -1,6 +1,3 @@
 [measure-exceptions.html]
-  [Passing 'redirectEnd' as a mark to measure API should cause error when the mark is empty.]
-    expected: FAIL
-
   [Passing 'secureConnectionStart' as a mark to measure API should cause error when the mark is empty.]
     expected: FAIL


### PR DESCRIPTION
Pass `redirectEnd` to document and expose it to PerformanceMark

Testing: More WPT tests Passed