### PR TITLE
script: Create Duration from microseconds timestamp instead of milliseconds

### DIFF
--- a/components/script/dom/performance/performance.rs
+++ b/components/script/dom/performance/performance.rs
@@ -569,7 +569,10 @@ impl Performance {
 
                 // Step 3.2 Otherwise, let end time be mark.
                 // NOTE: I think the spec wants us to return the value.
-                Ok(self.time_origin + Duration::milliseconds(timestamp.round() as i64))
+                Ok(
+                    self.time_origin +
+                        Duration::microseconds(timestamp.mul_add(1000.0, 0.0) as i64),
+                )
             },
         }
     }

--- a/tests/wpt/meta/user-timing/measure-with-dict.any.js.ini
+++ b/tests/wpt/meta/user-timing/measure-with-dict.any.js.ini
@@ -1,8 +1,0 @@
-[measure-with-dict.any.html]
-  [measure entries' detail and start/end are customizable]
-    expected: FAIL
-
-
-[measure-with-dict.any.worker.html]
-  [measure entries' detail and start/end are customizable]
-    expected: FAIL


### PR DESCRIPTION
By Using milliseconds we lose some precisions.

Testing: More WPT tests Passed and Attached Screenshot.
Fixes: #44568
<img width="1280" height="828" alt="Screenshot 2026-05-02 at 1 22 07 PM" src="https://github.com/user-attachments/assets/020f1f96-7af7-4d3d-9ebb-031247f99bf3" />
