### PR TITLE
script: Zeroize webcrypto sensitive information on drop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8766,6 +8766,7 @@ dependencies = [
  "tendril",
  "tracing",
  "xml5ever",
+ "zeroize",
 ]
 
 [[package]]

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -44,6 +44,7 @@ use js::rust::wrappers2::JS_ParseJSON;
 use js::rust::{HandleObject, MutableHandleValue, Trace};
 use js::typedarray::{ArrayBufferU8, HeapUint8Array};
 use strum::{EnumString, IntoStaticStr, VariantArray};
+use zeroize::Zeroizing;
 
 use crate::dom::bindings::buffer_source::create_buffer_source;
 use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::{
@@ -194,7 +195,7 @@ impl SubtleCrypto {
     /// Queue a global task on the crypto task source, given realm's global object, to resolve
     /// promise with the result of creating an ArrayBuffer in realm, containing data. If it fails
     /// to create buffer source, reject promise with a JSFailedError.
-    fn resolve_promise_with_data(&self, promise: Rc<Promise>, data: Vec<u8>) {
+    fn resolve_promise_with_data(&self, promise: Rc<Promise>, data: Zeroizing<Vec<u8>>) {
         let trusted_promise = TrustedPromise::new(promise);
         self.global()
             .task_manager()
@@ -381,8 +382,8 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
         // Step 4. Let data be the result of getting a copy of the bytes held by the data parameter
         // passed to the encrypt() method.
         let data = match data {
-            ArrayBufferViewOrArrayBuffer::ArrayBufferView(view) => view.to_vec(),
-            ArrayBufferViewOrArrayBuffer::ArrayBuffer(buffer) => buffer.to_vec(),
+            ArrayBufferViewOrArrayBuffer::ArrayBufferView(view) => Zeroizing::new(view.to_vec()),
+            ArrayBufferViewOrArrayBuffer::ArrayBuffer(buffer) => Zeroizing::new(buffer.to_vec()),
         };
 
         // Step 5. Let realm be the relevant realm of this.
@@ -436,7 +437,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 // Step 13. Let result be the result of creating an ArrayBuffer in realm,
                 // containing ciphertext.
                 // Step 14. Resolve promise with result.
-                subtle.resolve_promise_with_data(promise, ciphertext);
+                subtle.resolve_promise_with_data(promise, ciphertext.into());
             }));
         promise
     }
@@ -511,7 +512,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 // specified by normalizedAlgorithm using key and algorithm and with data as
                 // ciphertext.
                 let plaintext = match normalized_algorithm.decrypt(&key, &data) {
-                    Ok(plaintext) => plaintext,
+                    Ok(plaintext) => Zeroizing::new(plaintext),
                     Err(error) => {
                         subtle.reject_promise_with_error(promise, error);
                         return;
@@ -609,7 +610,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 // Step 13. Let result be the result of creating an ArrayBuffer in realm,
                 // containing signature.
                 // Step 14. Resolve promise with result.
-                subtle.resolve_promise_with_data(promise, signature);
+                subtle.resolve_promise_with_data(promise, signature.into());
             }));
         promise
     }
@@ -769,7 +770,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 // Step 11. Let result be the result of creating an ArrayBuffer in realm,
                 // containing digest.
                 // Step 12. Resolve promise with result.
-                subtle.resolve_promise_with_data(promise, digest);
+                subtle.resolve_promise_with_data(promise, digest.into());
             }));
         promise
     }
@@ -977,7 +978,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 // Step 15. Let secret be the result of performing the derive bits operation
                 // specified by normalizedAlgorithm using key, algorithm and length.
                 let secret = match normalized_algorithm.derive_bits(&base_key, length) {
-                    Ok(secret) => secret,
+                    Ok(secret) => Zeroizing::new(secret),
                     Err(error) => {
                         subtle.reject_promise_with_error(promise, error);
                         return;
@@ -1090,7 +1091,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 // Step 10. Let bits be the result of performing the derive bits operation
                 // specified by normalizedAlgorithm using baseKey, algorithm and length.
                 let bits = match normalized_algorithm.derive_bits(&base_key, length) {
-                    Ok(bits) => bits,
+                    Ok(bits) => Zeroizing::new(bits),
                     Err(error) => {
                         subtle.reject_promise_with_error(promise, error);
                         return;
@@ -1158,7 +1159,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                         // exception when a JS error is thrown. When this happens, we report the
                         // error.
                         match jwk.stringify(cx) {
-                            Ok(stringified) => stringified.as_bytes().to_vec(),
+                            Ok(stringified) => Zeroizing::new(stringified.as_bytes().to_vec()),
                             Err(error) => {
                                 let promise = Promise::new_in_realm(cx);
                                 promise.reject_error(error, CanGc::from_cx(cx));
@@ -1185,10 +1186,10 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                     // Step 4.2. Let keyData be the result of getting a copy of the bytes held by
                     // the keyData parameter passed to the importKey() method.
                     ArrayBufferViewOrArrayBufferOrJsonWebKey::ArrayBufferView(view) => {
-                        view.to_vec()
+                        Zeroizing::new(view.to_vec())
                     },
                     ArrayBufferViewOrArrayBufferOrJsonWebKey::ArrayBuffer(buffer) => {
-                        buffer.to_vec()
+                        Zeroizing::new(buffer.to_vec())
                     },
                 }
             },
@@ -1467,7 +1468,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 let bytes = match exported_key {
                     ExportedKey::Bytes(bytes) => bytes,
                     ExportedKey::Jwk(jwk) => match jwk.stringify(cx) {
-                        Ok(stringified_jwk) => stringified_jwk.as_bytes().to_vec(),
+                        Ok(stringified_jwk) => Zeroizing::new(stringified_jwk.as_bytes().to_vec()),
                         Err(error) => {
                             subtle.reject_promise_with_error(promise, error);
                             return;
@@ -1507,7 +1508,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 // Step 17. Let result be the result of creating an ArrayBuffer in realm,
                 // containing result.
                 // Step 18. Resolve promise with result.
-                subtle.resolve_promise_with_data(promise, result);
+                subtle.resolve_promise_with_data(promise, result.into());
             }));
         promise
     }
@@ -1634,7 +1635,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                     },
                 };
                 let bytes = match bytes {
-                    Ok(bytes) => bytes,
+                    Ok(bytes) => Zeroizing::new(bytes),
                     Err(error) => {
                         subtle.reject_promise_with_error(promise, error);
                         return;
@@ -2034,7 +2035,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 let decapsulated_bits_result =
                     normalized_decapsulation_algorithm.decapsulate(&decapsulation_key, &ciphertext);
                 let decapsulated_bits = match decapsulated_bits_result {
-                    Ok(decapsulated_bits) => decapsulated_bits,
+                    Ok(decapsulated_bits) => Zeroizing::new(decapsulated_bits),
                     Err(error) => {
                         subtle.reject_promise_with_error(promise, error);
                         return;
@@ -2157,7 +2158,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 let decapsulated_bits_result =
                     normalized_decapsulation_algorithm.decapsulate(&decapsulation_key, &ciphertext);
                 let decapsulated_bits = match decapsulated_bits_result {
-                    Ok(decapsulated_bits) => decapsulated_bits,
+                    Ok(decapsulated_bits) => Zeroizing::new(decapsulated_bits),
                     Err(error) => {
                         subtle.reject_promise_with_error(promise, error);
                         return;
@@ -3770,7 +3771,7 @@ impl SafeToJSValConvertible for SubtleEncapsulatedKey {
 /// <https://wicg.github.io/webcrypto-modern-algos/#dfn-EncapsulatedBits>
 struct SubtleEncapsulatedBits {
     /// <https://wicg.github.io/webcrypto-modern-algos/#dfn-EncapsulatedBits-sharedKey>
-    shared_key: Option<Vec<u8>>,
+    shared_key: Option<Zeroizing<Vec<u8>>>,
 
     /// <https://wicg.github.io/webcrypto-modern-algos/#dfn-EncapsulatedBits-ciphertext>
     ciphertext: Option<Vec<u8>>,
@@ -3919,8 +3920,18 @@ fn get_required_buffer_source(
 /// is exported in "raw", "spki" or "pkcs8" format. `Jwk` should be used when the key is exported
 /// in "jwk" format.
 enum ExportedKey {
-    Bytes(Vec<u8>),
+    Bytes(Zeroizing<Vec<u8>>),
     Jwk(Box<JsonWebKey>),
+}
+
+impl ExportedKey {
+    fn new_bytes(bytes: Vec<u8>) -> ExportedKey {
+        ExportedKey::Bytes(Zeroizing::new(bytes))
+    }
+
+    fn new_jwk(jwk: JsonWebKey) -> ExportedKey {
+        ExportedKey::Jwk(Box::new(jwk))
+    }
 }
 
 /// Union type of KeyAlgorithm and IDL dictionary types derived from it. Note that we actually use

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -228,7 +228,7 @@ impl SubtleCrypto {
         // NOTE: Serialize the JsonWebKey dictionary by stringifying it, in order to pass it to
         // other threads.
         let stringified_jwk = match jwk.stringify(cx) {
-            Ok(stringified_jwk) => stringified_jwk.to_string(),
+            Ok(stringified_jwk) => Zeroizing::new(stringified_jwk.to_string()),
             Err(error) => {
                 self.reject_promise_with_error(promise, error);
                 return;
@@ -4019,15 +4019,23 @@ impl Display for JwkStringField {
 
 trait JsonWebKeyExt {
     fn parse(cx: &mut js::context::JSContext, data: &[u8]) -> Result<JsonWebKey, Error>;
-    fn stringify(&self, cx: &mut js::context::JSContext) -> Result<DOMString, Error>;
+    fn stringify(&self, cx: &mut js::context::JSContext) -> Result<Zeroizing<DOMString>, Error>;
     fn get_usages_from_key_ops(&self) -> Result<Vec<KeyUsage>, Error>;
     fn check_key_ops(&self, specified_usages: &[KeyUsage]) -> Result<(), Error>;
     fn set_key_ops(&mut self, usages: Vec<KeyUsage>);
     fn encode_string_field(&mut self, field: JwkStringField, data: &[u8]);
-    fn decode_optional_string_field(&self, field: JwkStringField)
-    -> Result<Option<Vec<u8>>, Error>;
-    fn decode_required_string_field(&self, field: JwkStringField) -> Result<Vec<u8>, Error>;
-    fn decode_primes_from_oth_field(&self, primes: &mut Vec<Vec<u8>>) -> Result<(), Error>;
+    fn decode_optional_string_field(
+        &self,
+        field: JwkStringField,
+    ) -> Result<Option<Zeroizing<Vec<u8>>>, Error>;
+    fn decode_required_string_field(
+        &self,
+        field: JwkStringField,
+    ) -> Result<Zeroizing<Vec<u8>>, Error>;
+    fn decode_primes_from_oth_field(
+        &self,
+        primes: &mut Vec<Zeroizing<Vec<u8>>>,
+    ) -> Result<(), Error>;
 }
 
 impl JsonWebKeyExt for JsonWebKey {
@@ -4078,10 +4086,10 @@ impl JsonWebKeyExt for JsonWebKey {
     /// <https://infra.spec.whatwg.org/#serialize-a-javascript-value-to-a-json-string>. This acts
     /// like the opposite of JsonWebKey::parse if you further convert the stringified result to
     /// bytes.
-    fn stringify(&self, cx: &mut js::context::JSContext) -> Result<DOMString, Error> {
+    fn stringify(&self, cx: &mut js::context::JSContext) -> Result<Zeroizing<DOMString>, Error> {
         rooted!(&in(cx) let mut data = UndefinedValue());
         self.safe_to_jsval(cx.into(), data.handle_mut(), CanGc::from_cx(cx));
-        serialize_jsval_to_json_utf8(cx.into(), data.handle())
+        serialize_jsval_to_json_utf8(cx.into(), data.handle()).map(Zeroizing::new)
     }
 
     fn get_usages_from_key_ops(&self) -> Result<Vec<KeyUsage>, Error> {
@@ -4165,7 +4173,7 @@ impl JsonWebKeyExt for JsonWebKey {
     fn decode_optional_string_field(
         &self,
         field: JwkStringField,
-    ) -> Result<Option<Vec<u8>>, Error> {
+    ) -> Result<Option<Zeroizing<Vec<u8>>>, Error> {
         let field_string = match field {
             JwkStringField::X => &self.x,
             JwkStringField::Y => &self.y,
@@ -4184,14 +4192,19 @@ impl JsonWebKeyExt for JsonWebKey {
 
         field_string
             .as_ref()
-            .map(|field_string| Base64UrlUnpadded::decode_vec(&field_string.str()))
+            .map(|field_string| {
+                Base64UrlUnpadded::decode_vec(&field_string.str()).map(Zeroizing::new)
+            })
             .transpose()
             .map_err(|_| Error::Data(Some(format!("Failed to decode {} field in jwk", field))))
     }
 
     // Decode a field from a base64url-encoded string to a byte sequence. If the field is not
     // present or it is not a valid base64url-encoded string, then throw a DataError.
-    fn decode_required_string_field(&self, field: JwkStringField) -> Result<Vec<u8>, Error> {
+    fn decode_required_string_field(
+        &self,
+        field: JwkStringField,
+    ) -> Result<Zeroizing<Vec<u8>>, Error> {
         self.decode_optional_string_field(field)?
             .ok_or(Error::Data(Some(format!(
                 "The {} field is not present in jwk",
@@ -4207,7 +4220,10 @@ impl JsonWebKeyExt for JsonWebKey {
     // present, then throw a DataError. For each entry in the "oth" array, if any of the "r", "d"
     // and "t" field is not present or it is not a valid base64url-encoded string, then throw a
     // DataError.
-    fn decode_primes_from_oth_field(&self, primes: &mut Vec<Vec<u8>>) -> Result<(), Error> {
+    fn decode_primes_from_oth_field(
+        &self,
+        primes: &mut Vec<Zeroizing<Vec<u8>>>,
+    ) -> Result<(), Error> {
         if self.oth.is_some() &&
             (self.p.is_none() ||
                 self.q.is_none() ||
@@ -4236,7 +4252,7 @@ impl JsonWebKeyExt for JsonWebKey {
                     "Fail to decode r field in one of the entry of oth field in jwk".to_string(),
                 ))
             })?;
-            primes.push(r);
+            primes.push(Zeroizing::new(r));
 
             let _d = Base64UrlUnpadded::decode_vec(
                 &rsa_other_prime_info

--- a/components/script/dom/webcrypto/subtlecrypto/aes_common.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/aes_common.rs
@@ -6,6 +6,7 @@ use aes::cipher::crypto_common::Key;
 use aes::{Aes128, Aes192, Aes256};
 use js::context::JSContext;
 use pkcs8::rand_core::{OsRng, RngCore};
+use zeroize::Zeroizing;
 
 use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::{
     CryptoKeyMethods, KeyType, KeyUsage,
@@ -213,7 +214,7 @@ pub(crate) fn import_key(
     }
 
     // Step 2.
-    let data;
+    let data: Zeroizing<Vec<u8>>;
     match format {
         // If format is "raw": (Only applied to AES-CTR, AES-CBC, AES-GCM, AES-KW)
         KeyFormat::Raw
@@ -226,7 +227,7 @@ pub(crate) fn import_key(
             ) =>
         {
             // Step 2.1. Let data be keyData.
-            data = key_data.to_vec();
+            data = key_data.to_vec().into();
 
             // Step 2.2. If the length in bits of data is not 128, 192 or 256 then throw a
             // DataError.
@@ -239,7 +240,7 @@ pub(crate) fn import_key(
         // If format is "raw-secret":
         KeyFormat::Raw_secret => {
             // Step 2.1. Let data be keyData.
-            data = key_data.to_vec();
+            data = key_data.to_vec().into();
 
             // Step 2.2. If the length in bits of data is not 128, 192 or 256 then throw a
             // DataError.
@@ -572,11 +573,10 @@ pub(crate) fn export_key(
         // If format is "jwk":
         KeyFormat::Jwk => {
             // Step 2.1. Let jwk be a new JsonWebKey dictionary.
+            let mut jwk = JsonWebKey::default();
+
             // Step 2.2. Set the kty attribute of jwk to the string "oct".
-            let mut jwk = JsonWebKey {
-                kty: Some(DOMString::from("oct")),
-                ..Default::default()
-            };
+            jwk.kty = Some(DOMString::from("oct"));
 
             // Step 2.3. Set the k attribute of jwk to be a string containing the raw octets of the
             // key represented by [[handle]] internal slot of key, encoded according to Section 6.4

--- a/components/script/dom/webcrypto/subtlecrypto/aes_common.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/aes_common.rs
@@ -549,7 +549,7 @@ pub(crate) fn export_key(
             };
 
             // Step 2.2. Let result be data.
-            ExportedKey::Bytes(data)
+            ExportedKey::new_bytes(data)
         },
         // If format is "raw-secret":
         KeyFormat::Raw_secret => {
@@ -567,7 +567,7 @@ pub(crate) fn export_key(
             };
 
             // Step 2.2. Let result be data.
-            ExportedKey::Bytes(data)
+            ExportedKey::new_bytes(data)
         },
         // If format is "jwk":
         KeyFormat::Jwk => {
@@ -719,7 +719,7 @@ pub(crate) fn export_key(
             jwk.ext = Some(key.Extractable());
 
             // Step 2.7. Let result be jwk.
-            ExportedKey::Jwk(Box::new(jwk))
+            ExportedKey::new_jwk(jwk)
         },
         _ => {
             // throw a NotSupportedError.

--- a/components/script/dom/webcrypto/subtlecrypto/chacha20_poly1305_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/chacha20_poly1305_operation.rs
@@ -345,7 +345,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             let data = key_handle.to_vec();
 
             // Step 2.2 Let result be data.
-            ExportedKey::Bytes(data)
+            ExportedKey::new_bytes(data)
         },
         // If format is "jwk":
         KeyFormat::Jwk => {
@@ -372,7 +372,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             jwk.ext = Some(key.Extractable());
 
             // Step 2.7. Let result be jwk.
-            ExportedKey::Jwk(Box::new(jwk))
+            ExportedKey::new_jwk(jwk)
         },
         // Otherwise:
         _ => {

--- a/components/script/dom/webcrypto/subtlecrypto/chacha20_poly1305_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/chacha20_poly1305_operation.rs
@@ -5,6 +5,7 @@
 use chacha20poly1305::aead::{AeadMutInPlace, KeyInit, OsRng};
 use chacha20poly1305::{ChaCha20Poly1305, Key};
 use js::context::JSContext;
+use zeroize::Zeroizing;
 
 use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::{
     CryptoKeyMethods, KeyType, KeyUsage,
@@ -223,12 +224,12 @@ pub(crate) fn import_key(
     }
 
     // Step 3.
-    let data;
+    let data: Zeroizing<Vec<u8>>;
     match format {
         // If format is "raw-secret":
         KeyFormat::Raw_secret => {
             // Step 3.1. Let data be keyData.
-            data = key_data.to_vec();
+            data = key_data.to_vec().into();
 
             // Step 3.2. If the length in bits of data is not 256 then throw a DataError.
             if data.len() != 32 {
@@ -304,9 +305,10 @@ pub(crate) fn import_key(
     // Step 6. Let algorithm be a new KeyAlgorithm.
     // Step 7. Set the name attribute of algorithm to "ChaCha20-Poly1305".
     // Step 8. Set the [[algorithm]] internal slot of key to algorithm.
-    let handle = Handle::ChaCha20Poly1305Key(Key::from_exact_iter(data).ok_or(Error::Data(
-        Some("ChaCha20-Poly1305 fails to create key from data".to_string()),
-    ))?);
+    let handle =
+        Handle::ChaCha20Poly1305Key(Key::from_exact_iter(data.to_vec()).ok_or(Error::Data(
+            Some("ChaCha20-Poly1305 fails to create key from data".to_string()),
+        ))?);
     let algorithm = SubtleKeyAlgorithm {
         name: CryptoAlgorithm::ChaCha20Poly1305,
     };
@@ -350,11 +352,10 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
         // If format is "jwk":
         KeyFormat::Jwk => {
             // Step 2.1. Let jwk be a new JsonWebKey dictionary.
+            let mut jwk = JsonWebKey::default();
+
             // Step 2.2. Set the kty attribute of jwk to the string "oct".
-            let mut jwk = JsonWebKey {
-                kty: Some(DOMString::from("oct")),
-                ..Default::default()
-            };
+            jwk.kty = Some(DOMString::from("oct"));
 
             // Step 2.3. Set the k attribute of jwk to be a string containing the raw octets of the
             // key represented by [[handle]] internal slot of key, encoded according to Section 6.4

--- a/components/script/dom/webcrypto/subtlecrypto/ecdh_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ecdh_operation.rs
@@ -1112,11 +1112,10 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
         },
         KeyFormat::Jwk => {
             // Step 3.1. Let jwk be a new JsonWebKey dictionary.
+            let mut jwk = JsonWebKey::default();
+
             // Step 3.2. Set the kty attribute of jwk to "EC".
-            let mut jwk = JsonWebKey {
-                kty: Some(DOMString::from("EC")),
-                ..Default::default()
-            };
+            jwk.kty = Some(DOMString::from("EC"));
 
             // Step 3.3.
             let named_curve =

--- a/components/script/dom/webcrypto/subtlecrypto/ecdh_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ecdh_operation.rs
@@ -1048,7 +1048,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             }
             .map_err(|_| create_public_key_export_error())?;
 
-            ExportedKey::Bytes(data.to_vec())
+            ExportedKey::new_bytes(data.to_vec())
         },
         KeyFormat::Pkcs8 => {
             // Step 3.1. If the [[type]] internal slot of key is not "private", then throw an
@@ -1108,7 +1108,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             }
             .map_err(|_| create_private_key_export_error())?;
 
-            ExportedKey::Bytes(data.as_bytes().to_vec())
+            ExportedKey::new_bytes(data.as_bytes().to_vec())
         },
         KeyFormat::Jwk => {
             // Step 3.1. Let jwk be a new JsonWebKey dictionary.
@@ -1274,7 +1274,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             jwk.ext = Some(key.Extractable());
 
             // Step 3.4. Let result be jwk.
-            ExportedKey::Jwk(Box::new(jwk))
+            ExportedKey::new_jwk(jwk)
         },
         KeyFormat::Raw | KeyFormat::Raw_public => {
             // Step 3.1. If the [[type]] internal slot of key is not "public", then throw an
@@ -1325,7 +1325,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             };
 
             // Step 3.3. Let result be data.
-            ExportedKey::Bytes(data)
+            ExportedKey::new_bytes(data)
         },
         // Otherwise:
         _ => {

--- a/components/script/dom/webcrypto/subtlecrypto/ecdsa_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ecdsa_operation.rs
@@ -1098,11 +1098,10 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
         // If format is "jwk":
         KeyFormat::Jwk => {
             // Step 3.1. Let jwk be a new JsonWebKey dictionary.
+            let mut jwk = JsonWebKey::default();
+
             // Step 3.2. Set the kty attribute of jwk to "EC".
-            let mut jwk = JsonWebKey {
-                kty: Some(DOMString::from("EC")),
-                ..Default::default()
-            };
+            jwk.kty = Some(DOMString::from("EC"));
 
             // Step 3.3.
             let KeyAlgorithmAndDerivatives::EcKeyAlgorithm(algorithm) = key.algorithm() else {

--- a/components/script/dom/webcrypto/subtlecrypto/ecdsa_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ecdsa_operation.rs
@@ -1032,7 +1032,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             .map_err(|_| Error::Operation(None))?;
 
             // Step 3.3. Let result be the result of DER-encoding data.
-            ExportedKey::Bytes(data.to_vec())
+            ExportedKey::new_bytes(data.to_vec())
         },
         // If format is "pkcs8":
         KeyFormat::Pkcs8 => {
@@ -1093,7 +1093,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             .map_err(|_| Error::Operation(None))?;
 
             // Step 3.3. Let result be the result of DER-encoding data.
-            ExportedKey::Bytes(data.as_bytes().to_vec())
+            ExportedKey::new_bytes(data.as_bytes().to_vec())
         },
         // If format is "jwk":
         KeyFormat::Jwk => {
@@ -1212,7 +1212,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             jwk.ext = Some(key.Extractable());
 
             // Step 3.4. Let result be jwk.
-            ExportedKey::Jwk(Box::new(jwk))
+            ExportedKey::new_jwk(jwk)
         },
         // If format is "raw":
         KeyFormat::Raw | KeyFormat::Raw_public => {
@@ -1254,7 +1254,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             };
 
             // Step 3.3. Let result be data.
-            ExportedKey::Bytes(data)
+            ExportedKey::new_bytes(data)
         },
         // Otherwise:
         _ => {

--- a/components/script/dom/webcrypto/subtlecrypto/ed25519_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ed25519_operation.rs
@@ -540,7 +540,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             })?;
 
             // Step 3.3. Let result be the result of DER-encoding data.
-            ExportedKey::Bytes(
+            ExportedKey::new_bytes(
                 data.as_der()
                     .map_err(|_| {
                         Error::Operation(Some(
@@ -585,7 +585,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
                 })?;
 
             // Step 3.3. Let result be the result of DER-encoding data.
-            ExportedKey::Bytes(data.as_ref().to_vec())
+            ExportedKey::new_bytes(data.as_ref().to_vec())
         },
         // If format is "jwk":
         KeyFormat::Jwk => {
@@ -630,7 +630,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             jwk.ext = Some(key.Extractable());
 
             // Step 3.9. Let result be jwk.
-            ExportedKey::Jwk(Box::new(jwk))
+            ExportedKey::new_jwk(jwk)
         },
         // If format is "raw":
         KeyFormat::Raw | KeyFormat::Raw_public => {
@@ -645,7 +645,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             // Step 3.2. Let data be a byte sequence representing the Ed25519 public key
             // represented by the [[handle]] internal slot of key.
             // Step 3.3. Let result be data.
-            ExportedKey::Bytes(key_data.to_vec())
+            ExportedKey::new_bytes(key_data.to_vec())
         },
         // Otherwise:
         _ => {

--- a/components/script/dom/webcrypto/subtlecrypto/ed25519_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ed25519_operation.rs
@@ -388,7 +388,7 @@ pub(crate) fn import_key(
                     extractable,
                     KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
                     usages,
-                    Handle::Ed25519PrivateKey(d.into()),
+                    Handle::Ed25519PrivateKey(d),
                 )
             }
             // Otherwise:
@@ -407,7 +407,7 @@ pub(crate) fn import_key(
                     extractable,
                     KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
                     usages,
-                    Handle::Ed25519PublicKey(x),
+                    Handle::Ed25519PublicKey(x.to_vec()),
                 )
             }
 
@@ -590,15 +590,16 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
         // If format is "jwk":
         KeyFormat::Jwk => {
             // Step 3.1. Let jwk be a new JsonWebKey dictionary.
+            let mut jwk = JsonWebKey::default();
+
             // Step 3.2. Set the kty attribute of jwk to "OKP".
+            jwk.kty = Some(DOMString::from("OKP"));
+
             // Step 3.3. Set the alg attribute of jwk to "Ed25519".
+            jwk.alg = Some(DOMString::from("Ed25519"));
+
             // Step 3.4. Set the crv attribute of jwk to "Ed25519".
-            let mut jwk = JsonWebKey {
-                kty: Some(DOMString::from("OKP")),
-                alg: Some(DOMString::from("Ed25519")),
-                crv: Some(DOMString::from("Ed25519")),
-                ..Default::default()
-            };
+            jwk.crv = Some(DOMString::from("Ed25519"));
 
             // Step 3.5. Set the x attribute of jwk according to the definition in Section 2 of [RFC8037].
             // Step 3.6.

--- a/components/script/dom/webcrypto/subtlecrypto/hmac_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/hmac_operation.rs
@@ -371,7 +371,7 @@ pub(crate) fn import_key(
 pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedKey, Error> {
     match format {
         KeyFormat::Raw | KeyFormat::Raw_secret => match key.handle() {
-            Handle::Hmac(key_data) => Ok(ExportedKey::Bytes(key_data.as_slice().to_vec())),
+            Handle::Hmac(key_data) => Ok(ExportedKey::new_bytes(key_data.as_slice().to_vec())),
             _ => Err(Error::Operation(Some(
                 "The key handle is not representing an HMAC key".into(),
             ))),
@@ -434,7 +434,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             jwk.ext = Some(key.Extractable());
 
             // Step 4.9. Let result be jwk.
-            Ok(ExportedKey::Jwk(Box::new(jwk)))
+            Ok(ExportedKey::new_jwk(jwk))
         },
         // Otherwise:
         _ => {

--- a/components/script/dom/webcrypto/subtlecrypto/hmac_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/hmac_operation.rs
@@ -9,6 +9,7 @@ use rand::TryRngCore;
 use rand::rngs::OsRng;
 use script_bindings::codegen::GenericBindings::CryptoKeyBinding::CryptoKeyMethods;
 use script_bindings::domstring::DOMString;
+use zeroize::Zeroizing;
 
 use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::{KeyType, KeyUsage};
 use crate::dom::bindings::codegen::Bindings::SubtleCryptoBinding::{JsonWebKey, KeyFormat};
@@ -195,12 +196,12 @@ pub(crate) fn import_key(
     let hash;
 
     // Step 4.
-    let data;
+    let data: Zeroizing<Vec<u8>>;
     match format {
         // If format is "raw":
         KeyFormat::Raw | KeyFormat::Raw_secret => {
             // Step 4.1. Let data be keyData.
-            data = key_data.to_vec();
+            data = key_data.to_vec().into();
 
             // Step 4.2. Set hash to equal the hash member of normalizedAlgorithm.
             hash = &normalized_algorithm.hash;
@@ -378,11 +379,10 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
         },
         KeyFormat::Jwk => {
             // Step 4.1. Let jwk be a new JsonWebKey dictionary.
+            let mut jwk = JsonWebKey::default();
+
             // Step 4.2. Set the kty attribute of jwk to the string "oct".
-            let mut jwk = JsonWebKey {
-                kty: Some(DOMString::from("oct")),
-                ..Default::default()
-            };
+            jwk.kty = Some(DOMString::from("oct"));
 
             // Step 4.3. Set the k attribute of jwk to be a string containing data, encoded according
             // to Section 6.4 of JSON Web Algorithms [JWA].

--- a/components/script/dom/webcrypto/subtlecrypto/ml_dsa_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ml_dsa_operation.rs
@@ -879,7 +879,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             };
 
             // Step 3.4. Let result be the result of DER-encoding data.
-            ExportedKey::Bytes(data.to_der().map_err(|_| {
+            ExportedKey::new_bytes(data.to_der().map_err(|_| {
                 Error::Operation(Some(
                     "Failed to encode SubjectPublicKeyInfo in DER format".to_string(),
                 ))
@@ -986,7 +986,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             };
 
             // Step 3.4. Let result be the result of DER-encoding data.
-            ExportedKey::Bytes(private_key_info.to_der().map_err(|_| {
+            ExportedKey::new_bytes(private_key_info.to_der().map_err(|_| {
                 Error::Operation(Some(
                     "Failed to encode PrivateKeyInfo in DER format".to_string(),
                 ))
@@ -1007,7 +1007,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             let data = convert_handle_to_public_key(key.handle())?;
 
             // Step 3.2. Let result be data.
-            ExportedKey::Bytes(data)
+            ExportedKey::new_bytes(data)
         },
         // If format is "raw-seed":
         KeyFormat::Raw_seed => {
@@ -1024,7 +1024,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             let (data, _public_key_bytes) = convert_handle_to_seed_and_public_key(key.handle())?;
 
             // Step 3.3. Let result be data.
-            ExportedKey::Bytes(data)
+            ExportedKey::new_bytes(data)
         },
         // If format is "jwk":
         KeyFormat::Jwk => {
@@ -1067,7 +1067,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             jwk.ext = Some(key.Extractable());
 
             // Step 3.9. Let result be jwk.
-            ExportedKey::Jwk(Box::new(jwk))
+            ExportedKey::new_jwk(jwk)
         },
         // Otherwise:
         _ => {

--- a/components/script/dom/webcrypto/subtlecrypto/ml_kem_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ml_kem_operation.rs
@@ -197,7 +197,7 @@ pub(crate) fn encapsulate(
     // Step 8. Set the ciphertext attribute of result to the result of creating an ArrayBuffer
     // containing ciphertext.
     let result = SubtleEncapsulatedBits {
-        shared_key: Some(shared_key),
+        shared_key: Some(shared_key.into()),
         ciphertext: Some(ciphertext),
     };
 
@@ -961,7 +961,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             };
 
             // Step 2.4. Let result be the result of DER-encoding data.
-            ExportedKey::Bytes(data.to_der().map_err(|_| {
+            ExportedKey::new_bytes(data.to_der().map_err(|_| {
                 Error::Operation(Some(
                     "Failed to encode SubjectPublicKeyInfo in DER format".to_string(),
                 ))
@@ -1068,7 +1068,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             };
 
             // Step 2.4. Let result be the result of DER-encoding data.
-            ExportedKey::Bytes(private_key_info.to_der().map_err(|_| {
+            ExportedKey::new_bytes(private_key_info.to_der().map_err(|_| {
                 Error::Operation(Some(
                     "Failed to encode PrivateKeyInfo in DER format".to_string(),
                 ))
@@ -1089,7 +1089,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             let data = convert_handle_to_public_key(key.handle())?;
 
             // Step 2.3. Let result be data.
-            ExportedKey::Bytes(data)
+            ExportedKey::new_bytes(data)
         },
         // If format is "raw-seed":
         KeyFormat::Raw_seed => {
@@ -1106,7 +1106,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             let (data, _) = convert_handle_to_seed_and_public_key(key.handle())?;
 
             // Step 2.3. Let result be data.
-            ExportedKey::Bytes(data)
+            ExportedKey::new_bytes(data)
         },
         // If format is "jwk":
         KeyFormat::Jwk => {
@@ -1166,7 +1166,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             jwk.ext = Some(key.Extractable());
 
             // Step 2.9. Let result be jwk.
-            ExportedKey::Jwk(Box::new(jwk))
+            ExportedKey::new_jwk(jwk)
         },
         // Otherwise:
         _ => {

--- a/components/script/dom/webcrypto/subtlecrypto/rsa_common.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/rsa_common.rs
@@ -827,11 +827,10 @@ pub(crate) fn export_key(
         // If format is "jwk":
         KeyFormat::Jwk => {
             // Step 3.1. Let jwk be a new JsonWebKey dictionary.
+            let mut jwk = JsonWebKey::default();
+
             // Step 3.2. Set the kty attribute of jwk to the string "RSA".
-            let mut jwk = JsonWebKey {
-                kty: Some(DOMString::from("RSA")),
-                ..Default::default()
-            };
+            jwk.kty = Some(DOMString::from("RSA"));
 
             // Step 3.3. Let hash be the name attribute of the hash attribute of the [[algorithm]]
             // internal slot of key.

--- a/components/script/dom/webcrypto/subtlecrypto/rsa_common.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/rsa_common.rs
@@ -778,7 +778,7 @@ pub(crate) fn export_key(
             })?;
 
             // Step 3.3. Let result be the result of DER-encoding data.
-            ExportedKey::Bytes(data.to_der().map_err(|_| {
+            ExportedKey::new_bytes(data.to_der().map_err(|_| {
                 Error::Operation(Some(
                     "Failed to convert SubjectPublicKeyInfo to DER-encodeing data".to_string(),
                 ))
@@ -822,7 +822,7 @@ pub(crate) fn export_key(
             })?;
 
             // Step 3.3. Let result be the result of DER-encoding data.
-            ExportedKey::Bytes(data.to_bytes().to_vec())
+            ExportedKey::new_bytes(data.to_bytes().to_vec())
         },
         // If format is "jwk":
         KeyFormat::Jwk => {
@@ -1043,7 +1043,7 @@ pub(crate) fn export_key(
             jwk.ext = Some(key.Extractable());
 
             // Step 3.9. Let result be jwk.
-            ExportedKey::Jwk(Box::new(jwk))
+            ExportedKey::new_jwk(jwk)
         },
         // Otherwise
         _ => {

--- a/components/script/dom/webcrypto/subtlecrypto/x25519_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/x25519_operation.rs
@@ -508,7 +508,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             };
 
             // Step 3.3. Let result be the result of DER-encoding data.
-            ExportedKey::Bytes(data.to_der().map_err(|_| Error::Operation(None))?)
+            ExportedKey::new_bytes(data.to_der().map_err(|_| Error::Operation(None))?)
         },
         // If format is "pkcs8":
         KeyFormat::Pkcs8 => {
@@ -544,7 +544,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             };
 
             // Step 3.3. Let result be the result of DER-encoding data.
-            ExportedKey::Bytes(data.to_der().map_err(|_| Error::Operation(None))?)
+            ExportedKey::new_bytes(data.to_der().map_err(|_| Error::Operation(None))?)
         },
         // If format is "jwk":
         KeyFormat::Jwk => {
@@ -589,7 +589,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             jwk.ext = Some(key.Extractable());
 
             // Step 3.8. Let result be jwk.
-            ExportedKey::Jwk(Box::new(jwk))
+            ExportedKey::new_jwk(jwk)
         },
         // If format is "raw":
         KeyFormat::Raw | KeyFormat::Raw_public => {
@@ -607,7 +607,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             let data = public_key.as_bytes();
 
             // Step 3.3. Let result be data.
-            ExportedKey::Bytes(data.to_vec())
+            ExportedKey::new_bytes(data.to_vec())
         },
         // Otherwise:
         _ => {

--- a/components/script/dom/webcrypto/subtlecrypto/x25519_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/x25519_operation.rs
@@ -370,9 +370,9 @@ pub(crate) fn import_key(
                 let x = jwk.decode_required_string_field(JwkStringField::X)?;
                 let d = jwk.decode_required_string_field(JwkStringField::D)?;
                 let public_key_bytes: [u8; PUBLIC_KEY_LENGTH] =
-                    x.try_into().map_err(|_| Error::Data(None))?;
+                    x.as_slice().try_into().map_err(|_| Error::Data(None))?;
                 let private_key_bytes: [u8; PRIVATE_KEY_LENGTH] =
-                    d.try_into().map_err(|_| Error::Data(None))?;
+                    d.as_slice().try_into().map_err(|_| Error::Data(None))?;
                 let public_key = PublicKey::from(public_key_bytes);
                 let private_key = StaticSecret::from(private_key_bytes);
                 if PublicKey::from(&private_key) != public_key {
@@ -395,7 +395,7 @@ pub(crate) fn import_key(
                 // described in Section 2 of [RFC8037], then throw a DataError.
                 let x = jwk.decode_required_string_field(JwkStringField::X)?;
                 let public_key_bytes: [u8; PUBLIC_KEY_LENGTH] =
-                    x.try_into().map_err(|_| Error::Data(None))?;
+                    x.as_slice().try_into().map_err(|_| Error::Data(None))?;
                 let public_key = PublicKey::from(public_key_bytes);
 
                 // Step 2.9.1. Let key be a new CryptoKey object that represents the X25519 public
@@ -549,13 +549,13 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
         // If format is "jwk":
         KeyFormat::Jwk => {
             // Step 3.1. Let jwk be a new JsonWebKey dictionary.
+            let mut jwk = JsonWebKey::default();
+
             // Step 3.2. Set the kty attribute of jwk to "OKP".
+            jwk.kty = Some(DOMString::from("OKP"));
+
             // Step 3.3. Set the crv attribute of jwk to "X25519".
-            let mut jwk = JsonWebKey {
-                kty: Some(DOMString::from("OKP")),
-                crv: Some(DOMString::from("X25519")),
-                ..Default::default()
-            };
+            jwk.crv = Some(DOMString::from("X25519"));
 
             // Step 3.4. Set the x attribute of jwk according to the definition in Section 2 of
             // [RFC8037].

--- a/components/script_bindings/Cargo.toml
+++ b/components/script_bindings/Cargo.toml
@@ -50,6 +50,7 @@ tendril = { workspace = true }
 tracing = { workspace = true, optional = true }
 webxr-api = { workspace = true, optional = true }
 xml5ever = { workspace = true }
+zeroize = { workspace = true }
 
 [build-dependencies]
 phf_codegen = "0.13"

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1203,8 +1203,16 @@ Dictionaries = {
     'derives': ['Clone'],
 },
 
+'JsonWebKey': {
+    'derives': ['zeroize::Zeroize', 'zeroize::ZeroizeOnDrop'],
+},
+
 'RecommendedBreakpointLocation': {
     'derives': ['Debug'],
+},
+
+'RsaOtherPrimesInfo': {
+    'derives': ['zeroize::Zeroize', 'zeroize::ZeroizeOnDrop'],
 },
 
 'PauseFrameResult': {

--- a/components/script_bindings/domstring.rs
+++ b/components/script_bindings/domstring.rs
@@ -24,6 +24,7 @@ use regex::Regex;
 use servo_base::text::{Utf8CodeUnitLength, Utf16CodeUnitLength};
 use style::Atom;
 use style::str::HTML_SPACE_CHARACTERS;
+use zeroize::Zeroize;
 
 use crate::script_runtime::JSContext as SafeJSContext;
 use crate::trace::RootedTraceableBox;
@@ -107,6 +108,12 @@ enum DOMStringType {
 impl Default for DOMStringType {
     fn default() -> Self {
         Self::Rust(Default::default())
+    }
+}
+
+impl Zeroize for DOMStringType {
+    fn zeroize(&mut self) {
+        self.ensure_rust_string().zeroize()
     }
 }
 
@@ -882,6 +889,12 @@ impl From<DOMString> for Vec<u8> {
 impl From<Cow<'_, str>> for DOMString {
     fn from(value: Cow<'_, str>) -> Self {
         DOMString(RefCell::new(DOMStringType::Rust(value.into_owned())))
+    }
+}
+
+impl Zeroize for DOMString {
+    fn zeroize(&mut self) {
+        self.0.borrow_mut().zeroize()
     }
 }
 


### PR DESCRIPTION
We previously wrapped the raw key bytes in `Vec<u8>` stored in `CryptoKey` handles with `zeroize::zeroizing` (#44597). This ensures the raw bytes are zeroized (erased from memory) on drop, preventing them from remaining in memory after dropping.

We further wrap the following sensitive information stored in `Vec<u8>` with `zeroize::Zeroizing`:

- plaintext in `encrypt` and `decrypt` methods
- secret in `deriveKey` methods
- bits in `deriveBits` methods
- key bytes in `importKey`, `exportKey`, `wrapKey`, `unwrapKey` methods
- shared key in `encapsulateKey`, `decapsulateKey` methods
- shared bits in `encapsulateBits`, `decapsulateBits` methods

`JsonWebKey` also contains sensitive key bytes, so we make `JsonWebKey` zeroize on drop by deriving the `zeroize::Zeroize` and `zeroize::ZeroizeOnDrop` trait for the `JsonWebKey` type. To achieve this, we also implement the `zeroize::Zeroize` trait for `DOMString`.

Furthermore, we adjust the function signatures of the `JsonWebKeyExt` trait so that the `Vec<u8>` and `DOMString` read from and written to `JsonWebKey` are wrapped in `zeroize::Zeroizing`.

Testing: Hardening. No behavioral change.
Fixes: Follow-up of https://github.com/servo/servo/pull/44597#discussion_r3160291055