### PR TITLE
Bindings.conf: Remove stale `canGc`

### DIFF
--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -317,8 +317,8 @@ DOMInterfaces = {
 },
 
 'Element': {
-    'cx': ['GetHTML', 'GetInnerHTML', 'GetOuterHTML', 'RemoveAttribute', 'SetHTMLUnsafe', 'SetInnerHTML', 'SetOuterHTML', 'InsertAdjacentHTML', 'ToggleAttribute', 'SetAttribute', 'SetAttributeNS', 'SetAttributeNode', 'SetAttributeNodeNS', 'RemoveAttributeNS', 'RemoveAttributeNode', 'SetRole', 'SetAriaAtomic', 'SetAriaAutoComplete', 'SetAriaBrailleLabel', 'SetAriaBrailleRoleDescription', 'SetAriaBusy', 'SetAriaChecked', 'SetAriaColCount', 'SetAriaColIndex', 'SetAriaColIndexText', 'SetAriaColSpan', 'SetAriaCurrent', 'SetAriaDescription', 'SetAriaDisabled', 'SetAriaExpanded', 'SetAriaHasPopup', 'SetAriaHidden', 'SetAriaInvalid', 'SetAriaKeyShortcuts', 'SetAriaLabel', 'SetAriaLevel', 'SetAriaLive', 'SetAriaModal', 'SetAriaMultiLine', 'SetAriaMultiSelectable', 'SetAriaOrientation', 'SetAriaPlaceholder', 'SetAriaPosInSet', 'SetAriaPressed','SetAriaReadOnly', 'SetAriaRelevant', 'SetAriaRequired', 'SetAriaRoleDescription', 'SetAriaRowCount', 'SetAriaRowIndex', 'SetAriaRowIndexText', 'SetAriaRowSpan', 'SetAriaSelected', 'SetAriaSetSize','SetAriaSort', 'SetAriaValueMax', 'SetAriaValueMin', 'SetAriaValueNow', 'SetAriaValueText', 'ReplaceWith', 'MoveBefore', 'InsertAdjacentElement', 'InsertAdjacentText', 'Before', 'After', 'Prepend', 'Remove', 'ReplaceChildren', 'Append', 'AttachShadow', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'Children', 'GetClientRects', 'GetBoundingClientRect'],
-    'canGc': ['SetId','SetClassName', 'RequestFullscreen', 'ClassList', 'Attributes'],
+    'cx': ['GetHTML', 'GetInnerHTML', 'GetOuterHTML', 'RemoveAttribute', 'SetClassName', 'SetHTMLUnsafe', 'SetId', 'SetInnerHTML', 'SetOuterHTML', 'InsertAdjacentHTML', 'ToggleAttribute', 'SetAttribute', 'SetAttributeNS', 'SetAttributeNode', 'SetAttributeNodeNS', 'RemoveAttributeNS', 'RemoveAttributeNode', 'SetRole', 'SetAriaAtomic', 'SetAriaAutoComplete', 'SetAriaBrailleLabel', 'SetAriaBrailleRoleDescription', 'SetAriaBusy', 'SetAriaChecked', 'SetAriaColCount', 'SetAriaColIndex', 'SetAriaColIndexText', 'SetAriaColSpan', 'SetAriaCurrent', 'SetAriaDescription', 'SetAriaDisabled', 'SetAriaExpanded', 'SetAriaHasPopup', 'SetAriaHidden', 'SetAriaInvalid', 'SetAriaKeyShortcuts', 'SetAriaLabel', 'SetAriaLevel', 'SetAriaLive', 'SetAriaModal', 'SetAriaMultiLine', 'SetAriaMultiSelectable', 'SetAriaOrientation', 'SetAriaPlaceholder', 'SetAriaPosInSet', 'SetAriaPressed','SetAriaReadOnly', 'SetAriaRelevant', 'SetAriaRequired', 'SetAriaRoleDescription', 'SetAriaRowCount', 'SetAriaRowIndex', 'SetAriaRowIndexText', 'SetAriaRowSpan', 'SetAriaSelected', 'SetAriaSetSize','SetAriaSort', 'SetAriaValueMax', 'SetAriaValueMin', 'SetAriaValueNow', 'SetAriaValueText', 'ReplaceWith', 'MoveBefore', 'InsertAdjacentElement', 'InsertAdjacentText', 'Before', 'After', 'Prepend', 'Remove', 'ReplaceChildren', 'Append', 'AttachShadow', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'Children', 'GetClientRects', 'GetBoundingClientRect'],
+    'canGc': ['RequestFullscreen', 'ClassList', 'Attributes'],
 },
 
 'ElementInternals': {
@@ -530,8 +530,8 @@ DOMInterfaces = {
 },
 
 'HTMLLinkElement': {
-    'canGc': ['Blocking', 'GetSheet', 'SetRel','RelList'],
-    'cx': ['SetCrossOrigin'],
+    'canGc': ['Blocking', 'GetSheet', 'RelList'],
+    'cx': ['SetCrossOrigin', 'SetRel'],
 },
 
 'HTMLMapElement': {
@@ -547,8 +547,7 @@ DOMInterfaces = {
 },
 
 'HTMLMeterElement': {
-    'canGc': ['SetValue', 'SetMin', 'SetMax', 'SetLow', 'SetHigh', 'SetOptimum'],
-    'cx': ['CheckValidity', 'ReportValidity'],
+    'cx': ['CheckValidity', 'ReportValidity', 'SetHigh', 'SetLow', 'SetMax', 'SetMin', 'SetOptimum', 'SetValue'],
 },
 
 'HTMLObjectElement': {
@@ -575,17 +574,16 @@ DOMInterfaces = {
 },
 
 'HTMLProgressElement': {
-    'canGc': ['SetValue', 'SetMax']
+    'cx': ['SetValue', 'SetMax']
 },
 
 'HTMLScriptElement': {
-    'canGc': ['SetAsync'],
-    'cx': ['Blocking', 'SetCrossOrigin', 'SetInnerText', 'SetSrc', 'SetText', 'SetTextContent'],
+    'cx': ['Blocking', 'SetAsync', 'SetCrossOrigin', 'SetInnerText', 'SetSrc', 'SetText', 'SetTextContent'],
 },
 
 'HTMLSelectElement': {
-    'canGc': ['SetCustomValidity', 'SetValue', 'Validity'],
-    'cx': ['Add', 'CheckValidity', 'IndexedSetter', 'Remove', 'Remove_', 'ReportValidity', 'SelectedOptions', 'SetLength', 'SetSelectedIndex'],
+    'canGc': ['SetCustomValidity', 'Validity'],
+    'cx': ['Add', 'CheckValidity', 'IndexedSetter', 'Remove', 'Remove_', 'ReportValidity', 'SelectedOptions', 'SetLength', 'SetSelectedIndex', 'SetValue'],
 },
 
 'HTMLStyleElement': {
@@ -593,7 +591,6 @@ DOMInterfaces = {
 },
 
 'HTMLTableElement': {
-    'canGc': ['InsertCell', 'InsertRow'],
     'cx': [
         'CreateCaption',
         'CreateTBody',
@@ -631,8 +628,8 @@ DOMInterfaces = {
 },
 
 'HTMLTextAreaElement': {
-    'canGc': ['SetCustomValidity', 'SetValue', 'Validity'],
-    'cx': ['CheckValidity', 'ReportValidity', 'SetDefaultValue'],
+    'canGc': ['SetCustomValidity', 'Validity'],
+    'cx': ['CheckValidity', 'ReportValidity', 'SetDefaultValue', 'SetValue'],
 },
 
 'HTMLTitleElement': {


### PR DESCRIPTION
These were specified as `can_gc` in config. However, the function already use `cx`.
`can_gc` was ignored due to codegen script.

Testing: It compiles.