### PR TITLE
script: Propagate crown::unrooted_must_root through WebGPU buffer types

### DIFF
--- a/components/script/dom/bindings/buffer_source.rs
+++ b/components/script/dom/bindings/buffer_source.rs
@@ -914,6 +914,7 @@ pub(crate) fn create_array_buffer_with_size(
 
 #[cfg(feature = "webgpu")]
 #[derive(JSTraceable, MallocSizeOf)]
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct DataBlock {
     #[conditional_malloc_size_of]
     data: Arc<Box<[u8]>>,
@@ -1005,7 +1006,7 @@ impl DataBlock {
 
 #[cfg(feature = "webgpu")]
 #[derive(JSTraceable, MallocSizeOf)]
-#[cfg_attr(crown, expect(crown::unrooted_must_root))]
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct DataView {
     #[no_trace]
     range: Range<usize>,

--- a/components/script/dom/webgpu/gpubuffer.rs
+++ b/components/script/dom/webgpu/gpubuffer.rs
@@ -86,7 +86,7 @@ pub(crate) struct GPUBuffer {
     #[conditional_malloc_size_of]
     pending_map: DomRefCell<Option<Rc<Promise>>>,
     /// <https://gpuweb.github.io/gpuweb/#dom-gpubuffer-mapping-slot>
-    mapping: DomRefCell<Option<ActiveBufferMapping>>,
+    mapping: DomRefCell<Option<RootedTraceableBox<ActiveBufferMapping>>>,
 }
 
 impl GPUBuffer {
@@ -96,7 +96,7 @@ impl GPUBuffer {
         device: &GPUDevice,
         size: GPUSize64,
         usage: GPUFlagsConstant,
-        mapping: Option<ActiveBufferMapping>,
+        mapping: Option<RootedTraceableBox<ActiveBufferMapping>>,
         label: USVString,
     ) -> Self {
         Self {
@@ -120,7 +120,7 @@ impl GPUBuffer {
         device: &GPUDevice,
         size: GPUSize64,
         usage: GPUFlagsConstant,
-        mapping: Option<ActiveBufferMapping>,
+        mapping: Option<RootedTraceableBox<ActiveBufferMapping>>,
         label: USVString,
         can_gc: CanGc,
     ) -> DomRoot<Self> {
@@ -165,8 +165,10 @@ impl GPUBuffer {
 
         let buffer = WebGPUBuffer(id);
         let mapping = if descriptor.mappedAtCreation {
-            ActiveBufferMapping::new(GPUMapModeConstants::WRITE, 0..descriptor.size)?
-                .map(|m| *m.into_box())
+            Some(ActiveBufferMapping::new(
+                GPUMapModeConstants::WRITE,
+                0..descriptor.size,
+            )?)
         } else {
             None
         };
@@ -420,8 +422,7 @@ impl GPUBuffer {
                 HostMap::Write => GPUMapModeConstants::WRITE,
             },
             wgpu_mapping.range,
-        )
-        .map(|m| *m.into_box())?;
+        );
 
         match mapping {
             Err(error) => {

--- a/components/script/dom/webgpu/gpubuffer.rs
+++ b/components/script/dom/webgpu/gpubuffer.rs
@@ -48,7 +48,10 @@ pub(crate) struct ActiveBufferMapping {
 
 impl ActiveBufferMapping {
     /// <https://gpuweb.github.io/gpuweb/#abstract-opdef-initialize-an-active-buffer-mapping>
-    pub(crate) fn new(mode: GPUMapModeFlags, range: Range<u64>) -> Fallible<Self> {
+    pub(crate) fn new(
+        mode: GPUMapModeFlags,
+        range: Range<u64>,
+    ) -> Fallible<RootedTraceableBox<Self>> {
         // Step 1
         let size = range.end - range.start;
         // Step 2
@@ -58,11 +61,11 @@ impl ActiveBufferMapping {
         let size: usize = size
             .try_into()
             .map_err(|_| Error::Range(c"Over usize".to_owned()))?;
-        Ok(Self {
+        Ok(RootedTraceableBox::new(Self {
             data: DataBlock::new_zeroed(size),
             mode,
             range,
-        })
+        }))
     }
 }
 
@@ -83,7 +86,7 @@ pub(crate) struct GPUBuffer {
     #[conditional_malloc_size_of]
     pending_map: DomRefCell<Option<Rc<Promise>>>,
     /// <https://gpuweb.github.io/gpuweb/#dom-gpubuffer-mapping-slot>
-    mapping: DomRefCell<Option<RootedTraceableBox<ActiveBufferMapping>>>,
+    mapping: DomRefCell<Option<ActiveBufferMapping>>,
 }
 
 impl GPUBuffer {
@@ -93,7 +96,7 @@ impl GPUBuffer {
         device: &GPUDevice,
         size: GPUSize64,
         usage: GPUFlagsConstant,
-        mapping: Option<RootedTraceableBox<ActiveBufferMapping>>,
+        mapping: Option<ActiveBufferMapping>,
         label: USVString,
     ) -> Self {
         Self {
@@ -117,7 +120,7 @@ impl GPUBuffer {
         device: &GPUDevice,
         size: GPUSize64,
         usage: GPUFlagsConstant,
-        mapping: Option<RootedTraceableBox<ActiveBufferMapping>>,
+        mapping: Option<ActiveBufferMapping>,
         label: USVString,
         can_gc: CanGc,
     ) -> DomRoot<Self> {
@@ -137,7 +140,6 @@ impl GPUBuffer {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createbuffer>
-    #[cfg_attr(crown, allow(crown::unrooted_must_root))]
     pub(crate) fn create(
         device: &GPUDevice,
         descriptor: &GPUBufferDescriptor,
@@ -162,11 +164,9 @@ impl GPUBuffer {
             .expect("Failed to create WebGPU buffer");
 
         let buffer = WebGPUBuffer(id);
-        let mapping: Option<RootedTraceableBox<ActiveBufferMapping>> = if descriptor
-            .mappedAtCreation
-        {
-            let temp = ActiveBufferMapping::new(GPUMapModeConstants::WRITE, 0..descriptor.size)?;
-            Some(RootedTraceableBox::new(temp))
+        let mapping = if descriptor.mappedAtCreation {
+            ActiveBufferMapping::new(GPUMapModeConstants::WRITE, 0..descriptor.size)?
+                .map(|m| *m.into_box())
         } else {
             None
         };
@@ -403,7 +403,6 @@ impl GPUBuffer {
         }
     }
 
-    #[cfg_attr(crown, allow(crown::unrooted_must_root))]
     fn map_success(&self, p: &Rc<Promise>, wgpu_mapping: Mapping, can_gc: CanGc) {
         // Step 1
         if self.pending_map.borrow().as_ref() != Some(p) {
@@ -422,7 +421,7 @@ impl GPUBuffer {
             },
             wgpu_mapping.range,
         )
-        .map(RootedTraceableBox::new);
+        .map(|m| *m.into_box())?;
 
         match mapping {
             Err(error) => {

--- a/components/script/dom/webgpu/gpubuffer.rs
+++ b/components/script/dom/webgpu/gpubuffer.rs
@@ -34,6 +34,7 @@ use crate::routed_promise::{RoutedPromiseListener, callback_promise};
 use crate::script_runtime::{CanGc, JSContext};
 
 #[derive(JSTraceable, MallocSizeOf)]
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct ActiveBufferMapping {
     // TODO(sagudev): Use GenericSharedMemory when https://github.com/servo/ipc-channel/pull/356 lands
     /// <https://gpuweb.github.io/gpuweb/#active-buffer-mapping-data>
@@ -82,7 +83,7 @@ pub(crate) struct GPUBuffer {
     #[conditional_malloc_size_of]
     pending_map: DomRefCell<Option<Rc<Promise>>>,
     /// <https://gpuweb.github.io/gpuweb/#dom-gpubuffer-mapping-slot>
-    mapping: DomRefCell<Option<ActiveBufferMapping>>,
+    mapping: DomRefCell<Option<RootedTraceableBox<ActiveBufferMapping>>>,
 }
 
 impl GPUBuffer {
@@ -92,7 +93,7 @@ impl GPUBuffer {
         device: &GPUDevice,
         size: GPUSize64,
         usage: GPUFlagsConstant,
-        mapping: Option<ActiveBufferMapping>,
+        mapping: Option<RootedTraceableBox<ActiveBufferMapping>>,
         label: USVString,
     ) -> Self {
         Self {
@@ -116,7 +117,7 @@ impl GPUBuffer {
         device: &GPUDevice,
         size: GPUSize64,
         usage: GPUFlagsConstant,
-        mapping: Option<ActiveBufferMapping>,
+        mapping: Option<RootedTraceableBox<ActiveBufferMapping>>,
         label: USVString,
         can_gc: CanGc,
     ) -> DomRoot<Self> {
@@ -136,6 +137,7 @@ impl GPUBuffer {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createbuffer>
+    #[cfg_attr(crown, allow(crown::unrooted_must_root))]
     pub(crate) fn create(
         device: &GPUDevice,
         descriptor: &GPUBufferDescriptor,
@@ -160,11 +162,11 @@ impl GPUBuffer {
             .expect("Failed to create WebGPU buffer");
 
         let buffer = WebGPUBuffer(id);
-        let mapping = if descriptor.mappedAtCreation {
-            Some(ActiveBufferMapping::new(
-                GPUMapModeConstants::WRITE,
-                0..descriptor.size,
-            )?)
+        let mapping: Option<RootedTraceableBox<ActiveBufferMapping>> = if descriptor
+            .mappedAtCreation
+        {
+            let temp = ActiveBufferMapping::new(GPUMapModeConstants::WRITE, 0..descriptor.size)?;
+            Some(RootedTraceableBox::new(temp))
         } else {
             None
         };
@@ -401,6 +403,7 @@ impl GPUBuffer {
         }
     }
 
+    #[cfg_attr(crown, allow(crown::unrooted_must_root))]
     fn map_success(&self, p: &Rc<Promise>, wgpu_mapping: Mapping, can_gc: CanGc) {
         // Step 1
         if self.pending_map.borrow().as_ref() != Some(p) {
@@ -418,7 +421,8 @@ impl GPUBuffer {
                 HostMap::Write => GPUMapModeConstants::WRITE,
             },
             wgpu_mapping.range,
-        );
+        )
+        .map(RootedTraceableBox::new);
 
         match mapping {
             Err(error) => {

--- a/components/script/dom/webgpu/gpubuffer.rs
+++ b/components/script/dom/webgpu/gpubuffer.rs
@@ -86,7 +86,7 @@ pub(crate) struct GPUBuffer {
     #[conditional_malloc_size_of]
     pending_map: DomRefCell<Option<Rc<Promise>>>,
     /// <https://gpuweb.github.io/gpuweb/#dom-gpubuffer-mapping-slot>
-    mapping: DomRefCell<Option<RootedTraceableBox<ActiveBufferMapping>>>,
+    mapping: DomRefCell<Option<ActiveBufferMapping>>,
 }
 
 impl GPUBuffer {
@@ -108,7 +108,7 @@ impl GPUBuffer {
             pending_map: DomRefCell::new(None),
             size,
             usage,
-            mapping: DomRefCell::new(mapping),
+            mapping: DomRefCell::new(mapping.map(|mapping| *mapping.into_box())),
         }
     }
 
@@ -211,7 +211,7 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
             promise.reject_error(Error::Abort(None), CanGc::deprecated_note());
         }
         // Step 2
-        let mut mapping = self.mapping.borrow_mut().take();
+        let mut mapping = RootedTraceableBox::new(self.mapping.borrow_mut().take());
         let mapping = if let Some(mapping) = mapping.as_mut() {
             mapping
         } else {
@@ -327,6 +327,7 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
             .mapping
             .borrow_mut()
             .take()
+            .map(|mapping| RootedTraceableBox::new(mapping))
             .ok_or(Error::Operation(None))?;
 
         let valid = offset.is_multiple_of(wgpu_types::MAP_ALIGNMENT) &&
@@ -334,7 +335,7 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
             offset >= mapping.range.start &&
             offset + range_size <= mapping.range.end;
         if !valid {
-            self.mapping.borrow_mut().replace(mapping);
+            self.mapping.borrow_mut().replace(*mapping.into_box());
             return Err(Error::Operation(None));
         }
 
@@ -348,7 +349,7 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
             .map(|view| view.array_buffer())
             .map_err(|()| Error::Operation(None));
 
-        self.mapping.borrow_mut().replace(mapping);
+        self.mapping.borrow_mut().replace(*mapping.into_box());
         result
     }
 
@@ -433,7 +434,7 @@ impl GPUBuffer {
                 // Step 5
                 mapping.data.load(&wgpu_mapping.data);
                 // Step 6
-                self.mapping.borrow_mut().replace(mapping);
+                self.mapping.borrow_mut().replace(*mapping.into_box());
                 // Step 7
                 self.pending_map.borrow_mut().take();
                 p.resolve_native(&(), can_gc);

--- a/components/script/dom/webgpu/gpubuffer.rs
+++ b/components/script/dom/webgpu/gpubuffer.rs
@@ -327,7 +327,7 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
             .mapping
             .borrow_mut()
             .take()
-            .map(|mapping| RootedTraceableBox::new(mapping))
+            .map(RootedTraceableBox::new)
             .ok_or(Error::Operation(None))?;
 
         let valid = offset.is_multiple_of(wgpu_types::MAP_ALIGNMENT) &&

--- a/components/script/task_manager.rs
+++ b/components/script/task_manager.rs
@@ -141,7 +141,6 @@ impl TaskManager {
     task_source_functions!(self, dom_manipulation_task_source, DOMManipulation);
     task_source_functions!(self, file_reading_task_source, FileReading);
     task_source_functions!(self, font_loading_task_source, FontLoading);
-    #[cfg(feature = "gamepad")]
     task_source_functions!(self, gamepad_task_source, Gamepad);
     // FIXME(arihant2math): uncomment when geolocation is implemented.
     // task_source_functions!(self, geolocation_task_source, Geolocation);

--- a/components/script/task_manager.rs
+++ b/components/script/task_manager.rs
@@ -141,6 +141,7 @@ impl TaskManager {
     task_source_functions!(self, dom_manipulation_task_source, DOMManipulation);
     task_source_functions!(self, file_reading_task_source, FileReading);
     task_source_functions!(self, font_loading_task_source, FontLoading);
+    #[cfg(feature = "gamepad")]
     task_source_functions!(self, gamepad_task_source, Gamepad);
     // FIXME(arihant2math): uncomment when geolocation is implemented.
     // task_source_functions!(self, geolocation_task_source, Geolocation);


### PR DESCRIPTION
- Add #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)] to DataView and propagate through DataBlock and ActiveBufferMapping.
- Wrap ActiveBufferMapping in RootedTraceableBox
- Also fixes unused_import and feature gates for Testing

Testing: successful build --use-crown, fmt, test-tidy, clippy
Fixes: #44645

Signed-off-by: Noah Delpit <176803893+nodelpit@users.noreply.github.com>