### PR TITLE
script: Use correct slotchange event type for inline event handler.

### DIFF
--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -542,7 +542,7 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
     }
 
     // https://dom.spec.whatwg.org/#dom-shadowroot-onslotchange
-    event_handler!(onslotchange, GetOnslotchange, SetOnslotchange);
+    event_handler!(slotchange, GetOnslotchange, SetOnslotchange);
 
     /// <https://drafts.csswg.org/cssom/#dom-documentorshadowroot-adoptedstylesheets>
     fn AdoptedStyleSheets(&self, context: JSContext, can_gc: CanGc, retval: MutableHandleValue) {

--- a/components/script/script_mutation_observers.rs
+++ b/components/script/script_mutation_observers.rs
@@ -80,7 +80,7 @@ impl ScriptMutationObservers {
         // with its bubbles attribute set to true, at slot.
         for slot in signal_set {
             slot.upcast::<EventTarget>()
-                .fire_event(cx, atom!("slotchange"));
+                .fire_bubbling_event(cx, atom!("slotchange"));
         }
     }
 

--- a/tests/wpt/meta/shadow-dom/imperative-slot-api-slotchange.html.ini
+++ b/tests/wpt/meta/shadow-dom/imperative-slot-api-slotchange.html.ini
@@ -1,4 +1,0 @@
-[imperative-slot-api-slotchange.html]
-  expected: TIMEOUT
-  [Fire slotchange event when assign node to nested slot, ensure event bubbles ups.]
-    expected: TIMEOUT

--- a/tests/wpt/meta/shadow-dom/slotchange-event.html.ini
+++ b/tests/wpt/meta/shadow-dom/slotchange-event.html.ini
@@ -1,16 +1,4 @@
 [slotchange-event.html]
-  [slotchange event must fire on a slot element inside an open shadow root  in a document when nested slots's contents change]
-    expected: FAIL
-
-  [slotchange event must fire on a slot element inside a closed shadow root  in a document when nested slots's contents change]
-    expected: FAIL
-
-  [slotchange event must fire on a slot element inside an open shadow root  not in a document when nested slots's contents change]
-    expected: FAIL
-
-  [slotchange event must fire on a slot element inside a closed shadow root  not in a document when nested slots's contents change]
-    expected: FAIL
-
   [slotchange event must fire at the end of current microtask after mutation observers are invoked inside an open shadow root  in a document when slots's contents change]
     expected: FAIL
 

--- a/tests/wpt/tests/shadow-dom/slotchange.html
+++ b/tests/wpt/tests/shadow-dom/slotchange.html
@@ -43,6 +43,21 @@ async_test((test) => {
   let d1 = document.createElement('div');
   d1.setAttribute('slot', 'slot1');
 
+  n.host1.shadowRoot.onslotchange = test.step_func(() => {
+    arraysEqual(n.s1.assignedNodes(), [n.c1, d1]);
+    test.done()
+  });
+
+  n.host1.appendChild(d1);
+}, 'slotchange event: Append a child to a host (onslotchange).');
+
+async_test((test) => {
+  let n = createTestTree(test1);
+  removeWhiteSpaceOnlyTextNodes(n.test1);
+
+  let d1 = document.createElement('div');
+  d1.setAttribute('slot', 'slot1');
+
   doneIfSlotChange([n.s1], [[n.c1, d1]], test);
 
   n.host1.appendChild(d1);


### PR DESCRIPTION
The ShadowRoot.onslotchange handler was defined incorrectly, and writing a test for it exposed that our slotchange events were not bubbling as they should.

Testing: New test added for onslotchange handler, and new passing tests for bubbling.