### PR TITLE
Upgrade Stylo to 2026-05-01

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1657,9 +1657,9 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
+checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
 dependencies = [
  "cssparser-macros",
  "dtoa-short",
@@ -1671,9 +1671,9 @@ dependencies = [
 
 [[package]]
 name = "cssparser-macros"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
 dependencies = [
  "quote",
  "syn",
@@ -7311,8 +7311,8 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.37.0"
-source = "git+https://github.com/servo/stylo?rev=40aa59d7f3b2bce517c480c95a80d639843e1449#40aa59d7f3b2bce517c480c95a80d639843e1449"
+version = "0.38.0"
+source = "git+https://github.com/servo/stylo?rev=572ecba2d1600e7c3d490586692a209faf703baa#572ecba2d1600e7c3d490586692a209faf703baa"
 dependencies = [
  "bitflags 2.11.1",
  "cssparser",
@@ -9018,7 +9018,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=40aa59d7f3b2bce517c480c95a80d639843e1449#40aa59d7f3b2bce517c480c95a80d639843e1449"
+source = "git+https://github.com/servo/stylo?rev=572ecba2d1600e7c3d490586692a209faf703baa#572ecba2d1600e7c3d490586692a209faf703baa"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -9444,8 +9444,8 @@ dependencies = [
 
 [[package]]
 name = "stylo"
-version = "0.16.0"
-source = "git+https://github.com/servo/stylo?rev=40aa59d7f3b2bce517c480c95a80d639843e1449#40aa59d7f3b2bce517c480c95a80d639843e1449"
+version = "0.17.0"
+source = "git+https://github.com/servo/stylo?rev=572ecba2d1600e7c3d490586692a209faf703baa#572ecba2d1600e7c3d490586692a209faf703baa"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -9500,8 +9500,8 @@ dependencies = [
 
 [[package]]
 name = "stylo_atoms"
-version = "0.16.0"
-source = "git+https://github.com/servo/stylo?rev=40aa59d7f3b2bce517c480c95a80d639843e1449#40aa59d7f3b2bce517c480c95a80d639843e1449"
+version = "0.17.0"
+source = "git+https://github.com/servo/stylo?rev=572ecba2d1600e7c3d490586692a209faf703baa#572ecba2d1600e7c3d490586692a209faf703baa"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -9509,8 +9509,8 @@ dependencies = [
 
 [[package]]
 name = "stylo_derive"
-version = "0.16.0"
-source = "git+https://github.com/servo/stylo?rev=40aa59d7f3b2bce517c480c95a80d639843e1449#40aa59d7f3b2bce517c480c95a80d639843e1449"
+version = "0.17.0"
+source = "git+https://github.com/servo/stylo?rev=572ecba2d1600e7c3d490586692a209faf703baa#572ecba2d1600e7c3d490586692a209faf703baa"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -9521,8 +9521,8 @@ dependencies = [
 
 [[package]]
 name = "stylo_dom"
-version = "0.16.0"
-source = "git+https://github.com/servo/stylo?rev=40aa59d7f3b2bce517c480c95a80d639843e1449#40aa59d7f3b2bce517c480c95a80d639843e1449"
+version = "0.17.0"
+source = "git+https://github.com/servo/stylo?rev=572ecba2d1600e7c3d490586692a209faf703baa#572ecba2d1600e7c3d490586692a209faf703baa"
 dependencies = [
  "bitflags 2.11.1",
  "stylo_malloc_size_of",
@@ -9530,8 +9530,8 @@ dependencies = [
 
 [[package]]
 name = "stylo_malloc_size_of"
-version = "0.16.0"
-source = "git+https://github.com/servo/stylo?rev=40aa59d7f3b2bce517c480c95a80d639843e1449#40aa59d7f3b2bce517c480c95a80d639843e1449"
+version = "0.17.0"
+source = "git+https://github.com/servo/stylo?rev=572ecba2d1600e7c3d490586692a209faf703baa#572ecba2d1600e7c3d490586692a209faf703baa"
 dependencies = [
  "app_units",
  "cssparser",
@@ -9547,13 +9547,13 @@ dependencies = [
 
 [[package]]
 name = "stylo_static_prefs"
-version = "0.16.0"
-source = "git+https://github.com/servo/stylo?rev=40aa59d7f3b2bce517c480c95a80d639843e1449#40aa59d7f3b2bce517c480c95a80d639843e1449"
+version = "0.17.0"
+source = "git+https://github.com/servo/stylo?rev=572ecba2d1600e7c3d490586692a209faf703baa#572ecba2d1600e7c3d490586692a209faf703baa"
 
 [[package]]
 name = "stylo_traits"
-version = "0.16.0"
-source = "git+https://github.com/servo/stylo?rev=40aa59d7f3b2bce517c480c95a80d639843e1449#40aa59d7f3b2bce517c480c95a80d639843e1449"
+version = "0.17.0"
+source = "git+https://github.com/servo/stylo?rev=572ecba2d1600e7c3d490586692a209faf703baa#572ecba2d1600e7c3d490586692a209faf703baa"
 dependencies = [
  "app_units",
  "bitflags 2.11.1",
@@ -9974,8 +9974,8 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "to_shmem"
-version = "0.3.0"
-source = "git+https://github.com/servo/stylo?rev=40aa59d7f3b2bce517c480c95a80d639843e1449#40aa59d7f3b2bce517c480c95a80d639843e1449"
+version = "0.4.0"
+source = "git+https://github.com/servo/stylo?rev=572ecba2d1600e7c3d490586692a209faf703baa#572ecba2d1600e7c3d490586692a209faf703baa"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -9988,7 +9988,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=40aa59d7f3b2bce517c480c95a80d639843e1449#40aa59d7f3b2bce517c480c95a80d639843e1449"
+source = "git+https://github.com/servo/stylo?rev=572ecba2d1600e7c3d490586692a209faf703baa#572ecba2d1600e7c3d490586692a209faf703baa"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ cipher = { version = "0.4.4", features = ["alloc"] }
 content-security-policy = { version = "0.8.0", features = ["serde"] }
 cookie = { package = "cookie", version = "0.18" }
 crossbeam-channel = "0.5"
-cssparser = { version = "0.36", features = ["serde"] }
+cssparser = { version = "0.37", features = ["serde"] }
 ctr = "0.9.2"
 data-url = "0.3"
 der = { version = "0.7", features = ["alloc", "derive"] }
@@ -166,12 +166,12 @@ rustls-platform-verifier = "0.7.0"
 sea-query = { version = "=1.0.0-rc.31", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = { version = "=0.8.0-rc.15" }
 sec1 = "0.7"
-selectors = { git = "https://github.com/servo/stylo", rev = "40aa59d7f3b2bce517c480c95a80d639843e1449" }
+selectors = { git = "https://github.com/servo/stylo", rev = "572ecba2d1600e7c3d490586692a209faf703baa" }
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
 serde_json = "1.0"
-servo_arc = { git = "https://github.com/servo/stylo", rev = "40aa59d7f3b2bce517c480c95a80d639843e1449" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "572ecba2d1600e7c3d490586692a209faf703baa" }
 sha1 = "0.10"
 sha2 = "0.10"
 sha3 = "0.10"
@@ -180,12 +180,12 @@ skrifa = "0.37.0"
 smallvec = { version = "1.15", features = ["serde", "union"] }
 string_cache = "0.9"
 strum = { version = "0.28", features = ["derive"] }
-stylo = { git = "https://github.com/servo/stylo", rev = "40aa59d7f3b2bce517c480c95a80d639843e1449" }
-stylo_atoms = { git = "https://github.com/servo/stylo", rev = "40aa59d7f3b2bce517c480c95a80d639843e1449" }
-stylo_dom = { git = "https://github.com/servo/stylo", rev = "40aa59d7f3b2bce517c480c95a80d639843e1449" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "40aa59d7f3b2bce517c480c95a80d639843e1449" }
-stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "40aa59d7f3b2bce517c480c95a80d639843e1449" }
-stylo_traits = { git = "https://github.com/servo/stylo", rev = "40aa59d7f3b2bce517c480c95a80d639843e1449" }
+stylo = { git = "https://github.com/servo/stylo", rev = "572ecba2d1600e7c3d490586692a209faf703baa" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "572ecba2d1600e7c3d490586692a209faf703baa" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "572ecba2d1600e7c3d490586692a209faf703baa" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "572ecba2d1600e7c3d490586692a209faf703baa" }
+stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "572ecba2d1600e7c3d490586692a209faf703baa" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "572ecba2d1600e7c3d490586692a209faf703baa" }
 surfman = { version = "0.12.0", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -553,7 +553,7 @@ fn shorthand_to_css_string(
                 longhand,
                 Some(&mut Context {
                     style,
-                    for_property: longhand.into(),
+                    for_property: PropertyId::NonCustom(longhand.into()),
                     current_longhand: None,
                 }),
             ),

--- a/components/script/css.rs
+++ b/components/script/css.rs
@@ -33,6 +33,7 @@ pub(crate) fn parser_context_for_document<'a>(
         /* namespaces = */ Default::default(),
         Some(error_reporter),
         None,
+        /* attr_taint = */ Default::default(),
     )
 }
 
@@ -55,6 +56,7 @@ pub(crate) fn parser_context_for_document_with_reporter<'a>(
         /* namespaces = */ Default::default(),
         Some(error_reporter),
         None,
+        /* attr_taint = */ Default::default(),
     )
 }
 
@@ -74,5 +76,6 @@ pub(crate) fn parser_context_for_anonymous_content<'a>(
         /* namespaces = */ Default::default(),
         None,
         None,
+        /* attr_taint = */ Default::default(),
     )
 }

--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -2608,33 +2608,30 @@ pub(super) fn parse_color(
     let url = Url::parse("about:blank").unwrap().into();
     let context =
         parser_context_for_anonymous_content(CssRuleType::Style, ParsingMode::DEFAULT, &url);
-    match Color::parse_and_compute(&context, &mut parser, None) {
-        Some(color) => {
-            // TODO: https://github.com/whatwg/html/issues/1099
-            // Reconsider how to calculate currentColor in a display:none canvas
+    Color::parse_and_compute(&context, &mut parser, None).map(|color| {
+        // TODO: https://github.com/whatwg/html/issues/1099
+        // Reconsider how to calculate currentColor in a display:none canvas
 
-            // TODO: will need to check that the context bitmap mode is fixed
-            // once we implement CanvasProxy
-            let current_color = match canvas {
-                // https://drafts.css-houdini.org/css-paint-api/#2d-rendering-context
-                // Whenever "currentColor" is used as a color in the PaintRenderingContext2D API,
-                // it is treated as opaque black.
-                None => AbsoluteColor::BLACK,
-                Some(canvas) => {
-                    let canvas_element = canvas.upcast::<Element>();
-                    match canvas_element.style() {
-                        Some(ref s) if canvas_element.has_css_layout_box() => {
-                            s.get_inherited_text().color
-                        },
-                        _ => AbsoluteColor::BLACK,
-                    }
-                },
-            };
+        // TODO: will need to check that the context bitmap mode is fixed
+        // once we implement CanvasProxy
+        let current_color = match canvas {
+            // https://drafts.css-houdini.org/css-paint-api/#2d-rendering-context
+            // Whenever "currentColor" is used as a color in the PaintRenderingContext2D API,
+            // it is treated as opaque black.
+            None => AbsoluteColor::BLACK,
+            Some(canvas) => {
+                let canvas_element = canvas.upcast::<Element>();
+                match canvas_element.style() {
+                    Some(ref s) if canvas_element.has_css_layout_box() => {
+                        s.get_inherited_text().color
+                    },
+                    _ => AbsoluteColor::BLACK,
+                }
+            },
+        };
 
-            Ok(color.resolve_to_absolute(&current_color))
-        },
-        None => Err(()),
-    }
+        color.resolve_to_absolute(&current_color)
+    })
 }
 
 // Used by drawImage to determine if a source or destination rectangle is valid

--- a/components/script/dom/css/csskeyframesrule.rs
+++ b/components/script/dom/css/csskeyframesrule.rs
@@ -9,7 +9,7 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use servo_arc::Arc;
 use style::shared_lock::{Locked, SharedRwLockReadGuard, ToCssWithGuard};
-use style::stylesheets::keyframes_rule::{Keyframe, KeyframeSelector, KeyframesRule};
+use style::stylesheets::keyframes_rule::{Keyframe, KeyframeSelectors, KeyframesRule};
 use style::stylesheets::{CssRuleType, StylesheetInDocument};
 use style::values::KeyframesName;
 
@@ -79,7 +79,7 @@ impl CSSKeyframesRule {
         let selector = selector.str();
         let mut input = ParserInput::new(&selector);
         let mut input = Parser::new(&mut input);
-        if let Ok(sel) = KeyframeSelector::parse(&mut input) {
+        if let Ok(sel) = KeyframeSelectors::parse(&mut input) {
             let guard = self.css_rule.shared_lock().read();
             // This finds the *last* element matching a selector
             // because that's the rule that applies. Thus, rposition

--- a/components/script/dom/html/input_element/color_input_type.rs
+++ b/components/script/dom/html/input_element/color_input_type.rs
@@ -12,15 +12,14 @@ use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::HTMLInputElementBinding::HTMLInputElementMethods;
 use script_bindings::root::{Dom, DomRoot};
 use script_bindings::script_runtime::CanGc;
-use selectors::context::QuirksMode;
 use style::color::{AbsoluteColor, ColorFlags, ColorSpace};
-use style::parser::ParserContext;
 use style::selector_parser::PseudoElement;
-use style::stylesheets::{CssRuleType, Origin};
+use style::stylesheets::CssRuleType;
 use style::values::specified::Color;
 use style_traits::{ParsingMode, ToCss};
 use url::Url;
 
+use crate::css::parser_context_for_anonymous_content;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::str::{DOMString, FromInputValueString};
 use crate::dom::document_embedder_controls::ControlElement;
@@ -269,15 +268,10 @@ fn parse_color_value(value: &str, url: Url) -> AbsoluteColor {
     // TODO: Use a dummy url here, like gecko
     // https://searchfox.org/firefox-main/rev/3eaf7e2acf8186eb7aa579561eaa1312cb89132b/servo/ports/geckolib/glue.rs#8931
     let urlextradata = url.into();
-    let context = ParserContext::new(
-        Origin::Author,
-        &urlextradata,
-        Some(CssRuleType::Style),
+    let context = parser_context_for_anonymous_content(
+        CssRuleType::Style,
         ParsingMode::DEFAULT,
-        QuirksMode::NoQuirks,
-        Default::default(),
-        None,
-        None,
+        &urlextradata,
     );
     let mut input = ParserInput::new(value);
     let mut input = Parser::new(&mut input);

--- a/components/script/dom/media/medialist.rs
+++ b/components/script/dom/media/medialist.rs
@@ -129,6 +129,7 @@ impl MediaList {
             /* namespaces = */ Default::default(),
             None,
             None,
+            /* attr_taint = */ Default::default(),
         );
         let mut parser_input = ParserInput::new(media_query);
         let mut parser = Parser::new(&mut parser_input);

--- a/components/script/dom/svg/svgsvgelement.rs
+++ b/components/script/dom/svg/svgsvgelement.rs
@@ -234,6 +234,7 @@ impl VirtualMethods for SVGSVGElement {
                     /* namespaces = */ Default::default(),
                     None,
                     None,
+                    /* attr_taint = */ Default::default(),
                 );
                 let val = LengthPercentage::parse_quirky(
                     &context,

--- a/tests/unit/style/parsing/mod.rs
+++ b/tests/unit/style/parsing/mod.rs
@@ -33,6 +33,7 @@ where
         /* namespaces = */ Default::default(),
         None,
         None,
+        /* attr_taint = */ Default::default(),
     );
     let mut parser = Parser::new(input);
     f(&context, &mut parser)

--- a/tests/wpt/meta/css/css-values/attr-security.html.ini
+++ b/tests/wpt/meta/css/css-values/attr-security.html.ini
@@ -46,9 +46,3 @@
 
   ['--x: image-set(if(style(--condition-val >= attr(data-foo type(*))): url(https://does-not-exist.test/404.png);))' with data-foo="3"]
     expected: FAIL
-
-  ['background-image: attr(data-foo type(<url>))' with data-foo="url(https://does-not-exist.test/404.png)"]
-    expected: FAIL
-
-  ['background-image: attr(data-foo type(*))' with data-foo="url(https://does-not-exist.test/404.png), linear-gradient(black, white)"]
-    expected: FAIL


### PR DESCRIPTION
This continues  #43878

Changelog:
 - Upstream: https://github.com/servo/stylo/compare/6de1071549fe7585b8c4e1f756c1a4db76a9a149...9c7ce11bea5ea6f3a816095fe93fbc57b5829d4a
 - Servo fixups: https://github.com/servo/stylo/compare/610b0216f9923493f2564349d2f58ea0eee57998...572ecba2d1600e7c3d490586692a209faf703baa

Stylo tracking issue: https://github.com/servo/stylo/issues/359

Summary of improvements:
 - Add [`attr()` tainting](https://drafts.csswg.org/css-values-5/#attr-taint).
 - Color comparison now matches CSSWG resolutions. We don't pass tests for this because we don't support `style()` queries, but presumably this should be observable via transitions.
 - Optimization: if only non-inherited custom properties change, the cascade can be stopped (if children don't explicitly inherit). We still lack this optimization for standard properties.

Testing: One test improves