### PR TITLE
Add support for the focus-within selector

### DIFF
--- a/components/script/dom/document/focus.rs
+++ b/components/script/dom/document/focus.rs
@@ -11,6 +11,7 @@ use js::context::JSContext;
 use keyboard_types::Modifiers;
 use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::HTMLIFrameElementBinding::HTMLIFrameElementMethods;
+use script_bindings::codegen::GenericBindings::NodeBinding::NodeMethods;
 use script_bindings::codegen::GenericBindings::ShadowRootBinding::ShadowRootMethods;
 use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
 use script_bindings::inheritance::Castable;
@@ -203,7 +204,22 @@ impl DocumentFocusHandler {
         fn recursively_set_focus_status(element: &Element, new_state: bool) {
             element.set_focus_state(new_state);
 
+            // From https://drafts.csswg.org/selectors/#the-focus-within-pseudo:
+            // The :focus-within pseudo-class applies to any element (or pseudo-element)
+            // for which the :focus pseudo-class applies...
+            element.set_focus_within_state(new_state);
+
             let Some(shadow_root) = element.containing_shadow_root() else {
+                // ...as well as to an element (or pseudo-element)
+                // whose descendant in the flat tree
+                // (including non-element nodes, such as text nodes)
+                // matches the conditions for matching :focus.
+                let node = element.upcast::<Node>();
+                if let Some(ref parent) = node.GetParentNode() &&
+                    let Some(parent) = parent.downcast::<Element>()
+                {
+                    parent.set_focus_within_state(new_state);
+                }
                 return;
             };
             recursively_set_focus_status(&shadow_root.Host(), new_state);

--- a/components/script/dom/document/focus.rs
+++ b/components/script/dom/document/focus.rs
@@ -398,8 +398,8 @@ impl DocumentFocusHandler {
             // because of the popping we do at the start of these steps.
             let related_blur_target = match new_focus_chain.last() {
                 Some(FocusableArea::Node { node, .. })
-                    if index == last_old_focus_chain_entry
-                        && matches!(entry, FocusableArea::Node { .. }) =>
+                    if index == last_old_focus_chain_entry &&
+                        matches!(entry, FocusableArea::Node { .. }) =>
                 {
                     Some(node.upcast())
                 },
@@ -475,8 +475,8 @@ impl DocumentFocusHandler {
             // because of the popping we do at the start of these steps.
             let related_focus_target = match old_focus_chain.last() {
                 Some(FocusableArea::Node { node, .. })
-                    if index == last_new_focus_chain_entry
-                        && matches!(entry, FocusableArea::Node { .. }) =>
+                    if index == last_new_focus_chain_entry &&
+                        matches!(entry, FocusableArea::Node { .. }) =>
                 {
                     Some(node.upcast())
                 },

--- a/components/script/dom/document/focus.rs
+++ b/components/script/dom/document/focus.rs
@@ -215,10 +215,10 @@ impl DocumentFocusHandler {
                 // (including non-element nodes, such as text nodes)
                 // matches the conditions for matching :focus.
                 let node = element.upcast::<Node>();
-                if let Some(ref parent) = node.GetParentNode() &&
-                    let Some(parent) = parent.downcast::<Element>()
-                {
-                    parent.set_focus_within_state(new_state);
+                for ancestor in node.inclusive_ancestors_in_flat_tree() {
+                    if let Some(ancestor_el) = ancestor.downcast::<Element>() {
+                        ancestor_el.set_focus_within_state(new_state);
+                    }
                 }
                 return;
             };
@@ -398,8 +398,8 @@ impl DocumentFocusHandler {
             // because of the popping we do at the start of these steps.
             let related_blur_target = match new_focus_chain.last() {
                 Some(FocusableArea::Node { node, .. })
-                    if index == last_old_focus_chain_entry &&
-                        matches!(entry, FocusableArea::Node { .. }) =>
+                    if index == last_old_focus_chain_entry
+                        && matches!(entry, FocusableArea::Node { .. }) =>
                 {
                     Some(node.upcast())
                 },
@@ -475,8 +475,8 @@ impl DocumentFocusHandler {
             // because of the popping we do at the start of these steps.
             let related_focus_target = match old_focus_chain.last() {
                 Some(FocusableArea::Node { node, .. })
-                    if index == last_new_focus_chain_entry &&
-                        matches!(entry, FocusableArea::Node { .. }) =>
+                    if index == last_new_focus_chain_entry
+                        && matches!(entry, FocusableArea::Node { .. }) =>
                 {
                     Some(node.upcast())
                 },

--- a/components/script/dom/document/focus.rs
+++ b/components/script/dom/document/focus.rs
@@ -28,7 +28,10 @@ use crate::dom::node::focus::FocusNavigationScopeOwner;
 use crate::dom::types::{
     Element, EventTarget, FocusEvent, HTMLElement, HTMLIFrameElement, KeyboardEvent, Window,
 };
-use crate::dom::{Document, Event, EventBubbles, EventCancelable, Node, NodeTraits};
+use crate::dom::{
+    Document, Event, EventBubbles, EventCancelable, Node, NodeTraits, ShadowIncluding,
+    UnbindContext,
+};
 use crate::realms::enter_realm;
 
 /// The kind of focusable area a [`FocusableArea`] is. A [`FocusableArea`] may be click focusable,
@@ -181,6 +184,55 @@ impl DocumentFocusHandler {
         self.focused_area.borrow()
     }
 
+    // From <https://html.spec.whatwg.org/multipage/#selector-focus>
+    // > For the purposes of the CSS :focus pseudo-class, an element has the focus when:
+    // >  - it is not itself a navigable container; and
+    // >  - any of the following are true:
+    // >    - it is one of the elements listed in the current focus chain of the top-level
+    // >      traversable; or
+    // >    - its shadow root shadowRoot is not null and shadowRoot is the root of at least one
+    // >      element that has the focus.
+    //
+    // We are trying to accomplish the last requirement here, by walking up the tree and
+    // marking each shadow host as focused.
+    fn recursively_set_focus_status(element: &Element, new_state: bool) {
+        element.set_focus_state(new_state);
+
+        // From https://drafts.csswg.org/selectors/#the-focus-within-pseudo:
+        // The :focus-within pseudo-class applies to any element (or pseudo-element)
+        // for which the :focus pseudo-class applies...
+        element.set_focus_within_state(new_state);
+
+        let Some(shadow_root) = element.containing_shadow_root() else {
+            // ...as well as to an element (or pseudo-element)
+            // whose descendant in the flat tree
+            // (including non-element nodes, such as text nodes)
+            // matches the conditions for matching :focus.
+            let node = element.upcast::<Node>();
+            for ancestor in node.inclusive_ancestors_in_flat_tree() {
+                if let Some(ancestor_el) = ancestor.downcast::<Element>() {
+                    ancestor_el.set_focus_within_state(new_state);
+                }
+            }
+            return;
+        };
+        Self::recursively_set_focus_status(&shadow_root.Host(), new_state);
+    }
+
+    pub(crate) fn handle_focused_element_unbound(&self, context: &UnbindContext) {
+        let focused_area = self.focused_area.borrow();
+        let Some(focused_element) = focused_area.element() else {
+            return;
+        };
+
+        Self::recursively_set_focus_status(focused_element, false);
+        for ancestor in context.parent.inclusive_ancestors_in_flat_tree() {
+            if let Some(ancestor_el) = ancestor.downcast::<Element>() {
+                ancestor_el.set_focus_within_state(false);
+            }
+        }
+    }
+
     /// Set the element that currently has focus and update the focus state for both the previously
     /// set element (if any) and the new one, as well as the new one. This will not do anything if
     /// the new element is the same as the previous one. Note that this *will not* fire any focus
@@ -190,46 +242,11 @@ impl DocumentFocusHandler {
             return;
         }
 
-        // From <https://html.spec.whatwg.org/multipage/#selector-focus>
-        // > For the purposes of the CSS :focus pseudo-class, an element has the focus when:
-        // >  - it is not itself a navigable container; and
-        // >  - any of the following are true:
-        // >    - it is one of the elements listed in the current focus chain of the top-level
-        // >      traversable; or
-        // >    - its shadow root shadowRoot is not null and shadowRoot is the root of at least one
-        // >      element that has the focus.
-        //
-        // We are trying to accomplish the last requirement here, by walking up the tree and
-        // marking each shadow host as focused.
-        fn recursively_set_focus_status(element: &Element, new_state: bool) {
-            element.set_focus_state(new_state);
-
-            // From https://drafts.csswg.org/selectors/#the-focus-within-pseudo:
-            // The :focus-within pseudo-class applies to any element (or pseudo-element)
-            // for which the :focus pseudo-class applies...
-            element.set_focus_within_state(new_state);
-
-            let Some(shadow_root) = element.containing_shadow_root() else {
-                // ...as well as to an element (or pseudo-element)
-                // whose descendant in the flat tree
-                // (including non-element nodes, such as text nodes)
-                // matches the conditions for matching :focus.
-                let node = element.upcast::<Node>();
-                for ancestor in node.inclusive_ancestors_in_flat_tree() {
-                    if let Some(ancestor_el) = ancestor.downcast::<Element>() {
-                        ancestor_el.set_focus_within_state(new_state);
-                    }
-                }
-                return;
-            };
-            recursively_set_focus_status(&shadow_root.Host(), new_state);
-        }
-
         if let Some(previously_focused_element) = self.focused_area.borrow().element() {
-            recursively_set_focus_status(previously_focused_element, false);
+            Self::recursively_set_focus_status(previously_focused_element, false);
         }
         if let Some(newly_focused_element) = new_focusable_area.element() {
-            recursively_set_focus_status(newly_focused_element, true);
+            Self::recursively_set_focus_status(newly_focused_element, true);
         }
 
         *self.focused_area.borrow_mut() = new_focusable_area;

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -4576,7 +4576,6 @@ impl VirtualMethods for Element {
         }
 
         let doc = self.owner_document();
-
         let fullscreen = doc.fullscreen_element();
         if fullscreen.as_deref() == Some(self) {
             doc.exit_fullscreen(CanGc::from_cx(cx));

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -4892,6 +4892,10 @@ impl Element {
         self.set_state(ElementState::FOCUS, value);
     }
 
+    pub(crate) fn set_focus_within_state(&self, value: bool) {
+        self.set_state(ElementState::FOCUS_WITHIN, value);
+    }
+
     pub(crate) fn set_hover_state(&self, value: bool) {
         self.set_state(ElementState::HOVER, value);
     }

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -1345,6 +1345,9 @@ impl VirtualMethods for HTMLElement {
         {
             document
                 .focus_handler()
+                .handle_focused_element_unbound(context);
+            document
+                .focus_handler()
                 .set_focused_area(FocusableArea::Viewport);
         }
 

--- a/tests/wpt/meta/css/css-conditional/container-queries/canvas-as-container-001.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/canvas-as-container-001.html.ini
@@ -1,2 +1,0 @@
-[canvas-as-container-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/container-queries/canvas-as-container-002.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/canvas-as-container-002.html.ini
@@ -1,2 +1,0 @@
-[canvas-as-container-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-display/display-contents-state-change-001.html.ini
+++ b/tests/wpt/meta/css/css-display/display-contents-state-change-001.html.ini
@@ -1,2 +1,0 @@
-[display-contents-state-change-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/selectors/focus-in-focus-event-001.html.ini
+++ b/tests/wpt/meta/css/selectors/focus-in-focus-event-001.html.ini
@@ -1,7 +1,3 @@
 [focus-in-focus-event-001.html]
   [Checks that ':focus-visible' pseudo-class matches inside 'focus' event handler]
     expected: FAIL
-
-  [Checks that ':focus-within' pseudo-class matches inside 'focus' event handler]
-    expected: FAIL
-

--- a/tests/wpt/meta/css/selectors/focus-within-001.html.ini
+++ b/tests/wpt/meta/css/selectors/focus-within-001.html.ini
@@ -1,2 +1,0 @@
-[focus-within-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/selectors/focus-within-002.html.ini
+++ b/tests/wpt/meta/css/selectors/focus-within-002.html.ini
@@ -1,2 +1,0 @@
-[focus-within-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/selectors/focus-within-003.html.ini
+++ b/tests/wpt/meta/css/selectors/focus-within-003.html.ini
@@ -1,2 +1,0 @@
-[focus-within-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/selectors/focus-within-004.html.ini
+++ b/tests/wpt/meta/css/selectors/focus-within-004.html.ini
@@ -1,2 +1,0 @@
-[focus-within-004.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/selectors/focus-within-005.html.ini
+++ b/tests/wpt/meta/css/selectors/focus-within-005.html.ini
@@ -1,2 +1,0 @@
-[focus-within-005.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/selectors/focus-within-006.html.ini
+++ b/tests/wpt/meta/css/selectors/focus-within-006.html.ini
@@ -1,2 +1,0 @@
-[focus-within-006.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/selectors/focus-within-007.html.ini
+++ b/tests/wpt/meta/css/selectors/focus-within-007.html.ini
@@ -1,2 +1,0 @@
-[focus-within-007.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/selectors/focus-within-008.html.ini
+++ b/tests/wpt/meta/css/selectors/focus-within-008.html.ini
@@ -1,2 +1,0 @@
-[focus-within-008.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/selectors/focus-within-009.html.ini
+++ b/tests/wpt/meta/css/selectors/focus-within-009.html.ini
@@ -1,24 +1,9 @@
 [focus-within-009.html]
-  [Focus 'target1']
+  [Detach 'container1' from the document]
     expected: FAIL
 
-  [Focus 'target2']
+  [Try to focus 'target1']
     expected: FAIL
 
-  [Focus 'target1' again]
-    expected: FAIL
-
-  [Focus 'target2' again]
-    expected: FAIL
-
-  [Focus 'target1' once again]
-    expected: FAIL
-
-  [Focus 'target2' once again]
-    expected: FAIL
-
-  [Attach 'container1' in 'container2']
-    expected: FAIL
-
-  [Focus 'target1' for the last time]
+  [Move 'target1' in 'container2']
     expected: FAIL

--- a/tests/wpt/meta/css/selectors/focus-within-009.html.ini
+++ b/tests/wpt/meta/css/selectors/focus-within-009.html.ini
@@ -1,9 +1,0 @@
-[focus-within-009.html]
-  [Detach 'container1' from the document]
-    expected: FAIL
-
-  [Try to focus 'target1']
-    expected: FAIL
-
-  [Move 'target1' in 'container2']
-    expected: FAIL

--- a/tests/wpt/meta/css/selectors/focus-within-010.html.ini
+++ b/tests/wpt/meta/css/selectors/focus-within-010.html.ini
@@ -1,2 +1,0 @@
-[focus-within-010.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/selectors/focus-within-011.html.ini
+++ b/tests/wpt/meta/css/selectors/focus-within-011.html.ini
@@ -1,2 +1,0 @@
-[focus-within-011.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/selectors/focus-within-012.html.ini
+++ b/tests/wpt/meta/css/selectors/focus-within-012.html.ini
@@ -1,0 +1,2 @@
+[focus-within-012.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/selectors/focus-within-012.html.ini
+++ b/tests/wpt/meta/css/selectors/focus-within-012.html.ini
@@ -1,2 +1,0 @@
-[focus-within-012.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/selectors/focus-within-display-none-001.html.ini
+++ b/tests/wpt/meta/css/selectors/focus-within-display-none-001.html.ini
@@ -1,6 +1,0 @@
-[focus-within-display-none-001.html]
-  [Test ':focus-within' after 'display:none' on input]
-    expected: FAIL
-
-  [Test ':focus-within' after 'display:none' on input's parent]
-    expected: FAIL

--- a/tests/wpt/meta/css/selectors/focus-within-shadow-001.html.ini
+++ b/tests/wpt/meta/css/selectors/focus-within-shadow-001.html.ini
@@ -1,2 +1,0 @@
-[focus-within-shadow-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/selectors/focus-within-shadow-002.html.ini
+++ b/tests/wpt/meta/css/selectors/focus-within-shadow-002.html.ini
@@ -1,2 +1,0 @@
-[focus-within-shadow-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/selectors/focus-within-shadow-003.html.ini
+++ b/tests/wpt/meta/css/selectors/focus-within-shadow-003.html.ini
@@ -1,2 +1,0 @@
-[focus-within-shadow-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/selectors/focus-within-shadow-004.html.ini
+++ b/tests/wpt/meta/css/selectors/focus-within-shadow-004.html.ini
@@ -1,2 +1,0 @@
-[focus-within-shadow-004.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/selectors/focus-within-shadow-005.html.ini
+++ b/tests/wpt/meta/css/selectors/focus-within-shadow-005.html.ini
@@ -1,2 +1,0 @@
-[focus-within-shadow-005.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/selectors/focus-within-shadow-006.html.ini
+++ b/tests/wpt/meta/css/selectors/focus-within-shadow-006.html.ini
@@ -1,2 +1,0 @@
-[focus-within-shadow-006.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/selectors/user-action-pseudo-top-layer.html.ini
+++ b/tests/wpt/meta/css/selectors/user-action-pseudo-top-layer.html.ini
@@ -2,9 +2,6 @@
   [User action pseudo-classes on dialog (modal)]
     expected: FAIL
 
-  [User action pseudo-classes on dialog (non-modal)]
-    expected: FAIL
-
   [User action pseudo-classes on popover (popover)]
     expected: FAIL
 

--- a/tests/wpt/meta/dom/nodes/moveBefore/focus-within.html.ini
+++ b/tests/wpt/meta/dom/nodes/moveBefore/focus-within.html.ini
@@ -5,9 +5,6 @@
   [focus-within should be updated when reparenting an element that has focus within]
     expected: FAIL
 
-  [focus-within should remain the same when moving to the same parent]
-    expected: FAIL
-
   [:focus-within should be eventually up to date when moving to an inert subtree]
     expected: FAIL
 


### PR DESCRIPTION
Add support for the `:focus-within` selector by updating the `ElementState::FOCUS_WITHIN` flag for focused elements as well as any ancestors.

Testing: This produces several new passing WPTs, as shown in [this passing WPT run](https://github.com/reesmichael1/servo/actions/runs/25252917474). Some `focus-within` related ones still fail because of larger holes related to focus, which I thought seemed outside of the scope of this PR to fix.
Fixes: #44500 
