### PR TITLE
script: Enable Sanitizer API as experimental feature

### DIFF
--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -40,6 +40,7 @@ pub(crate) static EXPERIMENTAL_PREFS: &[&str] = &[
     "dom_notification_enabled",
     "dom_offscreen_canvas_enabled",
     "dom_permissions_enabled",
+    "dom_sanitizer_enabled",
     "dom_storage_manager_api_enabled",
     "dom_webgl2_enabled",
     "dom_webgpu_enabled",

--- a/tests/wpt/meta/sanitizer-api/__dir__.ini
+++ b/tests/wpt/meta/sanitizer-api/__dir__.ini
@@ -1,1 +1,0 @@
-prefs: [dom_sanitizer_enabled: true]

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -14419,7 +14419,7 @@
      ]
     ],
     "interfaces.https.html": [
-     "decaa2df2047787dbfc4b83d09ce49b117a7a53c",
+     "cdfa3234b0ffe917c616d890a95a69322224a8c5",
      [
       null,
       {}

--- a/tests/wpt/mozilla/tests/mozilla/interfaces.https.html
+++ b/tests/wpt/mozilla/tests/mozilla/interfaces.https.html
@@ -324,6 +324,7 @@ test_interfaces([
   "ResizeObserverEntry",
   "ResizeObserverSize",
   "Response",
+  "Sanitizer",
   "Screen",
   "SecurityPolicyViolationEvent",
   "Selection",


### PR DESCRIPTION
We already have some progress on implementing the Sanitizer API, with 205/704 WPT subtests passed.

Enable the Sanitizer API as an experimental feature so that it can be tested on wpt.fyi.

Testing: Update `tests/wpt/mozilla/tests/mozilla/interfaces.https.html`