### PR TITLE
config: Improve API for `DiagnosticsLogging` configuration.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7663,6 +7663,7 @@ dependencies = [
  "serde",
  "serde_json",
  "servo-config-macro",
+ "strum",
  "stylo_static_prefs",
 ]
 

--- a/components/config/Cargo.toml
+++ b/components/config/Cargo.toml
@@ -17,4 +17,5 @@ path = "lib.rs"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 servo-config-macro = { workspace = true }
+strum = { workspace = true }
 stylo_static_prefs = { workspace = true }

--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -5,12 +5,16 @@
 //! Options are global configuration options that are initialized once and cannot be changed at
 //! runtime.
 
+use core::str::FromStr;
 use std::default::Default;
 use std::path::PathBuf;
-use std::process;
 use std::sync::OnceLock;
 
 use serde::{Deserialize, Serialize};
+use strum::{
+    AsRefStr, Display as EnumDisplay, EnumCount, EnumIter, EnumMessage, EnumString,
+    IntoEnumIterator,
+};
 
 /// The set of global options supported by Servo. The values for these can be configured during
 /// initialization of Servo and cannot be changed later at runtime.
@@ -81,99 +85,125 @@ pub struct Opts {
     pub unminify_css: bool,
 }
 
-/// Debug options for Servo.
+/// The set of diagnostic options that can be enabled in Servo.
+#[derive(
+    AsRefStr,
+    Copy,
+    Clone,
+    Debug,
+    EnumCount,
+    EnumDisplay,
+    EnumIter,
+    EnumMessage,
+    EnumString,
+    PartialEq,
+)]
+pub enum DiagnosticsLoggingOption {
+    /// Log the DOM after each restyle
+    #[strum(to_string = "style-tree")]
+    StyleTree,
+
+    /// Log the rule tree
+    #[strum(to_string = "rule-tree")]
+    RuleTree,
+
+    /// Log the fragment tree after each layout
+    #[strum(to_string = "flow-tree")]
+    FlowTree,
+
+    /// Log the stacking context tree after each layout
+    #[strum(to_string = "stacking-context-tree")]
+    StackingContextTree,
+
+    /// Log the scroll tree (the hierarchy of scrollable areas) after each layout
+    #[strum(to_string = "scroll-tree")]
+    ScrollTree,
+
+    /// Log the display list after each layout
+    #[strum(to_string = "display-list")]
+    DisplayList,
+
+    /// Log notifications when a relayout occurs
+    #[strum(to_string = "relayout-event")]
+    RelayoutEvent,
+
+    /// Periodically log on which events script threads spend their processing time
+    #[strum(to_string = "profile-script-events")]
+    ProfileScriptEvents,
+
+    /// Log the the hit/miss statistics for the style sharing cache after each restyle
+    #[strum(to_string = "style-stats")]
+    StyleStatistics,
+
+    /// Log garbage collection passes and their durations
+    #[strum(to_string = "gc-profile")]
+    GcProfile,
+
+    /// Log Progressive Web Metrics
+    #[strum(to_string = "progressive-web-metrics")]
+    ProgressiveWebMetrics,
+}
+
+impl DiagnosticsLoggingOption {
+    /// Returns a string representation of this variant that is compatible with
+    /// [`FromStr::from_str`] and [`DiagnosticsLogging::extend_from_string`].
+    /// This value can be used as a command-line argument for an application.
+    pub fn help_option(&self) -> &str {
+        self.as_ref()
+    }
+
+    /// Returns a string with a short description of the diagnostic option.
+    /// This value can be used as a command-line argument description for an application.
+    pub fn help_message(&self) -> &str {
+        self.get_documentation()
+            .expect("all variants of `DiagnosticsLoggingOption` should have a help message")
+    }
+
+    /// Returns an `Iterator` that can be used to iterate over all the diagnostic options
+    /// supported by Servo. This is useful when constructing a help message that enumerates
+    /// all possible diagnostic flags and their respective help messages.
+    pub fn iter() -> impl Iterator<Item = Self> {
+        <Self as IntoEnumIterator>::iter()
+    }
+}
+
+/// The current configuration of the diagnostic options for Servo.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct DiagnosticsLogging {
-    /// Print all the debug options supported by Servo to the standard output.
-    pub help: bool,
-
-    /// Print the DOM after each restyle.
-    pub style_tree: bool,
-
-    /// Log the rule tree.
-    pub rule_tree: bool,
-
-    /// Log the fragment tree after each layout.
-    pub flow_tree: bool,
-
-    /// Log the stacking context tree after each layout.
-    pub stacking_context_tree: bool,
-
-    /// Log the scroll tree after each layout.
-    ///
-    /// Displays the hierarchy of scrollable areas and their properties.
-    pub scroll_tree: bool,
-
-    /// Log the display list after each layout.
-    pub display_list: bool,
-
-    /// Log notifications when a relayout occurs.
-    pub relayout_event: bool,
-
-    /// Periodically log on which events script threads spend their processing time.
-    pub profile_script_events: bool,
-
-    /// Log style sharing cache statistics to after each restyle.
-    ///
-    /// Shows hit/miss statistics for the style sharing cache
-    pub style_statistics: bool,
-
-    /// Log garbage collection passes and their durations.
-    pub gc_profile: bool,
-
-    /// Log Progressive Web Metrics.
-    pub progressive_web_metrics: bool,
+    options: [bool; DiagnosticsLoggingOption::COUNT],
 }
 
 impl DiagnosticsLogging {
     /// Create a new DiagnosticsLogging configuration.
     ///
-    /// In non-production builds, this will automatically read and parse the
+    /// In builds with debug assertions enabled, this will automatically read and parse the
     /// SERVO_DIAGNOSTICS environment variable if it is set.
     pub fn new() -> Self {
-        let mut config: DiagnosticsLogging = Default::default();
+        #[cfg(not(debug_assertions))]
+        return DiagnosticsLogging::default();
 
-        // Disabled for production builds
+        // Disabled for production and release builds
         #[cfg(debug_assertions)]
         {
+            let mut config: DiagnosticsLogging = Default::default();
             if let Ok(diagnostics_var) = std::env::var("SERVO_DIAGNOSTICS") {
                 if let Err(error) = config.extend_from_string(&diagnostics_var) {
                     eprintln!("Could not parse debug logging option: {error}");
                 }
-            }
+            };
+            config
         }
-
-        config
     }
 
-    /// Print available diagnostic logging options and their descriptions.
-    fn print_debug_options_usage(app: &str) {
-        fn print_option(name: &str, description: &str) {
-            println!("\t{:<35} {}", name, description);
-        }
+    /// Enables or disables the diagnostics represented by the given [`DiagnosticsLoggingOption`]
+    /// variant.
+    pub fn toggle_option(&mut self, option: DiagnosticsLoggingOption, enabled: bool) {
+        self.options[option as usize] = enabled;
+    }
 
-        println!(
-            "Usage: {} debug option,[options,...]\n\twhere options include\n\nOptions:",
-            app
-        );
-        print_option("help", "Show this help message");
-        print_option("style-tree", "Log the style tree after each restyle");
-        print_option("rule-tree", "Log the rule tree");
-        print_option("flow-tree", "Log the fragment tree after each layout");
-        print_option(
-            "stacking-context-tree",
-            "Log the stacking context tree after each layout",
-        );
-        print_option("scroll-tree", "Log the scroll tree after each layout");
-        print_option("display-list", "Log the display list after each layout");
-        print_option("style-stats", "Log style sharing cache statistics");
-        print_option("relayout-event", "Log when relayout occurs");
-        print_option("profile-script-events", "Log script event processing time");
-        print_option("gc-profile", "Log garbage collection statistics");
-        print_option("progressive-web-metrics", "Log Progressive Web Metrics");
-        println!();
-
-        process::exit(0);
+    /// Returns true if the given diagnostic option is enabled.
+    pub fn is_enabled(&self, option: DiagnosticsLoggingOption) -> bool {
+        self.options[option as usize]
     }
 
     /// Extend the current configuration with additional options.
@@ -182,21 +212,9 @@ impl DiagnosticsLogging {
     pub fn extend_from_string(&mut self, option_string: &str) -> Result<(), String> {
         for option in option_string.split(',') {
             let option = option.trim();
-            match option {
-                "help" => Self::print_debug_options_usage("servo"),
-                "display-list" => self.display_list = true,
-                "stacking-context-tree" => self.stacking_context_tree = true,
-                "flow-tree" => self.flow_tree = true,
-                "rule-tree" => self.rule_tree = true,
-                "style-tree" => self.style_tree = true,
-                "style-stats" => self.style_statistics = true,
-                "scroll-tree" => self.scroll_tree = true,
-                "gc-profile" => self.gc_profile = true,
-                "profile-script-events" => self.profile_script_events = true,
-                "relayout-event" => self.relayout_event = true,
-                "progressive-web-metrics" => self.progressive_web_metrics = true,
-                "" => {},
-                _ => return Err(format!("Unknown diagnostic option: {option}")),
+            match DiagnosticsLoggingOption::from_str(option) {
+                Ok(flag) => self.toggle_option(flag, true),
+                Err(_) => return Err(format!("Unknown diagnostic option: {option}")),
             };
         }
 
@@ -262,4 +280,41 @@ pub fn get() -> &'static Opts {
     // We rely on the `expect` in `initialize_options` to inform us if refactoring
     // causes a `get` call to move before `initialize_options`.
     OPTIONS.get_or_init(Default::default)
+}
+
+#[test]
+fn test_parsing_of_diagnostics_logging_options() {
+    assert!(DiagnosticsLoggingOption::iter().collect::<Vec<_>>().len() > 0);
+
+    let mut diagnostics = DiagnosticsLogging::new();
+    for option in DiagnosticsLoggingOption::iter() {
+        assert_eq!(diagnostics.is_enabled(option), false);
+    }
+
+    assert!(
+        diagnostics
+            .extend_from_string("profile-script-events,style-stats")
+            .is_ok()
+    );
+    assert!(diagnostics.is_enabled(DiagnosticsLoggingOption::ProfileScriptEvents));
+    assert!(diagnostics.is_enabled(DiagnosticsLoggingOption::StyleStatistics));
+    assert!(!diagnostics.is_enabled(DiagnosticsLoggingOption::ProgressiveWebMetrics));
+
+    assert!(
+        diagnostics
+            .extend_from_string("profile-script-events,syle-stats")
+            .is_err()
+    );
+
+    let mut diagnostics = DiagnosticsLogging::new();
+    for option in DiagnosticsLoggingOption::iter() {
+        assert_eq!(
+            DiagnosticsLoggingOption::from_str(option.help_option()),
+            Ok(option)
+        );
+
+        assert!(!diagnostics.is_enabled(option));
+        assert!(diagnostics.extend_from_string(option.help_option()).is_ok());
+        assert!(diagnostics.is_enabled(option),);
+    }
 }

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -15,7 +15,7 @@ use net_traits::image_cache::Image as CachedImage;
 use paint_api::display_list::{PaintDisplayListInfo, SpatialTreeNodeInfo};
 use servo_arc::Arc as ServoArc;
 use servo_base::id::{PipelineId, ScrollTreeNodeId};
-use servo_config::opts::DiagnosticsLogging;
+use servo_config::opts::{DiagnosticsLogging, DiagnosticsLoggingOption};
 use servo_config::{pref, prefs};
 use servo_url::ServoUrl;
 use style::Zero;
@@ -191,7 +191,7 @@ impl DisplayListBuilder<'_> {
         // the display list for printing the serialized version when `finalize()` is called.
         // We need to call this before adding any display items so that they are printed
         // during `finalize()`.
-        if debug.display_list {
+        if debug.is_enabled(DiagnosticsLoggingOption::DisplayList) {
             webrender_display_list_builder.dump_serialized_display_list();
         }
 

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -17,7 +17,7 @@ use paint_api::display_list::{
 };
 use servo_base::id::ScrollTreeNodeId;
 use servo_base::print_tree::PrintTree;
-use servo_config::opts::DiagnosticsLogging;
+use servo_config::opts::{DiagnosticsLogging, DiagnosticsLoggingOption};
 use servo_geometry::MaxRect;
 use style::Zero;
 use style::color::{AbsoluteColor, ColorSpace};
@@ -192,7 +192,7 @@ impl StackingContextTree {
         }
         root_stacking_context.sort();
 
-        if debug.stacking_context_tree {
+        if debug.is_enabled(DiagnosticsLoggingOption::StackingContextTree) {
             root_stacking_context.debug_print();
         }
 
@@ -521,7 +521,9 @@ impl StackingContext {
             real_stacking_contexts_and_positioned_stacking_containers: vec![],
             float_stacking_containers: vec![],
             atomic_inline_stacking_containers: vec![],
-            debug_print_items: debug.stacking_context_tree.then(|| vec![].into()),
+            debug_print_items: debug
+                .is_enabled(DiagnosticsLoggingOption::StackingContextTree)
+                .then(|| vec![].into()),
         }
     }
 

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -47,7 +47,7 @@ use servo_arc::Arc as ServoArc;
 use servo_base::Epoch;
 use servo_base::generic_channel::GenericSender;
 use servo_base::id::{PipelineId, WebViewId};
-use servo_config::opts::{self, DiagnosticsLogging};
+use servo_config::opts::{self, DiagnosticsLogging, DiagnosticsLoggingOption};
 use servo_config::pref;
 use servo_url::ServoUrl;
 use style::animation::DocumentAnimationSet;
@@ -885,7 +885,10 @@ impl LayoutThread {
     }
 
     fn maybe_print_reflow_event(&self, reflow_request: &ReflowRequest) {
-        if !self.debug.relayout_event {
+        if !self
+            .debug
+            .is_enabled(DiagnosticsLoggingOption::RelayoutEvent)
+        {
             return;
         }
 
@@ -1226,13 +1229,13 @@ impl LayoutThread {
 
         *self.fragment_tree.borrow_mut() = Some(fragment_tree);
 
-        if self.debug.style_tree {
+        if self.debug.is_enabled(DiagnosticsLoggingOption::StyleTree) {
             println!(
                 "{:?}",
                 ShowSubtreeDataAndPrimaryValues(dangerous_root_element.as_node())
             );
         }
-        if self.debug.rule_tree {
+        if self.debug.is_enabled(DiagnosticsLoggingOption::RuleTree) {
             recalc_style_traversal
                 .context()
                 .style_context
@@ -1259,7 +1262,7 @@ impl LayoutThread {
 
         if let Some(fragment_tree) = &*self.fragment_tree.borrow() {
             fragment_tree.calculate_scrollable_overflow();
-            if self.debug.flow_tree {
+            if self.debug.is_enabled(DiagnosticsLoggingOption::FlowTree) {
                 fragment_tree.print();
             }
         }
@@ -1316,7 +1319,7 @@ impl LayoutThread {
                 .set_all_scroll_offsets(&old_scroll_offsets);
         }
 
-        if self.debug.scroll_tree {
+        if self.debug.is_enabled(DiagnosticsLoggingOption::ScrollTree) {
             new_stacking_context_tree
                 .paint_info
                 .scroll_tree

--- a/components/metrics/lib.rs
+++ b/components/metrics/lib.rs
@@ -13,7 +13,7 @@ use profile_traits::time::{
 };
 use script_traits::ProgressiveWebMetricType;
 use servo_base::cross_process_instant::CrossProcessInstant;
-use servo_config::opts;
+use servo_config::opts::{self, DiagnosticsLoggingOption};
 use servo_url::ServoUrl;
 
 /// TODO make this configurable
@@ -52,7 +52,10 @@ fn set_metric(
         metric_time,
     );
 
-    if opts::get().debug.progressive_web_metrics {
+    if opts::get()
+        .debug
+        .is_enabled(DiagnosticsLoggingOption::ProgressiveWebMetrics)
+    {
         let navigation_start = pwm
             .navigation_start()
             .unwrap_or_else(CrossProcessInstant::epoch);

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -62,7 +62,8 @@ use profile_traits::path;
 use profile_traits::time::ProfilerCategory;
 use script_bindings::script_runtime::{mark_runtime_dead, runtime_is_alive};
 use script_bindings::settings_stack::run_a_script;
-use servo_config::{opts, pref};
+use servo_config::opts::{self, DiagnosticsLoggingOption};
+use servo_config::pref;
 use style::thread_state::{self, ThreadState};
 
 use crate::dom::bindings::codegen::Bindings::PromiseBinding::PromiseJobCallback;
@@ -789,7 +790,10 @@ impl Runtime {
                 JS_SetGCCallback(cx, Some(debug_gc_callback), ptr::null_mut());
             }
 
-            if opts::get().debug.gc_profile {
+            if opts::get()
+                .debug
+                .is_enabled(DiagnosticsLoggingOption::GcProfile)
+            {
                 SetGCSliceCallback(cx, Some(gc_slice_callback));
             }
         }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -88,7 +88,8 @@ use servo_base::id::{
 };
 use servo_base::{Epoch, generic_channel};
 use servo_canvas_traits::webgl::WebGLPipeline;
-use servo_config::{opts, pref, prefs};
+use servo_config::opts::{self, DiagnosticsLoggingOption};
+use servo_config::{pref, prefs};
 use servo_constellation_traits::{
     LoadData, LoadOrigin, NavigationHistoryBehavior, RemoteFocusOperation,
     ScreenshotReadinessResponse, ScriptToConstellationChan, ScriptToConstellationMessage,
@@ -1007,7 +1008,9 @@ impl ScriptThread {
                     docs_with_no_blocking_loads: Default::default(),
                     custom_element_reaction_stack: Rc::new(CustomElementReactionStack::new()),
                     paint_api: state.cross_process_paint_api,
-                    profile_script_events: opts.debug.profile_script_events,
+                    profile_script_events: opts
+                        .debug
+                        .is_enabled(DiagnosticsLoggingOption::ProfileScriptEvents),
                     unminify_js: opts.unminify_js,
                     local_script_source: opts.local_script_source.clone(),
                     unminify_css: opts.unminify_css,
@@ -1727,7 +1730,10 @@ impl ScriptThread {
         for (doc_id, doc) in self.documents.borrow().iter() {
             if let Some(pipeline_id) = pipeline_id {
                 if pipeline_id == doc_id && task_duration.as_nanos() > MAX_TASK_NS {
-                    if opts::get().debug.progressive_web_metrics {
+                    if opts::get()
+                        .debug
+                        .is_enabled(DiagnosticsLoggingOption::ProgressiveWebMetrics)
+                    {
                         println!(
                             "Task took longer than max allowed ({category:?}) {:?}",
                             task_duration.as_nanos()

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -57,7 +57,7 @@ pub use profile_traits;
 pub use resources;
 pub use servo_base::generic_channel::GenericSender;
 pub use servo_base::id::WebViewId;
-pub use servo_config::opts::{DiagnosticsLogging, Opts, OutputOptions};
+pub use servo_config::opts::{DiagnosticsLogging, DiagnosticsLoggingOption, Opts, OutputOptions};
 pub use servo_config::prefs::{PrefValue, Preferences, UserAgentPlatform};
 pub use servo_config::{opts, pref, prefs};
 pub use servo_geometry::{

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -47,7 +47,7 @@ use servo_base::id::{EMBEDDER_PIPELINE_NAMESPACE_ID, PipelineNamespace};
 use servo_bluetooth::BluetoothThreadFactory;
 #[cfg(feature = "bluetooth")]
 use servo_bluetooth_traits::BluetoothRequest;
-use servo_config::opts::Opts;
+use servo_config::opts::{DiagnosticsLoggingOption, Opts};
 use servo_config::prefs::{PrefValue, Preferences};
 use servo_config::{opts, pref, prefs};
 #[cfg(all(
@@ -852,8 +852,11 @@ impl Servo {
             !pref!(layout_style_sharing_cache_enabled),
             Ordering::Relaxed,
         );
-        style::context::DEFAULT_DUMP_STYLE_STATISTICS
-            .store(opts.debug.style_statistics, Ordering::Relaxed);
+        style::context::DEFAULT_DUMP_STYLE_STATISTICS.store(
+            opts.debug
+                .is_enabled(DiagnosticsLoggingOption::StyleStatistics),
+            Ordering::Relaxed,
+        );
 
         if !opts.multiprocess {
             media_platform::init();

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -19,7 +19,8 @@ use log::warn;
 use serde_json::Value;
 use servo::user_contents::UserStyleSheet;
 use servo::{
-    DeviceIndependentPixel, DiagnosticsLogging, Opts, OutputOptions, PrefValue, Preferences,
+    DeviceIndependentPixel, DiagnosticsLogging, DiagnosticsLoggingOption, Opts, OutputOptions,
+    PrefValue, Preferences,
 };
 use url::Url;
 
@@ -708,15 +709,9 @@ fn parse_arguments_helper(args_without_binary: Args) -> ArgumentParsingResult {
         ..Default::default()
     };
 
-    let mut debug_options = DiagnosticsLogging::new();
-
-    // Parse -Z command-line flags.
-    for debug_string in cmd_args.debug {
-        if let Err(error) = debug_options.extend_from_string(&debug_string) {
-            eprintln!("Could not parse debug logging option: {error}");
-            return ArgumentParsingResult::ErrorParsing;
-        }
-    }
+    let Ok(debug_options) = parse_diagnostics_logging(cmd_args.debug) else {
+        return ArgumentParsingResult::ErrorParsing;
+    };
 
     let opts = Opts {
         debug: debug_options,
@@ -746,6 +741,34 @@ fn parse_arguments_helper(args_without_binary: Args) -> ArgumentParsingResult {
     };
 
     ArgumentParsingResult::ChromeProcess(opts, preferences, servoshell_preferences)
+}
+
+/// Parse the '-Z' command-line flags.
+fn parse_diagnostics_logging(cli_options: Vec<String>) -> Result<DiagnosticsLogging, ()> {
+    fn print_option(name: &str, description: &str) {
+        println!("\t{:<35} {}", name, description);
+    }
+
+    if cli_options.contains(&"help".into()) {
+        // TODO: Remove hardcoded binary name by perhaps receiving this as an argument.
+        println!("Usage: servoshell -Z option,[option,...]\n\twhere options include:");
+        print_option("help", "Show this help message");
+        for option in DiagnosticsLoggingOption::iter() {
+            print_option(option.help_option(), option.help_message())
+        }
+
+        std::process::exit(0);
+    }
+
+    let mut diagnostics_logging = DiagnosticsLogging::new();
+    for cli_option in cli_options.iter() {
+        if let Err(error) = diagnostics_logging.extend_from_string(cli_option) {
+            eprintln!("Could not parse debug logging option: {error}");
+            return Err(());
+        }
+    }
+
+    Ok(diagnostics_logging)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The current `extend_from_string` API is not suitable for embedders as it was written specifically for servoshell and therefore makes a lot of assumptions - the binary name, the format and text of the help message, etc. It also exits the whole process after displaying the help string.

Change the behaviour of this API by making it responsible only for parsing string flags. The logic for formatting and displaying the help message is moved to servoshell. This patch also switches the `DiagnosticsLogging` from a struct to a `BitArray` and exposes strum-based APIs so that the embedder can enumerate the available diagnostics option, retrieve the documentation string associated with each option and also parse the strings back to a valid `DiagnosticsLogging` struct.

Testing: Includes a unit test for the API used by embedders.