### PR TITLE
Enable feature `zeroize_derive` for `zeroize` crate

### DIFF
--- a/components/script_bindings/Cargo.toml
+++ b/components/script_bindings/Cargo.toml
@@ -50,7 +50,7 @@ tendril = { workspace = true }
 tracing = { workspace = true, optional = true }
 webxr-api = { workspace = true, optional = true }
 xml5ever = { workspace = true }
-zeroize = { workspace = true }
+zeroize = { workspace = true, features = ["zeroize_derive"] }
 
 [build-dependencies]
 phf_codegen = "0.13"


### PR DESCRIPTION
Enable feature `zeroize_derive` for `zeroize` crate. This was missed in #44676.
Due to which the `servo-script-bindings` were not being run.

Testing: Tested Locally
Fixes: #44711 