### PR TITLE
script: Length checks for `SubtleCrypto.supports()` for ECDH and X25519

### DIFF
--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -2612,7 +2612,13 @@ pub(crate) fn check_support_for_algorithm(
             };
 
             match normalized_algorithm {
-                DeriveBitsAlgorithm::Ecdh(_) | DeriveBitsAlgorithm::X25519(_) => true,
+                DeriveBitsAlgorithm::Ecdh(normalized_algorithm) => length.is_none_or(|length| {
+                    ecdh_operation::secret_length(&normalized_algorithm)
+                        .is_ok_and(|secret_length| secret_length * 8 >= length)
+                }),
+                DeriveBitsAlgorithm::X25519(_) => {
+                    length.is_none_or(|length| x25519_operation::SECRET_LENGTH as u32 * 8 >= length)
+                },
                 DeriveBitsAlgorithm::Hkdf(_) => length.is_some_and(|length| length % 8 == 0),
                 DeriveBitsAlgorithm::Pbkdf2(normalized_algorithm) => {
                     length.is_some_and(|length| length % 8 == 0) &&

--- a/components/script/dom/webcrypto/subtlecrypto/ecdh_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ecdh_operation.rs
@@ -2,9 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use elliptic_curve::SecretKey;
+use elliptic_curve::generic_array::typenum::Unsigned;
 use elliptic_curve::rand_core::OsRng;
 use elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint, ValidatePublicKey};
+use elliptic_curve::{Curve, SecretKey};
 use js::context::JSContext;
 use p256::NistP256;
 use p384::NistP384;
@@ -1349,4 +1350,32 @@ pub(crate) fn get_public_key(
     usages: Vec<KeyUsage>,
 ) -> Result<DomRoot<CryptoKey>, Error> {
     ec_common::get_public_key(cx, global, key, algorithm, usages)
+}
+
+/// Given a normalizedAlgorithm (an EcdhKeyDeriveParams dictionary), return the length of the secret
+/// derived by the named curve specified by the `named_curve` member of the `[[algorithm]]` slot of
+/// the `public` member of normalizedAlgorithm.
+pub(crate) fn secret_length(
+    normalized_algorithm: &SubtleEcdhKeyDeriveParams,
+) -> Result<u32, Error> {
+    let public_key = normalized_algorithm.public.root();
+    let KeyAlgorithmAndDerivatives::EcKeyAlgorithm(algorithm) = public_key.algorithm() else {
+        return Err(Error::Operation(Some(
+            "The key is not an elliptic curve algorithm key".to_string(),
+        )));
+    };
+
+    let secret_length_in_bits = match algorithm.named_curve.as_str() {
+        NAMED_CURVE_P256 => <NistP256 as Curve>::FieldBytesSize::to_u32(),
+        NAMED_CURVE_P384 => <NistP384 as Curve>::FieldBytesSize::to_u32(),
+        NAMED_CURVE_P521 => <NistP521 as Curve>::FieldBytesSize::to_u32(),
+        named_curve => {
+            return Err(Error::NotSupported(Some(format!(
+                "Unsupported namedCurve: {}",
+                named_curve
+            ))));
+        },
+    };
+
+    Ok(secret_length_in_bits)
 }

--- a/components/script/dom/webcrypto/subtlecrypto/x25519_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/x25519_operation.rs
@@ -29,6 +29,7 @@ const X25519_OID_STRING: &str = "1.3.101.110";
 
 const PRIVATE_KEY_LENGTH: usize = 32;
 const PUBLIC_KEY_LENGTH: usize = 32;
+pub(crate) const SECRET_LENGTH: usize = 32;
 
 /// <https://w3c.github.io/webcrypto/#x25519-operations-derive-bits>
 pub(crate) fn derive_bits(

--- a/tests/wpt/meta/WebCryptoAPI/supports.tentative.https.any.js.ini
+++ b/tests/wpt/meta/WebCryptoAPI/supports.tentative.https.any.js.ini
@@ -1,8 +1,0 @@
-[supports.tentative.https.any.html]
-  [deriveKey promise tests]
-    expected: FAIL
-
-
-[supports.tentative.https.any.worker.html]
-  [deriveKey promise tests]
-    expected: FAIL


### PR DESCRIPTION
The "deriveBits" operations of ECDH and X25519 throw an error when the length of derived secret is less than the requested length. Therefore, we need to check the condition when calling `SubtleCrypto.supports()` for these two algorithms.

The check was missing in our implementation of `SubtleCrypto.supports()`, and this patch adds it back.

Specification of "deriveBits" operations of ECDH and X25519:
- https://w3c.github.io/webcrypto/#ecdh-operations-derive-bits
- https://w3c.github.io/webcrypto/#x25519-operations-derive-bits

Testing: Covered by WPT tests in `tests/wpt/tests/WebCryptoAPI/supports.tentative.https.any.js`
