### PR TITLE
script: Fix unit test panic for domstring test for release profile

### DIFF
--- a/components/script_bindings/domstring.rs
+++ b/components/script_bindings/domstring.rs
@@ -1241,6 +1241,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(debug_assertions)]
     #[should_panic]
     fn test_match_panic() {
         let s = DOMString::from("abcd");
@@ -1250,6 +1251,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(debug_assertions)]
     #[should_panic]
     fn test_match_panic2() {
         let s = DOMString::from("abcd");


### PR DESCRIPTION
A unit test in domstring was relying on debug_asserts to panic. This broke with a recent change to unit tests in release mode.


Testing: Tested in normal mode and release mode.
Fixes: https://github.com/servo/servo/issues/44692
