### PR TITLE
Implement async version for cookie APIs

### DIFF
--- a/components/net/embedder.rs
+++ b/components/net/embedder.rs
@@ -35,8 +35,8 @@ pub enum NetToEmbedderMsg {
         bool, /* for proxy */
         TokioOneshotSender<Option<AuthenticationResponse>>,
     ),
-    /// Response to a [`CoreResourceMsg::EmbedderGetCookiesForUrl`] request.
-    EmbedderGetCookiesForUrlResponse(CookieOperationId, Vec<Cookie<'static>>),
-    /// Response to a [`CoreResourceMsg::EmbedderSetCookieForUrl`] request.
-    EmbedderSetCookieForUrlResponse(CookieOperationId),
+    /// Response to an asynchronous request from SiteDataManager with cookies result.
+    EmbedderCookieOperationResponseWithCookies(CookieOperationId, Vec<Cookie<'static>>),
+    /// Response to an asynchronous request from SiteDataManager.
+    EmbedderCookieOperationResponse(CookieOperationId),
 }

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -570,12 +570,12 @@ impl ResourceChannelManager {
                 cookie_jar.remove_expired_cookies_for_url(&url);
                 let cookies: Vec<Cookie<'static>> =
                     cookie_jar.cookies_data_for_url(&url, source).collect();
-                http_state
-                    .embedder_proxy
-                    .send(NetToEmbedderMsg::EmbedderGetCookiesForUrlResponse(
+                http_state.embedder_proxy.send(
+                    NetToEmbedderMsg::EmbedderCookieOperationResponseWithCookies(
                         operation_id,
                         cookies,
-                    ));
+                    ),
+                );
             },
             CoreResourceMsg::EmbedderSetCookieForUrl(operation_id, url, cookie, source) => {
                 self.resource_manager.set_cookie_for_url(
@@ -586,7 +586,23 @@ impl ResourceChannelManager {
                 );
                 http_state
                     .embedder_proxy
-                    .send(NetToEmbedderMsg::EmbedderSetCookieForUrlResponse(
+                    .send(NetToEmbedderMsg::EmbedderCookieOperationResponse(
+                        operation_id,
+                    ));
+            },
+            CoreResourceMsg::EmbedderClearCookies(operation_id) => {
+                http_state.cookie_jar.write().clear_storage(None);
+                http_state
+                    .embedder_proxy
+                    .send(NetToEmbedderMsg::EmbedderCookieOperationResponse(
+                        operation_id,
+                    ));
+            },
+            CoreResourceMsg::EmbedderClearSessionCookies(operation_id) => {
+                http_state.cookie_jar.write().clear_session_cookies();
+                http_state
+                    .embedder_proxy
+                    .send(NetToEmbedderMsg::EmbedderCookieOperationResponse(
                         operation_id,
                     ));
             },

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -390,13 +390,13 @@ impl ServoInner {
                         .request_authentication(webview, authentication_request);
                 }
             },
-            NetToEmbedderMsg::EmbedderGetCookiesForUrlResponse(operation_id, cookies) => {
+            NetToEmbedderMsg::EmbedderCookieOperationResponseWithCookies(operation_id, cookies) => {
                 self.site_data_manager.handle_cookie_response(
                     operation_id,
                     CookieOperationResponse::Cookies(cookies),
                 );
             },
-            NetToEmbedderMsg::EmbedderSetCookieForUrlResponse(operation_id) => {
+            NetToEmbedderMsg::EmbedderCookieOperationResponse(operation_id) => {
                 self.site_data_manager
                     .handle_cookie_response(operation_id, CookieOperationResponse::Done);
             },

--- a/components/servo/site_data_manager.rs
+++ b/components/servo/site_data_manager.rs
@@ -279,31 +279,24 @@ impl SiteDataManager {
     }
 
     /// Returns the cookies for the domain associated with the given [`Url`].
-    ///
-    /// An optional callback is provided for async operation.
-    /// For async version, this method always returns `None`
-    /// and the cookies are delivered via the callback when ready.
-    pub fn cookies_for_url(
+    pub fn cookies_for_url(&self, url: Url, source: CookieSource) -> Vec<Cookie<'static>> {
+        self.public_resource_threads
+            .cookies_for_url(url.into(), source)
+    }
+
+    /// Asynchronously returns the cookies for the domain associated with the given [`Url`].
+    pub fn cookies_for_url_async(
         &self,
         url: Url,
         source: CookieSource,
-        callback: Option<Box<dyn FnOnce(Vec<Cookie<'static>>)>>,
-    ) -> Option<Vec<Cookie<'static>>> {
-        match callback {
-            None => Some(
-                self.public_resource_threads
-                    .cookies_for_url(url.into(), source),
-            ),
-            Some(callback) => {
-                let id = self.next_operation_id();
-                self.pending_cookie_callbacks
-                    .borrow_mut()
-                    .insert(id, CookieOperationCallback::Cookies(callback));
-                self.public_resource_threads
-                    .cookies_for_url_async(id, url.into(), source);
-                None
-            },
-        }
+        callback: impl FnOnce(Vec<Cookie<'static>>) + 'static,
+    ) {
+        let id = self.next_operation_id();
+        self.pending_cookie_callbacks
+            .borrow_mut()
+            .insert(id, CookieOperationCallback::Cookies(Box::new(callback)));
+        self.public_resource_threads
+            .cookies_for_url_async(id, url.into(), source);
     }
 
     /// Sets a cookie for the domain associated with the given [`Url`].

--- a/components/servo/site_data_manager.rs
+++ b/components/servo/site_data_manager.rs
@@ -77,6 +77,10 @@ pub(crate) enum CookieOperationResponse {
 enum CookieOperationCallback {
     Cookies(Box<dyn FnOnce(Vec<Cookie<'static>>)>),
     Done(Box<dyn FnOnce()>),
+    DoneAfterResponses {
+        remaining_responses: u8,
+        callback: Box<dyn FnOnce()>,
+    },
 }
 
 /// Provides APIs for inspecting and managing site data.
@@ -224,69 +228,114 @@ impl SiteDataManager {
         }
     }
 
-    pub fn clear_cookies(&self) {
-        self.public_resource_threads.clear_cookies();
-        self.private_resource_threads.clear_cookies();
+    /// Clears all cookies from both the public and private cookie jars.
+    ///
+    /// An optional callback is provided for async operation.
+    pub fn clear_cookies(&self, callback: Option<Box<dyn FnOnce()>>) {
+        match callback {
+            None => {
+                self.public_resource_threads.clear_cookies();
+                self.private_resource_threads.clear_cookies();
+            },
+            Some(callback) => {
+                let id = self.next_operation_id();
+                self.pending_cookie_callbacks.borrow_mut().insert(
+                    id,
+                    CookieOperationCallback::DoneAfterResponses {
+                        remaining_responses: 2,
+                        callback,
+                    },
+                );
+                self.public_resource_threads.clear_cookies_async(id);
+                self.private_resource_threads.clear_cookies_async(id);
+            },
+        }
     }
 
     /// Delete all session cookies (cookies that have no expiry or max-age).
+    ///
     /// Session cookies from both the public and private browsing session cookies are removed.
-    pub fn clear_session_cookies(&self) {
-        self.public_resource_threads.clear_session_cookies();
-        self.private_resource_threads.clear_session_cookies();
+    /// An optional callback is provided for async operation.
+    pub fn clear_session_cookies(&self, callback: Option<Box<dyn FnOnce()>>) {
+        match callback {
+            None => {
+                self.public_resource_threads.clear_session_cookies();
+                self.private_resource_threads.clear_session_cookies();
+            },
+            Some(callback) => {
+                let id = self.next_operation_id();
+                self.pending_cookie_callbacks.borrow_mut().insert(
+                    id,
+                    CookieOperationCallback::DoneAfterResponses {
+                        remaining_responses: 2,
+                        callback,
+                    },
+                );
+                self.public_resource_threads.clear_session_cookies_async(id);
+                self.private_resource_threads
+                    .clear_session_cookies_async(id);
+            },
+        }
     }
 
     /// Returns the cookies for the domain associated with the given [`Url`].
-    pub fn cookies_for_url(&self, url: Url, source: CookieSource) -> Vec<Cookie<'static>> {
-        self.public_resource_threads
-            .cookies_for_url(url.into(), source)
+    ///
+    /// An optional callback is provided for async operation.
+    /// For async version, this method always returns `None`
+    /// and the cookies are delivered via the callback when ready.
+    pub fn cookies_for_url(
+        &self,
+        url: Url,
+        source: CookieSource,
+        callback: Option<Box<dyn FnOnce(Vec<Cookie<'static>>)>>,
+    ) -> Option<Vec<Cookie<'static>>> {
+        match callback {
+            None => Some(
+                self.public_resource_threads
+                    .cookies_for_url(url.into(), source),
+            ),
+            Some(callback) => {
+                let id = self.next_operation_id();
+                self.pending_cookie_callbacks
+                    .borrow_mut()
+                    .insert(id, CookieOperationCallback::Cookies(callback));
+                self.public_resource_threads
+                    .cookies_for_url_async(id, url.into(), source);
+                None
+            },
+        }
     }
 
     /// Sets a cookie for the domain associated with the given [`Url`].
     ///
-    /// Returns `true` if the request to set the cookie is successfully sent.
-    /// This call will block, such that any operations triggered after the
-    /// call will use the provided cookie.
-    pub fn set_cookie_for_url(&self, url: Url, cookie: Cookie<'static>) {
-        self.public_resource_threads.set_cookie_for_url_sync(
-            url.into(),
-            cookie,
-            CookieSource::HTTP,
-        );
-    }
-
-    /// Asynchronously returns the cookies for the domain associated with the given [`Url`].
-    pub fn cookies_for_url_async(
-        &self,
-        url: Url,
-        source: CookieSource,
-        callback: impl FnOnce(Vec<Cookie<'static>>) + 'static,
-    ) {
-        let id = self.next_operation_id();
-        self.pending_cookie_callbacks
-            .borrow_mut()
-            .insert(id, CookieOperationCallback::Cookies(Box::new(callback)));
-        self.public_resource_threads
-            .cookies_for_url_async(id, url.into(), source);
-    }
-
-    /// Asynchronously sets a cookie for the domain associated with the given [`Url`].
-    pub fn set_cookie_for_url_async(
+    /// An optional callback is provided for async operation.
+    pub fn set_cookie_for_url(
         &self,
         url: Url,
         cookie: Cookie<'static>,
-        callback: impl FnOnce() + 'static,
+        callback: Option<Box<dyn FnOnce()>>,
     ) {
-        let id = self.next_operation_id();
-        self.pending_cookie_callbacks
-            .borrow_mut()
-            .insert(id, CookieOperationCallback::Done(Box::new(callback)));
-        self.public_resource_threads.set_cookie_for_url_async(
-            id,
-            url.into(),
-            cookie,
-            CookieSource::HTTP,
-        );
+        match callback {
+            None => {
+                self.public_resource_threads.set_cookie_for_url_sync(
+                    url.into(),
+                    cookie,
+                    CookieSource::HTTP,
+                );
+            },
+            Some(callback) => {
+                let id = self.next_operation_id();
+                self.pending_cookie_callbacks
+                    .borrow_mut()
+                    .insert(id, CookieOperationCallback::Done(callback));
+                self.public_resource_threads.set_cookie_for_url_async(
+                    id,
+                    url.into(),
+                    cookie,
+                    CookieSource::HTTP,
+                );
+            },
+        }
     }
 
     /// Handle a cookie operation response from the resource thread.
@@ -301,12 +350,31 @@ impl SiteDataManager {
             warn!("Received cookie response for unknown operation {id:?}");
             return;
         };
-        match (callback, response) {
-            (CookieOperationCallback::Cookies(cb), CookieOperationResponse::Cookies(cookies)) => {
+        match (response, callback) {
+            (CookieOperationResponse::Cookies(cookies), CookieOperationCallback::Cookies(cb)) => {
                 cb(cookies);
             },
-            (CookieOperationCallback::Done(cb), CookieOperationResponse::Done) => {
+            (CookieOperationResponse::Done, CookieOperationCallback::Done(cb)) => {
                 cb();
+            },
+            (
+                CookieOperationResponse::Done,
+                CookieOperationCallback::DoneAfterResponses {
+                    remaining_responses,
+                    callback,
+                },
+            ) => {
+                if remaining_responses > 1 {
+                    self.pending_cookie_callbacks.borrow_mut().insert(
+                        id,
+                        CookieOperationCallback::DoneAfterResponses {
+                            remaining_responses: remaining_responses - 1,
+                            callback,
+                        },
+                    );
+                } else {
+                    callback();
+                }
             },
             _ => {
                 warn!("Cookie response type mismatch for operation {id:?}");

--- a/components/servo/tests/site_data_manager.rs
+++ b/components/servo/tests/site_data_manager.rs
@@ -645,8 +645,7 @@ fn test_get_cookie() {
     let cookies = servo_test
         .servo()
         .site_data_manager()
-        .cookies_for_url(url.url().into_url(), CookieSource::NonHTTP, None)
-        .unwrap();
+        .cookies_for_url(url.url().into_url(), CookieSource::NonHTTP);
     assert_eq!(cookies.len(), 1);
     assert_eq!(cookies[0].name(), "foo");
     assert_eq!(cookies[0].value(), "bar");
@@ -692,8 +691,7 @@ fn test_set_cookie() {
     let cookies = servo_test
         .servo()
         .site_data_manager()
-        .cookies_for_url(page_url.clone(), CookieSource::HTTP, None)
-        .unwrap();
+        .cookies_for_url(page_url.clone(), CookieSource::HTTP);
     assert_eq!(cookies.len(), 1);
     assert_eq!(cookies[0].name(), "foo");
     assert_eq!(cookies[0].value(), "bar");
@@ -744,14 +742,17 @@ fn test_get_cookie_async() {
     let continued_after_call = Rc::new(Cell::new(false));
     let continued_clone = continued_after_call.clone();
     let result_clone = result.clone();
-    servo_test.servo().site_data_manager().cookies_for_url(
-        url.as_url().clone(),
-        CookieSource::NonHTTP,
-        Some(Box::new(move |cookies| {
-            assert!(continued_clone.get(), "callback fired synchronously");
-            *result_clone.borrow_mut() = Some(cookies);
-        })),
-    );
+    servo_test
+        .servo()
+        .site_data_manager()
+        .cookies_for_url_async(
+            url.as_url().clone(),
+            CookieSource::NonHTTP,
+            move |cookies| {
+                assert!(continued_clone.get(), "callback fired synchronously");
+                *result_clone.borrow_mut() = Some(cookies);
+            },
+        );
     assert!(result.borrow().is_none(), "result available before spin");
     continued_after_call.set(true);
 

--- a/components/servo/tests/site_data_manager.rs
+++ b/components/servo/tests/site_data_manager.rs
@@ -610,7 +610,7 @@ fn test_clear_cookies() {
         Ok(JSValue::String("foo1=bar1; foo2=bar2; foo3=bar3".into()))
     );
 
-    servo_test.servo().site_data_manager().clear_cookies();
+    servo_test.servo().site_data_manager().clear_cookies(None);
 
     let result = evaluate_javascript(&servo_test, webview.clone(), "document.cookie");
     assert_eq!(result, Ok(JSValue::String("".into())));
@@ -645,7 +645,8 @@ fn test_get_cookie() {
     let cookies = servo_test
         .servo()
         .site_data_manager()
-        .cookies_for_url(url.url().into_url(), CookieSource::NonHTTP);
+        .cookies_for_url(url.url().into_url(), CookieSource::NonHTTP, None)
+        .unwrap();
     assert_eq!(cookies.len(), 1);
     assert_eq!(cookies[0].name(), "foo");
     assert_eq!(cookies[0].value(), "bar");
@@ -684,14 +685,15 @@ fn test_set_cookie() {
     servo_test
         .servo()
         .site_data_manager()
-        .set_cookie_for_url(page_url.clone(), cookie);
+        .set_cookie_for_url(page_url.clone(), cookie, None);
 
     // Verify it is returned by get_cookies_for_url.
     // Don't need sync call because set and get messages are processed in order.
     let cookies = servo_test
         .servo()
         .site_data_manager()
-        .cookies_for_url(page_url.clone(), CookieSource::HTTP);
+        .cookies_for_url(page_url.clone(), CookieSource::HTTP, None)
+        .unwrap();
     assert_eq!(cookies.len(), 1);
     assert_eq!(cookies[0].name(), "foo");
     assert_eq!(cookies[0].value(), "bar");
@@ -742,17 +744,14 @@ fn test_get_cookie_async() {
     let continued_after_call = Rc::new(Cell::new(false));
     let continued_clone = continued_after_call.clone();
     let result_clone = result.clone();
-    servo_test
-        .servo()
-        .site_data_manager()
-        .cookies_for_url_async(
-            url.as_url().clone(),
-            CookieSource::NonHTTP,
-            move |cookies| {
-                assert!(continued_clone.get(), "callback fired synchronously");
-                *result_clone.borrow_mut() = Some(cookies);
-            },
-        );
+    servo_test.servo().site_data_manager().cookies_for_url(
+        url.as_url().clone(),
+        CookieSource::NonHTTP,
+        Some(Box::new(move |cookies| {
+            assert!(continued_clone.get(), "callback fired synchronously");
+            *result_clone.borrow_mut() = Some(cookies);
+        })),
+    );
     assert!(result.borrow().is_none(), "result available before spin");
     continued_after_call.set(true);
 

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -622,6 +622,18 @@ impl ResourceThreads {
                 source,
             ));
     }
+
+    pub fn clear_cookies_async(&self, id: CookieOperationId) {
+        let _ = self
+            .core_thread
+            .send(CoreResourceMsg::EmbedderClearCookies(id));
+    }
+
+    pub fn clear_session_cookies_async(&self, id: CookieOperationId) {
+        let _ = self
+            .core_thread
+            .send(CoreResourceMsg::EmbedderClearSessionCookies(id));
+    }
 }
 
 impl GenericSend<CoreResourceMsg> for ResourceThreads {
@@ -719,6 +731,10 @@ pub enum CoreResourceMsg {
         Serde<Cookie<'static>>,
         CookieSource,
     ),
+    /// Clear all cookies on behalf of the embedder. The response is sent via NetToEmbedderMsg.
+    EmbedderClearCookies(CookieOperationId),
+    /// Clear session cookies on behalf of the embedder. The response is sent via NetToEmbedderMsg.
+    EmbedderClearSessionCookies(CookieOperationId),
     GetCookieDataForUrlAsync(CookieStoreId, ServoUrl, Option<String>),
     GetAllCookieDataForUrlAsync(CookieStoreId, ServoUrl, Option<String>),
     DeleteCookiesForSites(Vec<String>, GenericSender<()>),

--- a/ports/servoshell/webdriver.rs
+++ b/ports/servoshell/webdriver.rs
@@ -139,7 +139,7 @@ impl RunningAppState {
         while let Ok(msg) = webdriver_receiver.try_recv() {
             match msg {
                 WebDriverCommandMsg::ResetAllCookies(sender) => {
-                    self.servo().site_data_manager().clear_cookies();
+                    self.servo().site_data_manager().clear_cookies(None);
                     let _ = sender.send(());
                 },
                 WebDriverCommandMsg::Shutdown => {


### PR DESCRIPTION
Follow up to https://github.com/servo/servo/pull/44166#discussion_r3160186950, this PR adds an optional callback to current synchronous APIs to allow asynchronous operation.

Test: existing unit tests of `SiteDataManager`.