### PR TITLE
script: Pass `&mut JSContext` to `HTMLTextAreaElement::handle_text_content_changed`

### DIFF
--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -145,7 +145,7 @@ impl HTMLFormElement {
     }
 
     pub(crate) fn new(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
@@ -293,7 +293,7 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
     make_getter!(Rel, "rel");
 
     /// <https://html.spec.whatwg.org/multipage/#the-form-element:concept-form-submit>
-    fn Submit(&self, cx: &mut js::context::JSContext) {
+    fn Submit(&self, cx: &mut JSContext) {
         self.submit(
             cx,
             SubmittedFrom::FromForm,
@@ -302,11 +302,7 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-form-requestsubmit>
-    fn RequestSubmit(
-        &self,
-        cx: &mut js::context::JSContext,
-        submitter: Option<&HTMLElement>,
-    ) -> Fallible<()> {
+    fn RequestSubmit(&self, cx: &mut JSContext, submitter: Option<&HTMLElement>) -> Fallible<()> {
         let submitter: FormSubmitterElement = match submitter {
             Some(submitter_element) => {
                 // Step 1.1
@@ -367,7 +363,7 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-form-reset>
-    fn Reset(&self, cx: &mut js::context::JSContext) {
+    fn Reset(&self, cx: &mut JSContext) {
         self.reset(cx, ResetFrom::FromForm);
     }
 
@@ -739,7 +735,7 @@ impl HTMLFormElement {
     /// [Form submission](https://html.spec.whatwg.org/multipage/#concept-form-submit)
     pub(crate) fn submit(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         submit_method_flag: SubmittedFrom,
         submitter: FormSubmitterElement,
     ) {
@@ -990,7 +986,7 @@ impl HTMLFormElement {
     #[allow(clippy::too_many_arguments)]
     fn submit_entity_body(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         form_data: &mut [FormDatum],
         mut load_data: LoadData,
         enctype: FormEncType,
@@ -1157,7 +1153,7 @@ impl HTMLFormElement {
 
     /// Interactively validate the constraints of form elements
     /// <https://html.spec.whatwg.org/multipage/#interactively-validate-the-constraints>
-    fn interactive_validation(&self, cx: &mut js::context::JSContext) -> Result<(), ()> {
+    fn interactive_validation(&self, cx: &mut JSContext) -> Result<(), ()> {
         // Step 1 - 2: Statically validate the constraints of form,
         // and let `unhandled invalid controls` be the list of elements
         // returned if the result was negative.
@@ -1197,10 +1193,7 @@ impl HTMLFormElement {
 
     /// Statitically validate the constraints of form elements
     /// <https://html.spec.whatwg.org/multipage/#statically-validate-the-constraints>
-    fn static_validation(
-        &self,
-        cx: &mut js::context::JSContext,
-    ) -> Result<(), Vec<DomRoot<Element>>> {
+    fn static_validation(&self, cx: &mut JSContext) -> Result<(), Vec<DomRoot<Element>>> {
         // Step 1-3
         let invalid_controls = self
             .controls
@@ -1379,7 +1372,7 @@ impl HTMLFormElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-form-reset>
-    pub(crate) fn reset(&self, cx: &mut js::context::JSContext, _reset_method_flag: ResetFrom) {
+    pub(crate) fn reset(&self, cx: &mut JSContext, _reset_method_flag: ResetFrom) {
         // https://html.spec.whatwg.org/multipage/#locked-for-reset
         if self.marked_for_reset.get() {
             return;
@@ -1405,7 +1398,7 @@ impl HTMLFormElement {
             .collect();
 
         for child in controls {
-            child.reset(CanGc::from_cx(cx));
+            child.reset(cx);
         }
         self.marked_for_reset.set(false);
     }
@@ -1468,12 +1461,7 @@ impl Element {
         )
     }
 
-    #[expect(unsafe_code)]
-    pub(crate) fn reset(&self, _can_gc: CanGc) {
-        // TODO https://github.com/servo/servo/issues/44652
-        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
-        let cx = &mut cx;
-
+    pub(crate) fn reset(&self, cx: &mut JSContext) {
         if !self.is_resettable() {
             return;
         }
@@ -1891,7 +1879,7 @@ impl VirtualMethods for HTMLFormElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn unbind_from_tree(&self, cx: &mut js::context::JSContext, context: &UnbindContext) {
+    fn unbind_from_tree(&self, cx: &mut JSContext, context: &UnbindContext) {
         self.super_type().unwrap().unbind_from_tree(cx, context);
 
         // Collect the controls to reset because reset_form_owner
@@ -1925,7 +1913,7 @@ impl VirtualMethods for HTMLFormElement {
 
     fn attribute_mutated(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -1471,7 +1471,7 @@ impl Element {
         } else if let Some(select_element) = self.downcast::<HTMLSelectElement>() {
             select_element.reset();
         } else if let Some(textarea_element) = self.downcast::<HTMLTextAreaElement>() {
-            textarea_element.reset(CanGc::from_cx(cx));
+            textarea_element.reset(cx);
         } else if let Some(output_element) = self.downcast::<HTMLOutputElement>() {
             output_element.reset(cx);
         } else if let Some(html_element) = self.downcast::<HTMLElement>() {

--- a/components/script/dom/html/htmlstyleelement.rs
+++ b/components/script/dom/html/htmlstyleelement.rs
@@ -338,8 +338,8 @@ impl VirtualMethods for HTMLStyleElement {
         }
     }
 
-    fn pop(&self) {
-        self.super_type().unwrap().pop();
+    fn pop(&self, cx: &mut js::context::JSContext) {
+        self.super_type().unwrap().pop(cx);
         self.in_stack_of_open_elements.set(false);
 
         // https://html.spec.whatwg.org/multipage/#update-a-style-block

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -142,7 +142,7 @@ impl HTMLTextAreaElement {
     }
 
     pub(crate) fn new(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
@@ -199,12 +199,7 @@ impl HTMLTextAreaElement {
         self.maybe_update_shared_selection();
     }
 
-    #[expect(unsafe_code)]
-    fn handle_text_content_changed(&self, _can_gc: CanGc) {
-        // TODO https://github.com/servo/servo/issues/43255
-        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
-        let cx = &mut cx;
-
+    fn handle_text_content_changed(&self, cx: &mut JSContext) {
         self.validity_state(CanGc::from_cx(cx))
             .perform_validation_and_update(ValidationFlags::all(), CanGc::from_cx(cx));
 
@@ -430,7 +425,7 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
         // if the element's dirty value flag is false, then the element's
         // raw value must be set to the value of the element's textContent IDL attribute
         if !self.value_dirty.get() {
-            self.reset(CanGc::from_cx(cx));
+            self.reset(cx);
         }
     }
 
@@ -456,7 +451,7 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
         // "none".
         if old_api_value != self.Value() {
             self.textinput.borrow_mut().clear_selection_to_end();
-            self.handle_text_content_changed(CanGc::from_cx(cx));
+            self.handle_text_content_changed(cx);
         }
     }
 
@@ -579,18 +574,18 @@ impl HTMLTextAreaElement {
         self.textinput.borrow_mut().set_content(DOMString::from(""));
     }
 
-    pub(crate) fn reset(&self, can_gc: CanGc) {
+    pub(crate) fn reset(&self, cx: &mut JSContext) {
         // https://html.spec.whatwg.org/multipage/#the-textarea-element:concept-form-reset-control
         self.value_dirty.set(false);
         self.textinput.borrow_mut().set_content(self.DefaultValue());
-        self.handle_text_content_changed(can_gc);
+        self.handle_text_content_changed(cx);
     }
 
     fn selection(&self) -> TextControlSelection<'_, Self> {
         TextControlSelection::new(self, &self.textinput)
     }
 
-    fn handle_key_reaction(&self, action: KeyReaction, event: &Event, can_gc: CanGc) {
+    fn handle_key_reaction(&self, cx: &mut JSContext, action: KeyReaction, event: &Event) {
         match action {
             KeyReaction::TriggerDefaultAction => (),
             KeyReaction::DispatchInput(text, is_composing, input_type) => {
@@ -603,7 +598,7 @@ impl HTMLTextAreaElement {
                     );
                 }
                 self.value_dirty.set(true);
-                self.handle_text_content_changed(can_gc);
+                self.handle_text_content_changed(cx);
                 event.mark_as_handled();
             },
             KeyReaction::RedrawSelection => {
@@ -622,7 +617,7 @@ impl VirtualMethods for HTMLTextAreaElement {
 
     fn attribute_mutated(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
@@ -687,7 +682,7 @@ impl VirtualMethods for HTMLTextAreaElement {
                         AttributeMutation::Removed => placeholder.clear(),
                     }
                 }
-                self.handle_text_content_changed(CanGc::from_cx(cx));
+                self.handle_text_content_changed(cx);
             },
             local_name!("readonly") => {
                 let el = self.upcast::<Element>();
@@ -718,7 +713,7 @@ impl VirtualMethods for HTMLTextAreaElement {
         self.upcast::<Element>()
             .check_ancestors_disabled_state_for_form_control();
 
-        self.handle_text_content_changed(CanGc::from_cx(cx));
+        self.handle_text_content_changed(cx);
     }
 
     fn parse_plain_attribute(&self, name: &LocalName, value: DOMString) -> AttrValue {
@@ -738,7 +733,7 @@ impl VirtualMethods for HTMLTextAreaElement {
         }
     }
 
-    fn unbind_from_tree(&self, cx: &mut js::context::JSContext, context: &UnbindContext) {
+    fn unbind_from_tree(&self, cx: &mut JSContext, context: &UnbindContext) {
         self.super_type().unwrap().unbind_from_tree(cx, context);
 
         let node = self.upcast::<Node>();
@@ -783,12 +778,12 @@ impl VirtualMethods for HTMLTextAreaElement {
             s.children_changed(cx, mutation);
         }
         if !self.value_dirty.get() {
-            self.reset(CanGc::from_cx(cx));
+            self.reset(cx);
         }
     }
 
     // copied and modified from htmlinputelement.rs
-    fn handle_event(&self, cx: &mut js::context::JSContext, event: &Event) {
+    fn handle_event(&self, cx: &mut JSContext, event: &Event) {
         if let Some(mouse_event) = event.downcast::<MouseEvent>() {
             self.handle_mouse_event(mouse_event);
             event.mark_as_handled();
@@ -797,7 +792,7 @@ impl VirtualMethods for HTMLTextAreaElement {
                 // This can't be inlined, as holding on to textinput.borrow_mut()
                 // during self.implicit_submission will cause a panic.
                 let action = self.textinput.borrow_mut().handle_keydown(keyboard_event);
-                self.handle_key_reaction(action, event, CanGc::from_cx(cx));
+                self.handle_key_reaction(cx, action, event);
             }
         } else if event.type_() == atom!("compositionstart") ||
             event.type_() == atom!("compositionupdate") ||
@@ -809,14 +804,14 @@ impl VirtualMethods for HTMLTextAreaElement {
                         .textinput
                         .borrow_mut()
                         .handle_compositionend(compositionevent);
-                    self.handle_key_reaction(action, event, CanGc::from_cx(cx));
+                    self.handle_key_reaction(cx, action, event);
                     self.upcast::<Node>().dirty(NodeDamage::Other);
                 } else if event.type_() == atom!("compositionupdate") {
                     let action = self
                         .textinput
                         .borrow_mut()
                         .handle_compositionupdate(compositionevent);
-                    self.handle_key_reaction(action, event, CanGc::from_cx(cx));
+                    self.handle_key_reaction(cx, action, event);
                     self.upcast::<Node>().dirty(NodeDamage::Other);
                 }
                 self.maybe_update_shared_selection();
@@ -846,7 +841,7 @@ impl VirtualMethods for HTMLTextAreaElement {
             }
             if !flags.is_empty() {
                 event.mark_as_handled();
-                self.handle_text_content_changed(CanGc::from_cx(cx));
+                self.handle_text_content_changed(cx);
             }
         } else if let Some(event) = event.downcast::<FocusEvent>() {
             self.handle_focus_event(event);
@@ -860,11 +855,11 @@ impl VirtualMethods for HTMLTextAreaElement {
         }
     }
 
-    fn pop(&self) {
-        self.super_type().unwrap().pop();
+    fn pop(&self, cx: &mut JSContext) {
+        self.super_type().unwrap().pop(cx);
 
         // https://html.spec.whatwg.org/multipage/#the-textarea-element:stack-of-open-elements
-        self.reset(CanGc::deprecated_note());
+        self.reset(cx);
     }
 }
 

--- a/components/script/dom/html/htmltitleelement.rs
+++ b/components/script/dom/html/htmltitleelement.rs
@@ -101,9 +101,9 @@ impl VirtualMethods for HTMLTitleElement {
         }
     }
 
-    fn pop(&self) {
+    fn pop(&self, cx: &mut js::context::JSContext) {
         if let Some(s) = self.super_type() {
-            s.pop();
+            s.pop(cx);
         }
 
         self.popped.set(true);

--- a/components/script/dom/servoparser/async_html.rs
+++ b/components/script/dom/servoparser/async_html.rs
@@ -604,7 +604,7 @@ impl Tokenizer {
                 }
             },
             ParseOperation::Pop { node } => {
-                vtable_for(&self.get_node(&node)).pop();
+                vtable_for(&self.get_node(&node)).pop(cx);
             },
             ParseOperation::CreatePI { node, target, data } => {
                 let pi = ProcessingInstruction::new(

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -2082,7 +2082,7 @@ fn create_element_for_token(
     // checkedness based on the element's attributes.)
     if let Some(html_element) = element.downcast::<HTMLElement>() {
         if element.is_resettable() && !html_element.is_form_associated_custom_element() {
-            element.reset(CanGc::from_cx(cx));
+            element.reset(cx);
         }
     }
 

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1934,9 +1934,14 @@ impl TreeSink for Sink {
         self.current_line.set(line_number);
     }
 
+    #[expect(unsafe_code)]
     fn pop(&self, node: &Dom<Node>) {
+        // TODO: https://github.com/servo/servo/issues/42839
+        let mut cx = unsafe { temp_cx() };
+        let cx = &mut cx;
+
         let node = DomRoot::from_ref(&**node);
-        vtable_for(&node).pop();
+        vtable_for(&node).pop(cx);
     }
 
     fn allow_declarative_shadow_roots(&self, intended_parent: &Dom<Node>) -> bool {

--- a/components/script/dom/virtualmethods.rs
+++ b/components/script/dom/virtualmethods.rs
@@ -193,9 +193,9 @@ pub(crate) trait VirtualMethods {
 
     /// Called on an element when it is popped off the stack of open elements
     /// of a parser.
-    fn pop(&self) {
+    fn pop(&self, cx: &mut js::context::JSContext) {
         if let Some(s) = self.super_type() {
-            s.pop();
+            s.pop(cx);
         }
     }
 }


### PR DESCRIPTION
Propagate `&mut JSContext` to `Element::reset` and `HTMLTextAreaElement::handle_text_content_changed`, required adding `cx` argument to `VirtualMethods::pop`

Testing: It compiles
Fixes: #43235
Fixes: #43255 
