### PR TITLE
ohos ci: Set PYTHONUNBUFFERED=1 for immediate output

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -40,6 +40,7 @@ env:
   CARGO_INCREMENTAL: 0
   BENCHER_PROJECT: ${{ vars.BENCHER_PROJECT || 'servo' }}
   HITRACE_BENCH_VERSION: 0.11.1
+  PYTHONUNBUFFERED: 1
   MITMDUMP_CACHE_KEY: mitmdump-ohos-cache-0.1
 
 jobs:


### PR DESCRIPTION
By default python stdout is block-buffered in CI, causing delayed output. 

Testing: This affects ohos CI tests.

