### PR TITLE
servoshell: Replace custom CJK font loading with egui-system-fonts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2119,6 +2119,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "egui-system-fonts"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f12533054ca28d8933c8557956efd0e8092e5cbf5252feada6c7daa9cec6eef"
+dependencies = [
+ "egui",
+ "log",
+ "system-fonts",
+]
+
+[[package]]
 name = "egui-winit"
 version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2355,7 +2366,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2920,7 +2931,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps 7.0.5",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4434,7 +4445,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7075,7 +7086,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7132,7 +7143,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9035,6 +9046,7 @@ dependencies = [
  "dpi",
  "egui",
  "egui-file-dialog",
+ "egui-system-fonts",
  "egui-winit",
  "egui_glow",
  "env_filter",
@@ -9701,6 +9713,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-fonts"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f369feb844d5e08bb4e938c3f88ff359261bc94c7553ddb34e174447120b64d6"
+dependencies = [
+ "fontdb",
+ "sys-locale",
+]
+
+[[package]]
 name = "taffy"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9745,7 +9767,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11254,7 +11276,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -118,6 +118,7 @@ surfman = { workspace = true, features = ["sm-angle-default"] }
 dirs = "6.0"
 egui = { version = "0.34.1" }
 egui-file-dialog = "0.13.0"
+egui-system-fonts = "0.34.0"
 egui-winit = { version = "0.34.1", default-features = false, features = ["accesskit", "clipboard", "wayland"] }
 egui_glow = { version = "0.34.1", features = ["winit"] }
 gilrs = "0.11.1"

--- a/ports/servoshell/desktop/gui.rs
+++ b/ports/servoshell/desktop/gui.rs
@@ -3,10 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::collections::HashMap;
-#[cfg(any(target_os = "windows", target_os = "linux", target_os = "freebsd"))]
-use std::fs;
-#[cfg(any(target_os = "windows", target_os = "linux", target_os = "freebsd"))]
-use std::path::Path;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -14,16 +10,12 @@ use dpi::PhysicalSize;
 use egui::text::{CCursor, CCursorRange};
 use egui::text_edit::TextEditState;
 use egui::{
-    Button, FontDefinitions, Id, Key, Label, LayerId, Modifiers, Order, PaintCallback, Panel, Vec2,
-    WidgetInfo, WidgetType, pos2,
+    Button, Id, Key, Label, LayerId, Modifiers, Order, PaintCallback, Panel, Vec2, WidgetInfo,
+    WidgetType, pos2,
 };
-#[cfg(any(target_os = "windows", target_os = "linux", target_os = "freebsd"))]
-use egui::{FontData, FontFamily};
 use egui_glow::{CallbackFn, EguiGlow};
 use egui_winit::EventResponse;
 use euclid::{Length, Point2D, Rect, Scale, Size2D};
-#[cfg(any(target_os = "windows", target_os = "linux", target_os = "freebsd"))]
-use log::info;
 use log::warn;
 use servo::{
     DeviceIndependentPixel, DevicePixel, Image, LoadStatus, OffscreenRenderingContext, PixelFormat,
@@ -82,99 +74,6 @@ fn truncate_with_ellipsis(input: &str, max_length: usize) -> String {
     }
 }
 
-#[cfg(any(target_os = "windows", target_os = "linux", target_os = "freebsd"))]
-fn load_cjk_fonts(font_candidates: &[(&str, &str)]) -> FontDefinitions {
-    let mut fonts = FontDefinitions::default();
-    let mut loaded_font_names = Vec::new();
-
-    for (path_str, font_name) in font_candidates.iter() {
-        let font_path = Path::new(path_str);
-        if font_path.exists() {
-            match fs::read(font_path) {
-                Ok(bytes) => {
-                    if !fonts.font_data.contains_key(*font_name) {
-                        fonts
-                            .font_data
-                            .insert(font_name.to_string(), Arc::new(FontData::from_owned(bytes)));
-                        loaded_font_names.push(font_name.to_string());
-                        info!("Loaded font: {}", font_name);
-                    }
-                },
-                Err(error) => {
-                    info!("Failed to read font {}: {}", font_name, error);
-                },
-            }
-        }
-    }
-
-    if !loaded_font_names.is_empty() {
-        let proportional = fonts.families.get_mut(&FontFamily::Proportional).unwrap();
-        for font_name in loaded_font_names.iter() {
-            proportional.insert(0, font_name.clone());
-        }
-    }
-
-    fonts
-}
-
-#[cfg(target_os = "windows")]
-fn configure_fonts() -> FontDefinitions {
-    load_cjk_fonts(&[
-        (r"C:\Windows\Fonts\malgun.ttf", "Malgun Gothic"), // Korean
-        (r"C:\Windows\Fonts\msyh.ttc", "Microsoft YaHei"), // Chinese + Japanese
-    ])
-}
-
-#[cfg(any(target_os = "linux", target_os = "freebsd"))]
-fn configure_fonts() -> FontDefinitions {
-    load_cjk_fonts(&[
-        (
-            "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
-            "Noto Sans CJK",
-        ), // Ubuntu/Debian
-        (
-            "/usr/share/fonts/noto-cjk/NotoSansCJK-Regular.ttc",
-            "Noto Sans CJK",
-        ), // Fedora/Arch
-        // FreeBSD splits the Noto CJK fonts into regional subsets
-        (
-            "/usr/local/share/fonts/noto/NotoSansCJKhk-Regular.otf",
-            "Noto Sans CJK HK",
-        ),
-        (
-            "/usr/local/share/fonts/noto/NotoSansCJKjp-Regular.otf",
-            "Noto Sans CJK JP",
-        ),
-        (
-            "/usr/local/share/fonts/noto/NotoSansCJKkr-Regular.otf",
-            "Noto Sans CJK KR",
-        ),
-        (
-            "/usr/local/share/fonts/noto/NotoSansCJKsc-Regular.otf",
-            "Noto Sans CJK SC",
-        ),
-        (
-            "/usr/local/share/fonts/noto/NotoSansCJKtc-Regular.otf",
-            "Noto Sans CJK TC",
-        ),
-        (
-            "/usr/share/fonts/truetype/wqy/wqy-microhei.ttc",
-            "WenQuanYi Micro Hei",
-        ), // common fallback
-        (
-            "/usr/local/share/fonts/wqy/wqy-microhei.ttc",
-            "WenQuanYi Micro Hei",
-        ), // FreeBSD
-    ])
-}
-
-#[cfg(target_os = "macos")]
-fn configure_fonts() -> FontDefinitions {
-    // TODO: Default proportional fonts: ["Ubuntu-Light", "NotoEmoji-Regular", "emoji-icon-font"]
-    // does not support CJK. Add them for Mac.
-    FontDefinitions::default()
-}
-
 impl Drop for Gui {
     fn drop(&mut self) {
         self.rendering_context
@@ -203,8 +102,7 @@ impl Gui {
             false,
         );
 
-        let font_definitions = configure_fonts();
-        context.egui_ctx.set_fonts(font_definitions);
+        egui_system_fonts::set_auto(&context.egui_ctx, egui_system_fonts::FontStyle::Sans);
 
         context
             .egui_winit


### PR DESCRIPTION
Replaced the hardcoded per-distro font path lists and platform-specific `configure_fonts` functions with `egui_system_fonts::set_auto()`, which discovers and loads the system's sans-serif fonts (including CJK) on Windows, macOS, and Linux uniformly.


Testing: 
No automated tests. Manually verified that system fonts (including CJK) render correctly in the tab title and servoshell UI on Linux os.

Fixes: #44066