### PR TITLE
script: Partially port `HTMLStyleElement` to `&mut JSContext`

### DIFF
--- a/components/script/dom/domtokenlist.rs
+++ b/components/script/dom/domtokenlist.rs
@@ -11,12 +11,11 @@ use stylo_atoms::Atom;
 use crate::dom::attr::Attr;
 use crate::dom::bindings::codegen::Bindings::DOMTokenListBinding::DOMTokenListMethods;
 use crate::dom::bindings::error::{Error, ErrorResult, Fallible};
-use crate::dom::bindings::reflector::{Reflector, reflect_dom_object};
+use crate::dom::bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::element::Element;
 use crate::dom::node::NodeTraits;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct DOMTokenList {
@@ -43,19 +42,19 @@ impl DOMTokenList {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         element: &Element,
         local_name: &LocalName,
         supported_tokens: Option<Vec<Atom>>,
-        can_gc: CanGc,
     ) -> DomRoot<DOMTokenList> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(DOMTokenList::new_inherited(
                 element,
                 local_name.clone(),
                 supported_tokens,
             )),
             &*element.owner_window(),
-            can_gc,
+            cx,
         )
     }
 

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -2842,9 +2842,9 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-element-classlist>
-    fn ClassList(&self, can_gc: CanGc) -> DomRoot<DOMTokenList> {
+    fn ClassList(&self, cx: &mut js::context::JSContext) -> DomRoot<DOMTokenList> {
         self.class_list
-            .or_init(|| DOMTokenList::new(self, &local_name!("class"), None, can_gc))
+            .or_init(|| DOMTokenList::new(cx, self, &local_name!("class"), None))
     }
 
     // https://dom.spec.whatwg.org/#dom-element-slot
@@ -4314,10 +4314,10 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     }
 
     /// <https://drafts.csswg.org/css-shadow-parts/#dom-element-part>
-    fn Part(&self) -> DomRoot<DOMTokenList> {
-        self.ensure_rare_data().part.or_init(|| {
-            DOMTokenList::new(self, &local_name!("part"), None, CanGc::deprecated_note())
-        })
+    fn Part(&self, cx: &mut JSContext) -> DomRoot<DOMTokenList> {
+        self.ensure_rare_data()
+            .part
+            .or_init(|| DOMTokenList::new(cx, self, &local_name!("part"), None))
     }
 }
 

--- a/components/script/dom/html/htmlanchorelement.rs
+++ b/components/script/dom/html/htmlanchorelement.rs
@@ -36,7 +36,6 @@ use crate::dom::mouseevent::MouseEvent;
 use crate::dom::node::{Node, NodeTraits};
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::links::{LinkRelations, follow_hyperlink};
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLAnchorElement {
@@ -157,6 +156,7 @@ impl HTMLAnchorElementMethods<crate::DomTypeHolder> for HTMLAnchorElement {
     fn RelList(&self, cx: &mut JSContext) -> DomRoot<DOMTokenList> {
         self.rel_list.or_init(|| {
             DOMTokenList::new(
+                cx,
                 self.upcast(),
                 &local_name!("rel"),
                 Some(vec![
@@ -164,7 +164,6 @@ impl HTMLAnchorElementMethods<crate::DomTypeHolder> for HTMLAnchorElement {
                     Atom::from("noreferrer"),
                     Atom::from("opener"),
                 ]),
-                CanGc::from_cx(cx),
             )
         })
     }

--- a/components/script/dom/html/htmlareaelement.rs
+++ b/components/script/dom/html/htmlareaelement.rs
@@ -34,7 +34,6 @@ use crate::dom::html::htmlhyperlinkelementutils::{HyperlinkElement, HyperlinkEle
 use crate::dom::node::Node;
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::links::{LinkRelations, follow_hyperlink};
-use crate::script_runtime::CanGc;
 
 #[derive(Debug, PartialEq)]
 pub enum Area {
@@ -387,6 +386,7 @@ impl HTMLAreaElementMethods<crate::DomTypeHolder> for HTMLAreaElement {
     fn RelList(&self, cx: &mut JSContext) -> DomRoot<DOMTokenList> {
         self.rel_list.or_init(|| {
             DOMTokenList::new(
+                cx,
                 self.upcast(),
                 &local_name!("rel"),
                 Some(vec![
@@ -394,7 +394,6 @@ impl HTMLAreaElementMethods<crate::DomTypeHolder> for HTMLAreaElement {
                     Atom::from("noreferrer"),
                     Atom::from("opener"),
                 ]),
-                CanGc::from_cx(cx),
             )
         })
     }

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -513,6 +513,7 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
     fn RelList(&self, cx: &mut JSContext) -> DomRoot<DOMTokenList> {
         self.rel_list.or_init(|| {
             DOMTokenList::new(
+                cx,
                 self.upcast(),
                 &local_name!("rel"),
                 Some(vec![
@@ -520,7 +521,6 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
                     Atom::from("noreferrer"),
                     Atom::from("opener"),
                 ]),
-                CanGc::from_cx(cx),
             )
         })
     }

--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -53,7 +53,6 @@ use crate::navigation::{
     determine_creation_sandboxing_flags, determine_iframe_element_referrer_policy,
 };
 use crate::network_listener::ResourceTimingListener;
-use crate::script_runtime::CanGc;
 use crate::script_thread::{ScriptThread, with_script_thread};
 use crate::script_window_proxies::ScriptWindowProxies;
 
@@ -980,6 +979,7 @@ impl HTMLIFrameElementMethods<crate::DomTypeHolder> for HTMLIFrameElement {
     fn Sandbox(&self, cx: &mut JSContext) -> DomRoot<DOMTokenList> {
         self.sandbox.or_init(|| {
             DOMTokenList::new(
+                cx,
                 self.upcast::<Element>(),
                 &local_name!("sandbox"),
                 Some(vec![
@@ -997,7 +997,6 @@ impl HTMLIFrameElementMethods<crate::DomTypeHolder> for HTMLIFrameElement {
                     Atom::from("allow-top-navigation-by-user-activation"),
                     Atom::from("allow-top-navigation-to-custom-protocols"),
                 ]),
-                CanGc::from_cx(cx),
             )
         })
     }

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -1098,10 +1098,10 @@ impl StylesheetOwner for HTMLLinkElement {
     }
 
     fn referrer_policy(&self) -> ReferrerPolicy {
-        if self
-            .RelList(CanGc::deprecated_note())
-            .Contains("noreferrer".into())
-        {
+        #[expect(unsafe_code)]
+        // TODO: https://github.com/servo/servo/issues/44683
+        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
+        if self.RelList(&mut cx).Contains("noreferrer".into()) {
             return ReferrerPolicy::NoReferrer;
         }
 
@@ -1177,9 +1177,10 @@ impl HTMLLinkElementMethods<crate::DomTypeHolder> for HTMLLinkElement {
     make_bool_setter!(SetDisabled, "disabled");
 
     /// <https://html.spec.whatwg.org/multipage/#dom-link-rellist>
-    fn RelList(&self, can_gc: CanGc) -> DomRoot<DOMTokenList> {
+    fn RelList(&self, cx: &mut js::context::JSContext) -> DomRoot<DOMTokenList> {
         self.rel_list.or_init(|| {
             DOMTokenList::new(
+                cx,
                 self.upcast(),
                 &local_name!("rel"),
                 Some(vec![
@@ -1199,7 +1200,6 @@ impl HTMLLinkElementMethods<crate::DomTypeHolder> for HTMLLinkElement {
                     Atom::from("prerender"),
                     Atom::from("stylesheet"),
                 ]),
-                can_gc,
             )
         })
     }
@@ -1223,13 +1223,13 @@ impl HTMLLinkElementMethods<crate::DomTypeHolder> for HTMLLinkElement {
     make_setter!(SetTarget, "target");
 
     /// <https://html.spec.whatwg.org/multipage/#attr-link-blocking>
-    fn Blocking(&self, can_gc: CanGc) -> DomRoot<DOMTokenList> {
+    fn Blocking(&self, cx: &mut js::context::JSContext) -> DomRoot<DOMTokenList> {
         self.blocking.or_init(|| {
             DOMTokenList::new(
+                cx,
                 self.upcast(),
                 &local_name!("blocking"),
                 Some(vec![Atom::from("render")]),
-                can_gc,
             )
         })
     }

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -1374,10 +1374,10 @@ impl HTMLScriptElementMethods<crate::DomTypeHolder> for HTMLScriptElement {
     fn Blocking(&self, cx: &mut JSContext) -> DomRoot<DOMTokenList> {
         self.blocking.or_init(|| {
             DOMTokenList::new(
+                cx,
                 self.upcast(),
                 &local_name!("blocking"),
                 Some(vec![Atom::from("render")]),
-                CanGc::from_cx(cx),
             )
         })
     }

--- a/components/script/dom/html/htmlstyleelement.rs
+++ b/components/script/dom/html/htmlstyleelement.rs
@@ -481,13 +481,13 @@ impl HTMLStyleElementMethods<crate::DomTypeHolder> for HTMLStyleElement {
     make_setter!(SetMedia, "media");
 
     /// <https://html.spec.whatwg.org/multipage/#attr-style-blocking>
-    fn Blocking(&self, can_gc: CanGc) -> DomRoot<DOMTokenList> {
+    fn Blocking(&self, cx: &mut js::context::JSContext) -> DomRoot<DOMTokenList> {
         self.blocking.or_init(|| {
             DOMTokenList::new(
+                cx,
                 self.upcast(),
                 &local_name!("blocking"),
                 Some(vec![Atom::from("render")]),
-                can_gc,
             )
         })
     }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -317,8 +317,8 @@ DOMInterfaces = {
 },
 
 'Element': {
-    'cx': ['GetHTML', 'GetInnerHTML', 'GetOuterHTML', 'RemoveAttribute', 'SetClassName', 'SetHTMLUnsafe', 'SetId', 'SetInnerHTML', 'SetOuterHTML', 'InsertAdjacentHTML', 'ToggleAttribute', 'SetAttribute', 'SetAttributeNS', 'SetAttributeNode', 'SetAttributeNodeNS', 'RemoveAttributeNS', 'RemoveAttributeNode', 'SetRole', 'SetAriaAtomic', 'SetAriaAutoComplete', 'SetAriaBrailleLabel', 'SetAriaBrailleRoleDescription', 'SetAriaBusy', 'SetAriaChecked', 'SetAriaColCount', 'SetAriaColIndex', 'SetAriaColIndexText', 'SetAriaColSpan', 'SetAriaCurrent', 'SetAriaDescription', 'SetAriaDisabled', 'SetAriaExpanded', 'SetAriaHasPopup', 'SetAriaHidden', 'SetAriaInvalid', 'SetAriaKeyShortcuts', 'SetAriaLabel', 'SetAriaLevel', 'SetAriaLive', 'SetAriaModal', 'SetAriaMultiLine', 'SetAriaMultiSelectable', 'SetAriaOrientation', 'SetAriaPlaceholder', 'SetAriaPosInSet', 'SetAriaPressed','SetAriaReadOnly', 'SetAriaRelevant', 'SetAriaRequired', 'SetAriaRoleDescription', 'SetAriaRowCount', 'SetAriaRowIndex', 'SetAriaRowIndexText', 'SetAriaRowSpan', 'SetAriaSelected', 'SetAriaSetSize','SetAriaSort', 'SetAriaValueMax', 'SetAriaValueMin', 'SetAriaValueNow', 'SetAriaValueText', 'ReplaceWith', 'MoveBefore', 'InsertAdjacentElement', 'InsertAdjacentText', 'Before', 'After', 'Prepend', 'Remove', 'ReplaceChildren', 'Append', 'AttachShadow', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'Children', 'GetClientRects', 'GetBoundingClientRect'],
-    'canGc': ['RequestFullscreen', 'ClassList', 'Attributes'],
+    'cx': ['GetHTML', 'GetInnerHTML', 'GetOuterHTML', 'Part', 'RemoveAttribute', 'SetClassName', 'SetHTMLUnsafe', 'SetId', 'SetInnerHTML', 'SetOuterHTML', 'InsertAdjacentHTML', 'ToggleAttribute', 'SetAttribute', 'SetAttributeNS', 'SetAttributeNode', 'SetAttributeNodeNS', 'RemoveAttributeNS', 'RemoveAttributeNode', 'SetRole', 'SetAriaAtomic', 'SetAriaAutoComplete', 'SetAriaBrailleLabel', 'SetAriaBrailleRoleDescription', 'SetAriaBusy', 'SetAriaChecked', 'SetAriaColCount', 'SetAriaColIndex', 'SetAriaColIndexText', 'SetAriaColSpan', 'SetAriaCurrent', 'SetAriaDescription', 'SetAriaDisabled', 'SetAriaExpanded', 'SetAriaHasPopup', 'SetAriaHidden', 'SetAriaInvalid', 'SetAriaKeyShortcuts', 'SetAriaLabel', 'SetAriaLevel', 'SetAriaLive', 'SetAriaModal', 'SetAriaMultiLine', 'SetAriaMultiSelectable', 'SetAriaOrientation', 'SetAriaPlaceholder', 'SetAriaPosInSet', 'SetAriaPressed','SetAriaReadOnly', 'SetAriaRelevant', 'SetAriaRequired', 'SetAriaRoleDescription', 'SetAriaRowCount', 'SetAriaRowIndex', 'SetAriaRowIndexText', 'SetAriaRowSpan', 'SetAriaSelected', 'SetAriaSetSize','SetAriaSort', 'SetAriaValueMax', 'SetAriaValueMin', 'SetAriaValueNow', 'SetAriaValueText', 'ReplaceWith', 'MoveBefore', 'InsertAdjacentElement', 'InsertAdjacentText', 'Before', 'After', 'Prepend', 'Remove', 'ReplaceChildren', 'Append', 'AttachShadow', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'Children', 'GetClientRects', 'GetBoundingClientRect', 'ClassList'],
+    'canGc': ['RequestFullscreen', 'Attributes'],
 },
 
 'ElementInternals': {
@@ -530,8 +530,8 @@ DOMInterfaces = {
 },
 
 'HTMLLinkElement': {
-    'canGc': ['Blocking', 'GetSheet', 'RelList'],
-    'cx': ['SetCrossOrigin', 'SetRel'],
+    'canGc': ['GetSheet'],
+    'cx': ['Blocking', 'RelList', 'SetCrossOrigin', 'SetRel'],
 },
 
 'HTMLMapElement': {
@@ -587,7 +587,7 @@ DOMInterfaces = {
 },
 
 'HTMLStyleElement': {
-    'canGc': ['Blocking'],
+    'cx': ['Blocking'],
 },
 
 'HTMLTableElement': {


### PR DESCRIPTION
#44686 is stuck with some Stylo cross-thread resource sharing issue.
So I only kept the first few commit of that here.

Testing: It compiles.