### PR TITLE
ohos: Record custom fields via hitrace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3631,9 +3631,9 @@ dependencies = [
 
 [[package]]
 name = "hitrace"
-version = "0.1.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f08b27f2170156e182b2c3e340d68d087b34b2479366986c4e2e5339d73fe18"
+checksum = "1c3f6973c97140d216f538db9341d209bba665c23ccbf7b1ec8c1a7896701fbc"
 dependencies = [
  "hitrace-sys",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ gstreamer-video = "0.25"
 gstreamer-webrtc = { version = "0.25", features = ["v1_18"] }
 harfbuzz-sys = "0.6.1"
 headers = "0.4"
-hitrace = { version = "0.1.6", features = ["api-19", "tracing-rs"] }
+hitrace = { version = "0.2.0", features = ["api-19", "tracing-rs"] }
 hkdf = "0.12"
 html5ever = "0.39"
 http = "1.4"

--- a/ports/servoshell/lib.rs
+++ b/ports/servoshell/lib.rs
@@ -118,7 +118,7 @@ pub const VERSION: &str = concat!("Servo ", env!("CARGO_PKG_VERSION"), "-", env!
 /// Plumbs tracing spans into HiTrace, with the following caveats:
 ///
 /// - We ignore spans unless they have a `servo_profiling` field.
-/// - We map span entry ([`Layer::on_enter`]) to `OH_HiTrace_StartTrace(metadata.name())`.
+/// - We map span entry ([`Layer::on_enter`]) to `OH_HiTrace_StartTraceEx(metadata.name(), fields)`.
 /// - We map span exit ([`Layer::on_exit`]) to `OH_HiTrace_FinishTrace()`.
 ///
 /// As a result, within each thread, spans must exit in reverse order of their entry, otherwise the
@@ -166,10 +166,42 @@ struct HitraceLayer {}
 cfg_if! {
     if #[cfg(feature = "tracing-hitrace")] {
         use std::cell::RefCell;
+        use std::fmt;
+        use std::fmt::Write;
 
+        use tracing::field::{Field, Visit};
         use tracing::span::Id;
         use tracing::Subscriber;
         use tracing_subscriber::Layer;
+
+        #[derive(Default)]
+        struct HitraceFields(String);
+
+        impl HitraceFields {
+            /// Simplified recording for HiTrace.
+            ///
+            /// Field values can be recorded by `tracing-rs` after the span creation,
+            /// but we intentionally don't support this.
+            /// Otherwise, we would need to keep a list, so we can set the value
+            /// later when it is recorded.
+            fn record_value(&mut self, field: &Field, value: &dyn fmt::Debug) {
+                if field.name() == "servo_profiling" {
+                    return;
+                }
+
+                if !self.0.is_empty() {
+                    self.0.push(',');
+                }
+                write!(&mut self.0, "{}={value:?}", field.name())
+                    .expect("Writing to a String should never fail");
+            }
+        }
+
+        impl Visit for HitraceFields {
+            fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+                self.record_value(field, value);
+            }
+        }
 
         #[cfg(debug_assertions)]
         thread_local! {
@@ -180,37 +212,65 @@ cfg_if! {
         impl<S: Subscriber + for<'lookup> tracing_subscriber::registry::LookupSpan<'lookup>>
             Layer<S> for HitraceLayer
         {
+            fn on_new_span(
+                &self,
+                attrs: &tracing::span::Attributes<'_>,
+                id: &Id,
+                ctx: tracing_subscriber::layer::Context<'_, S>,
+            ) {
+                if attrs.metadata().fields().field("servo_profiling").is_none() {
+                    return;
+                }
+
+                let Some(span) = ctx.span(id) else {
+                    return;
+                };
+
+                let mut fields = HitraceFields::default();
+                attrs.record(&mut fields);
+                span.extensions_mut().insert(fields);
+            }
+
             fn on_enter(&self, id: &Id, ctx: tracing_subscriber::layer::Context<'_, S>) {
-                if let Some(metadata) = ctx.metadata(id) {
-                    // TODO: is this expensive? Would extensions be faster?
-                    // <https://docs.rs/tracing-subscriber/0.3.18/tracing_subscriber/registry/struct.ExtensionsMut.html>
+                if let Some(span) = ctx.span(id) {
+                    let metadata = span.metadata();
                     if metadata.fields().field("servo_profiling").is_some() {
                         #[cfg(debug_assertions)]
                         HITRACE_NAME_STACK.with_borrow_mut(|stack|
                             stack.push(metadata.name().to_owned()));
 
-                        hitrace::start_trace(
+                        let custom_args = {
+                            let extensions = span.extensions();
+                            std::ffi::CString::new(
+                                extensions
+                                    .get::<HitraceFields>()
+                                    // We can't take the String out of the extensions, so
+                                    // unfortunately this won't reuse the allocation.
+                                    .map(|fields| fields.0.as_str())
+                                    .unwrap_or_default(),
+                            )
+                            .expect("Failed to convert to CString")
+                        };
+
+                        hitrace::start_trace_ex(
+                            (*metadata.level()).into(),
                             &std::ffi::CString::new(metadata.name())
                                 .expect("Failed to convert str to CString"),
+                            &custom_args,
                         );
                     }
                 }
             }
 
             fn on_event(&self, event: &tracing::Event<'_>, _ctx: tracing_subscriber::layer::Context<'_, S>) {
-                let mut key_value_string: String = String::new();
-
-                event.record(&mut |field: &tracing::field::Field, value: &dyn std::fmt::Debug| {
-                    if field.name() != "servo_profiling" {
-                        key_value_string.push_str(&format!("{}={:?},",field.name(),value));
-                    }
-                });
+                let mut fields = HitraceFields::default();
+                event.record(&mut fields);
 
                 hitrace::start_trace_ex(
                     (*event.metadata().level()).into(),
                     &std::ffi::CString::new(event.metadata().name())
                         .expect("Failed to convert str to CString"),
-                    &std::ffi::CString::new(key_value_string.trim_end_matches(","))
+                    &std::ffi::CString::new(fields.0)
                         .expect("Failed to convert str to CString"),
                 );
 

--- a/ports/servoshell/lib.rs
+++ b/ports/servoshell/lib.rs
@@ -232,34 +232,34 @@ cfg_if! {
             }
 
             fn on_enter(&self, id: &Id, ctx: tracing_subscriber::layer::Context<'_, S>) {
-                if let Some(span) = ctx.span(id) {
-                    let metadata = span.metadata();
-                    if metadata.fields().field("servo_profiling").is_some() {
-                        #[cfg(debug_assertions)]
-                        HITRACE_NAME_STACK.with_borrow_mut(|stack|
-                            stack.push(metadata.name().to_owned()));
+                let Some(span) = ctx.span(id) else {
+                    return;
+                };
+                let extensions = span.extensions();
+                // The HitraceFields extension being missing implies `servo_profiling` was set.
+                let Some(fields) = extensions.get::<HitraceFields>() else {
+                    return;
+                };
+                // We can't take the String out of the extensions, so
+                //  unfortunately, this won't reuse the allocation.
+                let custom_args = std::ffi::CString::new(fields.0.as_str())
+                        .expect("Failed to convert to CString");
 
-                        let custom_args = {
-                            let extensions = span.extensions();
-                            std::ffi::CString::new(
-                                extensions
-                                    .get::<HitraceFields>()
-                                    // We can't take the String out of the extensions, so
-                                    // unfortunately this won't reuse the allocation.
-                                    .map(|fields| fields.0.as_str())
-                                    .unwrap_or_default(),
-                            )
-                            .expect("Failed to convert to CString")
-                        };
+                let metadata = span.metadata();
+                let level = (*metadata.level()).into();
+                let name = metadata.name();
 
-                        hitrace::start_trace_ex(
-                            (*metadata.level()).into(),
-                            &std::ffi::CString::new(metadata.name())
-                                .expect("Failed to convert str to CString"),
-                            &custom_args,
-                        );
-                    }
-                }
+                #[cfg(debug_assertions)]
+                HITRACE_NAME_STACK.with_borrow_mut(|stack|
+                    stack.push(name.to_owned()));
+
+                hitrace::start_trace_ex(
+                    level,
+                    &std::ffi::CString::new(name)
+                        .expect("Failed to convert str to CString"),
+                    &custom_args,
+                );
+
             }
 
             fn on_event(&self, event: &tracing::Event<'_>, _ctx: tracing_subscriber::layer::Context<'_, S>) {
@@ -279,26 +279,31 @@ cfg_if! {
 
 
             fn on_exit(&self, id: &Id, ctx: tracing_subscriber::layer::Context<'_, S>) {
-                if let Some(metadata) = ctx.metadata(id) {
-                    if metadata.fields().field("servo_profiling").is_some() {
-                        hitrace::finish_trace();
-
-                        #[cfg(debug_assertions)]
-                        HITRACE_NAME_STACK.with_borrow_mut(|stack| {
-                            if stack.last().map(|name| &**name) != Some(metadata.name()) {
-                                log::error!(
-                                    "Tracing span out of order: {} (stack: {:?})",
-                                    metadata.name(),
-                                    stack
-                                );
-                            }
-                            if !stack.is_empty() {
-                                stack.pop();
-                            }
-                        });
-                    }
+                let Some(span) = ctx.span(id) else {
+                    return;
+                };
+                if span.extensions().get::<HitraceFields>().is_none() {
+                    return;
                 }
+
+                hitrace::finish_trace();
+
+                #[cfg(debug_assertions)]
+                HITRACE_NAME_STACK.with_borrow_mut(|stack| {
+                    let metadata = span.metadata();
+                    if stack.last().map(|name| &**name) != Some(metadata.name()) {
+                        log::error!(
+                            "Tracing span out of order: {} (stack: {:?})",
+                            metadata.name(),
+                            stack
+                        );
+                    }
+                    if !stack.is_empty() {
+                        stack.pop();
+                    }
+                });
             }
+
         }
     }
 }

--- a/ports/servoshell/lib.rs
+++ b/ports/servoshell/lib.rs
@@ -170,6 +170,7 @@ cfg_if! {
         use std::fmt::Write;
 
         use tracing::field::{Field, Visit};
+        use tracing::Level;
         use tracing::span::Id;
         use tracing::Subscriber;
         use tracing_subscriber::Layer;
@@ -209,6 +210,21 @@ cfg_if! {
             static HITRACE_NAME_STACK: RefCell<Vec<String>> = RefCell::default();
         }
 
+        /// Map a tracing level to a HiTrace level.
+        ///
+        /// The log-level of hitrace itself can only be configured globally,
+        /// which drastically increases the amount of data that needs to be saved.
+        /// For our purposes, the tracing-rs internal filtering is sufficient,
+        /// and we don't need additional `debug` log level on the hitrace side,
+        /// so we just map anything below INFO to INFO.
+        fn convert_level(tracing_level: Level) -> hitrace::api_19::HiTraceOutputLevel {
+            if tracing_level < Level::INFO {
+                Level::INFO.into()
+            } else {
+                tracing_level.into()
+            }
+        }
+
         impl<S: Subscriber + for<'lookup> tracing_subscriber::registry::LookupSpan<'lookup>>
             Layer<S> for HitraceLayer
         {
@@ -246,7 +262,7 @@ cfg_if! {
                         .expect("Failed to convert to CString");
 
                 let metadata = span.metadata();
-                let level = (*metadata.level()).into();
+                let level = convert_level(*metadata.level());
                 let name = metadata.name();
 
                 #[cfg(debug_assertions)]
@@ -265,10 +281,12 @@ cfg_if! {
             fn on_event(&self, event: &tracing::Event<'_>, _ctx: tracing_subscriber::layer::Context<'_, S>) {
                 let mut fields = HitraceFields::default();
                 event.record(&mut fields);
+                let metadata = event.metadata();
+                let level = convert_level(*metadata.level());
 
                 hitrace::start_trace_ex(
-                    (*event.metadata().level()).into(),
-                    &std::ffi::CString::new(event.metadata().name())
+                    level,
+                    &std::ffi::CString::new(metadata.name())
                         .expect("Failed to convert str to CString"),
                     &std::ffi::CString::new(fields.0)
                         .expect("Failed to convert str to CString"),

--- a/ports/servoshell/lib.rs
+++ b/ports/servoshell/lib.rs
@@ -179,12 +179,6 @@ cfg_if! {
         struct HitraceFields(String);
 
         impl HitraceFields {
-            /// Simplified recording for HiTrace.
-            ///
-            /// Field values can be recorded by `tracing-rs` after the span creation,
-            /// but we intentionally don't support this.
-            /// Otherwise, we would need to keep a list, so we can set the value
-            /// later when it is recorded.
             fn record_value(&mut self, field: &Field, value: &dyn fmt::Debug) {
                 if field.name() == "servo_profiling" {
                     return;
@@ -247,12 +241,30 @@ cfg_if! {
                 span.extensions_mut().insert(fields);
             }
 
+            fn on_record(
+                &self,
+                id: &Id,
+                values: &tracing::span::Record<'_>,
+                ctx: tracing_subscriber::layer::Context<'_, S>,
+            ) {
+                let Some(span) = ctx.span(id) else {
+                    return;
+                };
+
+                let mut extensions = span.extensions_mut();
+                let Some(fields) = extensions.get_mut::<HitraceFields>() else {
+                    return;
+                };
+
+                values.record(fields);
+            }
+
             fn on_enter(&self, id: &Id, ctx: tracing_subscriber::layer::Context<'_, S>) {
                 let Some(span) = ctx.span(id) else {
                     return;
                 };
                 let extensions = span.extensions();
-                // The HitraceFields extension being missing implies `servo_profiling` was set.
+                // The HitraceFields extension being present implies `servo_profiling` was set.
                 let Some(fields) = extensions.get::<HitraceFields>() else {
                     return;
                 };

--- a/ports/servoshell/lib.rs
+++ b/ports/servoshell/lib.rs
@@ -119,7 +119,7 @@ pub const VERSION: &str = concat!("Servo ", env!("CARGO_PKG_VERSION"), "-", env!
 ///
 /// - We ignore spans unless they have a `servo_profiling` field.
 /// - We map span entry ([`Layer::on_enter`]) to `OH_HiTrace_StartTraceEx(metadata.name(), fields)`.
-/// - We map span exit ([`Layer::on_exit`]) to `OH_HiTrace_FinishTrace()`.
+/// - We map span exit ([`Layer::on_exit`]) to `OH_HiTrace_FinishTraceEx()`.
 ///
 /// As a result, within each thread, spans must exit in reverse order of their entry, otherwise the
 /// resultant profiling data will be incorrect (see the section below). This is not necessarily the
@@ -153,8 +153,8 @@ pub const VERSION: &str = concat!("Servo ", env!("CARGO_PKG_VERSION"), "-", env!
 /// in stable Rust, and converts to a [`u64`] in unstable Rust, so we would also need to make our
 /// own thread ids, perhaps by having a global atomic counter cached in a thread-local.
 ///
-/// [synchronous API]: https://docs.rs/hitrace-sys/0.1.2/hitrace_sys/fn.OH_HiTrace_StartTrace.html
-/// [asynchronous API]: https://docs.rs/hitrace-sys/0.1.2/hitrace_sys/fn.OH_HiTrace_StartAsyncTrace.html
+/// [synchronous API]: https://docs.rs/hitrace-sys/0.1.9/hitrace_sys/fn.OH_HiTrace_StartTraceEx.html
+/// [asynchronous API]: https://docs.rs/hitrace-sys/0.1.9/hitrace_sys/fn.OH_HiTrace_StartAsyncTraceEx.html
 /// [`Registry`]: tracing_subscriber::Registry
 /// [come from]: https://docs.rs/tracing-subscriber/0.3.18/src/tracing_subscriber/registry/sharded.rs.html#237-269
 /// [packed representation]: https://docs.rs/sharded-slab/0.1.7/sharded_slab/trait.Config.html

--- a/ports/servoshell/lib.rs
+++ b/ports/servoshell/lib.rs
@@ -304,7 +304,7 @@ cfg_if! {
                         .expect("Failed to convert str to CString"),
                 );
 
-                hitrace::finish_trace();
+                hitrace::finish_trace_ex(level);
             }
 
 
@@ -316,7 +316,8 @@ cfg_if! {
                     return;
                 }
 
-                hitrace::finish_trace();
+                let level = convert_level(*span.metadata().level());
+                hitrace::finish_trace_ex(level);
 
                 #[cfg(debug_assertions)]
                 HITRACE_NAME_STACK.with_borrow_mut(|stack| {


### PR DESCRIPTION
Previously we ignored all custom fields for spans. We need to save
them on span creation (apparently) in the extensions to access them later.
Span values can also be recorded later via [`Span::record`], but we
don't use that functionality in servo and hence skip implementing
`on_record`, which allows us to directly save everything into one
String.

[`Span::record`]: https://docs.rs/tracing-core/latest/tracing_core/trait.Subscriber.html#tymethod.record

Since we anyway already are using extensions now, resolve a TODO, and use
the presence of the extension as an alternative to checking `servo_profiling`
for enter and exit. I did not measure performance changes.

Testing: ohos CI builds with tracing-hitrace, and matches on some hitrace strings. Those shouldn't log any custom fields and hopefully won't be broken by the change. 

