### PR TITLE
servo: Propagate return value for spin_event_loop

### DIFF
--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -1007,8 +1007,8 @@ impl Servo {
     ///   - Performs updates in `Paint`, such as queued pinch zoom events
     ///   - Runs delegate methods on all `WebView`s and `Servo` itself
     ///   - Maybe update the rendered `Paint` output, but *without* swapping buffers.
-    pub fn spin_event_loop(&self) {
-        self.0.spin_event_loop();
+    pub fn spin_event_loop(&self) -> bool {
+        self.0.spin_event_loop()
     }
 
     pub fn setup_logging(&self) {

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -1007,6 +1007,9 @@ impl Servo {
     ///   - Performs updates in `Paint`, such as queued pinch zoom events
     ///   - Runs delegate methods on all `WebView`s and `Servo` itself
     ///   - Maybe update the rendered `Paint` output, but *without* swapping buffers.
+    ///
+    /// The return value of this method indicates whether or not Servo, false indicates that Servo
+    /// has finished shutting down and you should not spin the event loop any longer.
     pub fn spin_event_loop(&self) -> bool {
         self.0.spin_event_loop()
     }


### PR DESCRIPTION
Propagate bool from Servoinner spin_event_loop method 

Testing: call `spin_event_loop` and check the return type.
This isn't used by servoshell, so tested by external embedder.