### PR TITLE
script: Add support for processing instructions to Sanitizer interface

### DIFF
--- a/components/script/dom/security/sanitizer.rs
+++ b/components/script/dom/security/sanitizer.rs
@@ -15,7 +15,8 @@ use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx
 use crate::dom::bindings::codegen::Bindings::SanitizerBinding::{
     SanitizerAttribute, SanitizerAttributeNamespace, SanitizerConfig, SanitizerElement,
     SanitizerElementNamespace, SanitizerElementNamespaceWithAttributes,
-    SanitizerElementWithAttributes, SanitizerMethods, SanitizerPresets,
+    SanitizerElementWithAttributes, SanitizerMethods, SanitizerPI, SanitizerPresets,
+    SanitizerProcessingInstruction,
 };
 use crate::dom::bindings::codegen::UnionTypes::SanitizerConfigOrSanitizerPresets;
 use crate::dom::bindings::domname::is_valid_attribute_local_name;
@@ -163,15 +164,43 @@ impl SanitizerMethods<crate::DomTypeHolder> for Sanitizer {
             config_replace_with_children_elements.sort_by(|item_a, item_b| item_a.compare(item_b));
         }
 
-        // TODO:
-        // Step 6. If config["processingInstructions"] exists:
-        // Step 6.1. Set config["processingInstructions"] to the result of sort in ascending order
-        // config["processingInstructions"], with piA["target"] being code unit less than
-        // piB["target"].
-        // Step 7. Otherwise:
-        // Step 7.1. Set config["removeProcessingInstructions"] to the result of sort in ascending
-        // order config["removeProcessingInstructions"], with piA["target"] being code unit less
-        // than piB["target"].
+        match &mut config.processingInstructions {
+            // Step 6. If config["processingInstructions"] exists:
+            Some(config_processing_instructions) => {
+                // Step 6.1. Set config["processingInstructions"] to the result of sort in ascending
+                // order config["processingInstructions"], with piA["target"] being code unit less
+                // than piB["target"].
+                config_processing_instructions.sort_by(
+                    |processing_instruction_a, processing_instruction_b| {
+                        if processing_instruction_a.target() < processing_instruction_b.target() {
+                            Ordering::Less
+                        } else {
+                            Ordering::Greater
+                        }
+                    },
+                )
+            },
+            // Step 7. Otherwise:
+            None => {
+                // Step 7.1. Set config["removeProcessingInstructions"] to the result of sort in
+                // ascending order config["removeProcessingInstructions"], with piA["target"] being
+                // code unit less than piB["target"].
+                if let Some(config_remove_processing_instructions) =
+                    &mut config.removeProcessingInstructions
+                {
+                    config_remove_processing_instructions.sort_by(
+                        |processing_instruction_a, processing_instruction_b| {
+                            if processing_instruction_a.target() < processing_instruction_b.target()
+                            {
+                                Ordering::Less
+                            } else {
+                                Ordering::Greater
+                            }
+                        },
+                    )
+                }
+            },
+        }
 
         match &mut config.attributes {
             // Step 8. If config["attributes"] exists:
@@ -470,6 +499,120 @@ impl SanitizerMethods<crate::DomTypeHolder> for Sanitizer {
         true
     }
 
+    /// <https://wicg.github.io/sanitizer-api/#dom-sanitizer-allowprocessinginstruction>
+    fn AllowProcessingInstruction(&self, processing_instruction: SanitizerPI) -> bool {
+        // Step 1. Let configuration be this’s configuration.
+        let mut configuration = self.configuration.borrow_mut();
+
+        // Step 2. Assert: configuration is valid.
+        debug_assert!(configuration.is_valid());
+
+        // Step 3. Set pi to the result of canonicalize a sanitizer processing instruction with pi.
+        let processing_instruction = processing_instruction.canonicalize();
+
+        match &mut configuration.processingInstructions {
+            // Step 4. If configuration["processingInstructions"] exists:
+            Some(configuration_processing_instructions) => {
+                // Step 4.1. If configuration["processingInstructions"] contains pi:
+                if configuration_processing_instructions.contains_target(&processing_instruction) {
+                    // Step 4.1.1. Return false.
+                    return false;
+                }
+
+                // Step 4.2. Append pi to configuration["processingInstructions"].
+                configuration_processing_instructions.push(processing_instruction);
+
+                // Step 4.3. Return true.
+                true
+            },
+            // Step 5. Otherwise:
+            None => {
+                // Step 5.1. If configuration["removeProcessingInstructions"] contains pi:
+                if configuration
+                    .removeProcessingInstructions
+                    .as_ref()
+                    .is_some_and(|configuration_remove_processing_instructions| {
+                        configuration_remove_processing_instructions
+                            .contains_target(&processing_instruction)
+                    })
+                {
+                    // Step 5.1.1. Remove the item from
+                    // configuration["removeProcessingInstructions"] whose "target" is pi["target"].
+                    if let Some(configuration_remove_processing_instructions) =
+                        &mut configuration.removeProcessingInstructions
+                    {
+                        configuration_remove_processing_instructions
+                            .retain(|item| item.target() != processing_instruction.target())
+                    }
+
+                    // Step 5.1.2. Return true.
+                    return true;
+                }
+
+                // Step 5.2. Return false.
+                false
+            },
+        }
+    }
+
+    /// <https://wicg.github.io/sanitizer-api/#dom-sanitizer-removeprocessinginstruction>
+    fn RemoveProcessingInstruction(&self, processing_instruction: SanitizerPI) -> bool {
+        // Step 1. Let configuration be this’s configuration.
+        let mut configuration = self.configuration.borrow_mut();
+
+        // Step 2. Assert: configuration is valid.
+        debug_assert!(configuration.is_valid());
+
+        // Step 3. Set pi to the result of canonicalize a sanitizer processing instruction with pi.
+        let processing_instruction = processing_instruction.canonicalize();
+
+        match &mut configuration.processingInstructions {
+            // Step 4. If configuration["processingInstructions"] exists:
+            Some(configuration_processing_instructions) => {
+                // Step 4.1. If configuration["processingInstructions"] contains pi:
+                if configuration_processing_instructions.contains_target(&processing_instruction) {
+                    // Step 4.1.1. Remove the item from configuration["processingInstructions"]
+                    // whose "target" is pi["target"].
+                    configuration_processing_instructions
+                        .retain(|item| item.target() != processing_instruction.target());
+
+                    // Step 4.1.2. Return true.
+                    return true;
+                }
+
+                // Step 4.2. Return false.
+                false
+            },
+            // Step 5. Otherwise:
+            None => {
+                // Step 5.1. If configuration["removeProcessingInstructions"] contains pi:
+                if configuration
+                    .removeProcessingInstructions
+                    .as_ref()
+                    .is_some_and(|configuration_remove_processing_instructions| {
+                        configuration_remove_processing_instructions
+                            .contains_target(&processing_instruction)
+                    })
+                {
+                    // Step 5.1.1. Return false.
+                    return false;
+                }
+
+                // Step 5.2. Append pi to configuration["removeProcessingInstructions"].
+                if let Some(configuration_remove_processing_instructions) =
+                    &mut configuration.removeProcessingInstructions
+                {
+                    configuration_remove_processing_instructions.push(processing_instruction);
+                } else {
+                    configuration.removeProcessingInstructions = Some(vec![processing_instruction]);
+                }
+
+                // Step 5.3. Return true.
+                true
+            },
+        }
+    }
+
     /// <https://wicg.github.io/sanitizer-api/#dom-sanitizer-allowattribute>
     fn AllowAttribute(&self, attribute: SanitizerAttribute) -> bool {
         // Step 1. Let configuration be this’s configuration.
@@ -701,11 +844,17 @@ impl SanitizerConfigAlgorithm for SanitizerConfig {
             return false;
         }
 
-        // TODO:
         // Step 3. Assert: Either config["processingInstructions"] exists or
         // config["removeProcessingInstructions"] exists.
+        assert!(
+            self.processingInstructions.is_some() || self.removeProcessingInstructions.is_some()
+        );
+
         // Step 4. If config["processingInstructions"] exists and
         // config["removeProcessingInstructions"] exists, then return false.
+        if self.processingInstructions.is_some() && self.removeProcessingInstructions.is_some() {
+            return false;
+        }
 
         // Step 5. Assert: Either config["attributes"] exists or config["removeAttributes"] exists.
         assert!(self.attributes.is_some() || self.removeAttributes.is_some());
@@ -759,12 +908,28 @@ impl SanitizerConfigAlgorithm for SanitizerConfig {
             return false;
         }
 
-        // TODO:
-        // Step 11. If config["processingInstructions"] exists:
-        // Step 11.1. If config["processingInstructions"] has duplicate targets, then return false.
-        // Step 12. Otherwise:
-        // Step 12.1. If config["removeProcessingInstructions"] has duplicate targets, then return
-        // false.
+        match &self.processingInstructions {
+            // Step 11. If config["processingInstructions"] exists:
+            Some(config_processing_instructions) => {
+                // Step 11.1. If config["processingInstructions"] has duplicate targets, then return
+                // false.
+                if config_processing_instructions.has_duplicate_targets() {
+                    return false;
+                }
+            },
+            // Step 12. Otherwise:
+            None => {
+                // Step 12.1. If config["removeProcessingInstructions"] has duplicate targets, then
+                // return false.
+                if self.removeProcessingInstructions.as_ref().is_some_and(
+                    |config_remove_processing_instructions| {
+                        config_remove_processing_instructions.has_duplicate_targets()
+                    },
+                ) {
+                    return false;
+                }
+            },
+        }
 
         match &self.attributes {
             // Step 13. If config["attributes"] exists:
@@ -1223,12 +1388,19 @@ impl SanitizerConfigAlgorithm for SanitizerConfig {
             self.removeElements = Some(Vec::new());
         }
 
-        // TODO:
         // Step 2. If neither configuration["processingInstructions"] nor
         // configuration["removeProcessingInstructions"] exist:
-        // Step 2.1. If allowCommentsPIsAndDataAttributes is true, then set
-        // configuration["removeProcessingInstructions"] to « ».
-        // Step 2.2. Otherwise, set configuration["processingInstructions"] to « ».
+        if self.processingInstructions.is_none() && self.removeProcessingInstructions.is_none() {
+            // Step 2.1. If allowCommentsPIsAndDataAttributes is true, then set
+            // configuration["removeProcessingInstructions"] to « ».
+            if allow_comments_pis_and_data_attributes {
+                self.removeProcessingInstructions = Some(Vec::new());
+            }
+            // Step 2.2. Otherwise, set configuration["processingInstructions"] to « ».
+            else {
+                self.processingInstructions = Some(Vec::new());
+            }
+        }
 
         // Step 3. If neither configuration["attributes"] nor configuration["removeAttributes"]
         // exist, then set configuration["removeAttributes"] to « ».
@@ -1278,21 +1450,34 @@ impl SanitizerConfigAlgorithm for SanitizerConfig {
                 .collect();
         }
 
-        // TODO:
         // Step 7. If configuration["processingInstructions"] exists:
-        // Step 7.1. Let processingInstructions be « ».
-        // Step 7.2. For each pi of configuration["processingInstructions"]:
-        // Step 7.2.1. Append the result of canonicalize a sanitizer processing instruction pi
-        // to processingInstructions.
-        // Step 7.3. Set configuration["processingInstructions"] to processingInstructions.
+        if let Some(processing_instructions) = &mut self.processingInstructions {
+            // Step 7.1. Let processingInstructions be « ».
+            // Step 7.2. For each pi of configuration["processingInstructions"]:
+            // Step 7.2.1. Append the result of canonicalize a sanitizer processing instruction pi
+            // to processingInstructions.
+            // Step 7.3. Set configuration["processingInstructions"] to processingInstructions.
+            *processing_instructions = processing_instructions
+                .iter()
+                .cloned()
+                .map(SanitizerPI::canonicalize)
+                .collect();
+        }
 
-        // TODO:
         // Step 8. If configuration["removeProcessingInstructions"] exists:
-        // Step 8.1. Let processingInstructions be « ».
-        // Step 8.2. For each pi of configuration["removeProcessingInstructions"]:
-        // Step 8.2.1. Append the result of canonicalize a sanitizer processing instruction
-        // pi to processingInstructions.
-        // Step 8.3. Set configuration["removeProcessingInstructions"] to processingInstructions.
+        if let Some(remove_processing_instructions) = &mut self.removeProcessingInstructions {
+            // Step 8.1. Let processingInstructions be « ».
+            // Step 8.2. For each pi of configuration["removeProcessingInstructions"]:
+            // Step 8.2.1. Append the result of canonicalize a sanitizer processing instruction
+            // pi to processingInstructions.
+            // Step 8.3. Set configuration["removeProcessingInstructions"] to
+            // processingInstructions.
+            *remove_processing_instructions = remove_processing_instructions
+                .iter()
+                .cloned()
+                .map(SanitizerPI::canonicalize)
+                .collect();
+        }
 
         // Step 9. If configuration["attributes"] exists:
         if let Some(attributes) = &mut self.attributes {
@@ -1339,6 +1524,7 @@ impl SanitizerConfigAlgorithm for SanitizerConfig {
 trait Canonicalization {
     /// <https://wicg.github.io/sanitizer-api/#canonicalize-a-sanitizer-element-with-attributes>
     /// <https://wicg.github.io/sanitizer-api/#canonicalize-a-sanitizer-element>
+    /// <https://wicg.github.io/sanitizer-api/#canonicalize-a-sanitizer-processing-instruction>
     /// <https://wicg.github.io/sanitizer-api/#canonicalize-a-sanitizer-attribute>
     fn canonicalize(self) -> Self;
 }
@@ -1425,6 +1611,33 @@ impl Canonicalization for SanitizerElement {
         // Return the result of canonicalize a sanitizer name with element and the HTML namespace as
         // the default namespace.
         self.canonicalize_name(Some(ns!(html).to_string()))
+    }
+}
+impl Canonicalization for SanitizerPI {
+    /// <https://wicg.github.io/sanitizer-api/#canonicalize-a-sanitizer-processing-instruction>
+    fn canonicalize(self) -> Self {
+        // Step 1. Assert: pi is either a DOMString or a dictionary.
+        assert!(matches!(
+            self,
+            SanitizerPI::String(_) | SanitizerPI::SanitizerProcessingInstruction(_)
+        ));
+
+        // Step 2. If pi is a DOMString, then return «[ "target" → pi ]».
+        if let SanitizerPI::String(target) = self {
+            return SanitizerPI::SanitizerProcessingInstruction(SanitizerProcessingInstruction {
+                target,
+            });
+        }
+
+        // Step 3. Assert: pi is a dictionary and pi["target"] exists.
+        // NOTE: The latter is guaranteed by Rust type system.
+        assert!(matches!(
+            self,
+            SanitizerPI::SanitizerProcessingInstruction(_)
+        ));
+
+        // Step 4. Return «[ "target" → pi["target"] ]».
+        self
     }
 }
 
@@ -1997,6 +2210,53 @@ impl AttributeMember for SanitizerElementWithAttributes {
     }
 }
 
+/// Helper functions for accessing the "target" members of [`SanitizerPI`].
+trait TargetMember {
+    fn target(&self) -> &DOMString;
+}
+
+impl TargetMember for SanitizerPI {
+    fn target(&self) -> &DOMString {
+        match self {
+            SanitizerPI::String(string) => string,
+            SanitizerPI::SanitizerProcessingInstruction(dictionary) => &dictionary.target,
+        }
+    }
+}
+
+/// Supporting algorithms on lists of processing instructions, from the specification.
+trait TargetSlice<T>
+where
+    T: TargetMember,
+{
+    /// <https://wicg.github.io/sanitizer-api/#sanitizerconfig-contains-a-target>
+    fn contains_target(&self, other: &T) -> bool;
+
+    /// <https://wicg.github.io/sanitizer-api/#sanitizerconfig-has-duplicate-targets>
+    fn has_duplicate_targets(&self) -> bool;
+}
+
+impl<T> TargetSlice<T> for [T]
+where
+    T: TargetMember,
+{
+    /// <https://wicg.github.io/sanitizer-api/#sanitizerconfig-contains-a-target>
+    fn contains_target(&self, other: &T) -> bool {
+        // A Sanitizer target list contains a target target if there exists an entry of list that is
+        // an ordered map, and where target equals entry["target"].
+        self.iter().any(|entry| entry.target() == other.target())
+    }
+
+    /// <https://wicg.github.io/sanitizer-api/#sanitizerconfig-has-duplicate-targets>
+    fn has_duplicate_targets(&self) -> bool {
+        // A list list has duplicate targets, if for any item of list, there is more than one entry
+        // in list where item["target"] is entry["target"].
+        let mut used = HashSet::new();
+        self.iter()
+            .any(move |entry| !used.insert(entry.target().to_string()))
+    }
+}
+
 /// <https://wicg.github.io/sanitizer-api/#built-in-safe-default-configuration>
 fn built_in_safe_default_configuration() -> SanitizerConfig {
     const ELEMENTS: &[(&str, &Namespace, &[&str])] = &[
@@ -2294,6 +2554,8 @@ fn built_in_safe_default_configuration() -> SanitizerConfig {
         elements: Some(elements),
         removeElements: None,
         replaceWithChildrenElements: None,
+        processingInstructions: Some(Vec::new()),
+        removeProcessingInstructions: None,
         attributes: Some(attributes),
         removeAttributes: None,
         comments: Some(false),
@@ -2327,6 +2589,8 @@ fn built_in_safe_baseline_configuration() -> SanitizerConfig {
         elements: None,
         removeElements: Some(remove_elements),
         replaceWithChildrenElements: None,
+        processingInstructions: None,
+        removeProcessingInstructions: None,
         attributes: None,
         removeAttributes: Some(Vec::new()),
         comments: None,

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1250,6 +1250,10 @@ Dictionaries = {
     'derives': ['Clone', 'MallocSizeOf', 'PartialEq'],
 },
 
+'SanitizerProcessingInstruction': {
+    'derives': ['Clone', 'MallocSizeOf', 'PartialEq'],
+},
+
 'ScrollOptions': {
     'derives': ['Clone'],
 },
@@ -1302,6 +1306,10 @@ Unions = {
 },
 
 'StringOrSanitizerElementNamespaceWithAttributes': {
+    'derives': ['Clone', 'MallocSizeOf', 'PartialEq'],
+},
+
+'StringOrSanitizerProcessingInstruction': {
     'derives': ['Clone', 'MallocSizeOf', 'PartialEq'],
 },
 

--- a/components/script_bindings/webidls/Sanitizer.webidl
+++ b/components/script_bindings/webidls/Sanitizer.webidl
@@ -23,6 +23,8 @@ interface Sanitizer {
   boolean allowElement(SanitizerElementWithAttributes element);
   boolean removeElement(SanitizerElement element);
   boolean replaceElementWithChildren(SanitizerElement element);
+  boolean allowProcessingInstruction(SanitizerPI pi);
+  boolean removeProcessingInstruction(SanitizerPI pi);
   boolean allowAttribute(SanitizerAttribute attribute);
   boolean removeAttribute(SanitizerAttribute attribute);
   boolean setComments(boolean allow);
@@ -47,6 +49,12 @@ dictionary SanitizerElementNamespaceWithAttributes : SanitizerElementNamespace {
 typedef (DOMString or SanitizerElementNamespace) SanitizerElement;
 typedef (DOMString or SanitizerElementNamespaceWithAttributes) SanitizerElementWithAttributes;
 
+dictionary SanitizerProcessingInstruction {
+  required DOMString target;
+};
+
+typedef (DOMString or SanitizerProcessingInstruction) SanitizerPI;
+
 dictionary SanitizerAttributeNamespace {
   required DOMString name;
   DOMString? _namespace = null;
@@ -57,6 +65,9 @@ dictionary SanitizerConfig {
   sequence<SanitizerElementWithAttributes> elements;
   sequence<SanitizerElement> removeElements;
   sequence<SanitizerElement> replaceWithChildrenElements;
+
+  sequence<SanitizerPI> processingInstructions;
+  sequence<SanitizerPI> removeProcessingInstructions;
 
   sequence<SanitizerAttribute> attributes;
   sequence<SanitizerAttribute> removeAttributes;

--- a/tests/wpt/meta/sanitizer-api/idlharness.https.window.js.ini
+++ b/tests/wpt/meta/sanitizer-api/idlharness.https.window.js.ini
@@ -1,22 +1,4 @@
 [idlharness.https.window.html]
-  [Sanitizer interface: operation allowProcessingInstruction(SanitizerPI)]
-    expected: FAIL
-
-  [Sanitizer interface: operation removeProcessingInstruction(SanitizerPI)]
-    expected: FAIL
-
-  [Sanitizer interface: new Sanitizer({}) must inherit property "allowProcessingInstruction(SanitizerPI)" with the proper type]
-    expected: FAIL
-
-  [Sanitizer interface: calling allowProcessingInstruction(SanitizerPI) on new Sanitizer({}) with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Sanitizer interface: new Sanitizer({}) must inherit property "removeProcessingInstruction(SanitizerPI)" with the proper type]
-    expected: FAIL
-
-  [Sanitizer interface: calling removeProcessingInstruction(SanitizerPI) on new Sanitizer({}) with too few arguments must throw TypeError]
-    expected: FAIL
-
   [Document interface: operation parseHTML(DOMString, optional SetHTMLOptions)]
     expected: FAIL
 

--- a/tests/wpt/meta/sanitizer-api/sanitizer-processing-instructions.tentative.html.ini
+++ b/tests/wpt/meta/sanitizer-api/sanitizer-processing-instructions.tentative.html.ini
@@ -151,3 +151,21 @@
 
   [parseHTMLUnsafe testcase unsafe-only/2, "<div><?target data?></div>"]
     expected: FAIL
+
+  [setHTMLUnsafe testcase agnostic/4, "<?target-1 data?><?target-2 data?>"]
+    expected: FAIL
+
+  [ShadowRoot.setHTMLUnsafe testcase agnostic/4, "<?target-1 data?><?target-2 data?>"]
+    expected: FAIL
+
+  [setHTML testcase agnostic/4, "<?target-1 data?><?target-2 data?>"]
+    expected: FAIL
+
+  [ShadowRoot.setHTML testcase agnostic/4, "<?target-1 data?><?target-2 data?>"]
+    expected: FAIL
+
+  [parseHTML testcase agnostic/4, "<?target-1 data?><?target-2 data?>"]
+    expected: FAIL
+
+  [parseHTMLUnsafe testcase agnostic/4, "<?target-1 data?><?target-2 data?>"]
+    expected: FAIL

--- a/tests/wpt/tests/sanitizer-api/sanitizer-config.tentative.html
+++ b/tests/wpt/tests/sanitizer-api/sanitizer-config.tentative.html
@@ -100,6 +100,14 @@ for (key of ["elements", "removeElements", "replaceWithChildrenElements"]) {
     {name: "bla", namespace: "http://fantasy.org/namespace"},
     {name: "bla", namespace: "http://fantasy.org/namespace", ...extra});
 }
+for (key of ["processingInstructions", "removeProcessingInstructions"]) {
+  test_normalization(key,
+    "target-1",
+    {target: "target-1"});
+  test_normalization(key,
+    {target: "target-1"},
+    {target: "target-1"});
+}
 for (key of ["attributes", "removeAttributes"]) {
   test_normalization(key,
     "href",
@@ -154,6 +162,34 @@ test(t => {
   assert_object_equals(s.get().replaceWithChildrenElements[0],
                        {name: "bla", namespace: "http://www.w3.org/1999/xhtml"});
 }, "Test elements replacewithchildren.");
+
+test(t => {
+  let s = new Sanitizer({processingInstructions: ["target-1", "target-2"]});
+  assert_equals(s.get().processingInstructions.length, 2);
+  s.allowProcessingInstruction("target-3");
+  assert_equals(s.get().processingInstructions.length, 3);
+  s.removeProcessingInstruction({target: "target-4"});
+  assert_equals(s.get().processingInstructions.length, 3);
+  s.removeProcessingInstruction({target: "target-1"});
+  assert_equals(s.get().processingInstructions.length, 2);
+  s.removeProcessingInstruction({target: "target-2"});
+  assert_equals(s.get().processingInstructions.length, 1);
+  assert_object_equals(s.get().processingInstructions[0],
+                       {target: "target-3"});
+}, "Test processingInstructions addition.");
+
+test(t => {
+  let s = new Sanitizer({removeProcessingInstructions: ["target-1", "target-2"]});
+  assert_equals(s.get().removeProcessingInstructions.length, 2);
+  s.removeProcessingInstruction("target-3");
+  assert_equals(s.get().removeProcessingInstructions.length, 3);
+  s.allowProcessingInstruction({target: "target-1"});
+  assert_equals(s.get().removeProcessingInstructions.length, 2);
+  s.allowProcessingInstruction({target: "target-2"});
+  assert_equals(s.get().removeProcessingInstructions.length, 1);
+  assert_object_equals(s.get().removeProcessingInstructions[0],
+                       {target: "target-3"});
+}, "Test processingInstructions removal.");
 
 test(t => {
   let s = new Sanitizer({attributes: ["href", "src"]});
@@ -228,6 +264,13 @@ test(() => {
   });
 }, "Both attributes and removeAttributes should not be allowed.");
 
+// The config has either a processingInstructions or a removeProcessingInstructions key, but not both.
+test(() => {
+  assert_throws_js(TypeError, () => {
+    new Sanitizer({ processingInstructions: [], removeProcessingInstructions: [] });
+  });
+}, "Both processingInstructions and removeProcessingInstructions should not be allowed.");
+
 // 3. Assert: All SanitizerElementNamespaceWithAttributes, SanitizerElementNamespace, and SanitizerAttributeNamespace items in config are canonical, meaning they have been run through canonicalize a sanitizer element or canonicalize a sanitizer attribute, as appropriate.
 // This is tested in the sanitizer-config test file.
 
@@ -291,6 +334,31 @@ test(() => {
     });
   }
 }, "config[removeAttributes] should not allow duplicates");
+
+// None of config[processingInstructions] or config[removeProcessingInstructions], if they exist, has duplicate targets.
+const DUPLICATE_TARGETS = [
+  ["", ""],
+  ["abc", "abc"],
+  ["data-xyz", "data-xyz"],
+  ["abc", {target: "abc"}],
+  [{target: "abc"}, {target: "abc"}]
+];
+
+test(() => {
+  for (let targets of DUPLICATE_TARGETS) {
+    assert_throws_js(TypeError, () => {
+      new Sanitizer({ processingInstructions: targets });
+    });
+  }
+}, "config[processingInstructions] should not allow duplicate targets");
+
+test(() => {
+  for (let targets of DUPLICATE_TARGETS) {
+    assert_throws_js(TypeError, () => {
+      new Sanitizer({ removeProcessingInstructions: targets });
+    });
+  }
+}, "config[removeProcessingInstructions] should not allow duplicate targets");
 
 // 11.1. For each element of config["replaceWithChildrenElements"]:
 // 11.1.1. If the built-in non-replaceable elements list contains element, then return false.

--- a/tests/wpt/tests/sanitizer-api/sanitizer-default-config.tentative.html
+++ b/tests/wpt/tests/sanitizer-api/sanitizer-default-config.tentative.html
@@ -1125,6 +1125,7 @@ test(() => {
         ]
       }
     ],
+    "processingInstructions": [],
     "attributes": [
       {
         "name": "alignment-baseline",

--- a/tests/wpt/tests/sanitizer-api/sanitizer-get.tentative.html
+++ b/tests/wpt/tests/sanitizer-api/sanitizer-get.tentative.html
@@ -61,6 +61,38 @@ for (const key of ["attributes", "removeAttributes"]) {
   }, `Sorting of element's ${key}`);
 }
 
+const PI_TEST_CASES = [
+  [
+    ["b", "a"],
+    ["a", "b"]
+  ],
+  [
+    ["c", "b", "a"],
+    ["a", "b", "c"]
+  ],
+  [
+    [{target: "b"}, {target: "a"}],
+    [{target: "a"}, {target: "b"}]
+  ],
+  [
+    [{target: "c"}, {target: "b"}, {target: "a"}],
+    [{target: "a"}, {target: "b"}, {target: "c"}]
+  ]
+];
+
+for (const key of ["processingInstructions", "removeProcessingInstructions"]) {
+  test(() => {
+    for (const [input, expected] of PI_TEST_CASES) {
+      let s = new Sanitizer({
+        [key]: input
+      });
+      assert_config(s.get(), {
+        [key]: expected
+      });
+    }
+  }, `Sorting of ${key}`);
+}
+
 </script>
 </body>
 </html>

--- a/tests/wpt/tests/sanitizer-api/sanitizer-processing-instructions.tentative.html
+++ b/tests/wpt/tests/sanitizer-api/sanitizer-processing-instructions.tentative.html
@@ -30,13 +30,6 @@
 #data
 <?target data?>
 #config
-{ "processingInstructions": ["target"], "removeProcessingInstructions": ["target"] }
-#document
-| <?target data>
-
-#data
-<?target data?>
-#config
 { "processingInstructions": ["Target"] }
 #document
 

--- a/tests/wpt/tests/sanitizer-api/support/util.js
+++ b/tests/wpt/tests/sanitizer-api/support/util.js
@@ -12,6 +12,10 @@ function is_same_sanitizer_name(a, b) {
   return a.name === b.name && a.namespace === b.namespace;
 }
 
+function is_same_sanitizer_target(a, b) {
+  return a.target === b.target;
+}
+
 function is_data_attribute(attribute) {
   return attribute.name.startsWith("data-") && attribute.namespace === null;
 }
@@ -24,6 +28,22 @@ function has_duplicates(list) {
   for (let i = 0; i < list.length; i++) {
     for (let j = i + 1; j < list.length; j++) {
       if (is_same_sanitizer_name(list[i], list[j])) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+function has_duplicate_targets(list) {
+  if (!list) {
+    return false;
+  }
+
+  for (let i = 0; i < list.length; i++) {
+    for (let j = i + 1; j < list.length; j++) {
+      if (is_same_sanitizer_target(list[i], list[j])) {
         return true;
       }
     }
@@ -76,57 +96,79 @@ function assert_config_is_valid(config) {
     'If config["elements"] exists and config["removeElements"] exists, then return false.',
   );
 
-  // 3. Assert: Either config["attributes"] exists or config["removeAttributes"] exists.
+  // 3. Assert: Either config["processingInstructions"] exists or config["removeProcessingInstructions"] exists.
+  assert_true(
+    "processingInstructions" in config || "removeProcessingInstructions" in config,
+    'Assert: Either config["processingInstructions"] exists or config["removeProcessingInstructions"] exists.',
+  );
+
+  // 4. If config["processingInstructions"] exists and config["removeProcessingInstructions"] exists, then return false.
+  assert_false(
+    "processingInstructions" in config && "removeProcessingInstructions" in config,
+    'If config["processingInstructions"] exists and config["removeProcessingInstructions"] exists, then return false.',
+  );
+
+  // 5. Assert: Either config["attributes"] exists or config["removeAttributes"] exists.
   assert_true(
     "attributes" in config || "removeAttributes" in config,
     'Assert: Either config["attributes"] exists or config["removeAttributes"] exists.',
   );
 
-  // 4. If config["attributes"] exists and config["removeAttributes"] exists, then return false.
+  // 6. If config["attributes"] exists and config["removeAttributes"] exists, then return false.
   assert_false(
     "attributes" in config && "removeAttributes" in config,
     'If config["attributes"] exists and config["removeAttributes"] exists, then return false.',
   );
 
-  // 5. Assert: All SanitizerElementNamespaceWithAttributes, SanitizerElementNamespace, and SanitizerAttributeNamespace items in config are canonical, meaning they have been run through canonicalize a sanitizer element or canonicalize a sanitizer attribute, as appropriate.
+  // 7. Assert: All SanitizerElementNamespaceWithAttributes, SanitizerElementNamespace, SanitizerProcessingInstruction, and SanitizerAttributeNamespace items in config are canonical, meaning they have been run through canonicalize a sanitizer element, canonicalize a sanitizer processing instruction, or canonicalize a sanitizer attribute, as appropriate.
 
-  // 6. If config["elements"] exists:
+  // 8. If config["elements"] exists:
   if ("elements" in config) {
-    // 6.1. If config["elements"] has duplicates, then return false.
+    // 8.1. If config["elements"] has duplicates, then return false.
     assert_false(has_duplicates(config.elements), 'If config["elements"] has duplicates, then return false.');
   } else {
-    // 7. Otherwise:
-    // 7.1. If config["removeElements"] has duplicates, then return false.
+    // 9. Otherwise:
+    // 9.1. If config["removeElements"] has duplicates, then return false.
     assert_false(has_duplicates(config.removeElements), 'If config["removeElements"] has duplicates, then return false.');
   }
 
-  // 8. If config["replaceWithChildrenElements"] exists and has duplicates, then return false.
+  // 10. If config["replaceWithChildrenElements"] exists and has duplicates, then return false.
   if (config.replaceWithChildrenElements) {
     assert_false(has_duplicates(config.replaceWithChildrenElements), 'If config["replaceWithChildrenElements"] exists and has duplicates, then return false.');
   }
 
-  // 9. If config["attributes"] exists:
+  // 11. If config["processingInstructions"] exists:
+  if ("processingInstructions" in config) {
+    // 11.1. If config["processingInstructions"] has duplicate targets, then return false.
+    assert_false(has_duplicate_targets(config.processingInstructions), 'If config["processingInstructions"] has duplicate targets, then return false.')
+  } else {
+    // 12. Otherwise:
+    // 12.1. If config["removeProcessingInstructions"] has duplicate targets, then return false.
+    assert_false(has_duplicate_targets(config.removeProcessingInstructions), 'If config["removeProcessingInstructions"] has duplicate targets, then return false.')
+  }
+
+  // 13. If config["attributes"] exists:
   if ("attributes" in config) {
-    // 9.1. If config["attributes"] has duplicates, then return false.
+    // 13.1. If config["attributes"] has duplicates, then return false.
     assert_false(has_duplicates(config.attributes), 'If config["attributes"] has duplicates, then return false.');
   } else {
-    // 10. Otherwise:
-    // 10.1. If config["removeAttributes"] has duplicates, then return false.
+    // 14. Otherwise:
+    // 14.1. If config["removeAttributes"] has duplicates, then return false.
     assert_false(has_duplicates(config.removeAttributes), 'If config["removeAttributes"] has duplicates, then return false.');
   }
 
-  // 11. If config["replaceWithChildrenElements"] exists:
+  // 15. If config["replaceWithChildrenElements"] exists:
   if (config.replaceWithChildrenElements) {
-    // 11.1. If config["elements"] exists:
+    // 15.1. If config["elements"] exists:
     if (config.elements) {
-      // 11.1.1. If the intersection of config["elements"] and config["replaceWithChildrenElements"] is not empty, then return false.
+      // 15.1.1. If the intersection of config["elements"] and config["replaceWithChildrenElements"] is not empty, then return false.
       assert_false(
         has_intersection(config.elements, config.replaceWithChildrenElements),
         'If the intersection of config["elements"] and config["replaceWithChildrenElements"] is not empty, then return false.',
       );
     } else {
-      // 11.2. Otherwise:
-      // 11.2.1. If the intersection of config["removeElements"] and config["replaceWithChildrenElements"] is not empty, then return false.
+      // 15.2. Otherwise:
+      // 15.2.1. If the intersection of config["removeElements"] and config["replaceWithChildrenElements"] is not empty, then return false.
       assert_false(
         has_intersection(config.removeElements, config.replaceWithChildrenElements),
         'If the intersection of config["removeElements"] and config["replaceWithChildrenElements"] is not empty, then return false.',
@@ -134,36 +176,36 @@ function assert_config_is_valid(config) {
     }
   }
 
-  // 12. If config["attributes"] exists:
+  // 16. If config["attributes"] exists:
   if (config.attributes) {
-    // 12.1. Assert: config["dataAttributes"] exists.
+    // 16.1. Assert: config["dataAttributes"] exists.
     assert_true("dataAttributes" in config, 'Assert: config["dataAttributes"] exists.');
 
-    // 12.2. If config["elements"] exists:
+    // 16.2. If config["elements"] exists:
     if (config.elements) {
-      // 12.2.1. For each element of config["elements"]:
+      // 16.2.1. For each element of config["elements"]:
       for (let element of config.elements) {
-        // 12.2.1.1. If element["attributes"] exists and element["attributes"] has duplicates, then return false.
+        // 16.2.1.1. If element["attributes"] exists and element["attributes"] has duplicates, then return false.
         if (element.attributes) {
           assert_false(has_duplicates(element.attributes),
                       `If element["attributes"] exists and element["attributes"] has duplicates, then return false. (element: ${element.name})`);
         }
 
-        // 12.2.1.2. If element["removeAttributes"] exists and element["removeAttributes"] has duplicates, then return false.
+        // 16.2.1.2. If element["removeAttributes"] exists and element["removeAttributes"] has duplicates, then return false.
         if (element.removeAttributes) {
           assert_false(has_duplicates(element.removeAttributes),
                       `If element["removeAttributes"] exists and element["removeAttributes"] has duplicates, then return false. (element: ${element.name})`);
         }
 
-        // 12.2.1.3. If the intersection of config["attributes"] and element["attributes"] with default « » is not empty, then return false.
+        // 16.2.1.3. If the intersection of config["attributes"] and element["attributes"] with default « » is not empty, then return false.
         assert_false(has_intersection(config.attributes, element.attributes),
                     `If the intersection of config["attributes"] and element["attributes"] with default « » is not empty, then return false. (element: ${element.name})`);
 
-        // 12.2.1.4. If element["removeAttributes"] with default « » is not a subset of config["attributes"], then return false.
+        // 16.2.1.4. If element["removeAttributes"] with default « » is not a subset of config["attributes"], then return false.
         assert_true(is_subset(element.removeAttributes, config.attributes),
                     `If element["removeAttributes"] with default « » is not a subset of config["attributes"], then return false. (element: ${element.name})`);
 
-        // 12.2.1.5. If config["dataAttributes"] is true and element["attributes"] contains a custom data attribute, then return false.
+        // 16.2.1.5. If config["dataAttributes"] is true and element["attributes"] contains a custom data attribute, then return false.
         if (config.dataAttributes && element.attributes) {
           for (let attr of element.attributes) {
             assert_false(is_data_attribute(attr),
@@ -173,7 +215,7 @@ function assert_config_is_valid(config) {
       }
     }
 
-    // 12.3. If config["dataAttributes"] is true and config["attributes"] contains a custom data attribute, then return false.
+    // 16.3. If config["dataAttributes"] is true and config["attributes"] contains a custom data attribute, then return false.
     if (config.dataAttributes) {
       for (let attr of config.attributes) {
         assert_false(is_data_attribute(attr),
@@ -181,34 +223,34 @@ function assert_config_is_valid(config) {
       }
     }
   } else {
-    // 13. Otherwise:
-    // 13.1. If config["elements"] exists:
+    // 17. Otherwise:
+    // 17.1. If config["elements"] exists:
     if (config.elements) {
-      // 13.1.1. For each element of config["elements"]:
+      // 17.1.1. For each element of config["elements"]:
       for (let element of config.elements) {
-        // 13.1.1.1. If element["attributes"] exists and element["removeAttributes"] exists, then return false.
+        // 17.1.1.1. If element["attributes"] exists and element["removeAttributes"] exists, then return false.
         assert_false("attributes" in element && "removeAttributes" in element,
                      `If element["attributes"] exists and element["removeAttributes"] exists, then return false. (element: ${element.name})`);
 
-        // 13.1.1.2. If element["attributes"] exist and element["attributes"] has duplicates, then return false.
+        // 17.1.1.2. If element["attributes"] exist and element["attributes"] has duplicates, then return false.
         if (element.attributes) {
           assert_false(has_duplicates(element.attributes),
                       `If element["attributes"] exist and element["attributes"] has duplicates, then return false. (element: ${element.name})`);
         }
 
-        // 13.1.1.3. If element["removeAttributes"] exist and element["removeAttributes"] has duplicates, then return false.
+        // 17.1.1.3. If element["removeAttributes"] exist and element["removeAttributes"] has duplicates, then return false.
         if (element.removeAttributes) {
           assert_false(has_duplicates(element.removeAttributes),
                       `If element["removeAttributes"] exist and element["removeAttributes"] has duplicates, then return false. (element: ${element.name})`);
         }
 
-        // 13.1.1.4. If the intersection of config["removeAttributes"] and element["attributes"] with default « » is not empty, then return false.
+        // 17.1.1.4. If the intersection of config["removeAttributes"] and element["attributes"] with default « » is not empty, then return false.
         if (element.attributes) {
           assert_false(has_intersection(config.removeAttributes, element.attributes),
                       `If the intersection of config["removeAttributes"] and element["attributes"] with default « » is not empty, then return false. (element: ${element.name})`);
         }
 
-        // 13.1.1.5. If the intersection of config["removeAttributes"] and element["removeAttributes"] with default « » is not empty, then return false.
+        // 17.1.1.5. If the intersection of config["removeAttributes"] and element["removeAttributes"] with default « » is not empty, then return false.
         if (element.removeAttributes) {
           assert_false(has_intersection(config.removeAttributes, element.removeAttributes),
                       `If the intersection of config["removeAttributes"] and element["removeAttributes"] with default « » is not empty, then return false. (element: ${element.name})`);
@@ -216,17 +258,19 @@ function assert_config_is_valid(config) {
       }
     }
 
-    // 13.2. If config["dataAttributes"] exists, then return false.
+    // 17.2. If config["dataAttributes"] exists, then return false.
     assert_false("dataAttributes" in config, 'If config["dataAttributes"] exists, then return false.');
   }
 
-  // 14. Return true.
+  // 18. Return true.
 }
 
 function assert_config(config, expected) {
   const PROPERTIES = [
     "attributes",
     "removeAttributes",
+    "processingInstructions",
+    "removeProcessingInstructions",
     "elements",
     "removeElements",
     "replaceWithChildrenElements",
@@ -277,6 +321,39 @@ function assert_config(config, expected) {
 
   assert_attrs("attributes", config, expected);
   assert_attrs("removeAttributes", config, expected);
+
+  function assert_pis(key, config, expected, prefix = "config") {
+    if (!(key in expected)) {
+      return;
+    }
+
+    if (expected[key] === undefined) {
+      assert_false(key in config, `Unexpected '${key}' in ${prefix}`);
+      return;
+    }
+
+    assert_true(key in config, `Missing '${key}' from ${prefix}`);
+    assert_equals(config[key]?.length, expected[key].length, `${prefix}.${key}.length`);
+    for (let i = 0; i < expected[key].length; i++) {
+      let processingInstructions = expected[key][i];
+      if (typeof processingInstructions === "string") {
+        assert_object_equals(
+          config[key][i],
+          { target: processingInstructions },
+          `${prefix}.${key}[${i}] should match`,
+        );
+      } else {
+        assert_object_equals(
+          config[key][i],
+          processingInstructions,
+          `${prefix}.${key}[${i}] should match`,
+        );
+      }
+    }
+  }
+
+  assert_pis("processingInstructions", config, expected);
+  assert_pis("removeProcessingInstructions", config, expected);
 
   function assert_elems(key) {
     if (!(key in expected)) {


### PR DESCRIPTION
Implement support for processing instructions in our Sanitizer API implementation.

This patch implements the `Sanitizer.allowProcessingInstructions()` and `Sanitizer.removeProcessingInstructions()` methods, along with some supporting algorithms and missing steps related to processing instructions.

Specification:
- https://wicg.github.io/sanitizer-api/#dom-sanitizer-allowprocessinginstruction
- https://wicg.github.io/sanitizer-api/#dom-sanitizer-removeprocessinginstruction
- https://wicg.github.io/sanitizer-api/#canonicalize-a-sanitizer-processing-instruction
- https://wicg.github.io/sanitizer-api/#sanitizerconfig-contains-a-target
- https://wicg.github.io/sanitizer-api/#sanitizerconfig-has-duplicate-targets

Testing:
- Add new WPT tests to:
  - `sanitizer-api/sanitizer-config.tentative.html` and
  - `sanitizer-api/sanitizer-get.tentative.html`
- Update tests in:
  - `sanitizer-api/sanitizer-default-config.tentative.html`
- Remove a test case from:
  - `sanitizer-api/sanitizer-processing-instructions.tentative.html` (According to Step 4 of https://wicg.github.io/sanitizer-api/#sanitizerconfig-valid, the configuration of that test case is invalid since both "processingInstructions" and "removeProcessingInstructions" keys exist.)
- Update supporting file:
  - `sanitizer-api/support/util.js`

Fixes: Part of #43948