### PR TITLE
script: Fix effectively contained including ancestors of text nodes

### DIFF
--- a/components/script/dom/execcommand/contenteditable/node.rs
+++ b/components/script/dom/execcommand/contenteditable/node.rs
@@ -134,16 +134,48 @@ where
     let old_parent = node.GetParentNode();
     let old_index = node.index();
 
+    let selection = node
+        .owner_document()
+        .GetSelection(cx)
+        .expect("Must always have a selection");
+    let active_range = selection
+        .active_range()
+        .expect("Must always have an active range");
+
+    // Relevant only in the case where we have a single text node that is partially/fully selected.
+    // In that case, the spec algorithm would update the selection to the parent of the text node.
+    // However, this then breaks the algorithm to compute "effectively contained" nodes. To remedy
+    // that, we record the values here and reset them as part of step 2.
+    let end_offsets_if_previously_selected_single_text_node = if active_range.start_container() ==
+        active_range.end_container() &&
+        active_range.start_container().is::<Text>()
+    {
+        Some((active_range.start_offset(), active_range.end_offset()))
+    } else {
+        None
+    };
+
     if move_(cx).is_err() {
         unreachable!("Must always be able to move");
     }
 
-    let Some(selection) = node.owner_document().GetSelection(cx) else {
+    // Step 2. If a boundary point's node is the same as or a descendant of node, leave it unchanged,
+    // so it moves to the new location.
+    //
+    // From the spec:
+    // > This is actually implicit, but I state it anyway for completeness.
+    //
+    // However, this is not actually implicit. The caveat here are text nodes that are
+    // partially/fully selected. In these cases, we shouldn't update the offsets to the new parent,
+    // but instead retain them on the original text node. Therefore, if that's the case,
+    // update them here and immediately return.
+    if let Some((previous_start_offset, previous_end_offset)) =
+        end_offsets_if_previously_selected_single_text_node
+    {
+        active_range.set_start(node, previous_start_offset);
+        active_range.set_end(node, previous_end_offset);
         return;
-    };
-    let Some(active_range) = selection.active_range() else {
-        return;
-    };
+    }
 
     let new_parent = node.GetParentNode().expect("Must always have a new parent");
     let new_index = node.index();
@@ -152,11 +184,6 @@ where
     let mut start_offset = active_range.start_offset();
     let mut end_node = active_range.end_container();
     let mut end_offset = active_range.end_offset();
-
-    // Step 2. If a boundary point's node is the same as or a descendant of node, leave it unchanged, so it moves to the new location.
-    //
-    // From the spec:
-    // > This is actually implicit, but I state it anyway for completeness.
 
     // Step 3. If a boundary point's node is new parent and its offset is greater than new index, add one to its offset.
     if start_node == new_parent && start_offset > new_index {

--- a/components/script/dom/execcommand/contenteditable/range.rs
+++ b/components/script/dom/execcommand/contenteditable/range.rs
@@ -96,12 +96,29 @@ impl Range {
         && (!node.is_ancestor_of(&end_container) || !end_container.is::<Text>() || self.end_offset() == end_container.len())
     }
 
+    /// The definition of "effectively contained" contains the recursion of
+    /// ancestors of a single fully selected text node. That is to say, that
+    /// if the selection is a fully selected text node <div>[foobar]</div>,
+    /// then the div would also be considered effectively contained. As such,
+    /// we can't use the common ancestor container, since that would be the
+    /// text node only.
+    ///
+    /// Instead, we traverse all the way up to the editing host, which we know
+    /// is sufficient to know to include all contained nodes. That way, we also
+    /// would traverse ancestors such as the parent div.
+    fn ancestor_for_effectively_contained(&self) -> DomRoot<Node> {
+        let ancestor_container = self.CommonAncestorContainer();
+        ancestor_container
+            .editing_host_of()
+            .unwrap_or(ancestor_container)
+    }
+
     pub(crate) fn first_formattable_contained_node(&self) -> Option<DomRoot<Node>> {
         if self.collapsed() {
             return None;
         }
 
-        self.CommonAncestorContainer()
+        self.ancestor_for_effectively_contained()
             .traverse_preorder(ShadowIncluding::No)
             .find(|child| child.is_formattable() && self.is_effectively_contained_node(child))
     }
@@ -117,7 +134,7 @@ impl Range {
         // Make sure to keep track of the tree nodes before, since `callback` might modify
         // the underyling tree and then the iterator would prematurely stop.
         let children = self
-            .CommonAncestorContainer()
+            .ancestor_for_effectively_contained()
             .traverse_preorder(ShadowIncluding::No)
             .collect::<Vec<DomRoot<Node>>>();
 

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -180,9 +180,10 @@ pub struct Node {
 
 impl fmt::Debug for Node {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if matches!(self.type_id(), NodeTypeId::Element(_)) {
-            let el = self.downcast::<Element>().unwrap();
-            el.fmt(f)
+        if let Some(element) = self.downcast::<Element>() {
+            element.fmt(f)
+        } else if let Some(character_data) = self.downcast::<CharacterData>() {
+            write!(f, "[Text({})]", character_data.data())
         } else {
             write!(f, "[Node({:?})]", self.type_id())
         }

--- a/tests/wpt/meta/editing/run/backcolor.html.ini
+++ b/tests/wpt/meta/editing/run/backcolor.html.ini
@@ -59,9 +59,6 @@
   [[["stylewithcss","false"\],["backcolor","#00FFFF"\]\] "foo[<span style=background-color:tan>b\]ar</span>baz" queryCommandValue("backcolor") after]
     expected: FAIL
 
-  [[["backcolor","#00FFFF"\]\] "foo<span style=background-color:tan>[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
   [[["backcolor","#00FFFF"\]\] "<p style=\\"background-color: rgb(0, 255, 255)\\">foo[bar\]baz</p>" compare innerHTML]
     expected: FAIL
 

--- a/tests/wpt/meta/editing/run/bold.html.ini
+++ b/tests/wpt/meta/editing/run/bold.html.ini
@@ -11,36 +11,6 @@
   [[["bold",""\]\] "foo bar <b>baz [qoz</b> quz\] sic" queryCommandIndeterm("bold") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["bold",""\]\] "foo<span style=\\"font-weight: 100\\">[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["bold",""\]\] "foo<span style=\\"font-weight: 100\\">[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["bold",""\]\] "foo<span style=\\"font-weight: 200\\">[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["bold",""\]\] "foo<span style=\\"font-weight: 200\\">[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["bold",""\]\] "foo<span style=\\"font-weight: 300\\">[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["bold",""\]\] "foo<span style=\\"font-weight: 300\\">[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["bold",""\]\] "foo<span style=\\"font-weight: 400\\">[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["bold",""\]\] "foo<span style=\\"font-weight: 400\\">[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["bold",""\]\] "foo<span style=\\"font-weight: 500\\">[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["bold",""\]\] "foo<span style=\\"font-weight: 500\\">[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["bold",""\]\] "foo[<span style=\\"font-weight: 400\\">bar\]</span>baz" compare innerHTML]
     expected: FAIL
 
@@ -80,22 +50,19 @@
   [[["stylewithcss","false"\],["bold",""\]\] "foo[<span style=\\"font-weight: bold\\">bar</span>\]baz" queryCommandState("bold") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["bold",""\]\] "<b id=purple>bar [baz\] qoz</b>" queryCommandState("bold") after]
+  [[["stylewithcss","true"\],["bold",""\]\] "<b id=purple>bar [baz\] qoz</b>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["bold",""\]\] "<b id=purple>bar [baz\] qoz</b>" queryCommandState("bold") after]
+  [[["stylewithcss","false"\],["bold",""\]\] "<b id=purple>bar [baz\] qoz</b>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["bold",""\]\] "<span style=\\"font-weight: 700\\">foo[bar\]baz</span>" queryCommandState("bold") after]
+  [[["stylewithcss","true"\],["bold",""\]\] "<span style=\\"font-weight: 700\\">foo[bar\]baz</span>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["bold",""\]\] "<span style=\\"font-weight: 700\\">foo[bar\]baz</span>" queryCommandState("bold") after]
+  [[["stylewithcss","false"\],["bold",""\]\] "<span style=\\"font-weight: 700\\">foo[bar\]baz</span>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["bold",""\]\] "<span style=\\"font-weight: 900\\">foo[bar\]baz</span>" queryCommandState("bold") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["bold",""\]\] "<span style=\\"font-weight: 900\\">foo[bar\]baz</span>" queryCommandState("bold") after]
+  [[["stylewithcss","true"\],["bold",""\]\] "<span style=\\"font-weight: 900\\">foo[bar\]baz</span>" compare innerHTML]
     expected: FAIL
 
 
@@ -156,6 +123,9 @@
   [[["stylewithcss","false"\],["bold",""\]\] "<span style=font-weight:100>fo[o</span><span style=font-weight:200>b\]ar</span>" queryCommandState("stylewithcss") after]
     expected: FAIL
 
+  [[["stylewithcss","false"\],["bold",""\]\] "abc<i>[def\]</i>ghi" compare innerHTML]
+    expected: FAIL
+
 
 [bold.html?2001-3000]
   [[["bold",""\]\] "<span style=\\"font-weight: 900\\">foo[barbaz</span>}" compare innerHTML]
@@ -197,12 +167,6 @@
   [[["stylewithcss","false"\],["bold",""\]\] "foo<span style=\\"font-weight: normal\\"><b>{bar}</b></span>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["bold",""\]\] "<b><span class=notbold>[foo\]</span></b>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["bold",""\]\] "<b><span class=notbold>[foo\]</span></b>" compare innerHTML]
-    expected: FAIL
-
   [[["bold",""\]\] "fo[o<b>b\]ar</b>baz" queryCommandIndeterm("bold") before]
     expected: FAIL
 
@@ -237,4 +201,16 @@
     expected: FAIL
 
   [[["bold",""\]\] "<span style=\\"font-weight: 900\\">foo[barbaz</span>}" queryCommandState("bold") after]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["bold",""\]\] "<b><span class=notbold>[foo\]</span></b>" queryCommandState("bold") after]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["bold",""\]\] "<b><span class=notbold>[foo\]</span></b>" queryCommandState("bold") after]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["bold",""\]\] "<p style=\\"font-weight: bold\\">foo[bar\]baz</p>" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["bold",""\]\] "<p style=\\"font-weight: bold\\">foo[bar\]baz</p>" compare innerHTML]
     expected: FAIL

--- a/tests/wpt/meta/editing/run/createlink.html.ini
+++ b/tests/wpt/meta/editing/run/createlink.html.ini
@@ -17,12 +17,6 @@
   [[["createlink","http://www.google.com/"\]\] "{<a href=otherurl>foobar\]baz</a>" compare innerHTML]
     expected: FAIL
 
-  [[["createlink","http://www.google.com/"\]\] "<a href=otherurl>[foobarbaz\]</a>" compare innerHTML]
-    expected: FAIL
-
-  [[["createlink","http://www.google.com/"\]\] "foo<a href=otherurl>[bar\]</a>baz" compare innerHTML]
-    expected: FAIL
-
   [[["createlink","http://www.google.com/"\]\] "[foo<a href=otherurl>bar\]</a>baz" compare innerHTML]
     expected: FAIL
 
@@ -33,7 +27,4 @@
     expected: FAIL
 
   [[["createlink","http://www.google.com/"\]\] "{<a href=otherurl><b>foobar\]baz</b></a>" compare innerHTML]
-    expected: FAIL
-
-  [[["createlink","http://www.google.com/"\]\] "<a href=otherurl><b>[foobarbaz\]</b></a>" compare innerHTML]
     expected: FAIL

--- a/tests/wpt/meta/editing/run/fontname.html.ini
+++ b/tests/wpt/meta/editing/run/fontname.html.ini
@@ -23,6 +23,30 @@
   [[["stylewithcss","true"\],["fontname","sans-serif"\]\] "<p>[foo</p> <p>bar\]</p>" queryCommandState("stylewithcss") before]
     expected: FAIL
 
+  [[["stylewithcss","true"\],["fontname","sans-serif"\]\] "foo<code>[bar\]</code>baz" queryCommandValue("fontname") after]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["fontname","sans-serif"\]\] "foo<code>[bar\]</code>baz" queryCommandValue("fontname") after]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["fontname","sans-serif"\]\] "foo<kbd>[bar\]</kbd>baz" queryCommandValue("fontname") after]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["fontname","sans-serif"\]\] "foo<kbd>[bar\]</kbd>baz" queryCommandValue("fontname") after]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["fontname","sans-serif"\]\] "foo<samp>[bar\]</samp>baz" queryCommandValue("fontname") after]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["fontname","sans-serif"\]\] "foo<samp>[bar\]</samp>baz" queryCommandValue("fontname") after]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["fontname","sans-serif"\]\] "foo<tt>[bar\]</tt>baz" queryCommandValue("fontname") after]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["fontname","sans-serif"\]\] "foo<tt>[bar\]</tt>baz" queryCommandValue("fontname") after]
+    expected: FAIL
+
 
 [fontname.html?2001-last]
   [[["stylewithcss","false"\],["fontname","sans-serif"\]\] "fo[o<listing>b\]ar</listing>" queryCommandValue("fontname") after]
@@ -55,15 +79,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontname","sans-serif"\]\] "[foo<tt>bar</tt>baz\]" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontname","sans-serif"\]\] "foo<span style=\\"font-family: sans-serif\\">[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontname","sans-serif"\]\] "foo<span style=\\"font-family: monospace\\">[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontname","sans-serif"\]\] "foo<span style=\\"font-family: monospace\\">[bar\]</span>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontname","sans-serif"\]\] "foo<span style=\\"font-family: monospace\\">b[a\]r</span>baz" compare innerHTML]
@@ -133,12 +148,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontname","sans-serif"\]\] "foo<span style=font-family:monospace>ba[r</span>\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontname","sans-serif"\]\] "foo<span style=font-family:monospace>[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontname","sans-serif"\]\] "foo<span style=font-family:monospace>[bar\]</span>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontname","sans-serif"\]\] "[foo<samp>bar</samp>baz\]" queryCommandState("stylewithcss") before]

--- a/tests/wpt/meta/editing/run/fontsize.html.ini
+++ b/tests/wpt/meta/editing/run/fontsize.html.ini
@@ -64,22 +64,10 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<table><tbody data-start=0 data-end=1><tr><td>foo<td>bar<td>baz</table>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=1>[bar\]</font>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=1>[bar\]</font>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=1>foo[bar\]baz</font>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=1>foo[bar\]baz</font>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=3>[bar\]</font>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=3>[bar\]</font>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=3>foo[bar\]baz</font>" compare innerHTML]
@@ -88,16 +76,7 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=3>foo[bar\]baz</font>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=4>[bar\]</font>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=+1>[bar\]</font>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=+1>[bar\]</font>baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=+1>[bar\]</font>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=+1>[bar\]</font>baz" queryCommandValue("fontsize") before]
@@ -106,13 +85,7 @@
   [[["fontsize","4"\]\] "<font size=+1>foo[bar\]baz</font>" queryCommandValue("fontsize") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<span style=\\"font-size: xx-small\\">[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<span style=\\"font-size: xx-small\\">[bar\]</span>baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<span style=\\"font-size: xx-small\\">[bar\]</span>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<span style=\\"font-size: xx-small\\">[bar\]</span>baz" queryCommandValue("fontsize") before]
@@ -130,19 +103,10 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<span style=\\"font-size: xx-small\\">foo[bar\]baz</span>" queryCommandValue("fontsize") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<span style=\\"font-size: medium\\">[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<span style=\\"font-size: medium\\">[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<span style=\\"font-size: medium\\">foo[bar\]baz</span>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<span style=\\"font-size: medium\\">foo[bar\]baz</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<span style=\\"font-size: large\\">[bar\]</span>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<span style=\\"font-size: large\\">foo<span style=\\"font-size: xx-small\\">b[a\]r</span>baz</span>" queryCommandValue("fontsize") before]
@@ -151,13 +115,7 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<span style=\\"font-size: large\\">foo<span style=\\"font-size: xx-small\\">b[a\]r</span>baz</span>" queryCommandValue("fontsize") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<span style=\\"font-size: 2em\\">[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<span style=\\"font-size: 2em\\">[bar\]</span>baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<span style=\\"font-size: 2em\\">[bar\]</span>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<span style=\\"font-size: 2em\\">[bar\]</span>baz" queryCommandValue("fontsize") before]
@@ -256,16 +214,28 @@
   [[["fontsize","4"\]\] "<font size=+1>foo[bar\]baz</font>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=4>foo<font size=1>b[a\]r</font>baz</font>" queryCommandValue("fontsize") after]
+  [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=4>foo<font size=1>b[a\]r</font>baz</font>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=4>foo<font size=1>b[a\]r</font>baz</font>" queryCommandValue("fontsize") after]
+  [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=4>foo<font size=1>b[a\]r</font>baz</font>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<span style=\\"font-size: large\\">foo<span style=\\"font-size: xx-small\\">b[a\]r</span>baz</span>" queryCommandValue("fontsize") after]
+  [[["stylewithcss","true"\],["fontsize","4"\]\] "<span style=\\"font-size: large\\">foo<span style=\\"font-size: xx-small\\">b[a\]r</span>baz</span>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<span style=\\"font-size: large\\">foo<span style=\\"font-size: xx-small\\">b[a\]r</span>baz</span>" queryCommandValue("fontsize") after]
+  [[["stylewithcss","false"\],["fontsize","4"\]\] "<span style=\\"font-size: large\\">foo<span style=\\"font-size: xx-small\\">b[a\]r</span>baz</span>" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["fontsize","3"\]\] "foo<big>[bar\]</big>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["fontsize","3"\]\] "foo<big>[bar\]</big>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["fontsize","3"\]\] "foo<small>[bar\]</small>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["fontsize","3"\]\] "foo<small>[bar\]</small>baz" compare innerHTML]
     expected: FAIL
 
 
@@ -295,12 +265,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=2>ba[r</font>\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=2>[bar\]</font>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=2>[bar\]</font>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=1>fo[o</font><span style=font-size:xx-small>b\]ar</span>" compare innerHTML]
@@ -346,9 +310,6 @@
     expected: FAIL
 
   [[["styleWithCSS","false"\],["fontSize","7"\]\] "<font color=#ff0000 face=monospace>[abc\]</font>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["fontSize","5"\]\] "<span style=\\"font-size:32px; background-color:rgb(0, 128, 128)\\">[abc\]</span>" compare innerHTML]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["fontSize","5"\]\] "<span style=\\"font-size:32px; background-color:rgb(0, 128, 128)\\">[a\]bc</span>" compare innerHTML]

--- a/tests/wpt/meta/editing/run/forecolor.html.ini
+++ b/tests/wpt/meta/editing/run/forecolor.html.ini
@@ -346,72 +346,6 @@
   [[["stylewithcss","true"\],["forecolor","#0000FF"\]\] "<font color=\\"#0000ff\\">[foo\]</font>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["forecolor","#0000FF"\]\] "<span style=\\"color: blue\\">[foo\]</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["forecolor","#0000FF"\]\] "<span style=\\"color: #0000ff\\">[foo\]</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["forecolor","#0000FF"\]\] "<span style=\\"color: rgb(0, 0, 255)\\">[foo\]</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["forecolor","#0000FF"\]\] "<span style=\\"color: rgb(0%, 0%, 100%)\\">[foo\]</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["forecolor","#0000FF"\]\] "<span style=\\"color: rgb( 0 ,0 ,255)\\">[foo\]</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["forecolor","#0000FF"\]\] "<span style=\\"color: rgba(0, 0, 255, 0.0)\\">[foo\]</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["forecolor","#0000FF"\]\] "<span style=\\"color: rgba(0, 0, 255, 0.0)\\">[foo\]</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["forecolor","#0000FF"\]\] "<span style=\\"color: rgb(15, -10, 375)\\">[foo\]</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["forecolor","#0000FF"\]\] "<span style=\\"color: rgb(15, -10, 375)\\">[foo\]</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["forecolor","#0000FF"\]\] "<span style=\\"color: rgba(0, 0, 0, 1)\\">[foo\]</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["forecolor","#0000FF"\]\] "<span style=\\"color: rgba(0, 0, 0, 1)\\">[foo\]</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["forecolor","#0000FF"\]\] "<span style=\\"color: rgba(255, 255, 255, 1)\\">[foo\]</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["forecolor","#0000FF"\]\] "<span style=\\"color: rgba(255, 255, 255, 1)\\">[foo\]</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["forecolor","#0000FF"\]\] "<span style=\\"color: rgba(0, 0, 255, 0.5)\\">[foo\]</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["forecolor","#0000FF"\]\] "<span style=\\"color: rgba(0, 0, 255, 0.5)\\">[foo\]</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["forecolor","#0000FF"\]\] "<span style=\\"color: hsl(240, 100%, 50%)\\">[foo\]</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["forecolor","#0000FF"\]\] "<span style=\\"color: cornsilk\\">[foo\]</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["forecolor","#0000FF"\]\] "<span style=\\"color: cornsilk\\">[foo\]</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["forecolor","#0000FF"\]\] "<span style=\\"color: transparent\\">[foo\]</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["forecolor","#0000FF"\]\] "<span style=\\"color: transparent\\">[foo\]</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["forecolor","#0000FF"\]\] "<span style=\\"color: currentColor\\">[foo\]</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["forecolor","#0000FF"\]\] "<span style=\\"color: currentColor\\">[foo\]</span>" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["forecolor","#0000FF"\]\] "fo[o<font color=brown>b\]ar</font>baz" compare innerHTML]
     expected: FAIL
 
@@ -431,24 +365,6 @@
     expected: FAIL
 
   [[["forecolor","#0000ff"\]\] "<a href=http://www.google.com>foo[bar\]baz</a>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["forecolor","#0000FF"\]\] "<span style=\\"color: blue\\">[foo\]</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["forecolor","#0000FF"\]\] "<span style=\\"color: #0000ff\\">[foo\]</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["forecolor","#0000FF"\]\] "<span style=\\"color: rgb(0, 0, 255)\\">[foo\]</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["forecolor","#0000FF"\]\] "<span style=\\"color: rgb(0%, 0%, 100%)\\">[foo\]</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["forecolor","#0000FF"\]\] "<span style=\\"color: rgb( 0 ,0 ,255)\\">[foo\]</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["forecolor","#0000FF"\]\] "<span style=\\"color: hsl(240, 100%, 50%)\\">[foo\]</span>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["forecolor","#0000FF"\]\] "<font color=\\"0000ff\\">[foo\]</font>" queryCommandValue("forecolor") before]
@@ -607,4 +523,10 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["forecolor","#0000FF"\]\] "<font color=brown>fo[o</font><span style=color:brown>b\]ar</span>" queryCommandIndeterm("forecolor") before]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["forecolor","#0000FF"\]\] "foo<font color=brown>[bar\]</font>baz" queryCommandValue("forecolor") after]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["forecolor","#0000FF"\]\] "foo<font color=brown>[bar\]</font>baz" queryCommandValue("forecolor") after]
     expected: FAIL

--- a/tests/wpt/meta/editing/run/hilitecolor.html.ini
+++ b/tests/wpt/meta/editing/run/hilitecolor.html.ini
@@ -62,9 +62,6 @@
   [[["stylewithcss","false"\],["hilitecolor","#00FFFF"\]\] "foo[<span style=background-color:tan>b\]ar</span>baz" queryCommandValue("hilitecolor") after]
     expected: FAIL
 
-  [[["hilitecolor","#00FFFF"\]\] "foo<span style=background-color:tan>[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["hilitecolor","#00FFFF"\]\] "<font size=6>[foo\]</font>" compare innerHTML]
     expected: FAIL
 
@@ -99,4 +96,10 @@
     expected: FAIL
 
   [[["hilitecolor","#00FFFF"\]\] "<p style=\\"background-color: aqua\\">foo[bar\]baz</p>" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["hilitecolor","#00FFFF"\]\] "<span style=font-size:xx-large>[foo\]</span>" queryCommandValue("hilitecolor") after]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["hilitecolor","#00FFFF"\]\] "<span style=font-size:xx-large>[foo\]</span>" queryCommandValue("hilitecolor") after]
     expected: FAIL

--- a/tests/wpt/meta/editing/run/italic.html.ini
+++ b/tests/wpt/meta/editing/run/italic.html.ini
@@ -71,16 +71,10 @@
   [[["stylewithcss","true"\],["italic",""\]\] "<p>[foo</p> <p>bar\]</p>" queryCommandState("stylewithcss") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<em>b[a\]r</em>baz" queryCommandState("italic") after]
+  [[["stylewithcss","true"\],["italic",""\]\] "foo<i>b[a\]r</i>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<em>b[a\]r</em>baz" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<i>b[a\]r</i>baz" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<i>b[a\]r</i>baz" queryCommandState("italic") after]
+  [[["stylewithcss","false"\],["italic",""\]\] "foo<i>b[a\]r</i>baz" compare innerHTML]
     expected: FAIL
 
 
@@ -231,8 +225,5 @@
   [[["stylewithcss","true"\],["italic",""\]\] "fo[o<dfn>bar</dfn>b\]az" queryCommandState("stylewithcss") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<span style=\\"font-style: oblique\\">b[a\]r</span>baz" queryCommandState("italic") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<span style=\\"font-style: oblique\\">b[a\]r</span>baz" queryCommandState("italic") after]
+  [[["stylewithcss","true"\],["italic",""\]\] "foo<span style=\\"font-style: oblique\\">b[a\]r</span>baz" compare innerHTML]
     expected: FAIL

--- a/tests/wpt/meta/editing/run/removeformat.html.ini
+++ b/tests/wpt/meta/editing/run/removeformat.html.ini
@@ -1,10 +1,4 @@
 [removeformat.html]
-  [[["stylewithcss","true"\],["removeformat",""\]\] "foo<b>[bar\]</b>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["removeformat",""\]\] "foo<b>[bar\]</b>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["removeformat",""\]\] "foo<b>b[a\]r</b>baz" compare innerHTML]
     expected: FAIL
 
@@ -171,4 +165,10 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["removeformat",""\]\] "[foo<b>bar</b>baz\]" queryCommandState("stylewithcss") before]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["removeformat",""\]\] "<p style=\\"font-weight: bold\\">foo[bar\]baz</p>" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["removeformat",""\]\] "<p style=\\"font-weight: bold\\">foo[bar\]baz</p>" compare innerHTML]
     expected: FAIL

--- a/tests/wpt/meta/editing/run/strikethrough.html.ini
+++ b/tests/wpt/meta/editing/run/strikethrough.html.ini
@@ -94,9 +94,6 @@
   [[["stylewithcss","true"\],["strikethrough",""\]\] "foo<u style=\\"text-decoration: overline\\">[bar\]</u>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["strikethrough",""\]\] "foo<u style=\\"text-decoration: overline\\">[bar\]</u>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["strikethrough",""\]\] "foo<span class=\\"underline\\">[bar\]</span>baz" compare innerHTML]
     expected: FAIL
 
@@ -154,12 +151,6 @@
   [[["stylewithcss","false"\],["strikethrough",""\]\] "<strike>foo[b<i>ar\]ba</i>z</strike>" queryCommandState("strikethrough") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["strikethrough",""\]\] "foo<u style=\\"text-decoration: line-through\\">b[a\]r</u>baz" queryCommandState("strikethrough") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["strikethrough",""\]\] "foo<u style=\\"text-decoration: line-through\\">b[a\]r</u>baz" queryCommandState("strikethrough") after]
-    expected: FAIL
-
   [[["strikethrough",""\]\] "foo<s>ba[r</s>b\]az" compare innerHTML]
     expected: FAIL
 
@@ -167,6 +158,30 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["strikethrough",""\]\] "foo<s>ba[r</s>\]baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["strikethrough",""\]\] "foo<ins>[bar\]</ins>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["strikethrough",""\]\] "foo<span style=\\"text-decoration: underline line-through\\">b[a\]r</span>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["strikethrough",""\]\] "foo<span style=\\"text-decoration: underline line-through\\">b[a\]r</span>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["strikethrough",""\]\] "foo<u style=\\"text-decoration: line-through\\">b[a\]r</u>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["strikethrough",""\]\] "foo<u style=\\"text-decoration: line-through\\">b[a\]r</u>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["strikethrough",""\]\] "<p style=\\"text-decoration: line-through\\">foo[bar\]baz</p>" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["strikethrough",""\]\] "<p style=\\"text-decoration: line-through\\">foo[bar\]baz</p>" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["strikethrough",""\]\] "foo<span class=\\"underline\\">[bar\]</span>baz" compare innerHTML]
     expected: FAIL
 
 
@@ -187,9 +202,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["strikethrough",""\]\] "foo<span style=\\"text-decoration: underline\\">[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["strikethrough",""\]\] "foo<span style=\\"text-decoration: underline\\">[bar\]</span>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["strikethrough",""\]\] "<s>foo[bar\]baz</s>" compare innerHTML]
@@ -222,12 +234,6 @@
   [[["stylewithcss","true"\],["strikethrough",""\]\] "<p>[foo</p> <p>bar\]</p>" queryCommandState("stylewithcss") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["strikethrough",""\]\] "<s>foo[bar\]baz</s>" queryCommandState("strikethrough") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["strikethrough",""\]\] "<s>foo[bar\]baz</s>" queryCommandState("strikethrough") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["strikethrough",""\]\] "<s>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</s>" queryCommandState("strikethrough") after]
     expected: FAIL
 
@@ -252,8 +258,14 @@
   [[["stylewithcss","false"\],["strikethrough",""\]\] "<s>foo[b<i>ar\]ba</i>z</s>" queryCommandState("strikethrough") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["strikethrough",""\]\] "<strike>foo[bar\]baz</strike>" queryCommandState("strikethrough") after]
+  [[["stylewithcss","false"\],["strikethrough",""\]\] "<s>foo[bar\]baz</s>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["strikethrough",""\]\] "<s>foo[bar\]baz</s>" compare innerHTML]
+  [[["stylewithcss","false"\],["strikethrough",""\]\] "foo<u>[bar\]</u>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["strikethrough",""\]\] "<strike>foo[bar\]baz</strike>" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["strikethrough",""\]\] "<strike>foo[bar\]baz</strike>" compare innerHTML]
     expected: FAIL

--- a/tests/wpt/meta/editing/run/subscript.html.ini
+++ b/tests/wpt/meta/editing/run/subscript.html.ini
@@ -11,12 +11,6 @@
   [[["stylewithcss","false"\],["subscript",""\]\] "<p>[foo<p><br><p>bar\]" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["subscript",""\]\] "foo<sup>[bar\]</sup>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["subscript",""\]\] "foo<sup>[bar\]</sup>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["subscript",""\]\] "foo<sup>b[a\]r</sup>baz" compare innerHTML]
     expected: FAIL
 
@@ -35,12 +29,6 @@
   [[["stylewithcss","false"\],["subscript",""\]\] "foo<span style=vertical-align:super>[bar\]</span>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["subscript",""\]\] "foo<sup><sup>[bar\]</sup></sup>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["subscript",""\]\] "foo<sup><sup>[bar\]</sup></sup>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["subscript",""\]\] "foo<sup><sup>b[a\]r</sup></sup>baz" compare innerHTML]
     expected: FAIL
 
@@ -53,13 +41,7 @@
   [[["stylewithcss","false"\],["subscript",""\]\] "foo<sup>b<sup>[a\]</sup>r</sup>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["subscript",""\]\] "foo<sub><sup>[bar\]</sup></sub>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["subscript",""\]\] "foo<sub><sup>[bar\]</sup></sub>baz" queryCommandIndeterm("subscript") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["subscript",""\]\] "foo<sub><sup>[bar\]</sup></sub>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["subscript",""\]\] "foo<sub><sup>[bar\]</sup></sub>baz" queryCommandIndeterm("subscript") before]
@@ -89,13 +71,7 @@
   [[["stylewithcss","false"\],["subscript",""\]\] "foo<sub>b<sup>[a\]</sup>r</sub>baz" queryCommandIndeterm("subscript") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["subscript",""\]\] "foo<sup><sub>[bar\]</sub></sup>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["subscript",""\]\] "foo<sup><sub>[bar\]</sub></sup>baz" queryCommandIndeterm("subscript") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["subscript",""\]\] "foo<sup><sub>[bar\]</sub></sup>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["subscript",""\]\] "foo<sup><sub>[bar\]</sub></sup>baz" queryCommandIndeterm("subscript") before]
@@ -176,8 +152,29 @@
   [[["stylewithcss","true"\],["subscript",""\]\] "<p>[foo</p> <p>bar\]</p>" queryCommandState("stylewithcss") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["subscript",""\]\] "foo<sub>b[a\]r</sub>baz" queryCommandState("subscript") after]
+  [[["stylewithcss","true"\],["subscript",""\]\] "foo<sub>b[a\]r</sub>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["subscript",""\]\] "foo<sub>b[a\]r</sub>baz" queryCommandState("subscript") after]
+  [[["stylewithcss","false"\],["subscript",""\]\] "foo<sub>b[a\]r</sub>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["subscript",""\]\] "foo<sub>b<sub>[a\]</sub>r</sub>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["subscript",""\]\] "foo<sup><sup>[bar\]</sup></sup>baz" queryCommandState("subscript") after]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["subscript",""\]\] "foo<sup><sup>[bar\]</sup></sup>baz" queryCommandState("subscript") after]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["subscript",""\]\] "foo<sub><sup>[bar\]</sup></sub>baz" queryCommandState("subscript") after]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["subscript",""\]\] "foo<sub><sup>[bar\]</sup></sub>baz" queryCommandState("subscript") after]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["subscript",""\]\] "foo<sup><sub>[bar\]</sub></sup>baz" queryCommandState("subscript") after]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["subscript",""\]\] "foo<sup><sub>[bar\]</sub></sup>baz" queryCommandState("subscript") after]
     expected: FAIL

--- a/tests/wpt/meta/editing/run/superscript.html.ini
+++ b/tests/wpt/meta/editing/run/superscript.html.ini
@@ -11,12 +11,6 @@
   [[["stylewithcss","false"\],["superscript",""\]\] "<p>[foo<p><br><p>bar\]" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["superscript",""\]\] "foo<sub>[bar\]</sub>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["superscript",""\]\] "foo<sub>[bar\]</sub>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["superscript",""\]\] "foo<sub>b[a\]r</sub>baz" compare innerHTML]
     expected: FAIL
 
@@ -35,12 +29,6 @@
   [[["stylewithcss","false"\],["superscript",""\]\] "foo<span style=vertical-align:super>[bar\]</span>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["superscript",""\]\] "foo<sub><sub>[bar\]</sub></sub>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["superscript",""\]\] "foo<sub><sub>[bar\]</sub></sub>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["superscript",""\]\] "foo<sub><sub>b[a\]r</sub></sub>baz" compare innerHTML]
     expected: FAIL
 
@@ -53,13 +41,7 @@
   [[["stylewithcss","false"\],["superscript",""\]\] "foo<sub>b<sub>[a\]</sub>r</sub>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["superscript",""\]\] "foo<sub><sup>[bar\]</sup></sub>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["superscript",""\]\] "foo<sub><sup>[bar\]</sup></sub>baz" queryCommandIndeterm("superscript") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["superscript",""\]\] "foo<sub><sup>[bar\]</sup></sub>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["superscript",""\]\] "foo<sub><sup>[bar\]</sup></sub>baz" queryCommandIndeterm("superscript") before]
@@ -89,13 +71,7 @@
   [[["stylewithcss","false"\],["superscript",""\]\] "foo<sub>b<sup>[a\]</sup>r</sub>baz" queryCommandIndeterm("superscript") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["superscript",""\]\] "foo<sup><sub>[bar\]</sub></sup>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["superscript",""\]\] "foo<sup><sub>[bar\]</sub></sup>baz" queryCommandIndeterm("superscript") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["superscript",""\]\] "foo<sup><sub>[bar\]</sub></sup>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["superscript",""\]\] "foo<sup><sub>[bar\]</sub></sup>baz" queryCommandIndeterm("superscript") before]
@@ -176,8 +152,29 @@
   [[["stylewithcss","true"\],["superscript",""\]\] "<p>[foo</p> <p>bar\]</p>" queryCommandState("stylewithcss") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["superscript",""\]\] "foo<sup>b[a\]r</sup>baz" queryCommandState("superscript") after]
+  [[["stylewithcss","true"\],["superscript",""\]\] "foo<sup>b[a\]r</sup>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["superscript",""\]\] "foo<sup>b[a\]r</sup>baz" queryCommandState("superscript") after]
+  [[["stylewithcss","false"\],["superscript",""\]\] "foo<sup>b[a\]r</sup>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["superscript",""\]\] "foo<sub><sub>[bar\]</sub></sub>baz" queryCommandState("superscript") after]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["superscript",""\]\] "foo<sub><sub>[bar\]</sub></sub>baz" queryCommandState("superscript") after]
+    expected: FAIL
+
+  [[["superscript",""\]\] "foo<sup>b<sup>[a\]</sup>r</sup>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["superscript",""\]\] "foo<sub><sup>[bar\]</sup></sub>baz" queryCommandState("superscript") after]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["superscript",""\]\] "foo<sub><sup>[bar\]</sup></sub>baz" queryCommandState("superscript") after]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["superscript",""\]\] "foo<sup><sub>[bar\]</sub></sup>baz" queryCommandState("superscript") after]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["superscript",""\]\] "foo<sup><sub>[bar\]</sub></sup>baz" queryCommandState("superscript") after]
     expected: FAIL

--- a/tests/wpt/meta/editing/run/underline.html.ini
+++ b/tests/wpt/meta/editing/run/underline.html.ini
@@ -41,16 +41,10 @@
   [[["stylewithcss","true"\],["underline",""\]\] "foo<span style=\\"text-decoration: line-through\\">[bar\]</span>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["underline",""\]\] "foo<span style=\\"text-decoration: line-through\\">[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "foo<strike>[bar\]</strike>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<p>[foo</p> <p>bar\]</p>" queryCommandState("stylewithcss") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "<u>foo[bar\]baz</u>" queryCommandState("underline") after]
     expected: FAIL
 
   [[["stylewithcss","false"\],["underline",""\]\] "<u>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</u>" queryCommandState("underline") after]
@@ -65,9 +59,6 @@
   [[["stylewithcss","false"\],["underline",""\]\] "<u>foo[b<i>ar\]ba</i>z</u>" queryCommandState("underline") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "<u>foo[bar\]baz</u>" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "<u>foo[b<span style=\\"color:blue\\">ar\]ba</span>z</u>" queryCommandState("underline") after]
     expected: FAIL
 
@@ -78,6 +69,24 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "<u>foo[b<i>ar\]ba</i>z</u>" queryCommandState("underline") after]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["underline",""\]\] "<u>foo[bar\]baz</u>" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["underline",""\]\] "<u>foo[bar\]baz</u>" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["underline",""\]\] "<p style=\\"text-decoration: underline\\">foo[bar\]baz</p>" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["underline",""\]\] "<p style=\\"text-decoration: underline\\">foo[bar\]baz</p>" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["underline",""\]\] "foo<s>[bar\]</s>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["underline",""\]\] "foo<strike>[bar\]</strike>baz" compare innerHTML]
     expected: FAIL
 
 
@@ -126,22 +135,7 @@
   [[["stylewithcss","true"\],["underline",""\]\] "foo<del>[bar\]</del>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "foo<u style=\\"text-decoration: line-through\\">[bar\]</u>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "foo<u style=\\"text-decoration: line-through\\">[bar\]</u>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "foo<s style=\\"text-decoration: overline\\">[bar\]</s>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "foo<s style=\\"text-decoration: overline\\">[bar\]</s>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "foo<u style=\\"text-decoration: overline\\">[bar\]</u>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "foo<u style=\\"text-decoration: overline\\">[bar\]</u>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["underline",""\]\] "foo<span class=\\"line-through\\">[bar\]</span>baz" compare innerHTML]
@@ -162,11 +156,23 @@
   [[["stylewithcss","true"\],["underline",""\]\] "<strike>foo[bar\]baz</strike>" queryCommandState("stylewithcss") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "foo<s style=\\"text-decoration: underline\\">b[a\]r</s>baz" queryCommandState("underline") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "foo<s style=\\"text-decoration: underline\\">b[a\]r</s>baz" queryCommandState("underline") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["underline",""\]\] "foo<u>ba[r</u>\]baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["underline",""\]\] "foo<del>[bar\]</del>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["underline",""\]\] "foo<span style=\\"text-decoration: underline line-through\\">b[a\]r</span>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["underline",""\]\] "foo<span style=\\"text-decoration: underline line-through\\">b[a\]r</span>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["underline",""\]\] "foo<s style=\\"text-decoration: underline\\">b[a\]r</s>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["underline",""\]\] "foo<s style=\\"text-decoration: underline\\">b[a\]r</s>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["underline",""\]\] "foo<span class=\\"line-through\\">[bar\]</span>baz" compare innerHTML]
     expected: FAIL

--- a/tests/wpt/meta/editing/run/unlink.html.ini
+++ b/tests/wpt/meta/editing/run/unlink.html.ini
@@ -8,25 +8,13 @@
   [[["unlink",""\]\] "{<a href=http://www.google.com/>foobar\]baz</a>" compare innerHTML]
     expected: FAIL
 
-  [[["unlink",""\]\] "<a href=http://www.google.com/>[foobarbaz\]</a>" compare innerHTML]
-    expected: FAIL
-
   [[["unlink",""\]\] "foo<a href=http://www.google.com/>b[\]ar</a>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["unlink",""\]\] "foo<a href=http://www.google.com/>[bar\]</a>baz" compare innerHTML]
     expected: FAIL
 
   [[["unlink",""\]\] "<a id=foo href=http://www.google.com/>foobar[\]baz</a>" compare innerHTML]
     expected: FAIL
 
   [[["unlink",""\]\] "<a id=foo href=http://www.google.com/>foo[bar\]baz</a>" compare innerHTML]
-    expected: FAIL
-
-  [[["unlink",""\]\] "<a id=foo href=http://www.google.com/>[foobarbaz\]</a>" compare innerHTML]
-    expected: FAIL
-
-  [[["unlink",""\]\] "foo<a id=foo href=http://www.google.com/>[bar\]</a>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["unlink",""\]\] "[foo<a href=https://example.com class=bold>bar</a>baz\]" compare innerHTML]

--- a/tests/wpt/tests/selection/crashtests/selection-modify-line-boundary-around-empty-details.html
+++ b/tests/wpt/tests/selection/crashtests/selection-modify-line-boundary-around-empty-details.html
@@ -9,7 +9,19 @@ addEventListener("load", () => {
   let i = 0;
   const details = document.querySelector("details");
   const id = setInterval(() => {
-    getSelection().modify("move", "forward", "lineboundary");
+    const selection = getSelection();
+    if (!selection) {
+      clearInterval(id);
+      throw new Error("Should always have a selection");
+    }
+    // This means that the browser doesn't support modify.
+    // Rather than endless looping and crashing the browser,
+    // exit early.
+    if (!selection.modify) {
+      clearInterval(id);
+      return;
+    }
+    selection.modify("move", "forward", "lineboundary");
     if (details.isConnected) {
       details.outerHTML = undefined;
     }


### PR DESCRIPTION
There is a tricky bit of text nodes that also consider their ancestors
effectively contained. To make that properly work, when computing all
nodes that are effectively contained, we now traverse from the
editing host, rather than the common ancestor container.

However, that then would fail numerous tests. That's because when
text nodes are moved, their positions would be updated to be the
new parent, instead of the original text node. The spec states that
this is implicit, but turns out it is not. It might be that this is
related to the implementation of ranges in Servo, but for now let's
make it explicit it when moving. I also think this is nicer anyways,
since we should retain the original selection and that should be
the text node.

Overall, this makes more tests pass, while also fail others. I will
continue investigating why, but unfortunately that's the nature of
this suite of WPT tests.

Lastly, during debugging I needed to know the exact text contents of
these text nodes. Therefore, update the way to format nodes to also
consider characterdata, for nicer debugging experience.

Part of #25005

Testing: WPT