### PR TITLE
script: Pass `secureConnectionStart` to document and expose it to PerformanceMark

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -497,6 +497,9 @@ pub(crate) struct Document {
     /// <https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-redirectend>
     #[no_trace]
     redirect_end: Cell<Option<CrossProcessInstant>>,
+    /// <https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-secureconnectionstart>
+    #[no_trace]
+    secure_connection_start: Cell<Option<CrossProcessInstant>>,
     /// Number of outstanding requests to prevent JS or layout from running.
     script_and_layout_blockers: Cell<u32>,
     /// List of tasks to execute as soon as last script/layout blocker is removed.
@@ -3606,6 +3609,7 @@ impl Document {
             redirect_count: Cell::new(0),
             redirect_start: Cell::new(None),
             redirect_end: Cell::new(None),
+            secure_connection_start: Cell::new(None),
             completely_loaded: Cell::new(false),
             script_and_layout_blockers: Cell::new(0),
             delayed_tasks: Default::default(),
@@ -3876,6 +3880,14 @@ impl Document {
 
     pub(crate) fn set_redirect_end(&self, time: Option<CrossProcessInstant>) {
         self.redirect_end.set(time)
+    }
+
+    pub(crate) fn get_secure_connection_start(&self) -> Option<CrossProcessInstant> {
+        self.secure_connection_start.get()
+    }
+
+    pub(crate) fn set_secure_connection_start(&self, time: Option<CrossProcessInstant>) {
+        self.secure_connection_start.set(time)
     }
 
     pub(crate) fn elements_by_name_count(&self, name: &DOMString) -> u32 {

--- a/components/script/dom/performance/performance.rs
+++ b/components/script/dom/performance/performance.rs
@@ -509,6 +509,7 @@ impl Performance {
             "loadEventEnd" => document.get_load_event_end(),
             "redirectStart" => document.get_redirect_start(),
             "redirectEnd" => document.get_redirect_end(),
+            "secureConnectionStart" => document.get_secure_connection_start(),
             other => {
                 if cfg!(debug_assertions) {
                     unreachable!("{other:?} is not the name of a timestamp");
@@ -550,7 +551,8 @@ impl Performance {
                         "loadEventStart" |
                         "loadEventEnd" |
                         "redirectStart" |
-                        "redirectEnd"
+                        "redirectEnd" |
+                        "secureConnectionStart"
                 ) {
                     self.convert_a_name_to_a_timestamp(&name.str())
                 }

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1544,6 +1544,9 @@ impl FetchResponseListener for ParserContext {
             parser.document.set_redirect_count(timing.redirect_count);
             parser.document.set_redirect_start(timing.redirect_start);
             parser.document.set_redirect_end(timing.redirect_end);
+            parser
+                .document
+                .set_secure_connection_start(timing.secure_connection_start);
         }
 
         parser.last_chunk_received.set(true);

--- a/tests/wpt/meta/user-timing/measure-exceptions.html.ini
+++ b/tests/wpt/meta/user-timing/measure-exceptions.html.ini
@@ -1,3 +1,0 @@
-[measure-exceptions.html]
-  [Passing 'secureConnectionStart' as a mark to measure API should cause error when the mark is empty.]
-    expected: FAIL


### PR DESCRIPTION
Pass `secureConnectionStart` to document and expose it to PerformanceMark

Testing: Additional WPT tests Passed
