### PR TITLE
Remove unfulfilled `unrooted_must_root` expect on `AttributeStorage::remove`

### DIFF
--- a/components/script/dom/element/attributes/storage.rs
+++ b/components/script/dom/element/attributes/storage.rs
@@ -271,7 +271,6 @@ impl AttributeStorage {
     }
 
     /// Remove an attribute by index, returning the entry.
-    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn remove(&self, index: usize) -> AttributeEntry {
         self.0.borrow_mut().remove(index)
     }


### PR DESCRIPTION
Closes #44737

The `#[cfg_attr(crown, expect(crown::unrooted_must_root))]` annotation on `AttributeStorage::remove` no longer suppresses any warning, so the compiler emits `unfulfilled_lint_expectations`:

```
warning: this lint expectation is unfulfilled
   --> components/script/dom/element/attributes/storage.rs:274:30
    |
274 |     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(unfulfilled_lint_expectations)]` on by default
```

Drop the now-dead annotation. The expect annotations on the sibling `set` and `ensure_dom` methods remain unchanged — those are still fulfilled and the warning does not flag them.