### PR TITLE
fix: resolving index out of bounds panic (#44633)

### DIFF
--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -66,6 +66,9 @@ fn root_transform_for_layout_node(
         .and_then(Fragment::retrieve_box_fragment)?
         .borrow();
     let scroll_tree_node_id = box_fragment.spatial_tree_node()?;
+    if !scroll_tree.has_node(scroll_tree_node_id) {
+        return None;
+    }
     Some(scroll_tree.cumulative_node_to_root_transform(scroll_tree_node_id))
 }
 

--- a/components/shared/paint/display_list.rs
+++ b/components/shared/paint/display_list.rs
@@ -473,6 +473,11 @@ impl ScrollTree {
         &self.nodes[id.index]
     }
 
+    /// To sanity-check if the id is valid.
+    pub fn has_node(&self, id: ScrollTreeNodeId) -> bool {
+        id.index < self.nodes.len()
+    }
+
     /// Get the WebRender [`SpatialId`] for the given [`ScrollNodeId`]. This will
     /// panic if [`ScrollTree::build_display_list`] has not been called yet.
     pub fn webrender_id(&self, id: ScrollTreeNodeId) -> SpatialId {
@@ -620,6 +625,9 @@ impl ScrollTree {
         &self,
         node_id: ScrollTreeNodeId,
     ) -> Option<FastLayoutTransform> {
+        if !self.has_node(node_id) {
+            return None;
+        }
         self.cumulative_node_transform(node_id)
             .root_to_node_transform
     }


### PR DESCRIPTION
With this change the panic is gone.
Please note, that this is resolving the symptom, not the root cause which is a desync of the id's lifetime from the tree to which the id refers. So the same issue could still appear in different contexts.

Testing: At the current stage I'm not sure how to perform a repeatable test for this issue, so I tried it manually as I described in the issue description.
Fixes: [44633](https://github.com/servo/servo/issues/44633)