### PR TITLE
config: remove unused mut from DiagnosticsLogging

### DIFF
--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -131,7 +131,7 @@ impl DiagnosticsLogging {
     /// In non-production builds, this will automatically read and parse the
     /// SERVO_DIAGNOSTICS environment variable if it is set.
     pub fn new() -> Self {
-        let mut config: DiagnosticsLogging = Default::default();
+        let config: DiagnosticsLogging = Default::default();
 
         // Disabled for production builds
         #[cfg(debug_assertions)]


### PR DESCRIPTION
Removes an unnecessary `mut` from DiagnosticsLogging initialization,
resolving an `unused_mut` warning.

No functional changes.

Testing:
No additional tests required since this is a non-functional cleanup.

Fixes #44689
