### PR TITLE
script: Fix panic when deleting after range.deleteContents

### DIFF
--- a/components/script/dom/execcommand/commands/delete.rs
+++ b/components/script/dom/execcommand/commands/delete.rs
@@ -187,10 +187,15 @@ pub(crate) fn execute_delete_command(
         // Step 9.1. If start offset is zero,
         // set start offset to the index of start node and then set start node to its parent.
         if start_offset == 0 {
+            // NOTE: This is not in the spec, but required in case we are traversing out of
+            // an editing host and end up at the root node. Since below we start deleting
+            // backwards and stop at the editing host, it's fine to stop at the root node
+            // as well.
+            let Some(parent) = start_node.GetParentNode() else {
+                break;
+            };
             start_offset = start_node.index();
-            start_node = start_node
-                .GetParentNode()
-                .expect("Must always have a parent");
+            start_node = parent;
             continue;
         }
         // Step 9.2. Otherwise, if start node has an editable invisible child with index start offset minus one,

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -952,28 +952,34 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
 
     /// <https://dom.spec.whatwg.org/#dom-range-deletecontents>
     fn DeleteContents(&self, cx: &mut JSContext) -> ErrorResult {
-        // Step 1.
+        // Step 1. If this is collapsed, then return.
         if self.collapsed() {
             return Ok(());
         }
 
-        // Step 2.
+        // Step 2. Let originalStartNode, originalStartOffset, originalEndNode,
+        // and originalEndOffset be this’s start node, start offset, end node, and end offset, respectively.
         let start_node = self.start_container();
         let end_node = self.end_container();
         let start_offset = self.start_offset();
         let end_offset = self.end_offset();
 
-        // Step 3.
+        // Step 3. If originalStartNode is originalEndNode and it is a CharacterData node:
         if start_node == end_node {
             if let Some(text) = start_node.downcast::<CharacterData>() {
                 if end_offset > start_offset {
                     self.report_change();
                 }
+
+                // Step 3.1. Replace data of originalStartNode with originalStartOffset,
+                // originalEndOffset − originalStartOffset, and the empty string.
+                // Step 3.2. Return.
                 return text.ReplaceData(start_offset, end_offset - start_offset, DOMString::new());
             }
         }
 
-        // Step 4.
+        // Step 4. Let nodesToRemove be a list of all the nodes that are contained in this,
+        // in tree order, omitting any node whose parent is also contained in this.
         rooted_vec!(let mut contained_children);
         let ancestor = self.CommonAncestorContainer();
 
@@ -989,15 +995,21 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
             }
         }
 
+        // Step 5. Let newNode and newOffset be null.
+        // Step 6. If originalStartNode is an inclusive ancestor of originalEndNode,
+        // then set newNode to originalStartNode and newOffset to originalStartOffset.
         let (new_node, new_offset) = if start_node.is_inclusive_ancestor_of(&end_node) {
-            // Step 5.
             (DomRoot::from_ref(&*start_node), start_offset)
         } else {
-            // Step 6.
+            // Step 7. Otherwise:
             fn compute_reference(start_node: &Node, end_node: &Node) -> (DomRoot<Node>, u32) {
+                // Step 7.1. Let referenceNode be originalStartNode.
                 let mut reference_node = DomRoot::from_ref(start_node);
+                // Step 7.2. While referenceNode’s parent is non-null and
+                // is not an inclusive ancestor of originalEndNode: set referenceNode to its parent.
                 while let Some(parent) = reference_node.GetParentNode() {
                     if parent.is_inclusive_ancestor_of(end_node) {
+                        // Step 7.3. Set newNode to referenceNode’s parent and newOffset to referenceNode’s index + 1.
                         return (parent, reference_node.index() + 1);
                     }
                     reference_node = parent;
@@ -1008,7 +1020,13 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
             compute_reference(&start_node, &end_node)
         };
 
-        // Step 7.
+        // Step 8. Set this’s start and end to (newNode, newOffset).
+        self.SetStart(&new_node, new_offset).unwrap();
+        self.SetEnd(&new_node, new_offset).unwrap();
+
+        // Step 9. If originalStartNode is a CharacterData node,
+        // then replace data of originalStartNode with originalStartOffset,
+        // originalStartNode’s length − originalStartOffset, and the empty string.
         if let Some(text) = start_node.downcast::<CharacterData>() {
             text.ReplaceData(
                 start_offset,
@@ -1018,19 +1036,17 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
             .unwrap();
         }
 
-        // Step 8.
+        // Step 10. For each node of nodesToRemove, in tree order: remove node.
         for child in &*contained_children {
             child.remove_self(cx);
         }
 
-        // Step 9.
+        // Step 11. If originalEndNode is a CharacterData node,
+        // then replace data of originalEndNode with 0, originalEndOffset, and the empty string.
         if let Some(text) = end_node.downcast::<CharacterData>() {
             text.ReplaceData(0, end_offset, DOMString::new()).unwrap();
         }
 
-        // Step 10.
-        self.SetStart(&new_node, new_offset).unwrap();
-        self.SetEnd(&new_node, new_offset).unwrap();
         Ok(())
     }
 

--- a/tests/wpt/tests/editing/crashtests/delete-after-removing-first-child.html
+++ b/tests/wpt/tests/editing/crashtests/delete-after-removing-first-child.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html id="a">
+<script id="b">
+window.onload = () => {
+  document.getSelection().collapse(span1);
+  const range = document.createRange();
+  range.setEndBefore(span2);
+  // This deletes the document element, but leaves behind span 2. The document
+  // now contains the div with 1 child, which is span 2.
+  range.deleteContents();
+  document.execCommand("delete", false, null);
+}
+</script>
+<div contenteditable><span id="span1"></span><span id="span2"></span></div>

--- a/tests/wpt/tests/editing/other/delete-editing-host.html
+++ b/tests/wpt/tests/editing/other/delete-editing-host.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Deletion of full editing host</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<div contenteditable id="empty"></div>
+<div contenteditable id="with-child"><span>Here is a child</span></div>
+<script>
+const emptyDiv = document.getElementById("empty");
+const withChildDiv = document.getElementById("with-child");
+
+test(function() {
+  document.getSelection().collapse(emptyDiv);
+
+  assert_true(document.execCommand("delete", false, null));
+
+  assert_true(emptyDiv.isConnected);
+  assert_equals(emptyDiv.innerHTML, "");
+}, "Should not do anything when deleting full editing host");
+
+test(function() {
+  document.getSelection().collapse(withChildDiv);
+
+  assert_true(document.execCommand("delete", false, null));
+
+  assert_true(withChildDiv.isConnected);
+  assert_equals(withChildDiv.innerHTML, "<span>Here is a child</span>");
+}, "Should retain all children when deleting full editing host");
+</script>


### PR DESCRIPTION
The state of the document after `range.deleteContents` leads to the delete command to traverse to the root element and then crash. Instead, we should simply stop the loop and continue the algorithm and delete backwards.

Also added an additional test I created when trying to figure out what other browsers are doing
and added spec comments to `deleteContents`. Lastly, also incorporate the spec fix of https://github.com/whatwg/dom/pull/1452

Fixes #44742

Testing: WPT