### PR TITLE
script: Give actual name to INVALID_ENTRY_NAME to PERFORMANCE_TIMING_ATTRIBUTES

### DIFF
--- a/components/script/dom/performance/mod.rs
+++ b/components/script/dom/performance/mod.rs
@@ -16,5 +16,31 @@ pub(crate) mod performanceobserver;
 pub(crate) mod performanceobserverentrylist;
 pub(crate) mod performancepainttiming;
 pub(crate) mod performanceresourcetiming;
-
 pub(crate) use self::performance::Performance;
+
+/// <https://w3c.github.io/navigation-timing/#the-performancetiming-interface>
+///
+/// Note: This interface is obselete and use of name is supported to remain backwards compatible.
+pub(crate) const PERFORMANCE_TIMING_ATTRIBUTES: &[&str] = &[
+    "navigationStart",
+    "unloadEventStart",
+    "unloadEventEnd",
+    "redirectStart",
+    "redirectEnd",
+    "fetchStart",
+    "domainLookupStart",
+    "domainLookupEnd",
+    "connectStart",
+    "connectEnd",
+    "secureConnectionStart",
+    "requestStart",
+    "responseStart",
+    "responseEnd",
+    "domLoading",
+    "domInteractive",
+    "domContentLoadedEventStart",
+    "domContentLoadedEventEnd",
+    "domComplete",
+    "loadEventStart",
+    "loadEventEnd",
+];

--- a/components/script/dom/performance/performance.rs
+++ b/components/script/dom/performance/performance.rs
@@ -24,6 +24,7 @@ use super::performancemeasure::PerformanceMeasure;
 use super::performancenavigation::PerformanceNavigation;
 use super::performancenavigationtiming::PerformanceNavigationTiming;
 use super::performanceobserver::PerformanceObserver as DOMPerformanceObserver;
+use crate::dom::PERFORMANCE_TIMING_ATTRIBUTES;
 use crate::dom::bindings::codegen::Bindings::PerformanceBinding::{
     DOMHighResTimeStamp, PerformanceEntryList as DOMPerformanceEntryList, PerformanceMethods,
 };
@@ -41,30 +42,6 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
 use crate::script_runtime::CanGc;
-
-pub(crate) const INVALID_ENTRY_NAMES: &[&str] = &[
-    "navigationStart",
-    "unloadEventStart",
-    "unloadEventEnd",
-    "redirectStart",
-    "redirectEnd",
-    "fetchStart",
-    "domainLookupStart",
-    "domainLookupEnd",
-    "connectStart",
-    "connectEnd",
-    "secureConnectionStart",
-    "requestStart",
-    "responseStart",
-    "responseEnd",
-    "domLoading",
-    "domInteractive",
-    "domContentLoadedEventStart",
-    "domContentLoadedEventEnd",
-    "domComplete",
-    "loadEventStart",
-    "loadEventEnd",
-];
 
 /// Implementation of a list of PerformanceEntry items shared by the
 /// Performance and PerformanceObserverEntryList interfaces implementations.
@@ -512,11 +489,10 @@ impl Performance {
             "redirectEnd" => document.get_redirect_end(),
             "secureConnectionStart" => document.get_secure_connection_start(),
             "responseEnd" => document.get_response_end(),
-            other => {
-                if cfg!(debug_assertions) {
-                    unreachable!("{other:?} is not the name of a timestamp");
-                }
-                return Err(Error::Operation(None));
+            _ => {
+                return Err(Error::Operation(Some(format!(
+                    "{name} hasn't been implemented."
+                ))));
             },
         };
         // Step 5. If endTime is 0, throw an InvalidAccessError.
@@ -540,23 +516,7 @@ impl Performance {
                 // Step 1. If mark is a DOMString and it has the same name as a read only attribute in the
                 // PerformanceTiming interface, let end time be the value returned by running the convert
                 // a name to a timestamp algorithm with name set to the value of mark.
-                // TODO: These aren't all fields because servo doesn't support some of them yet
-                if matches!(
-                    &*name.str(),
-                    "navigationStart" |
-                        "unloadEventStart" |
-                        "unloadEventEnd" |
-                        "domInteractive" |
-                        "domContentLoadedEventStart" |
-                        "domContentLoadedEventEnd" |
-                        "domComplete" |
-                        "loadEventStart" |
-                        "loadEventEnd" |
-                        "redirectStart" |
-                        "redirectEnd" |
-                        "secureConnectionStart" |
-                        "responseEnd"
-                ) {
+                if PERFORMANCE_TIMING_ATTRIBUTES.contains(&&*name.str()) {
                     self.convert_a_name_to_a_timestamp(&name.str())
                 }
                 // Step 2. Otherwise, if mark is a DOMString, let end time be the value of the startTime

--- a/components/script/dom/performance/performancemark.rs
+++ b/components/script/dom/performance/performancemark.rs
@@ -8,12 +8,12 @@ use js::jsval::{JSVal, NullValue};
 use js::rust::{HandleObject, MutableHandleValue};
 use script_bindings::codegen::GenericBindings::PerformanceBinding::PerformanceMarkOptions;
 
+use crate::dom::PERFORMANCE_TIMING_ATTRIBUTES;
 use crate::dom::bindings::codegen::Bindings::PerformanceMarkBinding::PerformanceMarkMethods;
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::structuredclone;
 use crate::dom::bindings::trace::RootedTraceableBox;
-use crate::dom::performance::performance::INVALID_ENTRY_NAMES;
 use crate::dom::window::Window;
 use crate::script_runtime::JSContext;
 
@@ -41,7 +41,7 @@ impl PerformanceMark {
         // The PerformanceMark constructor must run the following steps:
         // Step 1. If the current global object is a Window object and markName uses the same name
         // as a read only attribute in the PerformanceTiming interface, throw a SyntaxError.
-        if global.is::<Window>() && INVALID_ENTRY_NAMES.contains(&&*mark_name.str()) {
+        if global.is::<Window>() && PERFORMANCE_TIMING_ATTRIBUTES.contains(&&*mark_name.str()) {
             return Err(Error::Syntax(Some(
                 "Read-only attribute cannot be used as a mark name".to_owned(),
             )));


### PR DESCRIPTION
Give actual name to INVALID_ENTRY_NAME to PERFORMANCE_TIMING_ATTRIBUTES

From **Note** in section [3.2. Convert a name to a timestamp](https://w3c.github.io/user-timing/#convert-name-to-timestamp)

> The [PerformanceTiming](https://w3c.github.io/navigation-timing/#performancetiming-performancetiming) interface was defined in [[NAVIGATION-TIMING]](https://w3c.github.io/user-timing/#biblio-navigation-timing) and is now considered obsolete. The use of names from the [PerformanceTiming](https://w3c.github.io/navigation-timing/#performancetiming-performancetiming) interface is supported to remain backwards compatible, but there are no plans to extend this functionality to names in the [PerformanceNavigationTiming](https://w3c.github.io/navigation-timing/#performancenavigationtiming-performancenavigationtiming) interface defined in [[NAVIGATION-TIMING-2]](https://w3c.github.io/user-timing/#biblio-navigation-timing-2) (or other interfaces) in the future.

Testing: Existing WPT tests passed. 
