### PR TITLE
script: Fix DevTools exceptions not being shown.

### DIFF
--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2764,6 +2764,15 @@ impl GlobalScope {
 
     /// Steps 6-7 of <https://html.spec.whatwg.org/multipage/#report-an-exception>
     pub(crate) fn report_an_error(&self, error_info: ErrorInfo, value: HandleValue, can_gc: CanGc) {
+        self.send_to_embedder(EmbedderMsg::ShowConsoleApiMessage(
+            self.webview_id(),
+            ConsoleLogLevel::Error,
+            format!(
+                "Error at {}:{}:{} {}",
+                error_info.filename, error_info.lineno, error_info.column, error_info.message
+            ),
+        ));
+
         #[cfg(feature = "js_backtrace")]
         LAST_EXCEPTION_BACKTRACE.with(|backtrace| {
             if let Some((js_backtrace, rust_backtrace)) = backtrace.borrow_mut().take() {
@@ -2830,17 +2839,6 @@ impl GlobalScope {
                         },
                     ));
                 }
-                self.send_to_embedder(EmbedderMsg::ShowConsoleApiMessage(
-                    self.webview_id(),
-                    ConsoleLogLevel::Error,
-                    format!(
-                        "Error at {}:{}:{} {}",
-                        error_info.filename,
-                        error_info.lineno,
-                        error_info.column,
-                        error_info.message
-                    ),
-                ));
             }
         }
     }


### PR DESCRIPTION
Exceptions in debugger.js for DevTools can't show in the developer console, since the DevTools server itself has crashed. They used to show in the console, but not anymore. In #44243, the `error!` macro was replaced with `send_to_embedder` to show exceptions in the terminal in the correct order.

However, it was also moved inside the not handled block, but DevTools exceptions are handled. Since logging to the terminal is not in the spec, unlike logging to the developer console, we could have the `send_to_embedder` call at the start of the function before the checks that only apply to the developer console. That way we ensure that we always show the DevTools exceptions like before.

Testing: Passes the test added in #44243, `test_console_log_and_error_ordering`
