### PR TITLE
layout: Disregard 'content' property for <input> elements

### DIFF
--- a/components/layout/dom_traversal.rs
+++ b/components/layout/dom_traversal.rs
@@ -251,9 +251,6 @@ impl Contents {
     }
 
     pub(crate) fn for_element(node: ServoLayoutNode<'_>, context: &LayoutContext) -> Self {
-        if let Some(replaced) = ReplacedContents::for_element(node, context) {
-            return Self::Replaced(replaced);
-        }
         let is_widget = matches!(
             node.type_id(),
             Some(LayoutNodeType::Element(
@@ -264,6 +261,8 @@ impl Contents {
         );
         if is_widget {
             Self::Widget(NonReplacedContents::OfElement)
+        } else if let Some(replaced) = ReplacedContents::for_element(node, context) {
+            Self::Replaced(replaced)
         } else {
             Self::NonReplaced(NonReplacedContents::OfElement)
         }

--- a/tests/wpt/meta/html/rendering/replaced-elements/images/input-image-content.html.ini
+++ b/tests/wpt/meta/html/rendering/replaced-elements/images/input-image-content.html.ini
@@ -1,2 +1,0 @@
-[input-image-content.html]
-  expected: FAIL

--- a/tests/wpt/tests/css/css-ui/crashtests/input-range-content-url.html
+++ b/tests/wpt/tests/css/css-ui/crashtests/input-range-content-url.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/44540">
+<input style="content: url()" type="range">


### PR DESCRIPTION
On elements (as opposed to pseudo-elements), CSS `content: url(something)` turns the element into a replaced element like `<img>` and ignores the DOM child nodes

Some elements like `<input>` are "widgets" that can have native appearance: https://drafts.csswg.org/css-ui/#widget

When both apply to the same element like in the added test case, the native appearance should take priority and the `content` property should be disregarded: https://drafts.csswg.org/css-ui/#disregard

Previously Servo would do something half-way, generating boxes for the native appearance (including an absolutely-positioned pseudo-element for the slider of `<input type=range>`) but not generate fragments and later expect to find fragments, causing a panic.

Testing: adding the issue reproduction as a WPT crashtest
Fixes: https://github.com/servo/servo/issues/44540