### PR TITLE
devtools: Prevent sentinel values from being serialized as Object

### DIFF
--- a/components/default-resources/resources/debugger.js
+++ b/components/default-resources/resources/debugger.js
@@ -95,7 +95,11 @@ function createValueGrip(value, depth = 0) {
         case "string":
             return { valueType: "string", stringValue: value };
         case "object":
+            // <https://searchfox.org/firefox-main/source/devtools/server/actors/object/utils.js#153>
             if (value === null) {
+                return { valueType: "null" };
+            }
+            if (value.optimizedOut || value.uninitialized || value.missingArguments) {
                 return { valueType: "null" };
             }
             // Debugger.Object - get preview using registered previewers


### PR DESCRIPTION
Currently sentinel values get serialized as `Object { }`. This change prevents sentinel values from being serialized as Object. This is also closer to how Firefox handles it.

Testing: Current tests are passing
