### PR TITLE
devtools: Do not cache environment actor values

### DIFF
--- a/components/default-resources/resources/debugger.js
+++ b/components/default-resources/resources/debugger.js
@@ -7,7 +7,7 @@ const debuggeesToPipelineIds = new Map;
 const debuggeesToWorkerIds = new Map;
 const sourceIdsToScripts = new Map;
 const frameActorsToFrames = new Map;
-const environmentActorsToEnvironments = new Map;
+const environmentsToEnvironmentActors = new Map;
 
 // <https://searchfox.org/firefox-main/source/devtools/server/actors/thread.js#155>
 // Possible values for the `why.type` attribute in "paused" event
@@ -542,35 +542,31 @@ addEventListener("clearBreakpoint", event => {
 
 // TODO: Get variables (scopes don't show if they don't have a variable)
 function createEnvironmentActor(environment) {
-    let actor = findKeyByValue(environmentActorsToEnvironments, environment);
-
-    if (!actor) {
-        let info = {};
-        if (environment.type == "declarative") {
-            info.type_ = environment.calleeScript ? "function" : "block";
-        } else {
-            info.type_ = environment.type;
-        }
-
-        info.scopeKind = environment.scopeKind;
-
-        if (environment.calleeScript) {
-            info.functionDisplayName = environment.calleeScript.displayName;
-        }
-
-        let parent = null;
-        if (environment.parent) {
-            parent = createEnvironmentActor(environment.parent);
-        }
-
-        if (environment.type == "declarative") {
-            info.bindingVariables = buildBindings(environment)
-        }
-
-        actor = registerEnvironmentActor(info, parent);
-        environmentActorsToEnvironments.set(actor, environment);
+    let info = {};
+    if (environment.type == "declarative") {
+        info.type_ = environment.calleeScript ? "function" : "block";
+    } else {
+        info.type_ = environment.type;
     }
 
+    info.scopeKind = environment.scopeKind;
+
+    if (environment.calleeScript) {
+        info.functionDisplayName = environment.calleeScript.displayName;
+    }
+
+    let parent = null;
+    if (environment.parent) {
+        parent = createEnvironmentActor(environment.parent);
+    }
+
+    if (environment.type == "declarative") {
+        info.bindingVariables = buildBindings(environment);
+    }
+
+    let actor = environmentsToEnvironmentActors.get(environment);
+    actor = registerEnvironmentActor(info, parent, actor);
+    environmentsToEnvironmentActors.set(environment, actor);
     return actor;
 }
 
@@ -582,7 +578,10 @@ function buildBindings(environment) {
             name: name,
             configurable: false,
             enumerable: true,
-            writable: !value?.optimizedOut,
+            writable: !(
+                value &&
+                (value.optimizedOut || value.uninitialized || value.missingArguments)
+            ),
             isAccessor: false,
             value: createValueGrip(value),
         };

--- a/components/devtools/actors/environment.rs
+++ b/components/devtools/actors/environment.rs
@@ -4,6 +4,7 @@
 
 use std::collections::HashMap;
 
+use atomic_refcell::AtomicRefCell;
 use devtools_traits::EnvironmentInfo;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
@@ -49,7 +50,7 @@ pub(crate) struct EnvironmentActorMsg {
 #[derive(MallocSizeOf)]
 pub(crate) struct EnvironmentActor {
     name: String,
-    environment: EnvironmentInfo,
+    environment: AtomicRefCell<EnvironmentInfo>,
     parent_name: Option<String>,
 }
 
@@ -66,11 +67,17 @@ impl EnvironmentActor {
         parent_name: Option<String>,
         actor_name: Option<String>,
     ) -> String {
-        let environment_name = actor_name.unwrap_or_else(|| registry.new_name::<Self>());
+        if let Some(actor_name) = actor_name {
+            let environment_actor = registry.find::<Self>(&actor_name);
+            *environment_actor.environment.borrow_mut() = environment;
+            return actor_name;
+        }
+
+        let environment_name = registry.new_name::<Self>();
         let environment_actor = Self {
             name: environment_name.clone(),
             parent_name,
-            environment,
+            environment: environment.into(),
         };
         registry.register(environment_actor);
         environment_name
@@ -84,22 +91,21 @@ impl ActorEncode<EnvironmentActorMsg> for EnvironmentActor {
             .as_ref()
             .map(|p| registry.find::<EnvironmentActor>(p))
             .map(|p| Box::new(p.encode(registry)));
+        let environment = self.environment.borrow();
         // TODO: Change hardcoded values.
         EnvironmentActorMsg {
             actor: self.name(),
-            type_: self.environment.type_.clone(),
-            scope_kind: self.environment.scope_kind.clone(),
+            type_: environment.type_.clone(),
+            scope_kind: environment.scope_kind.clone(),
             parent,
-            function: self
-                .environment
+            function: environment
                 .function_display_name
                 .clone()
                 .map(|display_name| EnvironmentFunction { display_name }),
             object: None,
             bindings: Some(EnvironmentBindings {
                 arguments: [].to_vec(),
-                variables: self
-                    .environment
+                variables: environment
                     .binding_variables
                     .clone()
                     .into_iter()

--- a/components/devtools/actors/environment.rs
+++ b/components/devtools/actors/environment.rs
@@ -60,12 +60,13 @@ impl Actor for EnvironmentActor {
 }
 
 impl EnvironmentActor {
-    pub fn register(
+    pub fn register_or_update(
         registry: &ActorRegistry,
         environment: EnvironmentInfo,
         parent_name: Option<String>,
+        actor_name: Option<String>,
     ) -> String {
-        let environment_name = registry.new_name::<Self>();
+        let environment_name = actor_name.unwrap_or_else(|| registry.new_name::<Self>());
         let environment_actor = Self {
             name: environment_name.clone(),
             parent_name,

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -382,8 +382,11 @@ impl DevtoolsInstance {
                         result_sender,
                         environment,
                         parent,
+                        actor,
                     ),
-                ) => self.handle_create_environment_actor(result_sender, environment, parent),
+                ) => {
+                    self.handle_create_environment_actor(result_sender, environment, parent, actor)
+                },
                 DevtoolsControlMsg::FromChrome(ChromeToDevtoolsControlMsg::NetworkEvent(
                     request_id,
                     network_event,
@@ -868,8 +871,10 @@ impl DevtoolsInstance {
         result_sender: GenericSender<String>,
         environment_info: EnvironmentInfo,
         parent: Option<String>,
+        actor: Option<String>,
     ) {
-        let environment_name = EnvironmentActor::register(&self.registry, environment_info, parent);
+        let environment_name =
+            EnvironmentActor::register_or_update(&self.registry, environment_info, parent, actor);
         let _ = result_sender.send(environment_name);
     }
 }

--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -575,6 +575,7 @@ impl DebuggerGlobalScopeMethods<crate::DomTypeHolder> for DebuggerGlobalScope {
         &self,
         environment: &EnvironmentInfo,
         parent: Option<DOMString>,
+        actor: Option<DOMString>,
     ) -> Option<DOMString> {
         let chan = self.upcast::<GlobalScope>().devtools_chan()?;
         let (tx, rx) = channel::<String>().unwrap();
@@ -598,6 +599,7 @@ impl DebuggerGlobalScopeMethods<crate::DomTypeHolder> for DebuggerGlobalScope {
             tx,
             environment,
             parent.map(String::from),
+            actor.map(String::from),
         );
         let _ = chan.send(msg);
 

--- a/components/script_bindings/webidls/DebuggerGetEnvironmentEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerGetEnvironmentEvent.webidl
@@ -12,7 +12,8 @@ interface DebuggerGetEnvironmentEvent : Event {
 partial interface DebuggerGlobalScope {
     DOMString? registerEnvironmentActor(
         EnvironmentInfo result,
-        DOMString? parent
+        DOMString? parent,
+        optional DOMString? actor = null
     );
     undefined getEnvironmentResult(
         DOMString environmentActorId

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -140,7 +140,12 @@ pub enum ScriptToDevtoolsControlMsg {
     CreateFrameActor(GenericSender<String>, PipelineId, FrameInfo),
 
     /// Get environment information from script
-    CreateEnvironmentActor(GenericSender<String>, EnvironmentInfo, Option<String>),
+    CreateEnvironmentActor(
+        GenericSender<String>,
+        EnvironmentInfo,
+        Option<String>,
+        Option<String>,
+    ),
 }
 
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]


### PR DESCRIPTION
Currently Environment Objects are cached in `createEnvironmentActor`. That meant DevTools could keep showing an old value for a variable after execution had moved on to a different value.

In this change, we keep caching the environment actor name, but make sure the current state is being reflected by refreshing the environment actor data each time.

This keeps actor id stable and  is also closer to Firefox behavior.

Testing:  Current tests are passing
Fixes:  part of #36027 
