### PR TITLE
layout: Reuse shaping results between box tree layouts

### DIFF
--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -581,6 +581,12 @@ impl Font {
 #[derive(Clone, Debug, MallocSizeOf)]
 pub struct FontRef(#[conditional_malloc_size_of] pub(crate) Arc<Font>);
 
+impl PartialEq for FontRef {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(self, other)
+    }
+}
+
 impl Deref for FontRef {
     type Target = Arc<Font>;
     fn deref(&self) -> &Self::Target {

--- a/components/fonts/glyph.rs
+++ b/components/fonts/glyph.rs
@@ -568,6 +568,12 @@ pub struct ShapedTextSlice {
 }
 
 impl ShapedTextSlice {
+    /// Return the [`ShapedText`] that backs this [`ShapedTextSlice`].
+    #[inline]
+    pub fn shaped_text(&self) -> Arc<ShapedText> {
+        self.shaped_text.clone()
+    }
+
     /// Return the number of glyphs represented by this [`ShapedTextSlice`].
     #[inline]
     pub fn glyph_count(&self) -> usize {

--- a/components/layout/dom.rs
+++ b/components/layout/dom.rs
@@ -23,6 +23,7 @@ use crate::cell::{ArcRefCell, WeakRefCell};
 use crate::context::LayoutContext;
 use crate::dom_traversal::{Contents, NodeAndStyleInfo};
 use crate::flexbox::FlexLevelBox;
+use crate::flow::inline::text_run::TextRun;
 use crate::flow::inline::{InlineItem, SharedInlineStyles, WeakInlineItem};
 use crate::flow::{BlockLevelBox, BlockLevelCreator};
 use crate::fragment_tree::{Fragment, FragmentFlags};
@@ -123,12 +124,13 @@ pub(super) enum LayoutBox {
     FlexLevel(ArcRefCell<FlexLevelBox>),
     TableLevelBox(TableLevelBox),
     TaffyItemBox(ArcRefCell<TaffyItemBox>),
+    Text(ArcRefCell<TextRun>),
 }
 
 impl LayoutBox {
     pub(crate) fn with_base<T>(&self, callback: impl FnOnce(&LayoutBoxBase) -> T) -> Option<T> {
         Some(match self {
-            LayoutBox::DisplayContents(..) => return None,
+            LayoutBox::DisplayContents(..) | LayoutBox::Text(..) => return None,
             LayoutBox::BlockLevel(block_level_box) => block_level_box.borrow().with_base(callback),
             LayoutBox::InlineLevel(inline_item) => inline_item.with_base(callback),
             LayoutBox::FlexLevel(flex_level_box) => flex_level_box.borrow().with_base(callback),
@@ -142,7 +144,7 @@ impl LayoutBox {
         callback: impl FnOnce(&mut LayoutBoxBase) -> T,
     ) -> Option<T> {
         Some(match self {
-            LayoutBox::DisplayContents(..) => return None,
+            LayoutBox::DisplayContents(..) | LayoutBox::Text(..) => return None,
             LayoutBox::BlockLevel(block_level_box) => {
                 block_level_box.borrow_mut().with_base_mut(callback)
             },
@@ -185,6 +187,9 @@ impl LayoutBox {
             LayoutBox::TaffyItemBox(taffy_item_box) => taffy_item_box
                 .borrow_mut()
                 .repair_style(context, node, new_style),
+            LayoutBox::Text(..) => {
+                // There is nothing to update in this case.
+            },
         }
     }
 
@@ -202,6 +207,9 @@ impl LayoutBox {
             Self::TableLevelBox(table_level_box) => table_level_box.attached_to_tree(layout_box),
             Self::TaffyItemBox(taffy_item_box) => {
                 taffy_item_box.borrow().attached_to_tree(layout_box)
+            },
+            Self::Text(..) => {
+                // This kind of box cannot have children, so no need to do anything.
             },
         }
     }
@@ -222,6 +230,7 @@ impl LayoutBox {
             Self::TaffyItemBox(taffy_item_box) => {
                 WeakLayoutBox::TaffyItemBox(taffy_item_box.downgrade())
             },
+            Self::Text(text_run) => WeakLayoutBox::Text(text_run.downgrade()),
         }
     }
 }
@@ -234,6 +243,7 @@ pub(super) enum WeakLayoutBox {
     FlexLevel(WeakRefCell<FlexLevelBox>),
     TableLevelBox(WeakTableLevelBox),
     TaffyItemBox(WeakRefCell<TaffyItemBox>),
+    Text(WeakRefCell<TextRun>),
 }
 
 impl WeakLayoutBox {
@@ -251,6 +261,7 @@ impl WeakLayoutBox {
             Self::TaffyItemBox(taffy_item_box) => {
                 LayoutBox::TaffyItemBox(taffy_item_box.upgrade()?)
             },
+            Self::Text(text_run) => LayoutBox::Text(text_run.upgrade()?),
         })
     }
 }
@@ -292,6 +303,16 @@ impl BoxSlot<'_> {
 
     pub(crate) fn take_layout_box(&self) -> Option<LayoutBox> {
         self.slot.borrow_mut().take()
+    }
+
+    /// Call [`Self::take_layout_box`] and try to unwrap it into a [`TextRun`], returning `None` if
+    /// the slot is empty or it does not contain a [`TextRun`]. Note that this will *always* clear
+    /// the [`BoxSlot`].
+    pub(crate) fn take_layout_box_as_text_run(&self) -> Option<ArcRefCell<TextRun>> {
+        match self.take_layout_box()? {
+            LayoutBox::Text(old_text_run) => Some(old_text_run),
+            _ => None,
+        }
     }
 }
 
@@ -579,6 +600,7 @@ impl<'dom> NodeExt<'dom> for ServoLayoutNode<'dom> {
                 TableLevelBox::Cell(..) | TableLevelBox::Caption(..),
             ),
             LayoutBox::TaffyItemBox(..) => true,
+            LayoutBox::Text(..) => unreachable!("An element should never be a text node"),
         }
     }
 
@@ -748,6 +770,7 @@ impl<'dom> NodeExt<'dom> for ServoLayoutNode<'dom> {
                 _ => false,
             },
             LayoutBox::TaffyItemBox(..) => false,
+            LayoutBox::Text(..) => unreachable!("An element should never be a text node"),
         }
     }
 }

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -422,19 +422,39 @@ impl InlineFormattingContextBuilder {
                 .inline_styles
                 .ptr_eq(&current_inline_styles)
             {
-                text_run.borrow_mut().text_range.end = new_range.end;
-                text_run.borrow_mut().character_range.end = new_character_range.end;
+                let box_slot = info.node.box_slot();
+                let old_text_run = box_slot.take_layout_box_as_text_run();
+
+                {
+                    let mut text_run = text_run.borrow_mut();
+                    text_run.text_range.end = new_range.end;
+                    text_run.character_range.end = new_character_range.end;
+
+                    // If this text node does not have a `TextRun` in the box slot, this means that
+                    // it is either new or dirty, which means that the entire `TextRun` just extended
+                    // is dirty as well. In this case, never reuse existing shaping results. Clear
+                    // all old items to ensure this.
+                    if old_text_run.is_none() {
+                        text_run.items.clear();
+                    }
+                }
+
+                box_slot.set(LayoutBox::Text(text_run.clone()));
                 return;
             }
         }
 
+        let box_slot = info.node.box_slot();
+        let text_run = ArcRefCell::new(TextRun::new(
+            info.into(),
+            current_inline_styles,
+            new_range,
+            new_character_range,
+            box_slot.take_layout_box_as_text_run(),
+        ));
         self.inline_items
-            .push(InlineItem::TextRun(ArcRefCell::new(TextRun::new(
-                info.into(),
-                current_inline_styles,
-                new_range,
-                new_character_range,
-            ))));
+            .push(InlineItem::TextRun(text_run.clone()));
+        box_slot.set(LayoutBox::Text(text_run));
     }
 
     pub(crate) fn enter_display_contents(&mut self, shared_inline_styles: SharedInlineStyles) {

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -29,6 +29,7 @@ use unicode_script::Script;
 
 use super::line_breaker::LineBreaker;
 use super::{InlineFormattingContextLayout, SharedInlineStyles};
+use crate::ArcRefCell;
 use crate::context::LayoutContext;
 use crate::dom::WeakLayoutBox;
 use crate::flow::inline::line::TextRunOffsets;
@@ -50,7 +51,7 @@ enum SegmentStartSoftWrapPolicy {
 }
 
 /// A data structure which contains information used when shaping a [`TextRunSegment`].
-#[derive(Clone, Debug, MallocSizeOf)]
+#[derive(Clone, Debug, MallocSizeOf, PartialEq)]
 pub(crate) struct FontAndScriptInfo {
     /// The font used when shaping a [`TextRunSegment`].
     pub font: FontRef,
@@ -128,7 +129,7 @@ impl From<&FontAndScriptInfo> for ShapingOptions {
     }
 }
 
-#[derive(Debug, MallocSizeOf)]
+#[derive(Clone, Debug, MallocSizeOf)]
 pub(crate) struct TextRunSegment {
     /// Information about the font and language used in this text run. This is produced by
     /// segmenting the inline formatting context's text content by font, script, and bidi level.
@@ -243,6 +244,7 @@ impl TextRunSegment {
         parent_style: &ComputedValues,
         formatting_context_text: &str,
         linebreaker: &mut LineBreaker,
+        old_text_run_item: Option<TextRunItem>,
     ) {
         // Gather the linebreaks that apply to this segment from the inline formatting context's collection
         // of line breaks. Also add a simulated break at the end of the segment in order to ensure the final
@@ -252,11 +254,23 @@ impl TextRunSegment {
         let linebreak_iter = linebreaks.iter().chain(std::iter::once(&range.end));
 
         let options: ShapingOptions = (&*self.info).into();
-        let mut shaped_text_slicer = ShapedTextSlicer::new(
-            self.info
-                .font
-                .shape_text(&formatting_context_text[range.clone()], &options),
-        );
+        let shaped_text = old_text_run_item
+            .and_then(|old_text_run_item| {
+                let TextRunItem::TextSegment(old_text_segment) = old_text_run_item else {
+                    return None;
+                };
+                if !self.is_compatible_with_old_shaping_result(&old_text_segment) {
+                    return None;
+                }
+                Some(old_text_segment.runs.first()?.shaped_text())
+            })
+            .unwrap_or_else(|| {
+                self.info
+                    .font
+                    .shape_text(&formatting_context_text[range.clone()], &options)
+            });
+
+        let mut shaped_text_slicer = ShapedTextSlicer::new(shaped_text);
 
         self.runs.clear();
         self.runs.reserve(linebreaks.len());
@@ -353,6 +367,10 @@ impl TextRunSegment {
             ));
         }
     }
+
+    fn is_compatible_with_old_shaping_result(&self, old_segment: &Self) -> bool {
+        *old_segment.info == *self.info && self.byte_range == old_segment.byte_range
+    }
 }
 
 /// A single item in a [`TextRun`].
@@ -409,14 +427,19 @@ impl TextRun {
         inline_styles: SharedInlineStyles,
         text_range: Range<usize>,
         character_range: Range<usize>,
+        old_text_run: Option<ArcRefCell<TextRun>>,
     ) -> Self {
+        // If there was a previous box tree layout of this text run, try to preserve the old shaped text.
+        let items = old_text_run
+            .map(|old_text_run| std::mem::take(&mut old_text_run.borrow_mut().items))
+            .unwrap_or_default();
         Self {
             base_fragment_info,
             parent_box: None,
             inline_styles,
             text_range,
             character_range,
-            items: Vec::new(),
+            items,
         }
     }
 
@@ -428,15 +451,25 @@ impl TextRun {
         bidi_info: &BidiInfo,
     ) {
         let parent_style = self.inline_styles.style.borrow().clone();
-        self.items = self.segment_text_by_font(
+        let items = self.segment_text_by_font(
             layout_context,
             formatting_context_text,
             bidi_info,
             &parent_style,
         );
+
+        // If a previous box tree layout seeded this [`TextRun`] with old shaping results, use those
+        // to try to prevent re-shaping.
+        let mut old_text_run_items = std::mem::replace(&mut self.items, items).into_iter();
         for item in self.items.iter_mut() {
+            let old_text_run_item = old_text_run_items.next();
             if let TextRunItem::TextSegment(text_segment) = item {
-                text_segment.shape_text(&parent_style, formatting_context_text, linebreaker)
+                text_segment.shape_text(
+                    &parent_style,
+                    formatting_context_text,
+                    linebreaker,
+                    old_text_run_item,
+                );
             }
         }
     }

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -886,6 +886,10 @@ impl Node {
 
         match self.type_id() {
             NodeTypeId::CharacterData(CharacterDataTypeId::Text(TextTypeId::Text)) => {
+                // This drops the cached `TextRun` that is stored here, ultimately meaning that
+                // shaped text will no longer be reused for this text node.
+                *self.layout_data.borrow_mut() = None;
+
                 // For content changes in text nodes, we should accurately use
                 // [`NodeDamage::ContentOrHeritage`] to mark the parent node, thereby
                 // reducing the scope of incremental box tree construction.


### PR DESCRIPTION
Cache the resulting `TextRun` of a box tree layout in text nodes. This
allows reusing shaping results between box tree layouts. Currently,
these shaping results were stored in a cache in the `Font`, but this
avoids having to hash the entire string. In addition to avoiding the
performance cost of that hash this opens up two posibilities:

 1. Only caching short strings. This further reduces the performance
    cost of the shaping cache and matches what Blink does.
 2. Moving line breaking out of shaping. This should reduce the memory
    usage of unbreakable shaped text segments and also allow for more
    easily implementing break-anywhere type CSS features.

Testing: This should not change observable behavior, so is covered by existing tests.
