### PR TITLE
uv: Upgrade mako to 1.3.12 in uv.lock to fix security alert

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -793,14 +793,14 @@ wheels = [
 
 [[package]]
 name = "mako"
-version = "1.3.11"
+version = "1.3.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/59/8a/805404d0c0b9f3d7a326475ca008db57aea9c5c9f2e1e39ed0faa335571c/mako-1.3.11.tar.gz", hash = "sha256:071eb4ab4c5010443152255d77db7faa6ce5916f35226eb02dc34479b6858069", size = 399811, upload-time = "2026-04-14T20:19:51.493Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219, upload-time = "2026-04-28T19:01:08.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/a5/19d7aaa7e433713ffe881df33705925a196afb9532efc8475d26593921a6/mako-1.3.11-py3-none-any.whl", hash = "sha256:e372c6e333cf004aa736a15f425087ec977e1fcbd2966aae7f17c8dc1da27a77", size = 78503, upload-time = "2026-04-14T20:19:53.233Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521, upload-time = "2026-04-28T19:01:10.393Z" },
 ]
 
 [[package]]
@@ -1797,7 +1797,7 @@ requires-dist = [
     { name = "json-e", specifier = "==4.7.0" },
     { name = "jsonschema", marker = "python_full_version < '3.9'", specifier = "==4.23.0" },
     { name = "jsonschema", marker = "python_full_version >= '3.9'", specifier = "==4.25.1" },
-    { name = "mako", specifier = "==1.3.11" },
+    { name = "mako", specifier = "==1.3.12" },
     { name = "mozcrash", specifier = "==2.2.1" },
     { name = "mozdebug", specifier = "==0.4.0" },
     { name = "mozfile", specifier = "==3.0.0" },


### PR DESCRIPTION
Fixes: https://github.com/servo/servo/security/dependabot/301, high severity

Similar to https://github.com/servo/servo/pull/44291#issuecomment-4265766940, the dependabot fails us again.
We got an empty commit 0383a103d1354ace1e88130ffe494fd941eb07fa

Closes: https://github.com/servo/servo/pull/44779, which is invisible for reasons only gods know.