### PR TITLE
media: Make all media stream IDs contain a unique ID.

### DIFF
--- a/components/media/streams/registry.rs
+++ b/components/media/streams/registry.rs
@@ -15,15 +15,21 @@ type RegisteredMediaStream = Arc<Mutex<dyn MediaStream>>;
 static MEDIA_STREAMS_REGISTRY: LazyLock<Mutex<HashMap<MediaStreamId, RegisteredMediaStream>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
-#[derive(Clone, Copy, Default, Hash, Eq, PartialEq, MallocSizeOf)]
+#[derive(Clone, Copy, Hash, Eq, PartialEq, MallocSizeOf)]
 pub struct MediaStreamId(Uuid);
 impl MediaStreamId {
     pub fn new() -> MediaStreamId {
-        Default::default()
+        Self(Uuid::new_v4())
     }
 
     pub fn id(self) -> Uuid {
         self.0
+    }
+}
+
+impl Default for MediaStreamId {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/tests/wpt/meta/webaudio/the-audio-api/the-mediastreamaudiodestinationnode-interface/ctor-mediastreamaudiodestination.html.ini
+++ b/tests/wpt/meta/webaudio/the-audio-api/the-mediastreamaudiodestinationnode-interface/ctor-mediastreamaudiodestination.html.ini
@@ -1,2 +1,0 @@
-[ctor-mediastreamaudiodestination.html]
-  expected: CRASH

--- a/tests/wpt/meta/webaudio/the-audio-api/the-mediastreamaudiosourcenode-interface/mediastreamaudiosourcenode-from-context-with-different-rate.https.html.ini
+++ b/tests/wpt/meta/webaudio/the-audio-api/the-mediastreamaudiosourcenode-interface/mediastreamaudiosourcenode-from-context-with-different-rate.https.html.ini
@@ -1,5 +1,4 @@
 [mediastreamaudiosourcenode-from-context-with-different-rate.https.html]
-  expected: CRASH
   [Test closing one AudioContext stops only it (cloned tracks)]
     expected: FAIL
 
@@ -58,4 +57,226 @@
     expected: FAIL
 
   [Test removing tracks from one MediaStream silences only its detector when destination rates are the same (shared tracks, 48000->32000)]
+    expected: FAIL
+
+  [Test closing one AudioContext stops only it (cloned tracks, MediaStreamAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test suspending one AudioContext silences only it (cloned tracks, MediaStreamAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test disconnecting one source node silences only it (cloned tracks, MediaStreamAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test stopping one MediaStream's tracks silences only its detector (cloned tracks, MediaStreamAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test disabling one MediaStream's tracks silences only its detector (cloned tracks, MediaStreamAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test removing tracks from one MediaStream does not silence any detector (cloned tracks, MediaStreamAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test stopping the input MediaStream's tracks silences nothing (cloned tracks, MediaStreamAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test suspending the input AudioContext silences all detectors (cloned tracks, MediaStreamAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test closing the input AudioContext silences all detectors (cloned tracks, MediaStreamAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test closing one AudioContext stops only it (cloned tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test suspending one AudioContext silences only it (cloned tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test disconnecting one source node silences only it (cloned tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test stopping one MediaStream's tracks silences only its detector (cloned tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test disabling one MediaStream's tracks silences only its detector (cloned tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test removing tracks from one MediaStream does not silence any detector (cloned tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test stopping the input MediaStream's tracks silences nothing (cloned tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test suspending the input AudioContext silences all detectors (cloned tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test closing the input AudioContext silences all detectors (cloned tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test closing one AudioContext stops only it (cloned tracks, MediaStreamAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test suspending one AudioContext silences only it (cloned tracks, MediaStreamAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test disconnecting one source node silences only it (cloned tracks, MediaStreamAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test stopping one MediaStream's tracks silences only its detector (cloned tracks, MediaStreamAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test disabling one MediaStream's tracks silences only its detector (cloned tracks, MediaStreamAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test removing tracks from one MediaStream does not silence any detector (cloned tracks, MediaStreamAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test stopping the input MediaStream's tracks silences nothing (cloned tracks, MediaStreamAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test suspending the input AudioContext silences all detectors (cloned tracks, MediaStreamAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test closing the input AudioContext silences all detectors (cloned tracks, MediaStreamAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test closing one AudioContext stops only it (cloned tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test suspending one AudioContext silences only it (cloned tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test disconnecting one source node silences only it (cloned tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test stopping one MediaStream's tracks silences only its detector (cloned tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test disabling one MediaStream's tracks silences only its detector (cloned tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test removing tracks from one MediaStream does not silence any detector (cloned tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test stopping the input MediaStream's tracks silences nothing (cloned tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test suspending the input AudioContext silences all detectors (cloned tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test closing the input AudioContext silences all detectors (cloned tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test removing tracks from one MediaStream does not silence any detector when destination rates are the same (cloned tracks, MediaStreamAudioSourceNode@32000, MediaStreamAudioSourceNode@32000)]
+    expected: FAIL
+
+  [Test closing one AudioContext stops only it (shared tracks, MediaStreamAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test suspending one AudioContext silences only it (shared tracks, MediaStreamAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test disconnecting one source node silences only it (shared tracks, MediaStreamAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test stopping one MediaStream's tracks silences all detectors (shared tracks, MediaStreamAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test disabling one MediaStream's tracks silences all detectors (shared tracks, MediaStreamAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test removing tracks from one MediaStream does not silence any detector (shared tracks, MediaStreamAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test stopping the input MediaStream's tracks silences all detectors (shared tracks, MediaStreamAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test suspending the input AudioContext silences all detectors (shared tracks, MediaStreamAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test closing the input AudioContext silences all detectors (shared tracks, MediaStreamAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test closing one AudioContext stops only it (shared tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test suspending one AudioContext silences only it (shared tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test disconnecting one source node silences only it (shared tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test stopping one MediaStream's tracks silences all detectors (shared tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test disabling one MediaStream's tracks silences all detectors (shared tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test removing tracks from one MediaStream does not silence any detector (shared tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test stopping the input MediaStream's tracks silences all detectors (shared tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test suspending the input AudioContext silences all detectors (shared tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test closing the input AudioContext silences all detectors (shared tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test closing one AudioContext stops only it (shared tracks, MediaStreamAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test suspending one AudioContext silences only it (shared tracks, MediaStreamAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test disconnecting one source node silences only it (shared tracks, MediaStreamAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test stopping one MediaStream's tracks silences all detectors (shared tracks, MediaStreamAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test disabling one MediaStream's tracks silences all detectors (shared tracks, MediaStreamAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test removing tracks from one MediaStream does not silence any detector (shared tracks, MediaStreamAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test stopping the input MediaStream's tracks silences all detectors (shared tracks, MediaStreamAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test suspending the input AudioContext silences all detectors (shared tracks, MediaStreamAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test closing the input AudioContext silences all detectors (shared tracks, MediaStreamAudioSourceNode@32000, MediaStreamTrackAudioSourceNode@44100, MediaStreamTrackAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test closing one AudioContext stops only it (shared tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test suspending one AudioContext silences only it (shared tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test disconnecting one source node silences only it (shared tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test stopping one MediaStream's tracks silences all detectors (shared tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test disabling one MediaStream's tracks silences all detectors (shared tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test removing tracks from one MediaStream does not silence any detector (shared tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test stopping the input MediaStream's tracks silences all detectors (shared tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test suspending the input AudioContext silences all detectors (shared tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test closing the input AudioContext silences all detectors (shared tracks, MediaStreamTrackAudioSourceNode@32000, MediaStreamAudioSourceNode@44100, MediaStreamAudioSourceNode@96000)]
+    expected: FAIL
+
+  [Test removing tracks from one MediaStream does not silence any detector when destination rates are the same (shared tracks, MediaStreamAudioSourceNode@32000, MediaStreamAudioSourceNode@32000)]
     expected: FAIL

--- a/tests/wpt/meta/webaudio/the-audio-api/the-mediastreamaudiosourcenode-interface/mediastreamaudiosourcenode-routing.html.ini
+++ b/tests/wpt/meta/webaudio/the-audio-api/the-mediastreamaudiosourcenode-interface/mediastreamaudiosourcenode-routing.html.ini
@@ -1,4 +1,4 @@
 [mediastreamaudiosourcenode-routing.html]
-  expected: CRASH
+  expected: TIMEOUT
   [MediaStreamAudioSourceNode captures the right track.]
     expected: TIMEOUT


### PR DESCRIPTION
Fixes a regression from #42369 that caused deadlocks whenever more than one media stream was created.

Testing: Multiple WPT tests no longer timing out.
Fixes: #44778
