### PR TITLE
net: Remove spurious invalidate in http_cache

### DIFF
--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -14,7 +14,6 @@ use std::time::{Duration, Instant, SystemTime};
 use headers::{
     CacheControl, ContentRange, Expires, HeaderMapExt, LastModified, Pragma, Range, Vary,
 };
-use http::header::HeaderValue;
 use http::{HeaderMap, Method, StatusCode, header};
 use log::{debug, error};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
@@ -699,36 +698,7 @@ pub fn refresh(
     constructed_response
 }
 
-/// Invalidation.
-/// <https://tools.ietf.org/html/rfc7234#section-4.4>
-pub(crate) async fn invalidate(
-    request: &Request,
-    response: &Response,
-    cached_resources: &mut [CachedResource],
-) {
-    // TODO(eijebong): Once headers support typed_get, update this to use them
-    if let Some(Ok(location)) = response
-        .headers
-        .get(header::LOCATION)
-        .map(HeaderValue::to_str)
-    {
-        if request.current_url().join(location).is_ok() {
-            invalidate_cached_resources(cached_resources).await;
-        }
-    }
-    if let Some(Ok(content_location)) = response
-        .headers
-        .get(header::CONTENT_LOCATION)
-        .map(HeaderValue::to_str)
-    {
-        if request.current_url().join(content_location).is_ok() {
-            invalidate_cached_resources(cached_resources).await;
-        }
-    }
-    invalidate_cached_resources(cached_resources).await;
-}
-
-async fn invalidate_cached_resources(cached_resources: &mut [CachedResource]) {
+pub(crate) fn invalidate_cached_resources(cached_resources: &mut [CachedResource]) {
     for cached_resource in cached_resources.iter_mut() {
         cached_resource.expires = Duration::ZERO;
     }
@@ -847,7 +817,7 @@ impl HttpCache {
     async fn invalidate_entry(&self, key: &CacheKey) {
         if let Some(entry) = self.entries.get(key) {
             let mut guarded_resources = entry.write().await;
-            invalidate_cached_resources(guarded_resources.as_mut_slice()).await;
+            invalidate_cached_resources(guarded_resources.as_mut_slice());
         }
     }
 

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -92,7 +92,8 @@ use crate::fetch::headers::{SecFetchDest, SecFetchMode, SecFetchSite, SecFetchUs
 use crate::fetch::methods::{Data, DoneChannel, FetchContext, Target, main_fetch};
 use crate::hsts::HstsList;
 use crate::http_cache::{
-    CacheKey, CachedResourcesOrGuard, HttpCache, construct_response, invalidate, refresh,
+    CacheKey, CachedResourcesOrGuard, HttpCache, construct_response, invalidate_cached_resources,
+    refresh,
 };
 use crate::resource_thread::{AuthCache, AuthCacheEntry};
 use crate::websocket_loader::start_websocket;
@@ -1495,7 +1496,7 @@ async fn http_network_or_cache_fetch(
             // "Invalidating Stored Responses" chapter of HTTP Caching, and set storedResponse to null.
             if forward_response.status.in_range(200..=399) && !http_request.method.is_safe() {
                 if let Some(guard) = cache_guard.try_as_mut() {
-                    invalidate(http_request, &forward_response, guard).await;
+                    invalidate_cached_resources(guard);
                 }
                 context
                     .state


### PR DESCRIPTION
Previously we invalidated the same cachedresources multiple time via a call to http_cache::invalidate. This is unnecessary as the purpose of the code is by `invalidate_related_urls`.

Additionally, we remove some unnecessary async.

Testing: This does not change behavior as the code was just duplicating work on closer inspection.
