### PR TITLE
layout: Add a basic test for incremental accessibility tree updates.

### DIFF
--- a/components/script/dom/testing/servotestutils.rs
+++ b/components/script/dom/testing/servotestutils.rs
@@ -78,10 +78,9 @@ impl ServoTestUtilsMethods<crate::DomTypeHolder> for ServoTestUtils {
         panic!("explicit panic from script")
     }
 
-    fn ForceAccessibilityUpdate(
-        r#global: &<crate::DomTypeHolder as script_bindings::DomTypes>::GlobalScope,
-    ) {
-        global.as_window().layout().set_needs_accessibility_update();
-        let _ = global.as_window().Document().update_the_rendering();
+    fn ForceAccessibilityUpdate(global: &GlobalScope) {
+        let window = global.as_window();
+        window.layout().set_needs_accessibility_update();
+        let _ = window.Document().update_the_rendering();
     }
 }

--- a/components/script/dom/testing/servotestutils.rs
+++ b/components/script/dom/testing/servotestutils.rs
@@ -77,4 +77,11 @@ impl ServoTestUtilsMethods<crate::DomTypeHolder> for ServoTestUtils {
     fn Panic(_: &GlobalScope) {
         panic!("explicit panic from script")
     }
+
+    fn ForceAccessibilityUpdate(
+        r#global: &<crate::DomTypeHolder as script_bindings::DomTypes>::GlobalScope,
+    ) {
+        global.as_window().layout().set_needs_accessibility_update();
+        let _ = global.as_window().Document().update_the_rendering();
+    }
 }

--- a/components/script_bindings/webidls/ServoTestUtils.webidl
+++ b/components/script_bindings/webidls/ServoTestUtils.webidl
@@ -20,6 +20,8 @@ namespace ServoTestUtils {
   undefined js_backtrace();
 
   undefined panic();
+
+  undefined forceAccessibilityUpdate();
 };
 
 [Exposed=Window, Pref="dom_servo_helpers_enabled"]

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -174,7 +174,7 @@ net = { workspace = true, features = ["test-util"] }
 rustls = { version = "0.23", default-features = false }
 # This must always be a path dependency, we don't want to add a dependency on a
 # crates.io version of ourselves - we want to enable a feature of ourselves.
-servo = { path = ".", features = ["tracing"] }
+servo = { path = ".", features = ["tracing", "testbinding"] }
 tracing = { workspace = true }
 winit = { workspace = true }
 

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -369,10 +369,13 @@ fn test_accessibility_basic_mutation() {
         "document.getElementById('h2').remove()",
     );
 
-    let updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
-    for update in updates {
-        tree.update_and_process_changes(update, &mut NoOpChangeHandler);
-    }
+    let mut updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
+    assert_eq!(updates.len(), 1);
+    let update = updates.pop().expect("Guaranteed by assert above");
+    assert_eq!(update.nodes.len(), 1);
+    assert_eq!(update.nodes[0].1.role(), Role::RootWebArea);
+    assert_eq!(update.nodes[0].1.children().len(), 1);
+    tree.update_and_process_changes(update, &mut NoOpChangeHandler);
 
     let root = assert_tree_structure_and_get_root_web_area(&tree);
     let children: Vec<accesskit_consumer::Node> = root.children().collect();

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -355,7 +355,7 @@ fn test_accessibility_basic_mutation() {
     let updates = wait_for_min_updates(&servo_test, delegate.clone(), 2);
     let mut tree = build_tree(updates);
     let root = assert_tree_structure_and_get_root_web_area(&tree);
-    let children: Vec<accesskit_consumer::Node> = root.children().collect();
+    let children: Vec<_> = root.children().collect();
     assert_eq!(children.len(), 2);
     let h1 = children[0];
     assert_eq!(h1.label(), Some("This is an h1".to_owned()));
@@ -378,7 +378,7 @@ fn test_accessibility_basic_mutation() {
     tree.update_and_process_changes(update, &mut NoOpChangeHandler);
 
     let root = assert_tree_structure_and_get_root_web_area(&tree);
-    let children: Vec<accesskit_consumer::Node> = root.children().collect();
+    let children: Vec<_> = root.children().collect();
     assert_eq!(children.len(), 1);
     let h1 = children[0];
     assert_eq!(h1.label(), Some("This is an h1".to_owned()));

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -361,7 +361,7 @@ fn test_accessibility_basic_mutation() {
     let h2 = children[1];
     assert_eq!(h2.label(), Some("This is an h2".to_owned()));
 
-    webview.force_accessibility_update_for_testing();
+    webview.force_needs_accessibility_update_for_testing();
 
     let _ = evaluate_javascript(
         &servo_test,

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -13,7 +13,7 @@ use accesskit_consumer::TreeChangeHandler;
 use servo::{LoadStatus, Preferences, WebViewBuilder};
 use url::Url;
 
-use crate::common::{ServoTest, WebViewDelegateImpl};
+use crate::common::{ServoTest, WebViewDelegateImpl, evaluate_javascript};
 
 struct NoOpChangeHandler;
 
@@ -328,6 +328,57 @@ fn test_accessibility_name_from_contents_subtree() {
         ),
         "Heading label should be composed of the text contents of all of its descendant text nodes"
     );
+}
+
+#[test]
+fn test_accessibility_basic_mutation() {
+    let servo_test = ServoTest::new_with_builder(|builder| {
+        let mut preferences = Preferences::default();
+        preferences.accessibility_enabled = true;
+        builder.preferences(preferences)
+    });
+    let url = "data:text/html,<!DOCTYPE html>\
+               <h1 id='h1'>This is an h1</h1>\
+               <h2 id='h2'>This is an h2</h2>";
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .url(Url::parse(url).unwrap())
+        .build();
+
+    webview.set_accessibility_active(true);
+
+    let load_webview = webview.clone();
+    servo_test.spin(move || load_webview.load_status() != LoadStatus::Complete);
+
+    let updates = wait_for_min_updates(&servo_test, delegate.clone(), 2);
+    let mut tree = build_tree(updates);
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let children: Vec<accesskit_consumer::Node> = root.children().collect();
+    assert_eq!(children.len(), 2);
+    let h1 = children[0];
+    assert_eq!(h1.label(), Some("This is an h1".to_owned()));
+    let h2 = children[1];
+    assert_eq!(h2.label(), Some("This is an h2".to_owned()));
+
+    webview.force_accessibility_update_for_testing();
+
+    let _ = evaluate_javascript(
+        &servo_test,
+        webview.clone(),
+        "document.getElementById('h2').remove()",
+    );
+
+    let updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
+    for update in updates {
+        tree.update_and_process_changes(update, &mut NoOpChangeHandler);
+    }
+
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let children: Vec<accesskit_consumer::Node> = root.children().collect();
+    assert_eq!(children.len(), 1);
+    let h1 = children[0];
+    assert_eq!(h1.label(), Some("This is an h1".to_owned()));
 }
 
 fn wait_for_min_updates(

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -335,6 +335,7 @@ fn test_accessibility_basic_mutation() {
     let servo_test = ServoTest::new_with_builder(|builder| {
         let mut preferences = Preferences::default();
         preferences.accessibility_enabled = true;
+        preferences.dom_servo_helpers_enabled = true;
         builder.preferences(preferences)
     });
     let url = "data:text/html,<!DOCTYPE html>\
@@ -361,12 +362,11 @@ fn test_accessibility_basic_mutation() {
     let h2 = children[1];
     assert_eq!(h2.label(), Some("This is an h2".to_owned()));
 
-    webview.force_needs_accessibility_update_for_testing();
-
     let _ = evaluate_javascript(
         &servo_test,
         webview.clone(),
-        "document.getElementById('h2').remove()",
+        "document.getElementById('h2').remove();\
+         window.ServoTestUtils.forceAccessibilityUpdate();",
     );
 
     let mut updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -837,6 +837,18 @@ impl WebView {
         self.accesskit_tree_id()
     }
 
+    // TODO: This method should be removed once we implement incremental tree updates.
+    pub fn force_accessibility_update_for_testing(&self) {
+        if self.inner().accesskit_tree_id.is_none() {
+            self.set_accessibility_active(true);
+            return;
+        }
+
+        self.inner().servo.constellation_proxy().send(
+            EmbedderToConstellationMessage::SetAccessibilityActive(self.id(), true),
+        );
+    }
+
     pub(crate) fn notify_document_accessibility_tree_id(&self, grafted_tree_id: TreeId) {
         let Some(webview_accesskit_tree_id) = self.inner().accesskit_tree_id else {
             return;

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -837,8 +837,9 @@ impl WebView {
         self.accesskit_tree_id()
     }
 
-    // TODO: This method should be removed once we implement incremental tree updates.
-    pub fn force_accessibility_update_for_testing(&self) {
+    // TODO(#4344): This method should be removed once we implement incremental tree updates.
+    #[doc(hidden)]
+    pub fn force_needs_accessibility_update_for_testing(&self) {
         if self.inner().accesskit_tree_id.is_none() {
             self.set_accessibility_active(true);
             return;

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -837,19 +837,6 @@ impl WebView {
         self.accesskit_tree_id()
     }
 
-    // TODO(#4344): This method should be removed once we implement incremental tree updates.
-    #[doc(hidden)]
-    pub fn force_needs_accessibility_update_for_testing(&self) {
-        if self.inner().accesskit_tree_id.is_none() {
-            self.set_accessibility_active(true);
-            return;
-        }
-
-        self.inner().servo.constellation_proxy().send(
-            EmbedderToConstellationMessage::SetAccessibilityActive(self.id(), true),
-        );
-    }
-
     pub(crate) fn notify_document_accessibility_tree_id(&self, grafted_tree_id: TreeId) {
         let Some(webview_accesskit_tree_id) = self.inner().accesskit_tree_id else {
             return;


### PR DESCRIPTION
The new test checks that TreeUpdates which are generated after a page mutation after the initial page update has been sent are incremental: that is, that they include only nodes which have changed due to the mutation in the page.

This change adds a method to `ServoTestUtils`, `forceAccessibilityUpdate()`, to force an accessibility update to run. This is currently necessary as we don't trigger any incremental updates on page mutations, since our current implementation re-computes _all_ accessibility data (but only adds nodes to the TreeUpdate if they have actually changed). 

Testing: Adds a new test.