### PR TITLE
paint: Implent and use GenericSharedMemory::into_arc_vec to get the arc directly

### DIFF
--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -1046,7 +1046,7 @@ impl Painter {
     ) -> ImageData {
         match data {
             SerializableImageData::Raw(shared_memory) => {
-                let data = Arc::new(shared_memory.to_vec());
+                let data = shared_memory.take();
                 if is_animated_image {
                     self.animation_image_cache.insert(key, Arc::clone(&data));
                 }

--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -1046,7 +1046,7 @@ impl Painter {
     ) -> ImageData {
         match data {
             SerializableImageData::Raw(shared_memory) => {
-                let data = shared_memory.take();
+                let data = shared_memory.into_arc_vec();
                 if is_animated_image {
                     self.animation_image_cache.insert(key, Arc::clone(&data));
                 }

--- a/components/shared/base/generic_channel/shared_memory.rs
+++ b/components/shared/base/generic_channel/shared_memory.rs
@@ -67,6 +67,17 @@ impl GenericSharedMemory {
             ])))
         }
     }
+
+    /// Returns the arc directly if in `inprocess` mode or copies to a new vector from `GenericSharedMemory` if in IPC mode.
+    /// If multiple `GenericSharedmemory` point to the same value this is safe to use and only effects the value currently hold.
+    pub fn take(self) -> Arc<Vec<u8>> {
+        match self.0 {
+            GenericSharedMemoryVariant::Ipc(ipc_shared_memory) => {
+                Arc::new(ipc_shared_memory.to_vec())
+            },
+            GenericSharedMemoryVariant::InProcess(arc) => arc,
+        }
+    }
 }
 
 impl fmt::Debug for GenericSharedMemory {

--- a/components/shared/base/generic_channel/shared_memory.rs
+++ b/components/shared/base/generic_channel/shared_memory.rs
@@ -68,9 +68,9 @@ impl GenericSharedMemory {
         }
     }
 
-    /// Returns the arc directly if in `inprocess` mode or copies to a new vector from `GenericSharedMemory` if in IPC mode.
+    /// Free operation in single process mode.
     /// If multiple `GenericSharedmemory` point to the same value this is safe to use and only effects the value currently hold.
-    pub fn take(self) -> Arc<Vec<u8>> {
+    pub fn into_arc_vec(self) -> Arc<Vec<u8>> {
         match self.0 {
             GenericSharedMemoryVariant::Ipc(ipc_shared_memory) => {
                 Arc::new(ipc_shared_memory.to_vec())


### PR DESCRIPTION
This implements GenericSharedMemory::take which will return the arc if in non-ipc mode and create a new Arc<Vec<u8>> if in ipc mode.

This also modifies in painter `serializable_image_data_to_image_data_maybe_caching` to use this new function to not copy the bytes of images.

Theoretically this function could be used in the fonts section where a similar procedure happens. However, webrender does not seem to support fonts given as Arc<Vec<u8>> only as Vec<u8> at the moment.

This is a reimplementation of the idea in https://github.com/servo/servo/pull/41770.

Testing: There are no direct tests for this but general browsing does not show any errors.
