### PR TITLE
script: Remove client from service worker container, use storage key

### DIFF
--- a/components/script/dom/client.rs
+++ b/components/script/dom/client.rs
@@ -38,25 +38,13 @@ impl Client {
         }
     }
 
+    #[expect(dead_code)]
     pub(crate) fn new(window: &Window, can_gc: CanGc) -> DomRoot<Client> {
         reflect_dom_object(
             Box::new(Client::new_inherited(window.get_url())),
             window,
             can_gc,
         )
-    }
-
-    pub(crate) fn creation_url(&self) -> ServoUrl {
-        self.url.clone()
-    }
-
-    pub(crate) fn get_controller(&self) -> Option<DomRoot<ServiceWorker>> {
-        self.active_worker.get()
-    }
-
-    #[expect(dead_code)]
-    pub(crate) fn set_controller(&self, worker: &ServiceWorker) {
-        self.active_worker.set(Some(worker));
     }
 }
 

--- a/components/script/dom/client.rs
+++ b/components/script/dom/client.rs
@@ -3,12 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::Reflector;
 use servo_url::ServoUrl;
 use uuid::Uuid;
 
 use crate::dom::bindings::codegen::Bindings::ClientBinding::{ClientMethods, FrameType};
-use crate::dom::bindings::reflector::Reflector;
 use crate::dom::bindings::root::MutNullableDom;
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::serviceworker::ServiceWorker;

--- a/components/script/dom/client.rs
+++ b/components/script/dom/client.rs
@@ -2,19 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::default::Default;
-
 use dom_struct::dom_struct;
 use script_bindings::reflector::{Reflector, reflect_dom_object};
 use servo_url::ServoUrl;
 use uuid::Uuid;
 
 use crate::dom::bindings::codegen::Bindings::ClientBinding::{ClientMethods, FrameType};
-use crate::dom::bindings::root::{DomRoot, MutNullableDom};
+use crate::dom::bindings::reflector::Reflector;
+use crate::dom::bindings::root::MutNullableDom;
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::serviceworker::ServiceWorker;
-use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct Client {
@@ -25,18 +22,6 @@ pub(crate) struct Client {
     frame_type: FrameType,
     #[no_trace]
     id: Uuid,
-}
-
-impl Client {
-    fn new_inherited(url: ServoUrl) -> Client {
-        Client {
-            reflector_: Reflector::new(),
-            active_worker: Default::default(),
-            url,
-            frame_type: FrameType::None,
-            id: Uuid::new_v4(),
-        }
-    }
 }
 
 impl ClientMethods<crate::DomTypeHolder> for Client {

--- a/components/script/dom/client.rs
+++ b/components/script/dom/client.rs
@@ -37,15 +37,6 @@ impl Client {
             id: Uuid::new_v4(),
         }
     }
-
-    #[expect(dead_code)]
-    pub(crate) fn new(window: &Window, can_gc: CanGc) -> DomRoot<Client> {
-        reflect_dom_object(
-            Box::new(Client::new_inherited(window.get_url())),
-            window,
-            can_gc,
-        )
-    }
 }
 
 impl ClientMethods<crate::DomTypeHolder> for Client {

--- a/components/script/dom/indexeddb/idbfactory.rs
+++ b/components/script/dom/indexeddb/idbfactory.rs
@@ -70,7 +70,7 @@ impl IDBFactory {
     }
 
     /// <https://storage.spec.whatwg.org/#obtain-a-storage-key>
-    fn obtain_storage_key(environment: &GlobalScope) -> Option<ImmutableOrigin> {
+    pub(crate) fn obtain_storage_key(environment: &GlobalScope) -> Option<ImmutableOrigin> {
         // Step 1: Let key be the result of running obtain a storage key for non-storage purposes
         // with environment.
         let key = Self::obtain_storage_key_for_non_storage_purposes(environment);

--- a/components/script/dom/workers/serviceworkercontainer.rs
+++ b/components/script/dom/workers/serviceworkercontainer.rs
@@ -18,12 +18,12 @@ use crate::dom::bindings::codegen::Bindings::ServiceWorkerContainerBinding::{
 };
 use crate::dom::bindings::error::Error;
 use crate::dom::bindings::refcounted::TrustedPromise;
-use crate::dom::bindings::reflector::DomGlobal;
-use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
+use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object};
+use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::str::USVString;
-use crate::dom::client::Client;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
+use crate::dom::idbfactory::IDBFactory;
 use crate::dom::promise::Promise;
 use crate::dom::serviceworker::ServiceWorker;
 use crate::dom::serviceworkerregistration::ServiceWorkerRegistration;
@@ -35,30 +35,30 @@ use crate::task_source::SendableTaskSource;
 pub(crate) struct ServiceWorkerContainer {
     eventtarget: EventTarget,
     controller: MutNullableDom<ServiceWorker>,
-    client: Dom<Client>,
 }
 
 impl ServiceWorkerContainer {
-    fn new_inherited(client: &Client) -> ServiceWorkerContainer {
+    fn new_inherited() -> ServiceWorkerContainer {
         ServiceWorkerContainer {
             eventtarget: EventTarget::new_inherited(),
             controller: Default::default(),
-            client: Dom::from_ref(client),
         }
     }
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<ServiceWorkerContainer> {
-        let client = Client::new(global.as_window(), can_gc);
-        let container = ServiceWorkerContainer::new_inherited(&client);
-        reflect_dom_object(Box::new(container), global, can_gc)
+        reflect_dom_object(
+            Box::new(ServiceWorkerContainer::new_inherited()),
+            global,
+            can_gc,
+        )
     }
 }
 
 impl ServiceWorkerContainerMethods<crate::DomTypeHolder> for ServiceWorkerContainer {
     /// <https://w3c.github.io/ServiceWorker/#service-worker-container-controller-attribute>
     fn GetController(&self) -> Option<DomRoot<ServiceWorker>> {
-        self.client.get_controller()
+        None
     }
 
     /// <https://w3c.github.io/ServiceWorker/#dom-serviceworkercontainer-register> - A
@@ -71,7 +71,7 @@ impl ServiceWorkerContainerMethods<crate::DomTypeHolder> for ServiceWorkerContai
     ) -> Rc<Promise> {
         let can_gc = CanGc::from_cx(realm);
         // A: Step 2.
-        let global = self.client.global();
+        let global = self.global();
 
         // A: Step 1
         let promise = Promise::new_in_current_realm(InRealm::already(&realm.into()), can_gc);
@@ -166,13 +166,24 @@ impl ServiceWorkerContainerMethods<crate::DomTypeHolder> for ServiceWorkerContai
             ServiceWorkerRegistration::create_scope_things(&global, script_url.clone());
 
         // B: Step 8 - 13
+
+        // Step 10: Let storage key be the result of running obtain a storage key given client.
+        let Some(storage_key) = IDBFactory::obtain_storage_key(&global) else {
+            promise.reject_error(
+                Error::Type(c"Failed to obtain a storage key".to_owned()),
+                can_gc,
+            );
+            return promise;
+        };
+
         let job = Job::create_job(
             JobType::Register,
             scope,
             script_url,
             result_handler,
-            self.client.creation_url(),
+            global.creation_url(),
             Some(scope_things),
+            storage_key,
         );
 
         // B: Step 14: schedule job.
@@ -182,6 +193,10 @@ impl ServiceWorkerContainerMethods<crate::DomTypeHolder> for ServiceWorkerContai
 
         // A: Step 7
         promise
+    }
+
+    fn GetRegistration(&self, _client_url: script_bindings::str::USVString) -> Rc<Promise> {
+        todo!()
     }
 }
 

--- a/components/script/dom/workers/serviceworkercontainer.rs
+++ b/components/script/dom/workers/serviceworkercontainer.rs
@@ -18,7 +18,7 @@ use crate::dom::bindings::codegen::Bindings::ServiceWorkerContainerBinding::{
 };
 use crate::dom::bindings::error::Error;
 use crate::dom::bindings::refcounted::TrustedPromise;
-use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object};
+use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::str::USVString;
 use crate::dom::eventtarget::EventTarget;

--- a/components/script/dom/workers/serviceworkercontainer.rs
+++ b/components/script/dom/workers/serviceworkercontainer.rs
@@ -194,10 +194,6 @@ impl ServiceWorkerContainerMethods<crate::DomTypeHolder> for ServiceWorkerContai
         // A: Step 7
         promise
     }
-
-    fn GetRegistration(&self, _client_url: script_bindings::str::USVString) -> Rc<Promise> {
-        todo!()
-    }
 }
 
 /// Callback for resolve/reject job promise for Register.

--- a/components/script_bindings/webidls/ServiceWorkerContainer.webidl
+++ b/components/script_bindings/webidls/ServiceWorkerContainer.webidl
@@ -11,7 +11,7 @@ interface ServiceWorkerContainer : EventTarget {
   [NewObject] Promise<ServiceWorkerRegistration> register(USVString scriptURL,
                                                           optional RegistrationOptions options = {});
 
-  [NewObject] Promise<(ServiceWorkerRegistration or undefined)> getRegistration(optional USVString clientURL = "");
+  //[NewObject] Promise<(ServiceWorkerRegistration or undefined)> getRegistration(optional USVString clientURL = "");
   //[NewObject] Promise<FrozenArray<ServiceWorkerRegistration>> getRegistrations();
 
   //void startMessages();

--- a/components/script_bindings/webidls/ServiceWorkerContainer.webidl
+++ b/components/script_bindings/webidls/ServiceWorkerContainer.webidl
@@ -11,7 +11,7 @@ interface ServiceWorkerContainer : EventTarget {
   [NewObject] Promise<ServiceWorkerRegistration> register(USVString scriptURL,
                                                           optional RegistrationOptions options = {});
 
-  //[NewObject] Promise<any> getRegistration(optional USVString clientURL = "");
+  [NewObject] Promise<(ServiceWorkerRegistration or undefined)> getRegistration(optional USVString clientURL = "");
   //[NewObject] Promise<FrozenArray<ServiceWorkerRegistration>> getRegistrations();
 
   //void startMessages();

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -328,6 +328,8 @@ pub struct Job {
     pub referrer: ServoUrl,
     /// Various data needed to process job.
     pub scope_things: Option<ScopeThings>,
+    /// <https://w3c.github.io/ServiceWorker/#job-storage-key>
+    pub storage_key: ImmutableOrigin,
 }
 
 impl Job {
@@ -339,6 +341,7 @@ impl Job {
         client: GenericCallback<JobResult>,
         referrer: ServoUrl,
         scope_things: Option<ScopeThings>,
+        storage_key: ImmutableOrigin,
     ) -> Job {
         Job {
             job_type,
@@ -347,6 +350,7 @@ impl Job {
             client,
             referrer,
             scope_things,
+            storage_key,
         }
     }
 }


### PR DESCRIPTION
remove the use of Client on the service worker container, instead the spec uses an internal client concept which in our implementation can be the global scope; pass a storage key to create job. 

Testing: WPT
Fixes: None
