### PR TITLE
backport: Update aws-lc-rs to version 1.16.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,9 +702,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -712,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ argon2 = { version = "0.5", features = ["alloc"] }
 arrayvec = "0.7"
 async-tungstenite = { version = "0.34", features = ["tokio-rustls-webpki-roots"] }
 atomic_refcell = "0.1.13"
-aws-lc-rs = { version = "1.16", default-features = false, features = ["aws-lc-sys"] }
+aws-lc-rs = { version = "1.16.3", default-features = false, features = ["aws-lc-sys"] }
 backtrace = "0.3"
 base64 = "0.22.1"
 base64ct = { version = "1.8", features = ["alloc"] }


### PR DESCRIPTION
None of the fixed issues should directly affect us, but keeping the crypto libraries updated is best practice.

https://github.com/aws/aws-lc-rs/releases/tag/v1.16.3

Testing: Dependency patch bump, no extra testing required.

