### PR TITLE
script: Properly render CDATA sections

### DIFF
--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -885,7 +885,7 @@ impl Node {
         }
 
         match self.type_id() {
-            NodeTypeId::CharacterData(CharacterDataTypeId::Text(TextTypeId::Text)) => {
+            NodeTypeId::CharacterData(CharacterDataTypeId::Text(..)) => {
                 // This drops the cached `TextRun` that is stored here, ultimately meaning that
                 // shaped text will no longer be reused for this text node.
                 *self.layout_data.borrow_mut() = None;
@@ -2143,8 +2143,10 @@ impl<'dom> LayoutDom<'dom, Node> {
     }
 
     pub(crate) fn is_text_node_for_layout(&self) -> bool {
-        self.type_id_for_layout() ==
-            NodeTypeId::CharacterData(CharacterDataTypeId::Text(TextTypeId::Text))
+        matches!(
+            self.type_id_for_layout(),
+            NodeTypeId::CharacterData(CharacterDataTypeId::Text(..))
+        )
     }
 
     #[inline]

--- a/components/script/layout_dom/servo_dangerous_style_element.rs
+++ b/components/script/layout_dom/servo_dangerous_style_element.rs
@@ -46,7 +46,6 @@ use stylo_dom::ElementState;
 
 use crate::dom::bindings::inheritance::{
     CharacterDataTypeId, DocumentFragmentTypeId, ElementTypeId, HTMLElementTypeId, NodeTypeId,
-    TextTypeId,
 };
 use crate::dom::bindings::root::LayoutDom;
 use crate::dom::element::Element;
@@ -746,7 +745,7 @@ impl<'dom> ::selectors::Element for ServoDangerousStyleElement<'dom> {
             .dom_children()
             .all(|node| match node.node.type_id_for_layout() {
                 NodeTypeId::Element(..) => false,
-                NodeTypeId::CharacterData(CharacterDataTypeId::Text(TextTypeId::Text)) => {
+                NodeTypeId::CharacterData(CharacterDataTypeId::Text(..)) => {
                     node.node.downcast().unwrap().data_for_layout().is_empty()
                 },
                 _ => true,

--- a/tests/wpt/tests/html/rendering/cdata-001.xhtml
+++ b/tests/wpt/tests/html/rendering/cdata-001.xhtml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" class="reftest-wait">
+    <head>
+        <title>Rendering of dynamically added CDATA section</title>
+        <script src="/common/reftest-wait.js"></script>
+        <link rel="stylesheet" href="/fonts/ahem.css" />
+        <link rel="author" title="Martin Robinson" href="mailto:martin@abandonedwig.info" />
+        <link rel="match" href="/css/reference/ref-filled-green-100px-square.xht" />
+        <meta name="assert" content="CDATA content should be renderable when dynamically added to the DOM" />
+        <style>
+            #container {
+                font: 100px/1 Ahem;
+                width: 100px;
+                height: 100px;
+                color: green;
+                background: red;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+        <div id="container"></div>
+        <script>
+            const container = document.getElementById("container");
+            document.fonts.ready.then(() => {
+                container.appendChild(document.createCDATASection("X"));
+                takeScreenshot();
+            });
+        </script>
+    </body>
+</html>

--- a/tests/wpt/tests/html/rendering/cdata-002.xhtml
+++ b/tests/wpt/tests/html/rendering/cdata-002.xhtml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" class="reftest-wait">
+    <head>
+        <title>Rendering of dynamically modified CDATA section</title>
+        <script src="/common/reftest-wait.js"></script>
+        <link rel="stylesheet" href="/fonts/ahem.css" />
+        <link rel="author" title="Martin Robinson" href="mailto:martin@abandonedwig.info" />
+        <link rel="match" href="/css/reference/ref-filled-green-100px-square.xht" />
+        <meta name="assert" content="CDATA content should be rendered properly when dynamically modified" />
+
+        <style>
+            #container {
+                font: 100px/1 Ahem;
+                width: 100px;
+                height: 100px;
+                color: green;
+                background: red;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+        <div id="container"></div>
+        <script>
+            const container = document.getElementById("container");
+            container.appendChild(document.createCDATASection(""));
+            document.fonts.ready.then(() => {
+                container.childNodes[0].data = "X";
+                takeScreenshot();
+            });
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
This change makes it so that CDATA sections are rendered properly during
layout and also that damage is applied to them like it is applied to
text nodes.

Testing: This change adds two WPT tests.
