### PR TITLE
script: Poll gamepad events in a seperate thread

### DIFF
--- a/components/servo/gamepad_delegate.rs
+++ b/components/servo/gamepad_delegate.rs
@@ -12,14 +12,14 @@ pub enum GamepadHapticEffectRequestType {
 pub struct GamepadHapticEffectRequest {
     gamepad_index: usize,
     request_type: GamepadHapticEffectRequestType,
-    callback: Option<Box<dyn FnOnce(bool)>>,
+    callback: Option<Box<dyn FnOnce(bool) + Send>>,
 }
 
 impl GamepadHapticEffectRequest {
     pub(crate) fn new(
         gamepad_index: usize,
         request_type: GamepadHapticEffectRequestType,
-        callback: Box<dyn FnOnce(bool)>,
+        callback: Box<dyn FnOnce(bool) + Send>,
     ) -> Self {
         Self {
             gamepad_index,

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -130,12 +130,10 @@ impl App {
             user_content_manager,
             self.preferences.clone(),
             #[cfg(feature = "gamepad")]
-            ServoshellGamepadDelegate::maybe_new(
-                self.event_loop_proxy
-                    .clone()
-                    .expect("Must have event loop proxy"),
-            )
-            .map(Rc::new),
+            self.event_loop_proxy
+                .clone()
+                .map(ServoshellGamepadDelegate::new)
+                .map(Rc::new),
         ));
         running_state.open_window(platform_window, self.initial_url.as_url().clone());
 

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -130,7 +130,12 @@ impl App {
             user_content_manager,
             self.preferences.clone(),
             #[cfg(feature = "gamepad")]
-            ServoshellGamepadDelegate::maybe_new().map(Rc::new),
+            ServoshellGamepadDelegate::maybe_new(
+                self.event_loop_proxy
+                    .clone()
+                    .expect("Must have event loop proxy"),
+            )
+            .map(Rc::new),
         ));
         running_state.open_window(platform_window, self.initial_url.as_url().clone());
 
@@ -218,12 +223,18 @@ impl ApplicationHandler<AppEvent> for App {
             return;
         };
 
-        if let Some(window) = app_event
-            .window_id()
-            .and_then(|window_id| state.window(ServoShellWindowId::from(u64::from(window_id)))) &&
-            let Some(headed_window) = window.platform_window().as_headed_window()
-        {
-            headed_window.handle_winit_app_event(state.clone(), app_event);
+        match app_event {
+            AppEvent::Waker => (),
+            AppEvent::Accessibility(ref event) => {
+                if let Some(window) =
+                    state.window(ServoShellWindowId::from(u64::from(event.window_id)))
+                    && let Some(headed_window) = window.platform_window().as_headed_window() {
+                        headed_window.handle_winit_app_event(state.clone(), app_event);
+                    }
+            },
+            AppEvent::Gamepad(event, gamepad_name, gamepad_index) => {
+                state.handle_gamepad_events(event, gamepad_name, gamepad_index);
+            },
         }
 
         if !self.pump_servo_event_loop(event_loop.into()) {

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -227,10 +227,11 @@ impl ApplicationHandler<AppEvent> for App {
             AppEvent::Waker => (),
             AppEvent::Accessibility(ref event) => {
                 if let Some(window) =
-                    state.window(ServoShellWindowId::from(u64::from(event.window_id)))
-                    && let Some(headed_window) = window.platform_window().as_headed_window() {
-                        headed_window.handle_winit_app_event(state.clone(), app_event);
-                    }
+                    state.window(ServoShellWindowId::from(u64::from(event.window_id))) &&
+                    let Some(headed_window) = window.platform_window().as_headed_window()
+                {
+                    headed_window.handle_winit_app_event(state.clone(), app_event);
+                }
             },
             AppEvent::Gamepad(event, gamepad_name, gamepad_index) => {
                 state.handle_gamepad_events(event, gamepad_name, gamepad_index);

--- a/ports/servoshell/desktop/event_loop.rs
+++ b/ports/servoshell/desktop/event_loop.rs
@@ -11,7 +11,6 @@ use gilrs::Event;
 use log::warn;
 use servo::{EventLoopWaker, GamepadIndex};
 use winit::event_loop::{EventLoop, EventLoop as WinitEventLoop, EventLoopProxy};
-use winit::window::WindowId;
 
 use super::app::App;
 

--- a/ports/servoshell/desktop/event_loop.rs
+++ b/ports/servoshell/desktop/event_loop.rs
@@ -7,8 +7,9 @@
 use std::sync::{Arc, Condvar, Mutex};
 use std::time;
 
+use gilrs::Event;
 use log::warn;
-use servo::EventLoopWaker;
+use servo::{EventLoopWaker, GamepadIndex};
 use winit::event_loop::{EventLoop, EventLoop as WinitEventLoop, EventLoopProxy};
 use winit::window::WindowId;
 
@@ -19,20 +20,12 @@ pub enum AppEvent {
     /// Another process or thread has kicked the OS event loop with EventLoopWaker.
     Waker,
     Accessibility(egui_winit::accesskit_winit::Event),
+    Gamepad(Event, String, GamepadIndex),
 }
 
 impl From<egui_winit::accesskit_winit::Event> for AppEvent {
     fn from(event: egui_winit::accesskit_winit::Event) -> AppEvent {
         AppEvent::Accessibility(event)
-    }
-}
-
-impl AppEvent {
-    pub(crate) fn window_id(&self) -> Option<WindowId> {
-        match self {
-            AppEvent::Waker => None,
-            AppEvent::Accessibility(event) => Some(event.window_id),
-        }
     }
 }
 

--- a/ports/servoshell/desktop/gamepad.rs
+++ b/ports/servoshell/desktop/gamepad.rs
@@ -47,10 +47,12 @@ impl ServoshellGamepadDelegate {
                         let gamepad = handle.gamepad(event.id);
                         let name = gamepad.name();
                         let index = GamepadIndex(event.id.into());
-                        event_loop_proxy
-                            .clone()
-                            .send_event(AppEvent::Gamepad(event, name.to_owned(), index))
-                            .expect("Coulnt access to event loop proxy!");
+
+                        if event_loop_proxy.send_event(AppEvent::Gamepad(event, name.to_owned(), index))
+                            .is_err() {
+                                warn!("Error sending gamepad event to event loop proxy");
+                                return;
+                            }
                     }
                 }
             });

--- a/ports/servoshell/desktop/gamepad.rs
+++ b/ports/servoshell/desktop/gamepad.rs
@@ -26,7 +26,6 @@ pub struct HapticEffect {
 }
 
 pub(crate) struct ServoshellGamepadDelegate {
-    haptic_effects: RefCell<HashMap<usize, HapticEffect>>,
     sender: Sender<GamepadHapticEffectRequest>,
 }
 
@@ -37,7 +36,6 @@ impl ServoshellGamepadDelegate {
         let _ = thread::Builder::new()
             .name(String::from("GamepadThread"))
             .spawn(move || {
-
                 let mut haptic_effects: HashMap<usize, HapticEffect> = HashMap::new();
                 let mut handle = match Gilrs::new() {
                     Ok(handle) => handle,
@@ -51,9 +49,19 @@ impl ServoshellGamepadDelegate {
                     while let Some(event) =
                         handle.next_event_blocking(Some(Duration::from_millis(100)))
                     {
+                        let id: usize = event.id.into();
                         let gamepad = handle.gamepad(event.id);
                         let name = gamepad.name();
-                        let index = GamepadIndex(event.id.into());
+                        let index = GamepadIndex(id);
+
+                        if matches!(&event.event, EventType::ForceFeedbackEffectCompleted) {
+                            match haptic_effects.remove(&id) {
+                                Some(haptic_effect) => haptic_effect.request.succeeded(),
+                                None => warn!("Failed to find haptic effect for id {id}"),
+                            }
+
+                            continue;
+                        }
 
                         if event_loop_proxy
                             .send_event(AppEvent::Gamepad(event, name.to_owned(), index))
@@ -67,7 +75,12 @@ impl ServoshellGamepadDelegate {
                     while let Ok(request) = rx.try_recv() {
                         match request.request_type() {
                             GamepadHapticEffectRequestType::Play(effect_type) => {
-                                Self::play_haptic_effect(&mut haptic_effects, &effect_type.clone(), request, &mut handle);
+                                Self::play_haptic_effect(
+                                    &mut haptic_effects,
+                                    &effect_type.clone(),
+                                    request,
+                                    &mut handle,
+                                );
                             },
                             GamepadHapticEffectRequestType::Stop => {
                                 Self::stop_haptic_effect(&mut haptic_effects, request);
@@ -77,10 +90,7 @@ impl ServoshellGamepadDelegate {
                 }
             });
 
-        Some(Self {
-            haptic_effects: RefCell::new(Default::default()),
-            sender: tx,
-        })
+        Some(Self { sender: tx })
     }
 
     /// Handle updates to connected gamepads from GilRs
@@ -159,15 +169,6 @@ impl ServoshellGamepadDelegate {
             },
             EventType::Disconnected => {
                 gamepad_event = Some(GamepadEvent::Disconnected(index));
-            },
-            EventType::ForceFeedbackEffectCompleted => {
-                if let Some(haptic_effect) =
-                    self.haptic_effects.borrow_mut().remove(&event.id.into())
-                {
-                    haptic_effect.request.succeeded();
-                } else {
-                    warn!("Failed to find haptic effect for id {}", event.id);
-                }
             },
             _ => {},
         }
@@ -259,8 +260,10 @@ impl ServoshellGamepadDelegate {
             .expect("Failed to play haptic effect.");
     }
 
-    fn stop_haptic_effect(haptic_effects: &mut HashMap<usize, HapticEffect>,
-        request: GamepadHapticEffectRequest) {
+    fn stop_haptic_effect(
+        haptic_effects: &mut HashMap<usize, HapticEffect>,
+        request: GamepadHapticEffectRequest,
+    ) {
         let index = request.gamepad_index();
 
         let Some(haptic_effect) = haptic_effects.get(&index) else {

--- a/ports/servoshell/desktop/gamepad.rs
+++ b/ports/servoshell/desktop/gamepad.rs
@@ -4,15 +4,20 @@
 
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::thread;
 
 use gilrs::ff::{BaseEffect, BaseEffectType, Effect, EffectBuilder, Repeat, Replay, Ticks};
-use gilrs::{EventType, Gilrs};
+use gilrs::{Event, EventType, Gilrs};
 use log::{debug, warn};
 use servo::{
     GamepadDelegate, GamepadEvent, GamepadHapticEffectRequest, GamepadHapticEffectRequestType,
     GamepadHapticEffectType, GamepadIndex, GamepadInputBounds, GamepadSupportedHapticEffects,
     GamepadUpdateType, InputEvent, WebView,
 };
+use winit::event_loop::EventLoopProxy;
+
+use crate::desktop::event_loop::AppEvent;
 
 pub struct HapticEffect {
     pub effect: Effect,
@@ -20,116 +25,131 @@ pub struct HapticEffect {
 }
 
 pub(crate) struct ServoshellGamepadDelegate {
-    handle: RefCell<Gilrs>,
     haptic_effects: RefCell<HashMap<usize, HapticEffect>>,
 }
 
 impl ServoshellGamepadDelegate {
-    pub(crate) fn maybe_new() -> Option<Self> {
-        let handle = match Gilrs::new() {
-            Ok(handle) => handle,
-            Err(error) => {
-                warn!("Error creating gamepad input connection ({error})");
-                return None;
-            },
-        };
+    pub(crate) fn maybe_new(event_loop_proxy: EventLoopProxy<AppEvent>) -> Option<Self> {
+        let _ = thread::Builder::new()
+            .name(String::from("GamepadThread"))
+            .spawn(move || {
+                let mut handle = match Gilrs::new() {
+                    Ok(handle) => handle,
+                    Err(error) => {
+                        warn!("Error creating gamepad input connection ({error})");
+                        return;
+                    },
+                };
+
+                loop {
+                    while let Some(event) = handle.next_event() {
+                        let gamepad = handle.gamepad(event.id);
+                        let name = gamepad.name();
+                        let index = GamepadIndex(event.id.into());
+                        event_loop_proxy
+                            .clone()
+                            .send_event(AppEvent::Gamepad(event, name.to_owned(), index))
+                            .expect("Coulnt access to event loop proxy!");
+                    }
+                }
+            });
+
         Some(Self {
-            handle: RefCell::new(handle),
             haptic_effects: RefCell::new(Default::default()),
         })
     }
 
     /// Handle updates to connected gamepads from GilRs
-    pub(crate) fn handle_gamepad_events(&self, active_webview: WebView) {
-        let mut handle = self.handle.borrow_mut();
-        while let Some(event) = handle.next_event() {
-            let gamepad = handle.gamepad(event.id);
-            let name = gamepad.name();
-            let index = GamepadIndex(event.id.into());
-            let mut gamepad_event: Option<GamepadEvent> = None;
-            match event.event {
-                EventType::ButtonPressed(button, _) => {
-                    let mapped_index = Self::map_gamepad_button(button);
-                    // We only want to send this for a valid digital button, aka on/off only
-                    if !matches!(mapped_index, 6 | 7 | 17) {
-                        let update_type = GamepadUpdateType::Button(mapped_index, 1.0);
-                        gamepad_event = Some(GamepadEvent::Updated(index, update_type));
-                    }
-                },
-                EventType::ButtonReleased(button, _) => {
-                    let mapped_index = Self::map_gamepad_button(button);
-                    // We only want to send this for a valid digital button, aka on/off only
-                    if !matches!(mapped_index, 6 | 7 | 17) {
-                        let update_type = GamepadUpdateType::Button(mapped_index, 0.0);
-                        gamepad_event = Some(GamepadEvent::Updated(index, update_type));
-                    }
-                },
-                EventType::ButtonChanged(button, value, _) => {
-                    let mapped_index = Self::map_gamepad_button(button);
-                    // We only want to send this for a valid non-digital button, aka the triggers
-                    if matches!(mapped_index, 6 | 7) {
-                        let update_type = GamepadUpdateType::Button(mapped_index, value as f64);
-                        gamepad_event = Some(GamepadEvent::Updated(index, update_type));
-                    }
-                },
-                EventType::AxisChanged(axis, value, _) => {
-                    // Map axis index and value to represent Standard Gamepad axis
-                    // <https://www.w3.org/TR/gamepad/#dfn-represents-a-standard-gamepad-axis>
-                    let mapped_axis: usize = match axis {
-                        gilrs::Axis::LeftStickX => 0,
-                        gilrs::Axis::LeftStickY => 1,
-                        gilrs::Axis::RightStickX => 2,
-                        gilrs::Axis::RightStickY => 3,
-                        _ => 4, // Other axes do not map to "standard" gamepad mapping and are ignored
+    pub(crate) fn handle_gamepad_events(
+        &self,
+        event: Event,
+        name: String,
+        index: GamepadIndex,
+        active_webview: WebView,
+    ) {
+        let mut gamepad_event: Option<GamepadEvent> = None;
+        match event.event {
+            EventType::ButtonPressed(button, _) => {
+                let mapped_index = Self::map_gamepad_button(button);
+                // We only want to send this for a valid digital button, aka on/off only
+                if !matches!(mapped_index, 6 | 7 | 17) {
+                    let update_type = GamepadUpdateType::Button(mapped_index, 1.0);
+                    gamepad_event = Some(GamepadEvent::Updated(index, update_type));
+                }
+            },
+            EventType::ButtonReleased(button, _) => {
+                let mapped_index = Self::map_gamepad_button(button);
+                // We only want to send this for a valid digital button, aka on/off only
+                if !matches!(mapped_index, 6 | 7 | 17) {
+                    let update_type = GamepadUpdateType::Button(mapped_index, 0.0);
+                    gamepad_event = Some(GamepadEvent::Updated(index, update_type));
+                }
+            },
+            EventType::ButtonChanged(button, value, _) => {
+                let mapped_index = Self::map_gamepad_button(button);
+                // We only want to send this for a valid non-digital button, aka the triggers
+                if matches!(mapped_index, 6 | 7) {
+                    let update_type = GamepadUpdateType::Button(mapped_index, value as f64);
+                    gamepad_event = Some(GamepadEvent::Updated(index, update_type));
+                }
+            },
+            EventType::AxisChanged(axis, value, _) => {
+                // Map axis index and value to represent Standard Gamepad axis
+                // <https://www.w3.org/TR/gamepad/#dfn-represents-a-standard-gamepad-axis>
+                let mapped_axis: usize = match axis {
+                    gilrs::Axis::LeftStickX => 0,
+                    gilrs::Axis::LeftStickY => 1,
+                    gilrs::Axis::RightStickX => 2,
+                    gilrs::Axis::RightStickY => 3,
+                    _ => 4, // Other axes do not map to "standard" gamepad mapping and are ignored
+                };
+                if mapped_axis < 4 {
+                    // The Gamepad spec designates down as positive and up as negative.
+                    // GilRs does the inverse of this, so correct for it here.
+                    let axis_value = match mapped_axis {
+                        0 | 2 => value,
+                        1 | 3 => -value,
+                        _ => 0., // Should not reach here
                     };
-                    if mapped_axis < 4 {
-                        // The Gamepad spec designates down as positive and up as negative.
-                        // GilRs does the inverse of this, so correct for it here.
-                        let axis_value = match mapped_axis {
-                            0 | 2 => value,
-                            1 | 3 => -value,
-                            _ => 0., // Should not reach here
-                        };
-                        let update_type = GamepadUpdateType::Axis(mapped_axis, axis_value as f64);
-                        gamepad_event = Some(GamepadEvent::Updated(index, update_type));
-                    }
-                },
-                EventType::Connected => {
-                    let name = String::from(name);
-                    let bounds = GamepadInputBounds {
-                        axis_bounds: (-1.0, 1.0),
-                        button_bounds: (0.0, 1.0),
-                    };
-                    // GilRs does not yet support trigger rumble
-                    let supported_haptic_effects = GamepadSupportedHapticEffects {
-                        supports_dual_rumble: true,
-                        supports_trigger_rumble: false,
-                    };
-                    gamepad_event = Some(GamepadEvent::Connected(
-                        index,
-                        name,
-                        bounds,
-                        supported_haptic_effects,
-                    ));
-                },
-                EventType::Disconnected => {
-                    gamepad_event = Some(GamepadEvent::Disconnected(index));
-                },
-                EventType::ForceFeedbackEffectCompleted => {
-                    if let Some(haptic_effect) =
-                        self.haptic_effects.borrow_mut().remove(&event.id.into())
-                    {
-                        haptic_effect.request.succeeded();
-                    } else {
-                        warn!("Failed to find haptic effect for id {}", event.id);
-                    }
-                },
-                _ => {},
-            }
+                    let update_type = GamepadUpdateType::Axis(mapped_axis, axis_value as f64);
+                    gamepad_event = Some(GamepadEvent::Updated(index, update_type));
+                }
+            },
+            EventType::Connected => {
+                let name = name;
+                let bounds = GamepadInputBounds {
+                    axis_bounds: (-1.0, 1.0),
+                    button_bounds: (0.0, 1.0),
+                };
+                // GilRs does not yet support trigger rumble
+                let supported_haptic_effects = GamepadSupportedHapticEffects {
+                    supports_dual_rumble: true,
+                    supports_trigger_rumble: false,
+                };
+                gamepad_event = Some(GamepadEvent::Connected(
+                    index,
+                    name,
+                    bounds,
+                    supported_haptic_effects,
+                ));
+            },
+            EventType::Disconnected => {
+                gamepad_event = Some(GamepadEvent::Disconnected(index));
+            },
+            EventType::ForceFeedbackEffectCompleted => {
+                if let Some(haptic_effect) =
+                    self.haptic_effects.borrow_mut().remove(&event.id.into())
+                {
+                    haptic_effect.request.succeeded();
+                } else {
+                    warn!("Failed to find haptic effect for id {}", event.id);
+                }
+            },
+            _ => {},
+        }
 
-            if let Some(event) = gamepad_event {
-                active_webview.notify_input_event(InputEvent::Gamepad(event));
-            }
+        if let Some(event) = gamepad_event {
+            active_webview.notify_input_event(InputEvent::Gamepad(event));
         }
     }
 
@@ -163,6 +183,7 @@ impl ServoshellGamepadDelegate {
         effect_type: &GamepadHapticEffectType,
         request: GamepadHapticEffectRequest,
     ) {
+        /*
         let index = request.gamepad_index();
         let GamepadHapticEffectType::DualRumble(params) = effect_type;
 
@@ -214,6 +235,7 @@ impl ServoshellGamepadDelegate {
             .effect
             .play()
             .expect("Failed to play haptic effect.");
+        */
     }
 
     fn stop_haptic_effect(&self, request: GamepadHapticEffectRequest) {

--- a/ports/servoshell/desktop/gamepad.rs
+++ b/ports/servoshell/desktop/gamepad.rs
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::mpsc::{Sender, channel};
 use std::thread;
 use std::time::Duration;
 
 use gilrs::ff::{BaseEffect, BaseEffectType, Effect, EffectBuilder, Repeat, Replay, Ticks};
-use gilrs::{Event, EventType, Gamepad, Gilrs};
+use gilrs::{Event, EventType, GamepadId, Gilrs};
 use log::{debug, warn};
 use servo::{
     GamepadDelegate, GamepadEvent, GamepadHapticEffectRequest, GamepadHapticEffectRequestType,
@@ -45,6 +44,9 @@ impl ServoshellGamepadDelegate {
                     },
                 };
 
+                let mut connected_gamepads: Vec<GamepadId> =
+                    handle.gamepads().map(|(id, _)| id).collect();
+
                 loop {
                     while let Some(event) =
                         handle.next_event_blocking(Some(Duration::from_millis(100)))
@@ -53,6 +55,21 @@ impl ServoshellGamepadDelegate {
                         let gamepad = handle.gamepad(event.id);
                         let name = gamepad.name();
                         let index = GamepadIndex(id);
+
+                        if let Some(index) = connected_gamepads
+                            .iter()
+                            .position(|&gamepad_id| event.id == gamepad_id)
+                        {
+                            handle.insert_event(Event::new(
+                                event.id,
+                                EventType::Connected,
+                            ));
+                            handle.insert_event(event);
+
+                            connected_gamepads.swap_remove(index);
+
+                            continue;
+                        }
 
                         if matches!(&event.event, EventType::ForceFeedbackEffectCompleted) {
                             match haptic_effects.remove(&id) {
@@ -150,7 +167,6 @@ impl ServoshellGamepadDelegate {
                 }
             },
             EventType::Connected => {
-                let name = name;
                 let bounds = GamepadInputBounds {
                     axis_bounds: (-1.0, 1.0),
                     button_bounds: (0.0, 1.0),

--- a/ports/servoshell/desktop/gamepad.rs
+++ b/ports/servoshell/desktop/gamepad.rs
@@ -60,10 +60,7 @@ impl ServoshellGamepadDelegate {
                             .iter()
                             .position(|&gamepad_id| event.id == gamepad_id)
                         {
-                            handle.insert_event(Event::new(
-                                event.id,
-                                EventType::Connected,
-                            ));
+                            handle.insert_event(Event::new(event.id, EventType::Connected));
                             handle.insert_event(event);
 
                             connected_gamepads.swap_remove(index);

--- a/ports/servoshell/desktop/gamepad.rs
+++ b/ports/servoshell/desktop/gamepad.rs
@@ -29,7 +29,7 @@ pub(crate) struct ServoshellGamepadDelegate {
 }
 
 impl ServoshellGamepadDelegate {
-    pub(crate) fn maybe_new(event_loop_proxy: EventLoopProxy<AppEvent>) -> Option<Self> {
+    pub(crate) fn new(event_loop_proxy: EventLoopProxy<AppEvent>) -> Self {
         let (tx, rx) = channel::<GamepadHapticEffectRequest>();
 
         let _ = thread::Builder::new()
@@ -104,7 +104,7 @@ impl ServoshellGamepadDelegate {
                 }
             });
 
-        Some(Self { sender: tx })
+        Self { sender: tx }
     }
 
     /// Handle updates to connected gamepads from GilRs

--- a/ports/servoshell/desktop/gamepad.rs
+++ b/ports/servoshell/desktop/gamepad.rs
@@ -4,12 +4,12 @@
 
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::mpsc::{Sender, channel};
 use std::thread;
 use std::time::Duration;
 
 use gilrs::ff::{BaseEffect, BaseEffectType, Effect, EffectBuilder, Repeat, Replay, Ticks};
-use gilrs::{Event, EventType, Gilrs};
+use gilrs::{Event, EventType, Gamepad, Gilrs};
 use log::{debug, warn};
 use servo::{
     GamepadDelegate, GamepadEvent, GamepadHapticEffectRequest, GamepadHapticEffectRequestType,
@@ -27,13 +27,18 @@ pub struct HapticEffect {
 
 pub(crate) struct ServoshellGamepadDelegate {
     haptic_effects: RefCell<HashMap<usize, HapticEffect>>,
+    sender: Sender<GamepadHapticEffectRequest>,
 }
 
 impl ServoshellGamepadDelegate {
     pub(crate) fn maybe_new(event_loop_proxy: EventLoopProxy<AppEvent>) -> Option<Self> {
+        let (tx, rx) = channel::<GamepadHapticEffectRequest>();
+
         let _ = thread::Builder::new()
             .name(String::from("GamepadThread"))
             .spawn(move || {
+
+                let mut haptic_effects: HashMap<usize, HapticEffect> = HashMap::new();
                 let mut handle = match Gilrs::new() {
                     Ok(handle) => handle,
                     Err(error) => {
@@ -43,22 +48,38 @@ impl ServoshellGamepadDelegate {
                 };
 
                 loop {
-                    while let Some(event) = handle.next_event_blocking(Some(Duration::from_millis(100))) {
+                    while let Some(event) =
+                        handle.next_event_blocking(Some(Duration::from_millis(100)))
+                    {
                         let gamepad = handle.gamepad(event.id);
                         let name = gamepad.name();
                         let index = GamepadIndex(event.id.into());
 
-                        if event_loop_proxy.send_event(AppEvent::Gamepad(event, name.to_owned(), index))
-                            .is_err() {
-                                warn!("Error sending gamepad event to event loop proxy");
-                                return;
-                            }
+                        if event_loop_proxy
+                            .send_event(AppEvent::Gamepad(event, name.to_owned(), index))
+                            .is_err()
+                        {
+                            warn!("Error sending gamepad event to event loop proxy");
+                            return;
+                        }
+                    }
+
+                    while let Ok(request) = rx.try_recv() {
+                        match request.request_type() {
+                            GamepadHapticEffectRequestType::Play(effect_type) => {
+                                Self::play_haptic_effect(&mut haptic_effects, &effect_type.clone(), request, &mut handle);
+                            },
+                            GamepadHapticEffectRequestType::Stop => {
+                                Self::stop_haptic_effect(&mut haptic_effects, request);
+                            },
+                        }
                     }
                 }
             });
 
         Some(Self {
             haptic_effects: RefCell::new(Default::default()),
+            sender: tx,
         })
     }
 
@@ -182,15 +203,14 @@ impl ServoshellGamepadDelegate {
     }
 
     fn play_haptic_effect(
-        &self,
+        haptic_effects: &mut HashMap<usize, HapticEffect>,
         effect_type: &GamepadHapticEffectType,
         request: GamepadHapticEffectRequest,
+        handle: &mut Gilrs,
     ) {
-        /*
         let index = request.gamepad_index();
         let GamepadHapticEffectType::DualRumble(params) = effect_type;
 
-        let mut handle = self.handle.borrow_mut();
         let Some(connected_gamepad) = handle
             .gamepads()
             .find(|gamepad| usize::from(gamepad.0) == index)
@@ -227,24 +247,22 @@ impl ServoshellGamepadDelegate {
             })
             .repeat(Repeat::For(start_delay + duration))
             .add_gamepad(&connected_gamepad.1)
-            .finish(&mut handle)
+            .finish(handle)
             .expect(
                 "Failed to create haptic effect, ensure connected gamepad supports force feedback.",
             );
 
-        let mut haptic_effects = self.haptic_effects.borrow_mut();
         haptic_effects.insert(index, HapticEffect { effect, request });
         haptic_effects[&index]
             .effect
             .play()
             .expect("Failed to play haptic effect.");
-        */
     }
 
-    fn stop_haptic_effect(&self, request: GamepadHapticEffectRequest) {
+    fn stop_haptic_effect(haptic_effects: &mut HashMap<usize, HapticEffect>,
+        request: GamepadHapticEffectRequest) {
         let index = request.gamepad_index();
 
-        let mut haptic_effects = self.haptic_effects.borrow_mut();
         let Some(haptic_effect) = haptic_effects.get(&index) else {
             request.failed();
             return;
@@ -269,13 +287,8 @@ impl ServoshellGamepadDelegate {
 
 impl GamepadDelegate for ServoshellGamepadDelegate {
     fn handle_haptic_effect_request(&self, request: GamepadHapticEffectRequest) {
-        match request.request_type() {
-            GamepadHapticEffectRequestType::Play(effect_type) => {
-                self.play_haptic_effect(&effect_type.clone(), request);
-            },
-            GamepadHapticEffectRequestType::Stop => {
-                self.stop_haptic_effect(request);
-            },
+        if self.sender.send(request).is_err() {
+            warn!("Haptic effect couldn't be played!")
         }
     }
 }

--- a/ports/servoshell/desktop/gamepad.rs
+++ b/ports/servoshell/desktop/gamepad.rs
@@ -6,6 +6,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::thread;
+use std::time::Duration;
 
 use gilrs::ff::{BaseEffect, BaseEffectType, Effect, EffectBuilder, Repeat, Replay, Ticks};
 use gilrs::{Event, EventType, Gilrs};
@@ -42,7 +43,7 @@ impl ServoshellGamepadDelegate {
                 };
 
                 loop {
-                    while let Some(event) = handle.next_event() {
+                    while let Some(event) = handle.next_event_blocking(Some(Duration::from_millis(100))) {
                         let gamepad = handle.gamepad(event.id);
                         let name = gamepad.name();
                         let index = GamepadIndex(event.id.into());

--- a/ports/servoshell/desktop/tracing.rs
+++ b/ports/servoshell/desktop/tracing.rs
@@ -53,6 +53,7 @@ mod from_winit {
                 Self::DeviceEvent { .. } => target!("DeviceEvent"),
                 Self::UserEvent(AppEvent::Waker) => target!("UserEvent(Waker)"),
                 Self::UserEvent(AppEvent::Accessibility(..)) => target!("UserEvent(Accessibility)"),
+                Self::UserEvent(AppEvent::Gamepad(..)) => target!("UserEvent(Gamepad)"),
                 Self::Suspended => target!("Suspended"),
                 Self::Resumed => target!("Resumed"),
                 Self::AboutToWait => target!("AboutToWait"),

--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -11,6 +11,11 @@ use std::rc::Rc;
 
 use crossbeam_channel::{Receiver, Sender, unbounded};
 use euclid::Rect;
+#[cfg(all(
+    feature = "gamepad",
+    not(any(target_os = "android", target_env = "ohos"))
+))]
+use gilrs::Event;
 use image::{DynamicImage, ImageFormat, RgbaImage};
 #[cfg(all(
     any(coverage, llvm_pgo),
@@ -18,6 +23,11 @@ use image::{DynamicImage, ImageFormat, RgbaImage};
 ))]
 use libc::c_char;
 use log::{error, info, warn};
+#[cfg(all(
+    feature = "gamepad",
+    not(any(target_os = "android", target_env = "ohos"))
+))]
+use servo::GamepadIndex;
 use servo::{
     AllowOrDenyRequest, AuthenticationRequest, BluetoothDeviceSelectionRequest, CSSPixel,
     ConsoleLogLevel, CreateNewWebViewRequest, DeviceIntPoint, DeviceIntSize, EmbedderControl,
@@ -416,13 +426,13 @@ impl RunningAppState {
 
         self.handle_webdriver_messages(create_platform_window);
 
-        #[cfg(all(
+        /* #[cfg(all(
             feature = "gamepad",
             not(any(target_os = "android", target_env = "ohos"))
         ))]
         if servo::pref!(dom_gamepad_enabled) {
             self.handle_gamepad_events();
-        }
+        } */
 
         self.servo.spin_event_loop();
 
@@ -628,7 +638,12 @@ impl RunningAppState {
         feature = "gamepad",
         not(any(target_os = "android", target_env = "ohos"))
     ))]
-    pub(crate) fn handle_gamepad_events(&self) {
+    pub(crate) fn handle_gamepad_events(
+        &self,
+        event: Event,
+        gamepad_name: String,
+        gamepad_index: GamepadIndex,
+    ) {
         let Some(gamepad_delegate) = self.gamepad_delegate.as_ref() else {
             return;
         };
@@ -638,7 +653,7 @@ impl RunningAppState {
         else {
             return;
         };
-        gamepad_delegate.handle_gamepad_events(active_webview);
+        gamepad_delegate.handle_gamepad_events(event, gamepad_name, gamepad_index, active_webview);
     }
 
     #[cfg(not(any(target_os = "android", target_env = "ohos")))]


### PR DESCRIPTION
In order to reliably listen for gamepad events this PR is polling gamepad events in seperate thread and sending them as AppEvents via event loop proxy. The PR is working but not complete yet,  I'd like to ask for a feedback first on some issues before moving further:
1. I'm polling Gilrs gamepad events in an infinite loop. What should be the exit condition from the loop? Or should it sleep for some time if `handle.next_event` returns None?
2. I'm initiating Gilrs handle in a seperate thread, how can I share the handle with the haptic feedback handler (or other functions) while continuously polling it?

Testing: TBD
Fixes: #44575 #41448 
