### PR TITLE
mach: Use mach logging for single SVG tests

### DIFF
--- a/python/wpt/run.py
+++ b/python/wpt/run.py
@@ -118,7 +118,7 @@ def run_tests(default_binary_path: str, multiprocess: bool, **kwargs: Any) -> in
     use_mach_logging = False
     if len(kwargs["test_list"]) == 1:
         file_ext = os.path.splitext(kwargs["test_list"][0])[1].lower()
-        if file_ext in [".htm", ".html", ".js", ".xhtml", ".xht", ".py"]:
+        if file_ext in [".htm", ".html", ".js", ".xhtml", ".xht", ".py", ".svg"]:
             use_mach_logging = True
 
     # Enable headless mode by default, unless `--no-headless` is explicitly passed, in


### PR DESCRIPTION
Trying to understand what's happening in `tests/wpt/tests/svg/geometry/inheritance.svg`, I was surprised to have a very different kind of output when running it alone compared to what we get running a single say HTML test.

That's because the latter has mach logging on, while the former does not. This trivial patch fixes this, and should hopefully avoid some head scratching to the next new person investigating a SVG WPT test :)

Testing: Manual inspection of output of `./mach -v test-wpt tests/wpt/tests/svg/geometry/inheritance.svg`
