### PR TITLE
layout: Prune stale accessibility nodes from the cache after each update.

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -346,6 +346,7 @@ pub struct Preferences {
     pub log_filter: String,
     /// Whether the accessibility code is enabled.
     pub accessibility_enabled: bool,
+    pub expensive_accessibility_test_assertions_enabled: bool,
 }
 
 impl Preferences {
@@ -437,6 +438,7 @@ impl Preferences {
             dom_worklet_timeout_ms: 10,
             dom_visual_viewport_enabled: false,
             accessibility_enabled: false,
+            expensive_accessibility_test_assertions_enabled: false,
             fonts_default: String::new(),
             fonts_default_monospace_size: 13,
             fonts_default_size: 16,

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -346,6 +346,8 @@ pub struct Preferences {
     pub log_filter: String,
     /// Whether the accessibility code is enabled.
     pub accessibility_enabled: bool,
+    /// Whether to run accessibility tree integrity checks, and any other expensive checks.
+    /// This should only be true in tests.
     pub expensive_accessibility_test_assertions_enabled: bool,
 }
 

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -44,16 +44,42 @@ pub struct AccessibilityTree {
     tree_state_changes: FxHashMap<accesskit::NodeId, TreeStateChange>,
 }
 
+/// Tracks changes to a node's relation to the tree within an update.
+///
+/// This is used to remove nodes from the accessibility tree's cache when they are no longer in the
+/// tree.
 #[derive(Debug, PartialEq, Copy, Clone)]
 enum TreeStateChange {
+    /// The node was newly created in this update.
     New,
+
+    /// The node has been re-parented in this update.
+    /// The [`MoveState`] argument is used to maintain the invariant that a node move consists of a
+    /// removal from its parent and an addition to its new parent.
     Moved(MoveState),
+
+    /// The node is no longer a child of its previous parent.
     Removed,
 }
 
+/// When a node is moved within the tree, it must be both removed from its old parent and added to
+/// its new parent within the same update. This may happen in either order, depending on the
+/// relative positions of the node before and after it moves.
+///
+/// - If a node's new parent is updated before its old parent, the node will be in a
+///   `TreeStateChange::Moved(MoveState::Pending)` state until its old parent is updated. We expect
+///   that it must later be removed from its old parent, at which point its state will be updated to
+///   `TreeStateChange::Moved(MoveState::Complete)`.
+/// - If a node's old parent is updated before its new parent, the node will be first
+///   `TreeStateChange::Removed` and then `TreeStateChange::Moved(MoveState::Complete)`.
+///
+/// At the end of the update, we assert that there are no pending moves remaining.
 #[derive(Debug, PartialEq, Copy, Clone)]
 enum MoveState {
+    /// The node has been added to its new parent, but not yet removed from its old parent.
     Pending,
+
+    /// The node has been both removed from its old parent and added to its new parent.
     Complete,
 }
 
@@ -76,10 +102,6 @@ impl AccessibilityTree {
     ) -> Option<accesskit::TreeUpdate> {
         let root_node = self.get_or_create_node(root_dom_node);
         let root_node_id = root_node.borrow().id;
-
-        if pref!(expensive_accessibility_test_assertions_enabled) {
-            self.assert_integrity(root_node_id);
-        }
 
         let mut tree_update =
             AccessibilityUpdate::new(accesskit::Tree::new(root_node_id), self.tree_id);
@@ -279,6 +301,9 @@ impl AccessibilityNode {
         tree: &mut AccessibilityTree,
         tree_update: &mut AccessibilityUpdate,
     ) -> bool {
+        use MoveState::Pending;
+        use TreeStateChange::{Moved, Removed};
+
         let mut any_descendant_updated = false;
         let mut newly_created: FxHashSet<accesskit::NodeId> = FxHashSet::default();
         let new_children: Vec<accesskit::NodeId> = dom_node
@@ -309,7 +334,7 @@ impl AccessibilityNode {
                     let removed_child = tree.assert_node_by_id(*old_child_id);
                     removed_child
                         .borrow()
-                        .set_subtree_state_change(tree, TreeStateChange::Removed);
+                        .set_subtree_state_change(tree, Removed);
                 }
             }
             for new_child_id in new_children.iter() {
@@ -317,7 +342,7 @@ impl AccessibilityNode {
                     let moved_child = tree.assert_node_by_id(*new_child_id);
                     moved_child
                         .borrow()
-                        .set_subtree_state_change(tree, TreeStateChange::Moved(MoveState::Pending));
+                        .set_subtree_state_change(tree, Moved(Pending));
                 }
             }
             self.set_children(new_children);
@@ -326,17 +351,30 @@ impl AccessibilityNode {
         any_descendant_updated
     }
 
+    /// Recursively mark this subtree as having the given `TreeStateChange`.
+    ///
+    /// This is used when a node is `Moved` or `Removed`, since its entire subtree will also need to
+    /// be marked accordingly. When a node is `New`, it's marked as such when it is created. We
+    /// shouldn't call this method in that case, since it may have descendants which are not being
+    /// created in this update and shouldn't have a `New` state. Any descendants which are new will
+    /// already have their `New` state set when they are created.
+    ///
+    /// Note: if a node is moved, the requested `change` must always be `Moved(Pending)`: the logic
+    /// in this method will determine whether the move is `Complete` and set the stored value
+    /// accordingly.
     fn set_subtree_state_change(&self, tree: &mut AccessibilityTree, change: TreeStateChange) {
-        use MoveState::{Complete, Pending};
-        use TreeStateChange::{Moved, Removed};
+        use MoveState::*;
+        use TreeStateChange::*;
 
         let old_change = tree.tree_state_changes.get(&self.id);
         let new_change = match (old_change, change) {
-            (None, Moved(_)) => Moved(Pending),
+            (_, New) => panic!("New shouldn't be set recursively."),
+            (_, Moved(Complete)) => panic!("Incoming Moved must always be Pending"),
+
             (None, _) => change,
 
             (Some(Moved(Pending)), Removed) => Moved(Complete),
-            (Some(Removed), Moved(_)) => Moved(Complete),
+            (Some(Removed), Moved(Pending)) => Moved(Complete),
 
             (Some(old_change), _) => {
                 unreachable!("Logically impossible state change: {old_change:?} → {change:?}")

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -67,9 +67,9 @@ enum TreeChange {
     /// - If a node's new parent is updated before its old parent, the node will be in a
     ///   `TreeChange::Moved(Move::Pending)` state until its old parent is updated. We expect that it
     ///   must later be removed from its old parent, at which point its state will be updated to
-    ///   `TreeChange ::Moved(Move::Complete)`.
+    ///   `TreeChange::Moved(Move::Complete)`.
     /// - If a node's old parent is updated before its new parent, the node will be first
-    ///   `TreeChange ::Removed` and then `TreeChange ::Moved(Move::Complete)`.
+    ///   `TreeChange::Removed` and then `TreeChange ::Moved(Move::Complete)`.
     ///
     /// At the end of the update, we assert that there are no pending moves remaining.
     PendingMove,
@@ -223,10 +223,9 @@ impl AccessibilityTree {
 
     /// Assert that the tree is a tree without any dangling references or orphaned nodes.
     ///
-    /// For accessibility tests only, because it’s expensive and calls [`eprintln`].
+    /// For accessibility tests only, because it’s expensive.
     fn assert_integrity(&self, root_node_id: accesskit::NodeId) {
         assert!(pref!(expensive_accessibility_test_assertions_enabled));
-        eprintln!("Start of assert_integrity()");
         // Traverse the tree from the given root.
         let mut node_ids = vec![root_node_id];
         let mut seen_node_ids = FxHashSet::default();
@@ -239,24 +238,11 @@ impl AccessibilityTree {
             // If this fails, then the tree has dangling references.
             let node = self.assert_node_for_id(node_id);
             let node = node.borrow();
-            eprintln!(
-                "{node_id:?}: {:?} (html_tag: {:?})",
-                node.role(),
-                node.html_tag()
-            );
-            if let Some(label) = node.label() {
-                eprintln!("    label: {:?}", label);
-            }
-            if !node.children().is_empty() {
-                eprintln!("    children: {:?}", node.children());
-            }
             node_ids.extend(node.children().iter().rev());
         }
         // If this fails, then the tree has orphaned nodes (a leak).
         // Dangling references are already caught in the loop above.
         assert_eq!(seen_node_ids, self.nodes.keys().copied().collect());
-
-        eprintln!("End of assert_integrity()");
     }
 }
 

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -47,8 +47,14 @@ pub struct AccessibilityTree {
 #[derive(Debug, PartialEq, Copy, Clone)]
 enum TreeStateChange {
     New,
-    Moved,
+    Moved(MoveState),
     Removed,
+}
+
+#[derive(Debug, PartialEq, Copy, Clone)]
+enum MoveState {
+    Pending,
+    Complete,
 }
 
 impl AccessibilityTree {
@@ -94,12 +100,22 @@ impl AccessibilityTree {
     }
 
     fn finalize_tree_state_changes(&mut self) {
-        for id in self.tree_state_changes.drain().filter_map(|(id, change)| {
-            if change == TreeStateChange::Removed {
-                return Some(id);
-            }
-            None
-        }) {
+        use MoveState::Pending;
+        use TreeStateChange::{Moved, Removed};
+
+        for id in self
+            .tree_state_changes
+            .drain()
+            .filter_map(|(id, change)| match change {
+                Moved(Pending) => {
+                    panic!(
+                        "Pending move found for node id {id:?} when draining tree state changes"
+                    );
+                },
+                Removed => Some(id),
+                _ => None,
+            })
+        {
             let Some(node) = self.nodes.remove(&id) else {
                 continue;
             };
@@ -152,6 +168,14 @@ impl AccessibilityTree {
         }
 
         node.clone()
+    }
+
+    fn get_node_by_dom_node(
+        &mut self,
+        dom_node: &ServoLayoutNode<'_>,
+    ) -> Option<ArcRefCell<AccessibilityNode>> {
+        let id = self.id_for_opaque(dom_node.opaque());
+        self.nodes.get(&id).cloned()
     }
 
     fn assert_node_by_dom_node(
@@ -256,11 +280,19 @@ impl AccessibilityNode {
         tree_update: &mut AccessibilityUpdate,
     ) -> bool {
         let mut any_descendant_updated = false;
+        let mut newly_created: Vec<accesskit::NodeId> = vec![];
         let new_children: Vec<accesskit::NodeId> = dom_node
             .flat_tree_children()
             .map(|dom_child| {
-                let child_node = tree.get_or_create_node(&dom_child);
-                let child_node_id = child_node.borrow().id;
+                let child_node_id = match tree.get_node_by_dom_node(&dom_child) {
+                    Some(child_node) => child_node.borrow().id,
+                    None => {
+                        let new_child = tree.get_or_create_node(&dom_child);
+                        let child_node_id = new_child.borrow().id;
+                        newly_created.push(child_node_id);
+                        child_node_id
+                    },
+                };
 
                 // TODO: We actually need to propagate damage within the accessibility tree, rather than
                 // assuming it matches the DOM tree, but this will do for now.
@@ -281,11 +313,11 @@ impl AccessibilityNode {
                 }
             }
             for new_child_id in new_children.iter() {
-                if !old_children.contains(new_child_id) {
+                if !old_children.contains(new_child_id) && !newly_created.contains(new_child_id) {
                     let new_child = tree.assert_node_by_id(*new_child_id);
                     new_child
                         .borrow()
-                        .set_subtree_state_change(tree, TreeStateChange::Moved);
+                        .set_subtree_state_change(tree, TreeStateChange::Moved(MoveState::Pending));
                 }
             }
             self.set_children(new_children);
@@ -295,23 +327,25 @@ impl AccessibilityNode {
     }
 
     fn set_subtree_state_change(&self, tree: &mut AccessibilityTree, change: TreeStateChange) {
-        if change == TreeStateChange::Removed {
-            assert_ne!(
-                Some(TreeStateChange::New),
-                tree.tree_state_changes.get(&self.id).copied(),
-                "New nodes can't become stale within the same update"
-            );
+        use MoveState::{Complete, Pending};
+        use TreeStateChange::{Moved, Removed};
 
-            tree.tree_state_changes.entry(self.id).or_insert(change);
-        } else if change == TreeStateChange::Moved {
-            let old_change = tree.tree_state_changes.get(&self.id);
-            if old_change.is_none() || old_change == Some(&TreeStateChange::Removed) {
-                tree.tree_state_changes.insert(self.id, change);
-            }
-        }
+        let old_change = tree.tree_state_changes.get(&self.id);
+        let new_change = match (old_change, change) {
+            (None, _) => change,
+
+            (Some(Moved(Pending)), Removed) => Moved(Complete),
+            (Some(Removed), Moved(Pending)) => Moved(Complete),
+
+            (Some(old_change), _) => {
+                unreachable!("Logically impossible state change: {old_change:?} → {change:?}")
+            },
+        };
+        tree.tree_state_changes.insert(self.id, new_change);
 
         for child_id in self.children().to_vec() {
             let child = tree.assert_node_by_id(child_id);
+            // `new_change` might be different per node, if only some nodes were moved elsewhere.
             child.borrow().set_subtree_state_change(tree, change);
         }
     }

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -271,6 +271,11 @@ impl AccessibilityNode {
                     old_child.borrow().mark_subtree_stale(tree);
                 }
             }
+            for new_child_id in new_children.iter() {
+                if !old_children.contains(new_child_id) {
+                    tree.new_nodes.insert(*new_child_id);
+                }
+            }
             self.set_children(new_children);
         }
 

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -55,33 +55,27 @@ enum TreeChange {
     New,
 
     /// The node has been re-parented in this update.
-    /// The [`Move`] argument is used to maintain the invariant that a node move consists of a
-    /// removal from its parent and an addition to its new parent.
-    Moved(Move),
+    Moved,
+
+    /// The node has been added to its new parent, but not yet removed from its old
+    /// parent.
+    ///
+    /// When a node is moved within the tree, it must be both removed from its old parent
+    /// and added to its new parent within the same update. This may happen in either
+    /// order, depending on the relative positions of the node before and after it moves.
+    ///
+    /// - If a node's new parent is updated before its old parent, the node will be in a
+    ///   `TreeChange::Moved(Move::Pending)` state until its old parent is updated. We expect that it
+    ///   must later be removed from its old parent, at which point its state will be updated to
+    ///   `TreeChange ::Moved(Move::Complete)`.
+    /// - If a node's old parent is updated before its new parent, the node will be first
+    ///   `TreeChange ::Removed` and then `TreeChange ::Moved(Move::Complete)`.
+    ///
+    /// At the end of the update, we assert that there are no pending moves remaining.
+    PendingMove,
 
     /// The node is no longer a child of its previous parent.
     Removed,
-}
-
-/// When a node is moved within the tree, it must be both removed from its old parent and added to
-/// its new parent within the same update. This may happen in either order, depending on the
-/// relative positions of the node before and after it moves.
-///
-/// - If a node's new parent is updated before its old parent, the node will be in a
-///   `TreeChange::Moved(Move::Pending)` state until its old parent is updated. We expect that it
-///   must later be removed from its old parent, at which point its state will be updated to
-///   `TreeChange ::Moved(Move::Complete)`.
-/// - If a node's old parent is updated before its new parent, the node will be first
-///   `TreeChange ::Removed` and then `TreeChange ::Moved(Move::Complete)`.
-///
-/// At the end of the update, we assert that there are no pending moves remaining.
-#[derive(Debug, PartialEq, Copy, Clone)]
-enum Move {
-    /// The node has been added to its new parent, but not yet removed from its old parent.
-    Pending,
-
-    /// The node has been both removed from its old parent and added to its new parent.
-    Complete,
 }
 
 impl AccessibilityTree {
@@ -127,8 +121,8 @@ impl AccessibilityTree {
             .tree_changes
             .drain()
             .filter_map(|(id, change)| match change {
-                TreeChange::Moved(Move::Pending) => {
-                    panic!(
+                TreeChange::PendingMove => {
+                    unreachable!(
                         "Pending move found for node id {id:?} when draining tree state changes"
                     );
                 },
@@ -337,7 +331,7 @@ impl AccessibilityNode {
                     let moved_child = tree.assert_node_for_id(*new_child_id);
                     moved_child
                         .borrow()
-                        .set_subtree_state_change(tree, TreeChange::Moved(Move::Pending));
+                        .set_subtree_state_change(tree, TreeChange::PendingMove);
                 }
             }
             self.set_children(new_children);
@@ -358,23 +352,27 @@ impl AccessibilityNode {
     /// in this method will determine whether the move is `Complete` and set the stored value
     /// accordingly.
     fn set_subtree_state_change(&self, tree: &mut AccessibilityTree, change: TreeChange) {
-        use Move::{Complete, Pending};
-        use TreeChange::{Moved, New, Removed};
-
         let old_change = tree.tree_changes.get(&self.id);
-        let new_change = match (old_change, change) {
-            (_, New) => panic!("New shouldn't be set recursively."),
-            (_, Moved(Complete)) => panic!("Incoming Moved must always be Pending"),
 
-            (None, _) => change,
+        assert!(
+            change != TreeChange::New,
+            "New shouldn't be set recursively"
+        );
+        assert!(
+            change != TreeChange::Moved,
+            "Incoming change must never be Moved"
+        );
 
-            (Some(Moved(Pending)), Removed) => Moved(Complete),
-            (Some(Removed), Moved(Pending)) => Moved(Complete),
+        let new_change = old_change
+            .map(|old_change| match (old_change, change) {
+                (TreeChange::PendingMove, TreeChange::Removed) => TreeChange::Moved,
+                (TreeChange::Removed, TreeChange::PendingMove) => TreeChange::Moved,
+                _ => {
+                    unreachable!("Logically impossible state change: {old_change:?} → {change:?}")
+                },
+            })
+            .unwrap_or(change);
 
-            (Some(old_change), _) => {
-                unreachable!("Logically impossible state change: {old_change:?} → {change:?}")
-            },
-        };
         tree.tree_changes.insert(self.id, new_change);
 
         for child_id in self.children().to_vec() {

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -435,6 +435,7 @@ impl AccessibilityNode {
         self.updated = true;
     }
 
+    #[expect(dead_code)]
     fn label(&self) -> Option<&str> {
         self.accesskit_node.label()
     }
@@ -447,6 +448,7 @@ impl AccessibilityNode {
         self.updated = true;
     }
 
+    #[expect(dead_code)]
     fn html_tag(&self) -> Option<&str> {
         self.accesskit_node.html_tag()
     }

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -183,8 +183,7 @@ impl AccessibilityTree {
         self.epoch
     }
 
-    /// Assert that the tree is a tree without any dangling references or orphaned nodes,
-    /// and that nodes are either new, stale or neither.
+    /// Assert that the tree is a tree without any dangling references or orphaned nodes.
     ///
     /// For accessibility tests only, because it’s expensive and calls [`eprintln`].
     fn assert_integrity(&self, root_node_id: accesskit::NodeId) {

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -122,20 +122,10 @@ impl AccessibilityTree {
     ) -> ArcRefCell<AccessibilityNode> {
         let id = self.id_for_opaque(dom_node.opaque());
 
-        let node = match self.nodes.get(&id) {
-            Some(node) => {
-                self.stale_nodes.remove(&id);
-
-                node
-            },
-            None => {
-                self.new_nodes.insert(id);
-
-                self.nodes
-                    .entry(id)
-                    .or_insert_with(|| ArcRefCell::new(AccessibilityNode::new(id)))
-            },
-        };
+        let node = self
+            .nodes
+            .entry(id)
+            .or_insert_with(|| ArcRefCell::new(AccessibilityNode::new(id)));
 
         let mut new_node = node.borrow_mut();
 
@@ -177,7 +167,8 @@ impl AccessibilityTree {
         self.epoch
     }
 
-    /// Assert that the tree is a tree without any dangling references or orphaned nodes.
+    /// Assert that the tree is a tree without any dangling references or orphaned nodes,
+    /// and that nodes are either new, stale or neither.
     ///
     /// For accessibility tests only, because it’s expensive and calls [`eprintln`].
     fn assert_integrity(&self, root_node_id: accesskit::NodeId) {
@@ -211,6 +202,10 @@ impl AccessibilityTree {
         // If this fails, then the tree has orphaned nodes (a leak).
         // Dangling references are already caught in the loop above.
         assert_eq!(seen_node_ids, self.nodes.keys().copied().collect());
+
+        // Nodes can't be both new and stale.
+        assert!(self.stale_nodes.is_disjoint(&self.new_nodes));
+
         eprintln!("End of assert_integrity()");
     }
 }
@@ -273,7 +268,8 @@ impl AccessibilityNode {
             }
             for new_child_id in new_children.iter() {
                 if !old_children.contains(new_child_id) {
-                    tree.new_nodes.insert(*new_child_id);
+                    let new_child = tree.assert_node_by_id(*new_child_id);
+                    new_child.borrow().mark_subtree_fresh(tree);
                 }
             }
             self.set_children(new_children);
@@ -294,6 +290,16 @@ impl AccessibilityNode {
         for child_id in self.children().to_vec() {
             let child = tree.assert_node_by_id(child_id);
             child.borrow().mark_subtree_stale(tree);
+        }
+    }
+
+    fn mark_subtree_fresh(&self, tree: &mut AccessibilityTree) {
+        tree.stale_nodes.remove(&self.id);
+        tree.new_nodes.insert(self.id);
+
+        for child_id in self.children().to_vec() {
+            let child = tree.assert_node_by_id(child_id);
+            child.borrow().mark_subtree_fresh(tree);
         }
     }
 
@@ -364,7 +370,6 @@ impl AccessibilityNode {
         self.updated = true;
     }
 
-    #[expect(dead_code)]
     fn label(&self) -> Option<&str> {
         self.accesskit_node.label()
     }
@@ -377,7 +382,6 @@ impl AccessibilityNode {
         self.updated = true;
     }
 
-    #[expect(dead_code)]
     fn html_tag(&self) -> Option<&str> {
         self.accesskit_node.html_tag()
     }

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -11,6 +11,7 @@ use log::trace;
 use rustc_hash::{FxHashMap, FxHashSet};
 use script::layout_dom::ServoLayoutNode;
 use servo_base::Epoch;
+use servo_config::pref;
 use style::dom::{NodeInfo, OpaqueNode};
 use web_atoms::{LocalName, local_name};
 
@@ -63,8 +64,14 @@ impl AccessibilityTree {
         root_dom_node: &ServoLayoutNode<'_>,
     ) -> Option<accesskit::TreeUpdate> {
         let root_node = self.get_or_create_node(root_dom_node);
+        let root_node_id = root_node.borrow().id;
+
+        if pref!(expensive_accessibility_test_assertions_enabled) {
+            self.assert_integrity(root_node_id);
+        }
+
         let mut tree_update =
-            AccessibilityUpdate::new(accesskit::Tree::new(root_node.borrow().id), self.tree_id);
+            AccessibilityUpdate::new(accesskit::Tree::new(root_node_id), self.tree_id);
         let any_node_updated = self.update_node_and_descendants(root_dom_node, &mut tree_update);
 
         if !any_node_updated {
@@ -76,7 +83,11 @@ impl AccessibilityTree {
         self.new_nodes.clear();
 
         for stale_id in self.stale_nodes.drain() {
-            self.nodes.remove(&stale_id);
+            assert!(self.nodes.remove(&stale_id).is_some());
+        }
+
+        if pref!(expensive_accessibility_test_assertions_enabled) {
+            self.assert_integrity(root_node_id);
         }
 
         Some(tree_update.finalize())
@@ -149,7 +160,7 @@ impl AccessibilityTree {
 
     fn assert_node_by_id(&self, id: accesskit::NodeId) -> ArcRefCell<AccessibilityNode> {
         let Some(node) = self.nodes.get(&id) else {
-            panic!("Stale node ID found: {id:?}");
+            panic!("{id:?} does not exist in tree");
         };
         node.clone()
     }
@@ -164,6 +175,43 @@ impl AccessibilityTree {
 
     pub(crate) fn epoch(&self) -> Epoch {
         self.epoch
+    }
+
+    /// Assert that the tree is a tree without any dangling references or orphaned nodes.
+    ///
+    /// For accessibility tests only, because it’s expensive and calls [`eprintln`].
+    fn assert_integrity(&self, root_node_id: accesskit::NodeId) {
+        assert!(pref!(expensive_accessibility_test_assertions_enabled));
+        eprintln!("Start of assert_integrity()");
+        // Traverse the tree from the given root.
+        let mut node_ids = vec![root_node_id];
+        let mut seen_node_ids = FxHashSet::default();
+        while let Some(node_id) = node_ids.pop() {
+            // If this fails, then the tree is not a tree at all.
+            assert!(
+                seen_node_ids.insert(node_id),
+                "Tree contains {node_id:?} in multiple places"
+            );
+            // If this fails, then the tree has dangling references.
+            let node = self.assert_node_by_id(node_id);
+            let node = node.borrow();
+            eprintln!(
+                "{node_id:?}: {:?} (html_tag: {:?})",
+                node.role(),
+                node.html_tag()
+            );
+            if let Some(label) = node.label() {
+                eprintln!("    label: {:?}", label);
+            }
+            if !node.children().is_empty() {
+                eprintln!("    children: {:?}", node.children());
+            }
+            node_ids.extend(node.children().iter().rev());
+        }
+        // If this fails, then the tree has orphaned nodes (a leak).
+        // Dangling references are already caught in the loop above.
+        assert_eq!(seen_node_ids, self.nodes.keys().copied().collect());
+        eprintln!("End of assert_integrity()");
     }
 }
 

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -41,8 +41,17 @@ pub struct AccessibilityTree {
     opaque_node_to_id: FxHashMap<OpaqueNode, accesskit::NodeId>,
     tree_id: accesskit::TreeId,
     epoch: Epoch,
-    new_nodes: FxHashSet<accesskit::NodeId>,
-    stale_nodes: FxHashSet<accesskit::NodeId>,
+    tree_state_changes: FxHashMap<accesskit::NodeId, TreeStateChange>,
+    // new_nodes: FxHashSet<accesskit::NodeId>,
+    // fresh_nodes: FxHashSet<accesskit::NodeId>,
+    // stale_nodes: FxHashSet<accesskit::NodeId>,
+}
+
+#[derive(Debug, PartialEq, Copy, Clone)]
+enum TreeStateChange {
+    New,
+    Fresh,
+    Stale,
 }
 
 impl AccessibilityTree {
@@ -52,8 +61,7 @@ impl AccessibilityTree {
             opaque_node_to_id: FxHashMap::default(),
             tree_id,
             epoch,
-            new_nodes: FxHashSet::default(),
-            stale_nodes: FxHashSet::default(),
+            tree_state_changes: FxHashMap::default(),
         }
     }
 
@@ -75,22 +83,33 @@ impl AccessibilityTree {
         let any_node_updated = self.update_node_and_descendants(root_dom_node, &mut tree_update);
 
         if !any_node_updated {
-            assert!(self.new_nodes.is_empty());
-            assert!(self.stale_nodes.is_empty());
+            assert!(self.tree_state_changes.is_empty());
             return None;
         }
 
-        self.new_nodes.clear();
-
-        for stale_id in self.stale_nodes.drain() {
-            assert!(self.nodes.remove(&stale_id).is_some());
-        }
+        self.drain_tree_state_changes();
 
         if pref!(expensive_accessibility_test_assertions_enabled) {
             self.assert_integrity(root_node_id);
         }
 
         Some(tree_update.finalize())
+    }
+
+    fn drain_tree_state_changes(&mut self) {
+        for id in self.tree_state_changes.drain().filter_map(|(id, change)| {
+            if change == TreeStateChange::Stale {
+                return Some(id);
+            }
+            None
+        }) {
+            let Some(node) = self.nodes.remove(&id) else {
+                continue;
+            };
+            if let Some(opaque_node) = node.borrow().opaque_node {
+                self.opaque_node_to_id.remove(&opaque_node);
+            }
+        }
     }
 
     /// Update this tree starting at the given DOM node, adding any changed nodes to the given
@@ -122,10 +141,10 @@ impl AccessibilityTree {
     ) -> ArcRefCell<AccessibilityNode> {
         let id = self.id_for_opaque(dom_node.opaque());
 
-        let node = self
-            .nodes
-            .entry(id)
-            .or_insert_with(|| ArcRefCell::new(AccessibilityNode::new(id)));
+        let node = self.nodes.entry(id).or_insert_with(|| {
+            self.tree_state_changes.insert(id, TreeStateChange::New);
+            ArcRefCell::new(AccessibilityNode::new(id))
+        });
 
         let mut new_node = node.borrow_mut();
 
@@ -203,9 +222,6 @@ impl AccessibilityTree {
         // Dangling references are already caught in the loop above.
         assert_eq!(seen_node_ids, self.nodes.keys().copied().collect());
 
-        // Nodes can't be both new and stale.
-        assert!(self.stale_nodes.is_disjoint(&self.new_nodes));
-
         eprintln!("End of assert_integrity()");
     }
 }
@@ -263,13 +279,17 @@ impl AccessibilityNode {
             for old_child_id in old_children {
                 if !new_children.contains(old_child_id) {
                     let old_child = tree.assert_node_by_id(*old_child_id);
-                    old_child.borrow().mark_subtree_stale(tree);
+                    old_child
+                        .borrow()
+                        .set_subtree_state_change(tree, TreeStateChange::Stale);
                 }
             }
             for new_child_id in new_children.iter() {
                 if !old_children.contains(new_child_id) {
                     let new_child = tree.assert_node_by_id(*new_child_id);
-                    new_child.borrow().mark_subtree_fresh(tree);
+                    new_child
+                        .borrow()
+                        .set_subtree_state_change(tree, TreeStateChange::Fresh);
                 }
             }
             self.set_children(new_children);
@@ -278,28 +298,25 @@ impl AccessibilityNode {
         any_descendant_updated
     }
 
-    fn mark_subtree_stale(&self, tree: &mut AccessibilityTree) {
-        // If the node was moved to a point in the tree that’s earlier in the traversal,
-        // we know that it’s not stale.
-        if !tree.new_nodes.contains(&self.id) {
-            // If the node is moved to a point in the tree that’s later in the traversal,
-            // we will remove it from `stale_nodes` in `AccessibilityTree::get_or_create_node()`.
-            tree.stale_nodes.insert(self.id);
+    fn set_subtree_state_change(&self, tree: &mut AccessibilityTree, change: TreeStateChange) {
+        if change == TreeStateChange::Stale {
+            assert_ne!(
+                Some(TreeStateChange::New),
+                tree.tree_state_changes.get(&self.id).copied(),
+                "New nodes can't become stale within the same update"
+            );
+
+            tree.tree_state_changes.entry(self.id).or_insert(change);
+        } else if change == TreeStateChange::Fresh {
+            let old_change = tree.tree_state_changes.get(&self.id);
+            if old_change.is_none() || old_change == Some(&TreeStateChange::Stale) {
+                tree.tree_state_changes.insert(self.id, change);
+            }
         }
 
         for child_id in self.children().to_vec() {
             let child = tree.assert_node_by_id(child_id);
-            child.borrow().mark_subtree_stale(tree);
-        }
-    }
-
-    fn mark_subtree_fresh(&self, tree: &mut AccessibilityTree) {
-        tree.stale_nodes.remove(&self.id);
-        tree.new_nodes.insert(self.id);
-
-        for child_id in self.children().to_vec() {
-            let child = tree.assert_node_by_id(child_id);
-            child.borrow().mark_subtree_fresh(tree);
+            child.borrow().set_subtree_state_change(tree, change);
         }
     }
 

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -280,7 +280,7 @@ impl AccessibilityNode {
         tree_update: &mut AccessibilityUpdate,
     ) -> bool {
         let mut any_descendant_updated = false;
-        let mut newly_created: Vec<accesskit::NodeId> = vec![];
+        let mut newly_created: FxHashSet<accesskit::NodeId> = FxHashSet::default();
         let new_children: Vec<accesskit::NodeId> = dom_node
             .flat_tree_children()
             .map(|dom_child| {
@@ -289,7 +289,7 @@ impl AccessibilityNode {
                     None => {
                         let new_child = tree.get_or_create_node(&dom_child);
                         let child_node_id = new_child.borrow().id;
-                        newly_created.push(child_node_id);
+                        newly_created.insert(child_node_id);
                         child_node_id
                     },
                 };
@@ -306,16 +306,16 @@ impl AccessibilityNode {
             let old_children = self.children();
             for old_child_id in old_children {
                 if !new_children.contains(old_child_id) {
-                    let old_child = tree.assert_node_by_id(*old_child_id);
-                    old_child
+                    let removed_child = tree.assert_node_by_id(*old_child_id);
+                    removed_child
                         .borrow()
                         .set_subtree_state_change(tree, TreeStateChange::Removed);
                 }
             }
             for new_child_id in new_children.iter() {
-                if !old_children.contains(new_child_id) && !newly_created.contains(new_child_id) {
-                    let new_child = tree.assert_node_by_id(*new_child_id);
-                    new_child
+                if !newly_created.contains(new_child_id) && !old_children.contains(new_child_id) {
+                    let moved_child = tree.assert_node_by_id(*new_child_id);
+                    moved_child
                         .borrow()
                         .set_subtree_state_change(tree, TreeStateChange::Moved(MoveState::Pending));
                 }
@@ -332,10 +332,11 @@ impl AccessibilityNode {
 
         let old_change = tree.tree_state_changes.get(&self.id);
         let new_change = match (old_change, change) {
+            (None, Moved(_)) => Moved(Pending),
             (None, _) => change,
 
             (Some(Moved(Pending)), Removed) => Moved(Complete),
-            (Some(Removed), Moved(Pending)) => Moved(Complete),
+            (Some(Removed), Moved(_)) => Moved(Complete),
 
             (Some(old_change), _) => {
                 unreachable!("Logically impossible state change: {old_change:?} → {change:?}")

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -41,7 +41,8 @@ pub struct AccessibilityTree {
     opaque_node_to_id: FxHashMap<OpaqueNode, accesskit::NodeId>,
     tree_id: accesskit::TreeId,
     epoch: Epoch,
-    tree_state_changes: FxHashMap<accesskit::NodeId, TreeChange>,
+    /// Nodes that changed their relation to the tree within the current update.
+    tree_changes: FxHashMap<accesskit::NodeId, TreeChange>,
 }
 
 /// Tracks changes to a node's relation to the tree within an update.
@@ -54,7 +55,7 @@ enum TreeChange {
     New,
 
     /// The node has been re-parented in this update.
-    /// The [`MoveState`] argument is used to maintain the invariant that a node move consists of a
+    /// The [`Move`] argument is used to maintain the invariant that a node move consists of a
     /// removal from its parent and an addition to its new parent.
     Moved(Move),
 
@@ -67,11 +68,11 @@ enum TreeChange {
 /// relative positions of the node before and after it moves.
 ///
 /// - If a node's new parent is updated before its old parent, the node will be in a
-///   `TreeStateChange::Moved(MoveState::Pending)` state until its old parent is updated. We expect
-///   that it must later be removed from its old parent, at which point its state will be updated to
-///   `TreeStateChange::Moved(MoveState::Complete)`.
+///   `TreeChange::Moved(Move::Pending)` state until its old parent is updated. We expect that it
+///   must later be removed from its old parent, at which point its state will be updated to
+///   `TreeChange ::Moved(Move::Complete)`.
 /// - If a node's old parent is updated before its new parent, the node will be first
-///   `TreeStateChange::Removed` and then `TreeStateChange::Moved(MoveState::Complete)`.
+///   `TreeChange ::Removed` and then `TreeChange ::Moved(Move::Complete)`.
 ///
 /// At the end of the update, we assert that there are no pending moves remaining.
 #[derive(Debug, PartialEq, Copy, Clone)]
@@ -90,7 +91,7 @@ impl AccessibilityTree {
             opaque_node_to_id: FxHashMap::default(),
             tree_id,
             epoch,
-            tree_state_changes: FxHashMap::default(),
+            tree_changes: FxHashMap::default(),
         }
     }
 
@@ -108,11 +109,11 @@ impl AccessibilityTree {
         let any_node_updated = self.update_node_and_descendants(root_dom_node, &mut tree_update);
 
         if !any_node_updated {
-            assert!(self.tree_state_changes.is_empty());
+            assert!(self.tree_changes.is_empty());
             return None;
         }
 
-        self.finalize_tree_state_changes();
+        self.finalize_tree_changes();
 
         if pref!(expensive_accessibility_test_assertions_enabled) {
             self.assert_integrity(root_node_id);
@@ -121,9 +122,9 @@ impl AccessibilityTree {
         Some(tree_update.finalize())
     }
 
-    fn finalize_tree_state_changes(&mut self) {
+    fn finalize_tree_changes(&mut self) {
         for id in self
-            .tree_state_changes
+            .tree_changes
             .drain()
             .filter_map(|(id, change)| match change {
                 TreeChange::Moved(Move::Pending) => {
@@ -174,7 +175,7 @@ impl AccessibilityTree {
         let id = self.id_for_opaque(dom_node.opaque());
 
         let node = self.nodes.entry(id).or_insert_with(|| {
-            self.tree_state_changes.insert(id, TreeChange::New);
+            self.tree_changes.insert(id, TreeChange::New);
             ArcRefCell::new(AccessibilityNode::new(id))
         });
 
@@ -345,7 +346,7 @@ impl AccessibilityNode {
         any_descendant_updated
     }
 
-    /// Recursively mark this subtree as having the given `TreeStateChange`.
+    /// Recursively mark this subtree as having the given `TreeChange `.
     ///
     /// This is used when a node is `Moved` or `Removed`, since its entire subtree will also need to
     /// be marked accordingly. When a node is `New`, it's marked as such when it is created. We
@@ -360,7 +361,7 @@ impl AccessibilityNode {
         use Move::{Complete, Pending};
         use TreeChange::{Moved, New, Removed};
 
-        let old_change = tree.tree_state_changes.get(&self.id);
+        let old_change = tree.tree_changes.get(&self.id);
         let new_change = match (old_change, change) {
             (_, New) => panic!("New shouldn't be set recursively."),
             (_, Moved(Complete)) => panic!("Incoming Moved must always be Pending"),
@@ -374,7 +375,7 @@ impl AccessibilityNode {
                 unreachable!("Logically impossible state change: {old_change:?} → {change:?}")
             },
         };
-        tree.tree_state_changes.insert(self.id, new_change);
+        tree.tree_changes.insert(self.id, new_change);
 
         for child_id in self.children().to_vec() {
             let child = tree.assert_node_for_id(child_id);

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -40,6 +40,8 @@ pub struct AccessibilityTree {
     opaque_node_to_id: FxHashMap<OpaqueNode, accesskit::NodeId>,
     tree_id: accesskit::TreeId,
     epoch: Epoch,
+    new_nodes: FxHashSet<accesskit::NodeId>,
+    stale_nodes: FxHashSet<accesskit::NodeId>,
 }
 
 impl AccessibilityTree {
@@ -49,6 +51,8 @@ impl AccessibilityTree {
             opaque_node_to_id: FxHashMap::default(),
             tree_id,
             epoch,
+            new_nodes: FxHashSet::default(),
+            stale_nodes: FxHashSet::default(),
         }
     }
 
@@ -64,7 +68,15 @@ impl AccessibilityTree {
         let any_node_updated = self.update_node_and_descendants(root_dom_node, &mut tree_update);
 
         if !any_node_updated {
+            assert!(self.new_nodes.is_empty());
+            assert!(self.stale_nodes.is_empty());
             return None;
+        }
+
+        self.new_nodes.clear();
+
+        for stale_id in self.stale_nodes.drain() {
+            self.nodes.remove(&stale_id);
         }
 
         Some(tree_update.finalize())
@@ -99,18 +111,27 @@ impl AccessibilityTree {
     ) -> ArcRefCell<AccessibilityNode> {
         let id = self.id_for_opaque(dom_node.opaque());
 
-        let node = self
-            .nodes
-            .entry(id)
-            .or_insert_with(|| ArcRefCell::new(AccessibilityNode::new(id)));
-        {
-            let mut new_node = node.borrow_mut();
+        let node = match self.nodes.get(&id) {
+            Some(node) => {
+                self.stale_nodes.remove(&id);
 
-            new_node.opaque_node = Some(dom_node.opaque());
-            if let Some(dom_element) = dom_node.as_element() {
-                let local_name = dom_element.local_name().to_ascii_lowercase();
-                new_node.set_html_tag(&local_name);
-            }
+                node
+            },
+            None => {
+                self.new_nodes.insert(id);
+
+                self.nodes
+                    .entry(id)
+                    .or_insert_with(|| ArcRefCell::new(AccessibilityNode::new(id)))
+            },
+        };
+
+        let mut new_node = node.borrow_mut();
+
+        new_node.opaque_node = Some(dom_node.opaque());
+        if let Some(dom_element) = dom_node.as_element() {
+            let local_name = dom_element.local_name().to_ascii_lowercase();
+            new_node.set_html_tag(&local_name);
         }
 
         node.clone()
@@ -180,7 +201,7 @@ impl AccessibilityNode {
         tree_update: &mut AccessibilityUpdate,
     ) -> bool {
         let mut any_descendant_updated = false;
-        let new_children = dom_node
+        let new_children: Vec<accesskit::NodeId> = dom_node
             .flat_tree_children()
             .map(|dom_child| {
                 let child_node = tree.get_or_create_node(&dom_child);
@@ -193,10 +214,34 @@ impl AccessibilityNode {
                 child_node_id
             })
             .collect();
+
         if new_children != self.children() {
+            let old_children = self.children();
+            for old_child_id in old_children {
+                if !new_children.contains(old_child_id) {
+                    let old_child = tree.assert_node_by_id(*old_child_id);
+                    old_child.borrow().mark_subtree_stale(tree);
+                }
+            }
             self.set_children(new_children);
         }
+
         any_descendant_updated
+    }
+
+    fn mark_subtree_stale(&self, tree: &mut AccessibilityTree) {
+        // If the node was moved to a point in the tree that’s earlier in the traversal,
+        // we know that it’s not stale.
+        if !tree.new_nodes.contains(&self.id) {
+            // If the node is moved to a point in the tree that’s later in the traversal,
+            // we will remove it from `stale_nodes` in `AccessibilityTree::get_or_create_node()`.
+            tree.stale_nodes.insert(self.id);
+        }
+
+        for child_id in self.children().to_vec() {
+            let child = tree.assert_node_by_id(child_id);
+            child.borrow().mark_subtree_stale(tree);
+        }
     }
 
     fn update_node(

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -41,7 +41,7 @@ pub struct AccessibilityTree {
     opaque_node_to_id: FxHashMap<OpaqueNode, accesskit::NodeId>,
     tree_id: accesskit::TreeId,
     epoch: Epoch,
-    tree_state_changes: FxHashMap<accesskit::NodeId, TreeStateChange>,
+    tree_state_changes: FxHashMap<accesskit::NodeId, TreeChange>,
 }
 
 /// Tracks changes to a node's relation to the tree within an update.
@@ -49,14 +49,14 @@ pub struct AccessibilityTree {
 /// This is used to remove nodes from the accessibility tree's cache when they are no longer in the
 /// tree.
 #[derive(Debug, PartialEq, Copy, Clone)]
-enum TreeStateChange {
+enum TreeChange {
     /// The node was newly created in this update.
     New,
 
     /// The node has been re-parented in this update.
     /// The [`MoveState`] argument is used to maintain the invariant that a node move consists of a
     /// removal from its parent and an addition to its new parent.
-    Moved(MoveState),
+    Moved(Move),
 
     /// The node is no longer a child of its previous parent.
     Removed,
@@ -75,7 +75,7 @@ enum TreeStateChange {
 ///
 /// At the end of the update, we assert that there are no pending moves remaining.
 #[derive(Debug, PartialEq, Copy, Clone)]
-enum MoveState {
+enum Move {
     /// The node has been added to its new parent, but not yet removed from its old parent.
     Pending,
 
@@ -122,19 +122,16 @@ impl AccessibilityTree {
     }
 
     fn finalize_tree_state_changes(&mut self) {
-        use MoveState::Pending;
-        use TreeStateChange::{Moved, Removed};
-
         for id in self
             .tree_state_changes
             .drain()
             .filter_map(|(id, change)| match change {
-                Moved(Pending) => {
+                TreeChange::Moved(Move::Pending) => {
                     panic!(
                         "Pending move found for node id {id:?} when draining tree state changes"
                     );
                 },
-                Removed => Some(id),
+                TreeChange::Removed => Some(id),
                 _ => None,
             })
         {
@@ -154,7 +151,7 @@ impl AccessibilityTree {
         dom_node: &ServoLayoutNode<'_>,
         tree_update: &mut AccessibilityUpdate,
     ) -> bool {
-        let node = self.assert_node_by_dom_node(dom_node);
+        let node = self.assert_node_for_dom_node(dom_node);
         let mut node = node.borrow_mut();
 
         // TODO: read accessibility damage (right now, assume damage is complete)
@@ -177,7 +174,7 @@ impl AccessibilityTree {
         let id = self.id_for_opaque(dom_node.opaque());
 
         let node = self.nodes.entry(id).or_insert_with(|| {
-            self.tree_state_changes.insert(id, TreeStateChange::New);
+            self.tree_state_changes.insert(id, TreeChange::New);
             ArcRefCell::new(AccessibilityNode::new(id))
         });
 
@@ -192,7 +189,7 @@ impl AccessibilityTree {
         node.clone()
     }
 
-    fn get_node_by_dom_node(
+    fn node_for_dom_node(
         &mut self,
         dom_node: &ServoLayoutNode<'_>,
     ) -> Option<ArcRefCell<AccessibilityNode>> {
@@ -200,17 +197,17 @@ impl AccessibilityTree {
         self.nodes.get(&id).cloned()
     }
 
-    fn assert_node_by_dom_node(
+    fn assert_node_for_dom_node(
         &mut self,
         dom_node: &ServoLayoutNode<'_>,
     ) -> ArcRefCell<AccessibilityNode> {
         let id = self.id_for_opaque(dom_node.opaque());
-        let node = self.assert_node_by_id(id);
+        let node = self.assert_node_for_id(id);
         assert!(node.borrow().opaque_node == Some(dom_node.opaque()));
         node
     }
 
-    fn assert_node_by_id(&self, id: accesskit::NodeId) -> ArcRefCell<AccessibilityNode> {
+    fn assert_node_for_id(&self, id: accesskit::NodeId) -> ArcRefCell<AccessibilityNode> {
         let Some(node) = self.nodes.get(&id) else {
             panic!("{id:?} does not exist in tree");
         };
@@ -245,7 +242,7 @@ impl AccessibilityTree {
                 "Tree contains {node_id:?} in multiple places"
             );
             // If this fails, then the tree has dangling references.
-            let node = self.assert_node_by_id(node_id);
+            let node = self.assert_node_for_id(node_id);
             let node = node.borrow();
             eprintln!(
                 "{node_id:?}: {:?} (html_tag: {:?})",
@@ -301,15 +298,12 @@ impl AccessibilityNode {
         tree: &mut AccessibilityTree,
         tree_update: &mut AccessibilityUpdate,
     ) -> bool {
-        use MoveState::Pending;
-        use TreeStateChange::{Moved, Removed};
-
         let mut any_descendant_updated = false;
-        let mut newly_created: FxHashSet<accesskit::NodeId> = FxHashSet::default();
-        let new_children: Vec<accesskit::NodeId> = dom_node
+        let mut newly_created = FxHashSet::default();
+        let new_children: Vec<_> = dom_node
             .flat_tree_children()
             .map(|dom_child| {
-                let child_node_id = match tree.get_node_by_dom_node(&dom_child) {
+                let child_node_id = match tree.node_for_dom_node(&dom_child) {
                     Some(child_node) => child_node.borrow().id,
                     None => {
                         let new_child = tree.get_or_create_node(&dom_child);
@@ -331,18 +325,18 @@ impl AccessibilityNode {
             let old_children = self.children();
             for old_child_id in old_children {
                 if !new_children.contains(old_child_id) {
-                    let removed_child = tree.assert_node_by_id(*old_child_id);
+                    let removed_child = tree.assert_node_for_id(*old_child_id);
                     removed_child
                         .borrow()
-                        .set_subtree_state_change(tree, Removed);
+                        .set_subtree_state_change(tree, TreeChange::Removed);
                 }
             }
             for new_child_id in new_children.iter() {
                 if !newly_created.contains(new_child_id) && !old_children.contains(new_child_id) {
-                    let moved_child = tree.assert_node_by_id(*new_child_id);
+                    let moved_child = tree.assert_node_for_id(*new_child_id);
                     moved_child
                         .borrow()
-                        .set_subtree_state_change(tree, Moved(Pending));
+                        .set_subtree_state_change(tree, TreeChange::Moved(Move::Pending));
                 }
             }
             self.set_children(new_children);
@@ -362,9 +356,9 @@ impl AccessibilityNode {
     /// Note: if a node is moved, the requested `change` must always be `Moved(Pending)`: the logic
     /// in this method will determine whether the move is `Complete` and set the stored value
     /// accordingly.
-    fn set_subtree_state_change(&self, tree: &mut AccessibilityTree, change: TreeStateChange) {
-        use MoveState::*;
-        use TreeStateChange::*;
+    fn set_subtree_state_change(&self, tree: &mut AccessibilityTree, change: TreeChange) {
+        use Move::{Complete, Pending};
+        use TreeChange::{Moved, New, Removed};
 
         let old_change = tree.tree_state_changes.get(&self.id);
         let new_change = match (old_change, change) {
@@ -383,7 +377,7 @@ impl AccessibilityNode {
         tree.tree_state_changes.insert(self.id, new_change);
 
         for child_id in self.children().to_vec() {
-            let child = tree.assert_node_by_id(child_id);
+            let child = tree.assert_node_for_id(child_id);
             // `new_change` might be different per node, if only some nodes were moved elsewhere.
             child.borrow().set_subtree_state_change(tree, change);
         }
@@ -415,7 +409,7 @@ impl AccessibilityNode {
         let mut children = VecDeque::from_iter(self.children().iter().copied());
         let mut text = String::new();
         while let Some(child_id) = children.pop_front() {
-            let child = tree.assert_node_by_id(child_id);
+            let child = tree.assert_node_for_id(child_id);
             let child = child.borrow();
             match child.role() {
                 Role::TextRun => {

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -42,16 +42,13 @@ pub struct AccessibilityTree {
     tree_id: accesskit::TreeId,
     epoch: Epoch,
     tree_state_changes: FxHashMap<accesskit::NodeId, TreeStateChange>,
-    // new_nodes: FxHashSet<accesskit::NodeId>,
-    // fresh_nodes: FxHashSet<accesskit::NodeId>,
-    // stale_nodes: FxHashSet<accesskit::NodeId>,
 }
 
 #[derive(Debug, PartialEq, Copy, Clone)]
 enum TreeStateChange {
     New,
-    Fresh,
-    Stale,
+    Moved,
+    Removed,
 }
 
 impl AccessibilityTree {
@@ -87,7 +84,7 @@ impl AccessibilityTree {
             return None;
         }
 
-        self.drain_tree_state_changes();
+        self.finalize_tree_state_changes();
 
         if pref!(expensive_accessibility_test_assertions_enabled) {
             self.assert_integrity(root_node_id);
@@ -96,9 +93,9 @@ impl AccessibilityTree {
         Some(tree_update.finalize())
     }
 
-    fn drain_tree_state_changes(&mut self) {
+    fn finalize_tree_state_changes(&mut self) {
         for id in self.tree_state_changes.drain().filter_map(|(id, change)| {
-            if change == TreeStateChange::Stale {
+            if change == TreeStateChange::Removed {
                 return Some(id);
             }
             None
@@ -281,7 +278,7 @@ impl AccessibilityNode {
                     let old_child = tree.assert_node_by_id(*old_child_id);
                     old_child
                         .borrow()
-                        .set_subtree_state_change(tree, TreeStateChange::Stale);
+                        .set_subtree_state_change(tree, TreeStateChange::Removed);
                 }
             }
             for new_child_id in new_children.iter() {
@@ -289,7 +286,7 @@ impl AccessibilityNode {
                     let new_child = tree.assert_node_by_id(*new_child_id);
                     new_child
                         .borrow()
-                        .set_subtree_state_change(tree, TreeStateChange::Fresh);
+                        .set_subtree_state_change(tree, TreeStateChange::Moved);
                 }
             }
             self.set_children(new_children);
@@ -299,7 +296,7 @@ impl AccessibilityNode {
     }
 
     fn set_subtree_state_change(&self, tree: &mut AccessibilityTree, change: TreeStateChange) {
-        if change == TreeStateChange::Stale {
+        if change == TreeStateChange::Removed {
             assert_ne!(
                 Some(TreeStateChange::New),
                 tree.tree_state_changes.get(&self.id).copied(),
@@ -307,9 +304,9 @@ impl AccessibilityNode {
             );
 
             tree.tree_state_changes.entry(self.id).or_insert(change);
-        } else if change == TreeStateChange::Fresh {
+        } else if change == TreeStateChange::Moved {
             let old_change = tree.tree_state_changes.get(&self.id);
-            if old_change.is_none() || old_change == Some(&TreeStateChange::Stale) {
+            if old_change.is_none() || old_change == Some(&TreeStateChange::Removed) {
                 tree.tree_state_changes.insert(self.id, change);
             }
         }

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -384,6 +384,79 @@ fn test_accessibility_basic_mutation() {
     assert_eq!(h1.label(), Some("This is an h1".to_owned()));
 }
 
+#[test]
+fn test_accessibility_with_mutation_move_nodes() {
+    let servo_test = ServoTest::new_with_builder(|builder| {
+        let mut preferences = Preferences::default();
+        preferences.accessibility_enabled = true;
+        preferences.dom_servo_helpers_enabled = true;
+        builder.preferences(preferences)
+    });
+    let url = "data:text/html,<!DOCTYPE html>\
+               <div id='div1'></div>\
+               <h1 id='h1'>This is an h1</h1>\
+               <h2 id='h2'>This is an h2</h2>\
+               <div id='div2'></div>";
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .url(Url::parse(url).unwrap())
+        .build();
+
+    webview.set_accessibility_active(true);
+
+    let load_webview = webview.clone();
+    servo_test.spin(move || load_webview.load_status() != LoadStatus::Complete);
+
+    let updates = wait_for_min_updates(&servo_test, delegate.clone(), 2);
+    let mut tree = build_tree(updates);
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let children: Vec<accesskit_consumer::Node> = root.children().collect();
+    assert_eq!(children.len(), 4);
+    let div1 = children[0];
+    let h1 = children[1];
+    let h2 = children[2];
+    let div2 = children[3];
+    assert_eq!(div1.role(), Role::GenericContainer);
+    assert_eq!(h1.role(), Role::Heading);
+    assert_eq!(h1.label(), Some("This is an h1".to_owned()));
+    assert_eq!(h2.role(), Role::Heading);
+    assert_eq!(h2.label(), Some("This is an h2".to_owned()));
+    assert_eq!(div2.role(), Role::GenericContainer);
+
+    let _ = evaluate_javascript(
+        &servo_test,
+        webview.clone(),
+        "div1.moveBefore(h1,null); div2.moveBefore(h2,null);\
+         window.ServoTestUtils.forceAccessibilityUpdate();",
+    );
+
+    let mut updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
+    assert_eq!(updates.len(), 1);
+    let update = updates.pop().expect("Guaranteed by assert above");
+    assert_eq!(update.nodes.len(), 3);
+    assert_eq!(update.nodes[0].1.role(), Role::GenericContainer);
+    assert_eq!(update.nodes[0].1.children().len(), 1);
+    assert_eq!(update.nodes[1].1.role(), Role::GenericContainer);
+    assert_eq!(update.nodes[1].1.children().len(), 1);
+    assert_eq!(update.nodes[2].1.role(), Role::RootWebArea);
+    assert_eq!(update.nodes[2].1.children().len(), 2);
+    tree.update_and_process_changes(update, &mut NoOpChangeHandler);
+
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    assert_eq!(root.children().count(), 2);
+    let div1 = root.children().nth(0).unwrap();
+    let div2 = root.children().nth(1).unwrap();
+    assert_eq!(div1.children().count(), 1);
+    assert_eq!(div2.children().count(), 1);
+    let h1 = div1.children().nth(0).unwrap();
+    let h2 = div2.children().nth(0).unwrap();
+    assert_eq!(h1.role(), Role::Heading);
+    assert_eq!(h1.label().as_deref(), Some("This is an h1"));
+    assert_eq!(h2.role(), Role::Heading);
+    assert_eq!(h2.label().as_deref(), Some("This is an h2"));
+}
+
 fn wait_for_min_updates(
     servo_test: &ServoTest,
     delegate: Rc<WebViewDelegateImpl>,

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -34,6 +34,7 @@ fn test_basic_accessibility_update() {
     let servo_test = ServoTest::new_with_builder(|builder| {
         let mut preferences = Preferences::default();
         preferences.accessibility_enabled = true;
+        preferences.expensive_accessibility_test_assertions_enabled = true;
         builder.preferences(preferences)
     });
 
@@ -58,6 +59,7 @@ fn test_activate_accessibility_after_layout() {
     let servo_test = ServoTest::new_with_builder(|builder| {
         let mut preferences = Preferences::default();
         preferences.accessibility_enabled = true;
+        preferences.expensive_accessibility_test_assertions_enabled = true;
         builder.preferences(preferences)
     });
 
@@ -82,6 +84,7 @@ fn test_navigate_creates_new_accessibility_update() {
     let servo_test = ServoTest::new_with_builder(|builder| {
         let mut preferences = Preferences::default();
         preferences.accessibility_enabled = true;
+        preferences.expensive_accessibility_test_assertions_enabled = true;
         builder.preferences(preferences)
     });
 
@@ -137,6 +140,7 @@ fn test_accessibility_after_navigate_and_back() {
     let servo_test = ServoTest::new_with_builder(|builder| {
         let mut preferences = Preferences::default();
         preferences.accessibility_enabled = true;
+        preferences.expensive_accessibility_test_assertions_enabled = true;
         builder.preferences(preferences)
     });
 
@@ -206,6 +210,7 @@ fn test_accessibility_basic_mapping() {
     let servo_test = ServoTest::new_with_builder(|builder| {
         let mut preferences = Preferences::default();
         preferences.accessibility_enabled = true;
+        preferences.expensive_accessibility_test_assertions_enabled = true;
         builder.preferences(preferences)
     });
     let delegate = Rc::new(WebViewDelegateImpl::default());
@@ -263,6 +268,7 @@ fn test_accessibility_basic_name_from_contents() {
     let servo_test = ServoTest::new_with_builder(|builder| {
         let mut preferences = Preferences::default();
         preferences.accessibility_enabled = true;
+        preferences.expensive_accessibility_test_assertions_enabled = true;
         builder.preferences(preferences)
     });
     let delegate = Rc::new(WebViewDelegateImpl::default());
@@ -292,6 +298,7 @@ fn test_accessibility_name_from_contents_subtree() {
     let servo_test = ServoTest::new_with_builder(|builder| {
         let mut preferences = Preferences::default();
         preferences.accessibility_enabled = true;
+        preferences.expensive_accessibility_test_assertions_enabled = true;
         builder.preferences(preferences)
     });
     let url = "data:text/html,<!DOCTYPE html>\
@@ -336,6 +343,7 @@ fn test_accessibility_basic_mutation() {
         let mut preferences = Preferences::default();
         preferences.accessibility_enabled = true;
         preferences.dom_servo_helpers_enabled = true;
+        preferences.expensive_accessibility_test_assertions_enabled = true;
         builder.preferences(preferences)
     });
     let url = "data:text/html,<!DOCTYPE html>\
@@ -390,6 +398,7 @@ fn test_accessibility_with_mutation_move_nodes() {
         let mut preferences = Preferences::default();
         preferences.accessibility_enabled = true;
         preferences.dom_servo_helpers_enabled = true;
+        preferences.expensive_accessibility_test_assertions_enabled = true;
         builder.preferences(preferences)
     });
     let url = "data:text/html,<!DOCTYPE html>\


### PR DESCRIPTION
This adds a `tree_state_changes`  map on `AccessibilityTree` which tracks nodes which are:
- newly added to the tree (`TreeStateChange::New`)
- moved in the tree (`TreeStateChange:Moved`) or
- removed from the tree (`TreeStateChange::Removed`).

Nodes which are detected as removed from the tree aren't removed from the cache immediately; we can't be certain until we finish the update pass whether a particular node has been removed or just moved. At the end of the update, all nodes which are `Removed` and not `Moved` are deleted from the cache.

This change also adds an `assert_integrity()` method to AccessibilityTree, which walks the tree from the root node and determines whether there are any missing nodes (i.e. node IDs present in a node's `children()` but missing from the cache) or stale nodes (i.e. nodes present in the cache but not listed as the child of any other node, nor the root node). 

Since this method is expensive to run, it's behind a new pref, `expensive_accessibility_test_assertions_enabled`. This allows us to run these integrity checks at the beginning and end of each update pass during tests.

Testing: Adds a new test, `test_accessibility_with_mutation_move_nodes`, plus the new `assert_integrity()` method which is now run during each of the existing tests.