### PR TITLE
base/mach: Add --all to cargo fmt

### DIFF
--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -7,9 +7,6 @@ use std::collections::VecDeque;
 use std::ptr::{self};
 use std::rc::Rc;
 
-use servo_base::generic_channel::GenericSharedMemory;
-use servo_base::id::{MessagePortId, MessagePortIndex};
-use servo_constellation_traits::MessagePortImpl;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::jsapi::{Heap, JSObject};
@@ -22,6 +19,9 @@ use js::rust::{
 use js::typedarray::ArrayBufferViewU8;
 use rustc_hash::FxHashMap;
 use script_bindings::conversions::SafeToJSValConvertible;
+use servo_base::generic_channel::GenericSharedMemory;
+use servo_base::id::{MessagePortId, MessagePortIndex};
+use servo_constellation_traits::MessagePortImpl;
 
 use crate::dom::bindings::codegen::Bindings::QueuingStrategyBinding::QueuingStrategy;
 use crate::dom::bindings::codegen::Bindings::ReadableStreamBinding::{
@@ -68,8 +68,8 @@ use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::bindings::transferable::Transferable;
 use crate::dom::bindings::structuredclone::StructuredData;
 
-use crate::dom::bindings::buffer_source::HeapBufferSource;
 use super::readablestreambyobreader::ReadIntoRequest;
+use crate::dom::bindings::buffer_source::HeapBufferSource;
 
 /// State Machine for `PipeTo`.
 #[derive(Clone, Debug, Default, MallocSizeOf, PartialEq)]

--- a/components/script/dom/webxr/xrsession.rs
+++ b/components/script/dom/webxr/xrsession.rs
@@ -9,7 +9,6 @@ use std::rc::Rc;
 use std::{mem, ptr};
 
 use script_bindings::reflector::reflect_dom_object;
-use servo_base::cross_process_instant::CrossProcessInstant;
 use dom_struct::dom_struct;
 use euclid::{RigidTransform3D, Transform3D, Vector3D};
 use ipc_channel::ipc::IpcReceiver;
@@ -20,6 +19,7 @@ use js::typedarray::HeapFloat32Array;
 use profile_traits::generic_callback::GenericCallback as ProfileGenericCallback;
 use rustc_hash::FxBuildHasher;
 use script_bindings::trace::RootedTraceableBox;
+use servo_base::cross_process_instant::CrossProcessInstant;
 use stylo_atoms::Atom;
 use webxr_api::{
     self, ApiSpace, ContextId as WebXRContextId, Display, EntityTypes, EnvironmentBlendMode,

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -101,7 +101,7 @@ def format_python_files_with_ruff(check_only: bool = True) -> int:
 
 def format_with_rustfmt(check_only: bool = True) -> int:
     maybe_check_only = ["--check"] if check_only else []
-    result = call(["cargo", "fmt", "--", *UNSTABLE_RUSTFMT_ARGUMENTS, *maybe_check_only])
+    result = call(["cargo", "fmt", "--all", "--", *UNSTABLE_RUSTFMT_ARGUMENTS, *maybe_check_only])
     if result != 0:
         return result
 


### PR DESCRIPTION
rustfmt seems to miss two files ('components/script/dom/stream/readablestream.rs' and 'components/script/dom/webxr/xrsessions.rs') from formatting correctly.
The --all flag fixes this and correctly formats these files.

This PR formats the files with the new flags and adds it to mach.

Testing: Because test-tidy is based on rustfmt in mach there is no test for this.
