### PR TITLE
net: Do not rasterize SVG images for the same size multiple times

### DIFF
--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -17,7 +17,7 @@ test = false
 doctest = false
 
 [features]
-test-util = ["hyper-util/server-graceful", "dep:servo-default-resources"]
+test-util = ["hyper-util/server-graceful", "dep:servo-default-resources", "net_traits/test-util"]
 tracing = ["dep:tracing"]
 
 [dependencies]
@@ -96,7 +96,6 @@ hyper-util = { workspace = true, features = ["server-graceful"] }
 # This must always be a path dependency, we don't want to add a dependency on a
 # crates.io version of ourselves - we want to enable a feature of ourselves.
 net = { package = "servo-net", path = ".", features = ["test-util"] }
-net_traits = { package = "servo-net-traits", path = "../shared/net", features = ["test-util"] }
 rustls = { workspace = true, features = ["aws-lc-rs"] }
 
 [[test]]

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -96,6 +96,7 @@ hyper-util = { workspace = true, features = ["server-graceful"] }
 # This must always be a path dependency, we don't want to add a dependency on a
 # crates.io version of ourselves - we want to enable a feature of ourselves.
 net = { package = "servo-net", path = ".", features = ["test-util"] }
+net_traits = { package = "servo-net-traits", path = "../shared/net", features = ["test-util"] }
 rustls = { workspace = true, features = ["aws-lc-rs"] }
 
 [[test]]

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -96,7 +96,7 @@ hyper-util = { workspace = true, features = ["server-graceful"] }
 # This must always be a path dependency, we don't want to add a dependency on a
 # crates.io version of ourselves - we want to enable a feature of ourselves.
 net = { package = "servo-net", path = ".", features = ["test-util"] }
-net_traits = { package = "servo-net-traits", path = "../shared/net", features = ["test-util"] }
+net_traits = { package = "servo-net-traits", workspace = true, features = ["test-util"] }
 rustls = { workspace = true, features = ["aws-lc-rs"] }
 
 [[test]]

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -96,7 +96,7 @@ hyper-util = { workspace = true, features = ["server-graceful"] }
 # This must always be a path dependency, we don't want to add a dependency on a
 # crates.io version of ourselves - we want to enable a feature of ourselves.
 net = { package = "servo-net", path = ".", features = ["test-util"] }
-net_traits = { package = "servo-net-traits", workspace = true, features = ["test-util"] }
+net_traits = { package = "servo-net-traits", path = "../shared/net", features = ["test-util"] }
 rustls = { workspace = true, features = ["aws-lc-rs"] }
 
 [[test]]

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -452,12 +452,7 @@ impl SvgRasterizationTaskStore {
         pending_image_id: PendingImageId,
         size: DeviceIntSize,
     ) -> bool {
-        if self.0.contains(&(pending_image_id, size)) {
-            true
-        } else {
-            self.0.insert((pending_image_id, size));
-            false
-        }
+        !self.0.insert((pending_image_id, size))
     }
 
     /// Removes the task
@@ -466,7 +461,7 @@ impl SvgRasterizationTaskStore {
     }
 
     fn remove_all_for_id(&mut self, pending_image_id: PendingImageId) {
-        self.0.retain(|(id, _size)| *id == pending_image_id);
+        self.0.retain(|(id, _size)| *id != pending_image_id);
     }
 }
 
@@ -511,6 +506,11 @@ struct ImageCacheStore {
 }
 
 impl ImageCacheStore {
+    #[cfg(feature = "test-util")]
+    fn number_of_rasterize_tasks(&self) -> usize {
+        self.svg_rasterization_task_store.0.len()
+    }
+
     /// Finishes loading the image by setting the WebRenderImageKey and calling `compete_load` or `complete_load_svg`.
     fn set_key_and_finish_load(&mut self, pending_image: PendingKey, image_key: WebRenderImageKey) {
         match pending_image {
@@ -840,6 +840,11 @@ impl ImageCache for ImageCacheImpl {
                 size: fontdb_size,
             },
         ]
+    }
+
+    #[cfg(feature = "test-util")]
+    fn number_of_rasterize_tasks(&self) -> usize {
+        self.store.lock().number_of_rasterize_tasks()
     }
 
     fn get_image_key(&self) -> Option<WebRenderImageKey> {

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -28,7 +28,7 @@ use profile_traits::mem::{Report, ReportKind};
 use profile_traits::path;
 use resvg::tiny_skia;
 use resvg::usvg::{self, fontdb};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use servo_base::id::{PipelineId, WebViewId};
 use servo_base::threadpool::ThreadPool;
 use servo_url::{ImmutableOrigin, ServoUrl};
@@ -441,6 +441,35 @@ impl KeyCache {
     }
 }
 
+#[derive(Debug, Default, MallocSizeOf)]
+/// A structure that stores if a current SVG element with a PendingImageId and a DeviceIntSize is already being rasterized.
+struct SvgRasterizationTaskStore(FxHashSet<(PendingImageId, DeviceIntSize)>);
+
+impl SvgRasterizationTaskStore {
+    /// Returns true if it is already being rasterized, otherwise false and sets it.
+    fn is_or_set_being_rasterized(
+        &mut self,
+        pending_image_id: PendingImageId,
+        size: DeviceIntSize,
+    ) -> bool {
+        if self.0.contains(&(pending_image_id, size)) {
+            true
+        } else {
+            self.0.insert((pending_image_id, size));
+            false
+        }
+    }
+
+    /// Removes the task
+    fn remove_being_rasterized(&mut self, pending_image_id: PendingImageId, size: DeviceIntSize) {
+        self.0.remove(&(pending_image_id, size));
+    }
+
+    fn remove_all_for_id(&mut self, pending_image_id: PendingImageId) {
+        self.0.retain(|(id, _size)| *id == pending_image_id);
+    }
+}
+
 /// ## Image cache implementation.
 #[derive(MallocSizeOf)]
 struct ImageCacheStore {
@@ -459,6 +488,9 @@ struct ImageCacheStore {
     /// or completed. If completed, the `result` member of `RasterizationTask`
     /// contains the rasterized image.
     rasterized_vector_images: FxHashMap<(PendingImageId, DeviceIntSize), RasterizationTask>,
+
+    /// Maps a pending image id to a set of sizes for which that image was requested
+    svg_rasterization_task_store: SvgRasterizationTaskStore,
 
     /// The [`RasterImage`] used for the broken image icon, initialized lazily, only when necessary.
     #[conditional_malloc_size_of]
@@ -488,6 +520,8 @@ impl ImageCacheStore {
             },
             PendingKey::Svg((pending_id, mut raster_image, requested_size)) => {
                 set_webrender_image_key(&self.paint_api, &mut raster_image, image_key);
+                self.svg_rasterization_task_store
+                    .remove_being_rasterized(pending_id, requested_size);
                 self.complete_load_svg(raster_image, pending_id, requested_size);
             },
         }
@@ -501,8 +535,10 @@ impl ImageCacheStore {
                 .evicted_images
                 .remove(&(pending_id, requested_size))
         {
+            self.svg_rasterization_task_store
+                .remove_being_rasterized(pending_id, requested_size);
             return;
-        };
+        }
         match self.key_cache.cache {
             KeyCacheState::PendingBatch => {
                 self.key_cache.images_pending_keys.push_back(pending_image);
@@ -679,6 +715,12 @@ impl ImageCacheStore {
                 // KeyCache that it was evicted.
                 self.evict_image_from_keycache(image_id, device_size);
             }
+        } else {
+            // If there is no corresponding rasterized_vector_image result,
+            // then the vector image is either being rasterized or is in
+            // self.store.key_cache.pending_image_keys. Either way, we need to notify the
+            // KeyCache that it was evicted.
+            self.evict_image_from_keycache(image_id, device_size);
         }
     }
 
@@ -757,9 +799,9 @@ impl ImageCacheFactory for ImageCacheFactoryImpl {
                 pipeline_id,
                 webview_id,
                 key_cache: KeyCache::new(),
+                svg_rasterization_task_store: SvgRasterizationTaskStore::default(),
             })),
             svg_id_image_id_map: Arc::new(Mutex::new(FxHashMap::default())),
-            image_id_size_map: Arc::new(Mutex::new(FxHashMap::default())),
             broken_image_icon_data: self.broken_image_icon_data.clone(),
             thread_pool: self.thread_pool.clone(),
             fontdb: self.fontdb.clone(),
@@ -770,10 +812,8 @@ impl ImageCacheFactory for ImageCacheFactoryImpl {
 pub struct ImageCacheImpl {
     /// Per-[`ImageCache`] data.
     store: Arc<Mutex<ImageCacheStore>>,
-    /// Maps an SVGSVGElement uuid to a pending image id in the store
+    /// Maps an SVGElement uuid to a pending image id in the store
     svg_id_image_id_map: Arc<Mutex<FxHashMap<String, PendingImageId>>>,
-    /// Maps a pending image id to a set of sizes for which that image was requested
-    image_id_size_map: Arc<Mutex<FxHashMap<PendingImageId, Vec<DeviceIntSize>>>>,
     /// The data to use for the broken image icon used when images cannot load.
     broken_image_icon_data: Arc<Vec<u8>>,
     /// Thread pool for image decoding. This is shared with other [`ImageCache`]s in the
@@ -982,13 +1022,16 @@ impl ImageCache for ImageCacheImpl {
             store
                 .rasterized_vector_images
                 .remove(&(old_mapped_image_id, requested_size));
+            store
+                .svg_rasterization_task_store
+                .remove_all_for_id(old_mapped_image_id);
         }
-        if let Some(requested_sizes_for_id) = self.image_id_size_map.lock().get_mut(&image_id) {
-            requested_sizes_for_id.push(requested_size);
-        } else {
-            self.image_id_size_map
-                .lock()
-                .insert(image_id, vec![requested_size]);
+
+        if store
+            .svg_rasterization_task_store
+            .is_or_set_being_rasterized(image_id, requested_size)
+        {
+            return None;
         }
 
         let store = self.store.clone();
@@ -1046,7 +1089,6 @@ impl ImageCache for ImageCacheImpl {
                 requested_size,
             )));
         });
-
         None
     }
 
@@ -1072,10 +1114,14 @@ impl ImageCache for ImageCacheImpl {
         if let Some(mapped_image_id) = self.svg_id_image_id_map.lock().remove(svg_id) {
             store.pending_loads.remove(&mapped_image_id);
             store.vector_images.remove(&mapped_image_id);
-            if let Some(requested_sizes) = self.image_id_size_map.lock().remove(&mapped_image_id) {
-                for requested_size in requested_sizes.iter() {
-                    store.remove_rasterized_vector_image(&mapped_image_id, requested_size);
-                }
+            let images_to_remove = store
+                .rasterized_vector_images
+                .keys()
+                .filter(|(id, _size)| *id == mapped_image_id)
+                .cloned()
+                .collect::<Vec<_>>();
+            for (id, requested_size) in images_to_remove {
+                store.remove_rasterized_vector_image(&id, &requested_size);
             }
         }
     }

--- a/components/net/tests/image_cache.rs
+++ b/components/net/tests/image_cache.rs
@@ -632,3 +632,56 @@ fn test_rasterization_listener() {
         std::thread::sleep(std::time::Duration::from_millis(50));
     }
 }
+
+#[test]
+/// Test if multiple rasterization requests rasterize the svg only once.
+fn test_svg_rasterization_do_not_double_rasterize() {
+    let (cache, _key_receiver) = create_test_image_cache();
+    let url = ServoUrl::parse("http://example.com/image.svg").unwrap();
+    let origin = mock_origin();
+
+    let id = match cache.get_cached_image_status(url.clone(), origin.clone(), None) {
+        ImageCacheResult::ReadyForRequest(id) => id,
+        _ => panic!("Expected ReadyForRequest"),
+    };
+
+    cache.notify_pending_response(
+        id,
+        FetchResponseMsg::ProcessResponse(
+            create_request_id(),
+            Ok(create_test_metadata(Some(mime::IMAGE_SVG))),
+        ),
+    );
+
+    let svg_bytes = svg_image_bytes();
+    cache.notify_pending_response(
+        id,
+        FetchResponseMsg::ProcessResponseChunk(create_request_id(), DebugVec(svg_bytes)),
+    );
+
+    cache.notify_pending_response(
+        id,
+        FetchResponseMsg::ProcessResponseEOF(create_request_id(), Ok(()), create_timing()),
+    );
+
+    let vec_img = loop {
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let result = cache.get_cached_image_status(url.clone(), origin.clone(), None);
+        let ImageCacheResult::Available(ImageOrMetadataAvailable::ImageAvailable { image, .. }) =
+            result
+        else {
+            continue;
+        };
+
+        let net_traits::image_cache::Image::Vector(vec_img) = image else {
+            panic!("Expected vector image");
+        };
+        break vec_img;
+    };
+
+    let size = webrender_api::units::DeviceIntSize::new(100, 100);
+    // Because we do not set image keys yet, the rasterization
+    assert_eq!(cache.rasterize_vector_image(vec_img.id, size, None), None);
+    assert_eq!(cache.rasterize_vector_image(vec_img.id, size, None), None);
+    assert_eq!(cache.number_of_rasterize_tasks(), 1);
+}

--- a/components/net/tests/image_cache.rs
+++ b/components/net/tests/image_cache.rs
@@ -680,7 +680,7 @@ fn test_svg_rasterization_do_not_double_rasterize() {
     };
 
     let size = webrender_api::units::DeviceIntSize::new(100, 100);
-    // Because we do not set image keys yet, the rasterization
+    // Because we do not set image keys yet, the rasterization task will never finish, so we know the added tasks will stay in the queue.
     assert!(
         cache
             .rasterize_vector_image(vec_img.id, size, None)

--- a/components/net/tests/image_cache.rs
+++ b/components/net/tests/image_cache.rs
@@ -681,7 +681,15 @@ fn test_svg_rasterization_do_not_double_rasterize() {
 
     let size = webrender_api::units::DeviceIntSize::new(100, 100);
     // Because we do not set image keys yet, the rasterization
-    assert_eq!(cache.rasterize_vector_image(vec_img.id, size, None), None);
-    assert_eq!(cache.rasterize_vector_image(vec_img.id, size, None), None);
+    assert!(
+        cache
+            .rasterize_vector_image(vec_img.id, size, None)
+            .is_none()
+    );
+    assert!(
+        cache
+            .rasterize_vector_image(vec_img.id, size, None)
+            .is_none()
+    );
     assert_eq!(cache.number_of_rasterize_tasks(), 1);
 }

--- a/components/shared/net/Cargo.toml
+++ b/components/shared/net/Cargo.toml
@@ -15,6 +15,9 @@ path = "lib.rs"
 test = false
 doctest = false
 
+[features]
+test-util = []
+
 [dependencies]
 content-security-policy = { workspace = true }
 cookie = { workspace = true }

--- a/components/shared/net/image_cache.rs
+++ b/components/shared/net/image_cache.rs
@@ -174,6 +174,10 @@ pub trait ImageCacheFactory: Sync + Send {
 pub trait ImageCache: Sync + Send {
     fn memory_reports(&self, prefix: &str, ops: &mut MallocSizeOfOps) -> Vec<Report>;
 
+    #[cfg(feature = "test-util")]
+    /// Returns the number of rasterization tasks
+    fn number_of_rasterize_tasks(&self) -> usize;
+
     /// Get an [`ImageKey`] to be used for external WebRender image management for
     /// things like canvas rendering. Returns `None` when an [`ImageKey`] cannot
     /// be generated properly.

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -596,6 +596,7 @@ def path_dependency_names(cargo_toml: dict[str, Any]) -> list[str]:
 
 
 def dependency_tables(cargo_toml: dict[str, Any]) -> Iterator[dict[str, Any]]:
+    # For enabling integration test we need to enable certain features and the dependency cannot be a path dependency.
     dependency_keys = ("dependencies", "build-dependencies")
     for dependency_key in dependency_keys:
         dependency_table = cargo_toml.get(dependency_key)

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -596,7 +596,7 @@ def path_dependency_names(cargo_toml: dict[str, Any]) -> list[str]:
 
 
 def dependency_tables(cargo_toml: dict[str, Any]) -> Iterator[dict[str, Any]]:
-    dependency_keys = ("dependencies", "dev-dependencies", "build-dependencies")
+    dependency_keys = ("dependencies", "build-dependencies")
     for dependency_key in dependency_keys:
         dependency_table = cargo_toml.get(dependency_key)
         if dependency_table is not None:

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -596,8 +596,7 @@ def path_dependency_names(cargo_toml: dict[str, Any]) -> list[str]:
 
 
 def dependency_tables(cargo_toml: dict[str, Any]) -> Iterator[dict[str, Any]]:
-    # For enabling integration test we need to enable certain features and the dependency cannot be a path dependency.
-    dependency_keys = ("dependencies", "build-dependencies")
+    dependency_keys = ("dependencies", "dev-dependencies", "build-dependencies")
     for dependency_key in dependency_keys:
         dependency_table = cargo_toml.get(dependency_key)
         if dependency_table is not None:


### PR DESCRIPTION
Previously there was a bug that we rasterized the same svg image for the same size multiple times.
This PR fixes this.

Previously, we used image_id_size_map to store image_ids but just appended the size to it without checking.
This replaces this with a svg_rasterization_task_store that sets a flag if a rasterization task for a specific PendingImageId with a size is already requested and returns the customary None.

We remove this flag when we have an image key (when the already existing check works).

We also remove the exclusion of dev-dependencies from the path inclusion exception.

Testing: I am not sure if there are WPT tests loading the same svg image in different sizes but manual tests confirm that this works.
