### PR TITLE
script: Use `&mut JSContext` in `MessagePort::pack_and_post_message` and `post_message_impl`.

### DIFF
--- a/components/script/dom/messageport.rs
+++ b/components/script/dom/messageport.rs
@@ -8,8 +8,9 @@ use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use js::jsapi::{Heap, JS_NewObject, JSObject};
+use js::jsapi::{Heap, JSObject};
 use js::jsval::UndefinedValue;
+use js::rust::wrappers2::JS_NewObject;
 use js::rust::{CustomAutoRooter, CustomAutoRooterGuard, HandleValue};
 use rustc_hash::FxHashMap;
 use script_bindings::conversions::SafeToJSValConvertible;
@@ -32,7 +33,7 @@ use crate::dom::bindings::transferable::Transferable;
 use crate::dom::bindings::utils::set_dictionary_property;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 /// The MessagePort used in the DOM.
@@ -117,7 +118,7 @@ impl MessagePort {
     #[expect(unsafe_code)]
     fn post_message_impl(
         &self,
-        cx: SafeJSContext,
+        cx: &mut JSContext,
         message: HandleValue,
         transfer: CustomAutoRooterGuard<Vec<*mut JSObject>>,
     ) -> ErrorResult {
@@ -150,7 +151,7 @@ impl MessagePort {
         }
 
         // Step 5
-        let data = structuredclone::write(cx, message, Some(transfer))?;
+        let data = structuredclone::write(cx.into(), message, Some(transfer))?;
 
         if doomed {
             // TODO: The spec says to optionally report such a case to a dev console.
@@ -177,31 +178,33 @@ impl MessagePort {
     }
 
     /// <https://streams.spec.whatwg.org/#abstract-opdef-crossrealmtransformsenderror>
-    pub(crate) fn cross_realm_transform_send_error(&self, error: HandleValue, can_gc: CanGc) {
+    pub(crate) fn cross_realm_transform_send_error(&self, cx: &mut JSContext, error: HandleValue) {
         // Perform PackAndPostMessage(port, "error", error),
         // discarding the result.
-        let _ = self.pack_and_post_message("error", error, can_gc);
+        let _ = self.pack_and_post_message(cx, "error", error);
     }
 
     /// <https://streams.spec.whatwg.org/#abstract-opdef-packandpostmessagehandlingerror>
     pub(crate) fn pack_and_post_message_handling_error(
         &self,
+        cx: &mut JSContext,
         type_: &str,
         value: HandleValue,
-        can_gc: CanGc,
     ) -> ErrorResult {
         // Let result be PackAndPostMessage(port, type, value).
-        let result = self.pack_and_post_message(type_, value, can_gc);
+        let result = self.pack_and_post_message(cx, type_, value);
 
         // If result is an abrupt completion,
         if let Err(error) = result.as_ref() {
             // Perform ! CrossRealmTransformSendError(port, result.[[Value]]).
-            let cx = GlobalScope::get_cx();
-            rooted!(in(*cx) let mut rooted_error = UndefinedValue());
-            error
-                .clone()
-                .to_jsval(cx, &self.global(), rooted_error.handle_mut(), can_gc);
-            self.cross_realm_transform_send_error(rooted_error.handle(), can_gc);
+            rooted!(&in(cx) let mut rooted_error = UndefinedValue());
+            error.clone().to_jsval(
+                cx.into(),
+                &self.global(),
+                rooted_error.handle_mut(),
+                CanGc::from_cx(cx),
+            );
+            self.cross_realm_transform_send_error(cx, rooted_error.handle());
         }
 
         result
@@ -211,23 +214,21 @@ impl MessagePort {
     #[expect(unsafe_code)]
     pub(crate) fn pack_and_post_message(
         &self,
+        cx: &mut JSContext,
         type_: &str,
         value: HandleValue,
-        can_gc: CanGc,
     ) -> ErrorResult {
-        let cx = GlobalScope::get_cx();
-
         // Let message be OrdinaryObjectCreate(null).
-        rooted!(in(*cx) let mut message = unsafe { JS_NewObject(*cx, ptr::null()) });
-        rooted!(in(*cx) let mut type_string = UndefinedValue());
-        type_.safe_to_jsval(cx, type_string.handle_mut(), can_gc);
+        rooted!(&in(cx) let mut message = unsafe { JS_NewObject(cx, ptr::null()) });
+        rooted!(&in(cx) let mut type_string = UndefinedValue());
+        type_.safe_to_jsval(cx.into(), type_string.handle_mut(), CanGc::from_cx(cx));
 
         // Perform ! CreateDataProperty(message, "type", type).
-        set_dictionary_property(cx, message.handle(), c"type", type_string.handle())
+        set_dictionary_property(cx.into(), message.handle(), c"type", type_string.handle())
             .expect("Setting the message type should not fail.");
 
         // Perform ! CreateDataProperty(message, "value", value).
-        set_dictionary_property(cx, message.handle(), c"value", value)
+        set_dictionary_property(cx.into(), message.handle(), c"value", value)
             .expect("Setting the message value should not fail.");
 
         // Let targetPort be the port with which port is entangled, if any; otherwise let it be null.
@@ -235,11 +236,11 @@ impl MessagePort {
 
         // Let options be «[ "transfer" → « » ]».
         let mut rooted = CustomAutoRooter::new(vec![]);
-        let transfer = CustomAutoRooterGuard::new(*cx, &mut rooted);
+        let transfer = unsafe { CustomAutoRooterGuard::new(cx.raw_cx(), &mut rooted) };
 
         // Run the message port post message steps providing targetPort, message, and options.
-        rooted!(in(*cx) let mut message_val = UndefinedValue());
-        message.safe_to_jsval(cx, message_val.handle_mut(), can_gc);
+        rooted!(&in(cx) let mut message_val = UndefinedValue());
+        message.safe_to_jsval(cx.into(), message_val.handle_mut(), CanGc::from_cx(cx));
         self.post_message_impl(cx, message_val.handle(), transfer)
     }
 }
@@ -308,7 +309,7 @@ impl MessagePortMethods<crate::DomTypeHolder> for MessagePort {
         if self.detached.get() {
             return Ok(());
         }
-        self.post_message_impl(cx.into(), message, transfer)
+        self.post_message_impl(cx, message, transfer)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-messageport-postmessage>
@@ -330,7 +331,7 @@ impl MessagePortMethods<crate::DomTypeHolder> for MessagePort {
         );
         #[expect(unsafe_code)]
         let guard = unsafe { CustomAutoRooterGuard::new(cx.raw_cx(), &mut rooted) };
-        self.post_message_impl(cx.into(), message, guard)
+        self.post_message_impl(cx, message, guard)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-messageport-start>

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -2397,7 +2397,7 @@ impl CrossRealmTransformReadable {
         error.safe_to_jsval(cx.into(), rooted_error.handle_mut(), CanGc::from_cx(cx));
 
         // Perform ! CrossRealmTransformSendError(port, error).
-        port.cross_realm_transform_send_error(rooted_error.handle(), CanGc::from_cx(cx));
+        port.cross_realm_transform_send_error(cx, rooted_error.handle());
 
         // Perform ! ReadableStreamDefaultControllerError(controller, error).
         self.controller.error(cx, rooted_error.handle());

--- a/components/script/dom/stream/underlyingsourcecontainer.rs
+++ b/components/script/dom/stream/underlyingsourcecontainer.rs
@@ -184,8 +184,7 @@ impl UnderlyingSourceContainer {
                 // from <https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformreadable
 
                 // Let result be PackAndPostMessageHandlingError(port, "error", reason).
-                let result =
-                    port.pack_and_post_message_handling_error("error", reason, CanGc::from_cx(cx));
+                let result = port.pack_and_post_message_handling_error(cx, "error", reason);
 
                 // Disentangle port.
                 self.global().disentangle_port(cx, port);
@@ -242,7 +241,7 @@ impl UnderlyingSourceContainer {
 
                 // Perform ! PackAndPostMessage(port, "pull", undefined).
                 rooted!(&in(cx) let mut value = UndefinedValue());
-                port.pack_and_post_message("pull", value.handle(), CanGc::from_cx(cx))
+                port.pack_and_post_message(cx, "pull", value.handle())
                     .expect("Sending pull should not fail.");
 
                 // Return a promise resolved with undefined.

--- a/components/script/dom/stream/writablestream.rs
+++ b/components/script/dom/stream/writablestream.rs
@@ -1207,7 +1207,7 @@ impl CrossRealmTransformWritable {
         error.safe_to_jsval(cx.into(), rooted_error.handle_mut(), CanGc::from_cx(cx));
 
         // Perform ! CrossRealmTransformSendError(port, error).
-        port.cross_realm_transform_send_error(rooted_error.handle(), CanGc::from_cx(cx));
+        port.cross_realm_transform_send_error(cx, rooted_error.handle());
 
         // Perform ! WritableStreamDefaultControllerErrorIfNeeded(controller, error).
         self.controller

--- a/components/script/dom/stream/writablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/writablestreamdefaultcontroller.rs
@@ -176,9 +176,9 @@ impl Callback for TransferBackPressurePromiseReaction {
         // Let result be PackAndPostMessageHandlingError(port, "chunk", chunk).
         rooted!(&in(cx) let mut chunk = UndefinedValue());
         chunk.set(self.chunk.get());
-        let result =
-            self.port
-                .pack_and_post_message_handling_error("chunk", chunk.handle(), can_gc);
+        let result = self
+            .port
+            .pack_and_post_message_handling_error(cx, "chunk", chunk.handle());
 
         // If result is an abrupt completion,
         if let Err(error) = result {
@@ -623,8 +623,7 @@ impl WritableStreamDefaultController {
                 // <https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformwritable>
 
                 // Let result be PackAndPostMessageHandlingError(port, "error", reason).
-                let result =
-                    port.pack_and_post_message_handling_error("error", reason, CanGc::from_cx(cx));
+                let result = port.pack_and_post_message_handling_error(cx, "error", reason);
 
                 // Disentangle port.
                 global.disentangle_port(cx, port);
@@ -772,7 +771,7 @@ impl WritableStreamDefaultController {
 
                 // Perform ! PackAndPostMessage(port, "close", undefined).
                 rooted!(&in(cx) let mut value = UndefinedValue());
-                port.pack_and_post_message("close", value.handle(), CanGc::from_cx(cx))
+                port.pack_and_post_message(cx, "close", value.handle())
                     .expect("Sending close should not fail.");
 
                 // Disentangle port.


### PR DESCRIPTION
Continues the propagation of `&mut JSContext` (issue #42347) through the MessagePort message-passing chain: `pack_and_post_message`, `pack_and_post_message_handling_error`, `cross_realm_transform_send_error`, and `post_message_impl` now take `&mut JSContext` instead of `SafeJSContext` (or no `cx` parameter at all).  Stream callers in `underlyingsourcecontainer`, `writablestreamdefaultcontroller`, `readablestream`, and `writablestream` pass `cx` through.

The `structuredclone::write` signature itself is left as a follow-up; this PR keeps the existing `cx.into()` bridge at the call site in `MessagePort::post_message_impl`, matching the pattern from #42342.

Testing: No new tests; existing tests in CI cover the message-passing paths.  Local cargo check could not be run because `mozjs_sys` requires `lld` (part of `./mach bootstrap`), so I am relying on CI for compile verification.

Fixes: #42347 
