### PR TITLE
script: add error messages to ElementInternals

### DIFF
--- a/components/script/dom/elementinternals.rs
+++ b/components/script/dom/elementinternals.rs
@@ -226,7 +226,9 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
     ) -> ErrorResult {
         // Steps 1-2: If element is not a form-associated custom element, then throw a "NotSupportedError" DOMException
         if !self.is_target_form_associated() {
-            return Err(Error::NotSupported(None));
+            return Err(Error::NotSupported(Some(
+                "The target element is not a form-associated custom element".to_owned(),
+            )));
         }
 
         // Step 3: Set target element's submission value
@@ -252,7 +254,9 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
         // Step 1. Let element be this's target element.
         // Step 2: If element is not a form-associated custom element, then throw a "NotSupportedError" DOMException.
         if !self.is_target_form_associated() {
-            return Err(Error::NotSupported(None));
+            return Err(Error::NotSupported(Some(
+                "The target element is not a form-associated custom element".to_owned(),
+            )));
         }
 
         // Step 3: If flags contains one or more true values and message is not given or is the empty
@@ -298,7 +302,9 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
                     .upcast::<Node>()
                     .is_shadow_including_inclusive_ancestor_of(anchor.upcast::<Node>())
                 {
-                    return Err(Error::NotFound(None));
+                    return Err(Error::NotFound(Some(
+                        "The anchor element is not a shadow-including inclusive descendant of the target element".to_owned(),
+                    )));
                 }
                 anchor
             },
@@ -315,7 +321,9 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
         // This check isn't in the spec but it's in WPT tests and it maintains
         // consistency with other methods that do specify it
         if !self.is_target_form_associated() {
-            return Err(Error::NotSupported(None));
+            return Err(Error::NotSupported(Some(
+                "The target element is not a form-associated custom element".to_owned(),
+            )));
         }
         Ok(self.validation_message.borrow().clone())
     }
@@ -323,7 +331,9 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
     /// <https://html.spec.whatwg.org/multipage#dom-elementinternals-validity>
     fn GetValidity(&self, can_gc: CanGc) -> Fallible<DomRoot<ValidityState>> {
         if !self.is_target_form_associated() {
-            return Err(Error::NotSupported(None));
+            return Err(Error::NotSupported(Some(
+                "The target element is not a form-associated custom element".to_owned(),
+            )));
         }
         Ok(self.validity_state(can_gc))
     }
@@ -331,7 +341,9 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
     /// <https://html.spec.whatwg.org/multipage#dom-elementinternals-labels>
     fn GetLabels(&self, can_gc: CanGc) -> Fallible<DomRoot<NodeList>> {
         if !self.is_target_form_associated() {
-            return Err(Error::NotSupported(None));
+            return Err(Error::NotSupported(Some(
+                "The target element is not a form-associated custom element".to_owned(),
+            )));
         }
         Ok(self.labels_node_list.or_init(|| {
             NodeList::new_labels_list(
@@ -345,7 +357,9 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
     /// <https://html.spec.whatwg.org/multipage#dom-elementinternals-willvalidate>
     fn GetWillValidate(&self) -> Fallible<bool> {
         if !self.is_target_form_associated() {
-            return Err(Error::NotSupported(None));
+            return Err(Error::NotSupported(Some(
+                "The target element is not a form-associated custom element".to_owned(),
+            )));
         }
         Ok(self.is_instance_validatable())
     }
@@ -353,7 +367,9 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
     /// <https://html.spec.whatwg.org/multipage#dom-elementinternals-form>
     fn GetForm(&self) -> Fallible<Option<DomRoot<HTMLFormElement>>> {
         if !self.is_target_form_associated() {
-            return Err(Error::NotSupported(None));
+            return Err(Error::NotSupported(Some(
+                "The target element is not a form-associated custom element".to_owned(),
+            )));
         }
         Ok(self.form_owner.get())
     }
@@ -361,7 +377,9 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
     /// <https://html.spec.whatwg.org/multipage#dom-elementinternals-checkvalidity>
     fn CheckValidity(&self, cx: &mut JSContext) -> Fallible<bool> {
         if !self.is_target_form_associated() {
-            return Err(Error::NotSupported(None));
+            return Err(Error::NotSupported(Some(
+                "The target element is not a form-associated custom element".to_owned(),
+            )));
         }
         Ok(self.check_validity(cx))
     }
@@ -369,7 +387,9 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
     /// <https://html.spec.whatwg.org/multipage#dom-elementinternals-reportvalidity>
     fn ReportValidity(&self, cx: &mut JSContext) -> Fallible<bool> {
         if !self.is_target_form_associated() {
-            return Err(Error::NotSupported(None));
+            return Err(Error::NotSupported(Some(
+                "The target element is not a form-associated custom element".to_owned(),
+            )));
         }
         Ok(self.report_validity(cx))
     }


### PR DESCRIPTION
Replace all `Error::**(None)` with descriptive messages in `elementinternals.rs`, following the pattern established by #40768.

Testing: Automated tests do not verify the error messages in exceptions, so there are no automated tests for these changes.

Part of #40756