### PR TITLE
script: Vendor and update mime-multipart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5013,21 +5013,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "mime-multipart-hyper1"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc819448803ee517eb413276ca59613c2850a95c4fdcd87ec82c5a6ce6cdab1a"
-dependencies = [
- "buf-read-ext",
- "http 1.4.0",
- "httparse",
- "log",
- "mime",
- "tempfile",
- "textnonce",
-]
-
-[[package]]
 name = "mime_guess"
 version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8695,6 +8680,7 @@ dependencies = [
  "base64ct",
  "bitflags 2.11.1",
  "brotli",
+ "buf-read-ext",
  "cbc",
  "chacha20poly1305",
  "chardetng",
@@ -8718,6 +8704,7 @@ dependencies = [
  "hkdf",
  "html5ever",
  "http 1.4.0",
+ "httparse",
  "icu_locid",
  "indexmap",
  "ipc-channel",
@@ -8728,7 +8715,6 @@ dependencies = [
  "malloc_size_of_derive",
  "markup5ever",
  "mime",
- "mime-multipart-hyper1",
  "mime_guess",
  "ml-dsa",
  "ml-kem",
@@ -8803,6 +8789,7 @@ dependencies = [
  "swapper",
  "tempfile",
  "tendril",
+ "textnonce",
  "time",
  "tracing",
  "unicode-bidi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,12 +772,6 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -1445,7 +1439,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d348c3856ad6a6b957d69dc8cf93e66fe9be5a7657fdd7028b1a56d2775e3fce"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bitflags 2.11.1",
  "once_cell",
  "percent-encoding",
@@ -2860,24 +2854,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -3610,7 +3593,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "headers-core",
  "http 1.4.0",
@@ -3848,7 +3831,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -5045,7 +5028,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.61.2",
 ]
 
@@ -6683,19 +6666,6 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
@@ -6727,16 +6697,6 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
@@ -6753,15 +6713,6 @@ checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -6787,15 +6738,6 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
-]
 
 [[package]]
 name = "range-alloc"
@@ -7043,7 +6985,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "beceb6f7bf81c73e73aeef6dd1356d9a1b2b4909e1f0fc3e59b034f9572d7b7f"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bitflags 2.11.1",
  "serde",
  "serde_derive",
@@ -7768,7 +7710,7 @@ version = "0.2.0"
 dependencies = [
  "accesskit",
  "backtrace",
- "base64 0.22.1",
+ "base64",
  "content-security-policy",
  "crossbeam-channel",
  "euclid",
@@ -7814,7 +7756,7 @@ dependencies = [
 name = "servo-constellation-traits"
 version = "0.2.0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "content-security-policy",
  "encoding_rs",
  "euclid",
@@ -7867,7 +7809,7 @@ name = "servo-devtools"
 version = "0.2.0"
 dependencies = [
  "atomic_refcell",
- "base64 0.22.1",
+ "base64",
  "chrono",
  "crossbeam-channel",
  "headers",
@@ -8433,7 +8375,7 @@ dependencies = [
  "async-compression",
  "async-recursion",
  "async-tungstenite",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "chrono",
  "content-security-policy",
@@ -8676,7 +8618,7 @@ dependencies = [
  "atomic_refcell",
  "aws-lc-rs",
  "backtrace",
- "base64 0.22.1",
+ "base64",
  "base64ct",
  "bitflags 2.11.1",
  "brotli",
@@ -8789,7 +8731,6 @@ dependencies = [
  "swapper",
  "tempfile",
  "tendril",
- "textnonce",
  "time",
  "tracing",
  "unicode-bidi",
@@ -8966,7 +8907,7 @@ dependencies = [
 name = "servo-webdriver-server"
 version = "0.2.0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "cookie 0.18.1",
  "crossbeam-channel",
@@ -9832,16 +9773,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "textnonce"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7743f8d70cd784ed1dc33106a18998d77758d281dc40dc3e6d050cf0f5286683"
-dependencies = [
- "base64 0.12.3",
- "rand 0.7.3",
-]
-
-[[package]]
 name = "thin-vec"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10551,7 +10482,7 @@ version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d46cf96c5f498d36b7a9693bc6a7075c0bb9303189d61b2249b0dc3d309c07de"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "data-url",
  "flate2",
  "fontdb",
@@ -10801,12 +10732,6 @@ dependencies = [
  "tower-service",
  "tracing",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -11068,7 +10993,7 @@ version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91d53921e1bef27512fa358179c9a22428d55778d2c2ae3c5c37a52b82ce6e92"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "cookie 0.16.2",
  "http 0.2.12",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,6 @@ malloc_size_of_derive = "0.1"
 markup5ever = "0.39"
 memmap2 = "0.9.10"
 mime = "0.3.13"
-mime-multipart-hyper1 = "0.10.0"
 mime_guess = "2.0.5"
 ml-dsa = "0.0.4"
 ml-kem = { version = "0.2", features = ["deterministic"] }

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -156,7 +156,6 @@ stylo_traits = { workspace = true }
 swapper = "0.1"
 tempfile = "3"
 tendril = { workspace = true }
-textnonce = "1"
 time = { workspace = true }
 timers = { workspace = true }
 tracing = { workspace = true, optional = true }

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -52,6 +52,7 @@ base64 = { workspace = true }
 base64ct = { workspace = true }
 bitflags = { workspace = true }
 brotli = { workspace = true }
+buf-read-ext = "0.4"
 cbc = { workspace = true }
 chacha20poly1305 = { workspace = true }
 chardetng = { workspace = true }
@@ -81,6 +82,7 @@ headers = { workspace = true }
 hkdf = { workspace = true }
 html5ever = { workspace = true }
 http = { workspace = true }
+httparse = "1.9"
 hyper_serde = { workspace = true }
 icu_locid = { workspace = true }
 indexmap = { workspace = true }
@@ -98,7 +100,6 @@ markup5ever = { workspace = true }
 media = { workspace = true }
 metrics = { workspace = true }
 mime = { workspace = true }
-mime-multipart-hyper1 = { workspace = true }
 mime_guess = { workspace = true }
 ml-dsa = { workspace = true }
 ml-kem = { workspace = true }
@@ -155,6 +156,7 @@ stylo_traits = { workspace = true }
 swapper = "0.1"
 tempfile = "3"
 tendril = { workspace = true }
+textnonce = "1"
 time = { workspace = true }
 timers = { workspace = true }
 tracing = { workspace = true, optional = true }

--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -18,7 +18,6 @@ use js::rust::HandleValue;
 use js::rust::wrappers2::{JS_ClearPendingException, JS_GetPendingException, JS_ParseJSON};
 use js::typedarray::{ArrayBufferU8, Uint8};
 use mime::{self, Mime};
-use mime_multipart_hyper1::{Node, read_multipart_body};
 use net_traits::request::{
     BodyChunkRequest, BodyChunkResponse, BodySource as NetBodySource, RequestBody,
 };
@@ -47,6 +46,7 @@ use crate::dom::promise::Promise;
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::readablestream::{ReadableStream, get_read_promise_bytes, get_read_promise_done};
 use crate::dom::urlsearchparams::URLSearchParams;
+use crate::mime_multipart::{Node, read_multipart_body};
 use crate::realms::{InRealm, enter_auto_realm};
 use crate::script_runtime::CanGc;
 use crate::task_source::SendableTaskSource;

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -46,6 +46,7 @@ pub mod layout_dom;
 pub(crate) mod messaging;
 mod microtask;
 pub(crate) mod mime;
+mod mime_multipart;
 mod module_loading;
 mod navigation;
 mod network_listener;

--- a/components/script/mime_multipart.rs
+++ b/components/script/mime_multipart.rs
@@ -21,7 +21,6 @@ mod error {
     use std::io;
 
     use http::header::ToStrError;
-    use httparse;
 
     /// An error type for the `mime-multipart` crate.
     pub enum Error {
@@ -185,9 +184,9 @@ impl FilePart {
 }
 impl Drop for FilePart {
     fn drop(&mut self) {
-        if self.tempdir.is_some() {
+        if let Some(tempdir) = self.tempdir {
             let _ = std::fs::remove_file(&self.path);
-            let _ = std::fs::remove_dir(self.tempdir.as_ref().unwrap());
+            let _ = std::fs::remove_dir(tempdir);
         }
     }
 }

--- a/components/script/mime_multipart.rs
+++ b/components/script/mime_multipart.rs
@@ -138,7 +138,6 @@ use std::io::{BufRead, BufReader, Read};
 use std::ops::Drop;
 use std::path::PathBuf;
 use std::str::FromStr;
-use textnonce::TextNonce;
 
 /// A multipart part which is not a file (stored in memory)
 #[derive(Clone, Debug, PartialEq)]
@@ -165,13 +164,17 @@ impl FilePart {
     /// Create a new temporary FilePart (when created this way, the file will be
     /// deleted once the FilePart object goes out of scope).
     pub fn create(headers: HeaderMap) -> Result<FilePart, Error> {
+        // TODO: Do we really need a dir with only one file in it?
+        // Perhaps we just just do a tempfile, then we also have
+        // one cleanup step less!
         // Setup a file to capture the contents.
         let mut path = tempfile::Builder::new()
             .prefix("mime_multipart")
             .tempdir()?
             .keep();
         let tempdir = Some(path.clone());
-        path.push(TextNonce::sized_urlsafe(32).unwrap().into_string());
+        // The directory name is already guaranteed to be unique.
+        path.push("part");
         Ok(FilePart {
             headers,
             path,

--- a/components/script/mime_multipart.rs
+++ b/components/script/mime_multipart.rs
@@ -184,7 +184,7 @@ impl FilePart {
 }
 impl Drop for FilePart {
     fn drop(&mut self) {
-        if let Some(tempdir) = self.tempdir {
+        if let Some(tempdir) = &self.tempdir {
             let _ = std::fs::remove_file(&self.path);
             let _ = std::fs::remove_dir(tempdir);
         }

--- a/components/script/mime_multipart.rs
+++ b/components/script/mime_multipart.rs
@@ -1,0 +1,791 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// Copyright 2026      The Servo Developers
+// Copyright 2016-2025 mime-multipart Developers
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+//
+// This file originates from github.com/mikedilger/mime-multipart and https://github.com/gw-de/mime-multipart-hyper1.
+// The file as is, is licensed under MPL-2.0. Any code that is originally from mime-multipart
+// or its fork mime-multipart-hyper1 are additionally licensed under Apache-2.0 and MIT, as
+// per the original license.
+
+mod error {
+    use std::error::Error as StdError;
+    use std::fmt::{self, Display};
+    use std::io;
+    use std::string::FromUtf8Error;
+
+    use http;
+    use http::header::ToStrError;
+    use httparse;
+
+    /// An error type for the `mime-multipart` crate.
+    pub enum Error {
+        /// The Hyper request did not have a Content-Type header.
+        NoRequestContentType,
+        /// The Hyper request Content-Type top-level Mime was not `Multipart`.
+        NotMultipart,
+        /// The Content-Type header failed to specify boundary token.
+        BoundaryNotSpecified,
+        /// A multipart section contained only partial headers.
+        PartialHeaders,
+        EofInMainHeaders,
+        EofBeforeFirstBoundary,
+        NoCrLfAfterBoundary,
+        EofInPartHeaders,
+        EofInFile,
+        EofInPart,
+        HeaderMissing,
+        InvalidHeaderNameOrValue,
+        HeaderValueNotMime,
+        FilenameWithNonAsciiEncodingNotSupported,
+        ToStr(ToStrError),
+        /// An HTTP parsing error from a multipart section.
+        Httparse(httparse::Error),
+        /// An I/O error.
+        Io(io::Error),
+        /// An error was returned from Hyper.
+        Http(http::Error),
+        /// An error occurred during UTF-8 processing.
+        Utf8(FromUtf8Error),
+    }
+
+    impl From<io::Error> for Error {
+        fn from(err: io::Error) -> Error {
+            Error::Io(err)
+        }
+    }
+
+    impl From<httparse::Error> for Error {
+        fn from(err: httparse::Error) -> Error {
+            Error::Httparse(err)
+        }
+    }
+
+    impl From<http::Error> for Error {
+        fn from(err: http::Error) -> Error {
+            Error::Http(err)
+        }
+    }
+
+    impl From<FromUtf8Error> for Error {
+        fn from(err: FromUtf8Error) -> Error {
+            Error::Utf8(err)
+        }
+    }
+
+    impl Display for Error {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            match *self {
+                Error::Httparse(ref e) => format!("Httparse: {:?}", e).fmt(f),
+                Error::Io(ref e) => format!("Io: {}", e).fmt(f),
+                Error::Http(ref e) => format!("Http: {}", e).fmt(f),
+                Error::Utf8(ref e) => format!("Utf8: {}", e).fmt(f),
+                Error::ToStr(ref e) => format!("ToStr: {}", e).fmt(f),
+                Error::NoRequestContentType => "NoRequestContentType".to_string().fmt(f),
+                Error::NotMultipart => "NotMultipart".to_string().fmt(f),
+                Error::BoundaryNotSpecified => "BoundaryNotSpecified".to_string().fmt(f),
+                Error::PartialHeaders => "PartialHeaders".to_string().fmt(f),
+                Error::EofBeforeFirstBoundary => "EofBeforeFirstBoundary".to_string().fmt(f),
+                Error::NoCrLfAfterBoundary => "NoCrLfAfterBoundary".to_string().fmt(f),
+                Error::EofInPartHeaders => "EofInPartHeaders".to_string().fmt(f),
+                Error::EofInFile => "EofInFile".to_string().fmt(f),
+                Error::EofInPart => "EofInPart".to_string().fmt(f),
+                Error::EofInMainHeaders => "EofInMainHeaders".to_string().fmt(f),
+                Error::HeaderMissing => "HeaderMissing".to_string().fmt(f),
+                Error::InvalidHeaderNameOrValue => "InvalidHeaderNameOrValue".to_string().fmt(f),
+                Error::HeaderValueNotMime => "HeaderValueNotMime".to_string().fmt(f),
+                Error::FilenameWithNonAsciiEncodingNotSupported => {
+                    "NonAsciiFilenameNotSupported".to_string().fmt(f)
+                },
+            }
+        }
+    }
+
+    impl fmt::Debug for Error {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "{}", self)?;
+            if self.source().is_some() {
+                write!(f, ": {:?}", self.source().unwrap())?; // recurse
+            }
+            Ok(())
+        }
+    }
+
+    impl StdError for Error {
+        fn description(&self) -> &str {
+            match *self {
+                Error::NoRequestContentType => {
+                    "The Hyper request did not have a Content-Type header."
+                },
+                Error::NotMultipart => {
+                    "The Hyper request Content-Type top-level Mime was not multipart."
+                },
+                Error::BoundaryNotSpecified => {
+                    "The Content-Type header failed to specify a boundary token."
+                },
+                Error::PartialHeaders => "A multipart section contained only partial headers.",
+                Error::EofInMainHeaders => "The request headers ended pre-maturely.",
+                Error::EofBeforeFirstBoundary => {
+                    "The request body ended prior to reaching the expected starting boundary."
+                },
+                Error::NoCrLfAfterBoundary => "Missing CRLF after boundary.",
+                Error::EofInPartHeaders => {
+                    "The request body ended prematurely while parsing headers of a multipart part."
+                },
+                Error::EofInFile => {
+                    "The request body ended prematurely while streaming a file part."
+                },
+                Error::EofInPart => {
+                    "The request body ended prematurely while reading a multipart part."
+                },
+                Error::Httparse(_) => {
+                    "A parse error occurred while parsing the headers of a multipart section."
+                },
+                Error::Io(_) => "An I/O error occurred.",
+                Error::Http(_) => "A Http error occurred.",
+                Error::Utf8(_) => "A UTF-8 error occurred.",
+                Error::HeaderMissing => "The requested header could not be found in the HeaderMap",
+                Error::InvalidHeaderNameOrValue => "Parsing to HeaderName or HeaderValue failed",
+                Error::HeaderValueNotMime => "HeaderValue could not be parsed to Mime",
+                Error::ToStr(_) => "A ToStr error occurred.",
+                Error::FilenameWithNonAsciiEncodingNotSupported => {
+                    "Non-ASCII filename parsing not supported"
+                },
+            }
+        }
+    }
+}
+
+pub use error::Error;
+
+use buf_read_ext::BufReadExt;
+use http::header::{HeaderMap, HeaderName, HeaderValue};
+use mime::Mime;
+use std::fs::File;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::ops::Drop;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use textnonce::TextNonce;
+
+/// A multipart part which is not a file (stored in memory)
+#[derive(Clone, Debug, PartialEq)]
+pub struct Part {
+    pub headers: HeaderMap,
+    pub body: Vec<u8>,
+}
+impl Part {
+    /// Mime content-type specified in the header
+    pub fn content_type(&self) -> Option<Mime> {
+        match self.headers.get("content-type") {
+            Some(ct) => match ct.to_str() {
+                Ok(value) => match Mime::from_str(value) {
+                    Ok(value) => Some(value),
+                    Err(_) => None,
+                },
+                Err(_) => None,
+            },
+            None => None,
+        }
+    }
+}
+
+/// A file that is to be inserted into a `multipart/*` or alternatively an uploaded file that
+/// was received as part of `multipart/*` parsing.
+#[derive(Clone, Debug, PartialEq)]
+pub struct FilePart {
+    /// The headers of the part
+    pub headers: HeaderMap,
+    /// A temporary file containing the file content
+    pub path: PathBuf,
+    /// Optionally, the size of the file.  This is filled when multiparts are parsed, but is
+    /// not necessary when they are generated.
+    pub size: Option<usize>,
+    // The temporary directory the upload was put into, saved for the Drop trait
+    tempdir: Option<PathBuf>,
+}
+impl FilePart {
+    pub fn new(headers: HeaderMap, path: &Path) -> FilePart {
+        FilePart {
+            headers,
+            path: path.to_owned(),
+            size: None,
+            tempdir: None,
+        }
+    }
+
+    /// If you do not want the file on disk to be deleted when Self drops, call this
+    /// function.  It will become your responsibility to clean up.
+    pub fn do_not_delete_on_drop(&mut self) {
+        self.tempdir = None;
+    }
+
+    /// Create a new temporary FilePart (when created this way, the file will be
+    /// deleted once the FilePart object goes out of scope).
+    pub fn create(headers: HeaderMap) -> Result<FilePart, Error> {
+        // Setup a file to capture the contents.
+        let mut path = tempfile::Builder::new()
+            .prefix("mime_multipart")
+            .tempdir()?
+            .into_path();
+        let tempdir = Some(path.clone());
+        path.push(TextNonce::sized_urlsafe(32).unwrap().into_string());
+        Ok(FilePart {
+            headers,
+            path,
+            size: None,
+            tempdir,
+        })
+    }
+
+    /// Filename that was specified when the file was uploaded.  Returns `Ok<None>` if there
+    /// was no content-disposition header supplied.
+    pub fn filename(&self) -> Result<Option<String>, Error> {
+        match self.headers.get("content-disposition") {
+            Some(cd) => get_content_disposition_filename(cd),
+            None => Ok(None),
+        }
+    }
+
+    /// Mime content-type specified in the header
+    pub fn content_type(&self) -> Option<Mime> {
+        match self.headers.get("content-type") {
+            Some(ct) => match ct.to_str() {
+                Ok(value) => match Mime::from_str(value) {
+                    Ok(value) => Some(value),
+                    Err(_) => None,
+                },
+                Err(_) => None,
+            },
+            None => None,
+        }
+    }
+}
+impl Drop for FilePart {
+    fn drop(&mut self) {
+        if self.tempdir.is_some() {
+            let _ = std::fs::remove_file(&self.path);
+            let _ = std::fs::remove_dir(self.tempdir.as_ref().unwrap());
+        }
+    }
+}
+
+/// A multipart part which could be either a file, in memory, or another multipart
+/// container containing nested parts.
+#[derive(Clone, Debug)]
+pub enum Node {
+    /// A part in memory
+    Part(Part),
+    /// A part streamed to a file
+    File(FilePart),
+    /// A container of nested multipart parts
+    Multipart((HeaderMap, Vec<Node>)),
+}
+
+/// Parse a MIME `multipart/*` from a `Read`able stream into a `Vec` of `Node`s, streaming
+/// files to disk and keeping the rest in memory.  Recursive `multipart/*` parts will are
+/// parsed as well and returned within a `Node::Multipart` variant.
+///
+/// If `always_use_files` is true, all parts will be streamed to files.  If false, only parts
+/// with a `ContentDisposition` header set to `Attachment` or otherwise containing a `Filename`
+/// parameter will be streamed to files.
+///
+/// It is presumed that the headers are still in the stream.  If you have them separately,
+/// use `read_multipart_body()` instead.
+pub fn read_multipart<S: Read>(stream: &mut S, always_use_files: bool) -> Result<Vec<Node>, Error> {
+    let mut reader = BufReader::with_capacity(4096, stream);
+
+    let mut buf: Vec<u8> = Vec::new();
+
+    let (_, found) = reader.stream_until_token(b"\r\n\r\n", &mut buf)?;
+    if !found {
+        return Err(Error::EofInMainHeaders);
+    }
+
+    // Keep the CRLFCRLF as httparse will expect it
+    buf.extend(b"\r\n\r\n".iter().cloned());
+
+    // Parse the headers
+    let mut header_memory = [httparse::EMPTY_HEADER; 64];
+    let headers = match httparse::parse_headers(&buf, &mut header_memory) {
+        Ok(httparse::Status::Complete((_, raw_headers))) => {
+            let mut headers = HeaderMap::new();
+            for header in raw_headers {
+                if header.value.is_empty() {
+                    break;
+                }
+                let trim = header
+                    .value
+                    .iter()
+                    .rev()
+                    .take_while(|&&x| x == b' ')
+                    .count();
+                let value = &header.value[..header.value.len() - trim];
+
+                let header_value = match HeaderValue::from_bytes(value) {
+                    Ok(value) => value,
+                    Err(_) => return Err(Error::InvalidHeaderNameOrValue),
+                };
+
+                let header_name = header.name.to_owned();
+                let header_name = match HeaderName::from_str(&header_name) {
+                    Ok(value) => value,
+                    Err(_) => return Err(Error::InvalidHeaderNameOrValue),
+                };
+                headers.append(header_name, header_value);
+            }
+            Ok(headers)
+        },
+        Ok(httparse::Status::Partial) => Err(Error::PartialHeaders),
+        Err(err) => Err(From::from(err)),
+    }?;
+
+    inner(&mut reader, &headers, always_use_files)
+}
+
+/// Parse a MIME `multipart/*` from a `Read`able stream into a `Vec` of `Node`s, streaming
+/// files to disk and keeping the rest in memory.  Recursive `multipart/*` parts will are
+/// parsed as well and returned within a `Node::Multipart` variant.
+///
+/// If `always_use_files` is true, all parts will be streamed to files.  If false, only parts
+/// with a `ContentDisposition` header set to `Attachment` or otherwise containing a `Filename`
+/// parameter will be streamed to files.
+///
+/// It is presumed that you have the `Headers` already and the stream starts at the body.
+/// If the headers are still in the stream, use `read_multipart()` instead.
+pub fn read_multipart_body<S: Read>(
+    stream: &mut S,
+    headers: &HeaderMap,
+    always_use_files: bool,
+) -> Result<Vec<Node>, Error> {
+    let mut reader = BufReader::with_capacity(4096, stream);
+    inner(&mut reader, headers, always_use_files)
+}
+
+fn inner<R: BufRead>(
+    reader: &mut R,
+    headers: &HeaderMap,
+    always_use_files: bool,
+) -> Result<Vec<Node>, Error> {
+    let mut nodes: Vec<Node> = Vec::new();
+    let mut buf: Vec<u8> = Vec::new();
+
+    let boundary = get_multipart_boundary(headers)?;
+
+    // Read past the initial boundary
+    let (_, found) = reader.stream_until_token(&boundary, &mut buf)?;
+    if !found {
+        return Err(Error::EofBeforeFirstBoundary);
+    }
+
+    // Define the boundary, including the line terminator preceding it.
+    // Use their first line terminator to determine whether to use CRLF or LF.
+    let (lt, ltlt, lt_boundary) = {
+        let peeker = reader.fill_buf()?;
+        if peeker.len() > 1 && &peeker[..2] == b"\r\n" {
+            let mut output = Vec::with_capacity(2 + boundary.len());
+            output.push(b'\r');
+            output.push(b'\n');
+            output.extend(boundary.clone());
+            (vec![b'\r', b'\n'], vec![b'\r', b'\n', b'\r', b'\n'], output)
+        } else if !peeker.is_empty() && peeker[0] == b'\n' {
+            let mut output = Vec::with_capacity(1 + boundary.len());
+            output.push(b'\n');
+            output.extend(boundary.clone());
+            (vec![b'\n'], vec![b'\n', b'\n'], output)
+        } else {
+            return Err(Error::NoCrLfAfterBoundary);
+        }
+    };
+
+    loop {
+        // If the next two lookahead characters are '--', parsing is finished.
+        {
+            let peeker = reader.fill_buf()?;
+            if peeker.len() >= 2 && &peeker[..2] == b"--" {
+                return Ok(nodes);
+            }
+        }
+
+        // Read the line terminator after the boundary
+        let (_, found) = reader.stream_until_token(&lt, &mut buf)?;
+        if !found {
+            return Err(Error::NoCrLfAfterBoundary);
+        }
+
+        // Read the headers (which end in 2 line terminators)
+        buf.truncate(0); // start fresh
+        let (_, found) = reader.stream_until_token(&ltlt, &mut buf)?;
+        if !found {
+            return Err(Error::EofInPartHeaders);
+        }
+
+        // Keep the 2 line terminators as httparse will expect it
+        buf.extend(ltlt.iter().cloned());
+
+        // Parse the headers
+        let part_headers = {
+            let mut header_memory = [httparse::EMPTY_HEADER; 4];
+            match httparse::parse_headers(&buf, &mut header_memory) {
+                Ok(httparse::Status::Complete((_, raw_headers))) => {
+                    let mut headers = HeaderMap::new();
+                    for header in raw_headers {
+                        if header.value.is_empty() {
+                            break;
+                        }
+                        let trim = header
+                            .value
+                            .iter()
+                            .rev()
+                            .take_while(|&&x| x == b' ')
+                            .count();
+                        let value = &header.value[..header.value.len() - trim];
+
+                        let header_value = match HeaderValue::from_bytes(value) {
+                            Ok(value) => value,
+                            Err(_) => return Err(Error::InvalidHeaderNameOrValue),
+                        };
+
+                        let header_name = header.name.to_owned();
+                        let header_name = match HeaderName::from_str(&header_name) {
+                            Ok(value) => value,
+                            Err(_) => return Err(Error::InvalidHeaderNameOrValue),
+                        };
+                        headers.append(header_name, header_value);
+                    }
+                    Ok(headers)
+                },
+                Ok(httparse::Status::Partial) => Err(Error::PartialHeaders),
+                Err(err) => Err(From::from(err)),
+            }?
+        };
+
+        // Check for a nested multipart
+        let nested = {
+            match part_headers.get("content-type") {
+                Some(ct) => match ct.to_str() {
+                    Ok(value) => match Mime::from_str(value) {
+                        Ok(mime) => mime.type_() == mime::MULTIPART,
+                        Err(_) => return Err(Error::HeaderValueNotMime),
+                    },
+                    Err(err) => return Err(Error::ToStr(err)),
+                },
+                None => false,
+            }
+        };
+        if nested {
+            // Recurse:
+            let inner_nodes = inner(reader, &part_headers, always_use_files)?;
+            nodes.push(Node::Multipart((part_headers, inner_nodes)));
+            continue;
+        }
+
+        let is_file = always_use_files || {
+            match part_headers.get("content-disposition") {
+                Some(content) => match content.to_str() {
+                    Ok(value) => value.contains("attachment") || value.contains("filename"),
+                    Err(err) => return Err(Error::ToStr(err)),
+                },
+                None => false,
+            }
+        };
+        if is_file {
+            // Setup a file to capture the contents.
+            let mut filepart = FilePart::create(part_headers)?;
+            let mut file = File::create(filepart.path.clone())?;
+
+            // Stream out the file.
+            let (read, found) = reader.stream_until_token(&lt_boundary, &mut file)?;
+            if !found {
+                return Err(Error::EofInFile);
+            }
+            filepart.size = Some(read);
+
+            // TODO: Handle Content-Transfer-Encoding.  RFC 7578 section 4.7 deprecated
+            // this, and the authors state "Currently, no deployed implementations that
+            // send such bodies have been discovered", so this is very low priority.
+
+            nodes.push(Node::File(filepart));
+        } else {
+            buf.truncate(0); // start fresh
+            let (_, found) = reader.stream_until_token(&lt_boundary, &mut buf)?;
+            if !found {
+                return Err(Error::EofInPart);
+            }
+
+            nodes.push(Node::Part(Part {
+                headers: part_headers,
+                body: buf.clone(),
+            }));
+        }
+    }
+}
+
+/// Get the `multipart/*` boundary string from `hyper::Headers`
+pub fn get_multipart_boundary(headers: &HeaderMap) -> Result<Vec<u8>, Error> {
+    // Verify that the request is 'Content-Type: multipart/*'.
+    let mime = match headers.get("content-type") {
+        Some(ct) => match ct.to_str() {
+            Ok(value) => match Mime::from_str(value) {
+                Ok(value) => value,
+                Err(_) => return Err(Error::HeaderValueNotMime),
+            },
+            Err(err) => return Err(Error::ToStr(err)),
+        },
+        None => return Err(Error::NoRequestContentType),
+    };
+    let top_level = mime.type_();
+
+    if top_level != mime::MULTIPART {
+        return Err(Error::NotMultipart);
+    }
+
+    match mime.get_param(mime::BOUNDARY) {
+        None => Err(Error::BoundaryNotSpecified),
+        Some(content) => {
+            let mut boundary = vec![];
+            boundary.extend(b"--".iter().cloned());
+            boundary.extend(content.to_string().as_bytes());
+            Ok(boundary)
+        },
+    }
+}
+
+#[inline]
+fn get_content_disposition_filename(cd: &HeaderValue) -> Result<Option<String>, Error> {
+    match cd.to_str() {
+        Ok(value) => match value.contains("filename") {
+            true => match value.find("filename=") {
+                Some(index) => {
+                    let start = index + "filename=".len();
+                    Ok(Some(
+                        value.get(start..).unwrap().trim_matches('\"').to_owned(),
+                    ))
+                },
+                None => match value.find("filename*=UTF-8''") {
+                    Some(index) => {
+                        let start = index + "filename*=UTF-8''".len();
+                        Ok(Some(
+                            value.get(start..).unwrap().trim_matches('\"').to_owned(),
+                        ))
+                    },
+                    None => Ok(None),
+                },
+            },
+            false => Ok(None),
+        },
+        Err(err) => Err(Error::ToStr(err)),
+    }
+}
+
+/// Generate a valid multipart boundary, statistically unlikely to be found within
+/// the content of the parts.
+pub fn generate_boundary() -> Vec<u8> {
+    TextNonce::sized(68)
+        .unwrap()
+        .into_string()
+        .into_bytes()
+        .iter()
+        .map(|&ch| {
+            if ch == b'=' {
+                b'-'
+            } else if ch == b'/' {
+                b'.'
+            } else {
+                ch
+            }
+        })
+        .collect()
+}
+
+// Convenience method, like write_all(), but returns the count of bytes written.
+trait WriteAllCount {
+    fn write_all_count(&mut self, buf: &[u8]) -> std::io::Result<usize>;
+}
+impl<T: Write> WriteAllCount for T {
+    fn write_all_count(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.write_all(buf)?;
+        Ok(buf.len())
+    }
+}
+
+/// Stream a multipart body to the output `stream` given, made up of the `parts`
+/// given.  Top-level headers are NOT included in this stream; the caller must send
+/// those prior to calling write_multipart().
+/// Returns the number of bytes written, or an error.
+pub fn write_multipart<S: Write>(
+    stream: &mut S,
+    boundary: &[u8],
+    nodes: &Vec<Node>,
+) -> Result<usize, Error> {
+    let mut count: usize = 0;
+
+    for node in nodes {
+        // write a boundary
+        count += stream.write_all_count(b"--")?;
+        count += stream.write_all_count(boundary)?;
+        count += stream.write_all_count(b"\r\n")?;
+
+        match *node {
+            Node::Part(ref part) => {
+                // write the part's headers
+                for header in part.headers.iter() {
+                    count += stream.write_all_count(header.0.as_str().as_bytes())?;
+                    count += stream.write_all_count(b": ")?;
+                    count += stream.write_all_count(header.1.as_bytes())?;
+                    count += stream.write_all_count(b"\r\n")?;
+                }
+
+                // write the blank line
+                count += stream.write_all_count(b"\r\n")?;
+
+                // Write the part's content
+                count += stream.write_all_count(&part.body)?;
+            },
+            Node::File(ref filepart) => {
+                // write the part's headers
+                for header in filepart.headers.iter() {
+                    count += stream.write_all_count(header.0.as_str().as_bytes())?;
+                    count += stream.write_all_count(b": ")?;
+                    count += stream.write_all_count(header.1.as_bytes())?;
+                    count += stream.write_all_count(b"\r\n")?;
+                }
+
+                // write the blank line
+                count += stream.write_all_count(b"\r\n")?;
+
+                // Write out the files's content
+                let mut file = File::open(&filepart.path)?;
+                count += std::io::copy(&mut file, stream)? as usize;
+            },
+            Node::Multipart((ref headers, ref subnodes)) => {
+                // Get boundary
+                let boundary = get_multipart_boundary(headers)?;
+
+                // write the multipart headers
+                for header in headers.iter() {
+                    count += stream.write_all_count(header.0.as_str().as_bytes())?;
+                    count += stream.write_all_count(b": ")?;
+                    count += stream.write_all_count(header.1.as_bytes())?;
+                    count += stream.write_all_count(b"\r\n")?;
+                }
+
+                // write the blank line
+                count += stream.write_all_count(b"\r\n")?;
+
+                // Recurse
+                count += write_multipart(stream, &boundary, subnodes)?;
+            },
+        }
+
+        // write a line terminator
+        count += stream.write_all_count(b"\r\n")?;
+    }
+
+    // write a final boundary
+    count += stream.write_all_count(b"--")?;
+    count += stream.write_all_count(boundary)?;
+    count += stream.write_all_count(b"--")?;
+
+    Ok(count)
+}
+
+pub fn write_chunk<S: Write>(stream: &mut S, chunk: &[u8]) -> Result<(), ::std::io::Error> {
+    write!(stream, "{:x}\r\n", chunk.len())?;
+    stream.write_all(chunk)?;
+    stream.write_all(b"\r\n")?;
+    Ok(())
+}
+
+/// Stream a multipart body to the output `stream` given, made up of the `parts`
+/// given, using Tranfer-Encoding: Chunked.  Top-level headers are NOT included in this
+/// stream; the caller must send those prior to calling write_multipart_chunked().
+pub fn write_multipart_chunked<S: Write>(
+    stream: &mut S,
+    boundary: &[u8],
+    nodes: &Vec<Node>,
+) -> Result<(), Error> {
+    for node in nodes {
+        // write a boundary
+        write_chunk(stream, b"--")?;
+        write_chunk(stream, boundary)?;
+        write_chunk(stream, b"\r\n")?;
+
+        match *node {
+            Node::Part(ref part) => {
+                // write the part's headers
+                for header in part.headers.iter() {
+                    write_chunk(stream, header.0.as_str().as_bytes())?;
+                    write_chunk(stream, b": ")?;
+                    write_chunk(stream, header.1.as_bytes())?;
+                    write_chunk(stream, b"\r\n")?;
+                }
+
+                // write the blank line
+                write_chunk(stream, b"\r\n")?;
+
+                // Write the part's content
+                write_chunk(stream, &part.body)?;
+            },
+            Node::File(ref filepart) => {
+                // write the part's headers
+                for header in filepart.headers.iter() {
+                    write_chunk(stream, header.0.as_str().as_bytes())?;
+                    write_chunk(stream, b": ")?;
+                    write_chunk(stream, header.1.as_bytes())?;
+                    write_chunk(stream, b"\r\n")?;
+                }
+
+                // write the blank line
+                write_chunk(stream, b"\r\n")?;
+
+                // Write out the files's length
+                let metadata = std::fs::metadata(&filepart.path)?;
+                write!(stream, "{:x}\r\n", metadata.len())?;
+
+                // Write out the file's content
+                let mut file = File::open(&filepart.path)?;
+                std::io::copy(&mut file, stream)?;
+                stream.write_all(b"\r\n")?;
+            },
+            Node::Multipart((ref headers, ref subnodes)) => {
+                // Get boundary
+                let boundary = get_multipart_boundary(headers)?;
+
+                // write the multipart headers
+                for header in headers.iter() {
+                    write_chunk(stream, header.0.as_str().as_bytes())?;
+                    write_chunk(stream, b": ")?;
+                    write_chunk(stream, header.1.as_bytes())?;
+                    write_chunk(stream, b"\r\n")?;
+                }
+
+                // write the blank line
+                write_chunk(stream, b"\r\n")?;
+
+                // Recurse
+                write_multipart_chunked(stream, &boundary, subnodes)?;
+            },
+        }
+
+        // write a line terminator
+        write_chunk(stream, b"\r\n")?;
+    }
+
+    // write a final boundary
+    write_chunk(stream, b"--")?;
+    write_chunk(stream, boundary)?;
+    write_chunk(stream, b"--")?;
+
+    // Write an empty chunk to signal the end of the body
+    write_chunk(stream, b"")?;
+
+    Ok(())
+}

--- a/components/script/mime_multipart.rs
+++ b/components/script/mime_multipart.rs
@@ -128,16 +128,16 @@ mod error {
     }
 }
 
-pub use error::Error;
-
-use buf_read_ext::BufReadExt;
-use http::header::{HeaderMap, HeaderName, HeaderValue};
-use mime::Mime;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read};
 use std::ops::Drop;
 use std::path::PathBuf;
 use std::str::FromStr;
+
+use buf_read_ext::BufReadExt;
+pub use error::Error;
+use http::header::{HeaderMap, HeaderName, HeaderValue};
+use mime::Mime;
 
 /// A multipart part which is not a file (stored in memory)
 #[derive(Clone, Debug, PartialEq)]

--- a/components/script/mime_multipart.rs
+++ b/components/script/mime_multipart.rs
@@ -19,9 +19,7 @@ mod error {
     use std::error::Error as StdError;
     use std::fmt::{self, Display};
     use std::io;
-    use std::string::FromUtf8Error;
 
-    use http;
     use http::header::ToStrError;
     use httparse;
 
@@ -35,25 +33,18 @@ mod error {
         BoundaryNotSpecified,
         /// A multipart section contained only partial headers.
         PartialHeaders,
-        EofInMainHeaders,
         EofBeforeFirstBoundary,
         NoCrLfAfterBoundary,
         EofInPartHeaders,
         EofInFile,
         EofInPart,
-        HeaderMissing,
         InvalidHeaderNameOrValue,
         HeaderValueNotMime,
-        FilenameWithNonAsciiEncodingNotSupported,
         ToStr(ToStrError),
         /// An HTTP parsing error from a multipart section.
         Httparse(httparse::Error),
         /// An I/O error.
         Io(io::Error),
-        /// An error was returned from Hyper.
-        Http(http::Error),
-        /// An error occurred during UTF-8 processing.
-        Utf8(FromUtf8Error),
     }
 
     impl From<io::Error> for Error {
@@ -68,25 +59,11 @@ mod error {
         }
     }
 
-    impl From<http::Error> for Error {
-        fn from(err: http::Error) -> Error {
-            Error::Http(err)
-        }
-    }
-
-    impl From<FromUtf8Error> for Error {
-        fn from(err: FromUtf8Error) -> Error {
-            Error::Utf8(err)
-        }
-    }
-
     impl Display for Error {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             match *self {
                 Error::Httparse(ref e) => format!("Httparse: {:?}", e).fmt(f),
                 Error::Io(ref e) => format!("Io: {}", e).fmt(f),
-                Error::Http(ref e) => format!("Http: {}", e).fmt(f),
-                Error::Utf8(ref e) => format!("Utf8: {}", e).fmt(f),
                 Error::ToStr(ref e) => format!("ToStr: {}", e).fmt(f),
                 Error::NoRequestContentType => "NoRequestContentType".to_string().fmt(f),
                 Error::NotMultipart => "NotMultipart".to_string().fmt(f),
@@ -97,13 +74,8 @@ mod error {
                 Error::EofInPartHeaders => "EofInPartHeaders".to_string().fmt(f),
                 Error::EofInFile => "EofInFile".to_string().fmt(f),
                 Error::EofInPart => "EofInPart".to_string().fmt(f),
-                Error::EofInMainHeaders => "EofInMainHeaders".to_string().fmt(f),
-                Error::HeaderMissing => "HeaderMissing".to_string().fmt(f),
                 Error::InvalidHeaderNameOrValue => "InvalidHeaderNameOrValue".to_string().fmt(f),
                 Error::HeaderValueNotMime => "HeaderValueNotMime".to_string().fmt(f),
-                Error::FilenameWithNonAsciiEncodingNotSupported => {
-                    "NonAsciiFilenameNotSupported".to_string().fmt(f)
-                },
             }
         }
     }
@@ -131,7 +103,6 @@ mod error {
                     "The Content-Type header failed to specify a boundary token."
                 },
                 Error::PartialHeaders => "A multipart section contained only partial headers.",
-                Error::EofInMainHeaders => "The request headers ended pre-maturely.",
                 Error::EofBeforeFirstBoundary => {
                     "The request body ended prior to reaching the expected starting boundary."
                 },
@@ -149,15 +120,9 @@ mod error {
                     "A parse error occurred while parsing the headers of a multipart section."
                 },
                 Error::Io(_) => "An I/O error occurred.",
-                Error::Http(_) => "A Http error occurred.",
-                Error::Utf8(_) => "A UTF-8 error occurred.",
-                Error::HeaderMissing => "The requested header could not be found in the HeaderMap",
                 Error::InvalidHeaderNameOrValue => "Parsing to HeaderName or HeaderValue failed",
                 Error::HeaderValueNotMime => "HeaderValue could not be parsed to Mime",
                 Error::ToStr(_) => "A ToStr error occurred.",
-                Error::FilenameWithNonAsciiEncodingNotSupported => {
-                    "Non-ASCII filename parsing not supported"
-                },
             }
         }
     }
@@ -169,9 +134,9 @@ use buf_read_ext::BufReadExt;
 use http::header::{HeaderMap, HeaderName, HeaderValue};
 use mime::Mime;
 use std::fs::File;
-use std::io::{BufRead, BufReader, Read, Write};
+use std::io::{BufRead, BufReader, Read};
 use std::ops::Drop;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::str::FromStr;
 use textnonce::TextNonce;
 
@@ -180,21 +145,6 @@ use textnonce::TextNonce;
 pub struct Part {
     pub headers: HeaderMap,
     pub body: Vec<u8>,
-}
-impl Part {
-    /// Mime content-type specified in the header
-    pub fn content_type(&self) -> Option<Mime> {
-        match self.headers.get("content-type") {
-            Some(ct) => match ct.to_str() {
-                Ok(value) => match Mime::from_str(value) {
-                    Ok(value) => Some(value),
-                    Err(_) => None,
-                },
-                Err(_) => None,
-            },
-            None => None,
-        }
-    }
 }
 
 /// A file that is to be inserted into a `multipart/*` or alternatively an uploaded file that
@@ -212,21 +162,6 @@ pub struct FilePart {
     tempdir: Option<PathBuf>,
 }
 impl FilePart {
-    pub fn new(headers: HeaderMap, path: &Path) -> FilePart {
-        FilePart {
-            headers,
-            path: path.to_owned(),
-            size: None,
-            tempdir: None,
-        }
-    }
-
-    /// If you do not want the file on disk to be deleted when Self drops, call this
-    /// function.  It will become your responsibility to clean up.
-    pub fn do_not_delete_on_drop(&mut self) {
-        self.tempdir = None;
-    }
-
     /// Create a new temporary FilePart (when created this way, the file will be
     /// deleted once the FilePart object goes out of scope).
     pub fn create(headers: HeaderMap) -> Result<FilePart, Error> {
@@ -243,29 +178,6 @@ impl FilePart {
             size: None,
             tempdir,
         })
-    }
-
-    /// Filename that was specified when the file was uploaded.  Returns `Ok<None>` if there
-    /// was no content-disposition header supplied.
-    pub fn filename(&self) -> Result<Option<String>, Error> {
-        match self.headers.get("content-disposition") {
-            Some(cd) => get_content_disposition_filename(cd),
-            None => Ok(None),
-        }
-    }
-
-    /// Mime content-type specified in the header
-    pub fn content_type(&self) -> Option<Mime> {
-        match self.headers.get("content-type") {
-            Some(ct) => match ct.to_str() {
-                Ok(value) => match Mime::from_str(value) {
-                    Ok(value) => Some(value),
-                    Err(_) => None,
-                },
-                Err(_) => None,
-            },
-            None => None,
-        }
     }
 }
 impl Drop for FilePart {
@@ -287,67 +199,6 @@ pub enum Node {
     File(FilePart),
     /// A container of nested multipart parts
     Multipart((HeaderMap, Vec<Node>)),
-}
-
-/// Parse a MIME `multipart/*` from a `Read`able stream into a `Vec` of `Node`s, streaming
-/// files to disk and keeping the rest in memory.  Recursive `multipart/*` parts will are
-/// parsed as well and returned within a `Node::Multipart` variant.
-///
-/// If `always_use_files` is true, all parts will be streamed to files.  If false, only parts
-/// with a `ContentDisposition` header set to `Attachment` or otherwise containing a `Filename`
-/// parameter will be streamed to files.
-///
-/// It is presumed that the headers are still in the stream.  If you have them separately,
-/// use `read_multipart_body()` instead.
-pub fn read_multipart<S: Read>(stream: &mut S, always_use_files: bool) -> Result<Vec<Node>, Error> {
-    let mut reader = BufReader::with_capacity(4096, stream);
-
-    let mut buf: Vec<u8> = Vec::new();
-
-    let (_, found) = reader.stream_until_token(b"\r\n\r\n", &mut buf)?;
-    if !found {
-        return Err(Error::EofInMainHeaders);
-    }
-
-    // Keep the CRLFCRLF as httparse will expect it
-    buf.extend(b"\r\n\r\n".iter().cloned());
-
-    // Parse the headers
-    let mut header_memory = [httparse::EMPTY_HEADER; 64];
-    let headers = match httparse::parse_headers(&buf, &mut header_memory) {
-        Ok(httparse::Status::Complete((_, raw_headers))) => {
-            let mut headers = HeaderMap::new();
-            for header in raw_headers {
-                if header.value.is_empty() {
-                    break;
-                }
-                let trim = header
-                    .value
-                    .iter()
-                    .rev()
-                    .take_while(|&&x| x == b' ')
-                    .count();
-                let value = &header.value[..header.value.len() - trim];
-
-                let header_value = match HeaderValue::from_bytes(value) {
-                    Ok(value) => value,
-                    Err(_) => return Err(Error::InvalidHeaderNameOrValue),
-                };
-
-                let header_name = header.name.to_owned();
-                let header_name = match HeaderName::from_str(&header_name) {
-                    Ok(value) => value,
-                    Err(_) => return Err(Error::InvalidHeaderNameOrValue),
-                };
-                headers.append(header_name, header_value);
-            }
-            Ok(headers)
-        },
-        Ok(httparse::Status::Partial) => Err(Error::PartialHeaders),
-        Err(err) => Err(From::from(err)),
-    }?;
-
-    inner(&mut reader, &headers, always_use_files)
 }
 
 /// Parse a MIME `multipart/*` from a `Read`able stream into a `Vec` of `Node`s, streaming
@@ -556,236 +407,4 @@ pub fn get_multipart_boundary(headers: &HeaderMap) -> Result<Vec<u8>, Error> {
             Ok(boundary)
         },
     }
-}
-
-#[inline]
-fn get_content_disposition_filename(cd: &HeaderValue) -> Result<Option<String>, Error> {
-    match cd.to_str() {
-        Ok(value) => match value.contains("filename") {
-            true => match value.find("filename=") {
-                Some(index) => {
-                    let start = index + "filename=".len();
-                    Ok(Some(
-                        value.get(start..).unwrap().trim_matches('\"').to_owned(),
-                    ))
-                },
-                None => match value.find("filename*=UTF-8''") {
-                    Some(index) => {
-                        let start = index + "filename*=UTF-8''".len();
-                        Ok(Some(
-                            value.get(start..).unwrap().trim_matches('\"').to_owned(),
-                        ))
-                    },
-                    None => Ok(None),
-                },
-            },
-            false => Ok(None),
-        },
-        Err(err) => Err(Error::ToStr(err)),
-    }
-}
-
-/// Generate a valid multipart boundary, statistically unlikely to be found within
-/// the content of the parts.
-pub fn generate_boundary() -> Vec<u8> {
-    TextNonce::sized(68)
-        .unwrap()
-        .into_string()
-        .into_bytes()
-        .iter()
-        .map(|&ch| {
-            if ch == b'=' {
-                b'-'
-            } else if ch == b'/' {
-                b'.'
-            } else {
-                ch
-            }
-        })
-        .collect()
-}
-
-// Convenience method, like write_all(), but returns the count of bytes written.
-trait WriteAllCount {
-    fn write_all_count(&mut self, buf: &[u8]) -> std::io::Result<usize>;
-}
-impl<T: Write> WriteAllCount for T {
-    fn write_all_count(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.write_all(buf)?;
-        Ok(buf.len())
-    }
-}
-
-/// Stream a multipart body to the output `stream` given, made up of the `parts`
-/// given.  Top-level headers are NOT included in this stream; the caller must send
-/// those prior to calling write_multipart().
-/// Returns the number of bytes written, or an error.
-pub fn write_multipart<S: Write>(
-    stream: &mut S,
-    boundary: &[u8],
-    nodes: &Vec<Node>,
-) -> Result<usize, Error> {
-    let mut count: usize = 0;
-
-    for node in nodes {
-        // write a boundary
-        count += stream.write_all_count(b"--")?;
-        count += stream.write_all_count(boundary)?;
-        count += stream.write_all_count(b"\r\n")?;
-
-        match *node {
-            Node::Part(ref part) => {
-                // write the part's headers
-                for header in part.headers.iter() {
-                    count += stream.write_all_count(header.0.as_str().as_bytes())?;
-                    count += stream.write_all_count(b": ")?;
-                    count += stream.write_all_count(header.1.as_bytes())?;
-                    count += stream.write_all_count(b"\r\n")?;
-                }
-
-                // write the blank line
-                count += stream.write_all_count(b"\r\n")?;
-
-                // Write the part's content
-                count += stream.write_all_count(&part.body)?;
-            },
-            Node::File(ref filepart) => {
-                // write the part's headers
-                for header in filepart.headers.iter() {
-                    count += stream.write_all_count(header.0.as_str().as_bytes())?;
-                    count += stream.write_all_count(b": ")?;
-                    count += stream.write_all_count(header.1.as_bytes())?;
-                    count += stream.write_all_count(b"\r\n")?;
-                }
-
-                // write the blank line
-                count += stream.write_all_count(b"\r\n")?;
-
-                // Write out the files's content
-                let mut file = File::open(&filepart.path)?;
-                count += std::io::copy(&mut file, stream)? as usize;
-            },
-            Node::Multipart((ref headers, ref subnodes)) => {
-                // Get boundary
-                let boundary = get_multipart_boundary(headers)?;
-
-                // write the multipart headers
-                for header in headers.iter() {
-                    count += stream.write_all_count(header.0.as_str().as_bytes())?;
-                    count += stream.write_all_count(b": ")?;
-                    count += stream.write_all_count(header.1.as_bytes())?;
-                    count += stream.write_all_count(b"\r\n")?;
-                }
-
-                // write the blank line
-                count += stream.write_all_count(b"\r\n")?;
-
-                // Recurse
-                count += write_multipart(stream, &boundary, subnodes)?;
-            },
-        }
-
-        // write a line terminator
-        count += stream.write_all_count(b"\r\n")?;
-    }
-
-    // write a final boundary
-    count += stream.write_all_count(b"--")?;
-    count += stream.write_all_count(boundary)?;
-    count += stream.write_all_count(b"--")?;
-
-    Ok(count)
-}
-
-pub fn write_chunk<S: Write>(stream: &mut S, chunk: &[u8]) -> Result<(), ::std::io::Error> {
-    write!(stream, "{:x}\r\n", chunk.len())?;
-    stream.write_all(chunk)?;
-    stream.write_all(b"\r\n")?;
-    Ok(())
-}
-
-/// Stream a multipart body to the output `stream` given, made up of the `parts`
-/// given, using Tranfer-Encoding: Chunked.  Top-level headers are NOT included in this
-/// stream; the caller must send those prior to calling write_multipart_chunked().
-pub fn write_multipart_chunked<S: Write>(
-    stream: &mut S,
-    boundary: &[u8],
-    nodes: &Vec<Node>,
-) -> Result<(), Error> {
-    for node in nodes {
-        // write a boundary
-        write_chunk(stream, b"--")?;
-        write_chunk(stream, boundary)?;
-        write_chunk(stream, b"\r\n")?;
-
-        match *node {
-            Node::Part(ref part) => {
-                // write the part's headers
-                for header in part.headers.iter() {
-                    write_chunk(stream, header.0.as_str().as_bytes())?;
-                    write_chunk(stream, b": ")?;
-                    write_chunk(stream, header.1.as_bytes())?;
-                    write_chunk(stream, b"\r\n")?;
-                }
-
-                // write the blank line
-                write_chunk(stream, b"\r\n")?;
-
-                // Write the part's content
-                write_chunk(stream, &part.body)?;
-            },
-            Node::File(ref filepart) => {
-                // write the part's headers
-                for header in filepart.headers.iter() {
-                    write_chunk(stream, header.0.as_str().as_bytes())?;
-                    write_chunk(stream, b": ")?;
-                    write_chunk(stream, header.1.as_bytes())?;
-                    write_chunk(stream, b"\r\n")?;
-                }
-
-                // write the blank line
-                write_chunk(stream, b"\r\n")?;
-
-                // Write out the files's length
-                let metadata = std::fs::metadata(&filepart.path)?;
-                write!(stream, "{:x}\r\n", metadata.len())?;
-
-                // Write out the file's content
-                let mut file = File::open(&filepart.path)?;
-                std::io::copy(&mut file, stream)?;
-                stream.write_all(b"\r\n")?;
-            },
-            Node::Multipart((ref headers, ref subnodes)) => {
-                // Get boundary
-                let boundary = get_multipart_boundary(headers)?;
-
-                // write the multipart headers
-                for header in headers.iter() {
-                    write_chunk(stream, header.0.as_str().as_bytes())?;
-                    write_chunk(stream, b": ")?;
-                    write_chunk(stream, header.1.as_bytes())?;
-                    write_chunk(stream, b"\r\n")?;
-                }
-
-                // write the blank line
-                write_chunk(stream, b"\r\n")?;
-
-                // Recurse
-                write_multipart_chunked(stream, &boundary, subnodes)?;
-            },
-        }
-
-        // write a line terminator
-        write_chunk(stream, b"\r\n")?;
-    }
-
-    // write a final boundary
-    write_chunk(stream, b"--")?;
-    write_chunk(stream, boundary)?;
-    write_chunk(stream, b"--")?;
-
-    // Write an empty chunk to signal the end of the body
-    write_chunk(stream, b"")?;
-
-    Ok(())
 }

--- a/components/script/mime_multipart.rs
+++ b/components/script/mime_multipart.rs
@@ -148,7 +148,7 @@ pub struct Part {
 
 /// A file that is to be inserted into a `multipart/*` or alternatively an uploaded file that
 /// was received as part of `multipart/*` parsing.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct FilePart {
     /// The headers of the part
     pub headers: HeaderMap,
@@ -194,7 +194,7 @@ impl Drop for FilePart {
 
 /// A multipart part which could be either a file, in memory, or another multipart
 /// container containing nested parts.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub enum Node {
     /// A part in memory
     Part(Part),

--- a/components/script/mime_multipart.rs
+++ b/components/script/mime_multipart.rs
@@ -169,7 +169,7 @@ impl FilePart {
         let mut path = tempfile::Builder::new()
             .prefix("mime_multipart")
             .tempdir()?
-            .into_path();
+            .keep();
         let tempdir = Some(path.clone());
         path.push(TextNonce::sized_urlsafe(32).unwrap().into_string());
         Ok(FilePart {

--- a/deny.toml
+++ b/deny.toml
@@ -97,8 +97,6 @@ skip = [
     "bitflags",
     "cookie",
     "redox_syscall",
-    # Duplicated by getrandom 0.1 and getrandom 0.2
-    "wasi",
 
     # New versions of these dependencies is pulled in by GStreamer / GLib.
     "itertools",
@@ -127,9 +125,6 @@ skip = [
 
     # wgpu has the latest and greatest.
     "windows-core",
-
-    # rust-content-security-policy uses newest base64.
-    "base64",
 
     # Duplicated by gilrs.
     "core-foundation",


### PR DESCRIPTION
The commits should be reviewed individually.
`mime-multipart` is not actively maintained and we are already using a fork thats also not maintained.
We only use a subset of the crate, and the not maintained part is causing us issues with duplicate dependencies. 
This PR: 

- Vendor the library. The original license / copyright is preserved. We license the code and our changes as MPL-2.0 (which is compatible with the original license. 
- Delete the parts of the library we don't use (commit 2)
- Remove the `textnonce` dependency. It pulled in old versions of rand and base64. But we don't actually need it, since we already get a unique temporary file. Cleans up two duplicates.
- Fix `FilePart` Clone hazard. The Drop impl deletes the file and directory, which means Clone doesn't make sense.

Testing: Covered by existing tests, no behavior change.
Fixes: #44788
