### PR TITLE
layout_api: Fix build error for Production

### DIFF
--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -68,6 +68,7 @@ use style::selector_parser::{PseudoElement, RestyleDamage, Snapshot};
 use style::str::char_is_whitespace;
 use style::stylesheets::{DocumentStyleSheet, Stylesheet};
 use style::stylist::Stylist;
+#[cfg(debug_assertions)]
 use style::thread_state::{self, ThreadState};
 use style::values::computed::Overflow;
 use style_traits::CSSPixel;


### PR DESCRIPTION
We now treat compilation warning as error for most platforms since 75251444048784cbe07fc6e8d62d395dc6295e51.
That caused build error for Mac, Linux, Win Production, and therefore missing nightly builds.
Here we fix the build error for production.

Testing: No error in production.
Fixes: #44824