### PR TITLE
script: Treat GPUAdapter as a set instead of a map.

### DIFF
--- a/components/script/dom/webgpu/gpuadapter.rs
+++ b/components/script/dom/webgpu/gpuadapter.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 use dom_struct::dom_struct;
 use js::jsapi::{HandleObject, Heap, JSObject};
 use script_bindings::cformat;
-use script_bindings::like::Maplike;
+use script_bindings::like::Setlike;
 use script_bindings::reflector::{Reflector, reflect_dom_object};
 use webgpu_traits::{
     RequestDeviceError, WebGPU, WebGPUAdapter, WebGPUDeviceResponse, WebGPURequest,


### PR DESCRIPTION
This fixes a regression from 474ee1726ce7df3c2314051264ab3c8612c076ad, which replaced the Setlike import with Maplike. The Maplike implementation for types that implement Setlike is mostly stubbed out.

Testing: Fixes panics in webgpu tests, but those results weren't updated after the regressing change so there's no visible change in results.
Fixes: #44819
