### PR TITLE
webgpu: fixup GPUBuffer unmap

### DIFF
--- a/components/script/dom/webgpu/gpubuffer.rs
+++ b/components/script/dom/webgpu/gpubuffer.rs
@@ -196,7 +196,6 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
         let promise = self.pending_map.borrow_mut().take();
         if let Some(promise) = promise {
             promise.reject_error(Error::Abort(None), CanGc::deprecated_note());
-            *self.pending_map.borrow_mut() = Some(promise);
         }
         // Step 2
         let mut mapping = self.mapping.borrow_mut().take();

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_colorspace_rgba16float.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_colorspace_rgba16float.https.html.ini
@@ -1,3 +1,3 @@
 [canvas_colorspace_rgba16float.https.html]
   expected:
-    if os == "linux" and not debug: PASS
+    if os == "linux" and not debug: FAIL

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/resize_observer.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/resize_observer.https.html.ini
@@ -1,3 +1,3 @@
 [resize_observer.https.html]
   expected:
-    if os == "linux" and not debug: TIMEOUT
+    if os == "linux" and not debug: FAIL


### PR DESCRIPTION
This was regression from #42050. We should not return promise back, original code did take the promise out.

Second commit updates the rest of the expectations based on the results from run https://github.com/servo/servo/actions/runs/25619258199

Testing: Tests now pass
