### PR TITLE
fonts: Fix potential UB in is_rtl()

### DIFF
--- a/components/fonts/shapers/harfbuzz.rs
+++ b/components/fonts/shapers/harfbuzz.rs
@@ -148,6 +148,9 @@ impl GlyphShapingResult for HarfbuzzGlyphShapingResult {
     }
 
     fn is_rtl(&self) -> bool {
+        if self.count == 0 {
+            return false;
+        }
         unsafe {
             let first_glyph_info = self.glyph_infos.add(0);
             let last_glyph_info = self.glyph_infos.add(self.count - 1);

--- a/components/fonts/shapers/harfbuzz.rs
+++ b/components/fonts/shapers/harfbuzz.rs
@@ -151,6 +151,9 @@ impl GlyphShapingResult for HarfbuzzGlyphShapingResult {
         if self.count == 0 {
             return false;
         }
+        // SAFETY: We assume self.glyph_infos is a valid non-zero ptr
+        // to an array of self.count items. We checked self.count != 0
+        // and hence both calculated pointers are within the bounds.
         unsafe {
             let first_glyph_info = self.glyph_infos.add(0);
             let last_glyph_info = self.glyph_infos.add(self.count - 1);


### PR DESCRIPTION
If count is 0, self.count - 1 would underflow in release mode, leading to immediate UB when using ptr::add().
Since is_rtl() is a safe function, we can't omit the test. It might be better to change the field to a NonZeroUsize if thats possible, but that would be a larger change.

Testing: No behavior change is expected in existing tests, since they would have panicked in CI due to underflow.

