### PR TITLE
script: Pass `responseEnd` to document and expose it to PerformanceMark

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -501,6 +501,9 @@ pub(crate) struct Document {
     /// <https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-secureconnectionstart>
     #[no_trace]
     secure_connection_start: Cell<Option<CrossProcessInstant>>,
+    /// <https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-responseend>
+    #[no_trace]
+    response_end: Cell<Option<CrossProcessInstant>>,
     /// Number of outstanding requests to prevent JS or layout from running.
     script_and_layout_blockers: Cell<u32>,
     /// List of tasks to execute as soon as last script/layout blocker is removed.
@@ -3648,6 +3651,7 @@ impl Document {
             redirect_start: Cell::new(None),
             redirect_end: Cell::new(None),
             secure_connection_start: Cell::new(None),
+            response_end: Cell::new(None),
             completely_loaded: Cell::new(false),
             script_and_layout_blockers: Cell::new(0),
             delayed_tasks: Default::default(),
@@ -3926,6 +3930,14 @@ impl Document {
 
     pub(crate) fn set_secure_connection_start(&self, time: Option<CrossProcessInstant>) {
         self.secure_connection_start.set(time)
+    }
+
+    pub(crate) fn get_response_end(&self) -> Option<CrossProcessInstant> {
+        self.response_end.get()
+    }
+
+    pub(crate) fn set_response_end(&self, time: Option<CrossProcessInstant>) {
+        self.response_end.set(time)
     }
 
     pub(crate) fn elements_by_name_count(&self, name: &DOMString) -> u32 {

--- a/components/script/dom/performance/performance.rs
+++ b/components/script/dom/performance/performance.rs
@@ -511,6 +511,7 @@ impl Performance {
             "redirectStart" => document.get_redirect_start(),
             "redirectEnd" => document.get_redirect_end(),
             "secureConnectionStart" => document.get_secure_connection_start(),
+            "responseEnd" => document.get_response_end(),
             other => {
                 if cfg!(debug_assertions) {
                     unreachable!("{other:?} is not the name of a timestamp");
@@ -553,7 +554,8 @@ impl Performance {
                         "loadEventEnd" |
                         "redirectStart" |
                         "redirectEnd" |
-                        "secureConnectionStart"
+                        "secureConnectionStart" |
+                        "responseEnd"
                 ) {
                     self.convert_a_name_to_a_timestamp(&name.str())
                 }

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1570,6 +1570,7 @@ impl FetchResponseListener for ParserContext {
             parser
                 .document
                 .set_secure_connection_start(timing.secure_connection_start);
+            parser.document.set_response_end(timing.response_end);
         }
 
         parser.last_chunk_received.set(true);

--- a/tests/wpt/meta/user-timing/measure_exceptions_navigation_timing.html.ini
+++ b/tests/wpt/meta/user-timing/measure_exceptions_navigation_timing.html.ini
@@ -1,3 +1,0 @@
-[measure_exceptions_navigation_timing.html]
-  [window.performance.measure("measure", "loadEventEnd", "responseEnd"), where "loadEventEnd" is a navigation timing attribute with a value of 0, throws a InvalidAccessError exception.]
-    expected: FAIL

--- a/tests/wpt/meta/user-timing/measure_navigation_timing.html.ini
+++ b/tests/wpt/meta/user-timing/measure_navigation_timing.html.ini
@@ -1,5 +1,4 @@
 [measure_navigation_timing.html]
-  expected: ERROR
   [window.performance.getEntriesByName("measure_nav_start_no_end")[0\].startTime is correct]
     expected: FAIL
 


### PR DESCRIPTION
Pass `responseEnd` to document and expose it to PerformanceMark

Testing: More WPT tests Passed
