### PR TITLE
Fix and enable doctests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -181,7 +181,9 @@ jobs:
         env:
           NEXTEST_RETRIES: 2 # https://github.com/servo/servo/issues/30683
           LANG: en-US
-        run: ./mach test-unit --profile ${{ inputs.profile }} --nextest-profile ci
+        run: |
+          ./mach test-unit --profile ${{ inputs.profile }} --nextest-profile ci
+          ./mach test-unit --profile ${{ inputs.profile }} --doc
       # We upload the test-results to Codecov to help us identify flaky unit-tests.
       - name: Upload test results to Codecov
         # Upload test results to Codecov, also for failed unit-tests, but only

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8043,10 +8043,12 @@ dependencies = [
  "headers",
  "http 1.4.0",
  "hyper",
+ "ipc-channel",
  "mime",
  "serde",
  "serde_bytes",
  "serde_core",
+ "serde_json",
  "serde_test",
 ]
 

--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -948,7 +948,7 @@ pub struct FontBaseline {
 /// by creating an array as below. Values that fall between two mapped
 /// values, will be adjusted by the weighted mean.
 ///
-/// ```rust
+/// ```ignore
 /// let mapping = [
 ///     (0., 0.),
 ///     (FC_WEIGHT_REGULAR as f64, 400 as f64),

--- a/components/hyper_serde/Cargo.toml
+++ b/components/hyper_serde/Cargo.toml
@@ -25,5 +25,7 @@ serde_bytes = { workspace = true }
 serde_core = { workspace = true }
 
 [dev-dependencies]
+ipc-channel = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 serde_test = "1.0"

--- a/components/hyper_serde/lib.rs
+++ b/components/hyper_serde/lib.rs
@@ -26,10 +26,11 @@
 //! Use the serde attributes `deserialize_with` and `serialize_with`.
 //!
 //! ```
+//! #[derive(serde::Deserialize, serde::Serialize)]
 //! struct MyStruct {
-//! #[serde(deserialize_with = "hyper_serde::deserialize",
-//! serialize_with = "hyper_serde::serialize")]
-//! headers: HeaderMap,
+//!     #[serde(deserialize_with = "servo_hyper_serde::deserialize",
+//!             serialize_with = "servo_hyper_serde::serialize")]
+//!     headers: http::header::HeaderMap,
 //! }
 //! ```
 //!
@@ -38,15 +39,19 @@
 //! Use the `Ser` wrapper.
 //!
 //! ```
-//! serde_json::to_string(&Ser::new(&headers))
+//! use servo_hyper_serde::Ser;
+//! let headers = http::header::HeaderMap::new();
+//! serde_json::to_string(&Ser::new(&headers));
 //! ```
 //!
-//! # How do I decode a `Method` value with `serde_json::parse`?
+//! # How do I decode a `Method` value with `serde_json::from_str`?
 //!
 //! Use the `De` wrapper.
 //!
 //! ```
-//! serde_json::parse::<De<Method>>("\"PUT\"").map(De::into_inner)
+//! use servo_hyper_serde::De;
+//! use hyper::Method;
+//! serde_json::from_str::<De<Method>>("\"PUT\"").map(De::into_inner);
 //! ```
 //!
 //! # How do I send `Cookie` values as part of an IPC channel?
@@ -55,7 +60,9 @@
 //! convenience.
 //!
 //! ```
-//! ipc::channel::<Serde<Cookie>>()
+//! use servo_hyper_serde::Serde;
+//! use cookie::Cookie;
+//! ipc_channel::ipc::channel::<Serde<Cookie>>();
 //! ```
 //!
 //!

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -966,7 +966,7 @@ pub trait WebViewDelegate {
     /// ignored, no new `WebView` will be opened. Embedders can handle this method by
     /// using the provided [`CreateNewWebViewRequest`] to build a new `WebView`.
     ///
-    /// ```rust
+    /// ```ignore
     /// fn request_create_new(&self, parent_webview: WebView, request: CreateNewWebViewRequest) {
     ///     let webview = request
     ///         .builder(self.rendering_context())

--- a/components/shared/base/generic_channel/generic_channelset.rs
+++ b/components/shared/base/generic_channel/generic_channelset.rs
@@ -9,21 +9,21 @@ use crate::generic_channel::{GenericReceiver, GenericReceiverVariants, use_ipc};
 /// A GenericReceiverSet. Allows you to wait on multiple GenericReceivers.
 /// Automatically selects either Ipc or crossbeam depending on multiprocess mode.
 /// # Examples
-/// ```
-/// # let mut rx_set = GenericReceiverSet::new();
-/// # let private_channel = generic_channel::channel().unwrap();
-/// # let public_channel = generic_channel::channel().unwrap();
-/// # let reporter_channel = generic_channel::channel().unwrap();
-/// # let private_id = rx_set.add(private_receiver);
-/// # let public_id = rx_set.add(public_receiver);
-/// # let reporter_id = rx_set.add(memory_reporter);
-/// # for received in rx_set.select().into_iter() {
-/// #     match received {
-/// #         GenericSelectionResult::ChannelClosed(_) => continue,
-/// #         GenericSelectionResult::Error => println!("Found selection error"),
-/// #         GenericSelectionResult::MessageReceived(id, msg) => {
-/// #     }
-/// # }
+/// ```ignore
+/// let mut rx_set = GenericReceiverSet::new();
+/// let private_channel = generic_channel::channel().unwrap();
+/// let public_channel = generic_channel::channel().unwrap();
+/// let reporter_channel = generic_channel::channel().unwrap();
+/// let private_id = rx_set.add(private_receiver);
+/// let public_id = rx_set.add(public_receiver);
+/// let reporter_id = rx_set.add(memory_reporter);
+/// for received in rx_set.select().into_iter() {
+///     match received {
+///         GenericSelectionResult::ChannelClosed(_) => continue,
+///         GenericSelectionResult::Error => println!("Found selection error"),
+///         GenericSelectionResult::MessageReceived(id, msg) => { /*...*/ }
+///     }
+/// }
 /// ```
 pub struct GenericReceiverSet<T: Serialize + for<'de> Deserialize<'de>>(
     GenericReceiverSetVariants<T>,

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -233,15 +233,17 @@ class MachCommands(CommandBase):
             return 0
 
         args: list[str] = params or []
+        use_nextest = "--doc" not in args
 
         if build_type.is_release():
             args += ["--release"]
         elif build_type.is_dev():
             pass  # there is no argument for debug
         else:
-            args += ["--cargo-profile", build_type.profile]
+            cargo_profile_arg = "--cargo-profile" if use_nextest else "--profile"
+            args += [cargo_profile_arg, build_type.profile]
 
-        if nextest_profile is not None:
+        if use_nextest and nextest_profile is not None:
             args += ["--profile", nextest_profile]
 
         for crate in packages:
@@ -266,16 +268,25 @@ class MachCommands(CommandBase):
                 )
                 exit(1)
         elif code_coverage:
+            if not use_nextest:
+                print(
+                    "Error: Invalid argument combination for `./mach test-unit`. "
+                    "`--doc` and `--code-coverage` are mutually exclusive."
+                )
+                exit(1)
             cargo_llvm_cov_options: List[str] = llvm_cov_option or []
             crown_cargo_command.extend(["llvm-cov", "nextest"])
             crown_cargo_command.extend(cargo_llvm_cov_options)
             cargo_command = "llvm-cov"
             args.insert(0, "nextest")
             args.extend(cargo_llvm_cov_options)
-        else:
+        elif use_nextest:
             crown_cargo_command.extend(["nextest", "run"])
             cargo_command = "nextest"
             args.insert(0, "run")
+        else:
+            crown_cargo_command.extend(["test"])
+            cargo_command = "test"
         result = call(crown_cargo_command, cwd="support/crown")
         if result != 0:
             return result


### PR DESCRIPTION
Following up on https://github.com/servo/servo/pull/44808#discussion_r3212936727: the repository contain some doctests but CI hasn’t been running since https://github.com/servo/servo/pull/39812 replaced `cargo test` with `nextest` 7 months ago.

[cargo-nextest does not support doctests](https://github.com/nextest-rs/nextest/issues/16) and recommends to also run `cargo test --doc`. This PR changes:

* `./mach test-unit` without `--doc` runs `cargo nextest run` as before
* `./mach test-unit --doc` to run `cargo test --doc` instead
* CI for Linux runs both. (Should CI for Windows and macOS do so as well?)
* Fixes failing doctests, and ignores code samples in docs that were run as doctest but apparently not intended to

On my laptop, `./mach test-unit --doc` completes in under 10 seconds when run immediately after `./mach test-unit`, so CI cycle time shouldn’t be impacted much.

Testing: this fixes and re-enables some existing tests
