### PR TITLE
net: drop `HttpsState`

### DIFF
--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -20,7 +20,7 @@ use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use malloc_size_of_derive::MallocSizeOf;
 use net_traits::http_status::HttpStatus;
 use net_traits::request::Request;
-use net_traits::response::{HttpsState, Response, ResponseBody};
+use net_traits::response::{Response, ResponseBody};
 use net_traits::{CacheEntryDescriptor, FetchMetadata, Metadata, ResourceFetchTiming};
 use parking_lot::Mutex as ParkingLotMutex;
 use quick_cache::sync::{Cache, DefaultLifecycle, PlaceholderGuard};
@@ -66,7 +66,6 @@ pub struct CachedResource {
     awaiting_body: Arc<ParkingLotMutex<Vec<TokioSender<Data>>>>,
     metadata: CachedMetadata,
     location_url: Option<Result<ServoUrl, String>>,
-    https_state: HttpsState,
     status: HttpStatus,
     url_list: Vec<ServoUrl>,
     expires: Duration,
@@ -314,7 +313,6 @@ fn create_cached_response(
         .clone_from(&cached_resource.location_url);
     response.status.clone_from(&cached_resource.status);
     response.url_list.clone_from(&cached_resource.url_list);
-    response.https_state = cached_resource.https_state;
     response.referrer = request.referrer.to_url().cloned();
     response.referrer_policy = request.referrer_policy;
     response.aborted = cached_resource.aborted.clone();
@@ -347,7 +345,6 @@ fn create_resource_with_bytes_from_resource(
         awaiting_body: Arc::new(ParkingLotMutex::new(vec![])),
         metadata: resource.metadata.clone(),
         location_url: resource.location_url.clone(),
-        https_state: resource.https_state,
         status: StatusCode::PARTIAL_CONTENT.into(),
         url_list: resource.url_list.clone(),
         expires: resource.expires,
@@ -675,7 +672,6 @@ pub fn refresh(
         constructed_response
             .status
             .clone_from(&cached_resource.status);
-        constructed_response.https_state = cached_resource.https_state;
         constructed_response.referrer = request.referrer.to_url().cloned();
         constructed_response.referrer_policy = request.referrer_policy;
         constructed_response
@@ -886,7 +882,6 @@ impl<'a> CachedResourcesOrGuard<'a> {
             awaiting_body: Arc::new(ParkingLotMutex::new(vec![])),
             metadata: cacheable_metadata,
             location_url: response.location_url.clone(),
-            https_state: response.https_state,
             status: response.status.clone(),
             url_list: response.url_list.clone(),
             expires: expiry,

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -49,9 +49,7 @@ use net_traits::request::{
     is_cors_non_wildcard_request_header_name, is_cors_safelisted_method,
     is_cors_safelisted_request_header,
 };
-use net_traits::response::{
-    CacheState, HttpsState, RedirectTaint, Response, ResponseBody, ResponseType,
-};
+use net_traits::response::{CacheState, RedirectTaint, Response, ResponseBody, ResponseType};
 use net_traits::{
     CookieSource, DOCUMENT_ACCEPT_HEADER_VALUE, NetworkError, RedirectEndValue, RedirectStartValue,
     ReferrerPolicy, ResourceAttribute, ResourceFetchTimingContainer, ResourceTimeValue,
@@ -2260,11 +2258,6 @@ async fn http_network_fetch(
     // Substep 1
 
     // Substep 2
-
-    response.https_state = match url.scheme() {
-        "https" => HttpsState::Modern,
-        _ => HttpsState::None,
-    };
 
     // TODO Read request
 

--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -13,7 +13,6 @@ use embedder_traits::resources::{self, Resource};
 use js::context::JSContext;
 use js::rust::wrappers2::JS_DefineDebuggerObject;
 use net_traits::ResourceThreads;
-use net_traits::response::HttpsState;
 use profile_traits::{mem, time};
 use script_bindings::reflector::DomObject;
 use servo_base::generic_channel::{GenericCallback, GenericSender, channel};
@@ -118,7 +117,6 @@ impl DebuggerGlobalScope {
                 None,
                 false,
                 None, // font_context
-                HttpsState::None,
             ),
             devtools_to_script_sender,
             get_possible_breakpoints_result_sender: RefCell::new(None),

--- a/components/script/dom/dissimilaroriginwindow.rs
+++ b/components/script/dom/dissimilaroriginwindow.rs
@@ -7,7 +7,6 @@ use js::context::JSContext;
 use js::jsapi::{Heap, JSObject};
 use js::jsval::UndefinedValue;
 use js::rust::{CustomAutoRooter, CustomAutoRooterGuard, HandleValue, MutableHandleValue};
-use net_traits::response::HttpsState;
 use servo_base::id::PipelineId;
 use servo_constellation_traits::{
     RemoteFocusOperation, ScriptToConstellationMessage, StructuredSerializedData,
@@ -72,7 +71,6 @@ impl DissimilarOriginWindow {
                 Some(global_to_clone_from.is_secure_context()),
                 false,
                 global_to_clone_from.font_context().cloned(),
-                HttpsState::None,
             ),
             window_proxy: Dom::from_ref(window_proxy),
             location: Default::default(),

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -47,7 +47,6 @@ use net_traits::policy_container::{PolicyContainer, RequestPolicyContainer};
 use net_traits::request::{
     InsecureRequestsPolicy, Origin as RequestOrigin, Referrer, RequestBuilder, RequestClient,
 };
-use net_traits::response::HttpsState;
 use net_traits::{
     CoreResourceMsg, CoreResourceThread, ReferrerPolicy, ResourceThreads, fetch_async,
 };
@@ -356,10 +355,6 @@ pub(crate) struct GlobalScope {
     // https://w3c.github.io/performance-timeline/#supportedentrytypes-attribute
     #[ignore_malloc_size_of = "mozjs"]
     frozen_supported_performance_entry_types: CachedFrozenArray,
-
-    /// currect https state (from previous request)
-    #[no_trace]
-    https_state: Cell<HttpsState>,
 
     /// The stack of active group labels for the Console APIs.
     console_group_stack: DomRefCell<Vec<DOMString>>,
@@ -776,7 +771,6 @@ impl GlobalScope {
         inherited_secure_context: Option<bool>,
         unminify_js: bool,
         font_context: Option<Arc<FontContext>>,
-        initial_https_state: HttpsState,
     ) -> Self {
         Self {
             task_manager: Default::default(),
@@ -815,7 +809,6 @@ impl GlobalScope {
             #[cfg(feature = "webgpu")]
             gpu_devices: DomRefCell::new(HashMapTracedValues::new_fx()),
             frozen_supported_performance_entry_types: CachedFrozenArray::new(),
-            https_state: Cell::new(initial_https_state),
             console_group_stack: DomRefCell::new(Vec::new()),
             console_count_map: Default::default(),
             inherited_secure_context,
@@ -3152,14 +3145,6 @@ impl GlobalScope {
             retval,
             can_gc,
         );
-    }
-
-    pub(crate) fn get_https_state(&self) -> HttpsState {
-        self.https_state.get()
-    }
-
-    pub(crate) fn set_https_state(&self, https_state: HttpsState) {
-        self.https_state.set(https_state);
     }
 
     pub(crate) fn inherited_secure_context(&self) -> Option<bool> {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -57,7 +57,6 @@ use net_traits::image_cache::{
     ImageResponse, PendingImageId, PendingImageResponse, RasterizationCompleteResponse,
 };
 use net_traits::request::Referrer;
-use net_traits::response::HttpsState;
 use net_traits::{ResourceFetchTiming, ResourceThreads};
 use num_traits::ToPrimitive;
 use paint_api::{CrossProcessPaintApi, PinchZoomInfos};
@@ -3686,7 +3685,6 @@ impl Window {
         inherited_secure_context: Option<bool>,
         theme: Theme,
         weak_script_thread: Weak<ScriptThread>,
-        initial_https_state: HttpsState,
     ) -> DomRoot<Self> {
         let error_reporter = CSSErrorReporter {
             pipelineid: pipeline_id,
@@ -3712,7 +3710,6 @@ impl Window {
                 inherited_secure_context,
                 unminify_js,
                 Some(font_context),
-                initial_https_state,
             ),
             ongoing_navigation: Default::default(),
             script_chan,

--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -386,7 +386,6 @@ impl DedicatedWorkerGlobalScope {
         let origin = current_global.origin().immutable().clone();
         let referrer = current_global.get_referrer();
         let parent = current_global.runtime_handle();
-        let current_global_https_state = current_global.get_https_state();
         let current_global_ancestor_trustworthy = current_global.has_trustworthy_ancestor_origin();
         let is_secure_context = current_global.is_secure_context();
         let is_nested_browsing_context = current_global.is_nested_browsing_context();
@@ -510,7 +509,6 @@ impl DedicatedWorkerGlobalScope {
                     client: request_client,
                     pipeline_id,
                     origin,
-                    https_state: current_global_https_state,
                 };
 
                 // Step 12. Obtain script by switching on options["type"]:
@@ -802,7 +800,6 @@ fn fetch_a_classic_worker_script(
         .client(fetch_client.client)
         .pipeline_id(Some(fetch_client.pipeline_id))
         .origin(fetch_client.origin)
-        .https_state(fetch_client.https_state)
         // destination is destination,
         .destination(destination)
         // TODO initiator type is "other",

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -24,7 +24,6 @@ use net_traits::policy_container::PolicyContainer;
 use net_traits::request::{
     CredentialsMode, Destination, InsecureRequestsPolicy, ParserMetadata, RequestBuilder, RequestId,
 };
-use net_traits::response::HttpsState;
 use net_traits::{FetchMetadata, Metadata, NetworkError, ReferrerPolicy, ResourceFetchTiming};
 use profile_traits::mem::{ProcessReports, perform_memory_report};
 use script_bindings::cell::{DomRefCell, Ref};
@@ -373,7 +372,6 @@ impl WorkerGlobalScope {
                 init.inherited_secure_context,
                 init.unminify_js,
                 font_context,
-                HttpsState::None,
             ),
             microtask_queue: runtime.microtask_queue.clone(),
             worker_id: init.worker_id,
@@ -654,7 +652,6 @@ impl WorkerGlobalScope {
             &metadata.final_url.clone(),
             &metadata.headers,
         ));
-        self.globalscope.set_https_state(metadata.https_state);
     }
 }
 

--- a/components/script/dom/workletglobalscope.rs
+++ b/components/script/dom/workletglobalscope.rs
@@ -12,7 +12,6 @@ use embedder_traits::{JavaScriptEvaluationError, ScriptToEmbedderChan};
 use js::context::JSContext;
 use net_traits::ResourceThreads;
 use net_traits::image_cache::ImageCache;
-use net_traits::response::HttpsState;
 use profile_traits::{mem, time};
 use script_traits::Painter;
 use servo_base::generic_channel::{GenericCallback, GenericSender};
@@ -125,7 +124,6 @@ impl WorkletGlobalScope {
                 inherited_secure_context,
                 false,
                 None, // font_context
-                HttpsState::None,
             ),
             base_url,
             to_script_thread_sender: init.to_script_thread_sender.clone(),

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -170,7 +170,6 @@ fn request_init_from_request(request: NetTraitsRequest, global: &GlobalScope) ->
     .client(global.request_client())
     .insecure_requests_policy(request.insecure_requests_policy)
     .has_trustworthy_ancestor_origin(request.has_trustworthy_ancestor_origin)
-    .https_state(request.https_state)
     .response_tainting(request.response_tainting);
     builder.id = request.id;
     builder
@@ -746,7 +745,6 @@ pub(crate) fn load_whole_resource(
     csp_violations_processor: &dyn CspViolationsProcessor,
     cx: &mut js::context::JSContext,
 ) -> Result<(Metadata, Vec<u8>, bool), NetworkError> {
-    let request = request.https_state(global.get_https_state());
     let (action_sender, action_receiver) = ipc::channel().unwrap();
     let url = request.url.url();
     core_resource_thread
@@ -798,7 +796,6 @@ impl RequestWithGlobalScope for RequestBuilder {
             .client(global.request_client())
             .pipeline_id(Some(global.pipeline_id()))
             .origin(global.origin().immutable().clone())
-            .https_state(global.get_https_state())
     }
 }
 

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -47,7 +47,6 @@ use net_traits::request::{
     CredentialsMode, Destination, InsecureRequestsPolicy, ParserMetadata, Referrer, RequestBuilder,
     RequestClient, RequestId, RequestMode,
 };
-use net_traits::response::HttpsState;
 use net_traits::{FetchMetadata, Metadata, NetworkError, ReferrerPolicy, ResourceFetchTiming};
 use script_bindings::cell::DomRefCell;
 use script_bindings::cformat;
@@ -643,7 +642,6 @@ pub(crate) struct ModuleFetchClient {
     pub client: RequestClient,
     pub pipeline_id: PipelineId,
     pub origin: ImmutableOrigin,
-    pub https_state: HttpsState,
 }
 
 impl ModuleFetchClient {
@@ -655,7 +653,6 @@ impl ModuleFetchClient {
             client: global.request_client(),
             pipeline_id: global.pipeline_id(),
             origin: global.origin().immutable().clone(),
-            https_state: global.get_https_state(),
         }
     }
 }
@@ -1598,8 +1595,7 @@ pub(crate) fn fetch_a_single_module_script(
         .policy_container(fetch_client.policy_container)
         .client(fetch_client.client)
         .pipeline_id(Some(fetch_client.pipeline_id))
-        .origin(fetch_client.origin)
-        .https_state(fetch_client.https_state);
+        .origin(fetch_client.origin);
 
         let context = ModuleContext {
             owner: Trusted::new(global),

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3441,7 +3441,6 @@ impl ScriptThread {
             incomplete.load_data.inherited_secure_context,
             incomplete.theme,
             self.this.clone(),
-            metadata.https_state,
         );
         self.debugger_global
             .fire_add_debuggee(cx, window.upcast(), incomplete.pipeline_id, None);

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -43,7 +43,7 @@ use crate::filemanager_thread::FileManagerThreadMsg;
 use crate::http_status::HttpStatus;
 use crate::mime_classifier::{ApacheBugFlag, MimeClassifier};
 use crate::request::{PreloadId, Request, RequestBuilder};
-use crate::response::{HttpsState, Response, ResponseInit};
+use crate::response::{Response, ResponseInit};
 
 pub mod blob_url_store;
 pub mod filemanager_thread;
@@ -998,9 +998,6 @@ pub struct Metadata {
     /// HTTP Status
     pub status: HttpStatus,
 
-    /// Is successful HTTPS connection
-    pub https_state: HttpsState,
-
     /// Referrer Url
     pub referrer: Option<ServoUrl>,
 
@@ -1024,7 +1021,6 @@ impl Metadata {
             charset: None,
             headers: None,
             status: HttpStatus::default(),
-            https_state: HttpsState::None,
             referrer: None,
             referrer_policy: ReferrerPolicy::EmptyString,
             timing: None,

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -27,7 +27,7 @@ use crate::blob_url_store::UrlWithBlobClaim;
 use crate::policy_container::{PolicyContainer, RequestPolicyContainer};
 use crate::pub_domains::is_same_site;
 use crate::resource_fetch_timing::ResourceTimingType;
-use crate::response::{HttpsState, RedirectTaint, Response};
+use crate::response::{RedirectTaint, Response};
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, MallocSizeOf, PartialEq, Serialize)]
 /// An id to differentiate one network request from another.
@@ -500,7 +500,6 @@ pub struct RequestBuilder {
 
     /// <https://fetch.spec.whatwg.org/#concept-request-initiator>
     pub initiator: Initiator,
-    pub https_state: HttpsState,
     pub response_tainting: ResponseTainting,
     /// Servo internal: if crash details are present, trigger a crash error page with these details.
     pub crash: Option<String>,
@@ -544,7 +543,6 @@ impl RequestBuilder {
             url_list: vec![],
             parser_metadata: ParserMetadata::Default,
             initiator: Initiator::None,
-            https_state: HttpsState::None,
             response_tainting: ResponseTainting::Basic,
             crash: None,
         }
@@ -671,11 +669,6 @@ impl RequestBuilder {
         self
     }
 
-    pub fn https_state(mut self, https_state: HttpsState) -> RequestBuilder {
-        self.https_state = https_state;
-        self
-    }
-
     pub fn response_tainting(mut self, response_tainting: ResponseTainting) -> RequestBuilder {
         self.response_tainting = response_tainting;
         self
@@ -737,7 +730,6 @@ impl RequestBuilder {
             self.referrer,
             self.pipeline_id,
             self.target_webview_id,
-            self.https_state,
         );
         request.preload_id = self.preload_id;
         request.initiator = self.initiator;
@@ -856,7 +848,6 @@ pub struct Request {
     /// <https://w3c.github.io/webappsec-upgrade-insecure-requests/#insecure-requests-policy>
     pub insecure_requests_policy: InsecureRequestsPolicy,
     pub has_trustworthy_ancestor_origin: bool,
-    pub https_state: HttpsState,
     /// Servo internal: if crash details are present, trigger a crash error page with these details.
     pub crash: Option<String>,
 }
@@ -869,7 +860,6 @@ impl Request {
         referrer: Referrer,
         pipeline_id: Option<PipelineId>,
         webview_id: Option<WebViewId>,
-        https_state: HttpsState,
     ) -> Request {
         Request {
             id,
@@ -906,7 +896,6 @@ impl Request {
             policy_container: RequestPolicyContainer::Client,
             insecure_requests_policy: InsecureRequestsPolicy::DoNotUpgrade,
             has_trustworthy_ancestor_origin: false,
-            https_state,
             crash: None,
         }
     }

--- a/components/shared/net/response.rs
+++ b/components/shared/net/response.rs
@@ -77,14 +77,6 @@ pub enum CacheState {
     Partial,
 }
 
-/// [Https state](https://fetch.spec.whatwg.org/#concept-response-https-state)
-#[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
-pub enum HttpsState {
-    None,
-    Deprecated,
-    Modern,
-}
-
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub struct ResponseInit {
     pub url: ServoUrl,
@@ -114,7 +106,6 @@ pub struct Response {
     #[conditional_malloc_size_of]
     pub body: Arc<Mutex<ResponseBody>>,
     pub cache_state: CacheState,
-    pub https_state: HttpsState,
     pub tls_security_info: Option<TlsSecurityInfo>,
     pub referrer: Option<ServoUrl>,
     /// <https://fetch.spec.whatwg.org/#response-redirect-taint>
@@ -154,7 +145,6 @@ impl Response {
             headers: HeaderMap::new(),
             body: Arc::new(Mutex::new(ResponseBody::Empty)),
             cache_state: CacheState::None,
-            https_state: HttpsState::None,
             tls_security_info: None,
             referrer: None,
             referrer_policy: ReferrerPolicy::EmptyString,
@@ -189,7 +179,6 @@ impl Response {
             headers: HeaderMap::new(),
             body: Arc::new(Mutex::new(ResponseBody::Empty)),
             cache_state: CacheState::None,
-            https_state: HttpsState::None,
             tls_security_info: None,
             referrer: None,
             referrer_policy: ReferrerPolicy::EmptyString,
@@ -328,7 +317,6 @@ impl Response {
             metadata.location_url.clone_from(&response.location_url);
             metadata.headers = Some(Serde(response.headers.clone()));
             metadata.status.clone_from(&response.status);
-            metadata.https_state = response.https_state;
             metadata.referrer.clone_from(&response.referrer);
             metadata.referrer_policy = response.referrer_policy;
             metadata.redirected = response.actual_response().url_list.len() > 1;


### PR DESCRIPTION
`HttpsState` has been removed from the specification for a while.
Following the merge of #44828, we can now remove it from the codebase as well.

Testing: It compiles
