### PR TITLE
layout: Make scrollable overflow calculation incremental

### DIFF
--- a/components/layout/fragment_tree/box_fragment.rs
+++ b/components/layout/fragment_tree/box_fragment.rs
@@ -148,10 +148,9 @@ impl BoxFragment {
         border: PhysicalSides<Au>,
         margin: PhysicalSides<Au>,
         specific_layout_info: Option<SpecificLayoutInfo>,
-    ) -> BoxFragment {
+    ) -> Self {
         let rare_data = BoxFragmentRareData::try_boxed_from(specific_layout_info);
-
-        BoxFragment {
+        Self {
             base: BaseFragment::new(base_fragment_info, style.into(), content_rect),
             children,
             cumulative_containing_block_rect: Default::default(),
@@ -263,18 +262,35 @@ impl BoxFragment {
         self
     }
 
-    /// Get the scrollable overflow for this [`BoxFragment`] relative to its
-    /// containing block.
+    /// Get the scrollable overflow for this [`BoxFragment`] relative to its containing
+    /// block, recalculating scrollable overflow when necessary, for instance after a
+    /// style change.
     pub(crate) fn scrollable_overflow(&self) -> PhysicalRect<Au> {
-        self.scrollable_overflow
-            .borrow()
-            .expect("Should only call `scrollable_overflow()` after calculating overflow")
+        *self
+            .scrollable_overflow
+            .borrow_mut()
+            .get_or_insert_with(|| self.calculate_scrollable_overflow())
+    }
+
+    /// Clear the scrollable overflow on this [`BoxFragment`]. This is called
+    /// during damage propagation when a fragment is preserved, itself or one of its
+    /// descendants has scrollable overflow damage.
+    pub(crate) fn clear_scrollable_overflow(&self) {
+        *self.scrollable_overflow.borrow_mut() = None;
     }
 
     /// This is an implementation of:
     /// - <https://drafts.csswg.org/css-overflow-3/#scrollable>.
     /// - <https://drafts.csswg.org/cssom-view/#scrolling-area>
-    pub(crate) fn calculate_scrollable_overflow(&self) {
+    fn calculate_scrollable_overflow(&self) -> PhysicalRect<Au> {
+        // Fragments with `IS_COLLAPSED` (currently only table cells that are part of
+        // table tracks with `visibility: collapse`) should not contribute to scrollable
+        // overflow. This behavior matches Chrome, but not Firefox.
+        // See https://github.com/w3c/csswg-drafts/issues/12689
+        if self.base.flags.contains(FragmentFlags::IS_COLLAPSED) {
+            return Rect::zero();
+        }
+
         let physical_padding_rect = self.padding_rect();
         let content_origin = self.base.rect().origin.to_vector();
 
@@ -306,13 +322,13 @@ impl BoxFragment {
                 .iter()
                 .fold(physical_padding_rect, |acc, child| {
                     let scrollable_overflow_from_child = child
-                        .calculate_scrollable_overflow_for_parent()
+                        .scrollable_overflow_for_parent()
                         .translate(content_origin);
 
-                    // Note that this doesn't just exclude scrollable overflow outside the
-                    // wholly unrechable scrollable overflow area, but also clips it. This
-                    // makes the resulting value more like the "scroll area" rather than the
-                    // "scrollable overflow."
+                    // Note that this doesn't just exclude the wholly unreachable
+                    // scrollable overflow area from the rectangle, but also clips it.
+                    // This makes the resulting value more like the "scroll area" rather
+                    // than the "scrollable overflow."
                     let scrollable_overflow_from_child = self
                         .clip_wholly_unreachable_scrollable_overflow(
                             scrollable_overflow_from_child,
@@ -364,17 +380,7 @@ impl BoxFragment {
                     acc.union(&padding_contribution)
                 });
         }
-
-        // Fragments with `IS_COLLAPSED` (currently only table cells that are part of
-        // table tracks with `visibility: collapse`) should not contribute to scrollable
-        // overflow. This behavior matches Chrome, but not Firefox.
-        // See https://github.com/w3c/csswg-drafts/issues/12689
-        if self.base.flags.contains(FragmentFlags::IS_COLLAPSED) {
-            *self.scrollable_overflow.borrow_mut() = Some(Rect::zero());
-            return;
-        }
-
-        *self.scrollable_overflow.borrow_mut() = Some(scrollable_overflow)
+        scrollable_overflow
     }
 
     pub(crate) fn set_containing_block(&self, containing_block: &PhysicalRect<Au>) {

--- a/components/layout/fragment_tree/fragment.rs
+++ b/components/layout/fragment_tree/fragment.rs
@@ -155,6 +155,19 @@ impl Fragment {
         }
     }
 
+    /// Clear the scrollable overflow on this [`Fragment`]. This is called during damage
+    /// propagation when a fragment is preserved, itself or one of its descendants has
+    /// scrollable overflow damage.
+    pub(crate) fn clear_scrollable_overflow(&self) {
+        match self {
+            Fragment::Box(fragment) | Fragment::Float(fragment) => {
+                fragment.clear_scrollable_overflow()
+            },
+            Fragment::Positioning(fragment) => fragment.clear_scrollable_overflow(),
+            _ => {},
+        }
+    }
+
     pub(crate) fn scrollable_overflow_for_parent(&self) -> PhysicalRect<Au> {
         match self {
             Fragment::Box(fragment) | Fragment::Float(fragment) => {
@@ -165,21 +178,6 @@ impl Fragment {
             Fragment::Text(..) |
             Fragment::Image(..) |
             Fragment::IFrame(..) => self.base().map(|base| base.rect()).unwrap_or_default(),
-        }
-    }
-
-    pub(crate) fn calculate_scrollable_overflow_for_parent(&self) -> PhysicalRect<Au> {
-        self.calculate_scrollable_overflow();
-        self.scrollable_overflow_for_parent()
-    }
-
-    pub(crate) fn calculate_scrollable_overflow(&self) {
-        match self {
-            Fragment::Box(fragment) | Fragment::Float(fragment) => {
-                fragment.calculate_scrollable_overflow()
-            },
-            Fragment::Positioning(fragment) => fragment.calculate_scrollable_overflow(),
-            _ => {},
         }
     }
 

--- a/components/layout/fragment_tree/fragment_tree.rs
+++ b/components/layout/fragment_tree/fragment_tree.rs
@@ -50,6 +50,9 @@ impl FragmentTree {
             viewport_scroll_sensitivity,
         };
 
+        // Trigger scrollable overflow calculation unconditionally when creating a new Fragment.
+        fragment_tree.scrollable_overflow();
+
         fragment_tree.find(|fragment, _level, containing_block| {
             fragment.set_containing_block(containing_block);
             None::<()>
@@ -66,27 +69,29 @@ impl FragmentTree {
     }
 
     pub(crate) fn scrollable_overflow(&self) -> PhysicalRect<Au> {
-        self.scrollable_overflow
-            .get()
-            .expect("Should only call `scrollable_overflow()` after calculating overflow")
+        if let Some(scrollable_overflow) = self.scrollable_overflow.get() {
+            return scrollable_overflow;
+        }
+        let scrollable_overflow = self.calculate_scrollable_overflow();
+        self.scrollable_overflow.set(Some(scrollable_overflow));
+        scrollable_overflow
+    }
+
+    pub(crate) fn clear_scrollable_overflow(&self) {
+        self.scrollable_overflow.set(None);
     }
 
     /// Calculate the scrollable overflow / scrolling area for this [`FragmentTree`] according
     /// to <https://drafts.csswg.org/cssom-view/#scrolling-area>.
-    pub(crate) fn calculate_scrollable_overflow(&self) {
-        let scrollable_overflow = || {
-            let Some(first_root_fragment) = self.root_fragments.first() else {
-                return self.initial_containing_block;
-            };
+    fn calculate_scrollable_overflow(&self) -> PhysicalRect<Au> {
+        let Some(first_root_fragment) = self.root_fragments.first() else {
+            return self.initial_containing_block;
+        };
 
-            let scrollable_overflow = self.root_fragments.iter().fold(
-                self.initial_containing_block,
-                |overflow, fragment| {
-                    // Need to calculate the overflow for each fragments within the tree
-                    // because it is required in the next stages of reflow.
-                    let overflow_from_fragment =
-                        fragment.calculate_scrollable_overflow_for_parent();
-
+        let scrollable_overflow =
+            self.root_fragments
+                .iter()
+                .fold(self.initial_containing_block, |overflow, fragment| {
                     // Scrollable overflow should be accumulated in the block that
                     // establishes the containing block for the element. Thus, fixed
                     // positioned fragments whose containing block is the initial
@@ -101,28 +106,24 @@ impl FragmentTree {
                         return overflow;
                     }
 
-                    overflow.union(&overflow_from_fragment)
-                },
-            );
+                    overflow.union(&fragment.scrollable_overflow_for_parent())
+                });
 
-            // Assuming that the first fragment is the root element, ensure that
-            // scrollable overflow that is unreachable is not included in the final
-            // rectangle. See
-            // <https://drafts.csswg.org/css-overflow/#scrolling-direction>.
-            let first_root_fragment = match first_root_fragment {
-                Fragment::Box(fragment) | Fragment::Float(fragment) => fragment,
-                _ => return scrollable_overflow,
-            };
-            if !first_root_fragment.is_root_element() {
-                return scrollable_overflow;
-            }
-            first_root_fragment.clip_wholly_unreachable_scrollable_overflow(
-                scrollable_overflow,
-                self.initial_containing_block,
-            )
+        // Assuming that the first fragment is the root element, ensure that
+        // scrollable overflow that is unreachable is not included in the final
+        // rectangle. See
+        // <https://drafts.csswg.org/css-overflow/#scrolling-direction>.
+        let first_root_fragment = match first_root_fragment {
+            Fragment::Box(fragment) | Fragment::Float(fragment) => fragment,
+            _ => return scrollable_overflow,
         };
-
-        self.scrollable_overflow.set(Some(scrollable_overflow()))
+        if !first_root_fragment.is_root_element() {
+            return scrollable_overflow;
+        }
+        first_root_fragment.clip_wholly_unreachable_scrollable_overflow(
+            scrollable_overflow,
+            self.initial_containing_block,
+        )
     }
 
     pub(crate) fn find<T>(

--- a/components/layout/fragment_tree/positioning_fragment.rs
+++ b/components/layout/fragment_tree/positioning_fragment.rs
@@ -53,13 +53,12 @@ impl PositioningFragment {
         rect: PhysicalRect<Au>,
         children: Vec<Fragment>,
     ) -> Arc<Self> {
-        PositioningFragment {
+        Arc::new(Self {
             base: BaseFragment::new(base_fragment_info, style.into(), rect),
             children,
             scrollable_overflow: Default::default(),
             cumulative_containing_block_rect: Default::default(),
-        }
-        .into()
+        })
     }
 
     pub(crate) fn set_containing_block(&self, containing_block: &PhysicalRect<Au>) {
@@ -75,23 +74,33 @@ impl PositioningFragment {
         )
     }
 
-    pub(crate) fn calculate_scrollable_overflow(&self) {
-        *self.scrollable_overflow.borrow_mut() = Some(self.children.iter().fold(
-            PhysicalRect::zero(),
-            |acc, child| {
-                acc.union(
-                    &child
-                        .calculate_scrollable_overflow_for_parent()
-                        .translate(self.base.rect().origin.to_vector()),
-                )
-            },
-        ));
+    /// Get the scrollable overflow for this [`PositioningFragment`] relative to its
+    /// containing block, recalculating scrollable overflow when necessary, for instance
+    /// after a style change.
+    pub(crate) fn scrollable_overflow_for_parent(&self) -> PhysicalRect<Au> {
+        *self
+            .scrollable_overflow
+            .borrow_mut()
+            .get_or_insert_with(|| self.calculate_scrollable_overflow())
     }
 
-    pub(crate) fn scrollable_overflow_for_parent(&self) -> PhysicalRect<Au> {
-        self.scrollable_overflow.borrow().expect(
-            "Should only call `scrollable_overflow_for_parent()` after calculating overflow",
-        )
+    /// Clear the scrollable overflow on this [`PositioningFragment`]. This is called
+    /// during damage propagation when a fragment is preserved, itself or one of its
+    /// descendants has scrollable overflow damage.
+    pub(crate) fn clear_scrollable_overflow(&self) {
+        *self.scrollable_overflow.borrow_mut() = None;
+    }
+
+    fn calculate_scrollable_overflow(&self) -> PhysicalRect<Au> {
+        self.children
+            .iter()
+            .fold(PhysicalRect::zero(), |acc, child| {
+                acc.union(
+                    &child
+                        .scrollable_overflow_for_parent()
+                        .translate(self.base.rect().origin.to_vector()),
+                )
+            })
     }
 
     pub fn print(&self, tree: &mut PrintTree) {

--- a/components/layout/layout_box_base.rs
+++ b/components/layout/layout_box_base.rs
@@ -245,6 +245,12 @@ impl LayoutBoxBase {
                 },
             )));
     }
+
+    pub(crate) fn clear_scrollable_overflow_all_on_fragments(&self) {
+        for fragment in self.fragments.borrow().iter() {
+            fragment.clear_scrollable_overflow();
+        }
+    }
 }
 
 impl Debug for LayoutBoxBase {

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -168,10 +168,6 @@ pub struct LayoutThread {
     /// Whether the last display list we sent was effectively empty.
     last_display_list_was_empty: Cell<bool>,
 
-    /// Whether a new overflow calculation needs to happen due to changes to the fragment
-    /// tree. This is set to true every time a restyle requests overflow calculation.
-    need_overflow_calculation: Cell<bool>,
-
     /// Whether a new display list is necessary due to changes to layout or stacking
     /// contexts. This is set to true every time layout changes, even when a display list
     /// isn't requested for this layout, such as for layout queries. The next time a
@@ -774,7 +770,6 @@ impl LayoutThread {
             have_ever_generated_display_list: Cell::new(false),
             last_display_list_was_empty: Cell::new(true),
             device_has_changed: false,
-            need_overflow_calculation: Cell::new(false),
             need_new_display_list: Cell::new(false),
             need_new_stacking_context_tree: Cell::new(false),
             box_tree: Default::default(),
@@ -987,9 +982,6 @@ impl LayoutThread {
             root_element,
             &image_resolver,
         );
-        if self.calculate_overflow() {
-            reflow_phases_run.insert(ReflowPhasesRun::CalculatedOverflow);
-        }
         if self.build_stacking_context_tree_for_reflow(&reflow_request) {
             reflow_phases_run.insert(ReflowPhasesRun::BuiltStackingContextTree);
         }
@@ -1001,6 +993,13 @@ impl LayoutThread {
         }
         if self.handle_accessibility_tree_update(&root_element.as_node()) {
             reflow_phases_run.insert(ReflowPhasesRun::UpdatedAccessibilityTree);
+        }
+
+        if self.debug.is_enabled(DiagnosticsLoggingOption::FlowTree) &&
+            reflow_phases_run.contains(ReflowPhasesRun::RanLayout) &&
+            let Some(fragment_tree) = &*self.fragment_tree.borrow()
+        {
+            fragment_tree.print();
         }
 
         let pending_images = std::mem::take(&mut *image_resolver.pending_images.lock());
@@ -1199,16 +1198,24 @@ impl LayoutThread {
             }
         };
 
-        if damage.contains(RestyleDamage::RECALCULATE_OVERFLOW) {
-            self.need_overflow_calculation.set(true);
-        }
         if damage.contains(RestyleDamage::REBUILD_STACKING_CONTEXT) {
             self.need_new_stacking_context_tree.set(true);
         }
         if damage.contains(RestyleDamage::REPAINT) {
             self.need_new_display_list.set(true);
         }
+
         if !damage.contains(RestyleDamage::RELAYOUT) {
+            if damage.contains(RestyleDamage::RECALCULATE_OVERFLOW) {
+                assert!(self.need_new_display_list.get());
+                assert!(self.need_new_stacking_context_tree.get());
+                self.fragment_tree
+                    .borrow()
+                    .as_ref()
+                    .expect("Should always have a FragmentTree when layout unnecessary")
+                    .clear_scrollable_overflow();
+            }
+
             layout_context.style_context.stylist.rule_tree().maybe_gc();
             return (ReflowPhasesRun::empty(), IFrameSizes::default());
         }
@@ -1252,26 +1259,6 @@ impl LayoutThread {
             ReflowPhasesRun::RanLayout,
             std::mem::take(&mut *iframe_sizes),
         )
-    }
-
-    #[servo_tracing::instrument(name = "Overflow Calculation", skip_all)]
-    fn calculate_overflow(&self) -> bool {
-        if !self.need_overflow_calculation.get() {
-            return false;
-        }
-
-        if let Some(fragment_tree) = &*self.fragment_tree.borrow() {
-            fragment_tree.calculate_scrollable_overflow();
-            if self.debug.is_enabled(DiagnosticsLoggingOption::FlowTree) {
-                fragment_tree.print();
-            }
-        }
-
-        self.need_overflow_calculation.set(false);
-        assert!(self.need_new_display_list.get());
-        assert!(self.need_new_stacking_context_tree.get());
-
-        true
     }
 
     fn build_stacking_context_tree_for_reflow(&self, reflow_request: &ReflowRequest) -> bool {

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -122,7 +122,9 @@ pub(crate) fn compute_damage_and_rebuild_box_tree(
     // 2. Box tree reconstruction needs to run at the dirty root, in which case we need to
     //    find an appropriate place to run box tree reconstruction and *also* invalidate all
     //    fragments to the root of the DOM.
-    if !restyle_damage.contains(RestyleDamage::RELAYOUT) {
+    let needs_fragment_tree_rebuild = restyle_damage.contains(RestyleDamage::RELAYOUT);
+    let needs_overflow_recalculation = restyle_damage.contains(RestyleDamage::RECALCULATE_OVERFLOW);
+    if !needs_fragment_tree_rebuild && !needs_overflow_recalculation {
         return restyle_damage;
     }
 
@@ -146,7 +148,7 @@ pub(crate) fn compute_damage_and_rebuild_box_tree(
             // node's boxes to ensure that they are invalidated for the reconstruction we
             // will run later.
             parent_node.unset_all_boxes();
-        } else {
+        } else if needs_fragment_tree_rebuild {
             // Reconstruction has already run or was not necessary, so we just need to
             // ensure that fragment tree layout does not reuse any cached fragments.
             let new_damage_for_ancestors = Cell::new(LayoutDamage::empty());
@@ -157,6 +159,14 @@ pub(crate) fn compute_damage_and_rebuild_box_tree(
                 );
             });
             damage_for_ancestors = new_damage_for_ancestors.get();
+        } else {
+            // No fragment layout is necessary, but a descendant had scrollable overflow
+            // damage. In this case, clear any preexisting scrollable overflow so that it
+            // gets recalculated the next time it is queried.
+            assert!(needs_overflow_recalculation);
+            parent_node.with_layout_box_base_including_pseudos(|base| {
+                base.clear_scrollable_overflow_all_on_fragments();
+            });
         }
 
         maybe_parent_node = unsafe { parent_node.dangerous_flat_tree_parent() };
@@ -262,11 +272,11 @@ pub(crate) fn compute_damage_and_rebuild_box_tree_inner(
                 .insert(RestyleDamage::RELAYOUT | LayoutDamage::recompute_inline_content_sizes());
         }
     } else {
-        // In this case, this node's boxes are preserved! It's possible that we still need
-        // to run fragment tree layout in this subtree due to an ancestor, this node, or a
-        // descendant changing style. In that case, we ask the `LayoutBoxBase` to clear
-        // any cached information that cannot be used.
         if (element_and_parent_damage | damage_from_children).contains(RestyleDamage::RELAYOUT) {
+            // In this case, this node's boxes are preserved! It's possible that we still need
+            // to run fragment tree layout in this subtree due to an ancestor, this node, or a
+            // descendant changing style. In that case, we ask the `LayoutBoxBase` to clear
+            // any cached information that cannot be used.
             let extra_layout_damage_for_parent = Cell::new(LayoutDamage::empty());
             node.with_layout_box_base_including_pseudos(|base| {
                 extra_layout_damage_for_parent.set(
@@ -275,6 +285,15 @@ pub(crate) fn compute_damage_and_rebuild_box_tree_inner(
                 );
             });
             layout_damage_for_parent.insert(extra_layout_damage_for_parent.get().into());
+        } else if (damage_from_children | element_damage)
+            .contains(RestyleDamage::RECALCULATE_OVERFLOW)
+        {
+            // In this case the node's fragments are preserved, but it or one of its descendants
+            // had scrollable overflow damage, which means that scrollable overflow should be
+            // cleared. This causes it to be recalculated the next time it's queried.
+            node.with_layout_box_base_including_pseudos(|base| {
+                base.clear_scrollable_overflow_all_on_fragments();
+            });
         }
 
         // The box is preserved. Whether or not we run fragment tree layout, we need to

--- a/components/script/dom/testing/servotestutils.rs
+++ b/components/script/dom/testing/servotestutils.rs
@@ -42,9 +42,6 @@ impl ServoTestUtilsMethods<crate::DomTypeHolder> for ServoTestUtils {
         if phases_run.contains(ReflowPhasesRun::RanLayout) {
             phases.push(DOMString::from("RanLayout"))
         }
-        if phases_run.contains(ReflowPhasesRun::CalculatedOverflow) {
-            phases.push(DOMString::from("CalculatedOverflow"))
-        }
         if phases_run.contains(ReflowPhasesRun::BuiltStackingContextTree) {
             phases.push(DOMString::from("BuiltStackingContextTree"))
         }

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -631,7 +631,6 @@ bitflags! {
     #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
     pub struct ReflowPhasesRun: u8 {
         const RanLayout = 1 << 0;
-        const CalculatedOverflow = 1 << 1;
         const BuiltStackingContextTree = 1 << 2;
         const BuiltDisplayList = 1 << 3;
         const UpdatedScrollNodeOffset = 1 << 4;

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13164,14 +13164,14 @@
      ]
     ],
     "layout-phases-layout.html": [
-     "51a0239e9e3e1508581dee4d905b7565f4cba750",
+     "3db23d87f0d472e335fa9cfc125ee5fe152d403f",
      [
       null,
       {}
      ]
     ],
     "layout-phases-overflow.html": [
-     "eabcd289b9a5fed3ef3b2f57c2e9f3215e0cbd46",
+     "3b20541f066da773638d9e4d817295b129b979ec",
      [
       null,
       {}

--- a/tests/wpt/mozilla/tests/incremental-layout/layout-phases-layout.html
+++ b/tests/wpt/mozilla/tests/incremental-layout/layout-phases-layout.html
@@ -15,7 +15,7 @@
 
             assert_array_equals(
               ServoTestUtils.forceLayout().phases,
-              ["RanLayout", "CalculatedOverflow", "BuiltStackingContextTree", "BuiltDisplayList"]
+              ["RanLayout", "BuiltStackingContextTree", "BuiltDisplayList"]
             )
         }, "Adding div to body triggers full layout");
 

--- a/tests/wpt/mozilla/tests/incremental-layout/layout-phases-overflow.html
+++ b/tests/wpt/mozilla/tests/incremental-layout/layout-phases-overflow.html
@@ -14,7 +14,7 @@
 
             assert_array_equals(
               ServoTestUtils.forceLayout().phases,
-              ["CalculatedOverflow", "BuiltStackingContextTree", "BuiltDisplayList"]
+              ["BuiltStackingContextTree", "BuiltDisplayList"]
             )
         }, "Updating div's rotate property skips RanLayout");
 


### PR DESCRIPTION
This avoids another entire fragment tree traversal when rebuilding
fragments. In the case that scrollable overflow-related properties
change or fragment tree reconstruction happens, a lazy (but constrained)
traversal happens at the moment the scrollable overflow is queried.

This is accomplished by clearing scrollable overflow during damage
propagation. When a fragment has its scrollable overflow cleared, it
will be recalculated the next time it is queried. This leads to a few
benefits:

1. We delay a recalculation of scrollable overflow until it is actually
   needed.
2. Scrollable overflow recalculation should only happen on the subtree
   that actually needs it, rather than unconditionally on the entire
   tree.

Minor change: Now the fragment tree is printed for debugging purposes
after every box/fragment tree layout, not every time that overflow is
updated.

Testing: This should not change observable behavior, other than
doing less work during layout, so should be covered by existing tests.
