### PR TITLE
script: Expose `Document::performance_timing_attribute` for getting timing-related values

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -37,12 +37,12 @@ use layout_api::{
 use metrics::{InteractiveFlag, InteractiveWindow, ProgressiveWebMetrics};
 use net_traits::CookieSource::NonHTTP;
 use net_traits::CoreResourceMsg::{GetCookieStringForUrl, SetCookiesForUrl};
-use net_traits::ReferrerPolicy;
 use net_traits::policy_container::PolicyContainer;
 use net_traits::pub_domains::is_pub_domain;
 use net_traits::request::{
     InsecureRequestsPolicy, PreloadId, PreloadKey, PreloadedResources, RequestBuilder,
 };
+use net_traits::{ReferrerPolicy, ResourceFetchTiming};
 use percent_encoding::percent_decode;
 use profile_traits::generic_channel as profile_generic_channel;
 use profile_traits::time::TimerMetadataFrameType;
@@ -490,20 +490,11 @@ pub(crate) struct Document {
     fired_unload: Cell<bool>,
     /// List of responsive images
     responsive_images: DomRefCell<Vec<Dom<HTMLImageElement>>>,
-    /// Number of redirects for the document load
-    redirect_count: Cell<u16>,
-    /// <https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-redirectstart>
+
+    /// A [`ResourceFetchTiming`] that holds timing information for this [`Document`].
     #[no_trace]
-    redirect_start: Cell<Option<CrossProcessInstant>>,
-    /// <https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-redirectend>
-    #[no_trace]
-    redirect_end: Cell<Option<CrossProcessInstant>>,
-    /// <https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-secureconnectionstart>
-    #[no_trace]
-    secure_connection_start: Cell<Option<CrossProcessInstant>>,
-    /// <https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-responseend>
-    #[no_trace]
-    response_end: Cell<Option<CrossProcessInstant>>,
+    resource_fetch_timing: RefCell<Option<ResourceFetchTiming>>,
+
     /// Number of outstanding requests to prevent JS or layout from running.
     script_and_layout_blockers: Cell<u32>,
     /// List of tasks to execute as soon as last script/layout blocker is removed.
@@ -3647,11 +3638,7 @@ impl Document {
             active_parser_was_aborted: Cell::new(false),
             fired_unload: Cell::new(false),
             responsive_images: Default::default(),
-            redirect_count: Cell::new(0),
-            redirect_start: Cell::new(None),
-            redirect_end: Cell::new(None),
-            secure_connection_start: Cell::new(None),
-            response_end: Cell::new(None),
+            resource_fetch_timing: RefCell::new(None),
             completely_loaded: Cell::new(false),
             script_and_layout_blockers: Cell::new(0),
             delayed_tasks: Default::default(),
@@ -3901,43 +3888,48 @@ impl Document {
     }
 
     pub(crate) fn get_redirect_count(&self) -> u16 {
-        self.redirect_count.get()
+        self.resource_fetch_timing
+            .borrow()
+            .as_ref()
+            .map_or(0, |resource_fetch_timing| {
+                resource_fetch_timing.redirect_count
+            })
     }
 
-    pub(crate) fn set_redirect_count(&self, count: u16) {
-        self.redirect_count.set(count)
+    pub(crate) fn set_resource_fetch_timing(&self, timing: ResourceFetchTiming) {
+        self.resource_fetch_timing.replace(Some(timing));
     }
 
-    pub(crate) fn get_redirect_start(&self) -> Option<CrossProcessInstant> {
-        self.redirect_start.get()
-    }
-
-    pub(crate) fn set_redirect_start(&self, time: Option<CrossProcessInstant>) {
-        self.redirect_start.set(time)
-    }
-
-    pub(crate) fn get_redirect_end(&self) -> Option<CrossProcessInstant> {
-        self.redirect_end.get()
-    }
-
-    pub(crate) fn set_redirect_end(&self, time: Option<CrossProcessInstant>) {
-        self.redirect_end.set(time)
-    }
-
-    pub(crate) fn get_secure_connection_start(&self) -> Option<CrossProcessInstant> {
-        self.secure_connection_start.get()
-    }
-
-    pub(crate) fn set_secure_connection_start(&self, time: Option<CrossProcessInstant>) {
-        self.secure_connection_start.set(time)
-    }
-
-    pub(crate) fn get_response_end(&self) -> Option<CrossProcessInstant> {
-        self.response_end.get()
-    }
-
-    pub(crate) fn set_response_end(&self, time: Option<CrossProcessInstant>) {
-        self.response_end.set(time)
+    pub(crate) fn performance_timing_attribute(
+        &self,
+        name: &str,
+    ) -> Fallible<Option<CrossProcessInstant>> {
+        Ok(match name {
+            "unloadEventStart" => self.get_unload_event_start(),
+            "unloadEventEnd" => self.get_unload_event_end(),
+            "domInteractive" => self.get_dom_interactive(),
+            "domContentLoadedEventStart" => self.get_dom_content_loaded_event_start(),
+            "domContentLoadedEventEnd" => self.get_dom_content_loaded_event_end(),
+            "domComplete" => self.get_dom_complete(),
+            "loadEventStart" => self.get_load_event_start(),
+            "loadEventEnd" => self.get_load_event_end(),
+            "redirectStart" | "redirectEnd" | "secureConnectionStart" | "responseEnd" => self
+                .resource_fetch_timing
+                .borrow()
+                .as_ref()
+                .and_then(|resource_fetch_timing| match name {
+                    "redirectStart" => resource_fetch_timing.redirect_start,
+                    "redirectEnd" => resource_fetch_timing.redirect_end,
+                    "secureConnectionStart" => resource_fetch_timing.secure_connection_start,
+                    "responseEnd" => resource_fetch_timing.response_end,
+                    _ => None,
+                }),
+            _ => {
+                return Err(Error::Operation(Some(format!(
+                    "{name} hasn't been implemented."
+                ))));
+            },
+        })
     }
 
     pub(crate) fn elements_by_name_count(&self, name: &DOMString) -> u32 {

--- a/components/script/dom/performance/performance.rs
+++ b/components/script/dom/performance/performance.rs
@@ -474,27 +474,10 @@ impl Performance {
         // FIXME: We don't implement this value yet, so we assume it's zero (and then we don't need it at all)
 
         // Step 4. Let endTime be the value of name in the PerformanceTiming interface.
+        //
         // NOTE: We store all performance values on the document
-        let document = window.Document();
-        let end_time = match name {
-            "unloadEventStart" => document.get_unload_event_start(),
-            "unloadEventEnd" => document.get_unload_event_end(),
-            "domInteractive" => document.get_dom_interactive(),
-            "domContentLoadedEventStart" => document.get_dom_content_loaded_event_start(),
-            "domContentLoadedEventEnd" => document.get_dom_content_loaded_event_end(),
-            "domComplete" => document.get_dom_complete(),
-            "loadEventStart" => document.get_load_event_start(),
-            "loadEventEnd" => document.get_load_event_end(),
-            "redirectStart" => document.get_redirect_start(),
-            "redirectEnd" => document.get_redirect_end(),
-            "secureConnectionStart" => document.get_secure_connection_start(),
-            "responseEnd" => document.get_response_end(),
-            _ => {
-                return Err(Error::Operation(Some(format!(
-                    "{name} hasn't been implemented."
-                ))));
-            },
-        };
+        let end_time = window.Document().performance_timing_attribute(name)?;
+
         // Step 5. If endTime is 0, throw an InvalidAccessError.
         let Some(end_time) = end_time else {
             return Err(Error::InvalidAccess(Some(format!(

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1564,13 +1564,7 @@ impl FetchResponseListener for ParserContext {
         let cx = &mut realm;
 
         if status.is_ok() {
-            parser.document.set_redirect_count(timing.redirect_count);
-            parser.document.set_redirect_start(timing.redirect_start);
-            parser.document.set_redirect_end(timing.redirect_end);
-            parser
-                .document
-                .set_secure_connection_start(timing.secure_connection_start);
-            parser.document.set_response_end(timing.response_end);
+            parser.document.set_resource_fetch_timing(timing);
         }
 
         parser.last_chunk_received.set(true);


### PR DESCRIPTION
This moves the code which accesses timing related data to `Document` and moves a variety of timing-related fields to an `ResourceFetchTiming` instanced stored on the `Document` itself.

Testing: This is a refactor and shouldn't change behavior, so is covered by existing tests.