### PR TITLE
script: Ignore synthetic focus events in `<input>` and `<textarea>`

### DIFF
--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -191,8 +191,6 @@ impl HTMLTextAreaElement {
                     }),
                     None,
                 );
-        } else {
-            unreachable!("Got unexpected FocusEvent {event_type:?}");
         }
 
         // Focus changes can activate or deactivate a selection.

--- a/components/script/dom/html/input_element/mod.rs
+++ b/components/script/dom/html/input_element/mod.rs
@@ -1970,8 +1970,6 @@ impl HTMLInputElement {
                     }),
                     None,
                 );
-        } else {
-            unreachable!("Got unexpected FocusEvent {event_type:?}");
         }
     }
 

--- a/tests/wpt/tests/focus/synthetic-focus-event-crash.html
+++ b/tests/wpt/tests/focus/synthetic-focus-event-crash.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<link rel="assert" href="Synthetic focus events sent to form controls should not cause a crash">
+<link rel="help" href="https://github.com/servo/servo/issues/44865">
+
+<input id="input">
+<textarea id="textarea"></textarea>
+
+<script>
+  let event = document.createEvent("FocusEvent");
+  event.initEvent('', true);
+  input.dispatchEvent(event);
+
+  let event2 = document.createEvent("FocusEvent");
+  event2.initEvent('', true);
+  textarea.dispatchEvent(event2);
+</script>
+


### PR DESCRIPTION
As you can create these events with JavaScript, it isn't unexpected that
you see unknown kinds of focus events. Just ignore these instead of
panicking.

Testing: This change adds a WPT crash test.
Fixes: #44865