### PR TITLE
Revert "chore: bump vello_cpu (#44838)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2303,7 +2303,7 @@ dependencies = [
  "self_cell",
  "skrifa 0.40.0",
  "smallvec",
- "vello_cpu",
+ "vello_cpu 0.0.6",
 ]
 
 [[package]]
@@ -3512,6 +3512,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
  "serde",
 ]
@@ -4643,6 +4645,7 @@ checksum = "ce9729cc38c18d86123ab736fd2e7151763ba226ac2490ec092d1dd148825e32"
 dependencies = [
  "arrayvec",
  "euclid",
+ "serde",
  "smallvec",
 ]
 
@@ -4654,7 +4657,6 @@ checksum = "7564e90fe3c0d5771e1f0bc95322b21baaeaa0d9213fa6a0b61c99f8b17b3bfb"
 dependencies = [
  "arrayvec",
  "euclid",
- "serde",
  "smallvec",
 ]
 
@@ -6131,6 +6133,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3c76095c9a636173600478e0373218c7b955335048c2bcd12dc6a79657649d8"
 dependencies = [
+ "bytemuck",
  "color",
  "kurbo 0.12.0",
  "linebender_resource_handle",
@@ -7580,9 +7583,9 @@ dependencies = [
  "crossbeam-channel",
  "euclid",
  "futures-intrusive",
- "kurbo 0.13.0",
+ "kurbo 0.12.0",
  "log",
- "peniko 0.6.0",
+ "peniko 0.5.0",
  "pollster",
  "rustc-hash 2.1.2",
  "servo-base",
@@ -7596,7 +7599,7 @@ dependencies = [
  "stylo",
  "tracing",
  "vello",
- "vello_cpu",
+ "vello_cpu 0.0.4",
  "webrender_api",
 ]
 
@@ -7607,7 +7610,7 @@ dependencies = [
  "crossbeam-channel",
  "euclid",
  "glow 0.17.0",
- "kurbo 0.13.0",
+ "kurbo 0.12.0",
  "malloc_size_of_derive",
  "serde",
  "servo-base",
@@ -7955,7 +7958,7 @@ dependencies = [
  "icu_properties",
  "icu_segmenter",
  "itertools 0.14.0",
- "kurbo 0.13.0",
+ "kurbo 0.12.0",
  "log",
  "malloc_size_of_derive",
  "num-traits",
@@ -10524,6 +10527,22 @@ dependencies = [
 
 [[package]]
 name = "vello_common"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a235ba928b3109ad9e7696270edb09445a52ae1c7c08e6d31a19b1cdd6cbc24a"
+dependencies = [
+ "bytemuck",
+ "fearless_simd",
+ "hashbrown 0.15.5",
+ "log",
+ "peniko 0.5.0",
+ "png 0.17.16",
+ "skrifa 0.37.0",
+ "smallvec",
+]
+
+[[package]]
+name = "vello_common"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd1a4c633ce09e7d713df1a6e036644a125e15e0c169cfb5180ddf5836ca04b"
@@ -10533,9 +10552,18 @@ dependencies = [
  "hashbrown 0.16.1",
  "log",
  "peniko 0.6.0",
- "png 0.17.16",
  "skrifa 0.40.0",
  "smallvec",
+]
+
+[[package]]
+name = "vello_cpu"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0bd1fcf9c1814f17a491e07113623d44e3ec1125a9f3401f5e047d6d326da21"
+dependencies = [
+ "bytemuck",
+ "vello_common 0.0.4",
 ]
 
 [[package]]
@@ -10546,7 +10574,7 @@ checksum = "0162bfe48aabf6a9fdcd401b628c7d9f260c2cbabb343c70a65feba6f7849edc"
 dependencies = [
  "bytemuck",
  "hashbrown 0.16.1",
- "vello_common",
+ "vello_common 0.0.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ ipc-channel = "0.22"
 itertools = "0.14"
 js = { package = "mozjs", version = "=0.15.14", default-features = false, features = ["libz-sys", "intl"] }
 keyboard-types = { version = "0.8.3", features = ["serde", "webdriver"] }
-kurbo = { version = "0.13", features = ["euclid"] }
+kurbo = { version = "0.12", features = ["euclid"] }
 libc = "0.2"
 log = "0.4.29"
 mach2 = "0.6"
@@ -141,7 +141,7 @@ p256 = { version = "0.13", features = ["ecdh"] }
 p384 = { version = "0.13", features = ["ecdh"] }
 p521 = { version = "0.13", features = ["ecdh"] }
 parking_lot = { version = "0.12", features = ["serde"] }
-peniko = "0.6"
+peniko = "0.5"
 percent-encoding = "2.3"
 pkcs8 = { version = "0.10", features = ["rand_core"] }
 postcard = { version = "1.1.3", default-features = false, features = ["use-std"] }
@@ -207,7 +207,7 @@ url = "2.5"
 urlpattern = "0.3"
 uuid = { version = "1.23.1", features = ["v4", "v5"] }
 vello = "0.6"
-vello_cpu = "0.0.6"
+vello_cpu = "0.0.4"
 webdriver = { version = "0.53.0", default-features = false }
 webpki-roots = "1.0"
 webrender = { version = "0.68", features = ["capture"] }

--- a/components/canvas/vello_cpu_backend.rs
+++ b/components/canvas/vello_cpu_backend.rs
@@ -175,7 +175,6 @@ impl GenericDrawTarget for VelloCPUDrawTarget {
             Some(blend_mode.into()),
             None,
             None,
-            None,
         );
         self.ctx.pop_layer();
     }

--- a/deny.toml
+++ b/deny.toml
@@ -177,10 +177,8 @@ skip = [
     "toml_datetime",
     "toml_edit",
 
-    # duplicated by vello
+    # usvg depends on svgtypes, which depends on old version of kurbo
     "kurbo",
-    "peniko",
-    "png",
 
     # Dependency by quick_cache and other
     "hashbrown",
@@ -205,11 +203,15 @@ skip = [
     "font-types",
     "glow",
     "objc2-ui-kit",
+    "peniko",
     "read-fonts",
     "skrifa",
+    "vello_common",
+    "vello_cpu",
 
     # Duplicated by resvg/image
     "pastey",
+    "png",
     "roxmltree",
     "tiny-skia",
     "tiny-skia-path",


### PR DESCRIPTION
`vello` and `vello_cpu` should actually be updated together, as mismatched versions of kurbo or peniko can break the build.

Testing: It compiles with `vello` feature
Fixes: #44874
