### PR TITLE
script: Pass `&mut JSContext` to `AttributeStorage::ensure_dom`

### DIFF
--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -195,13 +195,13 @@ impl Attr {
 
     /// Sets the owner element. Should be called after the attribute is added
     /// or removed from its older parent.
-    pub(crate) fn set_owner(&self, owner: Option<&Element>) {
+    pub(crate) fn set_owner(&self, cx: &mut JSContext, owner: Option<&Element>) {
         let ns = self.namespace();
         match (self.owner(), owner) {
             (Some(old), None) => {
                 // Already gone from the list of attributes of old owner.
                 assert!(
-                    old.get_attribute_with_namespace(ns, &self.identifier.local_name)
+                    old.get_attribute_with_namespace(cx, ns, &self.identifier.local_name)
                         .as_deref() !=
                         Some(self)
                 )

--- a/components/script/dom/element/attributes/storage.rs
+++ b/components/script/dom/element/attributes/storage.rs
@@ -6,6 +6,7 @@ use std::cell::Ref;
 
 use devtools_traits::AttrInfo;
 use html5ever::{LocalName, Namespace, Prefix};
+use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
 use script_bindings::root::{Dom, DomRoot};
 use script_bindings::str::DOMString;
@@ -287,8 +288,12 @@ impl AttributeStorage {
     /// This method carefully splits the mutable borrow around the `Attr::new()`
     /// allocation so that GC tracing can safely borrow the storage.
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
-    #[expect(unsafe_code)]
-    pub(crate) fn ensure_dom(&self, index: usize, element: &Element) -> DomRoot<Attr> {
+    pub(crate) fn ensure_dom(
+        &self,
+        cx: &mut JSContext,
+        index: usize,
+        element: &Element,
+    ) -> DomRoot<Attr> {
         // Fast path: already materialized.
         if let AttributeEntry::Dom(attr) = &self.0.borrow()[index] {
             return DomRoot::from_ref(&**attr);
@@ -313,9 +318,6 @@ impl AttributeStorage {
             }
         };
 
-        // TODO: https://github.com/servo/servo/issues/42812
-        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
-        let cx = &mut cx;
         let doc = element.owner_document();
         let attr = Attr::new(
             cx,

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -1680,11 +1680,11 @@ impl Element {
         &self.attrs
     }
 
-    pub(crate) fn dom_attrs(&self) -> &AttributeStorage {
+    pub(crate) fn dom_attrs(&self, cx: &mut JSContext) -> &AttributeStorage {
         // Materialize all entries to Dom<Attr> so callers can access full Attr nodes.
         let len = self.attrs.borrow().len();
         for i in 0..len {
-            self.attrs.ensure_dom(i, self);
+            self.attrs.ensure_dom(cx, i, self);
         }
         &self.attrs
     }
@@ -2035,6 +2035,7 @@ impl Element {
     /// to be lowercase ASCII, in accordance with the specification.
     pub(crate) fn get_attribute_with_namespace(
         &self,
+        cx: &mut JSContext,
         namespace: &Namespace,
         local_name: &LocalName,
     ) -> Option<DomRoot<Attr>> {
@@ -2043,27 +2044,36 @@ impl Element {
             .borrow()
             .iter()
             .position(|a| a.local_name() == local_name && a.namespace() == namespace)?;
-        Some(self.attrs.ensure_dom(idx, self))
+        Some(self.attrs.ensure_dom(cx, idx, self))
     }
 
     /// This is the inner logic for:
     /// <https://dom.spec.whatwg.org/#concept-element-attributes-get-by-name>
     ///
     /// Callers should convert the `LocalName` to ASCII lowercase before calling.
+    #[expect(unsafe_code)]
     pub(crate) fn get_attribute(&self, local_name: &LocalName) -> Option<DomRoot<Attr>> {
+        // TODO: https://github.com/servo/servo/issues/42812
+        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
+        let cx = &mut cx;
+
         debug_assert_eq!(
             *local_name,
             local_name.to_ascii_lowercase(),
             "All namespace-less attribute accesses should use a lowercase ASCII name"
         );
-        self.get_attribute_with_namespace(&ns!(), local_name)
+        self.get_attribute_with_namespace(cx, &ns!(), local_name)
     }
 
     /// <https://dom.spec.whatwg.org/#concept-element-attributes-get-by-name>
-    pub(crate) fn get_attribute_by_name(&self, name: DOMString) -> Option<DomRoot<Attr>> {
+    pub(crate) fn get_attribute_by_name(
+        &self,
+        cx: &mut JSContext,
+        name: DOMString,
+    ) -> Option<DomRoot<Attr>> {
         let name = &self.parsed_name(name);
         let idx = self.attrs.borrow().iter().position(|a| a.name() == name)?;
-        let attr_dom = Some(self.attrs.ensure_dom(idx, self));
+        let attr_dom = Some(self.attrs.ensure_dom(cx, idx, self));
         fn id_and_name_must_be_atoms(name: &LocalName, maybe_attr: &Option<DomRoot<Attr>>) -> bool {
             if *name == local_name!("id") || *name == local_name!("name") {
                 match maybe_attr {
@@ -2171,7 +2181,7 @@ impl Element {
         // First check if a matching attribute exists (works for both Raw and Dom).
         let found_idx = self.attrs.borrow().iter().position(find);
         if let Some(idx) = found_idx {
-            let attr = self.attrs.ensure_dom(idx, self);
+            let attr = self.attrs.ensure_dom(cx, idx, self);
             // Step 3. Change attribute to value.
             self.will_mutate_attr(AttrRef::Dom(&attr));
             self.change_attribute(cx, &attr, value);
@@ -2235,13 +2245,13 @@ impl Element {
     {
         let idx = self.attrs.borrow().iter().position(find);
         idx.map(|idx| {
-            let attr = self.attrs.ensure_dom(idx, self);
+            let attr = self.attrs.ensure_dom(cx, idx, self);
 
             // Step 2. Remove attribute from element’s attribute list.
             self.will_mutate_attr(AttrRef::Dom(&attr));
             self.attrs.remove(idx);
             // Step 3. Set attribute’s element to null.
-            attr.set_owner(None);
+            attr.set_owner(cx, None);
             // Step 4. Handle attribute changes for attribute with element, attribute’s value, and null.
             self.handle_attribute_changes(
                 cx,
@@ -2401,7 +2411,7 @@ impl Element {
         });
 
         let old_attr = if let Some(position) = position {
-            let old_attr = self.attrs.ensure_dom(position, self);
+            let old_attr = self.attrs.ensure_dom(cx, position, self);
 
             // Step 4. If oldAttr is attr, return attr.
             if &*old_attr == attr {
@@ -2421,11 +2431,11 @@ impl Element {
             self.attrs
                 .set(position, AttributeEntry::Dom(Dom::from_ref(attr)));
             // Step 3. Set newAttribute’s element to element.
-            attr.set_owner(Some(self));
+            attr.set_owner(cx, Some(self));
             // Step 4. Set newAttribute’s node document to element’s node document.
             attr.upcast::<Node>().set_owner_doc(&self.node.owner_doc());
             // Step 5. Set oldAttribute’s element to null.
-            old_attr.set_owner(None);
+            old_attr.set_owner(cx, None);
             // Step 6. Handle attribute changes for oldAttribute with element, oldAttribute’s value, and newAttribute’s value.
             self.handle_attribute_changes(
                 cx,
@@ -2438,7 +2448,7 @@ impl Element {
             Some(old_attr)
         } else {
             // Step 7. Otherwise, append attr to element.
-            attr.set_owner(Some(self));
+            attr.set_owner(cx, Some(self));
             attr.upcast::<Node>().set_owner_doc(&self.node.owner_doc());
             self.push_attribute(cx, attr, AttributeMutationReason::Directly);
 
@@ -2868,33 +2878,35 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-element-getattribute>
-    fn GetAttribute(&self, name: DOMString) -> Option<DOMString> {
-        self.GetAttributeNode(name).map(|s| s.Value())
+    fn GetAttribute(&self, cx: &mut JSContext, name: DOMString) -> Option<DOMString> {
+        self.GetAttributeNode(cx, name).map(|s| s.Value())
     }
 
     /// <https://dom.spec.whatwg.org/#dom-element-getattributens>
     fn GetAttributeNS(
         &self,
+        cx: &mut JSContext,
         namespace: Option<DOMString>,
         local_name: DOMString,
     ) -> Option<DOMString> {
-        self.GetAttributeNodeNS(namespace, local_name)
+        self.GetAttributeNodeNS(cx, namespace, local_name)
             .map(|attr| attr.Value())
     }
 
     /// <https://dom.spec.whatwg.org/#dom-element-getattributenode>
-    fn GetAttributeNode(&self, name: DOMString) -> Option<DomRoot<Attr>> {
-        self.get_attribute_by_name(name)
+    fn GetAttributeNode(&self, cx: &mut JSContext, name: DOMString) -> Option<DomRoot<Attr>> {
+        self.get_attribute_by_name(cx, name)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-element-getattributenodens>
     fn GetAttributeNodeNS(
         &self,
+        cx: &mut JSContext,
         namespace: Option<DOMString>,
         local_name: DOMString,
     ) -> Option<DomRoot<Attr>> {
         let namespace = &namespace_from_domstring(namespace);
-        self.get_attribute_with_namespace(namespace, &LocalName::from(local_name))
+        self.get_attribute_with_namespace(cx, namespace, &LocalName::from(local_name))
     }
 
     /// <https://dom.spec.whatwg.org/#dom-element-toggleattribute>
@@ -2911,7 +2923,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         }
 
         // Step 3.
-        let attribute = self.GetAttribute(name.clone());
+        let attribute = self.GetAttribute(cx, name.clone());
 
         // Step 2.
         let name = self.parsed_name(name);
@@ -3071,13 +3083,18 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-element-hasattribute>
-    fn HasAttribute(&self, name: DOMString) -> bool {
-        self.GetAttribute(name).is_some()
+    fn HasAttribute(&self, cx: &mut JSContext, name: DOMString) -> bool {
+        self.GetAttribute(cx, name).is_some()
     }
 
     /// <https://dom.spec.whatwg.org/#dom-element-hasattributens>
-    fn HasAttributeNS(&self, namespace: Option<DOMString>, local_name: DOMString) -> bool {
-        self.GetAttributeNS(namespace, local_name).is_some()
+    fn HasAttributeNS(
+        &self,
+        cx: &mut JSContext,
+        namespace: Option<DOMString>,
+        local_name: DOMString,
+    ) -> bool {
+        self.GetAttributeNS(cx, namespace, local_name).is_some()
     }
 
     /// <https://dom.spec.whatwg.org/#dom-element-getelementsbytagname>

--- a/components/script/dom/namednodemap.rs
+++ b/components/script/dom/namednodemap.rs
@@ -4,6 +4,7 @@
 
 use dom_struct::dom_struct;
 use html5ever::LocalName;
+use js::context::JSContext;
 use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use crate::dom::attr::Attr;
@@ -43,55 +44,44 @@ impl NamedNodeMapMethods<crate::DomTypeHolder> for NamedNodeMap {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-namednodemap-item>
-    fn Item(&self, index: u32) -> Option<DomRoot<Attr>> {
+    fn Item(&self, cx: &mut JSContext, index: u32) -> Option<DomRoot<Attr>> {
         let index: usize = index as _;
         if self.owner.attrs().borrow().len() <= index {
             None
         } else {
-            Some(self.owner.attrs().ensure_dom(index, &self.owner))
+            Some(self.owner.attrs().ensure_dom(cx, index, &self.owner))
         }
     }
 
     /// <https://dom.spec.whatwg.org/#dom-namednodemap-getnameditem>
-    fn GetNamedItem(&self, name: DOMString) -> Option<DomRoot<Attr>> {
-        self.owner.get_attribute_by_name(name)
+    fn GetNamedItem(&self, cx: &mut JSContext, name: DOMString) -> Option<DomRoot<Attr>> {
+        self.owner.get_attribute_by_name(cx, name)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-namednodemap-getnameditemns>
     fn GetNamedItemNS(
         &self,
+        cx: &mut JSContext,
         namespace: Option<DOMString>,
         local_name: DOMString,
     ) -> Option<DomRoot<Attr>> {
         let ns = namespace_from_domstring(namespace);
         self.owner
-            .get_attribute_with_namespace(&ns, &LocalName::from(local_name))
+            .get_attribute_with_namespace(cx, &ns, &LocalName::from(local_name))
     }
 
     /// <https://dom.spec.whatwg.org/#dom-namednodemap-setnameditem>
-    fn SetNamedItem(
-        &self,
-        cx: &mut js::context::JSContext,
-        attr: &Attr,
-    ) -> Fallible<Option<DomRoot<Attr>>> {
+    fn SetNamedItem(&self, cx: &mut JSContext, attr: &Attr) -> Fallible<Option<DomRoot<Attr>>> {
         self.owner.SetAttributeNode(cx, attr)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-namednodemap-setnameditemns>
-    fn SetNamedItemNS(
-        &self,
-        cx: &mut js::context::JSContext,
-        attr: &Attr,
-    ) -> Fallible<Option<DomRoot<Attr>>> {
+    fn SetNamedItemNS(&self, cx: &mut JSContext, attr: &Attr) -> Fallible<Option<DomRoot<Attr>>> {
         self.SetNamedItem(cx, attr)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-namednodemap-removenameditem>
-    fn RemoveNamedItem(
-        &self,
-        cx: &mut js::context::JSContext,
-        name: DOMString,
-    ) -> Fallible<DomRoot<Attr>> {
+    fn RemoveNamedItem(&self, cx: &mut JSContext, name: DOMString) -> Fallible<DomRoot<Attr>> {
         let name = self.owner.parsed_name(name);
         self.owner
             .remove_attribute_by_name(cx, &name)
@@ -101,7 +91,7 @@ impl NamedNodeMapMethods<crate::DomTypeHolder> for NamedNodeMap {
     /// <https://dom.spec.whatwg.org/#dom-namednodemap-removenameditemns>
     fn RemoveNamedItemNS(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         namespace: Option<DOMString>,
         local_name: DOMString,
     ) -> Fallible<DomRoot<Attr>> {
@@ -112,13 +102,13 @@ impl NamedNodeMapMethods<crate::DomTypeHolder> for NamedNodeMap {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-namednodemap-item>
-    fn IndexedGetter(&self, index: u32) -> Option<DomRoot<Attr>> {
-        self.Item(index)
+    fn IndexedGetter(&self, cx: &mut JSContext, index: u32) -> Option<DomRoot<Attr>> {
+        self.Item(cx, index)
     }
 
     // check-tidy: no specs after this line
-    fn NamedGetter(&self, name: DOMString) -> Option<DomRoot<Attr>> {
-        self.GetNamedItem(name)
+    fn NamedGetter(&self, cx: &mut JSContext, name: DOMString) -> Option<DomRoot<Attr>> {
+        self.GetNamedItem(cx, name)
     }
 
     /// <https://heycam.github.io/webidl/#dfn-supported-property-names>

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -1922,11 +1922,11 @@ impl Node {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#language>
-    pub(crate) fn get_lang(&self) -> Option<String> {
+    pub(crate) fn get_lang(&self, cx: &mut JSContext) -> Option<String> {
         self.inclusive_ancestors(ShadowIncluding::Yes)
             .find_map(|node| {
                 node.downcast::<Element>().and_then(|el| {
-                    el.get_attribute_with_namespace(&ns!(xml), &local_name!("lang"))
+                    el.get_attribute_with_namespace(cx, &ns!(xml), &local_name!("lang"))
                         .or_else(|| el.get_attribute(&local_name!("lang")))
                         .map(|attr| String::from(attr.Value()))
                 })

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2537,6 +2537,7 @@ impl ScriptThread {
             },
             WebDriverScriptCommand::GetElementAttribute(node_id, name, reply) => {
                 webdriver_handlers::handle_get_attribute(
+                    cx,
                     &documents,
                     pipeline_id,
                     node_id,

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1679,6 +1679,7 @@ pub(crate) fn handle_get_name(
 }
 
 pub(crate) fn handle_get_attribute(
+    cx: &mut JSContext,
     documents: &DocumentCollection,
     pipeline: PipelineId,
     node_id: String,
@@ -1689,14 +1690,14 @@ pub(crate) fn handle_get_attribute(
         .send(
             get_known_element(documents, pipeline, node_id).map(|element| {
                 if is_boolean_attribute(&name) {
-                    if element.HasAttribute(DOMString::from(name)) {
+                    if element.HasAttribute(cx, DOMString::from(name)) {
                         Some(String::from("true"))
                     } else {
                         None
                     }
                 } else {
                     element
-                        .GetAttribute(DOMString::from(name))
+                        .GetAttribute(cx, DOMString::from(name))
                         .map(String::from)
                 }
             }),

--- a/components/script/xpath.rs
+++ b/components/script/xpath.rs
@@ -65,8 +65,12 @@ impl xpath::Node for XPathWrapper<DomRoot<Node>> {
         self.0.GetTextContent().unwrap_or_default().into()
     }
 
+    #[expect(unsafe_code)]
     fn language(&self) -> Option<String> {
-        self.0.get_lang()
+        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
+        let cx = &mut cx;
+
+        self.0.get_lang(cx)
     }
 
     fn parent(&self) -> Option<Self> {
@@ -208,7 +212,11 @@ impl xpath::Element for XPathWrapper<DomRoot<Element>> {
         DomRoot::from_ref(self.0.upcast::<Node>()).into()
     }
 
+    #[expect(unsafe_code)]
     fn attributes(&self) -> impl Iterator<Item = Self::Attribute> {
+        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
+        let cx = &mut cx;
+
         struct AttributeIterator<'a> {
             attributes: &'a AttributeStorage,
             position: usize,
@@ -232,7 +240,7 @@ impl xpath::Element for XPathWrapper<DomRoot<Element>> {
 
         // XPath needs full DOM attribute nodes.
         AttributeIterator {
-            attributes: self.0.dom_attrs(),
+            attributes: self.0.dom_attrs(cx),
             position: 0,
         }
     }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -318,7 +318,7 @@ DOMInterfaces = {
 },
 
 'Element': {
-    'cx': ['GetHTML', 'GetInnerHTML', 'GetOuterHTML', 'Part', 'RemoveAttribute', 'SetClassName', 'SetHTMLUnsafe', 'SetId', 'SetInnerHTML', 'SetOuterHTML', 'InsertAdjacentHTML', 'ToggleAttribute', 'SetAttribute', 'SetAttributeNS', 'SetAttributeNode', 'SetAttributeNodeNS', 'RemoveAttributeNS', 'RemoveAttributeNode', 'SetRole', 'SetAriaAtomic', 'SetAriaAutoComplete', 'SetAriaBrailleLabel', 'SetAriaBrailleRoleDescription', 'SetAriaBusy', 'SetAriaChecked', 'SetAriaColCount', 'SetAriaColIndex', 'SetAriaColIndexText', 'SetAriaColSpan', 'SetAriaCurrent', 'SetAriaDescription', 'SetAriaDisabled', 'SetAriaExpanded', 'SetAriaHasPopup', 'SetAriaHidden', 'SetAriaInvalid', 'SetAriaKeyShortcuts', 'SetAriaLabel', 'SetAriaLevel', 'SetAriaLive', 'SetAriaModal', 'SetAriaMultiLine', 'SetAriaMultiSelectable', 'SetAriaOrientation', 'SetAriaPlaceholder', 'SetAriaPosInSet', 'SetAriaPressed','SetAriaReadOnly', 'SetAriaRelevant', 'SetAriaRequired', 'SetAriaRoleDescription', 'SetAriaRowCount', 'SetAriaRowIndex', 'SetAriaRowIndexText', 'SetAriaRowSpan', 'SetAriaSelected', 'SetAriaSetSize','SetAriaSort', 'SetAriaValueMax', 'SetAriaValueMin', 'SetAriaValueNow', 'SetAriaValueText', 'ReplaceWith', 'MoveBefore', 'InsertAdjacentElement', 'InsertAdjacentText', 'Before', 'After', 'Prepend', 'Remove', 'ReplaceChildren', 'Append', 'AttachShadow', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'Children', 'GetClientRects', 'GetBoundingClientRect', 'ClassList'],
+    'cx': ['GetHTML', 'GetInnerHTML', 'GetOuterHTML', 'Part', 'RemoveAttribute', 'SetClassName', 'SetHTMLUnsafe', 'SetId', 'SetInnerHTML', 'SetOuterHTML', 'InsertAdjacentHTML', 'ToggleAttribute', 'SetAttribute', 'SetAttributeNS', 'SetAttributeNode', 'SetAttributeNodeNS', 'RemoveAttributeNS', 'RemoveAttributeNode', 'SetRole', 'SetAriaAtomic', 'SetAriaAutoComplete', 'SetAriaBrailleLabel', 'SetAriaBrailleRoleDescription', 'SetAriaBusy', 'SetAriaChecked', 'SetAriaColCount', 'SetAriaColIndex', 'SetAriaColIndexText', 'SetAriaColSpan', 'SetAriaCurrent', 'SetAriaDescription', 'SetAriaDisabled', 'SetAriaExpanded', 'SetAriaHasPopup', 'SetAriaHidden', 'SetAriaInvalid', 'SetAriaKeyShortcuts', 'SetAriaLabel', 'SetAriaLevel', 'SetAriaLive', 'SetAriaModal', 'SetAriaMultiLine', 'SetAriaMultiSelectable', 'SetAriaOrientation', 'SetAriaPlaceholder', 'SetAriaPosInSet', 'SetAriaPressed','SetAriaReadOnly', 'SetAriaRelevant', 'SetAriaRequired', 'SetAriaRoleDescription', 'SetAriaRowCount', 'SetAriaRowIndex', 'SetAriaRowIndexText', 'SetAriaRowSpan', 'SetAriaSelected', 'SetAriaSetSize','SetAriaSort', 'SetAriaValueMax', 'SetAriaValueMin', 'SetAriaValueNow', 'SetAriaValueText', 'ReplaceWith', 'MoveBefore', 'InsertAdjacentElement', 'InsertAdjacentText', 'Before', 'After', 'Prepend', 'Remove', 'ReplaceChildren', 'Append', 'AttachShadow', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'Children', 'GetClientRects', 'GetBoundingClientRect', 'ClassList', 'GetAttributeNodeNS', 'GetAttributeNS', 'HasAttributeNS', 'GetAttribute', 'GetAttributeNode', 'HasAttribute'],
     'canGc': ['RequestFullscreen', 'Attributes'],
 },
 
@@ -744,7 +744,18 @@ DOMInterfaces = {
 },
 
 'NamedNodeMap': {
-    'cx': ['SetNamedItem', 'SetNamedItemNS', 'RemoveNamedItem', 'RemoveNamedItemNS', 'RemoveAttribute'],
+    'cx': [
+        'GetNamedItem',
+        'GetNamedItemNS',
+        'Item',
+        'IndexedGetter',
+        'NamedGetter',
+        'RemoveAttribute',
+        'RemoveNamedItem',
+        'RemoveNamedItemNS',
+        'SetNamedItem',
+        'SetNamedItemNS',
+    ],
 },
 
 'NavigationPreloadManager': {


### PR DESCRIPTION
This PR introduces a couple more of `temp_cx`, for methods that are part of xpath traits and inside `Element::get_attribute` which is used in much more places.

Testing: It compiles
Part of #42812
