### PR TITLE
servoshell + net: Expose --host-file option

### DIFF
--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -70,6 +70,10 @@ pub struct Opts {
     /// Path to PEM encoded SSL CA certificate store.
     pub certificate_path: Option<String>,
 
+    /// Path to a hosts file (like `/etc/hosts`).
+    /// Ignored if the `HOST_FILE` environment variable is set.
+    pub host_file: Option<PathBuf>,
+
     /// Whether or not to completely ignore SSL certificate validation errors.
     /// TODO: We should see if we can eliminate the need for this by fixing
     /// <https://github.com/servo/servo/issues/30080>.
@@ -246,6 +250,7 @@ impl Default for Opts {
             temporary_storage: false,
             shaders_path: None,
             certificate_path: None,
+            host_file: None,
             ignore_certificate_errors: false,
             unminify_js: false,
             local_script_source: None,

--- a/components/net/hosts.rs
+++ b/components/net/hosts.rs
@@ -8,15 +8,19 @@ use std::env;
 use std::fs::File;
 use std::io::{BufReader, Read};
 use std::net::{IpAddr, Ipv4Addr};
+use std::path::PathBuf;
 use std::sync::LazyLock;
 
 use parking_lot::Mutex;
+use servo_config::opts;
 
 static HOST_TABLE: LazyLock<Mutex<Option<HashMap<String, IpAddr>>>> =
     LazyLock::new(|| Mutex::new(create_host_table()));
 
 fn create_host_table() -> Option<HashMap<String, IpAddr>> {
-    let path = env::var_os("HOST_FILE")?;
+    let path = env::var_os("HOST_FILE")
+        .map(PathBuf::from)
+        .or_else(|| opts::get().host_file.clone())?;
 
     let file = File::open(path).ok()?;
     let mut reader = BufReader::new(file);

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -444,6 +444,12 @@ struct CmdArgs {
     headless: bool,
 
     ///
+    /// Path to a hosts file (like `/etc/hosts`).
+    /// Ignored if the `HOST_FILE` environment variable is set.
+    #[bpaf(long("host-file"), argument("/path/to/hosts"))]
+    host_file: Option<PathBuf>,
+
+    ///
     ///  Whether or not to completely ignore certificate errors.
     #[bpaf(long)]
     ignore_certificate_errors: bool,
@@ -731,6 +737,7 @@ fn parse_arguments_helper(args_without_binary: Args) -> ArgumentParsingResult {
         certificate_path: cmd_args
             .certificate_path
             .map(|p| p.to_string_lossy().into_owned()),
+        host_file: cmd_args.host_file,
         ignore_certificate_errors: cmd_args.ignore_certificate_errors,
         unminify_js: cmd_args.unminify_js,
         local_script_source: cmd_args


### PR DESCRIPTION
To run wpt-tests one should set the hosts file, so test URLs get redirected. On Android / OHOS using an environment variable is not really an option. Expose a `doc(hidden)` function to allow overriding our internal hosts table based on an embedder provided file path.

Testing: Not covered by automated tests. This is a prerequisite to a proper wptrunner integration.
