### PR TITLE
script: Make Servo's `SharedRwLock` per-ScriptThread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7270,7 +7270,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.38.0"
-source = "git+https://github.com/servo/stylo?rev=71c42fd1ed99b759c5b6c7cbd407a39fb8d3a701#71c42fd1ed99b759c5b6c7cbd407a39fb8d3a701"
+source = "git+https://github.com/servo/stylo?rev=f70226c09f8a6fe36f2306730f0f924fbf429001#f70226c09f8a6fe36f2306730f0f924fbf429001"
 dependencies = [
  "bitflags 2.11.1",
  "cssparser",
@@ -8976,7 +8976,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=71c42fd1ed99b759c5b6c7cbd407a39fb8d3a701#71c42fd1ed99b759c5b6c7cbd407a39fb8d3a701"
+source = "git+https://github.com/servo/stylo?rev=f70226c09f8a6fe36f2306730f0f924fbf429001#f70226c09f8a6fe36f2306730f0f924fbf429001"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -9403,7 +9403,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.17.0"
-source = "git+https://github.com/servo/stylo?rev=71c42fd1ed99b759c5b6c7cbd407a39fb8d3a701#71c42fd1ed99b759c5b6c7cbd407a39fb8d3a701"
+source = "git+https://github.com/servo/stylo?rev=f70226c09f8a6fe36f2306730f0f924fbf429001#f70226c09f8a6fe36f2306730f0f924fbf429001"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -9459,7 +9459,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.17.0"
-source = "git+https://github.com/servo/stylo?rev=71c42fd1ed99b759c5b6c7cbd407a39fb8d3a701#71c42fd1ed99b759c5b6c7cbd407a39fb8d3a701"
+source = "git+https://github.com/servo/stylo?rev=f70226c09f8a6fe36f2306730f0f924fbf429001#f70226c09f8a6fe36f2306730f0f924fbf429001"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -9468,7 +9468,7 @@ dependencies = [
 [[package]]
 name = "stylo_derive"
 version = "0.17.0"
-source = "git+https://github.com/servo/stylo?rev=71c42fd1ed99b759c5b6c7cbd407a39fb8d3a701#71c42fd1ed99b759c5b6c7cbd407a39fb8d3a701"
+source = "git+https://github.com/servo/stylo?rev=f70226c09f8a6fe36f2306730f0f924fbf429001#f70226c09f8a6fe36f2306730f0f924fbf429001"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -9480,7 +9480,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.17.0"
-source = "git+https://github.com/servo/stylo?rev=71c42fd1ed99b759c5b6c7cbd407a39fb8d3a701#71c42fd1ed99b759c5b6c7cbd407a39fb8d3a701"
+source = "git+https://github.com/servo/stylo?rev=f70226c09f8a6fe36f2306730f0f924fbf429001#f70226c09f8a6fe36f2306730f0f924fbf429001"
 dependencies = [
  "bitflags 2.11.1",
  "stylo_malloc_size_of",
@@ -9489,7 +9489,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.17.0"
-source = "git+https://github.com/servo/stylo?rev=71c42fd1ed99b759c5b6c7cbd407a39fb8d3a701#71c42fd1ed99b759c5b6c7cbd407a39fb8d3a701"
+source = "git+https://github.com/servo/stylo?rev=f70226c09f8a6fe36f2306730f0f924fbf429001#f70226c09f8a6fe36f2306730f0f924fbf429001"
 dependencies = [
  "app_units",
  "cssparser",
@@ -9506,12 +9506,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.17.0"
-source = "git+https://github.com/servo/stylo?rev=71c42fd1ed99b759c5b6c7cbd407a39fb8d3a701#71c42fd1ed99b759c5b6c7cbd407a39fb8d3a701"
+source = "git+https://github.com/servo/stylo?rev=f70226c09f8a6fe36f2306730f0f924fbf429001#f70226c09f8a6fe36f2306730f0f924fbf429001"
 
 [[package]]
 name = "stylo_traits"
 version = "0.17.0"
-source = "git+https://github.com/servo/stylo?rev=71c42fd1ed99b759c5b6c7cbd407a39fb8d3a701#71c42fd1ed99b759c5b6c7cbd407a39fb8d3a701"
+source = "git+https://github.com/servo/stylo?rev=f70226c09f8a6fe36f2306730f0f924fbf429001#f70226c09f8a6fe36f2306730f0f924fbf429001"
 dependencies = [
  "app_units",
  "bitflags 2.11.1",
@@ -9932,7 +9932,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.4.0"
-source = "git+https://github.com/servo/stylo?rev=71c42fd1ed99b759c5b6c7cbd407a39fb8d3a701#71c42fd1ed99b759c5b6c7cbd407a39fb8d3a701"
+source = "git+https://github.com/servo/stylo?rev=f70226c09f8a6fe36f2306730f0f924fbf429001#f70226c09f8a6fe36f2306730f0f924fbf429001"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -9945,7 +9945,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=71c42fd1ed99b759c5b6c7cbd407a39fb8d3a701#71c42fd1ed99b759c5b6c7cbd407a39fb8d3a701"
+source = "git+https://github.com/servo/stylo?rev=f70226c09f8a6fe36f2306730f0f924fbf429001#f70226c09f8a6fe36f2306730f0f924fbf429001"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,12 +162,12 @@ rustls-platform-verifier = "0.7.0"
 sea-query = { version = "=1.0.0-rc.31", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = { version = "=0.8.0-rc.15" }
 sec1 = "0.7"
-selectors = { git = "https://github.com/servo/stylo", rev = "71c42fd1ed99b759c5b6c7cbd407a39fb8d3a701" }
+selectors = { git = "https://github.com/servo/stylo", rev = "f70226c09f8a6fe36f2306730f0f924fbf429001" }
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
 serde_json = "1.0"
-servo_arc = { git = "https://github.com/servo/stylo", rev = "71c42fd1ed99b759c5b6c7cbd407a39fb8d3a701" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "f70226c09f8a6fe36f2306730f0f924fbf429001" }
 sha1 = "0.10"
 sha2 = "0.10"
 sha3 = "0.10"
@@ -176,12 +176,12 @@ skrifa = "0.37.0"
 smallvec = { version = "1.15", features = ["serde", "union"] }
 string_cache = "0.9"
 strum = { version = "0.28", features = ["derive"] }
-stylo = { git = "https://github.com/servo/stylo", rev = "71c42fd1ed99b759c5b6c7cbd407a39fb8d3a701" }
-stylo_atoms = { git = "https://github.com/servo/stylo", rev = "71c42fd1ed99b759c5b6c7cbd407a39fb8d3a701" }
-stylo_dom = { git = "https://github.com/servo/stylo", rev = "71c42fd1ed99b759c5b6c7cbd407a39fb8d3a701" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "71c42fd1ed99b759c5b6c7cbd407a39fb8d3a701" }
-stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "71c42fd1ed99b759c5b6c7cbd407a39fb8d3a701" }
-stylo_traits = { git = "https://github.com/servo/stylo", rev = "71c42fd1ed99b759c5b6c7cbd407a39fb8d3a701" }
+stylo = { git = "https://github.com/servo/stylo", rev = "f70226c09f8a6fe36f2306730f0f924fbf429001" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "f70226c09f8a6fe36f2306730f0f924fbf429001" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "f70226c09f8a6fe36f2306730f0f924fbf429001" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "f70226c09f8a6fe36f2306730f0f924fbf429001" }
+stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "f70226c09f8a6fe36f2306730f0f924fbf429001" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "f70226c09f8a6fe36f2306730f0f924fbf429001" }
 surfman = { version = "0.12.1", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -4,10 +4,9 @@
 
 #![expect(unsafe_code)]
 
-use std::cell::{Cell, RefCell};
+use std::cell::{Cell, OnceCell, RefCell};
 use std::collections::HashMap;
 use std::fmt::Debug;
-use std::process;
 use std::rc::Rc;
 use std::sync::{Arc, LazyLock};
 
@@ -27,7 +26,7 @@ use layout_api::{
     ReflowRequestRestyle, ReflowResult, ReflowStatistics, ScrollContainerQueryFlags,
     ScrollContainerResponse, TrustedNodeAddress, with_layout_state,
 };
-use log::{debug, error, warn};
+use log::{debug, warn};
 use malloc_size_of::{MallocConditionalSizeOf, MallocSizeOf, MallocSizeOfOps};
 use net_traits::image_cache::ImageCache;
 use paint_api::CrossProcessPaintApi;
@@ -486,10 +485,10 @@ impl Layout for LayoutThread {
         with_layout_state(|| {
             let node = unsafe { ServoLayoutNode::new(&node) };
             let document = unsafe { node.dangerous_style_node() }.owner_doc();
-            let document_shared_lock = document.style_shared_lock();
+            let shared_locks = document.shared_style_locks();
             let guards = StylesheetGuards {
-                author: &document_shared_lock.read(),
-                ua_or_user: &GLOBAL_STYLE_DATA.shared_lock.read(),
+                author: &shared_locks.author.read(),
+                ua_or_user: &shared_locks.ua_or_user.read(),
             };
             let snapshot_map = SnapshotMap::new();
 
@@ -516,10 +515,11 @@ impl Layout for LayoutThread {
         with_layout_state(|| {
             let node = unsafe { ServoLayoutNode::new(&node) };
             let document = unsafe { node.dangerous_style_node() }.owner_doc();
-            let document_shared_lock = document.style_shared_lock();
+            let shared_locks = document.shared_style_locks();
+            let shared_author_lock = &shared_locks.author;
             let guards = StylesheetGuards {
-                author: &document_shared_lock.read(),
-                ua_or_user: &GLOBAL_STYLE_DATA.shared_lock.read(),
+                author: &shared_author_lock.read(),
+                ua_or_user: &shared_locks.ua_or_user.read(),
             };
             let snapshot_map = SnapshotMap::new();
             let shared_style_context = self.build_shared_style_context(
@@ -535,7 +535,7 @@ impl Layout for LayoutThread {
                 node,
                 value,
                 self.url.clone(),
-                document_shared_lock,
+                shared_author_lock,
             )
         })
     }
@@ -1086,12 +1086,11 @@ impl LayoutThread {
             None => return Default::default(),
         };
 
-        let document_shared_lock = document.style_shared_lock();
-        let author_guard = document_shared_lock.read();
-        let ua_stylesheets = &*UA_STYLESHEETS;
+        let shared_locks = document.shared_style_locks();
+        let user_agent_stylesheets = get_ua_stylesheets(&shared_locks.ua_or_user);
         let guards = StylesheetGuards {
-            author: &author_guard,
-            ua_or_user: &GLOBAL_STYLE_DATA.shared_lock.read(),
+            author: &shared_locks.author.read(),
+            ua_or_user: &shared_locks.ua_or_user.read(),
         };
 
         let rayon_pool = STYLE_THREAD_POOL.lock();
@@ -1112,7 +1111,7 @@ impl LayoutThread {
             }
         }
 
-        self.prepare_stylist_for_reflow(reflow_request, document, &guards, ua_stylesheets)
+        self.prepare_stylist_for_reflow(reflow_request, document, &guards, &user_agent_stylesheets)
             .process_style(dangerous_root_element, Some(&snapshot_map));
 
         if self.previously_highlighted_dom_node.get() != reflow_request.highlighted_dom_node {
@@ -1510,16 +1509,23 @@ impl LayoutThread {
     }
 }
 
-fn get_ua_stylesheets() -> Result<UserAgentStylesheets, &'static str> {
+fn get_ua_stylesheets(shared_lock: &SharedRwLock) -> Rc<UserAgentStylesheets> {
+    // There is an assumption here that there is only a single ScriptThread per thread, which
+    // is currently the case in Servo. If this were to change, these user agent stylesheets
+    // would need to be managed by the ScriptThread instance.
+    thread_local! {
+        static USER_AGENT_STYLESHEETS: OnceCell<Rc<UserAgentStylesheets>> = const { OnceCell::new() };
+    }
+
     fn parse_ua_stylesheet(
         shared_lock: &SharedRwLock,
         filename: &str,
         content: &[u8],
-    ) -> Result<DocumentStyleSheet, &'static str> {
-        let url = Url::parse(&format!("chrome://resources/{:?}", filename))
-            .ok()
-            .unwrap();
-        Ok(DocumentStyleSheet(ServoArc::new(Stylesheet::from_bytes(
+    ) -> DocumentStyleSheet {
+        let url = Url::parse(&format!("chrome://resources/{filename}")).unwrap_or_else(|_| {
+            panic!("Could not parse user stylesheet URL: {filename}");
+        });
+        DocumentStyleSheet(ServoArc::new(Stylesheet::from_bytes(
             content,
             url.into(),
             None,
@@ -1530,29 +1536,33 @@ fn get_ua_stylesheets() -> Result<UserAgentStylesheets, &'static str> {
             None,
             None,
             QuirksMode::NoQuirks,
-        ))))
+        )))
     }
 
-    let shared_lock = &GLOBAL_STYLE_DATA.shared_lock;
+    USER_AGENT_STYLESHEETS.with(|user_stylesheets| {
+        user_stylesheets
+            .get_or_init(|| {
+                // FIXME: presentational-hints.css should be at author origin with zero specificity.
+                //        (Does it make a difference?)
+                let user_agent_stylesheets = vec![
+                    parse_ua_stylesheet(shared_lock, "user-agent.css", USER_AGENT_CSS),
+                    parse_ua_stylesheet(shared_lock, "servo.css", SERVO_CSS),
+                    parse_ua_stylesheet(
+                        shared_lock,
+                        "presentational-hints.css",
+                        PRESENTATIONAL_HINTS_CSS,
+                    ),
+                ];
 
-    // FIXME: presentational-hints.css should be at author origin with zero specificity.
-    //        (Does it make a difference?)
-    let user_agent_stylesheets = vec![
-        parse_ua_stylesheet(shared_lock, "user-agent.css", USER_AGENT_CSS)?,
-        parse_ua_stylesheet(shared_lock, "servo.css", SERVO_CSS)?,
-        parse_ua_stylesheet(
-            shared_lock,
-            "presentational-hints.css",
-            PRESENTATIONAL_HINTS_CSS,
-        )?,
-    ];
+                let quirks_mode_stylesheet =
+                    parse_ua_stylesheet(shared_lock, "quirks-mode.css", QUIRKS_MODE_CSS);
 
-    let quirks_mode_stylesheet =
-        parse_ua_stylesheet(shared_lock, "quirks-mode.css", QUIRKS_MODE_CSS)?;
-
-    Ok(UserAgentStylesheets {
-        user_agent_stylesheets,
-        quirks_mode_stylesheet,
+                Rc::new(UserAgentStylesheets {
+                    user_agent_stylesheets,
+                    quirks_mode_stylesheet,
+                })
+            })
+            .clone()
     })
 }
 
@@ -1563,15 +1573,6 @@ pub struct UserAgentStylesheets {
     /// The quirks mode stylesheet.
     pub quirks_mode_stylesheet: DocumentStyleSheet,
 }
-
-static UA_STYLESHEETS: LazyLock<UserAgentStylesheets> =
-    LazyLock::new(|| match get_ua_stylesheets() {
-        Ok(stylesheets) => stylesheets,
-        Err(filename) => {
-            error!("Failed to load UA stylesheet {}!", filename);
-            process::exit(1);
-        },
-    });
 
 struct RegisteredPainterImpl {
     painter: Box<dyn Painter>,

--- a/components/script/dom/css/cssstyledeclaration.rs
+++ b/components/script/dom/css/cssstyledeclaration.rs
@@ -77,7 +77,7 @@ impl CSSStyleOwner {
             ),
             CSSStyleOwner::Element(ref el) => {
                 let document = el.owner_document();
-                let shared_lock = document.style_shared_lock();
+                let shared_lock = document.style_shared_author_lock();
                 let mut attr = el.style_attribute().borrow_mut().take();
                 let result = if let Some(lock) = attr.as_ref() {
                     let mut guard = shared_lock.write();
@@ -146,7 +146,7 @@ impl CSSStyleOwner {
             CSSStyleOwner::Element(ref el) => match *el.style_attribute().borrow() {
                 Some(ref pdb) => {
                     let document = el.owner_document();
-                    let guard = document.style_shared_lock().read();
+                    let guard = document.style_shared_author_lock().read();
                     f(pdb.read_with(&guard))
                 },
                 None => {

--- a/components/script/dom/css/cssstylesheet.rs
+++ b/components/script/dom/css/cssstylesheet.rs
@@ -351,7 +351,7 @@ impl CSSStyleSheetMethods<crate::DomTypeHolder> for CSSStyleSheet {
         options: &CSSStyleSheetInit,
     ) -> DomRoot<Self> {
         let doc = window.Document();
-        let shared_lock = doc.style_shared_lock().clone();
+        let shared_lock = doc.style_shared_author_lock().clone();
         let media = Arc::new(shared_lock.wrap(match &options.media {
             Some(media) => match media {
                 MediaListOrString::MediaList(media_list) => media_list.clone_media_list(),

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -66,7 +66,7 @@ use style::attr::AttrValue;
 use style::context::QuirksMode;
 use style::invalidation::element::restyle_hints::RestyleHint;
 use style::selector_parser::Snapshot;
-use style::shared_lock::{SharedRwLock as StyleSharedRwLock, SharedRwLockReadGuard};
+use style::shared_lock::{SharedRwLock, SharedRwLockReadGuard};
 use style::str::{split_html_space_chars, str_join};
 use style::stylesheet_set::DocumentStylesheetSet;
 use style::stylesheets::{Origin, OriginSet, Stylesheet};
@@ -200,7 +200,7 @@ use crate::mime::{APPLICATION, CHARSET};
 use crate::navigation::navigate;
 use crate::network_listener::{FetchResponseListener, NetworkListener};
 use crate::script_runtime::CanGc;
-use crate::script_thread::ScriptThread;
+use crate::script_thread::{ScriptThread, SharedRwLocks};
 use crate::stylesheet_set::StylesheetSetRef;
 use crate::task::NonSendTaskBox;
 use crate::task_source::TaskSourceName;
@@ -361,10 +361,11 @@ pub(crate) struct Document {
     applets: MutNullableDom<HTMLCollection>,
     /// Information about the `<iframes>` in this [`Document`].
     iframes: RefCell<IFrameCollection>,
-    /// Lock use for style attributes and author-origin stylesheet objects in this document.
-    /// Can be acquired once for accessing many objects.
+    /// Shared locks used for style attributes, author-origin stylesheets, and user and
+    /// user agent stylesheets in this document. Can be acquired once for accessing many
+    /// objects. This is shared with the owning [`ScriptThread`].
     #[no_trace]
-    style_shared_lock: StyleSharedRwLock,
+    shared_style_locks: SharedRwLocks,
     /// List of stylesheets associated with nodes in this document. |None| if the list needs to be refreshed.
     #[custom_trace]
     stylesheets: DomRefCell<DocumentStylesheetSet<ServoStylesheetInDocument>>,
@@ -3393,8 +3394,8 @@ impl<'dom> LayoutDom<'dom, Document> {
     }
 
     #[inline]
-    pub(crate) fn style_shared_lock(self) -> &'dom StyleSharedRwLock {
-        self.unsafe_get().style_shared_lock()
+    pub(crate) fn shared_style_locks(self) -> &'dom SharedRwLocks {
+        self.unsafe_get().shared_style_locks()
     }
 
     #[inline]
@@ -3540,8 +3541,8 @@ impl Document {
             .unwrap_or(UTF_8);
 
         let has_focus = window.parent_info().is_none();
-
         let has_browsing_context = has_browsing_context == HasBrowsingContext::Yes;
+        let shared_style_locks = window.script_thread().shared_style_locks().clone();
 
         Document {
             node: Node::new_document_node(),
@@ -3575,19 +3576,7 @@ impl Document {
             anchors: Default::default(),
             applets: Default::default(),
             iframes: RefCell::new(IFrameCollection::new()),
-            style_shared_lock: {
-                /// Per-process shared lock for author-origin stylesheets
-                ///
-                /// FIXME: make it per-document or per-pipeline instead:
-                /// <https://github.com/servo/servo/issues/16027>
-                /// (Need to figure out what to do with the style attribute
-                /// of elements adopted into another document.)
-                static PER_PROCESS_AUTHOR_SHARED_LOCK: LazyLock<StyleSharedRwLock> =
-                    LazyLock::new(StyleSharedRwLock::new);
-
-                PER_PROCESS_AUTHOR_SHARED_LOCK.clone()
-                // StyleSharedRwLock::new()
-            },
+            shared_style_locks,
             stylesheets: DomRefCell::new(DocumentStylesheetSet::new()),
             stylesheet_list: MutNullableDom::new(None),
             ready_state: Cell::new(ready_state),
@@ -3992,9 +3981,14 @@ impl Document {
         self.GetDocumentElement().and_then(DomRoot::downcast)
     }
 
-    /// Return a reference to the per-document shared lock used in stylesheets.
-    pub(crate) fn style_shared_lock(&self) -> &StyleSharedRwLock {
-        &self.style_shared_lock
+    /// Return a reference to the per-ScriptThread shared locks used for stylesheets.
+    pub(crate) fn shared_style_locks(&self) -> &SharedRwLocks {
+        &self.shared_style_locks
+    }
+
+    /// Return a reference to the per-ScriptThread shared lock used for author stylesheets.
+    pub(crate) fn style_shared_author_lock(&self) -> &SharedRwLock {
+        &self.shared_style_locks.author
     }
 
     /// Flushes the stylesheet list, and returns whether any stylesheet changed.
@@ -4285,7 +4279,7 @@ impl Document {
             StylesheetSetRef::Document(stylesheets),
             sheet,
             insertion_point,
-            self.style_shared_lock(),
+            self.style_shared_author_lock(),
         );
     }
 
@@ -4319,7 +4313,7 @@ impl Document {
             StylesheetSetRef::Document(stylesheets),
             sheet,
             insertion_point,
-            self.style_shared_lock(),
+            self.style_shared_author_lock(),
         );
     }
 

--- a/components/script/dom/element/attributes/accessors.rs
+++ b/components/script/dom/element/attributes/accessors.rs
@@ -196,7 +196,7 @@ impl Element {
             let Some(ref pdb) = *self.style_attribute().borrow()
         {
             let document = self.owner_document();
-            let shared_lock = document.style_shared_lock();
+            let shared_lock = document.style_shared_author_lock();
             let new_pdb = pdb.read_with(&shared_lock.read()).clone();
             return AttrValue::Declaration(
                 (**attr.value()).to_owned(),

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -1469,7 +1469,7 @@ impl<'dom> LayoutDom<'dom, Element> {
             return;
         };
 
-        let shared_lock = document.style_shared_lock();
+        let shared_lock = &document.shared_style_locks().author;
         hints.push(ApplicableDeclarationBlock::from_declarations(
             ServoArc::new(shared_lock.wrap(property_declaration_block)),
             CascadeLevel::new(CascadeOrigin::PresHints),
@@ -2326,7 +2326,7 @@ impl Element {
                         {
                             return;
                         }
-                        ServoArc::new(doc.style_shared_lock().wrap(parse_style_attribute(
+                        ServoArc::new(doc.style_shared_author_lock().wrap(parse_style_attribute(
                             source,
                             &UrlExtraData(doc.base_url().get_arc()),
                             Some(win.css_error_reporter()),

--- a/components/script/dom/execcommand/basecommand.rs
+++ b/components/script/dom/execcommand/basecommand.rs
@@ -176,7 +176,7 @@ impl CssPropertyName {
         let style_attribute = element.style_attribute().borrow();
         let declarations = style_attribute.as_ref()?;
         let document = element.owner_document();
-        let shared_lock = document.style_shared_lock();
+        let shared_lock = document.style_shared_author_lock();
         let read_lock = shared_lock.read();
         let style = declarations.read_with(&read_lock);
 

--- a/components/script/dom/execcommand/contenteditable/element.rs
+++ b/components/script/dom/execcommand/contenteditable/element.rs
@@ -195,7 +195,7 @@ impl Element {
         let style_attribute = self.style_attribute().borrow();
         style_attribute.as_ref().is_some_and(|declarations| {
             let document = self.owner_document();
-            let shared_lock = document.style_shared_lock();
+            let shared_lock = document.style_shared_author_lock();
             let read_lock = shared_lock.read();
             let style = declarations.read_with(&read_lock);
 
@@ -283,7 +283,7 @@ impl Element {
             return false;
         };
         let document = self.owner_document();
-        let shared_lock = document.style_shared_lock();
+        let shared_lock = document.style_shared_author_lock();
         let read_lock = shared_lock.read();
         let style = declarations.read_with(&read_lock);
 

--- a/components/script/dom/execcommand/contenteditable/htmlelement.rs
+++ b/components/script/dom/execcommand/contenteditable/htmlelement.rs
@@ -41,7 +41,7 @@ impl HTMLElement {
                 return;
             };
             let document = element.owner_document();
-            let shared_lock = document.style_shared_lock();
+            let shared_lock = document.style_shared_author_lock();
             let read_lock = shared_lock.read();
             let style = declarations.read_with(&read_lock);
 

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -410,7 +410,7 @@ impl VirtualMethods for HTMLLinkElement {
                     let Some(ref stylesheet) = *self.stylesheet.borrow_mut()
                 {
                     let document = self.owner_document();
-                    let shared_lock = document.style_shared_lock().clone();
+                    let shared_lock = document.style_shared_author_lock().clone();
                     let mut guard = shared_lock.write();
                     let media = stylesheet.media.write_with(&mut guard);
                     match mutation {
@@ -705,7 +705,7 @@ impl HTMLLinkElement {
         };
 
         let media = MediaList::parse_media_list(mq_str, document.window());
-        let media = Arc::new(document.style_shared_lock().wrap(media));
+        let media = Arc::new(document.style_shared_author_lock().wrap(media));
 
         let im_attribute = element.get_attribute(&local_name!("integrity"));
         let integrity_val = im_attribute.as_ref().map(|a| a.value());

--- a/components/script/dom/html/htmlstyleelement.rs
+++ b/components/script/dom/html/htmlstyleelement.rs
@@ -151,7 +151,7 @@ impl HTMLStyleElement {
         let data = node
             .GetTextContent()
             .expect("Element.textContent must be a string");
-        let shared_lock = node.owner_doc().style_shared_lock().clone();
+        let shared_lock = node.owner_doc().style_shared_author_lock().clone();
         let mq = Arc::new(shared_lock.wrap(self.create_media_list(&self.Media().str())));
 
         // For duplicate style sheets with identical content, `StylesheetContents` can be reused
@@ -387,7 +387,7 @@ impl VirtualMethods for HTMLStyleElement {
         } else if attr.name() == "media" &&
             let Some(ref stylesheet) = *self.stylesheet.borrow_mut()
         {
-            let shared_lock = node.owner_doc().style_shared_lock().clone();
+            let shared_lock = node.owner_doc().style_shared_author_lock().clone();
             let mut guard = shared_lock.write();
             let media = stylesheet.media.write_with(&mut guard);
             match mutation {

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -227,7 +227,7 @@ impl ShadowRoot {
             StylesheetSetRef::Author(stylesheets),
             sheet,
             insertion_point,
-            self.document.style_shared_lock(),
+            self.document.style_shared_author_lock(),
         );
     }
 
@@ -253,7 +253,7 @@ impl ShadowRoot {
             StylesheetSetRef::Author(stylesheets),
             sheet,
             insertion_point,
-            self.document.style_shared_lock(),
+            self.document.style_shared_author_lock(),
         );
     }
 

--- a/components/script/layout_dom/servo_dangerous_style_document.rs
+++ b/components/script/layout_dom/servo_dangerous_style_document.rs
@@ -16,6 +16,7 @@ use style::values::AtomIdent;
 use crate::dom::bindings::root::LayoutDom;
 use crate::dom::document::Document;
 use crate::layout_dom::{ServoDangerousStyleElement, ServoDangerousStyleNode, ServoLayoutElement};
+use crate::script_thread::SharedRwLocks;
 
 /// A wrapper around documents that ensures layout can only ever access safe properties.
 ///
@@ -48,7 +49,7 @@ impl<'dom> ::style::dom::TDocument for ServoDangerousStyleDocument<'dom> {
     }
 
     fn shared_lock(&self) -> &StyleSharedRwLock {
-        self.document.style_shared_lock()
+        &self.document.shared_style_locks().author
     }
 
     fn elements_with_id<'a>(
@@ -83,9 +84,9 @@ impl<'dom> ServoDangerousStyleDocument<'dom> {
             .map(|element| element.layout_element())
     }
 
-    /// Get the shared style lock for styling with Stylo for this [`ServoDangerousStyleDocument`].
-    pub fn style_shared_lock(&self) -> &StyleSharedRwLock {
-        self.document.style_shared_lock()
+    /// Get the shared style lock for author stylesheets for this [`ServoDangerousStyleDocument`].
+    pub fn shared_style_locks(&self) -> &SharedRwLocks {
+        self.document.shared_style_locks()
     }
 
     /// Flush the the stylesheets of all descendant shadow roots.

--- a/components/script/layout_dom/servo_dangerous_style_element.rs
+++ b/components/script/layout_dom/servo_dangerous_style_element.rs
@@ -184,7 +184,7 @@ impl<'dom> style::dom::TElement for ServoDangerousStyleElement<'dom> {
         context.animations.get_animation_declarations(
             &AnimationSetKey::new_for_non_pseudo(node.opaque()),
             context.current_time_for_animations,
-            document.style_shared_lock(),
+            &document.shared_style_locks().author,
         )
     }
 
@@ -197,7 +197,7 @@ impl<'dom> style::dom::TElement for ServoDangerousStyleElement<'dom> {
         context.animations.get_transition_declarations(
             &AnimationSetKey::new_for_non_pseudo(node.opaque()),
             context.current_time_for_animations,
-            document.style_shared_lock(),
+            &document.shared_style_locks().author,
         )
     }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -101,8 +101,8 @@ use storage_traits::StorageThreads;
 use storage_traits::webstorage_thread::WebStorageType;
 use style::context::QuirksMode;
 use style::error_reporting::RustLogReporter;
-use style::global_style_data::GLOBAL_STYLE_DATA;
 use style::media_queries::MediaList;
+use style::shared_lock::SharedRwLock;
 use style::stylesheets::{AllowImportRules, DocumentStyleSheet, Origin, Stylesheet};
 use style::thread_state::{self, ThreadState};
 use stylo_atoms::Atom;
@@ -222,9 +222,8 @@ struct ScriptThreadUserContents {
     user_stylesheets: Rc<Vec<DocumentStyleSheet>>,
 }
 
-impl From<UserContents> for ScriptThreadUserContents {
-    fn from(user_contents: UserContents) -> Self {
-        let shared_lock = &GLOBAL_STYLE_DATA.shared_lock;
+impl ScriptThreadUserContents {
+    fn new(user_contents: UserContents, shared_locks: &SharedRwLocks) -> Self {
         let user_stylesheets = user_contents
             .stylesheets
             .iter()
@@ -233,8 +232,8 @@ impl From<UserContents> for ScriptThreadUserContents {
                     user_stylesheet.source(),
                     user_stylesheet.url().into(),
                     Origin::User,
-                    ServoArc::new(shared_lock.wrap(MediaList::empty())),
-                    shared_lock.clone(),
+                    ServoArc::new(shared_locks.ua_or_user.wrap(MediaList::empty())),
+                    shared_locks.ua_or_user.clone(),
                     None,
                     Some(&RustLogReporter),
                     QuirksMode::NoQuirks,
@@ -245,6 +244,21 @@ impl From<UserContents> for ScriptThreadUserContents {
         Self {
             user_scripts: Rc::new(user_contents.scripts),
             user_stylesheets: Rc::new(user_stylesheets),
+        }
+    }
+}
+
+#[derive(Clone, MallocSizeOf)]
+pub struct SharedRwLocks {
+    pub author: SharedRwLock,
+    pub ua_or_user: SharedRwLock,
+}
+
+impl Default for SharedRwLocks {
+    fn default() -> Self {
+        Self {
+            author: SharedRwLock::new(),
+            ua_or_user: SharedRwLock::new(),
         }
     }
 }
@@ -354,6 +368,10 @@ pub struct ScriptThread {
 
     /// Unminify Css.
     unminify_css: bool,
+
+    /// The [`SharedRwLocks`] that are used by all Stylo operations in this ScriptThread.
+    #[no_trace]
+    shared_style_locks: SharedRwLocks,
 
     /// A map from [`UserContentManagerId`] to its [`UserContents`]. This is initialized
     /// with a copy of the map in constellation (via the `InitialScriptState`). After that,
@@ -529,6 +547,10 @@ impl ScriptThread {
 
     pub(crate) fn microtask_queue() -> Rc<MicrotaskQueue> {
         with_script_thread(|script_thread| script_thread.microtask_queue.clone())
+    }
+
+    pub(crate) fn shared_style_locks(&self) -> &SharedRwLocks {
+        &self.shared_style_locks
     }
 
     pub(crate) fn mark_document_with_no_blocked_loads(doc: &Document) {
@@ -975,10 +997,14 @@ impl ScriptThread {
 
         debugger_global.execute(&mut cx);
 
+        let shared_style_locks = Default::default();
         let user_contents_for_manager_id =
             FxHashMap::from_iter(state.user_contents_for_manager_id.into_iter().map(
                 |(user_content_manager_id, user_contents)| {
-                    (user_content_manager_id, user_contents.into())
+                    (
+                        user_content_manager_id,
+                        ScriptThreadUserContents::new(user_contents, &shared_style_locks),
+                    )
                 },
             ));
 
@@ -1018,6 +1044,7 @@ impl ScriptThread {
                     unminify_js: opts.unminify_js,
                     local_script_source: opts.local_script_source.clone(),
                     unminify_css: opts.unminify_css,
+                    shared_style_locks,
                     user_contents_for_manager_id: RefCell::new(user_contents_for_manager_id),
                     player_context: state.player_context,
                     pipeline_to_node_ids: Default::default(),
@@ -1971,9 +1998,10 @@ impl ScriptThread {
                 self.handle_embedder_control_response(id, response, cx);
             },
             ScriptThreadMessage::SetUserContents(user_content_manager_id, user_contents) => {
-                self.user_contents_for_manager_id
-                    .borrow_mut()
-                    .insert(user_content_manager_id, user_contents.into());
+                self.user_contents_for_manager_id.borrow_mut().insert(
+                    user_content_manager_id,
+                    ScriptThreadUserContents::new(user_contents, &self.shared_style_locks),
+                );
             },
             ScriptThreadMessage::DestroyUserContentManager(user_content_manager_id) => {
                 self.user_contents_for_manager_id

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -133,7 +133,7 @@ impl StylesheetContext {
     }
 
     fn empty_stylesheet(&self, document: &Document) -> Arc<Stylesheet> {
-        let shared_lock = document.style_shared_lock().clone();
+        let shared_lock = document.style_shared_author_lock().clone();
         let quirks_mode = document.quirks_mode();
 
         Arc::new(Stylesheet::from_bytes(
@@ -295,7 +295,7 @@ impl StylesheetContext {
                 // but Layout doesn't know about any new web fonts that it contains.
                 document.load_web_fonts_from_stylesheet(&stylesheet, &document_context);
 
-                let mut guard = document.style_shared_lock().write();
+                let mut guard = document.style_shared_author_lock().write();
                 import_rule.write_with(&mut guard).stylesheet = ImportSheet::Sheet(stylesheet);
             },
         }
@@ -544,7 +544,7 @@ impl ElementStylesheetLoader<'_> {
         document: &Document,
         cx: &mut js::context::JSContext,
     ) {
-        let shared_lock = document.style_shared_lock().clone();
+        let shared_lock = document.style_shared_author_lock().clone();
         let quirks_mode = document.quirks_mode();
         let window = element.owner_window();
 


### PR DESCRIPTION
This makes Stylo's locks per-`ScriptThread`. Before there was a single
lock per-`Document` for author stylesheets and one per-process for user
agent stylesheets. In order to allow the transition to `AtomicRefCell`
(a faster form of locking that will panic instead of deadlock) in Stylo,
all locks must become per-thread. This is to prevent reading or writing
from the lock when it is being written to.
    
The goal here is to improve performance and also to resolve
long-standing questions about what granularity style locking should
exist at.
    
The downside to this is that now user agent stylesheets must be created
per-ScriptThread instead of per-process, but modern pages have much more
CSS per page anyway and this only matters for the single process mode.
This is the Servo-side update to include the changes from
servo/style#362.

Testing: This should not change behavior in an observable way (other than
perhaps increasing performance), so is covered by existing tests.
Fixes: #16027.