### PR TITLE
servoshell: Add a horizontal scroll area for tabs

### DIFF
--- a/ports/servoshell/desktop/gui.rs
+++ b/ports/servoshell/desktop/gui.rs
@@ -529,41 +529,48 @@ impl Gui {
 
                 // A simple Tab header strip
                 let outer = Panel::top("tabs").show_inside(ctx, |ui| {
-                    ui.allocate_ui_with_layout(
-                        ui.available_size(),
-                        egui::Layout::left_to_right(egui::Align::Center),
-                        |ui| {
-                            for (id, webview) in window.webviews().into_iter() {
-                                let favicon = favicon_textures
-                                    .get(&id)
-                                    .map(|(_, favicon)| favicon)
-                                    .copied();
-                                Self::browser_tab(ui, window, webview, favicon);
-                            }
+                    // Add scroll for overflowing tabs
+                    egui::ScrollArea::horizontal()
+                        .scroll_bar_visibility(egui::scroll_area::ScrollBarVisibility::AlwaysHidden)
+                        .show(ui, |ui| {
+                            ui.allocate_ui_with_layout(
+                                ui.available_size(),
+                                egui::Layout::left_to_right(egui::Align::Center),
+                                |ui| {
+                                    for (id, webview) in window.webviews().into_iter() {
+                                        let favicon = favicon_textures
+                                            .get(&id)
+                                            .map(|(_, favicon)| favicon)
+                                            .copied();
+                                        Self::browser_tab(ui, window, webview, favicon);
+                                    }
 
-                            let new_tab_button = ui.add(Gui::toolbar_button("+"));
-                            new_tab_button.widget_info(|| {
-                                let mut info = WidgetInfo::new(WidgetType::Button);
-                                info.label = Some("New tab".into());
-                                info
-                            });
-                            if new_tab_button.clicked() {
-                                window
-                                    .queue_user_interface_command(UserInterfaceCommand::NewWebView);
-                            }
+                                    let new_tab_button = ui.add(Gui::toolbar_button("+"));
+                                    new_tab_button.widget_info(|| {
+                                        let mut info = WidgetInfo::new(WidgetType::Button);
+                                        info.label = Some("New tab".into());
+                                        info
+                                    });
+                                    if new_tab_button.clicked() {
+                                        window.queue_user_interface_command(
+                                            UserInterfaceCommand::NewWebView,
+                                        );
+                                    }
 
-                            let new_window_button = ui.add(Gui::toolbar_button("⊞"));
-                            new_window_button.widget_info(|| {
-                                let mut info = WidgetInfo::new(WidgetType::Button);
-                                info.label = Some("New window".into());
-                                info
-                            });
-                            if new_window_button.clicked() {
-                                window
-                                    .queue_user_interface_command(UserInterfaceCommand::NewWindow);
-                            }
-                        },
-                    );
+                                    let new_window_button = ui.add(Gui::toolbar_button("⊞"));
+                                    new_window_button.widget_info(|| {
+                                        let mut info = WidgetInfo::new(WidgetType::Button);
+                                        info.label = Some("New window".into());
+                                        info
+                                    });
+                                    if new_window_button.clicked() {
+                                        window.queue_user_interface_command(
+                                            UserInterfaceCommand::NewWindow,
+                                        );
+                                    }
+                                },
+                            );
+                        })
                 });
 
                 *toolbar_height = Length::new(outer.response.rect.max.y);


### PR DESCRIPTION
Add a horizontal scroll area for tabs, as I found if you have too many tabs open you can no longer access the newer ones

Testing: manually tested, only scrolls when cursor is hovering the tabs, see video

[scrollable-tabs.webm](https://github.com/user-attachments/assets/2cfad66a-bd55-4a90-b62d-9ab1f50af91b)
