### PR TITLE
tests: Remove stale FileReader idlharness expectations

### DIFF
--- a/components/script/dom/file/filereader.rs
+++ b/components/script/dom/file/filereader.rs
@@ -415,8 +415,8 @@ impl FileReaderMethods<crate::DomTypeHolder> for FileReader {
 
     /// <https://w3c.github.io/FileAPI/#dfn-readAsArrayBuffer>
     fn ReadAsArrayBuffer(&self, cx: &mut js::context::JSContext, blob: &Blob) -> ErrorResult {
-        // > The readAsBinaryString(blob) method, when invoked,
-        // must initiate a read operation for blob with BinaryString.
+        // > The readAsArrayBuffer(blob) method, when invoked,
+        // must initiate a read operation for blob with ArrayBuffer.
         self.read(cx, FileReaderFunction::ArrayBuffer, blob, None)
     }
 

--- a/tests/wpt/meta/FileAPI/idlharness.html.ini
+++ b/tests/wpt/meta/FileAPI/idlharness.html.ini
@@ -1,11 +1,4 @@
 [idlharness.html]
-  [FileReader interface: calling readAsBinaryString(Blob) on new FileReader() with too few arguments must throw TypeError]
-    TODO: Why are we failing these? 
-    expected: FAIL
-
-  [FileReader interface: new FileReader() must inherit property "readAsBinaryString(Blob)" with the proper type]
-    expected: FAIL
-
   [Blob interface: new Blob(["TEST"\]) must inherit property "stream()" with the proper type]
     expected: FAIL
 

--- a/tests/wpt/meta/FileAPI/idlharness.worker.js.ini
+++ b/tests/wpt/meta/FileAPI/idlharness.worker.js.ini
@@ -1,10 +1,4 @@
 [idlharness.worker.html]
-  [FileReader interface: calling readAsBinaryString(Blob) on new FileReader() with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [FileReader interface: new FileReader() must inherit property "readAsBinaryString(Blob)" with the proper type]
-    expected: FAIL
-
   [Blob interface: new Blob(["TEST"\]) must inherit property "stream()" with the proper type]
     expected: FAIL
 


### PR DESCRIPTION
Remove stale FileReader readAsBinaryString idlharness expectations

follow up #44858

The remaining expectations in `idlharness.html.ini` and `idlharness.worker.js.ini`
were stale metadata for subtests that those legacy harness files no longer emit.

Testing: `./mach test-wpt tests/wpt/tests/FileAPI/idlharness.html tests/wpt/tests/FileAPI/idlharness.worker.js`; `./mach test-wpt tests/wpt/tests/FileAPI/idlharness.any.js` Pass locally.
