### PR TITLE
script: Update selection to correct node when moving preserving ranges

### DIFF
--- a/components/script/dom/execcommand/contenteditable/node.rs
+++ b/components/script/dom/execcommand/contenteditable/node.rs
@@ -150,7 +150,11 @@ where
         active_range.end_container() &&
         active_range.start_container().is::<Text>()
     {
-        Some((active_range.start_offset(), active_range.end_offset()))
+        Some((
+            active_range.start_container(),
+            active_range.start_offset(),
+            active_range.end_offset(),
+        ))
     } else {
         None
     };
@@ -169,11 +173,11 @@ where
     // partially/fully selected. In these cases, we shouldn't update the offsets to the new parent,
     // but instead retain them on the original text node. Therefore, if that's the case,
     // update them here and immediately return.
-    if let Some((previous_start_offset, previous_end_offset)) =
+    if let Some((selected_text_node, previous_start_offset, previous_end_offset)) =
         end_offsets_if_previously_selected_single_text_node
     {
-        active_range.set_start(node, previous_start_offset);
-        active_range.set_end(node, previous_end_offset);
+        active_range.set_start(&selected_text_node, previous_start_offset);
+        active_range.set_end(&selected_text_node, previous_end_offset);
         return;
     }
 

--- a/tests/wpt/meta/editing/run/bold.html.ini
+++ b/tests/wpt/meta/editing/run/bold.html.ini
@@ -50,21 +50,6 @@
   [[["stylewithcss","false"\],["bold",""\]\] "foo[<span style=\\"font-weight: bold\\">bar</span>\]baz" queryCommandState("bold") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["bold",""\]\] "<b id=purple>bar [baz\] qoz</b>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["bold",""\]\] "<b id=purple>bar [baz\] qoz</b>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["bold",""\]\] "<span style=\\"font-weight: 700\\">foo[bar\]baz</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["bold",""\]\] "<span style=\\"font-weight: 700\\">foo[bar\]baz</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["bold",""\]\] "<span style=\\"font-weight: 900\\">foo[bar\]baz</span>" compare innerHTML]
-    expected: FAIL
-
 
 [bold.html?1-1000]
   [[["stylewithcss","true"\],["bold",""\]\] "<p>[foo</p><p> <span>bar</span> </p><p>baz\]</p>" compare innerHTML]
@@ -201,16 +186,4 @@
     expected: FAIL
 
   [[["bold",""\]\] "<span style=\\"font-weight: 900\\">foo[barbaz</span>}" queryCommandState("bold") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["bold",""\]\] "<b><span class=notbold>[foo\]</span></b>" queryCommandState("bold") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["bold",""\]\] "<b><span class=notbold>[foo\]</span></b>" queryCommandState("bold") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["bold",""\]\] "<p style=\\"font-weight: bold\\">foo[bar\]baz</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["bold",""\]\] "<p style=\\"font-weight: bold\\">foo[bar\]baz</p>" compare innerHTML]
     expected: FAIL

--- a/tests/wpt/meta/editing/run/fontname.html.ini
+++ b/tests/wpt/meta/editing/run/fontname.html.ini
@@ -23,30 +23,6 @@
   [[["stylewithcss","true"\],["fontname","sans-serif"\]\] "<p>[foo</p> <p>bar\]</p>" queryCommandState("stylewithcss") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontname","sans-serif"\]\] "foo<code>[bar\]</code>baz" queryCommandValue("fontname") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontname","sans-serif"\]\] "foo<code>[bar\]</code>baz" queryCommandValue("fontname") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontname","sans-serif"\]\] "foo<kbd>[bar\]</kbd>baz" queryCommandValue("fontname") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontname","sans-serif"\]\] "foo<kbd>[bar\]</kbd>baz" queryCommandValue("fontname") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontname","sans-serif"\]\] "foo<samp>[bar\]</samp>baz" queryCommandValue("fontname") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontname","sans-serif"\]\] "foo<samp>[bar\]</samp>baz" queryCommandValue("fontname") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontname","sans-serif"\]\] "foo<tt>[bar\]</tt>baz" queryCommandValue("fontname") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontname","sans-serif"\]\] "foo<tt>[bar\]</tt>baz" queryCommandValue("fontname") after]
-    expected: FAIL
-
 
 [fontname.html?2001-last]
   [[["stylewithcss","false"\],["fontname","sans-serif"\]\] "fo[o<listing>b\]ar</listing>" queryCommandValue("fontname") after]

--- a/tests/wpt/meta/editing/run/fontsize.html.ini
+++ b/tests/wpt/meta/editing/run/fontsize.html.ini
@@ -214,18 +214,6 @@
   [[["fontsize","4"\]\] "<font size=+1>foo[bar\]baz</font>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=4>foo<font size=1>b[a\]r</font>baz</font>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=4>foo<font size=1>b[a\]r</font>baz</font>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<span style=\\"font-size: large\\">foo<span style=\\"font-size: xx-small\\">b[a\]r</span>baz</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<span style=\\"font-size: large\\">foo<span style=\\"font-size: xx-small\\">b[a\]r</span>baz</span>" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","3"\]\] "foo<big>[bar\]</big>baz" compare innerHTML]
     expected: FAIL
 

--- a/tests/wpt/meta/editing/run/forecolor.html.ini
+++ b/tests/wpt/meta/editing/run/forecolor.html.ini
@@ -524,9 +524,3 @@
 
   [[["stylewithcss","false"\],["forecolor","#0000FF"\]\] "<font color=brown>fo[o</font><span style=color:brown>b\]ar</span>" queryCommandIndeterm("forecolor") before]
     expected: FAIL
-
-  [[["stylewithcss","true"\],["forecolor","#0000FF"\]\] "foo<font color=brown>[bar\]</font>baz" queryCommandValue("forecolor") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["forecolor","#0000FF"\]\] "foo<font color=brown>[bar\]</font>baz" queryCommandValue("forecolor") after]
-    expected: FAIL

--- a/tests/wpt/meta/editing/run/hilitecolor.html.ini
+++ b/tests/wpt/meta/editing/run/hilitecolor.html.ini
@@ -97,9 +97,3 @@
 
   [[["hilitecolor","#00FFFF"\]\] "<p style=\\"background-color: aqua\\">foo[bar\]baz</p>" compare innerHTML]
     expected: FAIL
-
-  [[["stylewithcss","true"\],["hilitecolor","#00FFFF"\]\] "<span style=font-size:xx-large>[foo\]</span>" queryCommandValue("hilitecolor") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["hilitecolor","#00FFFF"\]\] "<span style=font-size:xx-large>[foo\]</span>" queryCommandValue("hilitecolor") after]
-    expected: FAIL

--- a/tests/wpt/meta/editing/run/italic.html.ini
+++ b/tests/wpt/meta/editing/run/italic.html.ini
@@ -71,12 +71,6 @@
   [[["stylewithcss","true"\],["italic",""\]\] "<p>[foo</p> <p>bar\]</p>" queryCommandState("stylewithcss") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<i>b[a\]r</i>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["italic",""\]\] "foo<i>b[a\]r</i>baz" compare innerHTML]
-    expected: FAIL
-
 
 [italic.html?2001-last]
   [[["stylewithcss","false"\],["italic",""\]\] "<span style=font-style:oblique>fo[o</span><span style=font-style:italic>b\]ar</span>" compare innerHTML]
@@ -223,7 +217,4 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["italic",""\]\] "fo[o<dfn>bar</dfn>b\]az" queryCommandState("stylewithcss") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["italic",""\]\] "foo<span style=\\"font-style: oblique\\">b[a\]r</span>baz" compare innerHTML]
     expected: FAIL

--- a/tests/wpt/meta/editing/run/removeformat.html.ini
+++ b/tests/wpt/meta/editing/run/removeformat.html.ini
@@ -166,9 +166,3 @@
 
   [[["stylewithcss","true"\],["removeformat",""\]\] "[foo<b>bar</b>baz\]" queryCommandState("stylewithcss") before]
     expected: FAIL
-
-  [[["stylewithcss","true"\],["removeformat",""\]\] "<p style=\\"font-weight: bold\\">foo[bar\]baz</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["removeformat",""\]\] "<p style=\\"font-weight: bold\\">foo[bar\]baz</p>" compare innerHTML]
-    expected: FAIL

--- a/tests/wpt/meta/editing/run/strikethrough.html.ini
+++ b/tests/wpt/meta/editing/run/strikethrough.html.ini
@@ -163,24 +163,6 @@
   [[["stylewithcss","false"\],["strikethrough",""\]\] "foo<ins>[bar\]</ins>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["strikethrough",""\]\] "foo<span style=\\"text-decoration: underline line-through\\">b[a\]r</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["strikethrough",""\]\] "foo<span style=\\"text-decoration: underline line-through\\">b[a\]r</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["strikethrough",""\]\] "foo<u style=\\"text-decoration: line-through\\">b[a\]r</u>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["strikethrough",""\]\] "foo<u style=\\"text-decoration: line-through\\">b[a\]r</u>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["strikethrough",""\]\] "<p style=\\"text-decoration: line-through\\">foo[bar\]baz</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["strikethrough",""\]\] "<p style=\\"text-decoration: line-through\\">foo[bar\]baz</p>" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["strikethrough",""\]\] "foo<span class=\\"underline\\">[bar\]</span>baz" compare innerHTML]
     expected: FAIL
 
@@ -262,10 +244,4 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["strikethrough",""\]\] "foo<u>[bar\]</u>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["strikethrough",""\]\] "<strike>foo[bar\]baz</strike>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["strikethrough",""\]\] "<strike>foo[bar\]baz</strike>" compare innerHTML]
     expected: FAIL

--- a/tests/wpt/meta/editing/run/subscript.html.ini
+++ b/tests/wpt/meta/editing/run/subscript.html.ini
@@ -11,12 +11,6 @@
   [[["stylewithcss","false"\],["subscript",""\]\] "<p>[foo<p><br><p>bar\]" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["subscript",""\]\] "foo<sup>b[a\]r</sup>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["subscript",""\]\] "foo<sup>b[a\]r</sup>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["subscript",""\]\] "foo<span style=vertical-align:sub>[bar\]</span>baz" compare innerHTML]
     expected: FAIL
 
@@ -29,43 +23,19 @@
   [[["stylewithcss","false"\],["subscript",""\]\] "foo<span style=vertical-align:super>[bar\]</span>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["subscript",""\]\] "foo<sup><sup>b[a\]r</sup></sup>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["subscript",""\]\] "foo<sup><sup>b[a\]r</sup></sup>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["subscript",""\]\] "foo<sup>b<sup>[a\]</sup>r</sup>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["subscript",""\]\] "foo<sup>b<sup>[a\]</sup>r</sup>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["subscript",""\]\] "foo<sub><sup>[bar\]</sup></sub>baz" queryCommandIndeterm("subscript") before]
     expected: FAIL
 
   [[["stylewithcss","false"\],["subscript",""\]\] "foo<sub><sup>[bar\]</sup></sub>baz" queryCommandIndeterm("subscript") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["subscript",""\]\] "foo<sub><sup>b[a\]r</sup></sub>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["subscript",""\]\] "foo<sub><sup>b[a\]r</sup></sub>baz" queryCommandIndeterm("subscript") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["subscript",""\]\] "foo<sub><sup>b[a\]r</sup></sub>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["subscript",""\]\] "foo<sub><sup>b[a\]r</sup></sub>baz" queryCommandIndeterm("subscript") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["subscript",""\]\] "foo<sub>b<sup>[a\]</sup>r</sub>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["subscript",""\]\] "foo<sub>b<sup>[a\]</sup>r</sub>baz" queryCommandIndeterm("subscript") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["subscript",""\]\] "foo<sub>b<sup>[a\]</sup>r</sub>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["subscript",""\]\] "foo<sub>b<sup>[a\]</sup>r</sub>baz" queryCommandIndeterm("subscript") before]
@@ -77,25 +47,13 @@
   [[["stylewithcss","false"\],["subscript",""\]\] "foo<sup><sub>[bar\]</sub></sup>baz" queryCommandIndeterm("subscript") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["subscript",""\]\] "foo<sup><sub>b[a\]r</sub></sup>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["subscript",""\]\] "foo<sup><sub>b[a\]r</sub></sup>baz" queryCommandIndeterm("subscript") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["subscript",""\]\] "foo<sup><sub>b[a\]r</sub></sup>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["subscript",""\]\] "foo<sup><sub>b[a\]r</sub></sup>baz" queryCommandIndeterm("subscript") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["subscript",""\]\] "foo<sup>b<sub>[a\]</sub>r</sup>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["subscript",""\]\] "foo<sup>b<sub>[a\]</sub>r</sup>baz" queryCommandIndeterm("subscript") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["subscript",""\]\] "foo<sup>b<sub>[a\]</sub>r</sup>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["subscript",""\]\] "foo<sup>b<sub>[a\]</sub>r</sup>baz" queryCommandIndeterm("subscript") before]
@@ -150,31 +108,4 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["subscript",""\]\] "<p>[foo</p> <p>bar\]</p>" queryCommandState("stylewithcss") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["subscript",""\]\] "foo<sub>b[a\]r</sub>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["subscript",""\]\] "foo<sub>b[a\]r</sub>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["subscript",""\]\] "foo<sub>b<sub>[a\]</sub>r</sub>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["subscript",""\]\] "foo<sup><sup>[bar\]</sup></sup>baz" queryCommandState("subscript") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["subscript",""\]\] "foo<sup><sup>[bar\]</sup></sup>baz" queryCommandState("subscript") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["subscript",""\]\] "foo<sub><sup>[bar\]</sup></sub>baz" queryCommandState("subscript") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["subscript",""\]\] "foo<sub><sup>[bar\]</sup></sub>baz" queryCommandState("subscript") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["subscript",""\]\] "foo<sup><sub>[bar\]</sub></sup>baz" queryCommandState("subscript") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["subscript",""\]\] "foo<sup><sub>[bar\]</sub></sup>baz" queryCommandState("subscript") after]
     expected: FAIL

--- a/tests/wpt/meta/editing/run/superscript.html.ini
+++ b/tests/wpt/meta/editing/run/superscript.html.ini
@@ -11,12 +11,6 @@
   [[["stylewithcss","false"\],["superscript",""\]\] "<p>[foo<p><br><p>bar\]" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["superscript",""\]\] "foo<sub>b[a\]r</sub>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["superscript",""\]\] "foo<sub>b[a\]r</sub>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["superscript",""\]\] "foo<span style=vertical-align:sub>[bar\]</span>baz" compare innerHTML]
     expected: FAIL
 
@@ -29,43 +23,19 @@
   [[["stylewithcss","false"\],["superscript",""\]\] "foo<span style=vertical-align:super>[bar\]</span>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["superscript",""\]\] "foo<sub><sub>b[a\]r</sub></sub>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["superscript",""\]\] "foo<sub><sub>b[a\]r</sub></sub>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["superscript",""\]\] "foo<sub>b<sub>[a\]</sub>r</sub>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["superscript",""\]\] "foo<sub>b<sub>[a\]</sub>r</sub>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["superscript",""\]\] "foo<sub><sup>[bar\]</sup></sub>baz" queryCommandIndeterm("superscript") before]
     expected: FAIL
 
   [[["stylewithcss","false"\],["superscript",""\]\] "foo<sub><sup>[bar\]</sup></sub>baz" queryCommandIndeterm("superscript") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["superscript",""\]\] "foo<sub><sup>b[a\]r</sup></sub>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["superscript",""\]\] "foo<sub><sup>b[a\]r</sup></sub>baz" queryCommandIndeterm("superscript") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["superscript",""\]\] "foo<sub><sup>b[a\]r</sup></sub>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["superscript",""\]\] "foo<sub><sup>b[a\]r</sup></sub>baz" queryCommandIndeterm("superscript") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["superscript",""\]\] "foo<sub>b<sup>[a\]</sup>r</sub>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["superscript",""\]\] "foo<sub>b<sup>[a\]</sup>r</sub>baz" queryCommandIndeterm("superscript") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["superscript",""\]\] "foo<sub>b<sup>[a\]</sup>r</sub>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["superscript",""\]\] "foo<sub>b<sup>[a\]</sup>r</sub>baz" queryCommandIndeterm("superscript") before]
@@ -77,25 +47,13 @@
   [[["stylewithcss","false"\],["superscript",""\]\] "foo<sup><sub>[bar\]</sub></sup>baz" queryCommandIndeterm("superscript") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["superscript",""\]\] "foo<sup><sub>b[a\]r</sub></sup>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["superscript",""\]\] "foo<sup><sub>b[a\]r</sub></sup>baz" queryCommandIndeterm("superscript") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["superscript",""\]\] "foo<sup><sub>b[a\]r</sub></sup>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["superscript",""\]\] "foo<sup><sub>b[a\]r</sub></sup>baz" queryCommandIndeterm("superscript") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["superscript",""\]\] "foo<sup>b<sub>[a\]</sub>r</sup>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["superscript",""\]\] "foo<sup>b<sub>[a\]</sub>r</sup>baz" queryCommandIndeterm("superscript") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["superscript",""\]\] "foo<sup>b<sub>[a\]</sub>r</sup>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["superscript",""\]\] "foo<sup>b<sub>[a\]</sub>r</sup>baz" queryCommandIndeterm("superscript") before]
@@ -150,31 +108,4 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["superscript",""\]\] "<p>[foo</p> <p>bar\]</p>" queryCommandState("stylewithcss") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["superscript",""\]\] "foo<sup>b[a\]r</sup>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["superscript",""\]\] "foo<sup>b[a\]r</sup>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["superscript",""\]\] "foo<sub><sub>[bar\]</sub></sub>baz" queryCommandState("superscript") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["superscript",""\]\] "foo<sub><sub>[bar\]</sub></sub>baz" queryCommandState("superscript") after]
-    expected: FAIL
-
-  [[["superscript",""\]\] "foo<sup>b<sup>[a\]</sup>r</sup>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["superscript",""\]\] "foo<sub><sup>[bar\]</sup></sub>baz" queryCommandState("superscript") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["superscript",""\]\] "foo<sub><sup>[bar\]</sup></sub>baz" queryCommandState("superscript") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["superscript",""\]\] "foo<sup><sub>[bar\]</sub></sup>baz" queryCommandState("superscript") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["superscript",""\]\] "foo<sup><sub>[bar\]</sub></sup>baz" queryCommandState("superscript") after]
     expected: FAIL

--- a/tests/wpt/meta/editing/run/underline.html.ini
+++ b/tests/wpt/meta/editing/run/underline.html.ini
@@ -71,18 +71,6 @@
   [[["stylewithcss","true"\],["underline",""\]\] "<u>foo[b<i>ar\]ba</i>z</u>" queryCommandState("underline") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["underline",""\]\] "<u>foo[bar\]baz</u>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "<u>foo[bar\]baz</u>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "<p style=\\"text-decoration: underline\\">foo[bar\]baz</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "<p style=\\"text-decoration: underline\\">foo[bar\]baz</p>" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["underline",""\]\] "foo<s>[bar\]</s>baz" compare innerHTML]
     expected: FAIL
 
@@ -160,18 +148,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["underline",""\]\] "foo<del>[bar\]</del>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "foo<span style=\\"text-decoration: underline line-through\\">b[a\]r</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "foo<span style=\\"text-decoration: underline line-through\\">b[a\]r</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["underline",""\]\] "foo<s style=\\"text-decoration: underline\\">b[a\]r</s>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["underline",""\]\] "foo<s style=\\"text-decoration: underline\\">b[a\]r</s>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["underline",""\]\] "foo<span class=\\"line-through\\">[bar\]</span>baz" compare innerHTML]


### PR DESCRIPTION
This is a follow-up to #44735 which included some regressions. Turns out that the fix there wasn't strong enough. When moving nodes, it could be that the parent of the selected text node is moved. Therefore, we would incorrectly update the selection to the parent node, rather than the text node (with wrong offsets).

Now, we fully restore the selection when the text node is selected.

Part of #25005

Testing: WPT