### PR TITLE
constellation: Make warning about double-setting event loops more specific

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -931,7 +931,7 @@ where
             bc_group
                 .event_loops
                 .insert(host.clone(), Rc::downgrade(event_loop))
-                .is_some()
+                .is_some_and(|old_event_loop| old_event_loop.strong_count() != 0)
         {
             warn!(
                 "Double-setting an event-loop for {:?} at {:?}",


### PR DESCRIPTION
If the constellation sets a event loop for a browsing context that already has a event loop then we log a warning, because that's almost certainly a bug. However, the references to the event loop that are stored in the constellation are weak pointers. If a pipeline for `example.com` is shut down then the entry persists, and starting another pipeline for `example.com` will trigger the warning.

This change makes it so we only warn if the old event loop still exists. That removes the warning on turnstile.

Testing: No testing, this shouldn't affect the observable behaviour for users.