### PR TITLE
tidy: Use shellcheck for error-severity findings in check_shell

### DIFF
--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -9,12 +9,14 @@
 
 import configparser
 import fnmatch
+import functools
 import glob
 import io
 import itertools
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -627,6 +629,19 @@ def line_number_of_dependency(dependency_name: str, lines: list[str]) -> int:
     return 0
 
 
+@functools.cache
+def shellcheck_path() -> str | None:
+    """Return the path to the `shellcheck` binary, or None if it is not on PATH.
+
+    Emits a one-time warning when missing so that contributors without a
+    `shellcheck` install are not blocked by tidy and CI surfaces the gap.
+    """
+    path = shutil.which("shellcheck")
+    if path is None:
+        print("\r ⚠  `shellcheck` not found on PATH; skipping shellcheck-based shell-script lints.")
+    return path
+
+
 def check_shell(file_name: str, lines: list[bytes]) -> Iterator[tuple[int, str]]:
     if not file_name.endswith(".sh"):
         return
@@ -679,6 +694,29 @@ def check_shell(file_name: str, lines: list[bytes]) -> Iterator[tuple[int, str]]
                             yield idx + 1, 'variable substitutions should use the full "${VAR}" form'
                     else:
                         yield idx + 1, 'variable substitutions should use the full "${VAR}" form'
+
+    # Surface error-severity findings from `shellcheck`.
+    shellcheck = shellcheck_path()
+    if shellcheck is None:
+        return
+    result = subprocess.run(
+        [shellcheck, "--format=json1", file_name],
+        encoding="utf-8",
+        capture_output=True,
+    )
+    if not result.stdout:
+        return
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return
+    for finding in payload.get("comments", []):
+        if finding.get("level") != "error":
+            continue
+        line = finding.get("line", 1)
+        code = finding.get("code", "")
+        message = finding.get("message", "")
+        yield (line, f"shellcheck SC{code}: {message}")
 
 
 def check_rust(file_name: str, lines: list[bytes]) -> Iterator[tuple[int, str]]:


### PR DESCRIPTION
Wire shellcheck into the existing check_shell linter so its error-severity findings surface alongside Servo's hand-written checks for shebang, options, backticks, conditional-test bracketing, and variable-substitution form.  shellcheck does not cover those, so the in-tree checks stay.

Per @jdm's 2026-04-11 guidance on #42100 the integration starts with error severity only; warning, info, and style are deferred to follow-ups.  If `shellcheck` is not on PATH the lint prints a one-time warning and skips, so contributors without an install are not blocked locally.  GitHub Actions `ubuntu-latest` runners have shellcheck pre-installed so CI exercises the lint.

A follow-up could add a `./mach bootstrap` install step for shellcheck (mirroring the cargo-deny pattern in `python/servo/platform/base.py`) to make the lint fire reliably on fresh local trees.

Testing: Existing `test_shell` continues to pass (shellcheck only reports `style` / `info` findings on `shell_tidy.sh`, which the `error`-severity filter drops); local smoke tests on Servo's own `.sh` files confirm zero false positives.

Fixes: #42100