### PR TITLE
ci: Update test expectations fully when importing from upstream

### DIFF
--- a/.github/workflows/scheduled-wpt-import.yml
+++ b/.github/workflows/scheduled-wpt-import.yml
@@ -54,7 +54,7 @@ jobs:
           export CURRENT_DATE=$(date +"%d-%m-%Y")
           echo $CURRENT_DATE
           echo "CURRENT_DATE=$CURRENT_DATE" >> $GITHUB_ENV
-          ./mach update-wpt linux/raw/*.log
+          ./mach update-wpt --full linux/raw/*.log
           git add tests/wpt/meta
           uv lock
           git commit -a --amend -s --no-edit


### PR DESCRIPTION
Follow up of #44895.
This is actually faster than expected.
On my Windows laptop with NTFS filesystem, it took 68 seconds to finish. Things should be faster on Linux server.

Fixes: #42160