### PR TITLE
layout: Move containing block calculation to stacking context tree construction

### DIFF
--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -53,8 +53,8 @@ use crate::context::{ImageResolver, ResolvedImage};
 pub(crate) use crate::display_list::conversions::ToWebRender;
 use crate::display_list::stacking_context::StackingContextSection;
 use crate::fragment_tree::{
-    BackgroundMode, BoxFragment, Fragment, FragmentFlags, FragmentStatus, FragmentTree,
-    SpecificLayoutInfo, Tag, TextFragment,
+    BackgroundMode, BoxFragment, ContainingBlockCalculation, Fragment, FragmentFlags,
+    FragmentStatus, FragmentTree, SpecificLayoutInfo, Tag, TextFragment,
 };
 use crate::geom::{
     LengthPercentageOrAuto, PhysicalPoint, PhysicalRect, PhysicalSides, PhysicalSize,
@@ -487,7 +487,10 @@ impl DisplayListBuilder<'_> {
                     }
 
                     let bounds = box_fragment
-                        .offset_by_containing_block(&fragment_relative_bounds)
+                        .offset_by_containing_block(
+                            &fragment_relative_bounds,
+                            ContainingBlockCalculation::AlreadyDoneWithStackingContextTree,
+                        )
                         .to_webrender();
 
                     // We paint each highlighted area as if it was a border for simplicity

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -44,10 +44,12 @@ use super::clip::StackingContextTreeClipStore;
 use crate::display_list::conversions::{FilterToWebRender, ToWebRender};
 use crate::display_list::{BuilderForBoxFragment, DisplayListBuilder, offset_radii};
 use crate::fragment_tree::{
-    BoxFragment, ContainingBlockManager, Fragment, FragmentFlags, FragmentTree,
-    PositioningFragment, SpecificLayoutInfo,
+    BoxFragment, ContainingBlockCalculation, ContainingBlockManager, Fragment, FragmentFlags,
+    FragmentTree, PositioningFragment, SpecificLayoutInfo,
 };
-use crate::geom::{AuOrAuto, LengthPercentageOrAuto, PhysicalPoint, PhysicalRect, PhysicalSides};
+use crate::geom::{
+    AuOrAuto, LengthPercentageOrAuto, PhysicalPoint, PhysicalRect, PhysicalSides, PhysicalVec,
+};
 use crate::style_ext::{ComputedValuesExt, TransformExt};
 
 #[derive(Clone)]
@@ -66,6 +68,8 @@ pub(crate) struct ContainingBlock {
 
     /// The physical rect of this containing block.
     rect: PhysicalRect<Au>,
+
+    accumulated_reference_frame_offset: PhysicalVec<Au>,
 }
 
 impl ContainingBlock {
@@ -74,12 +78,14 @@ impl ContainingBlock {
         scroll_node_id: ScrollTreeNodeId,
         scroll_frame_size: Option<LayoutSize>,
         clip_id: ClipId,
+        accumulated_reference_frame_offset: PhysicalVec<Au>,
     ) -> Self {
         ContainingBlock {
             scroll_node_id,
             scroll_frame_size,
             clip_id,
             rect,
+            accumulated_reference_frame_offset,
         }
     }
 
@@ -151,12 +157,14 @@ impl StackingContextTree {
             root_scroll_node_id,
             Some(viewport_size),
             ClipId::INVALID,
+            PhysicalVec::zero(),
         );
         let cb_for_fixed_descendants = ContainingBlock::new(
             fragment_tree.initial_containing_block,
             paint_info.root_reference_frame_id,
             None,
             ClipId::INVALID,
+            PhysicalVec::zero(),
         );
 
         // We need to specify all three containing blocks here, because absolute
@@ -293,8 +301,12 @@ impl StackingContextTree {
             .scroll_tree
             .reference_frame_offset(spatial_tree_node)
             .map(Au::from_f32_px);
-        let fragment_origin =
-            fragment.cumulative_content_box_rect().origin - reference_frame_origin.cast_unit();
+        let fragment_origin = fragment
+            .cumulative_content_box_rect(
+                ContainingBlockCalculation::AlreadyDoneWithStackingContextTree,
+            )
+            .origin -
+            reference_frame_origin.cast_unit();
 
         // Use that to find the offset from the fragment origin.
         Some(transformed_point - fragment_origin)
@@ -924,6 +936,12 @@ impl Fragment {
         mode: StackingContextBuildMode,
         text_decorations: &Arc<Vec<FragmentTextDecoration>>,
     ) {
+        let containing_block = containing_block_info.get_containing_block_for_fragment(self);
+        let cumulative_containing_block = containing_block
+            .rect
+            .translate(containing_block.accumulated_reference_frame_offset);
+        self.set_containing_block(&cumulative_containing_block);
+
         if self
             .base()
             .is_some_and(|base| base.flags.contains(FragmentFlags::IS_COLLAPSED))
@@ -931,7 +949,6 @@ impl Fragment {
             return;
         }
 
-        let containing_block = containing_block_info.get_containing_block_for_fragment(self);
         let fragment_clone = self.clone();
         match self {
             Fragment::Box(fragment) | Fragment::Float(fragment) => {
@@ -1106,7 +1123,12 @@ impl BoxFragment {
         }
 
         let style = self.style();
-        let frame_origin_for_query = self.cumulative_border_box_rect().origin.to_webrender();
+        let frame_origin_for_query = self
+            .cumulative_border_box_rect(
+                ContainingBlockCalculation::AlreadyDoneWithStackingContextTree,
+            )
+            .origin
+            .to_webrender();
         let new_spatial_id = stacking_context_tree.push_reference_frame(
             reference_frame_data.origin.to_webrender(),
             frame_origin_for_query,
@@ -1126,13 +1148,13 @@ impl BoxFragment {
         // containing blocks for absolute and fixed descendants, so those
         // properties will be replaced before recursing into children.
         assert!(style.establishes_containing_block_for_all_descendants(self.base.flags));
+        let reference_frame_offset = reference_frame_data.origin.to_vector();
         let adjusted_containing_block = ContainingBlock::new(
-            containing_block
-                .rect
-                .translate(-reference_frame_data.origin.to_vector()),
+            containing_block.rect.translate(-reference_frame_offset),
             new_spatial_id,
             None,
             containing_block.clip_id,
+            containing_block.accumulated_reference_frame_offset + reference_frame_offset,
         );
         let new_containing_block_info =
             containing_block_info.new_for_non_absolute_descendants(&adjusted_containing_block);
@@ -1365,12 +1387,14 @@ impl BoxFragment {
             new_scroll_node_id,
             new_scroll_frame_size,
             new_clip_id,
+            containing_block.accumulated_reference_frame_offset,
         );
         let for_non_absolute_descendants = ContainingBlock::new(
             content_rect,
             new_scroll_node_id,
             new_scroll_frame_size,
             new_clip_id,
+            containing_block.accumulated_reference_frame_offset,
         );
 
         // Create a new `ContainingBlockInfo` for descendants depending on

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -69,6 +69,11 @@ pub(crate) struct ContainingBlock {
     /// The physical rect of this containing block.
     rect: PhysicalRect<Au>,
 
+    /// Normally containing block offsets and display list items are positioned relative
+    /// to their parent reference frame, but cumulative containing block boundaries on
+    /// fragments need to disregard reference frames entirely. This value tracks the
+    /// accumulated offset from the origin of the parent reference frame of this
+    /// containing block.
     accumulated_reference_frame_offset: PhysicalVec<Au>,
 }
 

--- a/components/layout/fragment_tree/box_fragment.rs
+++ b/components/layout/fragment_tree/box_fragment.rs
@@ -26,6 +26,7 @@ use crate::formatting_contexts::Baselines;
 use crate::geom::{
     AuOrAuto, LengthPercentageOrAuto, PhysicalPoint, PhysicalRect, PhysicalSides, ToLogical,
 };
+use crate::layout_impl::LayoutThread;
 use crate::style_ext::ComputedValuesExt;
 use crate::table::SpecificTableGridInfo;
 use crate::taffy::SpecificTaffyGridInfo;
@@ -135,6 +136,26 @@ pub(crate) struct BoxFragment {
     /// used to for determining final viewport size and position of this node and will
     /// also be used in the future for hit testing.
     pub spatial_tree_node: AtomicRefCell<Option<ScrollTreeNodeId>>,
+}
+
+pub(crate) enum ContainingBlockCalculation<'a> {
+    Lazy { layout_thread: &'a LayoutThread },
+    AlreadyDoneWithStackingContextTree,
+}
+
+impl ContainingBlockCalculation<'_> {
+    pub(crate) fn ensure(&self) {
+        match self {
+            Self::Lazy { layout_thread } => layout_thread.ensure_containing_block_calculation(),
+            Self::AlreadyDoneWithStackingContextTree => {},
+        }
+    }
+}
+
+impl<'a> From<&'a LayoutThread> for ContainingBlockCalculation<'a> {
+    fn from(layout_thread: &'a LayoutThread) -> Self {
+        Self::Lazy { layout_thread }
+    }
 }
 
 impl BoxFragment {
@@ -387,7 +408,12 @@ impl BoxFragment {
         *self.cumulative_containing_block_rect.borrow_mut() = *containing_block;
     }
 
-    pub(crate) fn offset_by_containing_block(&self, rect: &PhysicalRect<Au>) -> PhysicalRect<Au> {
+    pub(crate) fn offset_by_containing_block(
+        &self,
+        rect: &PhysicalRect<Au>,
+        containing_block_computation: ContainingBlockCalculation<'_>,
+    ) -> PhysicalRect<Au> {
+        containing_block_computation.ensure();
         rect.translate(
             self.cumulative_containing_block_rect
                 .borrow()
@@ -396,16 +422,25 @@ impl BoxFragment {
         )
     }
 
-    pub(crate) fn cumulative_content_box_rect(&self) -> PhysicalRect<Au> {
-        self.offset_by_containing_block(&self.base.rect())
+    pub(crate) fn cumulative_content_box_rect(
+        &self,
+        containing_block_computation: ContainingBlockCalculation<'_>,
+    ) -> PhysicalRect<Au> {
+        self.offset_by_containing_block(&self.base.rect(), containing_block_computation)
     }
 
-    pub(crate) fn cumulative_padding_box_rect(&self) -> PhysicalRect<Au> {
-        self.offset_by_containing_block(&self.padding_rect())
+    pub(crate) fn cumulative_padding_box_rect(
+        &self,
+        containing_block_computation: ContainingBlockCalculation<'_>,
+    ) -> PhysicalRect<Au> {
+        self.offset_by_containing_block(&self.padding_rect(), containing_block_computation)
     }
 
-    pub(crate) fn cumulative_border_box_rect(&self) -> PhysicalRect<Au> {
-        self.offset_by_containing_block(&self.border_rect())
+    pub(crate) fn cumulative_border_box_rect(
+        &self,
+        containing_block_computation: ContainingBlockCalculation<'_>,
+    ) -> PhysicalRect<Au> {
+        self.offset_by_containing_block(&self.border_rect(), containing_block_computation)
     }
 
     pub(crate) fn content_rect(&self) -> PhysicalRect<Au> {
@@ -549,7 +584,10 @@ impl BoxFragment {
         }
     }
 
-    pub(crate) fn calculate_resolved_insets_if_positioned(&self) -> PhysicalSides<AuOrAuto> {
+    pub(crate) fn calculate_resolved_insets_if_positioned(
+        &self,
+        containing_block_computation: ContainingBlockCalculation<'_>,
+    ) -> PhysicalSides<AuOrAuto> {
         let style = self.style();
         let position = style.get_box().position;
         debug_assert_ne!(
@@ -571,8 +609,10 @@ impl BoxFragment {
             )
         };
 
-        let containing_block_size =
-            LazyCell::new(|| self.cumulative_containing_block_rect.borrow().size);
+        let containing_block_size = LazyCell::new(|| {
+            containing_block_computation.ensure();
+            self.cumulative_containing_block_rect.borrow().size
+        });
 
         // "A resolved value special case property like top defined in another
         // specification If the property applies to a positioned element and the

--- a/components/layout/fragment_tree/box_fragment.rs
+++ b/components/layout/fragment_tree/box_fragment.rs
@@ -23,10 +23,10 @@ use super::{BaseFragment, BaseFragmentInfo, CollapsedBlockMargins, Fragment, Fra
 use crate::SharedStyle;
 use crate::display_list::ToWebRender;
 use crate::formatting_contexts::Baselines;
+use crate::fragment_tree::ContainingBlockCalculation;
 use crate::geom::{
     AuOrAuto, LengthPercentageOrAuto, PhysicalPoint, PhysicalRect, PhysicalSides, ToLogical,
 };
-use crate::layout_impl::LayoutThread;
 use crate::style_ext::ComputedValuesExt;
 use crate::table::SpecificTableGridInfo;
 use crate::taffy::SpecificTaffyGridInfo;
@@ -136,26 +136,6 @@ pub(crate) struct BoxFragment {
     /// used to for determining final viewport size and position of this node and will
     /// also be used in the future for hit testing.
     pub spatial_tree_node: AtomicRefCell<Option<ScrollTreeNodeId>>,
-}
-
-pub(crate) enum ContainingBlockCalculation<'a> {
-    Lazy { layout_thread: &'a LayoutThread },
-    AlreadyDoneWithStackingContextTree,
-}
-
-impl ContainingBlockCalculation<'_> {
-    pub(crate) fn ensure(&self) {
-        match self {
-            Self::Lazy { layout_thread } => layout_thread.ensure_containing_block_calculation(),
-            Self::AlreadyDoneWithStackingContextTree => {},
-        }
-    }
-}
-
-impl<'a> From<&'a LayoutThread> for ContainingBlockCalculation<'a> {
-    fn from(layout_thread: &'a LayoutThread) -> Self {
-        Self::Lazy { layout_thread }
-    }
 }
 
 impl BoxFragment {

--- a/components/layout/fragment_tree/fragment.rs
+++ b/components/layout/fragment_tree/fragment.rs
@@ -23,7 +23,6 @@ use super::{
 use crate::SharedStyle;
 use crate::cell::ArcRefCell;
 use crate::flow::inline::line::TextRunOffsets;
-use crate::fragment_tree::ContainingBlockCalculation;
 use crate::geom::{LogicalSides, PhysicalPoint, PhysicalRect};
 use crate::layout_impl::LayoutThread;
 use crate::style_ext::ComputedValuesExt;
@@ -500,5 +499,39 @@ impl CollapsedMargin {
 
     pub fn solve(&self) -> Au {
         self.max_positive + self.min_negative
+    }
+}
+
+/// A token which ensures the calculation and assignment of cumulative containing
+/// blocks to fragments in the fragment tree. This is used because these cumulative
+/// containing block offsets are set during stacking context tree construction, but
+/// some queries might need them beforehand. If the query is executed before stacking
+/// context tree construction, a quick traversal is performed to calculate them for
+/// the purpose of the query.
+pub(crate) enum ContainingBlockCalculation<'a> {
+    /// This token variant is for the purpose of a layout query. In this case, if stacking
+    /// context tree construction has not yet taken place, a cumulative containing block
+    /// calculation traversal will be performed.
+    Lazy { layout_thread: &'a LayoutThread },
+    /// This token variant is used when the code can guarantee that stacking context
+    /// tree construction has already taken place.
+    ///
+    /// Note: Using this before stacking context tree construction can lead
+    /// to incorrect layout or layout query results!
+    AlreadyDoneWithStackingContextTree,
+}
+
+impl ContainingBlockCalculation<'_> {
+    pub(crate) fn ensure(&self) {
+        match self {
+            Self::Lazy { layout_thread } => layout_thread.ensure_containing_block_calculation(),
+            Self::AlreadyDoneWithStackingContextTree => {},
+        }
+    }
+}
+
+impl<'a> From<&'a LayoutThread> for ContainingBlockCalculation<'a> {
+    fn from(layout_thread: &'a LayoutThread) -> Self {
+        Self::Lazy { layout_thread }
     }
 }

--- a/components/layout/fragment_tree/fragment.rs
+++ b/components/layout/fragment_tree/fragment.rs
@@ -23,7 +23,9 @@ use super::{
 use crate::SharedStyle;
 use crate::cell::ArcRefCell;
 use crate::flow::inline::line::TextRunOffsets;
+use crate::fragment_tree::ContainingBlockCalculation;
 use crate::geom::{LogicalSides, PhysicalPoint, PhysicalRect};
+use crate::layout_impl::LayoutThread;
 use crate::style_ext::ComputedValuesExt;
 
 #[derive(Clone, MallocSizeOf)]
@@ -146,11 +148,10 @@ impl Fragment {
         }
     }
 
-    pub(crate) fn scrolling_area(&self) -> PhysicalRect<Au> {
+    pub(crate) fn scrolling_area(&self, layout_thread: &LayoutThread) -> PhysicalRect<Au> {
         match self {
-            Fragment::Box(fragment) | Fragment::Float(fragment) => {
-                fragment.offset_by_containing_block(&fragment.scrollable_overflow())
-            },
+            Fragment::Box(fragment) | Fragment::Float(fragment) => fragment
+                .offset_by_containing_block(&fragment.scrollable_overflow(), layout_thread.into()),
             _ => self.scrollable_overflow_for_parent(),
         }
     }
@@ -212,15 +213,28 @@ impl Fragment {
         }
     }
 
-    pub(crate) fn cumulative_box_area_rect(&self, area: BoxAreaType) -> Option<PhysicalRect<Au>> {
+    pub(crate) fn cumulative_box_area_rect(
+        &self,
+        area: BoxAreaType,
+        containing_block_computation: ContainingBlockCalculation<'_>,
+    ) -> Option<PhysicalRect<Au>> {
         match self {
             Fragment::Box(fragment) | Fragment::Float(fragment) => Some(match area {
-                BoxAreaType::Content => fragment.cumulative_content_box_rect(),
-                BoxAreaType::Padding => fragment.cumulative_padding_box_rect(),
-                BoxAreaType::Border => fragment.cumulative_border_box_rect(),
+                BoxAreaType::Content => {
+                    fragment.cumulative_content_box_rect(containing_block_computation)
+                },
+                BoxAreaType::Padding => {
+                    fragment.cumulative_padding_box_rect(containing_block_computation)
+                },
+                BoxAreaType::Border => {
+                    fragment.cumulative_border_box_rect(containing_block_computation)
+                },
             }),
             Fragment::Positioning(fragment) => {
-                Some(fragment.offset_by_containing_block(&fragment.base.rect()))
+                Some(fragment.offset_by_containing_block(
+                    &fragment.base.rect(),
+                    containing_block_computation,
+                ))
             },
             Fragment::Text(_) |
             Fragment::AbsoluteOrFixedPositioned(_) |

--- a/components/layout/fragment_tree/fragment_tree.rs
+++ b/components/layout/fragment_tree/fragment_tree.rs
@@ -48,7 +48,7 @@ impl FragmentTree {
             scrollable_overflow: Cell::default(),
             initial_containing_block,
             viewport_scroll_sensitivity,
-       }
+        }
     }
 
     pub fn print(&self) {

--- a/components/layout/fragment_tree/fragment_tree.rs
+++ b/components/layout/fragment_tree/fragment_tree.rs
@@ -43,22 +43,12 @@ impl FragmentTree {
         initial_containing_block: PhysicalRect<Au>,
         viewport_scroll_sensitivity: AxesScrollSensitivity,
     ) -> Self {
-        let fragment_tree = Self {
+        Self {
             root_fragments,
             scrollable_overflow: Cell::default(),
             initial_containing_block,
             viewport_scroll_sensitivity,
-        };
-
-        // Trigger scrollable overflow calculation unconditionally when creating a new Fragment.
-        fragment_tree.scrollable_overflow();
-
-        fragment_tree.find(|fragment, _level, containing_block| {
-            fragment.set_containing_block(containing_block);
-            None::<()>
-        });
-
-        fragment_tree
+       }
     }
 
     pub fn print(&self) {

--- a/components/layout/fragment_tree/positioning_fragment.rs
+++ b/components/layout/fragment_tree/positioning_fragment.rs
@@ -12,6 +12,7 @@ use servo_base::print_tree::PrintTree;
 use style::properties::ComputedValues;
 
 use super::{BaseFragment, BaseFragmentInfo, Fragment};
+use crate::fragment_tree::ContainingBlockCalculation;
 use crate::geom::PhysicalRect;
 
 /// Can contain child fragments with relative coordinates, but does not contribute to painting
@@ -65,7 +66,12 @@ impl PositioningFragment {
         *self.cumulative_containing_block_rect.borrow_mut() = *containing_block;
     }
 
-    pub fn offset_by_containing_block(&self, rect: &PhysicalRect<Au>) -> PhysicalRect<Au> {
+    pub fn offset_by_containing_block(
+        &self,
+        rect: &PhysicalRect<Au>,
+        containing_block_computation: ContainingBlockCalculation<'_>,
+    ) -> PhysicalRect<Au> {
+        containing_block_computation.ensure();
         rect.translate(
             self.cumulative_containing_block_rect
                 .borrow()

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -20,7 +20,7 @@ use fonts::{FontContext, FontContextWebFontMethods, WebFontDocumentContext};
 use fonts_traits::StylesheetWebFontLoadFinishedCallback;
 use icu_locid::subtags::Language;
 use layout_api::{
-    AxesOverflow, BoxAreaType, CSSPixelRectIterator, DangerousStyleNode, IFrameSizes, Layout,
+    AxesOverflow, BoxAreaType, CSSPixelRectVec, DangerousStyleNode, IFrameSizes, Layout,
     LayoutConfig, LayoutElement, LayoutFactory, LayoutNode, NodeRenderingType,
     OffsetParentResponse, PhysicalSides, QueryMsg, ReflowGoal, ReflowPhasesRun, ReflowRequest,
     ReflowRequestRestyle, ReflowResult, ReflowStatistics, ScrollContainerQueryFlags,
@@ -173,6 +173,8 @@ pub struct LayoutThread {
     /// layout requests a display list, it is produced unconditionally, even when the
     /// layout trees remain the same.
     need_new_display_list: Cell<bool>,
+
+    need_containing_block_calculation: Cell<bool>,
 
     /// Whether or not the existing stacking context tree is dirty and needs to be
     /// rebuilt. This happens after a relayout or overflow update. The reason that we
@@ -393,6 +395,7 @@ impl Layout for LayoutThread {
             let stacking_context_tree = self.stacking_context_tree.borrow();
             let stacking_context_tree = stacking_context_tree.as_ref()?;
             process_box_area_request(
+                self,
                 stacking_context_tree,
                 node,
                 area,
@@ -406,7 +409,7 @@ impl Layout for LayoutThread {
     ///
     /// See <https://drafts.csswg.org/cssom-view/#dom-element-getclientrects>.
     #[servo_tracing::instrument(skip_all)]
-    fn query_box_areas(&self, node: TrustedNodeAddress, area: BoxAreaType) -> CSSPixelRectIterator {
+    fn query_box_areas(&self, node: TrustedNodeAddress, area: BoxAreaType) -> CSSPixelRectVec {
         with_layout_state(|| {
             // If we have not built a fragment tree yet, there is no way we have layout information for
             // this query, which can be run without forcing a layout (for IntersectionObserver).
@@ -417,9 +420,14 @@ impl Layout for LayoutThread {
             let node = unsafe { ServoLayoutNode::new(&node) };
             let stacking_context_tree = self.stacking_context_tree.borrow();
             let stacking_context_tree = stacking_context_tree.as_ref()?;
-            Some(process_box_areas_request(stacking_context_tree, node, area))
+            Some(process_box_areas_request(
+                self,
+                stacking_context_tree,
+                node,
+                area,
+            ))
         })
-        .unwrap_or_else(|| Box::new(std::iter::empty()))
+        .unwrap_or_default()
     }
 
     #[servo_tracing::instrument(skip_all)]
@@ -451,7 +459,7 @@ impl Layout for LayoutThread {
             let node = unsafe { ServoLayoutNode::new(&node) };
             let stacking_context_tree = self.stacking_context_tree.borrow();
             let stacking_context_tree = stacking_context_tree.as_ref()?;
-            process_offset_parent_query(&stacking_context_tree.paint_info.scroll_tree, node)
+            process_offset_parent_query(self, &stacking_context_tree.paint_info.scroll_tree, node)
         })
         .unwrap_or_default()
     }
@@ -496,7 +504,7 @@ impl Layout for LayoutThread {
                 TraversalFlags::empty(),
             );
 
-            process_resolved_style_request(&shared_style_context, node, &pseudo, &property_id)
+            process_resolved_style_request(self, &shared_style_context, node, &pseudo, &property_id)
         })
     }
 
@@ -540,7 +548,7 @@ impl Layout for LayoutThread {
     fn query_scrolling_area(&self, node: Option<TrustedNodeAddress>) -> Rect<i32, CSSPixel> {
         with_layout_state(|| {
             let node = node.map(|node| unsafe { ServoLayoutNode::new(&node) });
-            process_node_scroll_area_request(node, self.fragment_tree.borrow().clone())
+            process_node_scroll_area_request(self, node, self.fragment_tree.borrow().clone())
         })
     }
 
@@ -770,6 +778,7 @@ impl LayoutThread {
             have_ever_generated_display_list: Cell::new(false),
             last_display_list_was_empty: Cell::new(true),
             device_has_changed: false,
+            need_containing_block_calculation: Cell::new(false),
             need_new_display_list: Cell::new(false),
             need_new_stacking_context_tree: Cell::new(false),
             box_tree: Default::default(),
@@ -1284,6 +1293,9 @@ impl LayoutThread {
             .as_ref()
             .map(|tree| tree.paint_info.scroll_tree.scroll_offsets());
 
+        // This will be done during `StackingContextTree::new` below
+        self.need_containing_block_calculation.set(true);
+
         // Build the StackingContextTree. This turns the `FragmentTree` into a
         // tree of fragments in CSS painting order and also creates all
         // applicable spatial and clip nodes.
@@ -1493,6 +1505,20 @@ impl LayoutThread {
             reflow_phases_run: ReflowPhasesRun::BuiltDisplayList,
             ..Default::default()
         })
+    }
+
+    pub(crate) fn ensure_containing_block_calculation(&self) {
+        if !self.need_containing_block_calculation.get() {
+            return;
+        }
+        let fragment_tree = self.fragment_tree.borrow();
+        fragment_tree.as_ref().expect("missing fragment tree").find(
+            |fragment, _level, containing_block| {
+                fragment.set_containing_block(containing_block);
+                None::<()>
+            },
+        );
+        self.need_containing_block_calculation.set(false)
     }
 }
 

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -174,6 +174,10 @@ pub struct LayoutThread {
     /// layout trees remain the same.
     need_new_display_list: Cell<bool>,
 
+    /// Whether or not cumulative containing blocks offsets have been set into the
+    /// [`FragmentTree`]. This typically happens during [`StackingContextTree`]
+    /// construction, but if a layout query needs these value beforehand, they are
+    /// eagerly calculated.
     need_containing_block_calculation: Cell<bool>,
 
     /// Whether or not the existing stacking context tree is dirty and needs to be

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -11,7 +11,7 @@ use embedder_traits::UntrustedNodeAddress;
 use euclid::{Point2D, Rect, SideOffsets2D, Size2D};
 use itertools::Itertools;
 use layout_api::{
-    AxesOverflow, BoxAreaType, CSSPixelRectIterator, DangerousStyleElementOf, LayoutElement,
+    AxesOverflow, BoxAreaType, CSSPixelRectVec, DangerousStyleElementOf, LayoutElement,
     LayoutElementType, LayoutNode, LayoutNodeType, OffsetParentResponse, PhysicalSides,
     ScrollContainerQueryFlags, ScrollContainerResponse,
 };
@@ -51,6 +51,7 @@ use crate::flow::inline::construct::{TextTransformation, WhitespaceCollapse, cap
 use crate::fragment_tree::{
     BoxFragment, Fragment, FragmentFlags, FragmentTree, SpecificLayoutInfo, TextFragment,
 };
+use crate::layout_impl::LayoutThread;
 use crate::style_ext::ComputedValuesExt;
 use crate::taffy::SpecificTaffyGridInfo;
 
@@ -86,6 +87,7 @@ pub(crate) fn process_padding_request(node: ServoLayoutNode<'_>) -> Option<Physi
 }
 
 pub(crate) fn process_box_area_request(
+    layout_thread: &LayoutThread,
     stacking_context_tree: &StackingContextTree,
     node: ServoLayoutNode<'_>,
     area: BoxAreaType,
@@ -100,7 +102,7 @@ pub(crate) fn process_box_area_request(
                     .retrieve_box_fragment()
                     .is_none_or(|fragment| !fragment.is_inline_box())
         })
-        .filter_map(|node| node.cumulative_box_area_rect(area))
+        .filter_map(|node| node.cumulative_box_area_rect(area, layout_thread.into()))
         .peekable();
 
     rects.peek()?;
@@ -120,22 +122,27 @@ pub(crate) fn process_box_area_request(
 }
 
 pub(crate) fn process_box_areas_request(
+    layout_thread: &LayoutThread,
     stacking_context_tree: &StackingContextTree,
     node: ServoLayoutNode<'_>,
     area: BoxAreaType,
-) -> CSSPixelRectIterator {
+) -> CSSPixelRectVec {
     let fragments = node
         .fragments_for_pseudo(None)
         .into_iter()
-        .filter_map(move |fragment| fragment.cumulative_box_area_rect(area));
+        .filter_map(move |fragment| fragment.cumulative_box_area_rect(area, layout_thread.into()));
 
     let Some(transform) =
         root_transform_for_layout_node(&stacking_context_tree.paint_info.scroll_tree, node)
     else {
-        return Box::new(fragments.map(|rect| Rect::new(rect.origin, Size2D::zero())));
+        return fragments
+            .map(|rect| Rect::new(rect.origin, Size2D::zero()))
+            .collect();
     };
 
-    Box::new(fragments.filter_map(move |rect| transform_au_rectangle(rect, transform)))
+    fragments
+        .filter_map(move |rect| transform_au_rectangle(rect, transform))
+        .collect()
 }
 
 pub fn process_client_rect_request(node: ServoLayoutNode<'_>) -> Rect<i32, CSSPixel> {
@@ -166,6 +173,7 @@ pub fn process_current_css_zoom_query(node: ServoLayoutNode<'_>) -> f32 {
 
 /// <https://drafts.csswg.org/cssom-view/#scrolling-area>
 pub fn process_node_scroll_area_request(
+    layout_thread: &LayoutThread,
     requested_node: Option<ServoLayoutNode<'_>>,
     fragment_tree: Option<Rc<FragmentTree>>,
 ) -> Rect<i32, CSSPixel> {
@@ -177,7 +185,7 @@ pub fn process_node_scroll_area_request(
         Some(node) => node
             .fragments_for_pseudo(None)
             .first()
-            .map(Fragment::scrolling_area)
+            .map(|fragment| fragment.scrolling_area(layout_thread))
             .unwrap_or_default(),
         None => tree.scrollable_overflow(),
     };
@@ -193,6 +201,7 @@ pub fn process_node_scroll_area_request(
 /// Return the resolved value of property for a given (pseudo)element.
 /// <https://drafts.csswg.org/cssom/#resolved-value>
 pub fn process_resolved_style_request(
+    layout_thread: &LayoutThread,
     context: &SharedStyleContext,
     node: ServoLayoutNode<'_>,
     pseudo: &Option<PseudoElement>,
@@ -318,7 +327,9 @@ pub fn process_resolved_style_request(
         let (content_rect, margins, padding, specific_layout_info) = match fragment {
             Fragment::Box(box_fragment) | Fragment::Float(box_fragment) => {
                 if style.get_box().position != Position::Static {
-                    let resolved_insets = || box_fragment.calculate_resolved_insets_if_positioned();
+                    let resolved_insets = || {
+                        box_fragment.calculate_resolved_insets_if_positioned(layout_thread.into())
+                    };
                     match longhand_id {
                         LonghandId::Top => return resolved_insets().top.to_css_string(),
                         LonghandId::Right => {
@@ -633,6 +644,7 @@ fn offset_parent_fragments(node: ServoLayoutNode<'_>) -> Option<OffsetParentFrag
 
 #[inline]
 pub fn process_offset_parent_query(
+    layout_thread: &LayoutThread,
     scroll_tree: &ScrollTree,
     node: ServoLayoutNode<'_>,
 ) -> Option<OffsetParentResponse> {
@@ -653,7 +665,8 @@ pub fn process_offset_parent_query(
     // > 1. If the element is the HTML body element or does not have any associated CSS
     //      layout box return zero and terminate this algorithm.
     let fragment = node.fragments_for_pseudo(None).first().cloned()?;
-    let mut border_box = fragment.cumulative_box_area_rect(BoxAreaType::Border)?;
+    let mut border_box =
+        fragment.cumulative_box_area_rect(BoxAreaType::Border, layout_thread.into())?;
     let cumulative_sticky_offsets = fragment
         .retrieve_box_fragment()
         .and_then(|box_fragment| box_fragment.spatial_tree_node())
@@ -707,12 +720,17 @@ pub fn process_offset_parent_query(
     // See <https://github.com/w3c/csswg-drafts/issues/10549>.
     let parent_offset_rect = if parent_is_static_body_element {
         if let Some(grandparent_fragment) = grandparent_box_fragment() {
-            grandparent_fragment.offset_by_containing_block(&grandparent_fragment.border_rect())
+            grandparent_fragment.offset_by_containing_block(
+                &grandparent_fragment.border_rect(),
+                layout_thread.into(),
+            )
         } else {
-            parent_fragment.offset_by_containing_block(&parent_fragment.padding_rect())
+            parent_fragment
+                .offset_by_containing_block(&parent_fragment.padding_rect(), layout_thread.into())
         }
     } else {
-        parent_fragment.offset_by_containing_block(&parent_fragment.padding_rect())
+        parent_fragment
+            .offset_by_containing_block(&parent_fragment.padding_rect(), layout_thread.into())
     }
     .translate(
         cumulative_sticky_offsets

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -3108,6 +3108,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         let win = self.owner_window();
         let raw_rects = self.upcast::<Node>().border_boxes();
         let rects: Vec<DomRoot<DOMRect>> = raw_rects
+            .into_iter()
             .map(|rect| {
                 DOMRect::new(
                     win.upcast(),

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -28,9 +28,9 @@ use js::jsapi::JSObject;
 use js::rust::HandleObject;
 use keyboard_types::Modifiers;
 use layout_api::{
-    AxesOverflow, BoxAreaType, CSSPixelRectIterator, GenericLayoutData, HTMLCanvasData,
-    HTMLMediaData, LayoutElementType, LayoutNodeType, NodeRenderingType, PhysicalSides,
-    SVGElementData, SharedSelection, TrustedNodeAddress, with_layout_state,
+    AxesOverflow, BoxAreaType, CSSPixelRectVec, GenericLayoutData, HTMLCanvasData, HTMLMediaData,
+    LayoutElementType, LayoutNodeType, NodeRenderingType, PhysicalSides, SVGElementData,
+    SharedSelection, TrustedNodeAddress, with_layout_state,
 };
 use libc::{self, c_void, uintptr_t};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
@@ -1114,7 +1114,7 @@ impl Node {
             .box_area_query_without_reflow(self, BoxAreaType::Padding, false)
     }
 
-    pub(crate) fn border_boxes(&self) -> CSSPixelRectIterator {
+    pub(crate) fn border_boxes(&self) -> CSSPixelRectVec {
         self.owner_window()
             .box_areas_query(self, BoxAreaType::Border)
     }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -43,12 +43,11 @@ use js::rust::{
     MutableHandleValue,
 };
 use layout_api::{
-    AxesOverflow, BoxAreaType, CSSPixelRectIterator, ElementsFromPointFlags,
-    ElementsFromPointResult, FragmentType, Layout, LayoutImageDestination, PendingImage,
-    PendingImageState, PendingRasterizationImage, PhysicalSides, QueryMsg, ReflowGoal,
-    ReflowPhasesRun, ReflowRequest, ReflowRequestRestyle, ReflowStatistics, RestyleReason,
-    ScrollContainerQueryFlags, ScrollContainerResponse, TrustedNodeAddress,
-    combine_id_with_fragment_type,
+    AxesOverflow, BoxAreaType, CSSPixelRectVec, ElementsFromPointFlags, ElementsFromPointResult,
+    FragmentType, Layout, LayoutImageDestination, PendingImage, PendingImageState,
+    PendingRasterizationImage, PhysicalSides, QueryMsg, ReflowGoal, ReflowPhasesRun, ReflowRequest,
+    ReflowRequestRestyle, ReflowStatistics, RestyleReason, ScrollContainerQueryFlags,
+    ScrollContainerResponse, TrustedNodeAddress, combine_id_with_fragment_type,
 };
 use malloc_size_of::MallocSizeOf;
 use media::WindowGLContext;
@@ -2904,7 +2903,7 @@ impl Window {
         self.box_area_query_without_reflow(node, area, exclude_transform_and_inline)
     }
 
-    pub(crate) fn box_areas_query(&self, node: &Node, area: BoxAreaType) -> CSSPixelRectIterator {
+    pub(crate) fn box_areas_query(&self, node: &Node, area: BoxAreaType) -> CSSPixelRectVec {
         self.layout_reflow(QueryMsg::BoxAreas);
         self.layout
             .borrow()

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -361,7 +361,7 @@ pub trait Layout {
         area: BoxAreaType,
         exclude_transform_and_inline: bool,
     ) -> Option<Rect<Au, CSSPixel>>;
-    fn query_box_areas(&self, node: TrustedNodeAddress, area: BoxAreaType) -> CSSPixelRectIterator;
+    fn query_box_areas(&self, node: TrustedNodeAddress, area: BoxAreaType) -> CSSPixelRectVec;
     fn query_client_rect(&self, node: TrustedNodeAddress) -> Rect<i32, CSSPixel>;
     fn query_current_css_zoom(&self, node: TrustedNodeAddress) -> f32;
     fn query_element_inner_outer_text(&self, node: TrustedNodeAddress) -> String;
@@ -445,7 +445,7 @@ pub enum BoxAreaType {
     Border,
 }
 
-pub type CSSPixelRectIterator = Box<dyn Iterator<Item = Rect<Au, CSSPixel>>>;
+pub type CSSPixelRectVec = Vec<Rect<Au, CSSPixel>>;
 
 /// Whether or not this node is being rendered or delegates rendering according
 /// to the HTML standard.


### PR DESCRIPTION
Before this PR, calculating accumulated containing blocks is a stand-alone traversal of the fragment tree that takes ~4% of the layout time in one synthetic benchmark. This moves it to be part of the existing tree traversal for stacking context construction, hopefully improving performance.

Testing: expected not to change observable behavior or outcomes of existing tests. The intermediate commit **before** “Remove now-redundant containing block computation pass” has does calculations and asserts they give the same result. Latest WPT run with this assertion: https://github.com/servo/servo/actions/runs/25807772217