### PR TITLE
script: Interpret every byte as ASCII for FileReader{Sync}.ReadAsBinaryString

### DIFF
--- a/components/script/dom/file/filereader.rs
+++ b/components/script/dom/file/filereader.rs
@@ -361,7 +361,7 @@ impl FileReader {
     /// > is represented by a code unit of equal value [0..255].
     fn perform_readasbinarystring(result: &DomRefCell<Option<FileReaderResult>>, bytes: &[u8]) {
         *result.borrow_mut() = Some(FileReaderResult::String(DOMString::from(
-            String::from_utf8_lossy(bytes),
+            bytes.iter().map(|&byte| byte as char).collect::<String>(),
         )));
     }
 

--- a/components/script/dom/file/filereadersync.rs
+++ b/components/script/dom/file/filereadersync.rs
@@ -67,10 +67,12 @@ impl FileReaderSyncMethods<crate::DomTypeHolder> for FileReaderSync {
         // step 1
         let blob_contents = FileReaderSync::get_blob_bytes(blob)?;
 
-        // step 2. 
+        // step 2.
         // > Return bytes as a binary string, in which every byte
         // > is represented by a code unit of equal value [0..255].
-        Ok(DOMString::from(String::from_utf8_lossy(&blob_contents)))
+        Ok(DOMString::from(
+            blob_contents.iter().map(|&byte| byte as char).collect::<String>(),
+        ))
     }
 
     /// <https://w3c.github.io/FileAPI/#readAsTextSync>

--- a/components/script/dom/file/filereadersync.rs
+++ b/components/script/dom/file/filereadersync.rs
@@ -71,7 +71,10 @@ impl FileReaderSyncMethods<crate::DomTypeHolder> for FileReaderSync {
         // > Return bytes as a binary string, in which every byte
         // > is represented by a code unit of equal value [0..255].
         Ok(DOMString::from(
-            blob_contents.iter().map(|&byte| byte as char).collect::<String>(),
+            blob_contents
+                .iter()
+                .map(|&byte| byte as char)
+                .collect::<String>(),
         ))
     }
 

--- a/components/script/dom/file/filereadersync.rs
+++ b/components/script/dom/file/filereadersync.rs
@@ -67,7 +67,9 @@ impl FileReaderSyncMethods<crate::DomTypeHolder> for FileReaderSync {
         // step 1
         let blob_contents = FileReaderSync::get_blob_bytes(blob)?;
 
-        // step 2
+        // step 2. 
+        // > Return bytes as a binary string, in which every byte
+        // > is represented by a code unit of equal value [0..255].
         Ok(DOMString::from(String::from_utf8_lossy(&blob_contents)))
     }
 

--- a/tests/wpt/meta/FileAPI/reading-data-section/filereader_readAsBinaryString.any.js.ini
+++ b/tests/wpt/meta/FileAPI/reading-data-section/filereader_readAsBinaryString.any.js.ini
@@ -1,8 +1,0 @@
-[filereader_readAsBinaryString.any.worker.html]
-  [FileAPI Test: filereader_readAsBinaryString]
-    expected: FAIL
-
-
-[filereader_readAsBinaryString.any.html]
-  [FileAPI Test: filereader_readAsBinaryString]
-    expected: FAIL

--- a/tests/wpt/tests/FileAPI/FileReaderSync.worker.js
+++ b/tests/wpt/tests/FileAPI/FileReaderSync.worker.js
@@ -42,6 +42,12 @@ test(() => {
 }, "readAsBinaryString with empty blob");
 
 test(() => {
+    var data = readerSync.readAsBinaryString(new Blob(["σ"]));
+    assert_equals(data.length, 2, "The result length is 2");
+    assert_equals(data, "\xcf\x83", "The result is \xcf\x83");
+}, "readAsBinaryString with multi-byte UTF-8 char");
+
+test(() => {
     var data = readerSync.readAsArrayBuffer(blob);
     assert_true(data instanceof ArrayBuffer);
     assert_equals(data.byteLength, "test".length);


### PR DESCRIPTION
Spec:
> > Return bytes as a binary string, in which every byte
> > is represented by a code unit of equal value [0..255].

I was copying the implementation from `FileReaderSync` in https://github.com/servo/servo/pull/44858.
Apparently it is wrong. It went unnoticed as there was no test coverage for FileReaderSync, multi-byte UTF-8 char.

Testing: New passing in existing. Added a new test for `FileReaderSync` too.

Part of #10778