### PR TITLE
script: Use "application/octet-stream" for unspecified Blob type for `FileReaderSync.ReadAsDataURL`

### DIFF
--- a/components/script/dom/file/filereadersync.rs
+++ b/components/script/dom/file/filereadersync.rs
@@ -98,9 +98,15 @@ impl FileReaderSyncMethods<crate::DomTypeHolder> for FileReaderSync {
         // step 1
         let blob_contents = FileReaderSync::get_blob_bytes(blob)?;
 
-        // step 2
-        let output =
-            FileReaderSharedFunctionality::dataurl_format(&blob_contents, blob.Type().to_string());
+        // step 2. package data.
+        // https://w3c.github.io/FileAPI/#blob-package-data
+        let blob_type = blob.Type().to_string();
+        let mime_type = if blob_type.is_empty() {
+            "application/octet-stream".to_string()
+        } else {
+            blob_type
+        };
+        let output = FileReaderSharedFunctionality::dataurl_format(&blob_contents, mime_type);
 
         Ok(output)
     }

--- a/tests/wpt/tests/FileAPI/FileReaderSync.worker.js
+++ b/tests/wpt/tests/FileAPI/FileReaderSync.worker.js
@@ -28,7 +28,7 @@ test(() => {
 
 test(() => {
     var data = readerSync.readAsDataURL(empty_blob);
-    assert_equals(data.indexOf("data:"), 0);
+    assert_equals(data, "data:application/octet-stream;base64,");
 }, "readAsDataURL with empty blob");
 
 test(() => {


### PR DESCRIPTION
In https://github.com/servo/servo/pull/44897, I only did this for `FileReader` but not `FileReaderSync`. 

Testing: Similar to https://github.com/servo/servo/pull/44921, there was no such test for `FileReaderSync` but only `FileReader`.
We update the existing test to cover this. It seems in general, test coverage for `FileReader` is much better.

Part of #10778