### PR TITLE
layout: Improve FragmentStatus when changes happen within an abspos

### DIFF
--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -636,8 +636,8 @@ impl Fragment {
                     builder.reflow_statistics.restyle_fragment_count += 1;
                     base.set_status(FragmentStatus::Clean)
                 },
-                FragmentStatus::PositionMaybeChanged => {
-                    builder.reflow_statistics.possibly_moved_fragment_count += 1;
+                FragmentStatus::OnlyDescendantsChanged => {
+                    builder.reflow_statistics.only_descendants_changed_count += 1;
                     base.set_status(FragmentStatus::Clean)
                 },
                 FragmentStatus::Clean => {},

--- a/components/layout/dom.rs
+++ b/components/layout/dom.rs
@@ -373,6 +373,10 @@ pub(crate) trait NodeExt<'dom> {
         &self,
         layout_context: &LayoutContext,
     ) -> bool;
+
+    /// Whether or not the style of this node indicates that it should be absolutely
+    /// positioned.
+    fn is_absolutely_positioned(&self) -> bool;
 }
 
 impl<'dom> NodeExt<'dom> for ServoLayoutNode<'dom> {
@@ -772,5 +776,16 @@ impl<'dom> NodeExt<'dom> for ServoLayoutNode<'dom> {
             LayoutBox::TaffyItemBox(..) => false,
             LayoutBox::Text(..) => unreachable!("An element should never be a text node"),
         }
+    }
+
+    fn is_absolutely_positioned(&self) -> bool {
+        self.as_element().is_some_and(|element| {
+            element
+                .element_data()
+                .styles
+                .primary()
+                .clone_position()
+                .is_absolutely_positioned()
+        })
     }
 }

--- a/components/layout/fragment_tree/base_fragment.rs
+++ b/components/layout/fragment_tree/base_fragment.rs
@@ -25,7 +25,7 @@ use crate::SharedStyle;
 use crate::dom_traversal::NodeAndStyleInfo;
 use crate::geom::{PhysicalPoint, PhysicalRect, PhysicalSize};
 
-#[derive(Clone, Debug, Default, MallocSizeOf, FromPrimitive)]
+#[derive(Clone, Debug, Default, FromPrimitive, MallocSizeOf, PartialEq)]
 #[repr(u8)]
 pub(crate) enum FragmentStatus {
     /// This is a brand new fragment.
@@ -33,9 +33,9 @@ pub(crate) enum FragmentStatus {
     New,
     /// The style of the fragment has changed.
     StyleChanged,
-    /// The fragment was reused between layouts, but its final layout
-    /// position may have changed.
-    PositionMaybeChanged,
+    /// The fragment was reused between layouts, some descendant fragment may be different,
+    /// but otherwise nothing has changed on the fragment itself.
+    OnlyDescendantsChanged,
     /// The fragment hasn't changed.
     Clean,
 }

--- a/components/layout/layout_box_base.rs
+++ b/components/layout/layout_box_base.rs
@@ -15,6 +15,7 @@ use servo_arc::Arc as ServoArc;
 use style::computed_values::position::T as Position;
 use style::logical_geometry::WritingMode;
 use style::properties::ComputedValues;
+use style::selector_parser::RestyleDamage;
 use style::values::specified::align::AlignFlags;
 use style_traits::CSSPixel;
 
@@ -47,6 +48,7 @@ pub(crate) struct LayoutBoxBase {
     pub cached_layout_result: AtomicRefCell<Option<LayoutResultAndInputs>>,
     pub fragments: AtomicRefCell<Vec<Fragment>>,
     pub parent_box: Option<WeakLayoutBox>,
+    only_descendants_changed: AtomicBool,
 }
 
 impl LayoutBoxBase {
@@ -62,6 +64,7 @@ impl LayoutBoxBase {
             cached_layout_result: AtomicRefCell::default(),
             fragments: AtomicRefCell::default(),
             parent_box: None,
+            only_descendants_changed: AtomicBool::default(),
         }
     }
 
@@ -95,10 +98,20 @@ impl LayoutBoxBase {
     }
 
     pub(crate) fn add_fragment(&self, fragment: Fragment) {
+        if self.only_descendants_changed.load(Ordering::Relaxed) &&
+            let Some(base) = fragment.base()
+        {
+            base.set_status(FragmentStatus::OnlyDescendantsChanged)
+        }
         self.fragments.borrow_mut().push(fragment);
     }
 
     pub(crate) fn set_fragment(&self, fragment: Fragment) {
+        if self.only_descendants_changed.load(Ordering::Relaxed) &&
+            let Some(base) = fragment.base()
+        {
+            base.set_status(FragmentStatus::OnlyDescendantsChanged)
+        }
         *self.fragments.borrow_mut() = vec![fragment];
     }
 
@@ -129,7 +142,19 @@ impl LayoutBoxBase {
         &self,
         element_damage: LayoutDamage,
         damage_from_children: LayoutDamage,
+        damage_from_parent: RestyleDamage,
     ) -> LayoutDamage {
+        let only_descendants_changed = !RestyleDamage::from(element_damage)
+            .contains(RestyleDamage::RELAYOUT) &&
+            !damage_from_parent.contains(RestyleDamage::RELAYOUT) &&
+            !damage_from_children.contains(LayoutDamage::LAYOUT_AFFECTED_BY_INFLOW_DESCENDANT) &&
+            self.fragments.borrow().iter().all(|fragment| {
+                fragment
+                    .base()
+                    .is_some_and(|base| base.status() == FragmentStatus::Clean)
+            });
+        self.only_descendants_changed
+            .store(only_descendants_changed, Ordering::Relaxed);
         self.clear_fragments_and_fragment_cache();
 
         if !element_damage.is_empty() ||
@@ -188,14 +213,6 @@ impl LayoutBoxBase {
 
         let fragment = result.result.fragment.clone();
         {
-            // Ideally when the final position doesn't change, this wouldn't be set, but we have
-            // no way currently to track whether the final position wil differ from the one set in
-            // the cached fragment. Final positioning is done in the containing block and depends
-            // on things like margins and the size of siblings.
-            fragment
-                .base
-                .set_status(FragmentStatus::PositionMaybeChanged);
-
             let mut origin = result.result.original_offset;
             if self.style.clone_position() == Position::Relative {
                 origin += relative_adjustement(&self.style, containing_block)

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -133,6 +133,9 @@ pub(crate) fn compute_damage_and_rebuild_box_tree(
     let mut needs_box_tree_rebuild = layout_damage.needs_new_box();
 
     let mut damage_for_ancestors = LayoutDamage::RECOMPUTE_INLINE_CONTENT_SIZES;
+    if restyle_damage.contains(LayoutDamage::layout_affected_by_inflow_descendant()) {
+        damage_for_ancestors.insert(LayoutDamage::LAYOUT_AFFECTED_BY_INFLOW_DESCENDANT);
+    }
 
     let mut maybe_parent_node = unsafe { dirty_root.dangerous_flat_tree_parent() };
     while let Some(parent_node) = maybe_parent_node {
@@ -155,10 +158,23 @@ pub(crate) fn compute_damage_and_rebuild_box_tree(
             parent_node.with_layout_box_base_including_pseudos(|base| {
                 new_damage_for_ancestors.set(
                     new_damage_for_ancestors.get() |
-                        base.add_damage(Default::default(), damage_for_ancestors),
+                        base.add_damage(
+                            Default::default(),
+                            damage_for_ancestors,
+                            RestyleDamage::empty(),
+                        ),
                 );
             });
             damage_for_ancestors = new_damage_for_ancestors.get();
+
+            // If doing a fragment tree layout, we also need to apply the LAYOUT_AFFECTED_BY_INFLOW_DESCENDANT
+            // damage flag, unless this node is out of flow. In that case our ancestors are rebuilt, but
+            // their resulting fragments should be equivalent to the previous ones.
+            if damage_for_ancestors.contains(LayoutDamage::LAYOUT_AFFECTED_BY_INFLOW_DESCENDANT) &&
+                parent_node.is_absolutely_positioned()
+            {
+                damage_for_ancestors.remove(LayoutDamage::LAYOUT_AFFECTED_BY_INFLOW_DESCENDANT);
+            }
         } else {
             // No fragment layout is necessary, but a descendant had scrollable overflow
             // damage. In this case, clear any preexisting scrollable overflow so that it
@@ -241,8 +257,9 @@ pub(crate) fn compute_damage_and_rebuild_box_tree_inner(
 
     // Only propagate up layout phases from children. Other types of damage can be
     // propagated from children but via the `LayoutBoxBase::add_damage` return value.
-    let mut layout_damage_for_parent =
-        element_and_parent_damage | (damage_from_children & RestyleDamage::RELAYOUT);
+    let mut layout_damage_for_parent = element_and_parent_damage |
+        (damage_from_children &
+            (RestyleDamage::RELAYOUT | LayoutDamage::layout_affected_by_inflow_descendant()));
 
     let element_or_ancestors_need_rebuild =
         element_and_parent_damage.contains(LayoutDamage::descendant_has_box_damage());
@@ -281,7 +298,11 @@ pub(crate) fn compute_damage_and_rebuild_box_tree_inner(
             node.with_layout_box_base_including_pseudos(|base| {
                 extra_layout_damage_for_parent.set(
                     extra_layout_damage_for_parent.get() |
-                        base.add_damage(element_damage.into(), damage_from_children.into()),
+                        base.add_damage(
+                            element_damage.into(),
+                            damage_from_children.into(),
+                            damage_from_parent,
+                        ),
                 );
             });
             layout_damage_for_parent.insert(extra_layout_damage_for_parent.get().into());
@@ -302,6 +323,17 @@ pub(crate) fn compute_damage_and_rebuild_box_tree_inner(
         if !element_damage.is_empty() {
             node.repair_style(&layout_context.style_context);
         }
+    }
+
+    // If doing a fragment tree layout, we also need to apply the LAYOUT_AFFECTED_BY_INFLOW_DESCENDANT
+    // damage flag, unless this node is out of flow. In that case our ancestors are rebuilt, but
+    // their resulting fragments should be equivalent to the previous ones.
+    if layout_damage_for_parent.contains(LayoutDamage::layout_affected_by_inflow_descendant()) &&
+        node.is_absolutely_positioned()
+    {
+        layout_damage_for_parent.remove(LayoutDamage::layout_affected_by_inflow_descendant());
+    } else if element_damage.contains(RestyleDamage::RELAYOUT) {
+        layout_damage_for_parent.insert(LayoutDamage::layout_affected_by_inflow_descendant());
     }
 
     layout_damage_for_parent

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -255,8 +255,9 @@ pub(crate) fn compute_damage_and_rebuild_box_tree_inner(
         }
     }
 
-    // Only propagate up layout phases from children. Other types of damage can be
-    // propagated from children but via the `LayoutBoxBase::add_damage` return value.
+    // Only propagate up layout phases and whether layout affects inflow descendants from
+    // children. Other types of damage can be propagated from children but via the
+    // `LayoutBoxBase::add_damage` return value.
     let mut layout_damage_for_parent = element_and_parent_damage |
         (damage_from_children &
             (RestyleDamage::RELAYOUT | LayoutDamage::layout_affected_by_inflow_descendant()));
@@ -328,12 +329,16 @@ pub(crate) fn compute_damage_and_rebuild_box_tree_inner(
     // If doing a fragment tree layout, we also need to apply the LAYOUT_AFFECTED_BY_INFLOW_DESCENDANT
     // damage flag, unless this node is out of flow. In that case our ancestors are rebuilt, but
     // their resulting fragments should be equivalent to the previous ones.
-    if layout_damage_for_parent.contains(LayoutDamage::layout_affected_by_inflow_descendant()) &&
-        node.is_absolutely_positioned()
-    {
-        layout_damage_for_parent.remove(LayoutDamage::layout_affected_by_inflow_descendant());
-    } else if element_damage.contains(RestyleDamage::RELAYOUT) {
-        layout_damage_for_parent.insert(LayoutDamage::layout_affected_by_inflow_descendant());
+    if !layout_damage_for_parent.contains(LayoutDamage::descendant_has_box_damage()) {
+        if element_damage.contains(RestyleDamage::RELAYOUT) {
+            layout_damage_for_parent.insert(LayoutDamage::layout_affected_by_inflow_descendant());
+        }
+
+        if layout_damage_for_parent.contains(LayoutDamage::layout_affected_by_inflow_descendant()) &&
+            node.is_absolutely_positioned()
+        {
+            layout_damage_for_parent.remove(LayoutDamage::layout_affected_by_inflow_descendant());
+        }
     }
 
     layout_damage_for_parent

--- a/components/script/dom/testing/layoutresult.rs
+++ b/components/script/dom/testing/layoutresult.rs
@@ -19,7 +19,7 @@ pub(crate) struct LayoutResult {
     phases: Vec<DOMString>,
     rebuilt_fragment_count: u32,
     restyle_fragment_count: u32,
-    possibly_moved_fragment_count: u32,
+    only_descendants_changed_count: u32,
 }
 
 impl LayoutResult {
@@ -27,14 +27,14 @@ impl LayoutResult {
         phases: Vec<DOMString>,
         rebuilt_fragment_count: u32,
         restyle_fragment_count: u32,
-        possibly_moved_fragment_count: u32,
+        only_descendants_changed_count: u32,
     ) -> Self {
         Self {
             reflector_: Reflector::new(),
             phases,
             rebuilt_fragment_count,
             restyle_fragment_count,
-            possibly_moved_fragment_count,
+            only_descendants_changed_count,
         }
     }
 
@@ -43,7 +43,7 @@ impl LayoutResult {
         phases: Vec<DOMString>,
         rebuilt_fragment_count: u32,
         restyle_fragment_count: u32,
-        possibly_moved_fragment_count: u32,
+        only_descendants_changed_count: u32,
         can_gc: CanGc,
     ) -> DomRoot<Self> {
         reflect_dom_object(
@@ -51,7 +51,7 @@ impl LayoutResult {
                 phases,
                 rebuilt_fragment_count,
                 restyle_fragment_count,
-                possibly_moved_fragment_count,
+                only_descendants_changed_count,
             )),
             global,
             can_gc,
@@ -72,7 +72,7 @@ impl LayoutResultMethods<crate::DomTypeHolder> for LayoutResult {
         self.restyle_fragment_count
     }
 
-    fn PossiblyMovedFragmentCount(&self) -> u32 {
-        self.possibly_moved_fragment_count
+    fn OnlyDescendantsChangedCount(&self) -> u32 {
+        self.only_descendants_changed_count
     }
 }

--- a/components/script/dom/testing/servotestutils.rs
+++ b/components/script/dom/testing/servotestutils.rs
@@ -60,7 +60,7 @@ impl ServoTestUtilsMethods<crate::DomTypeHolder> for ServoTestUtils {
             phases,
             statistics.rebuilt_fragment_count,
             statistics.restyle_fragment_count,
-            statistics.possibly_moved_fragment_count,
+            statistics.only_descendants_changed_count,
             can_gc,
         )
     }

--- a/components/script_bindings/webidls/ServoTestUtils.webidl
+++ b/components/script_bindings/webidls/ServoTestUtils.webidl
@@ -27,5 +27,5 @@ interface LayoutResult {
     readonly attribute /* FrozenArray<DOMString> */ any phases;
     readonly attribute unsigned long rebuiltFragmentCount;
     readonly attribute unsigned long restyleFragmentCount;
-    readonly attribute unsigned long possiblyMovedFragmentCount;
+    readonly attribute unsigned long onlyDescendantsChangedCount;
 };

--- a/components/shared/layout/layout_damage.rs
+++ b/components/shared/layout/layout_damage.rs
@@ -12,10 +12,14 @@ bitflags! {
     pub struct LayoutDamage: u16 {
         /// Clear the cached inline content sizes and recompute them during the next layout.
         const RECOMPUTE_INLINE_CONTENT_SIZES = 0b1000_0000_0000 << 4;
+        /// There is a change in a descendant of this box that can affect its layout.
+        /// This flag is not propagated upwards when encountering an absolutely positioned
+        /// box, since it's out-of-flow.
+        const LAYOUT_AFFECTED_BY_INFLOW_DESCENDANT = 0b0100_0000_0000 << 4;
         /// Rebuild this box and all of its ancestors. Do not rebuild any children. This
         /// is used when a box's content (such as text content) changes or a descendant
         /// has box damage ([`Self::BOX_DAMAGE`]).
-        const DESCENDANT_HAS_BOX_DAMAGE = 0b0111_1111_1111 << 4;
+        const DESCENDANT_HAS_BOX_DAMAGE = 0b0011_1111_1111 << 4;
         /// Rebuild this box, all of its ancestors and all of its descendants. This is the
         /// most a box can be damaged.
         const BOX_DAMAGE = 0b1111_1111_1111 << 4;
@@ -37,6 +41,10 @@ impl LayoutDamage {
 
     pub fn recompute_inline_content_sizes() -> RestyleDamage {
         RestyleDamage::from_bits_retain(LayoutDamage::RECOMPUTE_INLINE_CONTENT_SIZES.bits())
+    }
+
+    pub fn layout_affected_by_inflow_descendant() -> RestyleDamage {
+        RestyleDamage::from_bits_retain(LayoutDamage::LAYOUT_AFFECTED_BY_INFLOW_DESCENDANT.bits())
     }
 }
 

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -656,9 +656,9 @@ pub struct ReflowStatistics {
     pub rebuilt_fragment_count: u32,
     /// A count of the number of fragments that are reused, but have had their style change.
     pub restyle_fragment_count: u32,
-    /// A count of the number of fragments that are reused, but may have had their final
-    /// position change.
-    pub possibly_moved_fragment_count: u32,
+    /// A count of the number of fragments that are reused, but may have had some descendant
+    /// fragment change.
+    pub only_descendants_changed_count: u32,
 }
 
 /// Information needed for a script-initiated reflow that requires a restyle

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13149,6 +13149,13 @@
       {}
      ]
     ],
+    "isolating-change-within-abspos.html": [
+     "371111400c32c65af53d8ea55d87b22b27faf25c",
+     [
+      null,
+      {}
+     ]
+    ],
     "layout-phases-display-list.html": [
      "0f08ae12a4610987d304bdd2431ccde0bec192be",
      [
@@ -13185,7 +13192,7 @@
      ]
     ],
     "preserved-same-formatting-context-block-layout.html": [
-     "068936574cedc2ad55a98f8a24ea419fab3535cf",
+     "0a370296d767cec1db6e2ce6893478506b6ee88c",
      [
       null,
       {}

--- a/tests/wpt/mozilla/tests/incremental-layout/isolating-change-within-abspos.html
+++ b/tests/wpt/mozilla/tests/incremental-layout/isolating-change-within-abspos.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+#abspos { position: absolute }
+</style>
+<div id="container">
+  <div id="abspos">
+    <div id="abspos_child"></div>
+  </div>
+  <p id="p1">Example</p>
+  <p id="p2">Example</p>
+</div>
+
+<script>
+setup({explicit_done:true});
+
+window.onload = () => {
+    test((t) => {
+        ServoTestUtils.forceLayout();
+        abspos_child.style.width = "100px";
+        let result = ServoTestUtils.forceLayout();
+
+        // abspos_child + abspos
+        assert_equals(result.rebuiltFragmentCount, 2, "rebuiltFragmentCount");
+        assert_equals(result.restyleFragmentCount, 0, "restyleFragmentCount");
+        // container + body + root
+        assert_equals(result.onlyDescendantsChangedCount, 3, "onlyDescendantsChangedCount");
+    }, "Changing an element within an abspos should mark ancestor fragments of the abspos as DescendantsChanged");
+
+    test((t) => {
+        ServoTestUtils.forceLayout();
+        abspos.style.width = "100px";
+        let result = ServoTestUtils.forceLayout();
+
+        // abspos_child + abspos
+        assert_equals(result.rebuiltFragmentCount, 2, "rebuiltFragmentCount");
+        assert_equals(result.restyleFragmentCount, 0, "restyleFragmentCount");
+        // container + body + root
+        assert_equals(result.onlyDescendantsChangedCount, 3, "onlyDescendantsChangedCount");
+    }, "Changing an abspos should mark ancestor fragments as DescendantsChanged");
+
+    done();
+}
+</script>

--- a/tests/wpt/mozilla/tests/incremental-layout/preserved-same-formatting-context-block-layout.html
+++ b/tests/wpt/mozilla/tests/incremental-layout/preserved-same-formatting-context-block-layout.html
@@ -24,7 +24,7 @@ window.onload = () => {
         assert_equals(result.rebuiltFragmentCount, 5, "rebuiltFragmentCount");
         assert_equals(result.restyleFragmentCount, 0, "restyleFragmentCount");
         // p2 + p3 + p4 + p5
-        assert_equals(result.possiblyMovedFragmentCount, 4, "possiblyMovedFragmentCount");
+        assert_equals(result.onlyDescendantsChangedCount, 0, "onlyDescendantsChangedCount");
 
     }, "Updating a sibling should not cause fragments to be rebuilt");
 


### PR DESCRIPTION
An absolutely position element is out-of-flow. Therefore, when a there is a layout change on or within it, we will now mark ancestor fragments with an OnlyDescendantsChanged status.

Additionally, PositionMaybeChanged is removed. When a fragment is marked as new, its descendants can change their position. This was previously inconsistent, since sometimes we were marking as PositionMaybeChanged and sometimes as Clean. Fragments are assumed to inherit a New status from ancestors.

Testing: No web observable behavior change, but adding a new internal test for the marking differences.
