### PR TITLE
ohos: Request Vsync on demand instead of every frame

### DIFF
--- a/ports/servoshell/egl/app.rs
+++ b/ports/servoshell/egl/app.rs
@@ -270,6 +270,7 @@ impl RefreshDriver for VsyncRefreshDriver {
     fn observe_next_frame(&self, new_start_frame_callback: Box<dyn Fn() + Send + 'static>) {
         // We only need to request a vsync callback if the queue is empty,
         // otherwise we will already have a pending callback.
+        #[cfg_attr(not(target_env = "ohos"), allow(unused_variables))]
         let was_empty = {
             let mut callbacks = self.start_frame_callbacks.borrow_mut();
             let was_empty = callbacks.is_empty();
@@ -280,8 +281,6 @@ impl RefreshDriver for VsyncRefreshDriver {
         if was_empty {
             super::ohos::request_vsync_callback(&self.native_vsync);
         }
-        #[cfg(not(target_env = "ohos"))]
-        let _ = was_empty;
     }
 }
 

--- a/ports/servoshell/egl/app.rs
+++ b/ports/servoshell/egl/app.rs
@@ -239,12 +239,24 @@ impl PlatformWindow for EmbeddedPlatformWindow {
     }
 }
 
-#[derive(Default)]
 pub(crate) struct VsyncRefreshDriver {
     start_frame_callbacks: RefCell<Vec<Box<dyn Fn() + Send>>>,
+    /// On OHOS we own the `OH_NativeVSync` handle and request a single callback
+    /// only when an observer asks for one.
+    #[cfg(target_env = "ohos")]
+    native_vsync: ohos_vsync::NativeVsync,
 }
 
 impl VsyncRefreshDriver {
+    pub(crate) fn new() -> Self {
+        Self {
+            start_frame_callbacks: Default::default(),
+            #[cfg(target_env = "ohos")]
+            native_vsync: ohos_vsync::NativeVsync::new("ServoVsync")
+                .expect("Failed to create NativeVsync"),
+        }
+    }
+
     fn notify_vsync(&self) {
         let start_frame_callbacks: Vec<_> =
             self.start_frame_callbacks.borrow_mut().drain(..).collect();
@@ -256,9 +268,20 @@ impl VsyncRefreshDriver {
 
 impl RefreshDriver for VsyncRefreshDriver {
     fn observe_next_frame(&self, new_start_frame_callback: Box<dyn Fn() + Send + 'static>) {
-        self.start_frame_callbacks
-            .borrow_mut()
-            .push(new_start_frame_callback);
+        // We only need to request a vsync callback if the queue is empty,
+        // otherwise we will already have a pending callback.
+        let was_empty = {
+            let mut callbacks = self.start_frame_callbacks.borrow_mut();
+            let was_empty = callbacks.is_empty();
+            callbacks.push(new_start_frame_callback);
+            was_empty
+        };
+        #[cfg(target_env = "ohos")]
+        if was_empty {
+            super::ohos::request_vsync_callback(&self.native_vsync);
+        }
+        #[cfg(not(target_env = "ohos"))]
+        let _ = was_empty;
     }
 }
 
@@ -326,7 +349,7 @@ impl App {
         window_id: Option<ServoShellWindowId>,
     ) {
         let viewport_size = viewport_rect.size;
-        let refresh_driver = Rc::new(VsyncRefreshDriver::default());
+        let refresh_driver = Rc::new(VsyncRefreshDriver::new());
         let rendering_context = Rc::new(
             WindowRenderingContext::new_with_refresh_driver(
                 display_handle,
@@ -634,8 +657,6 @@ impl App {
         }
     }
 
-    // TODO: Instead of letting the embedder drive the RefreshDriver we should move the vsync
-    // notification directly into the VsyncRefreshDriver.
     pub fn notify_vsync(&self) {
         let platform_window = self.window().platform_window();
         let embedded_platform_window = platform_window

--- a/ports/servoshell/egl/ohos/mod.rs
+++ b/ports/servoshell/egl/ohos/mod.rs
@@ -50,7 +50,8 @@
 /// `servoshell` registers callbacks for the xcomponent object.
 /// After [`init()`] finishes, ArkTS will call the callback for `on_surface_created`, that we just
 /// registered. In the callback we send a message to our main thread, informing it of the new window.
-/// Additionally, for the first window, we also setup vsync callbacks.
+/// Vsync subscription is owned by [`super::app::VsyncRefreshDriver`] (created when the platform
+/// window is registered) and armed on demand whenever an observer asks for the next frame.
 ///
 /// At this point the initialization is finished, and servoshell is ready.
 mod resources;
@@ -523,26 +524,28 @@ impl ServoAction {
     }
 }
 
-/// Vsync callback
+/// Ask the OHOS framework to invoke [`on_vsync_cb`] once on the next vsync.
 ///
-/// # Safety
-///
-/// The caller should pass a valid raw NativeVsync object to us via
-/// `native_vsync.request_raw_callback_with_self(Some(on_vsync_cb))`
+/// Calling this multiple times in the same vsync period will result in
+/// one callback execution.
+pub(crate) fn request_vsync_callback(native_vsync: &ohos_vsync::NativeVsync) {
+    // SAFETY: We don't pass any data, and `on_vsync_cb` is a function with static lifetime.
+    if let Err(e) =
+        unsafe { native_vsync.request_raw_callback(Some(on_vsync_cb), std::ptr::null_mut()) }
+    {
+        warn!("Failed to request vsync callback: {e:?}");
+    }
+}
+
+/// Vsync callback. Runs on the OHOS framework's vsync helper thread
 unsafe extern "C" fn on_vsync_cb(
     timestamp: ::core::ffi::c_longlong,
-    data: *mut ::core::ffi::c_void,
+    _data: *mut ::core::ffi::c_void,
 ) {
     trace!("Vsync callback at time {timestamp}");
-    // SAFETY: We require the function registering us as a callback provides a valid
-    //  `OH_NativeVSync` object. We do not use `data` after this point.
-    let native_vsync = unsafe { ohos_vsync::NativeVsync::from_raw(data.cast()) };
-    call(ServoAction::Vsync).unwrap();
-    // Todo: Do we have a callback for when the frame finished rendering?
-    unsafe {
-        native_vsync
-            .request_raw_callback_with_self(Some(on_vsync_cb))
-            .unwrap();
+    // Let's not panic here, that's been a source of confusion.
+    if let Err(e) = call(ServoAction::Vsync) {
+        error!("Failed to send Vsync event: {e:?} - Main thread died?");
     }
 }
 
@@ -588,15 +591,6 @@ extern "C" fn on_surface_created_cb(xcomponent: *mut OH_NativeXComponent, window
             window_wrapper,
         ))
         .expect("Servo main thread channel not initialized");
-
-        let native_vsync =
-            ohos_vsync::NativeVsync::new("ServoVsync").expect("Failed to create NativeVsync");
-        unsafe {
-            native_vsync
-                .request_raw_callback_with_self(Some(on_vsync_cb))
-                .expect("Failed to request vsync callback")
-        }
-        info!("Enabled Vsync!");
     } else {
         call(ServoAction::CreatePlatformWindow(
             xc_wrapper,


### PR DESCRIPTION
Instead of permantly requesting the vsync callback, only request on demand. This reduces cpu load on idle pages.

about:blank sees a massive reduction in instruction count on ohos. This also might slightly improve performance on ohos, but measurements aren't very accurate yet so low-confidence.

Testing: This shouldn't change observable behavior. 

