### PR TITLE
ohos/android: Fix various clippy issues

### DIFF
--- a/components/fonts/platform/freetype/ohos/font_cache.rs
+++ b/components/fonts/platform/freetype/ohos/font_cache.rs
@@ -24,14 +24,14 @@ pub fn font_file_cached_on_disk() -> bool {
             let Ok(res) = fs::exists(file_path) else {
                 return false;
             };
-            return res;
+            res
         },
         Err(e) => {
             error!(
                 "Failed to parse the file path of the OHOS FontList cache file: {:?}",
                 e
             );
-            return false;
+            false
         },
     }
 }
@@ -80,14 +80,13 @@ fn remove_redundant_cache_files() {
             if (filename_components.len() == 2) && // the font cache file only has one `_`. So the vector length from splitting must be 2.
                         (filename_components[1] == cache_filename_components[1]) && // check if the suffix is the same
                         (filename_components[0] != cache_filename_components[0])
+                && let Err(e) = fs::remove_file(format!("{}{}", &base_dir, filename))
             {
-                if let Err(e) = fs::remove_file(format!("{}{}", &base_dir, filename).to_string()) {
-                    error!(
-                        "Obsolete font cache file found; but failed to remove it: {:?}",
-                        e
-                    );
-                };
-            }
+                error!(
+                    "Obsolete font cache file found; but failed to remove it: {:?}",
+                    e
+                );
+            };
         }
     }
 }
@@ -97,7 +96,7 @@ fn parse_file_path() -> Result<String, Box<dyn Error>> {
     let base_dir = get_directory()?;
     let cache_filename = parse_filename()?;
 
-    Ok(format!("{}{}", base_dir, cache_filename).to_string())
+    Ok(format!("{}{}", base_dir, cache_filename))
 }
 
 /// Helper function to obtain the path to the directory where we'll eventually store our cache file in.
@@ -118,7 +117,7 @@ fn parse_filename() -> Result<String, Box<dyn Error>> {
         os_version_c_str.to_str()?
     };
 
-    Ok(format!("{}{}", os_version, "_font-cache.bin").to_string())
+    Ok(format!("{}{}", os_version, "_font-cache.bin"))
 }
 
 /// This function serializes `FontList` and caches its result into disk.

--- a/components/fonts/platform/freetype/ohos/font_list.rs
+++ b/components/fonts/platform/freetype/ohos/font_list.rs
@@ -116,7 +116,7 @@ fn detect_hos_font_style(font: &FontRef, file_path: &str) -> Option<String> {
             panic!("Failed to read {:?}'s postscript table!", file_path);
         })
         .italic_angle() !=
-        (0 as i32).into()
+        (0_i32).into()
     {
         Some("italic".to_string())
     } else {
@@ -140,10 +140,10 @@ fn detect_hos_font_width(font: &FontRef) -> FontWidth {
     // and we simply return `FontWidth::Normal` as a default.
     match font.os2() {
         Ok(result) => {
-            let font_width = result.us_width_class().clone();
+            let font_width = result.us_width_class();
             // According to https://learn.microsoft.com/en-us/typography/opentype/spec/os2#uswidthclass,
             // value between 1 & 4 inclusive represents condensed type.
-            if font_width >= 1 && font_width <= 4 {
+            if (1..=4).contains(&font_width) {
                 FontWidth::Condensed
             } else {
                 FontWidth::Normal
@@ -188,7 +188,7 @@ fn get_system_font_families(font_files: Vec<PathBuf>) -> Vec<FontFamily> {
 
         match file_ref {
             OHOS_Font(font) => {
-                if let Some(result) = get_family_name_and_generate_font_struct(&font, &font_file) {
+                if let Some(result) = get_family_name_and_generate_font_struct(&font, font_file) {
                     all_families.push(result);
                 }
             },
@@ -196,7 +196,7 @@ fn get_system_font_families(font_files: Vec<PathBuf>) -> Vec<FontFamily> {
                 // Process all the font files within the collection one by one.
                 for f in font_collection.iter() {
                     if let Some(result) =
-                        get_family_name_and_generate_font_struct(&(f.unwrap()), &font_file)
+                        get_family_name_and_generate_font_struct(&(f.unwrap()), font_file)
                     {
                         all_families.push(result);
                     };
@@ -221,12 +221,10 @@ fn get_system_font_families(font_files: Vec<PathBuf>) -> Vec<FontFamily> {
 
 fn get_family_name_and_generate_font_struct(
     font_ref: &FontRef,
-    file_path: &PathBuf,
+    file_path: &Path,
 ) -> Option<(String, Font)> {
     // Parse the file path to string. If this fails, then skip this font.
-    let Some(file_path_string_slice) = file_path.to_str() else {
-        return None;
-    };
+    let file_path_string_slice = file_path.to_str()?;
     let file_path_str = file_path_string_slice.to_string();
 
     // Obtain the font's styling
@@ -236,10 +234,8 @@ fn get_family_name_and_generate_font_struct(
 
     // Get the family name via the name table. According to TrueType's reference manual (https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6.html),
     // the name table is a mandatory table. Therefore, if Fontations fails to read this table for whatever reason, return `None` to skip this font altogether.
-    let Ok(font_name_table) = font_ref.name() else {
-        return None;
-    };
-    let Some(family_name) = font_name_table
+    let font_name_table = font_ref.name().ok()?;
+    let family_name = font_name_table
         .name_record()
         .iter()
         .filter(|record| record.name_id().to_u16() == 1) // According to the reference manual, name identifier code (nameID) `1` is the font family name.
@@ -248,10 +244,7 @@ fn get_family_name_and_generate_font_struct(
                 .string(font_name_table.string_data())
                 .ok()
                 .map(|s| s.to_string())
-        })
-    else {
-        return None;
-    };
+        })?;
 
     let font = Font {
         filepath: file_path_str,
@@ -275,21 +268,15 @@ impl FontList {
             return font_list;
         }
 
-        match read_from_disk() {
-            Ok(font_list) => font_list,
-            Err(e) => {
-                error!(
-                    "Servo fails to read cached FontList from disk. Error message: {:?}",
-                    e
-                );
+        read_from_disk().unwrap_or_else(|e| {
+            error!("Servo failed to read cached FontList from disk: {:?}", e);
 
-                // Since reading from disk fails, we have no choice but to generate the FontList...
-                return FontList {
-                    families: Self::detect_installed_font_families(),
-                    aliases: Self::fallback_font_aliases(),
-                };
-            },
-        }
+            // Since reading from disk failed, we have no choice but to generate the FontList...
+            FontList {
+                families: Self::detect_installed_font_families(),
+                aliases: Self::fallback_font_aliases(),
+            }
+        })
     }
 
     /// Detect available fonts or fallback to a hardcoded list
@@ -469,14 +456,14 @@ where
         return;
     }
 
-    if let Some(alias) = FONT_LIST.find_alias(family_name) {
-        if let Some(family) = FONT_LIST.find_family(&alias.to) {
-            for font in &family.fonts {
-                match (alias.weight, font.weight) {
-                    (None, _) => produce_font(font),
-                    (Some(w1), Some(w2)) if w1 == w2 => produce_font(font),
-                    _ => {},
-                }
+    if let Some(alias) = FONT_LIST.find_alias(family_name) &&
+        let Some(family) = FONT_LIST.find_family(&alias.to)
+    {
+        for font in &family.fonts {
+            match (alias.weight, font.weight) {
+                (None, _) => produce_font(font),
+                (Some(w1), Some(w2)) if w1 == w2 => produce_font(font),
+                _ => {},
             }
         }
     }

--- a/ports/servoshell/egl/app.rs
+++ b/ports/servoshell/egl/app.rs
@@ -183,12 +183,11 @@ impl PlatformWindow for EmbeddedPlatformWindow {
     fn show_embedder_control(&self, _: WebViewId, embedder_control: EmbedderControl) {
         let control_id = embedder_control.id();
         match embedder_control {
-            EmbedderControl::InputMethod(input_method_control) => {
-                if input_method_control.allow_virtual_keyboard() {
+            EmbedderControl::InputMethod(input_method_control)
+                if input_method_control.allow_virtual_keyboard() => {
                     self.visible_input_methods.borrow_mut().push(control_id);
                     self.host.on_ime_show(input_method_control);
-                }
-            },
+                },
             EmbedderControl::SimpleDialog(simple_dialog) => match simple_dialog {
                 SimpleDialog::Alert(alert_dialog) => {
                     self.host.show_alert(alert_dialog.message().into());
@@ -352,7 +351,7 @@ impl App {
             current_load_status: Default::default(),
         });
         self.state
-            .open_window(platform_window.clone(), self.initial_url.clone());
+            .open_window(platform_window, self.initial_url.clone());
     }
 
     pub(crate) fn servo(&self) -> &Servo {
@@ -367,7 +366,7 @@ impl App {
         self.state
             .focused_window()
             .expect("There is always an active window")
-            .clone()
+            
     }
 
     pub(crate) fn active_or_newest_webview(&self) -> Option<WebView> {

--- a/ports/servoshell/egl/app.rs
+++ b/ports/servoshell/egl/app.rs
@@ -184,18 +184,16 @@ impl PlatformWindow for EmbeddedPlatformWindow {
         let control_id = embedder_control.id();
         match embedder_control {
             EmbedderControl::InputMethod(input_method_control)
-                if input_method_control.allow_virtual_keyboard() => {
-                    self.visible_input_methods.borrow_mut().push(control_id);
-                    self.host.on_ime_show(input_method_control);
-                },
-            EmbedderControl::SimpleDialog(simple_dialog) => match simple_dialog {
-                SimpleDialog::Alert(alert_dialog) => {
-                    self.host.show_alert(alert_dialog.message().into());
-                    alert_dialog.confirm();
-                },
-                _ => {}, // The drop implementation will send the default response.
+                if input_method_control.allow_virtual_keyboard() =>
+            {
+                self.visible_input_methods.borrow_mut().push(control_id);
+                self.host.on_ime_show(input_method_control);
             },
-            _ => {},
+            EmbedderControl::SimpleDialog(SimpleDialog::Alert(alert_dialog)) => {
+                self.host.show_alert(alert_dialog.message().into());
+                alert_dialog.confirm();
+            },
+            _ => {}, // The drop implementation will send the default response.
         }
     }
 
@@ -366,7 +364,6 @@ impl App {
         self.state
             .focused_window()
             .expect("There is always an active window")
-            
     }
 
     pub(crate) fn active_or_newest_webview(&self) -> Option<WebView> {

--- a/ports/servoshell/egl/host_trait.rs
+++ b/ports/servoshell/egl/host_trait.rs
@@ -8,10 +8,12 @@ use servo::{InputMethodControl, LoadStatus, MediaSessionPlaybackState};
 pub trait HostTrait {
     fn show_alert(&self, message: String);
     /// Notify that the load status of the page has changed.
+    ///
     /// Started:
     ///  - "Reload button" should be disabled.
     ///  - "Stop button" should be enabled.
     ///  - Throbber starts spinning.
+    ///
     /// Complete:
     ///  - "Reload button" should be enabled.
     ///  - "Stop button" should be disabled.

--- a/ports/servoshell/egl/ohos/mod.rs
+++ b/ports/servoshell/egl/ohos/mod.rs
@@ -1085,8 +1085,8 @@ impl HostCallbacks {
             .enterkey_type(options.enterkey_type)
             .build();
         let editor = RawTextEditorProxy::new(Box::new(ServoIme { text_config }))
-            .map_err(|e| ImeError::TextEditorProxy(e))?;
-        ImeProxy::new(editor, attach_options).map_err(|e| ImeError::ImeProxy(e))
+            .map_err(ImeError::TextEditorProxy)?;
+        ImeProxy::new(editor, attach_options).map_err(ImeError::ImeProxy)
     }
 }
 

--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -643,6 +643,7 @@ impl RunningAppState {
         gamepad_delegate.handle_gamepad_events(active_webview);
     }
 
+    #[cfg(not(any(target_os = "android", target_env = "ohos")))]
     pub(crate) fn handle_focused(&self, window: Rc<ServoShellWindow>) {
         *self.focused_window.borrow_mut() = Some(window);
     }
@@ -670,6 +671,7 @@ impl RunningAppState {
         }
     }
 
+    #[cfg(not(any(target_os = "android", target_env = "ohos")))]
     pub(crate) fn set_accessibility_active(&self, active: bool) {
         let was_active = self.accessibility_active.replace(active);
         if active == was_active {

--- a/ports/servoshell/window.rs
+++ b/ports/servoshell/window.rs
@@ -98,6 +98,7 @@ impl ServoShellWindow {
     /// Must be called *after* `self` is in `state.windows`, otherwise it will panic.
     #[servo::servo_tracing::instrument(skip(self, state))]
     pub(crate) fn create_toplevel_webview(&self, state: Rc<RunningAppState>, url: Url) -> WebView {
+        #[cfg_attr(any(target_os = "android", target_env = "ohos"), expect(unused_mut))]
         let mut webview_builder =
             WebViewBuilder::new(state.servo(), self.platform_window.rendering_context())
                 .url(url)

--- a/python/servo/devenv_commands.py
+++ b/python/servo/devenv_commands.py
@@ -139,6 +139,14 @@ class MachCommands(CommandBase):
         # Note that some lints can additionally be configured by `.clippy.toml` at the repository root.
         clippy_args = ["--deny=clippy::disallowed_types", "--warn=clippy::redundant-clone"]
 
+        if self.target.is_cross_build():
+            if "--target" not in params:
+                params.append("--target")
+                params.append(self.target.triple())
+                # Suppress false positives for thread_local_statics when cross-compiling.
+                # Upstream issue: https://github.com/rust-lang/rust-clippy/issues/13422#issuecomment-3282764205
+            clippy_args.append("--allow=clippy::missing_const_for_thread_local")
+
         if "--" not in params:
             params.append("--")
         params.extend(clippy_args)


### PR DESCRIPTION
- Fixes `./mach clippy --ohos` and similar, by passing `--target` through to clippy. Previously one needed to pass target again through to clippy like `./mach clippy --ohos -- --target=aarch64-unknown-linux-ohos` (same for android)
- Silences false positive `clippy::missing_const_for_thread_local` lint (only fires when cross-compiling apparently).
- And your usual set of clippy fixes.

Testing: No behavior changes. Clippy is not run for android / ohos in CI.
Fixes: Part of #44908
