### PR TITLE
script: Start adding support for lazy serialization of `AttrValue`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7367,7 +7367,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.38.0"
-source = "git+https://github.com/servo/stylo?rev=f61100772df4b1e7273528b31269ad9d4c49f086#f61100772df4b1e7273528b31269ad9d4c49f086"
+source = "git+https://github.com/servo/stylo?rev=d2b3101e39c57a179c573e8f4c2fa4abb46f8482#d2b3101e39c57a179c573e8f4c2fa4abb46f8482"
 dependencies = [
  "bitflags 2.11.1",
  "cssparser",
@@ -9073,7 +9073,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=f61100772df4b1e7273528b31269ad9d4c49f086#f61100772df4b1e7273528b31269ad9d4c49f086"
+source = "git+https://github.com/servo/stylo?rev=d2b3101e39c57a179c573e8f4c2fa4abb46f8482#d2b3101e39c57a179c573e8f4c2fa4abb46f8482"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -9509,7 +9509,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.17.0"
-source = "git+https://github.com/servo/stylo?rev=f61100772df4b1e7273528b31269ad9d4c49f086#f61100772df4b1e7273528b31269ad9d4c49f086"
+source = "git+https://github.com/servo/stylo?rev=d2b3101e39c57a179c573e8f4c2fa4abb46f8482#d2b3101e39c57a179c573e8f4c2fa4abb46f8482"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -9565,7 +9565,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.17.0"
-source = "git+https://github.com/servo/stylo?rev=f61100772df4b1e7273528b31269ad9d4c49f086#f61100772df4b1e7273528b31269ad9d4c49f086"
+source = "git+https://github.com/servo/stylo?rev=d2b3101e39c57a179c573e8f4c2fa4abb46f8482#d2b3101e39c57a179c573e8f4c2fa4abb46f8482"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -9574,7 +9574,7 @@ dependencies = [
 [[package]]
 name = "stylo_derive"
 version = "0.17.0"
-source = "git+https://github.com/servo/stylo?rev=f61100772df4b1e7273528b31269ad9d4c49f086#f61100772df4b1e7273528b31269ad9d4c49f086"
+source = "git+https://github.com/servo/stylo?rev=d2b3101e39c57a179c573e8f4c2fa4abb46f8482#d2b3101e39c57a179c573e8f4c2fa4abb46f8482"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -9586,7 +9586,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.17.0"
-source = "git+https://github.com/servo/stylo?rev=f61100772df4b1e7273528b31269ad9d4c49f086#f61100772df4b1e7273528b31269ad9d4c49f086"
+source = "git+https://github.com/servo/stylo?rev=d2b3101e39c57a179c573e8f4c2fa4abb46f8482#d2b3101e39c57a179c573e8f4c2fa4abb46f8482"
 dependencies = [
  "bitflags 2.11.1",
  "stylo_malloc_size_of",
@@ -9595,7 +9595,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.17.0"
-source = "git+https://github.com/servo/stylo?rev=f61100772df4b1e7273528b31269ad9d4c49f086#f61100772df4b1e7273528b31269ad9d4c49f086"
+source = "git+https://github.com/servo/stylo?rev=d2b3101e39c57a179c573e8f4c2fa4abb46f8482#d2b3101e39c57a179c573e8f4c2fa4abb46f8482"
 dependencies = [
  "app_units",
  "cssparser",
@@ -9612,7 +9612,7 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.17.0"
-source = "git+https://github.com/servo/stylo?rev=f61100772df4b1e7273528b31269ad9d4c49f086#f61100772df4b1e7273528b31269ad9d4c49f086"
+source = "git+https://github.com/servo/stylo?rev=d2b3101e39c57a179c573e8f4c2fa4abb46f8482#d2b3101e39c57a179c573e8f4c2fa4abb46f8482"
 dependencies = [
  "toml",
 ]
@@ -9620,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "stylo_traits"
 version = "0.17.0"
-source = "git+https://github.com/servo/stylo?rev=f61100772df4b1e7273528b31269ad9d4c49f086#f61100772df4b1e7273528b31269ad9d4c49f086"
+source = "git+https://github.com/servo/stylo?rev=d2b3101e39c57a179c573e8f4c2fa4abb46f8482#d2b3101e39c57a179c573e8f4c2fa4abb46f8482"
 dependencies = [
  "app_units",
  "bitflags 2.11.1",
@@ -10041,7 +10041,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.4.0"
-source = "git+https://github.com/servo/stylo?rev=f61100772df4b1e7273528b31269ad9d4c49f086#f61100772df4b1e7273528b31269ad9d4c49f086"
+source = "git+https://github.com/servo/stylo?rev=d2b3101e39c57a179c573e8f4c2fa4abb46f8482#d2b3101e39c57a179c573e8f4c2fa4abb46f8482"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -10054,7 +10054,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=f61100772df4b1e7273528b31269ad9d4c49f086#f61100772df4b1e7273528b31269ad9d4c49f086"
+source = "git+https://github.com/servo/stylo?rev=d2b3101e39c57a179c573e8f4c2fa4abb46f8482#d2b3101e39c57a179c573e8f4c2fa4abb46f8482"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,12 +162,12 @@ rustls-platform-verifier = "0.7.0"
 sea-query = { version = "=1.0.0-rc.31", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = { version = "=0.8.0-rc.15" }
 sec1 = "0.7"
-selectors = { git = "https://github.com/servo/stylo", rev = "f61100772df4b1e7273528b31269ad9d4c49f086" }
+selectors = { git = "https://github.com/servo/stylo", rev = "d2b3101e39c57a179c573e8f4c2fa4abb46f8482" }
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
 serde_json = "1.0"
-servo_arc = { git = "https://github.com/servo/stylo", rev = "f61100772df4b1e7273528b31269ad9d4c49f086" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "d2b3101e39c57a179c573e8f4c2fa4abb46f8482" }
 sha1 = "0.10"
 sha2 = "0.10"
 sha3 = "0.10"
@@ -176,12 +176,12 @@ smallvec = { version = "1.15", features = ["serde", "union"] }
 speexdsp-resampler = "0.1.0"
 string_cache = "0.9"
 strum = { version = "0.28", features = ["derive"] }
-stylo = { git = "https://github.com/servo/stylo", rev = "f61100772df4b1e7273528b31269ad9d4c49f086" }
-stylo_atoms = { git = "https://github.com/servo/stylo", rev = "f61100772df4b1e7273528b31269ad9d4c49f086" }
-stylo_dom = { git = "https://github.com/servo/stylo", rev = "f61100772df4b1e7273528b31269ad9d4c49f086" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "f61100772df4b1e7273528b31269ad9d4c49f086" }
-stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "f61100772df4b1e7273528b31269ad9d4c49f086" }
-stylo_traits = { git = "https://github.com/servo/stylo", rev = "f61100772df4b1e7273528b31269ad9d4c49f086" }
+stylo = { git = "https://github.com/servo/stylo", rev = "d2b3101e39c57a179c573e8f4c2fa4abb46f8482" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "d2b3101e39c57a179c573e8f4c2fa4abb46f8482" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "d2b3101e39c57a179c573e8f4c2fa4abb46f8482" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "d2b3101e39c57a179c573e8f4c2fa4abb46f8482" }
+stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "d2b3101e39c57a179c573e8f4c2fa4abb46f8482" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "d2b3101e39c57a179c573e8f4c2fa4abb46f8482" }
 surfman = { version = "0.12.1", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"

--- a/components/script/dom/css/cssstyledeclaration.rs
+++ b/components/script/dom/css/cssstyledeclaration.rs
@@ -75,50 +75,53 @@ impl CSSStyleOwner {
             CSSStyleOwner::Null => unreachable!(
                 "CSSStyleDeclaration should always be read-only when CSSStyleOwner is Null"
             ),
-            CSSStyleOwner::Element(ref el) => {
-                let document = el.owner_document();
+            CSSStyleOwner::Element(ref element) => {
+                let document = element.owner_document();
                 let shared_lock = document.style_shared_author_lock();
-                let mut attr = el.style_attribute().borrow_mut().take();
-                let result = if let Some(lock) = attr.as_ref() {
-                    let mut guard = shared_lock.write();
-                    let pdb = lock.write_with(&mut guard);
-                    f(pdb, &mut changed)
-                } else {
-                    let mut pdb = PropertyDeclarationBlock::new();
-                    let result = f(&mut pdb, &mut changed);
+                let mut attribute_pdb = element.style_attribute().borrow_mut().take();
 
-                    // Here `changed` is somewhat silly, because we know the
-                    // exact conditions under it changes.
-                    changed = !pdb.declarations().is_empty();
-                    if changed {
-                        attr = Some(Arc::new(shared_lock.wrap(pdb)));
-                    }
-
-                    result
-                };
-
-                if changed {
-                    // Note that there's no need to remove the attribute here if
-                    // the declaration block is empty[1], and if `attr` is
-                    // `None` it means that it necessarily didn't change, so no
-                    // need to go through all the set_attribute machinery.
-                    //
-                    // [1]: https://github.com/whatwg/html/issues/2306
-                    if let Some(pdb) = attr {
-                        let guard = shared_lock.read();
-                        let mut serialization = String::new();
-                        pdb.read_with(&guard).to_css(&mut serialization).unwrap();
-                        el.set_attribute(
-                            cx,
-                            &local_name!("style"),
-                            AttrValue::Declaration(serialization, pdb),
-                        );
-                    }
-                } else {
-                    // Remember to put it back.
-                    *el.style_attribute().borrow_mut() = attr;
+                // When there are mutation observers, the old PDB and the new PDB need to
+                // co-exist so that both attribute values can be serialized and sent to
+                // the observer. In that case, first clone the block and mutate that instead
+                // of mutating the existing one.
+                if element.needs_preserved_style_attribute_after_change() {
+                    attribute_pdb = attribute_pdb.map(|attribute_pdb| {
+                        let new_pdb = attribute_pdb.read_with(&shared_lock.read()).clone();
+                        Arc::new(shared_lock.wrap(new_pdb))
+                    });
                 }
 
+                let (attribute_pdb, result) = if let Some(attribute_pdb) = attribute_pdb {
+                    let mut guard = shared_lock.write();
+                    let writable_pdb = attribute_pdb.write_with(&mut guard);
+                    let result = f(writable_pdb, &mut changed);
+                    (attribute_pdb, result)
+                } else {
+                    let mut new_pdb = PropertyDeclarationBlock::new();
+                    let result = f(&mut new_pdb, &mut changed);
+
+                    changed = !new_pdb.declarations().is_empty();
+                    if !changed {
+                        return result;
+                    }
+
+                    (Arc::new(shared_lock.wrap(new_pdb)), result)
+                };
+
+                // If nothing changed, replace the unchanged PDB in the attribute and just
+                // return. Note that there's no need to remove the attribute here if the
+                // declaration block is empty (see
+                // https://github.com/whatwg/html/issues/2306).
+                if !changed {
+                    *element.style_attribute().borrow_mut() = Some(attribute_pdb);
+                    return result;
+                }
+
+                element.set_attribute(
+                    cx,
+                    &local_name!("style"),
+                    AttrValue::from_declaration(attribute_pdb, shared_lock.clone()),
+                );
                 result
             },
             CSSStyleOwner::CSSRule(ref rule, ref pdb) => {

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -22,6 +22,7 @@ use script_bindings::cell::DomRefCell;
 use script_bindings::conversions::{SafeFromJSValConvertible, SafeToJSValConvertible};
 use script_bindings::reflector::{DomObject, Reflector, reflect_dom_object};
 use script_bindings::settings_stack::{run_a_callback, run_a_script};
+use style::attr::AttrValue;
 
 use super::bindings::trace::HashMapTracedValues;
 use crate::DomTypeHolder;
@@ -867,6 +868,10 @@ impl CustomElementDefinition {
 
         Ok(element)
     }
+
+    pub(crate) fn has_attribute_changed_callback(&self) -> bool {
+        self.callbacks.attribute_changed_callback.is_some()
+    }
 }
 
 /// <https://html.spec.whatwg.org/multipage/#concept-upgrade-an-element>
@@ -893,11 +898,10 @@ pub(crate) fn upgrade_element(
     let custom_element_reaction_stack = ScriptThread::custom_element_reaction_stack();
     for attr in element.attrs().borrow().iter() {
         let local_name = attr.local_name().clone();
-        let value = DOMString::from(&**attr.value());
         let namespace = attr.namespace().clone();
         custom_element_reaction_stack.enqueue_callback_reaction(
             element,
-            CallbackReaction::AttributeChanged(local_name, None, Some(value), namespace),
+            CallbackReaction::AttributeChanged(local_name, None, Some(&*attr.value()), namespace),
             Some(definition.clone()),
         );
     }
@@ -1111,11 +1115,16 @@ impl CustomElementReaction {
     }
 }
 
-pub(crate) enum CallbackReaction {
+pub(crate) enum CallbackReaction<'a> {
     Connected,
     Disconnected,
     Adopted(DomRoot<Document>, DomRoot<Document>),
-    AttributeChanged(LocalName, Option<DOMString>, Option<DOMString>, Namespace),
+    AttributeChanged(
+        LocalName,
+        Option<&'a AttrValue>,
+        Option<&'a AttrValue>,
+        Namespace,
+    ),
     FormAssociated(Option<DomRoot<HTMLFormElement>>),
     FormDisabled(bool),
     FormReset,

--- a/components/script/dom/domtokenlist.rs
+++ b/components/script/dom/domtokenlist.rs
@@ -81,7 +81,7 @@ impl DOMTokenList {
         }
         // step 2
         self.element
-            .set_atomic_tokenlist_attribute(cx, &self.local_name, atoms)
+            .set_attribute(cx, &self.local_name, atoms.into())
     }
 
     /// <https://dom.spec.whatwg.org/#concept-domtokenlist-validation>

--- a/components/script/dom/element/attributes/accessors.rs
+++ b/components/script/dom/element/attributes/accessors.rs
@@ -101,7 +101,7 @@ impl Element {
         local_name: &LocalName,
         value: DOMString,
     ) {
-        self.set_attribute(cx, local_name, AttrValue::String(value.into()));
+        self.set_attribute(cx, local_name, value.str().to_string().into());
     }
 
     /// Used for string attribute reflections where absence of the attribute returns `null`,
@@ -154,19 +154,6 @@ impl Element {
         );
     }
 
-    pub(crate) fn set_atomic_tokenlist_attribute(
-        &self,
-        cx: &mut JSContext,
-        local_name: &LocalName,
-        tokens: Vec<Atom>,
-    ) {
-        self.set_attribute(cx, local_name, AttrValue::from_atomic_tokens(tokens));
-    }
-
-    pub(crate) fn set_int_attribute(&self, cx: &mut JSContext, local_name: &LocalName, value: i32) {
-        self.set_attribute(cx, local_name, AttrValue::Int(value.to_string(), value));
-    }
-
     pub(crate) fn get_uint_attribute(&self, local_name: &LocalName, default: u32) -> u32 {
         match self.get_attribute(local_name) {
             Some(ref attribute) => match *attribute.value() {
@@ -177,31 +164,44 @@ impl Element {
         }
     }
 
-    pub(crate) fn set_uint_attribute(
-        &self,
-        cx: &mut JSContext,
-        local_name: &LocalName,
-        value: u32,
-    ) {
-        self.set_attribute(cx, local_name, AttrValue::UInt(value.to_string(), value));
-    }
-
     /// Ensure that for styles, we clone the already-parsed property declaration block.
     /// This does two things:
     /// 1. It uses the same fast-path as CSSStyleDeclaration
     /// 2. It also avoids the CSP checks when cloning (it shouldn't run any when cloning
     ///    existing valid attributes)
     fn compute_attribute_value_with_style_fast_path(&self, attr: AttrRef<'_>) -> AttrValue {
-        if *attr.local_name() == local_name!("style") &&
-            let Some(ref pdb) = *self.style_attribute().borrow()
-        {
+        if *attr.local_name() == local_name!("style") {
             let document = self.owner_document();
-            let shared_lock = document.style_shared_author_lock();
-            let new_pdb = pdb.read_with(&shared_lock.read()).clone();
-            return AttrValue::Declaration(
-                (**attr.value()).to_owned(),
-                ServoArc::new(shared_lock.wrap(new_pdb)),
-            );
+
+            if let AttrValue::Declaration {
+                block,
+                lock,
+                serialization,
+            } = &*attr.value()
+            {
+                // Even though the property declaration block inside this AttrValue will
+                // be replaced, the serialization will be exactly the same, so preserve
+                // that instead of re-serializing.
+                let cloned_block = block.read_with(&lock.read()).clone();
+                return AttrValue::Declaration {
+                    block: ServoArc::new(lock.wrap(cloned_block)),
+                    lock: lock.clone(),
+                    serialization: serialization.clone(),
+                };
+            }
+
+            if let Some(ref pdb) = *self.style_attribute().borrow() {
+                let shared_lock = document.style_shared_author_lock();
+                let new_pdb = pdb.read_with(&shared_lock.read()).clone();
+                return AttrValue::Declaration {
+                    block: ServoArc::new(shared_lock.wrap(new_pdb)),
+                    lock: shared_lock.clone(),
+                    // The style attribute was not set via a declaration, so try to
+                    // preserve any serialization that existed before instead of
+                    // re-serializing.
+                    serialization: (**attr.value()).to_owned().into(),
+                };
+            }
         }
 
         attr.value().clone()

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -1936,8 +1936,7 @@ impl Element {
             value: data.value.clone(),
         });
         // Step 4: Handle attribute changes using stack-local AttrRef.
-        let new_value = DOMString::from(&**attr_ref.value());
-        self.handle_attribute_changes(cx, attr_ref, None, Some(new_value), reason);
+        self.handle_attribute_changes(cx, attr_ref, None, Some(&*attr_ref.value()), reason);
     }
 
     /// <https://dom.spec.whatwg.org/#handle-attribute-changes>
@@ -1946,10 +1945,9 @@ impl Element {
         cx: &mut JSContext,
         attr: AttrRef<'_>,
         old_value: Option<&AttrValue>,
-        new_value: Option<DOMString>,
+        new_value: Option<&AttrValue>,
         reason: AttributeMutationReason,
     ) {
-        let old_value_string = old_value.map(|old_value| DOMString::from(&**old_value));
         // Step 1. Queue a mutation record of "attributes" for element with attribute’s local name,
         // attribute’s namespace, oldValue, « », « », null, and null.
         let name = attr.local_name().clone();
@@ -1957,7 +1955,7 @@ impl Element {
         let mutation = LazyCell::new(|| Mutation::Attribute {
             name: name.clone(),
             namespace: namespace.clone(),
-            old_value: old_value_string.clone(),
+            old_value: old_value.map(|old_value| DOMString::from(&**old_value)),
         });
         MutationObserver::queue_a_mutation_record(&self.node, mutation);
 
@@ -1969,7 +1967,7 @@ impl Element {
         if self.is_custom() {
             let reaction = CallbackReaction::AttributeChanged(
                 attr.local_name().clone(),
-                old_value_string,
+                old_value,
                 new_value,
                 attr.namespace().clone(),
             );
@@ -1999,12 +1997,11 @@ impl Element {
         // Step 3. Handle attribute changes for attribute with attribute’s element, oldValue, and value.
         //
         // Put on a separate line to avoid double borrow
-        let new_value = DOMString::from(&**attr.value());
         self.handle_attribute_changes(
             cx,
             AttrRef::Dom(attr),
             Some(old_value),
-            Some(new_value),
+            Some(&*attr.value()),
             AttributeMutationReason::Directly,
         );
     }
@@ -2030,8 +2027,7 @@ impl Element {
         // Step 4. Handle attribute changes for attribute with element, null, and attribute’s value.
         //
         // Put on a separate line to avoid double borrow
-        let new_value = DOMString::from(&**attr.value());
-        self.handle_attribute_changes(cx, AttrRef::Dom(attr), None, Some(new_value), reason);
+        self.handle_attribute_changes(cx, AttrRef::Dom(attr), None, Some(&*attr.value()), reason);
     }
 
     /// This is the inner logic for:
@@ -2311,7 +2307,7 @@ impl Element {
                 );
 
                 Some(match &*value {
-                    AttrValue::Declaration(_, block) => block.clone(),
+                    AttrValue::Declaration { block, .. } => block.clone(),
                     _ => {
                         let win = self.owner_window();
                         let source = &**attr.value();
@@ -2422,7 +2418,7 @@ impl Element {
                 cx,
                 AttrRef::Dom(attr),
                 Some(&old_attr.value()),
-                Some(verified_value),
+                Some(&AttrValue::String(verified_value.into())),
                 AttributeMutationReason::Directly,
             );
 
@@ -2768,6 +2764,24 @@ impl Element {
     #[inline]
     fn get_selector_flags(&self) -> ElementSelectorFlags {
         ElementSelectorFlags::from_bits_retain(self.selector_flags.load(Ordering::Relaxed))
+    }
+
+    /// Custom [`Element`]s and those with mutation observers sometimes need the old style
+    /// attribute to persist after modification, because it is sent as an argument to
+    /// script callbacks. Normally that's not the case, so this method tries to detect
+    /// when it's required so it can be avoided for performance reasons.
+    pub(crate) fn needs_preserved_style_attribute_after_change(&self) -> bool {
+        // This is a global check for whether any mutation observers are installed on this
+        // Document at all. If cloning of the property declaration block (look at the
+        // caller of this method), starts showing up in profiles, this check may need to
+        // be a bit smarter. For instance, maybe only returning true if any mutation
+        // observer is installed on an inclusive ancestor and only if it has an observer
+        // with the attribute filter set to include `style`.
+        self.owner_window().get_exists_mut_observer() ||
+            self.get_custom_element_definition()
+                .is_some_and(|custom_element_definition| {
+                    custom_element_definition.has_attribute_changed_callback()
+                })
     }
 }
 

--- a/components/script/dom/execcommand/contenteditable/node.rs
+++ b/components/script/dom/execcommand/contenteditable/node.rs
@@ -1347,7 +1347,7 @@ impl Node {
 
                 if size > 0 {
                     let new_font_element = document.create_element(cx, "font");
-                    new_font_element.set_int_attribute(cx, &local_name!("size"), size);
+                    new_font_element.set_attribute(cx, &local_name!("size"), size.into());
                     new_parent = Some(new_font_element);
                 }
             },

--- a/components/script/dom/html/htmlcanvaselement.rs
+++ b/components/script/dom/html/htmlcanvaselement.rs
@@ -150,8 +150,8 @@ impl HTMLCanvasElement {
         } else {
             value
         };
-        let element = self.upcast::<Element>();
-        element.set_uint_attribute(cx, &html5ever::local_name!("width"), value);
+        self.upcast::<Element>()
+            .set_attribute(cx, &html5ever::local_name!("width"), value.into());
     }
 
     pub(crate) fn set_natural_height(&self, cx: &mut js::context::JSContext, value: u32) {
@@ -160,8 +160,8 @@ impl HTMLCanvasElement {
         } else {
             value
         };
-        let element = self.upcast::<Element>();
-        element.set_uint_attribute(cx, &html5ever::local_name!("height"), value);
+        self.upcast::<Element>()
+            .set_attribute(cx, &html5ever::local_name!("height"), value.into());
     }
 }
 
@@ -453,8 +453,8 @@ impl HTMLCanvasElementMethods<crate::DomTypeHolder> for HTMLCanvasElement {
         } else {
             value
         };
-        let element = self.upcast::<Element>();
-        element.set_uint_attribute(cx, &html5ever::local_name!("width"), value);
+        self.upcast::<Element>()
+            .set_attribute(cx, &html5ever::local_name!("width"), value.into());
         Ok(())
     }
 
@@ -475,8 +475,8 @@ impl HTMLCanvasElementMethods<crate::DomTypeHolder> for HTMLCanvasElement {
         } else {
             value
         };
-        let element = self.upcast::<Element>();
-        element.set_uint_attribute(cx, &html5ever::local_name!("height"), value);
+        self.upcast::<Element>()
+            .set_attribute(cx, &html5ever::local_name!("height"), value.into());
         Ok(())
     }
 

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -777,7 +777,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     /// <https://html.spec.whatwg.org/multipage/#dom-tabindex>
     fn SetTabIndex(&self, cx: &mut JSContext, tab_index: i32) {
         self.element
-            .set_int_attribute(cx, &local_name!("tabindex"), tab_index);
+            .set_attribute(cx, &local_name!("tabindex"), tab_index.into());
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-accesskey

--- a/components/script/dom/html/htmlfontelement.rs
+++ b/components/script/dom/html/htmlfontelement.rs
@@ -224,5 +224,5 @@ fn parse_size(input: &DOMString) -> AttrValue {
     value = value.clamp(1, 7);
 
     // Step 12
-    AttrValue::UInt(original_input.str().into(), value as u32)
+    AttrValue::UInt(String::from(original_input.str()).into(), value as u32)
 }

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -40,7 +40,7 @@ macro_rules! make_limited_int_setter(
             };
 
             let element = self.upcast::<Element>();
-            element.set_int_attribute(cx, &html5ever::local_name!($htmlname), value);
+            element.set_attribute(cx, &html5ever::local_name!($htmlname), value.into());
             Ok(())
         }
     );
@@ -54,7 +54,7 @@ macro_rules! make_int_setter(
             use $crate::dom::element::Element;
 
             let element = self.upcast::<Element>();
-            element.set_int_attribute(cx, &html5ever::local_name!($htmlname), value)
+            element.set_attribute(cx, &html5ever::local_name!($htmlname), value.into())
         }
     );
 );
@@ -331,7 +331,7 @@ macro_rules! make_uint_setter(
                 value
             };
             let element = self.upcast::<Element>();
-            element.set_uint_attribute(cx, &html5ever::local_name!($htmlname), value)
+            element.set_attribute(cx, &html5ever::local_name!($htmlname), value.into())
         }
     );
     ($attr:ident, $htmlname:tt) => {
@@ -353,7 +353,7 @@ macro_rules! make_clamped_uint_setter(
             };
 
             let element = self.upcast::<Element>();
-            element.set_uint_attribute(cx, &html5ever::local_name!($htmlname), value)
+            element.set_attribute(cx, &html5ever::local_name!($htmlname), value.into())
         }
     );
 );
@@ -373,7 +373,7 @@ macro_rules! make_limited_uint_setter(
                 value
             };
             let element = self.upcast::<Element>();
-            element.set_uint_attribute(cx, &html5ever::local_name!($htmlname), value);
+            element.set_attribute(cx, &html5ever::local_name!($htmlname), value.into());
             Ok(())
         }
     );

--- a/components/script/dom/svg/svgelement.rs
+++ b/components/script/dom/svg/svgelement.rs
@@ -200,6 +200,6 @@ impl SVGElementMethods<crate::DomTypeHolder> for SVGElement {
     /// <https://html.spec.whatwg.org/multipage/#dom-tabindex>
     fn SetTabIndex(&self, cx: &mut JSContext, tab_index: i32) {
         self.element
-            .set_int_attribute(cx, &local_name!("tabindex"), tab_index);
+            .set_attribute(cx, &local_name!("tabindex"), tab_index.into());
     }
 }

--- a/tests/unit/style/attr.rs
+++ b/tests/unit/style/attr.rs
@@ -52,7 +52,7 @@ fn test_from_limited_i32_should_parse_a_uint_when_value_is_0_or_greater() {
 #[test]
 fn test_from_limited_i32_should_keep_parsed_value_when_not_an_int() {
     match AttrValue::from_limited_i32(String::from("parsed-value"), 0) {
-        AttrValue::Int(p, 0) => assert_eq!(p, String::from("parsed-value")),
+        attribute @ AttrValue::Int(_, 0) => assert_eq!(&*attribute, "parsed-value"),
         _ => panic!("expected an successful parsing"),
     }
 }


### PR DESCRIPTION
This change allows creating an `AttrValue` without a serialization.
This is *particularly* important when setting the `style` attribute on
elements, as many pages set the `style` attribute but never read it.
Eagerly serializing the attribute in these cases is pure overhead. This
kind of thing shows up prominently in profiles.

This change starts adapting Servo to Stylo's support for lazy
serialization of some attributes. In addition, some eager serialization
during attribute mutations is avoided as well.

Followup changes will:

 - Make it more obvious when a potentially expensive serialization of an
   attribute is performed.
 - Make it clear when an attribute is constructed with a pre-existing
   serialization.

Tthese changes lead to a 25% speedup when running
`tests/blink_perf_tests/perf_tests/layout/flexbox-deeply-nested-column-flow.html`
on my system.

Stylo PR: servo/stylo#365

Testing: This should not change observable behavior and unfortunately we do not
have automated performance tests.
Fixes: #17399.
