### PR TITLE
mach: Remove references to nonexistent `busted` subcommand

### DIFF
--- a/python/mach/mach/main.py
+++ b/python/mach/mach/main.py
@@ -36,17 +36,11 @@ from .logging import LoggingManager
 from .registrar import Registrar
 from .util import setenv
 
-SUGGEST_MACH_BUSTED = r'''
-You can invoke |./mach busted| to check if this issue is already on file. If it
-isn't, please use |./mach busted file| to report it. If |./mach busted| is
-misbehaving, you can also inspect the dependencies of bug 1543241.
-'''.lstrip()
-
 MACH_ERROR = r'''
 The error occurred in mach itself. This is likely a bug in mach itself or a
 fundamental problem with a loaded module.
 
-'''.lstrip() + SUGGEST_MACH_BUSTED
+'''.lstrip()
 
 ERROR_FOOTER = r'''
 If filing a bug, please include the full output of mach, including this error
@@ -60,12 +54,12 @@ The error occurred in the implementation of the invoked mach command.
 
 This should never occur and is likely a bug in the implementation of that
 command.
-'''.lstrip() + SUGGEST_MACH_BUSTED
+'''.lstrip()
 
 MODULE_ERROR = r'''
 The error occurred in code that was called by the mach command. This is either
 a bug in the called code itself or in the way that mach is calling it.
-'''.lstrip() + SUGGEST_MACH_BUSTED
+'''.lstrip()
 
 NO_COMMAND_ERROR = r'''
 It looks like you tried to run mach without a command.


### PR DESCRIPTION
Closes https://github.com/servo/servo/issues/33560