### PR TITLE
script: Prove that no GC can occur during slot assignment

### DIFF
--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -4429,15 +4429,13 @@ impl VirtualMethods for Element {
             },
             local_name!("slot") => {
                 // Update slottable data
-                let cx = GlobalScope::get_cx();
-
-                rooted!(in(*cx) let slottable = Slottable(Dom::from_ref(self.upcast::<Node>())));
+                rooted!(&in(cx) let slottable = Slottable(Dom::from_ref(self.upcast::<Node>())));
 
                 // Slottable name change steps from https://dom.spec.whatwg.org/#light-tree-slotables
                 if let Some(assigned_slot) = slottable.assigned_slot() {
-                    assigned_slot.assign_slottables();
+                    assigned_slot.assign_slottables(cx.no_gc());
                 }
-                slottable.assign_a_slot();
+                slottable.assign_a_slot(cx.no_gc());
             },
             _ => {
                 // FIXME(emilio): This is pretty dubious, and should be done in

--- a/components/script/dom/html/htmldetailselement.rs
+++ b/components/script/dom/html/htmldetailselement.rs
@@ -253,7 +253,7 @@ impl HTMLDetailsElement {
         if let Some(summary) = self.find_corresponding_summary_element() {
             shadow_tree
                 .summary
-                .Assign(vec![ElementOrText::Element(DomRoot::upcast(summary))]);
+                .Assign(cx, vec![ElementOrText::Element(DomRoot::upcast(summary))]);
         }
 
         let mut slottable_children = vec![];
@@ -270,7 +270,7 @@ impl HTMLDetailsElement {
                 slottable_children.push(ElementOrText::Text(DomRoot::from_ref(text)));
             }
         }
-        shadow_tree.details_content.Assign(slottable_children);
+        shadow_tree.details_content.Assign(cx, slottable_children);
     }
 
     fn update_shadow_tree_styles(&self, cx: &mut JSContext) {

--- a/components/script/dom/html/htmlslotelement.rs
+++ b/components/script/dom/html/htmlslotelement.rs
@@ -6,7 +6,7 @@ use std::cell::{Cell, Ref, RefCell};
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, local_name, ns};
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::gc::RootedVec;
 use js::rust::HandleObject;
 use script_bindings::codegen::InheritTypes::{CharacterDataTypeId, NodeTypeId};
@@ -60,7 +60,7 @@ impl HTMLSlotElementMethods<crate::DomTypeHolder> for HTMLSlotElement {
     make_atomic_setter!(SetName, "name");
 
     /// <https://html.spec.whatwg.org/multipage/#dom-slot-assignednodes>
-    fn AssignedNodes(&self, options: &AssignedNodesOptions) -> Vec<DomRoot<Node>> {
+    fn AssignedNodes(&self, cx: &JSContext, options: &AssignedNodesOptions) -> Vec<DomRoot<Node>> {
         // Step 1. If options["flatten"] is false, then return this's assigned nodes.
         if !options.flatten {
             return self
@@ -74,7 +74,7 @@ impl HTMLSlotElementMethods<crate::DomTypeHolder> for HTMLSlotElement {
 
         // Step 2. Return the result of finding flattened slottables with this.
         rooted_vec!(let mut flattened_slottables);
-        self.find_flattened_slottables(&mut flattened_slottables);
+        self.find_flattened_slottables(cx.no_gc(), &mut flattened_slottables);
 
         flattened_slottables
             .iter()
@@ -83,17 +83,19 @@ impl HTMLSlotElementMethods<crate::DomTypeHolder> for HTMLSlotElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-slot-assignedelements>
-    fn AssignedElements(&self, options: &AssignedNodesOptions) -> Vec<DomRoot<Element>> {
-        self.AssignedNodes(options)
+    fn AssignedElements(
+        &self,
+        cx: &JSContext,
+        options: &AssignedNodesOptions,
+    ) -> Vec<DomRoot<Element>> {
+        self.AssignedNodes(cx, options)
             .into_iter()
             .flat_map(|node| node.downcast::<Element>().map(DomRoot::from_ref))
             .collect()
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-slot-assign>
-    fn Assign(&self, nodes: Vec<ElementOrText>) {
-        let cx = GlobalScope::get_cx();
-
+    fn Assign(&self, cx: &JSContext, nodes: Vec<ElementOrText>) {
         // Step 1. For each node of this's manually assigned nodes, set node's manual slot assignment to null.
         for slottable in self.manually_assigned_nodes.borrow().iter() {
             slottable.set_manual_slot_assignment(None);
@@ -104,7 +106,7 @@ impl HTMLSlotElementMethods<crate::DomTypeHolder> for HTMLSlotElement {
 
         // Step 3. For each node of nodes:
         for element_or_text in nodes.into_iter() {
-            rooted!(in(*cx) let node = match element_or_text {
+            rooted!(&in(cx) let node = match element_or_text {
                 ElementOrText::Element(element) => Slottable(Dom::from_ref(element.upcast())),
                 ElementOrText::Text(text) => Slottable(Dom::from_ref(text.upcast())),
             });
@@ -136,7 +138,7 @@ impl HTMLSlotElementMethods<crate::DomTypeHolder> for HTMLSlotElement {
         // Step 5. Run assign slottables for a tree for this's root.
         self.upcast::<Node>()
             .GetRootNode(&GetRootNodeOptions::empty())
-            .assign_slottables_for_a_tree(ForceSlottableNodeReconciliation::Force);
+            .assign_slottables_for_a_tree(cx.no_gc(), ForceSlottableNodeReconciliation::Force);
     }
 }
 
@@ -201,7 +203,7 @@ impl HTMLSlotElement {
     }
 
     /// <https://dom.spec.whatwg.org/#find-flattened-slotables>
-    fn find_flattened_slottables(&self, result: &mut RootedVec<Slottable>) {
+    fn find_flattened_slottables(&self, no_gc: &NoGC, result: &mut RootedVec<Slottable>) {
         // Step 1. Let result be an empty list.
         // NOTE: In our case "result" is not necessarily empty, because it contains
         // the results of multiple successive calls to "find_flattened_slottables". This method
@@ -214,19 +216,19 @@ impl HTMLSlotElement {
 
         // Step 3. Let slottables be the result of finding slottables given slot.
         rooted_vec!(let mut slottables);
-        self.find_slottables(&mut slottables);
+        self.find_slottables(no_gc, &mut slottables);
 
         // Step 4. If slottables is the empty list, then append each slottable
         // child of slot, in tree order, to slottables.
         if slottables.is_empty() {
-            for child in self.upcast::<Node>().children() {
+            for child in self.upcast::<Node>().children_unrooted(no_gc) {
                 let is_slottable = matches!(
                     child.type_id(),
                     NodeTypeId::Element(_) |
                         NodeTypeId::CharacterData(CharacterDataTypeId::Text(_))
                 );
                 if is_slottable {
-                    slottables.push(Slottable(child.as_traced()));
+                    slottables.push(Slottable(Dom::from_ref(&*child)));
                 }
             }
         }
@@ -238,7 +240,7 @@ impl HTMLSlotElement {
                 Some(slot_element) if slot_element.upcast::<Node>().is_in_a_shadow_tree() => {
                     // Step 5.1.1 Let temporaryResult be the result of finding flattened slottables given node.
                     // Step 5.1.2 Append each slottable in temporaryResult, in order, to result.
-                    slot_element.find_flattened_slottables(result);
+                    slot_element.find_flattened_slottables(no_gc, result);
                 },
                 // Step 5.2 Otherwise, append node to result.
                 _ => {
@@ -254,7 +256,7 @@ impl HTMLSlotElement {
     ///
     /// To avoid rooting shenanigans, this writes the returned slottables
     /// into the `result` argument
-    fn find_slottables(&self, result: &mut RootedVec<Slottable>) {
+    fn find_slottables(&self, no_gc: &NoGC, result: &mut RootedVec<Slottable>) {
         let cx = GlobalScope::get_cx();
 
         // Step 1. Let result be an empty list.
@@ -288,14 +290,14 @@ impl HTMLSlotElement {
         }
         // Step 6. Otherwise, for each slottable child slottable of host, in tree order:
         else {
-            for child in host.upcast::<Node>().children() {
+            for child in host.upcast::<Node>().children_unrooted(no_gc) {
                 let is_slottable = matches!(
                     child.type_id(),
                     NodeTypeId::Element(_) |
                         NodeTypeId::CharacterData(CharacterDataTypeId::Text(_))
                 );
                 if is_slottable {
-                    rooted!(in(*cx) let slottable = Slottable(child.as_traced()));
+                    rooted!(in(*cx) let slottable = Slottable(Dom::from_ref(&*child)));
                     // Step 6.1 Let foundSlot be the result of finding a slot given slottable.
                     let found_slot = slottable.find_a_slot(false);
 
@@ -311,10 +313,10 @@ impl HTMLSlotElement {
     }
 
     /// <https://dom.spec.whatwg.org/#assign-slotables>
-    pub(crate) fn assign_slottables(&self) {
+    pub(crate) fn assign_slottables(&self, no_gc: &NoGC) {
         // Step 1. Let slottables be the result of finding slottables for slot.
         rooted_vec!(let mut slottables);
-        self.find_slottables(&mut slottables);
+        self.find_slottables(no_gc, &mut slottables);
 
         // Step 2. If slottables and slot’s assigned nodes are not identical,
         // then run signal a slot change for slot.
@@ -399,13 +401,13 @@ impl Slottable {
     }
 
     /// <https://dom.spec.whatwg.org/#assign-a-slot>
-    pub(crate) fn assign_a_slot(&self) {
+    pub(crate) fn assign_a_slot(&self, no_gc: &NoGC) {
         // Step 1. Let slot be the result of finding a slot with slottable.
         let slot = self.find_a_slot(false);
 
         // Step 2. If slot is non-null, then run assign slottables for slot.
         if let Some(slot) = slot {
-            slot.assign_slottables();
+            slot.assign_slottables(no_gc);
         }
     }
 
@@ -477,7 +479,7 @@ impl VirtualMethods for HTMLSlotElement {
             // Changing the name might cause slot assignments to change
             self.upcast::<Node>()
                 .GetRootNode(&GetRootNodeOptions::empty())
-                .assign_slottables_for_a_tree(ForceSlottableNodeReconciliation::Skip);
+                .assign_slottables_for_a_tree(cx.no_gc(), ForceSlottableNodeReconciliation::Skip);
         }
     }
 

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -1439,7 +1439,7 @@ impl Node {
 
         // Step 14. If node is assigned, then run assign slottables for node’s assigned slot.
         if let Some(slot) = node.assigned_slot() {
-            slot.assign_slottables();
+            slot.assign_slottables(cx.no_gc());
         }
 
         // Step 15. If oldParent’s root is a shadow root, and oldParent is a slot whose assigned
@@ -1459,10 +1459,10 @@ impl Node {
             // Step 16.1. Run assign slottables for a tree with oldParent’s root.
             old_parent
                 .GetRootNode(&GetRootNodeOptions::empty())
-                .assign_slottables_for_a_tree(ForceSlottableNodeReconciliation::Skip);
+                .assign_slottables_for_a_tree(cx.no_gc(), ForceSlottableNodeReconciliation::Skip);
 
             // Step 16.2. Run assign slottables for a tree with node.
-            node.assign_slottables_for_a_tree(ForceSlottableNodeReconciliation::Skip);
+            node.assign_slottables_for_a_tree(cx.no_gc(), ForceSlottableNodeReconciliation::Skip);
         }
 
         // Step 17. If child is non-null:
@@ -1496,7 +1496,7 @@ impl Node {
             (node.is::<Element>() || node.is::<Text>())
         {
             rooted!(&in(cx) let slottable = Slottable(Dom::from_ref(node)));
-            slottable.assign_a_slot();
+            slottable.assign_a_slot(cx.no_gc());
         }
 
         // Step 22. If newParent’s root is a shadow root, and newParent is a slot whose assigned
@@ -1510,7 +1510,7 @@ impl Node {
 
         // Step 23. Run assign slottables for a tree with node’s root.
         node.GetRootNode(&GetRootNodeOptions::empty())
-            .assign_slottables_for_a_tree(ForceSlottableNodeReconciliation::Skip);
+            .assign_slottables_for_a_tree(cx.no_gc(), ForceSlottableNodeReconciliation::Skip);
 
         // Step 24. For each shadow-including inclusive descendant inclusiveDescendant of node, in
         // shadow-including tree order:
@@ -1936,7 +1936,11 @@ impl Node {
     }
 
     /// <https://dom.spec.whatwg.org/#assign-slotables-for-a-tree>
-    pub(crate) fn assign_slottables_for_a_tree(&self, force: ForceSlottableNodeReconciliation) {
+    pub(crate) fn assign_slottables_for_a_tree(
+        &self,
+        no_gc: &NoGC,
+        force: ForceSlottableNodeReconciliation,
+    ) {
         // NOTE: This method traverses all descendants of the node and is potentially very
         // expensive. If the node is neither a shadowroot nor a slot then assigning slottables
         // for it won't have any effect, so we take a fast path out.
@@ -1955,9 +1959,9 @@ impl Node {
 
         // > To assign slottables for a tree, given a node root, run assign slottables for each slot
         // > slot in root’s inclusive descendants, in tree order.
-        for node in self.traverse_preorder(ShadowIncluding::No) {
+        for node in self.traverse_preorder_non_rooting(no_gc, ShadowIncluding::No) {
             if let Some(slot) = node.downcast::<HTMLSlotElement>() {
-                slot.assign_slottables();
+                slot.assign_slottables(no_gc);
             }
         }
     }
@@ -3160,13 +3164,11 @@ impl Node {
             // Step 7.4 If parent is a shadow host whose shadow root’s slot assignment is "named"
             // and node is a slottable, then assign a slot for node.
             if let Some(ref shadow_root) = parent_shadow_root &&
-                shadow_root.SlotAssignment() == SlotAssignmentMode::Named
+                shadow_root.SlotAssignment() == SlotAssignmentMode::Named &&
+                (kid.is::<Element>() || kid.is::<Text>())
             {
-                let cx = GlobalScope::get_cx();
-                if kid.is::<Element>() || kid.is::<Text>() {
-                    rooted!(in(*cx) let slottable = Slottable(Dom::from_ref(kid)));
-                    slottable.assign_a_slot();
-                }
+                rooted!(&in(cx) let slottable = Slottable(Dom::from_ref(kid)));
+                slottable.assign_a_slot(cx.no_gc());
             }
 
             // Step 7.5 If parent’s root is a shadow root, and parent is a slot whose assigned nodes
@@ -3180,7 +3182,7 @@ impl Node {
 
             // Step 7.6 Run assign slottables for a tree with node’s root.
             kid.GetRootNode(&GetRootNodeOptions::empty())
-                .assign_slottables_for_a_tree(ForceSlottableNodeReconciliation::Skip);
+                .assign_slottables_for_a_tree(cx.no_gc(), ForceSlottableNodeReconciliation::Skip);
 
             // Step 7.7. For each shadow-including inclusive descendant inclusiveDescendant of node,
             // in shadow-including tree order:
@@ -3367,7 +3369,7 @@ impl Node {
 
         // Step 8. If node is assigned, then run assign slottables for node’s assigned slot.
         if let Some(slot) = node.assigned_slot() {
-            slot.assign_slottables();
+            slot.assign_slottables(cx.no_gc());
         }
 
         // Step 9. If parent’s root is a shadow root, and parent is a slot whose assigned nodes is the empty list,
@@ -3387,10 +3389,10 @@ impl Node {
             // Step 10.1 Run assign slottables for a tree with parent’s root.
             parent
                 .GetRootNode(&GetRootNodeOptions::empty())
-                .assign_slottables_for_a_tree(ForceSlottableNodeReconciliation::Skip);
+                .assign_slottables_for_a_tree(cx.no_gc(), ForceSlottableNodeReconciliation::Skip);
 
             // Step 10.2 Run assign slottables for a tree with node.
-            node.assign_slottables_for_a_tree(ForceSlottableNodeReconciliation::Force);
+            node.assign_slottables_for_a_tree(cx.no_gc(), ForceSlottableNodeReconciliation::Force);
         }
 
         // TODO: Step 15. transient registered observers

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -587,6 +587,10 @@ DOMInterfaces = {
     'cx': ['Add', 'CheckValidity', 'IndexedSetter', 'Remove', 'Remove_', 'ReportValidity', 'SelectedOptions', 'SetLength', 'SetSelectedIndex', 'SetValue'],
 },
 
+'HTMLSlotElement': {
+    'cx_no_gc': ['AssignedNodes', 'AssignedElements', 'Assign']
+},
+
 'HTMLStyleElement': {
     'cx': ['Blocking'],
 },


### PR DESCRIPTION
No GC can occur during `HTMLSlotElement::Assign` and `Node::assign_slottables_for_a_tree`. Slot assignment involves a couple DOM traversals and can be very hot, so its worth proving that GC is impossible and using unrooted iterators.

This shaves around 5% of the runtime of `tests/blink_perf_tests/perf_tests/shadow_dom/v1-mutate-shallow-tree-then-slot-flatten.html` (thats on top of https://github.com/servo/servo/pull/44933)

Testing: This should not change existing behaviour and is covered by tests.