### PR TITLE
script: Port DOMParser to `&mut JSContext`

### DIFF
--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
 use script_traits::DocumentActivity;
 
 use crate::document_loader::DocumentLoader;
@@ -38,12 +38,16 @@ impl DOMParser {
         }
     }
 
-    fn new(window: &Window, proto: Option<HandleObject>, can_gc: CanGc) -> DomRoot<DOMParser> {
-        reflect_dom_object_with_proto(
+    fn new(
+        cx: &mut js::context::JSContext,
+        window: &Window,
+        proto: Option<HandleObject>,
+    ) -> DomRoot<DOMParser> {
+        reflect_dom_object_with_proto_and_cx(
             Box::new(DOMParser::new_inherited(window)),
             window,
             proto,
-            can_gc,
+            cx,
         )
     }
 }
@@ -51,11 +55,11 @@ impl DOMParser {
 impl DOMParserMethods<crate::DomTypeHolder> for DOMParser {
     /// <https://html.spec.whatwg.org/multipage/#dom-domparser-constructor>
     fn Constructor(
+        cx: &mut js::context::JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<DOMParser>> {
-        Ok(DOMParser::new(window, proto, can_gc))
+        Ok(DOMParser::new(cx, window, proto))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-domparser-parsefromstring>

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -289,7 +289,7 @@ DOMInterfaces = {
 },
 
 'DOMParser': {
-    'cx': ['ParseFromString'],
+    'cx': ['Constructor', 'ParseFromString'],
 },
 
 'DOMPoint': {


### PR DESCRIPTION
  Migrate DOMParser's Constructor and internal `new` factory from `CanGc` to
  `&mut JSContext` per #42638:

  - Add `'Constructor'` to DOMParser's `'cx'` array in `Bindings.conf` so
  codegen passes `cx: &mut JSContext` to the constructor stub.
  - Swap `reflect_dom_object_with_proto` for
  `reflect_dom_object_with_proto_and_cx` and thread `cx` through
  `DOMParser::new` and `DOMParser::Constructor`, moving `cx` to the first
  parameter slot per the convention established by #44671 (OffscreenCanvas /
  Navigator) and #44930 (BroadcastChannel).

  The only caller of `DOMParser::new` is the in-file `Constructor`, so no
  propagation beyond this file is required.  `ParseFromString` was already on
  `&mut JSContext`; the `CanGc` import is retained because that body still
  derives `CanGc::from_cx(cx)` for the `Document::new` and `set_ready_state`
  calls.

  Testing: No new tests required; this is a type-signature refactor (`CanGc` to
  `&mut JSContext`) with no runtime behavior change.  Existing DOMParser tests
  continue to exercise the same code paths through the codegen-generated
  `Constructor` stub and `reflect_dom_object_with_proto_and_cx`.
  
  Fixed: Part of #42638