### PR TITLE
script: Static built-in non-replaceable elements list

### DIFF
--- a/components/script/dom/security/sanitizer.rs
+++ b/components/script/dom/security/sanitizer.rs
@@ -2,11 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::cell::LazyCell;
 use std::cmp::Ordering;
 use std::collections::HashSet;
 
 use dom_struct::dom_struct;
-use html5ever::{Namespace, ns};
+use html5ever::{Namespace, local_name, ns};
 use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
@@ -459,7 +460,7 @@ impl SanitizerMethods<crate::DomTypeHolder> for Sanitizer {
         let element = element.canonicalize();
 
         // Step 4. If the built-in non-replaceable elements list contains element:
-        if built_in_non_replaceable_elements_list().contains_item(&element) {
+        if BUILT_IN_NON_REPLACEABLE_ELEMENTS_LIST.with(|list| list.contains_item(&element)) {
             // Step 4.1. Return false.
             return false;
         }
@@ -960,7 +961,7 @@ impl SanitizerConfigAlgorithm for SanitizerConfig {
             for element in config_replace_with_children_elements {
                 // Step 15.1.1. If the built-in non-replaceable elements list contains element, then
                 // return false.
-                if built_in_non_replaceable_elements_list().contains_item(element) {
+                if BUILT_IN_NON_REPLACEABLE_ELEMENTS_LIST.with(|list| list.contains_item(element)) {
                     return false;
                 }
             }
@@ -2598,22 +2599,25 @@ fn built_in_safe_baseline_configuration() -> SanitizerConfig {
     }
 }
 
-/// <https://wicg.github.io/sanitizer-api/#built-in-non-replaceable-elements-list>
-fn built_in_non_replaceable_elements_list() -> Vec<SanitizerElement> {
-    vec![
-        SanitizerElement::SanitizerElementNamespace(SanitizerElementNamespace {
-            name: "html".into(),
-            namespace: Some(ns!(html).to_string().into()),
-        }),
-        SanitizerElement::SanitizerElementNamespace(SanitizerElementNamespace {
-            name: "svg".into(),
-            namespace: Some(ns!(svg).to_string().into()),
-        }),
-        SanitizerElement::SanitizerElementNamespace(SanitizerElementNamespace {
-            name: "math".into(),
-            namespace: Some(ns!(mathml).to_string().into()),
-        }),
-    ]
+thread_local! {
+    /// <https://wicg.github.io/sanitizer-api/#built-in-non-replaceable-elements-list>
+    static BUILT_IN_NON_REPLACEABLE_ELEMENTS_LIST: LazyCell<Vec<SanitizerElement>> =
+        LazyCell::new(|| {
+            vec![
+                SanitizerElement::SanitizerElementNamespace(SanitizerElementNamespace {
+                    name: local_name!("html").as_ref().into(),
+                    namespace: Some(ns!(html).as_ref().into()),
+                }),
+                SanitizerElement::SanitizerElementNamespace(SanitizerElementNamespace {
+                    name: local_name!("svg").as_ref().into(),
+                    namespace: Some(ns!(svg).as_ref().into()),
+                }),
+                SanitizerElement::SanitizerElementNamespace(SanitizerElementNamespace {
+                    name: local_name!("math").as_ref().into(),
+                    namespace: Some(ns!(mathml).as_ref().into()),
+                }),
+            ]
+        });
 }
 
 /// <https://html.spec.whatwg.org/multipage/#custom-data-attribute>


### PR DESCRIPTION
The **built-in non-replaceable elements list** can be treated as static read-only data. We can wrap it in static `LazyCell` to initialize it lazily on first use, and reuse the same instance on subsequent accesses, instead of creating a new instance on every access.

The elements contain `DOMString`, which is not thread-safe, so the static `LazyCell` needs to be wrapped in a `thread_local!` block.

Testing: Refactoring. Covered by existing WPT tests in `sanitizer-api`.