### PR TITLE
layout: Stop cloning `ClipPath` for every single `Fragment` in the tree

### DIFF
--- a/components/layout/display_list/clip.rs
+++ b/components/layout/display_list/clip.rs
@@ -68,15 +68,15 @@ impl StackingContextTreeClipStore {
 
     pub(super) fn add_for_clip_path(
         &mut self,
-        clip_path: ClipPath,
+        clip_path: &ClipPath,
         parent_scroll_node_id: ScrollTreeNodeId,
         parent_clip_chain_id: ClipId,
         fragment_builder: BuilderForBoxFragment,
     ) -> Option<ClipId> {
         let geometry_box = match clip_path {
-            ClipPath::Shape(_, ShapeGeometryBox::ShapeBox(shape_box)) => shape_box,
+            ClipPath::Shape(_, ShapeGeometryBox::ShapeBox(shape_box)) => *shape_box,
             ClipPath::Shape(_, ShapeGeometryBox::ElementDependent) => ShapeBox::BorderBox,
-            ClipPath::Box(ShapeGeometryBox::ShapeBox(shape_box)) => shape_box,
+            ClipPath::Box(ShapeGeometryBox::ShapeBox(shape_box)) => *shape_box,
             ClipPath::Box(ShapeGeometryBox::ElementDependent) => ShapeBox::BorderBox,
             _ => return None,
         };
@@ -87,10 +87,10 @@ impl StackingContextTreeClipStore {
             ShapeBox::MarginBox => *fragment_builder.margin_rect(),
         };
         if let ClipPath::Shape(shape, _) = clip_path {
-            match *shape {
+            match **shape {
                 BasicShape::Circle(_) | BasicShape::Ellipse(_) | BasicShape::Rect(_) => self
                     .add_for_basic_shape(
-                        *shape,
+                        shape,
                         layout_rect,
                         parent_scroll_node_id,
                         parent_clip_chain_id,
@@ -117,7 +117,7 @@ impl StackingContextTreeClipStore {
     #[servo_tracing::instrument(name = "StackingContextClipStore::add_for_basic_shape", skip_all)]
     fn add_for_basic_shape(
         &mut self,
-        shape: BasicShape,
+        shape: &BasicShape,
         layout_box: LayoutRect,
         parent_scroll_node_id: ScrollTreeNodeId,
         parent_clip_chain_id: ClipId,
@@ -164,8 +164,8 @@ impl StackingContextTreeClipStore {
                 ))
             },
             BasicShape::Circle(circle) => {
-                let center = match circle.position {
-                    GenericPositionOrAuto::Position(position) => position,
+                let center = match &circle.position {
+                    GenericPositionOrAuto::Position(position) => position.clone(),
                     GenericPositionOrAuto::Auto => Position::center(),
                 };
                 let anchor_x = center
@@ -210,8 +210,8 @@ impl StackingContextTreeClipStore {
                 Some(self.add(radii, rect, parent_scroll_node_id, parent_clip_chain_id))
             },
             BasicShape::Ellipse(ellipse) => {
-                let center = match ellipse.position {
-                    GenericPositionOrAuto::Position(position) => position,
+                let center = match &ellipse.position {
+                    GenericPositionOrAuto::Position(position) => position.clone(),
                     GenericPositionOrAuto::Auto => Position::center(),
                 };
                 let anchor_x = center

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -597,7 +597,7 @@ impl StackingContext {
             effects.opacity == 1.0 &&
             effects.mix_blend_mode == ComputedMixBlendMode::Normal &&
             !style.has_effective_transform_or_perspective(FragmentFlags::empty()) &&
-            style.clone_clip_path() == ClipPath::None &&
+            style.get_svg().clip_path == ClipPath::None &&
             transform_style == TransformStyle::Flat
         {
             return false;
@@ -1188,7 +1188,7 @@ impl BoxFragment {
         let stacking_context_clip_id = stacking_context_tree
             .clip_store
             .add_for_clip_path(
-                self.style().clone_clip_path(),
+                &self.style().get_svg().clip_path,
                 containing_block.scroll_node_id,
                 containing_block.clip_id,
                 BuilderForBoxFragment::new(
@@ -1273,7 +1273,7 @@ impl BoxFragment {
 
         let style = self.style();
         if let Some(clip_id) = stacking_context_tree.clip_store.add_for_clip_path(
-            style.clone_clip_path(),
+            &style.get_svg().clip_path,
             new_scroll_node_id,
             new_clip_id,
             BuilderForBoxFragment::new(


### PR DESCRIPTION
During stacking context tree construction the code was cloning a
`ClipPath` for every single `Fragment` in the tree. `ClipPath` is a 24
byte data structure, so this behavior was causing `ClipPath` cloning and
dropping to show up as ~0.8% of the samples when profiling
`tests/blink_perf_tests/perf_tests/layout/flexbox-deeply-nested-column-flow.html`.
Needless to say, almost no `Fragment`s actually have a `ClipPath`.  This
change switches to using a reference to the `ClipPath` rather than a
clone. With the switch almost all `ClipPath` samples disappear from the
profile.

Testing: There are currently no automated performance tests sadly, but this
change shouldn't change observable behavior.
