### PR TITLE
script: Use `&mut JSContext` in structuredclone::write

### DIFF
--- a/components/script/dom/bindings/structuredclone.rs
+++ b/components/script/dom/bindings/structuredclone.rs
@@ -20,7 +20,8 @@ use js::jsapi::{
 };
 use js::jsval::UndefinedValue;
 use js::realm::CurrentRealm;
-use js::rust::wrappers::{JS_ReadStructuredClone, JS_WriteStructuredClone};
+use js::rust::wrappers::JS_ReadStructuredClone;
+use js::rust::wrappers2::JS_WriteStructuredClone;
 use js::rust::{
     CustomAutoRooterGuard, HandleValue, JSAutoStructuredCloneBufferWrapper, MutableHandleValue,
 };
@@ -709,14 +710,14 @@ pub(crate) struct StructuredDataWriter {
 
 /// Writes a structured clone. Returns a `DataClone` error if that fails.
 pub(crate) fn write(
-    cx: SafeJSContext,
+    cx: &mut js::context::JSContext,
     message: HandleValue,
     transfer: Option<CustomAutoRooterGuard<Vec<*mut JSObject>>>,
 ) -> Fallible<StructuredSerializedData> {
     unsafe {
         rooted!(&in(cx) let mut val = UndefinedValue());
         if let Some(transfer) = transfer {
-            transfer.safe_to_jsval(cx, val.handle_mut(), CanGc::deprecated_note());
+            transfer.safe_to_jsval(cx.into(), val.handle_mut(), CanGc::deprecated_note());
         }
         let mut sc_writer = StructuredDataWriter::default();
         let sc_writer_ptr = &mut sc_writer as *mut _;
@@ -731,7 +732,7 @@ pub(crate) fn write(
             allowSharedMemoryObjects_: false,
         };
         let result = JS_WriteStructuredClone(
-            *cx,
+            cx,
             message,
             scdata,
             StructuredCloneScope::DifferentProcess,
@@ -741,7 +742,7 @@ pub(crate) fn write(
             val.handle(),
         );
         if !result {
-            let error = if JS_IsExceptionPending(*cx) {
+            let error = if JS_IsExceptionPending(cx.raw_cx()) {
                 Error::JSFailed
             } else {
                 sc_writer.error.unwrap_or(Error::DataClone(None))

--- a/components/script/dom/broadcastchannel.rs
+++ b/components/script/dom/broadcastchannel.rs
@@ -86,7 +86,7 @@ impl BroadcastChannelMethods<crate::DomTypeHolder> for BroadcastChannel {
         }
 
         // Step 6, StructuredSerialize(message).
-        let data = structuredclone::write(cx.into(), message, None)?;
+        let data = structuredclone::write(cx, message, None)?;
 
         let global = self.global();
 

--- a/components/script/dom/dissimilaroriginwindow.rs
+++ b/components/script/dom/dissimilaroriginwindow.rs
@@ -218,7 +218,7 @@ impl DissimilarOriginWindow {
         transfer: CustomAutoRooterGuard<Vec<*mut JSObject>>,
     ) -> ErrorResult {
         // Step 6-7.
-        let data = structuredclone::write(cx.into(), message, Some(transfer))?;
+        let data = structuredclone::write(cx, message, Some(transfer))?;
 
         self.post_message(target_origin, data)
     }

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -3345,7 +3345,7 @@ impl GlobalScope {
         #[expect(unsafe_code)]
         let guard = unsafe { CustomAutoRooterGuard::new(cx.raw_cx(), &mut rooted) };
 
-        let data = structuredclone::write(cx.into(), value, Some(guard))?;
+        let data = structuredclone::write(cx, value, Some(guard))?;
 
         structuredclone::read(self, data, retval, CanGc::from_cx(cx))?;
 

--- a/components/script/dom/history.rs
+++ b/components/script/dom/history.rs
@@ -204,7 +204,7 @@ impl History {
         // https://github.com/servo/servo/issues/19159
 
         // Step 4. Let serializedData be StructuredSerializeForStorage(data). Rethrow any exceptions.
-        let serialized_data = structuredclone::write(cx.into(), data, None)?;
+        let serialized_data = structuredclone::write(cx, data, None)?;
 
         // Step 5. Let newURL be document's URL.
         let new_url: ServoUrl = match url {

--- a/components/script/dom/indexeddb/idbobjectstore.rs
+++ b/components/script/dom/indexeddb/idbobjectstore.rs
@@ -189,7 +189,7 @@ impl IDBObjectStore {
 
         let result = (|| {
             // Step 3. Let serialized be ? StructuredSerializeForStorage(value).
-            let serialized = structuredclone::write(cx.into(), value, None)?;
+            let serialized = structuredclone::write(cx, value, None)?;
 
             // Step 4. Let clone be ? StructuredDeserialize(serialized, targetRealm).
             let _ = structuredclone::read(&self.global(), serialized, clone, CanGc::from_cx(cx))?;
@@ -399,9 +399,9 @@ impl IDBObjectStore {
                     },
                 }
 
-                structuredclone::write(cx.into(), cloned_js_value.handle(), None)?
+                structuredclone::write(cx, cloned_js_value.handle(), None)?
             },
-            None => structuredclone::write(cx.into(), cloned_js_value.handle(), None)?,
+            None => structuredclone::write(cx, cloned_js_value.handle(), None)?,
         };
         let Ok(serialized_value) = postcard::to_stdvec(&cloned_value) else {
             return Err(Error::InvalidState(None));

--- a/components/script/dom/messageport.rs
+++ b/components/script/dom/messageport.rs
@@ -151,7 +151,7 @@ impl MessagePort {
         }
 
         // Step 5
-        let data = structuredclone::write(cx.into(), message, Some(transfer))?;
+        let data = structuredclone::write(cx, message, Some(transfer))?;
 
         if doomed {
             // TODO: The spec says to optionally report such a case to a dev console.

--- a/components/script/dom/performance/performance.rs
+++ b/components/script/dom/performance/performance.rs
@@ -770,7 +770,7 @@ impl PerformanceMethods<crate::DomTypeHolder> for Performance {
             !options.detail.get().is_null_or_undefined()
         {
             // Step 9.1.1. Let record be the result of calling the StructuredSerialize algorithm on startOrMeasureOptions’s detail.
-            let record = structuredclone::write(cx.into(), options.detail.handle(), None)?;
+            let record = structuredclone::write(cx, options.detail.handle(), None)?;
 
             // Step 9.1.2. Set entry’s detail to the result of calling the StructuredDeserialize algorithm on record and the current realm.
             structuredclone::read(

--- a/components/script/dom/performance/performancemark.rs
+++ b/components/script/dom/performance/performancemark.rs
@@ -80,7 +80,7 @@ impl PerformanceMark {
         // Step 8 Otherwise:
         if !mark_options.detail.get().is_null_or_undefined() {
             // Step 8.1. Let record be the result of calling the StructuredSerialize algorithm on markOptions’s detail.
-            let record = structuredclone::write(cx.into(), mark_options.detail.handle(), None)?;
+            let record = structuredclone::write(cx, mark_options.detail.handle(), None)?;
 
             // Step 8.2. Set entry’s detail to the result of calling the StructuredDeserialize algorithm on record and the current realm.
             structuredclone::read(global, record, detail.handle_mut(), CanGc::from_cx(cx))?;

--- a/components/script/dom/stream/defaultteereadrequest.rs
+++ b/components/script/dom/stream/defaultteereadrequest.rs
@@ -137,7 +137,7 @@ impl DefaultTeeReadRequest {
         if !self.canceled_2.get() && self.clone_for_branch_2.get() {
             // Let cloneResult be StructuredClone(chunk2).
             rooted!(&in(cx) let mut clone_result = UndefinedValue());
-            let data = structuredclone::write(cx.into(), chunk2_value.handle(), None).unwrap();
+            let data = structuredclone::write(cx, chunk2_value.handle(), None).unwrap();
             // If cloneResult is an abrupt completion,
             if structuredclone::read(global, data, clone_result.handle_mut(), CanGc::from_cx(cx))
                 .is_err()

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2432,7 +2432,7 @@ impl Window {
         transfer: CustomAutoRooterGuard<Vec<*mut JSObject>>,
     ) -> ErrorResult {
         // Step 1-2, 6-8.
-        let data = structuredclone::write(cx.into(), message, Some(transfer))?;
+        let data = structuredclone::write(cx, message, Some(transfer))?;
 
         // Step 3-5.
         let target_origin = match target_origin.0[..].as_ref() {

--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -736,7 +736,7 @@ impl DedicatedWorkerGlobalScope {
         message: HandleValue,
         transfer: CustomAutoRooterGuard<Vec<*mut JSObject>>,
     ) -> ErrorResult {
-        let data = structuredclone::write(cx.into(), message, Some(transfer))?;
+        let data = structuredclone::write(cx, message, Some(transfer))?;
         let worker = self.worker.borrow().as_ref().unwrap().clone();
         let global_scope = self.upcast::<GlobalScope>();
         let pipeline_id = global_scope.pipeline_id();

--- a/components/script/dom/workers/serviceworker.rs
+++ b/components/script/dom/workers/serviceworker.rs
@@ -105,7 +105,7 @@ impl ServiceWorker {
             return Err(Error::InvalidState(None));
         }
         // Step 7
-        let data = structuredclone::write(cx.into(), message, Some(transfer))?;
+        let data = structuredclone::write(cx, message, Some(transfer))?;
         let incumbent = GlobalScope::incumbent().expect("no incumbent global?");
         let msg_vec = DOMMessage {
             origin: incumbent.origin().immutable().clone(),

--- a/components/script/dom/workers/worker.rs
+++ b/components/script/dom/workers/worker.rs
@@ -149,7 +149,7 @@ impl Worker {
         message: HandleValue,
         transfer: CustomAutoRooterGuard<Vec<*mut JSObject>>,
     ) -> ErrorResult {
-        let data = structuredclone::write(cx.into(), message, Some(transfer))?;
+        let data = structuredclone::write(cx, message, Some(transfer))?;
         let address = Trusted::new(self);
 
         // NOTE: step 9 of https://html.spec.whatwg.org/multipage/#dom-messageport-postmessage


### PR DESCRIPTION
  Migrate `structuredclone::write` from `SafeJSContext` to `&mut JSContext`
  (issue #42347), the last remaining checkbox in the MessagePort /
  structured-clone propagation chain started by #42342.

  Changes in `components/script/dom/bindings/structuredclone.rs`:

  - Signature: `cx: SafeJSContext` becomes `cx: &mut JSContext`.
  - Body: `safe_to_jsval(cx, ...)` becomes `safe_to_jsval(cx.into(), ...)`;
  `*cx` becomes `cx.raw_cx()` at the two `JS_WriteStructuredClone` and
  `JS_IsExceptionPending` call sites.
  - The `SafeJSContext` import is retained because the `read_callback` and
  `read_transfer_callback` paths still construct one via
  `SafeJSContext::from_ptr`.

  Caller cleanup across 13 files: drops the now-redundant `cx.into()` bridge at
  all 15 call sites; `cx` is passed by reborrow directly.  All callers already
  had `cx: &mut JSContext` (or `&mut CurrentRealm` which auto-derefs) from
  earlier sub-PRs in the chain.

  Testing: No new tests required; this is a type-signature refactor
  (`SafeJSContext` to `&mut JSContext`) with no runtime behavior change.
  Existing structured-clone tests continue to exercise the same code paths
  through `JS_WriteStructuredClone` and the `safe_to_jsval` conversion.
  
  Fixes: #42347