### PR TITLE
mach: Add `--gc-zeal` flag to `mach run` and `mach test-wpt`

### DIFF
--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -72,6 +72,12 @@ class PostBuildCommands(CommandBase):
     @CommandArgument("--debugger-cmd", default=None, type=str, help="Name of debugger to use.")
     @CommandArgument("--headless", "-z", action="store_true", help="Launch in headless mode")
     @CommandArgument("--software", "-s", action="store_true", help="Launch with software rendering")
+    @CommandArgument(
+        "--gc-zeal",
+        action="store_true",
+        help="Enable SpiderMonkey GC zeal mode for debugging unsafe JS integration code "
+        "(only effective with debug-mozjs builds)",
+    )
     @CommandArgument("params", nargs="...", help="Command-line arguments to be passed through to Servo")
     @CommandBase.common_command_arguments(binary_selection=True)
     @CommandBase.allow_target_configuration
@@ -85,8 +91,9 @@ class PostBuildCommands(CommandBase):
         software: bool = False,
         emulator: bool = False,
         usb: bool = False,
+        gc_zeal: bool = False,
     ) -> int | None:
-        return self._run(servo_binary, params, debugger, debugger_cmd, headless, software, emulator, usb)
+        return self._run(servo_binary, params, debugger, debugger_cmd, headless, software, emulator, usb, gc_zeal)
 
     def _run(
         self,
@@ -98,7 +105,16 @@ class PostBuildCommands(CommandBase):
         software: bool = False,
         emulator: bool = False,
         usb: bool = False,
+        gc_zeal: bool = False,
     ) -> int | None:
+        if gc_zeal:
+            params = [
+                "--pref",
+                "js_mem_gc_zeal_level=2",
+                "--pref",
+                "js_mem_gc_zeal_frequency=1",
+                *params,
+            ]
         env = self.build_env()
         env["RUST_BACKTRACE"] = "1"
         if software:

--- a/python/wpt/__init__.py
+++ b/python/wpt/__init__.py
@@ -33,6 +33,13 @@ def create_parser() -> ArgumentParser:
     )
     parser.add_argument("--pref", default=[], action="append", dest="prefs", help="Pass preferences to servo")
     parser.add_argument(
+        "--gc-zeal",
+        default=False,
+        action="store_true",
+        help="Enable SpiderMonkey GC zeal mode for debugging unsafe JS integration code "
+        "(only effective with debug-mozjs builds)",
+    )
+    parser.add_argument(
         "--log-servojson",
         action="append",
         type=mozlog.commandline.log_file,

--- a/python/wpt/run.py
+++ b/python/wpt/run.py
@@ -77,6 +77,8 @@ def run_tests(default_binary_path: str, multiprocess: bool, **kwargs: Any) -> in
         # TODO: Delete rr traces from green test runs?
 
     prefs = kwargs.pop("prefs")
+    if kwargs.pop("gc_zeal", False):
+        prefs.extend(["js_mem_gc_zeal_level=2", "js_mem_gc_zeal_frequency=1"])
     if multiprocess:
         kwargs.setdefault("binary_args", ["-M"])
 


### PR DESCRIPTION
Surface SpiderMonkey GC zeal mode (`js_mem_gc_zeal_level=2`, `js_mem_gc_zeal_frequency=1`) as a single mach flag so contributors debugging unsafe JS integration code do not have to remember the two `--pref` invocations.

- `mach run --gc-zeal` prepends the two `--pref` arguments to the servo binary's params, so the same flag works for both the desktop run path and the Android `am start` path (the latter serializes params to JSON before launching).
- `mach test-wpt --gc-zeal` extends the existing `prefs` list in `python/wpt/run.py` with the same two prefs, so the WPT runner appends them as `--pref=` arguments to the servo binary it spawns.

Both help strings note that the flag is only effective with debug-mozjs builds, since `set_gc_zeal_options` in `components/script/script_runtime.rs` is compiled to a no-op otherwise.

Testing:  existing tests pass

Fixes #37558
