### PR TITLE
ci release.yml: add servo git sha when publishing to nightly repo.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,11 @@ jobs:
         run: |
           if [[ "${{ inputs.release_tag }}" != "" ]]; then
             RELEASE_TAG="${{ inputs.release_tag }}"
-            RELEASE_NOTES="Servo release ${{ inputs.release_tag }}"
+            if [[ "${{ inputs.regular_release }}" == "true" ]]; then
+              RELEASE_NOTES="Servo release ${{ inputs.release_tag }}"
+            else
+              RELEASE_NOTES="Servo release ${{ inputs.release_tag }} based on ${{ github.repository }}@${{ github.sha }}"          
+            fi
           else
             RELEASE_TAG=$(date "+%F")
             RELEASE_NOTES="Nightly build based on servo/servo@${{ github.sha }}"


### PR DESCRIPTION
If we are publishing to servo/servo, then there will be a tag on servo/servo associated with the release (hence we don't need to add a commit hash to the release description).
When doing a testing release, which we publish to the nightly repo, we now also add the sha, so that it's clear which commit it's based on. Workflow runs can happen from forks, if a supported token is added as a secret in the fork, so also encode the source repo instead of assuming servo/servo.

Testing: Not tested 

