### PR TITLE
video: Pass resolved_block_size of replaced item when layout for video control widget.

### DIFF
--- a/components/layout/formatting_contexts.rs
+++ b/components/layout/formatting_contexts.rs
@@ -26,13 +26,14 @@ use crate::positioned::PositioningContext;
 use crate::replaced::ReplacedContents;
 use crate::sizing::{
     self, ComputeInlineContentSizes, ContentSizes, InlineContentSizesResult, LazySize,
+    SizeConstraint,
 };
 use crate::style_ext::{AspectRatio, Display, DisplayInside, LayoutStyle};
 use crate::table::Table;
 use crate::taffy::TaffyContainer;
 use crate::{
-    ArcRefCell, ConstraintSpace, ContainingBlock, IndefiniteContainingBlock, LogicalVec2,
-    PropagatedBoxTreeData,
+    ArcRefCell, ConstraintSpace, ContainingBlock, ContainingBlockSize, IndefiniteContainingBlock,
+    LogicalVec2, PropagatedBoxTreeData,
 };
 
 /// <https://drafts.csswg.org/css-display/#independent-formatting-context>
@@ -414,12 +415,22 @@ impl IndependentFormattingContext {
                     &self.base,
                     lazy_block_size,
                 );
+                // Widget should know the size of the replaced contents.
+                let resolved_block_size =
+                    lazy_block_size.resolve(|| replaced_layout.content_block_size);
+                let widget_cb = ContainingBlock {
+                    size: ContainingBlockSize {
+                        inline: containing_block_for_children.size.inline,
+                        block: SizeConstraint::Definite(resolved_block_size),
+                    },
+                    style: &self.base.style,
+                };
                 if let Some(widget) = widget {
                     let mut widget_layout = widget.borrow().layout(
                         layout_context,
                         positioning_context,
-                        containing_block_for_children,
-                        containing_block_for_children,
+                        &widget_cb,
+                        &widget_cb,
                         None,
                         &LazySize::intrinsic(),
                     );

--- a/components/script/resources/media-controls.css
+++ b/components/script/resources/media-controls.css
@@ -17,6 +17,7 @@ button {
   position: relative;
   min-height: 40px;
   min-width: 230px;
+  height: 100%;
 }
 
 .controls {


### PR DESCRIPTION
This change allow video control widget root element to take as much space as the video element have. It contains two changes:
1. Calculate the `resolved_block_size` from replaced_item block size, use it as containing block block size for widget item layout process.
2. set the height of root item of video control widget to 100%.
After this change, the video control widget can be shown at the bottom of the video element.

Testing: manutal test case: 
```html
<div style="width: 500px; height: 300px">
 <video widh="500px" controls src=""> </video>
</div>
```
Fixes: N/A

p.s. this PR try to address https://github.com/servo/servo/issues/42489#issuecomment-4106417063, but there are still some styling to do.
