### PR TITLE
generic_channel: Optimize crossbeam select in resource_thread loop

### DIFF
--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -273,9 +273,10 @@ impl ResourceChannelManager {
         let reporter_id = rx_set.add(memory_reporter);
         let revoker_id = rx_set.add(revoke_receiver);
         let refresh_id = rx_set.add(refresh_receiver);
+        let mut selector = rx_set.selector();
 
         loop {
-            for received in rx_set.select().into_iter() {
+            for received in selector.select().into_iter() {
                 // Handles case where profiler thread shuts down before resource thread.
                 match received {
                     GenericSelectionResult::ChannelClosed(_) => continue,

--- a/components/shared/base/generic_channel/generic_channelset.rs
+++ b/components/shared/base/generic_channel/generic_channelset.rs
@@ -121,10 +121,75 @@ impl<T: Serialize + for<'de> Deserialize<'de>> GenericReceiverSet<T> {
         }
     }
 
-    /// Block until at least one of the Receivers receives a message and return a vector of the received messages.
+    /// Create a [`Selector`] that owns the underlying select state.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    ///  use servo_base::generic_channel::{self, GenericReceiverSet};
+    ///
+    ///  let (_, receiver_one) = generic_channel::channel::<()>().unwrap();
+    ///  let (_, receiver_two) = generic_channel::channel::<()>().unwrap();
+    ///  let mut rx_set = GenericReceiverSet::<()>::new();
+    ///  let _select_idx_1 = rx_set.add(receiver_one);
+    ///  let _select_idx_2 = rx_set.add(receiver_two);
+    ///  // Build the Selector once, before the loop if all receivers are known in advance.
+    ///  let mut selector = rx_set.selector();
+    ///  loop {
+    ///    for received in selector.select().into_iter() {
+    ///      // do something
+    ///    }
+    ///  }
+    /// ```
+    pub fn selector(&mut self) -> Selector<'_, T> {
+        let inner = match &mut self.0 {
+            GenericReceiverSetVariants::Ipc(set) => SelectorInner::Ipc(set),
+            GenericReceiverSetVariants::Crossbeam(receivers) => {
+                let mut sel = crossbeam_channel::Select::new();
+                for receiver in receivers.iter() {
+                    sel.recv(receiver);
+                }
+                SelectorInner::Crossbeam {
+                    receivers: receivers.as_slice(),
+                    sel,
+                }
+            },
+        };
+        Selector { inner }
+    }
+
+    /// One-shot select. Builds a [`Selector`], runs select once and drops it.
+    ///
+    /// For usage in loops consider using [`GenericReceiverSet::selector()`] to build the selector
+    /// once upfront.
     pub fn select(&mut self) -> Vec<GenericSelectionResult<T>> {
-        match &mut self.0 {
-            GenericReceiverSetVariants::Ipc(ipc_receiver_set) => ipc_receiver_set
+        self.selector().select()
+    }
+}
+
+/// Borrows of a [`GenericReceiverSet`] used to drive repeated `select` calls
+/// without rebuilding the underlying `crossbeam_channel::Select` each time.
+/// See [`GenericReceiverSet::selector`].
+pub struct Selector<'a, T: Serialize + for<'de> Deserialize<'de>> {
+    inner: SelectorInner<'a, T>,
+}
+
+enum SelectorInner<'a, T: for<'de> Deserialize<'de>> {
+    Ipc(&'a mut IpcReceiverSet),
+    Crossbeam {
+        receivers: &'a [crossbeam_channel::Receiver<Result<T, ipc_channel::IpcError>>],
+        sel: crossbeam_channel::Select<'a>,
+    },
+}
+
+impl<'a, T: Serialize + for<'de> Deserialize<'de>> Selector<'a, T> {
+    /// Block until at least one of the Receivers receives a message.
+    ///
+    /// Note: The IPC variant can return multiple results in one call.
+    /// The crossbeam variant always returns exactly one.
+    pub fn select(&mut self) -> Vec<GenericSelectionResult<T>> {
+        match &mut self.inner {
+            SelectorInner::Ipc(ipc_receiver_set) => ipc_receiver_set
                 .select()
                 .map(|result_value| {
                     result_value
@@ -133,16 +198,12 @@ impl<T: Serialize + for<'de> Deserialize<'de>> GenericReceiverSet<T> {
                         .collect()
                 })
                 .unwrap_or_else(|e| vec![GenericSelectionResult::Error(e.to_string())]),
-            GenericReceiverSetVariants::Crossbeam(receivers) => {
-                let mut sel = crossbeam_channel::Select::new();
-                for receiver in receivers.iter() {
-                    sel.recv(receiver);
-                }
-                let selector = sel.select();
-                let index = selector.index();
+            SelectorInner::Crossbeam { receivers, sel } => {
+                let selected = sel.select();
+                let index = selected.index();
                 let selection_result = match receivers.get(index) {
                     None => GenericSelectionResult::ChannelClosed(index as u64),
-                    Some(receiver) => match selector.recv(receiver) {
+                    Some(receiver) => match selected.recv(receiver) {
                         Ok(Ok(value)) => {
                             GenericSelectionResult::MessageReceived(index as u64, value)
                         },


### PR DESCRIPTION
Allow building a Selector struct upfront. This is useful for loops where we can `.add()` all receivers up-front, and don't need to rebuild the Selector in the loop.
This also showed up in callgrind, and hoisting the selector building out of the loop, removes useless allocations in the resource channel manager thread.
The IPC case is unaffected, since that is already using an IpcReceiverSet.

Follow-up work will investigate applying this to other message loops too, but more work might be required there.

Testing: No behavior change.
Fixes: Part of #44971

