### PR TITLE
devcontainer: Install some common cli tools

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,8 +10,11 @@
 	// },
 
 
+	"features": {
+		"./features/common-cli-tools": {}
+	},
 	// Most dependencies are installed in the image, but we run mach bootstrap to ensure
-	// the environment matches what's expected in the current servo version, which might 
+	// the environment matches what's expected in the current servo version, which might
 	// have changed since the image was built.
 	"postCreateCommand":
 		"./mach bootstrap --yes",

--- a/.devcontainer/features/common-cli-tools/devcontainer-feature.json
+++ b/.devcontainer/features/common-cli-tools/devcontainer-feature.json
@@ -1,0 +1,6 @@
+{
+  "id": "common-cli-tools",
+  "version": "1.0.0",
+  "name": "Common CLI Tools",
+  "description": "Installs common command-line tools for interactive work in the Servo devcontainer."
+}

--- a/.devcontainer/features/common-cli-tools/install.sh
+++ b/.devcontainer/features/common-cli-tools/install.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+# The tools we install here are not strictly required for developing servo,
+# but they may be useful when interactively developing.
+# We keep this seperate from the main Dockerfile, since installing this should be fast,
+# and we do want to have a minimal image of sorts.
+apt-get update
+apt-get install -y --no-install-recommends \
+    bat \
+    fd-find \
+    file \
+    less \
+    ripgrep \
+    xxd
+rm -rf /var/lib/apt/lists/*
+
+# Ubuntu packages expose some tools under Debian-specific names.
+ln -sf /usr/bin/batcat /usr/local/bin/bat
+ln -sf /usr/bin/fdfind /usr/local/bin/fd


### PR DESCRIPTION
Add a devcontainer feature which installs commonly used cli tools like `less`, `file`, `bat` etc.
The list is mainly based on tools that I've been missing when working with the devcontainer.
Since the devcontainer dockerfile build also doubles as a test of servos documented build dependency set,
I think it makes more sense to keep these optional dependencies as a devcontainer feature, hence they
are not added to the Dockerimage itself.

Testing: Tooling change, not covered by automatic tests.
Fixes: #44349
