### PR TITLE
servo: Hoist Select out of inner loop

### DIFF
--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -147,6 +147,69 @@ enum Message {
     FromUnknown(EmbedderMsg),
 }
 
+/// Holds a prebuilt `crossbeam_channel::Select` over the crossbeam
+/// receivers so our [`spin_event_loop`] loop doesn't rebuild it on every
+/// iteration.
+///
+/// [`spin_event_loop`]: ServoInner::spin_event_loop
+struct EmbedderMessageSelector<'a> {
+    select: crossbeam_channel::Select<'a>,
+    receivers: (
+        &'a Receiver<EmbedderMsg>,
+        &'a Receiver<NetToEmbedderMsg>,
+        &'a Receiver<ConstellationToEmbedderMsg>,
+    ),
+}
+
+impl<'a> EmbedderMessageSelector<'a> {
+    fn new(
+        embedder_receiver: &'a Receiver<EmbedderMsg>,
+        net_embedder_receiver: &'a Receiver<NetToEmbedderMsg>,
+        constellation_embedder_receiver: &'a Receiver<ConstellationToEmbedderMsg>,
+    ) -> Self {
+        let mut select = crossbeam_channel::Select::new();
+        // The order of `.recv()` calls **must** match the order of fields in `receivers`.
+        // In `try_recv()` we assume the `select` index matches the order of receivers in the tuple.
+        let embedder_index = select.recv(embedder_receiver);
+        debug_assert_eq!(embedder_index, 0);
+        let net_embedder_index = select.recv(net_embedder_receiver);
+        debug_assert_eq!(net_embedder_index, 1);
+        let constellation_embedder_index = select.recv(constellation_embedder_receiver);
+        debug_assert_eq!(constellation_embedder_index, 2);
+        Self {
+            select,
+            receivers: (
+                embedder_receiver,
+                net_embedder_receiver,
+                constellation_embedder_receiver,
+            ),
+        }
+    }
+
+    #[servo_tracing::instrument(
+        level = "debug",
+        name = "EmbedderMessageSelector::try_recv_one_message",
+        skip_all
+    )]
+    fn try_recv_one_message(&mut self) -> Option<Message> {
+        let operation = self.select.try_select().ok()?;
+        let index = operation.index();
+        if index == 0 {
+            let message = operation.recv(self.receivers.0).ok()?;
+            Some(Message::FromUnknown(message))
+        } else if index == 1 {
+            let message = operation.recv(self.receivers.1).ok()?;
+            Some(Message::FromNet(message))
+        } else if index == 2 {
+            let message = operation.recv(self.receivers.2).ok()?;
+            Some(Message::FromConstellation(message))
+        } else {
+            log::error!("No select operation registered for {index:?}");
+            None
+        }
+    }
+}
+
 pub struct PendingHandledInputEvent {
     pub event_id: InputEventId,
     pub webview_id: WebViewId,
@@ -212,8 +275,13 @@ impl ServoInner {
             paint.handle_messages(messages);
         }
 
+        let mut selector = EmbedderMessageSelector::new(
+            &self.embedder_receiver,
+            &self.net_embedder_receiver,
+            &self.constellation_embedder_receiver,
+        );
         // Only handle incoming embedder messages if `Paint` hasn't already started shutting down.
-        while let Some(message) = self.receive_one_message() {
+        while let Some(message) = selector.try_recv_one_message() {
             match message {
                 Message::FromUnknown(message) => self.handle_embedder_message(message),
                 Message::FromNet(message) => self.handle_net_embedder_message(message),
@@ -262,38 +330,6 @@ impl ServoInner {
         }
 
         true
-    }
-
-    #[servo_tracing::instrument(level = "debug", skip_all)]
-    fn receive_one_message(&self) -> Option<Message> {
-        let mut select = crossbeam_channel::Select::new();
-        let embedder_receiver_index = select.recv(&self.embedder_receiver);
-        let net_embedder_receiver_index = select.recv(&self.net_embedder_receiver);
-        let constellation_embedder_receiver_index =
-            select.recv(&self.constellation_embedder_receiver);
-        let Ok(operation) = select.try_select() else {
-            return None;
-        };
-        let index = operation.index();
-        if index == embedder_receiver_index {
-            let Ok(message) = operation.recv(&self.embedder_receiver) else {
-                return None;
-            };
-            Some(Message::FromUnknown(message))
-        } else if index == net_embedder_receiver_index {
-            let Ok(message) = operation.recv(&self.net_embedder_receiver) else {
-                return None;
-            };
-            Some(Message::FromNet(message))
-        } else if index == constellation_embedder_receiver_index {
-            let Ok(message) = operation.recv(&self.constellation_embedder_receiver) else {
-                return None;
-            };
-            Some(Message::FromConstellation(message))
-        } else {
-            log::error!("No select operation registered for {index:?}");
-            None
-        }
     }
 
     fn send_new_frame_ready_messages(&self) {


### PR DESCRIPTION
Instead of building a new `Select` in every iteration of draining the pending messages in spin_event_loop, build the selector once (per spin_event_loop call).
Maybe we can even hoist the Selector out of spin_event_loop, but that is future work. Avoiding rebuilding the Selector for every pending message anyway already gives most of the benefits.
The Select was observable under callgrind.

Notes:

- Instead of saving the indices in the struct, I decided to rely on field ordering in the tuple matching the `.recv()` calls in the constructor. Added a warning and some debug_asserts, so that future readers will be aware.
- slightly compacted the implementation of the receive, by using `.ok()?` instead of `let .. else return None`.

Testing: No behavior change.
Fixes: Part of #44971 and #44971
