### PR TITLE
webgpu: Update wgpu to 29

### DIFF
--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -72,6 +72,18 @@ jobs:
       matrix:
         chunk_id: ${{ fromJSON(needs.runner-select.outputs.selected-runner-indices) }}
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        if: ${{ runner.environment != 'self-hosted' }}
+        with:
+          tool-cache: false
+          large-packages: false
+          swap-storage: false
+      - uses: thejerrybao/setup-swap-space@v1
+        if: ${{ runner.environment != 'self-hosted' }}
+        with:
+          swap-space-path: /swapfile
+          swap-size-gb: 12
       - uses: actions/checkout@v5
         if: github.event_name != 'pull_request_target'
       # This is necessary to checkout the pull request if this run was triggered via a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,7 +815,16 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
+dependencies = [
+ "bit-vec 0.9.1",
 ]
 
 [[package]]
@@ -823,6 +832,12 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 
 [[package]]
 name = "bit_field"
@@ -1364,6 +1379,15 @@ checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
  "serde",
  "termcolor",
+ "unicode-width",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+dependencies = [
  "unicode-width",
 ]
 
@@ -3076,6 +3100,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "gpu-allocator"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
+dependencies = [
+ "ash",
+ "hashbrown 0.16.1",
+ "log",
+ "presser",
+ "thiserror 2.0.18",
+ "windows 0.62.2",
+]
+
+[[package]]
 name = "gpu-descriptor"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3515,7 +3553,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.1.5",
- "serde",
 ]
 
 [[package]]
@@ -3524,7 +3561,11 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -4839,6 +4880,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
 
 [[package]]
+name = "macro_rules_attribute"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5074,11 +5131,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "916cbc7cb27db60be930a4e2da243cf4bc39569195f22fd8ee419cd31d5b662c"
 dependencies = [
  "arrayvec",
- "bit-set",
+ "bit-set 0.8.0",
  "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
- "codespan-reporting",
+ "codespan-reporting 0.12.0",
  "half",
  "hashbrown 0.15.5",
  "hexf-parse",
@@ -5088,7 +5145,33 @@ dependencies = [
  "num-traits",
  "once_cell",
  "rustc-hash 1.1.0",
- "spirv",
+ "spirv 0.3.0+sdk-1.3.268.0",
+ "thiserror 2.0.18",
+ "unicode-ident",
+]
+
+[[package]]
+name = "naga"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd91265cc2454558f659b3b4b9640f0ddb8cc6521277f166b8a8c181c898079"
+dependencies = [
+ "arrayvec",
+ "bit-set 0.9.1",
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "codespan-reporting 0.13.1",
+ "half",
+ "hashbrown 0.16.1",
+ "hexf-parse",
+ "indexmap",
+ "libm",
+ "log",
+ "num-traits",
+ "once_cell",
+ "rustc-hash 1.1.0",
+ "spirv 0.4.0+sdk-1.4.341.0",
  "thiserror 2.0.18",
  "unicode-ident",
 ]
@@ -5676,6 +5759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
  "bitflags 2.11.1",
+ "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-foundation 0.3.2",
 ]
@@ -5703,6 +5787,7 @@ dependencies = [
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
 ]
 
 [[package]]
@@ -6748,6 +6833,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "raw-window-metal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+]
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7723,7 +7820,7 @@ dependencies = [
  "strum",
  "uuid",
  "webrender_api",
- "wgpu-core",
+ "wgpu-core 29.0.3",
 ]
 
 [[package]]
@@ -8680,8 +8777,8 @@ dependencies = [
  "web_atoms",
  "webdriver",
  "webrender_api",
- "wgpu-core",
- "wgpu-types",
+ "wgpu-core 29.0.3",
+ "wgpu-types 29.0.3",
  "x25519-dalek",
  "xml5ever",
  "zeroize",
@@ -8911,8 +9008,8 @@ dependencies = [
  "servo-pixels",
  "servo-webgpu-traits",
  "webrender_api",
- "wgpu-core",
- "wgpu-types",
+ "wgpu-core 29.0.3",
+ "wgpu-types 29.0.3",
 ]
 
 [[package]]
@@ -8926,8 +9023,8 @@ dependencies = [
  "servo-malloc-size-of",
  "servo-pixels",
  "webrender_api",
- "wgpu-core",
- "wgpu-types",
+ "wgpu-core 29.0.3",
+ "wgpu-types 29.0.3",
 ]
 
 [[package]]
@@ -9285,6 +9382,15 @@ name = "spirv"
 version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "spirv"
+version = "0.4.0+sdk-1.4.341.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -10581,7 +10687,7 @@ checksum = "8c381dde4e7d0d7957df0c0e3f8a7cc0976762d3972d97da5c71464e57ffefd3"
 dependencies = [
  "bytemuck",
  "log",
- "naga",
+ "naga 26.0.0",
  "thiserror 2.0.18",
  "vello_encoding",
 ]
@@ -11031,7 +11137,7 @@ dependencies = [
  "hashbrown 0.15.5",
  "js-sys",
  "log",
- "naga",
+ "naga 26.0.0",
  "parking_lot",
  "portable-atomic",
  "profiling",
@@ -11041,9 +11147,9 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "wgpu-core",
- "wgpu-hal",
- "wgpu-types",
+ "wgpu-core 26.0.1",
+ "wgpu-hal 26.0.6",
+ "wgpu-types 26.0.0",
 ]
 
 [[package]]
@@ -11053,29 +11159,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f62f1053bd28c2268f42916f31588f81f64796e2ff91b81293515017ca8bd9"
 dependencies = [
  "arrayvec",
- "bit-set",
- "bit-vec",
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
  "bitflags 2.11.1",
  "cfg_aliases",
  "document-features",
  "hashbrown 0.15.5",
  "indexmap",
  "log",
- "naga",
+ "naga 26.0.0",
  "once_cell",
  "parking_lot",
  "portable-atomic",
  "profiling",
  "raw-window-handle",
  "rustc-hash 1.1.0",
+ "smallvec",
+ "thiserror 2.0.18",
+ "wgpu-core-deps-apple 26.0.0",
+ "wgpu-core-deps-emscripten 26.0.0",
+ "wgpu-core-deps-windows-linux-android 26.0.0",
+ "wgpu-hal 26.0.6",
+ "wgpu-types 26.0.0",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02da3ad1b568337f25513b317870960ef87073ea0945502e44b864b67a8c77b7"
+dependencies = [
+ "arrayvec",
+ "bit-set 0.9.1",
+ "bit-vec 0.9.1",
+ "bitflags 2.11.1",
+ "bytemuck",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "log",
+ "macro_rules_attribute",
+ "naga 29.0.3",
+ "once_cell",
+ "parking_lot",
+ "profiling",
+ "raw-window-handle",
+ "rustc-hash 1.1.0",
  "serde",
  "smallvec",
  "thiserror 2.0.18",
- "wgpu-core-deps-apple",
- "wgpu-core-deps-emscripten",
- "wgpu-core-deps-windows-linux-android",
- "wgpu-hal",
- "wgpu-types",
+ "wgpu-core-deps-apple 29.0.3",
+ "wgpu-core-deps-emscripten 29.0.3",
+ "wgpu-core-deps-windows-linux-android 29.0.3",
+ "wgpu-hal 29.0.3",
+ "wgpu-naga-bridge",
+ "wgpu-types 29.0.3",
 ]
 
 [[package]]
@@ -11084,7 +11223,16 @@ version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18ae5fbde6a4cbebae38358aa73fcd6e0f15c6144b67ef5dc91ded0db125dbdf"
 dependencies = [
- "wgpu-hal",
+ "wgpu-hal 26.0.6",
+]
+
+[[package]]
+name = "wgpu-core-deps-apple"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e51b5447e144b3dbba4feb01f80f4fa21696fa0cd99afb2c3df1affd6fdb28"
+dependencies = [
+ "wgpu-hal 29.0.3",
 ]
 
 [[package]]
@@ -11093,7 +11241,16 @@ version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7670e390f416006f746b4600fdd9136455e3627f5bd763abf9a65daa216dd2d"
 dependencies = [
- "wgpu-hal",
+ "wgpu-hal 26.0.6",
+]
+
+[[package]]
+name = "wgpu-core-deps-emscripten"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3487cd6293a963bc5c0c0396f6a2192043c50003c07f4efdccbad3d90ec9d819"
+dependencies = [
+ "wgpu-hal 29.0.3",
 ]
 
 [[package]]
@@ -11102,7 +11259,16 @@ version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "720a5cb9d12b3d337c15ff0e24d3e97ed11490ff3f7506e7f3d98c68fa5d6f14"
 dependencies = [
- "wgpu-hal",
+ "wgpu-hal 26.0.6",
+]
+
+[[package]]
+name = "wgpu-core-deps-windows-linux-android"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb01076d0aa08b0ba9bd741e178b5cc440f5abe99d9581323a4c8b5d1a1916"
+dependencies = [
+ "wgpu-hal 29.0.3",
 ]
 
 [[package]]
@@ -11114,7 +11280,7 @@ dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
- "bit-set",
+ "bit-set 0.8.0",
  "bitflags 2.11.1",
  "block",
  "bytemuck",
@@ -11124,7 +11290,7 @@ dependencies = [
  "glow 0.16.0",
  "glutin_wgl_sys",
  "gpu-alloc",
- "gpu-allocator",
+ "gpu-allocator 0.27.0",
  "gpu-descriptor",
  "hashbrown 0.15.5",
  "js-sys",
@@ -11133,7 +11299,7 @@ dependencies = [
  "libloading 0.8.9",
  "log",
  "metal",
- "naga",
+ "naga 26.0.0",
  "ndk-sys",
  "objc",
  "ordered-float",
@@ -11148,9 +11314,70 @@ dependencies = [
  "thiserror 2.0.18",
  "wasm-bindgen",
  "web-sys",
- "wgpu-types",
+ "wgpu-types 26.0.0",
  "windows 0.58.0",
  "windows-core 0.58.0",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f8e1a9e7a8512f276f7c62e018c7fa8d60954303fed2e5750114332049193f"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bit-set 0.9.1",
+ "bitflags 2.11.1",
+ "block2 0.6.2",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "glow 0.17.0",
+ "glutin_wgl_sys",
+ "gpu-allocator 0.28.0",
+ "gpu-descriptor",
+ "hashbrown 0.16.1",
+ "js-sys",
+ "khronos-egl",
+ "libc",
+ "libloading 0.8.9",
+ "log",
+ "naga 29.0.3",
+ "ndk-sys",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
+ "objc2-quartz-core 0.3.2",
+ "once_cell",
+ "ordered-float",
+ "parking_lot",
+ "profiling",
+ "range-alloc",
+ "raw-window-handle",
+ "raw-window-metal",
+ "smallvec",
+ "thiserror 2.0.18",
+ "wasm-bindgen",
+ "wayland-sys",
+ "web-sys",
+ "wgpu-naga-bridge",
+ "wgpu-types 29.0.3",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+ "windows-result 0.4.1",
+]
+
+[[package]]
+name = "wgpu-naga-bridge"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59c654c483f058800972c3645e95388a7eca31bf9fe1933bc20e036588a0be02"
+dependencies = [
+ "naga 29.0.3",
+ "wgpu-types 29.0.3",
 ]
 
 [[package]]
@@ -11163,8 +11390,22 @@ dependencies = [
  "bytemuck",
  "js-sys",
  "log",
- "serde",
  "thiserror 2.0.18",
+ "web-sys",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9bcc31518a0e9735aefebedb5f7a9ef3ed1c42549c9f4c882fa9060ceaac639"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytemuck",
+ "js-sys",
+ "log",
+ "raw-window-handle",
+ "serde",
  "web-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -214,8 +214,8 @@ webdriver = { version = "0.53.0", default-features = false }
 webpki-roots = "1.0"
 webrender = { version = "0.68", features = ["capture"] }
 webrender_api = "0.68"
-wgpu-core = "26"
-wgpu-types = "26"
+wgpu-core = "29"
+wgpu-types = "29"
 winapi = "0.3"
 windows-sys = "0.61"
 winit = "0.30.13"

--- a/components/script/dom/webgpu/gpuadapter.rs
+++ b/components/script/dom/webgpu/gpuadapter.rs
@@ -313,6 +313,9 @@ impl RoutedPromiseListener<WebGPUDeviceResponse> for GPUAdapter {
             },
             // 3. user agent otherwise cannot fulfill the request
             (device_id, queue_id, Err(RequestDeviceError::Other(e))) => {
+                // TODO(sagudev): firefox always says operation error,
+                // meanwhile we create "invalid" device that is not invalid in wgpu
+                // causing crashes when one tries to use it
                 // 1. Let device be a new device.
                 let device = GPUDevice::new(
                     &self.global(),

--- a/components/script/dom/webgpu/gpuadapter.rs
+++ b/components/script/dom/webgpu/gpuadapter.rs
@@ -12,7 +12,7 @@ use script_bindings::reflector::{Reflector, reflect_dom_object};
 use webgpu_traits::{
     RequestDeviceError, WebGPU, WebGPUAdapter, WebGPUDeviceResponse, WebGPURequest,
 };
-use wgpu_types::{self, AdapterInfo, MemoryHints};
+use wgpu_types::{self, AdapterInfo, ExperimentalFeatures, MemoryHints};
 
 use super::gpusupportedfeatures::GPUSupportedFeatures;
 use super::gpusupportedlimits::set_limit;
@@ -101,7 +101,7 @@ impl GPUAdapter {
     ) -> DomRoot<Self> {
         let features = GPUSupportedFeatures::Constructor(global, None, features, can_gc).unwrap();
         let limits = GPUSupportedLimits::new(global, limits, can_gc);
-        let info = GPUAdapter::create_adapter_info(global, info, &features, &limits, can_gc);
+        let info = GPUAdapter::create_adapter_info(global, info, &features, can_gc);
         let dom_root = reflect_dom_object(
             Box::new(GPUAdapter::new_inherited(
                 channel, name, &features, &limits, &info, adapter,
@@ -118,7 +118,6 @@ impl GPUAdapter {
         global: &GlobalScope,
         info: AdapterInfo,
         features: &GPUSupportedFeatures,
-        limits: &GPUSupportedLimits,
         can_gc: CanGc,
     ) -> DomRoot<GPUAdapterInfo> {
         // Step 2. If the vendor is known, set adapterInfo.vendor to the name of adapter’s vendor as
@@ -161,10 +160,7 @@ impl GPUAdapter {
         // Step 7. If "subgroups" is supported, set subgroupMaxSize to the largest supported
         // subgroup size. Otherwise, set this value to 128.
         let (subgroup_min_size, subgroup_max_size) = if features.has("subgroups".into()) {
-            (
-                limits.wgpu_limits().min_subgroup_size,
-                limits.wgpu_limits().max_subgroup_size,
-            )
+            (info.subgroup_min_size, info.subgroup_max_size)
         } else {
             (4, 128)
         };
@@ -232,6 +228,7 @@ impl GPUAdapterMethods<crate::DomTypeHolder> for GPUAdapter {
             label: Some(descriptor.parent.label.to_string()),
             memory_hints: MemoryHints::MemoryUsage,
             trace: wgpu_types::Trace::Off,
+            experimental_features: ExperimentalFeatures::disabled(),
         };
         let device_id = self.global().wgpu_id_hub().create_device_id();
         let queue_id = self.global().wgpu_id_hub().create_queue_id();

--- a/components/script/dom/webgpu/gpucanvascontext.rs
+++ b/components/script/dom/webgpu/gpucanvascontext.rs
@@ -258,6 +258,7 @@ impl GPUCanvasContext {
         self.current_texture.get().map(|texture| PendingTexture {
             texture_id: texture.id().0,
             encoder_id: self.global().wgpu_id_hub().create_command_encoder_id(),
+            command_buffer_id: self.global().wgpu_id_hub().create_command_buffer_id(),
             configuration: self
                 .context_configuration()
                 .expect("Context should be configured if there is a texture."),

--- a/components/script/dom/webgpu/gpucommandbuffer.rs
+++ b/components/script/dom/webgpu/gpucommandbuffer.rs
@@ -12,6 +12,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
 use crate::script_runtime::CanGc;
+
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPUCommandBuffer {
     #[no_trace]

--- a/components/script/dom/webgpu/gpucommandencoder.rs
+++ b/components/script/dom/webgpu/gpucommandencoder.rs
@@ -10,7 +10,6 @@ use webgpu_traits::{
     WebGPURenderPass, WebGPURequest,
 };
 use wgpu_core::command as wgpu_com;
-use wgpu_core::id::Id;
 
 use crate::conversions::{Convert, TryConvert};
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
@@ -31,15 +30,32 @@ use crate::dom::webgpu::gpudevice::GPUDevice;
 use crate::dom::webgpu::gpurenderpassencoder::GPURenderPassEncoder;
 use crate::script_runtime::CanGc;
 
+#[derive(JSTraceable, MallocSizeOf)]
+struct DroppableGPUCommandEncoder {
+    #[no_trace]
+    channel: WebGPU,
+    #[no_trace]
+    encoder: WebGPUCommandEncoder,
+}
+
 #[dom_struct]
 pub(crate) struct GPUCommandEncoder {
     reflector_: Reflector,
-    #[no_trace]
-    channel: WebGPU,
+    droppable: DroppableGPUCommandEncoder,
     label: DomRefCell<USVString>,
-    #[no_trace]
-    encoder: WebGPUCommandEncoder,
     device: Dom<GPUDevice>,
+}
+
+impl Drop for DroppableGPUCommandEncoder {
+    fn drop(&mut self) {
+        if let Err(e) = self
+            .channel
+            .0
+            .send(WebGPURequest::DropCommandEncoder(self.encoder.0))
+        {
+            warn!("Failed to send WebGPURequest::DropCommandEncoder with {e:?}");
+        }
+    }
 }
 
 impl GPUCommandEncoder {
@@ -50,11 +66,10 @@ impl GPUCommandEncoder {
         label: USVString,
     ) -> Self {
         Self {
-            channel,
+            droppable: DroppableGPUCommandEncoder { channel, encoder },
             reflector_: Reflector::new(),
             label: DomRefCell::new(label),
             device: Dom::from_ref(device),
-            encoder,
         }
     }
 
@@ -78,7 +93,7 @@ impl GPUCommandEncoder {
 
 impl GPUCommandEncoder {
     pub(crate) fn id(&self) -> WebGPUCommandEncoder {
-        self.encoder
+        self.droppable.encoder
     }
 
     pub(crate) fn device_id(&self) -> WebGPUDevice {
@@ -135,18 +150,23 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
     ) -> DomRoot<GPUComputePassEncoder> {
         let compute_pass_id = self.global().wgpu_id_hub().create_compute_pass_id();
 
-        if let Err(e) = self.channel.0.send(WebGPURequest::BeginComputePass {
-            command_encoder_id: self.id().0,
-            compute_pass_id,
-            label: (&descriptor.parent).convert(),
-            device_id: self.device.id().0,
-        }) {
+        if let Err(e) = self
+            .droppable
+            .channel
+            .0
+            .send(WebGPURequest::BeginComputePass {
+                command_encoder_id: self.id().0,
+                compute_pass_id,
+                label: (&descriptor.parent).convert(),
+                device_id: self.device.id().0,
+            })
+        {
             warn!("Failed to send WebGPURequest::BeginComputePass {e:?}");
         }
 
         GPUComputePassEncoder::new(
             &self.global(),
-            self.channel.clone(),
+            self.droppable.channel.clone(),
             self,
             WebGPUComputePass(compute_pass_id),
             descriptor.parent.label.clone(),
@@ -204,20 +224,25 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
             .collect::<Fallible<Vec<_>>>()?;
         let render_pass_id = self.global().wgpu_id_hub().create_render_pass_id();
 
-        if let Err(e) = self.channel.0.send(WebGPURequest::BeginRenderPass {
-            command_encoder_id: self.id().0,
-            render_pass_id,
-            label: (&descriptor.parent).convert(),
-            depth_stencil_attachment,
-            color_attachments,
-            device_id: self.device.id().0,
-        }) {
+        if let Err(e) = self
+            .droppable
+            .channel
+            .0
+            .send(WebGPURequest::BeginRenderPass {
+                command_encoder_id: self.id().0,
+                render_pass_id,
+                label: (&descriptor.parent).convert(),
+                depth_stencil_attachment,
+                color_attachments,
+                device_id: self.device.id().0,
+            })
+        {
             warn!("Failed to send WebGPURequest::BeginRenderPass {e:?}");
         }
 
         Ok(GPURenderPassEncoder::new(
             &self.global(),
-            self.channel.clone(),
+            self.droppable.channel.clone(),
             WebGPURenderPass(render_pass_id),
             self,
             descriptor.parent.label.clone(),
@@ -234,15 +259,17 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
         destination_offset: GPUSize64,
         size: GPUSize64,
     ) {
-        self.channel
+        self.droppable
+            .channel
             .0
             .send(WebGPURequest::CopyBufferToBuffer {
-                command_encoder_id: self.encoder.0,
+                command_encoder_id: self.droppable.encoder.0,
                 source_id: source.id().0,
                 source_offset,
                 destination_id: destination.id().0,
                 destination_offset,
                 size,
+                device_id: self.device.id().0,
             })
             .expect("Failed to send CopyBufferToBuffer");
     }
@@ -254,13 +281,15 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
         destination: &GPUImageCopyTexture,
         copy_size: GPUExtent3D,
     ) -> Fallible<()> {
-        self.channel
+        self.droppable
+            .channel
             .0
             .send(WebGPURequest::CopyBufferToTexture {
-                command_encoder_id: self.encoder.0,
+                command_encoder_id: self.droppable.encoder.0,
                 source: source.convert(),
                 destination: destination.try_convert()?,
                 copy_size: (&copy_size).try_convert()?,
+                device_id: self.device.id().0,
             })
             .expect("Failed to send CopyBufferToTexture");
 
@@ -274,13 +303,15 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
         destination: &GPUImageCopyBuffer,
         copy_size: GPUExtent3D,
     ) -> Fallible<()> {
-        self.channel
+        self.droppable
+            .channel
             .0
             .send(WebGPURequest::CopyTextureToBuffer {
-                command_encoder_id: self.encoder.0,
+                command_encoder_id: self.droppable.encoder.0,
                 source: source.try_convert()?,
                 destination: destination.convert(),
                 copy_size: (&copy_size).try_convert()?,
+                device_id: self.device.id().0,
             })
             .expect("Failed to send CopyTextureToBuffer");
 
@@ -294,13 +325,15 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
         destination: &GPUImageCopyTexture,
         copy_size: GPUExtent3D,
     ) -> Fallible<()> {
-        self.channel
+        self.droppable
+            .channel
             .0
             .send(WebGPURequest::CopyTextureToTexture {
-                command_encoder_id: self.encoder.0,
+                command_encoder_id: self.droppable.encoder.0,
                 source: source.try_convert()?,
                 destination: destination.try_convert()?,
                 copy_size: (&copy_size).try_convert()?,
+                device_id: self.device.id().0,
             })
             .expect("Failed to send CopyTextureToTexture");
 
@@ -309,22 +342,24 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-finish>
     fn Finish(&self, descriptor: &GPUCommandBufferDescriptor) -> DomRoot<GPUCommandBuffer> {
-        self.channel
+        let command_buffer_id = self.global().wgpu_id_hub().create_command_buffer_id();
+        self.droppable
+            .channel
             .0
             .send(WebGPURequest::CommandEncoderFinish {
-                command_encoder_id: self.encoder.0,
+                command_encoder_id: self.droppable.encoder.0,
                 device_id: self.device.id().0,
                 desc: wgpu_types::CommandBufferDescriptor {
                     label: (&descriptor.parent).convert(),
                 },
+                command_buffer_id,
             })
             .expect("Failed to send Finish");
 
-        #[expect(unsafe_code)]
-        let buffer = WebGPUCommandBuffer(unsafe { Id::from_raw(self.encoder.0.into_raw()) });
+        let buffer = WebGPUCommandBuffer(command_buffer_id);
         GPUCommandBuffer::new(
             &self.global(),
-            self.channel.clone(),
+            self.droppable.channel.clone(),
             buffer,
             descriptor.parent.label.clone(),
             CanGc::deprecated_note(),

--- a/components/script/dom/webgpu/gpucommandencoder.rs
+++ b/components/script/dom/webgpu/gpucommandencoder.rs
@@ -10,6 +10,7 @@ use webgpu_traits::{
     WebGPURenderPass, WebGPURequest,
 };
 use wgpu_core::command as wgpu_com;
+use wgpu_core::id::Id;
 
 use crate::conversions::{Convert, TryConvert};
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
@@ -319,7 +320,8 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
             })
             .expect("Failed to send Finish");
 
-        let buffer = WebGPUCommandBuffer(self.encoder.0.into_command_buffer_id());
+        #[expect(unsafe_code)]
+        let buffer = WebGPUCommandBuffer(unsafe { Id::from_raw(self.encoder.0.into_raw()) });
         GPUCommandBuffer::new(
             &self.global(),
             self.channel.clone(),

--- a/components/script/dom/webgpu/gpucomputepassencoder.rs
+++ b/components/script/dom/webgpu/gpucomputepassencoder.rs
@@ -139,7 +139,6 @@ impl GPUComputePassEncoderMethods<crate::DomTypeHolder> for GPUComputePassEncode
             .send(WebGPURequest::EndComputePass {
                 compute_pass_id: self.droppable.compute_pass.0,
                 device_id: self.command_encoder.device_id().0,
-                command_encoder_id: self.command_encoder.id().0,
             })
         {
             warn!("Failed to send WebGPURequest::EndComputePass: {e:?}");

--- a/components/script/dom/webgpu/gpucomputepipeline.rs
+++ b/components/script/dom/webgpu/gpucomputepipeline.rs
@@ -121,7 +121,6 @@ impl GPUComputePipeline {
                 device_id: device.id().0,
                 compute_pipeline_id,
                 descriptor: desc,
-                implicit_ids: pipeline_layout.implicit(),
                 async_sender,
             })
             .expect("Failed to create WebGPU ComputePipeline");

--- a/components/script/dom/webgpu/gpuconvert.rs
+++ b/components/script/dom/webgpu/gpuconvert.rs
@@ -348,6 +348,16 @@ impl Convert<wgpu_types::FilterMode> for GPUFilterMode {
     }
 }
 
+// TODO(sagudev): this will become GPUMipmapFilterMode once the webidl is updated
+impl Convert<wgpu_types::MipmapFilterMode> for GPUFilterMode {
+    fn convert(self) -> wgpu_types::MipmapFilterMode {
+        match self {
+            GPUFilterMode::Nearest => wgpu_types::MipmapFilterMode::Nearest,
+            GPUFilterMode::Linear => wgpu_types::MipmapFilterMode::Linear,
+        }
+    }
+}
+
 impl Convert<wgpu_types::TextureViewDimension> for GPUTextureViewDimension {
     fn convert(self) -> wgpu_types::TextureViewDimension {
         match self {
@@ -668,7 +678,7 @@ impl<'a> Convert<BindGroupEntry<'a>> for &GPUBindGroupEntry {
                     BindingResource::Buffer(BufferBinding {
                         buffer: b.buffer.id().0,
                         offset: b.offset,
-                        size: b.size.and_then(wgpu_types::BufferSize::new),
+                        size: b.size,
                     })
                 },
             },

--- a/components/script/dom/webgpu/gpudevice.rs
+++ b/components/script/dom/webgpu/gpudevice.rs
@@ -16,7 +16,7 @@ use webgpu_traits::{
     WebGPUPoppedErrorScopeResponse, WebGPUQueue, WebGPURenderPipeline,
     WebGPURenderPipelineResponse, WebGPURequest,
 };
-use wgpu_core::id::{BindGroupLayoutId, PipelineLayoutId};
+use wgpu_core::id::PipelineLayoutId;
 use wgpu_core::pipeline as wgpu_pipe;
 use wgpu_core::pipeline::RenderPipelineDescriptor;
 use wgpu_types::{self, TextureFormat};
@@ -32,8 +32,8 @@ use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUCommandEncoderDescriptor, GPUComputePipelineDescriptor, GPUDeviceLostReason,
     GPUDeviceMethods, GPUErrorFilter, GPUPipelineErrorReason, GPUPipelineLayoutDescriptor,
     GPURenderBundleEncoderDescriptor, GPURenderPipelineDescriptor, GPUSamplerDescriptor,
-    GPUShaderModuleDescriptor, GPUSupportedLimitsMethods, GPUTextureDescriptor, GPUTextureFormat,
-    GPUUncapturedErrorEventInit, GPUVertexStepMode,
+    GPUShaderModuleDescriptor, GPUTextureDescriptor, GPUTextureFormat, GPUUncapturedErrorEventInit,
+    GPUVertexStepMode,
 };
 use crate::dom::bindings::codegen::UnionTypes::GPUPipelineLayoutOrGPUAutoLayoutMode;
 use crate::dom::bindings::error::{Error, Fallible};
@@ -107,7 +107,7 @@ pub(crate) struct GPUDevice {
 }
 
 pub(crate) enum PipelineLayout {
-    Implicit(PipelineLayoutId, Vec<BindGroupLayoutId>),
+    Implicit,
     Explicit(PipelineLayoutId),
 }
 
@@ -115,16 +115,7 @@ impl PipelineLayout {
     pub(crate) fn explicit(&self) -> Option<PipelineLayoutId> {
         match self {
             PipelineLayout::Explicit(layout_id) => Some(*layout_id),
-            _ => None,
-        }
-    }
-
-    pub(crate) fn implicit(self) -> Option<(PipelineLayoutId, Vec<BindGroupLayoutId>)> {
-        match self {
-            PipelineLayout::Implicit(layout_id, bind_group_layout_ids) => {
-                Some((layout_id, bind_group_layout_ids))
-            },
-            _ => None,
+            PipelineLayout::Implicit => None,
         }
     }
 }
@@ -277,23 +268,15 @@ impl GPUDevice {
         if let GPUPipelineLayoutOrGPUAutoLayoutMode::GPUPipelineLayout(layout) = layout {
             PipelineLayout::Explicit(layout.id().0)
         } else {
-            let layout_id = self.global().wgpu_id_hub().create_pipeline_layout_id();
-            let max_bind_grps = self.limits.MaxBindGroups();
-            let mut bgl_ids = Vec::with_capacity(max_bind_grps as usize);
-            for _ in 0..max_bind_grps {
-                let bgl = self.global().wgpu_id_hub().create_bind_group_layout_id();
-                bgl_ids.push(bgl);
-            }
-            PipelineLayout::Implicit(layout_id, bgl_ids)
+            PipelineLayout::Implicit
         }
     }
 
     pub(crate) fn parse_render_pipeline<'a>(
         &self,
         descriptor: &GPURenderPipelineDescriptor,
-    ) -> Fallible<(PipelineLayout, RenderPipelineDescriptor<'a>)> {
+    ) -> Fallible<RenderPipelineDescriptor<'a>> {
         let pipeline_layout = self.get_pipeline_layout_data(&descriptor.parent.layout);
-
         let desc = wgpu_pipe::RenderPipelineDescriptor {
             label: (&descriptor.parent.parent).convert(),
             layout: pipeline_layout.explicit(),
@@ -367,8 +350,9 @@ impl GPUDevice {
                     self.validate_texture_format_required_features(&dss_desc.format)
                         .map(|format| wgpu_types::DepthStencilState {
                             format,
-                            depth_write_enabled: dss_desc.depthWriteEnabled,
-                            depth_compare: dss_desc.depthCompare.convert(),
+                            // TODO(sagudev): these need webidl sync
+                            depth_write_enabled: Some(dss_desc.depthWriteEnabled),
+                            depth_compare: Some(dss_desc.depthCompare.convert()),
                             stencil: wgpu_types::StencilState {
                                 front: wgpu_types::StencilFaceState {
                                     compare: dss_desc.stencilFront.compare.convert(),
@@ -399,9 +383,9 @@ impl GPUDevice {
                 mask: descriptor.multisample.mask as u64,
                 alpha_to_coverage_enabled: descriptor.multisample.alphaToCoverageEnabled,
             },
-            multiview: None,
+            multiview_mask: None,
         };
-        Ok((pipeline_layout, desc))
+        Ok(desc)
     }
 
     /// <https://gpuweb.github.io/gpuweb/#lose-the-device>
@@ -549,8 +533,8 @@ impl GPUDeviceMethods<crate::DomTypeHolder> for GPUDevice {
         &self,
         descriptor: &GPURenderPipelineDescriptor,
     ) -> Fallible<DomRoot<GPURenderPipeline>> {
-        let (pipeline_layout, desc) = self.parse_render_pipeline(descriptor)?;
-        let render_pipeline = GPURenderPipeline::create(self, pipeline_layout, desc, None)?;
+        let desc = self.parse_render_pipeline(descriptor)?;
+        let render_pipeline = GPURenderPipeline::create(self, desc, None)?;
         Ok(GPURenderPipeline::new(
             &self.global(),
             render_pipeline,
@@ -567,14 +551,14 @@ impl GPUDeviceMethods<crate::DomTypeHolder> for GPUDevice {
         comp: InRealm,
         can_gc: CanGc,
     ) -> Fallible<Rc<Promise>> {
-        let (implicit_ids, desc) = self.parse_render_pipeline(descriptor)?;
+        let desc = self.parse_render_pipeline(descriptor)?;
         let promise = Promise::new_in_current_realm(comp, can_gc);
         let callback = callback_promise(
             &promise,
             self,
             self.global().task_manager().dom_manipulation_task_source(),
         );
-        GPURenderPipeline::create(self, implicit_ids, desc, Some(callback))?;
+        GPURenderPipeline::create(self, desc, Some(callback))?;
         Ok(promise)
     }
 

--- a/components/script/dom/webgpu/gpupipelinelayout.rs
+++ b/components/script/dom/webgpu/gpupipelinelayout.rs
@@ -115,8 +115,9 @@ impl GPUPipelineLayout {
 
         let desc = PipelineLayoutDescriptor {
             label: (&descriptor.parent).convert(),
-            bind_group_layouts: Cow::Owned(bgls.iter().map(|l| l.0).collect::<Vec<_>>()),
-            push_constant_ranges: Cow::Owned(vec![]),
+            // TODO(sagudev): this needs webidl sync
+            bind_group_layouts: Cow::Owned(bgls.iter().map(|l| Some(l.0)).collect::<Vec<_>>()),
+            immediate_size: 0,
         };
 
         let pipeline_layout_id = device.global().wgpu_id_hub().create_pipeline_layout_id();

--- a/components/script/dom/webgpu/gpurenderbundleencoder.rs
+++ b/components/script/dom/webgpu/gpurenderbundleencoder.rs
@@ -117,7 +117,7 @@ impl GPURenderBundleEncoder {
         };
 
         // Handle error gracefully
-        let render_bundle_encoder = RenderBundleEncoder::new(&desc, device.id().0, None).unwrap();
+        let render_bundle_encoder = RenderBundleEncoder::new(&desc, device.id().0).unwrap();
 
         Ok(GPURenderBundleEncoder::new(
             &device.global(),

--- a/components/script/dom/webgpu/gpurenderpassencoder.rs
+++ b/components/script/dom/webgpu/gpurenderpassencoder.rs
@@ -176,7 +176,6 @@ impl GPURenderPassEncoderMethods<crate::DomTypeHolder> for GPURenderPassEncoder 
         if let Err(e) = self.droppable.channel.0.send(WebGPURequest::EndRenderPass {
             render_pass_id: self.id().0,
             device_id: self.command_encoder.device_id().0,
-            command_encoder_id: self.command_encoder.id().0,
         }) {
             warn!("Failed to send WebGPURequest::EndRenderPass: {e:?}");
         }

--- a/components/script/dom/webgpu/gpurenderpipeline.rs
+++ b/components/script/dom/webgpu/gpurenderpipeline.rs
@@ -19,7 +19,7 @@ use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::webgpu::gpubindgrouplayout::GPUBindGroupLayout;
-use crate::dom::webgpu::gpudevice::{GPUDevice, PipelineLayout};
+use crate::dom::webgpu::gpudevice::GPUDevice;
 use crate::script_runtime::CanGc;
 
 #[derive(JSTraceable, MallocSizeOf)]
@@ -97,7 +97,6 @@ impl GPURenderPipeline {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createrenderpipeline>
     pub(crate) fn create(
         device: &GPUDevice,
-        pipeline_layout: PipelineLayout,
         descriptor: RenderPipelineDescriptor<'static>,
         async_sender: Option<GenericCallback<WebGPURenderPipelineResponse>>,
     ) -> Fallible<WebGPURenderPipeline> {
@@ -110,7 +109,6 @@ impl GPURenderPipeline {
                 device_id: device.id().0,
                 render_pipeline_id,
                 descriptor,
-                implicit_ids: pipeline_layout.implicit(),
                 async_sender,
             })
             .expect("Failed to create WebGPU render pipeline");

--- a/components/script/dom/webgpu/gpusupportedlimits.rs
+++ b/components/script/dom/webgpu/gpusupportedlimits.rs
@@ -34,12 +34,6 @@ impl GPUSupportedLimits {
     }
 }
 
-impl GPUSupportedLimits {
-    pub(crate) fn wgpu_limits(&self) -> &Limits {
-        &self.limits
-    }
-}
-
 impl GPUSupportedLimitsMethods<crate::DomTypeHolder> for GPUSupportedLimits {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxtexturedimension1d>
     fn MaxTextureDimension1D(&self) -> u32 {
@@ -108,12 +102,12 @@ impl GPUSupportedLimitsMethods<crate::DomTypeHolder> for GPUSupportedLimits {
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxuniformbufferbindingsize>
     fn MaxUniformBufferBindingSize(&self) -> u64 {
-        self.limits.max_uniform_buffer_binding_size as u64
+        self.limits.max_uniform_buffer_binding_size
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxstoragebufferbindingsize>
     fn MaxStorageBufferBindingSize(&self) -> u64 {
-        self.limits.max_storage_buffer_binding_size as u64
+        self.limits.max_storage_buffer_binding_size
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-minuniformbufferoffsetalignment>
@@ -148,7 +142,7 @@ impl GPUSupportedLimitsMethods<crate::DomTypeHolder> for GPUSupportedLimits {
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxinterstageshadercomponents>
     fn MaxInterStageShaderComponents(&self) -> u32 {
-        self.limits.max_inter_stage_shader_components
+        self.limits.max_inter_stage_shader_variables
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxcomputeworkgroupstoragesize>
@@ -294,7 +288,7 @@ pub(crate) fn set_limit(limits: &mut Limits, limit: &str, value: u64) -> bool {
             set_maximum(&mut limits.max_vertex_buffer_array_stride, value)
         },
         "maxInterStageShaderComponents" => {
-            set_maximum(&mut limits.max_inter_stage_shader_components, value)
+            set_maximum(&mut limits.max_inter_stage_shader_variables, value)
         },
         "maxInterStageShaderVariables" => {
             // not in wgpu but we're allowed to give back better limits than requested.

--- a/components/script/dom/webgpu/identityhub.rs
+++ b/components/script/dom/webgpu/identityhub.rs
@@ -4,14 +4,14 @@
 
 use webgpu_traits::{ComputePass, ComputePassId, RenderPass, RenderPassId};
 use wgpu_core::id::markers::{
-    Adapter, BindGroup, BindGroupLayout, Buffer, CommandEncoder, ComputePipeline, Device,
-    PipelineLayout, Queue, RenderBundle, RenderPipeline, Sampler, ShaderModule, Texture,
+    Adapter, BindGroup, BindGroupLayout, Buffer, CommandBuffer, CommandEncoder, ComputePipeline,
+    Device, PipelineLayout, Queue, RenderBundle, RenderPipeline, Sampler, ShaderModule, Texture,
     TextureView,
 };
 use wgpu_core::id::{
-    AdapterId, BindGroupId, BindGroupLayoutId, BufferId, CommandEncoderId, ComputePipelineId,
-    DeviceId, PipelineLayoutId, QueueId, RenderBundleId, RenderPipelineId, SamplerId,
-    ShaderModuleId, TextureId, TextureViewId,
+    AdapterId, BindGroupId, BindGroupLayoutId, BufferId, CommandBufferId, CommandEncoderId,
+    ComputePipelineId, DeviceId, PipelineLayoutId, QueueId, RenderBundleId, RenderPipelineId,
+    SamplerId, ShaderModuleId, TextureId, TextureViewId,
 };
 use wgpu_core::identity::IdentityManager;
 
@@ -27,6 +27,7 @@ pub(crate) struct IdentityHub {
     pipeline_layouts: IdentityManager<PipelineLayout>,
     shader_modules: IdentityManager<ShaderModule>,
     command_encoders: IdentityManager<CommandEncoder>,
+    command_buffers: IdentityManager<CommandBuffer>,
     textures: IdentityManager<Texture>,
     texture_views: IdentityManager<TextureView>,
     samplers: IdentityManager<Sampler>,
@@ -49,6 +50,7 @@ impl Default for IdentityHub {
             pipeline_layouts: IdentityManager::new(),
             shader_modules: IdentityManager::new(),
             command_encoders: IdentityManager::new(),
+            command_buffers: IdentityManager::new(),
             textures: IdentityManager::new(),
             texture_views: IdentityManager::new(),
             samplers: IdentityManager::new(),
@@ -137,8 +139,16 @@ impl IdentityHub {
         self.command_encoders.process()
     }
 
-    pub(crate) fn free_command_buffer_id(&self, id: CommandEncoderId) {
+    pub(crate) fn free_command_encoder_id(&self, id: CommandEncoderId) {
         self.command_encoders.free(id);
+    }
+
+    pub(crate) fn create_command_buffer_id(&self) -> CommandBufferId {
+        self.command_buffers.process()
+    }
+
+    pub(crate) fn free_command_buffer_id(&self, id: CommandBufferId) {
+        self.command_buffers.free(id);
     }
 
     pub(crate) fn create_sampler_id(&self) -> SamplerId {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2062,7 +2062,7 @@ impl ScriptThread {
             WebGPUMsg::FreeBindGroupLayout(id) => self.gpu_id_hub.free_bind_group_layout_id(id),
             WebGPUMsg::FreeCommandBuffer(id) => self
                 .gpu_id_hub
-                .free_command_buffer_id(id.into_command_encoder_id()),
+                .free_command_buffer_id(unsafe { wgpu_core::id::Id::from_raw(id.into_raw()) }),
             WebGPUMsg::FreeSampler(id) => self.gpu_id_hub.free_sampler_id(id),
             WebGPUMsg::FreeShaderModule(id) => self.gpu_id_hub.free_shader_module_id(id),
             WebGPUMsg::FreeRenderBundle(id) => self.gpu_id_hub.free_render_bundle_id(id),

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2060,9 +2060,7 @@ impl ScriptThread {
             WebGPUMsg::FreeComputePipeline(id) => self.gpu_id_hub.free_compute_pipeline_id(id),
             WebGPUMsg::FreeBindGroup(id) => self.gpu_id_hub.free_bind_group_id(id),
             WebGPUMsg::FreeBindGroupLayout(id) => self.gpu_id_hub.free_bind_group_layout_id(id),
-            WebGPUMsg::FreeCommandBuffer(id) => self
-                .gpu_id_hub
-                .free_command_buffer_id(unsafe { wgpu_core::id::Id::from_raw(id.into_raw()) }),
+            WebGPUMsg::FreeCommandBuffer(id) => self.gpu_id_hub.free_command_buffer_id(id),
             WebGPUMsg::FreeSampler(id) => self.gpu_id_hub.free_sampler_id(id),
             WebGPUMsg::FreeShaderModule(id) => self.gpu_id_hub.free_shader_module_id(id),
             WebGPUMsg::FreeRenderBundle(id) => self.gpu_id_hub.free_render_bundle_id(id),

--- a/components/shared/webgpu/error.rs
+++ b/components/shared/webgpu/error.rs
@@ -7,7 +7,7 @@
 use std::fmt;
 
 use serde::{Deserialize, Serialize};
-use wgpu_core::device::DeviceError;
+use wgpu_types::error::{ErrorType, WebGpuError};
 
 /// <https://www.w3.org/TR/webgpu/#gpu-error-scope>
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -70,23 +70,16 @@ impl Error {
         }
     }
 
-    // TODO: labels
-    // based on https://github.com/gfx-rs/wgpu/blob/trunk/wgpu/src/backend/wgpu_core.rs#L289
-    pub fn from_error<E: std::error::Error + 'static>(error: E) -> Self {
-        let mut source_opt: Option<&(dyn std::error::Error + 'static)> = Some(&error);
-        while let Some(source) = source_opt {
-            if let Some(DeviceError::OutOfMemory) = source.downcast_ref::<DeviceError>() {
-                return Self::OutOfMemory(error.to_string());
-            }
-            source_opt = source.source();
+    /// Converts a wgpu's errors into a (GPU)Error if possible.
+    /// Returns `None` if device is lost,
+    /// as those need to be ignored in validation as they are handled by device lost callback
+    pub fn from_wgpu_error<E: WebGpuError>(error: E) -> Option<Self> {
+        match error.webgpu_error_type() {
+            ErrorType::Validation => Some(Self::Validation(error.to_string())),
+            ErrorType::OutOfMemory => Some(Self::OutOfMemory(error.to_string())),
+            ErrorType::Internal => Some(Self::Internal(error.to_string())),
+            ErrorType::DeviceLost => None,
         }
-        // TODO: This hack is needed because there are
-        // multiple OutOfMemory error variant in wgpu-core
-        // and even upstream does not handle them correctly
-        if format!("{error:?}").contains("OutOfMemory") {
-            return Self::OutOfMemory(error.to_string());
-        }
-        Self::Validation(error.to_string())
     }
 }
 

--- a/components/shared/webgpu/messages/recv.rs
+++ b/components/shared/webgpu/messages/recv.rs
@@ -59,6 +59,7 @@ use crate::{
 pub struct PendingTexture {
     pub texture_id: TextureId,
     pub encoder_id: CommandEncoderId,
+    pub command_buffer_id: CommandBufferId,
     pub configuration: ContextConfiguration,
 }
 
@@ -80,8 +81,10 @@ pub enum WebGPURequest {
         command_encoder_id: CommandEncoderId,
         device_id: DeviceId,
         desc: CommandBufferDescriptor<Label<'static>>,
+        command_buffer_id: CommandBufferId,
     },
     CopyBufferToBuffer {
+        device_id: DeviceId,
         command_encoder_id: CommandEncoderId,
         source_id: BufferId,
         source_offset: BufferAddress,
@@ -90,18 +93,21 @@ pub enum WebGPURequest {
         size: BufferAddress,
     },
     CopyBufferToTexture {
+        device_id: DeviceId,
         command_encoder_id: CommandEncoderId,
         source: TexelCopyBufferInfo,
         destination: TexelCopyTextureInfo,
         copy_size: Extent3d,
     },
     CopyTextureToBuffer {
+        device_id: DeviceId,
         command_encoder_id: CommandEncoderId,
         source: TexelCopyTextureInfo,
         destination: TexelCopyBufferInfo,
         copy_size: Extent3d,
     },
     CopyTextureToTexture {
+        device_id: DeviceId,
         command_encoder_id: CommandEncoderId,
         source: TexelCopyTextureInfo,
         destination: TexelCopyTextureInfo,
@@ -209,6 +215,7 @@ pub enum WebGPURequest {
     DropRenderPipeline(RenderPipelineId),
     DropBindGroup(BindGroupId),
     DropBindGroupLayout(BindGroupLayoutId),
+    DropCommandEncoder(CommandEncoderId),
     DropCommandBuffer(CommandBufferId),
     DropTextureView(TextureViewId),
     DropSampler(SamplerId),
@@ -272,7 +279,6 @@ pub enum WebGPURequest {
     EndComputePass {
         compute_pass_id: ComputePassId,
         device_id: DeviceId,
-        command_encoder_id: CommandEncoderId,
     },
     // Render Pass
     BeginRenderPass {
@@ -291,7 +297,6 @@ pub enum WebGPURequest {
     EndRenderPass {
         render_pass_id: RenderPassId,
         device_id: DeviceId,
-        command_encoder_id: CommandEncoderId,
     },
     Submit {
         device_id: DeviceId,

--- a/components/shared/webgpu/messages/recv.rs
+++ b/components/shared/webgpu/messages/recv.rs
@@ -131,7 +131,6 @@ pub enum WebGPURequest {
         device_id: DeviceId,
         compute_pipeline_id: ComputePipelineId,
         descriptor: ComputePipelineDescriptor<'static>,
-        implicit_ids: Option<(PipelineLayoutId, Vec<BindGroupLayoutId>)>,
         /// present only on ASYNC versions
         async_sender: Option<GenericCallback<WebGPUComputePipelineResponse>>,
     },
@@ -144,7 +143,6 @@ pub enum WebGPURequest {
         device_id: DeviceId,
         render_pipeline_id: RenderPipelineId,
         descriptor: RenderPipelineDescriptor<'static>,
-        implicit_ids: Option<(PipelineLayoutId, Vec<BindGroupLayoutId>)>,
         /// present only on ASYNC versions
         async_sender: Option<GenericCallback<WebGPURenderPipelineResponse>>,
     },
@@ -282,7 +280,7 @@ pub enum WebGPURequest {
         render_pass_id: RenderPassId,
         label: Label<'static>,
         color_attachments: Vec<Option<RenderPassColorAttachment>>,
-        depth_stencil_attachment: Option<RenderPassDepthStencilAttachment>,
+        depth_stencil_attachment: Option<RenderPassDepthStencilAttachment<TextureViewId>>,
         device_id: DeviceId,
     },
     RenderPassCommand {

--- a/components/shared/webgpu/messages/to_script.rs
+++ b/components/shared/webgpu/messages/to_script.rs
@@ -7,10 +7,10 @@
 use serde::{Deserialize, Serialize};
 use servo_base::id::PipelineId;
 use wgpu_core::id::{
-    AdapterId, BindGroupId, BindGroupLayoutId, BufferId, CommandBufferId, ComputePassEncoderId,
-    ComputePipelineId, DeviceId, PipelineLayoutId, QuerySetId, RenderBundleId, RenderPassEncoderId,
-    RenderPipelineId, SamplerId, ShaderModuleId, StagingBufferId, SurfaceId, TextureId,
-    TextureViewId,
+    AdapterId, BindGroupId, BindGroupLayoutId, BufferId, CommandBufferId, CommandEncoderId,
+    ComputePassEncoderId, ComputePipelineId, DeviceId, PipelineLayoutId, QuerySetId,
+    RenderBundleId, RenderPassEncoderId, RenderPipelineId, SamplerId, ShaderModuleId,
+    StagingBufferId, SurfaceId, TextureId, TextureViewId,
 };
 
 use crate::{DeviceLostReason, Error, WebGPUDevice};
@@ -28,6 +28,7 @@ pub enum WebGPUMsg {
     FreeRenderPipeline(RenderPipelineId),
     FreeBindGroup(BindGroupId),
     FreeBindGroupLayout(BindGroupLayoutId),
+    FreeCommandEncoder(CommandEncoderId),
     FreeCommandBuffer(CommandBufferId),
     FreeTexture(TextureId),
     FreeTextureView(TextureViewId),

--- a/components/webgpu/canvas_context.rs
+++ b/components/webgpu/canvas_context.rs
@@ -194,6 +194,7 @@ impl StagingBuffer {
         &mut self,
         texture_id: TextureId,
         encoder_id: CommandEncoderId,
+        command_buffer_id: CommandBufferId,
         config: &ContextConfiguration,
     ) -> Result<CommandBufferId, Box<dyn std::error::Error>> {
         self.ensure_available(config)?;
@@ -238,7 +239,7 @@ impl StagingBuffer {
         let (command_buffer_id, error) = self.global.command_encoder_finish(
             encoder_id,
             &CommandBufferDescriptor::default(),
-            Some(unsafe { id::Id::from_raw(encoder_id.into_raw()) }),
+            Some(command_buffer_id),
         );
         if let Some((_, error)) = error {
             return Err(error.into());
@@ -574,6 +575,7 @@ impl crate::WGPU {
         if let Some(PendingTexture {
             texture_id,
             encoder_id,
+            command_buffer_id,
             configuration,
         }) = pending_texture
         {
@@ -593,6 +595,7 @@ impl crate::WGPU {
             self.texture_download(
                 texture_id,
                 encoder_id,
+                command_buffer_id,
                 staging_buffer,
                 configuration,
                 move |staging_buffer| {
@@ -653,6 +656,7 @@ impl crate::WGPU {
         let Some(PendingTexture {
             texture_id,
             encoder_id,
+            command_buffer_id,
             configuration,
         }) = pending_texture
         else {
@@ -689,6 +693,7 @@ impl crate::WGPU {
         self.texture_download(
             texture_id,
             encoder_id,
+            command_buffer_id,
             staging_buffer,
             configuration,
             move |staging_buffer| {
@@ -724,13 +729,17 @@ impl crate::WGPU {
         &self,
         texture_id: TextureId,
         encoder_id: CommandEncoderId,
+        command_buffer_id: CommandBufferId,
         mut staging_buffer: StagingBuffer,
         config: ContextConfiguration,
         callback: impl FnOnce(StagingBuffer) + Send + 'static,
     ) {
-        let Ok(command_buffer_id) =
-            staging_buffer.prepare_load_texture_command_buffer(texture_id, encoder_id, &config)
-        else {
+        let Ok(command_buffer_id) = staging_buffer.prepare_load_texture_command_buffer(
+            texture_id,
+            encoder_id,
+            command_buffer_id,
+            &config,
+        ) else {
             return callback(staging_buffer);
         };
         let StagingBufferState::Available(buffer) = &staging_buffer.state else {

--- a/components/webgpu/canvas_context.rs
+++ b/components/webgpu/canvas_context.rs
@@ -235,10 +235,12 @@ impl StagingBuffer {
             &buffer_info,
             &copy_size,
         )?;
-        let (command_buffer_id, error) = self
-            .global
-            .command_encoder_finish(encoder_id, &CommandBufferDescriptor::default());
-        if let Some(error) = error {
+        let (command_buffer_id, error) = self.global.command_encoder_finish(
+            encoder_id,
+            &CommandBufferDescriptor::default(),
+            Some(unsafe { id::Id::from_raw(encoder_id.into_raw()) }),
+        );
+        if let Some((_, error)) = error {
             return Err(error.into());
         };
         Ok(command_buffer_id)

--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -21,7 +21,7 @@ use webgpu_traits::{
 };
 use webrender_api::ExternalImageId;
 use wgc::command::{ComputePass, ComputePassDescriptor, RenderPass};
-use wgc::device::{DeviceDescriptor, ImplicitPipelineIds};
+use wgc::device::DeviceDescriptor;
 use wgc::id;
 use wgc::id::DeviceId;
 use wgc::pipeline::ShaderModuleDescriptor;
@@ -32,7 +32,7 @@ use wgpu_core::device::DeviceError;
 use wgpu_core::pipeline::{CreateComputePipelineError, CreateRenderPipelineError};
 use wgpu_core::resource::BufferAccessResult;
 pub use wgpu_types as wgt;
-use wgpu_types::MemoryHints;
+use wgpu_types::{ExperimentalFeatures, MemoryHints};
 use wgt::InstanceDescriptor;
 
 use crate::canvas_context::WebGpuExternalImageMap;
@@ -135,10 +135,29 @@ impl WGPU {
         };
         let global = Arc::new(wgc::global::Global::new(
             "wgpu-core",
-            &InstanceDescriptor {
+            InstanceDescriptor {
                 backends,
-                ..Default::default()
+                backend_options: wgt::BackendOptions {
+                    gl: wgt::GlBackendOptions {
+                        gles_minor_version: wgt::Gles3MinorVersion::Automatic,
+                        fence_behavior: wgt::GlFenceBehavior::Normal,
+                        debug_fns: wgt::GlDebugFns::Auto,
+                    },
+                    dx12: wgt::Dx12BackendOptions {
+                        ..Default::default()
+                    },
+                    noop: wgt::NoopBackendOptions::default(),
+                },
+
+                flags: wgt::InstanceFlags::from_build_config() |
+                    wgt::InstanceFlags::AUTOMATIC_TIMESTAMP_NORMALIZATION,
+                memory_budget_thresholds: wgt::MemoryBudgetThresholds {
+                    for_resource_creation: Some(95),
+                    for_device_loss: Some(99),
+                },
+                display: None,
             },
+            None,
         ));
         WGPU {
             poller: Poller::new(Arc::clone(&global)),
@@ -221,8 +240,13 @@ impl WGPU {
                             self.error_command_encoders.get(&command_encoder_id)
                         {
                             Err(Error::Validation(err.clone()))
-                        } else if let Some(error) =
-                            global.command_encoder_finish(command_encoder_id, &desc).1
+                        } else if let Some((_, error)) = global
+                            .command_encoder_finish(
+                                command_encoder_id,
+                                &desc,
+                                Some(unsafe { id::Id::from_raw(command_encoder_id.into_raw()) }),
+                            )
+                            .1
                         {
                             Err(Error::from_error(error))
                         } else {
@@ -356,27 +380,13 @@ impl WGPU {
                         device_id,
                         compute_pipeline_id,
                         descriptor,
-                        implicit_ids,
                         async_sender: sender,
                     } => {
                         let global = &self.global;
-                        let bgls = implicit_ids
-                            .as_ref()
-                            .map_or(Vec::with_capacity(0), |(_, bgls)| {
-                                bgls.iter().map(|x| x.to_owned()).collect()
-                            });
-                        let implicit =
-                            implicit_ids
-                                .as_ref()
-                                .map(|(layout, _)| ImplicitPipelineIds {
-                                    root_id: *layout,
-                                    group_ids: bgls.as_slice(),
-                                });
                         let (_, error) = global.device_create_compute_pipeline(
                             device_id,
                             &descriptor,
                             Some(compute_pipeline_id),
-                            implicit,
                         );
                         if let Some(sender) = sender {
                             let res = match error {
@@ -412,27 +422,13 @@ impl WGPU {
                         device_id,
                         render_pipeline_id,
                         descriptor,
-                        implicit_ids,
                         async_sender: sender,
                     } => {
                         let global = &self.global;
-                        let bgls = implicit_ids
-                            .as_ref()
-                            .map_or(Vec::with_capacity(0), |(_, bgls)| {
-                                bgls.iter().map(|x| x.to_owned()).collect()
-                            });
-                        let implicit =
-                            implicit_ids
-                                .as_ref()
-                                .map(|(layout, _)| ImplicitPipelineIds {
-                                    root_id: *layout,
-                                    group_ids: bgls.as_slice(),
-                                });
                         let (_, error) = global.device_create_render_pipeline(
                             device_id,
                             &descriptor,
                             Some(render_pipeline_id),
-                            implicit,
                         );
 
                         if let Some(sender) = sender {
@@ -592,7 +588,7 @@ impl WGPU {
                     },
                     WebGPURequest::DropCommandBuffer(id) => {
                         self.error_command_encoders
-                            .remove(&id.into_command_encoder_id());
+                            .remove(&unsafe { id::Id::from_raw(id.into_raw()) });
                         let global = &self.global;
                         global.command_buffer_drop(id);
                         if let Err(e) = self.script_sender.send(WebGPUMsg::FreeCommandBuffer(id)) {
@@ -675,6 +671,7 @@ impl WGPU {
                             required_limits: descriptor.required_limits.clone(),
                             memory_hints: MemoryHints::MemoryUsage,
                             trace: wgpu_types::Trace::Off,
+                            experimental_features: ExperimentalFeatures::disabled(),
                         };
                         let global = &self.global;
                         let device = WebGPUDevice(device_id);
@@ -889,6 +886,7 @@ impl WGPU {
                             depth_stencil_attachment: depth_stencil_attachment.as_ref(),
                             timestamp_writes: None,
                             occlusion_query_set: None,
+                            multiview_mask: None,
                         };
                         let (pass, error) =
                             global.command_encoder_begin_render_pass(command_encoder_id, desc);
@@ -955,7 +953,7 @@ impl WGPU {
                         let global = &self.global;
                         let cmd_id = command_buffers.iter().find(|id| {
                             self.error_command_encoders
-                                .contains_key(&id.into_command_encoder_id())
+                                .contains_key(&unsafe { id::Id::from_raw(id.into_raw()) })
                         });
                         let result = if cmd_id.is_some() {
                             Err(Error::Validation(String::from(
@@ -1115,7 +1113,7 @@ impl WGPU {
                     },
                     WebGPURequest::DropTextureView(id) => {
                         let global = &self.global;
-                        let _result = global.texture_view_drop(id);
+                        global.texture_view_drop(id);
                         self.poller.wake();
                         if let Err(e) = self.script_sender.send(WebGPUMsg::FreeTextureView(id)) {
                             warn!("Unable to send FreeTextureView({:?}) ({:?})", id, e);

--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -28,10 +28,9 @@ use wgc::pipeline::ShaderModuleDescriptor;
 use wgc::resource::BufferMapOperation;
 pub use wgpu_core as wgc;
 use wgpu_core::command::RenderPassDescriptor;
-use wgpu_core::device::DeviceError;
-use wgpu_core::pipeline::{CreateComputePipelineError, CreateRenderPipelineError};
 use wgpu_core::resource::BufferAccessResult;
 pub use wgpu_types as wgt;
+use wgpu_types::error::WebGpuError;
 use wgpu_types::{ExperimentalFeatures, MemoryHints};
 use wgt::InstanceDescriptor;
 
@@ -63,34 +62,6 @@ impl DeviceScope {
     }
 }
 
-/// This roughly matches <https://www.w3.org/TR/2024/WD-webgpu-20240703/#encoder-state>
-#[derive(Debug, Default, Eq, PartialEq)]
-enum Pass<P> {
-    /// Pass is open (not ended)
-    Open {
-        /// Actual pass
-        pass: P,
-        /// we need to store valid field
-        /// because wgpu does not invalidate pass on error
-        valid: bool,
-    },
-    /// When pass is ended we need to drop it so we replace it with this
-    #[default]
-    Ended,
-}
-
-impl<P> Pass<P> {
-    /// Creates new open pass
-    fn new(pass: P, valid: bool) -> Self {
-        Self::Open { pass, valid }
-    }
-
-    /// Replaces pass with ended
-    fn take(&mut self) -> Self {
-        std::mem::take(self)
-    }
-}
-
 #[expect(clippy::upper_case_acronyms)] // Name of the library
 pub(crate) struct WGPU {
     receiver: GenericReceiver<WebGPURequest>,
@@ -98,20 +69,15 @@ pub(crate) struct WGPU {
     pub(crate) script_sender: GenericSender<WebGPUMsg>,
     pub(crate) global: Arc<wgc::global::Global>,
     devices: Arc<Mutex<FxHashMap<DeviceId, DeviceScope>>>,
-    // TODO: Remove this (https://github.com/gfx-rs/wgpu/issues/867)
-    /// This stores first error on command encoder,
-    /// because wgpu does not invalidate command encoder object
-    /// (this is also reused for invalidation of command buffers)
-    error_command_encoders: FxHashMap<id::CommandEncoderId, String>,
     pub(crate) paint_api: CrossProcessPaintApi,
     pub(crate) webrender_external_image_id_manager: WebRenderExternalImageIdManager,
     pub(crate) wgpu_image_map: WebGpuExternalImageMap,
     /// Provides access to poller thread
     pub(crate) poller: Poller,
     /// Store compute passes
-    compute_passes: FxHashMap<ComputePassId, Pass<ComputePass>>,
+    compute_passes: FxHashMap<ComputePassId, ComputePass>,
     /// Store render passes
-    render_passes: FxHashMap<RenderPassId, Pass<RenderPass>>,
+    render_passes: FxHashMap<RenderPassId, RenderPass>,
 }
 
 impl WGPU {
@@ -151,6 +117,8 @@ impl WGPU {
 
                 flags: wgt::InstanceFlags::from_build_config() |
                     wgt::InstanceFlags::AUTOMATIC_TIMESTAMP_NORMALIZATION,
+                // TODO(sagudev): firefox actually sets this, but it can cause OOM for us
+                // meaning that we are likely leaking something
                 memory_budget_thresholds: wgt::MemoryBudgetThresholds {
                     for_resource_creation: Some(95),
                     for_device_loss: Some(99),
@@ -166,7 +134,6 @@ impl WGPU {
             script_sender,
             global,
             devices: Arc::new(Mutex::new(FxHashMap::default())),
-            error_command_encoders: FxHashMap::default(),
             paint_api,
             webrender_external_image_id_manager,
             wgpu_image_map,
@@ -234,31 +201,18 @@ impl WGPU {
                         command_encoder_id,
                         device_id,
                         desc,
+                        command_buffer_id,
                     } => {
                         let global = &self.global;
-                        let result = if let Some(err) =
-                            self.error_command_encoders.get(&command_encoder_id)
-                        {
-                            Err(Error::Validation(err.clone()))
-                        } else if let Some((_, error)) = global
-                            .command_encoder_finish(
-                                command_encoder_id,
-                                &desc,
-                                Some(unsafe { id::Id::from_raw(command_encoder_id.into_raw()) }),
-                            )
-                            .1
-                        {
-                            Err(Error::from_error(error))
-                        } else {
-                            Ok(())
-                        };
-
-                        // invalidate command buffer too
-                        self.encoder_record_error(command_encoder_id, &result);
-                        // dispatch validation error
-                        self.maybe_dispatch_error(device_id, result.err());
+                        let (_, error) = global.command_encoder_finish(
+                            command_encoder_id,
+                            &desc,
+                            Some(command_buffer_id),
+                        );
+                        self.maybe_dispatch_wgpu_error(device_id, error.map(|(_, e)| e));
                     },
                     WebGPURequest::CopyBufferToBuffer {
+                        device_id,
                         command_encoder_id,
                         source_id,
                         source_offset,
@@ -275,9 +229,10 @@ impl WGPU {
                             destination_offset,
                             Some(size),
                         );
-                        self.encoder_record_error(command_encoder_id, &result);
+                        self.maybe_dispatch_wgpu_error(device_id, result.err());
                     },
                     WebGPURequest::CopyBufferToTexture {
+                        device_id,
                         command_encoder_id,
                         source,
                         destination,
@@ -290,9 +245,10 @@ impl WGPU {
                             &destination,
                             &copy_size,
                         );
-                        self.encoder_record_error(command_encoder_id, &result);
+                        self.maybe_dispatch_wgpu_error(device_id, result.err());
                     },
                     WebGPURequest::CopyTextureToBuffer {
+                        device_id,
                         command_encoder_id,
                         source,
                         destination,
@@ -305,9 +261,10 @@ impl WGPU {
                             &destination,
                             &copy_size,
                         );
-                        self.encoder_record_error(command_encoder_id, &result);
+                        self.maybe_dispatch_wgpu_error(device_id, result.err());
                     },
                     WebGPURequest::CopyTextureToTexture {
+                        device_id,
                         command_encoder_id,
                         source,
                         destination,
@@ -320,7 +277,7 @@ impl WGPU {
                             &destination,
                             &copy_size,
                         );
-                        self.encoder_record_error(command_encoder_id, &result);
+                        self.maybe_dispatch_wgpu_error(device_id, result.err());
                     },
                     WebGPURequest::CreateBindGroup {
                         device_id,
@@ -389,14 +346,13 @@ impl WGPU {
                             Some(compute_pipeline_id),
                         );
                         if let Some(sender) = sender {
-                            let res = match error {
+                            let res = match error.and_then(Error::from_wgpu_error) {
                                 // if device is lost we must return pipeline and not raise any error
-                                Some(CreateComputePipelineError::Device(DeviceError::Lost)) |
                                 None => Ok(Pipeline {
                                     id: compute_pipeline_id,
                                     label: descriptor.label.unwrap_or_default().to_string(),
                                 }),
-                                Some(e) => Err(Error::from_error(e)),
+                                Some(e) => Err(e),
                             };
                             if let Err(e) = sender.send(res) {
                                 warn!("Failed sending WebGPUComputePipelineResponse {e:?}");
@@ -432,14 +388,13 @@ impl WGPU {
                         );
 
                         if let Some(sender) = sender {
-                            let res = match error {
+                            let res = match error.and_then(Error::from_wgpu_error) {
                                 // if device is lost we must return pipeline and not raise any error
-                                Some(CreateRenderPipelineError::Device(DeviceError::Lost)) |
                                 None => Ok(Pipeline {
                                     id: render_pipeline_id,
                                     label: descriptor.label.unwrap_or_default().to_string(),
                                 }),
-                                Some(e) => Err(Error::from_error(e)),
+                                Some(e) => Err(e),
                             };
                             if let Err(e) = sender.send(res) {
                                 warn!("Failed sending WebGPURenderPipelineResponse {e:?}");
@@ -586,9 +541,14 @@ impl WGPU {
                         }
                         break;
                     },
+                    WebGPURequest::DropCommandEncoder(id) => {
+                        let global = &self.global;
+                        global.command_encoder_drop(id);
+                        if let Err(e) = self.script_sender.send(WebGPUMsg::FreeCommandEncoder(id)) {
+                            warn!("Unable to send FreeCommandEncoder({:?}) ({:?})", id, e);
+                        };
+                    },
                     WebGPURequest::DropCommandBuffer(id) => {
-                        self.error_command_encoders
-                            .remove(&unsafe { id::Id::from_raw(id.into_raw()) });
                         let global = &self.global;
                         global.command_buffer_drop(id);
                         if let Err(e) = self.script_sender.send(WebGPUMsg::FreeCommandBuffer(id)) {
@@ -731,7 +691,7 @@ impl WGPU {
                         command_encoder_id,
                         compute_pass_id,
                         label,
-                        device_id: _device_id,
+                        device_id,
                     } => {
                         let global = &self.global;
                         let (pass, error) = global.command_encoder_begin_compute_pass(
@@ -742,13 +702,10 @@ impl WGPU {
                             },
                         );
                         assert!(
-                            self.compute_passes
-                                .insert(compute_pass_id, Pass::new(pass, error.is_none()))
-                                .is_none(),
+                            self.compute_passes.insert(compute_pass_id, pass).is_none(),
                             "ComputePass should not exist yet."
                         );
-                        // TODO: Command encoder state errors
-                        // self.maybe_dispatch_wgpu_error(device_id, error);
+                        self.maybe_dispatch_wgpu_error(device_id, error);
                     },
                     WebGPURequest::ComputePassSetPipeline {
                         compute_pass_id,
@@ -759,17 +716,8 @@ impl WGPU {
                             .compute_passes
                             .get_mut(&compute_pass_id)
                             .expect("ComputePass should exists");
-                        if let Pass::Open { pass, valid } = pass {
-                            *valid &= self
-                                .global
-                                .compute_pass_set_pipeline(pass, pipeline_id)
-                                .is_ok();
-                        } else {
-                            self.maybe_dispatch_error(
-                                device_id,
-                                Some(Error::Validation("pass already ended".to_string())),
-                            );
-                        };
+                        let result = self.global.compute_pass_set_pipeline(pass, pipeline_id);
+                        self.maybe_dispatch_wgpu_error(device_id, result.err());
                     },
                     WebGPURequest::ComputePassSetBindGroup {
                         compute_pass_id,
@@ -782,22 +730,13 @@ impl WGPU {
                             .compute_passes
                             .get_mut(&compute_pass_id)
                             .expect("ComputePass should exists");
-                        if let Pass::Open { pass, valid } = pass {
-                            *valid &= self
-                                .global
-                                .compute_pass_set_bind_group(
-                                    pass,
-                                    index,
-                                    Some(bind_group_id),
-                                    &offsets,
-                                )
-                                .is_ok();
-                        } else {
-                            self.maybe_dispatch_error(
-                                device_id,
-                                Some(Error::Validation("pass already ended".to_string())),
-                            );
-                        };
+                        let result = self.global.compute_pass_set_bind_group(
+                            pass,
+                            index,
+                            Some(bind_group_id),
+                            &offsets,
+                        );
+                        self.maybe_dispatch_wgpu_error(device_id, result.err());
                     },
                     WebGPURequest::ComputePassDispatchWorkgroups {
                         compute_pass_id,
@@ -810,17 +749,8 @@ impl WGPU {
                             .compute_passes
                             .get_mut(&compute_pass_id)
                             .expect("ComputePass should exists");
-                        if let Pass::Open { pass, valid } = pass {
-                            *valid &= self
-                                .global
-                                .compute_pass_dispatch_workgroups(pass, x, y, z)
-                                .is_ok();
-                        } else {
-                            self.maybe_dispatch_error(
-                                device_id,
-                                Some(Error::Validation("pass already ended".to_string())),
-                            );
-                        };
+                        let result = self.global.compute_pass_dispatch_workgroups(pass, x, y, z);
+                        self.maybe_dispatch_wgpu_error(device_id, result.err());
                     },
                     WebGPURequest::ComputePassDispatchWorkgroupsIndirect {
                         compute_pass_id,
@@ -832,44 +762,22 @@ impl WGPU {
                             .compute_passes
                             .get_mut(&compute_pass_id)
                             .expect("ComputePass should exists");
-                        if let Pass::Open { pass, valid } = pass {
-                            *valid &= self
-                                .global
-                                .compute_pass_dispatch_workgroups_indirect(pass, buffer_id, offset)
-                                .is_ok();
-                        } else {
-                            self.maybe_dispatch_error(
-                                device_id,
-                                Some(Error::Validation("pass already ended".to_string())),
-                            );
-                        };
+                        let result = self
+                            .global
+                            .compute_pass_dispatch_workgroups_indirect(pass, buffer_id, offset);
+                        self.maybe_dispatch_wgpu_error(device_id, result.err());
                     },
                     WebGPURequest::EndComputePass {
                         compute_pass_id,
                         device_id,
-                        command_encoder_id,
                     } => {
                         // https://www.w3.org/TR/2024/WD-webgpu-20240703/#dom-gpucomputepassencoder-end
                         let pass = self
                             .compute_passes
                             .get_mut(&compute_pass_id)
                             .expect("ComputePass should exists");
-                        // TODO: Command encoder state error
-                        if let Pass::Open { mut pass, valid } = pass.take() {
-                            // `pass.end` does step 1-4
-                            // and if it returns ok we check the validity of the pass at step 5
-                            if self.global.compute_pass_end(&mut pass).is_ok() && !valid {
-                                self.encoder_record_error(
-                                    command_encoder_id,
-                                    &Err::<(), _>("Pass is invalid".to_string()),
-                                );
-                            }
-                        } else {
-                            self.dispatch_error(
-                                device_id,
-                                Error::Validation("pass already ended".to_string()),
-                            );
-                        };
+                        let result = self.global.compute_pass_end(pass);
+                        self.maybe_dispatch_wgpu_error(device_id, result.err());
                     },
                     WebGPURequest::BeginRenderPass {
                         command_encoder_id,
@@ -877,7 +785,7 @@ impl WGPU {
                         label,
                         color_attachments,
                         depth_stencil_attachment,
-                        device_id: _device_id,
+                        device_id,
                     } => {
                         let global = &self.global;
                         let desc = &RenderPassDescriptor {
@@ -891,13 +799,10 @@ impl WGPU {
                         let (pass, error) =
                             global.command_encoder_begin_render_pass(command_encoder_id, desc);
                         assert!(
-                            self.render_passes
-                                .insert(render_pass_id, Pass::new(pass, error.is_none()))
-                                .is_none(),
+                            self.render_passes.insert(render_pass_id, pass).is_none(),
                             "RenderPass should not exist yet."
                         );
-                        // TODO: Command encoder state errors
-                        // self.maybe_dispatch_wgpu_error(device_id, error);
+                        self.maybe_dispatch_wgpu_error(device_id, error);
                     },
                     WebGPURequest::RenderPassCommand {
                         render_pass_id,
@@ -908,42 +813,20 @@ impl WGPU {
                             .render_passes
                             .get_mut(&render_pass_id)
                             .expect("RenderPass should exists");
-                        if let Pass::Open { pass, valid } = pass {
-                            *valid &=
-                                apply_render_command(&self.global, pass, render_command).is_ok();
-                        } else {
-                            self.maybe_dispatch_error(
-                                device_id,
-                                Some(Error::Validation("pass already ended".to_string())),
-                            );
-                        };
+                        let result = apply_render_command(&self.global, pass, render_command);
+                        self.maybe_dispatch_wgpu_error(device_id, result.err());
                     },
                     WebGPURequest::EndRenderPass {
                         render_pass_id,
                         device_id,
-                        command_encoder_id,
                     } => {
                         // https://www.w3.org/TR/2024/WD-webgpu-20240703/#dom-gpurenderpassencoder-end
                         let pass = self
                             .render_passes
                             .get_mut(&render_pass_id)
                             .expect("RenderPass should exists");
-                        // TODO: Command encoder state error
-                        if let Pass::Open { mut pass, valid } = pass.take() {
-                            // `pass.end` does step 1-4
-                            // and if it returns ok we check the validity of the pass at step 5
-                            if self.global.render_pass_end(&mut pass).is_ok() && !valid {
-                                self.encoder_record_error(
-                                    command_encoder_id,
-                                    &Err::<(), _>("Pass is invalid".to_string()),
-                                );
-                            }
-                        } else {
-                            self.dispatch_error(
-                                device_id,
-                                Error::Validation("Pass already ended".to_string()),
-                            );
-                        };
+                        let result = self.global.render_pass_end(pass);
+                        self.maybe_dispatch_wgpu_error(device_id, result.err());
                     },
                     WebGPURequest::Submit {
                         device_id,
@@ -951,21 +834,11 @@ impl WGPU {
                         command_buffers,
                     } => {
                         let global = &self.global;
-                        let cmd_id = command_buffers.iter().find(|id| {
-                            self.error_command_encoders
-                                .contains_key(&unsafe { id::Id::from_raw(id.into_raw()) })
-                        });
-                        let result = if cmd_id.is_some() {
-                            Err(Error::Validation(String::from(
-                                "Invalid command buffer submitted",
-                            )))
-                        } else {
+                        let result = {
                             let _guard = self.poller.lock();
-                            global
-                                .queue_submit(queue_id, &command_buffers)
-                                .map_err(|(_, error)| Error::from_error(error))
+                            global.queue_submit(queue_id, &command_buffers)
                         };
-                        self.maybe_dispatch_error(device_id, result.err());
+                        self.maybe_dispatch_wgpu_error(device_id, result.err().map(|(_, x)| x));
                     },
                     WebGPURequest::UnmapBuffer { buffer_id, mapping } => {
                         let global = &self.global;
@@ -1223,12 +1096,13 @@ impl WGPU {
         }
     }
 
-    fn maybe_dispatch_wgpu_error<E: std::error::Error + 'static>(
+    #[inline]
+    fn maybe_dispatch_wgpu_error<E: WebGpuError>(
         &mut self,
         device_id: id::DeviceId,
         error: Option<E>,
     ) {
-        self.maybe_dispatch_error(device_id, error.map(|e| Error::from_error(e)))
+        self.maybe_dispatch_error(device_id, error.and_then(Error::from_wgpu_error))
     }
 
     /// Dispatches error (if there is any)
@@ -1263,17 +1137,5 @@ impl WGPU {
                 warn!("Failed to send WebGPUMsg::UncapturedError: {error:?}");
             }
         } // else device is lost
-    }
-
-    fn encoder_record_error<U, T: std::fmt::Debug>(
-        &mut self,
-        encoder_id: id::CommandEncoderId,
-        result: &Result<U, T>,
-    ) {
-        if let Err(e) = result {
-            self.error_command_encoders
-                .entry(encoder_id)
-                .or_insert_with(|| format!("{:?}", e));
-        }
     }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -206,6 +206,20 @@ skip = [
     "roxmltree",
     "tiny-skia",
     "tiny-skia-path",
+
+    # wgpu-core stuff gets duplicated by vello (which is disabled by default)
+    "bit-set",
+    "bit-vec",
+    "codespan-reporting",
+    "gpu-allocator",
+    "naga",
+    "spirv",
+    "wgpu-core",
+    "wgpu-core-deps-apple",
+    "wgpu-core-deps-emscripten",
+    "wgpu-core-deps-windows-linux-android",
+    "wgpu-hal",
+    "wgpu-types",
 ]
 
 # github.com organizations to allow git sources for

--- a/python/servo/try_parser.py
+++ b/python/servo/try_parser.py
@@ -114,7 +114,7 @@ def handle_preset(s: str) -> Optional[JobConfig]:
             "WebGPU CTS",
             Workflow.LINUX,
             wpt=True,
-            wpt_args="_webgpu",  # run only webgpu cts
+            wpt_args="_webgpu --processes 1",  # run only webgpu cts
             profile="production",  # WebGPU works to slow with debug assert
             unit_tests=False,
             number_of_wpt_chunks=20,

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/idl/exposed.http.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/idl/exposed.http.html.ini
@@ -1,2 +1,3 @@
 [exposed.http.html]
-  expected: ERROR
+  expected:
+    if os == "linux" and not debug: ERROR

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_premultiplied_draw.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_premultiplied_draw.https.html.ini
@@ -1,3 +1,3 @@
 [canvas_composite_alpha_rgba8unorm_premultiplied_draw.https.html]
   expected:
-    if os == "linux" and not debug: [CRASH, PASS]
+    if os == "linux" and not debug: PASS

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_display_after_device_lost.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_display_after_device_lost.https.html.ini
@@ -1,3 +1,3 @@
 [canvas_display_after_device_lost.https.html]
   expected:
-    if os == "linux" and not debug: [TIMEOUT, FAIL]
+    if os == "linux" and not debug: FAIL


### PR DESCRIPTION
As always new wgpu brings us more CTS test passes and better handling low-memory. It also allows us removing various hacks we have around encoder/passes error handling as wgpu is now more spec compliant (shutout to https://github.com/andyleiserson).

I thought I could get away with minimal changes (tried in first commit), but that didn't work out because CommandBufferId != CommandEncoderId.

wgpu introduced support for resource memory limits (we return OOM as webgpu error). This is needed otherwise CI runners are starved (80 chunks does not help). We also need to limit parallelism of CTS run or else we get crashes (but not runner hangs anymore, so I consider that a progress), because of wgpu: https://github.com/servo/servo/issues/44969

Testing: Covered by webgpu CTS
try run: https://github.com/sagudev/servo/actions/runs/25989667443
