### PR TITLE
refresh_driver: Optimize timeout code

### DIFF
--- a/components/paint/refresh_driver.rs
+++ b/components/paint/refresh_driver.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
-use crossbeam_channel::{Sender, select};
+use crossbeam_channel::{RecvTimeoutError, Sender};
 use embedder_traits::{EventLoopWaker, RefreshDriver};
 use log::warn;
 use servo_constellation_traits::EmbedderToConstellationMessage;
@@ -207,19 +207,19 @@ impl Default for TimerRefreshDriver {
                 let mut scheduler = TimerScheduler::default();
 
                 loop {
-                    select! {
-                        recv(receiver) -> message => {
-                            match message {
-                                Ok(TimerThreadMessage::Request(request)) => {
-                                    scheduler.schedule_timer(request);
-                                },
-                                _ => return,
-                            }
-                        },
-                        recv(scheduler.wait_channel()) -> _message => {
-                            scheduler.dispatch_completed_timers();
-                        },
+                    let recv_result = match scheduler.next_deadline() {
+                        Some(deadline) => receiver.recv_deadline(deadline),
+                        None => receiver.recv().map_err(|_| RecvTimeoutError::Disconnected),
                     };
+                    match recv_result {
+                        Ok(TimerThreadMessage::Request(request)) => {
+                            scheduler.schedule_timer(request);
+                        },
+                        Err(RecvTimeoutError::Timeout) => scheduler.dispatch_completed_timers(),
+                        Ok(TimerThreadMessage::Quit) | Err(RecvTimeoutError::Disconnected) => {
+                            return;
+                        },
+                    }
                 }
             })
             .expect("Could not create RefreshDriver timer thread.");

--- a/components/timers/lib.rs
+++ b/components/timers/lib.rs
@@ -109,6 +109,11 @@ impl TimerScheduler {
             .unwrap_or_else(never)
     }
 
+    /// The deadline of the next scheduled timer, or `None` if the queue is empty.
+    pub fn next_deadline(&self) -> Option<Instant> {
+        self.queue.peek().map(|event| event.for_time)
+    }
+
     /// Dispatch any timer events from this [`TimerScheduler`]'s `queue` when `now` is
     /// past the due time of the event.
     pub fn dispatch_completed_timers(&mut self) {


### PR DESCRIPTION
Instead of using `wait_channel`, we can simply use `recv_deadline()`, which avoids creating a oneshot channel and a Select in every loop iteration.

Testing: No behavior changes, covered by existing tests
Fixes: Part of #44962
