### PR TITLE
script: Fix issues with manipulating current selection

### DIFF
--- a/components/script/dom/execcommand/commands/delete.rs
+++ b/components/script/dom/execcommand/commands/delete.rs
@@ -6,7 +6,6 @@ use html5ever::local_name;
 use script_bindings::inheritance::Castable;
 
 use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
-use crate::dom::bindings::codegen::Bindings::SelectionBinding::SelectionMethods;
 use crate::dom::document::Document;
 use crate::dom::element::Element;
 use crate::dom::execcommand::contenteditable::node::{
@@ -128,13 +127,9 @@ pub(crate) fn execute_delete_command(
                 }))
     {
         // Step 5.1. Call collapse(node, offset) on the context object's selection.
-        if selection.Collapse(cx, Some(&node), offset).is_err() {
-            unreachable!("Must not fail to collapse");
-        }
+        selection.collapse_current_range(&node, offset);
         // Step 5.2. Call extend(node, offset − 1) on the context object's selection.
-        if selection.Extend(cx, &node, offset - 1).is_err() {
-            unreachable!("Must not fail to extend");
-        }
+        selection.extend_current_range(&node, offset - 1);
         // Step 5.3. Delete the selection.
         selection.delete_the_selection(
             cx,
@@ -263,16 +258,9 @@ pub(crate) fn execute_delete_command(
                 }))
     {
         // Step 13.1. Call collapse(start node, start offset − 1) on the context object's selection.
-        if selection
-            .Collapse(cx, Some(&start_node), start_offset - 1)
-            .is_err()
-        {
-            unreachable!("Must not fail to collapse");
-        }
+        selection.collapse_current_range(&start_node, start_offset - 1);
         // Step 13.2. Call extend(start node, start offset) on the context object's selection.
-        if selection.Extend(cx, &start_node, start_offset).is_err() {
-            unreachable!("Must not fail to extend");
-        }
+        selection.extend_current_range(&start_node, start_offset);
         // Step 13.3. Delete the selection.
         selection.delete_the_selection(
             cx,
@@ -282,9 +270,7 @@ pub(crate) fn execute_delete_command(
             Default::default(),
         );
         // Step 13.4. Call collapse(node, offset) on the selection.
-        if selection.Collapse(cx, Some(&node), offset).is_err() {
-            unreachable!("Must not fail to collapse");
-        }
+        selection.collapse_current_range(&node, offset);
         // Step 13.5. Return true.
         return true;
     }
@@ -323,17 +309,10 @@ pub(crate) fn execute_delete_command(
     }
 
     // Step 17. Call collapse(start node, start offset) on the context object's selection.
-    if selection
-        .Collapse(cx, Some(&start_node), start_offset)
-        .is_err()
-    {
-        unreachable!("Must not fail to collapse");
-    }
+    selection.collapse_current_range(&start_node, start_offset);
 
     // Step 18. Call extend(node, offset) on the context object's selection.
-    if selection.Extend(cx, &node, offset).is_err() {
-        unreachable!("Must not fail to extend");
-    }
+    selection.extend_current_range(&node, offset);
 
     // Step 19. Delete the selection, with direction "backward".
     selection.delete_the_selection(

--- a/components/script/dom/execcommand/commands/insertparagraph.rs
+++ b/components/script/dom/execcommand/commands/insertparagraph.rs
@@ -9,7 +9,6 @@ use script_bindings::inheritance::Castable;
 use crate::dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use crate::dom::bindings::codegen::Bindings::RangeBinding::RangeMethods;
-use crate::dom::bindings::codegen::Bindings::SelectionBinding::SelectionMethods;
 use crate::dom::bindings::codegen::Bindings::TextBinding::TextMethods;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::comment::Comment;
@@ -70,9 +69,7 @@ pub(crate) fn execute_insert_paragraph_command(
         node = node.GetParentNode().expect("Must always have a parent");
     }
     // Step 7. Call collapse(node, offset) on the context object's selection.
-    if selection.Collapse(cx, Some(&node), offset).is_err() {
-        unreachable!("Must not fail to collapse");
-    }
+    selection.collapse_current_range(&node, offset);
     // Step 8. Let container equal node.
     let mut container = node.clone();
     // Step 9. While container is not a single-line container,
@@ -139,10 +136,7 @@ pub(crate) fn execute_insert_paragraph_command(
             vec![eligible_node]
         } else {
             // Step 11.3. Let node list be a list of nodes, initially empty.
-            vec![]
-        };
-        // Step 11.5. If node list is empty:
-        if node_list.is_empty() {
+            // Step 11.5. If node list is empty:
             // Step 11.5.1. If tag is not an allowed child of the active range's start node, return true.
             if !is_allowed_child(
                 NodeOrString::String(tag.str().to_owned()),
@@ -164,12 +158,10 @@ pub(crate) fn execute_insert_paragraph_command(
                 unreachable!("Must always be able to append");
             }
             // Step 11.5.5. Call collapse(container, 0) on the context object's selection.
-            if selection.Collapse(cx, Some(container), 0).is_err() {
-                unreachable!("Must not fail to collapse");
-            }
+            selection.collapse_current_range(container, 0);
             // Step 11.5.6. Return true.
             return true;
-        }
+        };
         // Step 11.6. While the nextSibling of the last member of node list is not null
         // and is an allowed child of "p", append it to node list.
         while let Some(next_of_last) = node_list
@@ -188,14 +180,13 @@ pub(crate) fn execute_insert_paragraph_command(
         // Step 11.7. Wrap node list, with sibling criteria returning false
         // and new parent instructions returning the result of calling createElement(tag) on the context object.
         // Set container to the result.
-        if let Some(new_node) = wrap_node_list(
+        container = wrap_node_list(
             cx,
             node_list,
             |_| false,
             |cx| Some(DomRoot::upcast(document.create_element(cx, tag.str()))),
-        ) {
-            container = new_node;
-        }
+        )
+        .expect("Must always be able to wrap");
     }
     // Step 12. If container's local name is "address", "listing", or "pre":
     if node_matches_local_name!(
@@ -209,9 +200,7 @@ pub(crate) fn execute_insert_paragraph_command(
             unreachable!("Must always be able to insert");
         }
         // Step 12.3. Call collapse(node, offset + 1) on the context object's selection.
-        if selection.Collapse(cx, Some(&node), offset + 1).is_err() {
-            unreachable!("Must not fail to collapse");
-        }
+        selection.collapse_current_range(&node, offset + 1);
         // Step 12.4. If br is the last descendant of container,
         // let br be the result of calling createElement("br") on the context object,
         // then call insertNode(br) on the active range.
@@ -427,12 +416,7 @@ pub(crate) fn execute_insert_paragraph_command(
         }
     }
     // Step 34. Call collapse(new container, 0) on the context object's selection.
-    if selection
-        .Collapse(cx, Some(&new_container_node), 0)
-        .is_err()
-    {
-        unreachable!("Must not fail to collapse");
-    }
+    selection.collapse_current_range(&new_container_node, 0);
     // Step 35. Return true.
     true
 }

--- a/components/script/dom/execcommand/contenteditable/node.rs
+++ b/components/script/dom/execcommand/contenteditable/node.rs
@@ -1612,7 +1612,7 @@ impl Node {
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#block-boundary-point>
-    fn is_block_boundary_point(&self, offset: u32) -> bool {
+    pub(crate) fn is_block_boundary_point(&self, offset: u32) -> bool {
         // > A boundary point is a block boundary point if it is either a block start point or a block end point.
         self.is_block_start_point(offset as usize) || self.is_block_end_point(offset)
     }

--- a/components/script/dom/execcommand/contenteditable/range.rs
+++ b/components/script/dom/execcommand/contenteditable/range.rs
@@ -119,20 +119,23 @@ impl Range {
                 .expect("Must always have a parent");
         }
         // Step 3. If (start node, start offset) is not a block start point, repeat the following steps:
-        while !start_node.is_block_start_point(start_offset as usize) {
-            // Step 3.1. If start offset is zero, set it to start node's index, then set start node to its parent.
-            if start_offset == 0 {
-                start_offset = start_node.index();
-                start_node = start_node
-                    .GetParentNode()
-                    .expect("Must always have a parent");
-            } else {
-                // Step 3.2. Otherwise, subtract one from start offset.
-                start_offset -= 1;
+        if !start_node.is_block_start_point(start_offset as usize) {
+            loop {
+                // Step 3.1. If start offset is zero, set it to start node's index, then set start node to its parent.
+                if start_offset == 0 {
+                    start_offset = start_node.index();
+                    start_node = start_node
+                        .GetParentNode()
+                        .expect("Must always have a parent");
+                } else {
+                    // Step 3.2. Otherwise, subtract one from start offset.
+                    start_offset -= 1;
+                }
+                // Step 3.3. If (start node, start offset) is a block boundary point, break from this loop.
+                if start_node.is_block_boundary_point(start_offset) {
+                    break;
+                }
             }
-            // Step 3.3. If (start node, start offset) is a block boundary point, break from this loop.
-            //
-            // That's the while-condition
         }
         // Step 4. While start offset is zero and start node's parent is not null,
         // set start offset to start node's index, then set start node to its parent.
@@ -155,18 +158,21 @@ impl Range {
                 .expect("Must always have a parent");
         }
         // Step 6. If (end node, end offset) is not a block end point, repeat the following steps:
-        while !end_node.is_block_end_point(end_offset) {
-            // Step 6.1. If end offset is end node's length, set it to one plus end node's index, then set end node to its parent.
-            if end_offset == end_node.len() {
-                end_offset = 1 + end_node.index();
-                end_node = end_node.GetParentNode().expect("Must always have a parent");
-            } else {
-                // Step 6.2. Otherwise, add one to end offset.
-                end_offset += 1;
+        if !end_node.is_block_end_point(end_offset) {
+            loop {
+                // Step 6.1. If end offset is end node's length, set it to one plus end node's index, then set end node to its parent.
+                if end_offset == end_node.len() {
+                    end_offset = 1 + end_node.index();
+                    end_node = end_node.GetParentNode().expect("Must always have a parent");
+                } else {
+                    // Step 6.2. Otherwise, add one to end offset.
+                    end_offset += 1;
+                }
+                // Step 6.3. If (end node, end offset) is a block boundary point, break from this loop.
+                if end_node.is_block_boundary_point(end_offset) {
+                    break;
+                }
             }
-            // Step 6.3. If (end node, end offset) is a block boundary point, break from this loop.
-            //
-            // That's the while-condition
         }
         // Step 7. While end offset is end node's length and end node's parent is not null,
         // set end offset to one plus end node's index, then set end node to its parent.

--- a/components/script/dom/execcommand/contenteditable/selection.rs
+++ b/components/script/dom/execcommand/contenteditable/selection.rs
@@ -10,7 +10,6 @@ use script_bindings::inheritance::Castable;
 use crate::dom::abstractrange::bp_position;
 use crate::dom::bindings::codegen::Bindings::CharacterDataBinding::CharacterDataMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
-use crate::dom::bindings::codegen::Bindings::SelectionBinding::SelectionMethods;
 use crate::dom::bindings::codegen::Bindings::TextBinding::TextMethods;
 use crate::dom::bindings::root::{DomRoot, DomSlice};
 use crate::dom::bindings::str::DOMString;
@@ -199,14 +198,16 @@ impl Selection {
         {
             // Step 6.1. If direction is "forward", call collapseToStart() on the context object's selection.
             if direction == SelectionDeleteDirection::Forward {
-                if self.CollapseToStart(cx).is_err() {
-                    unreachable!("Should be able to collapse to start");
-                }
+                self.collapse_current_range(
+                    &active_range.start_container(),
+                    active_range.start_offset(),
+                );
             } else {
                 // Step 6.2. Otherwise, call collapseToEnd() on the context object's selection.
-                if self.CollapseToEnd(cx).is_err() {
-                    unreachable!("Should be able to collapse to end");
-                }
+                self.collapse_current_range(
+                    &active_range.end_container(),
+                    active_range.end_offset(),
+                );
             }
             // Step 6.3. Abort these steps.
             return;
@@ -229,23 +230,16 @@ impl Selection {
         }
 
         // Step 9. Call collapse(start node, start offset) on the context object's selection.
-        if self.Collapse(cx, Some(&start_node), start_offset).is_err() {
-            unreachable!("Must always be able to collapse");
-        }
+        self.collapse_current_range(&start_node, start_offset);
 
         // Step 10. Call extend(end node, end offset) on the context object's selection.
-        if self.Extend(cx, &end_node, end_offset).is_err() {
-            unreachable!("Must always be able to extend");
-        }
+        self.extend_current_range(&end_node, end_offset);
 
         // Step 11.
         //
         // This step does not exist in the spec
 
         // Step 12. Let start block be the active range's start node.
-        let Some(active_range) = self.active_range() else {
-            return;
-        };
         let mut start_block = active_range.start_container();
 
         // Step 13. While start block's parent is in the same editing host and start block is an inline node,
@@ -333,14 +327,16 @@ impl Selection {
             start_node.canonicalize_whitespace(start_offset, false);
             // Step 21.3. If direction is "forward", call collapseToStart() on the context object's selection.
             if direction == SelectionDeleteDirection::Forward {
-                if self.CollapseToStart(cx).is_err() {
-                    unreachable!("Should be able to collapse to start");
-                }
+                self.collapse_current_range(
+                    &active_range.start_container(),
+                    active_range.start_offset(),
+                );
             } else {
                 // Step 21.4. Otherwise, call collapseToEnd() on the context object's selection.
-                if self.CollapseToEnd(cx).is_err() {
-                    unreachable!("Should be able to collapse to end");
-                }
+                self.collapse_current_range(
+                    &active_range.end_container(),
+                    active_range.end_offset(),
+                );
             }
             // Step 21.5. Restore states and values from overrides.
             active_range.restore_states_and_values(cx, self, context_object, overrides);
@@ -469,14 +465,16 @@ impl Selection {
         {
             // Step 30.1. If direction is "forward", call collapseToStart() on the context object's selection.
             if direction == SelectionDeleteDirection::Forward {
-                if self.CollapseToStart(cx).is_err() {
-                    unreachable!("Should be able to collapse to start");
-                }
+                self.collapse_current_range(
+                    &active_range.start_container(),
+                    active_range.start_offset(),
+                );
             } else {
                 // Step 30.2. Otherwise, call collapseToEnd() on the context object's selection.
-                if self.CollapseToEnd(cx).is_err() {
-                    unreachable!("Should be able to collapse to end");
-                }
+                self.collapse_current_range(
+                    &active_range.end_container(),
+                    active_range.end_offset(),
+                );
             }
             // Step 30.3. Restore states and values from overrides.
             active_range.restore_states_and_values(cx, self, context_object, overrides);
@@ -517,12 +515,7 @@ impl Selection {
             }
             // Step 32.3. Call collapse() on the context object's selection,
             // with first argument start block and second argument the index of reference node.
-            if self
-                .Collapse(cx, Some(&start_block), reference_node.index())
-                .is_err()
-            {
-                unreachable!("Must always be able to collapse");
-            }
+            self.collapse_current_range(&start_block, reference_node.index());
             // Step 32.4. If end block has no children:
             if end_block.children_count() == 0 {
                 let mut end_block = end_block;
@@ -636,12 +629,7 @@ impl Selection {
         } else if end_block.is_ancestor_of(&start_block) {
             // Step 33.1. Call collapse() on the context object's selection,
             // with first argument start block and second argument start block's length.
-            if self
-                .Collapse(cx, Some(&start_block), start_block.len())
-                .is_err()
-            {
-                unreachable!("Must always be able to collapse");
-            }
+            self.collapse_current_range(&start_block, start_block.len());
             // Step 33.2. Let reference node be start block.
             let mut reference_node = start_block.clone();
             // Step 33.3. While reference node is not a child of end block, set reference node to its parent.
@@ -702,12 +690,7 @@ impl Selection {
         } else {
             // Step 34.1. Call collapse() on the context object's selection,
             // with first argument start block and second argument start block's length.
-            if self
-                .Collapse(cx, Some(&start_block), start_block.len())
-                .is_err()
-            {
-                unreachable!("Must always be able to collapse");
-            }
+            self.collapse_current_range(&start_block, start_block.len());
             // Step 34.2. If end block's firstChild is an inline node and start block's lastChild is a br,
             // remove start block's lastChild from it.
             if end_block

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -399,6 +399,19 @@ impl Range {
     }
 }
 
+impl std::fmt::Debug for Range {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "[({:?}, {}) -> ({:?}, {})]",
+            self.start_container(),
+            self.start_offset(),
+            self.end_container(),
+            self.end_offset()
+        )
+    }
+}
+
 enum StartOrEnd {
     Start,
     End,

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -130,6 +130,26 @@ impl Selection {
         // > The active range is the range of the selection given by calling getSelection() on the context object. (Thus the active range may be null.)
         self.range.get()
     }
+
+    pub(crate) fn collapse_current_range(&self, node: &Node, offset: u32) {
+        let range = self.range.get().expect("Must always have a range");
+        range.set_start(node, offset);
+        range.set_end(node, offset);
+    }
+
+    pub(crate) fn extend_current_range(&self, node: &Node, offset: u32) {
+        let range = self.range.get().expect("Must always have a range");
+        assert!(range.collapsed(), "Must only extend after collapsing");
+
+        let anchor_node = range.start_container();
+        if (*anchor_node == *node && range.start_offset() < offset) || anchor_node.is_before(node) {
+            range.set_end(node, offset);
+            self.direction.set(Direction::Forwards);
+        } else {
+            range.set_start(node, offset);
+            self.direction.set(Direction::Backwards);
+        }
+    }
 }
 
 impl SelectionMethods<crate::DomTypeHolder> for Selection {

--- a/tests/wpt/meta/editing/run/insertparagraph.html.ini
+++ b/tests/wpt/meta/editing/run/insertparagraph.html.ini
@@ -44,12 +44,6 @@
   [[["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "foo<br>[\]bar<span>baz</span><br>qux" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "{}<br><span style=display:block>abc<br>def<br></span>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "{}<br><span style=display:block>abc<br>def<br></span>" compare innerHTML]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "<div style=display:flex><span>[\]abc</span></div>" compare innerHTML]
     expected: FAIL
 
@@ -126,60 +120,6 @@
     expected: FAIL
 
   [[["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "<output>a[\]b</output>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "foo<br>[\]bar<br><span>baz</span>" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "foo<br>[\]bar<span contenteditable=\\"false\\">baz</span>qux" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "foo<br>[\]bar<span contenteditable=\\"false\\">baz</span><br>qux" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "foo<br>[\]bar<span>baz</span><br>qux" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "foo<br>bar[\]<br><span contenteditable=\\"false\\">baz</span>" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "foo<br>bar[\]<br><span>baz</span>" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "foo<br>bar[\]<br><span contenteditable=\\"false\\">baz</span>qux" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "foo<br>ba[\]r<br><span contenteditable=\\"false\\">baz</span>" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "foo<br>ba[\]r<br><span>baz</span>" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "foo<br>ba[\]r<br><span contenteditable=\\"false\\">baz</span>qux" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "foo<br>[\]bar<br><span contenteditable=\\"false\\">baz</span>" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "foo<br>[\]bar<br><span>baz</span>" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "foo<br>[\]bar<span contenteditable=\\"false\\">baz</span>qux" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "foo<br>[\]bar<span contenteditable=\\"false\\">baz</span><br>qux" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "foo<br>[\]bar<span>baz</span><br>qux" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "{}<br><span style=display:block>abc<br>def<br></span>" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "{}<br><span style=display:block>abc<br>def<br></span>" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\]\] " <span contenteditable=\\"false\\">A</span>[\] ; <span contenteditable=\\"false\\">B</span> ; <span contenteditable=\\"false\\">C</span> " checks for modifications to non-editable content]
     expected: FAIL
 
 
@@ -261,7 +201,6 @@
 
 
 [insertparagraph.html?1001-2000]
-  expected: ERROR
   [[["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "<script>foo[\]bar</script>baz" compare innerHTML]
     expected: FAIL
 
@@ -325,24 +264,6 @@
   [[["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "{}<br><p>foo</p>" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "<p>foo</p>{}<br><h1>bar</h1>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "<p>foo</p>{}<br><h1>bar</h1>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "<h1>foo</h1>{}<br><p>bar</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "<h1>foo</h1>{}<br><p>bar</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "<h1>foo</h1>{}<br><h2>bar</h2>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "<h1>foo</h1>{}<br><h2>bar</h2>" compare innerHTML]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "<p>foo</p><h1>[bar\]</h1><p>baz</p>" compare innerHTML]
     expected: FAIL
 
@@ -380,12 +301,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "<div style=display:none>foo[\]bar</div>baz" queryCommandState("stylewithcss") before]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "{}<br><p>foo</p>" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "{}<br><p>foo</p>" checks for modifications to non-editable content]
     expected: FAIL
 
 
@@ -802,27 +717,6 @@
   [[["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "foo<br>[\]bar<br><span contenteditable=\\"false\\">baz</span>" compare innerHTML]
     expected: FAIL
 
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "foo<br>bar[\]<br><span contenteditable=\\"false\\">baz</span>" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "foo<br>bar[\]<br><span>baz</span>" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "foo<br>bar[\]<br><span contenteditable=\\"false\\">baz</span>qux" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "foo<br>ba[\]r<br><span contenteditable=\\"false\\">baz</span>" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "foo<br>ba[\]r<br><span>baz</span>" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "foo<br>ba[\]r<br><span contenteditable=\\"false\\">baz</span>qux" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "foo<br>[\]bar<br><span contenteditable=\\"false\\">baz</span>" checks for modifications to non-editable content]
-    expected: FAIL
-
 
 [insertparagraph.html?1-1000]
   [[["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "foo[bar\]baz" compare innerHTML]
@@ -906,9 +800,6 @@
   [[["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["insertparagraph",""\]\] "<address>foo[\]</address>" compare innerHTML]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "<div>foo[\]<br></div>" compare innerHTML]
     expected: FAIL
 
@@ -933,49 +824,7 @@
   [[["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "<p>foo[\]<br></p>" compare innerHTML]
     expected: FAIL
 
-  [[["insertparagraph",""\]\] "<pre>foo[\]</pre>" compare innerHTML]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "foo[bar\]baz" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "foo[bar\]baz" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "fo[o<table><tr><td>b\]ar</table>" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "fo[o<table><tr><td>b\]ar</table>" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "{<table><tr><td>foo</table>}" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "{<table><tr><td>foo</table>}" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "[\]foo" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "[\]foo" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "foo[\]" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "foo[\]" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "foo[\]<br>" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "foo[\]<br>" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["insertparagraph",""\]\] "foo[\]bar" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["insertparagraph",""\]\] "foo[\]bar" checks for modifications to non-editable content]
+  [[["insertparagraph",""\]\] "<pre>foo&#10;[\]</pre>" compare innerHTML]
     expected: FAIL
 
 

--- a/tests/wpt/meta/editing/run/multitest.html.ini
+++ b/tests/wpt/meta/editing/run/multitest.html.ini
@@ -458,12 +458,6 @@
   [[["subscript",""\],["superscript",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("subscript") after]
     expected: FAIL
 
-  [[["hilitecolor","#00FFFF"\],["insertparagraph",""\]\] "foo[\]bar" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["hilitecolor","#00FFFF"\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar" checks for modifications to non-editable content]
-    expected: FAIL
-
 
 [multitest.html?1-1000]
   [[["bold",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
@@ -929,12 +923,6 @@
     expected: FAIL
 
   [[["italic",""\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("insertorderedlist") after]
-    expected: FAIL
-
-  [[["bold",""\],["insertparagraph",""\]\] "foo[\]bar" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["bold",""\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar" checks for modifications to non-editable content]
     expected: FAIL
 
 
@@ -1465,18 +1453,6 @@
     expected: FAIL
 
   [[["subscript",""\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
-    expected: FAIL
-
-  [[["italic",""\],["insertparagraph",""\]\] "foo[\]bar" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["italic",""\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["strikethrough",""\],["insertparagraph",""\]\] "foo[\]bar" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["strikethrough",""\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar" checks for modifications to non-editable content]
     expected: FAIL
 
 
@@ -2018,18 +1994,6 @@
   [[["forecolor","#0000FF"\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("justifyright") after]
     expected: FAIL
 
-  [[["fontsize","4"\],["insertparagraph",""\]\] "foo[\]bar" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["fontsize","4"\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["forecolor","#0000FF"\],["insertparagraph",""\]\] "foo[\]bar" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["forecolor","#0000FF"\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar" checks for modifications to non-editable content]
-    expected: FAIL
-
 
 [multitest.html?5001-6000]
   [[["createlink","http://www.google.com/"\],["justifyleft",""\]\] "foo[\]bar": execCommand("justifyleft", false, "") return value]
@@ -2527,12 +2491,6 @@
   [[["fontsize","4"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["fontname","sans-serif"\],["insertparagraph",""\]\] "foo[\]bar" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["fontname","sans-serif"\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar" checks for modifications to non-editable content]
-    expected: FAIL
-
 
 [multitest.html?2001-3000]
   [[["subscript",""\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("subscript") after]
@@ -3001,18 +2959,6 @@
     expected: FAIL
 
   [[["superscript",""\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("insertunorderedlist") after]
-    expected: FAIL
-
-  [[["subscript",""\],["insertparagraph",""\]\] "foo[\]bar" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["subscript",""\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["superscript",""\],["insertparagraph",""\]\] "foo[\]bar" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["superscript",""\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar" checks for modifications to non-editable content]
     expected: FAIL
 
 
@@ -4852,21 +4798,6 @@
   [[["styleWithCSS","false"\],["insertparagraph",""\],["inserttext","d"\]\] "<div>abc<b>[def\]</b></div>" queryCommandState("bold") after]
     expected: FAIL
 
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "abc<b>[def</b>\]ghi" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "abc[<b>def\]</b>ghi" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "abc<b>[def\]</b>ghi" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "abc<b>{def}</b>ghi" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["insertparagraph",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "abc{<b>def</b>}ghi" checks for modifications to non-editable content]
-    expected: FAIL
-
 
 [multitest.html?3001-4000]
   [[["superscript",""\],["justifycenter",""\]\] "foo[\]bar": execCommand("justifycenter", false, "") return value]
@@ -5406,12 +5337,6 @@
   [[["backcolor","#00FFFF"\],["indent",""\],["inserttext","a"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["underline",""\],["insertparagraph",""\]\] "foo[\]bar" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["underline",""\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar" checks for modifications to non-editable content]
-    expected: FAIL
-
 
 [multitest.html?4001-5000]
   [[["backcolor","#00FFFF"\],["inserthorizontalrule",""\]\] "foo[\]bar": execCommand("inserthorizontalrule", false, "") return value]
@@ -5912,20 +5837,8 @@
   [[["createlink","http://www.google.com/"\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("justifyfull") after]
     expected: FAIL
 
-  [[["backcolor","#00FFFF"\],["insertparagraph",""\]\] "foo[\]bar" checks for modifications to non-editable content]
-    expected: FAIL
-
   [[["backcolor","#00FFFF"\],["insertparagraph",""\]\] "foo[\]bar" queryCommandValue("backcolor") after]
     expected: FAIL
 
-  [[["backcolor","#00FFFF"\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar" checks for modifications to non-editable content]
-    expected: FAIL
-
   [[["backcolor","#00FFFF"\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("backcolor") after]
-    expected: FAIL
-
-  [[["createlink","http://www.google.com/"\],["insertparagraph",""\]\] "foo[\]bar" checks for modifications to non-editable content]
-    expected: FAIL
-
-  [[["createlink","http://www.google.com/"\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar" checks for modifications to non-editable content]
     expected: FAIL


### PR DESCRIPTION
There were two separate issues that I uncovered:
1. For insertParagraph, the `block_extend` implementation was wrong. I wrongly concluded that the third substep was also the while condition. But I didn't read correctly. They are two separate block conditions
2. Update all modifications of the selection object to use the current range. As it turns out, all of those `Collapse` and `Extend` calls would set a new range on the selection object. That means that the `active_range` that all those algorithms use would be the old range. Hence, some of the checks wouldn't look at the new range, but the old one. However we shouldn't even update the range. Thus we use the current range to make the logic work.

Also adds a formatting output for `Range`, since I was copy pasting range printlns too often.

Part of #25005

Testing: WPT