### PR TITLE
net: Allow internal requests to be fetched regardless of CSP

### DIFF
--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -15,6 +15,7 @@ use layout_api::{
 use net_traits::image_cache::{
     Image as CachedImage, ImageCache, ImageCacheResult, ImageOrMetadataAvailable, PendingImageId,
 };
+use net_traits::request::InternalRequest;
 use parking_lot::{Mutex, RwLock};
 use pixels::RasterImage;
 use script::layout_dom::ServoLayoutNode;
@@ -129,6 +130,7 @@ impl ImageResolver {
         node: OpaqueNode,
         url: ServoUrl,
         destination: LayoutImageDestination,
+        is_internal_request: InternalRequest,
     ) -> LayoutImageCacheResult {
         // Check for available image or start tracking.
         let cache_result =
@@ -148,6 +150,7 @@ impl ImageResolver {
                     id,
                     origin: self.origin.clone(),
                     destination,
+                    is_internal_request,
                 };
                 self.pending_images.lock().push(image);
                 LayoutImageCacheResult::Pending
@@ -160,6 +163,7 @@ impl ImageResolver {
                     id,
                     origin: self.origin.clone(),
                     destination,
+                    is_internal_request,
                 };
                 self.pending_images.lock().push(image);
                 LayoutImageCacheResult::Pending
@@ -183,12 +187,14 @@ impl ImageResolver {
         node: OpaqueNode,
         url: ServoUrl,
         destination: LayoutImageDestination,
+        is_internal_request: InternalRequest,
     ) -> Result<CachedImage, ResolveImageError> {
         if let Some(cached_image) = self.resolved_images_cache.read().get(&url) {
             return cached_image.clone();
         }
 
-        let result = self.get_or_request_image_or_meta(node, url.clone(), destination);
+        let result =
+            self.get_or_request_image_or_meta(node, url.clone(), destination, is_internal_request);
         match result {
             LayoutImageCacheResult::DataAvailable(img_or_meta) => match img_or_meta {
                 ImageOrMetadataAvailable::ImageAvailable { image, .. } => {
@@ -267,6 +273,7 @@ impl ImageResolver {
                     node,
                     image_url.clone().into(),
                     LayoutImageDestination::DisplayListBuilding,
+                    InternalRequest::No,
                 )?;
                 let metadata = image.metadata();
                 let size = Size2D::new(metadata.width, metadata.height).to_f32();

--- a/components/layout/replaced.rs
+++ b/components/layout/replaced.rs
@@ -11,6 +11,7 @@ use euclid::{Scale, Size2D};
 use layout_api::{IFrameSize, LayoutElement, LayoutImageDestination, LayoutNode, SVGElementData};
 use malloc_size_of_derive::MallocSizeOf;
 use net_traits::image_cache::{Image, ImageOrMetadataAvailable, VectorImage};
+use net_traits::request::InternalRequest;
 use script::layout_dom::ServoLayoutNode;
 use servo_arc::Arc as ServoArc;
 use servo_base::id::{BrowsingContextId, PipelineId};
@@ -289,6 +290,7 @@ impl ReplacedContents {
                     node.opaque(),
                     svg_source,
                     LayoutImageDestination::BoxTreeConstruction,
+                    InternalRequest::Yes,
                 )
                 .ok()
         });
@@ -336,6 +338,7 @@ impl ReplacedContents {
                 node.opaque(),
                 image_url.clone().into(),
                 LayoutImageDestination::BoxTreeConstruction,
+                InternalRequest::No,
             ) {
                 LayoutImageCacheResult::DataAvailable(img_or_meta) => match img_or_meta {
                     ImageOrMetadataAvailable::ImageAvailable { image, .. } => {

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -25,8 +25,8 @@ use net_traits::http_status::HttpStatus;
 use net_traits::policy_container::{PolicyContainer, RequestPolicyContainer};
 use net_traits::request::{
     BodyChunkRequest, BodyChunkResponse, CredentialsMode, Destination, Initiator,
-    InsecureRequestsPolicy, Origin, ParserMetadata, RedirectMode, Referrer, Request, RequestBody,
-    RequestId, RequestMode, ResponseTainting, is_cors_safelisted_method,
+    InsecureRequestsPolicy, InternalRequest, Origin, ParserMetadata, RedirectMode, Referrer,
+    Request, RequestBody, RequestId, RequestMode, ResponseTainting, is_cors_safelisted_method,
     is_cors_safelisted_request_header,
 };
 use net_traits::response::{Response, ResponseBody, ResponseType, TerminationReason};
@@ -300,6 +300,9 @@ pub async fn fetch_with_cors_cache(
 }
 
 pub(crate) fn convert_request_to_csp_request(request: &Request) -> Option<csp::Request> {
+    if request.is_internal_request == InternalRequest::Yes {
+        return None;
+    }
     let origin = match &request.origin {
         Origin::Client => return None,
         Origin::Origin(origin) => origin,

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -3536,7 +3536,13 @@ impl Window {
             let node = unsafe { from_untrusted_node_address(image.node) };
 
             if let PendingImageState::Unrequested(ref url) = image.state {
-                fetch_image_for_layout(url.clone(), &node, id, self.image_cache.clone());
+                fetch_image_for_layout(
+                    url.clone(),
+                    &node,
+                    id,
+                    image.is_internal_request,
+                    self.image_cache.clone(),
+                );
             }
 
             let mut images = self.pending_layout_images.borrow_mut();

--- a/components/script/layout_image.rs
+++ b/components/script/layout_image.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use net_traits::blob_url_store::UrlWithBlobClaim;
 use net_traits::image_cache::{ImageCache, PendingImageId};
-use net_traits::request::{Destination, RequestBuilder, RequestId};
+use net_traits::request::{Destination, InternalRequest, RequestBuilder, RequestId};
 use net_traits::{FetchMetadata, FetchResponseMsg, NetworkError, ResourceFetchTiming};
 use servo_url::ServoUrl;
 
@@ -92,6 +92,7 @@ pub(crate) fn fetch_image_for_layout(
     url: ServoUrl,
     node: &Node,
     id: PendingImageId,
+    is_internal_request: InternalRequest,
     cache: Arc<dyn ImageCache>,
 ) {
     let document = node.owner_document();
@@ -109,6 +110,7 @@ pub(crate) fn fetch_image_for_layout(
         global.get_referrer(),
     )
     .destination(Destination::Image)
+    .is_internal_request(is_internal_request)
     .with_global_scope(&global);
 
     // Layout image loads do not delay the document load event.

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -40,6 +40,7 @@ use libc::c_void;
 use malloc_size_of::{MallocSizeOf as MallocSizeOfTrait, MallocSizeOfOps, malloc_size_of_is_0};
 use malloc_size_of_derive::MallocSizeOf;
 use net_traits::image_cache::{ImageCache, ImageCacheFactory, PendingImageId};
+use net_traits::request::InternalRequest;
 use paint_api::CrossProcessPaintApi;
 use parking_lot::RwLock;
 use pixels::RasterImage;
@@ -216,6 +217,7 @@ pub struct PendingImage {
     pub id: PendingImageId,
     pub origin: ImmutableOrigin,
     pub destination: LayoutImageDestination,
+    pub is_internal_request: InternalRequest,
 }
 
 /// A data structure to tarck vector image that are fully loaded (i.e has a parsed SVG

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -135,6 +135,14 @@ pub enum ResponseTainting {
     Opaque,
 }
 
+/// Servo-internal to keep track of which requests originate from Servo internal implementation
+#[derive(Clone, Copy, Debug, Default, Deserialize, MallocSizeOf, PartialEq, Serialize)]
+pub enum InternalRequest {
+    Yes,
+    #[default]
+    No,
+}
+
 /// <https://html.spec.whatwg.org/multipage/#preload-key>
 #[derive(Clone, Debug, Eq, Hash, Deserialize, MallocSizeOf, Serialize, PartialEq)]
 pub struct PreloadKey {
@@ -503,6 +511,8 @@ pub struct RequestBuilder {
     pub response_tainting: ResponseTainting,
     /// Servo internal: if crash details are present, trigger a crash error page with these details.
     pub crash: Option<String>,
+    /// Servo internal: whether this request originates from Servo internal implementation
+    pub is_internal_request: InternalRequest,
 }
 
 impl RequestBuilder {
@@ -544,6 +554,7 @@ impl RequestBuilder {
             parser_metadata: ParserMetadata::Default,
             initiator: Initiator::None,
             response_tainting: ResponseTainting::Basic,
+            is_internal_request: Default::default(),
             crash: None,
         }
     }
@@ -722,6 +733,11 @@ impl RequestBuilder {
         self
     }
 
+    pub fn is_internal_request(mut self, is_internal_request: InternalRequest) -> RequestBuilder {
+        self.is_internal_request = is_internal_request;
+        self
+    }
+
     pub fn build(self) -> Request {
         let mut request = Request::new(
             self.id,
@@ -767,6 +783,7 @@ impl RequestBuilder {
         request.policy_container = self.policy_container;
         request.insecure_requests_policy = self.insecure_requests_policy;
         request.has_trustworthy_ancestor_origin = self.has_trustworthy_ancestor_origin;
+        request.is_internal_request = self.is_internal_request;
         request
     }
 
@@ -850,6 +867,8 @@ pub struct Request {
     pub has_trustworthy_ancestor_origin: bool,
     /// Servo internal: if crash details are present, trigger a crash error page with these details.
     pub crash: Option<String>,
+    /// Servo internal: whether this request originates from Servo internal implementation
+    pub is_internal_request: InternalRequest,
 }
 
 impl Request {
@@ -896,6 +915,7 @@ impl Request {
             policy_container: RequestPolicyContainer::Client,
             insecure_requests_policy: InsecureRequestsPolicy::DoNotUpgrade,
             has_trustworthy_ancestor_origin: false,
+            is_internal_request: Default::default(),
             crash: None,
         }
     }

--- a/tests/wpt/meta/content-security-policy/img-src/svg-use-blocked.tentative.html.ini
+++ b/tests/wpt/meta/content-security-policy/img-src/svg-use-blocked.tentative.html.ini
@@ -1,3 +1,4 @@
 [svg-use-blocked.tentative.html]
+  expected: TIMEOUT
   [Blocked SVG <use> element]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/tests/content-security-policy/img-src/img-src-none-blocks-css-background-image.html
+++ b/tests/wpt/tests/content-security-policy/img-src/img-src-none-blocks-css-background-image.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta http-equiv="Content-Security-Policy" content="img-src 'none';">
+<html>
+<head>
+    <title>CSS background-image is blocked by img-src.</title>
+    <script src='/resources/testharness.js'></script>
+    <script src='/resources/testharnessreport.js'></script>
+</head>
+<body>
+    <script>
+      var t_spv = async_test("Test that spv event is fired");
+      window.addEventListener("securitypolicyviolation", t_spv.step_func_done(function(e) {
+        assert_equals(e.violatedDirective, 'img-src');
+        assert_equals(e.target, document);
+        assert_true(e.blockedURI.endsWith('/support/fail.png'));
+      }));
+    </script>
+
+    <style>
+      #container {
+        background-image: url('../support/fail.png');
+      }
+    </style>
+
+    <div id="container">
+      <p>This text should NOT have a red background.</p>
+    </div>
+</body>
+</html>

--- a/tests/wpt/tests/content-security-policy/svg/resources/svg-inline-without-scripting-without-csp.html
+++ b/tests/wpt/tests/content-security-policy/svg/resources/svg-inline-without-scripting-without-csp.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>SVG without scripting should load</title>
+    <link rel="match" href="resources/svg-inline-only-path-without-csp.html">
+</head>
+
+<body>
+    <p>Tests that an SVG loaded without any scripting should load.</p>
+    <?xml version="1.0" standalone="no"?>
+
+    <svg width="6cm" height="5cm" viewBox="0 0 600 500"
+        xmlns="http://www.w3.org/2000/svg" version="1.1">
+
+      <circle cx="300" cy="225" r="100" fill="green"/>
+
+      <text x="300" y="250"
+            font-family="Verdana"
+            font-size="50"
+            text-anchor="middle">
+          PASS
+      </text>
+    </svg>
+</body>
+</html>

--- a/tests/wpt/tests/content-security-policy/svg/resources/svg-inline-without-scripting-without-csp.html
+++ b/tests/wpt/tests/content-security-policy/svg/resources/svg-inline-without-scripting-without-csp.html
@@ -2,12 +2,10 @@
 <html>
 <head>
     <title>SVG without scripting should load</title>
-    <link rel="match" href="resources/svg-inline-only-path-without-csp.html">
 </head>
 
 <body>
     <p>Tests that an SVG loaded without any scripting should load.</p>
-    <?xml version="1.0" standalone="no"?>
 
     <svg width="6cm" height="5cm" viewBox="0 0 600 500"
         xmlns="http://www.w3.org/2000/svg" version="1.1">

--- a/tests/wpt/tests/content-security-policy/svg/svg-inline-without-scripting.html
+++ b/tests/wpt/tests/content-security-policy/svg/svg-inline-without-scripting.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>SVG without scripting should load</title>
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'unsafe-inline';">
+    <link rel="match" href="resources/svg-inline-without-scripting-without-csp.html">
+</head>
+
+<body>
+    <p>Tests that an SVG loaded without any scripting should load.</p>
+    <?xml version="1.0" standalone="no"?>
+
+    <svg width="6cm" height="5cm" viewBox="0 0 600 500"
+        xmlns="http://www.w3.org/2000/svg" version="1.1">
+
+      <circle cx="300" cy="225" r="100" fill="green"/>
+
+      <text x="300" y="250"
+            font-family="Verdana"
+            font-size="50"
+            text-anchor="middle">
+          PASS
+      </text>
+    </svg>
+</body>
+</html>

--- a/tests/wpt/tests/content-security-policy/svg/svg-inline-without-scripting.html
+++ b/tests/wpt/tests/content-security-policy/svg/svg-inline-without-scripting.html
@@ -8,7 +8,6 @@
 
 <body>
     <p>Tests that an SVG loaded without any scripting should load.</p>
-    <?xml version="1.0" standalone="no"?>
 
     <svg width="6cm" height="5cm" viewBox="0 0 600 500"
         xmlns="http://www.w3.org/2000/svg" version="1.1">


### PR DESCRIPTION
For Servo internal machinery that makes requests, we should not enforce CSP. This is relevant for inline SVG's, which are currently implemented as data URLs.

Also adds missing test coverage for `background-image` URLs blocked by `img-src`.

Testing: Adds a new WPT test
Fixes: #42189