### PR TITLE
script: Extract common parts of FileReader and FileReaderSync

### DIFF
--- a/components/script/dom/file/filereader.rs
+++ b/components/script/dom/file/filereader.rs
@@ -124,7 +124,7 @@ pub(crate) struct FileReaderSharedFunctionality;
 
 impl FileReaderSharedFunctionality {
     /// <https://w3c.github.io/FileAPI/#blob-package-data>
-    pub(crate) fn dataurl_for_bytes(blob_contents: &[u8], blob_type: &str) -> DOMString {
+    pub(crate) fn dataurl_for_bytes(bytes: &[u8], blob_type: &str) -> DOMString {
         // If mimeType (blobType) is not available return a Data URL without a media-type. [RFC2397].
         // Spec says a Data URL without a media-type when blob_type is unavailable.
         // However, all other browsers use "application/octet-stream" in this case.
@@ -134,31 +134,26 @@ impl FileReaderSharedFunctionality {
             blob_type
         };
 
-        Self::dataurl_format(blob_contents, mime_type)
+        Self::dataurl_format(bytes, mime_type)
     }
 
     /// [RFC2397]
     /// <https://www.rfc-editor.org/rfc/rfc2397.html>
-    fn dataurl_format(blob_contents: &[u8], mime_type: &str) -> DOMString {
-        let base64 = base64::engine::general_purpose::STANDARD.encode(blob_contents);
+    fn dataurl_format(bytes: &[u8], mime_type: &str) -> DOMString {
+        let base64 = base64::engine::general_purpose::STANDARD.encode(bytes);
         let dataurl = format!("data:{};base64,{}", mime_type, base64);
 
         DOMString::from(dataurl)
     }
 
     /// <https://w3c.github.io/FileAPI/#blob-package-data>
-    pub(crate) fn binary_string_for_bytes(blob_contents: &[u8]) -> DOMString {
-        DOMString::from(
-            blob_contents
-                .iter()
-                .map(|&byte| byte as char)
-                .collect::<String>(),
-        )
+    pub(crate) fn binary_string_for_bytes(bytes: &[u8]) -> DOMString {
+        DOMString::from(bytes.iter().map(|&byte| byte as char).collect::<String>())
     }
 
-    /// <https://encoding.spec.whatwg.org/#decode>
+    /// <https://w3c.github.io/FileAPI/#blob-package-data>
     pub(crate) fn text_for_bytes(
-        blob_contents: &[u8],
+        bytes: &[u8],
         blob_type: &str,
         encoding: &Option<String>,
     ) -> DOMString {
@@ -183,8 +178,9 @@ impl FileReaderSharedFunctionality {
         // Step 6
         let enc = encoding.unwrap_or(UTF_8);
 
-        let convert = blob_contents;
+        let convert = bytes;
         // Step 7
+        // https://encoding.spec.whatwg.org/#decode
         let (output, _, _) = enc.decode(convert);
         DOMString::from(output)
     }
@@ -350,10 +346,13 @@ impl FileReader {
         data: ReadMetaData,
         blob_bytes: &[u8],
     ) {
-        let encoding = &data.encoding;
-        let blob_type = &data.blobtype;
-        let output = FileReaderSharedFunctionality::text_for_bytes(blob_bytes, blob_type, encoding);
-        *result.borrow_mut() = Some(FileReaderResult::String(output));
+        *result.borrow_mut() = Some(FileReaderResult::String(
+            FileReaderSharedFunctionality::text_for_bytes(
+                blob_bytes,
+                &data.blobtype,
+                &data.encoding,
+            ),
+        ));
     }
 
     /// <https://w3c.github.io/FileAPI/#packaging-data>
@@ -362,16 +361,18 @@ impl FileReader {
         data: ReadMetaData,
         bytes: &[u8],
     ) {
-        let output = FileReaderSharedFunctionality::dataurl_for_bytes(bytes, &data.blobtype);
-        *result.borrow_mut() = Some(FileReaderResult::String(output));
+        *result.borrow_mut() = Some(FileReaderResult::String(
+            FileReaderSharedFunctionality::dataurl_for_bytes(bytes, &data.blobtype),
+        ));
     }
 
     /// <https://w3c.github.io/FileAPI/#packaging-data>
     /// > Return bytes as a binary string, in which every byte
     /// > is represented by a code unit of equal value [0..255].
     fn perform_readasbinarystring(result: &DomRefCell<Option<FileReaderResult>>, bytes: &[u8]) {
-        let output = FileReaderSharedFunctionality::binary_string_for_bytes(bytes);
-        *result.borrow_mut() = Some(FileReaderResult::String(output));
+        *result.borrow_mut() = Some(FileReaderResult::String(
+            FileReaderSharedFunctionality::binary_string_for_bytes(bytes),
+        ));
     }
 
     /// <https://w3c.github.io/FileAPI/#packaging-data>
@@ -552,10 +553,11 @@ impl FileReader {
         // Let reader be the result of getting a reader from stream.
         let reader = stream.and_then(|s| s.acquire_default_reader(CanGc::from_cx(cx)))?;
 
-        let type_ = blob.Type();
-
-        let load_data =
-            ReadMetaData::new(String::from(type_), encoding.map(String::from), function);
+        let load_data = ReadMetaData::new(
+            String::from(blob.Type()),
+            encoding.map(String::from),
+            function,
+        );
 
         let GenerationId(prev_id) = self.generation_id.get();
         self.generation_id.set(GenerationId(prev_id + 1));

--- a/components/script/dom/file/filereader.rs
+++ b/components/script/dom/file/filereader.rs
@@ -123,18 +123,41 @@ pub(crate) enum FileReaderResult {
 pub(crate) struct FileReaderSharedFunctionality;
 
 impl FileReaderSharedFunctionality {
+    /// <https://w3c.github.io/FileAPI/#blob-package-data>
+    pub(crate) fn dataurl_for_bytes(blob_contents: &[u8], blob_type: &str) -> DOMString {
+        // If mimeType (blobType) is not available return a Data URL without a media-type. [RFC2397].
+        // Spec says a Data URL without a media-type when blob_type is unavailable.
+        // However, all other browsers use "application/octet-stream" in this case.
+        let mime_type = if blob_type.is_empty() {
+            "application/octet-stream"
+        } else {
+            blob_type
+        };
+
+        Self::dataurl_format(blob_contents, mime_type)
+    }
+
     /// [RFC2397]
     /// <https://www.rfc-editor.org/rfc/rfc2397.html>
-    pub(crate) fn dataurl_format(blob_contents: &[u8], mime_type: String) -> DOMString {
+    fn dataurl_format(blob_contents: &[u8], mime_type: &str) -> DOMString {
         let base64 = base64::engine::general_purpose::STANDARD.encode(blob_contents);
-
         let dataurl = format!("data:{};base64,{}", mime_type, base64);
 
         DOMString::from(dataurl)
     }
 
+    /// <https://w3c.github.io/FileAPI/#blob-package-data>
+    pub(crate) fn binary_string_for_bytes(blob_contents: &[u8]) -> DOMString {
+        DOMString::from(
+            blob_contents
+                .iter()
+                .map(|&byte| byte as char)
+                .collect::<String>(),
+        )
+    }
+
     /// <https://encoding.spec.whatwg.org/#decode>
-    pub(crate) fn text_decode(
+    pub(crate) fn text_for_bytes(
         blob_contents: &[u8],
         blob_type: &str,
         encoding: &Option<String>,
@@ -329,8 +352,7 @@ impl FileReader {
     ) {
         let encoding = &data.encoding;
         let blob_type = &data.blobtype;
-
-        let output = FileReaderSharedFunctionality::text_decode(blob_bytes, blob_type, encoding);
+        let output = FileReaderSharedFunctionality::text_for_bytes(blob_bytes, blob_type, encoding);
         *result.borrow_mut() = Some(FileReaderResult::String(output));
     }
 
@@ -340,19 +362,7 @@ impl FileReader {
         data: ReadMetaData,
         bytes: &[u8],
     ) {
-        // > Return bytes as a DataURL [RFC2397] subject to the considerations below:
-        // 1. Use mimeType (blobType) as part of the Data URL if it is available
-        //    in keeping with the Data URL specification [RFC2397].
-        // 2. If mimeType (blobType) is not available return a Data URL without a media-type. [RFC2397].
-        // N.B.: Spec says a Data URL without a media-type.
-        // However, all other browsers do "application/octet-stream" in this case.
-        let mime_type = if data.blobtype.is_empty() {
-            "application/octet-stream".to_string()
-        } else {
-            data.blobtype
-        };
-        let output = FileReaderSharedFunctionality::dataurl_format(bytes, mime_type);
-
+        let output = FileReaderSharedFunctionality::dataurl_for_bytes(bytes, &data.blobtype);
         *result.borrow_mut() = Some(FileReaderResult::String(output));
     }
 
@@ -360,9 +370,8 @@ impl FileReader {
     /// > Return bytes as a binary string, in which every byte
     /// > is represented by a code unit of equal value [0..255].
     fn perform_readasbinarystring(result: &DomRefCell<Option<FileReaderResult>>, bytes: &[u8]) {
-        *result.borrow_mut() = Some(FileReaderResult::String(DOMString::from(
-            bytes.iter().map(|&byte| byte as char).collect::<String>(),
-        )));
+        let output = FileReaderSharedFunctionality::binary_string_for_bytes(bytes);
+        *result.borrow_mut() = Some(FileReaderResult::String(output));
     }
 
     /// <https://w3c.github.io/FileAPI/#packaging-data>

--- a/components/script/dom/file/filereadersync.rs
+++ b/components/script/dom/file/filereadersync.rs
@@ -68,13 +68,8 @@ impl FileReaderSyncMethods<crate::DomTypeHolder> for FileReaderSync {
         let blob_contents = FileReaderSync::get_blob_bytes(blob)?;
 
         // step 2.
-        // > Return bytes as a binary string, in which every byte
-        // > is represented by a code unit of equal value [0..255].
-        Ok(DOMString::from(
-            blob_contents
-                .iter()
-                .map(|&byte| byte as char)
-                .collect::<String>(),
+        Ok(FileReaderSharedFunctionality::binary_string_for_bytes(
+            &blob_contents,
         ))
     }
 
@@ -88,7 +83,7 @@ impl FileReaderSyncMethods<crate::DomTypeHolder> for FileReaderSync {
         let blob_type = String::from(blob.Type());
 
         let output =
-            FileReaderSharedFunctionality::text_decode(&blob_contents, &blob_type, &blob_label);
+            FileReaderSharedFunctionality::text_for_bytes(&blob_contents, &blob_type, &blob_label);
 
         Ok(output)
     }
@@ -101,12 +96,7 @@ impl FileReaderSyncMethods<crate::DomTypeHolder> for FileReaderSync {
         // step 2. package data.
         // https://w3c.github.io/FileAPI/#blob-package-data
         let blob_type = blob.Type().to_string();
-        let mime_type = if blob_type.is_empty() {
-            "application/octet-stream".to_string()
-        } else {
-            blob_type
-        };
-        let output = FileReaderSharedFunctionality::dataurl_format(&blob_contents, mime_type);
+        let output = FileReaderSharedFunctionality::dataurl_for_bytes(&blob_contents, &blob_type);
 
         Ok(output)
     }

--- a/components/script/dom/file/filereadersync.rs
+++ b/components/script/dom/file/filereadersync.rs
@@ -82,10 +82,11 @@ impl FileReaderSyncMethods<crate::DomTypeHolder> for FileReaderSync {
         let blob_label = label.map(String::from);
         let blob_type = String::from(blob.Type());
 
-        let output =
-            FileReaderSharedFunctionality::text_for_bytes(&blob_contents, &blob_type, &blob_label);
-
-        Ok(output)
+        Ok(FileReaderSharedFunctionality::text_for_bytes(
+            &blob_contents,
+            &blob_type,
+            &blob_label,
+        ))
     }
 
     /// <https://w3c.github.io/FileAPI/#readAsDataURLSync-section>
@@ -95,8 +96,8 @@ impl FileReaderSyncMethods<crate::DomTypeHolder> for FileReaderSync {
 
         // step 2. package data.
         // https://w3c.github.io/FileAPI/#blob-package-data
-        let blob_type = blob.Type().to_string();
-        let output = FileReaderSharedFunctionality::dataurl_for_bytes(&blob_contents, &blob_type);
+        let output =
+            FileReaderSharedFunctionality::dataurl_for_bytes(&blob_contents, &blob.Type().str());
 
         Ok(output)
     }


### PR DESCRIPTION
Extract common parts of FileReader and FileReaderSync & Extract data URL and binary string conversion logic into FileReaderSharedFunctionality.

Testing: mach test-wpt tests/wpt/tests/FileAPI/    101 tests finished and 101 ran as expected
Fixes #44923