### PR TITLE
Remove servo-media Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,9 +65,6 @@ updates:
       patterns:
         - "serde"
         - "serde_core"
-    servo-media-related:
-      patterns:
-        - "servo-media*"
     strum-related:
       patterns:
         - "strum"


### PR DESCRIPTION
servo-media are now internal Servo crates so this group is no longer needed.

Testing: No tests for dependabot.yml edit.