### PR TITLE
Fix borrow hazard creating intersection observer entries

### DIFF
--- a/components/script/dom/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver.rs
@@ -355,8 +355,8 @@ impl IntersectionObserver {
             Finite::wrap(intersection_ratio),
             target,
         );
-        // Step 2
-        // > 2. Append it to observer's internal [[QueuedEntries]] slot.
+
+        // Step 2. Append it to observer's internal [[QueuedEntries]] slot.
         self.queued_entries.borrow_mut().push(entry.as_traced());
 
         // Step 3. Queue an intersection observer task for document.

--- a/components/script/dom/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver.rs
@@ -337,8 +337,7 @@ impl IntersectionObserver {
         let bounding_client_rect = rect_to_domrectreadonly(bounding_client_rect);
         let intersection_rect = rect_to_domrectreadonly(intersection_rect);
 
-        // Step 1
-        // > 1. Construct an IntersectionObserverEntry, passing in time, rootBounds,
+        // Step 1. Construct an IntersectionObserverEntry, passing in time, rootBounds,
         // >    boundingClientRect, intersectionRect, isIntersecting, and target.
         let entry = IntersectionObserverEntry::new(
             cx,

--- a/components/script/dom/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver.rs
@@ -337,29 +337,28 @@ impl IntersectionObserver {
         let bounding_client_rect = rect_to_domrectreadonly(bounding_client_rect);
         let intersection_rect = rect_to_domrectreadonly(intersection_rect);
 
-        // Step 1-2
+        // Step 1
         // > 1. Construct an IntersectionObserverEntry, passing in time, rootBounds,
         // >    boundingClientRect, intersectionRect, isIntersecting, and target.
-        // > 2. Append it to observer’s internal [[QueuedEntries]] slot.
-        self.queued_entries.borrow_mut().push(
-            IntersectionObserverEntry::new(
-                cx,
-                self.owner_doc.window(),
-                None,
-                document
-                    .owner_global()
-                    .performance()
-                    .to_dom_high_res_time_stamp(time),
-                Some(&root_bounds),
-                &bounding_client_rect,
-                &intersection_rect,
-                is_intersecting,
-                is_visible,
-                Finite::wrap(intersection_ratio),
-                target,
-            )
-            .as_traced(),
+        let entry = IntersectionObserverEntry::new(
+            cx,
+            self.owner_doc.window(),
+            None,
+            document
+                .owner_global()
+                .performance()
+                .to_dom_high_res_time_stamp(time),
+            Some(&root_bounds),
+            &bounding_client_rect,
+            &intersection_rect,
+            is_intersecting,
+            is_visible,
+            Finite::wrap(intersection_ratio),
+            target,
         );
+        // Step 2
+        // > 2. Append it to observer's internal [[QueuedEntries]] slot.
+        self.queued_entries.borrow_mut().push(entry.as_traced());
         // > Step 3
         // Queue an intersection observer task for document.
         document.queue_an_intersection_observer_task();

--- a/components/script/dom/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver.rs
@@ -358,8 +358,8 @@ impl IntersectionObserver {
         // Step 2
         // > 2. Append it to observer's internal [[QueuedEntries]] slot.
         self.queued_entries.borrow_mut().push(entry.as_traced());
-        // > Step 3
-        // Queue an intersection observer task for document.
+
+        // Step 3. Queue an intersection observer task for document.
         document.queue_an_intersection_observer_task();
     }
 


### PR DESCRIPTION
`IntersectionObserverEntry::new()` can trigger garbage collection but `self.queued_entries.borrow_mut()` was held during the call when GC traces the cell it tries to borrow again causing a panic , create the entry first then push it to avoid the borrow hazard

Fixes #44988