### PR TITLE
layout: Avoid extra work when there is no strong BiDi content

### DIFF
--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -6,9 +6,11 @@ use std::borrow::Cow;
 use std::char::{ToLowercase, ToUppercase};
 use std::ops::Range;
 
+use icu_properties::BidiClass;
 use icu_segmenter::WordSegmenter;
 use layout_api::{LayoutNode, SharedSelection};
 use style::computed_values::_webkit_text_security::T as WebKitTextSecurity;
+use style::computed_values::direction::T as Direction;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
 use style::selector_parser::PseudoElement;
 use style::values::specified::text::TextTransformCase;
@@ -97,6 +99,11 @@ pub(crate) struct InlineFormattingContextBuilder {
     /// Whether or not the `::first-letter` pseudo-element of this inline formatting context
     /// has been processed yet.
     has_processed_first_letter: bool,
+
+    /// Whether or not the inline formatting context under construction has any kind of
+    /// right-to-left content such as a character with an RTL character class or a `dir`
+    /// attribute specifying right-to-left content.
+    pub(crate) has_right_to_left_content: bool,
 }
 
 impl InlineFormattingContextBuilder {
@@ -117,6 +124,7 @@ impl InlineFormattingContextBuilder {
     }
 
     pub(crate) fn new(info: &NodeAndStyleInfo, context: &LayoutContext) -> Self {
+        let has_right_to_left_content = info.style.get_inherited_box().direction == Direction::Rtl;
         Self {
             // For the purposes of `text-transform: capitalize` the start of the IFC is a word boundary.
             on_word_boundary: true,
@@ -125,6 +133,7 @@ impl InlineFormattingContextBuilder {
                 info, context,
             )],
             shared_selection: info.node.selection(),
+            has_right_to_left_content,
             ..Default::default()
         }
     }
@@ -250,7 +259,11 @@ impl InlineFormattingContextBuilder {
             .unwrap_or_else(inline_box_creator);
 
         let borrowed_inline_box = inline_box.borrow();
-        self.push_control_character_string(borrowed_inline_box.base.style.bidi_control_chars().0);
+
+        let style = &borrowed_inline_box.base.style;
+        self.push_control_character_string(style.bidi_control_chars().0);
+        self.has_right_to_left_content =
+            self.has_right_to_left_content || style.get_inherited_box().direction == Direction::Rtl;
 
         self.shared_inline_styles_stack
             .push(borrowed_inline_box.shared_inline_styles.clone());
@@ -378,11 +391,25 @@ impl InlineFormattingContextBuilder {
             char_iterator
         };
 
+        let bidi_class_map = icu_properties::maps::bidi_class();
         let white_space_collapse = info.style.clone_white_space_collapse();
         let mut character_count = 0;
         let new_text: String = char_iterator
             .inspect(|&character| {
                 character_count += 1;
+
+                // If this character has a strong right-to-left class the new inline formatting context will
+                // need to be BiDi-aware. This match is derived from the list of strong right-to-left classes
+                // at https://www.unicode.org/reports/tr44/#Bidi_Class_Values.
+                self.has_right_to_left_content = self.has_right_to_left_content ||
+                    matches!(
+                        bidi_class_map.get(character),
+                        BidiClass::RightToLeft |
+                            BidiClass::ArabicLetter |
+                            BidiClass::RightToLeftEmbedding |
+                            BidiClass::RightToLeftIsolate |
+                            BidiClass::RightToLeftOverride
+                    );
 
                 self.is_empty = self.is_empty &&
                     match white_space_collapse {

--- a/components/layout/flow/inline/line.rs
+++ b/components/layout/flow/inline/line.rs
@@ -212,7 +212,37 @@ impl LineItemLayout<'_, '_> {
         }
     }
 
-    pub(super) fn layout(&mut self, mut line_items: Vec<LineItem>) -> Vec<Fragment> {
+    /// If the inline formatting context that this line is being laid out for had
+    /// right-to-left content, reorder the line contents according to their pre-calculated
+    /// BiDi levels.
+    ///
+    /// Returns an iterator over the line contents.
+    fn reorder_line_items_for_bidi(
+        &self,
+        mut line_items: Vec<LineItem>,
+    ) -> impl Iterator<Item = LineItem> + use<> {
+        let iterator = |line_items: Vec<LineItem>| {
+            // `BidiInfo::reorder_visual` will reorder the contents of the line so that they
+            // are in the correct order as if one was looking at the line from left-to-right.
+            // During this layout we do not lay out from left to right. Instead we lay out
+            // from inline-start to inline-end. If the overall line contents have been flipped
+            // for BiDi, flip them again so that they are in line start-to-end order rather
+            // than left-to-right order.
+            if self.containing_block().style.writing_mode.is_bidi_ltr() {
+                Either::Left(line_items.into_iter())
+            } else {
+                Either::Right(line_items.into_iter().rev())
+            }
+        };
+
+        if !self.layout.ifc.has_right_to_left_content {
+            // Even if the actual content of the inline formatting context does not
+            // contain internal right-to-left text, the overall direction of the inline
+            // formatting context might be right-to-left. In that case we still want to
+            // return a reverse iterator.
+            return iterator(line_items);
+        }
+
         let mut last_level = Level::ltr();
         let levels: Vec<_> = line_items
             .iter()
@@ -239,23 +269,12 @@ impl LineItemLayout<'_, '_> {
             })
             .collect();
 
-        if self.layout.ifc.has_right_to_left_content {
-            sort_by_indices_in_place(&mut line_items, BidiInfo::reorder_visual(&levels));
-        }
+        sort_by_indices_in_place(&mut line_items, BidiInfo::reorder_visual(&levels));
+        iterator(line_items)
+    }
 
-        // `BidiInfo::reorder_visual` will reorder the contents of the line so that they
-        // are in the correct order as if one was looking at the line from left-to-right.
-        // During this layout we do not lay out from left to right. Instead we lay out
-        // from inline-start to inline-end. If the overall line contents have been flipped
-        // for BiDi, flip them again so that they are in line start-to-end order rather
-        // than left-to-right order.
-        let containing_block = self.containing_block();
-        let line_item_iterator = if containing_block.style.writing_mode.is_bidi_ltr() {
-            Either::Left(line_items.into_iter())
-        } else {
-            Either::Right(line_items.into_iter().rev())
-        };
-
+    pub(super) fn layout(&mut self, line_items: Vec<LineItem>) -> Vec<Fragment> {
+        let line_item_iterator = self.reorder_line_items_for_bidi(line_items);
         for item in line_item_iterator.into_iter().by_ref() {
             // When preparing to lay out a new line item, start and end inline boxes, so that the current
             // inline box state reflects the item's parent. Items in the line are not necessarily in tree

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -1865,8 +1865,12 @@ impl InlineFormattingContext {
         // This is to prevent a double borrow.
         let text_content: String = builder.text_segments.into_iter().collect();
 
-        let bidi_info = BidiInfo::new(&text_content, Some(starting_bidi_level));
-        let has_right_to_left_content = bidi_info.has_rtl();
+        let bidi_levels = BidiLevels {
+            info: builder
+                .has_right_to_left_content
+                .then(|| BidiInfo::new(&text_content, Some(starting_bidi_level))),
+        };
+
         let shared_inline_styles = builder
             .shared_inline_styles_stack
             .last()
@@ -1916,7 +1920,7 @@ impl InlineFormattingContext {
                         &text_content,
                         layout_context,
                         &mut new_linebreaker,
-                        &bidi_info,
+                        &bidi_levels,
                     );
                 },
                 InlineItem::StartInlineBox(inline_box) => {
@@ -1929,7 +1933,7 @@ impl InlineFormattingContext {
                     }
                 },
                 InlineItem::Atomic(_, index_in_text, bidi_level) => {
-                    *bidi_level = bidi_info.levels[*index_in_text];
+                    *bidi_level = bidi_levels.level(*index_in_text);
                 },
                 InlineItem::OutOfFlowAbsolutelyPositionedBox(..) |
                 InlineItem::OutOfFlowFloatBox(_) |
@@ -1943,6 +1947,7 @@ impl InlineFormattingContext {
             &layout_context.font_context,
         );
 
+        let has_right_to_left_content = bidi_levels.info.as_ref().is_some_and(BidiInfo::has_rtl);
         InlineFormattingContext {
             text_content,
             inline_items: builder.inline_items,
@@ -3052,6 +3057,18 @@ impl<'layout_data> ContentSizesComputation<'layout_data> {
             depends_on_block_constraints: false,
         }
         .traverse(inline_formatting_context)
+    }
+}
+
+pub(crate) struct BidiLevels<'a> {
+    info: Option<BidiInfo<'a>>,
+}
+
+impl BidiLevels<'_> {
+    fn level(&self, byte_offset_in_ifc_text: usize) -> Level {
+        self.info
+            .as_ref()
+            .map_or_else(Level::ltr, |info| info.levels[byte_offset_in_ifc_text])
     }
 }
 

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -28,7 +28,7 @@ use style::values::computed::{
     FontFeatureSettings, FontVariantEastAsian, FontVariantLigatures, FontVariantNumeric,
     OverflowWrap,
 };
-use unicode_bidi::{BidiInfo, Level};
+use unicode_bidi::Level;
 use unicode_script::Script;
 
 use super::line_breaker::LineBreaker;
@@ -37,7 +37,7 @@ use crate::ArcRefCell;
 use crate::context::LayoutContext;
 use crate::dom::WeakLayoutBox;
 use crate::flow::inline::line::TextRunOffsets;
-use crate::flow::inline::{LineBlockSizes, LineItem, SegmentContentFlags};
+use crate::flow::inline::{BidiLevels, LineBlockSizes, LineItem, SegmentContentFlags};
 use crate::fragment_tree::BaseFragmentInfo;
 
 // There are two reasons why we might want to break at the start:
@@ -472,13 +472,13 @@ impl TextRun {
         formatting_context_text: &str,
         layout_context: &LayoutContext,
         linebreaker: &mut LineBreaker,
-        bidi_info: &BidiInfo,
+        bidi_levels: &BidiLevels,
     ) {
         let parent_style = self.inline_styles.style.borrow().clone();
         let items = self.segment_text_by_font(
             layout_context,
             formatting_context_text,
-            bidi_info,
+            bidi_levels,
             &parent_style,
         );
 
@@ -505,7 +505,7 @@ impl TextRun {
         &mut self,
         layout_context: &LayoutContext,
         formatting_context_text: &str,
-        bidi_info: &BidiInfo,
+        bidi_levels: &BidiLevels,
         parent_style: &ServoArc<ComputedValues>,
     ) -> Vec<TextRunItem> {
         let font_style = parent_style.clone_font();
@@ -562,13 +562,13 @@ impl TextRun {
             if character == '\t' {
                 finish_current_segment(&mut current, &mut results);
                 results.push(TextRunItem::Tab {
-                    bidi_level: bidi_info.levels[current_byte_index],
+                    bidi_level: bidi_levels.level(current_byte_index),
                 });
                 continue;
             }
 
             let (font, script, bidi_level) = if character_cannot_change_font(character) {
-                (None, Script::Common, bidi_info.levels[current_byte_index])
+                (None, Script::Common, bidi_levels.level(current_byte_index))
             } else {
                 (
                     font_group.find_by_codepoint(
@@ -578,7 +578,7 @@ impl TextRun {
                         language,
                     ),
                     Script::from(character),
-                    bidi_info.levels[current_byte_index],
+                    bidi_levels.level(current_byte_index),
                 )
             };
 


### PR DESCRIPTION
When constructing and laying out an inline formatting context, this
change makes it so that we avoid running the BiDi level generating
algorithm and level collection when there is no strong BiDi content. The
creation of the BiDi levels is not incredibly expensive, but most
languages are left-to-right so this work can usually be avoided.

In addition to a minor performance improvement, this should reduce the
amount of allocation during IFC layout.

Testing: This should not change observable behavior, so is covered by existing WPT tests.
