### PR TITLE
Convert more component dependencies to workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ rust-version = "1.88.0"
 
 [workspace.dependencies]
 accesskit = { version = "0.24.0", features = ["serde"] }
+accesskit_consumer = "0.35.0"
 aes = "0.8.4"
 aes-gcm = "0.10.3"
 aes-kw = { version = "0.2.1", features = ["alloc"] }
@@ -35,6 +36,7 @@ app_units = "0.7"
 arboard = "3"
 argon2 = { version = "0.5", features = ["alloc"] }
 arrayvec = "0.7"
+async-recursion = "1.1"
 async-tungstenite = { version = "0.34", features = ["tokio-rustls-webpki-roots"] }
 atomic_refcell = "0.1.14"
 aws-lc-rs = { version = "1.17", default-features = false, features = ["aws-lc-sys"] }
@@ -42,7 +44,10 @@ backtrace = "0.3"
 base64 = "0.22.1"
 base64ct = { version = "1.8", features = ["alloc"] }
 bitflags = "2.11"
+blurmock = "0.1.2"
 brotli = "8.0.2"
+btleplug = "0.12"
+buf-read-ext = "0.4"
 byte-slice-cast = "1.2.3"
 bytemuck = "1"
 byteorder = "1.5"
@@ -69,10 +74,15 @@ encoding_rs = { version = "0.8", features = ["serde"] }
 env_logger = "0.11"
 euclid = "0.22"
 flate2 = "1.1"
+fontsan = "0.6.1"
 freetype-sys = "0.20"
+fst = "0.4"
 futures = { version = "0.3", default-features = false }
 futures-core = { version = "0.3", default-features = false }
+futures-intrusive = "0.5"
 futures-util = { version = "0.3", default-features = false }
+gaol = "0.2.1"
+generic-array = "0.14"
 gleam = "0.15"
 glib = "0.22"
 glib-sys = "0.22"
@@ -90,6 +100,7 @@ gstreamer-sdp = "0.25"
 gstreamer-sys = "0.25"
 gstreamer-video = "0.25"
 gstreamer-webrtc = { version = "0.25", features = ["v1_18"] }
+half = "2"
 harfbuzz-sys = "0.6.1"
 headers = "0.4"
 hitrace = { version = "0.2.0", features = ["api-19", "tracing-rs"] }
@@ -97,6 +108,7 @@ hkdf = "0.12"
 html5ever = "0.39"
 http = "1.4"
 http-body-util = "0.1"
+httparse = "1.9"
 hyper = "1.9"
 hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "logging", "tls12", "webpki-tokio"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "http2", "tokio"] }
@@ -144,9 +156,15 @@ p521 = { version = "0.13", features = ["ecdh"] }
 parking_lot = { version = "0.12", features = ["serde"] }
 peniko = "0.5"
 percent-encoding = "2.3"
+phf = "0.13"
+phf_codegen = "0.13"
+phf_shared = "0.13"
 pkcs8 = { version = "0.10", features = ["rand_core"] }
+pollster = "0.4"
 postcard = { version = "1.1.3", default-features = false, features = ["use-std"] }
+prettyplease = "0.2.32"
 proc-macro2 = "1"
+quickcheck = "1"
 quote = "1"
 rand = "0.9"
 raw-window-handle = "0.6"
@@ -155,6 +173,7 @@ read-fonts = "0.35.0"
 regex = "1.12"
 resvg = "0.47.0"
 rsa = { version = "0.9.10", features = ["sha1", "sha2"] }
+rustc-demangle = "0.1"
 rustc-hash = "2.1.2"
 rustls = { version = "0.23", default-features = false, features = ["logging", "std", "tls12"] }
 rustls-pki-types = "1.14"
@@ -167,6 +186,7 @@ serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
 serde_json = "1.0"
+serde_test = "1.0"
 servo_arc = { git = "https://github.com/servo/stylo", rev = "d2b3101e39c57a179c573e8f4c2fa4abb46f8482" }
 sha1 = "0.10"
 sha2 = "0.10"
@@ -183,9 +203,12 @@ stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "d2b3101e
 stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "d2b3101e39c57a179c573e8f4c2fa4abb46f8482" }
 stylo_traits = { git = "https://github.com/servo/stylo", rev = "d2b3101e39c57a179c573e8f4c2fa4abb46f8482" }
 surfman = { version = "0.12.1", features = ["chains"] }
+swapper = "0.1"
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"
+sys-locale = "0.3"
 taffy = { version = "0.10.1", default-features = false, features = ["calc", "detailed_layout_info", "grid", "std"] }
+tempfile = "3"
 tendril = { version = "0.5", features = ["encoding_rs"] }
 tikv-jemalloc-sys = "0.6.1"
 tikv-jemallocator = "0.6.1"
@@ -222,6 +245,7 @@ winit = "0.30.13"
 wio = "0.2"
 wr_malloc_size_of = "0.2.2"
 x25519-dalek = { version = "2.0.1", features = ["static_secrets"] }
+xml = "1.1"
 xml5ever = "0.39"
 yuv = { version = "0.8.14", features = ["rayon"] }
 zeroize = "1.8"

--- a/components/background_hang_monitor/Cargo.toml
+++ b/components/background_hang_monitor/Cargo.toml
@@ -20,7 +20,7 @@ backtrace = { workspace = true }
 crossbeam-channel = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
-rustc-demangle = { version = "0.1", optional = true }
+rustc-demangle = { workspace = true, optional = true }
 rustc-hash = { workspace = true }
 serde_json = { workspace = true }
 servo-background-hang-monitor-api = { workspace = true }

--- a/components/bluetooth/Cargo.toml
+++ b/components/bluetooth/Cargo.toml
@@ -15,8 +15,8 @@ path = "lib.rs"
 
 [dependencies]
 bitflags = { workspace = true }
-blurmock = { version = "0.1.2", optional = true }
-btleplug = { version = "0.12", optional = true }
+blurmock = { workspace = true, optional = true }
+btleplug = { workspace = true, optional = true }
 embedder_traits = { workspace = true }
 futures = { workspace = true, features = ["executor"] }
 log = { workspace = true }

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -22,13 +22,13 @@ bytemuck = { workspace = true, features = ["extern_crate_alloc"] }
 crossbeam-channel = { workspace = true }
 euclid = { workspace = true }
 fonts = { workspace = true }
-futures-intrusive = { version = "0.5", optional = true }
+futures-intrusive = { workspace = true, optional = true }
 kurbo = { workspace = true }
 log = { workspace = true }
 paint_api = { workspace = true }
 peniko = { workspace = true }
 pixels = { workspace = true }
-pollster = { version = "0.4", optional = true }
+pollster = { workspace = true, optional = true }
 profile_traits = { workspace = true }
 rustc-hash = { workspace = true }
 servo-base = { workspace = true }

--- a/components/constellation/Cargo.toml
+++ b/components/constellation/Cargo.toml
@@ -68,4 +68,4 @@ webgpu_traits = { workspace = true, optional = true }
 webxr-api = { workspace = true }
 
 [target.'cfg(any(target_os="macos", all(not(target_os = "windows"), not(target_os = "ios"), not(target_os="android"), not(target_env="ohos"), not(target_arch="arm"), not(target_arch="aarch64"))))'.dependencies]
-gaol = "0.2.1"
+gaol = { workspace = true }

--- a/components/fonts/Cargo.toml
+++ b/components/fonts/Cargo.toml
@@ -24,7 +24,7 @@ bitflags = { workspace = true }
 content-security-policy = { workspace = true }
 euclid = { workspace = true }
 fonts_traits = { workspace = true }
-fontsan = "0.6.1"
+fontsan = { workspace = true }
 # FIXME (#34517): macOS only needs this when building servo without `--features media-gstreamer`
 harfbuzz-sys = { workspace = true, features = ["bundled"] }
 icu_locid = { workspace = true }
@@ -76,7 +76,7 @@ servo-allocator = { workspace = true }
 fontconfig_sys = { package = "yeslogic-fontconfig-sys", version = "6" }
 
 [target.'cfg(target_os = "android")'.dependencies]
-xml = "1.1"
+xml = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 dwrote = { workspace = true }

--- a/components/hyper_serde/Cargo.toml
+++ b/components/hyper_serde/Cargo.toml
@@ -28,4 +28,4 @@ serde_core = { workspace = true }
 ipc-channel = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_test = "1.0"
+serde_test = { workspace = true }

--- a/components/layout/Cargo.toml
+++ b/components/layout/Cargo.toml
@@ -71,4 +71,4 @@ web_atoms = { workspace = true }
 webrender_api = { workspace = true }
 
 [dev-dependencies]
-quickcheck = "1"
+quickcheck = { workspace = true }

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -22,10 +22,10 @@ tracing = ["dep:tracing"]
 
 [dependencies]
 async-compression = { version = "0.4.12", default-features = false, features = ["brotli", "gzip", "tokio", "zlib", "zstd"] }
-async-recursion = "1.1"
+async-recursion = { workspace = true }
 async-tungstenite = { workspace = true }
 base64 = { workspace = true }
-bytes = "1"
+bytes = { workspace = true }
 chrono = { workspace = true }
 content-security-policy = { workspace = true }
 cookie = { workspace = true }
@@ -33,11 +33,11 @@ crossbeam-channel = { workspace = true }
 data-url = { workspace = true }
 devtools_traits = { workspace = true }
 embedder_traits = { workspace = true }
-fst = "0.4"
+fst = { workspace = true }
 futures = { workspace = true }
 futures-core = { workspace = true }
 futures-util = { workspace = true }
-generic-array = "0.14"
+generic-array = { workspace = true }
 headers = { workspace = true }
 http = { workspace = true }
 http-body-util = { workspace = true }
@@ -89,7 +89,7 @@ webrender_api = { workspace = true }
 
 [dev-dependencies]
 flate2 = { workspace = true }
-fst = "0.4"
+fst = { workspace = true }
 hyper = { workspace = true, features = ["full"] }
 hyper-util = { workspace = true, features = ["server-graceful"] }
 # This must always be a path dependency, we don't want to add a dependency on a

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -52,7 +52,7 @@ base64 = { workspace = true }
 base64ct = { workspace = true }
 bitflags = { workspace = true }
 brotli = { workspace = true }
-buf-read-ext = "0.4"
+buf-read-ext = { workspace = true }
 cbc = { workspace = true }
 chacha20poly1305 = { workspace = true }
 chardetng = { workspace = true }
@@ -82,7 +82,7 @@ headers = { workspace = true }
 hkdf = { workspace = true }
 html5ever = { workspace = true }
 http = { workspace = true }
-httparse = "1.9"
+httparse = { workspace = true }
 hyper_serde = { workspace = true }
 icu_locid = { workspace = true }
 indexmap = { workspace = true }
@@ -115,7 +115,7 @@ p521 = { workspace = true }
 paint_api = { workspace = true }
 parking_lot = { workspace = true }
 percent-encoding = { workspace = true }
-phf = "0.13"
+phf = { workspace = true }
 pixels = { workspace = true }
 pkcs8 = { workspace = true }
 postcard = { workspace = true }
@@ -152,8 +152,8 @@ stylo_atoms = { workspace = true }
 stylo_dom = { workspace = true }
 stylo_malloc_size_of = { workspace = true }
 stylo_traits = { workspace = true }
-swapper = "0.1"
-tempfile = "3"
+swapper = { workspace = true }
+tempfile = { workspace = true }
 tendril = { workspace = true }
 time = { workspace = true }
 timers = { workspace = true }

--- a/components/script_bindings/Cargo.toml
+++ b/components/script_bindings/Cargo.toml
@@ -36,7 +36,7 @@ malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 num-traits = { workspace = true }
 parking_lot = { workspace = true }
-phf = "0.13"
+phf = { workspace = true }
 profile_traits = { workspace = true }
 regex = { workspace = true }
 servo-base = { workspace = true }
@@ -53,8 +53,8 @@ xml5ever = { workspace = true }
 zeroize = { workspace = true, features = ["zeroize_derive"] }
 
 [build-dependencies]
-phf_codegen = "0.13"
-phf_shared = "0.13"
+phf_codegen = { workspace = true }
+phf_shared = { workspace = true }
 serde_json = { workspace = true }
 
 [features]

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -155,7 +155,7 @@ arboard = { workspace = true, optional = true }
 webxr = { workspace = true, features = ["glwindow", "headless"] }
 
 [target.'cfg(all(not(target_os = "windows"), not(target_os = "ios"), not(target_os = "android"), not(target_env = "ohos"), not(target_arch = "arm"), not(target_arch = "aarch64")))'.dependencies]
-gaol = "0.2.1"
+gaol = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 webxr = { workspace = true, features = ["glwindow", "headless", "openxr-api"] }
@@ -164,7 +164,7 @@ webxr = { workspace = true, features = ["glwindow", "headless", "openxr-api"] }
 servo-media-ohos = { workspace = true }
 
 [dev-dependencies]
-accesskit_consumer = "0.35.0"
+accesskit_consumer = { workspace = true }
 content-security-policy = { workspace = true }
 http = { workspace = true }
 http-body-util = { workspace = true }

--- a/components/servo_tracing/Cargo.toml
+++ b/components/servo_tracing/Cargo.toml
@@ -20,4 +20,4 @@ proc-macro = true
 doctest = false
 
 [dev-dependencies]
-prettyplease = "0.2.32"
+prettyplease = { workspace = true }

--- a/components/shared/net/Cargo.toml
+++ b/components/shared/net/Cargo.toml
@@ -44,7 +44,7 @@ servo-base = { workspace = true }
 servo-config = { workspace = true }
 servo-url = { workspace = true }
 servo_arc = { workspace = true }
-sys-locale = "0.3"
+sys-locale = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }

--- a/components/storage/Cargo.toml
+++ b/components/storage/Cargo.toml
@@ -31,7 +31,7 @@ servo-base = { workspace = true }
 servo-config = { workspace = true }
 servo-url = { workspace = true }
 storage_traits = { workspace = true }
-tempfile = "3"
+tempfile = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]

--- a/components/webgl/Cargo.toml
+++ b/components/webgl/Cargo.toml
@@ -23,7 +23,7 @@ byteorder = { workspace = true }
 crossbeam-channel = { workspace = true }
 euclid = { workspace = true }
 glow = { workspace = true }
-half = "2"
+half = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
 paint_api = { workspace = true }


### PR DESCRIPTION
The component dependencies used by Servo are mostly now workspace dependencies but there are still some that aren't. This converts many of the remaining ones to workspace dependencies.

Testing: No tests for Cargo.toml edits.