### PR TITLE
script: Introduce `Element::get_attribute_string_value`

### DIFF
--- a/components/script/dom/element/attributes/accessors.rs
+++ b/components/script/dom/element/attributes/accessors.rs
@@ -8,7 +8,6 @@ use servo_arc::Arc as ServoArc;
 use style::attr::AttrValue;
 use stylo_atoms::Atom;
 
-use crate::dom::bindings::codegen::Bindings::AttrBinding::AttrMethods;
 use crate::dom::bindings::codegen::UnionTypes::{TrustedHTMLOrString, TrustedScriptURLOrUSVString};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::element::attributes::storage::AttrRef;
@@ -90,8 +89,8 @@ impl Element {
     }
 
     pub(crate) fn get_string_attribute(&self, local_name: &LocalName) -> DOMString {
-        self.get_attribute(local_name)
-            .map(|attribute| attribute.Value())
+        self.get_attribute_string_value(local_name)
+            .map(|value| value.into())
             .unwrap_or_default()
     }
 

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -2030,6 +2030,30 @@ impl Element {
         self.handle_attribute_changes(cx, AttrRef::Dom(attr), None, Some(&*attr.value()), reason);
     }
 
+    pub(crate) fn get_attribute_string_value(&self, local_name: &LocalName) -> Option<String> {
+        debug_assert_eq!(
+            *local_name,
+            local_name.to_ascii_lowercase(),
+            "All namespace-less attribute accesses should use a lowercase ASCII name"
+        );
+
+        self.get_attribute_string_value_with_namespace(&ns!(), local_name)
+    }
+
+    pub(crate) fn get_attribute_string_value_with_namespace(
+        &self,
+        namespace: &Namespace,
+        local_name: &LocalName,
+    ) -> Option<String> {
+        self.attrs
+            .borrow()
+            .iter()
+            .find(|attribute| {
+                attribute.local_name() == local_name && attribute.namespace() == namespace
+            })
+            .map(|attribute| String::from(&**attribute.value()))
+    }
+
     /// This is the inner logic for:
     /// <https://dom.spec.whatwg.org/#concept-element-attributes-get-by-namespace>
     ///
@@ -5104,9 +5128,9 @@ impl TagName {
 /// <https://html.spec.whatwg.org/multipage/#cors-settings-attribute>
 pub(crate) fn reflect_cross_origin_attribute(element: &Element) -> Option<DOMString> {
     element
-        .get_attribute(&local_name!("crossorigin"))
-        .map(|attribute| {
-            let value = attribute.value().to_ascii_lowercase();
+        .get_attribute_string_value(&local_name!("crossorigin"))
+        .map(|value| {
+            let value = value.to_ascii_lowercase();
             if value == "anonymous" || value == "use-credentials" {
                 DOMString::from(value)
             } else {
@@ -5131,9 +5155,9 @@ pub(crate) fn set_cross_origin_attribute(
 /// <https://html.spec.whatwg.org/multipage/#referrer-policy-attribute>
 pub(crate) fn reflect_referrer_policy_attribute(element: &Element) -> DOMString {
     element
-        .get_attribute(&local_name!("referrerpolicy"))
-        .map(|attribute| {
-            let value = attribute.value().to_ascii_lowercase();
+        .get_attribute_string_value(&local_name!("referrerpolicy"))
+        .map(|value| {
+            let value = value.to_ascii_lowercase();
             if value == "no-referrer" ||
                 value == "no-referrer-when-downgrade" ||
                 value == "same-origin" ||
@@ -5153,23 +5177,23 @@ pub(crate) fn reflect_referrer_policy_attribute(element: &Element) -> DOMString 
 
 pub(crate) fn referrer_policy_for_element(element: &Element) -> ReferrerPolicy {
     element
-        .get_attribute(&local_name!("referrerpolicy"))
-        .map(|attribute| ReferrerPolicy::from(&**attribute.value()))
+        .get_attribute_string_value(&local_name!("referrerpolicy"))
+        .map(|value| ReferrerPolicy::from(value.as_ref()))
         .unwrap_or(element.owner_document().get_referrer_policy())
 }
 
 pub(crate) fn cors_setting_for_element(element: &Element) -> Option<CorsSettings> {
     element
-        .get_attribute(&local_name!("crossorigin"))
-        .map(|attribute| CorsSettings::from_enumerated_attribute(&attribute.value()))
+        .get_attribute_string_value(&local_name!("crossorigin"))
+        .map(|value| CorsSettings::from_enumerated_attribute(value.as_ref()))
 }
 
 /// <https://html.spec.whatwg.org/multipage/#cors-settings-attribute-credentials-mode>
 pub(crate) fn cors_settings_attribute_credential_mode(element: &Element) -> CredentialsMode {
     element
-        .get_attribute(&local_name!("crossorigin"))
-        .map(|attr| {
-            if attr.value().eq_ignore_ascii_case("use-credentials") {
+        .get_attribute_string_value(&local_name!("crossorigin"))
+        .map(|value| {
+            if value.eq_ignore_ascii_case("use-credentials") {
                 CredentialsMode::Include
             } else {
                 // The attribute's invalid value default and empty value default are both the Anonymous state.

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -1922,13 +1922,12 @@ impl Node {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#language>
-    pub(crate) fn get_lang(&self, cx: &mut JSContext) -> Option<String> {
+    pub(crate) fn get_lang(&self) -> Option<String> {
         self.inclusive_ancestors(ShadowIncluding::Yes)
             .find_map(|node| {
                 node.downcast::<Element>().and_then(|el| {
-                    el.get_attribute_with_namespace(cx, &ns!(xml), &local_name!("lang"))
-                        .or_else(|| el.get_attribute(&local_name!("lang")))
-                        .map(|attr| String::from(attr.Value()))
+                    el.get_attribute_string_value_with_namespace(&ns!(xml), &local_name!("lang"))
+                        .or_else(|| el.get_attribute_string_value(&local_name!("lang")))
                 })
                 // TODO: Check meta tags for a pragma-set default language
                 // TODO: Check HTTP Content-Language header

--- a/components/script/links.rs
+++ b/components/script/links.rs
@@ -11,7 +11,6 @@ use net_traits::request::Referrer;
 use servo_constellation_traits::{LoadData, LoadOrigin, NavigationHistoryBehavior};
 use style::str::HTML_SPACE_CHARACTERS;
 
-use crate::dom::bindings::codegen::Bindings::AttrBinding::Attr_Binding::AttrMethods;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::str::DOMString;
@@ -183,10 +182,7 @@ impl LinkRelations {
     /// [`<area>`]: https://html.spec.whatwg.org/multipage/#the-area-element
     /// [`<form>`]: https://html.spec.whatwg.org/multipage/#the-form-element
     pub(crate) fn for_element(element: &Element) -> Self {
-        let rel = element.get_attribute(&local_name!("rel")).map(|e| {
-            let value = e.value();
-            (**value).to_owned()
-        });
+        let rel = element.get_attribute_string_value(&local_name!("rel"));
 
         let mut relations = rel
             .map(|attribute| {
@@ -199,8 +195,8 @@ impl LinkRelations {
 
         // For historical reasons, "rev=made" is treated as if the "author" relation was specified
         let has_legacy_author_relation = element
-            .get_attribute(&local_name!("rev"))
-            .is_some_and(|rev| &**rev.value() == "made");
+            .get_attribute_string_value(&local_name!("rev"))
+            .is_some_and(|rev| rev == "made");
         if has_legacy_author_relation {
             relations |= Self::AUTHOR;
         }
@@ -459,14 +455,15 @@ pub(crate) fn follow_hyperlink(
         // Step 9: Let urlString be the result of applying the URL serializer to urlRecord.
         // TODO: Implement this.
 
-        let attribute = subject.get_attribute(&local_name!("href")).unwrap();
-        let mut href = attribute.Value();
+        let mut href = subject
+            .get_attribute_string_value(&local_name!("href"))
+            .unwrap();
 
         // Step 10: If hyperlinkSuffix is non-null, then append it to urlString.
         if let Some(suffix) = hyperlink_suffix {
             href.push_str(&suffix);
         }
-        let Ok(url) = document.encoding_parse_a_url(&href.str()) else {
+        let Ok(url) = document.encoding_parse_a_url(&href) else {
             return;
         };
 

--- a/components/script/xpath.rs
+++ b/components/script/xpath.rs
@@ -65,12 +65,8 @@ impl xpath::Node for XPathWrapper<DomRoot<Node>> {
         self.0.GetTextContent().unwrap_or_default().into()
     }
 
-    #[expect(unsafe_code)]
     fn language(&self) -> Option<String> {
-        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
-        let cx = &mut cx;
-
-        self.0.get_lang(cx)
+        self.0.get_lang()
     }
 
     fn parent(&self) -> Option<Self> {


### PR DESCRIPTION
Not all accesses to attributes require a `cx`, since most of them don't actually need the `Attr` node, but only the value contained within. Therefore, introduce a variant that directly accesses the value, to avoid materializing attribute nodes.

Doing so removes the need for one of the `temp_cx` in XPath, since it only requires the attribute value and not the full node.

Part of #45022

Testing: WPT