### PR TITLE
mach/uv: Switch from native-tls to system-certs

### DIFF
--- a/etc/ci/scenario/pyproject.toml
+++ b/etc/ci/scenario/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
 license = "Apache-2.0 OR MIT"
 
 [tool.uv]
-native-tls = true
+system-certs = true
 
 [tool.pyrefly]
 search-path = ["."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,4 +82,4 @@ project-excludes = [
 ]
 
 [tool.uv]
-native-tls = true
+system-certs = true


### PR DESCRIPTION
uv switched from native-tls to system-certs in version 0.11 (released 2026-03-23).
I don't think we have a version requirement for uv.

Testing: uv does not have tests.
Fixes: https://github.com/servo/servo/issues/45499
