### PR TITLE
script: Remove unecessary `ignore_malloc_size_of` on `AudioNode::node_id`

### DIFF
--- a/components/script/dom/audio/audionode.rs
+++ b/components/script/dom/audio/audionode.rs
@@ -36,7 +36,6 @@ pub(crate) const MAX_CHANNEL_COUNT: u32 = 32;
 #[dom_struct]
 pub(crate) struct AudioNode {
     eventtarget: EventTarget,
-    #[ignore_malloc_size_of = "servo_media"]
     #[no_trace]
     node_id: Option<NodeId>,
     context: Dom<BaseAudioContext>,


### PR DESCRIPTION
`NodeId` [implements](https://github.com/servo/servo/blob/ca6edffb5081e2c3b1e3d0e543ab98fb08ef3abc/components/media/audio/graph.rs#L22-L25) `MallocSizeOf`, with a [generic implementation](https://github.com/servo/malloc_size_of/blob/7ab69383b0d8d7cfeec5964b9806c405770c654a/malloc_size_of/src/impls.rs#L193) for Option<T>.

Testing: This just ensures that the memory of `AudioNode::node_id` is tracked, so doesn't require a new test.
