### PR TITLE
Add a DiagnosticLoggingOption to print the accessibility tree

### DIFF
--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -146,6 +146,10 @@ pub enum DiagnosticsLoggingOption {
     /// Log Progressive Web Metrics
     #[strum(to_string = "progressive-web-metrics")]
     ProgressiveWebMetrics,
+
+    /// Log the accessibility tree
+    #[strum(to_string = "accessibility-tree")]
+    AccessibilityTree,
 }
 
 impl DiagnosticsLoggingOption {

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -434,11 +434,11 @@ impl AccessibilityNode {
 
     fn print(&self, tree: &AccessibilityTree, print_tree: &mut PrintTree) {
         if self.children().is_empty() {
-            print_tree.add_item(format!("{:?}", self));
+            print_tree.add_item(format!("{self:?}"));
             return;
         }
 
-        print_tree.new_level(format!("{:?}", self));
+        print_tree.new_level(format!("{self:?}"));
 
         for child_id in self.children() {
             let child = tree.assert_node_for_id(*child_id);
@@ -509,12 +509,12 @@ impl AccessibilityNode {
 
 impl Debug for AccessibilityNode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}: {:?}", self.id, self.role(),)?;
+        write!(f, "{:?}: {:?}", self.id, self.role())?;
         if let Some(html_tag) = self.html_tag() {
-            write!(f, " (html_tag: {:?})", html_tag)?;
+            write!(f, " (html_tag: {html_tag:?})")?;
         }
         if let Some(label) = self.label() {
-            write!(f, "\nlabel: {:?}", label)?;
+            write!(f, "\nlabel: {label:?}")?;
         }
         if !self.children().is_empty() {
             write!(f, "\nchildren: {:?}", self.children())?;

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 use std::collections::VecDeque;
+use std::fmt::Debug;
 use std::sync::atomic::AtomicU64;
 use std::sync::{LazyLock, atomic};
 
@@ -11,6 +12,7 @@ use log::trace;
 use rustc_hash::{FxHashMap, FxHashSet};
 use script::layout_dom::ServoLayoutNode;
 use servo_base::Epoch;
+use servo_config::opts::{self, DiagnosticsLogging, DiagnosticsLoggingOption};
 use servo_config::pref;
 use style::dom::{NodeInfo, OpaqueNode};
 use web_atoms::{LocalName, local_name};
@@ -23,7 +25,6 @@ struct AccessibilityUpdate {
     nodes: FxHashMap<accesskit::NodeId, accesskit::Node>,
 }
 
-#[derive(Debug)]
 struct AccessibilityNode {
     id: accesskit::NodeId,
     accesskit_node: accesskit::Node,
@@ -43,6 +44,7 @@ pub struct AccessibilityTree {
     epoch: Epoch,
     /// Nodes that changed their relation to the tree within the current update.
     tree_changes: FxHashMap<accesskit::NodeId, TreeChange>,
+    debug: DiagnosticsLogging,
 }
 
 /// Tracks changes to a node's relation to the tree within an update.
@@ -86,6 +88,7 @@ impl AccessibilityTree {
             tree_id,
             epoch,
             tree_changes: FxHashMap::default(),
+            debug: opts::get().debug.clone(),
         }
     }
 
@@ -471,6 +474,25 @@ impl AccessibilityNode {
         }
         self.accesskit_node.set_value(value);
         self.updated = true;
+    }
+}
+
+impl Debug for AccessibilityNode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "{:?}: {:?} (html_tag: {:?})",
+            self.id,
+            self.role(),
+            self.html_tag()
+        );
+        if let Some(label) = self.label() {
+            writeln!(f, "    label: {:?}", label);
+        }
+        if !self.children().is_empty() {
+            writeln!(f, "    children: {:?}", self.children());
+        }
+        Ok(())
     }
 }
 

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -12,6 +12,7 @@ use log::trace;
 use rustc_hash::{FxHashMap, FxHashSet};
 use script::layout_dom::ServoLayoutNode;
 use servo_base::Epoch;
+use servo_base::print_tree::PrintTree;
 use servo_config::opts::{self, DiagnosticsLogging, DiagnosticsLoggingOption};
 use servo_config::pref;
 use style::dom::{NodeInfo, OpaqueNode};
@@ -44,6 +45,8 @@ pub struct AccessibilityTree {
     epoch: Epoch,
     /// Nodes that changed their relation to the tree within the current update.
     tree_changes: FxHashMap<accesskit::NodeId, TreeChange>,
+    /// Debug options, copied from configuration to this `AccessibilityTree` in order
+    /// to avoid having to constantly access the thread-safe global options.
     debug: DiagnosticsLogging,
 }
 
@@ -111,6 +114,13 @@ impl AccessibilityTree {
         }
 
         self.finalize_tree_changes();
+
+        if self
+            .debug
+            .is_enabled(DiagnosticsLoggingOption::AccessibilityTree)
+        {
+            self.print(root_node_id);
+        }
 
         if pref!(expensive_accessibility_test_assertions_enabled) {
             self.assert_integrity(root_node_id);
@@ -246,6 +256,13 @@ impl AccessibilityTree {
         // If this fails, then the tree has orphaned nodes (a leak).
         // Dangling references are already caught in the loop above.
         assert_eq!(seen_node_ids, self.nodes.keys().copied().collect());
+    }
+
+    fn print(&self, root_node_id: accesskit::NodeId) {
+        let mut print_tree = PrintTree::new("Accessibility Tree".to_string());
+        let node = self.assert_node_for_id(root_node_id);
+        node.borrow().print(self, &mut print_tree);
+        print_tree.end_level();
     }
 }
 
@@ -415,6 +432,21 @@ impl AccessibilityNode {
         Some(text.trim().to_owned())
     }
 
+    fn print(&self, tree: &AccessibilityTree, print_tree: &mut PrintTree) {
+        if self.children().is_empty() {
+            print_tree.add_item(format!("{:?}", self));
+            return;
+        }
+
+        print_tree.new_level(format!("{:?}", self));
+
+        for child_id in self.children() {
+            let child = tree.assert_node_for_id(*child_id);
+            child.borrow().print(tree, print_tree);
+        }
+        print_tree.end_level();
+    }
+
     // TODO: use macros to generate getter/setter methods.
 
     fn children(&self) -> &[accesskit::NodeId] {
@@ -438,7 +470,6 @@ impl AccessibilityNode {
         self.updated = true;
     }
 
-    #[expect(dead_code)]
     fn label(&self) -> Option<&str> {
         self.accesskit_node.label()
     }
@@ -451,7 +482,6 @@ impl AccessibilityNode {
         self.updated = true;
     }
 
-    #[expect(dead_code)]
     fn html_tag(&self) -> Option<&str> {
         self.accesskit_node.html_tag()
     }
@@ -479,18 +509,15 @@ impl AccessibilityNode {
 
 impl Debug for AccessibilityNode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(
-            f,
-            "{:?}: {:?} (html_tag: {:?})",
-            self.id,
-            self.role(),
-            self.html_tag()
-        );
+        write!(f, "{:?}: {:?}", self.id, self.role(),)?;
+        if let Some(html_tag) = self.html_tag() {
+            write!(f, " (html_tag: {:?})", html_tag)?;
+        }
         if let Some(label) = self.label() {
-            writeln!(f, "    label: {:?}", label);
+            write!(f, "\nlabel: {:?}", label)?;
         }
         if !self.children().is_empty() {
-            writeln!(f, "    children: {:?}", self.children());
+            write!(f, "\nchildren: {:?}", self.children())?;
         }
         Ok(())
     }

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -10,7 +10,7 @@ use std::rc::Rc;
 
 use accesskit::{NodeId, Role, TreeId, TreeUpdate};
 use accesskit_consumer::TreeChangeHandler;
-use servo::{LoadStatus, Preferences, WebViewBuilder};
+use servo::{DiagnosticsLoggingOption, LoadStatus, Opts, Preferences, WebViewBuilder};
 use url::Url;
 
 use crate::common::{ServoTest, WebViewDelegateImpl, evaluate_javascript};
@@ -35,7 +35,10 @@ fn test_basic_accessibility_update() {
         let mut preferences = Preferences::default();
         preferences.accessibility_enabled = true;
         preferences.expensive_accessibility_test_assertions_enabled = true;
-        builder.preferences(preferences)
+        let mut opts = Opts::default();
+        opts.debug
+            .toggle_option(DiagnosticsLoggingOption::AccessibilityTree, true);
+        builder.preferences(preferences).opts(opts)
     });
 
     let delegate = Rc::new(WebViewDelegateImpl::default());
@@ -60,7 +63,10 @@ fn test_activate_accessibility_after_layout() {
         let mut preferences = Preferences::default();
         preferences.accessibility_enabled = true;
         preferences.expensive_accessibility_test_assertions_enabled = true;
-        builder.preferences(preferences)
+        let mut opts = Opts::default();
+        opts.debug
+            .toggle_option(DiagnosticsLoggingOption::AccessibilityTree, true);
+        builder.preferences(preferences).opts(opts)
     });
 
     let delegate = Rc::new(WebViewDelegateImpl::default());
@@ -85,7 +91,10 @@ fn test_navigate_creates_new_accessibility_update() {
         let mut preferences = Preferences::default();
         preferences.accessibility_enabled = true;
         preferences.expensive_accessibility_test_assertions_enabled = true;
-        builder.preferences(preferences)
+        let mut opts = Opts::default();
+        opts.debug
+            .toggle_option(DiagnosticsLoggingOption::AccessibilityTree, true);
+        builder.preferences(preferences).opts(opts)
     });
 
     let page_1_url = Url::parse("data:text/html,<!DOCTYPE html> page 1").unwrap();
@@ -141,7 +150,10 @@ fn test_accessibility_after_navigate_and_back() {
         let mut preferences = Preferences::default();
         preferences.accessibility_enabled = true;
         preferences.expensive_accessibility_test_assertions_enabled = true;
-        builder.preferences(preferences)
+        let mut opts = Opts::default();
+        opts.debug
+            .toggle_option(DiagnosticsLoggingOption::AccessibilityTree, true);
+        builder.preferences(preferences).opts(opts)
     });
 
     let page_1_url = Url::parse("data:text/html,<!DOCTYPE html> page 1").unwrap();
@@ -211,7 +223,10 @@ fn test_accessibility_basic_mapping() {
         let mut preferences = Preferences::default();
         preferences.accessibility_enabled = true;
         preferences.expensive_accessibility_test_assertions_enabled = true;
-        builder.preferences(preferences)
+        let mut opts = Opts::default();
+        opts.debug
+            .toggle_option(DiagnosticsLoggingOption::AccessibilityTree, true);
+        builder.preferences(preferences).opts(opts)
     });
     let delegate = Rc::new(WebViewDelegateImpl::default());
 
@@ -269,7 +284,10 @@ fn test_accessibility_basic_name_from_contents() {
         let mut preferences = Preferences::default();
         preferences.accessibility_enabled = true;
         preferences.expensive_accessibility_test_assertions_enabled = true;
-        builder.preferences(preferences)
+        let mut opts = Opts::default();
+        opts.debug
+            .toggle_option(DiagnosticsLoggingOption::AccessibilityTree, true);
+        builder.preferences(preferences).opts(opts)
     });
     let delegate = Rc::new(WebViewDelegateImpl::default());
     let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
@@ -299,7 +317,10 @@ fn test_accessibility_name_from_contents_subtree() {
         let mut preferences = Preferences::default();
         preferences.accessibility_enabled = true;
         preferences.expensive_accessibility_test_assertions_enabled = true;
-        builder.preferences(preferences)
+        let mut opts = Opts::default();
+        opts.debug
+            .toggle_option(DiagnosticsLoggingOption::AccessibilityTree, true);
+        builder.preferences(preferences).opts(opts)
     });
     let url = "data:text/html,<!DOCTYPE html>\
                <h1>Servo aims to empower <code>developers</code> with a <em>lightweight</em>, \
@@ -344,7 +365,10 @@ fn test_accessibility_basic_mutation() {
         preferences.accessibility_enabled = true;
         preferences.dom_servo_helpers_enabled = true;
         preferences.expensive_accessibility_test_assertions_enabled = true;
-        builder.preferences(preferences)
+        let mut opts = Opts::default();
+        opts.debug
+            .toggle_option(DiagnosticsLoggingOption::AccessibilityTree, true);
+        builder.preferences(preferences).opts(opts)
     });
     let url = "data:text/html,<!DOCTYPE html>\
                <h1 id='h1'>This is an h1</h1>\
@@ -399,7 +423,10 @@ fn test_accessibility_with_mutation_move_nodes() {
         preferences.accessibility_enabled = true;
         preferences.dom_servo_helpers_enabled = true;
         preferences.expensive_accessibility_test_assertions_enabled = true;
-        builder.preferences(preferences)
+        let mut opts = Opts::default();
+        opts.debug
+            .toggle_option(DiagnosticsLoggingOption::AccessibilityTree, true);
+        builder.preferences(preferences).opts(opts)
     });
     let url = "data:text/html,<!DOCTYPE html>\
                <div id='div1'></div>\


### PR DESCRIPTION
Uses `PrintTree` to print a tree of accessibility nodes at the end of the update, if the diagnostic is enabled.

Example output:

```
┌ Accessibility Tree
│  ├─ #0: GenericContainer (html_tag: "html")
│  │         children: [#1, #2]
│  │  ├─ #1: GenericContainer (html_tag: "head")
│  │  ├─ #2: RootWebArea (html_tag: "body")
│  │  │         children: [#3, #8]
│  │  │  ├─ #3: GenericContainer (html_tag: "div")
│  │  │  │         children: [#4]
│  │  │  │  ├─ #4: Heading (html_tag: "h1")
│  │  │  │  │         label: "This is an h1"
│  │  │  │  │         children: [#5]
│  │  │  │  │  └─ #5: TextRun
│  │  │  ├─ #8: GenericContainer (html_tag: "div")
│  │  │  │         children: [#6]
│  │  │  │  ├─ #6: Heading (html_tag: "h2")
│  │  │  │  │         label: "This is an h2"
│  │  │  │  │         children: [#7]
│  │  │  │  │  └─ #7: TextRun
```

Testing: Just adds a new diagnostic log type
