### PR TITLE
Using let/else for ReplacedContents::from_image_url

### DIFF
--- a/components/layout/replaced.rs
+++ b/components/layout/replaced.rs
@@ -333,40 +333,40 @@ impl ReplacedContents {
         context: &LayoutContext,
         image_url: &ComputedUrl,
     ) -> Option<Self> {
-        if let ComputedUrl::Valid(image_url) = image_url {
-            let (image, width, height) = match context.image_resolver.get_or_request_image_or_meta(
-                node.opaque(),
-                image_url.clone().into(),
-                LayoutImageDestination::BoxTreeConstruction,
-                InternalRequest::No,
-            ) {
-                LayoutImageCacheResult::DataAvailable(img_or_meta) => match img_or_meta {
-                    ImageOrMetadataAvailable::ImageAvailable { image, .. } => {
-                        if let Image::Raster(image) = &image {
-                            context
-                                .image_resolver
-                                .handle_animated_image(node.opaque(), image.clone());
-                        }
-                        let metadata = image.metadata();
-                        (Some(image), metadata.width as f32, metadata.height as f32)
-                    },
-                    ImageOrMetadataAvailable::MetadataAvailable(metadata, _id) => {
-                        (None, metadata.width as f32, metadata.height as f32)
-                    },
+        let ComputedUrl::Valid(image_url) = image_url else {
+            return None;
+        };
+        let (image, width, height) = match context.image_resolver.get_or_request_image_or_meta(
+            node.opaque(),
+            image_url.clone().into(),
+            LayoutImageDestination::BoxTreeConstruction,
+            InternalRequest::No,
+        ) {
+            LayoutImageCacheResult::DataAvailable(img_or_meta) => match img_or_meta {
+                ImageOrMetadataAvailable::ImageAvailable { image, .. } => {
+                    if let Image::Raster(image) = &image {
+                        context
+                            .image_resolver
+                            .handle_animated_image(node.opaque(), image.clone());
+                    }
+                    let metadata = image.metadata();
+                    (Some(image), metadata.width as f32, metadata.height as f32)
                 },
-                LayoutImageCacheResult::Pending | LayoutImageCacheResult::LoadError => return None,
-            };
-            return Some(Self {
-                kind: ReplacedContentKind::Image(ImageInfo {
-                    image,
-                    showing_broken_image_icon: false,
-                    url: Some(image_url.clone().into()),
-                }),
-                natural_size: NaturalSizes::from_width_and_height(width, height),
-                base_fragment_info: node.into(),
-            });
-        }
-        None
+                ImageOrMetadataAvailable::MetadataAvailable(metadata, _id) => {
+                    (None, metadata.width as f32, metadata.height as f32)
+                },
+            },
+            LayoutImageCacheResult::Pending | LayoutImageCacheResult::LoadError => return None,
+        };
+        Some(Self {
+            kind: ReplacedContentKind::Image(ImageInfo {
+                image,
+                showing_broken_image_icon: false,
+                url: Some(image_url.clone().into()),
+            }),
+            natural_size: NaturalSizes::from_width_and_height(width, height),
+            base_fragment_info: node.into(),
+        })
     }
 
     pub fn from_image(


### PR DESCRIPTION
ReplacedContents::from_image_url had a single if let condition which was the entire body of the function. Changed the code to use let/else expression which returns None from the else branch. This has reduced indentation nesting in the method.

Testing: @jdm said no new test cases were needed. Existing tests for CSS images would catch any regressions that may occur.
Fixes: #44994 
