### PR TITLE
Expose is_servo_internal for gc outside about scope

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -363,6 +363,9 @@ pub struct Preferences {
     /// Whether to run accessibility tree integrity checks, and any other expensive checks.
     /// This should only be true in tests.
     pub expensive_accessibility_test_assertions_enabled: bool,
+    /// Exposes internal JS API functions that are usually restricted to `about:...` pages
+    /// Useful if you want to get memory report or force GC in a test page
+    pub expose_servointernals_globally: bool,
 }
 
 impl Preferences {
@@ -536,6 +539,7 @@ impl Preferences {
             webgl_testing_context_creation_error: false,
             user_agent: String::new(),
             viewport_meta_enabled: false,
+            expose_servointernals_globally: false,
         }
     }
 

--- a/components/script/dom/servointernals.rs
+++ b/components/script/dom/servointernals.rs
@@ -217,6 +217,7 @@ impl ServoInternalsHelpers for ServoInternals {
         let global_scope = GlobalScope::from_current_realm(&realm);
         let url = global_scope.get_url();
         (url.scheme() == "about" && url.as_str() != "about:blank") ||
-            ScriptThread::is_servo_privileged(url)
+            ScriptThread::is_servo_privileged(url) ||
+            prefs::get().expose_servointernals_globally
     }
 }


### PR DESCRIPTION
More context in the  https://github.com/servo/servo/issues/44878. But generally. I wanted to be able to run 
```javascript
navigator.servo.garbageCollectAllContexts()
```
In the `blink-perf-test`'s `runner.js` so that it does not use the strange fallback method.
```javascript
function gcRec(n) {
     if (n < 1)
         return {};
     var temp = {i: "ab" + i + (i / 100000)};
     temp += "foo";
     gcRec(n-1);
 }
 for (var i = 0; i < 1000; i++)
     gcRec(10);
```

So now, this PR introduces `--pref dom_servo_gc_enabled=true`
That makes `is_servo_internal` in the `components/script/dom/servointernals.rs` to return `true`, so that the `navigator.servo.garbageCollectAllContexts()` could be called outside the `about:memory` url. 

Testing: To test, I've locally put a `print!` in the `fn GarbageCollectAllContexts(&self)` that is in the `components/script/dom/servointernals.rs` and run the servo with and without the `--pref dom_servo_gc_enabled=true`. As expected, the `print!` worked only when the correct `--pref` is present.

Fixes: https://github.com/servo/servo/issues/44878
