### PR TITLE
ci: Add vello backend compilation to Windows build

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -145,13 +145,17 @@ jobs:
           cat C:\init\incremental_build_debug.txt
           echo "`$env:LIBCLANG_PATH now = $env:LIBCLANG_PATH"
           echo "`$env:PATH now = $env:PATH"
-
       - name: Build (${{ inputs.profile }})
         env:
           RUSTFLAGS: "-D warnings"
         run: |
           .\mach build --use-crown --locked --profile ${{ inputs.profile }} ${{ inputs.build-args }}
           mv C:\a\servo\servo\target\cargo-timings C:\a\servo\servo\target\cargo-timings-windows
+      - name: Build with vello backend (${{ inputs.profile }})
+        env:
+          RUSTFLAGS: "-D warnings"
+        run: |
+          .\mach build --use-crown --locked --profile ${{ inputs.profile }} ${{ inputs.build-args }} --feature vello
       - name: Copy resources
         # GitHub-hosted runners sometimes check out the repo on D: drive.
         if: ${{ runner.environment != 'self-hosted' && startsWith(github.workspace, 'D:\') }}


### PR DESCRIPTION
We just add one build step right after normal build.
This is quick as we still have the build cache for most crates. [Linux](https://github.com/servo/servo/actions/runs/26172406491/job/76993567178) finishes with 47 sec.

But we add to Windows instead, so that this is only run in merge group.

This prevent #41415, #45036, #44874.

Testing: Tested on [Linux](https://github.com/servo/servo/actions/runs/26172406491/job/76993567178) and [Windows](https://github.com/servo/servo/actions/runs/26174011442/job/76999597376#logs).
Depends on: #45036
