### PR TITLE
layout: Do not clear fragment layout cache immediately when damaged

### DIFF
--- a/components/layout/flow/mod.rs
+++ b/components/layout/flow/mod.rs
@@ -1025,7 +1025,7 @@ fn layout_in_flow_non_replaced_block_level_same_formatting_context_cached(
     allows_caching = allows_caching && positioning_context_length == positioning_context.len();
 
     if !allows_caching {
-        base.clear_fragments_and_fragment_cache();
+        base.clear_fragments_and_dirty_fragment_cache();
     } else {
         base.cache_same_formatting_context_block_layout(
             containing_block,

--- a/components/layout/formatting_contexts.rs
+++ b/components/layout/formatting_contexts.rs
@@ -18,10 +18,7 @@ use crate::dom_traversal::{Contents, NodeAndStyleInfo, NonReplacedContents};
 use crate::flexbox::FlexContainer;
 use crate::flow::BlockFormattingContext;
 use crate::fragment_tree::{BaseFragmentInfo, FragmentFlags};
-use crate::layout_box_base::{
-    IndependentFormattingContextLayoutResult, IndependentFormattingContextLayoutResultAndInputs,
-    LayoutBoxBase, LayoutResultAndInputs,
-};
+use crate::layout_box_base::{IndependentFormattingContextLayoutResult, LayoutBoxBase};
 use crate::positioned::PositioningContext;
 use crate::replaced::ReplacedContents;
 use crate::sizing::{
@@ -112,7 +109,7 @@ impl IndependentFormattingContext {
             self.propagated_data,
         );
 
-        self.base.clear_fragments_and_fragment_cache();
+        self.base.clear_fragments_and_dirty_fragment_cache();
         *self.base.cached_inline_content_size.borrow_mut() = None;
         self.base.repair_style(&node_and_style_info.style);
     }
@@ -464,27 +461,21 @@ impl IndependentFormattingContext {
         preferred_aspect_ratio: Option<AspectRatio>,
         lazy_block_size: &LazySize,
     ) -> (IndependentFormattingContextLayoutResult, bool) {
-        if let Some(LayoutResultAndInputs::IndependentFormattingContext(cache)) =
-            self.base.cached_layout_result.borrow().as_ref()
+        if let Some(cached_layout_result) = self
+            .base
+            .cached_independent_formatting_context_layout_if_applicable(
+                positioning_context,
+                containing_block_for_children,
+            )
         {
-            let cache = &**cache;
-            if cache.containing_block_for_children_size.inline ==
-                containing_block_for_children.size.inline &&
-                (cache.containing_block_for_children_size.block ==
-                    containing_block_for_children.size.block ||
-                    !cache.result.depends_on_block_constraints)
-            {
-                positioning_context.append(cache.positioning_context.clone());
-                return (cache.result.clone(), true);
-            }
-            #[cfg(feature = "tracing")]
-            tracing::debug!(
-                name: "IndependentFormattingContext::layout cache miss",
-                cached = ?cache.containing_block_for_children_size,
-                required = ?containing_block_for_children.size,
-            );
+            return (cached_layout_result, true);
         }
 
+        #[cfg(feature = "tracing")]
+        tracing::debug!(
+            name: "IndependentFormattingContext::layout cache miss",
+            required = ?containing_block_for_children.size,
+        );
         let mut child_positioning_context = PositioningContext::default();
         let result = self.layout_without_caching(
             layout_context,
@@ -494,17 +485,12 @@ impl IndependentFormattingContext {
             preferred_aspect_ratio,
             lazy_block_size,
         );
-
-        *self.base.cached_layout_result.borrow_mut() =
-            Some(LayoutResultAndInputs::IndependentFormattingContext(
-                Box::new(IndependentFormattingContextLayoutResultAndInputs {
-                    result: result.clone(),
-                    positioning_context: child_positioning_context.clone(),
-                    containing_block_for_children_size: containing_block_for_children.size.clone(),
-                }),
-            ));
+        self.base.cache_independent_formatting_context_layout(
+            containing_block_for_children,
+            &child_positioning_context,
+            &result,
+        );
         positioning_context.append(child_positioning_context);
-
         (result, false)
     }
 

--- a/components/layout/layout_box_base.rs
+++ b/components/layout/layout_box_base.rs
@@ -45,7 +45,17 @@ pub(crate) struct LayoutBoxBase {
     pub cached_inline_content_size:
         AtomicRefCell<Option<Box<(SizeConstraint, InlineContentSizesResult)>>>,
     pub outer_inline_content_sizes_depend_on_content: AtomicBool,
-    pub cached_layout_result: AtomicRefCell<Option<LayoutResultAndInputs>>,
+
+    /// The cached layout results for this [`LayoutBoxBase`]. These are either cached
+    /// independent formatting context results or a cached block layout for use within
+    /// a block flow.
+    cached_layout_result: AtomicRefCell<Option<LayoutResultAndInputs>>,
+
+    /// Whether or not the cached layout result for this [`LayoutBoxBase`] is dirty.
+    /// This flag is used to preserve the cache when it can be used to do a faster
+    /// layout, but cannot be reused directly.
+    cached_layout_result_dirty: AtomicBool,
+
     pub fragments: AtomicRefCell<Vec<Fragment>>,
     pub parent_box: Option<WeakLayoutBox>,
     only_descendants_changed: AtomicBool,
@@ -62,6 +72,7 @@ impl LayoutBoxBase {
             cached_inline_content_size: AtomicRefCell::default(),
             outer_inline_content_sizes_depend_on_content: AtomicBool::new(true),
             cached_layout_result: AtomicRefCell::default(),
+            cached_layout_result_dirty: AtomicBool::default(),
             fragments: AtomicRefCell::default(),
             parent_box: None,
             only_descendants_changed: AtomicBool::default(),
@@ -119,9 +130,12 @@ impl LayoutBoxBase {
         self.fragments.borrow_mut().clear();
     }
 
-    pub(crate) fn clear_fragments_and_fragment_cache(&self) {
+    /// Clear all resulting fragments and dirty and fragment caches. Resulting fragments are
+    /// used for layout queries and fragment caches are used for incremental layout.
+    pub(crate) fn clear_fragments_and_dirty_fragment_cache(&self) {
         self.fragments.borrow_mut().clear();
-        *self.cached_layout_result.borrow_mut() = None;
+        self.cached_layout_result_dirty
+            .store(true, Ordering::Relaxed);
     }
 
     pub(crate) fn repair_style(&mut self, new_style: &ServoArc<ComputedValues>) {
@@ -155,7 +169,7 @@ impl LayoutBoxBase {
             });
         self.only_descendants_changed
             .store(only_descendants_changed, Ordering::Relaxed);
-        self.clear_fragments_and_fragment_cache();
+        self.clear_fragments_and_dirty_fragment_cache();
 
         if !element_damage.is_empty() ||
             damage_from_children.contains(LayoutDamage::RECOMPUTE_INLINE_CONTENT_SIZES)
@@ -186,6 +200,55 @@ impl LayoutBoxBase {
         damage_for_parent
     }
 
+    pub(crate) fn cached_independent_formatting_context_layout_if_applicable(
+        &self,
+        positioning_context: &mut PositioningContext,
+        containing_block_for_children: &ContainingBlock<'_>,
+    ) -> Option<IndependentFormattingContextLayoutResult> {
+        if self.cached_layout_result_dirty.load(Ordering::Relaxed) {
+            return None;
+        }
+
+        let cache = self.cached_layout_result.borrow();
+        let Some(LayoutResultAndInputs::IndependentFormattingContext(cache)) = &*cache else {
+            return None;
+        };
+
+        let cache = &**cache;
+        if cache.containing_block_for_children_size.inline !=
+            containing_block_for_children.size.inline
+        {
+            return None;
+        }
+        if cache.containing_block_for_children_size.block !=
+            containing_block_for_children.size.block &&
+            cache.result.depends_on_block_constraints
+        {
+            return None;
+        }
+
+        positioning_context.append(cache.positioning_context.clone());
+        Some(cache.result.clone())
+    }
+
+    pub(crate) fn cache_independent_formatting_context_layout(
+        &self,
+        containing_block_for_children: &ContainingBlock<'_>,
+        child_positioning_context: &PositioningContext,
+        result: &IndependentFormattingContextLayoutResult,
+    ) {
+        self.cached_layout_result_dirty
+            .store(false, Ordering::Relaxed);
+        *self.cached_layout_result.borrow_mut() =
+            Some(LayoutResultAndInputs::IndependentFormattingContext(
+                Box::new(IndependentFormattingContextLayoutResultAndInputs {
+                    result: result.clone(),
+                    positioning_context: child_positioning_context.clone(),
+                    containing_block_for_children_size: containing_block_for_children.size.clone(),
+                }),
+            ));
+    }
+
     pub(crate) fn cached_same_formatting_context_block_if_applicable(
         &self,
         containing_block: &ContainingBlock,
@@ -193,6 +256,10 @@ impl LayoutBoxBase {
         ignore_block_margins_for_stretch: LogicalSides1D<bool>,
         has_inline_parent: bool,
     ) -> Option<Arc<BoxFragment>> {
+        if self.cached_layout_result_dirty.load(Ordering::Relaxed) {
+            return None;
+        }
+
         let mut cached_layout_result = self.cached_layout_result.borrow_mut();
         let Some(LayoutResultAndInputs::SameFormattingContextBlock(result)) =
             &mut *cached_layout_result
@@ -241,6 +308,8 @@ impl LayoutBoxBase {
             }
         }
 
+        self.cached_layout_result_dirty
+            .store(false, Ordering::Relaxed);
         *self.cached_layout_result.borrow_mut() =
             Some(LayoutResultAndInputs::SameFormattingContextBlock(Box::new(
                 SameFormattingContextBlockLayoutResultAndInputs {


### PR DESCRIPTION
We are adding a new lightweight layout mode for situations where only a
descendant positioned fragment has changed. It's useful when
implementing this that caches can be marked dirty, but not cleared. The
dirty layout cache will be used to do partial layouts of some
independent formatting contexts during implementation of this feature.

This change does that, only clearing a cache when it's replaced.

Testing: This should not change observable behavior, so should be covered by existing tests.
