### PR TITLE
servoshell: Add `layout_css_attr_enabled` as an experimental pref

### DIFF
--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -45,6 +45,7 @@ pub(crate) static EXPERIMENTAL_PREFS: &[&str] = &[
     "dom_storage_manager_api_enabled",
     "dom_webgl2_enabled",
     "dom_webgpu_enabled",
+    "layout_css_attr_enabled",
     "layout_columns_enabled",
     "layout_container_queries_enabled",
     "layout_grid_enabled",

--- a/tests/wpt/meta/css/css-conditional/at-supports-namespace-001.html.ini
+++ b/tests/wpt/meta/css/css-conditional/at-supports-namespace-001.html.ini
@@ -1,0 +1,2 @@
+[at-supports-namespace-001.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-content/__dir__.ini
+++ b/tests/wpt/meta/css/css-content/__dir__.ini
@@ -1,1 +1,0 @@
-prefs: [layout_css_attr_enabled: true]

--- a/tests/wpt/meta/css/css-values/__dir__.ini
+++ b/tests/wpt/meta/css/css-values/__dir__.ini
@@ -1,1 +1,0 @@
-prefs: [layout_css_attr_enabled: true]

--- a/tests/wpt/meta/css/cssom/serialize-values.html.ini
+++ b/tests/wpt/meta/css/cssom/serialize-values.html.ini
@@ -59,9 +59,6 @@
   [page-break-inside: auto]
     expected: FAIL
 
-  [content: attr(foo, "")]
-    expected: FAIL
-
   [alignment-baseline: alphabetic]
     expected: FAIL
 
@@ -75,16 +72,4 @@
     expected: FAIL
 
   [font-family: 'Lucida Grande']
-    expected: FAIL
-
-  [content: attr(|bar, "fallback")]
-    expected: FAIL
-
-  [content: attr( |bar )]
-    expected: FAIL
-
-  [content: attr( |foo ,  "" )]
-    expected: FAIL
-
-  [content: attr(|bar)]
     expected: FAIL

--- a/tests/wpt/meta/html/rendering/the-details-element/details-content-pseudo-attr.html.ini
+++ b/tests/wpt/meta/html/rendering/the-details-element/details-content-pseudo-attr.html.ini
@@ -1,2 +1,0 @@
-[details-content-pseudo-attr.html]
-  expected: FAIL


### PR DESCRIPTION
This will enable it on all tests. Previously it was only enabled for `/css/css-content/` and `/css/css-values/`, but there are relevant tests in other directories.

Note that Firefox has also enabled `layout.css.attr.enabled` on Nightly.

Testing: Some new test passing. One test is now failing, but it fails in all browsers.
