### PR TITLE
script: Enable legacy touch events event handler 

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -199,6 +199,8 @@ pub struct Preferences {
     pub dom_testperf_enabled: bool,
     // https://testutils.spec.whatwg.org#availability
     pub dom_testutils_enabled: bool,
+    /// <https://w3c.github.io/touch-events/#conditionally-exposing-legacy-touch-event-apis>
+    pub dom_touch_events_legacy_apis_enabled: bool,
     /// <https://html.spec.whatwg.org/multipage/#transient-activation-duration>
     pub dom_transient_activation_duration_ms: i64,
     /// Enable WebGL2 APIs.
@@ -411,6 +413,7 @@ impl Preferences {
             dom_testing_html_input_element_select_files_enabled: false,
             dom_testperf_enabled: false,
             dom_testutils_enabled: false,
+            dom_touch_events_legacy_apis_enabled: false,
             dom_transient_activation_duration_ms: 5000,
             dom_webgl2_enabled: false,
             dom_webgpu_enabled: false,
@@ -543,6 +546,9 @@ impl Default for Preferences {
             preferences.network_http_no_proxy = no_proxy
         }
 
+        // Following Firefox, we are enabling the touch events legacy APIs whenever we are dealing with mobile devices.
+        preferences.dom_touch_events_legacy_apis_enabled = UserAgentPlatform::default().is_mobile();
+
         preferences
     }
 }
@@ -571,6 +577,10 @@ impl UserAgentPlatform {
 }
 
 impl UserAgentPlatform {
+    pub fn is_mobile(&self) -> bool {
+        matches!(self, Self::Android | Self::OpenHarmony)
+    }
+
     /// Convert this [`UserAgentPlatform`] into its corresponding `String` value, ie the
     /// default user-agent to use for this platform.
     pub fn to_user_agent_string(&self) -> String {

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -413,7 +413,10 @@ impl Preferences {
             dom_testing_html_input_element_select_files_enabled: false,
             dom_testperf_enabled: false,
             dom_testutils_enabled: false,
-            dom_touch_events_legacy_apis_enabled: false,
+            // Following Firefox and Chrome, we are enabling the touch events legacy APIs for android.
+            // Additionally, enabling it in ohos for compatibility as well.
+            dom_touch_events_legacy_apis_enabled: cfg!(target_os = "android") |
+                cfg!(target_env = "ohos"),
             dom_transient_activation_duration_ms: 5000,
             dom_webgl2_enabled: false,
             dom_webgpu_enabled: false,
@@ -546,9 +549,6 @@ impl Default for Preferences {
             preferences.network_http_no_proxy = no_proxy
         }
 
-        // Following Firefox, we are enabling the touch events legacy APIs whenever we are dealing with mobile devices.
-        preferences.dom_touch_events_legacy_apis_enabled = UserAgentPlatform::default().is_mobile();
-
         preferences
     }
 }
@@ -577,10 +577,6 @@ impl UserAgentPlatform {
 }
 
 impl UserAgentPlatform {
-    pub fn is_mobile(&self) -> bool {
-        matches!(self, Self::Android | Self::OpenHarmony)
-    }
-
     /// Convert this [`UserAgentPlatform`] into its corresponding `String` value, ie the
     /// default user-agent to use for this platform.
     pub fn to_user_agent_string(&self) -> String {

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -731,6 +731,10 @@ macro_rules! global_event_handlers(
         event_handler!(suspend, GetOnsuspend, SetOnsuspend);
         event_handler!(timeupdate, GetOntimeupdate, SetOntimeupdate);
         event_handler!(toggle, GetOntoggle, SetOntoggle);
+        event_handler!(touchcancel, GetOntouchcancel, SetOntouchcancel);
+        event_handler!(touchend, GetOntouchend, SetOntouchend);
+        event_handler!(touchmove, GetOntouchmove, SetOntouchmove);
+        event_handler!(touchstart, GetOntouchstart, SetOntouchstart);
         event_handler!(transitioncancel, GetOntransitioncancel, SetOntransitioncancel);
         event_handler!(transitionend, GetOntransitionend, SetOntransitionend);
         event_handler!(transitionrun, GetOntransitionrun, SetOntransitionrun);

--- a/components/script_bindings/webidls/EventHandler.webidl
+++ b/components/script_bindings/webidls/EventHandler.webidl
@@ -160,3 +160,15 @@ partial interface mixin GlobalEventHandlers {
            attribute EventHandler onpointerout;
            attribute EventHandler onpointerleave;
 };
+
+// https://w3c.github.io/touch-events/#extensions-to-the-globaleventhandlers-mixin
+partial interface mixin GlobalEventHandlers {
+           [Pref="dom_touch_events_legacy_apis_enabled"]
+           attribute EventHandler ontouchstart;
+           [Pref="dom_touch_events_legacy_apis_enabled"]
+           attribute EventHandler ontouchend;
+           [Pref="dom_touch_events_legacy_apis_enabled"]
+           attribute EventHandler ontouchmove;
+           [Pref="dom_touch_events_legacy_apis_enabled"]
+           attribute EventHandler ontouchcancel;
+};

--- a/tests/wpt/meta/dom/events/__dir__.ini
+++ b/tests/wpt/meta/dom/events/__dir__.ini
@@ -1,0 +1,3 @@
+prefs: [
+    "dom_touch_events_legacy_apis_enabled:true",
+]

--- a/tests/wpt/meta/touch-events/__dir__.ini
+++ b/tests/wpt/meta/touch-events/__dir__.ini
@@ -1,0 +1,3 @@
+prefs: [
+    "dom_touch_events_legacy_apis_enabled:true",
+]

--- a/tests/wpt/meta/touch-events/idlharness.window.js.ini
+++ b/tests/wpt/meta/touch-events/idlharness.window.js.ini
@@ -1,10 +1,4 @@
 [idlharness.window.html]
-  [Document interface: document must inherit property "ontouchcancel" with the proper type]
-    expected: FAIL
-
-  [GlobalEventHandlers interface: document.body must inherit property "ontouchend" with the proper type]
-    expected: FAIL
-
   [GlobalEventHandlers interface: window must inherit property "ontouchend" with the proper type]
     expected: FAIL
 
@@ -20,16 +14,7 @@
   [TouchEvent must be primary interface of new TouchEvent("name")]
     expected: FAIL
 
-  [GlobalEventHandlers interface: document.body must inherit property "ontouchmove" with the proper type]
-    expected: FAIL
-
-  [Window interface: attribute ontouchend]
-    expected: FAIL
-
   [Touch interface: new Touch({identifier: 1, target: document}) must inherit property "altitudeAngle" with the proper type]
-    expected: FAIL
-
-  [GlobalEventHandlers interface: document must inherit property "ontouchmove" with the proper type]
     expected: FAIL
 
   [GlobalEventHandlers interface: window must inherit property "ontouchmove" with the proper type]
@@ -42,18 +27,6 @@
     expected: FAIL
 
   [Touch must be primary interface of new Touch({identifier: 1, target: document})]
-    expected: FAIL
-
-  [GlobalEventHandlers interface: document must inherit property "ontouchstart" with the proper type]
-    expected: FAIL
-
-  [Window interface: attribute ontouchcancel]
-    expected: FAIL
-
-  [HTMLElement interface: attribute ontouchend]
-    expected: FAIL
-
-  [Document interface: document must inherit property "ontouchend" with the proper type]
     expected: FAIL
 
   [TouchEvent interface: new TouchEvent("name") must inherit property "targetTouches" with the proper type]
@@ -80,31 +53,13 @@
   [TouchEvent interface: new TouchEvent("name") must inherit property "metaKey" with the proper type]
     expected: FAIL
 
-  [GlobalEventHandlers interface: document.body must inherit property "ontouchstart" with the proper type]
-    expected: FAIL
-
-  [HTMLElement interface: attribute ontouchstart]
-    expected: FAIL
-
-  [Window interface: attribute ontouchmove]
-    expected: FAIL
-
-  [HTMLElement interface: attribute ontouchmove]
-    expected: FAIL
-
   [Touch interface: new Touch({identifier: 1, target: document}) must inherit property "touchType" with the proper type]
     expected: FAIL
 
   [GlobalEventHandlers interface: window must inherit property "ontouchstart" with the proper type]
     expected: FAIL
 
-  [Document interface: attribute ontouchend]
-    expected: FAIL
-
   [Touch interface: attribute rotationAngle]
-    expected: FAIL
-
-  [Document interface: document must inherit property "ontouchstart" with the proper type]
     expected: FAIL
 
   [Touch interface: new Touch({identifier: 1, target: document}) must inherit property "screenX" with the proper type]
@@ -134,43 +89,16 @@
   [TouchEvent interface: new TouchEvent("name") must inherit property "changedTouches" with the proper type]
     expected: FAIL
 
-  [GlobalEventHandlers interface: document.body must inherit property "ontouchcancel" with the proper type]
-    expected: FAIL
-
-  [Window interface: attribute ontouchstart]
-    expected: FAIL
-
   [TouchEvent interface: new TouchEvent("name") must inherit property "ctrlKey" with the proper type]
     expected: FAIL
 
   [Touch interface: attribute altitudeAngle]
     expected: FAIL
 
-  [Document interface: attribute ontouchcancel]
-    expected: FAIL
-
-  [Document interface: attribute ontouchstart]
-    expected: FAIL
-
-  [Document interface: document must inherit property "ontouchmove" with the proper type]
-    expected: FAIL
-
   [Touch interface: new Touch({identifier: 1, target: document}) must inherit property "pageX" with the proper type]
     expected: FAIL
 
   [Stringification of new Touch({identifier: 1, target: document})]
-    expected: FAIL
-
-  [GlobalEventHandlers interface: document must inherit property "ontouchend" with the proper type]
-    expected: FAIL
-
-  [Document interface: attribute ontouchmove]
-    expected: FAIL
-
-  [GlobalEventHandlers interface: document must inherit property "ontouchcancel" with the proper type]
-    expected: FAIL
-
-  [HTMLElement interface: attribute ontouchcancel]
     expected: FAIL
 
   [Touch interface: attribute radiusX]

--- a/tests/wpt/meta/touch-events/touch-globaleventhandler-interface.html.ini
+++ b/tests/wpt/meta/touch-events/touch-globaleventhandler-interface.html.ini
@@ -1,6 +1,0 @@
-[touch-globaleventhandler-interface.html]
-  [Touch events in GlobalEventHandlers]
-    expected: PRECONDITION_FAILED
-
-  [Touch events are GlobalEventHandlers' own property]
-    expected: PRECONDITION_FAILED


### PR DESCRIPTION
Implement the [extensions to the `GlobalEventHandlers` mixin](https://w3c.github.io/touch-events/#extensions-to-the-globaleventhandlers-mixin) from touch event spec. This is implemented whenever the expose legacy touch event APIs flag is enabled. Following Firefox, we would enable it by default according to the platform for mobile devices (e.g., Android and Ohos).