### PR TITLE
devtools: Fix deadlock-like silent failure in DevTools

### DIFF
--- a/components/default-resources/resources/debugger.js
+++ b/components/default-resources/resources/debugger.js
@@ -10,6 +10,7 @@ const frameActorsToFrames = new Map;
 const environmentsToEnvironmentActors = new Map;
 let suspendedFrame = null;
 let lastPauseLocation = null;
+let debuggerPaused = false;
 
 // <https://searchfox.org/firefox-main/source/devtools/server/actors/thread.js#155>
 // Possible values for the `why.type` attribute in "paused" event
@@ -335,6 +336,13 @@ function createFrameActor(frame, pipelineId) {
 }
 
 function handlePauseAndRespond(frame, pauseReason) {
+    // https://searchfox.org/firefox-main/source/devtools/server/actors/thread.js#1706
+    // We don't handle nested pauses correctly.  Don't try - if we're
+    // paused, just continue running whatever code triggered the pause.
+    if (debuggerPaused) {
+        return undefined;
+    }
+
     dbg.onEnterFrame = undefined;
     clearSteppingHooks(frame);
 
@@ -358,11 +366,16 @@ function handlePauseAndRespond(frame, pauseReason) {
     lastPauseLocation = { line: offsetMetadata.lineNumber, column: offsetMetadata.columnNumber };
 
     // Notify devtools and enter pause loop. This blocks until Resume.
-    pauseAndRespond(
-        pipelineId,
-        frameOffset,
-        pauseReason
-    );
+    debuggerPaused = true;
+    try {
+        pauseAndRespond(
+            pipelineId,
+            frameOffset,
+            pauseReason
+        );
+    } finally {
+        debuggerPaused = false;
+    }
 
     // <https://web.archive.org/web/20251212212538/https://firefox-source-docs.mozilla.org/js/Debugger/Conventions.html#resumption-values>
     // Return undefined to continue execution normally after resume.

--- a/python/servo/devtools_tests.py
+++ b/python/servo/devtools_tests.py
@@ -311,6 +311,42 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
             )
             self.assertIn("from", response)
 
+    def test_console_eval_does_not_pause_again_while_already_paused(self):
+        self.run_servoshell(url=f"{self.base_urls[0]}/debugger/stepping.html")
+        with Devtools.connect() as devtools:
+            thread_actor = attach_thread(devtools)
+            console_actor = devtools.targets[0]["consoleActor"]
+
+            # Stop at the breakpoint in end()
+            def trigger():
+                set_breakpoint(devtools, f"{self.base_urls[0]}/debugger/stepping.html", 5, 16)
+
+            paused_data = wait_for_pause(devtools.client, thread_actor, trigger)
+
+            eval_result = Future()
+            nested_pause = Future()
+
+            devtools.client.add_event_listener(
+                console_actor, Events.WebConsole.EVALUATION_RESULT, eval_result.set_result
+            )
+            devtools.client.add_event_listener(thread_actor, "paused", nested_pause.set_result)
+            devtools.client.send_receive(
+                {
+                    "to": console_actor,
+                    "type": "evaluateJSAsync",
+                    "text": "end()",
+                    "frameActor": paused_data["frame"]["actor"],
+                }
+            )
+
+            # The console evaluation should not pause again
+            time.sleep(0.5)
+            self.assertFalse(nested_pause.done())
+            eval_result.result(2)
+
+            # Clean up by resuming from the original pause
+            devtools.client.send_receive({"to": thread_actor, "type": "resume"})
+
     def test_manual_pause(self):
         self.run_servoshell(url=f"{self.base_urls[0]}/debugger/loop.html")
         with Devtools.connect() as devtools:


### PR DESCRIPTION
When the debugger was already paused, console evaluation could hit another breakpoint and send a second paused packet. This created a deadlock-like nested pause flow where DevTools appeared to resume, but behind the scenes pause/resume handling got stuck silently.


Testing: Added a test
Fixes: part of #39858 
