### PR TITLE
script: Inline some event dispatching methods

### DIFF
--- a/components/script/dom/event/event.rs
+++ b/components/script/dom/event/event.rs
@@ -774,12 +774,7 @@ impl Event {
         legacy_output_did_listeners_throw: &Cell<bool>,
     ) -> bool {
         self.set_trusted(true);
-        self.dispatch_inner(
-            cx,
-            target,
-            false,
-            Some(legacy_output_did_listeners_throw),
-        )
+        self.dispatch_inner(cx, target, false, Some(legacy_output_did_listeners_throw))
     }
 
     /// <https://dom.spec.whatwg.org/#inner-event-creation-steps>

--- a/components/script/dom/event/event.rs
+++ b/components/script/dom/event/event.rs
@@ -295,21 +295,6 @@ impl Event {
         self.dispatch_inner(cx, target, legacy_target_override, None)
     }
 
-    pub(crate) fn dispatch_with_legacy_output_did_listeners_throw(
-        &self,
-        cx: &mut JSContext,
-        target: &EventTarget,
-        legacy_target_override: bool,
-        legacy_output_did_listeners_throw: &Cell<bool>,
-    ) -> bool {
-        self.dispatch_inner(
-            cx,
-            target,
-            legacy_target_override,
-            Some(legacy_output_did_listeners_throw),
-        )
-    }
-
     fn dispatch_inner(
         &self,
         cx: &mut JSContext,
@@ -774,13 +759,12 @@ impl Event {
         let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
         let cx = &mut cx;
 
-        target.dispatch_event(cx, self)
+        self.dispatch(cx, target, false)
     }
 
     pub(crate) fn fire_with_cx(&self, cx: &mut JSContext, target: &EventTarget) -> bool {
         self.set_trusted(true);
-
-        target.dispatch_event(cx, self)
+        self.dispatch(cx, target, false)
     }
 
     pub(crate) fn fire_with_legacy_output_did_listeners_throw(
@@ -790,11 +774,11 @@ impl Event {
         legacy_output_did_listeners_throw: &Cell<bool>,
     ) -> bool {
         self.set_trusted(true);
-        self.dispatch_with_legacy_output_did_listeners_throw(
+        self.dispatch_inner(
             cx,
             target,
             false,
-            legacy_output_did_listeners_throw,
+            Some(legacy_output_did_listeners_throw),
         )
     }
 

--- a/components/script/dom/event/eventtarget.rs
+++ b/components/script/dom/event/eventtarget.rs
@@ -473,10 +473,6 @@ impl EventTarget {
             .map_or(EventListeners(vec![]), |listeners| listeners.clone())
     }
 
-    pub(crate) fn dispatch_event(&self, cx: &mut JSContext, event: &Event) -> bool {
-        event.dispatch(cx, self, false)
-    }
-
     pub(crate) fn remove_all_listeners(&self) {
         let mut handlers = self.handlers.borrow_mut();
         for (ty, entries) in handlers.iter() {
@@ -1111,7 +1107,7 @@ impl EventTargetMethods<crate::DomTypeHolder> for EventTarget {
             return Err(Error::InvalidState(None));
         }
         event.set_trusted(false);
-        Ok(self.dispatch_event(cx, event))
+        Ok(event.dispatch(cx, self, false))
     }
 }
 

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -50,7 +50,7 @@ use crate::dom::element::{
     cors_settings_attribute_credential_mode, referrer_policy_for_element,
     reflect_cross_origin_attribute, reflect_referrer_policy_attribute, set_cross_origin_attribute,
 };
-use crate::dom::event::{Event, EventBubbles, EventCancelable};
+use crate::dom::event::eventtarget::EventTarget;
 use crate::dom::global_scope_script_execution::{ClassicScript, ErrorReporting, RethrowErrors};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::html::htmlelement::HTMLElement;
@@ -1056,7 +1056,8 @@ impl HTMLScriptElement {
         let script = match result {
             // Step 4. If el's result is null, then fire an event named error at el, and return.
             Err(_) => {
-                self.dispatch_event(cx, atom!("error"));
+                self.upcast::<EventTarget>()
+                    .fire_event(atom!("error"), CanGc::from_cx(cx));
                 return;
             },
 
@@ -1120,7 +1121,8 @@ impl HTMLScriptElement {
 
         // Step 8. If el's from an external file is true, then fire an event named load at el.
         if self.from_an_external_file.get() {
-            self.dispatch_event(cx, atom!("load"));
+            self.upcast::<EventTarget>()
+                .fire_event(atom!("load"), CanGc::from_cx(cx));
         }
     }
 
@@ -1197,18 +1199,6 @@ impl HTMLScriptElement {
 
     pub(crate) fn get_non_blocking(&self) -> bool {
         self.non_blocking.get()
-    }
-
-    fn dispatch_event(&self, cx: &mut JSContext, type_: Atom) -> bool {
-        let window = self.owner_window();
-        let event = Event::new(
-            window.upcast(),
-            type_,
-            EventBubbles::DoesNotBubble,
-            EventCancelable::NotCancelable,
-            CanGc::from_cx(cx),
-        );
-        event.fire_with_cx(cx, self.upcast())
     }
 
     fn text(&self) -> DOMString {

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -66,7 +66,7 @@ use crate::script_module::{
     ImportMap, ModuleTree, ScriptFetchOptions, fetch_an_external_module_script,
     fetch_inline_module_script, parse_an_import_map_string, register_import_map,
 };
-use crate::script_runtime::{CanGc, IntroductionType};
+use crate::script_runtime::IntroductionType;
 
 /// An unique id for script element.
 #[derive(Clone, Copy, Debug, Eq, Hash, JSTraceable, PartialEq, MallocSizeOf)]
@@ -1056,8 +1056,7 @@ impl HTMLScriptElement {
         let script = match result {
             // Step 4. If el's result is null, then fire an event named error at el, and return.
             Err(_) => {
-                self.upcast::<EventTarget>()
-                    .fire_event(atom!("error"), CanGc::from_cx(cx));
+                self.upcast::<EventTarget>().fire_event(cx, atom!("error"));
                 return;
             },
 
@@ -1121,8 +1120,7 @@ impl HTMLScriptElement {
 
         // Step 8. If el's from an external file is true, then fire an event named load at el.
         if self.from_an_external_file.get() {
-            self.upcast::<EventTarget>()
-                .fire_event(atom!("load"), CanGc::from_cx(cx));
+            self.upcast::<EventTarget>().fire_event(cx, atom!("load"));
         }
     }
 

--- a/components/script/dom/workers/serviceworkerglobalscope.rs
+++ b/components/script/dom/workers/serviceworkerglobalscope.rs
@@ -552,7 +552,7 @@ impl ServiceWorkerGlobalScope {
     fn dispatch_activate(&self, cx: &mut js::context::JSContext, _realm: InRealm) {
         let event = ExtendableEvent::new(self, atom!("activate"), false, false, CanGc::from_cx(cx));
         let event = (*event).upcast::<Event>();
-        event.fire(self.upcast(), CanGc::from_cx(cx));
+        event.dispatch(cx, self.upcast(), false);
     }
 }
 

--- a/components/script/dom/workers/serviceworkerglobalscope.rs
+++ b/components/script/dom/workers/serviceworkerglobalscope.rs
@@ -552,7 +552,7 @@ impl ServiceWorkerGlobalScope {
     fn dispatch_activate(&self, cx: &mut js::context::JSContext, _realm: InRealm) {
         let event = ExtendableEvent::new(self, atom!("activate"), false, false, CanGc::from_cx(cx));
         let event = (*event).upcast::<Event>();
-        self.upcast::<EventTarget>().dispatch_event(cx, event);
+        event.fire(self.upcast(), CanGc::from_cx(cx));
     }
 }
 

--- a/components/script/dom/workers/serviceworkerglobalscope.rs
+++ b/components/script/dom/workers/serviceworkerglobalscope.rs
@@ -13,6 +13,7 @@ use dom_struct::dom_struct;
 use fonts::FontContext;
 use js::jsapi::{JS_AddInterruptCallback, JSContext};
 use js::jsval::UndefinedValue;
+use js::realm::CurrentRealm;
 use net_traits::CustomResponseMediator;
 use net_traits::blob_url_store::UrlWithBlobClaim;
 use net_traits::request::{
@@ -457,8 +458,7 @@ impl ServiceWorkerGlobalScope {
                         true,
                     );
                     _ = global_scope.run_a_classic_script(&mut realm, script, RethrowErrors::No);
-                    let in_realm_proof = (&mut realm).into();
-                    global.dispatch_activate(&mut realm, InRealm::Already(&in_realm_proof));
+                    global.dispatch_activate(&mut realm);
                 }
 
                 let reporter_name = format!("service-worker-reporter-{}", random::<u64>());
@@ -549,7 +549,7 @@ impl ServiceWorkerGlobalScope {
         ScriptEventLoopSender::ServiceWorker(self.own_sender.clone())
     }
 
-    fn dispatch_activate(&self, cx: &mut js::context::JSContext, _realm: InRealm) {
+    fn dispatch_activate(&self, cx: &mut CurrentRealm) {
         let event = ExtendableEvent::new(self, atom!("activate"), false, false, CanGc::from_cx(cx));
         let event = (*event).upcast::<Event>();
         event.dispatch(cx, self.upcast(), false);


### PR DESCRIPTION
Noticed this a while ago, event dispatching code would go back and forth between `Event` and `EventTarget`, thus some of the methods are now inlined.

Testing: Covered by existing tests
