### PR TITLE
devtools: Avoid recursive previews when getting `ownPropertyLength`

### DIFF
--- a/components/default-resources/resources/debugger.js
+++ b/components/default-resources/resources/debugger.js
@@ -104,11 +104,14 @@ function createValueGrip(value, depth = 0) {
             if (value.optimizedOut || value.uninitialized || value.missingArguments) {
                 return { valueType: "null" };
             }
+            // TODO: handle typed arrays and storage independently
+            const ownPropertyLength = value.getOwnPropertyNamesLength();
             // Debugger.Object - get preview using registered previewers
             // <https://firefox-source-docs.mozilla.org/devtools-user/debugger-api/debugger.object/index.html>
             return {
                 valueType: "object",
                 objectClass: value.class,
+                ownPropertyLength: Number.isFinite(ownPropertyLength) ? ownPropertyLength : undefined,
                 preview: getPreview(value, depth),
             };
         default:
@@ -169,7 +172,6 @@ const previewers = {};
 
 // <https://searchfox.org/mozilla-central/source/devtools/server/actors/object/previewers.js#125>
 previewers.Function = [ function FunctionPreviewer(obj, depth) {
-    const { ownProperties, ownPropertiesLength } = extractOwnProperties(obj, depth);
     let function_details = {
         name: obj.name,
         displayName: obj.displayName,
@@ -178,36 +180,34 @@ previewers.Function = [ function FunctionPreviewer(obj, depth) {
         isGenerator: obj.isGeneratorFunction,
     }
 
+    let preview = { kind: "Object", function: function_details };
     if (depth > 1) {
-        return { kind: "Object", function: function_details, ownPropertiesLength };
+        return undefined;
     }
 
-    return {
-        kind: "Object",
-        ownProperties,
-        ownPropertiesLength,
-        function: function_details
-    };
+    const { ownProperties, ownPropertiesLength } = extractOwnProperties(obj, depth);
+    preview.ownProperties = ownProperties;
+    preview.ownPropertiesLength = ownPropertiesLength;
+
+    return preview;
 } ];
 
 // <https://searchfox.org/mozilla-central/source/devtools/server/actors/object/previewers.js#172>
 previewers.Array = [ function ArrayPreviewer(obj, depth) {
     const lengthDescriptor = obj.getOwnPropertyDescriptor("length");
-    const length = lengthDescriptor ? lengthDescriptor.value : 0;
+    const arrayLength = lengthDescriptor ? lengthDescriptor.value : 0;
 
+    let preview = { kind: "ArrayLike", arrayLength };
     if (depth > 1) {
-        return {
-            kind: "ArrayLike",
-            arrayLength: length,
-        };
+        return undefined;
     }
 
-    const items = [];
-    for (let i = 0; i < length; i++) {
+    let items = (preview.items = []);
+    for (let i = 0; i < arrayLength; i++) {
         try {
             const desc = obj.getOwnPropertyDescriptor(i);
             if (desc && desc.value !== undefined) {
-                const grip = createValueGrip(desc.value, depth);
+                const grip = createValueGrip(desc.value, depth + 1);
                 delete grip.preview;
                 items.push(grip);
             }
@@ -216,27 +216,22 @@ previewers.Array = [ function ArrayPreviewer(obj, depth) {
         }
     }
 
-    return {
-        kind: "ArrayLike",
-        arrayLength: length,
-        items: items,
-    };
+    return preview;
 } ];
 
 // Generic fallback for object previewer
 // <https://searchfox.org/mozilla-central/source/devtools/server/actors/object/previewers.js#856>
 previewers.Object = [ function ObjectPreviewer(obj, depth) {
-    const { ownProperties, ownPropertiesLength } = extractOwnProperties(obj, depth);
-
+    let preview = { kind: "Object" };
     if (depth > 1) {
-       return { kind: "Object", ownPropertiesLength };
+       return undefined;
     }
 
-    return {
-        kind: "Object",
-        ownProperties,
-        ownPropertiesLength,
-    };
+    const { ownProperties, ownPropertiesLength } = extractOwnProperties(obj, depth);
+    preview.ownProperties = ownProperties;
+    preview.ownPropertiesLength = ownPropertiesLength;
+
+    return preview;
 } ];
 
 function getPreview(obj, depth) {
@@ -249,7 +244,7 @@ function getPreview(obj, depth) {
         if (result) return result;
     }
 
-    return { ownProperties: [], ownPropertiesLength: 0 };
+    return undefined;
 }
 
 // Evaluate some javascript code in the global context of the debuggee

--- a/components/devtools/actors/frame.rs
+++ b/components/devtools/actors/frame.rs
@@ -112,7 +112,8 @@ impl FrameActor {
         source_name: String,
         frame_result: FrameInfo,
     ) -> String {
-        let object_name = ObjectActor::register(registry, None, "Object".to_owned(), None);
+        // TODO: Get the real frame object from the debugger.
+        let object_name = ObjectActor::register(registry, None, "Object".to_owned(), None, None);
 
         let name = registry.new_name::<Self>();
         let actor = Self {

--- a/components/devtools/actors/object.rs
+++ b/components/devtools/actors/object.rs
@@ -122,6 +122,7 @@ pub(crate) struct ObjectActor {
     name: String,
     _uuid: Option<String>,
     class: String,
+    own_property_length: Option<u32>,
     preview: Option<devtools_traits::ObjectPreview>,
 }
 
@@ -228,6 +229,7 @@ impl ObjectActor {
         registry: &ActorRegistry,
         uuid: Option<String>,
         class: String,
+        own_property_length: Option<u32>,
         preview: Option<devtools_traits::ObjectPreview>,
     ) -> String {
         let Some(uuid) = uuid else {
@@ -236,6 +238,7 @@ impl ObjectActor {
                 name: name.clone(),
                 _uuid: None,
                 class,
+                own_property_length,
                 preview,
             };
             registry.register(actor);
@@ -247,6 +250,7 @@ impl ObjectActor {
                 name: name.clone(),
                 _uuid: Some(uuid.clone()),
                 class,
+                own_property_length,
                 preview,
             };
 
@@ -271,7 +275,7 @@ impl ActorEncode<ObjectActorMsg> for ObjectActor {
             sealed: false,
             function: None,
             preview: None,
-            own_property_length: None,
+            own_property_length: self.own_property_length,
         };
 
         // Build preview
@@ -279,7 +283,6 @@ impl ActorEncode<ObjectActorMsg> for ObjectActor {
         let Some(preview) = self.preview.clone() else {
             return msg;
         };
-        msg.own_property_length = preview.own_properties_length;
 
         let function = preview.function.map(|function| FunctionPreview {
             name: function.name.clone(),

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -990,12 +990,11 @@ pub(crate) fn debugger_value_to_json(registry: &ActorRegistry, value: DebuggerVa
         DebuggerValue::ObjectValue {
             uuid,
             class,
+            own_property_length,
             preview,
-            ..
         } => {
-            // TODO: We should have a field called `ownPropertyLength` here
-            // That will show "{...}" when an object has more properties
-            let object_name = ObjectActor::register(registry, Some(uuid), class, preview);
+            let object_name =
+                ObjectActor::register(registry, Some(uuid), class, own_property_length, preview);
             let object_msg = registry.encode::<ObjectActor, _>(&object_name);
             let value = serde_json::to_value(object_msg).unwrap_or_default();
             Value::Object(value.as_object().cloned().unwrap_or_default())

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -214,6 +214,7 @@ fn console_argument_from_handle_value(
                 return Ok(DebuggerValue::ObjectValue {
                     uuid: uuid::Uuid::new_v4().to_string(),
                     class,
+                    own_property_length: preview.own_properties_length,
                     preview: Some(preview),
                 });
             }

--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -696,6 +696,7 @@ fn parse_debugger_value(
             ObjectValue {
                 uuid: uuid::Uuid::new_v4().to_string(),
                 class,
+                own_property_length: value.ownPropertyLength,
                 preview: preview.map(parse_object_preview),
             }
         },

--- a/components/script_bindings/webidls/DebuggerEvalEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerEvalEvent.webidl
@@ -38,6 +38,7 @@ dictionary DebuggerValue {
     double numberValue;
     DOMString stringValue;
     DOMString objectClass;
+    unsigned long ownPropertyLength;
 };
 
 dictionary ObjectPreview {

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -186,6 +186,7 @@ pub enum DebuggerValue {
     ObjectValue {
         uuid: String,
         class: String,
+        own_property_length: Option<u32>,
         preview: Option<ObjectPreview>,
     },
 }


### PR DESCRIPTION
There are two fields that an object message contains to indicate the number of properties that it has: `ownPropertyLength` and `preview.ownPropertiesLength`. Before we were just copying the one in preview out, but this doesn't work for objects without a preview (such as nested objects).

What's more, calling `extractOwnProperties` before doing the `depth` check can result in infinite recursion or issues in some cases. This patch doesn't fix all recursions, but it is a step in the right direction.

Testing: ./mach test-devtools
Part of: #36027
