### PR TITLE
devtools: Fix inspector not loading when navigating on the same page

### DIFF
--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -8,7 +8,7 @@
 
 use atomic_refcell::AtomicRefCell;
 use devtools_traits::DevtoolScriptControlMsg::{self, GetCssDatabase, SimulateColorScheme};
-use devtools_traits::{DevtoolsPageInfo, NavigationState};
+use devtools_traits::DevtoolsPageInfo;
 use embedder_traits::Theme;
 use malloc_size_of_derive::MallocSizeOf;
 use rustc_hash::FxHashMap;
@@ -26,8 +26,8 @@ use crate::actors::stylesheets::StyleSheetsActor;
 use crate::actors::tab::TabDescriptorActor;
 use crate::actors::thread::ThreadActor;
 use crate::actors::watcher::{SessionContext, SessionContextType, WatcherActor};
-use crate::id::{DevtoolsBrowserId, DevtoolsBrowsingContextId, DevtoolsOuterWindowId, IdMap};
-use crate::protocol::{ClientRequest, DevtoolsConnection, JsonPacketStream};
+use crate::id::{DevtoolsBrowserId, DevtoolsBrowsingContextId, DevtoolsOuterWindowId};
+use crate::protocol::{ClientRequest, JsonPacketStream};
 use crate::resource::ResourceAvailable;
 use crate::{EmptyReplyMsg, StreamId};
 
@@ -52,19 +52,6 @@ struct FrameUpdateMsg {
     is_top_level: bool,
     url: String,
     title: String,
-}
-
-#[derive(Serialize)]
-struct TabNavigated {
-    from: String,
-    #[serde(rename = "type")]
-    type_: String,
-    url: String,
-    title: Option<String>,
-    #[serde(rename = "nativeConsoleAPI")]
-    native_console_api: bool,
-    state: String,
-    is_frame_switching: bool,
 }
 
 #[derive(Serialize)]
@@ -131,8 +118,6 @@ pub(crate) struct BrowsingContextActorMsg {
 #[derive(MallocSizeOf)]
 pub(crate) struct BrowsingContextActor {
     name: String,
-    pub title: AtomicRefCell<String>,
-    pub url: AtomicRefCell<String>,
     /// This corresponds to webview_id
     pub browser_id: DevtoolsBrowserId,
     // TODO: Should these ids be atomic?
@@ -142,11 +127,11 @@ pub(crate) struct BrowsingContextActor {
     accessibility_name: String,
     pub console_name: String,
     css_properties_name: String,
-    pub(crate) inspector_name: String,
+    pub inspector_name: String,
+    pub page_info: AtomicRefCell<DevtoolsPageInfo>,
     reflow_name: String,
     pub style_sheets_name: String,
     pub thread_name: String,
-    _tab: String,
     // Different pipelines may run on different script threads.
     // These should be kept around even when the active pipeline is updated,
     // in case the browsing context revisits a pipeline via history navigation.
@@ -208,12 +193,6 @@ impl BrowsingContextActor {
         script_sender: GenericSender<DevtoolScriptControlMsg>,
     ) -> String {
         let name = registry.new_name::<BrowsingContextActor>();
-        let DevtoolsPageInfo {
-            title,
-            url,
-            is_top_level_global,
-            ..
-        } = page_info;
 
         let accessibility_name = AccessibilityActor::register(registry);
 
@@ -232,8 +211,7 @@ impl BrowsingContextActor {
         let style_sheets_name =
             StyleSheetsActor::register(registry, script_sender.clone(), name.clone());
 
-        let tab_descriptor_name =
-            TabDescriptorActor::register(registry, name.clone(), is_top_level_global);
+        let _ = TabDescriptorActor::register(registry, name.clone());
 
         let thread_name =
             ThreadActor::register(registry, script_sender.clone(), Some(name.clone()));
@@ -249,20 +227,18 @@ impl BrowsingContextActor {
 
         let actor = BrowsingContextActor {
             name: name.clone(),
-            script_chans: AtomicRefCell::new(script_chans),
-            title: AtomicRefCell::new(title),
-            url: AtomicRefCell::new(url.into_string()),
-            active_pipeline_id: AtomicRefCell::new(pipeline_id),
-            active_outer_window_id: AtomicRefCell::new(outer_window_id),
+            script_chans: script_chans.into(),
+            active_pipeline_id: pipeline_id.into(),
+            active_outer_window_id: outer_window_id.into(),
             browser_id,
             browsing_context_id,
             accessibility_name,
             console_name,
             css_properties_name,
             inspector_name,
+            page_info: page_info.into(),
             reflow_name,
             style_sheets_name,
-            _tab: tab_descriptor_name,
             thread_name,
             watcher_name,
         };
@@ -282,48 +258,11 @@ impl BrowsingContextActor {
             .insert(pipeline, script_sender);
     }
 
-    pub(crate) fn handle_navigate<'a>(
-        &self,
-        state: NavigationState,
-        id_map: &mut IdMap,
-        connections: impl Iterator<Item = &'a mut DevtoolsConnection>,
-    ) {
-        let (pipeline_id, title, url, state) = match state {
-            NavigationState::Start(url) => (None, None, url, "start"),
-            NavigationState::Stop(pipeline, info) => {
-                (Some(pipeline), Some(info.title), info.url, "stop")
-            },
-        };
-        if let Some(pipeline_id) = pipeline_id {
-            let outer_window_id = id_map.outer_window_id(pipeline_id);
-            *self.active_outer_window_id.borrow_mut() = outer_window_id;
-            *self.active_pipeline_id.borrow_mut() = pipeline_id;
-        }
-        url.as_str().clone_into(&mut self.url.borrow_mut());
-        if let Some(ref t) = title {
-            self.title.borrow_mut().clone_from(t);
-        }
-
-        let msg = TabNavigated {
-            from: self.name(),
-            type_: "tabNavigated".to_owned(),
-            url: url.as_str().to_owned(),
-            title,
-            native_console_api: true,
-            state: state.to_owned(),
-            is_frame_switching: false,
-        };
-
-        for stream in connections {
-            let _ = stream.write_json_packet(&msg);
-        }
-    }
-
     pub(crate) fn title_changed(&self, pipeline_id: PipelineId, title: String) {
         if pipeline_id != self.pipeline_id() {
             return;
         }
-        *self.title.borrow_mut() = title;
+        self.page_info.borrow_mut().title = title;
     }
 
     pub(crate) fn frame_update(&self, request: &mut ClientRequest) {
@@ -333,8 +272,8 @@ impl BrowsingContextActor {
             frames: vec![FrameUpdateMsg {
                 id: self.browsing_context_id.value(),
                 is_top_level: true,
-                title: self.title.borrow().clone(),
-                url: self.url.borrow().clone(),
+                title: self.title(),
+                url: self.url(),
             }],
         });
     }
@@ -347,6 +286,25 @@ impl BrowsingContextActor {
 
     pub(crate) fn pipeline_id(&self) -> PipelineId {
         *self.active_pipeline_id.borrow()
+    }
+
+    pub(crate) fn title(&self) -> String {
+        self.page_info.borrow().title.clone()
+    }
+
+    pub(crate) fn url(&self) -> String {
+        self.page_info.borrow().url.clone().into_string()
+    }
+
+    pub(crate) fn update_pipeline(
+        &self,
+        pipeline_id: PipelineId,
+        outer_window_id: DevtoolsOuterWindowId,
+        page_info: DevtoolsPageInfo,
+    ) {
+        *self.active_pipeline_id.borrow_mut() = pipeline_id;
+        *self.active_outer_window_id.borrow_mut() = outer_window_id;
+        *self.page_info.borrow_mut() = page_info;
     }
 
     pub(crate) fn outer_window_id(&self) -> DevtoolsOuterWindowId {
@@ -388,8 +346,8 @@ impl ActorEncode<BrowsingContextActorMsg> for BrowsingContextActor {
                 supports_top_level_target_flag: true,
                 watchpoints: true,
             },
-            title: self.title.borrow().clone(),
-            url: self.url.borrow().clone(),
+            title: self.title(),
+            url: self.url(),
             browser_id: self.browser_id.value(),
             browsing_context_id: self.browsing_context_id.value(),
             outer_window_id: self.outer_window_id().value(),

--- a/components/devtools/actors/network_event.rs
+++ b/components/devtools/actors/network_event.rs
@@ -26,7 +26,6 @@ use crate::StreamId;
 use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
 use crate::actors::browsing_context::BrowsingContextActor;
 use crate::actors::long_string::LongStringActor;
-use crate::actors::watcher::WatcherActor;
 use crate::network_handler::Cause;
 use crate::protocol::ClientRequest;
 
@@ -37,7 +36,7 @@ pub(crate) struct NetworkEventActor {
     resource_id: u64,
     response: AtomicRefCell<Option<NetworkEventResponse>>,
     security_info: AtomicRefCell<TlsSecurityInfo>,
-    pub watcher_name: String,
+    pub browsing_context_name: String,
 }
 
 #[derive(Clone, Serialize)]
@@ -536,12 +535,16 @@ impl Actor for NetworkEventActor {
 }
 
 impl NetworkEventActor {
-    pub fn register(registry: &ActorRegistry, resource_id: u64, watcher_name: String) -> String {
+    pub fn register(
+        registry: &ActorRegistry,
+        resource_id: u64,
+        browsing_context_name: String,
+    ) -> String {
         let name = registry.new_name::<Self>();
         let actor = NetworkEventActor {
             name: name.clone(),
             resource_id,
-            watcher_name,
+            browsing_context_name,
             ..Default::default()
         };
         registry.register::<Self>(actor);
@@ -628,9 +631,8 @@ impl NetworkEventActor {
     }
 
     pub fn resource_updates(&self, registry: &ActorRegistry) -> NetworkEventResource {
-        let watcher_actor = registry.find::<WatcherActor>(&self.watcher_name);
         let browsing_context_actor =
-            registry.find::<BrowsingContextActor>(&watcher_actor.browsing_context_name);
+            registry.find::<BrowsingContextActor>(&self.browsing_context_name);
 
         NetworkEventResource {
             resource_id: self.resource_id,
@@ -706,9 +708,8 @@ impl ActorEncode<NetworkEventMsg> for NetworkEventActor {
             LocalResult::Ambiguous(date_time, _) => date_time.to_rfc3339(),
         };
 
-        let watcher_actor = registry.find::<WatcherActor>(&self.watcher_name);
         let browsing_context_actor =
-            registry.find::<BrowsingContextActor>(&watcher_actor.browsing_context_name);
+            registry.find::<BrowsingContextActor>(&self.browsing_context_name);
 
         NetworkEventMsg {
             actor: self.name(),

--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -292,7 +292,7 @@ impl Actor for RootActor {
                             let tab_descriptor_actor =
                                 registry.find::<TabDescriptorActor>(tab_descriptor_name);
                             // Filter out iframes and workers
-                            if tab_descriptor_actor.is_top_level_global() {
+                            if tab_descriptor_actor.is_top_level_global(registry) {
                                 Some(tab_descriptor_actor.encode(registry))
                             } else {
                                 None

--- a/components/devtools/actors/stylesheets.rs
+++ b/components/devtools/actors/stylesheets.rs
@@ -162,27 +162,22 @@ impl StyleSheetsActor {
                 tx,
             ));
         let style_sheets = rx.recv().unwrap();
+        let url = browsing_context_actor.url();
+        let browsing_context_id = browsing_context_actor.browsing_context_id.value();
         style_sheets
             .into_iter()
             .map(|info| StyleSheetData {
-                resource_id: format!(
-                    "{}-{}",
-                    browsing_context_actor.browsing_context_id.value(),
-                    info.style_sheet_index
-                ),
-                browsing_context_id: browsing_context_actor.browsing_context_id.value(),
+                resource_id: format!("{}-{}", browsing_context_id, info.style_sheet_index),
+                browsing_context_id,
                 href: info.href.clone(),
-                node_href: browsing_context_actor.url.borrow().clone(),
+                node_href: url.clone(),
                 disabled: info.disabled,
                 title: (!info.title.is_empty()).then_some(info.title),
                 system: info.system,
                 is_new: false,
                 file_name: None,
                 source_map_url: Some("".to_string()),
-                source_map_base_url: Some(
-                    info.href
-                        .unwrap_or_else(|| browsing_context_actor.url.borrow().clone()),
-                ),
+                source_map_base_url: Some(info.href.unwrap_or_else(|| url.clone())),
                 style_sheet_index: info.style_sheet_index,
                 constructed: false,
                 rule_count: info.rule_count,

--- a/components/devtools/actors/tab.rs
+++ b/components/devtools/actors/tab.rs
@@ -72,8 +72,7 @@ struct GetWatcherReply {
 #[derive(MallocSizeOf)]
 pub(crate) struct TabDescriptorActor {
     name: String,
-    browsing_context_name: String,
-    is_top_level_global: bool,
+    pub browsing_context_name: String,
 }
 
 impl Actor for TabDescriptorActor {
@@ -167,29 +166,24 @@ impl Actor for TabDescriptorActor {
 }
 
 impl TabDescriptorActor {
-    pub(crate) fn register(
-        registry: &ActorRegistry,
-        browsing_context_name: String,
-        is_top_level_global: bool,
-    ) -> String {
+    pub(crate) fn register(registry: &ActorRegistry, browsing_context_name: String) -> String {
         let name = registry.new_name::<Self>();
         let root_actor = registry.find::<RootActor>("root");
         root_actor.tabs.borrow_mut().push(name.clone());
-        let actor = TabDescriptorActor {
+        let actor = Self {
             name: name.clone(),
             browsing_context_name,
-            is_top_level_global,
         };
         registry.register::<Self>(actor);
         name
     }
 
-    pub(crate) fn is_top_level_global(&self) -> bool {
-        self.is_top_level_global
-    }
-
-    pub fn browsing_context(&self) -> String {
-        self.browsing_context_name.clone()
+    pub(crate) fn is_top_level_global(&self, registry: &ActorRegistry) -> bool {
+        registry
+            .find::<BrowsingContextActor>(&self.browsing_context_name)
+            .page_info
+            .borrow()
+            .is_top_level_global
     }
 }
 
@@ -197,9 +191,6 @@ impl ActorEncode<TabDescriptorActorMsg> for TabDescriptorActor {
     fn encode(&self, registry: &ActorRegistry) -> TabDescriptorActorMsg {
         let browsing_context_actor =
             registry.find::<BrowsingContextActor>(&self.browsing_context_name);
-        let title = browsing_context_actor.title.borrow().clone();
-        let url = browsing_context_actor.url.borrow().clone();
-
         TabDescriptorActorMsg {
             actor: self.name(),
             browser_id: browsing_context_actor.browser_id.value(),
@@ -207,13 +198,13 @@ impl ActorEncode<TabDescriptorActorMsg> for TabDescriptorActor {
             is_zombie_tab: false,
             outer_window_id: browsing_context_actor.outer_window_id().value(),
             selected: false,
-            title,
+            title: browsing_context_actor.title(),
             traits: DescriptorTraits {
                 watcher: true,
                 supports_navigation: true,
                 supports_reload_descriptor: true,
             },
-            url,
+            url: browsing_context_actor.url(),
         }
     }
 }

--- a/components/devtools/actors/thread.rs
+++ b/components/devtools/actors/thread.rs
@@ -13,11 +13,12 @@ use servo_base::generic_channel::GenericSender;
 
 use super::source::{SourceManager, SourcesReply};
 use crate::actor::{Actor, ActorError, ActorRegistry};
+use crate::actors::browsing_context::BrowsingContextActor;
 use crate::actors::frame::{FrameActor, FrameActorMsg};
 use crate::actors::pause::PauseActor;
 use crate::generic_channel::channel;
 use crate::protocol::{ClientRequest, JsonPacketStream};
-use crate::{BrowsingContextActor, EmptyReplyMsg, StreamId};
+use crate::{EmptyReplyMsg, StreamId};
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -191,7 +191,7 @@ pub(crate) struct WatcherActorMsg {
 #[derive(MallocSizeOf)]
 pub(crate) struct WatcherActor {
     name: String,
-    pub browsing_context_name: String,
+    browsing_context_name: String,
     network_parent_name: String,
     target_configuration_name: String,
     thread_configuration_name: String,
@@ -329,8 +329,8 @@ impl Actor for WatcherActor {
                                     name: name.into(),
                                     new_uri: None,
                                     time: get_time_stamp(),
-                                    title: Some(browsing_context_actor.title.borrow().clone()),
-                                    url: Some(browsing_context_actor.url.borrow().clone()),
+                                    title: Some(browsing_context_actor.title()),
+                                    url: Some(browsing_context_actor.url()),
                                 };
                                 browsing_context_actor.resource_array(
                                     event,
@@ -519,6 +519,29 @@ impl WatcherActor {
                 ResourceArrayType::Available,
                 stream,
             );
+        }
+    }
+
+    pub fn emit_target_available_or_destroyed<'a>(
+        &self,
+        browsing_context_actor: &BrowsingContextActor,
+        registry: &ActorRegistry,
+        connections: impl Iterator<Item = &'a mut DevtoolsConnection>,
+        available: bool,
+    ) {
+        let msg = WatchTargetsReply {
+            from: self.name(),
+            type_: (if available {
+                "target-available-form"
+            } else {
+                "target-destroyed-form"
+            })
+            .into(),
+            target: TargetActorMsg::BrowsingContext(browsing_context_actor.encode(registry)),
+        };
+
+        for stream in connections {
+            let _ = stream.write_json_packet(&msg);
         }
     }
 }

--- a/components/devtools/actors/watcher/target_configuration.rs
+++ b/components/devtools/actors/watcher/target_configuration.rs
@@ -78,9 +78,9 @@ impl Actor for TargetConfigurationActor {
                     let root_actor = registry.find::<RootActor>("root");
                     if let Some(tab_name) = root_actor.active_tab() {
                         let tab_descriptor_actor = registry.find::<TabDescriptorActor>(&tab_name);
-                        let browsing_context_name = tab_descriptor_actor.browsing_context();
-                        let browsing_context_actor =
-                            registry.find::<BrowsingContextActor>(&browsing_context_name);
+                        let browsing_context_actor = registry.find::<BrowsingContextActor>(
+                            &tab_descriptor_actor.browsing_context_name,
+                        );
                         browsing_context_actor
                             .simulate_color_scheme(theme)
                             .map_err(|_| ActorError::Internal)?;

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -442,26 +442,54 @@ impl DevtoolsInstance {
         framerate_actor.add_tick(tick);
     }
 
-    fn handle_navigate(&self, browsing_context_id: BrowsingContextId, state: NavigationState) {
-        let browsing_context_name = self.browsing_contexts.get(&browsing_context_id).unwrap();
+    fn handle_navigate(&mut self, browsing_context_id: BrowsingContextId, state: NavigationState) {
+        let Some(browsing_context_name) = self.browsing_contexts.get(&browsing_context_id) else {
+            return;
+        };
+        let browsing_context_name = browsing_context_name.clone();
         let browsing_context_actor = self
             .registry
-            .find::<BrowsingContextActor>(browsing_context_name);
+            .find::<BrowsingContextActor>(&browsing_context_name);
+        let watcher_actor = self
+            .registry
+            .find::<WatcherActor>(&browsing_context_actor.watcher_name);
         let mut id_map = self.id_map.lock().unwrap();
         let mut connections = self.connections.lock().unwrap();
-        if let NavigationState::Start(url) = &state {
-            let watcher_actor = self
-                .registry
-                .find::<WatcherActor>(&browsing_context_actor.watcher_name);
-            watcher_actor.emit_will_navigate(
-                browsing_context_id,
-                url.clone(),
-                &mut connections.values_mut(),
-                &mut id_map,
-            );
-        }
 
-        browsing_context_actor.handle_navigate(state, &mut id_map, connections.values_mut());
+        match &state {
+            NavigationState::Start(url) => {
+                watcher_actor.emit_will_navigate(
+                    browsing_context_id,
+                    url.clone(),
+                    &mut connections.values_mut(),
+                    &mut id_map,
+                );
+            },
+            NavigationState::Stop(pipeline_id, page_info) => {
+                watcher_actor.emit_target_available_or_destroyed(
+                    &browsing_context_actor,
+                    &self.registry,
+                    connections.values_mut(),
+                    false,
+                );
+
+                let outer_window_id = id_map.outer_window_id(*pipeline_id);
+                browsing_context_actor.update_pipeline(
+                    *pipeline_id,
+                    outer_window_id,
+                    page_info.clone(),
+                );
+
+                watcher_actor.emit_target_available_or_destroyed(
+                    &browsing_context_actor,
+                    &self.registry,
+                    connections.values_mut(),
+                    true,
+                );
+
+                // TODO: Correctly destroy targets, we probably need to create new browsing context actors too.
+            },
+        }
     }
 
     // We need separate actor representations for each script global that exists;
@@ -659,15 +687,10 @@ impl DevtoolsInstance {
         let Some(browsing_context_name) = self.browsing_contexts.get(&browsing_context_id) else {
             return;
         };
-        let watcher_name = self
-            .registry
-            .find::<BrowsingContextActor>(browsing_context_name)
-            .watcher_name
-            .clone();
 
         let network_event_name = match self.actor_requests.get(&request_id) {
             Some(name) => name.clone(),
-            None => self.create_network_event_actor(request_id, watcher_name),
+            None => self.create_network_event_actor(request_id, browsing_context_name.clone()),
         };
 
         handle_network_event(
@@ -678,13 +701,17 @@ impl DevtoolsInstance {
         )
     }
 
-    /// Create a new NetworkEventActor for a given request ID and watcher name.
-    fn create_network_event_actor(&mut self, request_id: String, watcher_name: String) -> String {
+    /// Create a new NetworkEventActor for a given request ID and browsing context name.
+    fn create_network_event_actor(
+        &mut self,
+        request_id: String,
+        browsing_context_name: String,
+    ) -> String {
         let resource_id = self.next_resource_id;
         self.next_resource_id += 1;
 
         let network_event_name =
-            NetworkEventActor::register(&self.registry, resource_id, watcher_name);
+            NetworkEventActor::register(&self.registry, resource_id, browsing_context_name);
 
         self.actor_requests
             .insert(request_id, network_event_name.clone());
@@ -749,20 +776,14 @@ impl DevtoolsInstance {
                 return;
             };
 
-            let thread_actor_name = {
-                let browsing_context_actor = self
-                    .registry
-                    .find::<BrowsingContextActor>(browsing_context_name);
-                browsing_context_actor.thread_name.clone()
-            };
-
-            let thread_actor = self.registry.find::<ThreadActor>(&thread_actor_name);
-            thread_actor.source_manager.add_source(&source_actor);
-
             // Notify browsing context about the new source
             let browsing_context_actor = self
                 .registry
                 .find::<BrowsingContextActor>(browsing_context_name);
+
+            let thread_actor_name = browsing_context_actor.thread_name.clone();
+            let thread_actor = self.registry.find::<ThreadActor>(&thread_actor_name);
+            thread_actor.source_manager.add_source(&source_actor);
 
             for stream in self.connections.lock().unwrap().values_mut() {
                 browsing_context_actor.resource_array(
@@ -835,14 +856,12 @@ impl DevtoolsInstance {
         pipeline_id: PipelineId,
         frame: FrameInfo,
     ) {
-        let Some(browsing_context_name) = self
-            .pipelines
-            .get(&pipeline_id)
-            .and_then(|id| self.browsing_contexts.get(id))
-        else {
+        let Some(browsing_context_id) = self.pipelines.get(&pipeline_id) else {
             return;
         };
-
+        let Some(browsing_context_name) = self.browsing_contexts.get(browsing_context_id) else {
+            return;
+        };
         let browsing_context_actor = self
             .registry
             .find::<BrowsingContextActor>(browsing_context_name);

--- a/components/devtools/network_handler.rs
+++ b/components/devtools/network_handler.rs
@@ -8,6 +8,7 @@ use devtools_traits::NetworkEvent;
 use serde::Serialize;
 
 use crate::actor::{ActorEncode, ActorRegistry};
+use crate::actors::browsing_context::BrowsingContextActor;
 use crate::actors::network_event::NetworkEventActor;
 use crate::actors::watcher::WatcherActor;
 use crate::protocol::DevtoolsConnection;
@@ -28,7 +29,9 @@ pub(crate) fn handle_network_event(
     network_event: NetworkEvent,
 ) {
     let network_event_actor = registry.find::<NetworkEventActor>(&network_event_name);
-    let watcher_actor = registry.find::<WatcherActor>(&network_event_actor.watcher_name);
+    let browsing_context_actor =
+        registry.find::<BrowsingContextActor>(&network_event_actor.browsing_context_name);
+    let watcher_actor = registry.find::<WatcherActor>(&browsing_context_actor.watcher_name);
 
     match network_event {
         NetworkEvent::HttpRequest(httprequest) => {

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -40,7 +40,7 @@ use uuid::Uuid;
 
 // Information would be attached to NewGlobal to be received and show in devtools.
 // Extend these fields if we need more information.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub struct DevtoolsPageInfo {
     pub title: String,
     pub url: ServoUrl,

--- a/python/servo/devtools_tests.py
+++ b/python/servo/devtools_tests.py
@@ -1251,17 +1251,26 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
 
         self.run_servoshell(url=f"{self.base_urls[0]}/tab/page1.html")
         with Devtools.connect() as devtools:
-            nav_done = Future()
+            target_destroyed = Future()
+            target_available = Future()
 
-            def on_tab_navigated(data):
-                if data.get("state") == "stop" and data.get("url").endswith("/tab/page2.html"):
-                    nav_done.set_result(None)
-                    return
+            def on_target_destroyed(_):
+                target_destroyed.set_result(None)
+
+            def on_target_available(data):
+                target = data.get("target", {})
+                if target.get("url", "").endswith("/tab/page2.html"):
+                    target_available.set_result(target)
 
             devtools.client.add_event_listener(
-                devtools.targets[0]["actor"],
-                "tabNavigated",
-                on_tab_navigated,
+                devtools.watcher.actor_id,
+                Events.Watcher.TARGET_DESTROYED_FORM,
+                on_target_destroyed,
+            )
+            devtools.client.add_event_listener(
+                devtools.watcher.actor_id,
+                Events.Watcher.TARGET_AVAILABLE_FORM,
+                on_target_available,
             )
             devtools.client.send_receive(
                 {
@@ -1271,10 +1280,10 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
                     "url": f"{self.base_urls[1]}/tab/page2.html",
                 },
             )
-            # Wait for navigation to complete.
-            nav_done.result(1)
+            target_destroyed.result(1)
+            new_target = target_available.result(1)
 
-            inspector = InspectorActor(devtools.client, devtools.targets[0]["inspectorActor"])
+            inspector = InspectorActor(devtools.client, new_target["inspectorActor"])
             walker_info = inspector.get_walker()
             walker = WalkerActor(devtools.client, walker_info["actor"])
             root_node = walker_info["root"]["actor"]
@@ -1294,15 +1303,14 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
             ]:
                 done = Future()
 
-                def on_tab_navigated(data):
-                    if data.get("state") == "stop" and data.get("url").endswith(target_path):
+                def on_target_available(data):
+                    if data.get("target", {}).get("url", "").endswith(target_path):
                         done.set_result(None)
-                        return
 
                 devtools.client.add_event_listener(
-                    devtools.targets[0]["actor"],
-                    "tabNavigated",
-                    on_tab_navigated,
+                    devtools.watcher.actor_id,
+                    Events.Watcher.TARGET_AVAILABLE_FORM,
+                    on_target_available,
                 )
                 devtools.client.send_receive({"to": devtools.tab.actor_id, **message_data})
 


### PR DESCRIPTION
Previously, navigating on a website with the DevTools inspector open would make it not show the new HTML tree and not properly update. It could only be fixed by disconnecting the DevTools client and connecting again.

Now navigation correctly updates the inspector, both for the same page and external navigation. We now send `target-{available/destroyed}-form` messages when navigating, and the pipeline id, title and url are retrieved through a reference to the `BrowsingContextActor`, not hardcoded on actor creation.

This is also a first step in cleaning the actor dependencies and avoid registration issues.

**Know issues (better addressed in followups):**

- After navigating within the same domain, new console messages don't appear in the console. They appear again once navigating to a different domain.
- The console messages are not cleared when navigating.
- Navigating quickly through multiple pages can trigger an "already mutably borrowed" panic. This is an existing issue that is tracked in #45055
- After reloading, the HTML tree is not correctly displayed. A workaround is to manually navigate.

Testing: ./mach test-devtools
Fixes: #41848
Fixes: #42603
Part of: #39862
Part of: #45055