### PR TITLE
script: Migrate remaining usages to `get_attribute_string_value`

### DIFF
--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -2,11 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::borrow::ToOwned;
 use std::mem;
 use std::sync::LazyLock;
 
-use devtools_traits::AttrInfo;
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Namespace, Prefix, local_name, ns};
 use js::context::JSContext;
@@ -214,14 +212,6 @@ impl Attr {
 
     pub(crate) fn owner(&self) -> Option<DomRoot<Element>> {
         self.owner.get()
-    }
-
-    pub(crate) fn summarize(&self) -> AttrInfo {
-        AttrInfo {
-            namespace: (**self.namespace()).to_owned(),
-            name: (**self.name()).to_owned(),
-            value: (**self.value()).to_owned(),
-        }
     }
 
     pub(crate) fn qualified_name(&self) -> DOMString {

--- a/components/script/dom/element/attributes/accessors.rs
+++ b/components/script/dom/element/attributes/accessors.rs
@@ -51,14 +51,13 @@ impl Element {
     }
 
     pub(crate) fn get_url_attribute(&self, local_name: &LocalName) -> USVString {
-        let Some(attribute) = self.get_attribute(local_name) else {
+        let Some(value) = self.get_attribute_string_value(local_name) else {
             return Default::default();
         };
-        let value = &**attribute.value();
         self.owner_document()
-            .encoding_parse_a_url(value)
+            .encoding_parse_a_url(&value)
             .map(|parsed| USVString(parsed.into_string()))
-            .unwrap_or_else(|_| USVString(value.to_owned()))
+            .unwrap_or_else(|_| USVString(value))
     }
 
     pub(crate) fn set_url_attribute(
@@ -74,14 +73,13 @@ impl Element {
         &self,
         local_name: &LocalName,
     ) -> TrustedScriptURLOrUSVString {
-        let Some(attribute) = self.get_attribute(local_name) else {
+        let Some(value) = self.get_attribute_string_value(local_name) else {
             return TrustedScriptURLOrUSVString::USVString(USVString::default());
         };
-        let value = &**attribute.value();
         self.owner_document()
-            .encoding_parse_a_url(value)
+            .encoding_parse_a_url(&value)
             .map(|parsed| TrustedScriptURLOrUSVString::USVString(USVString(parsed.into_string())))
-            .unwrap_or_else(|_| TrustedScriptURLOrUSVString::USVString(USVString(value.to_owned())))
+            .unwrap_or_else(|_| TrustedScriptURLOrUSVString::USVString(USVString(value)))
     }
 
     pub(crate) fn get_trusted_html_attribute(&self, local_name: &LocalName) -> TrustedHTMLOrString {

--- a/components/script/dom/element/attributes/storage.rs
+++ b/components/script/dom/element/attributes/storage.rs
@@ -137,7 +137,7 @@ impl<'a> AttrRef<'a> {
         DOMString::from(&**self.value())
     }
 
-    /// Returns a summary for devtools, equivalent to `Attr::summarize()`.
+    /// Returns a summary for devtools.
     pub(crate) fn summarize(&self) -> AttrInfo {
         AttrInfo {
             namespace: (**self.namespace()).to_owned(),

--- a/components/script/dom/execcommand/contenteditable/element.rs
+++ b/components/script/dom/execcommand/contenteditable/element.rs
@@ -45,8 +45,8 @@ impl Element {
                 if let Some(anchor) = self.downcast::<HTMLAnchorElement>() {
                     return anchor
                         .upcast::<Element>()
-                        .get_attribute(&local_name!("href"))
-                        .map(|attr| DOMString::from(&**attr.value()));
+                        .get_attribute_string_value(&local_name!("href"))
+                        .map(|value| value.into());
                 }
 
                 // Step 2.2. Return null.

--- a/components/script/dom/execcommand/contenteditable/node.rs
+++ b/components/script/dom/execcommand/contenteditable/node.rs
@@ -2250,11 +2250,11 @@ impl Node {
                         node.downcast::<HTMLAnchorElement>().and_then(|anchor| {
                             anchor
                                 .upcast::<Element>()
-                                .get_attribute(&local_name!("href"))
+                                .get_attribute_string_value(&local_name!("href"))
                         })
                     {
                         // Step 3.3. Return the value of node's href attribute.
-                        return Some(DOMString::from(&**anchor_value.value()));
+                        return Some(anchor_value.into());
                     }
                     current_node = node.GetParentNode();
                 }

--- a/components/script/dom/html/htmlanchorelement.rs
+++ b/components/script/dom/html/htmlanchorelement.rs
@@ -81,8 +81,9 @@ impl HTMLAnchorElement {
     /// Get the full URL of the `href` attribute of this `<a>` element, returning `None` if
     /// the URL could not be joined with the `Document` URL.
     pub(crate) fn full_href_url_for_user_interface(&self) -> Option<ServoUrl> {
-        self.upcast::<Element>()
-            .get_attribute(&local_name!("href"))?;
+        if !self.upcast::<Element>().has_attribute(&local_name!("href")) {
+            return None;
+        }
         self.owner_document().base_url().join(&self.Href()).ok()
     }
 }

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -637,13 +637,13 @@ impl HTMLImageElement {
 
         // Step 2. If srcset is not an empty string, then set source set to the result of parsing
         // srcset.
-        if let Some(srcset) = element.get_attribute(&local_name!("srcset")) {
-            source_set.image_sources = parse_a_srcset_attribute(&srcset.value());
+        if let Some(srcset) = element.get_attribute_string_value(&local_name!("srcset")) {
+            source_set.image_sources = parse_a_srcset_attribute(&srcset);
         }
 
         // Step 3. Set source set's source size to the result of parsing sizes with img.
-        if let Some(sizes) = element.get_attribute(&local_name!("sizes")) {
-            source_set.source_size = parse_a_sizes_attribute(&sizes.value());
+        if let Some(sizes) = element.get_attribute_string_value(&local_name!("sizes")) {
+            source_set.source_size = parse_a_sizes_attribute(&sizes);
         }
 
         // Step 4. If default source is not the empty string and source set does not contain an
@@ -722,9 +722,9 @@ impl HTMLImageElement {
             // Step 5.3. If child does not have a srcset attribute, continue to the next child.
             // Step 5.4. Parse child's srcset attribute and let source set be the returned source
             // set.
-            match element.get_attribute(&local_name!("srcset")) {
+            match element.get_attribute_string_value(&local_name!("srcset")) {
                 Some(srcset) => {
-                    source_set.image_sources = parse_a_srcset_attribute(&srcset.value());
+                    source_set.image_sources = parse_a_srcset_attribute(&srcset);
                 },
                 _ => continue,
             }
@@ -736,30 +736,30 @@ impl HTMLImageElement {
 
             // Step 5.6. If child has a media attribute, and its value does not match the
             // environment, continue to the next child.
-            if let Some(media) = element.get_attribute(&local_name!("media")) &&
-                !MediaList::matches_environment(&element.owner_document(), &media.value())
+            if let Some(media) = element.get_attribute_string_value(&local_name!("media")) &&
+                !MediaList::matches_environment(&element.owner_document(), &media)
             {
                 continue;
             }
 
             // Step 5.7. Parse child's sizes attribute with img, and let source set's source size be
             // the returned value.
-            if let Some(sizes) = element.get_attribute(&local_name!("sizes")) {
-                source_set.source_size = parse_a_sizes_attribute(&sizes.value());
+            if let Some(sizes) = element.get_attribute_string_value(&local_name!("sizes")) {
+                source_set.source_size = parse_a_sizes_attribute(&sizes);
             }
 
             // Step 5.8. If child has a type attribute, and its value is an unknown or unsupported
             // MIME type, continue to the next child.
-            if let Some(type_) = element.get_attribute(&local_name!("type")) &&
-                !is_supported_image_mime_type(&type_.value())
+            if let Some(type_) = element.get_attribute_string_value(&local_name!("type")) &&
+                !is_supported_image_mime_type(&type_)
             {
                 continue;
             }
 
             // Step 5.9. If child has width or height attributes, set el's dimension attribute
             // source to child. Otherwise, set el's dimension attribute source to el.
-            if element.get_attribute(&local_name!("width")).is_some() ||
-                element.get_attribute(&local_name!("height")).is_some()
+            if element.has_attribute(&local_name!("width")) ||
+                element.has_attribute(&local_name!("height"))
             {
                 self.dimension_attribute_source.set(Some(element));
             } else {
@@ -1554,9 +1554,7 @@ impl HTMLImageElement {
 
     pub(crate) fn areas(&self) -> Option<Vec<DomRoot<HTMLAreaElement>>> {
         let elem = self.upcast::<Element>();
-        let usemap_attr = elem.get_attribute(&local_name!("usemap"))?;
-
-        let value = usemap_attr.value();
+        let value = elem.get_attribute_string_value(&local_name!("usemap"))?;
 
         if value.is_empty() || !value.is_char_boundary(1) {
             return None;

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -231,14 +231,6 @@ impl HTMLLinkElement {
     }
 }
 
-fn get_attr(element: &Element, local_name: &LocalName) -> Option<String> {
-    let elem = element.get_attribute(local_name);
-    elem.map(|e| {
-        let value = e.value();
-        (**value).to_owned()
-    })
-}
-
 impl VirtualMethods for HTMLLinkElement {
     fn super_type(&self) -> Option<&dyn VirtualMethods> {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
@@ -446,38 +438,38 @@ impl VirtualMethods for HTMLLinkElement {
             s.bind_to_tree(cx, context);
         }
 
-        if context.tree_connected {
-            let element = self.upcast();
+        if context.tree_connected &&
+            let Some(href) = self
+                .upcast::<Element>()
+                .get_attribute_string_value(&local_name!("href"))
+        {
+            let relations = self.relations.get();
+            // https://html.spec.whatwg.org/multipage/#link-type-stylesheet:fetch-and-process-the-linked-resource
+            // > When the external resource link's link element becomes browsing-context connected.
+            if relations.contains(LinkRelations::STYLESHEET) {
+                self.handle_stylesheet_url(cx);
+            }
 
-            if let Some(href) = get_attr(element, &local_name!("href")) {
-                let relations = self.relations.get();
-                // https://html.spec.whatwg.org/multipage/#link-type-stylesheet:fetch-and-process-the-linked-resource
-                // > When the external resource link's link element becomes browsing-context connected.
-                if relations.contains(LinkRelations::STYLESHEET) {
-                    self.handle_stylesheet_url(cx);
-                }
+            if relations.contains(LinkRelations::ICON) {
+                self.handle_favicon_url(&href);
+            }
 
-                if relations.contains(LinkRelations::ICON) {
-                    self.handle_favicon_url(&href);
-                }
+            if relations.contains(LinkRelations::PREFETCH) {
+                self.fetch_and_process_prefetch_link(&href);
+            }
 
-                if relations.contains(LinkRelations::PREFETCH) {
-                    self.fetch_and_process_prefetch_link(&href);
-                }
+            if relations.contains(LinkRelations::PRELOAD) {
+                self.handle_preload_url();
+            }
 
-                if relations.contains(LinkRelations::PRELOAD) {
-                    self.handle_preload_url();
-                }
-
-                // https://html.spec.whatwg.org/multipage/#link-type-modulepreload
-                if relations.contains(LinkRelations::MODULE_PRELOAD) {
-                    let link = DomRoot::from_ref(self);
-                    self.owner_document().add_delayed_task(
-                        task!(FetchModulePreload: |cx, link: DomRoot<HTMLLinkElement>| {
-                            link.fetch_and_process_modulepreload(cx);
-                        }),
-                    );
-                }
+            // https://html.spec.whatwg.org/multipage/#link-type-modulepreload
+            if relations.contains(LinkRelations::MODULE_PRELOAD) {
+                let link = DomRoot::from_ref(self);
+                self.owner_document().add_delayed_task(
+                    task!(FetchModulePreload: |cx, link: DomRoot<HTMLLinkElement>| {
+                        link.fetch_and_process_modulepreload(cx);
+                    }),
+                );
             }
         }
     }
@@ -497,8 +489,8 @@ impl HTMLLinkElement {
         // representing the state of el's as attribute.
         let element = self.upcast::<Element>();
         element
-            .get_attribute(&local_name!("as"))
-            .and_then(|attr| LinkProcessingOptions::translate_a_preload_destination(&attr.value()))
+            .get_attribute_string_value(&local_name!("as"))
+            .and_then(|attr| LinkProcessingOptions::translate_a_preload_destination(&attr))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#create-link-options-from-element>
@@ -529,19 +521,21 @@ impl HTMLLinkElement {
         };
 
         // Step 3. If el has an href attribute, then set options's href to the value of el's href attribute.
-        if let Some(href_attribute) = element.get_attribute(&local_name!("href")) {
-            options.href = (**href_attribute.value()).to_owned();
+        if let Some(href_attribute) = element.get_attribute_string_value(&local_name!("href")) {
+            options.href = href_attribute;
         }
 
         // Step 4. If el has an integrity attribute, then set options's integrity
         //         to the value of el's integrity content attribute.
-        if let Some(integrity_attribute) = element.get_attribute(&local_name!("integrity")) {
-            options.integrity = (**integrity_attribute.value()).to_owned();
+        if let Some(integrity_attribute) =
+            element.get_attribute_string_value(&local_name!("integrity"))
+        {
+            options.integrity = integrity_attribute;
         }
 
         // Step 5. If el has a type attribute, then set options's type to the value of el's type attribute.
-        if let Some(type_attribute) = element.get_attribute(&local_name!("type")) {
-            options.link_type = (**type_attribute.value()).to_owned();
+        if let Some(type_attribute) = element.get_attribute_string_value(&local_name!("type")) {
+            options.link_type = type_attribute;
         }
 
         // Step 6. Assert: options's href is not the empty string, or options's source set is not null.
@@ -697,22 +691,15 @@ impl HTMLLinkElement {
         // Step 3
         let cors_setting = cors_setting_for_element(element);
 
-        let mq_attribute = element.get_attribute(&local_name!("media"));
-        let value = mq_attribute.as_ref().map(|a| a.value());
-        let mq_str = match value {
-            Some(ref value) => &***value,
-            None => "",
-        };
-
-        let media = MediaList::parse_media_list(mq_str, document.window());
+        let mq_str = element
+            .get_attribute_string_value(&local_name!("media"))
+            .unwrap_or_default();
+        let media = MediaList::parse_media_list(&mq_str, document.window());
         let media = Arc::new(document.style_shared_author_lock().wrap(media));
 
-        let im_attribute = element.get_attribute(&local_name!("integrity"));
-        let integrity_val = im_attribute.as_ref().map(|a| a.value());
-        let integrity_metadata = match integrity_val {
-            Some(ref value) => &***value,
-            None => "",
-        };
+        let integrity_metadata = element
+            .get_attribute_string_value(&local_name!("integrity"))
+            .unwrap_or_default();
 
         self.request_generation_id
             .set(self.request_generation_id.get().increment());
@@ -725,7 +712,7 @@ impl HTMLLinkElement {
             media,
             link_url,
             cors_setting,
-            integrity_metadata.to_owned(),
+            integrity_metadata,
         );
     }
 
@@ -958,8 +945,8 @@ impl HTMLLinkElement {
 
         // Step 2. Let destination be the current state of el's as attribute (a destination), or "script" if it is in no state.
         let destination = el
-            .get_attribute(&local_name!("as"))
-            .map(|attr| attr.value().to_ascii_lowercase())
+            .get_attribute_string_value(&local_name!("as"))
+            .map(|value| value.to_ascii_lowercase())
             .and_then(|value| match value.as_str() {
                 // `Destination::from_str` will map an empty string to `Destination::None`
                 "" => None,
@@ -1005,16 +992,15 @@ impl HTMLLinkElement {
         let cryptographic_nonce = el.nonce_value();
 
         // Step 9. Let integrity metadata be the value of el's integrity attribute, if it is specified, or the empty string otherwise.
-        let integrity_attribute = el.get_attribute(&local_name!("integrity"));
-        let integrity_value = integrity_attribute.as_ref().map(|attr| attr.value());
-        let integrity_metadata = match integrity_value {
-            Some(ref value) => (***value).to_owned(),
-            // Step 10. If el does not have an integrity attribute, then set integrity metadata to
-            // the result of resolving a module integrity metadata with url and settings object.
-            None => global
-                .import_map()
-                .resolve_a_module_integrity_metadata(&url),
-        };
+        // Step 10. If el does not have an integrity attribute, then set integrity metadata to
+        // the result of resolving a module integrity metadata with url and settings object.
+        let integrity_metadata = el
+            .get_attribute_string_value(&local_name!("integrity"))
+            .unwrap_or_else(|| {
+                global
+                    .import_map()
+                    .resolve_a_module_integrity_metadata(&url)
+            });
 
         // Step 11. Let referrer policy be the current state of el's referrerpolicy attribute.
         let referrer_policy = referrer_policy_for_element(el);

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -1111,11 +1111,13 @@ impl HTMLMediaElement {
         let mode = if self.src_object.borrow().is_some() {
             // If the media element has an assigned media provider object, then let mode be object.
             Mode::Object
-        } else if let Some(attribute) = self.upcast::<Element>().get_attribute(&local_name!("src"))
+        } else if let Some(src) = self
+            .upcast::<Element>()
+            .get_attribute_string_value(&local_name!("src"))
         {
             // Otherwise, if the media element has no assigned media provider object but has a src
             // attribute, then let mode be attribute.
-            Mode::Attribute((**attribute.value()).to_owned())
+            Mode::Attribute(src)
         } else if let Some(source) = self
             .upcast::<Node>()
             .children_unrooted(cx.no_gc())
@@ -1230,8 +1232,8 @@ impl HTMLMediaElement {
         // its src attribute's value is the empty string, then end the synchronous section, and jump
         // down to the failed with elements step below.
         let Some(src) = element
-            .get_attribute(&local_name!("src"))
-            .filter(|attribute| !attribute.value().is_empty())
+            .get_attribute_string_value(&local_name!("src"))
+            .filter(|value| !value.is_empty())
         else {
             self.load_from_source_child_failure_steps(source);
             return;
@@ -1240,8 +1242,8 @@ impl HTMLMediaElement {
         // Step 9.children.3. If candidate has a media attribute whose value does not match the
         // environment, then end the synchronous section, and jump down to the failed with elements
         // step below.
-        if let Some(media) = element.get_attribute(&local_name!("media")) &&
-            !MediaList::matches_environment(&element.owner_document(), &media.value())
+        if let Some(media) = element.get_attribute_string_value(&local_name!("media")) &&
+            !MediaList::matches_environment(&element.owner_document(), &media)
         {
             self.load_from_source_child_failure_steps(source);
             return;
@@ -1250,7 +1252,7 @@ impl HTMLMediaElement {
         // Step 9.children.4. Let urlRecord be the result of encoding-parsing a URL given
         // candidate's src attribute's value, relative to candidate's node document when the src
         // attribute was last changed.
-        let Ok(url_record) = source.owner_document().base_url().join(&src.value()) else {
+        let Ok(url_record) = source.owner_document().base_url().join(&src) else {
             // Step 9.children.5. If urlRecord is failure, then end the synchronous section,
             // and jump down to the failed with elements step below.
             self.load_from_source_child_failure_steps(source);
@@ -1261,8 +1263,8 @@ impl HTMLMediaElement {
         // type (including any codecs described by the codecs parameter, for types that define that
         // parameter), represents a type that the user agent knows it cannot render, then end the
         // synchronous section, and jump down to the failed with elements step below.
-        if let Some(type_) = element.get_attribute(&local_name!("type")) &&
-            ServoMedia::get().can_play_type(&type_.value()) == SupportsMediaType::No
+        if let Some(type_) = element.get_attribute_string_value(&local_name!("type")) &&
+            ServoMedia::get().can_play_type(&type_) == SupportsMediaType::No
         {
             self.load_from_source_child_failure_steps(source);
             return;

--- a/components/script/dom/html/htmlmetaelement.rs
+++ b/components/script/dom/html/htmlmetaelement.rs
@@ -115,8 +115,8 @@ impl HTMLMetaElement {
         // empty string, then return.
         if let Some(content) = self
             .upcast::<Element>()
-            .get_attribute(&local_name!("content"))
-            .filter(|attr| !attr.value().is_empty())
+            .get_attribute_string_value(&local_name!("content"))
+            .filter(|value| !value.is_empty())
         {
             // Step 4. Let value be the value of element's content attribute, converted to ASCII
             // lowercase.
@@ -124,7 +124,7 @@ impl HTMLMetaElement {
             // table, then set value to the value given in the second column:
             // Step 6. If value is a referrer policy, then set element's node document's policy
             // container's referrer policy to policy.
-            doc.set_referrer_policy(ReferrerPolicy::from_with_legacy(&content.value()));
+            doc.set_referrer_policy(ReferrerPolicy::from_with_legacy(&content));
         }
     }
 
@@ -139,11 +139,11 @@ impl HTMLMetaElement {
             return;
         }
         let element = self.upcast::<Element>();
-        let Some(content) = element.get_attribute(&local_name!("content")) else {
+        let Some(content) = element.get_attribute_string_value(&local_name!("content")) else {
             return;
         };
 
-        if let Ok(viewport) = ViewportDescription::from_str(&content.value()) {
+        if let Ok(viewport) = ViewportDescription::from_str(&content) {
             let initial_scale = viewport.initial_scale.get();
             let window = self.owner_window();
             window.paint_api().viewport(window.webview_id(), viewport);
@@ -166,11 +166,10 @@ impl HTMLMetaElement {
         // Step 2. If the meta element has no content attribute, or if that attribute's value is the empty string, then return.
         let Some(content) = self
             .upcast::<Element>()
-            .get_attribute(&local_name!("content"))
+            .get_attribute_string_value(&local_name!("content"))
         else {
             return;
         };
-        let content = content.value();
         if content.is_empty() {
             return;
         }

--- a/components/script/dom/html/htmlobjectelement.rs
+++ b/components/script/dom/html/htmlobjectelement.rs
@@ -81,8 +81,8 @@ impl ProcessDataURL for &HTMLObjectElement {
 
         // TODO: support other values
         if let (None, Some(_uri)) = (
-            element.get_attribute(&local_name!("type")),
-            element.get_attribute(&local_name!("data")),
+            element.get_attribute_string_value(&local_name!("type")),
+            element.get_attribute_string_value(&local_name!("data")),
         ) {
             // TODO(gw): Prefetch the image here.
         }

--- a/components/script/dom/html/input_element/mod.rs
+++ b/components/script/dom/html/input_element/mod.rs
@@ -1155,7 +1155,8 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
             ValueMode::Default => self
                 .upcast::<Element>()
                 .get_attribute_string_value(&local_name!("value"))
-                .map_or_default(|value| value.into()),
+                .map(|value| value.into())
+                .unwrap_or_default(),
             ValueMode::DefaultOn => self
                 .upcast::<Element>()
                 .get_attribute_string_value(&local_name!("value"))

--- a/components/script/dom/html/input_element/mod.rs
+++ b/components/script/dom/html/input_element/mod.rs
@@ -22,7 +22,6 @@ use js::rust::wrappers2::{DateGetMsecSinceEpoch, ObjectIsDate};
 use js::rust::{HandleObject, MutableHandleObject};
 use layout_api::{ScriptSelection, SharedSelection};
 use script_bindings::cell::{DomRefCell, Ref};
-use script_bindings::codegen::GenericBindings::AttrBinding::AttrMethods;
 use script_bindings::domstring::parse_floating_point_number;
 use servo_base::generic_channel::GenericSender;
 use servo_base::text::Utf16CodeUnitLength;
@@ -388,13 +387,16 @@ impl HTMLInputElement {
 
         // Step 2. Otherwise, if the attribute is absent, then the allowed value step
         // is the default step multiplied by the step scale factor.
-        let Some(attribute) = self.upcast::<Element>().get_attribute(&local_name!("step")) else {
+        let Some(step_value) = self
+            .upcast::<Element>()
+            .get_attribute_string_value(&local_name!("step"))
+        else {
             return Some(default_step * self.step_scale_factor());
         };
 
         // Step 3. Otherwise, if the attribute's value is an ASCII case-insensitive match
         // for the string "any", then there is no allowed value step.
-        if attribute.value().eq_ignore_ascii_case("any") {
+        if step_value.eq_ignore_ascii_case("any") {
             return None;
         }
 
@@ -402,7 +404,7 @@ impl HTMLInputElement {
         // are applied to the attribute's value, return an error, zero, or a number less than zero,
         // then the allowed value step is the default step multiplied by the step scale factor.
         let Some(parsed_value) =
-            parse_floating_point_number(&attribute.value()).filter(|value| *value > 0.0)
+            parse_floating_point_number(&step_value).filter(|value| *value > 0.0)
         else {
             return Some(default_step * self.step_scale_factor());
         };
@@ -416,16 +418,16 @@ impl HTMLInputElement {
     /// <https://html.spec.whatwg.org/multipage#concept-input-min>
     fn minimum(&self) -> Option<f64> {
         self.upcast::<Element>()
-            .get_attribute(&local_name!("min"))
-            .and_then(|attribute| self.convert_string_to_number(&attribute.value()))
+            .get_attribute_string_value(&local_name!("min"))
+            .and_then(|value| self.convert_string_to_number(&value))
             .or_else(|| self.default_minimum())
     }
 
     /// <https://html.spec.whatwg.org/multipage#concept-input-max>
     fn maximum(&self) -> Option<f64> {
         self.upcast::<Element>()
-            .get_attribute(&local_name!("max"))
-            .and_then(|attribute| self.convert_string_to_number(&attribute.value()))
+            .get_attribute_string_value(&local_name!("max"))
+            .and_then(|value| self.convert_string_to_number(&value))
             .or_else(|| self.default_maximum())
     }
 
@@ -521,8 +523,8 @@ impl HTMLInputElement {
         // is not an error, then return that result.
         if let Some(minimum) = self
             .upcast::<Element>()
-            .get_attribute(&local_name!("min"))
-            .and_then(|attribute| self.convert_string_to_number(&attribute.value()))
+            .get_attribute_string_value(&local_name!("min"))
+            .and_then(|value| self.convert_string_to_number(&value))
         {
             return minimum;
         }
@@ -532,8 +534,8 @@ impl HTMLInputElement {
         // is not an error, then return that result.
         if let Some(value) = self
             .upcast::<Element>()
-            .get_attribute(&local_name!("value"))
-            .and_then(|attribute| self.convert_string_to_number(&attribute.value()))
+            .get_attribute_string_value(&local_name!("value"))
+            .and_then(|value| self.convert_string_to_number(&value))
         {
             return value;
         }
@@ -892,10 +894,9 @@ impl HTMLInputElement {
             _ => {
                 if let Some(attribute_value) = self
                     .upcast::<Element>()
-                    .get_attribute(&local_name!("value"))
-                    .map(|attribute| attribute.Value())
+                    .get_attribute_string_value(&local_name!("value"))
                 {
-                    return attribute_value;
+                    return attribute_value.into();
                 }
                 input_type.as_specific().value_for_shadow_dom(self)
             },
@@ -1153,16 +1154,14 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
             ValueMode::Value => self.textinput.borrow().get_content(),
             ValueMode::Default => self
                 .upcast::<Element>()
-                .get_attribute(&local_name!("value"))
-                .map_or(DOMString::from(""), |a| {
-                    DOMString::from(a.summarize().value)
-                }),
+                .get_attribute_string_value(&local_name!("value"))
+                .map(|value| value.into())
+                .unwrap_or_default(),
             ValueMode::DefaultOn => self
                 .upcast::<Element>()
-                .get_attribute(&local_name!("value"))
-                .map_or(DOMString::from("on"), |a| {
-                    DOMString::from(a.summarize().value)
-                }),
+                .get_attribute_string_value(&local_name!("value"))
+                .map(|value| value.into())
+                .unwrap_or(DOMString::from("on")),
             ValueMode::Filename => {
                 let mut path = DOMString::from("");
                 match self.input_type().as_specific().get_files() {
@@ -2080,10 +2079,9 @@ impl VirtualMethods for HTMLInputElement {
                                 self.SetValue(
                                     cx,
                                     self.upcast::<Element>()
-                                        .get_attribute(&local_name!("value"))
-                                        .map_or(DOMString::from(""), |a| {
-                                            DOMString::from(a.summarize().value)
-                                        }),
+                                        .get_attribute_string_value(&local_name!("value"))
+                                        .unwrap_or_default()
+                                        .into(),
                                 )
                                 .expect(
                                     "Failed to set input value on type change to ValueMode::Value.",

--- a/components/script/dom/html/input_element/mod.rs
+++ b/components/script/dom/html/input_element/mod.rs
@@ -1155,8 +1155,7 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
             ValueMode::Default => self
                 .upcast::<Element>()
                 .get_attribute_string_value(&local_name!("value"))
-                .map(|value| value.into())
-                .unwrap_or_default(),
+                .map_or_default(|value| value.into()),
             ValueMode::DefaultOn => self
                 .upcast::<Element>()
                 .get_attribute_string_value(&local_name!("value"))

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1931,10 +1931,10 @@ impl TreeSink for Sink {
     /// Specifically, the `<annotation-xml>` cases.
     fn is_mathml_annotation_xml_integration_point(&self, handle: &Dom<Node>) -> bool {
         let elem = handle.downcast::<Element>().unwrap();
-        elem.get_attribute(&local_name!("encoding"))
-            .is_some_and(|attr| {
-                attr.value().eq_ignore_ascii_case("text/html") ||
-                    attr.value().eq_ignore_ascii_case("application/xhtml+xml")
+        elem.get_attribute_string_value(&local_name!("encoding"))
+            .is_some_and(|value| {
+                value.eq_ignore_ascii_case("text/html") ||
+                    value.eq_ignore_ascii_case("application/xhtml+xml")
             })
     }
 


### PR DESCRIPTION
These are all of the usages of `get_attribute` that actually only need the value.

The remaining usages of `get_attribute` either actually need the attribute itself, or need its tokens. Will tackle that in a follow-up.

Testing: WPT
Fixes #45022
