### PR TITLE
script: Eliminate DOMString::to_string calls were alternatives are available

### DIFF
--- a/components/pixels/lib.rs
+++ b/components/pixels/lib.rs
@@ -241,29 +241,16 @@ pub enum EncodedImageType {
     Webp,
 }
 
-impl From<String> for EncodedImageType {
+impl From<&str> for EncodedImageType {
     // From: https://html.spec.whatwg.org/multipage/#serialising-bitmaps-to-a-file
     // User agents must support PNG ("image/png"). User agents may support other
     // types. If the user agent does not support the requested type, then it
     // must create the file using the PNG format.
     // Anything different than image/jpeg or image/webp is thus treated as PNG.
-    fn from(mime_type: String) -> Self {
-        let mime = mime_type.to_lowercase();
-        if mime == "image/jpeg" {
+    fn from(mime_string: &str) -> Self {
+        if mime_string.eq_ignore_ascii_case("image/jpeg") {
             Self::Jpeg
-        } else if mime == "image/webp" {
-            Self::Webp
-        } else {
-            Self::Png
-        }
-    }
-}
-
-impl From<&[u8]> for EncodedImageType {
-    fn from(mime_string: &[u8]) -> Self {
-        if mime_string.eq_ignore_ascii_case("image/jpeg".as_bytes()) {
-            Self::Jpeg
-        } else if mime_string.eq_ignore_ascii_case("image/webp".as_bytes()) {
+        } else if mime_string.eq_ignore_ascii_case("image/webp") {
             Self::Webp
         } else {
             Self::Png

--- a/components/pixels/lib.rs
+++ b/components/pixels/lib.rs
@@ -259,6 +259,18 @@ impl From<String> for EncodedImageType {
     }
 }
 
+impl From<&[u8]> for EncodedImageType {
+    fn from(mime_string: &[u8]) -> Self {
+        if mime_string.eq_ignore_ascii_case("image/jpeg".as_bytes()) {
+            Self::Jpeg
+        } else if mime_string.eq_ignore_ascii_case("image/webp".as_bytes()) {
+            Self::Webp
+        } else {
+            Self::Png
+        }
+    }
+}
+
 impl EncodedImageType {
     pub fn as_mime_type(&self) -> String {
         match self {

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -240,9 +240,9 @@ pub(crate) fn handle_get_stylesheets(
         for i in 0..node.stylesheet_list_owner().stylesheet_count() {
             if let Some(s) = node.stylesheet_list_owner().stylesheet_at(i) {
                 stylesheets.push(StyleSheetInfo {
-                    href: s.href().map(|h| h.to_string()),
+                    href: s.href().map(String::from),
                     disabled: s.disabled(),
-                    title: s.title().to_string(),
+                    title: String::from(s.title()),
                     style_sheet_index: i as i32,
                     system: s.origin() == Origin::UserAgent,
                     rule_count: s.get_rule_count(),
@@ -271,7 +271,7 @@ pub(crate) fn handle_get_stylesheet_text(
         if let Some(node) = stylesheet.owner_node() {
             let text = node.upcast::<Node>().GetTextContent().unwrap_or_default();
             if !text.is_empty() {
-                return Some(text.to_string());
+                return Some(String::from(text));
             }
         }
 
@@ -280,7 +280,7 @@ pub(crate) fn handle_get_stylesheet_text(
         let mut css_text = String::new();
         for i in 0..rules.Length() {
             if let Some(rule) = rules.Item(cx, i) {
-                css_text.push_str(&rule.CssText().to_string());
+                css_text.push_str(&rule.CssText().str());
                 css_text.push('\n');
             }
         }
@@ -369,9 +369,15 @@ pub(crate) fn handle_get_attribute_style(
         .map(|i| {
             let name = style.Item(i);
             NodeStyle {
-                name: name.to_string(),
-                value: style.GetPropertyValue(name.clone()).to_string(),
-                priority: style.GetPropertyPriority(name).to_string(),
+                // This code has to clone the name values, even though
+                // these function actually would only need to borrow,
+                // but the binding generator forces an owned DOMString
+                // in the signature.
+                // It'd be nice to not have to do this here and in the
+                // similar cases below, but I don't see how.
+                value: String::from(style.GetPropertyValue(name.clone())),
+                priority: String::from(style.GetPropertyPriority(name.clone())),
+                name: String::from(name),
             }
         })
         .collect();
@@ -403,7 +409,7 @@ fn build_rule_map(
         }
 
         if let Some(layer_rule) = rule.downcast::<CSSLayerBlockRule>() {
-            let name = layer_rule.Name().to_string();
+            let name = String::from(layer_rule.Name());
             let mut next = ancestors.to_vec();
             next.push(AncestorData::Layer {
                 actor_id: None,
@@ -524,9 +530,9 @@ pub(crate) fn handle_get_stylesheet_style(
                 .map(|i| {
                     let name = declaration.Item(i);
                     NodeStyle {
-                        name: name.to_string(),
-                        value: declaration.GetPropertyValue(name.clone()).to_string(),
-                        priority: declaration.GetPropertyPriority(name).to_string(),
+                        value: String::from(declaration.GetPropertyValue(name.clone())),
+                        priority: String::from(declaration.GetPropertyPriority(name.clone())),
+                        name: String::from(name),
                     }
                 })
                 .collect(),
@@ -557,9 +563,9 @@ pub(crate) fn handle_get_computed_style(
         .map(|i| {
             let name = computed_style.Item(i);
             NodeStyle {
-                name: name.to_string(),
-                value: computed_style.GetPropertyValue(name.clone()).to_string(),
-                priority: computed_style.GetPropertyPriority(name).to_string(),
+                value: String::from(computed_style.GetPropertyValue(name.clone())),
+                priority: String::from(computed_style.GetPropertyPriority(name.clone())),
+                name: String::from(name),
             }
         })
         .collect();

--- a/components/script/dom/bluetooth/bluetooth.rs
+++ b/components/script/dom/bluetooth/bluetooth.rs
@@ -208,7 +208,7 @@ impl Bluetooth {
         for opt_service in optional_services {
             // Step 2.5 - 2.6.
             let uuid = match BluetoothUUID::service(opt_service.clone()) {
-                Ok(u) => u.to_string(),
+                Ok(u) => String::from(u),
                 Err(e) => {
                     p.reject_error(e, CanGc::from_cx(cx));
                     return;
@@ -304,7 +304,7 @@ where
     let result_uuid = if let Some(u) = uuid {
         // Step 1.
         let canonicalized = match uuid_canonicalizer(u) {
-            Ok(canonicalized_uuid) => canonicalized_uuid.to_string(),
+            Ok(canonicalized_uuid) => String::from(canonicalized_uuid),
             Err(e) => {
                 p.reject_error(e, CanGc::from_cx(cx));
                 return p;
@@ -373,7 +373,7 @@ fn canonicalize_filter(filter: &BluetoothLEScanFilterInit) -> Fallible<Bluetooth
 
             for service in services {
                 // Step 3.2 - 3.3.
-                let uuid = BluetoothUUID::service(service.clone())?.to_string();
+                let uuid = String::from(BluetoothUUID::service(service.clone())?);
 
                 // Step 3.4.
                 if uuid_is_blocklisted(uuid.as_ref(), Blocklist::All) {
@@ -467,7 +467,7 @@ fn canonicalize_filter(filter: &BluetoothLEScanFilterInit) -> Fallible<Bluetooth
                 };
 
                 // Step 9.3 - 9.4.
-                let service = BluetoothUUID::service(service_name)?.to_string();
+                let service = String::from(BluetoothUUID::service(service_name)?);
 
                 // Step 9.5.
                 if uuid_is_blocklisted(service.as_ref(), Blocklist::All) {

--- a/components/script/dom/bluetooth/bluetoothdevice.rs
+++ b/components/script/dom/bluetooth/bluetoothdevice.rs
@@ -252,7 +252,7 @@ impl BluetoothDevice {
         let context = self.get_context();
         for (id, device) in context.get_device_map().borrow().iter() {
             // Step 2.1 - 2.2.
-            if id == &String::from(self.Id()) && device.get_gatt(cx).Connected() {
+            if id == &self.Id().str() as &str && device.get_gatt(cx).Connected() {
                 return Ok(());
             }
         }

--- a/components/script/dom/bluetooth/bluetoothdevice.rs
+++ b/components/script/dom/bluetooth/bluetoothdevice.rs
@@ -170,7 +170,7 @@ impl BluetoothDevice {
             generic_channel::channel(self.global().time_profiler_chan().clone()).unwrap();
         self.get_bluetooth_thread()
             .send(BluetoothRequest::IsRepresentedDeviceNull(
-                self.Id().to_string(),
+                String::from(self.Id()),
                 sender,
             ))
             .unwrap();
@@ -252,7 +252,7 @@ impl BluetoothDevice {
         let context = self.get_context();
         for (id, device) in context.get_device_map().borrow().iter() {
             // Step 2.1 - 2.2.
-            if id == &self.Id().to_string() && device.get_gatt(cx).Connected() {
+            if id == &String::from(self.Id()) && device.get_gatt(cx).Connected() {
                 return Ok(());
             }
         }

--- a/components/script/dom/broadcastchannel.rs
+++ b/components/script/dom/broadcastchannel.rs
@@ -92,7 +92,7 @@ impl BroadcastChannelMethods<crate::DomTypeHolder> for BroadcastChannel {
 
         let msg = BroadcastChannelMsg {
             origin: global.origin().immutable().clone(),
-            channel_name: self.Name().to_string(),
+            channel_name: String::from(self.Name()),
             data,
         };
 

--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -1629,7 +1629,7 @@ impl CanvasState {
         let node = canvas.upcast::<Node>();
         let window = canvas.owner_window();
 
-        let Some(resolved_font_style) = window.resolved_font_style_query(node, value.to_string())
+        let Some(resolved_font_style) = window.resolved_font_style_query(node, String::from(value))
         else {
             // This will happen when there is a syntax error.
             return;

--- a/components/script/dom/canvas/offscreencanvas.rs
+++ b/components/script/dom/canvas/offscreencanvas.rs
@@ -550,7 +550,7 @@ impl OffscreenCanvasMethods<crate::DomTypeHolder> for OffscreenCanvas {
         let trusted_this = Trusted::new(self);
         let trusted_promise = TrustedPromise::new(promise.clone());
 
-        let image_type = EncodedImageType::from(options.type_.to_string());
+        let image_type = EncodedImageType::from(options.type_.encoded_bytes().bytes());
         let quality = options.quality;
 
         self.global()

--- a/components/script/dom/canvas/offscreencanvas.rs
+++ b/components/script/dom/canvas/offscreencanvas.rs
@@ -550,7 +550,7 @@ impl OffscreenCanvasMethods<crate::DomTypeHolder> for OffscreenCanvas {
         let trusted_this = Trusted::new(self);
         let trusted_promise = TrustedPromise::new(promise.clone());
 
-        let image_type = EncodedImageType::from(options.type_.encoded_bytes().bytes());
+        let image_type = EncodedImageType::from(&options.type_.str() as &str);
         let quality = options.quality;
 
         self.global()

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -493,7 +493,7 @@ pub(crate) fn stringify_handle_value(message: HandleValue) -> DOMString {
                     };
                     props.push(format!("{}: {}", key, value_string,));
                 } else {
-                    props.push(value_string.to_string());
+                    props.push(String::from(value_string));
                 }
             }
             if truncate {
@@ -612,7 +612,7 @@ fn apply_sprintf_substitutions(cx: JSContext, messages: &[HandleValue]) -> (Stri
             Some('s') => {
                 chars.next();
                 if arg_index < messages.len() {
-                    result.push_str(&stringify_handle_value(messages[arg_index]).to_string());
+                    result.push_str(&stringify_handle_value(messages[arg_index]).str());
                     arg_index += 1;
                 } else {
                     result.push_str("%s");
@@ -648,7 +648,7 @@ fn apply_sprintf_substitutions(cx: JSContext, messages: &[HandleValue]) -> (Stri
             Some('o') | Some('O') => {
                 let spec = chars.next().unwrap();
                 if arg_index < messages.len() {
-                    result.push_str(&stringify_handle_value(messages[arg_index]).to_string());
+                    result.push_str(&stringify_handle_value(messages[arg_index]).str());
                     arg_index += 1;
                 } else {
                     result.push('%');

--- a/components/script/dom/document/document_embedder_controls.rs
+++ b/components/script/dom/document/document_embedder_controls.rs
@@ -469,7 +469,7 @@ impl ContextMenuNodes {
                     .full_href_url_for_user_interface()
                     .as_ref()
                     .map(ServoUrl::to_string)
-                    .unwrap_or_else(|| anchor_element.Href().to_string());
+                    .unwrap_or_else(|| String::from(anchor_element.Href()));
                 set_clipboard_text(url_string);
             },
             ContextMenuAction::OpenLinkInNewWebView => {
@@ -488,7 +488,7 @@ impl ContextMenuNodes {
                     .full_image_url_for_user_interface()
                     .as_ref()
                     .map(ServoUrl::to_string)
-                    .unwrap_or_else(|| image_element.CurrentSrc().to_string());
+                    .unwrap_or_else(|| String::from(image_element.CurrentSrc()));
                 set_clipboard_text(url_string);
             },
             ContextMenuAction::OpenImageInNewView => {

--- a/components/script/dom/dommatrix.rs
+++ b/components/script/dom/dommatrix.rs
@@ -100,7 +100,7 @@ impl DOMMatrixMethods<crate::DomTypeHolder> for DOMMatrix {
                 if s.is_empty() {
                     return Ok(Self::new(global, true, Transform3D::identity(), can_gc));
                 }
-                transform_to_matrix(s.to_string())
+                transform_to_matrix(&s.str())
                     .map(|(is2D, matrix)| Self::new_with_proto(global, proto, is2D, matrix, can_gc))
             },
             StringOrUnrestrictedDoubleSequence::UnrestrictedDoubleSequence(ref entries) => {
@@ -484,7 +484,7 @@ impl DOMMatrixMethods<crate::DomTypeHolder> for DOMMatrix {
         // 1. Parse transformList into an abstract matrix, and let
         // matrix and 2dTransform be the result. If the result is failure,
         // then throw a "SyntaxError" DOMException.
-        match transform_to_matrix(String::from(transformList)) {
+        match transform_to_matrix(&transformList.str()) {
             Ok(tuple) => {
                 // 2. Set is 2D to the value of 2dTransform.
                 self.parent.set_is2D(tuple.0);

--- a/components/script/dom/dommatrix.rs
+++ b/components/script/dom/dommatrix.rs
@@ -484,7 +484,7 @@ impl DOMMatrixMethods<crate::DomTypeHolder> for DOMMatrix {
         // 1. Parse transformList into an abstract matrix, and let
         // matrix and 2dTransform be the result. If the result is failure,
         // then throw a "SyntaxError" DOMException.
-        match transform_to_matrix(transformList.to_string()) {
+        match transform_to_matrix(String::from(transformList)) {
             Ok(tuple) => {
                 // 2. Set is 2D to the value of 2dTransform.
                 self.parent.set_is2D(tuple.0);

--- a/components/script/dom/dommatrixreadonly.rs
+++ b/components/script/dom/dommatrixreadonly.rs
@@ -501,7 +501,7 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
                 if s.is_empty() {
                     return Ok(Self::new(global, true, Transform3D::identity(), can_gc));
                 }
-                transform_to_matrix(s.to_string())
+                transform_to_matrix(&s.str())
                     .map(|(is2D, matrix)| Self::new_with_proto(global, proto, is2D, matrix, can_gc))
             },
             StringOrUnrestrictedDoubleSequence::UnrestrictedDoubleSequence(ref entries) => {
@@ -1220,10 +1220,10 @@ fn normalize_point(x: f64, y: f64, z: f64) -> (f64, f64, f64) {
     }
 }
 
-pub(crate) fn transform_to_matrix(value: String) -> Fallible<(bool, Transform3D<f64>)> {
+pub(crate) fn transform_to_matrix(value: &str) -> Fallible<(bool, Transform3D<f64>)> {
     use style::properties::longhands::transform;
 
-    let mut input = ParserInput::new(&value);
+    let mut input = ParserInput::new(value);
     let mut parser = Parser::new(&mut input);
     let url_data = Url::parse("about:blank").unwrap().into();
     let context =

--- a/components/script/dom/element/attributes/accessors.rs
+++ b/components/script/dom/element/attributes/accessors.rs
@@ -66,7 +66,7 @@ impl Element {
         local_name: &LocalName,
         value: USVString,
     ) {
-        self.set_attribute(cx, local_name, AttrValue::String(value.to_string()));
+        self.set_attribute(cx, local_name, AttrValue::String(value.into()));
     }
 
     pub(crate) fn get_trusted_type_url_attribute(

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -1741,7 +1741,7 @@ impl GlobalScope {
                 let _ = self.script_to_constellation_chan().send(
                     ScriptToConstellationMessage::NewBroadcastChannelNameInRouter(
                         *router_id,
-                        dom_channel.Name().to_string(),
+                        String::from(dom_channel.Name()),
                         self.origin().immutable().clone(),
                     ),
                 );

--- a/components/script/dom/html/htmlcanvaselement.rs
+++ b/components/script/dom/html/htmlcanvaselement.rs
@@ -533,7 +533,7 @@ impl HTMLCanvasElementMethods<crate::DomTypeHolder> for HTMLCanvasElement {
             return Ok(USVString("data:,".into()));
         };
 
-        let image_type = EncodedImageType::from(mime_type.encoded_bytes().bytes());
+        let image_type = EncodedImageType::from(&mime_type.str() as &str);
 
         let mut url = format!("data:{};base64,", image_type.as_mime_type());
 
@@ -588,7 +588,7 @@ impl HTMLCanvasElementMethods<crate::DomTypeHolder> for HTMLCanvasElement {
             .borrow_mut()
             .insert(callback_id, callback);
         let quality = Self::maybe_quality(quality);
-        let image_type = EncodedImageType::from(mime_type.encoded_bytes().bytes());
+        let image_type = EncodedImageType::from(&mime_type.str() as &str);
 
         self.global()
             .task_manager()

--- a/components/script/dom/html/htmlcanvaselement.rs
+++ b/components/script/dom/html/htmlcanvaselement.rs
@@ -533,7 +533,7 @@ impl HTMLCanvasElementMethods<crate::DomTypeHolder> for HTMLCanvasElement {
             return Ok(USVString("data:,".into()));
         };
 
-        let image_type = EncodedImageType::from(mime_type.to_string());
+        let image_type = EncodedImageType::from(String::from(mime_type));
 
         let mut url = format!("data:{};base64,", image_type.as_mime_type());
 
@@ -588,7 +588,7 @@ impl HTMLCanvasElementMethods<crate::DomTypeHolder> for HTMLCanvasElement {
             .borrow_mut()
             .insert(callback_id, callback);
         let quality = Self::maybe_quality(quality);
-        let image_type = EncodedImageType::from(mime_type.to_string());
+        let image_type = EncodedImageType::from(String::from(mime_type));
 
         self.global()
             .task_manager()

--- a/components/script/dom/html/htmlcanvaselement.rs
+++ b/components/script/dom/html/htmlcanvaselement.rs
@@ -533,7 +533,7 @@ impl HTMLCanvasElementMethods<crate::DomTypeHolder> for HTMLCanvasElement {
             return Ok(USVString("data:,".into()));
         };
 
-        let image_type = EncodedImageType::from(String::from(mime_type));
+        let image_type = EncodedImageType::from(mime_type.encoded_bytes().bytes());
 
         let mut url = format!("data:{};base64,", image_type.as_mime_type());
 
@@ -588,7 +588,7 @@ impl HTMLCanvasElementMethods<crate::DomTypeHolder> for HTMLCanvasElement {
             .borrow_mut()
             .insert(callback_id, callback);
         let quality = Self::maybe_quality(quality);
-        let image_type = EncodedImageType::from(String::from(mime_type));
+        let image_type = EncodedImageType::from(mime_type.encoded_bytes().bytes());
 
         self.global()
             .task_manager()

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -753,7 +753,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     /// <https://html.spec.whatwg.org/multipage/#dom-noncedelement-nonce>
     fn SetNonce(&self, _cx: &mut JSContext, value: DOMString) {
         self.as_element()
-            .update_nonce_internal_slot(value.to_string())
+            .update_nonce_internal_slot(String::from(value))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-fe-autofocus>
@@ -793,10 +793,8 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
             return Default::default();
         }
 
-        let access_key_string = self
-            .element
-            .get_string_attribute(&local_name!("accesskey"))
-            .to_string();
+        let access_key_string =
+            String::from(self.element.get_string_attribute(&local_name!("accesskey")));
 
         #[cfg(target_os = "macos")]
         let access_key_label = format!("⌃⌥{access_key_string}");

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -660,7 +660,7 @@ impl HTMLImageElement {
             .all(|source| source.descriptor.width.is_none());
         if !src.is_empty() && no_density_source_of_1 && no_width_descriptor {
             source_set.image_sources.push(ImageSource {
-                url: src.to_string(),
+                url: String::from(src),
                 descriptor: Descriptor {
                     width: None,
                     density: None,
@@ -1117,7 +1117,7 @@ impl HTMLImageElement {
             .get_string_attribute(&local_name!("src"));
 
         if !self.uses_srcset_or_picture() && !src.is_empty() {
-            selected_source = Some(USVString(src.to_string()));
+            selected_source = Some(USVString(String::from(src)));
             selected_pixel_density = Some(1_f64);
         };
 

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -159,7 +159,7 @@ impl HTMLTextAreaElement {
     }
 
     pub(crate) fn auto_directionality(&self) -> String {
-        let value: String = self.Value().to_string();
+        let value: String = String::from(self.Value());
         HTMLInputElement::directionality_from_value(&value)
     }
 
@@ -183,7 +183,7 @@ impl HTMLTextAreaElement {
                     ControlElement::Ime(DomRoot::from_ref(self.upcast())),
                     EmbedderControlRequest::InputMethod(InputMethodRequest {
                         input_method_type: InputMethodType::Text,
-                        text: self.Value().to_string(),
+                        text: String::from(self.Value()),
                         insertion_point: self.GetSelectionEnd(),
                         multiline: false,
                         // We follow chromium's heuristic to show the virtual keyboard only if user had interacted before.

--- a/components/script/dom/html/input_element/file_input_type.rs
+++ b/components/script/dom/html/input_element/file_input_type.rs
@@ -157,7 +157,7 @@ impl SpecificInputType for FileInputType {
             }
             return DEFAULT_FILE_INPUT_VALUE.into();
         };
-        first_item.name().to_string().into()
+        first_item.name().clone()
     }
 
     /// <https://html.spec.whatwg.org/multipage/#file-upload-state-(type=file):input-activation-behavior>

--- a/components/script/dom/html/input_element/mod.rs
+++ b/components/script/dom/html/input_element/mod.rs
@@ -241,7 +241,7 @@ impl HTMLInputElement {
     pub(crate) fn auto_directionality(&self) -> Option<String> {
         match *self.input_type() {
             InputType::Text(_) | InputType::Search(_) | InputType::Url(_) | InputType::Email(_) => {
-                let value: String = self.Value().to_string();
+                let value: String = String::from(self.Value());
                 Some(HTMLInputElement::directionality_from_value(&value))
             },
             _ => None,
@@ -1961,7 +1961,7 @@ impl HTMLInputElement {
                     ControlElement::Ime(DomRoot::from_ref(self.upcast())),
                     EmbedderControlRequest::InputMethod(InputMethodRequest {
                         input_method_type,
-                        text: self.Value().to_string(),
+                        text: String::from(self.Value()),
                         insertion_point: self.GetSelectionEnd(),
                         multiline: false,
                         // We follow chromium's heuristic to show the virtual keyboard only if user had interacted before.

--- a/components/script/dom/indexeddb/idbdatabase.rs
+++ b/components/script/dom/indexeddb/idbdatabase.rs
@@ -400,7 +400,7 @@ impl IDBDatabaseMethods<crate::DomTypeHolder> for IDBDatabase {
             sender,
             self.global().origin().immutable().clone(),
             self.name.to_string(),
-            name.to_string(),
+            String::from(name),
         );
 
         self.get_idb_thread()

--- a/components/script/dom/indexeddb/idbfactory.rs
+++ b/components/script/dom/indexeddb/idbfactory.rs
@@ -71,7 +71,7 @@ impl IDBFactory {
     }
 
     pub(crate) fn register_indexeddb_transaction(&self, txn: &IDBTransaction) {
-        let db_name = DBName(txn.get_db_name().to_string());
+        let db_name = DBName(String::from(txn.get_db_name()));
         let mut map = self.indexeddb_transactions.borrow_mut();
         let bucket = map.entry(db_name).or_default();
         if !bucket.iter().any(|entry| &**entry == txn) {
@@ -81,7 +81,7 @@ impl IDBFactory {
     }
 
     pub(crate) fn unregister_indexeddb_transaction(&self, txn: &IDBTransaction) {
-        let db_name = DBName(txn.get_db_name().to_string());
+        let db_name = DBName(String::from(txn.get_db_name()));
         let mut map = self.indexeddb_transactions.borrow_mut();
         if let Some(bucket) = map.get_mut(&db_name) {
             bucket.retain(|entry| &**entry != txn);
@@ -470,7 +470,7 @@ impl IDBFactory {
         let open_operation = SyncOperation::OpenDatabase(
             callback,
             storage_key,
-            name.to_string(),
+            String::from(name),
             version,
             request.get_id(),
             proxy_map,
@@ -603,7 +603,7 @@ impl IDBFactoryMethods<crate::DomTypeHolder> for IDBFactory {
 
         // Step 4: Runs in parallel
         if request
-            .delete_database(storage_key, name.to_string(), proxy_map)
+            .delete_database(storage_key, String::from(name), proxy_map)
             .is_err()
         {
             return Err(Error::Operation(None));

--- a/components/script/dom/indexeddb/idbobjectstore.rs
+++ b/components/script/dom/indexeddb/idbobjectstore.rs
@@ -77,9 +77,9 @@ impl From<indexeddb::KeyPath> for KeyPath {
 impl From<KeyPath> for indexeddb::KeyPath {
     fn from(item: KeyPath) -> Self {
         match item {
-            KeyPath::String(s) => Self::String(s.to_string()),
+            KeyPath::String(s) => Self::String(String::from(s)),
             KeyPath::StringSequence(ss) => {
-                Self::Sequence(ss.into_iter().map(|s| s.to_string()).collect())
+                Self::Sequence(ss.into_iter().map(String::from).collect())
             },
         }
     }
@@ -1031,7 +1031,7 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
             self.global().origin().immutable().clone(),
             self.db_name.to_string(),
             self.name.borrow().to_string(),
-            name.to_string(),
+            String::from(name),
         );
         self.get_idb_thread()
             .send(IndexedDBThreadMsg::Sync(delete_index_operation))

--- a/components/script/dom/indexeddb/idbrequest.rs
+++ b/components/script/dom/indexeddb/idbrequest.rs
@@ -133,7 +133,7 @@ impl RequestListener {
         let send_result = global.storage_threads().send(IndexedDBThreadMsg::Sync(
             SyncOperation::RequestHandled {
                 origin: global.origin().immutable().clone(),
-                db_name: transaction.get_db_name().to_string(),
+                db_name: String::from(transaction.get_db_name()),
                 txn: transaction.get_serial_number(),
                 request_id,
             },
@@ -548,8 +548,8 @@ impl IDBRequest {
             .storage_threads()
             .send(IndexedDBThreadMsg::Async(
                 global.origin().immutable().clone(),
-                transaction.get_db_name().to_string(),
-                source.get_name().to_string(),
+                String::from(transaction.get_db_name()),
+                String::from(source.get_name()),
                 transaction.get_serial_number(),
                 request_id,
                 transaction_mode,

--- a/components/script/dom/indexeddb/idbtransaction.rs
+++ b/components/script/dom/indexeddb/idbtransaction.rs
@@ -182,7 +182,7 @@ impl IDBTransaction {
         };
         let scope: Vec<String> = (0..scope.Length())
             .filter_map(|i| scope.Item(i))
-            .map(|name| name.to_string())
+            .map(String::from)
             .collect();
         let (sender, receiver) = channel(global.time_profiler_chan().clone()).unwrap();
 
@@ -191,7 +191,7 @@ impl IDBTransaction {
             .send(IndexedDBThreadMsg::Sync(SyncOperation::CreateTransaction {
                 sender,
                 origin: global.origin().immutable().clone(),
-                db_name: db_name.to_string(),
+                db_name: String::from(db_name),
                 mode: backend_mode,
                 scope,
             }))
@@ -343,7 +343,7 @@ impl IDBTransaction {
         let commit_operation = SyncOperation::Commit(
             callback,
             global.origin().immutable().clone(),
-            self.db.get_name().to_string(),
+            String::from(self.db.get_name()),
             self.serial_number,
         );
 
@@ -534,7 +534,7 @@ impl IDBTransaction {
         let operation = SyncOperation::Abort(
             callback,
             global.origin().immutable().clone(),
-            self.db.get_name().to_string(),
+            String::from(self.db.get_name()),
             self.serial_number,
         );
         let _ = self
@@ -547,7 +547,7 @@ impl IDBTransaction {
         let _ = self.get_idb_thread().send(IndexedDBThreadMsg::Sync(
             SyncOperation::TransactionFinished {
                 origin: global.origin().immutable().clone(),
-                db_name: self.db.get_name().to_string(),
+                db_name: String::from(self.db.get_name()),
                 txn: self.serial_number,
             },
         ));
@@ -590,7 +590,7 @@ impl IDBTransaction {
                         .get_indexeddb()
                         .clear_open_request_transaction_for_txn(&this);
                     let origin = this.global().origin().immutable().clone();
-                    let db_name = this.db.get_name().to_string();
+                    let db_name = String::from(this.db.get_name());
                     let txn = this.serial_number;
                     let _ = this.get_idb_thread().send(IndexedDBThreadMsg::Sync(
                         SyncOperation::UpgradeTransactionFinished {
@@ -660,7 +660,7 @@ impl IDBTransaction {
                         .get_indexeddb()
                         .clear_open_request_transaction_for_txn(&this);
                     let origin = this.global().origin().immutable().clone();
-                    let db_name = this.db.get_name().to_string();
+                    let db_name = String::from(this.db.get_name());
                     let txn = this.serial_number;
                     let _ = this.get_idb_thread().send(IndexedDBThreadMsg::Sync(
                         SyncOperation::UpgradeTransactionFinished {
@@ -693,7 +693,7 @@ impl IDBTransaction {
             channel(global.time_profiler_chan().clone()).expect("failed to create channel");
 
         let origin = global.origin().immutable().clone();
-        let db_name = self.db.get_name().to_string();
+        let db_name = String::from(self.db.get_name());
         let object_store_name = object_store_name.to_string();
 
         let operation = SyncOperation::GetObjectStore(sender, origin, db_name, object_store_name);

--- a/components/script/dom/origin.rs
+++ b/components/script/dom/origin.rs
@@ -136,7 +136,7 @@ impl OriginMethods<crate::DomTypeHolder> for Origin {
             // Step 2.1. Let parsedURL be the result of basic URL parsing value.
             // Step 2.2. If parsedURL is not failure, then return a new Origin object whose
             //           origin is set to parsedURL's origin.
-            match ServoUrl::parse(&s.to_string()) {
+            match ServoUrl::parse(&s.str()) {
                 Ok(url) => return Ok(Origin::new(global, None, url.origin(), can_gc)),
                 Err(_) => return Err(Error::Type(c"Failed to parse URL".to_owned())),
             }

--- a/components/script/dom/reporting/reportingendpoint.rs
+++ b/components/script/dom/reporting/reportingendpoint.rs
@@ -288,13 +288,13 @@ pub(crate) struct CSPReportingEndpointBody {
 impl From<CSPViolationReportBody> for CSPReportingEndpointBody {
     fn from(value: CSPViolationReportBody) -> Self {
         CSPReportingEndpointBody {
-            sample: value.sample.map(|s| s.to_string()),
+            sample: value.sample.map(String::from),
             blocked_url: value.blockedURL.map(|s| s.to_string()),
             referrer: value.referrer.map(|s| s.to_string()),
             status_code: value.statusCode,
             document_url: value.documentURL.to_string(),
             source_file: value.sourceFile.map(|s| s.to_string()),
-            effective_directive: value.effectiveDirective.to_string(),
+            effective_directive: String::from(value.effectiveDirective),
             line_number: value.lineNumber,
             column_number: value.columnNumber,
             original_policy: value.originalPolicy.into(),

--- a/components/script/dom/reporting/reportingendpoint.rs
+++ b/components/script/dom/reporting/reportingendpoint.rs
@@ -289,11 +289,11 @@ impl From<CSPViolationReportBody> for CSPReportingEndpointBody {
     fn from(value: CSPViolationReportBody) -> Self {
         CSPReportingEndpointBody {
             sample: value.sample.map(String::from),
-            blocked_url: value.blockedURL.map(|s| s.to_string()),
-            referrer: value.referrer.map(|s| s.to_string()),
+            blocked_url: value.blockedURL.map(String::from),
+            referrer: value.referrer.map(String::from),
             status_code: value.statusCode,
-            document_url: value.documentURL.to_string(),
-            source_file: value.sourceFile.map(|s| s.to_string()),
+            document_url: String::from(value.documentURL),
+            source_file: value.sourceFile.map(String::from),
             effective_directive: String::from(value.effectiveDirective),
             line_number: value.lineNumber,
             column_number: value.columnNumber,

--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -303,7 +303,7 @@ impl Request {
 
         // Step 23. If init["integrity"] exists, then set request’s integrity metadata to it.
         if let Some(init_integrity) = init.integrity.as_ref() {
-            let integrity = init_integrity.clone().to_string();
+            let integrity = init_integrity.to_string();
             request.integrity_metadata = integrity;
         }
 

--- a/components/script/dom/svg/svgelement.rs
+++ b/components/script/dom/svg/svgelement.rs
@@ -129,7 +129,7 @@ impl SVGElementMethods<crate::DomTypeHolder> for SVGElement {
     /// <https://html.spec.whatwg.org/multipage/#dom-noncedelement-nonce>
     fn SetNonce(&self, _cx: &mut JSContext, value: DOMString) {
         self.as_element()
-            .update_nonce_internal_slot(value.to_string())
+            .update_nonce_internal_slot(String::from(value))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-fe-autofocus>

--- a/components/script/dom/trustedtypes/trustedtypepolicyfactory.rs
+++ b/components/script/dom/trustedtypes/trustedtypepolicyfactory.rs
@@ -365,7 +365,7 @@ impl TrustedTypePolicyFactoryMethods<crate::DomTypeHolder> for TrustedTypePolicy
         policy_name: DOMString,
         options: &TrustedTypePolicyOptions,
     ) -> Fallible<DomRoot<TrustedTypePolicy>> {
-        self.create_trusted_type_policy(cx, policy_name.to_string(), options, &self.global())
+        self.create_trusted_type_policy(cx, String::from(policy_name), options, &self.global())
     }
     /// <https://www.w3.org/TR/trusted-types/#dom-trustedtypepolicyfactory-ishtml>
     fn IsHTML(&self, cx: JSContext, value: HandleValue) -> bool {

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -3091,13 +3091,12 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleEcKeyGenParams {
     ) -> Result<Self, Self::Error> {
         Ok(SubtleEcKeyGenParams {
             name: algorithm_name,
-            named_curve: get_required_parameter::<DOMString>(
+            named_curve: String::from(get_required_parameter::<DOMString>(
                 cx,
                 object,
                 c"namedCurve",
                 StringificationBehavior::Default,
-            )?
-            .to_string(),
+            )?),
         })
     }
 }
@@ -3145,13 +3144,12 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleEcKeyImportParams {
     ) -> Result<Self, Self::Error> {
         Ok(SubtleEcKeyImportParams {
             name: algorithm_name,
-            named_curve: get_required_parameter::<DOMString>(
+            named_curve: String::from(get_required_parameter::<DOMString>(
                 cx,
                 object,
                 c"namedCurve",
                 StringificationBehavior::Default,
-            )?
-            .to_string(),
+            )?),
         })
     }
 }

--- a/components/script/dom/webrtc/rtcdatachannel.rs
+++ b/components/script/dom/webrtc/rtcdatachannel.rs
@@ -94,7 +94,7 @@ impl RTCDataChannel {
         servo_media_id: Option<DataChannelId>,
     ) -> RTCDataChannel {
         let mut init: DataChannelInit = options.convert();
-        init.label = label.to_string();
+        init.label = label.0.clone();
 
         let controller = peer_connection.get_webrtc_controller().borrow();
         let servo_media_id = servo_media_id.unwrap_or(

--- a/components/script/dom/webrtc/rtcpeerconnection.rs
+++ b/components/script/dom/webrtc/rtcpeerconnection.rs
@@ -209,7 +209,7 @@ impl RTCPeerConnection {
                     .borrow()
                     .as_ref()
                     .unwrap()
-                    .configure(server.to_string(), policy);
+                    .configure(String::from(server), policy);
             }
         }
         this

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1151,7 +1151,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
             ProfiledGenericChannel::channel(self.global().time_profiler_chan().clone()).unwrap();
         let dialog = SimpleDialogRequest::Alert {
             id: self.Document().embedder_controls().next_control_id(),
-            message: message.to_string(),
+            message: String::from(message),
             response_sender: sender,
         };
         self.send_to_embedder(EmbedderMsg::ShowSimpleDialog(self.webview_id(), dialog));
@@ -1184,7 +1184,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
             ProfiledGenericChannel::channel(self.global().time_profiler_chan().clone()).unwrap();
         let dialog = SimpleDialogRequest::Confirm {
             id: self.Document().embedder_controls().next_control_id(),
-            message: message.to_string(),
+            message: String::from(message),
             response_sender: sender,
         };
         self.send_to_embedder(EmbedderMsg::ShowSimpleDialog(self.webview_id(), dialog));
@@ -1235,8 +1235,8 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
             ProfiledGenericChannel::channel(self.global().time_profiler_chan().clone()).unwrap();
         let dialog = SimpleDialogRequest::Prompt {
             id: self.Document().embedder_controls().next_control_id(),
-            message: message.to_string(),
-            default: default.to_string(),
+            message: String::from(message),
+            default: String::from(default),
             response_sender: sender,
         };
         self.send_to_embedder(EmbedderMsg::ShowSimpleDialog(self.webview_id(), dialog));

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1378,12 +1378,12 @@ pub(crate) fn handle_get_page_source(
                 .ok_or(ErrorStatus::UnknownError)
                 .and_then(|document| match document.GetDocumentElement() {
                     Some(element) => match element.outer_html(cx) {
-                        Ok(source) => Ok(source.to_string()),
+                        Ok(source) => Ok(String::from(source)),
                         Err(_) => {
                             match XMLSerializer::new(document.window(), None, CanGc::from_cx(cx))
                                 .SerializeToString(element.upcast::<Node>())
                             {
-                                Ok(source) => Ok(source.to_string()),
+                                Ok(source) => Ok(String::from(source)),
                                 Err(_) => Err(ErrorStatus::UnknownError),
                             }
                         },
@@ -1649,7 +1649,7 @@ pub(crate) fn handle_get_text(
             get_known_element(documents, pipeline, node_id).map(|element| {
                 element
                     .downcast::<HTMLElement>()
-                    .map(|htmlelement| htmlelement.InnerText().to_string())
+                    .map(|htmlelement| String::from(htmlelement.InnerText()))
                     .unwrap_or_else(|| {
                         element
                             .upcast::<Node>()


### PR DESCRIPTION
This pull requests replaces many calls to `DOMString::to_string` with `String::from` calls.
These don't have to go through a formatter (in the `Display` trait), and instead directly return owned memory (although in some cases a `String` is still allocated for this purpose).
All compiled usages of `DOMString::to_string`, found by grep'ing the emitted MIR, have been audited.
Some cases of `USVString::to_string` have been eliminated too.

Testing: no change in behavior, no changes in test results, the Rust ownership system would error at any case where it is not possible to move the `DOMString` to create a `String`.
Fixes: #44999 (though nothing prevents anyone from using `to_string` again where `String::from` would be better)
