### PR TITLE
script_bindings: Improve From<DOMString> methods and properly implement zeroize

### DIFF
--- a/components/script_bindings/domstring.rs
+++ b/components/script_bindings/domstring.rs
@@ -94,10 +94,12 @@ impl EncodedBytes<'_> {
     }
 }
 
+#[derive(Zeroize)]
 enum DOMStringType {
     /// A simple rust string
     Rust(String),
     /// A JS String stored in mozjs.
+    #[zeroize(skip)]
     JSString(RootedTraceableBox<Heap<*mut JSString>>),
     #[cfg(test)]
     /// This is used for testing of the bindings to give
@@ -108,12 +110,6 @@ enum DOMStringType {
 impl Default for DOMStringType {
     fn default() -> Self {
         Self::Rust(Default::default())
-    }
-}
-
-impl Zeroize for DOMStringType {
-    fn zeroize(&mut self) {
-        self.ensure_rust_string().zeroize()
     }
 }
 
@@ -913,13 +909,27 @@ impl From<DOMString> for Atom {
 
 impl From<DOMString> for String {
     fn from(val: DOMString) -> Self {
-        val.str().to_owned()
+        val.ensure_rust_string();
+        let inner = val.0.take();
+        match inner {
+            DOMStringType::Rust(s) => s,
+            DOMStringType::JSString(_) => unreachable!(),
+            #[cfg(test)]
+            DOMStringType::Latin1Vec(items) => String::from_utf8(items).expect("Not valid latin1"),
+        }
     }
 }
 
 impl From<DOMString> for Vec<u8> {
     fn from(value: DOMString) -> Self {
-        value.str().as_bytes().to_vec()
+        value.ensure_rust_string();
+        let inner = value.0.take();
+        match inner {
+            DOMStringType::Rust(s) => s.into_bytes(),
+            DOMStringType::JSString(_) => unreachable!(),
+            #[cfg(test)]
+            DOMStringType::Latin1Vec(items) => items,
+        }
     }
 }
 
@@ -931,7 +941,7 @@ impl From<Cow<'_, str>> for DOMString {
 
 impl Zeroize for DOMString {
     fn zeroize(&mut self) {
-        self.0.borrow_mut().zeroize()
+        self.0.get_mut().zeroize();
     }
 }
 


### PR DESCRIPTION
This PR combines two small changes:
- Reduce the allocations used by From<DOMString> for Vec<u8> and String. As in both cases the DOMString is consumed, the extra alocating of a string that is then cloned is not necessary.
- Zeroize on DOMStringType was creating the rust string and then zeroing it, making the GC clean up the JS string. We now skip zeroizing if we have a JS string. This is an equivalent solution without the extra allocation. Additionally, we opened an issue (https://github.com/servo/servo/issues/45077).

Testing: These should be equivalent changes. DOMString is used throughout so WPT tests would find anything missing.
