### PR TITLE
libservo: Mark `webxr` crate as optional dependency for all targets.

### DIFF
--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -152,13 +152,13 @@ webxr = { workspace = true, optional = true }
 
 [target.'cfg(not(any(target_os = "android", target_env = "ohos")))'.dependencies]
 arboard = { workspace = true, optional = true }
-webxr = { workspace = true, features = ["glwindow", "headless"] }
+webxr = { workspace = true, optional = true, features = ["glwindow", "headless"] }
 
 [target.'cfg(all(not(target_os = "windows"), not(target_os = "ios"), not(target_os = "android"), not(target_env = "ohos"), not(target_arch = "arm"), not(target_arch = "aarch64")))'.dependencies]
 gaol = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-webxr = { workspace = true, features = ["glwindow", "headless", "openxr-api"] }
+webxr = { workspace = true, optional = true, features = ["glwindow", "headless", "openxr-api"] }
 
 [target.'cfg(target_env = "ohos")'.dependencies]
 servo-media-ohos = { workspace = true }


### PR DESCRIPTION
Currently some targets include `webxr` as a non-optional dependency which leads to issues like #45027 where the features enabled for `webxr` support conflict with other `servo` features.

Since `servo` crate already exposes `webxr` feature as a non-default feature, it makes sense to also mark `webxr` crate as optional dependency on all platforms.

Testing: The issue in #45027 is resolved by this fix and this has been validated manually as part of #44984. However, there are no automated tests in servo that validate WGL support specifically and WGL doesn't seem to work in CI either. Since `servoshell` already enables `webxr` feature unconditionally for `servo`, this should not cause any change in the behaviour of servoshell.

Fixes: #45027