### PR TITLE
wpt: skip the service workers test suite

### DIFF
--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -261,7 +261,7 @@ skip: true
 [selection]
   skip: false
 [service-workers]
-  skip: false
+  skip: true
 [shadow-dom]
   skip: false
 [streams]


### PR DESCRIPTION
This skips the service workers wpt suite, making it easier going forward to incrementally develop features of service workers and test them by unskipping the relevant parts of the suite. With the entire suite running, new features tend to switch large part of the suite from fail to timeout expectation, adding a large time overhead to all wpt runs. 