### PR TITLE
script: Replace `get_attribute` with `with_attribute`

### DIFF
--- a/components/script/dom/domtokenlist.rs
+++ b/components/script/dom/domtokenlist.rs
@@ -9,7 +9,6 @@ use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use style::str::HTML_SPACE_CHARACTERS;
 use stylo_atoms::Atom;
 
-use crate::dom::attr::Attr;
 use crate::dom::bindings::codegen::Bindings::DOMTokenListBinding::DOMTokenListMethods;
 use crate::dom::bindings::error::{Error, ErrorResult, Fallible};
 use crate::dom::bindings::root::{Dom, DomRoot};
@@ -58,10 +57,6 @@ impl DOMTokenList {
         )
     }
 
-    fn attribute(&self) -> Option<DomRoot<Attr>> {
-        self.element.get_attribute(&self.local_name)
-    }
-
     fn check_token_exceptions(&self, token: &DOMString) -> Fallible<Atom> {
         let token = token.str();
         match &*token {
@@ -105,26 +100,22 @@ impl DOMTokenList {
 impl DOMTokenListMethods<crate::DomTypeHolder> for DOMTokenList {
     /// <https://dom.spec.whatwg.org/#dom-domtokenlist-length>
     fn Length(&self) -> u32 {
-        self.attribute()
-            .map_or(0, |attr| attr.value().as_tokens().len()) as u32
+        self.element.get_tokenlist_attribute(&self.local_name).len() as u32
     }
 
     /// <https://dom.spec.whatwg.org/#dom-domtokenlist-item>
     fn Item(&self, index: u32) -> Option<DOMString> {
-        self.attribute().and_then(|attr| {
-            // FIXME(ajeffrey): Convert directly from Atom to DOMString
-            attr.value()
-                .as_tokens()
-                .get(index as usize)
-                .map(|token| DOMString::from(&**token))
-        })
+        self.element
+            .get_tokenlist_attribute(&self.local_name)
+            .get(index as usize)
+            .map(|token| DOMString::from(&**token))
     }
 
     /// <https://dom.spec.whatwg.org/#dom-domtokenlist-contains>
     fn Contains(&self, token: DOMString) -> bool {
-        let token = Atom::from(token);
-        self.attribute()
-            .is_some_and(|attr| attr.value().as_tokens().contains(&token))
+        self.element
+            .get_tokenlist_attribute(&self.local_name)
+            .contains(&Atom::from(token))
     }
 
     /// <https://dom.spec.whatwg.org/#dom-domtokenlist-add>

--- a/components/script/dom/element/attributes/accessors.rs
+++ b/components/script/dom/element/attributes/accessors.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use html5ever::{LocalName, local_name, ns};
+use html5ever::{LocalName, Namespace, local_name, ns};
 use js::context::JSContext;
 use servo_arc::Arc as ServoArc;
 use style::attr::AttrValue;
@@ -15,14 +15,39 @@ use crate::dom::element::{AttributeMutationReason, Element};
 use crate::dom::node::NodeTraits;
 
 impl Element {
+    /// Callers should convert the `LocalName` to ASCII lowercase before calling.
+    /// <https://dom.spec.whatwg.org/#concept-element-attributes-get-by-name>
+    pub(crate) fn get_attribute_string_value(&self, local_name: &LocalName) -> Option<String> {
+        // Step 1. If element is in the HTML namespace and its node document is an HTML document,
+        // then set qualifiedName to qualifiedName in ASCII lowercase.
+        debug_assert_eq!(
+            *local_name,
+            local_name.to_ascii_lowercase(),
+            "All namespace-less attribute accesses should use a lowercase ASCII name"
+        );
+
+        self.get_attribute_string_value_with_namespace(&ns!(), local_name)
+    }
+
+    pub(crate) fn get_attribute_string_value_with_namespace(
+        &self,
+        namespace: &Namespace,
+        local_name: &LocalName,
+    ) -> Option<String> {
+        self.with_attribute(namespace, local_name, |attribute| {
+            String::from(&**attribute.value())
+        })
+    }
+
     pub(crate) fn get_int_attribute(&self, local_name: &LocalName, default: i32) -> i32 {
-        match self.get_attribute(local_name) {
-            Some(ref attribute) => match *attribute.value() {
-                AttrValue::Int(_, value) => value,
-                _ => unreachable!("Expected an AttrValue::Int: implement parse_plain_attribute"),
-            },
-            None => default,
-        }
+        self.with_attribute(&ns!(), local_name, |attribute| {
+            if let AttrValue::Int(_, value) = *attribute.value() {
+                value
+            } else {
+                unreachable!("Expected an AttrValue::Int: implement parse_plain_attribute")
+            }
+        })
+        .unwrap_or(default)
     }
 
     pub(crate) fn set_atomic_attribute(
@@ -133,9 +158,10 @@ impl Element {
     }
 
     pub(crate) fn get_tokenlist_attribute(&self, local_name: &LocalName) -> Vec<Atom> {
-        self.get_attribute(local_name)
-            .map(|attribute| attribute.value().as_tokens().to_vec())
-            .unwrap_or_default()
+        self.with_attribute(&ns!(), local_name, |attribute| {
+            attribute.value().as_tokens().to_vec()
+        })
+        .unwrap_or_default()
     }
 
     pub(crate) fn set_tokenlist_attribute(
@@ -152,13 +178,14 @@ impl Element {
     }
 
     pub(crate) fn get_uint_attribute(&self, local_name: &LocalName, default: u32) -> u32 {
-        match self.get_attribute(local_name) {
-            Some(ref attribute) => match *attribute.value() {
-                AttrValue::UInt(_, value) => value,
-                _ => unreachable!("Expected an AttrValue::UInt: implement parse_plain_attribute"),
-            },
-            None => default,
-        }
+        self.with_attribute(&ns!(), local_name, |attribute| {
+            if let AttrValue::UInt(_, value) = *attribute.value() {
+                value
+            } else {
+                unreachable!("Expected an AttrValue::Int: implement parse_plain_attribute")
+            }
+        })
+        .unwrap_or(default)
     }
 
     /// Ensure that for styles, we clone the already-parsed property declaration block.

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -2030,28 +2030,22 @@ impl Element {
         self.handle_attribute_changes(cx, AttrRef::Dom(attr), None, Some(&*attr.value()), reason);
     }
 
-    pub(crate) fn get_attribute_string_value(&self, local_name: &LocalName) -> Option<String> {
-        debug_assert_eq!(
-            *local_name,
-            local_name.to_ascii_lowercase(),
-            "All namespace-less attribute accesses should use a lowercase ASCII name"
-        );
-
-        self.get_attribute_string_value_with_namespace(&ns!(), local_name)
-    }
-
-    pub(crate) fn get_attribute_string_value_with_namespace(
+    pub(crate) fn with_attribute<R, F>(
         &self,
         namespace: &Namespace,
         local_name: &LocalName,
-    ) -> Option<String> {
+        map_func: F,
+    ) -> Option<R>
+    where
+        F: FnOnce(AttrRef<'_>) -> R,
+    {
         self.attrs
             .borrow()
             .iter()
             .find(|attribute| {
                 attribute.local_name() == local_name && attribute.namespace() == namespace
             })
-            .map(|attribute| String::from(&**attribute.value()))
+            .map(map_func)
     }
 
     /// This is the inner logic for:
@@ -2071,24 +2065,6 @@ impl Element {
             .iter()
             .position(|a| a.local_name() == local_name && a.namespace() == namespace)?;
         Some(self.attrs.ensure_dom(cx, idx, self))
-    }
-
-    /// This is the inner logic for:
-    /// <https://dom.spec.whatwg.org/#concept-element-attributes-get-by-name>
-    ///
-    /// Callers should convert the `LocalName` to ASCII lowercase before calling.
-    #[expect(unsafe_code)]
-    pub(crate) fn get_attribute(&self, local_name: &LocalName) -> Option<DomRoot<Attr>> {
-        // TODO: https://github.com/servo/servo/issues/42812
-        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
-        let cx = &mut cx;
-
-        debug_assert_eq!(
-            *local_name,
-            local_name.to_ascii_lowercase(),
-            "All namespace-less attribute accesses should use a lowercase ASCII name"
-        );
-        self.get_attribute_with_namespace(cx, &ns!(), local_name)
     }
 
     /// <https://dom.spec.whatwg.org/#concept-element-attributes-get-by-name>
@@ -2292,13 +2268,9 @@ impl Element {
     }
 
     pub(crate) fn has_class(&self, name: &Atom, case_sensitivity: CaseSensitivity) -> bool {
-        self.get_attribute(&local_name!("class"))
-            .is_some_and(|attr| {
-                attr.value()
-                    .as_tokens()
-                    .iter()
-                    .any(|atom| case_sensitivity.eq_atom(name, atom))
-            })
+        self.get_tokenlist_attribute(&local_name!("class"))
+            .iter()
+            .any(|atom| case_sensitivity.eq_atom(name, atom))
     }
 
     pub(crate) fn has_attribute(&self, local_name: &LocalName) -> bool {

--- a/components/script/dom/execcommand/contenteditable/element.rs
+++ b/components/script/dom/execcommand/contenteditable/element.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use html5ever::{LocalName, local_name};
+use html5ever::{LocalName, local_name, ns};
 use js::context::JSContext;
 use script_bindings::inheritance::Castable;
 use style::attr::AttrValue;
@@ -102,10 +102,17 @@ impl Element {
         // Step 11. If element is a font element that has an attribute whose effect is to create a presentational hint for property,
         // return the value that the hint sets property to. (For a size of 7, this will be the non-CSS value "xxx-large".)
         if self.is::<HTMLFontElement>() &&
-            let Some(font_size) = self.get_attribute(&local_name!("size")) &&
-            let AttrValue::UInt(_, value) = *font_size.value()
+            let Some(font_size) = self
+                .with_attribute(&ns!(), &local_name!("size"), |attribute| {
+                    if let AttrValue::UInt(_, value) = *attribute.value() {
+                        Some(value)
+                    } else {
+                        None
+                    }
+                })
+                .flatten()
         {
-            return Some(font_size_to_css_font(&value).into());
+            return Some(font_size_to_css_font(&font_size).into());
         }
 
         // Step 12. If element is in the following list, and property is equal to the CSS property name listed for it,

--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -822,19 +822,18 @@ impl HTMLIFrameElement {
     /// property or clears it is the value isn't specified. Notably, an unspecified sandboxing
     /// attribute (no sandboxing) is different from an empty one (full sandboxing).
     fn parse_sandbox_attribute(&self) {
-        let attribute = self
-            .upcast::<Element>()
-            .get_attribute(&local_name!("sandbox"));
-        self.sandboxing_flag_set
-            .set(attribute.map(|attribute_value| {
-                let tokens: Vec<_> = attribute_value
-                    .value()
-                    .as_tokens()
-                    .iter()
-                    .map(|atom| atom.to_string().to_ascii_lowercase())
-                    .collect();
-                parse_a_sandboxing_directive(&tokens)
-            }));
+        let sandbox_value =
+            self.upcast::<Element>()
+                .with_attribute(&ns!(), &local_name!("sandbox"), |attribute| {
+                    let tokens: Vec<_> = attribute
+                        .value()
+                        .as_tokens()
+                        .iter()
+                        .map(|atom| atom.to_string().to_ascii_lowercase())
+                        .collect();
+                    parse_a_sandboxing_directive(&tokens)
+                });
+        self.sandboxing_flag_set.set(sandbox_value);
     }
 
     /// Step 4.2. of <https://html.spec.whatwg.org/multipage/#destroy-a-document-and-its-descendants>


### PR DESCRIPTION
Rather than requiring a `cx` for these attribute accessors, we can implement it as a mapping function on a `AttrRef`. This saves a lot more memory for every attribute access, that now no longer materializes an `Attr`.

Testing: WPT
Fixes #42812