### PR TITLE
ci: Reduce Windows unit tests parallel compilation processes by 2

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -176,6 +176,7 @@ jobs:
         id: run_unit_tests
         env:
           NEXTEST_RETRIES: 3 # https://github.com/servo/servo/issues/30683
+          CARGO_BUILD_JOBS: -2
         run: ./mach test-unit --profile ${{ inputs.profile }} --nextest-profile ci
       # We upload the test-results to Codecov to help us identify flaky unit-tests.
       - name: Upload test results to Codecov


### PR DESCRIPTION
Windows UT OOM quite frequently. 

We refer to [Cargo Book](https://doc.rust-lang.org/cargo/reference/config.html#buildjobs) here.
By default, the # of compilation processes is the # of logical CPUs. We reduce it by 2.

Note that this increases the time cost of UT step by 30 seconds.
Given that Windows runners are never the bottleneck, it should be acceptable.

Testing: Three consecutive successes.
https://github.com/servo/servo/actions/runs/26270054775
https://github.com/servo/servo/actions/runs/26270050300
https://github.com/servo/servo/actions/runs/26270041463
