### PR TITLE
media: support MP4 with moov atom at the end of the file

### DIFF
--- a/components/media/backends/dummy/lib.rs
+++ b/components/media/backends/dummy/lib.rs
@@ -194,6 +194,10 @@ impl Player for DummyPlayer {
         Ok(())
     }
 
+    fn set_seekable(&self, _: bool) -> Result<(), PlayerError> {
+        Ok(())
+    }
+
     fn set_playback_rate(&self, _: f64) -> Result<(), PlayerError> {
         Ok(())
     }

--- a/components/media/backends/gstreamer/Cargo.toml
+++ b/components/media/backends/gstreamer/Cargo.toml
@@ -16,6 +16,7 @@ path = "lib.rs"
 [features]
 glx = ["servo-media-gstreamer-render-unix/gl-x11"]
 wayland = ["servo-media-gstreamer-render-unix/gl-wayland"]
+v1_28 = ["gstreamer/v1_28"]
 
 [dependencies]
 byte-slice-cast = { workspace = true }

--- a/components/media/backends/gstreamer/player.rs
+++ b/components/media/backends/gstreamer/player.rs
@@ -128,6 +128,7 @@ struct PlayerInner {
     source: Option<PlayerSource>,
     video_sink: gstreamer_app::AppSink,
     input_size: u64,
+    seekable: bool,
     play_state: gstreamer_play::PlayState,
     paused: Cell<bool>,
     can_resume: Cell<bool>,
@@ -151,6 +152,14 @@ impl PlayerInner {
             } else {
                 -1 // live source
             });
+        }
+        Ok(())
+    }
+
+    pub fn set_seekable(&mut self, seekable: bool) -> Result<(), PlayerError> {
+        self.seekable = seekable;
+        if let Some(PlayerSource::Seekable(ref mut source)) = self.source {
+            source.set_seekable(seekable);
         }
         Ok(())
     }
@@ -625,6 +634,7 @@ impl GStreamerPlayer {
             source: None,
             video_sink,
             input_size: 0,
+            seekable: true,
             play_state: gstreamer_play::PlayState::Stopped,
             paused: Cell::new(DEFAULT_PAUSED),
             can_resume: Cell::new(DEFAULT_CAN_RESUME),
@@ -827,6 +837,7 @@ impl GStreamerPlayer {
                         if inner.input_size > 0 {
                             servosrc.set_size(inner.input_size as i64);
                         }
+                        servosrc.set_seekable(inner.seekable);
 
                         let sender_clone = sender.clone();
                         let is_ready = is_ready_clone.clone();
@@ -968,6 +979,7 @@ impl Player for GStreamerPlayer {
     inner_player_proxy!(stop, ());
     inner_player_proxy!(end_of_stream, ());
     inner_player_proxy!(set_input_size, size, u64);
+    inner_player_proxy!(set_seekable, seekable, bool);
     inner_player_proxy!(set_mute, muted, bool);
     inner_player_proxy_getter!(muted, bool, DEFAULT_MUTED);
     inner_player_proxy!(set_playback_rate, playback_rate, f64);

--- a/components/media/backends/gstreamer/source.rs
+++ b/components/media/backends/gstreamer/source.rs
@@ -47,6 +47,7 @@ mod imp {
         srcpad: gstreamer::GhostPad,
         position: Mutex<Position>,
         seeking: AtomicBool,
+        seekable: AtomicBool,
         size: Mutex<Option<i64>>,
     }
 
@@ -63,6 +64,10 @@ mod imp {
             if self.appsrc.size() == -1 {
                 self.appsrc.set_size(size);
             }
+        }
+
+        pub fn set_seekable(&self, seekable: bool) {
+            self.seekable.store(seekable, Ordering::Relaxed);
         }
 
         pub fn set_seek_offset<O: IsA<gstreamer::Object>>(&self, parent: &O, offset: u64) -> bool {
@@ -204,22 +209,25 @@ mod imp {
 
             // In order to make buffering/downloading work as we want, apart from
             // setting the appropriate flags on the player playbin,
-            // the source needs to either:
+            // the source:
             //
-            // 1. be an http, mms, etc. scheme
-            // 2. report that it is "bandwidth limited".
-            //
-            // 1. is not straightforward because we are using a servosrc scheme for now.
-            // This may change in the future if we end up handling http/https/data
-            // URIs, which is what WebKit does.
-            //
-            // For 2. we need to make servosrc handle the scheduling properties query
-            // to report that it "is bandwidth limited".
+            // 1. Announces seekability when the media element confirmed it.
+            // 2. Assumes seekable = true as default.
+            // 3. Keeps assuming bandwidth limited.
+            // 4. set_seekable is called when range requests are supported or not.
             let ret = match query.view_mut() {
                 gstreamer::QueryViewMut::Scheduling(ref mut q) => {
-                    let flags = gstreamer::SchedulingFlags::SEQUENTIAL |
-                        gstreamer::SchedulingFlags::BANDWIDTH_LIMITED;
-                    q.set(flags, 1, -1, 0);
+                    let seekability_flag = if self.seekable.load(Ordering::Relaxed) {
+                        gstreamer::SchedulingFlags::SEEKABLE
+                    } else {
+                        gstreamer::SchedulingFlags::SEQUENTIAL
+                    };
+                    q.set(
+                        seekability_flag | gstreamer::SchedulingFlags::BANDWIDTH_LIMITED,
+                        1,
+                        -1,
+                        0,
+                    );
                     q.add_scheduling_modes([gstreamer::PadMode::Push]);
                     true
                 },
@@ -272,6 +280,7 @@ mod imp {
                 srcpad: ghost_pad,
                 position: Mutex::new(Default::default()),
                 seeking: AtomicBool::new(false),
+                seekable: AtomicBool::new(true),
                 size: Mutex::new(None),
             }
         }
@@ -389,6 +398,10 @@ unsafe impl Sync for ServoSrc {}
 impl ServoSrc {
     pub fn set_size(&self, size: i64) {
         self.imp().set_size(size);
+    }
+
+    pub fn set_seekable(&self, seekable: bool) {
+        self.imp().set_seekable(seekable);
     }
 
     pub fn set_seek_offset(&self, offset: u64) -> bool {

--- a/components/media/backends/ohos/player.rs
+++ b/components/media/backends/ohos/player.rs
@@ -465,6 +465,12 @@ impl Player for OhosAvPlayer {
         Ok(())
     }
 
+    fn set_seekable(&self, seekable: bool) -> Result<(), servo_media::player::PlayerError> {
+        debug!("SetSeekable: {}", seekable);
+
+        Ok(())
+    }
+
     fn set_playback_rate(
         &self,
         playback_rate: f64,

--- a/components/media/player/lib.rs
+++ b/components/media/player/lib.rs
@@ -109,6 +109,7 @@ pub trait Player: Send + MediaInstance {
     fn set_volume(&self, volume: f64) -> Result<(), PlayerError>;
     fn volume(&self) -> f64;
     fn set_input_size(&self, size: u64) -> Result<(), PlayerError>;
+    fn set_seekable(&self, seekable: bool) -> Result<(), PlayerError>;
     fn set_playback_rate(&self, playback_rate: f64) -> Result<(), PlayerError>;
     fn playback_rate(&self) -> f64;
     fn push_data(&self, data: Vec<u8>) -> Result<(), PlayerError>;

--- a/components/net/protocols/file.rs
+++ b/components/net/protocols/file.rs
@@ -7,7 +7,7 @@ use std::future::{Future, ready};
 use std::io::{BufReader, Seek, SeekFrom};
 use std::pin::Pin;
 
-use headers::{ContentType, HeaderMapExt, Range};
+use headers::{ContentLength, ContentRange, ContentType, HeaderMapExt, Range};
 use http::Method;
 use net_traits::request::Request;
 use net_traits::response::{Response, ResponseBody};
@@ -71,6 +71,22 @@ impl ProtocolHandler for FileProtocolHander {
                 // At this point we should have already validated the header.
                 if is_range_request {
                     partial_content(&mut response);
+                }
+
+                // Set Content-Length and Content-Range headers when end is determinable.
+                let end_byte = range.end.map(|e| e as u64).or(file_size);
+                if let Some(end_byte) = end_byte {
+                    let start_byte = range.start as u64;
+
+                    response
+                        .headers
+                        .typed_insert(ContentLength(end_byte - start_byte));
+                    if is_range_request &&
+                        let Ok(content_range) =
+                            ContentRange::bytes(start_byte..end_byte, file_size)
+                    {
+                        response.headers.typed_insert(content_range);
+                    }
                 }
 
                 // Set Content-Type header.

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -262,7 +262,7 @@ fn test_file() {
     // have the file's MIME type and contents.
     let actual_response = fetch_response.actual_response();
     assert!(!actual_response.is_network_error());
-    assert_eq!(actual_response.headers.len(), 1);
+    assert_eq!(actual_response.headers.len(), 2);
     let content_type: Mime = actual_response
         .headers
         .typed_get::<ContentType>()
@@ -270,8 +270,16 @@ fn test_file() {
         .into();
     assert_eq!(content_type, mime::TEXT_CSS);
 
-    let resp_body = actual_response.body.lock();
     let file = fs::read(path).unwrap();
+
+    let content_size: u64 = actual_response
+        .headers
+        .typed_get::<ContentLength>()
+        .unwrap()
+        .0;
+    assert_eq!(content_size, file.len() as u64);
+
+    let resp_body = actual_response.body.lock();
 
     match *resp_body {
         ResponseBody::Done(ref val) => {

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -3796,6 +3796,18 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
         }
 
         // Explicit media player initialization with live/seekable source.
+        if let Err(e) = element
+            .player
+            .borrow()
+            .as_ref()
+            .unwrap()
+            .lock()
+            .unwrap()
+            .set_seekable(is_seekable)
+        {
+            warn!("Could not set player seekable {:?}", e);
+        }
+
         if let Some(expected_content_length) = self.expected_content_length &&
             let Err(e) = element
                 .player


### PR DESCRIPTION
qtdemux failed with "no 'moov' atom within the first 10 MB" when the MP4 did not have fast start because ServoSrc declared only SEQUENTIAL push-only to the pipeline, making qtdemux quit the seek-to-end. Besides, the file:// protocol did not expose the asset size in the HTTP headers so the media backend never got the set_input_size.

Testing: fetch::test_file checks for the new header in file://. Adding a test for the qtdemux bug would require a bigger mp4 file to force qtdemux to request the src to seek and it looks like too much.
Fixes: https://github.com/servo/servo/issues/24180
