### PR TITLE
script: Remove `temp_cx` in Drop of LoadBlocker

### DIFF
--- a/components/script/document_loader.rs
+++ b/components/script/document_loader.rs
@@ -9,7 +9,7 @@
 use net_traits::request::RequestBuilder;
 use net_traits::{BoxedFetchCallback, ResourceThreads, fetch_async};
 use script_bindings::cell::DomRefCell;
-use script_bindings::script_runtime::temp_cx;
+use script_bindings::script_runtime::runtime_is_alive;
 use servo_url::ServoUrl;
 
 use crate::dom::bindings::root::Dom;
@@ -70,11 +70,17 @@ impl LoadBlocker {
 }
 
 impl Drop for LoadBlocker {
-    #[expect(unsafe_code)]
     fn drop(&mut self) {
-        if let Some(load) = self.load.take() {
-            let mut cx = unsafe { temp_cx() };
-            self.doc.finish_load(load, &mut cx);
+        // We need to check here if the whole runtime is alive, otherwise
+        // we interact with a document that is also being dropped. That
+        // would panic, since we should no longer schedule a task for
+        // a dropped runtime. Therefore, we should only run the drop logic
+        // in case this element is dropped, but its containing document
+        // is still alive.
+        if runtime_is_alive() &&
+            let Some(load) = self.load.take()
+        {
+            self.doc.finish_load_for_dropped_blocker(load);
         }
     }
 }

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -1943,6 +1943,16 @@ impl Document {
         }
     }
 
+    pub(crate) fn finish_load_for_dropped_blocker(&self, load: LoadType) {
+        let this = Trusted::new(self);
+        self.owner_global()
+            .task_manager()
+            .dom_manipulation_task_source()
+            .queue(task!(check_finished_load: move |cx| {
+                this.root().finish_load(load, cx);
+            }));
+    }
+
     // https://html.spec.whatwg.org/multipage/#the-end
     // https://html.spec.whatwg.org/multipage/#delay-the-load-event
     pub(crate) fn finish_load(&self, load: LoadType, cx: &mut js::context::JSContext) {

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -753,9 +753,13 @@ impl HTMLMediaElement {
     /// <https://html.spec.whatwg.org/multipage/#delaying-the-load-event-flag>
     pub(crate) fn delay_load_event(&self, delay: bool, cx: &mut js::context::JSContext) {
         let blocker = &self.delaying_the_load_event_flag;
-        if delay && blocker.borrow().is_none() {
-            *blocker.borrow_mut() = Some(LoadBlocker::new(&self.owner_document(), LoadType::Media));
-        } else if !delay && blocker.borrow().is_some() {
+
+        if delay {
+            if blocker.borrow().is_none() {
+                *blocker.borrow_mut() =
+                    Some(LoadBlocker::new(&self.owner_document(), LoadType::Media));
+            }
+        } else {
             LoadBlocker::terminate(blocker, cx);
         }
     }
@@ -3436,6 +3440,9 @@ impl VirtualMethods for HTMLMediaElement {
 
         self.remove_controls();
 
+        // Step 1. Await a stable state, allowing the task that removed the media element from the Document to continue.
+        // The synchronous section consists of all the remaining steps of this algorithm.
+        // (Steps in the synchronous section are marked with ⌛.)
         if context.tree_connected {
             let task = MediaElementMicrotask::PauseIfNotInDocument {
                 elem: DomRoot::from_ref(self),
@@ -3500,10 +3507,14 @@ impl MicrotaskRunnable for MediaElementMicrotask {
                     elem.resource_selection_algorithm_sync(base_url.clone(), cx);
                 }
             },
+            // https://html.spec.whatwg.org/multipage/#playing-the-media-resource:remove-an-element-from-a-document
             MediaElementMicrotask::PauseIfNotInDocument { elem } => {
-                if !elem.upcast::<Node>().is_connected() {
-                    elem.internal_pause_steps();
+                // Step 2. ⌛ If the media element is in a document, return.
+                if elem.upcast::<Node>().is_connected() {
+                    return;
                 }
+                // Step 3. ⌛ Run the internal pause steps for the media element.
+                elem.internal_pause_steps();
             },
             &MediaElementMicrotask::Seeked {
                 ref elem,

--- a/components/script/dom/html/htmlvideoelement.rs
+++ b/components/script/dom/html/htmlvideoelement.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use dom_struct::dom_struct;
 use euclid::default::Size2D;
 use html5ever::{LocalName, Prefix, local_name, ns};
+use js::context::JSContext;
 use js::rust::HandleObject;
 use layout_api::{HTMLMediaData, MediaMetadata};
 use net_traits::blob_url_store::UrlWithBlobClaim;
@@ -80,7 +81,7 @@ impl HTMLVideoElement {
     }
 
     pub(crate) fn new(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
@@ -149,7 +150,7 @@ impl HTMLVideoElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#poster-frame>
-    fn update_poster_frame(&self, poster_url: Option<&str>, cx: &mut js::context::JSContext) {
+    fn update_poster_frame(&self, poster_url: Option<&str>, cx: &mut JSContext) {
         // Step 1. If there is an existing instance of this algorithm running
         // for this video element, abort that instance of this algorithm without
         // changing the poster frame.
@@ -230,7 +231,7 @@ impl HTMLVideoElement {
         &self,
         poster_url: UrlWithBlobClaim,
         id: PendingImageId,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
     ) {
         // Step 5. Let request be a new request whose URL is url, client is the element's node
         // document's relevant settings object, destination is "image", initiator type is "video",
@@ -255,8 +256,9 @@ impl HTMLVideoElement {
         // will block the document's load event forever.
         let blocker = &self.load_blocker;
         LoadBlocker::terminate(blocker, cx);
+        let document = self.owner_document();
         *blocker.borrow_mut() = Some(LoadBlocker::new(
-            &self.owner_document(),
+            &document,
             LoadType::Image(poster_url.url()),
         ));
 
@@ -275,7 +277,7 @@ impl HTMLVideoElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#poster-frame>
-    fn process_image_response(&self, response: ImageResponse, cx: &mut js::context::JSContext) {
+    fn process_image_response(&self, response: ImageResponse, cx: &mut JSContext) {
         // Step 7. If an image is thus obtained, the poster frame is that image.
         // Otherwise, there is no poster frame.
         match response {
@@ -361,7 +363,7 @@ impl VirtualMethods for HTMLVideoElement {
 
     fn attribute_mutated(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
@@ -423,7 +425,7 @@ impl FetchResponseListener for PosterFrameFetchContext {
 
     fn process_response(
         &mut self,
-        _: &mut js::context::JSContext,
+        _: &mut JSContext,
         request_id: RequestId,
         metadata: Result<FetchMetadata, NetworkError>,
     ) {
@@ -449,7 +451,7 @@ impl FetchResponseListener for PosterFrameFetchContext {
 
     fn process_response_chunk(
         &mut self,
-        _: &mut js::context::JSContext,
+        _: &mut JSContext,
         request_id: RequestId,
         payload: Vec<u8>,
     ) {
@@ -466,7 +468,7 @@ impl FetchResponseListener for PosterFrameFetchContext {
 
     fn process_response_eof(
         self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         request_id: RequestId,
         response: Result<(), NetworkError>,
         timing: ResourceFetchTiming,


### PR DESCRIPTION
Instead, we now schedule a task on an alive document.

Part of #40600

Testing: No behavioral change