### PR TITLE
Convert more dependencies to workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ app_units = "0.7"
 arboard = "3"
 argon2 = { version = "0.5", features = ["alloc"] }
 arrayvec = "0.7"
+async-compression = { version = "0.4.12", default-features = false }
 async-recursion = "1.1"
 async-tungstenite = { version = "0.34", features = ["tokio-rustls-webpki-roots"] }
 atomic_refcell = "0.1.14"
@@ -60,6 +61,7 @@ chrono = { version = "0.4", features = ["serde"] }
 cipher = { version = "0.4.4", features = ["alloc"] }
 content-security-policy = { version = "0.8.0", features = ["serde"] }
 cookie = { package = "cookie", version = "0.18" }
+criterion = "0.5"
 crossbeam-channel = "0.5"
 cssparser = { version = "0.37", features = ["serde"] }
 ctr = "0.9.2"
@@ -149,6 +151,9 @@ objc2-core-graphics = "0.3.2"
 objc2-core-text = "0.3.2"
 ocb3 = "0.1.0"
 ohos-deviceinfo-sys = "0.1.6"
+ohos-media-sys = "0.0.5"
+ohos-sys-opaque-types = "0.1.7"
+ohos-window-sys = "0.1.3"
 openxr = "0.21"
 p256 = { version = "0.13", features = ["ecdh"] }
 p384 = { version = "0.13", features = ["ecdh"] }
@@ -156,6 +161,7 @@ p521 = { version = "0.13", features = ["ecdh"] }
 parking_lot = { version = "0.12", features = ["serde"] }
 peniko = "0.5"
 percent-encoding = "2.3"
+petgraph = "0.4.12"
 phf = "0.13"
 phf_codegen = "0.13"
 phf_shared = "0.13"
@@ -164,6 +170,7 @@ pollster = "0.4"
 postcard = { version = "1.1.3", default-features = false, features = ["use-std"] }
 prettyplease = "0.2.32"
 proc-macro2 = "1"
+quick_cache = { version = "0.6.18", default-features = false }
 quickcheck = "1"
 quote = "1"
 rand = "0.9"
@@ -173,6 +180,7 @@ read-fonts = "0.35.0"
 regex = "1.12"
 resvg = "0.47.0"
 rsa = { version = "0.9.10", features = ["sha1", "sha2"] }
+rusqlite = "0.37"
 rustc-demangle = "0.1"
 rustc-hash = "2.1.2"
 rustls = { version = "0.23", default-features = false, features = ["logging", "std", "tls12"] }
@@ -232,6 +240,7 @@ urlpattern = "0.3"
 uuid = { version = "1.23.1", features = ["v4", "v5"] }
 vello = "0.6"
 vello_cpu = "0.0.4"
+warp = "0.4.2"
 web_atoms = "0.2.4"
 webdriver = { version = "0.53.0", default-features = false }
 webpki-roots = "1.0"

--- a/components/dom_struct/Cargo.toml
+++ b/components/dom_struct/Cargo.toml
@@ -10,10 +10,10 @@ repository.workspace = true
 description.workspace = true
 
 [dependencies]
+prettyplease = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true, features = ["extra-traits", "full", "parsing", "printing", "proc-macro"] }
-prettyplease = "0.2"
 
 [lib]
 path = "lib.rs"

--- a/components/media/audio/Cargo.toml
+++ b/components/media/audio/Cargo.toml
@@ -21,7 +21,7 @@ malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 num-complex = { workspace = true }
 num-traits = { workspace = true }
-petgraph = { version = "0.4.12", features = ["stable_graph"] }
+petgraph = { workspace = true, features = ["stable_graph"] }
 serde = { workspace = true, features = ["derive"] }
 servo-media-derive = { workspace = true }
 servo-media-player = { workspace = true }

--- a/components/media/backends/ohos/Cargo.toml
+++ b/components/media/backends/ohos/Cargo.toml
@@ -19,9 +19,9 @@ ipc-channel = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
 mime = { workspace = true }
-ohos-media-sys = { version = "0.0.5", features = ["api-21"] }
-ohos-sys-opaque-types = "0.1.7"
-ohos-window-sys = { version = "0.1.3", features = ["api-13"] }
+ohos-media-sys = { workspace = true, features = ["api-21"] }
+ohos-sys-opaque-types = { workspace = true }
+ohos-window-sys = { workspace = true, features = ["api-13"] }
 servo-media = { workspace = true }
 servo-media-audio = { workspace = true }
 servo-media-player = { workspace = true }

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -21,7 +21,7 @@ test-util = ["hyper-util/server-graceful", "dep:servo-default-resources"]
 tracing = ["dep:tracing"]
 
 [dependencies]
-async-compression = { version = "0.4.12", default-features = false, features = ["brotli", "gzip", "tokio", "zlib", "zstd"] }
+async-compression = { workspace = true, features = ["brotli", "gzip", "tokio", "zlib", "zstd"] }
 async-recursion = { workspace = true }
 async-tungstenite = { workspace = true }
 base64 = { workspace = true }
@@ -59,7 +59,7 @@ paint_api = { workspace = true }
 parking_lot = { workspace = true }
 pixels = { workspace = true }
 profile_traits = { workspace = true }
-quick_cache = { version = "0.6.18", default-features = false, features = ["ahash"] }
+quick_cache = { workspace = true, features = ["ahash"] }
 regex = { workspace = true }
 resvg = { workspace = true }
 rustc-hash = { workspace = true }

--- a/components/pixels/Cargo.toml
+++ b/components/pixels/Cargo.toml
@@ -24,7 +24,7 @@ servo-base = { workspace = true }
 webrender_api = { workspace = true }
 
 [dev-dependencies]
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { workspace = true, features = ["html_reports"] }
 
 [[bench]]
 name = "benches"

--- a/components/servo_tracing/Cargo.toml
+++ b/components/servo_tracing/Cargo.toml
@@ -12,7 +12,7 @@ description.workspace = true
 [dependencies]
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
-syn = { version = "2", features = ["full"] }
+syn = { workspace = true, features = ["full"] }
 
 [lib]
 path = "lib.rs"

--- a/components/storage/Cargo.toml
+++ b/components/storage/Cargo.toml
@@ -22,7 +22,7 @@ malloc_size_of_derive = { workspace = true }
 net_traits = { workspace = true }
 postcard = { workspace = true }
 profile_traits = { workspace = true }
-rusqlite = { version = "0.37", features = ["bundled"] }
+rusqlite = { workspace = true, features = ["bundled"] }
 rustc-hash = { workspace = true }
 sea-query = { workspace = true }
 sea-query-rusqlite = { workspace = true }

--- a/components/webdriver_server/Cargo.toml
+++ b/components/webdriver_server/Cargo.toml
@@ -37,5 +37,5 @@ time = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }
-warp = { version = "0.4.2", features = ["server"] }
+warp = { workspace = true, features = ["server"] }
 webdriver = { workspace = true }


### PR DESCRIPTION
Convert more dependencies to workspace dependencies.

Testing: No tests for Cargo.toml edits.
