### PR TITLE
script: refactor WebGL context creation

### DIFF
--- a/components/script/dom/webgl/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl/webgl2renderingcontext.rs
@@ -30,7 +30,7 @@ use url::Host;
 use webrender_api::ImageKey;
 
 use super::validations::types::TexImageTarget;
-use crate::canvas_context::{CanvasContext, HTMLCanvasElementOrOffscreenCanvas};
+use crate::canvas_context::CanvasContext;
 use crate::dom::bindings::codegen::Bindings::WebGL2RenderingContextBinding::{
     WebGL2RenderingContextConstants as constants, WebGL2RenderingContextMethods,
 };

--- a/components/script/dom/webgl/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl/webgl2renderingcontext.rs
@@ -18,7 +18,7 @@ use js::typedarray::{ArrayBufferView, CreateWith, Float32, Int32Array, Uint32, U
 use pixels::{Alpha, Snapshot};
 use script_bindings::conversions::SafeToJSValConvertible;
 use script_bindings::interfaces::WebGL2RenderingContextHelpers;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::reflect_dom_object_with_cx;
 use servo_base::generic_channel::{self, GenericSharedMemory};
 use servo_canvas_traits::webgl::WebGLError::*;
 use servo_canvas_traits::webgl::{
@@ -30,7 +30,7 @@ use url::Host;
 use webrender_api::ImageKey;
 
 use super::validations::types::TexImageTarget;
-use crate::canvas_context::CanvasContext;
+use crate::canvas_context::{CanvasContext, HTMLCanvasElementOrOffscreenCanvas};
 use crate::dom::bindings::codegen::Bindings::WebGL2RenderingContextBinding::{
     WebGL2RenderingContextConstants as constants, WebGL2RenderingContextMethods,
 };
@@ -44,7 +44,7 @@ use crate::dom::bindings::codegen::UnionTypes::{
 };
 use crate::dom::bindings::error::{ErrorResult, Fallible};
 use crate::dom::bindings::reflector::DomGlobal;
-use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
+use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 #[cfg(feature = "webxr")]
@@ -95,10 +95,9 @@ impl IndexedBinding {
     }
 }
 
-#[dom_struct] // no need to report size here as it is reported as part of WebGLRenderingContext
+#[dom_struct(associated_memory)] // no need to report size here as it is reported as part of WebGLRenderingContext
 pub(crate) struct WebGL2RenderingContext {
-    reflector_: Reflector,
-    base: Dom<WebGLRenderingContext>,
+    base: WebGLRenderingContext,
     occlusion_query: MutNullableDom<WebGLQuery>,
     primitives_query: MutNullableDom<WebGLQuery>,
     samplers: Box<[MutNullableDom<WebGLSampler>]>,
@@ -132,32 +131,37 @@ struct ReadPixelsSizes {
 
 impl WebGL2RenderingContext {
     fn new_inherited(
-        cx: &mut js::context::JSContext,
         window: &Window,
         canvas: &RootedHTMLCanvasElementOrOffscreenCanvas,
         size: Size2D<u32>,
         attrs: GLContextAttributes,
     ) -> Option<WebGL2RenderingContext> {
-        let base =
-            WebGLRenderingContext::new(cx, window, canvas, WebGLVersion::WebGL2, size, attrs)?;
+        let ctx_data =
+            WebGLRenderingContext::create_context_data(window, WebGLVersion::WebGL2, size, attrs)
+                .ok()?;
 
-        let samplers = (0..base.limits().max_combined_texture_image_units)
+        let limits = &ctx_data.limits;
+        let samplers = (0..limits.max_combined_texture_image_units)
             .map(|_| Default::default())
             .collect::<Vec<_>>()
             .into();
-        let indexed_uniform_buffer_bindings = (0..base.limits().max_uniform_buffer_bindings)
+        let indexed_uniform_buffer_bindings = (0..limits.max_uniform_buffer_bindings)
             .map(|_| IndexedBinding::new())
             .collect::<Vec<_>>()
             .into();
-        let indexed_transform_feedback_buffer_bindings =
-            (0..base.limits().max_transform_feedback_separate_attribs)
-                .map(|_| IndexedBinding::new())
-                .collect::<Vec<_>>()
-                .into();
+        let indexed_transform_feedback_buffer_bindings = (0..limits
+            .max_transform_feedback_separate_attribs)
+            .map(|_| IndexedBinding::new())
+            .collect::<Vec<_>>()
+            .into();
 
         Some(WebGL2RenderingContext {
-            reflector_: Reflector::new(),
-            base: Dom::from_ref(&*base),
+            base: WebGLRenderingContext::new_inherited(
+                canvas,
+                WebGLVersion::WebGL2,
+                size,
+                ctx_data,
+            ),
             occlusion_query: MutNullableDom::new(None),
             primitives_query: MutNullableDom::new(None),
             samplers,
@@ -186,7 +190,7 @@ impl WebGL2RenderingContext {
         size: Size2D<u32>,
         attrs: GLContextAttributes,
     ) -> Option<DomRoot<WebGL2RenderingContext>> {
-        WebGL2RenderingContext::new_inherited(cx, window, canvas, size, attrs)
+        WebGL2RenderingContext::new_inherited(window, canvas, size, attrs)
             .map(|ctx| reflect_dom_object_with_cx(Box::new(ctx), window, cx))
     }
 
@@ -321,7 +325,7 @@ impl WebGL2RenderingContext {
     }
 
     pub(crate) fn base_context(&self) -> DomRoot<WebGLRenderingContext> {
-        DomRoot::from_ref(&*self.base)
+        DomRoot::from_ref(&self.base)
     }
 
     fn bound_buffer(&self, target: u32) -> WebGLResult<Option<DomRoot<WebGLBuffer>>> {
@@ -2891,7 +2895,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
             return retval.set(NullValue())
         );
 
-        let triple = (&*self.base, program.id(), location.id());
+        let triple = (&self.base, program.id(), location.id());
 
         match location.type_() {
             constants::UNSIGNED_INT => retval.set(UInt32Value(uniform_get(

--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -263,7 +263,6 @@ impl WebGLRenderingContext {
         size: Size2D<u32>,
         ctx_data: WebGLCreateContextResult,
     ) -> WebGLRenderingContext {
-        let canvas = HTMLCanvasElementOrOffscreenCanvas::from(canvas);
         let max_combined_texture_image_units = ctx_data.limits.max_combined_texture_image_units;
         let max_vertex_attribs = ctx_data.limits.max_vertex_attribs as usize;
         WebGLRenderingContext {
@@ -271,7 +270,7 @@ impl WebGLRenderingContext {
             webgl_version,
             glsl_version: ctx_data.glsl_version,
             limits: ctx_data.limits,
-            canvas,
+            canvas: HTMLCanvasElementOrOffscreenCanvas::from(canvas),
             last_error: Cell::new(None),
             texture_packing_alignment: Cell::new(4),
             texture_unpacking_settings: Cell::new(TextureUnpacking::CONVERT_COLORSPACE),
@@ -307,7 +306,6 @@ impl WebGLRenderingContext {
         }
     }
 
-    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new(
         cx: &mut js::context::JSContext,
         window: &Window,

--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -30,9 +30,9 @@ use servo_base::{Epoch, generic_channel};
 use servo_canvas_traits::webgl::WebGLError::*;
 use servo_canvas_traits::webgl::{
     AlphaTreatment, GLContextAttributes, GLLimits, GlType, Parameter, SizedDataType, TexDataType,
-    TexFormat, TexParameter, WebGLCommand, WebGLCommandBacktrace, WebGLContextId, WebGLError,
-    WebGLFramebufferBindingRequest, WebGLMsg, WebGLMsgSender, WebGLProgramId, WebGLResult,
-    WebGLSLVersion, WebGLVersion, YAxisTreatment, webgl_channel,
+    TexFormat, TexParameter, WebGLCommand, WebGLCommandBacktrace, WebGLContextId,
+    WebGLCreateContextResult, WebGLError, WebGLFramebufferBindingRequest, WebGLMsg, WebGLMsgSender,
+    WebGLProgramId, WebGLResult, WebGLSLVersion, WebGLVersion, YAxisTreatment, webgl_channel,
 };
 use servo_config::pref;
 use webrender_api::ImageKey;
@@ -229,14 +229,12 @@ pub(crate) struct WebGLRenderingContext {
 }
 
 impl WebGLRenderingContext {
-    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
-    pub(crate) fn new_inherited(
+    pub(crate) fn create_context_data(
         window: &Window,
-        canvas: HTMLCanvasElementOrOffscreenCanvas,
         webgl_version: WebGLVersion,
         size: Size2D<u32>,
         attrs: GLContextAttributes,
-    ) -> Result<WebGLRenderingContext, String> {
+    ) -> Result<WebGLCreateContextResult, String> {
         if pref!(webgl_testing_context_creation_error) {
             return Err("WebGL context creation error forced by pref `webgl.testing.context_creation_error`".into());
         }
@@ -256,51 +254,57 @@ impl WebGLRenderingContext {
                 sender,
             ))
             .unwrap();
-        let result = receiver.recv().unwrap();
+        receiver.recv().unwrap()
+    }
 
-        result.map(|ctx_data| {
-            let max_combined_texture_image_units = ctx_data.limits.max_combined_texture_image_units;
-            let max_vertex_attribs = ctx_data.limits.max_vertex_attribs as usize;
-            Self {
-                reflector_: Reflector::new(),
+    pub(crate) fn new_inherited(
+        canvas: &RootedHTMLCanvasElementOrOffscreenCanvas,
+        webgl_version: WebGLVersion,
+        size: Size2D<u32>,
+        ctx_data: WebGLCreateContextResult,
+    ) -> WebGLRenderingContext {
+        let canvas = HTMLCanvasElementOrOffscreenCanvas::from(canvas);
+        let max_combined_texture_image_units = ctx_data.limits.max_combined_texture_image_units;
+        let max_vertex_attribs = ctx_data.limits.max_vertex_attribs as usize;
+        WebGLRenderingContext {
+            reflector_: Reflector::new(),
+            webgl_version,
+            glsl_version: ctx_data.glsl_version,
+            limits: ctx_data.limits,
+            canvas,
+            last_error: Cell::new(None),
+            texture_packing_alignment: Cell::new(4),
+            texture_unpacking_settings: Cell::new(TextureUnpacking::CONVERT_COLORSPACE),
+            texture_unpacking_alignment: Cell::new(4),
+            bound_draw_framebuffer: MutNullableDom::new(None),
+            bound_read_framebuffer: MutNullableDom::new(None),
+            bound_buffer_array: MutNullableDom::new(None),
+            bound_renderbuffer: MutNullableDom::new(None),
+            current_program: MutNullableDom::new(None),
+            current_vertex_attribs: DomRefCell::new(
+                vec![VertexAttrib::Float(0f32, 0f32, 0f32, 1f32); max_vertex_attribs].into(),
+            ),
+            current_scissor: Cell::new((0, 0, size.width, size.height)),
+            // FIXME(#21718) The backend is allowed to choose a size smaller than
+            // what was requested
+            size: Cell::new(size),
+            current_clear_color: Cell::new((0.0, 0.0, 0.0, 0.0)),
+            extension_manager: WebGLExtensions::new(
                 webgl_version,
-                glsl_version: ctx_data.glsl_version,
-                limits: ctx_data.limits,
-                canvas,
-                last_error: Cell::new(None),
-                texture_packing_alignment: Cell::new(4),
-                texture_unpacking_settings: Cell::new(TextureUnpacking::CONVERT_COLORSPACE),
-                texture_unpacking_alignment: Cell::new(4),
-                bound_draw_framebuffer: MutNullableDom::new(None),
-                bound_read_framebuffer: MutNullableDom::new(None),
-                bound_buffer_array: MutNullableDom::new(None),
-                bound_renderbuffer: MutNullableDom::new(None),
-                current_program: MutNullableDom::new(None),
-                current_vertex_attribs: DomRefCell::new(
-                    vec![VertexAttrib::Float(0f32, 0f32, 0f32, 1f32); max_vertex_attribs].into(),
-                ),
-                current_scissor: Cell::new((0, 0, size.width, size.height)),
-                // FIXME(#21718) The backend is allowed to choose a size smaller than
-                // what was requested
-                size: Cell::new(size),
-                current_clear_color: Cell::new((0.0, 0.0, 0.0, 0.0)),
-                extension_manager: WebGLExtensions::new(
-                    webgl_version,
-                    ctx_data.api_type,
-                    ctx_data.glsl_version,
-                ),
-                capabilities: Default::default(),
-                default_vao: Default::default(),
-                current_vao: Default::default(),
-                default_vao_webgl2: Default::default(),
-                current_vao_webgl2: Default::default(),
-                textures: Textures::new(max_combined_texture_image_units),
-                api_type: ctx_data.api_type,
-                droppable: DroppableWebGLRenderingContext {
-                    webgl_sender: ctx_data.sender,
-                },
-            }
-        })
+                ctx_data.api_type,
+                ctx_data.glsl_version,
+            ),
+            capabilities: Default::default(),
+            default_vao: Default::default(),
+            current_vao: Default::default(),
+            default_vao_webgl2: Default::default(),
+            current_vao_webgl2: Default::default(),
+            textures: Textures::new(max_combined_texture_image_units),
+            api_type: ctx_data.api_type,
+            droppable: DroppableWebGLRenderingContext {
+                webgl_sender: ctx_data.sender,
+            },
+        }
     }
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
@@ -312,14 +316,8 @@ impl WebGLRenderingContext {
         size: Size2D<u32>,
         attrs: GLContextAttributes,
     ) -> Option<DomRoot<WebGLRenderingContext>> {
-        match WebGLRenderingContext::new_inherited(
-            window,
-            HTMLCanvasElementOrOffscreenCanvas::from(canvas),
-            webgl_version,
-            size,
-            attrs,
-        ) {
-            Ok(ctx) => Some(reflect_dom_object_with_cx(Box::new(ctx), window, cx)),
+        let ctx_data = match Self::create_context_data(window, webgl_version, size, attrs) {
+            Ok(data) => data,
             Err(msg) => {
                 error!("Couldn't create WebGLRenderingContext: {}", msg);
                 let event = WebGLContextEvent::new(
@@ -338,9 +336,20 @@ impl WebGLRenderingContext {
                         event.upcast::<Event>().fire(cx, canvas.upcast());
                     },
                 }
-                None
+                return None;
             },
-        }
+        };
+
+        Some(reflect_dom_object_with_cx(
+            Box::new(WebGLRenderingContext::new_inherited(
+                canvas,
+                webgl_version,
+                size,
+                ctx_data,
+            )),
+            window,
+            cx,
+        ))
     }
 
     pub(crate) fn set_image_key(&self, image_key: ImageKey) {

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -2708,6 +2708,8 @@ class CGAssertInheritance(CGThing):
             #
             # FIXME *RenderingContext2D should use Inline
             parentName = "crate::dom::canvasrenderingcontext2d::CanvasRenderingContext2D"
+        if selfName == "WebGL2RenderingContext":
+            parentName = "crate::dom::webgl::webglrenderingcontext::WebGLRenderingContext"
         args = {
             "parentName": parentName,
             "selfName": selfName,


### PR DESCRIPTION
This fix embeds `WebGLRenderingContext` directly as the first field of the struct instead of behind a dom pointer so both views share a single reflector the context creation logic was also extracted into a shared `create_context_data` method that both constructors call, with `new_inherited` now receiving pre-computed values instead of creating the context itself 

The `WebIDL` was updated to declare `WebGL2RenderingContext : WebGLRenderingContext` to match the new struct layout and browser prototype chain behavior.

Fixes: #45066 
