### PR TITLE
Remove all instances of `rustfmt::skip`

### DIFF
--- a/components/script/dom/webgl/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl/webgl2renderingcontext.rs
@@ -3826,26 +3826,23 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.12>
-    #[rustfmt::skip]
     fn DeleteQuery(&self, query: Option<&WebGLQuery>) {
         if let Some(query) = query {
             handle_potential_webgl_error!(self.base, self.base.validate_ownership(query), return);
 
             if let Some(query_target) = query.target() {
                 let slot = match query_target {
-                    constants::ANY_SAMPLES_PASSED |
-                    constants::ANY_SAMPLES_PASSED_CONSERVATIVE => {
+                    constants::ANY_SAMPLES_PASSED | constants::ANY_SAMPLES_PASSED_CONSERVATIVE => {
                         &self.occlusion_query
                     },
-                    constants::TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN => {
-                        &self.primitives_query
-                    },
+                    constants::TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN => &self.primitives_query,
                     _ => unreachable!(),
                 };
-                if let Some(stored_query) = slot.get()
-                    && stored_query.target() == query.target() {
-                        slot.set(None);
-                    }
+                if let Some(stored_query) = slot.get() &&
+                    stored_query.target() == query.target()
+                {
+                    slot.set(None);
+                }
             }
 
             query.delete(Operation::Infallible);
@@ -3887,18 +3884,14 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.12>
-    #[rustfmt::skip]
     fn BeginQuery(&self, target: u32, query: &WebGLQuery) {
         handle_potential_webgl_error!(self.base, self.base.validate_ownership(query), return);
 
         let active_query = match target {
-            constants::ANY_SAMPLES_PASSED |
-            constants::ANY_SAMPLES_PASSED_CONSERVATIVE => {
+            constants::ANY_SAMPLES_PASSED | constants::ANY_SAMPLES_PASSED_CONSERVATIVE => {
                 &self.occlusion_query
             },
-            constants::TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN => {
-                &self.primitives_query
-            },
+            constants::TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN => &self.primitives_query,
             _ => {
                 self.base.webgl_error(InvalidEnum);
                 return;
@@ -3916,16 +3909,12 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.12>
-    #[rustfmt::skip]
     fn EndQuery(&self, target: u32) {
         let active_query = match target {
-            constants::ANY_SAMPLES_PASSED |
-            constants::ANY_SAMPLES_PASSED_CONSERVATIVE => {
+            constants::ANY_SAMPLES_PASSED | constants::ANY_SAMPLES_PASSED_CONSERVATIVE => {
                 self.occlusion_query.take()
             },
-            constants::TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN => {
-                self.primitives_query.take()
-            },
+            constants::TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN => self.primitives_query.take(),
             _ => {
                 self.base.webgl_error(InvalidEnum);
                 return;
@@ -3943,35 +3932,37 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.12>
-    #[rustfmt::skip]
     fn GetQuery(&self, target: u32, pname: u32) -> Option<DomRoot<WebGLQuery>> {
         if pname != constants::CURRENT_QUERY {
             self.base.webgl_error(InvalidEnum);
             return None;
         }
         let active_query = match target {
-            constants::ANY_SAMPLES_PASSED |
-            constants::ANY_SAMPLES_PASSED_CONSERVATIVE => {
+            constants::ANY_SAMPLES_PASSED | constants::ANY_SAMPLES_PASSED_CONSERVATIVE => {
                 self.occlusion_query.get()
             },
-            constants::TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN => {
-                self.primitives_query.get()
-            },
+            constants::TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN => self.primitives_query.get(),
             _ => {
                 self.base.webgl_error(InvalidEnum);
                 None
             },
         };
-        if let Some(query) = active_query.as_ref()
-            && query.target() != Some(target) {
-                return None;
-            }
+        if let Some(query) = active_query.as_ref() &&
+            query.target() != Some(target)
+        {
+            return None;
+        }
         active_query
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.12>
-    #[rustfmt::skip]
-    fn GetQueryParameter(&self, _cx: JSContext, query: &WebGLQuery, pname: u32, mut retval: MutableHandleValue) {
+    fn GetQueryParameter(
+        &self,
+        _cx: JSContext,
+        query: &WebGLQuery,
+        pname: u32,
+        mut retval: MutableHandleValue,
+    ) {
         handle_potential_webgl_error!(
             self.base,
             self.base.validate_ownership(query),

--- a/components/script/dom/webgl/webglquery.rs
+++ b/components/script/dom/webgl/webglquery.rs
@@ -174,7 +174,6 @@ impl WebGLQuery {
         self.query_result_available.set(Some(is_available));
     }
 
-    #[rustfmt::skip]
     pub(crate) fn get_parameter(
         &self,
         context: &WebGLRenderingContext,
@@ -184,8 +183,7 @@ impl WebGLQuery {
             return Err(InvalidOperation);
         }
         match pname {
-            constants::QUERY_RESULT |
-            constants::QUERY_RESULT_AVAILABLE => {},
+            constants::QUERY_RESULT | constants::QUERY_RESULT_AVAILABLE => {},
             _ => return Err(InvalidEnum),
         }
 

--- a/components/shared/net/response.rs
+++ b/components/shared/net/response.rs
@@ -245,13 +245,11 @@ impl Response {
 
     /// Convert to a filtered response, of type `filter_type`.
     /// Do not use with type Error or Default
-    #[rustfmt::skip]
     pub fn to_filtered(self, filter_type: ResponseType) -> Response {
-        match filter_type {
-            ResponseType::Default |
-            ResponseType::Error(..) => panic!(),
-            _ => (),
-        }
+        assert!(!matches!(
+            filter_type,
+            ResponseType::Default | ResponseType::Error(..)
+        ));
 
         let old_response = self.to_actual();
 
@@ -266,27 +264,35 @@ impl Response {
         response.response_type = filter_type;
 
         match response.response_type {
-            ResponseType::Default |
-            ResponseType::Error(..) => unreachable!(),
+            ResponseType::Default | ResponseType::Error(..) => unreachable!(),
 
             ResponseType::Basic => {
-                let headers = old_headers.iter().filter(|(name, _)| {
-                    !matches!(&*name.as_str().to_ascii_lowercase(), "set-cookie" | "set-cookie2")
-                }).map(|(n, v)| (n.clone(), v.clone())).collect();
+                let headers = old_headers
+                    .iter()
+                    .filter(|(name, _)| {
+                        !matches!(
+                            &*name.as_str().to_ascii_lowercase(),
+                            "set-cookie" | "set-cookie2"
+                        )
+                    })
+                    .map(|(n, v)| (n.clone(), v.clone()))
+                    .collect();
                 response.headers = headers;
             },
 
             ResponseType::Cors => {
-                let headers = old_headers.iter().filter(|(name, _)| {
-                    match &*name.as_str().to_ascii_lowercase() {
-                        "cache-control" | "content-language" | "content-length" | "content-type" |
-                        "expires" | "last-modified" | "pragma" => true,
+                let headers = old_headers
+                    .iter()
+                    .filter(|(name, _)| match &*name.as_str().to_ascii_lowercase() {
+                        "cache-control" | "content-language" | "content-length" |
+                        "content-type" | "expires" | "last-modified" | "pragma" => true,
                         "set-cookie" | "set-cookie2" => false,
-                        header => {
-                            exposed_headers.iter().any(|h| *header == h.as_str().to_ascii_lowercase())
-                        }
-                    }
-                }).map(|(n, v)| (n.clone(), v.clone())).collect();
+                        header => exposed_headers
+                            .iter()
+                            .any(|h| *header == h.as_str().to_ascii_lowercase()),
+                    })
+                    .map(|(n, v)| (n.clone(), v.clone()))
+                    .collect();
                 response.headers = headers;
             },
 

--- a/components/webxr/glwindow/mod.rs
+++ b/components/webxr/glwindow/mod.rs
@@ -589,17 +589,13 @@ impl GlWindowDevice {
         let viewport_size = self.viewport_size();
         let aspect = viewport_size.width as f32 / viewport_size.height as f32;
 
-        // Dear rustfmt, This is a 4x4 matrix, please leave it alone. Best, ajeffrey.
-        {
-            #[rustfmt::skip]
-            // Sigh, row-major vs column-major
-            return Transform3D::new(
-                f / aspect, 0.0, 0.0,                   0.0,
-                0.0,        f,   0.0,                   0.0,
-                0.0,        0.0, (far + near) * nf,     -1.0,
-                0.0,        0.0, 2.0 * far * near * nf, 0.0,
-            );
-        }
+        // Sigh, row-major vs column-major
+        Transform3D::from_arrays([
+            [f / aspect, 0.0, 0.0, 0.0],
+            [0.0, f, 0.0, 0.0],
+            [0.0, 0.0, (far + near) * nf, -1.0],
+            [0.0, 0.0, 2.0 * far * near * nf, 0.0],
+        ])
     }
 }
 

--- a/tests/unit/malloc_size_of/lib.rs
+++ b/tests/unit/malloc_size_of/lib.rs
@@ -20,7 +20,6 @@ fn main() {
 */
 pub fn imports_ok() {}
 
-#[rustfmt::skip]
 pub mod does_not_impl_malloc_size_of {
     /**
     ```compile_fail,E0277
@@ -63,7 +62,6 @@ pub mod does_not_impl_malloc_size_of {
     pub fn rc() {}
 }
 
-#[rustfmt::skip]
 pub mod does_not_impl_malloc_shallow_size_of {
     /**
     ```compile_fail,E0277


### PR DESCRIPTION
In general, this isn't necessary. In one case it was used to call
`Transform3D::new` with aligned formatting. Unfortuantely this can't be
preserved exactly how we want, but `Transform3D::from_arrays` gets us
most of the way there.

Testing: This should not change behavior so is covered by existing tests.
Fixes: #45086.
