### PR TITLE
script_bindings: Pass `&mut JSContext` to dictionary constructors

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -47,7 +47,7 @@ use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::readablestream::{ReadableStream, get_read_promise_bytes, get_read_promise_done};
 use crate::dom::urlsearchparams::URLSearchParams;
 use crate::mime_multipart::{Node, read_multipart_body};
-use crate::realms::{InRealm, enter_auto_realm};
+use crate::realms::enter_auto_realm;
 use crate::script_runtime::CanGc;
 use crate::task_source::SendableTaskSource;
 
@@ -319,8 +319,7 @@ impl js::gc::Rootable for TransmitBodyPromiseHandler {}
 impl Callback for TransmitBodyPromiseHandler {
     /// Step 5 of <https://fetch.spec.whatwg.org/#concept-request-transmit-body>
     fn callback(&self, cx: &mut CurrentRealm, v: HandleValue) {
-        let _realm = InRealm::Already(&cx.into());
-        let is_done = match get_read_promise_done(cx.into(), &v, CanGc::from_cx(cx)) {
+        let is_done = match get_read_promise_done(cx, &v) {
             Ok(is_done) => is_done,
             Err(_) => {
                 // Step 5.5, the "otherwise" steps.
@@ -337,7 +336,7 @@ impl Callback for TransmitBodyPromiseHandler {
             return self.stream.stop_reading(cx);
         }
 
-        let chunk = match get_read_promise_bytes(cx.into(), &v, CanGc::from_cx(cx)) {
+        let chunk = match get_read_promise_bytes(cx, &v) {
             Ok(chunk) => chunk,
             Err(_) => {
                 // Step 5.5, the "otherwise" steps.

--- a/components/script/dom/bluetooth/bluetooth.rs
+++ b/components/script/dom/bluetooth/bluetooth.rs
@@ -635,7 +635,7 @@ impl PermissionAlgorithm for Bluetooth {
         property
             .handle_mut()
             .set(ObjectValue(permission_descriptor_obj));
-        match BluetoothPermissionDescriptor::new(cx.into(), property.handle(), CanGc::from_cx(cx)) {
+        match BluetoothPermissionDescriptor::new(cx, property.handle()) {
             Ok(ConversionResult::Success(descriptor)) => Ok(descriptor),
             Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into_owned())),
             Err(_) => Err(Error::Type(BT_DESC_CONVERSION_ERROR.into())),

--- a/components/script/dom/canvas/offscreencanvas.rs
+++ b/components/script/dom/canvas/offscreencanvas.rs
@@ -108,7 +108,7 @@ impl OffscreenCanvas {
         options: HandleValue,
     ) -> Option<GLContextAttributes> {
         unsafe {
-            match WebGLContextAttributes::new(cx.into(), options, CanGc::from_cx(cx)) {
+            match WebGLContextAttributes::new(cx, options) {
                 Ok(ConversionResult::Success(attrs)) => Some(attrs.convert()),
                 Ok(ConversionResult::Failure(error)) => {
                     throw_type_error(cx.raw_cx(), &error);

--- a/components/script/dom/html/htmlcanvaselement.rs
+++ b/components/script/dom/html/htmlcanvaselement.rs
@@ -362,7 +362,7 @@ impl HTMLCanvasElement {
         options: HandleValue,
     ) -> Option<GLContextAttributes> {
         unsafe {
-            match WebGLContextAttributes::new(cx.into(), options, CanGc::from_cx(cx)) {
+            match WebGLContextAttributes::new(cx, options) {
                 Ok(ConversionResult::Success(attrs)) => Some(attrs.convert()),
                 Ok(ConversionResult::Failure(error)) => {
                     throw_type_error(cx.raw_cx(), &error);

--- a/components/script/dom/permissions.rs
+++ b/components/script/dom/permissions.rs
@@ -236,7 +236,7 @@ impl PermissionAlgorithm for Permissions {
         property
             .handle_mut()
             .set(ObjectValue(permission_descriptor_obj));
-        match PermissionDescriptor::new(cx.into(), property.handle(), CanGc::from_cx(cx)) {
+        match PermissionDescriptor::new(cx, property.handle()) {
             Ok(ConversionResult::Success(descriptor)) => Ok(descriptor),
             Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into_owned())),
             Err(_) => Err(Error::JSFailed),

--- a/components/script/dom/stream/bytelengthqueuingstrategy.rs
+++ b/components/script/dom/stream/bytelengthqueuingstrategy.rs
@@ -88,10 +88,7 @@ impl ByteLengthQueuingStrategyMethods<crate::DomTypeHolder> for ByteLengthQueuin
 
 /// <https://streams.spec.whatwg.org/#byte-length-queuing-strategy-size-function>
 #[expect(unsafe_code)]
-pub(crate) fn byte_length_queuing_strategy_size(
-    cx: &mut js::context::JSContext,
-    args: CallArgs,
-) -> bool {
+fn byte_length_queuing_strategy_size(cx: &mut js::context::JSContext, args: CallArgs) -> bool {
     // Step 1. Let steps be the following steps, given chunk:
     // Step 1.1. Return ? GetV(chunk, "byteLength").
     let chunk = unsafe { HandleValue::from_raw(args.get(0)) };
@@ -118,15 +115,9 @@ pub(crate) fn byte_length_queuing_strategy_size(
     rooted!(&in(cx) let object = chunk.to_object());
 
     // Return ? O.[[Get]](P, V).
-    match unsafe {
-        get_dictionary_property(
-            cx.raw_cx(),
-            object.handle(),
-            c"byteLength",
-            MutableHandleValue::from_raw(args.rval()),
-            CanGc::from_cx(cx),
-        )
-    } {
+    match get_dictionary_property(cx, object.handle(), c"byteLength", unsafe {
+        MutableHandleValue::from_raw(args.rval())
+    }) {
         Ok(true) => true,
         Ok(false) => {
             args.rval().set(UndefinedValue());

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -12,6 +12,7 @@ use servo_base::id::{MessagePortId, MessagePortIndex};
 use servo_constellation_traits::MessagePortImpl;
 use dom_struct::dom_struct;
 use js::context::JSContext;
+use js::conversions::{FromJSValConvertible, ToJSValConvertible};
 use js::jsapi::{Heap, JSObject};
 use js::jsval::{JSVal, ObjectValue, UndefinedValue};
 use js::realm::CurrentRealm;
@@ -21,7 +22,6 @@ use js::rust::{
 };
 use js::typedarray::ArrayBufferViewU8;
 use rustc_hash::FxHashMap;
-use script_bindings::conversions::SafeToJSValConvertible;
 
 use crate::dom::bindings::codegen::Bindings::QueuingStrategyBinding::QueuingStrategy;
 use crate::dom::bindings::codegen::Bindings::ReadableStreamBinding::{
@@ -37,7 +37,7 @@ use crate::dom::abortsignal::{AbortAlgorithm, AbortSignal};
 use crate::dom::bindings::codegen::Bindings::ReadableStreamDefaultReaderBinding::ReadableStreamDefaultReaderMethods;
 use crate::dom::bindings::codegen::Bindings::ReadableStreamDefaultControllerBinding::ReadableStreamDefaultController_Binding::ReadableStreamDefaultControllerMethods;
 use crate::dom::bindings::codegen::Bindings::UnderlyingSourceBinding::UnderlyingSource as JsUnderlyingSource;
-use crate::dom::bindings::conversions::{ConversionBehavior, ConversionResult, SafeFromJSValConvertible};
+use crate::dom::bindings::conversions::{ConversionBehavior, ConversionResult};
 use crate::dom::bindings::error::{Error, ErrorToJsval, Fallible};
 use crate::dom::bindings::codegen::GenericBindings::WritableStreamDefaultWriterBinding::WritableStreamDefaultWriter_Binding::WritableStreamDefaultWriterMethods;
 use crate::dom::stream::writablestream::WritableStream;
@@ -63,7 +63,7 @@ use crate::dom::stream::writablestreamdefaultwriter::WritableStreamDefaultWriter
 use script_bindings::codegen::GenericBindings::MessagePortBinding::MessagePortMethods;
 use crate::dom::messageport::MessagePort;
 use crate::realms::{enter_auto_realm};
-use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
+use crate::script_runtime::CanGc;
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::bindings::transferable::Transferable;
 use crate::dom::bindings::structuredclone::StructuredData;
@@ -1571,8 +1571,7 @@ impl ReadableStream {
         if self.is_errored() {
             let promise = Promise::new2(cx, global);
             rooted!(&in(cx) let mut rval = UndefinedValue());
-            self.stored_error
-                .safe_to_jsval(cx.into(), rval.handle_mut(), CanGc::from_cx(cx));
+            self.stored_error.safe_to_jsval(cx, rval.handle_mut());
             promise.reject_native(&rval.handle(), CanGc::from_cx(cx));
             return promise;
         }
@@ -2294,13 +2293,8 @@ pub(crate) fn get_type_and_value_from_message(
         .expect("Getting the value should not fail.");
 
     // Assert: type is a String.
-    let result = DOMString::safe_from_jsval(
-        cx.into(),
-        type_.handle(),
-        StringificationBehavior::Empty,
-        CanGc::from_cx(cx),
-    )
-    .expect("The type of the message should be a string");
+    let result = DOMString::safe_from_jsval(cx, type_.handle(), StringificationBehavior::Empty)
+        .expect("The type of the message should be a string");
     let ConversionResult::Success(type_string) = result else {
         unreachable!("The type of the message should be a string");
     };
@@ -2371,7 +2365,7 @@ impl CrossRealmTransformReadable {
         // Let error be a new "DataCloneError" DOMException.
         let error = DOMException::new(global, DOMErrorName::DataCloneError, CanGc::from_cx(cx));
         rooted!(&in(cx) let mut rooted_error = UndefinedValue());
-        error.safe_to_jsval(cx.into(), rooted_error.handle_mut(), CanGc::from_cx(cx));
+        error.safe_to_jsval(cx, rooted_error.handle_mut());
 
         // Perform ! CrossRealmTransformSendError(port, error).
         port.cross_realm_transform_send_error(cx, rooted_error.handle());
@@ -2396,7 +2390,7 @@ pub(crate) fn get_read_promise_done(
     rooted!(&in(cx) let object = v.to_object());
     rooted!(&in(cx) let mut done = UndefinedValue());
     match get_dictionary_property(cx, object.handle(), c"done", done.handle_mut()) {
-        Ok(true) => match bool::safe_from_jsval(cx.into(), done.handle(), (), CanGc::from_cx(cx)) {
+        Ok(true) => match bool::safe_from_jsval(cx, done.handle(), ()) {
             Ok(ConversionResult::Success(val)) => Ok(val),
             Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into_owned())),
             _ => Err(Error::Type(c"Unknown format for done property.".to_owned())),
@@ -2421,12 +2415,7 @@ pub(crate) fn get_read_promise_bytes(
     rooted!(&in(cx) let mut bytes = UndefinedValue());
     match get_dictionary_property(cx, object.handle(), c"value", bytes.handle_mut()) {
         Ok(true) => {
-            match Vec::<u8>::safe_from_jsval(
-                cx.into(),
-                bytes.handle(),
-                ConversionBehavior::EnforceRange,
-                CanGc::from_cx(cx),
-            ) {
+            match Vec::<u8>::safe_from_jsval(cx, bytes.handle(), ConversionBehavior::EnforceRange) {
                 Ok(ConversionResult::Success(val)) => Ok(val),
                 Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into_owned())),
                 _ => Err(Error::Type(c"Unknown format for bytes read.".to_owned())),
@@ -2441,11 +2430,10 @@ pub(crate) fn get_read_promise_bytes(
 /// This mirrors the conversion used inside `get_read_promise_bytes`,
 /// but operates on the raw chunk (no `{ value, done }` wrapper).
 pub(crate) fn bytes_from_chunk_jsval(
-    cx: SafeJSContext,
+    cx: &mut JSContext,
     chunk: &RootedTraceableBox<Heap<JSVal>>,
-    can_gc: CanGc,
 ) -> Result<Vec<u8>, Error> {
-    match Vec::<u8>::safe_from_jsval(cx, chunk.handle(), ConversionBehavior::EnforceRange, can_gc) {
+    match Vec::<u8>::safe_from_jsval(cx, chunk.handle(), ConversionBehavior::EnforceRange) {
         Ok(ConversionResult::Success(vec)) => Ok(vec),
         Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into_owned())),
         _ => Err(Error::Type(c"Unknown format for bytes read.".to_owned())),

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -250,8 +250,7 @@ impl Callback for PipeTo {
                 // If dest.[[state]] is "writable",
                 // and ! WritableStreamCloseQueuedOrInFlight(dest) is false,
                 if dest.is_writable() && !dest.close_queued_or_in_flight() {
-                    let Ok(done) = get_read_promise_done(cx.into(), &result, CanGc::from_cx(cx))
-                    else {
+                    let Ok(done) = get_read_promise_done(cx, &result) else {
                         // This is the case that the microtask ran in reaction
                         // to the closed promise of the reader,
                         // so we should wait for subsequent chunks,
@@ -417,7 +416,6 @@ impl PipeTo {
 
     /// Try to write a chunk using the jsval, and returns wether it succeeded
     // It will fail if it is the last `done` chunk, or if it is not a chunk at all.
-    #[expect(unsafe_code)]
     fn write_chunk(
         &self,
         cx: &mut JSContext,
@@ -427,16 +425,9 @@ impl PipeTo {
         if chunk.is_object() {
             rooted!(&in(cx) let object = chunk.to_object());
             rooted!(&in(cx) let mut bytes = UndefinedValue());
-            let has_value = unsafe {
-                get_dictionary_property(
-                    cx.raw_cx(),
-                    object.handle(),
-                    c"value",
-                    bytes.handle_mut(),
-                    CanGc::from_cx(cx),
-                )
-                .expect("Chunk should have a value.")
-            };
+            let has_value =
+                get_dictionary_property(cx, object.handle(), c"value", bytes.handle_mut())
+                    .expect("Chunk should have a value.");
             if has_value {
                 // Write the chunk.
                 let write_promise = self.writer.write(cx, global, bytes.handle());
@@ -2277,15 +2268,13 @@ impl ReadableStreamMethods<crate::DomTypeHolder> for ReadableStream {
     }
 }
 
-#[expect(unsafe_code)]
 /// The initial steps for the message handler for both readable and writable cross realm transforms.
 /// <https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformreadable>
 /// <https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformwritable>
-pub(crate) unsafe fn get_type_and_value_from_message(
-    cx: SafeJSContext,
+pub(crate) fn get_type_and_value_from_message(
+    cx: &mut JSContext,
     data: SafeHandleValue,
     value: SafeMutableHandleValue,
-    can_gc: CanGc,
 ) -> DOMString {
     // Let data be the data of the message.
     // Note: we are passed the data as argument,
@@ -2293,29 +2282,25 @@ pub(crate) unsafe fn get_type_and_value_from_message(
 
     // Assert: data is an Object.
     assert!(data.is_object());
-    rooted!(in(*cx) let data_object = data.to_object());
+    rooted!(&in(cx) let data_object = data.to_object());
 
     // Let type be ! Get(data, "type").
-    rooted!(in(*cx) let mut type_ = UndefinedValue());
-    unsafe {
-        get_dictionary_property(
-            *cx,
-            data_object.handle(),
-            c"type",
-            type_.handle_mut(),
-            can_gc,
-        )
-    }
-    .expect("Getting the type should not fail.");
+    rooted!(&in(cx) let mut type_ = UndefinedValue());
+    get_dictionary_property(cx, data_object.handle(), c"type", type_.handle_mut())
+        .expect("Getting the type should not fail.");
 
     // Let value be ! Get(data, "value").
-    unsafe { get_dictionary_property(*cx, data_object.handle(), c"value", value, can_gc) }
+    get_dictionary_property(cx, data_object.handle(), c"value", value)
         .expect("Getting the value should not fail.");
 
     // Assert: type is a String.
-    let result =
-        DOMString::safe_from_jsval(cx, type_.handle(), StringificationBehavior::Empty, can_gc)
-            .expect("The type of the message should be a string");
+    let result = DOMString::safe_from_jsval(
+        cx.into(),
+        type_.handle(),
+        StringificationBehavior::Empty,
+        CanGc::from_cx(cx),
+    )
+    .expect("The type of the message should be a string");
     let ConversionResult::Success(type_string) = result else {
         unreachable!("The type of the message should be a string");
     };
@@ -2338,7 +2323,6 @@ pub(crate) struct CrossRealmTransformReadable {
 impl CrossRealmTransformReadable {
     /// <https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformreadable>
     /// Add a handler for port’s message event with the following steps:
-    #[expect(unsafe_code)]
     pub(crate) fn handle_message(
         &self,
         cx: &mut CurrentRealm,
@@ -2347,14 +2331,7 @@ impl CrossRealmTransformReadable {
         message: SafeHandleValue,
     ) {
         rooted!(&in(cx) let mut value = UndefinedValue());
-        let type_string = unsafe {
-            get_type_and_value_from_message(
-                cx.into(),
-                message,
-                value.handle_mut(),
-                CanGc::from_cx(cx),
-            )
-        };
+        let type_string = get_type_and_value_from_message(cx, message, value.handle_mut());
 
         // If type is "chunk",
         if type_string == "chunk" {
@@ -2407,62 +2384,56 @@ impl CrossRealmTransformReadable {
     }
 }
 
-#[expect(unsafe_code)]
 /// Get the `done` property of an object that a read promise resolved to.
 pub(crate) fn get_read_promise_done(
-    cx: SafeJSContext,
+    cx: &mut JSContext,
     v: &SafeHandleValue,
-    can_gc: CanGc,
 ) -> Result<bool, Error> {
     if !v.is_object() {
         return Err(Error::Type(c"Unknown format for done property.".to_owned()));
     }
-    unsafe {
-        rooted!(in(*cx) let object = v.to_object());
-        rooted!(in(*cx) let mut done = UndefinedValue());
-        match get_dictionary_property(*cx, object.handle(), c"done", done.handle_mut(), can_gc) {
-            Ok(true) => match bool::safe_from_jsval(cx, done.handle(), (), can_gc) {
-                Ok(ConversionResult::Success(val)) => Ok(val),
-                Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into_owned())),
-                _ => Err(Error::Type(c"Unknown format for done property.".to_owned())),
-            },
-            Ok(false) => Err(Error::Type(c"Promise has no done property.".to_owned())),
-            Err(()) => Err(Error::JSFailed),
-        }
+
+    rooted!(&in(cx) let object = v.to_object());
+    rooted!(&in(cx) let mut done = UndefinedValue());
+    match get_dictionary_property(cx, object.handle(), c"done", done.handle_mut()) {
+        Ok(true) => match bool::safe_from_jsval(cx.into(), done.handle(), (), CanGc::from_cx(cx)) {
+            Ok(ConversionResult::Success(val)) => Ok(val),
+            Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into_owned())),
+            _ => Err(Error::Type(c"Unknown format for done property.".to_owned())),
+        },
+        Ok(false) => Err(Error::Type(c"Promise has no done property.".to_owned())),
+        Err(()) => Err(Error::JSFailed),
     }
 }
 
-#[expect(unsafe_code)]
 /// Get the `value` property of an object that a read promise resolved to.
 pub(crate) fn get_read_promise_bytes(
-    cx: SafeJSContext,
+    cx: &mut JSContext,
     v: &SafeHandleValue,
-    can_gc: CanGc,
 ) -> Result<Vec<u8>, Error> {
     if !v.is_object() {
         return Err(Error::Type(
             c"Unknown format for for bytes read.".to_owned(),
         ));
     }
-    unsafe {
-        rooted!(in(*cx) let object = v.to_object());
-        rooted!(in(*cx) let mut bytes = UndefinedValue());
-        match get_dictionary_property(*cx, object.handle(), c"value", bytes.handle_mut(), can_gc) {
-            Ok(true) => {
-                match Vec::<u8>::safe_from_jsval(
-                    cx,
-                    bytes.handle(),
-                    ConversionBehavior::EnforceRange,
-                    can_gc,
-                ) {
-                    Ok(ConversionResult::Success(val)) => Ok(val),
-                    Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into_owned())),
-                    _ => Err(Error::Type(c"Unknown format for bytes read.".to_owned())),
-                }
-            },
-            Ok(false) => Err(Error::Type(c"Promise has no value property.".to_owned())),
-            Err(()) => Err(Error::JSFailed),
-        }
+
+    rooted!(&in(cx) let object = v.to_object());
+    rooted!(&in(cx) let mut bytes = UndefinedValue());
+    match get_dictionary_property(cx, object.handle(), c"value", bytes.handle_mut()) {
+        Ok(true) => {
+            match Vec::<u8>::safe_from_jsval(
+                cx.into(),
+                bytes.handle(),
+                ConversionBehavior::EnforceRange,
+                CanGc::from_cx(cx),
+            ) {
+                Ok(ConversionResult::Success(val)) => Ok(val),
+                Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into_owned())),
+                _ => Err(Error::Type(c"Unknown format for bytes read.".to_owned())),
+            }
+        },
+        Ok(false) => Err(Error::Type(c"Promise has no value property.".to_owned())),
+        Err(()) => Err(Error::JSFailed),
     }
 }
 

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -2076,7 +2076,7 @@ impl ReadableStreamMethods<crate::DomTypeHolder> for ReadableStream {
         // converted to an IDL value of type UnderlyingSource.
         let underlying_source_dict = if !underlying_source_obj.is_null() {
             rooted!(&in(cx) let obj_val = ObjectValue(underlying_source_obj.get()));
-            match JsUnderlyingSource::new(cx.into(), obj_val.handle(), CanGc::from_cx(cx)) {
+            match JsUnderlyingSource::new(cx, obj_val.handle()) {
                 Ok(ConversionResult::Success(val)) => val,
                 Ok(ConversionResult::Failure(error)) => {
                     return Err(Error::Type(error.into_owned()));

--- a/components/script/dom/stream/readablestreamdefaultreader.rs
+++ b/components/script/dom/stream/readablestreamdefaultreader.rs
@@ -144,7 +144,7 @@ impl ReadRequest {
                 // Spec: chunk steps, given chunk
                 let global = reader.global();
 
-                match bytes_from_chunk_jsval(cx.into(), &chunk, CanGc::from_cx(cx)) {
+                match bytes_from_chunk_jsval(cx, &chunk) {
                     Ok(vec) => {
                         // Step 2. Append the bytes represented by chunk to bytes.
                         bytes.borrow_mut().extend_from_slice(&vec);

--- a/components/script/dom/stream/transformstream.rs
+++ b/components/script/dom/stream/transformstream.rs
@@ -955,7 +955,7 @@ impl TransformStreamMethods<crate::DomTypeHolder> for TransformStream {
         // converted to an IDL value of type UnderlyingSink.
         let transformer_dict = if !transformer_obj.is_null() {
             rooted!(&in(cx) let obj_val = ObjectValue(transformer_obj.get()));
-            match Transformer::new(cx.into(), obj_val.handle(), CanGc::from_cx(cx)) {
+            match Transformer::new(cx, obj_val.handle()) {
                 Ok(ConversionResult::Success(val)) => val,
                 Ok(ConversionResult::Failure(error)) => {
                     return Err(Error::Type(error.into_owned()));

--- a/components/script/dom/stream/writablestream.rs
+++ b/components/script/dom/stream/writablestream.rs
@@ -1024,7 +1024,7 @@ impl WritableStreamMethods<crate::DomTypeHolder> for WritableStream {
         // converted to an IDL value of type UnderlyingSink.
         let underlying_sink_dict = if !underlying_sink_obj.is_null() {
             rooted!(&in(cx) let obj_val = ObjectValue(underlying_sink_obj.get()));
-            match UnderlyingSink::new(cx.into(), obj_val.handle(), CanGc::from_cx(cx)) {
+            match UnderlyingSink::new(cx, obj_val.handle()) {
                 Ok(ConversionResult::Success(val)) => val,
                 Ok(ConversionResult::Failure(error)) => {
                     return Err(Error::Type(error.into_owned()));

--- a/components/script/dom/stream/writablestream.rs
+++ b/components/script/dom/stream/writablestream.rs
@@ -1154,7 +1154,6 @@ pub(crate) struct CrossRealmTransformWritable {
 impl CrossRealmTransformWritable {
     /// <https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformwritable>
     /// Add a handler for port’s message event with the following steps:
-    #[expect(unsafe_code)]
     pub(crate) fn handle_message(
         &self,
         cx: &mut CurrentRealm,
@@ -1162,14 +1161,7 @@ impl CrossRealmTransformWritable {
         message: SafeHandleValue,
     ) {
         rooted!(&in(cx) let mut value = UndefinedValue());
-        let type_string = unsafe {
-            get_type_and_value_from_message(
-                cx.into(),
-                message,
-                value.handle_mut(),
-                CanGc::from_cx(cx),
-            )
-        };
+        let type_string = get_type_and_value_from_message(cx, message, value.handle_mut());
 
         // If type is "pull",
         // Done below as the steps are the same for both types.

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -3804,7 +3804,6 @@ impl SafeToJSValConvertible for SubtleEncapsulatedBits {
 }
 
 /// Helper to retrieve an optional paramter from WebIDL dictionary.
-#[expect(unsafe_code)]
 fn get_optional_parameter<T: SafeFromJSValConvertible>(
     cx: &mut js::context::JSContext,
     object: HandleObject,
@@ -3812,16 +3811,9 @@ fn get_optional_parameter<T: SafeFromJSValConvertible>(
     option: T::Config,
 ) -> Fallible<Option<T>> {
     rooted!(&in(cx) let mut rval = UndefinedValue());
-    if unsafe {
-        get_dictionary_property(
-            cx.raw_cx(),
-            object,
-            parameter,
-            rval.handle_mut(),
-            CanGc::from_cx(cx),
-        )
-        .map_err(|_| Error::JSFailed)?
-    } && !rval.is_undefined()
+    if get_dictionary_property(cx, object, parameter, rval.handle_mut())
+        .map_err(|_| Error::JSFailed)? &&
+        !rval.is_undefined()
     {
         let conversion_result =
             T::safe_from_jsval(cx.into(), rval.handle(), option, CanGc::from_cx(cx))
@@ -3847,7 +3839,6 @@ fn get_required_parameter<T: SafeFromJSValConvertible>(
 }
 
 /// Helper to retrieve an optional paramter, in RootedTraceableBox, from WebIDL dictionary.
-#[expect(unsafe_code)]
 fn get_optional_parameter_in_box<T: SafeFromJSValConvertible + Trace>(
     cx: &mut js::context::JSContext,
     object: HandleObject,
@@ -3855,16 +3846,9 @@ fn get_optional_parameter_in_box<T: SafeFromJSValConvertible + Trace>(
     option: T::Config,
 ) -> Fallible<Option<RootedTraceableBox<T>>> {
     rooted!(&in(cx) let mut rval = UndefinedValue());
-    if unsafe {
-        get_dictionary_property(
-            cx.raw_cx(),
-            object,
-            parameter,
-            rval.handle_mut(),
-            CanGc::from_cx(cx),
-        )
-        .map_err(|_| Error::JSFailed)?
-    } && !rval.is_undefined()
+    if get_dictionary_property(cx, object, parameter, rval.handle_mut())
+        .map_err(|_| Error::JSFailed)? &&
+        !rval.is_undefined()
     {
         let conversion_result: ConversionResult<T> = SafeFromJSValConvertible::safe_from_jsval(
             cx.into(),

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -4068,7 +4068,7 @@ impl JsonWebKeyExt for JsonWebKey {
         }
 
         // Step 5. Let key be the result of converting result to the IDL dictionary type of JsonWebKey.
-        let key = match JsonWebKey::new(cx.into(), result.handle(), CanGc::from_cx(cx)) {
+        let key = match JsonWebKey::new(cx, result.handle()) {
             Ok(ConversionResult::Success(key)) => key,
             Ok(ConversionResult::Failure(error)) => {
                 return Err(Error::Type(error.into_owned()));

--- a/components/script/indexeddb.rs
+++ b/components/script/indexeddb.rs
@@ -37,7 +37,6 @@ use crate::dom::blob::Blob;
 use crate::dom::file::File;
 use crate::dom::idbkeyrange::IDBKeyRange;
 use crate::dom::idbobjectstore::KeyPath;
-use crate::script_runtime::CanGc;
 
 // https://www.w3.org/TR/IndexedDB-3/#convert-key-to-value
 #[expect(unsafe_code)]
@@ -615,43 +614,39 @@ pub(crate) fn evaluate_key_path_on_value(
                 }
 
                 // Otherwise
-                unsafe {
-                    // If Type(value) is not Object, return failure.
-                    if !current_value.is_object() {
-                        return Ok(EvaluationResult::Failure);
-                    }
+                // If Type(value) is not Object, return failure.
+                if !current_value.is_object() {
+                    return Ok(EvaluationResult::Failure);
+                }
 
-                    rooted!(&in(cx) let object = current_value.to_object());
-                    let identifier_name =
-                        CString::new(identifier).expect("Failed to convert str to CString");
+                rooted!(&in(cx) let object = current_value.to_object());
+                let identifier_name =
+                    CString::new(identifier).expect("Failed to convert str to CString");
 
-                    // Let hop be ! HasOwnProperty(value, identifier).
-                    let hop =
-                        has_own_property(cx.into(), object.handle(), identifier_name.as_c_str())
-                            .map_err(|_| Error::JSFailed)?;
+                // Let hop be ! HasOwnProperty(value, identifier).
+                let hop = has_own_property(cx.into(), object.handle(), identifier_name.as_c_str())
+                    .map_err(|_| Error::JSFailed)?;
 
-                    // If hop is false, return failure.
-                    if !hop {
-                        return Ok(EvaluationResult::Failure);
-                    }
+                // If hop is false, return failure.
+                if !hop {
+                    return Ok(EvaluationResult::Failure);
+                }
 
-                    // Let value be ! Get(value, identifier).
-                    match get_dictionary_property(
-                        cx.raw_cx(),
-                        object.handle(),
-                        identifier_name.as_c_str(),
-                        current_value.handle_mut(),
-                        CanGc::deprecated_note(),
-                    ) {
-                        Ok(true) => {},
-                        Ok(false) => return Ok(EvaluationResult::Failure),
-                        Err(()) => return Err(Error::JSFailed),
-                    }
+                // Let value be ! Get(value, identifier).
+                match get_dictionary_property(
+                    cx,
+                    object.handle(),
+                    identifier_name.as_c_str(),
+                    current_value.handle_mut(),
+                ) {
+                    Ok(true) => {},
+                    Ok(false) => return Ok(EvaluationResult::Failure),
+                    Err(()) => return Err(Error::JSFailed),
+                }
 
-                    // If value is undefined, return failure.
-                    if current_value.get().is_undefined() {
-                        return Ok(EvaluationResult::Failure);
-                    }
+                // If value is undefined, return failure.
+                if current_value.get().is_undefined() {
+                    return Ok(EvaluationResult::Failure);
                 }
             }
 
@@ -674,7 +669,6 @@ pub(crate) enum ExtractionResult {
 }
 
 /// <https://w3c.github.io/IndexedDB/#check-that-a-key-could-be-injected-into-a-value>
-#[expect(unsafe_code)]
 pub(crate) fn can_inject_key_into_value(
     cx: &mut JSContext,
     value: HandleValue,
@@ -720,15 +714,12 @@ pub(crate) fn can_inject_key_into_value(
         }
 
         // Step 3.4. Set value to ? Get(value, identifier).
-        match unsafe {
-            get_dictionary_property(
-                cx.raw_cx(),
-                current_object.handle(),
-                identifier_name.as_c_str(),
-                current_value.handle_mut(),
-                CanGc::deprecated_note(),
-            )
-        } {
+        match get_dictionary_property(
+            cx,
+            current_object.handle(),
+            identifier_name.as_c_str(),
+            current_value.handle_mut(),
+        ) {
             Ok(true) => {},
             Ok(false) => return Ok(false),
             Err(()) => return Err(Error::JSFailed),
@@ -800,15 +791,12 @@ pub(crate) fn inject_key_into_value(
         }
 
         // Step 4.3 Let value be ! Get(value, identifier).
-        match unsafe {
-            get_dictionary_property(
-                cx.raw_cx(),
-                current_object.handle(),
-                identifier_name.as_c_str(),
-                current_value.handle_mut(),
-                CanGc::deprecated_note(),
-            )
-        } {
+        match get_dictionary_property(
+            cx,
+            current_object.handle(),
+            identifier_name.as_c_str(),
+            current_value.handle_mut(),
+        ) {
             Ok(true) => {},
             Ok(false) => return Ok(false),
             Err(()) => return Err(Error::JSFailed),

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -7903,9 +7903,8 @@ impl{self.generic} Clone for {self.makeClassName(self.dictionary)}{self.genericS
         conversion = (
             "{\n"
             "    rooted!(&in(cx) let mut rval = UndefinedValue());\n"
-            "    if get_dictionary_property(cx.raw_cx(), object.handle(), "
-            f'c"{member.identifier.name}", '
-            "rval.handle_mut(), CanGc::deprecated_note())? && !rval.is_undefined() {\n"
+            f'    if get_dictionary_property(cx, object.handle(), c"{member.identifier.name}", '
+            "rval.handle_mut())? && !rval.is_undefined() {\n"
             f"{indent(conversion)}\n"
             "    } else {\n"
             f"{indent(default)}\n"

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -7752,7 +7752,7 @@ impl{self.generic} Clone for {self.makeClassName(self.dictionary)}{self.genericS
             assert isinstance(d.parent, IDLDictionary)
             initParent = (
                 "{\n"
-                f"    match {self.makeModuleName(d.parent)}::{self.makeClassName(d.parent)}::new(cx, val, can_gc)? {{\n"
+                f"    match {self.makeModuleName(d.parent)}::{self.makeClassName(d.parent)}::new(cx, val)? {{\n"
                 "        ConversionResult::Success(v) => v,\n"
                 "        ConversionResult::Failure(error) => {\n"
                 "            throw_type_error(cx.raw_cx(), error.as_ref());\n"
@@ -7811,7 +7811,7 @@ impl{self.generic} Clone for {self.makeClassName(self.dictionary)}{self.genericS
         return (
             f"impl{self.generic} {selfName}{self.genericSuffix} {{\n"
             f"{CGIndenter(CGGeneric(self.makeEmpty()), indentLevel=4).define()}\n"
-            "    pub fn new(cx: SafeJSContext, val: HandleValue, can_gc: CanGc) \n"
+            "    pub fn new(cx: &mut JSContext, val: HandleValue) \n"
             f"                      -> Result<ConversionResult<{actualType}>, ()> {{\n"
             f"        {unsafe_if_necessary} {{\n"
             "            let object = if val.get().is_null_or_undefined() {\n"
@@ -7835,7 +7835,8 @@ impl{self.generic} Clone for {self.makeClassName(self.dictionary)}{self.genericS
             "    type Config = ();\n"
             "    unsafe fn from_jsval(cx: *mut RawJSContext, value: HandleValue, _option: ())\n"
             f"                         -> Result<ConversionResult<{actualType}>, ()> {{\n"
-            f"        {selfName}::new(SafeJSContext::from_ptr(cx), value, CanGc::deprecated_note())\n"
+            "         let mut cx = JSContext::from_ptr(ptr::NonNull::new(cx).unwrap());\n"
+            f"        {selfName}::new(&mut cx, value)\n"
             "    }\n"
             "}\n"
             "\n"
@@ -7904,7 +7905,7 @@ impl{self.generic} Clone for {self.makeClassName(self.dictionary)}{self.genericS
             "    rooted!(&in(cx) let mut rval = UndefinedValue());\n"
             "    if get_dictionary_property(cx.raw_cx(), object.handle(), "
             f'c"{member.identifier.name}", '
-            "rval.handle_mut(), can_gc)? && !rval.is_undefined() {\n"
+            "rval.handle_mut(), CanGc::deprecated_note())? && !rval.is_undefined() {\n"
             f"{indent(conversion)}\n"
             "    } else {\n"
             f"{indent(default)}\n"

--- a/components/script_bindings/import.rs
+++ b/components/script_bindings/import.rs
@@ -42,7 +42,7 @@ pub(crate) mod base {
     pub(crate) use crate::proxyhandler::CrossOriginProperties;
     pub(crate) use crate::reflector::{DomGlobalGeneric, DomObject};
     pub(crate) use crate::root::DomRoot;
-    pub(crate) use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
+    pub(crate) use crate::script_runtime::JSContext as SafeJSContext;
     pub(crate) use crate::str::{ByteString, DOMString, USVString};
     pub(crate) use crate::trace::RootedTraceableBox;
     pub(crate) use crate::utils::{get_dictionary_property, set_dictionary_property};

--- a/components/script_bindings/utils.rs
+++ b/components/script_bindings/utils.rs
@@ -28,9 +28,10 @@ use js::jsid::StringId;
 use js::jsval::{JSVal, UndefinedValue};
 use js::rust::wrappers::{
     CallOriginalPromiseReject, JS_DefineProperty, JS_DeletePropertyById, JS_ForwardGetPropertyTo,
-    JS_GetPendingException, JS_GetProperty, JS_GetPrototype, JS_HasOwnProperty, JS_HasProperty,
-    JS_HasPropertyById, JS_SetPendingException, JS_SetProperty,
+    JS_GetPendingException, JS_GetPrototype, JS_HasOwnProperty, JS_HasPropertyById,
+    JS_SetPendingException, JS_SetProperty,
 };
+use js::rust::wrappers2::{JS_GetProperty, JS_HasProperty};
 use js::rust::{
     HandleId, HandleObject, HandleValue, MutableHandleValue, Runtime, ToString, get_object_class,
 };
@@ -240,40 +241,19 @@ pub(crate) unsafe fn find_enum_value<'a, T>(
 /// Get the property with name `property` from `object`.
 /// Returns `Err(())` on JSAPI failure (there is a pending exception), and
 /// `Ok(false)` if there was no property with the given name.
-///
-/// # Safety
-/// `cx` must point to a valid, non-null JSContext.
 #[allow(clippy::result_unit_err)]
-pub unsafe fn get_dictionary_property(
-    cx: *mut JSContext,
+pub fn get_dictionary_property(
+    cx: &mut js::context::JSContext,
     object: HandleObject,
     property: &CStr,
     rval: MutableHandleValue,
-    _can_gc: CanGc,
 ) -> Result<bool, ()> {
-    unsafe fn has_property(
-        cx: *mut JSContext,
-        object: HandleObject,
-        property: &CStr,
-        found: &mut bool,
-    ) -> bool {
-        JS_HasProperty(cx, object, property.as_ptr(), found)
-    }
-    unsafe fn get_property(
-        cx: *mut JSContext,
-        object: HandleObject,
-        property: &CStr,
-        value: MutableHandleValue,
-    ) -> bool {
-        JS_GetProperty(cx, object, property.as_ptr(), value)
-    }
-
     if object.get().is_null() {
         return Ok(false);
     }
 
     let mut found = false;
-    if !has_property(cx, object, property, &mut found) {
+    if unsafe { !JS_HasProperty(cx, object, property.as_ptr(), &mut found) } {
         return Err(());
     }
 
@@ -281,7 +261,7 @@ pub unsafe fn get_dictionary_property(
         return Ok(false);
     }
 
-    if !get_property(cx, object, property, rval) {
+    if unsafe { !JS_GetProperty(cx, object, property.as_ptr(), rval) } {
         return Err(());
     }
 


### PR DESCRIPTION
This is a first step to use `FromJSValConvertible::safe_from_jsval` in codegen, also convert `get_dictionary_property`.

Testing: It compiles
Part of #40600 
