### PR TITLE
ci(Windows): Only limit parallel compilation processes for Unit tests for self-hosted runner

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -171,12 +171,15 @@ jobs:
       - name: Install cargo nextest (self-hosted)
         if: ${{ runner.environment == 'self-hosted' && inputs.unit-tests }}
         run: cargo install cargo-nextest --locked
+      # On self-hosted windows runners sometimes OOM for Unit tests
+      - name: Set CARGO_BUILD_JOBS for self-hosted runner
+        if: ${{ runner.environment == 'self-hosted' }}
+        run: echo "CARGO_BUILD_JOBS=-2" >> $GITHUB_ENV
       - name: Unit tests
         if: ${{ inputs.unit-tests }}
         id: run_unit_tests
         env:
           NEXTEST_RETRIES: 3 # https://github.com/servo/servo/issues/30683
-          CARGO_BUILD_JOBS: -2
         run: ./mach test-unit --profile ${{ inputs.profile }} --nextest-profile ci
       # We upload the test-results to Codecov to help us identify flaky unit-tests.
       - name: Upload test results to Codecov


### PR DESCRIPTION
Follow up of https://github.com/servo/servo/pull/45083#discussion_r3291700998

Github hosted runner has 4 cores (4 logical cpu), 16GB RAM: https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories

Self-hosted runner has 8 cores (16 logical cpu), 24GB RAM. We should never have OOM problem for Github-hosted runner.
But reducing it by 2 would double the UT compilation time.

Testing: Not tested. Should be trivial.