### PR TITLE
Prepare v0.1.1 (LTS) release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5078,9 +5078,9 @@ dependencies = [
 
 [[package]]
 name = "mozjs"
-version = "0.15.10"
+version = "0.15.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1deb49f990f5e277f8b134f3c61665013b7f3aac8ce9e5601f6f559dbfd780"
+checksum = "6ae3dcd73fd1aa7ab08c33c128d27243d07574874338b902872802c2b1d4b7d4"
 dependencies = [
  "bindgen",
  "cc",
@@ -5093,9 +5093,9 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "0.140.10-0"
+version = "140.10.1-0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ff2407ac8b6c9e73fdc351013036dd02d5175287b27546e6df8dc20a37d0154"
+checksum = "bf708f34816a335a5c019451a3776196d2c66eb7d4d950c04d4b781821e8feff"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7412,7 +7412,7 @@ dependencies = [
 
 [[package]]
 name = "servo"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "accesskit",
  "accesskit_consumer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -230,70 +230,70 @@ xml5ever = "0.39"
 # be listed here, between the `Begin` and `End` comments, so that we can easily find and
 # update the version requirements when bumping the workspace version.
 # Begin workspace-version dependencies - Don't change this comment, we grep for it in scripts!
-deny_public_fields = { package = "servo-deny-public-fields", version = "0.1.0", path = "components/deny_public_fields" }
-devtools = { package = "servo-devtools", version = "0.1.0", path = "components/devtools" }
-devtools_traits = { package = "servo-devtools-traits", version = "0.1.0", path = "components/shared/devtools" }
-dom_struct = { package = "servo-dom-struct", version = "0.1.0", path = "components/dom_struct" }
-embedder_traits = { package = "servo-embedder-traits", version = "0.1.0", path = "components/shared/embedder" }
-fonts = { package = "servo-fonts", version = "0.1.0", path = "components/fonts" }
-fonts_traits = { package = "servo-fonts-traits", version = "0.1.0", path = "components/shared/fonts" }
-hyper_serde = { package = "servo-hyper-serde", version = "0.1.0", path = "components/hyper_serde" }
-jstraceable_derive = { package = "servo-jstraceable-derive", version = "0.1.0", path = "components/jstraceable_derive" }
-layout = { package = "servo-layout", version = "0.1.0", path = "components/layout" }
-layout_api = { package = "servo-layout-api", version = "0.1.0", path = "components/shared/layout" }
-malloc_size_of = { package = "servo-malloc-size-of", version = "0.1.0", path = "components/malloc_size_of" }
-media = { package = "servo-media-thread", version = "0.1.0", path = "components/media/media-thread" }
-metrics = { package = "servo-metrics", version = "0.1.0", path = "components/metrics" }
-net = { package = "servo-net", version = "0.1.0", path = "components/net" }
-net_traits = { package = "servo-net-traits", version = "0.1.0", path = "components/shared/net" }
-paint = { package = "servo-paint", version = "0.1.0", path = "components/paint" }
-paint_api = { package = "servo-paint-api", version = "0.1.0", path = "components/shared/paint" }
-pixels = { package = "servo-pixels", version = "0.1.0", path = "components/pixels" }
-profile = { package = "servo-profile", version = "0.1.0", path = "components/profile" }
-profile_traits = { package = "servo-profile-traits", version = "0.1.0", path = "components/shared/profile" }
-script = { package = "servo-script", version = "0.1.0", path = "components/script" }
-script_bindings = { package = "servo-script-bindings", version = "0.1.0", path = "components/script_bindings" }
-script_traits = { package = "servo-script-traits", version = "0.1.0", path = "components/shared/script" }
-servo = { version = "0.1.0", path = "components/servo", default-features = false }
-servo-allocator = { version = "0.1.0", path = "components/allocator" }
-servo-background-hang-monitor = { version = "0.1.0", path = "components/background_hang_monitor" }
-servo-background-hang-monitor-api = { version = "0.1.0", path = "components/shared/background_hang_monitor" }
-servo-base = { version = "0.1.0", path = "components/shared/base" }
-servo-bluetooth = { version = "0.1.0", path = "components/bluetooth" }
-servo-bluetooth-traits = { version = "0.1.0", path = "components/shared/bluetooth" }
-servo-canvas = { version = "0.1.0", path = "components/canvas" }
-servo-canvas-traits = { version = "0.1.0", path = "components/shared/canvas" }
-servo-config = { version = "0.1.0", path = "components/config" }
-servo-config-macro = { version = "0.1.0", path = "components/config/macro" }
-servo-constellation = { version = "0.1.0", path = "components/constellation" }
-servo-constellation-traits = { version = "0.1.0", path = "components/shared/constellation" }
-servo-default-resources = { version = "0.1.0", path = "components/default-resources" }
-servo-geometry = { version = "0.1.0", path = "components/geometry" }
-servo-media = { version = "0.1.0", path = "components/media/servo-media" }
-servo-media-audio = { version = "0.1.0", path = "components/media/audio" }
-servo-media-auto = { version = "0.1.0", path = "components/media/backends/auto" }
-servo-media-derive = { version = "0.1.0", path = "components/media/servo-media-derive" }
-servo-media-dummy = { version = "0.1.0", path = "components/media/backends/dummy" }
-servo-media-gstreamer = { version = "0.1.0", path = "components/media/backends/gstreamer" }
-servo-media-gstreamer-render = { version = "0.1.0", path = "components/media/backends/gstreamer/render" }
-servo-media-gstreamer-render-android = { version = "0.1.0", path = "components/media/backends/gstreamer/render-android" }
-servo-media-gstreamer-render-unix = { version = "0.1.0", path = "components/media/backends/gstreamer/render-unix" }
-servo-media-player = { version = "0.1.0", path = "components/media/player" }
-servo-media-streams = { version = "0.1.0", path = "components/media/streams" }
-servo-media-traits = { version = "0.1.0", path = "components/media/traits" }
-servo-media-webrtc = { version = "0.1.0", path = "components/media/webrtc" }
-servo-tracing = { version = "0.1.0", path = "components/servo_tracing" }
-servo-url = { version = "0.1.0", path = "components/url" }
-storage = { package = "servo-storage", version = "0.1.0", path = "components/storage" }
-storage_traits = { package = "servo-storage-traits", version = "0.1.0", path = "components/shared/storage" }
-timers = { package = "servo-timers", version = "0.1.0", path = "components/timers" }
-webdriver_server = { package = "servo-webdriver-server", version = "0.1.0", path = "components/webdriver_server" }
-webgl = { package = "servo-webgl", version = "0.1.0", path = "components/webgl", default-features = false }
-webgpu = { package = "servo-webgpu", version = "0.1.0", path = "components/webgpu" }
-webgpu_traits = { package = "servo-webgpu-traits", version = "0.1.0", path = "components/shared/webgpu" }
-webxr = { package = "servo-webxr", version = "0.1.0", path = "components/webxr" }
-webxr-api = { package = "servo-webxr-api", version = "0.1.0", path = "components/shared/webxr" }
-xpath = { package = "servo-xpath", version = "0.1.0", path = "components/xpath" }
+deny_public_fields = { package = "servo-deny-public-fields", version = "=0.1.0", path = "components/deny_public_fields" }
+devtools = { package = "servo-devtools", version = "=0.1.0", path = "components/devtools" }
+devtools_traits = { package = "servo-devtools-traits", version = "=0.1.0", path = "components/shared/devtools" }
+dom_struct = { package = "servo-dom-struct", version = "=0.1.0", path = "components/dom_struct" }
+embedder_traits = { package = "servo-embedder-traits", version = "=0.1.0", path = "components/shared/embedder" }
+fonts = { package = "servo-fonts", version = "=0.1.0", path = "components/fonts" }
+fonts_traits = { package = "servo-fonts-traits", version = "=0.1.0", path = "components/shared/fonts" }
+hyper_serde = { package = "servo-hyper-serde", version = "=0.1.0", path = "components/hyper_serde" }
+jstraceable_derive = { package = "servo-jstraceable-derive", version = "=0.1.0", path = "components/jstraceable_derive" }
+layout = { package = "servo-layout", version = "=0.1.0", path = "components/layout" }
+layout_api = { package = "servo-layout-api", version = "=0.1.0", path = "components/shared/layout" }
+malloc_size_of = { package = "servo-malloc-size-of", version = "=0.1.0", path = "components/malloc_size_of" }
+media = { package = "servo-media-thread", version = "=0.1.0", path = "components/media/media-thread" }
+metrics = { package = "servo-metrics", version = "=0.1.0", path = "components/metrics" }
+net = { package = "servo-net", version = "=0.1.0", path = "components/net" }
+net_traits = { package = "servo-net-traits", version = "=0.1.0", path = "components/shared/net" }
+paint = { package = "servo-paint", version = "=0.1.0", path = "components/paint" }
+paint_api = { package = "servo-paint-api", version = "=0.1.0", path = "components/shared/paint" }
+pixels = { package = "servo-pixels", version = "=0.1.0", path = "components/pixels" }
+profile = { package = "servo-profile", version = "=0.1.0", path = "components/profile" }
+profile_traits = { package = "servo-profile-traits", version = "=0.1.0", path = "components/shared/profile" }
+script = { package = "servo-script", version = "=0.1.0", path = "components/script" }
+script_bindings = { package = "servo-script-bindings", version = "=0.1.0", path = "components/script_bindings" }
+script_traits = { package = "servo-script-traits", version = "=0.1.0", path = "components/shared/script" }
+servo = { version = "=0.1.0", path = "components/servo", default-features = false }
+servo-allocator = { version = "=0.1.0", path = "components/allocator" }
+servo-background-hang-monitor = { version = "=0.1.0", path = "components/background_hang_monitor" }
+servo-background-hang-monitor-api = { version = "=0.1.0", path = "components/shared/background_hang_monitor" }
+servo-base = { version = "=0.1.0", path = "components/shared/base" }
+servo-bluetooth = { version = "=0.1.0", path = "components/bluetooth" }
+servo-bluetooth-traits = { version = "=0.1.0", path = "components/shared/bluetooth" }
+servo-canvas = { version = "=0.1.0", path = "components/canvas" }
+servo-canvas-traits = { version = "=0.1.0", path = "components/shared/canvas" }
+servo-config = { version = "=0.1.0", path = "components/config" }
+servo-config-macro = { version = "=0.1.0", path = "components/config/macro" }
+servo-constellation = { version = "=0.1.0", path = "components/constellation" }
+servo-constellation-traits = { version = "=0.1.0", path = "components/shared/constellation" }
+servo-default-resources = { version = "=0.1.0", path = "components/default-resources" }
+servo-geometry = { version = "=0.1.0", path = "components/geometry" }
+servo-media = { version = "=0.1.0", path = "components/media/servo-media" }
+servo-media-audio = { version = "=0.1.0", path = "components/media/audio" }
+servo-media-auto = { version = "=0.1.0", path = "components/media/backends/auto" }
+servo-media-derive = { version = "=0.1.0", path = "components/media/servo-media-derive" }
+servo-media-dummy = { version = "=0.1.0", path = "components/media/backends/dummy" }
+servo-media-gstreamer = { version = "=0.1.0", path = "components/media/backends/gstreamer" }
+servo-media-gstreamer-render = { version = "=0.1.0", path = "components/media/backends/gstreamer/render" }
+servo-media-gstreamer-render-android = { version = "=0.1.0", path = "components/media/backends/gstreamer/render-android" }
+servo-media-gstreamer-render-unix = { version = "=0.1.0", path = "components/media/backends/gstreamer/render-unix" }
+servo-media-player = { version = "=0.1.0", path = "components/media/player" }
+servo-media-streams = { version = "=0.1.0", path = "components/media/streams" }
+servo-media-traits = { version = "=0.1.0", path = "components/media/traits" }
+servo-media-webrtc = { version = "=0.1.0", path = "components/media/webrtc" }
+servo-tracing = { version = "=0.1.0", path = "components/servo_tracing" }
+servo-url = { version = "=0.1.0", path = "components/url" }
+storage = { package = "servo-storage", version = "=0.1.0", path = "components/storage" }
+storage_traits = { package = "servo-storage-traits", version = "=0.1.0", path = "components/shared/storage" }
+timers = { package = "servo-timers", version = "=0.1.0", path = "components/timers" }
+webdriver_server = { package = "servo-webdriver-server", version = "=0.1.0", path = "components/webdriver_server" }
+webgl = { package = "servo-webgl", version = "=0.1.0", path = "components/webgl", default-features = false }
+webgpu = { package = "servo-webgpu", version = "=0.1.0", path = "components/webgpu" }
+webgpu_traits = { package = "servo-webgpu-traits", version = "=0.1.0", path = "components/shared/webgpu" }
+webxr = { package = "servo-webxr", version = "=0.1.0", path = "components/webxr" }
+webxr-api = { package = "servo-webxr-api", version = "=0.1.0", path = "components/shared/webxr" }
+xpath = { package = "servo-xpath", version = "=0.1.0", path = "components/xpath" }
 # End workspace-version dependencies - Don't change this comment, we grep for it in scripts!
 
 # RSA key generation could be very slow without compilation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -254,7 +254,7 @@ profile_traits = { package = "servo-profile-traits", version = "=0.1.0", path = 
 script = { package = "servo-script", version = "=0.1.0", path = "components/script" }
 script_bindings = { package = "servo-script-bindings", version = "=0.1.0", path = "components/script_bindings" }
 script_traits = { package = "servo-script-traits", version = "=0.1.0", path = "components/shared/script" }
-servo = { version = "=0.1.0", path = "components/servo", default-features = false }
+servo = { version = "=0.1.1", path = "components/servo", default-features = false }
 servo-allocator = { version = "=0.1.0", path = "components/allocator" }
 servo-background-hang-monitor = { version = "=0.1.0", path = "components/background_hang_monitor" }
 servo-background-hang-monitor-api = { version = "=0.1.0", path = "components/shared/background_hang_monitor" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ indexmap = { version = "2.11.4", features = ["std"] }
 inventory = { version = "0.3.24" }
 ipc-channel = "0.21"
 itertools = "0.14"
-js = { package = "mozjs", version = "=0.15.10", default-features = false, features = ["libz-sys", "intl"] }
+js = { package = "mozjs", version = "=0.15.14", default-features = false, features = ["libz-sys", "intl"] }
 keyboard-types = { version = "0.8.3", features = ["serde", "webdriver"] }
 kurbo = { version = "0.12", features = ["euclid"] }
 libc = "0.2"

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "servo"
-version.workspace = true
+version = "0.1.1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -126,7 +126,7 @@ class PackageCommands(CommandBase):
             raise ValueError(f"Could not find end marker: {end_marker}")
 
         block = content[block_start:block_end]
-        updated_block, count = re.subn(r'version\s*=\s*"[^"]*"', f'version = "{new_version}"', block)
+        updated_block, count = re.subn(r'version\s*=\s*"[^"]*"', f'version = "={new_version}"', block)
         if count == 0:
             raise ValueError("No workspace-version dependency references found in Cargo.toml.")
         elif count == 1:
@@ -534,6 +534,10 @@ class PackageCommands(CommandBase):
         except (ValueError, RuntimeError) as error:
             print(f"Failed to update workspace version: `{error}`", file=sys.stderr)
             return 1
+
+        # Add a trailing newline to the file if it doesn't already have one.
+        if not workspace_toml_content.endswith("\n"):
+            workspace_toml_content += "\n"
 
         with open(workspace_toml_path, "w") as file:
             file.write(workspace_toml_content)


### PR DESCRIPTION
- Update mozjs to the latest version (spidermonkey 140.10.1 release)
- backport fix to rely on exact dependencies ( not required for this release per-se, but would help prevent accidental breakage from future LTS updates which might need to modify workspace crates besides servo)
- Bump the servo crate (and only servo) to 0.1.1. We don't need to republish any of the other crates, since all backports were either dependency updates, CI changes, or a test change.

This PR should be merged by rebasing, so the commits are preserved.

Testing: Covered by existing tests. [mach try](https://github.com/jschwe/servo/actions/runs/26335943529)


