### PR TITLE
script_bindings: switch to `FromJSValConvertible::safe_from_jsval` in codegen

### DIFF
--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -46,7 +46,7 @@ use crate::dom::bindings::root::{AsHandleValue, DomRoot};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::microtask::{Microtask, MicrotaskRunnable};
-use crate::realms::{AlreadyInRealm, InRealm, enter_auto_realm, enter_realm};
+use crate::realms::{InRealm, enter_auto_realm, enter_realm};
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 use crate::script_thread::ScriptThread;
 
@@ -411,19 +411,26 @@ fn create_native_handler_function(
 impl FromJSValConvertibleRc for Promise {
     #[expect(unsafe_code)]
     unsafe fn from_jsval(
-        cx: *mut RawJSContext,
+        _cx: *mut RawJSContext,
+        value: HandleValue,
+    ) -> Result<ConversionResult<Rc<Promise>>, ()> {
+        // TODO https://github.com/servo/mozjs/issues/749
+        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
+        Self::safe_from_jsval(&mut cx, value)
+    }
+
+    fn safe_from_jsval(
+        cx: &mut JSContext,
         value: HandleValue,
     ) -> Result<ConversionResult<Rc<Promise>>, ()> {
         if value.get().is_null() {
             return Ok(ConversionResult::Failure(c"null not allowed".into()));
         }
 
-        let cx = unsafe { SafeJSContext::from_ptr(cx) };
-        let in_realm_proof = AlreadyInRealm::assert_for_cx(cx);
-        let global_scope =
-            unsafe { GlobalScope::from_context(*cx, InRealm::Already(&in_realm_proof)) };
+        let realm = CurrentRealm::assert(cx);
+        let global_scope = GlobalScope::from_current_realm(&realm);
 
-        let promise = Promise::new_resolved(&global_scope, cx, value, CanGc::deprecated_note());
+        let promise = Promise::new_resolved(&global_scope, cx.into(), value, CanGc::from_cx(cx));
         Ok(ConversionResult::Success(promise))
     }
 }

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -5344,6 +5344,7 @@ use crate::cformat;
 use js::conversions::ConversionResult;
 use js::conversions::FromJSValConvertible;
 use js::conversions::ToJSValConvertible;
+use js::context::JSContext;
 use js::context::RawJSContext;
 use js::rust::HandleValue;
 use js::rust::MutableHandleValue;
@@ -5386,6 +5387,13 @@ impl ToJSValConvertible for super::{ident} {{
 impl FromJSValConvertible for super::{ident} {{
     type Config = ();
     unsafe fn from_jsval(cx: *mut RawJSContext, value: HandleValue, _option: ())
+                         -> Result<ConversionResult<super::{ident}>, ()> {{
+        let mut cx = JSContext::from_ptr(std::ptr::NonNull::new(cx).unwrap());
+        let cx = &mut cx;
+        Self::safe_from_jsval(cx, value, _option)
+    }}
+
+    fn safe_from_jsval(cx: &mut JSContext, value: HandleValue, _option: ())
                          -> Result<ConversionResult<super::{ident}>, ()> {{
         match find_enum_value(cx, value, pairs) {{
             Err(_) => Err(()),
@@ -7838,6 +7846,10 @@ impl{self.generic} Clone for {self.makeClassName(self.dictionary)}{self.genericS
             f"                         -> Result<ConversionResult<{actualType}>, ()> {{\n"
             "         let mut cx = JSContext::from_ptr(ptr::NonNull::new(cx).unwrap());\n"
             f"        {selfName}::new(&mut cx, value)\n"
+            "    }\n"
+            "    fn safe_from_jsval(cx: &mut JSContext, value: HandleValue, _option: ())\n"
+            f"                         -> Result<ConversionResult<{actualType}>, ()> {{\n"
+            f"        {selfName}::new(cx, value)\n"
             "    }\n"
             "}\n"
             "\n"

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -5386,11 +5386,11 @@ impl ToJSValConvertible for super::{ident} {{
 
 impl FromJSValConvertible for super::{ident} {{
     type Config = ();
-    unsafe fn from_jsval(cx: *mut RawJSContext, value: HandleValue, _option: ())
+    unsafe fn from_jsval(_cx: *mut RawJSContext, value: HandleValue, _option: ())
                          -> Result<ConversionResult<super::{ident}>, ()> {{
-        let mut cx = JSContext::from_ptr(std::ptr::NonNull::new(cx).unwrap());
-        let cx = &mut cx;
-        Self::safe_from_jsval(cx, value, _option)
+        // TODO https://github.com/servo/mozjs/issues/749
+        let mut cx = crate::script_runtime::temp_cx();
+        Self::safe_from_jsval(&mut cx, value, _option)
     }}
 
     fn safe_from_jsval(cx: &mut JSContext, value: HandleValue, _option: ())
@@ -5771,11 +5771,12 @@ class CGUnionConversionStruct(CGThing):
         generic, genericSuffix = genericsForType(self.type)
         method = CGWrapper(
             CGIndenter(CGList(conversions, "\n\n")),
-            pre="unsafe fn from_jsval(cx: *mut RawJSContext,\n"
+            pre="unsafe fn from_jsval(_cx: *mut RawJSContext,\n"
                 "                     value: HandleValue,\n"
                 "                     _option: ())\n"
                 f"                     -> Result<ConversionResult<{self.type}{genericSuffix}>, ()> {{\n"
-                "   let mut cx = JSContext::from_ptr(ptr::NonNull::new(cx).unwrap());\n",
+                "   // TODO https://github.com/servo/mozjs/issues/749\n"
+                "   let mut cx = crate::script_runtime::temp_cx();\n",
             post="\n}")
         return CGWrapper(
             CGIndenter(CGList([
@@ -7842,9 +7843,10 @@ impl{self.generic} Clone for {self.makeClassName(self.dictionary)}{self.genericS
             "\n"
             f"impl{self.generic} FromJSValConvertible for {actualType} {{\n"
             "    type Config = ();\n"
-            "    unsafe fn from_jsval(cx: *mut RawJSContext, value: HandleValue, _option: ())\n"
+            "    unsafe fn from_jsval(_cx: *mut RawJSContext, value: HandleValue, _option: ())\n"
             f"                         -> Result<ConversionResult<{actualType}>, ()> {{\n"
-            "         let mut cx = JSContext::from_ptr(ptr::NonNull::new(cx).unwrap());\n"
+            "         // TODO https://github.com/servo/mozjs/issues/749\n"
+            "         let mut cx = crate::script_runtime::temp_cx();\n"
             f"        {selfName}::new(&mut cx, value)\n"
             "    }\n"
             "    fn safe_from_jsval(cx: &mut JSContext, value: HandleValue, _option: ())\n"

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -882,7 +882,7 @@ def getJSToNativeConversionInfo(type: IDLType, descriptorProvider: DescriptorPro
 
     # A helper function for types that implement FromJSValConvertible trait
     def fromJSValTemplate(config: str, errorHandler: str, exceptionCode: str) -> str:
-        return f"""match FromJSValConvertible::from_jsval(cx.raw_cx(), ${{val}}, {config}) {{
+        return f"""match FromJSValConvertible::safe_from_jsval(cx, ${{val}}, {config}) {{
     Ok(ConversionResult::Success(value)) => value,
     Ok(ConversionResult::Failure(error)) => {{
         {errorHandler}
@@ -5632,7 +5632,7 @@ class CGUnionConversionStruct(CGThing):
         def get_match(name: str) -> str:
             generic = "::<D>" if containsDomInterface(self.type) else ""
             return (
-                f"match {self.type}{generic}::TryConvertTo{name}(SafeJSContext::from_ptr(cx), value) {{\n"
+                f"match {self.type}{generic}::TryConvertTo{name}(&mut cx, value) {{\n"
                 "    Err(_) => return Err(()),\n"
                 f"    Ok(Some(value)) => return Ok(ConversionResult::Success({self.type}::{name}(value))),\n"
                 "    Ok(None) => (),\n"
@@ -5766,7 +5766,8 @@ class CGUnionConversionStruct(CGThing):
             pre="unsafe fn from_jsval(cx: *mut RawJSContext,\n"
                 "                     value: HandleValue,\n"
                 "                     _option: ())\n"
-                f"                     -> Result<ConversionResult<{self.type}{genericSuffix}>, ()> {{\n",
+                f"                     -> Result<ConversionResult<{self.type}{genericSuffix}>, ()> {{\n"
+                "   let mut cx = JSContext::from_ptr(ptr::NonNull::new(cx).unwrap());\n",
             post="\n}")
         return CGWrapper(
             CGIndenter(CGList([
@@ -5792,7 +5793,7 @@ class CGUnionConversionStruct(CGThing):
 
         return CGWrapper(
             CGIndenter(jsConversion, 4),
-            pre=f"unsafe fn TryConvertTo{t.name}(cx: SafeJSContext, value: HandleValue) -> {returnType} {{\n",
+            pre=f"unsafe fn TryConvertTo{t.name}(cx: &mut JSContext, value: HandleValue) -> {returnType} {{\n",
             post="\n}")
 
     def define(self) -> str:

--- a/components/script_bindings/utils.rs
+++ b/components/script_bindings/utils.rs
@@ -218,14 +218,14 @@ pub fn get_array_index_from_id(id: HandleId) -> Option<u32> {
 /// # Safety
 /// `cx` must point to a valid, non-null JSContext.
 #[allow(clippy::result_unit_err)]
-pub(crate) unsafe fn find_enum_value<'a, T>(
-    cx: *mut JSContext,
+pub(crate) fn find_enum_value<'a, T>(
+    cx: &mut js::context::JSContext,
     v: HandleValue,
     pairs: &'a [(&'static str, T)],
 ) -> Result<(Option<&'a T>, DOMString), ()> {
-    match ptr::NonNull::new(ToString(cx, v)) {
+    match ptr::NonNull::new(unsafe { ToString(cx.raw_cx(), v) }) {
         Some(jsstr) => {
-            let search = jsstr_to_string(cx, jsstr).into();
+            let search = unsafe { jsstr_to_string(cx.raw_cx(), jsstr).into() };
             Ok((
                 pairs
                     .iter()


### PR DESCRIPTION
Start implementing `FromJSValConvertible::safe_from_jsval` for some types: enums, dictionaries and Promise.
Inside bindings code we now call `safe_from_jsval`, for types that don't implement it the trait has a default implementation that calls the unsafe version.

Testing: It compiles
Part of #40600
