### PR TITLE
script: Add missing early return in shared-declarative-refresh-steps

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -4515,6 +4515,10 @@ impl Document {
             } else {
                 // 11.12 If urlRecord is failure, then return.
                 return;
+            };
+            // 11.13 If urlRecord's scheme is "javascript", then return.
+            if url_record.scheme() == "javascript" {
+                return;
             }
         }
         // 12. Set document's will declaratively refresh to true.

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/refresh/javascript.window.js.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/refresh/javascript.window.js.ini
@@ -1,3 +1,0 @@
-[javascript.window.html]
-  [Refresh to a javascript: URL should not work]
-    expected: FAIL


### PR DESCRIPTION
https://html.spec.whatwg.org/multipage/semantics.html#shared-declarative-refresh-steps

Testing: tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/refresh/javascript.window.js now passes.

