### PR TITLE
webgpu: Reorder/add/remove limits to match the spec

### DIFF
--- a/components/script/dom/webgpu/gpusupportedlimits.rs
+++ b/components/script/dom/webgpu/gpusupportedlimits.rs
@@ -13,6 +13,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
 use crate::script_runtime::CanGc;
 
+/// <https://gpuweb.github.io/gpuweb/#gpusupportedlimits>
 #[dom_struct]
 pub(crate) struct GPUSupportedLimits {
     reflector_: Reflector,
@@ -63,7 +64,7 @@ impl GPUSupportedLimitsMethods<crate::DomTypeHolder> for GPUSupportedLimits {
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxbindgroupsplusvertexbuffers>
     fn MaxBindGroupsPlusVertexBuffers(&self) -> u32 {
-        // Not on wgpu yet, so we craft it manually
+        // Not in published wgpu yet (https://github.com/gfx-rs/wgpu/issues/8832), so we craft it manually
         self.limits.max_bind_groups + self.limits.max_vertex_buffers
     }
 
@@ -104,13 +105,13 @@ impl GPUSupportedLimitsMethods<crate::DomTypeHolder> for GPUSupportedLimits {
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxstoragebuffersinvertexstage>
     fn MaxStorageBuffersInVertexStage(&self) -> u32 {
-        // Not in wgpu yet, report per stage limit instead
+        // Not in wgpu yet (https://github.com/gfx-rs/wgpu/issues/8748), report per stage limit instead
         self.limits.max_storage_buffers_per_shader_stage
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxstoragebuffersinfragmentstage>
     fn MaxStorageBuffersInFragmentStage(&self) -> u32 {
-        // Not in wgpu yet, report per stage limit instead
+        // Not in wgpu yet (https://github.com/gfx-rs/wgpu/issues/8748), report per stage limit instead
         self.limits.max_storage_buffers_per_shader_stage
     }
 
@@ -121,13 +122,13 @@ impl GPUSupportedLimitsMethods<crate::DomTypeHolder> for GPUSupportedLimits {
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxstoragetexturesinvertexstage>
     fn MaxStorageTexturesInVertexStage(&self) -> u32 {
-        // Not in wgpu yet, report per stage limit instead
+        // Not in wgpu yet (https://github.com/gfx-rs/wgpu/issues/8748), report per stage limit instead
         self.limits.max_storage_textures_per_shader_stage
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxstoragetexturesinfragmentstage>
     fn MaxStorageTexturesInFragmentStage(&self) -> u32 {
-        // Not in wgpu yet, report per stage limit instead
+        // Not in wgpu yet (https://github.com/gfx-rs/wgpu/issues/8748), report per stage limit instead
         self.limits.max_storage_textures_per_shader_stage
     }
 
@@ -265,7 +266,8 @@ pub(crate) fn set_limit(limits: &mut Limits, limit: &str, value: u64) -> bool {
         "maxTextureArrayLayers" => set_maximum(&mut limits.max_texture_array_layers, value),
         "maxBindGroups" => set_maximum(&mut limits.max_bind_groups, value),
         "maxBindGroupsPlusVertexBuffers" => {
-            // not in wgpu but we're allowed to give back better limits than requested.
+            // not in wgpu (https://github.com/gfx-rs/wgpu/issues/8832)
+            // but we're allowed to give back better limits than requested.
             // we use dummy value to still produce value verification
             let mut v: u32 = 0;
             set_maximum(&mut v, value)
@@ -290,13 +292,15 @@ pub(crate) fn set_limit(limits: &mut Limits, limit: &str, value: u64) -> bool {
             set_maximum(&mut limits.max_storage_buffers_per_shader_stage, value)
         },
         "maxStorageBuffersInVertexStage" => {
-            // not in wgpu but we're allowed to give back better limits than requested.
+            // not in wgpu (https://github.com/gfx-rs/wgpu/issues/8748)
+            // but we're allowed to give back better limits than requested.
             // we use dummy value to still produce value verification
             let mut v: u32 = 0;
             set_maximum(&mut v, value)
         },
         "maxStorageBuffersInFragmentStage" => {
-            // not in wgpu but we're allowed to give back better limits than requested.
+            // not in wgpu (https://github.com/gfx-rs/wgpu/issues/8748)
+            // but we're allowed to give back better limits than requested.
             // we use dummy value to still produce value verification
             let mut v: u32 = 0;
             set_maximum(&mut v, value)
@@ -305,13 +309,15 @@ pub(crate) fn set_limit(limits: &mut Limits, limit: &str, value: u64) -> bool {
             set_maximum(&mut limits.max_storage_textures_per_shader_stage, value)
         },
         "maxStorageTexturesInVertexStage" => {
-            // not in wgpu but we're allowed to give back better limits than requested.
+            // not in wgpu (https://github.com/gfx-rs/wgpu/issues/8748)
+            // but we're allowed to give back better limits than requested.
             // we use dummy value to still produce value verification
             let mut v: u32 = 0;
             set_maximum(&mut v, value)
         },
         "maxStorageTexturesInFragmentStage" => {
-            // not in wgpu but we're allowed to give back better limits than requested.
+            // not in wgpu (https://github.com/gfx-rs/wgpu/issues/8748)
+            // but we're allowed to give back better limits than requested.
             // we use dummy value to still produce value verification
             let mut v: u32 = 0;
             set_maximum(&mut v, value)

--- a/components/script/dom/webgpu/gpusupportedlimits.rs
+++ b/components/script/dom/webgpu/gpusupportedlimits.rs
@@ -34,6 +34,7 @@ impl GPUSupportedLimits {
     }
 }
 
+// Limits are ordered by their declaration in the spec.
 impl GPUSupportedLimitsMethods<crate::DomTypeHolder> for GPUSupportedLimits {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxtexturedimension1d>
     fn MaxTextureDimension1D(&self) -> u32 {
@@ -58,6 +59,17 @@ impl GPUSupportedLimitsMethods<crate::DomTypeHolder> for GPUSupportedLimits {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxbindgroups>
     fn MaxBindGroups(&self) -> u32 {
         self.limits.max_bind_groups
+    }
+
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxbindgroupsplusvertexbuffers>
+    fn MaxBindGroupsPlusVertexBuffers(&self) -> u32 {
+        // Not on wgpu yet, so we craft it manually
+        self.limits.max_bind_groups + self.limits.max_vertex_buffers
+    }
+
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maximmediatesize>
+    fn MaxImmediateSize(&self) -> u32 {
+        self.limits.max_immediate_size
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxbindingsperbindgroup>
@@ -90,8 +102,32 @@ impl GPUSupportedLimitsMethods<crate::DomTypeHolder> for GPUSupportedLimits {
         self.limits.max_storage_buffers_per_shader_stage
     }
 
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxstoragebuffersinvertexstage>
+    fn MaxStorageBuffersInVertexStage(&self) -> u32 {
+        // Not in wgpu yet, report per stage limit instead
+        self.limits.max_storage_buffers_per_shader_stage
+    }
+
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxstoragebuffersinfragmentstage>
+    fn MaxStorageBuffersInFragmentStage(&self) -> u32 {
+        // Not in wgpu yet, report per stage limit instead
+        self.limits.max_storage_buffers_per_shader_stage
+    }
+
     /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxstoragetexturespershaderstage>
     fn MaxStorageTexturesPerShaderStage(&self) -> u32 {
+        self.limits.max_storage_textures_per_shader_stage
+    }
+
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxstoragetexturesinvertexstage>
+    fn MaxStorageTexturesInVertexStage(&self) -> u32 {
+        // Not in wgpu yet, report per stage limit instead
+        self.limits.max_storage_textures_per_shader_stage
+    }
+
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxstoragetexturesinfragmentstage>
+    fn MaxStorageTexturesInFragmentStage(&self) -> u32 {
+        // Not in wgpu yet, report per stage limit instead
         self.limits.max_storage_textures_per_shader_stage
     }
 
@@ -140,9 +176,19 @@ impl GPUSupportedLimitsMethods<crate::DomTypeHolder> for GPUSupportedLimits {
         self.limits.max_vertex_buffer_array_stride
     }
 
-    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxinterstageshadercomponents>
-    fn MaxInterStageShaderComponents(&self) -> u32 {
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxinterstageshadervariables>
+    fn MaxInterStageShaderVariables(&self) -> u32 {
         self.limits.max_inter_stage_shader_variables
+    }
+
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxcolorattachments>
+    fn MaxColorAttachments(&self) -> u32 {
+        self.limits.max_color_attachments
+    }
+
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxcolorattachmentbytespersample>
+    fn MaxColorAttachmentBytesPerSample(&self) -> u32 {
+        self.limits.max_color_attachment_bytes_per_sample
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxcomputeworkgroupstoragesize>
@@ -173,28 +219,6 @@ impl GPUSupportedLimitsMethods<crate::DomTypeHolder> for GPUSupportedLimits {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxcomputeworkgroupsperdimension>
     fn MaxComputeWorkgroupsPerDimension(&self) -> u32 {
         self.limits.max_compute_workgroups_per_dimension
-    }
-
-    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxbindgroupsplusvertexbuffers>
-    fn MaxBindGroupsPlusVertexBuffers(&self) -> u32 {
-        // Not on wgpu yet, so we craft it manually
-        self.limits.max_bind_groups + self.limits.max_vertex_buffers
-    }
-
-    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxinterstageshadervariables>
-    fn MaxInterStageShaderVariables(&self) -> u32 {
-        // Not in wgpu yet, so we use default value from spec
-        16
-    }
-
-    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxcolorattachments>
-    fn MaxColorAttachments(&self) -> u32 {
-        self.limits.max_color_attachments
-    }
-
-    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxcolorattachmentbytespersample>
-    fn MaxColorAttachmentBytesPerSample(&self) -> u32 {
-        self.limits.max_color_attachment_bytes_per_sample
     }
 }
 
@@ -233,6 +257,7 @@ pub(crate) fn set_limit(limits: &mut Limits, limit: &str, value: u64) -> bool {
         }
     }
 
+    // Limits are ordered by their declaration in the spec.
     match limit {
         "maxTextureDimension1D" => set_maximum(&mut limits.max_texture_dimension_1d, value),
         "maxTextureDimension2D" => set_maximum(&mut limits.max_texture_dimension_2d, value),
@@ -245,6 +270,7 @@ pub(crate) fn set_limit(limits: &mut Limits, limit: &str, value: u64) -> bool {
             let mut v: u32 = 0;
             set_maximum(&mut v, value)
         },
+        "maxImmediateSize" => set_maximum(&mut limits.max_immediate_size, value),
         "maxBindingsPerBindGroup" => set_maximum(&mut limits.max_bindings_per_bind_group, value),
         "maxDynamicUniformBuffersPerPipelineLayout" => set_maximum(
             &mut limits.max_dynamic_uniform_buffers_per_pipeline_layout,
@@ -263,8 +289,32 @@ pub(crate) fn set_limit(limits: &mut Limits, limit: &str, value: u64) -> bool {
         "maxStorageBuffersPerShaderStage" => {
             set_maximum(&mut limits.max_storage_buffers_per_shader_stage, value)
         },
+        "maxStorageBuffersInVertexStage" => {
+            // not in wgpu but we're allowed to give back better limits than requested.
+            // we use dummy value to still produce value verification
+            let mut v: u32 = 0;
+            set_maximum(&mut v, value)
+        },
+        "maxStorageBuffersInFragmentStage" => {
+            // not in wgpu but we're allowed to give back better limits than requested.
+            // we use dummy value to still produce value verification
+            let mut v: u32 = 0;
+            set_maximum(&mut v, value)
+        },
         "maxStorageTexturesPerShaderStage" => {
             set_maximum(&mut limits.max_storage_textures_per_shader_stage, value)
+        },
+        "maxStorageTexturesInVertexStage" => {
+            // not in wgpu but we're allowed to give back better limits than requested.
+            // we use dummy value to still produce value verification
+            let mut v: u32 = 0;
+            set_maximum(&mut v, value)
+        },
+        "maxStorageTexturesInFragmentStage" => {
+            // not in wgpu but we're allowed to give back better limits than requested.
+            // we use dummy value to still produce value verification
+            let mut v: u32 = 0;
+            set_maximum(&mut v, value)
         },
         "maxUniformBuffersPerShaderStage" => {
             set_maximum(&mut limits.max_uniform_buffers_per_shader_stage, value)
@@ -287,14 +337,8 @@ pub(crate) fn set_limit(limits: &mut Limits, limit: &str, value: u64) -> bool {
         "maxVertexBufferArrayStride" => {
             set_maximum(&mut limits.max_vertex_buffer_array_stride, value)
         },
-        "maxInterStageShaderComponents" => {
-            set_maximum(&mut limits.max_inter_stage_shader_variables, value)
-        },
         "maxInterStageShaderVariables" => {
-            // not in wgpu but we're allowed to give back better limits than requested.
-            // we use dummy value to still produce value verification
-            let mut v: u32 = 0;
-            set_maximum(&mut v, value)
+            set_maximum(&mut limits.max_inter_stage_shader_variables, value)
         },
         "maxColorAttachments" => set_maximum(&mut limits.max_color_attachments, value),
         "maxColorAttachmentBytesPerSample" => {

--- a/components/script/dom/webgpu/gpusupportedlimits.rs
+++ b/components/script/dom/webgpu/gpusupportedlimits.rs
@@ -68,10 +68,12 @@ impl GPUSupportedLimitsMethods<crate::DomTypeHolder> for GPUSupportedLimits {
         self.limits.max_bind_groups + self.limits.max_vertex_buffers
     }
 
+    /*
     /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maximmediatesize>
     fn MaxImmediateSize(&self) -> u32 {
         self.limits.max_immediate_size
     }
+    */
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxbindingsperbindgroup>
     fn MaxBindingsPerBindGroup(&self) -> u32 {

--- a/components/script_bindings/webidls/WebGPU.webidl
+++ b/components/script_bindings/webidls/WebGPU.webidl
@@ -23,7 +23,8 @@ interface GPUSupportedLimits {
     readonly attribute unsigned long maxTextureArrayLayers;
     readonly attribute unsigned long maxBindGroups;
     readonly attribute unsigned long maxBindGroupsPlusVertexBuffers;
-    readonly attribute unsigned long maxImmediateSize;
+    // disabled as we do not have actual implementation yet
+    // readonly attribute unsigned long maxImmediateSize;
     readonly attribute unsigned long maxBindingsPerBindGroup;
     readonly attribute unsigned long maxDynamicUniformBuffersPerPipelineLayout;
     readonly attribute unsigned long maxDynamicStorageBuffersPerPipelineLayout;

--- a/components/script_bindings/webidls/WebGPU.webidl
+++ b/components/script_bindings/webidls/WebGPU.webidl
@@ -15,7 +15,7 @@ dictionary GPUObjectDescriptorBase {
     USVString label = "";
 };
 
-[Exposed=(Window, Worker), SecureContext, Pref="dom_webgpu_enabled"]
+[Exposed=(Window, Worker), SecureContext]
 interface GPUSupportedLimits {
     readonly attribute unsigned long maxTextureDimension1D;
     readonly attribute unsigned long maxTextureDimension2D;
@@ -23,13 +23,18 @@ interface GPUSupportedLimits {
     readonly attribute unsigned long maxTextureArrayLayers;
     readonly attribute unsigned long maxBindGroups;
     readonly attribute unsigned long maxBindGroupsPlusVertexBuffers;
+    readonly attribute unsigned long maxImmediateSize;
     readonly attribute unsigned long maxBindingsPerBindGroup;
     readonly attribute unsigned long maxDynamicUniformBuffersPerPipelineLayout;
     readonly attribute unsigned long maxDynamicStorageBuffersPerPipelineLayout;
     readonly attribute unsigned long maxSampledTexturesPerShaderStage;
     readonly attribute unsigned long maxSamplersPerShaderStage;
     readonly attribute unsigned long maxStorageBuffersPerShaderStage;
+    readonly attribute unsigned long maxStorageBuffersInVertexStage;
+    readonly attribute unsigned long maxStorageBuffersInFragmentStage;
     readonly attribute unsigned long maxStorageTexturesPerShaderStage;
+    readonly attribute unsigned long maxStorageTexturesInVertexStage;
+    readonly attribute unsigned long maxStorageTexturesInFragmentStage;
     readonly attribute unsigned long maxUniformBuffersPerShaderStage;
     readonly attribute unsigned long long maxUniformBufferBindingSize;
     readonly attribute unsigned long long maxStorageBufferBindingSize;
@@ -39,7 +44,6 @@ interface GPUSupportedLimits {
     readonly attribute unsigned long long maxBufferSize;
     readonly attribute unsigned long maxVertexAttributes;
     readonly attribute unsigned long maxVertexBufferArrayStride;
-    readonly attribute unsigned long maxInterStageShaderComponents;
     readonly attribute unsigned long maxInterStageShaderVariables;
     readonly attribute unsigned long maxColorAttachments;
     readonly attribute unsigned long maxColorAttachmentBytesPerSample;

--- a/components/script_bindings/webidls/WebGPU.webidl
+++ b/components/script_bindings/webidls/WebGPU.webidl
@@ -15,7 +15,7 @@ dictionary GPUObjectDescriptorBase {
     USVString label = "";
 };
 
-[Exposed=(Window, Worker), SecureContext]
+[Exposed=(Window, Worker), SecureContext, Pref="dom_webgpu_enabled"]
 interface GPUSupportedLimits {
     readonly attribute unsigned long maxTextureDimension1D;
     readonly attribute unsigned long maxTextureDimension2D;


### PR DESCRIPTION
This PR basically syncs [`GPUSupportedLimits`](https://gpuweb.github.io/gpuweb/#gpusupportedlimits). Some stuff is unavailable to us due to wgpu not having it implemented yet, but we can emulate most functionality or at least value validation, so we pass more tests (the same trick is also done in Firefox and Deno). For `ImmediateSize` we should wait until we get full implementation for them otherwise CTS thinks we support it and FAILs us in tests, so we will let the code commented out for now (this will be resolved in upcoming PR).

Testing: Covered by WebGPU CTS
