### PR TITLE
script: Block meta refresh considering sandbox flag

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -236,6 +236,8 @@ pub(crate) struct RefreshRedirectDue {
     pub(crate) url: ServoUrl,
     #[ignore_malloc_size_of = "non-owning"]
     pub(crate) window: DomRoot<Window>,
+    /// Whether the refresh originated from a `<meta>` element.
+    pub(crate) from_meta: bool,
 }
 impl RefreshRedirectDue {
     /// Step 13 of <https://html.spec.whatwg.org/multipage/#shared-declarative-refresh-steps>
@@ -246,9 +248,13 @@ impl RefreshRedirectDue {
         // automatic features browsing context flag set,
         // then navigate document's node navigable to urlRecord using document,
         // with historyHandling set to "replace".
-        //
-        // TODO: check sandbox
-        // TODO: Check if meta was given
+        if self.from_meta &&
+            self.window.Document().has_active_sandboxing_flag(
+                SandboxingFlagSet::SANDBOXED_AUTOMATIC_FEATURES_BROWSING_CONTEXT_FLAG,
+            )
+        {
+            return;
+        }
         let load_data = self
             .window
             .load_data_for_document(self.url.clone(), self.window.pipeline_id());
@@ -275,6 +281,8 @@ pub(crate) enum DeclarativeRefresh {
         #[no_trace]
         url: ServoUrl,
         time: u64,
+        /// Whether the refresh originated from a `<meta>` element.
+        from_meta: bool,
     },
     CreatedAfterLoad,
 }
@@ -2158,13 +2166,17 @@ impl Document {
         //
         // At least time seconds have elapsed since document's completely loaded time,
         // adjusted to take into account user or user agent preferences.
-        if let Some(DeclarativeRefresh::PendingLoad { url, time }) =
-            &*self.declarative_refresh.borrow()
+        if let Some(DeclarativeRefresh::PendingLoad {
+            url,
+            time,
+            from_meta,
+        }) = &*self.declarative_refresh.borrow()
         {
             self.window.as_global_scope().schedule_callback(
                 OneshotTimerCallback::RefreshRedirectDue(RefreshRedirectDue {
                     window: DomRoot::from_ref(self.window()),
                     url: url.clone(),
+                    from_meta: *from_meta,
                 }),
                 Duration::from_secs(*time),
             );
@@ -4450,7 +4462,7 @@ impl Document {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#shared-declarative-refresh-steps>
-    pub(crate) fn shared_declarative_refresh_steps(&self, content: &[u8]) {
+    pub(crate) fn shared_declarative_refresh_steps(&self, content: &[u8], from_meta: bool) {
         // 1. If document's will declaratively refresh is true, then return.
         if self.will_declaratively_refresh() {
             return;
@@ -4523,11 +4535,11 @@ impl Document {
         }
         // 12. Set document's will declaratively refresh to true.
         if self.completely_loaded() {
-            // TODO: handle active sandboxing flag
             self.window.as_global_scope().schedule_callback(
                 OneshotTimerCallback::RefreshRedirectDue(RefreshRedirectDue {
                     window: DomRoot::from_ref(self.window()),
                     url: url_record,
+                    from_meta,
                 }),
                 Duration::from_secs(time),
             );
@@ -4536,6 +4548,7 @@ impl Document {
             self.set_declarative_refresh(DeclarativeRefresh::PendingLoad {
                 url: url_record,
                 time,
+                from_meta,
             });
         }
     }

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -237,7 +237,7 @@ pub(crate) struct RefreshRedirectDue {
     #[ignore_malloc_size_of = "non-owning"]
     pub(crate) window: DomRoot<Window>,
     /// Whether the refresh originated from a `<meta>` element.
-    pub(crate) from_meta: bool,
+    pub(crate) from_meta_element: bool,
 }
 impl RefreshRedirectDue {
     /// Step 13 of <https://html.spec.whatwg.org/multipage/#shared-declarative-refresh-steps>
@@ -248,7 +248,7 @@ impl RefreshRedirectDue {
         // automatic features browsing context flag set,
         // then navigate document's node navigable to urlRecord using document,
         // with historyHandling set to "replace".
-        if self.from_meta &&
+        if self.from_meta_element &&
             self.window.Document().has_active_sandboxing_flag(
                 SandboxingFlagSet::SANDBOXED_AUTOMATIC_FEATURES_BROWSING_CONTEXT_FLAG,
             )
@@ -282,7 +282,7 @@ pub(crate) enum DeclarativeRefresh {
         url: ServoUrl,
         time: u64,
         /// Whether the refresh originated from a `<meta>` element.
-        from_meta: bool,
+        from_meta_element: bool,
     },
     CreatedAfterLoad,
 }
@@ -2169,14 +2169,14 @@ impl Document {
         if let Some(DeclarativeRefresh::PendingLoad {
             url,
             time,
-            from_meta,
+            from_meta_element,
         }) = &*self.declarative_refresh.borrow()
         {
             self.window.as_global_scope().schedule_callback(
                 OneshotTimerCallback::RefreshRedirectDue(RefreshRedirectDue {
                     window: DomRoot::from_ref(self.window()),
                     url: url.clone(),
-                    from_meta: *from_meta,
+                    from_meta_element: *from_meta_element,
                 }),
                 Duration::from_secs(*time),
             );
@@ -4462,7 +4462,7 @@ impl Document {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#shared-declarative-refresh-steps>
-    pub(crate) fn shared_declarative_refresh_steps(&self, content: &[u8], from_meta: bool) {
+    pub(crate) fn shared_declarative_refresh_steps(&self, content: &[u8], from_meta_element: bool) {
         // 1. If document's will declaratively refresh is true, then return.
         if self.will_declaratively_refresh() {
             return;
@@ -4539,7 +4539,7 @@ impl Document {
                 OneshotTimerCallback::RefreshRedirectDue(RefreshRedirectDue {
                     window: DomRoot::from_ref(self.window()),
                     url: url_record,
-                    from_meta,
+                    from_meta_element,
                 }),
                 Duration::from_secs(time),
             );
@@ -4548,7 +4548,7 @@ impl Document {
             self.set_declarative_refresh(DeclarativeRefresh::PendingLoad {
                 url: url_record,
                 time,
-                from_meta,
+                from_meta_element,
             });
         }
     }

--- a/components/script/dom/html/htmlmetaelement.rs
+++ b/components/script/dom/html/htmlmetaelement.rs
@@ -202,7 +202,7 @@ impl HTMLMetaElement {
         if !content.is_empty() {
             // Step 3. Run the shared declarative refresh steps with the meta element's node document, input, and the meta element.
             self.owner_document()
-                .shared_declarative_refresh_steps(&content.as_bytes(), true);
+                .shared_declarative_refresh_steps(&content.as_bytes(), true /* from_meta_element */);
         }
     }
 }

--- a/components/script/dom/html/htmlmetaelement.rs
+++ b/components/script/dom/html/htmlmetaelement.rs
@@ -202,7 +202,7 @@ impl HTMLMetaElement {
         if !content.is_empty() {
             // Step 3. Run the shared declarative refresh steps with the meta element's node document, input, and the meta element.
             self.owner_document()
-                .shared_declarative_refresh_steps(&content.as_bytes());
+                .shared_declarative_refresh_steps(&content.as_bytes(), true);
         }
     }
 }

--- a/components/script/dom/html/htmlmetaelement.rs
+++ b/components/script/dom/html/htmlmetaelement.rs
@@ -201,8 +201,10 @@ impl HTMLMetaElement {
         // Step 1. If the meta element has no content attribute, or if that attribute's value is the empty string, then return.
         if !content.is_empty() {
             // Step 3. Run the shared declarative refresh steps with the meta element's node document, input, and the meta element.
-            self.owner_document()
-                .shared_declarative_refresh_steps(&content.as_bytes(), true /* from_meta_element */);
+            self.owner_document().shared_declarative_refresh_steps(
+                &content.as_bytes(),
+                /* from_meta_element */ true,
+            );
         }
     }
 }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3582,7 +3582,10 @@ impl ScriptThread {
         let refresh_header = metadata.headers.as_deref().and_then(|h| h.get(REFRESH));
         if let Some(refresh_val) = refresh_header {
             // There are tests that this header handles Unicode code points
-            document.shared_declarative_refresh_steps(refresh_val.as_bytes(), false /* from_meta_element */);
+            document.shared_declarative_refresh_steps(
+                refresh_val.as_bytes(),
+                /* from_meta_element */ false,
+            );
         }
 
         document.set_ready_state(cx, DocumentReadyState::Loading);

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3582,7 +3582,7 @@ impl ScriptThread {
         let refresh_header = metadata.headers.as_deref().and_then(|h| h.get(REFRESH));
         if let Some(refresh_val) = refresh_header {
             // There are tests that this header handles Unicode code points
-            document.shared_declarative_refresh_steps(refresh_val.as_bytes());
+            document.shared_declarative_refresh_steps(refresh_val.as_bytes(), false);
         }
 
         document.set_ready_state(cx, DocumentReadyState::Loading);

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3582,7 +3582,7 @@ impl ScriptThread {
         let refresh_header = metadata.headers.as_deref().and_then(|h| h.get(REFRESH));
         if let Some(refresh_val) = refresh_header {
             // There are tests that this header handles Unicode code points
-            document.shared_declarative_refresh_steps(refresh_val.as_bytes(), false);
+            document.shared_declarative_refresh_steps(refresh_val.as_bytes(), false /* from_meta_element */);
         }
 
         document.set_ready_state(cx, DocumentReadyState::Loading);

--- a/tests/wpt/meta/html/semantics/document-metadata/the-meta-element/pragma-directives/attr-meta-http-equiv-refresh/allow-scripts-flag-changing-1.html.ini
+++ b/tests/wpt/meta/html/semantics/document-metadata/the-meta-element/pragma-directives/attr-meta-http-equiv-refresh/allow-scripts-flag-changing-1.html.ini
@@ -1,3 +1,0 @@
-[allow-scripts-flag-changing-1.html]
-  [Meta refresh is blocked by the allow-scripts sandbox flag at its creation time, not when refresh comes due]
-    expected: FAIL


### PR DESCRIPTION
I'm not very familiar with this part, so review by a familiar reviewer would be appreciated.

Testing: a WPT-test starts passing.

