### PR TITLE
script: Support event handler content attributes on SVG elements

### DIFF
--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -70,6 +70,7 @@ use crate::dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use crate::dom::bindings::codegen::Bindings::ElementBinding::{
     ElementMethods, GetHTMLOptions, ScrollIntoViewContainer, ScrollLogicalPosition, ShadowRootInit,
 };
+use crate::dom::bindings::codegen::Bindings::EventHandlerBinding::EventHandlerNonNull;
 use crate::dom::bindings::codegen::Bindings::FunctionBinding::Function;
 use crate::dom::bindings::codegen::Bindings::HTMLElementBinding::HTMLElementMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLTemplateElementBinding::HTMLTemplateElementMethods;
@@ -110,6 +111,7 @@ use crate::dom::element::attributes::storage::{
     AttrRef, AttrValueRef, AttributeEntry, AttributeStorage, ContentAttributeData,
 };
 use crate::dom::elementinternals::ElementInternals;
+use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::html::htmlanchorelement::HTMLAnchorElement;
 use crate::dom::html::htmlareaelement::HTMLAreaElement;
@@ -4376,6 +4378,31 @@ impl VirtualMethods for Element {
         let node = self.upcast::<Node>();
         let doc = node.owner_doc();
         match *attr.local_name() {
+            // https://html.spec.whatwg.org/multipage/#event-handler-attributes:event-handler-content-attributes-3
+            // Event handler content attributes are defined on `Element` rather than `HTMLElement`
+            // so that other element types (such as SVG elements) activate them as well.
+            ref name if name.starts_with("on") && EventTarget::is_content_event_handler(name) => {
+                let evtarget = self.upcast::<EventTarget>();
+                let event_name = &name[2..];
+                match mutation {
+                    // https://html.spec.whatwg.org/multipage/#activate-an-event-handler
+                    AttributeMutation::Set(..) => {
+                        let source = &**attr.value();
+                        let source_line = 1; // TODO(#9604) get current JS execution line
+                        evtarget.set_event_handler_uncompiled(
+                            self.owner_window().get_url(),
+                            source_line,
+                            event_name,
+                            source,
+                        );
+                    },
+                    // https://html.spec.whatwg.org/multipage/#deactivate-an-event-handler
+                    AttributeMutation::Removed => {
+                        evtarget
+                            .set_event_handler_common::<EventHandlerNonNull>(cx, event_name, None);
+                    },
+                }
+            },
             local_name!("style") => self.update_style_attribute(attr, mutation),
             local_name!("id") => {
                 // https://dom.spec.whatwg.org/#ref-for-concept-element-attributes-change-ext%E2%91%A2

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -1211,32 +1211,6 @@ impl VirtualMethods for HTMLElement {
             .attribute_mutated(cx, attr, mutation);
         let element = self.as_element();
         match (attr.local_name(), mutation) {
-            // https://html.spec.whatwg.org/multipage/#event-handler-attributes:event-handler-content-attributes-3
-            (name, mutation)
-                if name.starts_with("on") && EventTarget::is_content_event_handler(name) =>
-            {
-                let evtarget = self.upcast::<EventTarget>();
-                let event_name = &name[2..];
-                match mutation {
-                    // https://html.spec.whatwg.org/multipage/#activate-an-event-handler
-                    AttributeMutation::Set(..) => {
-                        let source = &**attr.value();
-                        let source_line = 1; // TODO(#9604) get current JS execution line
-                        evtarget.set_event_handler_uncompiled(
-                            self.owner_window().get_url(),
-                            source_line,
-                            event_name,
-                            source,
-                        );
-                    },
-                    // https://html.spec.whatwg.org/multipage/#deactivate-an-event-handler
-                    AttributeMutation::Removed => {
-                        evtarget
-                            .set_event_handler_common::<EventHandlerNonNull>(cx, event_name, None);
-                    },
-                }
-            },
-
             (&local_name!("accesskey"), ..) => {
                 self.update_assigned_access_key();
             },

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -14962,6 +14962,13 @@
       {}
      ]
     ],
+    "svg-content-event-handler.html": [
+     "651dd8563e059da447fab9aebb8c257c812afaf0",
+     [
+      null,
+      {}
+     ]
+    ],
     "table-rowspan-colspan-crashtest.html": [
      "05c16a5d9051bd69ede7258625dcedf1c37d1a94",
      [

--- a/tests/wpt/mozilla/tests/mozilla/svg-content-event-handler.html
+++ b/tests/wpt/mozilla/tests/mozilla/svg-content-event-handler.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>SVG elements support event handler content attributes</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+test(() => {
+  const svg = document.createElementNS(SVG_NS, "svg");
+  let ran = false;
+  window.__svgContentEventHandlerCallback = () => { ran = true; };
+  svg.setAttribute("onclick", "window.__svgContentEventHandlerCallback()");
+  assert_equals(typeof svg.onclick, "function",
+    "the onclick content attribute should be reflected as an event handler");
+  svg.dispatchEvent(new Event("click"));
+  assert_true(ran,
+    "dispatching a click event should invoke the content attribute handler");
+}, "An event handler content attribute set on an SVG element is activated");
+
+test(() => {
+  const svg = document.createElementNS(SVG_NS, "svg");
+  svg.setAttribute("onclick", "void 0");
+  assert_equals(typeof svg.onclick, "function",
+    "the onclick content attribute should be reflected as an event handler");
+  svg.removeAttribute("onclick");
+  assert_equals(svg.onclick, null,
+    "removing the content attribute should deactivate the event handler");
+}, "Removing an event handler content attribute on an SVG element deactivates it");
+</script>


### PR DESCRIPTION
Event handler content attributes such as `onclick` were only activated in
`HTMLElement::attribute_mutated`, so setting one on an SVG element had no
effect even though SVG elements expose the same event handler IDL
attributes. Move the handling to `Element::attribute_mutated`, which every
element type reaches through the `VirtualMethods` super-type chain, so that
SVG elements (and any other non-HTML element) activate their event handler
content attributes too. The behaviour for HTML elements is unchanged.

Testing: Adds a WPT test that sets an event handler content attribute on an
SVG element, dispatches a matching event and verifies the handler runs, and
that removing the attribute deactivates the handler.
Fixes: #45090
