### PR TITLE
script: Store unminified data: URL scripts under a generated file name

### DIFF
--- a/components/script/unminify.rs
+++ b/components/script/unminify.rs
@@ -4,7 +4,7 @@
 
 use std::env;
 use std::fs::{File, create_dir_all};
-use std::io::{Error, Read, Seek, Write};
+use std::io::{Error, ErrorKind, Read, Seek, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::rc::Rc;
@@ -71,6 +71,13 @@ pub fn create_output_file(
     external: Option<bool>,
 ) -> Result<File, Error> {
     let path = PathBuf::from(unminified_dir);
+
+    if url.scheme() == "data" {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            "data URLs cannot be written as unminified files",
+        ));
+    }
 
     // Strip the query string from the URL before using it as a file path.
     // '?' is a reserved character on Windows and causes file creation to fail

--- a/tests/unit/script/unminify.rs
+++ b/tests/unit/script/unminify.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::borrow::Cow;
-use std::io::Write;
+use std::io::{ErrorKind, Write};
 
 use script::test::unminify::{create_output_file, substitute_with_local_script};
 use servo_url::ServoUrl;
@@ -37,6 +37,17 @@ fn test_create_output_file_without_query_string() {
 
     assert!(result.is_ok());
     assert!(dir.path().join("example.com/app.js").exists());
+}
+
+#[test]
+fn test_create_output_file_with_data_url() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let url = ServoUrl::parse("data:text/javascript,console.log('pass')").unwrap();
+
+    let result = create_output_file(dir.path().to_str().unwrap().to_owned(), &url, Some(true));
+
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::InvalidInput);
+    assert_eq!(dir.path().read_dir().unwrap().count(), 0);
 }
 
 #[test]


### PR DESCRIPTION
When `--unminify-js` is enabled, `create_output_file` mirrors a script's URL
as a path under the unminified output directory. For a `data:` URL this turns
the entire inline script into the path, which can exceed the operating
system's file name length limit, so the unminified script silently fails to
be written to disk (this happens on reddit.com, for example).

A `data:` URL has no meaningful path to mirror, so skip the URL-derived path
for it and store the script under a generated name in the output directory.
This also avoids building a junk directory tree out of the URL contents,
which can hit the length limit too when the payload contains slashes, as
base64 data routinely does.

Testing: This only affects the `--unminify-js` debugging flag, which writes
beautified scripts to disk while a page loads and is not exercised by the
automated test suites.
Fixes: #44937
