### PR TITLE
Implement Window.screenLeft and Window.screenTop

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2110,8 +2110,18 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
         self.client_window().min.x
     }
 
+    /// <https://drafts.csswg.org/cssom-view/#ref-for-dom-window-screenleft>
+    fn ScreenLeft(&self) -> i32 {
+        self.client_window().min.x
+    }
+
     /// <https://drafts.csswg.org/cssom-view/#dom-window-screeny>
     fn ScreenY(&self) -> i32 {
+        self.client_window().min.y
+    }
+
+    /// <https://drafts.csswg.org/cssom-view/#ref-for-dom-window-screentop>
+    fn ScreenTop(&self) -> i32 {
         self.client_window().min.y
     }
 

--- a/components/script_bindings/webidls/Window.webidl
+++ b/components/script_bindings/webidls/Window.webidl
@@ -129,7 +129,9 @@ partial interface Window {
 
   // client
   [Replaceable] readonly attribute long screenX;
+  [Replaceable] readonly attribute long screenLeft;
   [Replaceable] readonly attribute long screenY;
+  [Replaceable] readonly attribute long screenTop;
   [Replaceable] readonly attribute long outerWidth;
   [Replaceable] readonly attribute long outerHeight;
   [Replaceable] readonly attribute double devicePixelRatio;

--- a/tests/wpt/meta/css/cssom-view/idlharness.html.ini
+++ b/tests/wpt/meta/css/cssom-view/idlharness.html.ini
@@ -11,9 +11,6 @@
   [CaretPosition interface: existence and properties of interface object]
     expected: FAIL
 
-  [Window interface: window must inherit property "screenTop" with the proper type]
-    expected: FAIL
-
   [HTMLImageElement interface: attribute x]
     expected: FAIL
 
@@ -38,9 +35,6 @@
   [CaretPosition interface object name]
     expected: FAIL
 
-  [Window interface: attribute screenTop]
-    expected: FAIL
-
   [CaretPosition interface: document.caretPositionFromPoint(5, 5) must inherit property "offset" with the proper type]
     expected: FAIL
 
@@ -50,16 +44,10 @@
   [HTMLImageElement interface: document.createElement("img") must inherit property "y" with the proper type]
     expected: FAIL
 
-  [Window interface: attribute screenLeft]
-    expected: FAIL
-
   [CaretPosition interface: existence and properties of interface prototype object's @@unscopables property]
     expected: FAIL
 
   [CaretPosition interface: document.caretPositionFromPoint(5, 5) must inherit property "getClientRect()" with the proper type]
-    expected: FAIL
-
-  [Window interface: window must inherit property "screenLeft" with the proper type]
     expected: FAIL
 
   [CaretPosition must be primary interface of document.caretPositionFromPoint(5, 5)]

--- a/tests/wpt/meta/css/cssom-view/screenLeftTop.html.ini
+++ b/tests/wpt/meta/css/cssom-view/screenLeftTop.html.ini
@@ -1,7 +1,0 @@
-[screenLeftTop.html]
-  [screenTop]
-    expected: FAIL
-
-  [screenLeft]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/browsers/the-window-object/window-properties.https.html.ini
+++ b/tests/wpt/meta/html/browsers/the-window-object/window-properties.https.html.ini
@@ -22,9 +22,3 @@
 
   [Window replaceable attribute: external]
     expected: FAIL
-
-  [Window replaceable attribute: screenLeft]
-    expected: FAIL
-
-  [Window replaceable attribute: screenTop]
-    expected: FAIL

--- a/tests/wpt/meta/webidl/ecmascript-binding/setter-argument.html.ini
+++ b/tests/wpt/meta/webidl/ecmascript-binding/setter-argument.html.ini
@@ -11,12 +11,6 @@
   [String attribute setter called with string should just work]
     expected: FAIL
 
-  [[Replaceable\] setter called with undefined should behave in the same way as no arguments]
-    expected: FAIL
-
-  [[Replaceable\] setter called with other value should just work]
-    expected: FAIL
-
   [[LegacyLenientThis\] setter should not throw even if this value is invalid, regardless of the arguments count]
     expected: FAIL
 


### PR DESCRIPTION
Implement Window.screenLeft and Window.screenTop 

Testing: tests/wpt/tests/css/cssom-view/screenLeftTop.html
Fixes: #45092 
