### PR TITLE
webgpu: Add `GPUMipmapFilterMode`

### DIFF
--- a/components/script/dom/webgpu/gpuconvert.rs
+++ b/components/script/dom/webgpu/gpuconvert.rs
@@ -16,10 +16,10 @@ use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUAddressMode, GPUBindGroupEntry, GPUBindGroupLayoutEntry, GPUBindingResource,
     GPUBlendComponent, GPUBlendFactor, GPUBlendOperation, GPUBufferBindingType, GPUColor,
     GPUCompareFunction, GPUCullMode, GPUExtent3D, GPUFilterMode, GPUFrontFace, GPUImageCopyBuffer,
-    GPUImageCopyTexture, GPUImageDataLayout, GPUIndexFormat, GPULoadOp, GPUObjectDescriptorBase,
-    GPUOrigin3D, GPUPrimitiveState, GPUPrimitiveTopology, GPUProgrammableStage,
-    GPUSamplerBindingType, GPUStencilOperation, GPUStorageTextureAccess, GPUStoreOp,
-    GPUTextureAspect, GPUTextureDescriptor, GPUTextureDimension, GPUTextureFormat,
+    GPUImageCopyTexture, GPUImageDataLayout, GPUIndexFormat, GPULoadOp, GPUMipmapFilterMode,
+    GPUObjectDescriptorBase, GPUOrigin3D, GPUPrimitiveState, GPUPrimitiveTopology,
+    GPUProgrammableStage, GPUSamplerBindingType, GPUStencilOperation, GPUStorageTextureAccess,
+    GPUStoreOp, GPUTextureAspect, GPUTextureDescriptor, GPUTextureDimension, GPUTextureFormat,
     GPUTextureSampleType, GPUTextureViewDimension, GPUVertexFormat,
 };
 use crate::dom::bindings::error::{Error, Fallible};
@@ -348,12 +348,11 @@ impl Convert<wgpu_types::FilterMode> for GPUFilterMode {
     }
 }
 
-// TODO(sagudev): this will become GPUMipmapFilterMode once the webidl is updated
-impl Convert<wgpu_types::MipmapFilterMode> for GPUFilterMode {
+impl Convert<wgpu_types::MipmapFilterMode> for GPUMipmapFilterMode {
     fn convert(self) -> wgpu_types::MipmapFilterMode {
         match self {
-            GPUFilterMode::Nearest => wgpu_types::MipmapFilterMode::Nearest,
-            GPUFilterMode::Linear => wgpu_types::MipmapFilterMode::Linear,
+            GPUMipmapFilterMode::Nearest => wgpu_types::MipmapFilterMode::Nearest,
+            GPUMipmapFilterMode::Linear => wgpu_types::MipmapFilterMode::Linear,
         }
     }
 }

--- a/components/script_bindings/webidls/WebGPU.webidl
+++ b/components/script_bindings/webidls/WebGPU.webidl
@@ -427,9 +427,9 @@ dictionary GPUSamplerDescriptor : GPUObjectDescriptorBase {
     GPUAddressMode addressModeW = "clamp-to-edge";
     GPUFilterMode magFilter = "nearest";
     GPUFilterMode minFilter = "nearest";
-    GPUFilterMode mipmapFilter = "nearest";
+    GPUMipmapFilterMode mipmapFilter = "nearest";
     float lodMinClamp = 0;
-    float lodMaxClamp = 1000.0; // TODO: What should this be?
+    float lodMaxClamp = 32;
     GPUCompareFunction compare;
     [Clamp] unsigned short maxAnisotropy = 1;
 };
@@ -444,6 +444,12 @@ enum GPUFilterMode {
     "nearest",
     "linear",
 };
+
+enum GPUMipmapFilterMode {
+    "nearest",
+    "linear",
+};
+
 
 enum GPUCompareFunction {
     "never",


### PR DESCRIPTION
`GPUFilterMode` was split in spec into similar `GPUMipmapFilterMode`. Relevant wgpu PR: https://github.com/gfx-rs/wgpu/pull/8314

Testing: This is actually internal to engine so WebGPU CTS have no changes
