### PR TITLE
Make Blob.stream() supports readable byte streams

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -421,7 +421,14 @@ impl ExtractedBody {
         let task_source = global.task_manager().networking_task_source();
 
         // In case of the data being in-memory, send everything in one chunk, by-passing SM.
-        let in_memory = stream.get_in_memory_bytes();
+        // Empty extracted bodies are always representable as an in-memory empty payload.
+        let in_memory = stream.get_in_memory_bytes().or_else(|| {
+            if total_bytes == Some(0) {
+                Some(GenericSharedMemory::from_bytes(&[]))
+            } else {
+                None
+            }
+        });
 
         let net_source = match source {
             BodySource::Null => NetBodySource::Null,

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2210,12 +2210,12 @@ impl GlobalScope {
         let (file_id, size) = match self.get_blob_bytes_or_file_id(blob_id) {
             BlobResult::Bytes(bytes) => {
                 // If we have all the bytes in memory, queue them and close the stream.
-                return ReadableStream::new_from_bytes(cx, self, bytes);
+                return ReadableStream::new_from_bytes_with_byte_reading_support(cx, self, bytes);
             },
             BlobResult::File(id, size) => (id, size),
         };
 
-        let stream = ReadableStream::new_with_external_underlying_source(
+        let stream = ReadableStream::new_with_external_underlying_byte_source(
             cx,
             self,
             UnderlyingSourceType::Blob(size),

--- a/components/script/dom/stream/readablebytestreamcontroller.rs
+++ b/components/script/dom/stream/readablebytestreamcontroller.rs
@@ -864,41 +864,43 @@ impl ReadableByteStreamController {
             return Ok(());
         }
 
-        // If controller.[[pendingPullIntos]] is not empty,
-        let pending_pull_intos = self.pending_pull_intos.borrow();
-        if !pending_pull_intos.is_empty() {
-            // Let firstPendingPullInto be controller.[[pendingPullIntos]][0].
-            let first_pending_pull_into = pending_pull_intos.first().unwrap();
+        {
+            // If controller.[[pendingPullIntos]] is not empty,
+            let pending_pull_intos = self.pending_pull_intos.borrow();
+            if !pending_pull_intos.is_empty() {
+                // Let firstPendingPullInto be controller.[[pendingPullIntos]][0].
+                let first_pending_pull_into = pending_pull_intos.first().unwrap();
 
-            // If the remainder after dividing firstPendingPullInto’s bytes filled by
-            // firstPendingPullInto’s element size is not 0,
-            if !first_pending_pull_into
-                .bytes_filled
-                .get()
-                .is_multiple_of(first_pending_pull_into.element_size)
-            {
-                // needed to drop the borrow and avoid BorrowMutError
-                drop(pending_pull_intos);
+                // If the remainder after dividing firstPendingPullInto’s bytes filled by
+                // firstPendingPullInto’s element size is not 0,
+                if !first_pending_pull_into
+                    .bytes_filled
+                    .get()
+                    .is_multiple_of(first_pending_pull_into.element_size)
+                {
+                    // needed to drop the borrow and avoid BorrowMutError
+                    drop(pending_pull_intos);
 
-                // Let e be a new TypeError exception.
-                let e = Error::Type(
-                    c"remainder after dividing firstPendingPullInto's bytes
+                    // Let e be a new TypeError exception.
+                    let e = Error::Type(
+                        c"remainder after dividing firstPendingPullInto's bytes
                     filled by firstPendingPullInto's element size is not 0"
-                        .to_owned(),
-                );
+                            .to_owned(),
+                    );
 
-                // Perform ! ReadableByteStreamControllerError(controller, e).
-                rooted!(&in(cx) let mut error = UndefinedValue());
-                e.clone().to_jsval(
-                    cx.into(),
-                    &self.global(),
-                    error.handle_mut(),
-                    CanGc::from_cx(cx),
-                );
-                self.error(cx, error.handle());
+                    // Perform ! ReadableByteStreamControllerError(controller, e).
+                    rooted!(&in(cx) let mut error = UndefinedValue());
+                    e.clone().to_jsval(
+                        cx.into(),
+                        &self.global(),
+                        error.handle_mut(),
+                        CanGc::from_cx(cx),
+                    );
+                    self.error(cx, error.handle());
 
-                // Throw e.
-                return Err(e);
+                    // Throw e.
+                    return Err(e);
+                }
             }
         }
 
@@ -1490,6 +1492,47 @@ impl ReadableByteStreamController {
         // Set controller.[[queueTotalSize]] to controller.[[queueTotalSize]] + byteLength.
         self.queue_total_size
             .set(self.queue_total_size.get() + byte_length as f64);
+    }
+
+    pub(crate) fn in_memory(&self) -> bool {
+        if let Some(underlying_source) = self.underlying_source.get() {
+            return underlying_source.in_memory();
+        }
+
+        self.stream.get().is_some_and(|stream| stream.is_closed()) && self.queue.borrow().is_empty()
+    }
+
+    pub(crate) fn get_in_memory_bytes(&self) -> Option<Vec<u8>> {
+        if let Some(underlying_source) = self.underlying_source.get() {
+            if !underlying_source.in_memory() {
+                return None;
+            }
+        } else if self.stream.get().is_some_and(|stream| stream.is_closed()) &&
+            self.queue.borrow().is_empty()
+        {
+            return Some(Vec::new());
+        } else {
+            return None;
+        }
+
+        let cx = GlobalScope::get_cx();
+        self.queue.borrow().iter().try_fold(
+            Vec::with_capacity(self.queue_total_size.get() as usize),
+            |mut bytes, entry| {
+                let mut chunk = vec![0; entry.byte_length];
+                entry
+                    .buffer
+                    .copy_data_to(
+                        cx,
+                        &mut chunk,
+                        entry.byte_offset,
+                        entry.byte_offset + entry.byte_length,
+                    )
+                    .ok()?;
+                bytes.extend(chunk);
+                Some(bytes)
+            },
+        )
     }
 
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-shift-pending-pull-into>

--- a/components/script/dom/stream/readablebytestreamcontroller.rs
+++ b/components/script/dom/stream/readablebytestreamcontroller.rs
@@ -1495,23 +1495,15 @@ impl ReadableByteStreamController {
     }
 
     pub(crate) fn in_memory(&self) -> bool {
-        if let Some(underlying_source) = self.underlying_source.get() {
-            return underlying_source.in_memory();
-        }
-
-        self.stream.get().is_some_and(|stream| stream.is_closed()) && self.queue.borrow().is_empty()
+        let Some(underlying_source) = self.underlying_source.get() else {
+            return false;
+        };
+        underlying_source.in_memory()
     }
 
     pub(crate) fn get_in_memory_bytes(&self) -> Option<Vec<u8>> {
-        if let Some(underlying_source) = self.underlying_source.get() {
-            if !underlying_source.in_memory() {
-                return None;
-            }
-        } else if self.stream.get().is_some_and(|stream| stream.is_closed()) &&
-            self.queue.borrow().is_empty()
-        {
-            return Some(Vec::new());
-        } else {
+        let underlying_source = self.underlying_source.get()?;
+        if !underlying_source.in_memory() {
             return None;
         }
 

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -1262,11 +1262,11 @@ impl ReadableStream {
                 .get()
                 .expect("Stream should have controller.")
                 .in_memory(),
-            _ => {
-                unreachable!(
-                    "Checking if source is in memory for a stream with a non-default controller"
-                )
-            },
+            Some(ControllerType::Byte(controller)) => controller
+                .get()
+                .expect("Stream should have controller.")
+                .in_memory(),
+            _ => unreachable!("Checking if source is in memory for a stream without a controller"),
         }
     }
 
@@ -1280,9 +1280,13 @@ impl ReadableStream {
                 .get_in_memory_bytes()
                 .as_deref()
                 .map(GenericSharedMemory::from_bytes),
-            _ => {
-                unreachable!("Getting in-memory bytes for a stream with a non-default controller")
-            },
+            Some(ControllerType::Byte(controller)) => controller
+                .get()
+                .expect("Stream should have controller.")
+                .get_in_memory_bytes()
+                .as_deref()
+                .map(GenericSharedMemory::from_bytes),
+            _ => unreachable!("Getting in-memory bytes for a stream without a controller"),
         }
     }
 

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -20,7 +20,7 @@ use js::rust::{
     HandleObject as SafeHandleObject, HandleValue as SafeHandleValue,
     MutableHandleValue as SafeMutableHandleValue,
 };
-use js::typedarray::ArrayBufferViewU8;
+use js::typedarray::{ArrayBufferViewU8, Uint8};
 use rustc_hash::FxHashMap;
 
 use crate::dom::bindings::codegen::Bindings::QueuingStrategyBinding::QueuingStrategy;
@@ -68,7 +68,7 @@ use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::bindings::transferable::Transferable;
 use crate::dom::bindings::structuredclone::StructuredData;
 
-use crate::dom::bindings::buffer_source::HeapBufferSource;
+use crate::dom::bindings::buffer_source::{BufferSource, HeapBufferSource, create_buffer_source};
 use super::readablestreambyobreader::ReadIntoRequest;
 
 /// State Machine for `PipeTo`.
@@ -983,6 +983,22 @@ impl ReadableStream {
         Ok(stream)
     }
 
+    /// <https://streams.spec.whatwg.org/#readablestream-set-up-with-byte-reading-support>
+    pub(crate) fn new_from_bytes_with_byte_reading_support(
+        cx: &mut JSContext,
+        global: &GlobalScope,
+        bytes: Vec<u8>,
+    ) -> Fallible<DomRoot<ReadableStream>> {
+        let stream = ReadableStream::new_with_external_underlying_byte_source(
+            cx,
+            global,
+            UnderlyingSourceType::Memory(bytes.len()),
+        )?;
+        stream.enqueue_native(cx, bytes);
+        stream.controller_close_native(cx);
+        Ok(stream)
+    }
+
     /// Build a stream backed by a Rust underlying source.
     /// Note: external sources are always paired with a default controller.
     pub(crate) fn new_with_external_underlying_source(
@@ -1000,6 +1016,19 @@ impl ReadableStream {
             CanGc::from_cx(cx),
         );
         controller.setup(cx, stream.clone())?;
+        Ok(stream)
+    }
+
+    /// <https://streams.spec.whatwg.org/#readablestream-set-up-with-byte-reading-support>
+    pub(crate) fn new_with_external_underlying_byte_source(
+        cx: &mut JSContext,
+        global: &GlobalScope,
+        source: UnderlyingSourceType,
+    ) -> Fallible<DomRoot<ReadableStream>> {
+        assert!(source.is_native());
+        let stream = ReadableStream::new_with_proto(global, None, CanGc::from_cx(cx));
+        let controller = ReadableByteStreamController::new(source, 0.0, global, CanGc::from_cx(cx));
+        controller.setup(cx, global, stream.clone())?;
         Ok(stream)
     }
 
@@ -1107,18 +1136,37 @@ impl ReadableStream {
         }
     }
 
-    /// Endpoint to enqueue chunks directly from Rust.
-    /// Note: in other use cases this call happens via the controller.
+    /// <https://streams.spec.whatwg.org/#readablestream-enqueue>
     pub(crate) fn enqueue_native(&self, cx: &mut JSContext, bytes: Vec<u8>) {
         match self.controller.borrow().as_ref() {
             Some(ControllerType::Default(controller)) => controller
                 .get()
                 .expect("Stream should have controller.")
                 .enqueue_native(cx, bytes),
+            Some(ControllerType::Byte(controller)) => {
+                if bytes.is_empty() {
+                    return;
+                }
+
+                let controller = controller.get().expect("Stream should have controller.");
+                rooted!(&in(cx) let mut chunk_object = ptr::null_mut::<JSObject>());
+                create_buffer_source::<Uint8>(
+                    cx.into(),
+                    &bytes,
+                    chunk_object.handle_mut(),
+                    CanGc::from_cx(cx),
+                )
+                .expect("failed to create buffer source for native byte chunk.");
+
+                let chunk = RootedTraceableBox::new(HeapBufferSource::<ArrayBufferViewU8>::new(
+                    BufferSource::ArrayBufferView(Heap::boxed(*chunk_object.handle())),
+                ));
+                controller
+                    .enqueue(cx, chunk)
+                    .expect("Enqueuing a native byte chunk should not fail.");
+            },
             _ => {
-                unreachable!(
-                    "Enqueueing chunk to a stream from Rust on other than default controller"
-                );
+                unreachable!("Enqueueing chunk to a stream from Rust without a controller");
             },
         }
     }
@@ -1185,7 +1233,7 @@ impl ReadableStream {
     }
 
     /// Call into the controller's `Close` method.
-    /// <https://streams.spec.whatwg.org/#readable-stream-default-controller-close>
+    /// <https://streams.spec.whatwg.org/#readablestream-close>
     pub(crate) fn controller_close_native(&self, cx: &mut JSContext) {
         match self.controller.borrow().as_ref() {
             Some(ControllerType::Default(controller)) => {
@@ -1194,8 +1242,14 @@ impl ReadableStream {
                     .expect("Stream should have controller.")
                     .Close(cx);
             },
+            Some(ControllerType::Byte(controller)) => {
+                let _ = controller
+                    .get()
+                    .expect("Stream should have controller.")
+                    .close(cx);
+            },
             _ => {
-                unreachable!("Native closing is only done on default controllers.")
+                unreachable!("Native closing requires a stream controller.")
             },
         }
     }

--- a/tests/wpt/meta/FileAPI/blob/Blob-stream.any.js.ini
+++ b/tests/wpt/meta/FileAPI/blob/Blob-stream.any.js.ini
@@ -1,8 +1,0 @@
-[Blob-stream.any.worker.html]
-  [Reading Blob.stream() with BYOB reader]
-    expected: FAIL
-
-
-[Blob-stream.any.html]
-  [Reading Blob.stream() with BYOB reader]
-    expected: FAIL

--- a/tests/wpt/meta/fetch/api/response/response-consume-stream.any.js.ini
+++ b/tests/wpt/meta/fetch/api/response/response-consume-stream.any.js.ini
@@ -8,9 +8,6 @@
   [Getting an error Response stream]
     expected: FAIL
 
-  [Read blob response's body as readableStream with mode=byob]
-    expected: FAIL
-
   [Read text response's body as readableStream with mode=byob]
     expected: FAIL
 
@@ -32,9 +29,6 @@
     expected: FAIL
 
   [Getting an error Response stream]
-    expected: FAIL
-
-  [Read blob response's body as readableStream with mode=byob]
     expected: FAIL
 
   [Read text response's body as readableStream with mode=byob]


### PR DESCRIPTION
Blob.stream() now creates readable byte streams for both in-memory and file backed blobs, matching the file APi requirement to set up byte reading support.

Testing: Removed the expected-FAIL metadata from tests/wpt/meta/FileAPI/blob/Blob-stream.any.js.ini so the existing Blob.stream() BYOB WPTs now cover this behavior.