### PR TITLE
shell.nix: Rename xorg packages to fix warnings

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -83,8 +83,8 @@ stdenv.mkDerivation (androidEnvironment // {
   buildInputs = [
     # Native dependencies
     fontconfig freetype libunwind
-    xorg.libxcb
-    xorg.libX11
+    libxcb
+    libx11
 
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base
@@ -146,7 +146,7 @@ stdenv.mkDerivation (androidEnvironment // {
   # Provide libraries that aren’t linked against but somehow required
   LD_LIBRARY_PATH = lib.makeLibraryPath [
     # Fixes missing library errors
-    wayland xorg.libXcursor xorg.libXrandr xorg.libXi libxkbcommon
+    wayland libxcursor libxrandr libxi libxkbcommon
 
     # [WARN  script::dom::gpu] Could not get GPUAdapter ("NotFound")
     # TLA Err: Error: Couldn't request WebGPU adapter.


### PR DESCRIPTION
This fixes some warnings from shell.nix:

```
trace: evaluation warning: The xorg package set has been deprecated, 'xorg.libXcursor' has been renamed to 'libxcursor'
trace: evaluation warning: The xorg package set has been deprecated, 'xorg.libXrandr' has been renamed to 'libxrandr'
trace: evaluation warning: The xorg package set has been deprecated, 'xorg.libXi' has been renamed to 'libxi'
trace: evaluation warning: The xorg package set has been deprecated, 'xorg.libxcb' has been renamed to 'libxcb'
trace: evaluation warning: The xorg package set has been deprecated, 'xorg.libX11' has been renamed to 'libx11'
```

Testing: Not needed, no semantic changes
