### PR TITLE
layout: Root unbound nodes until next reflow is finished.

### DIFF
--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -563,7 +563,7 @@ impl AccessibilityUpdate {
                     }
                 },
                 TreeChange::PendingMove => {
-                    panic!(
+                    unreachable!(
                         "Pending move found for node id {id:?} when draining tree state changes"
                     );
                 },

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -101,20 +101,15 @@ impl AccessibilityTree {
     pub(super) fn update_tree(
         &mut self,
         root_dom_node: &ServoLayoutNode<'_>,
-    ) -> Option<accesskit::TreeUpdate> {
+    ) -> Option<(accesskit::TreeUpdate, Vec<OpaqueNode>, Vec<OpaqueNode>)> {
         let mut update = AccessibilityUpdate::new();
         let root_node = self.get_or_create_node(root_dom_node, &mut update);
         let root_node_id = root_node.borrow().id;
         self.root_node_id = Some(root_node_id);
 
-        let any_node_updated = self.update_node_and_descendants(root_dom_node, &mut update);
+        self.update_node_and_descendants(root_dom_node, &mut update);
 
-        if !any_node_updated {
-            assert!(update.tree_changes.is_empty());
-            return None;
-        }
-
-        let accesskit_update = update.finalize(self)?;
+        let (accesskit_update, new_opaque_nodes, stale_opaque_nodes) = update.finalize(self)?;
 
         if self
             .debug
@@ -127,7 +122,7 @@ impl AccessibilityTree {
             self.assert_integrity();
         }
 
-        Some(accesskit_update)
+        Some((accesskit_update, new_opaque_nodes, stale_opaque_nodes))
     }
 
     /// Update this tree starting at the given DOM node, adding any changed nodes to the given
@@ -201,14 +196,13 @@ impl AccessibilityTree {
         node.clone()
     }
 
-    /// Remove the node with the given ID from the cache, if it exists.
-    fn remove_node(&mut self, id: &NodeId) {
-        let Some(node) = self.nodes.remove(id) else {
-            return;
-        };
+    /// Remove the node with the given ID from the cache and return it, if it exists.
+    fn remove_node(&mut self, id: NodeId) -> Option<ArcRefCell<AccessibilityNode>> {
+        let node = self.nodes.remove(&id)?;
         if let Some(opaque_node) = node.borrow().opaque_node {
             self.opaque_node_to_id.remove(&opaque_node);
         }
+        Some(node)
     }
 
     fn id_for_opaque(&mut self, opaque: OpaqueNode) -> NodeId {
@@ -545,39 +539,71 @@ impl AccessibilityUpdate {
         node.updated = false;
     }
 
-    fn finalize(mut self, tree: &mut AccessibilityTree) -> Option<accesskit::TreeUpdate> {
-        for id in self
-            .tree_changes
-            .drain()
-            .filter_map(|(id, change)| match change {
+    fn finalize(
+        mut self,
+        tree: &mut AccessibilityTree,
+    ) -> Option<(accesskit::TreeUpdate, Vec<OpaqueNode>, Vec<OpaqueNode>)> {
+        let root_node_id = tree
+            .root_node_id
+            .expect("AccessibilityUpdate::finalize() called but no root_node_id set in tree");
+
+        if self.changed_nodes.is_empty() {
+            assert!(self.tree_changes.is_empty());
+            return None;
+        }
+
+        let mut new_opaque_nodes: Vec<OpaqueNode> = Vec::default();
+        let mut stale_opaque_nodes: Vec<OpaqueNode> = Vec::default();
+        for (id, change) in self.tree_changes.drain() {
+            match change {
+                TreeChange::New => {
+                    let node = tree.assert_node_for_id(id);
+                    if let Some(opaque_node) = node.borrow().opaque_node {
+                        // Currently all accessibility nodes correspond to DOM nodes, but this may
+                        // not always be true.
+                        new_opaque_nodes.push(opaque_node);
+                    }
+                },
+                TreeChange::Removed => {
+                    let Some(node) = tree.remove_node(id) else {
+                        panic!("Removed node with id {id:?} not found in tree");
+                    };
+                    if let Some(opaque_node) = node.borrow().opaque_node {
+                        stale_opaque_nodes.push(opaque_node);
+                    }
+                },
                 TreeChange::PendingMove => {
-                    unreachable!(
+                    panic!(
                         "Pending move found for node id {id:?} when draining tree state changes"
                     );
                 },
-                TreeChange::Removed => Some(id),
-                _ => None,
-            })
-        {
-            tree.remove_node(&id);
+                TreeChange::Moved => {
+                    // We only track moved nodes to avoid incorrectly marking them as removed, so
+                    // we just silently drop them here.
+                },
+            }
         }
 
-        let accesskit_tree = accesskit::Tree::new(tree.root_node_id?);
-        Some(accesskit::TreeUpdate {
-            nodes: self
-                .changed_nodes
-                .into_iter()
-                .map(|id| {
-                    (
-                        id,
-                        tree.assert_node_for_id(id).borrow().accesskit_node.clone(),
-                    )
-                })
-                .collect(),
-            tree: Some(accesskit_tree),
-            focus: accesskit::NodeId(1),
-            tree_id: tree.tree_id,
-        })
+        let accesskit_tree = accesskit::Tree::new(root_node_id);
+        Some((
+            accesskit::TreeUpdate {
+                nodes: self
+                    .changed_nodes
+                    .into_iter()
+                    .map(|id| {
+                        (
+                            id,
+                            tree.assert_node_for_id(id).borrow().accesskit_node.clone(),
+                        )
+                    })
+                    .collect(),
+                tree: Some(accesskit_tree),
+                focus: accesskit::NodeId(1),
+                tree_id: tree.tree_id,
+            },
+            new_opaque_nodes,
+            stale_opaque_nodes,
+        ))
     }
 }
 
@@ -618,7 +644,7 @@ fn test_accessibility_update_add_some_nodes_twice() {
         update.add(&mut node_3);
     }
 
-    let mut tree_update = update
+    let (mut tree_update, _, _) = update
         .finalize(&mut tree)
         .expect("finalize should produce a tree update");
     tree_update.nodes.sort_by_key(|(node_id, _node)| *node_id);

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -51,12 +51,6 @@ pub struct AccessibilityTree {
     debug: DiagnosticsLogging,
 }
 
-pub struct AccessibilityUpdateResult {
-    pub tree_update: accesskit::TreeUpdate,
-    pub new_opaque_nodes: Vec<OpaqueNode>,
-    pub removed_opaque_nodes: Vec<OpaqueNode>,
-}
-
 /// Tracks changes to a node's relation to the tree within an update.
 ///
 /// This is used to remove nodes from the accessibility tree's cache when they are no longer in the
@@ -107,7 +101,7 @@ impl AccessibilityTree {
     pub(super) fn update_tree(
         &mut self,
         root_dom_node: &ServoLayoutNode<'_>,
-    ) -> Option<AccessibilityUpdateResult> {
+    ) -> Option<accesskit::TreeUpdate> {
         let mut update = AccessibilityUpdate::new();
         let root_node = self.get_or_create_node(root_dom_node, &mut update);
         let root_node_id = root_node.borrow().id;
@@ -532,7 +526,7 @@ impl AccessibilityUpdate {
         node.updated = false;
     }
 
-    fn finalize(mut self, tree: &mut AccessibilityTree) -> Option<AccessibilityUpdateResult> {
+    fn finalize(mut self, tree: &mut AccessibilityTree) -> Option<accesskit::TreeUpdate> {
         let root_node_id = tree
             .root_node_id
             .expect("AccessibilityUpdate::finalize() called but no root_node_id set in tree");
@@ -542,25 +536,15 @@ impl AccessibilityUpdate {
             return None;
         }
 
-        let mut new_opaque_nodes: Vec<OpaqueNode> = Vec::default();
-        let mut removed_opaque_nodes: Vec<OpaqueNode> = Vec::default();
         for (id, change) in self.tree_changes.drain() {
             match change {
                 TreeChange::New => {
-                    let node = tree.assert_node_for_id(id);
-                    if let Some(opaque_node) = node.borrow().opaque_node {
-                        // Currently all accessibility nodes correspond to DOM nodes, but this may
-                        // not always be true.
-                        new_opaque_nodes.push(opaque_node);
-                    }
+                    let _ = tree.assert_node_for_id(id);
                 },
                 TreeChange::Removed => {
-                    let Some(node) = tree.remove_node(id) else {
+                    let Some(_) = tree.remove_node(id) else {
                         panic!("Removed node with id {id:?} not found in tree");
                     };
-                    if let Some(opaque_node) = node.borrow().opaque_node {
-                        removed_opaque_nodes.push(opaque_node);
-                    }
                 },
                 TreeChange::PendingMove => {
                     unreachable!(
@@ -602,11 +586,7 @@ impl AccessibilityUpdate {
             tree.assert_integrity();
         }
 
-        Some(AccessibilityUpdateResult {
-            tree_update,
-            new_opaque_nodes,
-            removed_opaque_nodes,
-        })
+        Some(tree_update)
     }
 }
 

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -49,6 +49,7 @@ pub struct AccessibilityTree {
     /// Debug options, copied from configuration to this `AccessibilityTree` in order
     /// to avoid having to constantly access the thread-safe global options.
     debug: DiagnosticsLogging,
+    recently_removed_opaque_nodes: Vec<OpaqueNode>,
 }
 
 /// Tracks changes to a node's relation to the tree within an update.
@@ -93,6 +94,7 @@ impl AccessibilityTree {
             root_node_id: None,
             epoch,
             debug: opts::get().debug.clone(),
+            recently_removed_opaque_nodes: vec![],
         }
     }
 
@@ -110,6 +112,10 @@ impl AccessibilityTree {
         self.update_node_and_descendants(root_dom_node, &mut update);
 
         update.finalize(self)
+    }
+
+    pub(super) fn take_recently_removed_opaque_nodes(&mut self) -> Vec<OpaqueNode> {
+        std::mem::take(&mut self.recently_removed_opaque_nodes)
     }
 
     /// Update this tree starting at the given DOM node, adding any changed nodes to the given
@@ -536,15 +542,23 @@ impl AccessibilityUpdate {
             return None;
         }
 
+        // This field should be taken after each update, if it's being used.
+        assert!(tree.recently_removed_opaque_nodes.is_empty());
+
         for (id, change) in self.tree_changes.drain() {
             match change {
                 TreeChange::New => {
                     let _ = tree.assert_node_for_id(id);
                 },
                 TreeChange::Removed => {
-                    let Some(_) = tree.remove_node(id) else {
+                    let Some(node) = tree.remove_node(id) else {
                         panic!("Removed node with id {id:?} not found in tree");
                     };
+                    if pref!(expensive_accessibility_test_assertions_enabled) &&
+                        let Some(opaque_node) = node.borrow().opaque_node
+                    {
+                        tree.recently_removed_opaque_nodes.push(opaque_node);
+                    }
                 },
                 TreeChange::PendingMove => {
                     unreachable!(

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -51,6 +51,12 @@ pub struct AccessibilityTree {
     debug: DiagnosticsLogging,
 }
 
+pub struct AccessibilityUpdateResult {
+    pub tree_update: accesskit::TreeUpdate,
+    pub new_opaque_nodes: Vec<OpaqueNode>,
+    pub removed_opaque_nodes: Vec<OpaqueNode>,
+}
+
 /// Tracks changes to a node's relation to the tree within an update.
 ///
 /// This is used to remove nodes from the accessibility tree's cache when they are no longer in the
@@ -101,7 +107,7 @@ impl AccessibilityTree {
     pub(super) fn update_tree(
         &mut self,
         root_dom_node: &ServoLayoutNode<'_>,
-    ) -> Option<(accesskit::TreeUpdate, Vec<OpaqueNode>, Vec<OpaqueNode>)> {
+    ) -> Option<AccessibilityUpdateResult> {
         let mut update = AccessibilityUpdate::new();
         let root_node = self.get_or_create_node(root_dom_node, &mut update);
         let root_node_id = root_node.borrow().id;
@@ -109,20 +115,7 @@ impl AccessibilityTree {
 
         self.update_node_and_descendants(root_dom_node, &mut update);
 
-        let (accesskit_update, new_opaque_nodes, stale_opaque_nodes) = update.finalize(self)?;
-
-        if self
-            .debug
-            .is_enabled(DiagnosticsLoggingOption::AccessibilityTree)
-        {
-            self.print();
-        }
-
-        if pref!(expensive_accessibility_test_assertions_enabled) {
-            self.assert_integrity();
-        }
-
-        Some((accesskit_update, new_opaque_nodes, stale_opaque_nodes))
+        update.finalize(self)
     }
 
     /// Update this tree starting at the given DOM node, adding any changed nodes to the given
@@ -539,10 +532,7 @@ impl AccessibilityUpdate {
         node.updated = false;
     }
 
-    fn finalize(
-        mut self,
-        tree: &mut AccessibilityTree,
-    ) -> Option<(accesskit::TreeUpdate, Vec<OpaqueNode>, Vec<OpaqueNode>)> {
+    fn finalize(mut self, tree: &mut AccessibilityTree) -> Option<AccessibilityUpdateResult> {
         let root_node_id = tree
             .root_node_id
             .expect("AccessibilityUpdate::finalize() called but no root_node_id set in tree");
@@ -553,7 +543,7 @@ impl AccessibilityUpdate {
         }
 
         let mut new_opaque_nodes: Vec<OpaqueNode> = Vec::default();
-        let mut stale_opaque_nodes: Vec<OpaqueNode> = Vec::default();
+        let mut removed_opaque_nodes: Vec<OpaqueNode> = Vec::default();
         for (id, change) in self.tree_changes.drain() {
             match change {
                 TreeChange::New => {
@@ -569,7 +559,7 @@ impl AccessibilityUpdate {
                         panic!("Removed node with id {id:?} not found in tree");
                     };
                     if let Some(opaque_node) = node.borrow().opaque_node {
-                        stale_opaque_nodes.push(opaque_node);
+                        removed_opaque_nodes.push(opaque_node);
                     }
                 },
                 TreeChange::PendingMove => {
@@ -585,25 +575,38 @@ impl AccessibilityUpdate {
         }
 
         let accesskit_tree = accesskit::Tree::new(root_node_id);
-        Some((
-            accesskit::TreeUpdate {
-                nodes: self
-                    .changed_nodes
-                    .into_iter()
-                    .map(|id| {
-                        (
-                            id,
-                            tree.assert_node_for_id(id).borrow().accesskit_node.clone(),
-                        )
-                    })
-                    .collect(),
-                tree: Some(accesskit_tree),
-                focus: accesskit::NodeId(1),
-                tree_id: tree.tree_id,
-            },
+        let tree_update = accesskit::TreeUpdate {
+            nodes: self
+                .changed_nodes
+                .into_iter()
+                .map(|id| {
+                    (
+                        id,
+                        tree.assert_node_for_id(id).borrow().accesskit_node.clone(),
+                    )
+                })
+                .collect(),
+            tree: Some(accesskit_tree),
+            focus: accesskit::NodeId(1),
+            tree_id: tree.tree_id,
+        };
+
+        if tree
+            .debug
+            .is_enabled(DiagnosticsLoggingOption::AccessibilityTree)
+        {
+            tree.print();
+        }
+
+        if pref!(expensive_accessibility_test_assertions_enabled) {
+            tree.assert_integrity();
+        }
+
+        Some(AccessibilityUpdateResult {
+            tree_update,
             new_opaque_nodes,
-            stale_opaque_nodes,
-        ))
+            removed_opaque_nodes,
+        })
     }
 }
 
@@ -644,9 +647,10 @@ fn test_accessibility_update_add_some_nodes_twice() {
         update.add(&mut node_3);
     }
 
-    let (mut tree_update, _, _) = update
+    let mut update_result = update
         .finalize(&mut tree)
-        .expect("finalize should produce a tree update");
+        .expect("finalize should produce an update result");
+    let mut tree_update = update_result.tree_update;
     tree_update.nodes.sort_by_key(|(node_id, _node)| *node_id);
     assert_eq!(
         tree_update,

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -1023,11 +1023,11 @@ impl LayoutThread {
         let pending_svg_elements_for_serialization =
             std::mem::take(&mut *image_resolver.pending_svg_elements_for_serialization.lock());
 
-        let mut removed_nodes_for_accessibility = None;
+        let mut removed_nodes_for_accessibility_integrity_check = None;
         if pref!(accessibility_enabled) && pref!(expensive_accessibility_test_assertions_enabled) {
             let mut accessibility_tree = self.accessibility_tree.borrow_mut();
             if let Some(accessibility_tree) = accessibility_tree.as_mut() {
-                removed_nodes_for_accessibility = Some(
+                removed_nodes_for_accessibility_integrity_check = Some(
                     accessibility_tree
                         .take_recently_removed_opaque_nodes()
                         .into_iter()
@@ -1044,7 +1044,7 @@ impl LayoutThread {
             pending_svg_elements_for_serialization,
             iframe_sizes: Some(iframe_sizes),
             reflow_statistics,
-            removed_nodes_for_accessibility,
+            removed_nodes_for_accessibility_integrity_check,
         })
     }
 

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -7,6 +7,7 @@
 use std::cell::{Cell, OnceCell, RefCell};
 use std::collections::HashMap;
 use std::fmt::Debug;
+use std::mem;
 use std::rc::Rc;
 use std::sync::{Arc, LazyLock};
 
@@ -236,7 +237,7 @@ pub struct LayoutThread {
     /// Nodes which no longer have a corresponding node in the accessibility.
     /// These should be drained and unrooted at some point.
     /// See [Layout::drain_stale_nodes_for_accessibility]
-    stale_nodes_for_accessibility: Vec<OpaqueNode>,
+    removed_nodes_for_accessibility: Vec<OpaqueNode>,
 }
 
 pub struct LayoutFactoryImpl();
@@ -752,13 +753,12 @@ impl Layout for LayoutThread {
         self.needs_accessibility_update.set(true);
     }
 
-    fn drain_new_nodes_for_accessibility(&mut self) -> std::vec::Drain<'_, OpaqueNode> {
-        // TODO: can we ensure at compile time that this _must_ be called before the end of layout?
-        self.new_nodes_for_accessibility.drain(..)
+    fn take_new_nodes_for_accessibility(&mut self) -> Vec<OpaqueNode> {
+        mem::take(&mut self.new_nodes_for_accessibility)
     }
 
-    fn drain_stale_nodes_for_accessibility(&mut self) -> std::vec::Drain<'_, OpaqueNode> {
-        self.stale_nodes_for_accessibility.drain(..)
+    fn take_removed_nodes_for_accessibility(&mut self) -> Vec<OpaqueNode> {
+        mem::take(&mut self.removed_nodes_for_accessibility)
     }
 }
 
@@ -820,7 +820,7 @@ impl LayoutThread {
             accessibility_tree: Default::default(),
             needs_accessibility_update: Cell::new(false),
             new_nodes_for_accessibility: vec![],
-            stale_nodes_for_accessibility: vec![],
+            removed_nodes_for_accessibility: vec![],
         }
     }
 
@@ -956,12 +956,15 @@ impl LayoutThread {
             return false;
         };
 
+        // These fields should either never have been populated, or been taken at the end of the
+        // previous reflow.
+        assert!(self.new_nodes_for_accessibility.is_empty());
+        assert!(self.removed_nodes_for_accessibility.is_empty());
+
         let accessibility_tree = &mut *accessibility_tree;
-        if let Some((tree_update, new_opaque_nodes, stale_opaque_nodes)) =
-            accessibility_tree.update_tree(root_element)
-        {
-            self.new_nodes_for_accessibility = new_opaque_nodes;
-            self.stale_nodes_for_accessibility = stale_opaque_nodes;
+        if let Some(update_result) = accessibility_tree.update_tree(root_element) {
+            self.new_nodes_for_accessibility = update_result.new_opaque_nodes;
+            self.removed_nodes_for_accessibility = update_result.removed_opaque_nodes;
 
             // FIXME: Handle send error. Could have a method on accessibility tree to
             // finalise after sending, removing accessibility damage? On fail, retain damage
@@ -970,7 +973,7 @@ impl LayoutThread {
                 .embedder_chan
                 .send(EmbedderMsg::AccessibilityTreeUpdate(
                     self.webview_id,
-                    tree_update,
+                    update_result.tree_update,
                     accessibility_tree.epoch(),
                 ));
         }

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -230,13 +230,14 @@ pub struct LayoutThread {
     needs_accessibility_update: Cell<bool>,
 
     /// Nodes which newly have a corresponding node in the accessibility tree.
-    /// These should be drained and rooted immediately after reflow.
-    /// See [Layout::drain_new_nodes_for_accessibility]
+    /// These should be taken and rooted before any DOM mutations can occur
+    /// after a reflow.
+    /// See [Layout::take_new_nodes_for_accessibility()]
     new_nodes_for_accessibility: Vec<OpaqueNode>,
 
-    /// Nodes which no longer have a corresponding node in the accessibility.
-    /// These should be drained and unrooted at some point.
-    /// See [Layout::drain_stale_nodes_for_accessibility]
+    /// Nodes which no longer have a corresponding node in the accessibility
+    /// tree. These should be taken and unrooted at some point.
+    /// See [Layout::take_removed_nodes_for_accessibility()]
     removed_nodes_for_accessibility: Vec<OpaqueNode>,
 }
 

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -1023,6 +1023,20 @@ impl LayoutThread {
         let pending_svg_elements_for_serialization =
             std::mem::take(&mut *image_resolver.pending_svg_elements_for_serialization.lock());
 
+        let mut removed_nodes_for_accessibility = None;
+        if pref!(accessibility_enabled) && pref!(expensive_accessibility_test_assertions_enabled) {
+            let mut accessibility_tree = self.accessibility_tree.borrow_mut();
+            if let Some(accessibility_tree) = accessibility_tree.as_mut() {
+                removed_nodes_for_accessibility = Some(
+                    accessibility_tree
+                        .take_recently_removed_opaque_nodes()
+                        .into_iter()
+                        .map(|opaque_node| opaque_node.into())
+                        .collect(),
+                );
+            }
+        }
+
         Some(ReflowResult {
             reflow_phases_run,
             pending_images,
@@ -1030,6 +1044,7 @@ impl LayoutThread {
             pending_svg_elements_for_serialization,
             iframe_sizes: Some(iframe_sizes),
             reflow_statistics,
+            removed_nodes_for_accessibility,
         })
     }
 

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -7,7 +7,6 @@
 use std::cell::{Cell, OnceCell, RefCell};
 use std::collections::HashMap;
 use std::fmt::Debug;
-use std::mem;
 use std::rc::Rc;
 use std::sync::{Arc, LazyLock};
 
@@ -228,17 +227,6 @@ pub struct LayoutThread {
 
     /// See [Layout::needs_accessibility_update()].
     needs_accessibility_update: Cell<bool>,
-
-    /// Nodes which newly have a corresponding node in the accessibility tree.
-    /// These should be taken and rooted before any DOM mutations can occur
-    /// after a reflow.
-    /// See [Layout::take_new_nodes_for_accessibility()]
-    new_nodes_for_accessibility: Vec<OpaqueNode>,
-
-    /// Nodes which no longer have a corresponding node in the accessibility
-    /// tree. These should be taken and unrooted at some point.
-    /// See [Layout::take_removed_nodes_for_accessibility()]
-    removed_nodes_for_accessibility: Vec<OpaqueNode>,
 }
 
 pub struct LayoutFactoryImpl();
@@ -753,14 +741,6 @@ impl Layout for LayoutThread {
     fn set_needs_accessibility_update(&self) {
         self.needs_accessibility_update.set(true);
     }
-
-    fn take_new_nodes_for_accessibility(&mut self) -> Vec<OpaqueNode> {
-        mem::take(&mut self.new_nodes_for_accessibility)
-    }
-
-    fn take_removed_nodes_for_accessibility(&mut self) -> Vec<OpaqueNode> {
-        mem::take(&mut self.removed_nodes_for_accessibility)
-    }
 }
 
 impl LayoutThread {
@@ -820,8 +800,6 @@ impl LayoutThread {
             user_stylesheets: config.user_stylesheets,
             accessibility_tree: Default::default(),
             needs_accessibility_update: Cell::new(false),
-            new_nodes_for_accessibility: vec![],
-            removed_nodes_for_accessibility: vec![],
         }
     }
 
@@ -957,16 +935,8 @@ impl LayoutThread {
             return false;
         };
 
-        // These fields should either never have been populated, or been taken at the end of the
-        // previous reflow.
-        assert!(self.new_nodes_for_accessibility.is_empty());
-        assert!(self.removed_nodes_for_accessibility.is_empty());
-
         let accessibility_tree = &mut *accessibility_tree;
-        if let Some(update_result) = accessibility_tree.update_tree(root_element) {
-            self.new_nodes_for_accessibility = update_result.new_opaque_nodes;
-            self.removed_nodes_for_accessibility = update_result.removed_opaque_nodes;
-
+        if let Some(tree_update) = accessibility_tree.update_tree(root_element) {
             // FIXME: Handle send error. Could have a method on accessibility tree to
             // finalise after sending, removing accessibility damage? On fail, retain damage
             // for next reflow, as well as retaining document.needs_accessibility_update.
@@ -974,7 +944,7 @@ impl LayoutThread {
                 .embedder_chan
                 .send(EmbedderMsg::AccessibilityTreeUpdate(
                     self.webview_id,
-                    update_result.tree_update,
+                    tree_update,
                     accessibility_tree.epoch(),
                 ));
         }

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -227,6 +227,16 @@ pub struct LayoutThread {
 
     /// See [Layout::needs_accessibility_update()].
     needs_accessibility_update: Cell<bool>,
+
+    /// Nodes which newly have a corresponding node in the accessibility tree.
+    /// These should be drained and rooted immediately after reflow.
+    /// See [Layout::drain_new_nodes_for_accessibility]
+    new_nodes_for_accessibility: Vec<OpaqueNode>,
+
+    /// Nodes which no longer have a corresponding node in the accessibility.
+    /// These should be drained and unrooted at some point.
+    /// See [Layout::drain_stale_nodes_for_accessibility]
+    stale_nodes_for_accessibility: Vec<OpaqueNode>,
 }
 
 pub struct LayoutFactoryImpl();
@@ -741,6 +751,15 @@ impl Layout for LayoutThread {
     fn set_needs_accessibility_update(&self) {
         self.needs_accessibility_update.set(true);
     }
+
+    fn drain_new_nodes_for_accessibility(&mut self) -> std::vec::Drain<'_, OpaqueNode> {
+        // TODO: can we ensure at compile time that this _must_ be called before the end of layout?
+        self.new_nodes_for_accessibility.drain(..)
+    }
+
+    fn drain_stale_nodes_for_accessibility(&mut self) -> std::vec::Drain<'_, OpaqueNode> {
+        self.stale_nodes_for_accessibility.drain(..)
+    }
 }
 
 impl LayoutThread {
@@ -800,6 +819,8 @@ impl LayoutThread {
             user_stylesheets: config.user_stylesheets,
             accessibility_tree: Default::default(),
             needs_accessibility_update: Cell::new(false),
+            new_nodes_for_accessibility: vec![],
+            stale_nodes_for_accessibility: vec![],
         }
     }
 
@@ -926,7 +947,7 @@ impl LayoutThread {
         }
     }
 
-    fn handle_accessibility_tree_update(&self, root_element: &ServoLayoutNode) -> bool {
+    fn handle_accessibility_tree_update(&mut self, root_element: &ServoLayoutNode) -> bool {
         if !self.needs_accessibility_update() {
             return false;
         }
@@ -936,8 +957,12 @@ impl LayoutThread {
         };
 
         let accessibility_tree = &mut *accessibility_tree;
-        if let Some(tree_update) = accessibility_tree.update_tree(root_element) {
-            // TODO(#4344): send directly to embedder over the pipeline_to_embedder_sender cloned from ScriptThread.
+        if let Some((tree_update, new_opaque_nodes, stale_opaque_nodes)) =
+            accessibility_tree.update_tree(root_element)
+        {
+            self.new_nodes_for_accessibility = new_opaque_nodes;
+            self.stale_nodes_for_accessibility = stale_opaque_nodes;
+
             // FIXME: Handle send error. Could have a method on accessibility tree to
             // finalise after sending, removing accessibility damage? On fail, retain damage
             // for next reflow, as well as retaining document.needs_accessibility_update.

--- a/components/script/dom/document/accessibility_data.rs
+++ b/components/script/dom/document/accessibility_data.rs
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use embedder_traits::UntrustedNodeAddress;
+use js::context::NoGC;
+use rustc_hash::FxHashSet;
+use script_bindings::root::DomRoot;
+use servo_config::pref;
+
+use crate::dom::{Node, from_untrusted_node_address};
+
+#[derive(Clone, Default, JSTraceable, MallocSizeOf)]
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
+pub(crate) struct AccessibilityData {
+    /// Nodes which have been unbound from the DOM but may not yet have been removed from the
+    /// accessibility tree. This is cleared after each reflow.
+    rooted_nodes: FxHashSet<DomRoot<Node>>,
+}
+
+impl AccessibilityData {
+    /// Root a node which has been removed from the DOM but which may still have an associated
+    /// accessibility tree node. It will be unrooted after the next reflow, as the accessibility
+    /// tree is updated as part of the reflow process.
+    pub(crate) fn root_removed_node_for_accessibility(
+        &mut self,
+        _no_gc: &NoGC,
+        node_to_root: &Node,
+    ) {
+        assert!(pref!(accessibility_enabled));
+
+        self.rooted_nodes.insert(DomRoot::from_ref(node_to_root));
+    }
+
+    /// Unroot a node which has been added to the DOM, if it was previously rooted due to
+    /// `[Self::root_removed_node_for_accessibility()`].
+    pub(crate) fn unroot_node_for_accessibility(&mut self, _no_gc: &NoGC, node_to_unroot: &Node) {
+        assert!(pref!(accessibility_enabled));
+
+        self.rooted_nodes.remove(&DomRoot::from_ref(node_to_unroot));
+    }
+
+    /// Clear all nodes which were rooted using [`Self::root_removed_node_for_accessibility()`].
+    #[expect(unsafe_code)]
+    pub(crate) fn unroot_all_nodes_for_accessibility(
+        &mut self,
+        removed_nodes_for_integrity_check: Option<Vec<UntrustedNodeAddress>>,
+    ) {
+        assert!(pref!(accessibility_enabled));
+
+        if let Some(removed_nodes) = removed_nodes_for_integrity_check {
+            assert!(pref!(expensive_accessibility_test_assertions_enabled));
+            for address in removed_nodes {
+                unsafe {
+                    let removed_node = from_untrusted_node_address(address);
+                    self.rooted_nodes.remove(&removed_node);
+                }
+            }
+            assert!(self.rooted_nodes.is_empty());
+        }
+
+        self.rooted_nodes.clear();
+    }
+}

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -23,13 +23,11 @@ use devtools_traits::ScriptToDevtoolsControlMsg;
 use dom_struct::dom_struct;
 use embedder_traits::{
     AllowOrDeny, AnimationState, CustomHandlersAutomationMode, EmbedderMsg, Image, LoadStatus,
-    UntrustedNodeAddress,
 };
 use encoding_rs::{Encoding, UTF_8};
 use fonts::WebFontDocumentContext;
 use html5ever::{LocalName, Namespace, QualName, local_name, ns};
 use hyper_serde::Serde;
-use js::context::NoGC;
 use js::realm::CurrentRealm;
 use js::rust::{HandleObject, HandleValue, MutableHandleValue};
 use layout_api::{
@@ -49,7 +47,7 @@ use percent_encoding::percent_decode;
 use profile_traits::generic_channel as profile_generic_channel;
 use profile_traits::time::TimerMetadataFrameType;
 use regex::bytes::Regex;
-use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
+use rustc_hash::{FxBuildHasher, FxHashMap};
 use script_bindings::cell::{DomRefCell, Ref, RefMut};
 use script_bindings::interfaces::DocumentHelpers;
 use script_bindings::reflector::reflect_dom_object_with_proto;
@@ -129,6 +127,7 @@ use crate::dom::customelementregistry::{
     CustomElementDefinition, CustomElementReactionStack, CustomElementRegistry,
 };
 use crate::dom::customevent::CustomEvent;
+use crate::dom::document::accessibility_data::AccessibilityData;
 use crate::dom::document::focus::{DocumentFocusHandler, FocusableArea};
 use crate::dom::document_embedder_controls::DocumentEmbedderControls;
 use crate::dom::document_event_handler::DocumentEventHandler;
@@ -146,7 +145,6 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::execcommand::basecommand::{CommandName, DefaultSingleLineContainerName};
 use crate::dom::execcommand::execcommands::DocumentExecCommandSupport;
 use crate::dom::focusevent::FocusEvent;
-use crate::dom::from_untrusted_node_address;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::hashchangeevent::HashChangeEvent;
 use crate::dom::html::htmlanchorelement::HTMLAnchorElement;
@@ -296,14 +294,6 @@ impl PendingScrollEvent {
     fn equivalent(&self, target: &EventTarget, event: &Atom) -> bool {
         &*self.target == target && self.event == *event
     }
-}
-
-#[derive(Clone, Default, JSTraceable, MallocSizeOf)]
-#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
-struct AccessibilityData {
-    /// Nodes which have been unbound from the DOM but may not yet have been removed from the
-    /// accessibility tree. This is cleared after each reflow.
-    rooted_nodes: FxHashSet<DomRoot<Node>>,
 }
 
 /// Reasons why a [`Document`] might need a rendering update that is otherwise
@@ -3394,45 +3384,10 @@ impl Document {
         )
     }
 
-    fn accessibility_data_mut(&self) -> RefMut<'_, AccessibilityData> {
+    pub(crate) fn accessibility_data_mut(&self) -> RefMut<'_, AccessibilityData> {
         assert!(pref!(accessibility_enabled));
 
         self.accessibility_data.borrow_mut()
-    }
-
-    /// Root a node which has been removed from the DOM but which may still have an associated
-    /// accessibility tree node. It will be unrooted after the next reflow, as the accessibility
-    /// tree is updated as part of the reflow process.
-    pub(crate) fn root_removed_node_for_accessibility(&self, _no_gc: &NoGC, node_to_root: &Node) {
-        assert!(pref!(accessibility_enabled));
-
-        let mut accessibility_data = self.accessibility_data_mut();
-        let rooted_nodes = &mut accessibility_data.rooted_nodes;
-        rooted_nodes.insert(DomRoot::from_ref(node_to_root));
-    }
-
-    /// Clear all nodes which were rooted using [`Self::root_removed_node_for_accessibility()`].
-    #[expect(unsafe_code)]
-    pub(crate) fn unroot_nodes_for_accessibility(
-        &self,
-        removed_nodes: Option<Vec<UntrustedNodeAddress>>,
-    ) {
-        assert!(pref!(accessibility_enabled));
-
-        let mut accessibility_data = self.accessibility_data_mut();
-
-        if let Some(removed_nodes) = removed_nodes {
-            assert!(pref!(expensive_accessibility_test_assertions_enabled));
-            for address in removed_nodes {
-                unsafe {
-                    let removed_node = from_untrusted_node_address(address);
-                    accessibility_data.rooted_nodes.remove(&removed_node);
-                }
-            }
-            assert!(accessibility_data.rooted_nodes.is_empty());
-        }
-
-        accessibility_data.rooted_nodes.clear();
     }
 }
 

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -3421,7 +3421,7 @@ impl Document {
 
             let address = UntrustedNodeAddress(opaque_node.0 as *const c_void);
             // SAFETY: This is called immediately following layout, during which no GC occurs.
-            //.This ensures that the opaque nodes can't be GCed before we try to
+            // This ensures that the opaque nodes can't be GCed before we try to
             // interact with them.
             unsafe {
                 let node_to_root = from_untrusted_node_address(address);

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -23,6 +23,7 @@ use devtools_traits::ScriptToDevtoolsControlMsg;
 use dom_struct::dom_struct;
 use embedder_traits::{
     AllowOrDeny, AnimationState, CustomHandlersAutomationMode, EmbedderMsg, Image, LoadStatus,
+    UntrustedNodeAddress,
 };
 use encoding_rs::{Encoding, UTF_8};
 use fonts::WebFontDocumentContext;
@@ -48,7 +49,7 @@ use percent_encoding::percent_decode;
 use profile_traits::generic_channel as profile_generic_channel;
 use profile_traits::time::TimerMetadataFrameType;
 use regex::bytes::Regex;
-use rustc_hash::{FxBuildHasher, FxHashMap};
+use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use script_bindings::cell::{DomRefCell, Ref, RefMut};
 use script_bindings::interfaces::DocumentHelpers;
 use script_bindings::reflector::reflect_dom_object_with_proto;
@@ -145,6 +146,7 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::execcommand::basecommand::{CommandName, DefaultSingleLineContainerName};
 use crate::dom::execcommand::execcommands::DocumentExecCommandSupport;
 use crate::dom::focusevent::FocusEvent;
+use crate::dom::from_untrusted_node_address;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::hashchangeevent::HashChangeEvent;
 use crate::dom::html::htmlanchorelement::HTMLAnchorElement;
@@ -301,7 +303,7 @@ impl PendingScrollEvent {
 struct AccessibilityData {
     /// Nodes which have been unbound from the DOM but may not yet have been removed from the
     /// accessibility tree. This is cleared after each reflow.
-    rooted_nodes: Vec<Dom<Node>>,
+    rooted_nodes: FxHashSet<DomRoot<Node>>,
 }
 
 /// Reasons why a [`Document`] might need a rendering update that is otherwise
@@ -3406,14 +3408,30 @@ impl Document {
 
         let mut accessibility_data = self.accessibility_data_mut();
         let rooted_nodes = &mut accessibility_data.rooted_nodes;
-        rooted_nodes.push(Dom::from_ref(node_to_root));
+        rooted_nodes.insert(DomRoot::from_ref(node_to_root));
     }
 
     /// Clear all nodes which were rooted using [`Self::root_removed_node_for_accessibility()`].
-    pub(crate) fn unroot_nodes_for_accessibility(&self) {
+    #[expect(unsafe_code)]
+    pub(crate) fn unroot_nodes_for_accessibility(
+        &self,
+        removed_nodes: Option<Vec<UntrustedNodeAddress>>,
+    ) {
         assert!(pref!(accessibility_enabled));
 
         let mut accessibility_data = self.accessibility_data_mut();
+
+        if let Some(removed_nodes) = removed_nodes {
+            assert!(pref!(expensive_accessibility_test_assertions_enabled));
+            for address in removed_nodes {
+                unsafe {
+                    let removed_node = from_untrusted_node_address(address);
+                    accessibility_data.rooted_nodes.remove(&removed_node);
+                }
+            }
+            assert!(accessibility_data.rooted_nodes.is_empty());
+        }
+
         accessibility_data.rooted_nodes.clear();
     }
 }

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -3406,10 +3406,7 @@ impl Document {
     }
 
     #[expect(unsafe_code)]
-    pub(crate) fn root_nodes_for_accessibility(
-        &self,
-        opaque_nodes: impl Iterator<Item = OpaqueNode>,
-    ) {
+    pub(crate) fn root_nodes_for_accessibility(&self, opaque_nodes: Vec<OpaqueNode>) {
         assert!(pref!(accessibility_enabled));
 
         let accessibility_data = self.accessibility_data();
@@ -3427,10 +3424,7 @@ impl Document {
         }
     }
 
-    pub(crate) fn unroot_nodes_for_accessibility(
-        &self,
-        opaque_nodes: impl Iterator<Item = OpaqueNode>,
-    ) {
+    pub(crate) fn unroot_nodes_for_accessibility(&self, opaque_nodes: Vec<OpaqueNode>) {
         assert!(pref!(accessibility_enabled));
 
         let accessibility_data = self.accessibility_data();

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -300,6 +300,7 @@ impl PendingScrollEvent {
 }
 
 #[derive(Clone, Default, JSTraceable, MallocSizeOf)]
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 struct AccessibilityData {
     /// Nodes which have corresponding nodes in the accessibility tree, which need to be rooted
     /// until their corresponding nodes removed from the accessibility tree.

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -30,6 +30,7 @@ use encoding_rs::{Encoding, UTF_8};
 use fonts::WebFontDocumentContext;
 use html5ever::{LocalName, Namespace, QualName, local_name, ns};
 use hyper_serde::Serde;
+use js::context::NoGC;
 use js::realm::CurrentRealm;
 use js::rust::{HandleObject, HandleValue, MutableHandleValue};
 use layout_api::{
@@ -306,7 +307,7 @@ struct AccessibilityData {
     /// until their corresponding nodes removed from the accessibility tree.
     /// This allows the lifetime of nodes to be guaranteed to be at least as long as the lifetime
     /// of their corresponding accessibility nodes.
-    rooted_nodes: DomRefCell<FxHashMap<NoTrace<OpaqueNode>, Dom<Node>>>,
+    rooted_nodes: FxHashMap<NoTrace<OpaqueNode>, Dom<Node>>,
 }
 
 /// Reasons why a [`Document`] might need a rendering update that is otherwise
@@ -662,7 +663,7 @@ pub(crate) struct Document {
     css_styling_flag: Cell<bool>,
 
     /// Data necessary for maintaining the accessibility tree.
-    accessibility_data: DomRefCell<Option<AccessibilityData>>,
+    accessibility_data: DomRefCell<AccessibilityData>,
 }
 
 impl Document {
@@ -3397,26 +3398,31 @@ impl Document {
         )
     }
 
-    fn accessibility_data(&self) -> RefMut<'_, AccessibilityData> {
+    fn accessibility_data_mut(&self) -> RefMut<'_, AccessibilityData> {
         assert!(pref!(accessibility_enabled));
 
-        RefMut::map(self.accessibility_data.borrow_mut(), |accessibility_data| {
-            accessibility_data.get_or_insert_default()
-        })
+        self.accessibility_data.borrow_mut()
     }
 
     #[expect(unsafe_code)]
-    pub(crate) fn root_nodes_for_accessibility(&self, opaque_nodes: Vec<OpaqueNode>) {
+    pub(crate) fn root_nodes_for_accessibility(
+        &self,
+        _no_gc: &NoGC,
+        opaque_nodes: Vec<OpaqueNode>,
+    ) {
         assert!(pref!(accessibility_enabled));
 
-        let accessibility_data = self.accessibility_data();
-        let mut rooted_nodes = accessibility_data.rooted_nodes.borrow_mut();
+        let mut accessibility_data = self.accessibility_data_mut();
+        let rooted_nodes = &mut accessibility_data.rooted_nodes;
         for opaque_node in opaque_nodes {
             if rooted_nodes.contains_key(&NoTrace(opaque_node)) {
                 continue;
             }
 
             let address = UntrustedNodeAddress(opaque_node.0 as *const c_void);
+            // SAFETY: This is called immediately following layout, during which no GC occurs.
+            //.This ensures that the opaque nodes can't be GCed before we try to
+            // interact with them.
             unsafe {
                 let node_to_root = from_untrusted_node_address(address);
                 rooted_nodes.insert(NoTrace(opaque_node), Dom::from_ref(&*node_to_root))
@@ -3427,8 +3433,8 @@ impl Document {
     pub(crate) fn unroot_nodes_for_accessibility(&self, opaque_nodes: Vec<OpaqueNode>) {
         assert!(pref!(accessibility_enabled));
 
-        let accessibility_data = self.accessibility_data();
-        let mut rooted_nodes = accessibility_data.rooted_nodes.borrow_mut();
+        let mut accessibility_data = self.accessibility_data_mut();
+        let rooted_nodes = &mut accessibility_data.rooted_nodes;
         for opaque_node in opaque_nodes {
             rooted_nodes.remove(&NoTrace(opaque_node));
         }

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -7,6 +7,7 @@ use std::cmp::Ordering;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::default::Default;
+use std::ffi::c_void;
 use std::ops::Deref;
 use std::rc::Rc;
 use std::str::FromStr;
@@ -23,6 +24,7 @@ use devtools_traits::ScriptToDevtoolsControlMsg;
 use dom_struct::dom_struct;
 use embedder_traits::{
     AllowOrDeny, AnimationState, CustomHandlersAutomationMode, EmbedderMsg, Image, LoadStatus,
+    UntrustedNodeAddress,
 };
 use encoding_rs::{Encoding, UTF_8};
 use fonts::WebFontDocumentContext;
@@ -64,6 +66,7 @@ use servo_media::{ClientContextId, ServoMedia};
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
 use style::attr::AttrValue;
 use style::context::QuirksMode;
+use style::dom::OpaqueNode;
 use style::invalidation::element::restyle_hints::RestyleHint;
 use style::selector_parser::Snapshot;
 use style::shared_lock::{SharedRwLock, SharedRwLockReadGuard};
@@ -144,6 +147,7 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::execcommand::basecommand::{CommandName, DefaultSingleLineContainerName};
 use crate::dom::execcommand::execcommands::DocumentExecCommandSupport;
 use crate::dom::focusevent::FocusEvent;
+use crate::dom::from_untrusted_node_address;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::hashchangeevent::HashChangeEvent;
 use crate::dom::html::htmlanchorelement::HTMLAnchorElement;
@@ -293,6 +297,15 @@ impl PendingScrollEvent {
     fn equivalent(&self, target: &EventTarget, event: &Atom) -> bool {
         &*self.target == target && self.event == *event
     }
+}
+
+#[derive(Clone, Default, JSTraceable, MallocSizeOf)]
+struct AccessibilityData {
+    /// Nodes which have corresponding nodes in the accessibility tree, which need to be rooted
+    /// until their corresponding nodes removed from the accessibility tree.
+    /// This allows the lifetime of nodes to be guaranteed to be at least as long as the lifetime
+    /// of their corresponding accessibility nodes.
+    rooted_nodes: DomRefCell<FxHashMap<NoTrace<OpaqueNode>, Dom<Node>>>,
 }
 
 /// Reasons why a [`Document`] might need a rendering update that is otherwise
@@ -646,6 +659,9 @@ pub(crate) struct Document {
 
     /// <https://w3c.github.io/editing/docs/execCommand/#css-styling-flag>
     css_styling_flag: Cell<bool>,
+
+    /// Data necessary for maintaining the accessibility tree.
+    accessibility_data: DomRefCell<Option<AccessibilityData>>,
 }
 
 impl Document {
@@ -3379,6 +3395,49 @@ impl Document {
             |details_name_groups| details_name_groups.get_or_insert_default(),
         )
     }
+
+    fn accessibility_data(&self) -> RefMut<'_, AccessibilityData> {
+        assert!(pref!(accessibility_enabled));
+
+        RefMut::map(self.accessibility_data.borrow_mut(), |accessibility_data| {
+            accessibility_data.get_or_insert_default()
+        })
+    }
+
+    #[expect(unsafe_code)]
+    pub(crate) fn root_nodes_for_accessibility(
+        &self,
+        opaque_nodes: impl Iterator<Item = OpaqueNode>,
+    ) {
+        assert!(pref!(accessibility_enabled));
+
+        let accessibility_data = self.accessibility_data();
+        let mut rooted_nodes = accessibility_data.rooted_nodes.borrow_mut();
+        for opaque_node in opaque_nodes {
+            if rooted_nodes.contains_key(&NoTrace(opaque_node)) {
+                continue;
+            }
+
+            let address = UntrustedNodeAddress(opaque_node.0 as *const c_void);
+            unsafe {
+                let node_to_root = from_untrusted_node_address(address);
+                rooted_nodes.insert(NoTrace(opaque_node), Dom::from_ref(&*node_to_root))
+            };
+        }
+    }
+
+    pub(crate) fn unroot_nodes_for_accessibility(
+        &self,
+        opaque_nodes: impl Iterator<Item = OpaqueNode>,
+    ) {
+        assert!(pref!(accessibility_enabled));
+
+        let accessibility_data = self.accessibility_data();
+        let mut rooted_nodes = accessibility_data.rooted_nodes.borrow_mut();
+        for opaque_node in opaque_nodes {
+            rooted_nodes.remove(&NoTrace(opaque_node));
+        }
+    }
 }
 
 #[derive(MallocSizeOf, PartialEq)]
@@ -3678,6 +3737,7 @@ impl Document {
             value_override: Default::default(),
             default_single_line_container_name: Default::default(),
             css_styling_flag: Default::default(),
+            accessibility_data: Default::default(),
         }
     }
 

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -7,7 +7,6 @@ use std::cmp::Ordering;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::default::Default;
-use std::ffi::c_void;
 use std::ops::Deref;
 use std::rc::Rc;
 use std::str::FromStr;
@@ -24,7 +23,6 @@ use devtools_traits::ScriptToDevtoolsControlMsg;
 use dom_struct::dom_struct;
 use embedder_traits::{
     AllowOrDeny, AnimationState, CustomHandlersAutomationMode, EmbedderMsg, Image, LoadStatus,
-    UntrustedNodeAddress,
 };
 use encoding_rs::{Encoding, UTF_8};
 use fonts::WebFontDocumentContext;
@@ -67,7 +65,6 @@ use servo_media::{ClientContextId, ServoMedia};
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
 use style::attr::AttrValue;
 use style::context::QuirksMode;
-use style::dom::OpaqueNode;
 use style::invalidation::element::restyle_hints::RestyleHint;
 use style::selector_parser::Snapshot;
 use style::shared_lock::{SharedRwLock, SharedRwLockReadGuard};
@@ -148,7 +145,6 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::execcommand::basecommand::{CommandName, DefaultSingleLineContainerName};
 use crate::dom::execcommand::execcommands::DocumentExecCommandSupport;
 use crate::dom::focusevent::FocusEvent;
-use crate::dom::from_untrusted_node_address;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::hashchangeevent::HashChangeEvent;
 use crate::dom::html::htmlanchorelement::HTMLAnchorElement;
@@ -303,11 +299,9 @@ impl PendingScrollEvent {
 #[derive(Clone, Default, JSTraceable, MallocSizeOf)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 struct AccessibilityData {
-    /// Nodes which have corresponding nodes in the accessibility tree, which need to be rooted
-    /// until their corresponding nodes removed from the accessibility tree.
-    /// This allows the lifetime of nodes to be guaranteed to be at least as long as the lifetime
-    /// of their corresponding accessibility nodes.
-    rooted_nodes: FxHashMap<NoTrace<OpaqueNode>, Dom<Node>>,
+    /// Nodes which have been unbound from the DOM but may not yet have been removed from the
+    /// accessibility tree. This is cleared after each reflow.
+    rooted_nodes: Vec<Dom<Node>>,
 }
 
 /// Reasons why a [`Document`] might need a rendering update that is otherwise
@@ -3404,40 +3398,23 @@ impl Document {
         self.accessibility_data.borrow_mut()
     }
 
-    #[expect(unsafe_code)]
-    pub(crate) fn root_nodes_for_accessibility(
-        &self,
-        _no_gc: &NoGC,
-        opaque_nodes: Vec<OpaqueNode>,
-    ) {
+    /// Root a node which has been removed from the DOM but which may still have an associated
+    /// accessibility tree node. It will be unrooted after the next reflow, as the accessibility
+    /// tree is updated as part of the reflow process.
+    pub(crate) fn root_removed_node_for_accessibility(&self, _no_gc: &NoGC, node_to_root: &Node) {
         assert!(pref!(accessibility_enabled));
 
         let mut accessibility_data = self.accessibility_data_mut();
         let rooted_nodes = &mut accessibility_data.rooted_nodes;
-        for opaque_node in opaque_nodes {
-            if rooted_nodes.contains_key(&NoTrace(opaque_node)) {
-                continue;
-            }
-
-            let address = UntrustedNodeAddress(opaque_node.0 as *const c_void);
-            // SAFETY: This is called immediately following layout, during which no GC occurs.
-            // This ensures that the opaque nodes can't be GCed before we try to
-            // interact with them.
-            unsafe {
-                let node_to_root = from_untrusted_node_address(address);
-                rooted_nodes.insert(NoTrace(opaque_node), Dom::from_ref(&*node_to_root))
-            };
-        }
+        rooted_nodes.push(Dom::from_ref(node_to_root));
     }
 
-    pub(crate) fn unroot_nodes_for_accessibility(&self, opaque_nodes: Vec<OpaqueNode>) {
+    /// Clear all nodes which were rooted using [`Self::root_removed_node_for_accessibility()`].
+    pub(crate) fn unroot_nodes_for_accessibility(&self) {
         assert!(pref!(accessibility_enabled));
 
         let mut accessibility_data = self.accessibility_data_mut();
-        let rooted_nodes = &mut accessibility_data.rooted_nodes;
-        for opaque_node in opaque_nodes {
-            rooted_nodes.remove(&NoTrace(opaque_node));
-        }
+        accessibility_data.rooted_nodes.clear();
     }
 }
 

--- a/components/script/dom/document/mod.rs
+++ b/components/script/dom/document/mod.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #[allow(clippy::module_inception, reason = "The interface name is Document")]
+pub(crate) mod accessibility_data;
 pub(crate) mod document;
 pub(crate) mod document_embedder_controls;
 pub(crate) mod document_event_handler;

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -4755,6 +4755,19 @@ impl VirtualMethods for Node {
         self.owner_doc().content_and_heritage_changed(self);
     }
 
+    fn bind_to_tree(&self, cx: &mut JSContext, context: &BindContext) {
+        self.super_type().unwrap().bind_to_tree(cx, context);
+
+        // Only unroot the node now if we're going to run the integrity check, which will fail if
+        // the node is still in [`AccessibilityData::rooted_nodes`] when the check is run. If the
+        // check is disabled, the node will be unrooted after the next reflow anyway.
+        if pref!(accessibility_enabled) && pref!(expensive_accessibility_test_assertions_enabled) {
+            self.owner_document()
+                .accessibility_data_mut()
+                .unroot_node_for_accessibility(cx.no_gc(), self);
+        }
+    }
+
     // This handles the ranges mentioned in steps 2-3 when removing a node.
     /// <https://dom.spec.whatwg.org/#concept-node-remove>
     fn unbind_from_tree(&self, cx: &mut js::context::JSContext, context: &UnbindContext) {
@@ -4771,6 +4784,7 @@ impl VirtualMethods for Node {
 
         if pref!(accessibility_enabled) {
             self.owner_document()
+                .accessibility_data_mut()
                 .root_removed_node_for_accessibility(cx.no_gc(), self);
         }
     }

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -4768,6 +4768,11 @@ impl VirtualMethods for Node {
             self.ranges()
                 .drain_to_parent(context.parent, context.index(), self);
         }
+
+        if pref!(accessibility_enabled) {
+            self.owner_document()
+                .root_removed_node_for_accessibility(cx.no_gc(), self);
+        }
     }
 
     fn moving_steps(&self, cx: &mut JSContext, context: &MoveContext) {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2721,12 +2721,12 @@ impl Window {
 
         if pref!(accessibility_enabled) {
             document.root_nodes_for_accessibility(
-                self.layout.borrow_mut().drain_new_nodes_for_accessibility(),
+                self.layout.borrow_mut().take_new_nodes_for_accessibility(),
             );
             document.unroot_nodes_for_accessibility(
                 self.layout
                     .borrow_mut()
-                    .drain_stale_nodes_for_accessibility(),
+                    .take_removed_nodes_for_accessibility(),
             );
         }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2720,7 +2720,7 @@ impl Window {
         document.update_animations_post_reflow();
 
         if pref!(accessibility_enabled) {
-            document.unroot_nodes_for_accessibility();
+            document.unroot_nodes_for_accessibility(reflow_result.removed_nodes_for_accessibility);
         }
 
         (

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2720,15 +2720,7 @@ impl Window {
         document.update_animations_post_reflow();
 
         if pref!(accessibility_enabled) {
-            document.root_nodes_for_accessibility(
-                cx.no_gc(),
-                self.layout.borrow_mut().take_new_nodes_for_accessibility(),
-            );
-            document.unroot_nodes_for_accessibility(
-                self.layout
-                    .borrow_mut()
-                    .take_removed_nodes_for_accessibility(),
-            );
+            document.unroot_nodes_for_accessibility();
         }
 
         (

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2720,7 +2720,11 @@ impl Window {
         document.update_animations_post_reflow();
 
         if pref!(accessibility_enabled) {
-            document.unroot_nodes_for_accessibility(reflow_result.removed_nodes_for_accessibility);
+            document
+                .accessibility_data_mut()
+                .unroot_all_nodes_for_accessibility(
+                    reflow_result.removed_nodes_for_accessibility_integrity_check,
+                );
         }
 
         (

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2719,6 +2719,17 @@ impl Window {
 
         document.update_animations_post_reflow();
 
+        if pref!(accessibility_enabled) {
+            document.root_nodes_for_accessibility(
+                self.layout.borrow_mut().drain_new_nodes_for_accessibility(),
+            );
+            document.unroot_nodes_for_accessibility(
+                self.layout
+                    .borrow_mut()
+                    .drain_stale_nodes_for_accessibility(),
+            );
+        }
+
         (
             reflow_result.reflow_phases_run,
             reflow_result.reflow_statistics,

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2721,6 +2721,7 @@ impl Window {
 
         if pref!(accessibility_enabled) {
             document.root_nodes_for_accessibility(
+                cx.no_gc(),
                 self.layout.borrow_mut().take_new_nodes_for_accessibility(),
             );
             document.unroot_nodes_for_accessibility(

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -460,10 +460,11 @@ fn test_accessibility_with_mutation_move_nodes() {
     assert_eq!(h2.label(), Some("This is an h2".to_owned()));
     assert_eq!(div2.role(), Role::GenericContainer);
 
+    // use both moveBefore and appendChild to exercise the different ways nodes move.
     let _ = evaluate_javascript(
         &servo_test,
         webview.clone(),
-        "div1.moveBefore(h1,null); div2.moveBefore(h2,null);\
+        "div1.moveBefore(h1,null); div2.appendChild(h2);\
          window.ServoTestUtils.forceAccessibilityUpdate();",
     );
 

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -626,6 +626,7 @@ pub struct ReflowResult {
     /// finished before reaching this stage of the layout. I.e., no update
     /// required.
     pub iframe_sizes: Option<IFrameSizes>,
+    pub removed_nodes_for_accessibility: Option<Vec<UntrustedNodeAddress>>,
 }
 
 bitflags! {

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicIsize;
 use std::thread::JoinHandle;
 use std::time::Duration;
+use std::vec::Drain;
 
 use app_units::Au;
 use atomic_refcell::AtomicRefCell;
@@ -423,6 +424,14 @@ pub trait Layout {
 
     /// See [Self::needs_accessibility_update()].
     fn set_needs_accessibility_update(&self);
+
+    /// Drain the list of nodes which newly have corresponding accessibility nodes,
+    /// so they can be rooted.
+    fn drain_new_nodes_for_accessibility(&mut self) -> Drain<'_, OpaqueNode>;
+
+    /// Drain the list of nodes which no longer have corresponding accessibility nodes,
+    /// so they can be unrooted.
+    fn drain_stale_nodes_for_accessibility(&mut self) -> Drain<'_, OpaqueNode>;
 }
 
 /// This trait is part of `layout_api` because it depends on both `script_traits`

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -21,7 +21,6 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicIsize;
 use std::thread::JoinHandle;
 use std::time::Duration;
-use std::vec::Drain;
 
 use app_units::Au;
 use atomic_refcell::AtomicRefCell;
@@ -425,13 +424,15 @@ pub trait Layout {
     /// See [Self::needs_accessibility_update()].
     fn set_needs_accessibility_update(&self);
 
-    /// Drain the list of nodes which newly have corresponding accessibility nodes,
+    /// Take the list of nodes which newly have corresponding accessibility nodes,
     /// so they can be rooted.
-    fn drain_new_nodes_for_accessibility(&mut self) -> Drain<'_, OpaqueNode>;
+    #[must_use]
+    fn take_new_nodes_for_accessibility(&mut self) -> Vec<OpaqueNode>;
 
-    /// Drain the list of nodes which no longer have corresponding accessibility nodes,
+    /// Take the list of nodes which no longer have corresponding accessibility nodes,
     /// so they can be unrooted.
-    fn drain_stale_nodes_for_accessibility(&mut self) -> Drain<'_, OpaqueNode>;
+    #[must_use]
+    fn take_removed_nodes_for_accessibility(&mut self) -> Vec<OpaqueNode>;
 }
 
 /// This trait is part of `layout_api` because it depends on both `script_traits`

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -423,16 +423,6 @@ pub trait Layout {
 
     /// See [Self::needs_accessibility_update()].
     fn set_needs_accessibility_update(&self);
-
-    /// Take the list of nodes which newly have corresponding accessibility nodes,
-    /// so they can be rooted.
-    #[must_use]
-    fn take_new_nodes_for_accessibility(&mut self) -> Vec<OpaqueNode>;
-
-    /// Take the list of nodes which no longer have corresponding accessibility nodes,
-    /// so they can be unrooted.
-    #[must_use]
-    fn take_removed_nodes_for_accessibility(&mut self) -> Vec<OpaqueNode>;
 }
 
 /// This trait is part of `layout_api` because it depends on both `script_traits`

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -626,7 +626,11 @@ pub struct ReflowResult {
     /// finished before reaching this stage of the layout. I.e., no update
     /// required.
     pub iframe_sizes: Option<IFrameSizes>,
-    pub removed_nodes_for_accessibility: Option<Vec<UntrustedNodeAddress>>,
+    /// If `expensive_accessibility_test_assertions_enabled` is true, this will contain the
+    /// UntrustedNodeAddresses for dom Nodes corresponding to the accessibility nodes removed from
+    /// the accessibility tree in the most recent update. This is used exclusively for an integrity
+    /// check.
+    pub removed_nodes_for_accessibility_integrity_check: Option<Vec<UntrustedNodeAddress>>,
 }
 
 bitflags! {


### PR DESCRIPTION
Since we use OpaqueNodes to look up accessibility nodes, we want to ensure OpaqueNodes aren't reused before their corresponding accessibility nodes are pruned from the tree.

This change roots nodes as they are unbound from the tree, and unroots them following reflow. This ensures that any node which is removed from the tree before a reflow can't be garbage collected until after the reflow has given the accessibility tree an opportunity to evict the corresponding accessibility node.

We have an expensive integrity check which runs if the `expensive_accessibility_test_assertions_enabled` pref is set: during the accessibility tree update, we collect `OpaqueNode`s corresponding to accessibility nodes removed during the update, and compare this to the nodes which were temporarily rooted after unbinding from the tree.

Testing: Keeps existing behaviour; not sure how to test the new behaviour.
