### PR TITLE
devtools: introduce `PreviewId` in order to get previews

### DIFF
--- a/components/default-resources/resources/debugger.js
+++ b/components/default-resources/resources/debugger.js
@@ -80,7 +80,7 @@ addEventListener("addDebuggee", event => {
 
 // Convert debuggee value to property descriptor value
 // <https://searchfox.org/firefox-main/source/devtools/server/actors/object/utils.js#116>
-function createValueGrip(value, depth = 0) {
+function createValueGrip(value, depth, previewState) {
     switch (typeof value) {
         case "undefined":
             return { valueType: "undefined" };
@@ -111,11 +111,18 @@ function createValueGrip(value, depth = 0) {
             const ownPropertyLength = value.getOwnPropertyNamesLength();
             // Debugger.Object - get preview using registered previewers
             // <https://firefox-source-docs.mozilla.org/devtools-user/debugger-api/debugger.object/index.html>
+            const preview = getPreview(value, depth + 1, previewState);
+            let previewId = undefined;
+            if (preview) {
+                previewState.push(preview);
+                previewId = previewState.length - 1;
+            }
             return {
                 valueType: "object",
                 objectClass: value.class,
                 ownPropertyLength: Number.isFinite(ownPropertyLength) ? ownPropertyLength : undefined,
                 preview: getPreview(value, depth),
+                previewId,
             };
         default:
             return { valueType: "string", stringValue: String(value) };
@@ -124,7 +131,7 @@ function createValueGrip(value, depth = 0) {
 
 // Extract own properties from a debuggee object
 // <https://firefox-source-docs.mozilla.org/devtools-user/debugger-api/debugger.object/index.html#function-properties-of-the-debugger-object-prototype>
-function extractOwnProperties(obj, depth) {
+function extractOwnProperties(obj, depth, previewState) {
     const ownProperties = [];
     let totalLength = 0;
 
@@ -146,16 +153,16 @@ function extractOwnProperties(obj, depth) {
                     enumerable: desc.enumerable ?? false,
                     writable: desc.writable ?? false,
                     isAccessor: desc.get !== undefined || desc.set !== undefined,
-                    value: createValueGrip(undefined, depth + 1),
+                    value: createValueGrip(undefined, depth + 1, previewState),
                 };
 
                 if (desc.value !== undefined) {
-                    prop.value = createValueGrip(desc.value, depth + 1);
+                    prop.value = createValueGrip(desc.value, depth + 1, previewState);
                 } else if (desc.get) {
                     try {
                         const result = desc.get.call(obj);
                         if (result && "return" in result) {
-                            prop.value = createValueGrip(result.return, depth + 1);
+                            prop.value = createValueGrip(result.return, depth + 1, previewState);
                         }
                     } catch (e) { }
                 }
@@ -174,7 +181,7 @@ function extractOwnProperties(obj, depth) {
 const previewers = {};
 
 // <https://searchfox.org/mozilla-central/source/devtools/server/actors/object/previewers.js#125>
-previewers.Function = [ function FunctionPreviewer(obj, depth) {
+previewers.Function = [ function FunctionPreviewer(obj, depth, previewState) {
     let function_details = {
         name: obj.name,
         displayName: obj.displayName,
@@ -188,7 +195,7 @@ previewers.Function = [ function FunctionPreviewer(obj, depth) {
         return undefined;
     }
 
-    const { ownProperties, ownPropertiesLength } = extractOwnProperties(obj, depth);
+    const { ownProperties, ownPropertiesLength } = extractOwnProperties(obj, depth, previewState);
     preview.ownProperties = ownProperties;
     preview.ownPropertiesLength = ownPropertiesLength;
 
@@ -196,23 +203,20 @@ previewers.Function = [ function FunctionPreviewer(obj, depth) {
 } ];
 
 // <https://searchfox.org/mozilla-central/source/devtools/server/actors/object/previewers.js#172>
-previewers.Array = [ function ArrayPreviewer(obj, depth) {
+previewers.Array = [ function ArrayPreviewer(obj, depth, previewState) {
     const lengthDescriptor = obj.getOwnPropertyDescriptor("length");
     const arrayLength = lengthDescriptor ? lengthDescriptor.value : 0;
 
-    let preview = { kind: "ArrayLike", arrayLength };
+    let preview = { kind: "ArrayLike", arrayLength, items: [] };
     if (depth > 1) {
         return undefined;
     }
 
-    let items = (preview.items = []);
     for (let i = 0; i < arrayLength; i++) {
         try {
             const desc = obj.getOwnPropertyDescriptor(i);
             if (desc && desc.value !== undefined) {
-                const grip = createValueGrip(desc.value, depth + 1);
-                delete grip.preview;
-                items.push(grip);
+                preview.items.push(createValueGrip(desc.value, depth + 1, previewState));
             }
         } catch (e) {
             // For now skip properties that throw on access
@@ -224,26 +228,26 @@ previewers.Array = [ function ArrayPreviewer(obj, depth) {
 
 // Generic fallback for object previewer
 // <https://searchfox.org/mozilla-central/source/devtools/server/actors/object/previewers.js#856>
-previewers.Object = [ function ObjectPreviewer(obj, depth) {
+previewers.Object = [ function ObjectPreviewer(obj, depth, previewState) {
     let preview = { kind: "Object" };
     if (depth > 1) {
        return undefined;
     }
 
-    const { ownProperties, ownPropertiesLength } = extractOwnProperties(obj, depth);
+    const { ownProperties, ownPropertiesLength } = extractOwnProperties(obj, depth, previewState);
     preview.ownProperties = ownProperties;
     preview.ownPropertiesLength = ownPropertiesLength;
 
     return preview;
 } ];
 
-function getPreview(obj, depth) {
+function getPreview(obj, depth, previewState) {
     const className = obj.class;
 
     // <https://searchfox.org/mozilla-central/source/devtools/server/actors/object.js#295>
     const typePreviewers = previewers[className] || previewers.Object;
     for (const previewer of typePreviewers) {
-        const result = previewer(obj, depth);
+        const result = previewer(obj, depth, previewState);
         if (result) return result;
     }
 
@@ -254,6 +258,7 @@ function getPreview(obj, depth) {
 // See executeInGlobal() at <https://firefox-source-docs.mozilla.org/devtools-user/debugger-api/debugger.object/index.html#function-properties-of-the-debugger-object-prototype>
 addEventListener("eval", event => {
     const {code, pipelineId, workerId, frameActorId} = event;
+    const previewState = [];
 
     let completionValue;
     if (frameActorId) {
@@ -274,22 +279,30 @@ addEventListener("eval", event => {
     // Completion values: <https://firefox-source-docs.mozilla.org/devtools/backend/protocol.html#completion-values>
     let resultValue;
     if (completionValue === null) {
-        resultValue = { completionType: "terminated", value: createValueGrip(undefined), hasException: false };
+        resultValue = {
+            completionType: "terminated",
+            value: createValueGrip(undefined, 0, previewState),
+            hasException: false,
+        };
     } else if ("throw" in completionValue) {
         // See adoptDebuggeeValue() in <https://firefox-source-docs.mozilla.org/devtools-user/debugger-api/debugger/index.html>
         // <https://searchfox.org/firefox-main/source/devtools/server/actors/webconsole/eval-with-debugger.js#312>
         // we probably don't need adoptDebuggeeValue, as we only have one debugger instance for now
         // let value = dbg.adoptDebuggeeValue(completionValue.throw);
-        resultValue = { completionType: "throw", value: createValueGrip(completionValue.throw), hasException: true };
+        resultValue = {
+            completionType: "throw",
+            value: createValueGrip(completionValue.throw, 0, previewState),
+            hasException: true,
+        };
     } else if ("return" in completionValue) {
-        resultValue = { completionType: "return", value: createValueGrip(completionValue.return), hasException: false };
+        resultValue = {
+            completionType: "return",
+            value: createValueGrip(completionValue.return, 0, previewState),
+            hasException: false,
+        };
     }
 
-    // To avoid recursion errors in the WebIDL, preview needs to live outside of the property descriptor
-    if (resultValue.value.preview) {
-        resultValue.preview = resultValue.value.preview;
-        delete resultValue.value.preview;
-    }
+    resultValue.previews = previewState;
 
     evalResult(event, resultValue);
 });
@@ -592,7 +605,9 @@ function createEnvironmentActor(environment) {
     }
 
     if (environment.type == "declarative") {
-        info.bindingVariables = buildBindings(environment);
+        const { bindingVariables, previewState } = buildBindings(environment);
+        info.bindingVariables = bindingVariables;
+        info.previews = previewState;
     }
 
     let actor = environmentsToEnvironmentActors.get(environment);
@@ -602,7 +617,8 @@ function createEnvironmentActor(environment) {
 }
 
 function buildBindings(environment) {
-    let bindingVars = [];
+    const previewState = [];
+    const bindingVariables = [];
     for (const name of environment.names()) {
         const value = environment.getVariable(name);
         const property = {
@@ -614,19 +630,12 @@ function buildBindings(environment) {
                 (value.optimizedOut || value.uninitialized || value.missingArguments)
             ),
             isAccessor: false,
-            value: createValueGrip(value),
+            value: createValueGrip(value, 0, previewState),
         };
 
-        // To avoid recursion errors in the WebIDL, preview needs to live outside of the property descriptor
-        let preview = undefined;
-        if (property.value.preview) {
-            preview = property.value.preview;
-            delete property.value.preview;
-        }
-
-        bindingVars.push({ property, preview });
+        bindingVariables.push(property);
     }
-    return bindingVars;
+    return { bindingVariables, previewState };
 }
 
 // Get a `Debugger.Environment` instance within which evaluation is taking place.

--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -24,10 +24,8 @@ use storage_traits::StorageThreads;
 
 use crate::dom::bindings::codegen::Bindings::DebuggerEvalEventBinding::DebuggerValue;
 use crate::dom::bindings::codegen::Bindings::DebuggerEvalEventBinding::GenericBindings::ObjectPreview;
-use crate::dom::bindings::codegen::Bindings::DebuggerGetEnvironmentEventBinding::{
-    EnvironmentInfo, EnvironmentVariable,
-};
-use crate::dom::bindings::codegen::Bindings::DebuggerGlobalScopeBinding::{self};
+use crate::dom::bindings::codegen::Bindings::DebuggerGetEnvironmentEventBinding::EnvironmentInfo;
+use crate::dom::bindings::codegen::Bindings::DebuggerGlobalScopeBinding;
 use crate::dom::bindings::codegen::Bindings::DebuggerInterruptEventBinding::{
     FrameInfo, FrameOffset, PauseReason,
 };
@@ -530,8 +528,9 @@ impl DebuggerGlobalScopeMethods<crate::DomTypeHolder> for DebuggerGlobalScope {
             .take()
             .expect("Guaranteed by Self::fire_eval()");
 
+        let previews = result.previews.as_deref();
         let reply = EvaluateJSReply {
-            value: parse_debugger_value(&result.value, result.preview.as_ref()),
+            value: parse_debugger_value(&result.value, previews),
             has_exception: result.hasException.unwrap_or(false),
         };
 
@@ -617,6 +616,7 @@ impl DebuggerGlobalScopeMethods<crate::DomTypeHolder> for DebuggerGlobalScope {
         let chan = self.upcast::<GlobalScope>().devtools_chan()?;
         let (tx, rx) = channel::<String>().unwrap();
 
+        let previews = environment.previews.as_deref();
         let environment = devtools_traits::EnvironmentInfo {
             type_: environment.type_.clone().map(String::from),
             scope_kind: environment.scopeKind.clone().map(String::from),
@@ -626,9 +626,7 @@ impl DebuggerGlobalScopeMethods<crate::DomTypeHolder> for DebuggerGlobalScope {
                 .as_deref()
                 .into_iter()
                 .flatten()
-                .map(|EnvironmentVariable { property, preview }| {
-                    parse_property_descriptor(property, preview.as_ref())
-                })
+                .map(|property| parse_property_descriptor(property, previews))
                 .collect(),
         };
 
@@ -655,11 +653,11 @@ impl DebuggerGlobalScopeMethods<crate::DomTypeHolder> for DebuggerGlobalScope {
 
 fn parse_property_descriptor(
     property: &PropertyDescriptor,
-    preview: Option<&ObjectPreview>,
+    previews: Option<&[ObjectPreview]>,
 ) -> devtools_traits::PropertyDescriptor {
     devtools_traits::PropertyDescriptor {
         name: property.name.to_string(),
-        value: parse_debugger_value(&property.value, preview),
+        value: parse_debugger_value(&property.value, previews),
         configurable: property.configurable,
         enumerable: property.enumerable,
         writable: property.writable,
@@ -667,13 +665,18 @@ fn parse_property_descriptor(
     }
 }
 
-fn parse_object_preview(preview: &ObjectPreview) -> devtools_traits::ObjectPreview {
-    devtools_traits::ObjectPreview {
+fn parse_object_preview(
+    preview_id: Option<usize>,
+    previews: Option<&[ObjectPreview]>,
+) -> Option<devtools_traits::ObjectPreview> {
+    let preview_id = preview_id?;
+    let preview = previews?.get(preview_id)?;
+    Some(devtools_traits::ObjectPreview {
         kind: preview.kind.clone().into(),
         own_properties: preview.ownProperties.as_ref().map(|properties| {
             properties
                 .iter()
-                .map(|property| parse_property_descriptor(property, None))
+                .map(|property| parse_property_descriptor(property, previews))
                 .collect()
         }),
         own_properties_length: preview.ownPropertiesLength,
@@ -695,15 +698,15 @@ fn parse_object_preview(preview: &ObjectPreview) -> devtools_traits::ObjectPrevi
         items: preview.items.as_ref().map(|items| {
             items
                 .iter()
-                .map(|item| parse_debugger_value(item, None))
+                .map(|item| parse_debugger_value(item, previews))
                 .collect()
         }),
-    }
+    })
 }
 
 fn parse_debugger_value(
     value: &DebuggerValue,
-    preview: Option<&ObjectPreview>,
+    previews: Option<&[ObjectPreview]>,
 ) -> devtools_traits::DebuggerValue {
     use devtools_traits::DebuggerValue::*;
     match &*value.valueType.str() {
@@ -731,12 +734,11 @@ fn parse_debugger_value(
                 .as_ref()
                 .map(|s| s.to_string())
                 .unwrap_or_else(|| "Object".to_string());
-
             ObjectValue {
                 uuid: uuid::Uuid::new_v4().to_string(),
                 class,
                 own_property_length: value.ownPropertyLength,
-                preview: preview.map(parse_object_preview),
+                preview: parse_object_preview(value.previewId.map(|m| m as usize), previews),
             }
         },
         _ => unreachable!(),

--- a/components/script_bindings/webidls/DebuggerEvalEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerEvalEvent.webidl
@@ -18,7 +18,7 @@ partial interface DebuggerGlobalScope {
 
 dictionary EvalResult {
     required DebuggerValue value;
-    ObjectPreview preview;
+    sequence<ObjectPreview> previews;
     required DOMString completionType;
     boolean hasException;
 };
@@ -39,6 +39,7 @@ dictionary DebuggerValue {
     DOMString stringValue;
     DOMString objectClass;
     unsigned long ownPropertyLength;
+    unsigned long previewId;
 };
 
 dictionary ObjectPreview {

--- a/components/script_bindings/webidls/DebuggerGetEnvironmentEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerGetEnvironmentEvent.webidl
@@ -20,14 +20,10 @@ partial interface DebuggerGlobalScope {
     );
 };
 
-dictionary EnvironmentVariable {
-    required PropertyDescriptor property;
-    ObjectPreview preview;
-};
-
 dictionary EnvironmentInfo {
     DOMString type_;
     DOMString scopeKind;
     DOMString functionDisplayName;
-    sequence<EnvironmentVariable> bindingVariables;
+    sequence<PropertyDescriptor> bindingVariables;
+    sequence<ObjectPreview> previews;
 };


### PR DESCRIPTION
This is a design change in devtools for how we handle object previews. Currently WebIDL does not allow the recursive shape between `DebuggerValue`, `ObjectPreview`, and `PropertyDescriptor`, so we were using `EvalResult.preview` and `EnvironmentVariable.preview` to pass previews separately.

This change adds `previewId` to `DebuggerValue` and moves object previews into a previews list. The `previewId` is the index of the matching `ObjectPreview` in that list, and we use it to resolve the correct preview while parsing `DebuggerValue`.

This also removes `EvalResult.preview`, `EnvironmentVariable.preview`, and the `EnvironmentVariable` wrapper. Eval results, environment bindings, object properties, and array items now use the same preview path.

**This represents the structure of DevTools(before this change)**

<img width="6339" height="9459" alt="shapes at 26-05-25 18 30 50" src="https://github.com/user-attachments/assets/a4a87f68-b7c0-4d5f-862c-2e7c7831cb72" />


Testing: ./mach test-devtools
Part of: https://github.com/servo/servo/issues/36027