### PR TITLE
 webgpu: Allow `GPUTexture` in all places where `GPUTextureView` is allowed

### DIFF
--- a/components/script/dom/webgpu/gpucommandencoder.rs
+++ b/components/script/dom/webgpu/gpucommandencoder.rs
@@ -197,7 +197,7 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
                     store_op: ds.stencilStoreOp.as_ref().map(Convert::convert),
                     read_only: ds.stencilReadOnly,
                 },
-                view: ds.view.id().0,
+                view: ds.view.convert().0,
             }
         });
 
@@ -206,7 +206,7 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
             .iter()
             .map(|color| -> Fallible<_> {
                 Ok(Some(wgpu_com::RenderPassColorAttachment {
-                    resolve_target: color.resolveTarget.as_ref().map(|t| t.id().0),
+                    resolve_target: color.resolveTarget.as_ref().map(|t| t.convert().0),
                     load_op: convert_load_op(
                         &color.loadOp,
                         color
@@ -217,7 +217,7 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
                             .unwrap_or_default(),
                     ),
                     store_op: color.storeOp.convert(),
-                    view: color.view.id().0,
+                    view: color.view.convert().0,
                     depth_slice: None,
                 }))
             })

--- a/components/script/dom/webgpu/gpuconvert.rs
+++ b/components/script/dom/webgpu/gpuconvert.rs
@@ -5,9 +5,7 @@
 use std::borrow::Cow;
 use std::num::NonZeroU64;
 
-use script_bindings::codegen::GenericBindings::WebGPUBinding::{
-    GPUTextureMethods as _, GPUTextureViewDescriptor,
-};
+use webgpu_traits::WebGPUTextureView;
 use wgpu_core::binding_model::{BindGroupEntry, BindingResource, BufferBinding};
 use wgpu_core::command as wgpu_com;
 use wgpu_core::pipeline::ProgrammableStageDescriptor;
@@ -25,6 +23,7 @@ use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUStoreOp, GPUTextureAspect, GPUTextureDescriptor, GPUTextureDimension, GPUTextureFormat,
     GPUTextureSampleType, GPUTextureViewDimension, GPUVertexFormat,
 };
+use crate::dom::bindings::codegen::UnionTypes::GPUTextureOrGPUTextureView;
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::types::GPUDevice;
 
@@ -669,6 +668,15 @@ impl<'a> Convert<ProgrammableStageDescriptor<'a>> for &GPUProgrammableStage {
     }
 }
 
+impl Convert<WebGPUTextureView> for &GPUTextureOrGPUTextureView {
+    fn convert(self) -> WebGPUTextureView {
+        match self {
+            GPUTextureOrGPUTextureView::GPUTextureView(view) => view.id(),
+            GPUTextureOrGPUTextureView::GPUTexture(texture) => texture.get_default_view(),
+        }
+    }
+}
+
 impl<'a> Convert<BindGroupEntry<'a>> for &GPUBindGroupEntry {
     fn convert(self) -> BindGroupEntry<'a> {
         BindGroupEntry {
@@ -676,12 +684,9 @@ impl<'a> Convert<BindGroupEntry<'a>> for &GPUBindGroupEntry {
             resource: match self.resource {
                 GPUBindingResource::GPUSampler(ref s) => BindingResource::Sampler(s.id().0),
                 GPUBindingResource::GPUTextureView(ref t) => BindingResource::TextureView(t.id().0),
-                GPUBindingResource::GPUTexture(ref t) => BindingResource::TextureView(
-                    t.CreateView(&GPUTextureViewDescriptor::default())
-                        .expect("Default descriptor should always be valid.")
-                        .id()
-                        .0,
-                ),
+                GPUBindingResource::GPUTexture(ref t) => {
+                    BindingResource::TextureView(t.get_default_view().0)
+                },
                 GPUBindingResource::GPUBufferBinding(ref b) => {
                     BindingResource::Buffer(BufferBinding {
                         buffer: b.buffer.id().0,

--- a/components/script/dom/webgpu/gputexture.rs
+++ b/components/script/dom/webgpu/gputexture.rs
@@ -18,7 +18,7 @@ use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
 };
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::reflector::DomGlobal;
-use crate::dom::bindings::root::{Dom, DomRoot};
+use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::webgpu::gpudevice::GPUDevice;
@@ -62,6 +62,7 @@ pub(crate) struct GPUTexture {
     format: GPUTextureFormat,
     texture_usage: u32,
     droppable: DroppableGPUTexture,
+    default_view: MutNullableDom<GPUTextureView>,
 }
 
 impl GPUTexture {
@@ -89,6 +90,7 @@ impl GPUTexture {
             format,
             texture_usage,
             droppable: DroppableGPUTexture { channel, texture },
+            default_view: MutNullableDom::new(None),
         }
     }
 
@@ -167,6 +169,15 @@ impl GPUTexture {
             descriptor.parent.label.clone(),
             can_gc,
         ))
+    }
+
+    pub(crate) fn get_default_view(&self) -> WebGPUTextureView {
+        self.default_view
+            .or_init(|| {
+                self.CreateView(&GPUTextureViewDescriptor::default())
+                    .expect("Default descriptor should always be valid.")
+            })
+            .id()
     }
 }
 

--- a/components/script_bindings/webidls/WebGPU.webidl
+++ b/components/script_bindings/webidls/WebGPU.webidl
@@ -1007,8 +1007,8 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
 };
 
 dictionary GPURenderPassColorAttachment {
-    required GPUTextureView view;
-    GPUTextureView resolveTarget;
+    required (GPUTexture or GPUTextureView) view;
+    (GPUTexture or GPUTextureView) resolveTarget;
 
     GPUColor clearValue;
     required GPULoadOp loadOp;
@@ -1016,7 +1016,7 @@ dictionary GPURenderPassColorAttachment {
 };
 
 dictionary GPURenderPassDepthStencilAttachment {
-    required GPUTextureView view;
+    required (GPUTexture or GPUTextureView) view;
 
     float depthClearValue;
     GPULoadOp depthLoadOp;


### PR DESCRIPTION
We create default texture view lazily and then reuse it across invocations as done in https://github.com/gfx-rs/wgpu/pull/8245 

Testing: WebGPU CTS run
