### PR TITLE
devtools: Add diagnostics when actor downcasting panics

### DIFF
--- a/components/devtools/actor.rs
+++ b/components/devtools/actor.rs
@@ -89,7 +89,16 @@ pub(crate) struct DowncastableActorArc<T> {
 impl<T: 'static> std::ops::Deref for DowncastableActorArc<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
-        self.actor.actor_as_any().downcast_ref::<T>().unwrap()
+        self.actor
+            .actor_as_any()
+            .downcast_ref::<T>()
+            .unwrap_or_else(|| {
+                panic!(
+                    "Failed to downcast {} to type {}",
+                    self.actor.name(),
+                    type_name::<T>()
+                )
+            })
     }
 }
 


### PR DESCRIPTION
This should help with panics such as https://github.com/servo/servo/issues/45141 where there is a mismatch between actual and expected type.

Testing: Not relevant for internal diagnostics