### PR TITLE
script: coalesce touch move events in the script thread

### DIFF
--- a/components/paint/touch.rs
+++ b/components/paint/touch.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 use embedder_traits::{InputEventId, PaintHitTestResult, Scroll, TouchEventType, TouchId};
 use euclid::{Point2D, Scale, Vector2D};
 use log::{debug, error, warn};
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 use servo_base::id::WebViewId;
 use style_traits::CSSPixel;
 use webrender_api::units::{DevicePixel, DevicePoint, DeviceVector2D};
@@ -73,11 +73,6 @@ pub enum TouchMoveAllowed {
     Pending,
 }
 
-pub(crate) enum TouchIdMoveTracking {
-    Track,
-    Remove,
-}
-
 /// A cached [`PaintHitTestResult`] to use during a touch sequence. This
 /// is kept so that the renderer doesn't have to constantly keep making hit tests
 /// while during panning and flinging actions.
@@ -91,11 +86,6 @@ pub struct TouchSequenceInfo {
     pub(crate) state: TouchSequenceState,
     /// touch sequence active touch points
     active_touch_points: Vec<TouchPoint>,
-    /// Whether the script thread is already processing a touchmove operation for the TouchId.
-    ///
-    /// We use this to skip sending the event to the script thread,
-    /// to prevent overloading script.
-    touch_ids_in_move: FxHashSet<TouchId>,
     /// Do not perform a click action.
     ///
     /// This happens when
@@ -214,7 +204,6 @@ impl TouchHandler {
         let finished_info = TouchSequenceInfo {
             state: TouchSequenceState::Finished,
             active_touch_points: vec![],
-            touch_ids_in_move: FxHashSet::default(),
             prevent_click: false,
             prevent_move: TouchMoveAllowed::Pending,
             pending_touch_move_actions: vec![],
@@ -232,34 +221,6 @@ impl TouchHandler {
             pending_touch_input_events: Default::default(),
             observing_frames_for_fling: Default::default(),
         }
-    }
-
-    pub(crate) fn set_handling_touch_move_for_touch_id(
-        &mut self,
-        sequence_id: TouchSequenceId,
-        touch_id: TouchId,
-        flag: TouchIdMoveTracking,
-    ) {
-        if let Some(sequence) = self.touch_sequence_map.get_mut(&sequence_id) {
-            match flag {
-                TouchIdMoveTracking::Track => {
-                    sequence.touch_ids_in_move.insert(touch_id);
-                },
-                TouchIdMoveTracking::Remove => {
-                    sequence.touch_ids_in_move.remove(&touch_id);
-                },
-            }
-        }
-    }
-
-    pub(crate) fn is_handling_touch_move_for_touch_id(
-        &self,
-        sequence_id: TouchSequenceId,
-        touch_id: TouchId,
-    ) -> bool {
-        self.touch_sequence_map
-            .get(&sequence_id)
-            .is_some_and(|seq| seq.touch_ids_in_move.contains(&touch_id))
     }
 
     pub(crate) fn prevent_click(&mut self, sequence_id: TouchSequenceId) {
@@ -360,7 +321,6 @@ impl TouchHandler {
                 TouchSequenceInfo {
                     state: Touching,
                     active_touch_points,
-                    touch_ids_in_move: FxHashSet::default(),
                     prevent_click: false,
                     prevent_move: TouchMoveAllowed::Pending,
                     pending_touch_move_actions: vec![],
@@ -676,7 +636,6 @@ impl TouchHandler {
     pub(crate) fn add_pending_touch_input_event(
         &self,
         id: InputEventId,
-        touch_id: TouchId,
         event_type: TouchEventType,
     ) {
         self.pending_touch_input_events.borrow_mut().insert(
@@ -684,7 +643,6 @@ impl TouchHandler {
             PendingTouchInputEvent {
                 event_type,
                 sequence_id: self.current_sequence_id,
-                touch_id,
             },
         );
     }
@@ -730,7 +688,6 @@ impl TouchHandler {
 pub(crate) struct PendingTouchInputEvent {
     pub event_type: TouchEventType,
     pub sequence_id: TouchSequenceId,
-    pub touch_id: TouchId,
 }
 
 pub(crate) struct FlingRefreshDriverObserver {

--- a/components/paint/webview_renderer.rs
+++ b/components/paint/webview_renderer.rs
@@ -36,9 +36,7 @@ use crate::painter::Painter;
 use crate::pinch_zoom::PinchZoom;
 use crate::pipeline_details::PipelineDetails;
 use crate::refresh_driver::BaseRefreshDriver;
-use crate::touch::{
-    PendingTouchInputEvent, TouchHandler, TouchIdMoveTracking, TouchMoveAllowed, TouchSequenceState,
-};
+use crate::touch::{PendingTouchInputEvent, TouchHandler, TouchMoveAllowed, TouchSequenceState};
 
 #[derive(Clone, Copy)]
 pub(crate) struct ScrollEvent {
@@ -447,7 +445,7 @@ impl WebViewRenderer {
         // Constellation.
         if cancelable && result {
             self.touch_handler
-                .add_pending_touch_input_event(id, event.touch_id, event_type);
+                .add_pending_touch_input_event(id, event_type);
         }
 
         result
@@ -515,24 +513,10 @@ impl WebViewRenderer {
                 self.pending_scroll_zoom_events.push(action);
             }
         }
-        let mut reached_constellation = false;
-        // When the event is touchmove, if the script thread is processing the touch
-        // move event, we skip sending the event to the script thread.
-        // This prevents the script thread from stacking up for a large amount of time.
-        if !self.touch_handler.is_handling_touch_move_for_touch_id(
-            self.touch_handler.current_sequence_id,
-            event.touch_id,
-        ) {
-            reached_constellation = self.send_touch_event(render_api, event, id);
-            if reached_constellation && event.is_cancelable() {
-                self.touch_handler.set_handling_touch_move_for_touch_id(
-                    self.touch_handler.current_sequence_id,
-                    event.touch_id,
-                    TouchIdMoveTracking::Track,
-                );
-            }
-        }
-        reached_constellation
+        // Touchmove coalescing is now handled in the script thread (see
+        // `DocumentEventHandler::note_pending_input_event`), so we always send the
+        // event onwards.
+        self.send_touch_event(render_api, event, id)
     }
 
     fn on_touch_up(&mut self, render_api: &RenderApi, event: TouchEvent, id: InputEventId) -> bool {
@@ -565,7 +549,6 @@ impl WebViewRenderer {
         let PendingTouchInputEvent {
             sequence_id,
             event_type,
-            touch_id,
         } = pending_touch_input_event;
 
         if result.contains(InputEventResult::DefaultPrevented) {
@@ -588,11 +571,6 @@ impl WebViewRenderer {
                         if let TouchSequenceState::PendingFling { .. } = info.state {
                             info.state = TouchSequenceState::Finished;
                         }
-                        self.touch_handler.set_handling_touch_move_for_touch_id(
-                            self.touch_handler.current_sequence_id,
-                            touch_id,
-                            TouchIdMoveTracking::Remove,
-                        );
                         self.touch_handler
                             .remove_pending_touch_move_actions(sequence_id);
                     }
@@ -651,11 +629,6 @@ impl WebViewRenderer {
                     self.pending_scroll_zoom_events.extend(
                         self.touch_handler
                             .take_pending_touch_move_actions(sequence_id),
-                    );
-                    self.touch_handler.set_handling_touch_move_for_touch_id(
-                        self.touch_handler.current_sequence_id,
-                        touch_id,
-                        TouchIdMoveTracking::Remove,
                     );
                     if let Some(info) = self.touch_handler.get_touch_sequence_mut(sequence_id) &&
                         info.prevent_move == TouchMoveAllowed::Pending

--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -167,6 +167,15 @@ pub(crate) struct DocumentEventHandler {
     #[no_trace]
     #[ignore_malloc_size_of = "InputEventId contains data from outside crates"]
     coalesced_wheel_event_ids: DomRefCell<Vec<InputEventId>>,
+    /// Indices into `pending_input_events` of the most recent pending touchmove
+    /// event for each active touch identifier. Used to coalesce successive
+    /// touchmove events for the same touch point.
+    touch_move_event_indices: DomRefCell<FxHashMap<i32, usize>>,
+    /// The [`InputEventId`]s of touchmove events that have been coalesced,
+    /// grouped by touch identifier.
+    #[no_trace]
+    #[ignore_malloc_size_of = "InputEventId contains data from outside crates"]
+    coalesced_touch_move_event_ids: DomRefCell<FxHashMap<i32, Vec<InputEventId>>>,
     /// <https://w3c.github.io/uievents/#event-type-dblclick>
     click_counting_info: DomRefCell<ClickCountingInfo>,
     #[no_trace]
@@ -218,6 +227,8 @@ impl DocumentEventHandler {
             coalesced_mouse_move_event_ids: Default::default(),
             wheel_event_index: Default::default(),
             coalesced_wheel_event_ids: Default::default(),
+            touch_move_event_indices: Default::default(),
+            coalesced_touch_move_event_ids: Default::default(),
             click_counting_info: Default::default(),
             last_mouse_button_down_point: Default::default(),
             mouse_buttons_down: Cell::new(0),
@@ -280,6 +291,50 @@ impl DocumentEventHandler {
             *self.wheel_event_index.borrow_mut() = Some(pending_input_events.len());
         }
 
+        if let InputEvent::Touch(ref new_touch_event) = event.event.event {
+            let TouchId(identifier) = new_touch_event.touch_id;
+            match new_touch_event.event_type {
+                TouchEventType::Move => {
+                    // Try to replace any existing pending touchmove for this touch point.
+                    let existing_index = self
+                        .touch_move_event_indices
+                        .borrow()
+                        .get(&identifier)
+                        .copied();
+                    if let Some(touch_move_event) =
+                        existing_index.and_then(|index| pending_input_events.get_mut(index))
+                    {
+                        debug!(
+                            "touchmove coalesce: replacing pending event id={:?} with id={:?} for touch_id={}",
+                            touch_move_event.event.id, event.event.id, identifier
+                        );
+                        self.coalesced_touch_move_event_ids
+                            .borrow_mut()
+                            .entry(identifier)
+                            .or_default()
+                            .push(touch_move_event.event.id);
+                        *touch_move_event = event;
+                        return;
+                    }
+
+                    debug!(
+                        "touchmove coalesce: queuing new event id={:?} for touch_id={}",
+                        event.event.id, identifier
+                    );
+                    self.touch_move_event_indices
+                        .borrow_mut()
+                        .insert(identifier, pending_input_events.len());
+                },
+                TouchEventType::Down | TouchEventType::Up | TouchEventType::Cancel => {
+                    // The touch point is starting or ending; any pending move index
+                    // for this touch identifier is no longer valid for coalescing.
+                    self.touch_move_event_indices
+                        .borrow_mut()
+                        .remove(&identifier);
+                },
+            }
+        }
+
         pending_input_events.push(event);
     }
 
@@ -311,19 +366,26 @@ impl DocumentEventHandler {
         );
         let _realm = enter_realm(&*self.window);
 
-        // Reset the mouse and wheel event indices.
+        // Reset the mouse, wheel and touchmove event indices.
         *self.mouse_move_event_index.borrow_mut() = None;
         *self.wheel_event_index.borrow_mut() = None;
+        self.touch_move_event_indices.borrow_mut().clear();
         let pending_input_events = mem::take(&mut *self.pending_input_events.borrow_mut());
         let mut coalesced_mouse_move_event_ids =
             mem::take(&mut *self.coalesced_mouse_move_event_ids.borrow_mut());
         let mut coalesced_wheel_event_ids =
             mem::take(&mut *self.coalesced_wheel_event_ids.borrow_mut());
+        let mut coalesced_touch_move_event_ids =
+            mem::take(&mut *self.coalesced_touch_move_event_ids.borrow_mut());
 
         let mut input_event_outcomes = Vec::with_capacity(
             pending_input_events.len() +
                 coalesced_mouse_move_event_ids.len() +
-                coalesced_wheel_event_ids.len(),
+                coalesced_wheel_event_ids.len() +
+                coalesced_touch_move_event_ids
+                    .values()
+                    .map(Vec::len)
+                    .sum::<usize>(),
         );
         // TODO: For some of these we still aren't properly calculating whether or not
         // the event was handled or if `preventDefault()` was called on it. Each of
@@ -354,7 +416,28 @@ impl DocumentEventHandler {
                     self.handle_mouse_left_viewport_event(cx, &event, &mouse_leave_event);
                     InputEventResult::default()
                 },
-                InputEvent::Touch(touch_event) => self.handle_touch_event(cx, touch_event, &event),
+                InputEvent::Touch(touch_event) => {
+                    let result = self.handle_touch_event(cx, touch_event, &event);
+                    if matches!(touch_event.event_type, TouchEventType::Move) {
+                        let TouchId(identifier) = touch_event.touch_id;
+                        if let Some(coalesced_ids) =
+                            coalesced_touch_move_event_ids.remove(&identifier)
+                        {
+                            debug!(
+                                "touchmove coalesce: reporting {} coalesced id(s) for touch_id={} (processed id={:?})",
+                                coalesced_ids.len(),
+                                identifier,
+                                event.event.id
+                            );
+                            input_event_outcomes.extend(
+                                coalesced_ids
+                                    .into_iter()
+                                    .map(|id| InputEventOutcome { id, result }),
+                            );
+                        }
+                    }
+                    result
+                },
                 InputEvent::Wheel(wheel_event) => {
                     let result = self.handle_wheel_event(cx, wheel_event, &event);
                     input_event_outcomes.extend(


### PR DESCRIPTION
This moves the coalescing of touch move events into the document event handler, in a way similar to mouse move and wheel events. The additional complexity here comes from the tracking per touch ID.

Testing: refactoring covered by existing tests
Fixes: https://github.com/servo/servo/issues/43163
