### PR TITLE
script: Limit write lock guard in `CSSKeyframesRuleMethods::AppendRule`

### DIFF
--- a/components/script/dom/css/csskeyframesrule.rs
+++ b/components/script/dom/css/csskeyframesrule.rs
@@ -129,12 +129,16 @@ impl CSSKeyframesRuleMethods<crate::DomTypeHolder> for CSSKeyframesRule {
 
         if let Ok(rule) = rule {
             self.css_rule.parent_stylesheet().will_modify();
-            let mut guard = self.css_rule.shared_lock().write();
-            self.keyframes_rule
-                .borrow()
-                .write_with(&mut guard)
-                .keyframes
-                .push(rule);
+
+            {
+                let mut guard = self.css_rule.shared_lock().write();
+                self.keyframes_rule
+                    .borrow()
+                    .write_with(&mut guard)
+                    .keyframes
+                    .push(rule);
+            }
+
             self.rulelist(cx).append_lazy_dom_rule();
             self.css_rule.parent_stylesheet().notify_invalidations();
         }

--- a/tests/wpt/tests/css/cssom/CSSRuleList-appendRule-keyframe-crash.html
+++ b/tests/wpt/tests/css/cssom/CSSRuleList-appendRule-keyframe-crash.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<title>CSSOM Test: Servo crash when modifying keyframe rules </title>
+<link rel="help" href="https://github.com/servo/servo/issues/44990">
+<style>
+  @keyframes keyframes0 {}
+</style>
+<script>
+  onload = _ =>
+    document.styleSheets[0].cssRules[0].appendRule("0% {}");
+</script>


### PR DESCRIPTION
Keeping this guard alive while calling `CSSKeyFramesRule::rulelist`
leads to a double-borrow. This change limits the guard, fixing the
original panic.

Testing: This change includes a WPT crash test.
Fixes: #44990.
