### PR TITLE
font: Properly handle when shaping produces no glyphs

### DIFF
--- a/components/fonts/glyph.rs
+++ b/components/fonts/glyph.rs
@@ -283,6 +283,10 @@ impl ShapedText {
 
         let mut previous_character_offset = None;
         let mut glyph_store = ShapedText::new(shaped_glyph_data.len(), shaped_run_is_rtl);
+        if shaped_glyph_data.len() == 0 {
+            return glyph_store;
+        }
+
         for mut shaped_glyph in shaped_glyph_data.iter() {
             // The glyph "cluster" (HarfBuzz terminology) is the byte offset in the string that
             // this glyph corresponds to. More than one glyph can share a cluster.

--- a/tests/wpt/tests/css/css-text/shaping/shaping-no-glyphs-crash.html
+++ b/tests/wpt/tests/css/css-text/shaping/shaping-no-glyphs-crash.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta name="assert" content="Shaped runs that produce no glyphs should not cause a crash.">
+<link rel="help" href="https://github.com/servo/servo/issues/45174">
+<style>
+  span { font-family: 'MyCustomFont'; }
+  @font-face {
+      src: url('/css/css-values/resources/ExTest-NoSpace.woff') format('woff');
+      font-family: 'MyCustomFont';
+  }
+</style>
+<span>&ZeroWidthSpace;</span>


### PR DESCRIPTION
When shaping produces no glyphs, which can happen when a zero-width
space is shaped for a font that has no space or zero-width space glyph,
just return an empty `ShapedText` instead of trying to process any
glyphs. This prevents logic issues due to the rest of the code assuming
there are glyphs.

Testing: This change adds a new WPT crash test.
Fixes: #45174.
