### PR TITLE
Revert "painter: Insert a cache for animation with smarter updates (#41956)"

### DIFF
--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -41,7 +41,7 @@ impl<DrawTarget: GenericDrawTarget> CanvasData<DrawTarget> {
 
     pub(crate) fn set_image_key(&mut self, image_key: ImageKey) {
         let (descriptor, data) = self.draw_target.image_descriptor_and_serializable_data();
-        self.paint_api.add_image(image_key, descriptor, data, false);
+        self.paint_api.add_image(image_key, descriptor, data);
 
         if let Some(old_image_key) = self.image_key.replace(image_key) {
             self.paint_api.delete_image(old_image_key);

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -131,7 +131,7 @@ fn set_webrender_image_key(
     let (descriptor, ipc_shared_memory) = image.webrender_image_descriptor_and_data_for_frame(0);
     let data = SerializableImageData::Raw(ipc_shared_memory);
 
-    paint_api.add_image(image_key, descriptor, data, image.should_animate());
+    paint_api.add_image(image_key, descriptor, data);
     image.id = Some(image_key);
 }
 

--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -24,7 +24,7 @@ use paint_api::rendering_context::RenderingContext;
 use paint_api::viewport_description::ViewportDescription;
 use paint_api::{
     ImageUpdate, PipelineExitSource, SendableFrameTree, SerializableDisplayListPayload,
-    SerializableImageData, WebRenderExternalImageHandlers, WebRenderImageHandlerType, WebViewTrait,
+    WebRenderExternalImageHandlers, WebRenderImageHandlerType, WebViewTrait,
 };
 use profile_traits::time::{ProfilerCategory, ProfilerChan};
 use profile_traits::time_profile;
@@ -48,7 +48,7 @@ use webrender_api::units::{
 use webrender_api::{
     self, BuiltDisplayList, BuiltDisplayListDescriptor, ColorF, DirtyRect, DisplayListPayload,
     DocumentId, DynamicProperties, Epoch as WebRenderEpoch, ExternalScrollId, FontInstanceFlags,
-    FontInstanceKey, FontInstanceOptions, FontKey, FontVariation, ImageData, ImageKey,
+    FontInstanceKey, FontInstanceOptions, FontKey, FontVariation, ImageKey,
     NativeFontHandle, PipelineId as WebRenderPipelineId, PropertyBinding, ReferenceFrameKind,
     RenderReasons, SampledScrollOffset, SpaceAndClipInfo, SpatialId, TransformStyle,
 };
@@ -124,10 +124,6 @@ pub(crate) struct Painter {
 
     /// Calculater for largest-contentful-paint.
     lcp_calculator: LargestContentfulPaintCalculator,
-
-    /// A cache that stores data for all animating images uploaded to WebRender. This is used
-    /// for animated images, which only need to update their offset in the data.
-    animation_image_cache: FxHashMap<ImageKey, Arc<Vec<u8>>>,
 
     /// A [`WebContentAnimator`] used to manage web content-derived animations. Currently this only
     /// manages blinking caret animations.
@@ -279,7 +275,6 @@ impl Painter {
             last_mouse_move_position: None,
             frame_delayer: Default::default(),
             lcp_calculator: LargestContentfulPaintCalculator::new(),
-            animation_image_cache: FxHashMap::default(),
             web_content_animator: WebContentAnimator::new(
                 paint.event_loop_waker.clone_box(),
                 (*timer_refresh_driver).clone(),
@@ -1038,62 +1033,22 @@ impl Painter {
             .prepare_screenshot_requests_for_render(self)
     }
 
-    fn serializable_image_data_to_image_data_maybe_caching(
-        &mut self,
-        key: ImageKey,
-        data: SerializableImageData,
-        is_animated_image: bool,
-    ) -> ImageData {
-        match data {
-            SerializableImageData::Raw(shared_memory) => {
-                let data = shared_memory.into_arc_vec();
-                if is_animated_image {
-                    self.animation_image_cache.insert(key, Arc::clone(&data));
-                }
-                ImageData::Raw(data)
-            },
-            SerializableImageData::External(image) => ImageData::External(image),
-        }
-    }
-
     pub(crate) fn update_images(&mut self, updates: SmallVec<[ImageUpdate; 1]>) {
         let mut txn = Transaction::new();
         for update in updates {
             match update {
-                ImageUpdate::AddImage(key, description, data, is_animated_image) => {
-                    txn.add_image(
-                        key,
-                        description,
-                        self.serializable_image_data_to_image_data_maybe_caching(
-                            key,
-                            data,
-                            is_animated_image,
-                        ),
-                        None,
-                    );
+                ImageUpdate::AddImage(key, desc, data) => {
+                    txn.add_image(key, desc, data.into(), None)
                 },
                 ImageUpdate::DeleteImage(key) => {
                     txn.delete_image(key);
                     self.frame_delayer.delete_image(key);
-                    self.animation_image_cache.remove(&key);
                 },
                 ImageUpdate::UpdateImage(key, desc, data, epoch) => {
                     if let Some(epoch) = epoch {
                         self.frame_delayer.update_image(key, epoch);
                     }
                     txn.update_image(key, desc, data.into(), &DirtyRect::All)
-                },
-                ImageUpdate::UpdateImageForAnimation(image_key, desc) => {
-                    let Some(image) = self.animation_image_cache.get(&image_key) else {
-                        error!("Could not find image key in image cache.");
-                        continue;
-                    };
-                    txn.update_image(
-                        image_key,
-                        desc,
-                        ImageData::new_shared(image.clone()),
-                        &DirtyRect::All,
-                    );
                 },
             }
         }

--- a/components/pixels/lib.rs
+++ b/components/pixels/lib.rs
@@ -19,7 +19,7 @@ use image::{
     AnimationDecoder, DynamicImage, ImageBuffer, ImageDecoder, ImageError, ImageFormat,
     ImageResult, Limits, Rgba,
 };
-use log::{debug, error};
+use log::debug;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
 use servo_base::generic_channel::GenericSharedMemory;
@@ -397,10 +397,6 @@ impl RasterImage {
         )
     }
 
-    pub fn frame_data(&self, index: usize) -> Option<&ImageFrame> {
-        self.frames.get(index)
-    }
-
     pub fn webrender_image_descriptor_and_data_for_frame(
         &self,
         frame_index: usize,
@@ -446,38 +442,6 @@ impl RasterImage {
             flags,
         };
         (descriptor, data)
-    }
-
-    /// For animations the image already exists in a cache in 'Painter'. We just send the description.
-    /// Currently we do not support 'PixelFormat::RGB8'
-    pub fn webrender_image_descriptor_and_offset_for_frame(&self) -> Option<ImageDescriptor> {
-        if self.format == PixelFormat::RGB8 ||
-            self.format == PixelFormat::K8 ||
-            self.format == PixelFormat::KA8
-        {
-            return None;
-        }
-        let format = match self.format {
-            PixelFormat::BGRA8 => WebRenderImageFormat::BGRA8,
-            PixelFormat::RGBA8 => WebRenderImageFormat::RGBA8,
-            PixelFormat::RGB8 => WebRenderImageFormat::BGRA8,
-            PixelFormat::KA8 | PixelFormat::K8 => {
-                error!("Pixel format currently not supported");
-                return None;
-            },
-        };
-        let mut flags = ImageDescriptorFlags::ALLOW_MIPMAPS;
-        flags.set(ImageDescriptorFlags::IS_OPAQUE, self.is_opaque);
-
-        let size = DeviceIntSize::new(self.metadata.width as i32, self.metadata.height as i32);
-        let descriptor = ImageDescriptor {
-            size,
-            stride: None,
-            format,
-            offset: 0,
-            flags,
-        };
-        Some(descriptor)
     }
 
     pub fn to_shared(&self) -> Arc<SharedRasterImage> {

--- a/components/script/dom/canvas/imagebitmaprenderingcontext.rs
+++ b/components/script/dom/canvas/imagebitmaprenderingcontext.rs
@@ -109,7 +109,7 @@ impl ImageBitmapRenderingContext {
             if self.image_added.get() {
                 paint_api.update_image(image_key, descriptor, data, Some(epoch));
             } else {
-                paint_api.add_image(image_key, descriptor, data, false);
+                paint_api.add_image(image_key, descriptor, data);
                 self.image_added.set(true);
             }
         }

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -409,12 +409,7 @@ impl VideoFrameRenderer for MediaFrameRenderer {
                     .get_or_insert_with(|| FrameHolder::new(frame.clone()))
                     .set(frame);
 
-                updates.push(ImageUpdate::AddImage(
-                    new_image_key,
-                    descriptor,
-                    image_data,
-                    false,
-                ));
+                updates.push(ImageUpdate::AddImage(new_image_key, descriptor, image_data));
             },
             None => {
                 let Some(image_key) = self.paint_api.generate_image_key_blocking(self.webview_id)
@@ -453,9 +448,7 @@ impl VideoFrameRenderer for MediaFrameRenderer {
 
                 self.current_frame_holder = Some(FrameHolder::new(frame));
 
-                updates.push(ImageUpdate::AddImage(
-                    image_key, descriptor, image_data, false,
-                ));
+                updates.push(ImageUpdate::AddImage(image_key, descriptor, image_data));
             },
         }
         self.paint_api

--- a/components/script/image_animation.rs
+++ b/components/script/image_animation.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 use embedder_traits::UntrustedNodeAddress;
 use layout_api::AnimatingImages;
-use paint_api::ImageUpdate;
+use paint_api::{ImageUpdate, SerializableImageData};
 use parking_lot::RwLock;
 use rustc_hash::FxHashMap;
 use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
@@ -72,22 +72,15 @@ impl ImageAnimationManager {
                 }
 
                 let image = &state.image;
-                let frame = image
-                    .frame_data(state.active_frame)
-                    .expect("No frame found")
-                    .clone();
-                if let Some(mut descriptor) =
-                    image.webrender_image_descriptor_and_offset_for_frame()
-                {
-                    descriptor.offset = frame.byte_range.start as i32;
-                    Some(ImageUpdate::UpdateImageForAnimation(
-                        image.id.unwrap(),
-                        descriptor,
-                    ))
-                } else {
-                    error!("Doing normal image update which will be slow!");
-                    None
-                }
+                let (descriptor, ipc_shared_memory) =
+                    image.webrender_image_descriptor_and_data_for_frame(state.active_frame);
+
+                Some(ImageUpdate::UpdateImage(
+                    image.id.unwrap(),
+                    descriptor,
+                    SerializableImageData::Raw(ipc_shared_memory),
+                    None,
+                ))
             })
             .collect();
         window

--- a/components/shared/paint/lib.rs
+++ b/components/shared/paint/lib.rs
@@ -423,17 +423,10 @@ impl CrossProcessPaintApi {
         key: ImageKey,
         descriptor: ImageDescriptor,
         data: SerializableImageData,
-        is_animated_image: bool,
     ) {
         self.update_images(
             key.into(),
-            [ImageUpdate::AddImage(
-                key,
-                descriptor,
-                data,
-                is_animated_image,
-            )]
-            .into(),
+            [ImageUpdate::AddImage(key, descriptor, data)].into(),
         );
     }
 
@@ -733,12 +726,7 @@ impl ExternalImageHandler for WebRenderExternalImageHandlers {
 /// Serializable image updates that must be performed by WebRender.
 pub enum ImageUpdate {
     /// Register a new image.
-    AddImage(
-        ImageKey,
-        ImageDescriptor,
-        SerializableImageData,
-        bool, /* is_animated_image */
-    ),
+    AddImage(ImageKey, ImageDescriptor, SerializableImageData),
     /// Delete a previously registered image registration.
     DeleteImage(ImageKey),
     /// Update an existing image registration.
@@ -748,19 +736,15 @@ pub enum ImageUpdate {
         SerializableImageData,
         Option<Epoch>,
     ),
-    /// Update an [`ImageDescriptor`] for an existing image. This is used primarily
-    /// to modify the data offset for image animations.
-    UpdateImageForAnimation(ImageKey, ImageDescriptor),
 }
 
 impl Debug for ImageUpdate {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::AddImage(image_key, image_desc, _, is_animated_image) => f
+            Self::AddImage(image_key, image_desc, _) => f
                 .debug_tuple("AddImage")
                 .field(image_key)
                 .field(image_desc)
-                .field(is_animated_image)
                 .finish(),
             Self::DeleteImage(image_key) => f.debug_tuple("DeleteImage").field(image_key).finish(),
             Self::UpdateImage(image_key, image_desc, _, epoch) => f
@@ -768,11 +752,6 @@ impl Debug for ImageUpdate {
                 .field(image_key)
                 .field(image_desc)
                 .field(epoch)
-                .finish(),
-            Self::UpdateImageForAnimation(image_key, image_desc) => f
-                .debug_tuple("UpdateAnimation")
-                .field(image_key)
-                .field(image_desc)
                 .finish(),
         }
     }

--- a/components/webgl/webgl_thread.rs
+++ b/components/webgl/webgl_thread.rs
@@ -1005,12 +1005,8 @@ impl WebGLThread {
             return;
         }
 
-        self.paint_api.add_image(
-            image_key,
-            info.image_descriptor(),
-            external_image_data,
-            false,
-        );
+        self.paint_api
+            .add_image(image_key, info.image_descriptor(), external_image_data);
     }
 }
 

--- a/components/webgpu/canvas_context.rs
+++ b/components/webgpu/canvas_context.rs
@@ -560,7 +560,6 @@ impl crate::WGPU {
                 flags: ImageDescriptorFlags::empty(),
             },
             SerializableImageData::External(image_data(context_id)),
-            false,
         );
     }
 


### PR DESCRIPTION
This reverts commit d41bb930e16c08950d7094dd60fd5120c9a9537d.

This change led to a large regression in performance testing (instruction executed).
