### PR TITLE
script: Generate new blob URL per `createObjectURL` call

### DIFF
--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2149,6 +2149,27 @@ impl GlobalScope {
             },
             BlobData::File(f) => {
                 if set_valid {
+                    // File blobs with cached byte data (converted from Memory)
+                    // need a unique UUID per URL.createObjectURL call.
+                    if let Some(cached_bytes) = f.get_cache() {
+                        let new_id = Uuid::new_v4();
+                        let origin = self.origin().immutable();
+                        let blob_buf = BlobBuf {
+                            filename: None,
+                            type_string: blob_info.blob_impl.type_string(),
+                            size: cached_bytes.len() as u64,
+                            bytes: cached_bytes,
+                        };
+                        let msg = FileManagerThreadMsg::PromoteMemory(
+                            new_id,
+                            blob_buf,
+                            true,
+                            origin.clone(),
+                        );
+                        self.send_to_file_manager(msg);
+                        return new_id;
+                    }
+
                     let origin = self.origin().immutable();
                     let (tx, rx) = profile_ipc::channel(self.time_profiler_chan().clone()).unwrap();
 

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2135,6 +2135,28 @@ impl GlobalScope {
         }
     }
 
+    /// Send a PromoteMemory message to register a new blob URL entry
+    /// with the file manager for the given byte data.
+    /// Return the generated UUID.
+    fn promote_memory_entry(
+        &self,
+        blob_info: &BlobInfo,
+        blob_bytes: &[u8],
+        set_valid: bool,
+    ) -> Uuid {
+        let origin = self.origin().immutable();
+        let blob_buf = BlobBuf {
+            filename: None,
+            type_string: blob_info.blob_impl.type_string(),
+            size: blob_bytes.len() as u64,
+            bytes: blob_bytes.to_vec(),
+        };
+        let id = Uuid::new_v4();
+        let msg = FileManagerThreadMsg::PromoteMemory(id, blob_buf, set_valid, origin.clone());
+        self.send_to_file_manager(msg);
+        id
+    }
+
     /// Promote non-Slice blob:
     /// 1. Memory-based: The bytes in data slice will be transferred to file manager thread.
     /// 2. File-based: If set_valid, then activate the FileID so it can serve as URL
@@ -2152,22 +2174,7 @@ impl GlobalScope {
                     // File blobs with cached byte data (converted from Memory)
                     // need a unique UUID per URL.createObjectURL call.
                     if let Some(cached_bytes) = f.get_cache() {
-                        let new_id = Uuid::new_v4();
-                        let origin = self.origin().immutable();
-                        let blob_buf = BlobBuf {
-                            filename: None,
-                            type_string: blob_info.blob_impl.type_string(),
-                            size: cached_bytes.len() as u64,
-                            bytes: cached_bytes,
-                        };
-                        let msg = FileManagerThreadMsg::PromoteMemory(
-                            new_id,
-                            blob_buf,
-                            true,
-                            origin.clone(),
-                        );
-                        self.send_to_file_manager(msg);
-                        return new_id;
+                        return self.promote_memory_entry(blob_info, &cached_bytes, true);
                     }
 
                     let origin = self.origin().immutable();
@@ -2189,18 +2196,7 @@ impl GlobalScope {
             BlobData::Memory(bytes_in) => mem::swap(bytes_in, &mut bytes),
         };
 
-        let origin = self.origin().immutable();
-
-        let blob_buf = BlobBuf {
-            filename: None,
-            type_string: blob_info.blob_impl.type_string(),
-            size: bytes.len() as u64,
-            bytes: bytes.to_vec(),
-        };
-
-        let id = Uuid::new_v4();
-        let msg = FileManagerThreadMsg::PromoteMemory(id, blob_buf, set_valid, origin.clone());
-        self.send_to_file_manager(msg);
+        let id = self.promote_memory_entry(blob_info, &bytes, set_valid);
 
         *blob_info.blob_impl.blob_data_mut() = BlobData::File(FileBlob::new(
             id,

--- a/tests/wpt/meta/FileAPI/url/sandboxed-iframe.html.ini
+++ b/tests/wpt/meta/FileAPI/url/sandboxed-iframe.html.ini
@@ -1,8 +1,5 @@
 [sandboxed-iframe.html]
   expected: TIMEOUT
-  [Generated Blob URLs are unique]
-    expected: FAIL
-
   [Blob URLs can be used in <script> tags]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/FileAPI/url/url-format.any.js.ini
+++ b/tests/wpt/meta/FileAPI/url/url-format.any.js.ini
@@ -1,8 +1,0 @@
-[url-format.any.html]
-  [Generated Blob URLs are unique]
-    expected: FAIL
-
-
-[url-format.any.worker.html]
-  [Generated Blob URLs are unique]
-    expected: FAIL


### PR DESCRIPTION
Previously, we generate same URL when calling `createObjectURL` on same `Blob`.

[Spec](https://w3c.github.io/FileAPI/#dfn-createObjectURL):
> ..
> Step 2. Let url be the result of [generating a new blob URL](https://w3c.github.io/FileAPI/#unicodeBlobURL).
> Step 3. Let entry be a new [blob URL entry](https://w3c.github.io/FileAPI/#blob-url-entry) consisting of object and the [current settings object](https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object).

I guess there is a good security reason: it is likely a website call `createObjectURL` 
on the same Blob object multiple times. We must be able to revoke them separately.

Testing: Passing in existing tests.
Part of #10778