### PR TITLE
script: Remove redundant `NavigatorStorageUtils`

### DIFF
--- a/components/script_bindings/webidls/Navigator.webidl
+++ b/components/script_bindings/webidls/Navigator.webidl
@@ -11,7 +11,6 @@ Navigator includes NavigatorID;
 Navigator includes NavigatorLanguage;
 Navigator includes NavigatorOnLine;
 Navigator includes NavigatorContentUtils;
-//Navigator includes NavigatorStorageUtils;
 Navigator includes NavigatorPlugins;
 Navigator includes NavigatorCookies;
 Navigator includes NavigatorConcurrentHardware;


### PR DESCRIPTION
Remove redundant `NavigatorStorageUtils`. It was renamed
to `NavigatorCookies` in
https://github.com/whatwg/html/commit/1b918cf72fcbba011f83b92ab5d1f483fb1cafa3

Testing: Removes stale comment. This doesn't even require compilation.
