### PR TITLE
base: Make `PrintTree::new` accept `impl Display`

### DIFF
--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -256,7 +256,7 @@ impl AccessibilityTree {
             return;
         };
 
-        let mut print_tree = PrintTree::new("Accessibility Tree".to_string());
+        let mut print_tree = PrintTree::new("Accessibility Tree");
         let node = self.assert_node_for_id(root_node_id);
         node.borrow().print(self, &mut print_tree);
         print_tree.end_level();

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -875,7 +875,7 @@ impl StackingContext {
             warn!("failed to print stacking context tree: debug_print_items was None");
             return;
         }
-        let mut tree = PrintTree::new("Stacking context tree".to_owned());
+        let mut tree = PrintTree::new("Stacking context tree");
         self.debug_print_with_tree(&mut tree);
     }
 

--- a/components/layout/fragment_tree/fragment_tree.rs
+++ b/components/layout/fragment_tree/fragment_tree.rs
@@ -52,7 +52,7 @@ impl FragmentTree {
     }
 
     pub fn print(&self) {
-        let mut print_tree = PrintTree::new("Fragment Tree".to_string());
+        let mut print_tree = PrintTree::new("Fragment Tree");
         for fragment in &self.root_fragments {
             fragment.print(&mut print_tree);
         }

--- a/components/shared/base/print_tree.rs
+++ b/components/shared/base/print_tree.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::fmt::Display;
+
 /// A struct that makes it easier to print out a pretty tree of data, which
 /// can be visually scanned more easily.
 pub struct PrintTree {
@@ -14,8 +16,8 @@ pub struct PrintTree {
 }
 
 impl PrintTree {
-    pub fn new(title: String) -> PrintTree {
-        println!("\u{250c} {}", title);
+    pub fn new(title: impl Display) -> PrintTree {
+        println!("\u{250c} {title}");
         PrintTree {
             level: 1,
             queued_item: None,

--- a/components/shared/paint/display_list.rs
+++ b/components/shared/paint/display_list.rs
@@ -802,7 +802,7 @@ impl ScrollTree {
     // TODO(stevennovaryo): add information about which fragment that
     //                      defines this node.
     pub fn debug_print(&self) {
-        let mut print_tree = PrintTree::new("Scroll Tree".to_owned());
+        let mut print_tree = PrintTree::new("Scroll Tree");
 
         let adj_list = self.nodes_in_adjacency_list();
         let root_id = ScrollTreeNodeId { index: 0 };


### PR DESCRIPTION
This makes the API a bit friendlier and avoids having to allocate a
string when calling new.

Testing: This does not change observable behavior and debug printing is untested.
