### PR TITLE
layout: Improve debugging output of `BaseFragment`

### DIFF
--- a/components/layout/fragment_tree/base_fragment.rs
+++ b/components/layout/fragment_tree/base_fragment.rs
@@ -69,14 +69,14 @@ pub(crate) struct BaseFragment {
 
 impl std::fmt::Debug for BaseFragment {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("BaseFragment")
-            .field("tag", &self.tag)
-            .field("flags", &self.flags)
-            .field("rect", &self.rect)
-            .field(
-                "status",
-                &FragmentStatus::from_u8(self.status.load(Ordering::Relaxed)),
-            )
+        let mut formatter = f.debug_struct("BaseFragment");
+        let mut formatter = formatter.field("tag", &self.tag);
+        if !self.flags.is_empty() {
+            formatter = formatter.field("flags", &self.flags);
+        }
+        formatter
+            .field("rect", &self.rect())
+            .field("status", &self.status())
             .finish()
     }
 }
@@ -304,10 +304,23 @@ malloc_size_of_is_0!(FragmentFlags);
 
 /// A data structure used to hold DOM and pseudo-element information about
 /// a particular layout object.
-#[derive(Clone, Copy, Debug, Eq, MallocSizeOf, PartialEq)]
+#[derive(Clone, Copy, Eq, MallocSizeOf, PartialEq)]
 pub(crate) struct Tag {
     pub(crate) node: OpaqueNode,
     pub(crate) pseudo_element_chain: PseudoElementChain,
+}
+
+impl std::fmt::Debug for Tag {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("Tag({:?}", self.node))?;
+        if let Some(pseudo) = self.pseudo_element_chain.primary {
+            f.write_fmt(format_args!(", PseudoElement::{pseudo:?}"))?;
+        }
+        if let Some(pseudo) = self.pseudo_element_chain.secondary {
+            f.write_fmt(format_args!(", PseudoElement::{pseudo:?}"))?;
+        }
+        f.write_str(")")
+    }
 }
 
 impl Tag {


### PR DESCRIPTION
This change does a few things to improve debugging output of
`BaseFragment`:

- Print the `PhysicalRect<Au>` of the rect rather than the way it is
  stored (as a collection of `AtomicI32`).
- Make the printing of `Tag` shorter, so that it is easier to read.
- Only print the `FragmentFlags` if they are not empty.
- Simplify printing of status.

Before:
```
┌ Fragment Tree
│  ├─ Box
│  │         base=BaseFragment { tag: Some(Tag { node: OpaqueNode(65734861902240), pseudo_element_chain: PseudoElementChain { primary: None, secondary: None } }), flags: FragmentFlags(IS_ROOT_ELEMENT), rect: Rect(61440x6960 at (0, 0)), status: Some(Clean) }
...
│  │  ├─ Box
│  │  │         base=BaseFragment { tag: Some(Tag { node: OpaqueNode(65734861902440), pseudo_element_chain: PseudoElementChain { primary: None, secondary: None } }), flags: FragmentFlags(IS_BODY_ELEMENT_OF_HTML_ELEMENT_ROOT | PROPAGATED_OVERFLOW_TO_VIEWPORT), rect: Rect(60480x6000 at (480, 480)), status: Some(Clean) }
...
│  │  │  ├─ Box
│  │  │  │         base=BaseFragment { tag: Some(Tag { node: OpaqueNode(65734861902480), pseudo_element_chain: PseudoElementChain { primary: None, secondary: None } }), flags: FragmentFlags(0x0), rect: Rect(6000x6000 at (0, 0)), status: Some(Clean) }
...
│  │  │  │  ├─ Box
│  │  │  │  │         base=BaseFragment { tag: Some(Tag { node: OpaqueNode(65734861902480), pseudo_element_chain: PseudoElementChain { primary: Some(Before), secondary: None } }), flags: FragmentFlags(0x0), rect: Rect(6000x6000 at (0, 0)), status: Some(Clean) }
...
```

After:

```
┌ Fragment Tree
│  ├─ Box
│  │         base=BaseFragment { tag: Some(Tag(OpaqueNode(34370859028896))), flags: FragmentFlags(IS_ROOT_ELEMENT), rect: Rect(1024pxx116px at (0px, 0px)), status: Clean }
...
│  │  ├─ Box
│  │  │         base=BaseFragment { tag: Some(Tag(OpaqueNode(34370859029096))), flags: FragmentFlags(IS_BODY_ELEMENT_OF_HTML_ELEMENT_ROOT | PROPAGATED_OVERFLOW_TO_VIEWPORT), rect: Rect(1008pxx100px at (8px, 8px)), status: Clean }
...
│  │  │  ├─ Box
│  │  │  │         base=BaseFragment { tag: Some(Tag(OpaqueNode(34370859029136))), rect: Rect(100pxx100px at (0px, 0px)), status: Clean }
...
│  │  │  │  ├─ Box
│  │  │  │  │         base=BaseFragment { tag: Some(Tag(OpaqueNode(34370859029136), PseudoElement::Before)), rect: Rect(100pxx100px at (0px, 0px)), status: Clean }
...
```

Testing: This change just change debugging output, so doesn't need tests.
