### PR TITLE
ci: Fix etc/ci/scenario Python types

### DIFF
--- a/etc/ci/scenario/blink_perf_test.py
+++ b/etc/ci/scenario/blink_perf_test.py
@@ -18,7 +18,8 @@ import re
 import json
 import argparse
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
-from hdc_py.hdc import HarmonyDeviceConnector, HarmonyDevicePerfMode
+from types import TracebackType
+from hdc_py.hdc import HarmonyDeviceConnector, HarmonyDevicePerfMode  # type: ignore[import-untyped]
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.common.exceptions import NoSuchElementException
@@ -27,7 +28,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from dataclasses import dataclass
 import threading
 import csv
-from typing import Dict
+from typing import Any, Dict, Optional, Type
 from common_function_for_servo_test import create_driver, setup_hdc_forward, stop_servo, close_usb_popup
 
 
@@ -108,15 +109,15 @@ class AbortReason(Enum):
 
 
 class LocalFileServe:
-    def __init__(self, port: int, *args, **kwargs):
-        self.local_server = None
+    def __init__(self, port: int) -> None:
+        self.local_server: Optional[ThreadingHTTPServer] = None
         self.port = port
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         print(f"Serving local test files on port {self.port}")
 
         class StaticHandler(SimpleHTTPRequestHandler):
-            def __init__(self, *args, **kwargs):
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
                 super().__init__(*args, directory=DIRECTORY, **kwargs)
 
         self.local_server = ThreadingHTTPServer(
@@ -127,7 +128,12 @@ class LocalFileServe:
         thread = threading.Thread(target=self.local_server.serve_forever, daemon=True)
         thread.start()
 
-    def __exit__(self, *args):
+    def __exit__(
+        self,
+        exc_type: Type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
         if self.local_server is not None:
             self.local_server.server_close()
 
@@ -137,7 +143,7 @@ def get_serve_path_for_file(root: str, file: str) -> str:
 
 
 def run_single_test(
-    test_file_name: str, driver: webdriver.Remote, port: int, serve_path, cli_args
+    test_file_name: str, driver: webdriver.Remote, port: int, serve_path: str, cli_args: argparse.Namespace
 ) -> TestResult | AbortReason:
     """Run a test by loading a website, and returning (avg, min, max).
     This will run for MAX_WAIT_TIME seconds and return as soon as the avg line exists in the log element"""
@@ -163,8 +169,11 @@ def run_single_test(
             )
         print(f">>> Page loading took {(after_get - before_get):.2f}s")
 
-        avg_line, min_line, max_line = None, None, None
-        start_time, latest_time = time.perf_counter(), 0
+        avg_line: Optional[float] = None
+        min_line: Optional[float] = None
+        max_line: Optional[float] = None
+        unit: Optional[str] = None
+        start_time, latest_time = time.perf_counter(), 0.0
         while latest_time - start_time < 60:
             try:
                 element = driver.find_element(By.ID, "log")
@@ -192,12 +201,12 @@ def run_single_test(
     return AbortReason.NotFound
 
 
-def oswalk_error(error: OSError):
+def oswalk_error(error: OSError) -> None:
     print(error)
     sys.exit(1)
 
 
-def write_file(results):
+def write_file(results: dict[str, dict[str, Any]]) -> None:
     with open("results.json", "w") as f:
         json.dump(results, f)
 
@@ -322,15 +331,15 @@ def memory_report_to_bencher_metrics(
     }
 
 
-def verbose_print(str_to_print: str, is_verbose: bool = False):
+def verbose_print(str_to_print: str, is_verbose: bool = False) -> None:
     if is_verbose:
         print(str_to_print)
 
 
-def run_tests(port, cli_args):
+def run_tests(port: int, cli_args: argparse.Namespace) -> None:
     skip_until = cli_args.skip_until
 
-    final_result = {}
+    final_result: dict[str, dict[str, Any]] = {}
     csv_file, csv_writer = None, None
     if cli_args and cli_args.extra_csv:
         csv_file = open("blink_perf_test_logs.csv", "w", newline="", encoding="utf-8")
@@ -363,10 +372,11 @@ def run_tests(port, cli_args):
 
                             verbose_print(f"result: {result}", cli_args.verbose)
 
-                            if result == AbortReason.NotFound or result == AbortReason.Panic:
+                            if isinstance(result, AbortReason):
                                 if csv_writer:
                                     csv_writer.writerow([filePath, "error"])
                             else:
+                                metrics: dict[str, dict[str, float]] = {}
                                 combined_result = {
                                     "value": result.value,
                                     "lower_value": result.lower_value,
@@ -405,7 +415,7 @@ def run_tests(port, cli_args):
                                     csv_writer.writerow([filePath, result.value])
                         finally:
                             webdriver.quit()
-                        if csv_writer:
+                        if csv_writer and csv_file:
                             csv_file.flush()
                     stop_servo()
         print(f"final_result {final_result}")

--- a/etc/ci/scenario/blink_perf_test.py
+++ b/etc/ci/scenario/blink_perf_test.py
@@ -359,65 +359,71 @@ def run_tests(port: int, cli_args: argparse.Namespace) -> None:
                     print("Starting new servo instance...")
                     cmd_str = f"aa start -a EntryAbility -b org.servo.servo -U {ABOUT_BLANK} --psn=--webdriver --psn=--pref=session_history_max_length=1"
                     hdc.cmd(cmd_str, timeout=10)
-                    with HarmonyDevicePerfMode(screen_timeout_seconds=2 * 60 * 60):
-                        close_usb_popup(hdc)
-                        webdriver = create_driver(timeout=1)
-                        if webdriver is None:
-                            continue
-
-                        try:
-                            result = run_single_test(
-                                filePath, webdriver, port, get_serve_path_for_file(root, filePath), cli_args=cli_args
-                            )
-
-                            verbose_print(f"result: {result}", cli_args.verbose)
-
-                            if isinstance(result, AbortReason):
+                    try:
+                        with HarmonyDevicePerfMode(screen_timeout_seconds=2 * 60 * 60):
+                            close_usb_popup(hdc)
+                            try:
+                                webdriver = create_driver(timeout=1)
+                            except RuntimeError as exc:
+                                print(f"Failed to create webdriver for {filePath}: {exc}")
                                 if csv_writer:
-                                    csv_writer.writerow([filePath, "error"])
-                            else:
-                                metrics: dict[str, dict[str, float]] = {}
-                                combined_result = {
-                                    "value": result.value,
-                                    "lower_value": result.lower_value,
-                                    "upper_value": result.upper_value,
-                                }
-                                parent_dir = get_serve_path_for_file(root, filePath)
+                                    csv_writer.writerow([filePath, "driver_start_failed"])
+                                continue
 
-                                bencher_unit = None
-                                if result.unit == "ms":
-                                    bencher_unit = "ms"
-                                elif result.unit == "runs/s":
-                                    bencher_unit = "throughput"
+                            try:
+                                result = run_single_test(
+                                    filePath, webdriver, port, get_serve_path_for_file(root, filePath), cli_args=cli_args
+                                )
+
+                                verbose_print(f"result: {result}", cli_args.verbose)
+
+                                if isinstance(result, AbortReason):
+                                    if csv_writer:
+                                        csv_writer.writerow([filePath, "error"])
                                 else:
-                                    bencher_unit = "other"
+                                    metrics: dict[str, dict[str, float]] = {}
+                                    combined_result = {
+                                        "value": result.value,
+                                        "lower_value": result.lower_value,
+                                        "upper_value": result.upper_value,
+                                    }
+                                    parent_dir = get_serve_path_for_file(root, filePath)
 
-                                if cli_args.memory_report and filePath not in tests_that_hang_memory_report:
-                                    memory_report = get_memory_report_str(webdriver)
-
-                                    if isinstance(memory_report, ParseError):
-                                        print(f"Test memory parsing failed: {memory_report.message}")
+                                    bencher_unit = None
+                                    if result.unit == "ms":
+                                        bencher_unit = "ms"
+                                    elif result.unit == "runs/s":
+                                        bencher_unit = "throughput"
                                     else:
-                                        verbose_print(
-                                            f"memory after test {memory_report}",
-                                            cli_args.verbose,
-                                        )
-                                        metrics = memory_report_to_bencher_metrics(memory_report)
-                                    final_result[f"perf_tests/{parent_dir}/{filePath}"] = {
-                                        bencher_unit: combined_result,
-                                        **metrics,
-                                    }
-                                else:
-                                    final_result[f"perf_tests/{parent_dir}/{filePath}"] = {
-                                        bencher_unit: combined_result
-                                    }
-                                if csv_writer:
-                                    csv_writer.writerow([filePath, result.value])
-                        finally:
-                            webdriver.quit()
-                        if csv_writer and csv_file:
-                            csv_file.flush()
-                    stop_servo()
+                                        bencher_unit = "other"
+
+                                    if cli_args.memory_report and filePath not in tests_that_hang_memory_report:
+                                        memory_report = get_memory_report_str(webdriver)
+
+                                        if isinstance(memory_report, ParseError):
+                                            print(f"Test memory parsing failed: {memory_report.message}")
+                                        else:
+                                            verbose_print(
+                                                f"memory after test {memory_report}",
+                                                cli_args.verbose,
+                                            )
+                                            metrics = memory_report_to_bencher_metrics(memory_report)
+                                        final_result[f"perf_tests/{parent_dir}/{filePath}"] = {
+                                            bencher_unit: combined_result,
+                                            **metrics,
+                                        }
+                                    else:
+                                        final_result[f"perf_tests/{parent_dir}/{filePath}"] = {
+                                            bencher_unit: combined_result
+                                        }
+                                    if csv_writer:
+                                        csv_writer.writerow([filePath, result.value])
+                            finally:
+                                webdriver.quit()
+                            if csv_writer and csv_file:
+                                csv_file.flush()
+                    finally:
+                        stop_servo()
         print(f"final_result {final_result}")
     finally:
         if csv_file:

--- a/etc/ci/scenario/blink_perf_test.py
+++ b/etc/ci/scenario/blink_perf_test.py
@@ -372,7 +372,11 @@ def run_tests(port: int, cli_args: argparse.Namespace) -> None:
 
                             try:
                                 result = run_single_test(
-                                    filePath, webdriver, port, get_serve_path_for_file(root, filePath), cli_args=cli_args
+                                    filePath,
+                                    webdriver,
+                                    port,
+                                    get_serve_path_for_file(root, filePath),
+                                    cli_args=cli_args,
                                 )
 
                                 verbose_print(f"result: {result}", cli_args.verbose)

--- a/etc/ci/scenario/common_function_for_mossel.py
+++ b/etc/ci/scenario/common_function_for_mossel.py
@@ -15,7 +15,7 @@ from selenium import webdriver
 from time import sleep
 
 
-def load_mossel(driver: webdriver.Remote):
+def load_mossel(driver: webdriver.Remote) -> None:
     PAGE_URL = "https://m.huaweimossel.com"
     driver.set_page_load_timeout(30)
     while True:
@@ -38,7 +38,7 @@ def load_mossel(driver: webdriver.Remote):
 # Note that the pop-up may not exist, either because we did this in the past
 # which sets localstorage, or the website does not have seasonal promotions/recommendations.
 # ASSUMPTION: driver is already created, and implicit wait is set properly.
-def close_popup(driver: webdriver.Remote):
+def close_popup(driver: webdriver.Remote) -> None:
     popup_css_selector = (
         "#app > uni-app > uni-page > uni-page-wrapper > uni-page-body > uni-view "
         "> uni-view:nth-child(5) "
@@ -55,7 +55,7 @@ def close_popup(driver: webdriver.Remote):
         print(f"Failed to find pop_up element with selector `{popup_css_selector}`. Skip it.")
 
 
-def click_category(driver: webdriver.Remote):
+def click_category(driver: webdriver.Remote) -> None:
     print("Clicking 'Categories' element.")
     category_css_selector = "div.uni-tabbar__item:nth-child(3)"
     try:
@@ -66,7 +66,7 @@ def click_category(driver: webdriver.Remote):
     category_element.click()
 
 
-def identify_element_in_category(driver: webdriver.Remote):
+def identify_element_in_category(driver: webdriver.Remote) -> None:
     driver.implicitly_wait(30)
     target_css_selector = "#goodsGroup"
     while True:

--- a/etc/ci/scenario/common_function_for_servo_test.py
+++ b/etc/ci/scenario/common_function_for_servo_test.py
@@ -20,7 +20,7 @@ import time
 from decimal import Decimal
 from enum import Enum
 from types import TracebackType
-from typing import Any, Callable, Optional, Self, Type
+from typing import Callable, Optional, Self, Type
 
 from hdc_py.hdc import HarmonyDeviceConnector, HarmonyDevicePerfMode
 from PIL import Image

--- a/etc/ci/scenario/common_function_for_servo_test.py
+++ b/etc/ci/scenario/common_function_for_servo_test.py
@@ -19,6 +19,8 @@ import sys
 import time
 from decimal import Decimal
 from enum import Enum
+from types import TracebackType
+from typing import Any, Callable, Optional, Self, Type
 
 from hdc_py.hdc import HarmonyDeviceConnector, HarmonyDevicePerfMode
 from PIL import Image
@@ -49,13 +51,13 @@ class MitmProxyRunType(enum.Enum):
 
 
 class MitmProxy:
-    def __init__(self, use_proxy: MitmProxyRunType, dump_file, port: int):
-        self.mitmproxy = None
+    def __init__(self, use_proxy: MitmProxyRunType, dump_file: pathlib.Path, port: int) -> None:
+        self.mitmproxy: subprocess.Popen[bytes] | None = None
         self.use_proxy = use_proxy
         self.dump_file = dump_file
         self.port = port
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         # for record the external recorder will record
         # make sure mitmproxy is installed
         if self.use_proxy == MitmProxyRunType.REPLAY:
@@ -91,14 +93,19 @@ class MitmProxy:
             )
         return self
 
-    def __exit__(self, exception_type, exception_value, exception_traceback):
+    def __exit__(
+        self,
+        exception_type: Type[BaseException] | None,
+        exception_value: BaseException | None,
+        exception_traceback: TracebackType | None,
+    ) -> None:
         if self.mitmproxy:
             print("Killing mitmproxy")
             self.mitmproxy.kill()
             time.sleep(2)
 
 
-def calculate_frame_rate():
+def calculate_frame_rate() -> float:
     """
     Pull trace from device and calculate frame rate through trace
     calculate frame rate: When there are elements moving on the page, H: EndCommands will be printed
@@ -120,7 +127,7 @@ def calculate_frame_rate():
     print(f"Pull trace file to {file_name} success.")
 
     trace_key = "H:ReceiveVsync"
-    check_list = []
+    check_list: list[str] = []
     with open(file_name, "r") as f:
         lines = f.readlines()
         if "TouchHandler::FlingStart" not in lines:
@@ -153,7 +160,7 @@ def create_driver(timeout: int = 10) -> webdriver.Remote:
     print("Trying to create driver")
     options = ArgOptions()
     options.set_capability("browserName", "servo")
-    driver = None
+    driver: Optional[webdriver.Remote] = None
     start_time = time.time()
     while driver is None and time.time() - start_time < timeout:
         try:
@@ -164,7 +171,7 @@ def create_driver(timeout: int = 10) -> webdriver.Remote:
             print(f"Unexpected exception when creating webdriver: {e}, {type(e)}")
             time.sleep(1)
     if driver is None:
-        print(f"The driver is not created due to {timeout}s timeout (took: {time.time() - start_time}s)")
+        raise RuntimeError(f"The driver is not created due to {timeout}s timeout (took: {time.time() - start_time}s)")
     else:
         print(
             f"Established Webdriver connection in {time.time() - start_time}s",
@@ -206,7 +213,9 @@ def port_forward(port: int | str, reverse: bool) -> PortMapResult:
     return PortMapResult.SUCCESSFUL
 
 
-def setup_hdc_forward(timeout: int = 5, webdriver_port: int = WEBDRIVER_PORT, host_service_port: int = MITMPROXY_PORT):
+def setup_hdc_forward(
+    timeout: int = 5, webdriver_port: int = WEBDRIVER_PORT, host_service_port: int = MITMPROXY_PORT
+) -> None:
     """
     set hdc forward
     :return: If successful, return driver; If failed, return False
@@ -232,7 +241,7 @@ def setup_hdc_forward(timeout: int = 5, webdriver_port: int = WEBDRIVER_PORT, ho
     raise TimeoutError("HDC port forwarding timed out")
 
 
-def stop_servo():
+def stop_servo() -> None:
     """stop servo application"""
     print("Prepare to stop Test Application...")
     cmd = ["hdc", "shell", "aa force-stop org.servo.servo"]
@@ -240,7 +249,7 @@ def stop_servo():
     print("Stop Test Application successful!")
 
 
-def element_scroll_into_view_and_rect(driver: webdriver.Remote, element: WebElement):
+def element_scroll_into_view_and_rect(driver: webdriver.Remote, element: WebElement) -> Any:
     """
     This scrolls element into view, and return the DOMRect tuple:
     [left, top, right, bottom]
@@ -273,13 +282,13 @@ def element_scroll_into_view_and_rect(driver: webdriver.Remote, element: WebElem
     return physical_rect
 
 
-def element_screenshot(element: WebElement, filename: str):
+def element_screenshot(driver: webdriver.Remote, element: WebElement, filename: str) -> None:
     if not (filename.lower().endswith(".jpg") or filename.lower().endswith(".jpeg")):
         raise ValueError(f"Invalid file type: {filename}. Expected a .jpg/.jpeg file.")
 
     try:
         print(f"Scrolling {element}")
-        region = element_scroll_into_view_and_rect(element)
+        region = element_scroll_into_view_and_rect(driver, element)
         time.sleep(2)
         hdc = HarmonyDeviceConnector()
         hdc.screenshot(filename)
@@ -295,8 +304,8 @@ def is_servo_window_focused(hdc: HarmonyDeviceConnector) -> bool:
     completed_process = hdc.cmd("hidumper -s WindowManagerService -a '-a'", capture_output=True, encoding="utf-8")
     output = str(completed_process.stdout)
     lines = output.splitlines()
-    focused_window = None
-    servo_window_id = None
+    focused_window: Optional[int] = None
+    servo_window_id: Optional[int] = None
     for line in lines:
         if line.lower().startswith("focus window:"):
             focused_window = int(line.split(":")[1].strip())
@@ -315,7 +324,7 @@ def is_servo_window_focused(hdc: HarmonyDeviceConnector) -> bool:
     return focused_window == servo_window_id
 
 
-def close_usb_popup(hdc: HarmonyDeviceConnector):
+def close_usb_popup(hdc: HarmonyDeviceConnector) -> None:
     """
     When connecting an OpenHarmony device, a system pop-up will be opened on the device,
     asking the user to confirm which USB mode should be used for the connection.
@@ -335,11 +344,12 @@ def close_usb_popup(hdc: HarmonyDeviceConnector):
 # We always load "about:blank" first, and then use
 # WebDriver to load target url so that it is blocked until fully loaded.
 def run_test(
-    test_fn,
+    test_fn: Callable[[], None],
     test_name: str,
     use_mitmproxy: MitmProxyRunType = MitmProxyRunType.NOPROXY,
     session_history_max_length: int | None = None,
-):
+    url: Optional[str] = None,
+) -> None:
     if os.environ.get("CI") and use_mitmproxy == MitmProxyRunType.NOPROXY:
         # if we are in CI and nobody overrode our mitmproxy type we want to replay.
         print("Setting mitmproxy replay")
@@ -349,6 +359,7 @@ def run_test(
     if use_mitmproxy == MitmProxyRunType.REPLAY and not dump_file.is_file():
         print(f"Dump file {dump_file} did not exist. We will abort")
         return
+    resolved_url = url if url is not None else ABOUT_BLANK
     hdc = HarmonyDeviceConnector()
     try:
         print("Stopping potential old servo instance ...")
@@ -358,7 +369,7 @@ def run_test(
         with MitmProxy(use_mitmproxy, dump_file, MITMPROXY_PORT):
             print("Starting new servo instance...")
             time.sleep(5)
-            cmd_str = f"aa start -a EntryAbility -b org.servo.servo -U {ABOUT_BLANK} --psn=--webdriver"
+            cmd_str = f"aa start -a EntryAbility -b org.servo.servo -U {resolved_url} --psn=--webdriver"
             if use_mitmproxy.should_servo_proxy():
                 cmd_str += f" --psn=--pref=network_https_proxy_uri=http://127.0.0.1:{str(MITMPROXY_PORT)} --psn=--pref=network_http_proxy_uri=http://127.0.0.1:{MITMPROXY_PORT} --psn=--ignore-certificate-errors"
                 if session_history_max_length is not None:

--- a/etc/ci/scenario/common_function_for_servo_test.py
+++ b/etc/ci/scenario/common_function_for_servo_test.py
@@ -249,7 +249,9 @@ def stop_servo() -> None:
     print("Stop Test Application successful!")
 
 
-def element_scroll_into_view_and_rect(driver: webdriver.Remote, element: WebElement) -> Any:
+def element_scroll_into_view_and_rect(
+    driver: webdriver.Remote, element: WebElement
+) -> tuple[float, float, float, float]:
     """
     This scrolls element into view, and return the DOMRect tuple:
     [left, top, right, bottom]
@@ -279,7 +281,10 @@ def element_scroll_into_view_and_rect(driver: webdriver.Remote, element: WebElem
         element,
     )
 
-    return physical_rect
+    if not isinstance(physical_rect, list) or len(physical_rect) != 4:
+        raise TypeError("Expected a 4-item rect list")
+    left, top, right, bottom = physical_rect
+    return (left, top, right, bottom)
 
 
 def element_screenshot(driver: webdriver.Remote, element: WebElement, filename: str) -> None:

--- a/etc/ci/scenario/memory_usage_plotter.py
+++ b/etc/ci/scenario/memory_usage_plotter.py
@@ -234,7 +234,6 @@ class NonBlockingMemoryLogging:
 
     def __enter__(self) -> Self:
         self.start()
-        self.csv_file = None
         return self
 
     def __exit__(

--- a/etc/ci/scenario/memory_usage_plotter.py
+++ b/etc/ci/scenario/memory_usage_plotter.py
@@ -9,19 +9,23 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+from io import TextIOWrapper
 import argparse
 import threading
 import time
 import csv
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 import subprocess
-from typing import List, Optional
+from typing import List, Optional, Self, Type
 import matplotlib.pyplot as plt
+import matplotlib.dates as mdates
 import datetime as dt
 from pathlib import Path
 from selenium import webdriver
+from selenium.webdriver.remote.webdriver import WebDriver
 import sys
-from hdc_py.hdc import HarmonyDeviceConnector
+from hdc_py.hdc import HarmonyDeviceConnector  # type: ignore[import-untyped]
+from types import TracebackType
 from common_function_for_servo_test import create_driver
 
 PACKAGE_NAME = "org.servo.servo"
@@ -31,17 +35,17 @@ PACKAGE_NAME = "org.servo.servo"
 @dataclass
 class MemoryLoggingOptions:
     verbose: bool = False
-    frequency: int = 2
-    pid: int = None
+    frequency: float = 2
+    pid: Optional[int] = None
     log_to_file: bool = False
     plot: bool = False
     file_name: str = "memory_usage_plotter"
-    pre_time: int = 0
-    post_time: int = 0
+    pre_time: float = 0
+    post_time: float = 0
     set_minimal_history: bool = False
-    from_dump: str = None
+    from_dump: Optional[str] = None
     mode: str = "collect"
-    reset_tab: str = None
+    reset_tab: Optional[str | bool] = None
     create_own_webdriver: bool = False
 
 
@@ -154,10 +158,10 @@ class MemorySample:
 class MemoryLog:
     samples: List[MemorySample] = field(default_factory=list)
 
-    def add(self, sample: MemorySample):
+    def add(self, sample: MemorySample) -> None:
         self.samples.append(sample)
 
-    def clear(self):
+    def clear(self) -> None:
         self.samples.clear()
 
 
@@ -187,34 +191,34 @@ class WebDriverIsNotSet(Exception):
 
 
 class NonBlockingMemoryLogging:
-    def set_webdriver(self, webdriver: webdriver):
-        self.driver = webdriver
+    def set_webdriver(self, driver: webdriver.Remote) -> None:
+        self.driver = driver
 
-    def from_dump(self):
-        self.log = load_memory_log(self.options.from_dump)
-        self.plot_memory_log()
+    def from_dump(self) -> None:
+        if self.options.from_dump is not None:
+            self.log = load_memory_log(self.options.from_dump)
+            self.plot_memory_log()
 
-    def __init__(self, options: MemoryLoggingOptions = None):
+    def __init__(self, options: Optional[MemoryLoggingOptions] = None) -> None:
         # Defaults:
         self.options = MemoryLoggingOptions()
         if options is not None:
             self.options = options
-        self.driver = None
+        self.driver: Optional[WebDriver] = None
+        self.hdc: Optional[HarmonyDeviceConnector] = None
+        self.csv_file: Optional[TextIOWrapper] = None
         if self.options.create_own_webdriver:
             self.driver = create_driver(timeout=1)
-            if self.driver is None:
-                print("Doublecheck that servo is running and has `--psn=--webdriver`")
-                sys.exit(0)
 
         if self.options.verbose:
             print(f"Memory plotter options: {self.options}")
 
         # check for the `file` mode
-        if options.mode is None:
+        if self.options.mode is None:
             print("No mode has been specified. Exiting")
             sys.exit(1)
-        if options.mode == "plot" and options.from_dump is not None:
-            raise_if_input_invalid(options.from_dump)
+        if self.options.mode == "plot" and self.options.from_dump is not None:
+            raise_if_input_invalid(self.options.from_dump)
             self.from_dump()
             sys.exit(0)
         self.log = MemoryLog()
@@ -228,20 +232,24 @@ class NonBlockingMemoryLogging:
             daemon=True,
         )
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         self.start()
         self.csv_file = None
         return self
 
-    def __exit__(self, exc_type, exc, tb):
+    def __exit__(
+        self,
+        exc_type: Type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
         self.stop()
         if self.csv_file:
             self.csv_file.close()
         if self.driver is not None:
             self.driver.quit()
-        return False
 
-    def start(self):
+    def start(self) -> None:
         if self.options.pid is None:
             try:
                 self.hdc = HarmonyDeviceConnector()
@@ -255,7 +263,7 @@ class NonBlockingMemoryLogging:
                     time.sleep(abs(self.options.pre_time))
                 self.event("start")
 
-    def stop(self):
+    def stop(self) -> None:
         self.event("stop")
         if self.options.post_time is not None:
             self.verbose_print(f"post-logging for {self.options.post_time}s...")
@@ -263,7 +271,7 @@ class NonBlockingMemoryLogging:
                 if self.driver is None:
                     raise WebDriverIsNotSet("The `-r` argument or Tab Reset was passed, but the webdriver is not set")
                 self.verbose_print(f"Setting the url to reset_tab: {self.options.reset_tab}")
-                if self.options.reset_tab is not str:
+                if not isinstance(self.options.reset_tab, str):
                     self.options.reset_tab = "about:blank"
                 self.driver.get(self.options.reset_tab)
             time.sleep(self.options.post_time)
@@ -273,18 +281,24 @@ class NonBlockingMemoryLogging:
             self._thread.join()
             if self.options.verbose:
                 print(self.log)
-            if self.options.log_to_file:
+            if self.options.log_to_file and self.csv_file:
                 self.csv_file.close()
             if self.options.plot:
                 self.plot_memory_log()
 
-    def _run(self):
+    def _run(self) -> None:
         while not self._stop_event.is_set():
             self.event()
             time.sleep(1 / self.options.frequency)
 
-    def event(self, event_name: str = None):
+    def event(self, event_name: Optional[str] = None) -> None:
+        if self.options.pid is None:
+            return
+
         memory_point = get_memory_info(self.options.pid)
+        if memory_point is None:
+            return
+
         if self.options.verbose:
             print(memory_point)
         sample = MemorySample(
@@ -295,7 +309,8 @@ class NonBlockingMemoryLogging:
         )
         if self.options.log_to_file:
             self.writer.writerow([sample.timestamp, sample.RSS_MB, sample.Swap_MB, event_name])
-            self.csv_file.flush()
+            if self.csv_file:
+                self.csv_file.flush()
         self.log.add(sample)
 
     def verbose_print(self, to_print: str) -> None:
@@ -307,7 +322,7 @@ class NonBlockingMemoryLogging:
             raise ValueError("MemoryLog is empty")
 
         # Extract data
-        times = [dt.datetime.fromtimestamp(s.timestamp) for s in self.log.samples]
+        times = mdates.date2num([dt.datetime.fromtimestamp(s.timestamp) for s in self.log.samples])
         rss = [s.RSS_MB for s in self.log.samples]
         swap = [s.Swap_MB for s in self.log.samples]
         total = [r + s for r, s in zip(rss, swap)]
@@ -349,6 +364,9 @@ class NonBlockingMemoryLogging:
             plt.title(self.options.file_name)
         else:
             plt.title("Memory Usage Over Time")
+        ax = plt.gca()
+        ax.xaxis.set_major_formatter(mdates.DateFormatter("%d %b %H:%M:%S"))
+        plt.gcf().autofmt_xdate()
         plt.ylim(bottom=0)
         plt.legend()
         plt.grid(True)
@@ -447,6 +465,11 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     args.create_own_webdriver = True
-    with NonBlockingMemoryLogging(args) as worker:
+    options_kwargs = {
+        field.name: getattr(args, field.name) for field in fields(MemoryLoggingOptions) if hasattr(args, field.name)
+    }
+    options = MemoryLoggingOptions(**options_kwargs)
+    options.create_own_webdriver = True
+    with NonBlockingMemoryLogging(options) as worker:
         time.sleep(2)
         print("Exiting memory_usage_plotter.py")

--- a/etc/ci/scenario/pyproject.toml
+++ b/etc/ci/scenario/pyproject.toml
@@ -12,3 +12,10 @@ license = "Apache-2.0 OR MIT"
 
 [tool.uv]
 native-tls = true
+
+[tool.pyrefly]
+search-path = ["."]
+python-interpreter-path = ".venv/bin/python"
+project-excludes = [
+    "**/.venv/**",
+]

--- a/etc/ci/scenario/pyproject.toml
+++ b/etc/ci/scenario/pyproject.toml
@@ -15,7 +15,6 @@ native-tls = true
 
 [tool.pyrefly]
 search-path = ["."]
-python-interpreter-path = ".venv/bin/python"
 project-excludes = [
     "**/.venv/**",
 ]

--- a/etc/ci/scenario/servo_test_frame_rate_base_page.py
+++ b/etc/ci/scenario/servo_test_frame_rate_base_page.py
@@ -20,7 +20,7 @@ import common_function_for_servo_test
 from selenium.webdriver.common.by import By
 
 
-def operator():
+def operator() -> None:
     driver = common_function_for_servo_test.create_driver()
 
     popup_css_selector = (
@@ -74,7 +74,7 @@ def operator():
         "shell",
         "hitrace -b 81920 -t 10 ace app ohos ability graphic -o /data/local/tmp/my_trace.html",
     ]
-    process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
     time.sleep(5)
 
     print("Swiping ...")
@@ -84,10 +84,10 @@ def operator():
     process.wait(timeout=15)
     stdout, stderr = process.communicate()
     print("hitrace command complete. Output:")
-    print(stdout.decode())
+    print(stdout)
     if stderr:
         print("Error message:")
-        print(stderr.decode())
+        print(stderr)
 
     frame_rate = common_function_for_servo_test.calculate_frame_rate()
     print(f"framerate is {frame_rate}")
@@ -97,4 +97,4 @@ def operator():
 
 
 if __name__ == "__main__":
-    common_function_for_servo_test.run_test(operator, "mossel_frame_rate_base", "https://m.huaweimossel.com")
+    common_function_for_servo_test.run_test(operator, "mossel_frame_rate_base", url="https://m.huaweimossel.com")

--- a/etc/ci/scenario/servo_test_frame_rate_with_carousel.py
+++ b/etc/ci/scenario/servo_test_frame_rate_with_carousel.py
@@ -20,7 +20,7 @@ import common_function_for_servo_test
 from selenium.webdriver.common.by import By
 
 
-def operator():
+def operator() -> None:
     driver = common_function_for_servo_test.create_driver()
 
     popup_css_selector = (
@@ -77,7 +77,7 @@ def operator():
         "shell",
         "hitrace -b 81920 -t 10 ace app ohos ability graphic -o /data/local/tmp/my_trace.html",
     ]
-    process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
     time.sleep(5)
 
     print("Swiping...")
@@ -87,10 +87,10 @@ def operator():
     process.wait(timeout=15)
     stdout, stderr = process.communicate()
     print("hitrace command complete. Output:")
-    print(stdout.decode())
+    print(stdout)
     if stderr:
         print("Error message:")
-        print(stderr.decode())
+        print(stderr)
 
     frame_rate = common_function_for_servo_test.calculate_frame_rate()
     print(f"framerate is {frame_rate}")
@@ -100,4 +100,6 @@ def operator():
 
 
 if __name__ == "__main__":
-    common_function_for_servo_test.run_test(operator, "mossel_frame_rate_with_carousel", "https://m.huaweimossel.com")
+    common_function_for_servo_test.run_test(
+        operator, "mossel_frame_rate_with_carousel", url="https://m.huaweimossel.com"
+    )

--- a/etc/ci/scenario/servo_test_frame_rate_with_video.py
+++ b/etc/ci/scenario/servo_test_frame_rate_with_video.py
@@ -20,7 +20,7 @@ import common_function_for_servo_test
 from selenium.webdriver.common.by import By
 
 
-def operator():
+def operator() -> None:
     driver = common_function_for_servo_test.create_driver()
 
     popup_css_selector = (
@@ -65,7 +65,7 @@ def operator():
         "shell",
         "hitrace -b 81920 -t 10 ace app ohos ability graphic -o /data/local/tmp/my_trace.html",
     ]
-    process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
     time.sleep(5)
 
     print("Swiping ...")
@@ -75,10 +75,10 @@ def operator():
     process.wait(timeout=15)
     stdout, stderr = process.communicate()
     print("hitrace command complete. Output:")
-    print(stdout.decode())
+    print(stdout)
     if stderr:
         print("Error message:")
-        print(stderr.decode())
+        print(stderr)
 
     frame_rate = common_function_for_servo_test.calculate_frame_rate()
     print(f"framerate is {frame_rate}")
@@ -88,4 +88,4 @@ def operator():
 
 
 if __name__ == "__main__":
-    common_function_for_servo_test.run_test(operator, "mossel_framerate_with_video", "https://m.huaweimossel.com")
+    common_function_for_servo_test.run_test(operator, "mossel_framerate_with_video", url="https://m.huaweimossel.com")

--- a/etc/ci/scenario/servo_test_slide.py
+++ b/etc/ci/scenario/servo_test_slide.py
@@ -18,7 +18,7 @@ import common_function_for_mossel
 from memory_usage_plotter import NonBlockingMemoryLogging, MemoryLoggingOptions
 
 
-def operator():
+def operator() -> None:
     memory_logging_options = MemoryLoggingOptions(
         log_to_file=True, plot=True, pre_time=2, post_time=5, verbose=True, reset_tab=True
     )


### PR DESCRIPTION
This is a small step toward a bigger goal. 
Main goal: to enable python type checking in the whole servo unless specifically required (ex: third_party code). More on https://github.com/servo/servo/issues/45062
This PR's goal: to fix existing type checker errors and warning in the etc/ci/scenario

Testing: the python files in the dir could be run with uv commands:
```bash
UV_PROJECT=etc/ci/scenario uv run --active etc/ci/scenario/blink_perf_test.py -h
```
to manually run the type checking in that specific dir I used:
```bash
uv run pyrefly check etc/ci/scenario/
```

Fixes: https://github.com/servo/servo/issues/45062  (not fix, more like "addresses") 
