### PR TITLE
layout: Add an integrity check for AccessibilityData::rooted_nodes.

### DIFF
--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -7,7 +7,6 @@ use std::sync::atomic::AtomicU64;
 use std::sync::{LazyLock, atomic};
 
 use accesskit::{NodeId, Role};
-use embedder_traits::UntrustedNodeAddress;
 use layout_api::{LayoutElement, LayoutNode, LayoutNodeType};
 use log::trace;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -27,6 +26,10 @@ struct AccessibilityUpdate {
     changed_nodes: FxHashSet<NodeId>,
     /// Nodes that changed their relation to the tree within the current update.
     tree_changes: FxHashMap<NodeId, TreeChange>,
+    /// Nodes which were removed from the DOM tree since the last reflow, which were rooted in
+    /// [`AccessibilityData`]. Only set if [`pref::expensive_accessibility_test_assertions_enabled`]
+    /// is set.
+    rooted_nodes: Option<Vec<OpaqueNode>>,
 }
 
 struct AccessibilityNode {
@@ -71,9 +74,6 @@ pub struct AccessibilityTree {
     /// Debug options, copied from configuration to this `AccessibilityTree` in order
     /// to avoid having to constantly access the thread-safe global options.
     debug: DiagnosticsLogging,
-    /// Nodes which were removed from the tree in the most recent update. If set, should be taken
-    /// using [`Self::take_recently_removed_opaque_nodes()`] before the next update.
-    recently_removed_opaque_nodes: Option<Vec<OpaqueNode>>,
 }
 
 /// Tracks changes to a node's relation to the tree within an update.
@@ -119,7 +119,6 @@ impl AccessibilityTree {
             root_node_id: None,
             embedder_epoch,
             debug: opts::get().debug.clone(),
-            recently_removed_opaque_nodes: None,
         }
     }
 
@@ -128,8 +127,9 @@ impl AccessibilityTree {
     pub(super) fn update_tree(
         &mut self,
         root_dom_node: &ServoLayoutNode<'_>,
+        rooted_nodes: Option<Vec<OpaqueNode>>,
     ) -> Option<accesskit::TreeUpdate> {
-        let mut update = AccessibilityUpdate::new();
+        let mut update = AccessibilityUpdate::new(rooted_nodes);
         let root_node = self.get_or_create_node(root_dom_node, &mut update);
         let root_node_id = root_node.borrow().id;
         self.root_node_id = Some(root_node_id);
@@ -137,18 +137,6 @@ impl AccessibilityTree {
         self.update_node_and_descendants(root_dom_node, &mut update);
 
         update.finalize(self)
-    }
-
-    pub(super) fn take_recently_removed_opaque_nodes(
-        &mut self,
-    ) -> Option<Vec<UntrustedNodeAddress>> {
-        let opaque_nodes = std::mem::take(&mut self.recently_removed_opaque_nodes)?;
-        Some(
-            opaque_nodes
-                .into_iter()
-                .map(|opaque_node| opaque_node.into())
-                .collect(),
-        )
     }
 
     /// Update this tree starting at the given DOM node, adding any changed nodes to the given
@@ -227,21 +215,19 @@ impl AccessibilityTree {
     /// Consume the [`AccessibilityUpdate`] by deleting all nodes it detected as being removed from
     /// the tree.
     fn remove_stale_nodes(&mut self, mut update: AccessibilityUpdate) {
-        if pref!(expensive_accessibility_test_assertions_enabled) {
-            // This field should be taken after each update, if it's being used.
-            assert!(self.recently_removed_opaque_nodes.is_none());
-            let mut recently_removed_opaque_nodes = vec![];
-
+        // If we got rooted_nodes from the document's AccessibilityData, assert that every node
+        // we removed during this update was rooted.
+        if let Some(rooted_nodes) = update.rooted_nodes {
+            debug_assert!(pref!(expensive_accessibility_test_assertions_enabled));
+            let rooted_nodes = FxHashSet::from_iter(rooted_nodes);
             for (id, change) in update.tree_changes.iter() {
                 if change == &TreeChange::Removed {
                     let node = self.assert_node_for_id(id);
                     if let Some(opaque_node) = node.borrow().opaque_node {
-                        recently_removed_opaque_nodes.push(opaque_node);
+                        assert!(rooted_nodes.contains(&opaque_node));
                     }
                 };
             }
-
-            self.recently_removed_opaque_nodes = Some(recently_removed_opaque_nodes);
         }
 
         for id in update
@@ -296,11 +282,10 @@ impl AccessibilityTree {
     ///
     /// For accessibility tests only, because it’s expensive.
     fn assert_integrity(&self) {
+        debug_assert!(pref!(expensive_accessibility_test_assertions_enabled));
         let Some(root_node_id) = self.root_node_id else {
             return;
         };
-
-        assert!(pref!(expensive_accessibility_test_assertions_enabled));
         // Traverse the tree from the given root.
         let mut node_ids = vec![root_node_id];
         let mut seen_node_ids = FxHashSet::default();
@@ -585,10 +570,11 @@ impl Debug for AccessibilityNode {
 }
 
 impl AccessibilityUpdate {
-    fn new() -> Self {
+    fn new(rooted_nodes: Option<Vec<OpaqueNode>>) -> Self {
         Self {
             changed_nodes: FxHashSet::default(),
             tree_changes: FxHashMap::default(),
+            rooted_nodes,
         }
     }
 
@@ -673,7 +659,7 @@ fn test_accessibility_update_add_some_nodes_twice() {
         );
     }
 
-    let mut update = AccessibilityUpdate::new();
+    let mut update = AccessibilityUpdate::new(None);
 
     {
         let node_3 = tree.assert_node_for_id(&NodeId(3));

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -7,6 +7,7 @@ use std::sync::atomic::AtomicU64;
 use std::sync::{LazyLock, atomic};
 
 use accesskit::{NodeId, Role};
+use embedder_traits::UntrustedNodeAddress;
 use layout_api::{LayoutElement, LayoutNode, LayoutNodeType};
 use log::trace;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -70,6 +71,9 @@ pub struct AccessibilityTree {
     /// Debug options, copied from configuration to this `AccessibilityTree` in order
     /// to avoid having to constantly access the thread-safe global options.
     debug: DiagnosticsLogging,
+    /// Nodes which were removed from the tree in the most recent update. If set, should be taken
+    /// using [`Self::take_recently_removed_opaque_nodes()`] before the next update.
+    recently_removed_opaque_nodes: Option<Vec<OpaqueNode>>,
 }
 
 /// Tracks changes to a node's relation to the tree within an update.
@@ -115,6 +119,7 @@ impl AccessibilityTree {
             root_node_id: None,
             embedder_epoch,
             debug: opts::get().debug.clone(),
+            recently_removed_opaque_nodes: None,
         }
     }
 
@@ -132,6 +137,18 @@ impl AccessibilityTree {
         self.update_node_and_descendants(root_dom_node, &mut update);
 
         update.finalize(self)
+    }
+
+    pub(super) fn take_recently_removed_opaque_nodes(
+        &mut self,
+    ) -> Option<Vec<UntrustedNodeAddress>> {
+        let opaque_nodes = std::mem::take(&mut self.recently_removed_opaque_nodes)?;
+        Some(
+            opaque_nodes
+                .into_iter()
+                .map(|opaque_node| opaque_node.into())
+                .collect(),
+        )
     }
 
     /// Update this tree starting at the given DOM node, adding any changed nodes to the given
@@ -210,6 +227,23 @@ impl AccessibilityTree {
     /// Consume the [`AccessibilityUpdate`] by deleting all nodes it detected as being removed from
     /// the tree.
     fn remove_stale_nodes(&mut self, mut update: AccessibilityUpdate) {
+        if pref!(expensive_accessibility_test_assertions_enabled) {
+            // This field should be taken after each update, if it's being used.
+            assert!(self.recently_removed_opaque_nodes.is_none());
+            let mut recently_removed_opaque_nodes = vec![];
+
+            for (id, change) in update.tree_changes.iter() {
+                if change == &TreeChange::Removed {
+                    let node = self.assert_node_for_id(id);
+                    if let Some(opaque_node) = node.borrow().opaque_node {
+                        recently_removed_opaque_nodes.push(opaque_node);
+                    }
+                };
+            }
+
+            self.recently_removed_opaque_nodes = Some(recently_removed_opaque_nodes);
+        }
+
         for id in update
             .tree_changes
             .drain()

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -215,29 +215,8 @@ impl AccessibilityTree {
     /// Consume the [`AccessibilityUpdate`] by deleting all nodes it detected as being removed from
     /// the tree.
     fn remove_stale_nodes(&mut self, mut update: AccessibilityUpdate) {
-        // If we got rooted_nodes from the document's AccessibilityData, assert that every node
-        // we removed during this update was rooted, and any leftover rooted nodes were never known
-        // to the accessibility tree.
-        if let Some(mut rooted_nodes) = update.rooted_nodes {
-            debug_assert!(pref!(expensive_accessibility_test_assertions_enabled));
-            for (id, change) in update.tree_changes.iter() {
-                if change == &TreeChange::Removed {
-                    let node = self.assert_node_for_id(id);
-                    if let Some(opaque_node) = node.borrow().opaque_node {
-                        assert!(
-                            rooted_nodes.remove(&opaque_node),
-                            "Node removed from accessibility tree wasn't rooted: {node:?}"
-                        );
-                    }
-                };
-            }
-
-            for leftover_node in rooted_nodes {
-                assert!(
-                    !self.opaque_node_to_id.contains_key(&leftover_node),
-                    "Found node removed from DOM tree but not accessibility tree"
-                );
-            }
+        if let Some(rooted_nodes) = std::mem::take(&mut update.rooted_nodes) {
+            self.assert_removed_nodes_were_rooted(&update, rooted_nodes);
         }
 
         for id in update
@@ -269,6 +248,35 @@ impl AccessibilityTree {
 
         if pref!(expensive_accessibility_test_assertions_enabled) {
             self.assert_integrity();
+        }
+    }
+
+    /// If we got `rooted_nodes` from the document's `AccessibilityData`, assert that every node we
+    /// removed during this update was rooted, and any leftover rooted nodes were never known to the
+    /// accessibility tree.
+    fn assert_removed_nodes_were_rooted(
+        &mut self,
+        update: &AccessibilityUpdate,
+        mut rooted_nodes: std::collections::HashSet<OpaqueNode, rustc_hash::FxBuildHasher>,
+    ) {
+        debug_assert!(pref!(expensive_accessibility_test_assertions_enabled));
+        for (id, change) in update.tree_changes.iter() {
+            if change == &TreeChange::Removed {
+                let node = self.assert_node_for_id(id);
+                if let Some(opaque_node) = node.borrow().opaque_node {
+                    assert!(
+                        rooted_nodes.remove(&opaque_node),
+                        "Node removed from accessibility tree wasn't rooted: {node:?}"
+                    );
+                }
+            };
+        }
+
+        for leftover_node in rooted_nodes {
+            assert!(
+                !self.opaque_node_to_id.contains_key(&leftover_node),
+                "Found node removed from DOM tree but not accessibility tree"
+            );
         }
     }
 

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -257,7 +257,7 @@ impl AccessibilityTree {
     fn assert_removed_nodes_were_rooted(
         &mut self,
         update: &AccessibilityUpdate,
-        mut rooted_nodes: std::collections::HashSet<OpaqueNode, rustc_hash::FxBuildHasher>,
+        mut rooted_nodes: FxHashSet<OpaqueNode>,
     ) {
         debug_assert!(pref!(expensive_accessibility_test_assertions_enabled));
         for (id, change) in update.tree_changes.iter() {

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -29,7 +29,7 @@ struct AccessibilityUpdate {
     /// Nodes which were removed from the DOM tree since the last reflow, which were rooted in
     /// [`AccessibilityData`]. Only set if [`pref::expensive_accessibility_test_assertions_enabled`]
     /// is set.
-    rooted_nodes: Option<Vec<OpaqueNode>>,
+    rooted_nodes: Option<FxHashSet<OpaqueNode>>,
 }
 
 struct AccessibilityNode {
@@ -127,7 +127,7 @@ impl AccessibilityTree {
     pub(super) fn update_tree(
         &mut self,
         root_dom_node: &ServoLayoutNode<'_>,
-        rooted_nodes: Option<Vec<OpaqueNode>>,
+        rooted_nodes: Option<FxHashSet<OpaqueNode>>,
     ) -> Option<accesskit::TreeUpdate> {
         let mut update = AccessibilityUpdate::new(rooted_nodes);
         let root_node = self.get_or_create_node(root_dom_node, &mut update);
@@ -216,17 +216,27 @@ impl AccessibilityTree {
     /// the tree.
     fn remove_stale_nodes(&mut self, mut update: AccessibilityUpdate) {
         // If we got rooted_nodes from the document's AccessibilityData, assert that every node
-        // we removed during this update was rooted.
-        if let Some(rooted_nodes) = update.rooted_nodes {
+        // we removed during this update was rooted, and any leftover rooted nodes were never known
+        // to the accessibility tree.
+        if let Some(mut rooted_nodes) = update.rooted_nodes {
             debug_assert!(pref!(expensive_accessibility_test_assertions_enabled));
-            let rooted_nodes = FxHashSet::from_iter(rooted_nodes);
             for (id, change) in update.tree_changes.iter() {
                 if change == &TreeChange::Removed {
                     let node = self.assert_node_for_id(id);
                     if let Some(opaque_node) = node.borrow().opaque_node {
-                        assert!(rooted_nodes.contains(&opaque_node));
+                        assert!(
+                            rooted_nodes.remove(&opaque_node),
+                            "Node removed from accessibility tree wasn't rooted: {node:?}"
+                        );
                     }
                 };
+            }
+
+            for leftover_node in rooted_nodes {
+                assert!(
+                    !self.opaque_node_to_id.contains_key(&leftover_node),
+                    "Found node removed from DOM tree but not accessibility tree"
+                );
             }
         }
 
@@ -570,7 +580,7 @@ impl Debug for AccessibilityNode {
 }
 
 impl AccessibilityUpdate {
-    fn new(rooted_nodes: Option<Vec<OpaqueNode>>) -> Self {
+    fn new(rooted_nodes: Option<FxHashSet<OpaqueNode>>) -> Self {
         Self {
             changed_nodes: FxHashSet::default(),
             tree_changes: FxHashMap::default(),

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -935,7 +935,11 @@ impl LayoutThread {
         }
     }
 
-    fn handle_accessibility_tree_update(&self, root_element: &ServoLayoutNode) -> bool {
+    fn handle_accessibility_tree_update(
+        &self,
+        root_element: &ServoLayoutNode,
+        reflow_request: &mut ReflowRequest,
+    ) -> bool {
         if !self.needs_accessibility_update() {
             return false;
         }
@@ -945,7 +949,10 @@ impl LayoutThread {
         };
 
         let accessibility_tree = &mut *accessibility_tree;
-        if let Some(tree_update) = accessibility_tree.update_tree(root_element) {
+        let rooted_nodes =
+            std::mem::take(&mut reflow_request.rooted_nodes_for_accessibility_integrity_check);
+
+        if let Some(tree_update) = accessibility_tree.update_tree(root_element, rooted_nodes) {
             // FIXME: Handle send error. Could have a method on accessibility tree to
             // finalise after sending, removing accessibility damage? On fail, retain damage
             // for next reflow, as well as retaining document.needs_accessibility_update.
@@ -1015,7 +1022,7 @@ impl LayoutThread {
         if self.handle_update_scroll_node_request(&reflow_request) {
             reflow_phases_run.insert(ReflowPhasesRun::UpdatedScrollNodeOffset);
         }
-        if self.handle_accessibility_tree_update(&root_element.as_node()) {
+        if self.handle_accessibility_tree_update(&root_element.as_node(), &mut reflow_request) {
             reflow_phases_run.insert(ReflowPhasesRun::UpdatedAccessibilityTree);
         }
 
@@ -1032,15 +1039,6 @@ impl LayoutThread {
         let pending_svg_elements_for_serialization =
             std::mem::take(&mut *image_resolver.pending_svg_elements_for_serialization.lock());
 
-        let mut removed_nodes_for_accessibility_integrity_check = None;
-        if self.accessibility_active() {
-            let mut accessibility_tree = self.accessibility_tree.borrow_mut();
-            if let Some(accessibility_tree) = accessibility_tree.as_mut() {
-                removed_nodes_for_accessibility_integrity_check =
-                    accessibility_tree.take_recently_removed_opaque_nodes();
-            }
-        }
-
         Some(ReflowResult {
             reflow_phases_run,
             pending_images,
@@ -1048,7 +1046,6 @@ impl LayoutThread {
             pending_svg_elements_for_serialization,
             iframe_sizes: Some(iframe_sizes),
             reflow_statistics,
-            removed_nodes_for_accessibility_integrity_check,
         })
     }
 

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -1032,6 +1032,15 @@ impl LayoutThread {
         let pending_svg_elements_for_serialization =
             std::mem::take(&mut *image_resolver.pending_svg_elements_for_serialization.lock());
 
+        let mut removed_nodes_for_accessibility_integrity_check = None;
+        if self.accessibility_active() {
+            let mut accessibility_tree = self.accessibility_tree.borrow_mut();
+            if let Some(accessibility_tree) = accessibility_tree.as_mut() {
+                removed_nodes_for_accessibility_integrity_check =
+                    accessibility_tree.take_recently_removed_opaque_nodes();
+            }
+        }
+
         Some(ReflowResult {
             reflow_phases_run,
             pending_images,
@@ -1039,6 +1048,7 @@ impl LayoutThread {
             pending_svg_elements_for_serialization,
             iframe_sizes: Some(iframe_sizes),
             reflow_statistics,
+            removed_nodes_for_accessibility_integrity_check,
         })
     }
 

--- a/components/script/dom/document/accessibility_data.rs
+++ b/components/script/dom/document/accessibility_data.rs
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use embedder_traits::UntrustedNodeAddress;
 use js::context::NoGC;
 use rustc_hash::FxHashSet;
-use script_bindings::root::{Dom, DomRoot};
+use script_bindings::root::Dom;
 use servo_config::pref;
+use style::dom::OpaqueNode;
 
-use crate::dom::{Node, from_untrusted_node_address};
+use crate::dom::Node;
 
 #[derive(Clone, Default, JSTraceable, MallocSizeOf)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
@@ -44,52 +44,36 @@ impl AccessibilityData {
     ///   temporarily root it here in between its removal from the tree and the subsequent reflow.
     /// - During reflow, the accessibility tree is updated, and all stale accessibility nodes are
     ///   removed.
-    /// - After reflow, we can safely un-root these nodes by dropping all the strong references
-    ///   being held here, and allow them to potentially be GCed.
-    ///   See [`Self::unroot_all_removed_nodes()`].
+    /// - Once reflow has begun, no further DOM mutations can occur, and we can safely un-root these
+    ///   nodes by dropping all the strong references being held here. This will allow them to be
+    ///   potential candidates for GC after reflow has finished.
+    ///   See [`Self::unroot_all_removed_nodes()`] and
+    ///   [`Self::unroot_and_drain_all_removed_nodes()`].
     pub(crate) fn root_removed_node(&mut self, _no_gc: &NoGC, node_to_root: &Node) {
         debug_assert!(pref!(accessibility_enabled));
 
         self.rooted_nodes.insert(Dom::from_ref(node_to_root));
     }
 
-    /// Clear all nodes which were rooted using [`Self::root_removed_node()`].
-    /// This should be called at the end of reflow.
-    pub(crate) fn unroot_all_removed_nodes(&mut self) {
-        self.rooted_nodes.clear();
+    /// Clear all nodes which were rooted using [`Self::root_removed_node()`], and return the nodes
+    /// which are still disconnected from the tree.
+    /// This should be called instead of [`Self::unroot_all_removed_nodes()`] during reflow
+    /// if [`pref::expensive_accessibility_test_assertions_enabled`] set.
+    pub(crate) fn unroot_and_drain_all_removed_nodes(&mut self) -> Vec<OpaqueNode> {
+        self.rooted_nodes
+            .drain()
+            .filter_map(|node| {
+                if node.is_connected() {
+                    return None;
+                }
+                Some(node.to_opaque())
+            })
+            .collect()
     }
 
-    /// Clear all nodes which were rooted using [`Self::root_removed_node_for_accessibility()`],
-    /// while also asserting that the nodes which were removed from the accessibility tree:
-    /// - were also removed from the document, and
-    /// - match the nodes which were rooted here after being removed from the tree.
-    ///
-    /// This should be called instead of [`Self::unroot_all_removed_nodes()`] at the end of reflow
-    /// if [`ReflowResult::removed_nodes_for_accessibility_integrity_check`] is not `None`.
-    #[expect(unsafe_code)]
-    pub(crate) fn unroot_all_removed_nodes_with_integrity_check(
-        &mut self,
-        removed_nodes_from_accessibility_tree: Vec<UntrustedNodeAddress>,
-    ) {
-        debug_assert!(pref!(expensive_accessibility_test_assertions_enabled));
-
-        let mut rooted_nodes: FxHashSet<DomRoot<Node>> = self
-            .rooted_nodes
-            .drain()
-            .map(|node| node.as_rooted())
-            .collect();
-
-        // If nodes were re-added to the tree, they will still be rooted here as well, but we can
-        // ignore them for the purposes of the integrity check.
-        rooted_nodes.retain(|node| !node.is_connected());
-
-        for address in removed_nodes_from_accessibility_tree {
-            unsafe {
-                let removed_node = from_untrusted_node_address(address);
-                assert!(rooted_nodes.remove(&removed_node));
-            }
-        }
-
-        assert!(rooted_nodes.is_empty());
+    /// Clear all nodes which were rooted using [`Self::root_removed_node()`].
+    /// This should only be called during reflow.
+    pub(crate) fn unroot_all_removed_nodes(&mut self) {
+        self.rooted_nodes.clear();
     }
 }

--- a/components/script/dom/document/accessibility_data.rs
+++ b/components/script/dom/document/accessibility_data.rs
@@ -59,7 +59,7 @@ impl AccessibilityData {
     /// which are still disconnected from the tree.
     /// This should be called instead of [`Self::unroot_all_removed_nodes()`] during reflow
     /// if [`pref::expensive_accessibility_test_assertions_enabled`] set.
-    pub(crate) fn unroot_and_drain_all_removed_nodes(&mut self) -> Vec<OpaqueNode> {
+    pub(crate) fn unroot_and_drain_all_removed_nodes(&mut self) -> FxHashSet<OpaqueNode> {
         self.rooted_nodes
             .drain()
             .filter_map(|node| {

--- a/components/script/dom/document/accessibility_data.rs
+++ b/components/script/dom/document/accessibility_data.rs
@@ -2,12 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use embedder_traits::UntrustedNodeAddress;
 use js::context::NoGC;
 use rustc_hash::FxHashSet;
-use script_bindings::root::Dom;
+use script_bindings::root::{Dom, DomRoot};
 use servo_config::pref;
 
-use crate::dom::Node;
+use crate::dom::{Node, from_untrusted_node_address};
 
 #[derive(Clone, Default, JSTraceable, MallocSizeOf)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
@@ -56,5 +57,39 @@ impl AccessibilityData {
     /// This should be called at the end of reflow.
     pub(crate) fn unroot_all_removed_nodes(&mut self) {
         self.rooted_nodes.clear();
+    }
+
+    /// Clear all nodes which were rooted using [`Self::root_removed_node_for_accessibility()`],
+    /// while also asserting that the nodes which were removed from the accessibility tree:
+    /// - were also removed from the document, and
+    /// - match the nodes which were rooted here after being removed from the tree.
+    ///
+    /// This should be called instead of [`Self::unroot_all_removed_nodes()`] at the end of reflow
+    /// if [`ReflowResult::removed_nodes_for_accessibility_integrity_check`] is not `None`.
+    #[expect(unsafe_code)]
+    pub(crate) fn unroot_all_removed_nodes_with_integrity_check(
+        &mut self,
+        removed_nodes_from_accessibility_tree: Vec<UntrustedNodeAddress>,
+    ) {
+        debug_assert!(pref!(expensive_accessibility_test_assertions_enabled));
+
+        let mut rooted_nodes: FxHashSet<DomRoot<Node>> = self
+            .rooted_nodes
+            .drain()
+            .map(|node| node.as_rooted())
+            .collect();
+
+        // If nodes were re-added to the tree, they will still be rooted here as well, but we can
+        // ignore them for the purposes of the integrity check.
+        rooted_nodes.retain(|node| !node.is_connected());
+
+        for address in removed_nodes_from_accessibility_tree {
+            unsafe {
+                let removed_node = from_untrusted_node_address(address);
+                assert!(rooted_nodes.remove(&removed_node));
+            }
+        }
+
+        assert!(rooted_nodes.is_empty());
     }
 }

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -47,7 +47,7 @@ use percent_encoding::percent_decode;
 use profile_traits::generic_channel as profile_generic_channel;
 use profile_traits::time::TimerMetadataFrameType;
 use regex::bytes::Regex;
-use rustc_hash::{FxBuildHasher, FxHashMap};
+use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use script_bindings::cell::{DomRefCell, Ref, RefMut};
 use script_bindings::interfaces::DocumentHelpers;
 use script_bindings::reflector::reflect_dom_object_with_proto;
@@ -64,6 +64,7 @@ use servo_media::{ClientContextId, ServoMedia};
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
 use style::attr::AttrValue;
 use style::context::QuirksMode;
+use style::dom::OpaqueNode;
 use style::invalidation::element::restyle_hints::RestyleHint;
 use style::selector_parser::Snapshot;
 use style::shared_lock::{SharedRwLock, SharedRwLockReadGuard};
@@ -3401,6 +3402,23 @@ impl Document {
 
     pub(crate) fn accessibility_active(&self) -> bool {
         self.window().layout().accessibility_active()
+    }
+
+    pub(crate) fn rooted_nodes_for_accessibility_integrity_check(
+        &self,
+    ) -> Option<FxHashSet<OpaqueNode>> {
+        if !self.accessibility_active() {
+            return None;
+        }
+
+        let mut accessibility_data = self.accessibility_data_mut();
+
+        if pref!(expensive_accessibility_test_assertions_enabled) {
+            return Some(accessibility_data.unroot_and_drain_all_removed_nodes());
+        }
+
+        accessibility_data.unroot_all_removed_nodes();
+        None
     }
 }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -87,6 +87,7 @@ use servo_geometry::DeviceIndependentIntRect;
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
 use storage_traits::StorageThreads;
 use storage_traits::webstorage_thread::WebStorageType;
+use style::dom::OpaqueNode;
 use style::error_reporting::{ContextualParseError, ParseErrorReporter};
 use style::properties::PropertyId;
 use style::properties::style_structs::Font;
@@ -2689,6 +2690,19 @@ impl Window {
 
         let document_context = self.web_font_context();
 
+        let mut rooted_nodes_for_accessibility_integrity_check: Option<Vec<OpaqueNode>> = None;
+
+        if self.layout().accessibility_active() {
+            let mut accessibility_data = document.accessibility_data_mut();
+
+            if pref!(expensive_accessibility_test_assertions_enabled) {
+                rooted_nodes_for_accessibility_integrity_check =
+                    Some(accessibility_data.unroot_and_drain_all_removed_nodes());
+            } else {
+                accessibility_data.unroot_all_removed_nodes();
+            }
+        }
+
         // Send new document and relevant styles to layout.
         let reflow = ReflowRequest {
             document: document.upcast::<Node>().to_trusted_node_address(),
@@ -2702,6 +2716,7 @@ impl Window {
             animating_images: document.image_animation_manager().animating_images(),
             highlighted_dom_node: document.highlighted_dom_node().map(|node| node.to_opaque()),
             document_context,
+            rooted_nodes_for_accessibility_integrity_check,
         };
 
         let Some(reflow_result) = self.layout.borrow_mut().reflow(reflow) else {
@@ -2727,16 +2742,6 @@ impl Window {
         }
 
         document.update_animations_post_reflow();
-
-        if let Some(removed_nodes_for_integrity_check) =
-            reflow_result.removed_nodes_for_accessibility_integrity_check
-        {
-            document
-                .accessibility_data_mut()
-                .unroot_all_removed_nodes_with_integrity_check(removed_nodes_for_integrity_check);
-        } else {
-            document.accessibility_data_mut().unroot_all_removed_nodes();
-        }
 
         (
             reflow_result.reflow_phases_run,

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -62,7 +62,7 @@ use paint_api::{CrossProcessPaintApi, PinchZoomInfos};
 use profile_traits::generic_channel as ProfiledGenericChannel;
 use profile_traits::mem::ProfilerChan as MemProfilerChan;
 use profile_traits::time::ProfilerChan as TimeProfilerChan;
-use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
+use rustc_hash::{FxBuildHasher, FxHashMap};
 use script_bindings::cell::{DomRefCell, Ref};
 use script_bindings::codegen::GenericBindings::WindowBinding::ScrollToOptions;
 use script_bindings::conversions::SafeToJSValConvertible;
@@ -87,7 +87,6 @@ use servo_geometry::DeviceIndependentIntRect;
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
 use storage_traits::StorageThreads;
 use storage_traits::webstorage_thread::WebStorageType;
-use style::dom::OpaqueNode;
 use style::error_reporting::{ContextualParseError, ParseErrorReporter};
 use style::properties::PropertyId;
 use style::properties::style_structs::Font;
@@ -2690,19 +2689,8 @@ impl Window {
 
         let document_context = self.web_font_context();
 
-        let mut rooted_nodes_for_accessibility_integrity_check: Option<FxHashSet<OpaqueNode>> =
-            None;
-
-        if self.layout().accessibility_active() {
-            let mut accessibility_data = document.accessibility_data_mut();
-
-            if pref!(expensive_accessibility_test_assertions_enabled) {
-                rooted_nodes_for_accessibility_integrity_check =
-                    Some(accessibility_data.unroot_and_drain_all_removed_nodes());
-            } else {
-                accessibility_data.unroot_all_removed_nodes();
-            }
-        }
+        let rooted_nodes_for_accessibility_integrity_check =
+            document.rooted_nodes_for_accessibility_integrity_check();
 
         // Send new document and relevant styles to layout.
         let reflow = ReflowRequest {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -62,7 +62,7 @@ use paint_api::{CrossProcessPaintApi, PinchZoomInfos};
 use profile_traits::generic_channel as ProfiledGenericChannel;
 use profile_traits::mem::ProfilerChan as MemProfilerChan;
 use profile_traits::time::ProfilerChan as TimeProfilerChan;
-use rustc_hash::{FxBuildHasher, FxHashMap};
+use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use script_bindings::cell::{DomRefCell, Ref};
 use script_bindings::codegen::GenericBindings::WindowBinding::ScrollToOptions;
 use script_bindings::conversions::SafeToJSValConvertible;
@@ -2690,7 +2690,8 @@ impl Window {
 
         let document_context = self.web_font_context();
 
-        let mut rooted_nodes_for_accessibility_integrity_check: Option<Vec<OpaqueNode>> = None;
+        let mut rooted_nodes_for_accessibility_integrity_check: Option<FxHashSet<OpaqueNode>> =
+            None;
 
         if self.layout().accessibility_active() {
             let mut accessibility_data = document.accessibility_data_mut();

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2728,7 +2728,15 @@ impl Window {
 
         document.update_animations_post_reflow();
 
-        document.accessibility_data_mut().unroot_all_removed_nodes();
+        if let Some(removed_nodes_for_integrity_check) =
+            reflow_result.removed_nodes_for_accessibility_integrity_check
+        {
+            document
+                .accessibility_data_mut()
+                .unroot_all_removed_nodes_with_integrity_check(removed_nodes_for_integrity_check);
+        } else {
+            document.accessibility_data_mut().unroot_all_removed_nodes();
+        }
 
         (
             reflow_result.reflow_phases_run,

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -625,6 +625,11 @@ pub struct ReflowResult {
     /// finished before reaching this stage of the layout. I.e., no update
     /// required.
     pub iframe_sizes: Option<IFrameSizes>,
+    /// If `expensive_accessibility_test_assertions_enabled` is true, this will contain the
+    /// UntrustedNodeAddresses for dom Nodes corresponding to the accessibility nodes removed from
+    /// the accessibility tree in the most recent update. This is used exclusively for an integrity
+    /// check.
+    pub removed_nodes_for_accessibility_integrity_check: Option<Vec<UntrustedNodeAddress>>,
 }
 
 bitflags! {

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -47,7 +47,7 @@ use pixels::{RasterImage, Repeat};
 use profile_traits::mem::Report;
 use profile_traits::time;
 pub use pseudo_element_chain::PseudoElementChain;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use script_traits::{InitialScriptState, Painter, ScriptThreadMessage};
 use serde::{Deserialize, Serialize};
 use servo_arc::Arc as ServoArc;
@@ -704,7 +704,7 @@ pub struct ReflowRequest {
     /// Nodes which were removed from the DOM tree since the last reflow, which were rooted in
     /// [`AccessibilityData`]. Only set if [`pref::expensive_accessibility_test_assertions_enabled`]
     /// is set.
-    pub rooted_nodes_for_accessibility_integrity_check: Option<Vec<OpaqueNode>>,
+    pub rooted_nodes_for_accessibility_integrity_check: Option<FxHashSet<OpaqueNode>>,
 }
 
 impl ReflowRequest {

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -625,11 +625,6 @@ pub struct ReflowResult {
     /// finished before reaching this stage of the layout. I.e., no update
     /// required.
     pub iframe_sizes: Option<IFrameSizes>,
-    /// If `expensive_accessibility_test_assertions_enabled` is true, this will contain the
-    /// UntrustedNodeAddresses for dom Nodes corresponding to the accessibility nodes removed from
-    /// the accessibility tree in the most recent update. This is used exclusively for an integrity
-    /// check.
-    pub removed_nodes_for_accessibility_integrity_check: Option<Vec<UntrustedNodeAddress>>,
 }
 
 bitflags! {
@@ -706,6 +701,10 @@ pub struct ReflowRequest {
     pub highlighted_dom_node: Option<OpaqueNode>,
     /// The current font context.
     pub document_context: WebFontDocumentContext,
+    /// Nodes which were removed from the DOM tree since the last reflow, which were rooted in
+    /// [`AccessibilityData`]. Only set if [`pref::expensive_accessibility_test_assertions_enabled`]
+    /// is set.
+    pub rooted_nodes_for_accessibility_integrity_check: Option<Vec<OpaqueNode>>,
 }
 
 impl ReflowRequest {


### PR DESCRIPTION
This compares the nodes in `AccessibilityData::rooted_nodes` when `remove_stale_nodes()` is called at the end of  the accessibility tree update.

This entails, if the integrity check is enabled via `pref!(expensive_accessibility_test_assertions_enabled)`, passing in the list of nodes removed from the accessibility tree in `ReflowRequest`, so that they can be passed in to `AccessibilityTree::update_tree()` and used for the integrity check in `AccessibilityTree::remove_stale_nodes()`.

Testing: Keeps previous behaviour; adds an integrity check for `AccessibilityData::rooted_nodes`.