### PR TITLE
layout: Rewrite the StackingContextTree to be sparse

### DIFF
--- a/components/layout/display_list/background.rs
+++ b/components/layout/display_list/background.rs
@@ -17,6 +17,7 @@ use style::values::specified::background::{
 use webrender_api::{self as wr, units};
 use wr::ClipChainId;
 
+use crate::display_list::{DisplayListBuilder, TraversalState};
 use crate::replaced::NaturalSizes;
 
 pub(super) struct BackgroundLayer {
@@ -80,7 +81,8 @@ impl<'a> BackgroundPainter<'a> {
     fn clip(
         &self,
         fragment_builder: &'a super::BuilderForBoxFragment,
-        builder: &mut super::DisplayListBuilder,
+        builder: &mut DisplayListBuilder,
+        state: &TraversalState,
         layer_index: usize,
     ) -> Option<ClipChainId> {
         if self.painting_area_override.is_some() {
@@ -88,7 +90,7 @@ impl<'a> BackgroundPainter<'a> {
         }
 
         if self.positioning_area_override.is_some() {
-            return fragment_builder.border_edge_clip(builder, false);
+            return fragment_builder.border_edge_clip(builder, state, false);
         }
 
         // The 'backgound-clip' property maps directly to `clip_rect` in `CommonItemProperties`:
@@ -96,9 +98,15 @@ impl<'a> BackgroundPainter<'a> {
         let force_clip_creation = get_cyclic(&background.background_attachment.0, layer_index) ==
             &BackgroundAttachment::Fixed;
         match get_cyclic(&background.background_clip.0, layer_index) {
-            Clip::ContentBox => fragment_builder.content_edge_clip(builder, force_clip_creation),
-            Clip::PaddingBox => fragment_builder.padding_edge_clip(builder, force_clip_creation),
-            Clip::BorderBox => fragment_builder.border_edge_clip(builder, force_clip_creation),
+            Clip::ContentBox => {
+                fragment_builder.content_edge_clip(builder, state, force_clip_creation)
+            },
+            Clip::PaddingBox => {
+                fragment_builder.padding_edge_clip(builder, state, force_clip_creation)
+            },
+            Clip::BorderBox => {
+                fragment_builder.border_edge_clip(builder, state, force_clip_creation)
+            },
         }
     }
 
@@ -109,12 +117,13 @@ impl<'a> BackgroundPainter<'a> {
         &self,
         fragment_builder: &'a super::BuilderForBoxFragment,
         builder: &mut super::DisplayListBuilder,
+        state: &TraversalState,
         layer_index: usize,
         painting_area: units::LayoutRect,
     ) -> wr::CommonItemProperties {
-        let clip = self.clip(fragment_builder, builder, layer_index);
+        let clip = self.clip(fragment_builder, builder, state, layer_index);
         let style = fragment_builder.fragment.style();
-        let mut common = builder.common_properties(painting_area, &style);
+        let mut common = builder.common_properties(state, painting_area, &style);
         if let Some(clip_chain_id) = clip {
             common.clip_chain_id = clip_chain_id;
         }
@@ -159,13 +168,15 @@ impl<'a> BackgroundPainter<'a> {
 pub(super) fn layout_layer(
     fragment_builder: &mut super::BuilderForBoxFragment,
     painter: &BackgroundPainter,
-    builder: &mut super::DisplayListBuilder,
+    builder: &mut DisplayListBuilder,
+    state: &TraversalState,
     layer_index: usize,
     natural_sizes: NaturalSizes,
 ) -> Option<BackgroundLayer> {
     let painting_area = painter.painting_area(fragment_builder, builder, layer_index);
     let positioning_area = painter.positioning_area(fragment_builder, builder, layer_index);
-    let common = painter.common_properties(fragment_builder, builder, layer_index, painting_area);
+    let common =
+        painter.common_properties(fragment_builder, builder, state, layer_index, painting_area);
 
     // https://drafts.csswg.org/css-backgrounds/#background-size
     enum ContainOrCover {

--- a/components/layout/display_list/clip.rs
+++ b/components/layout/display_list/clip.rs
@@ -25,6 +25,12 @@ impl ClipId {
     pub(crate) const INVALID: ClipId = ClipId(usize::MAX);
 }
 
+impl Default for ClipId {
+    fn default() -> Self {
+        Self::INVALID
+    }
+}
+
 /// All the information needed to create a clip on a WebRender display list. These are created at
 /// two times: during `StackingContextTree` creation and during WebRender display list construction.
 /// Only the former are stored in a [`ClipStore`].

--- a/components/layout/display_list/hit_test.rs
+++ b/components/layout/display_list/hit_test.rs
@@ -2,11 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::sync::Arc;
+
 use app_units::Au;
 use embedder_traits::Cursor;
 use euclid::{Box2D, Vector2D};
 use kurbo::{Ellipse, Shape};
-use layout_api::{ElementsFromPointFlags, ElementsFromPointResult};
+use layout_api::ElementsFromPointResult;
 use rustc_hash::FxHashMap;
 use servo_base::id::ScrollTreeNodeId;
 use servo_geometry::FastLayoutTransform;
@@ -19,16 +21,12 @@ use webrender_api::BorderRadius;
 use webrender_api::units::{LayoutPoint, LayoutRect, LayoutSize, RectExt};
 
 use crate::display_list::clip::{Clip, ClipId};
-use crate::display_list::stacking_context::StackingContextSection;
-use crate::display_list::{
-    StackingContext, StackingContextContent, StackingContextTree, ToWebRender,
-};
-use crate::fragment_tree::{Fragment, FragmentFlags};
+use crate::display_list::paint_traversal::{PaintTraversal, PaintTraversalHandler};
+use crate::display_list::{StackingContext, StackingContextTree, ToWebRender, TraversalState};
+use crate::fragment_tree::{BoxFragment, Fragment, FragmentFlags, TextFragment};
 use crate::geom::PhysicalRect;
 
 pub(crate) struct HitTest<'a> {
-    /// The flags which describe how to perform this [`HitTest`].
-    flags: ElementsFromPointFlags,
     /// The point to test for this hit test, relative to the page.
     point_to_test: LayoutPoint,
     /// A cached version of [`Self::point_to_test`] projected to a spatial node, to avoid
@@ -46,19 +44,25 @@ impl<'a> HitTest<'a> {
     pub(crate) fn run(
         stacking_context_tree: &'a StackingContextTree,
         point_to_test: LayoutPoint,
-        flags: ElementsFromPointFlags,
     ) -> Vec<ElementsFromPointResult> {
         let mut hit_test = Self {
-            flags,
             point_to_test,
             projected_point_to_test: None,
             stacking_context_tree,
             results: Vec::new(),
             clip_hit_test_results: FxHashMap::default(),
         };
-        stacking_context_tree
-            .root_stacking_context
-            .hit_test(&mut hit_test);
+
+        PaintTraversal::traverse(&stacking_context_tree.root_stacking_context, &mut hit_test);
+
+        // PaintTraversal::traverse walks forward through all fragments via the stacking
+        // context tree, so results will be in back-to-front order. We want results to be
+        // front-to-back order, so reverse them.
+        //
+        // TODO: Eventually PaintTraversal should support walking backward through
+        // fragments.
+        hit_test.results.reverse();
+
         hit_test.results
     }
 
@@ -112,127 +116,38 @@ impl<'a> HitTest<'a> {
     }
 }
 
+impl PaintTraversalHandler for HitTest<'_> {
+    type StackingContextState = ();
+
+    fn visit_stacking_context(&mut self, _: &StackingContext) -> Self::StackingContextState {}
+    fn leave_stacking_context(&mut self, _: &TraversalState, _: Self::StackingContextState) {}
+    fn visit_box(&mut self, state: &TraversalState, fragment: &Arc<BoxFragment>) {
+        Fragment::Box(fragment.clone()).hit_test(state, self);
+    }
+    fn visit_text(
+        &mut self,
+        state: &TraversalState,
+        _: PhysicalRect<Au>,
+        fragment: &Arc<TextFragment>,
+    ) {
+        Fragment::Text(fragment.clone()).hit_test(state, self);
+    }
+}
+
 impl Clip {
     fn contains(&self, point: LayoutPoint) -> bool {
         rounded_rect_contains_point(self.rect, &self.radii, point)
     }
 }
 
-impl StackingContext {
-    /// Perform a hit test against a [`StackingContext`]. Note that this is the reverse
-    /// of the stacking context walk algorithm in `stacking_context.rs`. Any changes made
-    /// here should be reflected in the forward version in that file.
-    fn hit_test(&self, hit_test: &mut HitTest) -> bool {
-        let mut contents = self.contents.iter().rev().peekable();
-
-        // Step 10: Outlines
-        // We only use `StackingContextSection::Outline` as an override when building the
-        // display list. So we shouldn't encounter it here.
-        assert!(
-            contents
-                .peek()
-                .is_none_or(|child| child.section() != StackingContextSection::Outline)
-        );
-
-        // Steps 8 and 9: Stacking contexts with non-negative ‘z-index’, and
-        // positioned stacking containers (where ‘z-index’ is auto)
-        let mut real_stacking_contexts_and_positioned_stacking_containers = self
-            .real_stacking_contexts_and_positioned_stacking_containers
-            .iter()
-            .rev()
-            .peekable();
-        while real_stacking_contexts_and_positioned_stacking_containers
-            .peek()
-            .is_some_and(|child| child.z_index() >= 0)
-        {
-            let child = real_stacking_contexts_and_positioned_stacking_containers
-                .next()
-                .unwrap();
-            if child.hit_test(hit_test) {
-                return true;
-            }
-        }
-
-        // Steps 7 and 8: Fragments and inline stacking containers
-        while contents
-            .peek()
-            .is_some_and(|child| child.section() == StackingContextSection::Foreground)
-        {
-            let child = contents.next().unwrap();
-            if self.hit_test_content(child, hit_test) {
-                return true;
-            }
-        }
-
-        // Step 6: Float stacking containers
-        for child in self.float_stacking_containers.iter().rev() {
-            if child.hit_test(hit_test) {
-                return true;
-            }
-        }
-
-        // Step 5: Block backgrounds and borders
-        while contents.peek().is_some_and(|child| {
-            child.section() == StackingContextSection::DescendantBackgroundsAndBorders
-        }) {
-            let child = contents.next().unwrap();
-            if self.hit_test_content(child, hit_test) {
-                return true;
-            }
-        }
-
-        // Step 4: Stacking contexts with negative ‘z-index’
-        for child in real_stacking_contexts_and_positioned_stacking_containers {
-            if child.hit_test(hit_test) {
-                return true;
-            }
-        }
-
-        // Steps 2 and 3: Borders and background for the root
-        while contents.peek().is_some_and(|child| {
-            child.section() == StackingContextSection::OwnBackgroundsAndBorders
-        }) {
-            let child = contents.next().unwrap();
-            if self.hit_test_content(child, hit_test) {
-                return true;
-            }
-        }
-        false
-    }
-
-    pub(crate) fn hit_test_content(
-        &self,
-        content: &StackingContextContent,
-        hit_test: &mut HitTest<'_>,
-    ) -> bool {
-        match content {
-            StackingContextContent::Fragment {
-                scroll_node_id,
-                clip_id,
-                containing_block,
-                fragment,
-                ..
-            } => {
-                hit_test.hit_test_clip_id(*clip_id) &&
-                    fragment.hit_test(hit_test, *scroll_node_id, containing_block)
-            },
-            StackingContextContent::AtomicInlineStackingContainer { index } => {
-                self.atomic_inline_stacking_containers[*index].hit_test(hit_test)
-            },
-        }
-    }
-}
-
 impl Fragment {
-    pub(crate) fn hit_test(
-        &self,
-        hit_test: &mut HitTest,
-        spatial_node_id: ScrollTreeNodeId,
-        containing_block: &PhysicalRect<Au>,
-    ) -> bool {
+    pub(crate) fn hit_test(&self, state: &TraversalState, hit_test: &mut HitTest) -> bool {
         let Some(tag) = self.tag() else {
             return false;
         };
+        if !hit_test.hit_test_clip_id(state.clip_id) {
+            return false;
+        }
 
         let mut hit_test_fragment_inner =
             |style: &ComputedValues,
@@ -252,7 +167,7 @@ impl Fragment {
                 }
 
                 let (point_in_spatial_node, transform) =
-                    match hit_test.location_in_spatial_node(spatial_node_id) {
+                    match hit_test.location_in_spatial_node(state.spatial_id) {
                         Some(point) => point,
                         None => return false,
                     };
@@ -264,7 +179,7 @@ impl Fragment {
                     return false;
                 }
 
-                let fragment_rect = fragment_rect.translate(containing_block.origin.to_vector());
+                let fragment_rect = fragment_rect.translate(state.origin.to_vector());
                 if is_root_element {
                     let viewport_size = hit_test
                         .stacking_context_tree
@@ -297,7 +212,13 @@ impl Fragment {
                     point_in_target,
                     cursor: cursor(style.get_inherited_ui().cursor.keyword, auto_cursor),
                 });
-                !hit_test.flags.contains(ElementsFromPointFlags::FindAll)
+
+                // Since there is no reverse PaintTraversal, hit testing always searches
+                // the entire fragment tree (in stacking context order), which is why this
+                // is always returning `false` (keep looking). Once PaintTraversal can
+                // walk backward through fragments, this can return `true` if FindAll
+                // isn't specified.
+                false
             };
 
         match self {

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -6,7 +6,8 @@ use std::cell::{OnceCell, RefCell};
 use std::sync::Arc;
 
 use app_units::{AU_PER_PX, Au};
-use clip::{Clip, ClipId};
+use clip::Clip;
+pub(crate) use clip::ClipId;
 use euclid::{Box2D, Point2D, Rect, Scale, SideOffsets2D, Size2D, UnknownUnit, Vector2D};
 use fonts::ShapedTextSlice;
 use gradient::WebRenderGradient;
@@ -22,6 +23,8 @@ use style::Zero;
 use style::color::{AbsoluteColor, ColorSpace};
 use style::computed_values::background_blend_mode::SingleComputedValue as BackgroundBlendMode;
 use style::computed_values::border_image_outset::T as BorderImageOutset;
+use style::computed_values::mix_blend_mode::T as ComputedMixBlendMode;
+use style::computed_values::overflow_x::T as ComputedOverflow;
 use style::computed_values::text_decoration_style::{
     T as ComputedTextDecorationStyle, T as TextDecorationStyle,
 };
@@ -29,6 +32,7 @@ use style::dom::OpaqueNode;
 use style::properties::ComputedValues;
 use style::properties::longhands::visibility::computed_value::T as Visibility;
 use style::properties::style_structs::Border;
+use style::values::computed::basic_shape::ClipPath;
 use style::values::computed::{
     BorderImageSideWidth, BorderImageWidth, BorderStyle, LengthPercentage,
     NonNegativeLengthOrNumber, NumberOrPercentage, OutlineStyle,
@@ -36,6 +40,7 @@ use style::values::computed::{
 use style::values::generics::NonNegative;
 use style::values::generics::color::ColorOrAuto;
 use style::values::generics::rect::Rect as StyleRect;
+use style::values::specified::TransformStyle;
 use style::values::specified::text::TextDecorationLine;
 use style_traits::{CSSPixel as StyloCSSPixel, DevicePixel as StyloDevicePixel};
 use webrender_api::units::{
@@ -50,11 +55,14 @@ use webrender_api::{
 use wr::units::LayoutVector2D;
 
 use crate::context::{ImageResolver, ResolvedImage};
+use crate::display_list::background::BackgroundPainter;
+use crate::display_list::conversions::FilterToWebRender;
 pub(crate) use crate::display_list::conversions::ToWebRender;
-use crate::display_list::stacking_context::StackingContextSection;
+use crate::display_list::paint_traversal::{PaintTraversal, PaintTraversalHandler, TraversalState};
 use crate::fragment_tree::{
-    BackgroundMode, BoxFragment, ContainingBlockCalculation, Fragment, FragmentFlags,
-    FragmentStatus, FragmentTree, SpecificLayoutInfo, Tag, TextFragment,
+    BackgroundMode, BaseFragment, BoxFragment, ContainingBlockCalculation, Fragment, FragmentFlags,
+    FragmentStatus, FragmentTree, IFrameFragment, ImageFragment, PositioningFragment,
+    SpecificLayoutInfo, Tag, TextFragment,
 };
 use crate::geom::{
     LengthPercentageOrAuto, PhysicalPoint, PhysicalRect, PhysicalSides, PhysicalSize,
@@ -68,9 +76,9 @@ mod conversions;
 mod gradient;
 mod hit_test;
 mod paint_timing_handler;
+mod paint_traversal;
 mod stacking_context;
 
-use background::BackgroundPainter;
 pub(crate) use hit_test::HitTest;
 pub(crate) use paint_timing_handler::PaintTimingHandler;
 pub(crate) use stacking_context::*;
@@ -78,22 +86,14 @@ pub(crate) use stacking_context::*;
 const INSERTION_POINT_LOGICAL_WIDTH: Au = Au(AU_PER_PX);
 
 pub(crate) struct DisplayListBuilder<'a> {
-    /// The current [ScrollTreeNodeId] for this [DisplayListBuilder]. This
-    /// allows only passing the builder instead passing the containing
-    /// [stacking_context::StackingContextContent::Fragment] as an argument to display
-    /// list building functions.
-    current_scroll_node_id: ScrollTreeNodeId,
+    /// The [`FragmentTree`] that we are building a display list for.
+    fragment_tree: &'a FragmentTree,
 
-    /// The current [ScrollTreeNodeId] for this [DisplayListBuilder]. This is necessary in addition
-    /// to the [Self::current_scroll_node_id], because some pieces of fragments as backgrounds with
-    /// `background-attachment: fixed` need to not scroll while the rest of the fragment does.
+    /// The current [`ScrollTreeNodeId`] for this [`DisplayListBuilder`]. This is
+    /// necessary because some pieces of fragments as backgrounds with
+    /// `background-attachment: fixed` need to not scroll while the rest of the fragment
+    /// does.
     current_reference_frame_scroll_node_id: ScrollTreeNodeId,
-
-    /// The current [`ClipId`] for this [DisplayListBuilder]. This allows
-    /// only passing the builder instead passing the containing
-    /// [stacking_context::StackingContextContent::Fragment] as an argument to display
-    /// list building functions.
-    current_clip_id: ClipId,
 
     /// The [`wr::DisplayListBuilder`] for this Servo [`DisplayListBuilder`].
     pub webrender_display_list_builder: &'a mut wr::DisplayListBuilder,
@@ -196,9 +196,8 @@ impl DisplayListBuilder<'_> {
 
         let _span = profile_traits::trace_span!("DisplayListBuilder::build").entered();
         let mut builder = DisplayListBuilder {
-            current_scroll_node_id: paint_info.root_reference_frame_id,
+            fragment_tree,
             current_reference_frame_scroll_node_id: paint_info.root_reference_frame_id,
-            current_clip_id: ClipId::INVALID,
             webrender_display_list_builder: &mut webrender_display_list_builder,
             paint_info,
             inspector_highlight: highlighted_dom_node.map(InspectorHighlight::for_node),
@@ -232,13 +231,7 @@ impl DisplayListBuilder<'_> {
             (0, 0), /* tag */
         );
 
-        // Paint the canvas’ background (if any) before/under everything else
-        stacking_context_tree
-            .root_stacking_context
-            .build_canvas_background_display_list(&mut builder, fragment_tree);
-        stacking_context_tree
-            .root_stacking_context
-            .build_display_list(&mut builder);
+        PaintTraversal::traverse(&stacking_context_tree.root_stacking_context, &mut builder);
         builder.paint_dom_inspector_highlight();
 
         webrender_display_list_builder.end().1
@@ -393,6 +386,7 @@ impl DisplayListBuilder<'_> {
     /// from the `StackingContextTree` have already been processed.
     fn maybe_create_clip(
         &mut self,
+        state: &TraversalState,
         radii: wr::BorderRadius,
         rect: units::LayoutRect,
         force_clip_creation: bool,
@@ -405,13 +399,91 @@ impl DisplayListBuilder<'_> {
             id: ClipId(self.clip_map.len()),
             radii,
             rect,
-            parent_scroll_node_id: self.current_scroll_node_id,
-            parent_clip_id: self.current_clip_id,
+            parent_scroll_node_id: state.spatial_id,
+            parent_clip_id: state.clip_id,
         }))
+    }
+
+    fn push_webrender_stacking_context_if_necessary(
+        &mut self,
+        stacking_context: &StackingContext,
+    ) -> bool {
+        if stacking_context.context_type == StackingContextType::StackingContainer {
+            return false;
+        }
+
+        let StackingContextFragments::Fragment(fragment) = &stacking_context.fragment else {
+            return false;
+        };
+
+        // WebRender only uses the stacking context to apply certain effects. If we don't
+        // actually need to create a stacking context, just avoid creating one.
+        let style = fragment.style();
+        let effects = style.get_effects();
+        let transform_style = style.get_used_transform_style();
+        if effects.filter.0.is_empty() &&
+            effects.opacity == 1.0 &&
+            effects.mix_blend_mode == ComputedMixBlendMode::Normal &&
+            !style.has_effective_transform_or_perspective(FragmentFlags::empty()) &&
+            style.get_svg().clip_path == ClipPath::None &&
+            transform_style == TransformStyle::Flat
+        {
+            return false;
+        }
+
+        // Create the filter pipeline.
+        let current_color = style.clone_color();
+        let mut filters: Vec<wr::FilterOp> = effects
+            .filter
+            .0
+            .iter()
+            .map(|filter| FilterToWebRender::to_webrender(filter, &current_color))
+            .collect();
+        if effects.opacity != 1.0 {
+            filters.push(wr::FilterOp::Opacity(
+                effects.opacity.into(),
+                effects.opacity,
+            ));
+        }
+
+        // TODO(jdm): WebRender now requires us to create stacking context items
+        //            with the IS_BLEND_CONTAINER flag enabled if any children
+        //            of the stacking context have a blend mode applied.
+        //            This will require additional tracking during layout
+        //            before we start collecting stacking contexts so that
+        //            information will be available when we reach this point.
+        let spatial_id = self.spatial_id(stacking_context.scroll_tree_node_id);
+
+        // WebRender has two different ways of expressing "no clip." ClipChainId::INVALID
+        // should be used for primitives, but `None` is used for stacking contexts and
+        // clip chains. We convert to the `Option<ClipChainId>` representation here. Just
+        // passing Some(ClipChainId::INVALID) causes a panic.
+        let clip_chain_id = match stacking_context.clip_id {
+            ClipId::INVALID => None,
+            clip_id => Some(self.clip_chain_id(clip_id)),
+        };
+
+        self.wr().push_stacking_context(
+            LayoutPoint::zero(), // origin
+            spatial_id,
+            style.get_webrender_primitive_flags(),
+            clip_chain_id,
+            transform_style.to_webrender(),
+            effects.mix_blend_mode.to_webrender(),
+            &filters,
+            &[], // filter_datas
+            &[], // filter_primitives
+            wr::RasterSpace::Screen,
+            wr::StackingContextFlags::empty(),
+            None, // snapshot
+        );
+
+        true
     }
 
     fn common_properties(
         &self,
+        state: &TraversalState,
         clip_rect: units::LayoutRect,
         style: &ComputedValues,
     ) -> wr::CommonItemProperties {
@@ -420,8 +492,8 @@ impl DisplayListBuilder<'_> {
         // for fragments that paint their entire border rectangle.
         wr::CommonItemProperties {
             clip_rect,
-            spatial_id: self.spatial_id(self.current_scroll_node_id),
-            clip_chain_id: self.clip_chain_id(self.current_clip_id),
+            spatial_id: self.spatial_id(state.spatial_id),
+            clip_chain_id: self.clip_chain_id(state.clip_id),
             flags: style.get_webrender_primitive_flags(),
         }
     }
@@ -558,6 +630,7 @@ impl DisplayListBuilder<'_> {
 
     fn check_for_lcp_candidate(
         &mut self,
+        state: &TraversalState,
         clip_rect: LayoutRect,
         bounds: LayoutRect,
         tag: Option<Tag>,
@@ -570,26 +643,297 @@ impl DisplayListBuilder<'_> {
         let transform = self
             .paint_info
             .scroll_tree
-            .cumulative_node_to_root_transform(self.current_scroll_node_id);
+            .cumulative_node_to_root_transform(state.spatial_id);
 
         self.paint_timing_handler
             .update_lcp_candidate(tag, bounds, clip_rect, transform, url);
     }
 }
 
+impl PaintTraversalHandler for DisplayListBuilder<'_> {
+    type StackingContextState = (bool, Option<ScrollTreeNodeId>);
+
+    fn visit_stacking_context(
+        &mut self,
+        stacking_context: &StackingContext,
+    ) -> Self::StackingContextState {
+        let pushed_stacking_context =
+            self.push_webrender_stacking_context_if_necessary(stacking_context);
+
+        // Note: Reference frames always establish a stacking context, so it is fine to check if
+        // this stacking context establishes a reference frame as well. We don't need to check
+        // every fragment.
+        let root_fragment = stacking_context.fragment();
+        let old_reference_frame = root_fragment.and_then(|root_fragment| {
+            root_fragment
+                .style()
+                .has_effective_transform_or_perspective(root_fragment.base.flags)
+                .then(|| {
+                    std::mem::replace(
+                        &mut self.current_reference_frame_scroll_node_id,
+                        stacking_context.scroll_tree_node_id,
+                    )
+                })
+        });
+        (pushed_stacking_context, old_reference_frame)
+    }
+
+    fn leave_stacking_context(
+        &mut self,
+        _: &TraversalState,
+        stacking_context_state: Self::StackingContextState,
+    ) {
+        let (pushed_stacking_context, old_reference_frame) = stacking_context_state;
+        if pushed_stacking_context {
+            self.wr().pop_stacking_context();
+        }
+
+        if let Some(old_reference_frame) = old_reference_frame {
+            self.current_reference_frame_scroll_node_id = old_reference_frame;
+        }
+    }
+
+    fn visit_box(&mut self, state: &TraversalState, fragment: &Arc<BoxFragment>) {
+        fragment.base.visit_fragment(self);
+
+        if let Some(mut inspector_highlight) = self.inspector_highlight.take() &&
+            fragment.base.tag == Some(inspector_highlight.tag)
+        {
+            inspector_highlight.register_fragment_of_highlighted_dom_node(self, state, fragment);
+            self.inspector_highlight = Some(inspector_highlight);
+        }
+
+        if fragment.style().get_inherited_box().visibility != Visibility::Visible {
+            return;
+        };
+
+        BuilderForBoxFragment::new(fragment, state.origin).build(self, state)
+    }
+
+    fn visit_iframe(&mut self, state: &TraversalState, fragment: &Arc<IFrameFragment>) {
+        fragment.base.visit_fragment(self);
+
+        let style = fragment.base.style();
+        if style.get_inherited_box().visibility != Visibility::Visible {
+            return;
+        }
+
+        let rect = fragment.base.rect().translate(state.origin.to_vector());
+        let common = self.common_properties(state, rect.to_webrender(), &style);
+        self.wr().push_iframe(
+            rect.to_webrender(),
+            common.clip_rect,
+            &wr::SpaceAndClipInfo {
+                spatial_id: common.spatial_id,
+                clip_chain_id: common.clip_chain_id,
+            },
+            fragment.pipeline_id.into(),
+            true,
+        );
+        // From <https://www.w3.org/TR/paint-timing/#mark-paint-timing>:
+        // > A parent frame should not be aware of the paint events from its child iframes, and
+        // > vice versa. This means that a frame that contains just iframes will have first paint
+        // > (due to the enclosing boxes of the iframes) but no first contentful paint.
+        self.check_if_paintable(rect.to_webrender(), common.clip_rect, style.clone_opacity());
+    }
+
+    fn visit_image(
+        &mut self,
+        state: &TraversalState,
+        containing_block: PhysicalRect<Au>,
+        fragment: &Arc<ImageFragment>,
+    ) {
+        fragment.base.visit_fragment(self);
+
+        let style = fragment.base.style();
+        if style.get_inherited_box().visibility != Visibility::Visible {
+            return;
+        }
+
+        let image_rendering = style.get_inherited_box().image_rendering.to_webrender();
+        let rect = fragment
+            .base
+            .rect()
+            .translate(containing_block.origin.to_vector())
+            .to_webrender();
+        let clip = fragment
+            .clip
+            .translate(containing_block.origin.to_vector())
+            .to_webrender();
+        let common = self.common_properties(state, clip, &style);
+
+        if let Some(image_key) = fragment.image_key {
+            self.wr().push_image(
+                &common,
+                rect,
+                image_rendering,
+                wr::AlphaType::PremultipliedAlpha,
+                image_key,
+                wr::ColorF::WHITE,
+            );
+
+            self.check_if_paintable(rect, common.clip_rect, style.clone_opacity());
+
+            // From <https://www.w3.org/TR/paint-timing/#contentful>:
+            // An element target is contentful when one or more of the following apply:
+            // > target is a replaced element representing an available image.
+            // From: <https://html.spec.whatwg.org/multipage/#img-available>
+            // When an image request's state is either partially available or completely available,
+            // the image request is said to be available.
+            // Hence, Skip Broken Images.
+            if !fragment.showing_broken_image_icon {
+                self.mark_is_contentful();
+
+                self.check_for_lcp_candidate(
+                    state,
+                    common.clip_rect,
+                    rect,
+                    fragment.base.tag,
+                    fragment.url.clone(),
+                );
+            }
+        }
+
+        if fragment.showing_broken_image_icon {
+            Fragment::build_display_list_for_broken_image_border(self, &containing_block, &common);
+        }
+    }
+
+    fn visit_text(
+        &mut self,
+        state: &TraversalState,
+        containing_block: PhysicalRect<Au>,
+        fragment: &Arc<TextFragment>,
+    ) {
+        fragment.base.visit_fragment(self);
+
+        let style = fragment.base.style();
+        if style.get_inherited_box().visibility != Visibility::Visible {
+            return;
+        }
+        Fragment::build_display_list_for_text_fragment(fragment, self, state, &containing_block);
+    }
+
+    fn visit_positioning(&mut self, _state: &TraversalState, fragment: &Arc<PositioningFragment>) {
+        fragment.base.visit_fragment(self);
+    }
+
+    /// This is an implementation of step 3 from:
+    /// <https://drafts.csswg.org/css-position-4/#paint-a-stacking-context>:
+    ///
+    /// - See also: <https://drafts.csswg.org/css-backgrounds/#special-backgrounds>.
+    /// - Note: This is only called for the root `StackingContext`.
+    fn visit_box_for_root_background(&mut self, state: &TraversalState) {
+        let Some(fragment) = self.fragment_tree.root_box_fragment() else {
+            return;
+        };
+
+        let source_style = {
+            // > For documents whose root element is an HTML HTML element or an XHTML html element
+            // > [HTML]: if the computed value of background-image on the root element is none and its
+            // > background-color is transparent, user agents must instead propagate the computed
+            // > values of the background properties from that element’s first HTML BODY or XHTML body
+            // > child element.
+            let root_fragment_style = fragment.style();
+            if root_fragment_style.background_is_transparent() {
+                let body_fragment = self.fragment_tree.body_fragment();
+                self.paint_body_background = body_fragment.is_none();
+                body_fragment
+                    .map(|body_fragment| body_fragment.style().clone())
+                    .unwrap_or(fragment.style().clone())
+            } else {
+                root_fragment_style.clone()
+            }
+        };
+
+        // This can happen if the root fragment does not have a `<body>` child (either because it is
+        // `display: none` or `display: contents`) or if the `<body>`'s background is transparent.
+        if source_style.background_is_transparent() {
+            return;
+        }
+
+        // The painting area is theoretically the infinite 2D plane,
+        // but we need a rectangle with finite coordinates.
+        //
+        // If the document is smaller than the viewport (and doesn’t scroll),
+        // we still want to paint the rest of the viewport.
+        // If it’s larger, we also want to paint areas reachable after scrolling.
+        let painting_area = self
+            .fragment_tree
+            .initial_containing_block
+            .union(&self.fragment_tree.scrollable_overflow())
+            .to_webrender();
+
+        let background_color =
+            source_style.resolve_color(&source_style.get_background().background_color);
+        if background_color.alpha > 0.0 {
+            let common = self.common_properties(state, painting_area, &source_style);
+            let color = rgba(background_color);
+            self.wr().push_rect(&common, painting_area, color);
+
+            // From <https://www.w3.org/TR/paint-timing/#sec-terminology>:
+            // First paint ... includes non-default background paint and the enclosing box of an iframe.
+            // The spec is vague. See also: https://github.com/w3c/paint-timing/issues/122
+            let default_background_color = servo_config::pref!(shell_background_color_rgba);
+            let default_background_color = AbsoluteColor::new(
+                ColorSpace::Srgb,
+                default_background_color[0] as f32,
+                default_background_color[1] as f32,
+                default_background_color[2] as f32,
+                default_background_color[3] as f32,
+            )
+            .into_srgb_legacy();
+            if background_color != default_background_color {
+                self.mark_is_paintable();
+            }
+        }
+
+        let mut fragment_builder = BuilderForBoxFragment::new(
+            &fragment,
+            self.fragment_tree.initial_containing_block.origin,
+        );
+        let painter = BackgroundPainter {
+            style: &source_style,
+            painting_area_override: Some(painting_area),
+            positioning_area_override: None,
+        };
+        fragment_builder.build_background_image(self, state, &painter);
+    }
+
+    fn visit_box_for_outline(&mut self, state: &TraversalState, fragment: &Arc<BoxFragment>) {
+        if fragment.style().get_inherited_box().visibility != Visibility::Visible {
+            return;
+        };
+        BuilderForBoxFragment::new(fragment, state.origin).build_outline(self, state)
+    }
+
+    fn visit_box_for_collapsed_table_borders(
+        &mut self,
+        state: &TraversalState,
+        fragment: &Arc<BoxFragment>,
+    ) {
+        if fragment.style().get_inherited_box().visibility != Visibility::Visible {
+            return;
+        };
+        BuilderForBoxFragment::new(fragment, state.origin)
+            .build_collapsed_table_borders(self, state)
+    }
+}
+
 impl InspectorHighlight {
     fn register_fragment_of_highlighted_dom_node(
         &mut self,
-        fragment: &Fragment,
-        spatial_id: SpatialId,
-        clip_chain_id: ClipChainId,
-        containing_block: &PhysicalRect<Au>,
+        builder: &mut DisplayListBuilder,
+        traversal_state: &TraversalState,
+        fragment: &Arc<BoxFragment>,
     ) {
-        let state = self.state.get_or_insert(HighlightTraversalState {
+        let spatial_id = builder.spatial_id(traversal_state.spatial_id);
+        let clip_chain_id = builder.clip_chain_id(traversal_state.clip_id);
+        let state = self.state.get_or_insert_with(|| HighlightTraversalState {
             content_box: Rect::zero(),
             spatial_id,
             clip_chain_id,
-            maybe_box_fragment: None,
+            maybe_box_fragment: Some(fragment.clone()),
         });
 
         // We only need to highlight the first `SpatialId`. Typically this will include the bottommost
@@ -605,193 +949,22 @@ impl InspectorHighlight {
             );
         }
 
-        let Some(fragment_relative_rect) = fragment.base().map(|base| base.rect()) else {
-            return;
-        };
-        state.maybe_box_fragment = match fragment {
-            Fragment::Box(fragment) | Fragment::Float(fragment) => Some(fragment.clone()),
-            _ => None,
-        };
-
-        state.content_box = state
-            .content_box
-            .union(&fragment_relative_rect.translate(containing_block.origin.to_vector()));
+        state.maybe_box_fragment = Some(fragment.clone());
+        state.content_box = state.content_box.union(
+            &fragment
+                .base
+                .rect()
+                .translate(traversal_state.origin.to_vector()),
+        );
     }
 }
 
 impl Fragment {
-    pub(crate) fn build_display_list(
-        &self,
-        builder: &mut DisplayListBuilder,
-        containing_block: &PhysicalRect<Au>,
-        section: StackingContextSection,
-        is_hit_test_for_scrollable_overflow: bool,
-        is_collapsed_table_borders: bool,
-        text_decorations: &Arc<Vec<FragmentTextDecoration>>,
-    ) {
-        if let Some(base) = self.base() {
-            match base.status() {
-                FragmentStatus::New => {
-                    builder.reflow_statistics.rebuilt_fragment_count += 1;
-                    base.set_status(FragmentStatus::Clean)
-                },
-                FragmentStatus::StyleChanged => {
-                    builder.reflow_statistics.restyle_fragment_count += 1;
-                    base.set_status(FragmentStatus::Clean)
-                },
-                FragmentStatus::OnlyDescendantsChanged => {
-                    builder.reflow_statistics.only_descendants_changed_count += 1;
-                    base.set_status(FragmentStatus::Clean)
-                },
-                FragmentStatus::Clean => {},
-            }
-        }
-
-        let spatial_id = builder.spatial_id(builder.current_scroll_node_id);
-        let clip_chain_id = builder.clip_chain_id(builder.current_clip_id);
-        if let Some(inspector_highlight) = &mut builder.inspector_highlight &&
-            self.tag() == Some(inspector_highlight.tag)
-        {
-            inspector_highlight.register_fragment_of_highlighted_dom_node(
-                self,
-                spatial_id,
-                clip_chain_id,
-                containing_block,
-            );
-        }
-
-        match self {
-            Fragment::Box(box_fragment) | Fragment::Float(box_fragment) => {
-                match box_fragment.style().get_inherited_box().visibility {
-                    Visibility::Visible => BuilderForBoxFragment::new(
-                        box_fragment,
-                        containing_block,
-                        is_hit_test_for_scrollable_overflow,
-                        is_collapsed_table_borders,
-                    )
-                    .build(builder, section),
-                    Visibility::Hidden => (),
-                    Visibility::Collapse => (),
-                }
-            },
-            Fragment::AbsoluteOrFixedPositioned(_) | Fragment::Positioning(_) => {},
-            Fragment::Image(image) => {
-                let style = image.base.style();
-                match style.get_inherited_box().visibility {
-                    Visibility::Visible => {
-                        let image_rendering =
-                            style.get_inherited_box().image_rendering.to_webrender();
-                        let rect = image
-                            .base
-                            .rect()
-                            .translate(containing_block.origin.to_vector())
-                            .to_webrender();
-                        let clip = image
-                            .clip
-                            .translate(containing_block.origin.to_vector())
-                            .to_webrender();
-                        let common = builder.common_properties(clip, &style);
-
-                        if let Some(image_key) = image.image_key {
-                            builder.wr().push_image(
-                                &common,
-                                rect,
-                                image_rendering,
-                                wr::AlphaType::PremultipliedAlpha,
-                                image_key,
-                                wr::ColorF::WHITE,
-                            );
-
-                            builder.check_if_paintable(
-                                rect,
-                                common.clip_rect,
-                                style.clone_opacity(),
-                            );
-
-                            // From <https://www.w3.org/TR/paint-timing/#contentful>:
-                            // An element target is contentful when one or more of the following apply:
-                            // > target is a replaced element representing an available image.
-                            // From: <https://html.spec.whatwg.org/multipage/#img-available>
-                            // When an image request's state is either partially available or completely available,
-                            // the image request is said to be available.
-                            // Hence, Skip Broken Images.
-                            if !image.showing_broken_image_icon {
-                                builder.mark_is_contentful();
-
-                                builder.check_for_lcp_candidate(
-                                    common.clip_rect,
-                                    rect,
-                                    image.base.tag,
-                                    image.url.clone(),
-                                );
-                            }
-                        }
-
-                        if image.showing_broken_image_icon {
-                            self.build_display_list_for_broken_image_border(
-                                builder,
-                                containing_block,
-                                &common,
-                            );
-                        }
-                    },
-                    Visibility::Hidden => (),
-                    Visibility::Collapse => (),
-                }
-            },
-            Fragment::IFrame(iframe) => {
-                let style = iframe.base.style();
-                match style.get_inherited_box().visibility {
-                    Visibility::Visible => {
-                        let rect = iframe
-                            .base
-                            .rect()
-                            .translate(containing_block.origin.to_vector());
-
-                        let common = builder.common_properties(rect.to_webrender(), &style);
-                        builder.wr().push_iframe(
-                            rect.to_webrender(),
-                            common.clip_rect,
-                            &wr::SpaceAndClipInfo {
-                                spatial_id: common.spatial_id,
-                                clip_chain_id: common.clip_chain_id,
-                            },
-                            iframe.pipeline_id.into(),
-                            true,
-                        );
-                        // From <https://www.w3.org/TR/paint-timing/#mark-paint-timing>:
-                        // > A parent frame should not be aware of the paint events from its child iframes, and
-                        // > vice versa. This means that a frame that contains just iframes will have first paint
-                        // > (due to the enclosing boxes of the iframes) but no first contentful paint.
-                        builder.check_if_paintable(
-                            rect.to_webrender(),
-                            common.clip_rect,
-                            style.clone_opacity(),
-                        );
-                    },
-                    Visibility::Hidden => (),
-                    Visibility::Collapse => (),
-                }
-            },
-            Fragment::Text(text) => match text.base.style().get_inherited_box().visibility {
-                Visibility::Visible => self.build_display_list_for_text_fragment(
-                    text,
-                    builder,
-                    containing_block,
-                    text_decorations,
-                ),
-                Visibility::Hidden => (),
-                Visibility::Collapse => (),
-            },
-        }
-    }
-
     fn build_display_list_for_text_fragment(
-        &self,
         fragment: &TextFragment,
         builder: &mut DisplayListBuilder,
+        state: &TraversalState,
         containing_block: &PhysicalRect<Au>,
-        text_decorations: &Arc<Vec<FragmentTextDecoration>>,
     ) {
         // NB: The order of painting text components (CSS Text Decoration Module Level 3) is:
         // shadows, underline, overline, text, text-emphasis, and then line-through.
@@ -801,8 +974,12 @@ impl Fragment {
             .translate(containing_block.origin.to_vector());
         let mut baseline_origin = rect.origin;
         baseline_origin.y += fragment.font_metrics.ascent;
-        let include_whitespace =
-            fragment.offsets.is_some() || text_decorations.iter().any(|item| !item.line.is_empty());
+
+        let include_whitespace = fragment.offsets.is_some() ||
+            state
+                .text_decorations
+                .iter()
+                .any(|item| !item.line.is_empty());
 
         let (glyphs, largest_advance) = glyphs(
             &fragment.glyphs,
@@ -829,7 +1006,7 @@ impl Fragment {
         let glyph_bounds = rect
             .inflate(largest_advance.scale_by(2.0), Au::zero())
             .to_webrender();
-        let common = builder.common_properties(glyph_bounds, &parent_style);
+        let common = builder.common_properties(state, glyph_bounds, &parent_style);
 
         // Shadows. According to CSS-BACKGROUNDS, text shadows render in *reverse* order (front to
         // back).
@@ -849,14 +1026,15 @@ impl Fragment {
             );
         }
 
-        for text_decoration in text_decorations.iter() {
+        for text_decoration in state.text_decorations.iter() {
             if text_decoration.line.contains(TextDecorationLine::UNDERLINE) {
                 let mut rect = rect;
                 rect.origin.y += font_metrics.ascent - font_metrics.underline_offset;
                 rect.size.height =
                     Au::from_f32_px(font_metrics.underline_size.to_nearest_pixel(dppx));
 
-                self.build_display_list_for_text_decoration(
+                Self::build_display_list_for_text_decoration(
+                    state,
                     &parent_style,
                     builder,
                     &rect,
@@ -866,12 +1044,13 @@ impl Fragment {
             }
         }
 
-        for text_decoration in text_decorations.iter() {
+        for text_decoration in state.text_decorations.iter() {
             if text_decoration.line.contains(TextDecorationLine::OVERLINE) {
                 let mut rect = rect;
                 rect.size.height =
                     Au::from_f32_px(font_metrics.underline_size.to_nearest_pixel(dppx));
-                self.build_display_list_for_text_decoration(
+                Self::build_display_list_for_text_decoration(
+                    state,
                     &parent_style,
                     builder,
                     &rect,
@@ -881,9 +1060,10 @@ impl Fragment {
             }
         }
 
-        self.build_display_list_for_text_selection(
+        Self::build_display_list_for_text_selection(
             fragment,
             builder,
+            state,
             containing_block,
             fragment.base.rect().min_x(),
             fragment.justification_adjustment,
@@ -905,7 +1085,7 @@ impl Fragment {
         // > target has a text node child, representing non-empty text, and the node’s used opacity is greater than zero.
         builder.mark_is_contentful();
 
-        for text_decoration in text_decorations.iter() {
+        for text_decoration in state.text_decorations.iter() {
             if text_decoration
                 .line
                 .contains(TextDecorationLine::LINE_THROUGH)
@@ -914,7 +1094,8 @@ impl Fragment {
                 rect.origin.y += font_metrics.ascent - font_metrics.strikeout_offset;
                 rect.size.height =
                     Au::from_f32_px(font_metrics.strikeout_size.to_nearest_pixel(dppx));
-                self.build_display_list_for_text_decoration(
+                Self::build_display_list_for_text_decoration(
+                    state,
                     &parent_style,
                     builder,
                     &rect,
@@ -930,7 +1111,7 @@ impl Fragment {
     }
 
     fn build_display_list_for_text_decoration(
-        &self,
+        state: &TraversalState,
         parent_style: &ServoArc<ComputedValues>,
         builder: &mut DisplayListBuilder,
         rect: &PhysicalRect<Au>,
@@ -948,7 +1129,7 @@ impl Fragment {
             rect = rect.inflate(0.0, line_thickness * 1.0);
         }
 
-        let common_properties = builder.common_properties(rect, parent_style);
+        let common_properties = builder.common_properties(state, rect, parent_style);
         builder.wr().push_line(
             &common_properties,
             &rect,
@@ -965,7 +1146,7 @@ impl Fragment {
                 _ => rect.height() + half_height,
             };
             let rect = rect.translate(Vector2D::new(0.0, y_offset));
-            let common_properties = builder.common_properties(rect, parent_style);
+            let common_properties = builder.common_properties(state, rect, parent_style);
             builder.wr().push_line(
                 &common_properties,
                 &rect,
@@ -978,7 +1159,6 @@ impl Fragment {
     }
 
     fn build_display_list_for_broken_image_border(
-        &self,
         builder: &mut DisplayListBuilder,
         containing_block: &PhysicalRect<Au>,
         common: &CommonItemProperties,
@@ -1005,9 +1185,9 @@ impl Fragment {
     // TODO: This caret/text selection implementation currently does not account for vertical text
     // and RTL text properly.
     fn build_display_list_for_text_selection(
-        &self,
         fragment: &TextFragment,
         builder: &mut DisplayListBuilder<'_>,
+        state: &TraversalState,
         containing_block_rect: &PhysicalRect<Au>,
         fragment_x_offset: Au,
         justification_adjustment: Au,
@@ -1093,7 +1273,8 @@ impl Fragment {
                 .clone_background_color()
                 .as_absolute()
             {
-                let selection_common = builder.common_properties(selection_rect, &parent_style);
+                let selection_common =
+                    builder.common_properties(state, selection_rect, &parent_style);
                 builder
                     .wr()
                     .push_rect(&selection_common, selection_rect, rgba(*selection_color));
@@ -1115,7 +1296,8 @@ impl Fragment {
             ColorOrAuto::Color(caret_color) => caret_color.resolve_to_absolute(&color),
             ColorOrAuto::Auto => color,
         };
-        let insertion_point_common = builder.common_properties(insertion_point_rect, &parent_style);
+        let insertion_point_common =
+            builder.common_properties(state, insertion_point_rect, &parent_style);
 
         let caret_color = rgba(caret_color);
         let property_binding = if prefs::get().editing_caret_blink_time().is_some() {
@@ -1140,7 +1322,7 @@ impl Fragment {
 
 struct BuilderForBoxFragment<'a> {
     fragment: &'a BoxFragment,
-    containing_block: &'a PhysicalRect<Au>,
+    containing_block_origin: PhysicalPoint<Au>,
     border_rect: units::LayoutRect,
     margin_rect: OnceCell<units::LayoutRect>,
     padding_rect: OnceCell<units::LayoutRect>,
@@ -1149,23 +1331,16 @@ struct BuilderForBoxFragment<'a> {
     border_edge_clip_chain_id: RefCell<Option<ClipChainId>>,
     padding_edge_clip_chain_id: RefCell<Option<ClipChainId>>,
     content_edge_clip_chain_id: RefCell<Option<ClipChainId>>,
-    is_hit_test_for_scrollable_overflow: bool,
-    is_collapsed_table_borders: bool,
 }
 
 impl<'a> BuilderForBoxFragment<'a> {
-    fn new(
-        fragment: &'a BoxFragment,
-        containing_block: &'a PhysicalRect<Au>,
-        is_hit_test_for_scrollable_overflow: bool,
-        is_collapsed_table_borders: bool,
-    ) -> Self {
+    fn new(fragment: &'a BoxFragment, containing_block_origin: PhysicalPoint<Au>) -> Self {
         let border_rect = fragment
             .border_rect()
-            .translate(containing_block.origin.to_vector());
+            .translate(containing_block_origin.to_vector());
         Self {
             fragment,
-            containing_block,
+            containing_block_origin,
             border_rect: border_rect.to_webrender(),
             border_radius: fragment.border_radius(),
             margin_rect: OnceCell::new(),
@@ -1174,8 +1349,6 @@ impl<'a> BuilderForBoxFragment<'a> {
             border_edge_clip_chain_id: RefCell::new(None),
             padding_edge_clip_chain_id: RefCell::new(None),
             content_edge_clip_chain_id: RefCell::new(None),
-            is_hit_test_for_scrollable_overflow,
-            is_collapsed_table_borders,
         }
     }
 
@@ -1183,7 +1356,7 @@ impl<'a> BuilderForBoxFragment<'a> {
         self.content_rect.get_or_init(|| {
             self.fragment
                 .content_rect()
-                .translate(self.containing_block.origin.to_vector())
+                .translate(self.containing_block_origin.to_vector())
                 .to_webrender()
         })
     }
@@ -1192,7 +1365,7 @@ impl<'a> BuilderForBoxFragment<'a> {
         self.padding_rect.get_or_init(|| {
             self.fragment
                 .padding_rect()
-                .translate(self.containing_block.origin.to_vector())
+                .translate(self.containing_block_origin.to_vector())
                 .to_webrender()
         })
     }
@@ -1201,7 +1374,7 @@ impl<'a> BuilderForBoxFragment<'a> {
         self.margin_rect.get_or_init(|| {
             self.fragment
                 .margin_rect()
-                .translate(self.containing_block.origin.to_vector())
+                .translate(self.containing_block_origin.to_vector())
                 .to_webrender()
         })
     }
@@ -1209,14 +1382,19 @@ impl<'a> BuilderForBoxFragment<'a> {
     fn border_edge_clip(
         &self,
         builder: &mut DisplayListBuilder,
+        state: &TraversalState,
         force_clip_creation: bool,
     ) -> Option<ClipChainId> {
         if let Some(clip) = *self.border_edge_clip_chain_id.borrow() {
             return Some(clip);
         }
 
-        let maybe_clip =
-            builder.maybe_create_clip(self.border_radius, self.border_rect, force_clip_creation);
+        let maybe_clip = builder.maybe_create_clip(
+            state,
+            self.border_radius,
+            self.border_rect,
+            force_clip_creation,
+        );
         *self.border_edge_clip_chain_id.borrow_mut() = maybe_clip;
         maybe_clip
     }
@@ -1224,6 +1402,7 @@ impl<'a> BuilderForBoxFragment<'a> {
     fn padding_edge_clip(
         &self,
         builder: &mut DisplayListBuilder,
+        state: &TraversalState,
         force_clip_creation: bool,
     ) -> Option<ClipChainId> {
         if let Some(clip) = *self.padding_edge_clip_chain_id.borrow() {
@@ -1232,7 +1411,7 @@ impl<'a> BuilderForBoxFragment<'a> {
 
         let radii = offset_radii(self.border_radius, -self.fragment.border.to_webrender());
         let maybe_clip =
-            builder.maybe_create_clip(radii, *self.padding_rect(), force_clip_creation);
+            builder.maybe_create_clip(state, radii, *self.padding_rect(), force_clip_creation);
         *self.padding_edge_clip_chain_id.borrow_mut() = maybe_clip;
         maybe_clip
     }
@@ -1240,6 +1419,7 @@ impl<'a> BuilderForBoxFragment<'a> {
     fn content_edge_clip(
         &self,
         builder: &mut DisplayListBuilder,
+        state: &TraversalState,
         force_clip_creation: bool,
     ) -> Option<ClipChainId> {
         if let Some(clip) = *self.content_edge_clip_chain_id.borrow() {
@@ -1251,35 +1431,12 @@ impl<'a> BuilderForBoxFragment<'a> {
             -(self.fragment.border + self.fragment.padding).to_webrender(),
         );
         let maybe_clip =
-            builder.maybe_create_clip(radii, *self.content_rect(), force_clip_creation);
+            builder.maybe_create_clip(state, radii, *self.content_rect(), force_clip_creation);
         *self.content_edge_clip_chain_id.borrow_mut() = maybe_clip;
         maybe_clip
     }
 
-    fn build(&mut self, builder: &mut DisplayListBuilder, section: StackingContextSection) {
-        if self.is_hit_test_for_scrollable_overflow &&
-            self.fragment.style().get_inherited_ui().pointer_events !=
-                style::computed_values::pointer_events::T::None
-        {
-            self.build_hit_test(
-                builder,
-                self.fragment
-                    .scrollable_overflow()
-                    .translate(self.containing_block.origin.to_vector())
-                    .to_webrender(),
-            );
-            return;
-        }
-        if self.is_collapsed_table_borders {
-            self.build_collapsed_table_borders(builder);
-            return;
-        }
-
-        if section == StackingContextSection::Outline {
-            self.build_outline(builder);
-            return;
-        }
-
+    fn build(&mut self, builder: &mut DisplayListBuilder, state: &TraversalState) {
         if self
             .fragment
             .base
@@ -1289,18 +1446,52 @@ impl<'a> BuilderForBoxFragment<'a> {
             return;
         }
 
-        self.build_background(builder);
-        self.build_box_shadow(builder);
-        self.build_border(builder);
+        self.build_background(builder, state);
+        self.build_box_shadow(builder, state);
+        if !self.fragment.is_table_grid_with_collapsed_borders() {
+            self.build_border(builder, state);
+        }
+
+        let overflow = self
+            .fragment
+            .style()
+            .effective_overflow(self.fragment.base.flags);
+        let scrolls_via_user_input =
+            |overflow| matches!(overflow, ComputedOverflow::Scroll | ComputedOverflow::Auto);
+        if (scrolls_via_user_input(overflow.x) || scrolls_via_user_input(overflow.y)) &&
+            self.fragment.style().get_inherited_ui().pointer_events !=
+                style::computed_values::pointer_events::T::None
+        {
+            let mut inner_state = state.clone();
+            inner_state.spatial_id = self
+                .fragment
+                .generated_scroll_tree_node_id()
+                .unwrap_or(state.spatial_id);
+            inner_state.clip_id = self.fragment.generated_clip_id().unwrap_or(state.clip_id);
+
+            self.build_hit_test(
+                builder,
+                &inner_state,
+                self.fragment
+                    .scrollable_overflow()
+                    .translate(self.containing_block_origin.to_vector())
+                    .to_webrender(),
+            );
+        }
     }
 
-    fn build_hit_test(&self, builder: &mut DisplayListBuilder, rect: LayoutRect) {
+    fn build_hit_test(
+        &self,
+        builder: &mut DisplayListBuilder,
+        state: &TraversalState,
+        rect: LayoutRect,
+    ) {
         let external_scroll_node_id = builder
             .paint_info
-            .external_scroll_id_for_scroll_tree_node(builder.current_scroll_node_id);
+            .external_scroll_id_for_scroll_tree_node(state.spatial_id);
 
-        let mut common = builder.common_properties(rect, &self.fragment.style());
-        if let Some(clip_chain_id) = self.border_edge_clip(builder, false) {
+        let mut common = builder.common_properties(state, rect, &self.fragment.style());
+        if let Some(clip_chain_id) = self.border_edge_clip(builder, state, false) {
             common.clip_chain_id = clip_chain_id;
         }
         builder.wr().push_hit_test(
@@ -1315,6 +1506,7 @@ impl<'a> BuilderForBoxFragment<'a> {
     fn build_background_for_painter(
         &mut self,
         builder: &mut DisplayListBuilder,
+        state: &TraversalState,
         painter: &BackgroundPainter,
     ) {
         let b = painter.style.get_background();
@@ -1325,7 +1517,7 @@ impl<'a> BuilderForBoxFragment<'a> {
             //  value associated with the bottom-most background image layer.”
             let layer_index = b.background_image.0.len() - 1;
             let bounds = painter.painting_area(self, builder, layer_index);
-            let common = painter.common_properties(self, builder, layer_index, bounds);
+            let common = painter.common_properties(self, builder, state, layer_index, bounds);
             builder
                 .wr()
                 .push_rect(&common, bounds, rgba(background_color));
@@ -1347,10 +1539,10 @@ impl<'a> BuilderForBoxFragment<'a> {
             }
         }
 
-        self.build_background_image(builder, painter);
+        self.build_background_image(builder, state, painter);
     }
 
-    fn build_background(&mut self, builder: &mut DisplayListBuilder) {
+    fn build_background(&mut self, builder: &mut DisplayListBuilder, state: &TraversalState) {
         let flags = self.fragment.base.flags;
 
         // The root element's background is painted separately as it might inherit the `<body>`'s
@@ -1381,11 +1573,11 @@ impl<'a> BuilderForBoxFragment<'a> {
                     painting_area_override: None,
                     positioning_area_override: Some(
                         positioning_area
-                            .translate(self.containing_block.origin.to_vector())
+                            .translate(self.containing_block_origin.to_vector())
                             .to_webrender(),
                     ),
                 };
-                self.build_background_for_painter(builder, &painter);
+                self.build_background_for_painter(builder, state, &painter);
             }
         }
 
@@ -1394,12 +1586,13 @@ impl<'a> BuilderForBoxFragment<'a> {
             painting_area_override: None,
             positioning_area_override: None,
         };
-        self.build_background_for_painter(builder, &painter);
+        self.build_background_for_painter(builder, state, &painter);
     }
 
     fn build_background_image(
         &mut self,
         builder: &mut DisplayListBuilder,
+        state: &TraversalState,
         painter: &BackgroundPainter,
     ) {
         let style = painter.style;
@@ -1415,7 +1608,7 @@ impl<'a> BuilderForBoxFragment<'a> {
                                      blend_mode: BackgroundBlendMode,
                                      flags: StackingContextFlags|
          -> bool {
-            let spatial_id = builder.spatial_id(builder.current_scroll_node_id);
+            let spatial_id = builder.spatial_id(state.spatial_id);
             builder.wr().push_stacking_context(
                 LayoutPoint::zero(), // origin
                 spatial_id,
@@ -1449,7 +1642,7 @@ impl<'a> BuilderForBoxFragment<'a> {
                 Ok(ResolvedImage::Gradient(gradient)) => {
                     let intrinsic = NaturalSizes::empty();
                     let Some(layer) =
-                        &background::layout_layer(self, painter, builder, index, intrinsic)
+                        &background::layout_layer(self, painter, builder, state, index, intrinsic)
                     else {
                         continue;
                     };
@@ -1502,7 +1695,8 @@ impl<'a> BuilderForBoxFragment<'a> {
                     let dppx = 1.0;
                     let intrinsic =
                         NaturalSizes::from_width_and_height(size.width / dppx, size.height / dppx);
-                    let layer = background::layout_layer(self, painter, builder, index, intrinsic);
+                    let layer =
+                        background::layout_layer(self, painter, builder, state, index, intrinsic);
 
                     let image_wr_key = match image {
                         CachedImage::Raster(raster_image) => raster_image.id,
@@ -1580,6 +1774,7 @@ impl<'a> BuilderForBoxFragment<'a> {
                         builder.mark_is_contentful();
 
                         builder.check_for_lcp_candidate(
+                            state,
                             layer.common.clip_rect,
                             layer.bounds,
                             self.fragment.base.tag,
@@ -1613,7 +1808,20 @@ impl<'a> BuilderForBoxFragment<'a> {
         }
     }
 
-    fn build_collapsed_table_borders(&mut self, builder: &mut DisplayListBuilder) {
+    fn build_collapsed_table_borders(
+        &mut self,
+        builder: &mut DisplayListBuilder,
+        state: &TraversalState,
+    ) {
+        if self
+            .fragment
+            .base
+            .flags
+            .contains(FragmentFlags::DO_NOT_PAINT)
+        {
+            return;
+        }
+
         let layout_info = self.fragment.specific_layout_info();
         let Some(SpecificLayoutInfo::TableGridWithCollapsedBorders(table_info)) =
             layout_info.as_deref()
@@ -1621,7 +1829,7 @@ impl<'a> BuilderForBoxFragment<'a> {
             return;
         };
         let mut common =
-            builder.common_properties(units::LayoutRect::default(), &self.fragment.style());
+            builder.common_properties(state, units::LayoutRect::default(), &self.fragment.style());
         let radius = wr::BorderRadius::default();
         let mut column_sum = Au::zero();
         for (x, column_size) in table_info.track_sizes.x.iter().enumerate() {
@@ -1663,7 +1871,7 @@ impl<'a> BuilderForBoxFragment<'a> {
                 );
                 let border_rect = PhysicalRect::new(origin, size)
                     .translate(self.fragment.content_rect().origin.to_vector())
-                    .translate(self.containing_block.origin.to_vector())
+                    .translate(self.containing_block_origin.to_vector())
                     .to_webrender();
                 common.clip_rect = border_rect;
                 builder.wr().push_border(
@@ -1678,7 +1886,7 @@ impl<'a> BuilderForBoxFragment<'a> {
         }
     }
 
-    fn build_border(&mut self, builder: &mut DisplayListBuilder) {
+    fn build_border(&mut self, builder: &mut DisplayListBuilder, state: &TraversalState) {
         if self.fragment.has_collapsed_borders() {
             // Avoid painting borders for tables and table parts in collapsed-borders mode,
             // since the resulting collapsed borders are painted on their own in a special way.
@@ -1694,7 +1902,7 @@ impl<'a> BuilderForBoxFragment<'a> {
         }
 
         // `border-image` replaces an element's border entirely.
-        if self.build_border_image(builder, border, border_widths) {
+        if self.build_border_image(builder, state, border, border_widths) {
             return;
         }
 
@@ -1708,7 +1916,7 @@ impl<'a> BuilderForBoxFragment<'a> {
             radius: self.border_radius,
             do_aa: true,
         });
-        let common = builder.common_properties(self.border_rect, &style);
+        let common = builder.common_properties(state, self.border_rect, &style);
         builder
             .wr()
             .push_border(&common, self.border_rect, border_widths, details)
@@ -1718,6 +1926,7 @@ impl<'a> BuilderForBoxFragment<'a> {
     fn build_border_image(
         &self,
         builder: &mut DisplayListBuilder,
+        state: &TraversalState,
         border: &Border,
         border_widths: SideOffsets2D<f32, LayoutPixel>,
     ) -> bool {
@@ -1735,7 +1944,7 @@ impl<'a> BuilderForBoxFragment<'a> {
         let border_image_repeat = &border_style_struct.border_image_repeat;
         let border_image_fill = border_style_struct.border_image_slice.fill;
         let border_image_slice = &border_style_struct.border_image_slice.offsets;
-        let common = builder.common_properties(border_image_area.to_box2d(), &style);
+        let common = builder.common_properties(state, border_image_area.to_box2d(), &style);
 
         let stops = Vec::new();
         let mut width = border_image_size.width;
@@ -1827,7 +2036,7 @@ impl<'a> BuilderForBoxFragment<'a> {
         true
     }
 
-    fn build_outline(&mut self, builder: &mut DisplayListBuilder) {
+    fn build_outline(&mut self, builder: &mut DisplayListBuilder, state: &TraversalState) {
         let style = self.fragment.style();
         let outline = style.get_outline();
         if outline.outline_style.none_or_hidden() {
@@ -1850,7 +2059,7 @@ impl<'a> BuilderForBoxFragment<'a> {
             offset.max(-self.border_rect.width() / 2.0 + width),
             offset.max(-self.border_rect.height() / 2.0 + width),
         );
-        let common = builder.common_properties(outline_rect, &style);
+        let common = builder.common_properties(state, outline_rect, &style);
         let widths = SideOffsets2D::new_all_same(width);
         let border_style = match outline.outline_style {
             // TODO: treating 'auto' as 'solid' is allowed by the spec,
@@ -1875,7 +2084,7 @@ impl<'a> BuilderForBoxFragment<'a> {
             .push_border(&common, outline_rect, widths, details)
     }
 
-    fn build_box_shadow(&self, builder: &mut DisplayListBuilder<'_>) {
+    fn build_box_shadow(&self, builder: &mut DisplayListBuilder, state: &TraversalState) {
         let style = self.fragment.style();
         let box_shadows = &style.get_effects().box_shadow.0;
         if box_shadows.is_empty() {
@@ -1908,7 +2117,7 @@ impl<'a> BuilderForBoxFragment<'a> {
                         .inflate(extra_size_from_blur, extra_size_from_blur)
                 },
             };
-            let common = builder.common_properties(clip_rect, &style);
+            let common = builder.common_properties(state, clip_rect, &style);
 
             builder.wr().push_box_shadow(
                 &common,
@@ -2190,5 +2399,25 @@ impl BoxFragment {
 
         normalize_radii(&border_rect.to_webrender(), &mut radius);
         radius
+    }
+}
+
+impl BaseFragment {
+    fn visit_fragment(&self, builder: &mut DisplayListBuilder) {
+        match self.status() {
+            FragmentStatus::New => {
+                builder.reflow_statistics.rebuilt_fragment_count += 1;
+                self.set_status(FragmentStatus::Clean)
+            },
+            FragmentStatus::StyleChanged => {
+                builder.reflow_statistics.restyle_fragment_count += 1;
+                self.set_status(FragmentStatus::Clean)
+            },
+            FragmentStatus::OnlyDescendantsChanged => {
+                builder.reflow_statistics.only_descendants_changed_count += 1;
+                self.set_status(FragmentStatus::Clean)
+            },
+            FragmentStatus::Clean => {},
+        }
     }
 }

--- a/components/layout/display_list/paint_traversal.rs
+++ b/components/layout/display_list/paint_traversal.rs
@@ -1,0 +1,584 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::rc::Rc;
+use std::sync::Arc;
+
+use app_units::Au;
+use servo_base::id::ScrollTreeNodeId;
+use style::values::computed::TextDecorationLine;
+
+use crate::display_list::{
+    ClipId, FragmentTextDecoration, StackingContext, StackingContextFragments,
+};
+use crate::fragment_tree::{
+    BoxFragment, Fragment, FragmentFlags, IFrameFragment, ImageFragment, PositioningFragment,
+    TextFragment,
+};
+use crate::geom::{PhysicalPoint, PhysicalRect};
+
+pub(crate) struct PaintTraversal<'a, Handler: PaintTraversalHandler> {
+    handler: &'a mut Handler,
+    outlines: Vec<(TraversalState, Arc<BoxFragment>)>,
+    floats: Vec<(TraversalState, Arc<BoxFragment>)>,
+}
+
+impl<'a, Handler: PaintTraversalHandler> PaintTraversal<'a, Handler> {
+    pub(crate) fn traverse(root_stacking_context: &StackingContext, handler: &'a mut Handler) {
+        Self {
+            handler,
+            outlines: Vec::new(),
+            floats: Vec::new(),
+        }
+        .traverse_stacking_context(&TraversalState::default(), root_stacking_context);
+    }
+
+    /// <https://drafts.csswg.org/css-position-4/#paint-a-stacking-context>
+    fn traverse_stacking_context(
+        &mut self,
+        state: &TraversalState,
+        stacking_context: &StackingContext,
+    ) {
+        let old_outlines_length = self.outlines.len();
+        let state = state.push_stacking_context(stacking_context);
+        let stacking_context_state = self.handler.visit_stacking_context(stacking_context);
+
+        // > Step 1: If root is an element, paint a stacking context given root’s principal
+        // > box and canvas, then return.
+        // > Step 2: Assert: root is a box, and generates a stacking context.
+        // > Ensured by the fact that `self` is a stacking context.
+
+        // > Step 3: If root is a root element’s principal box, paint root’s background over
+        // > the entire canvas, with the origin of the background positioning area being the
+        // > position on canvas that would be used if root’s background was being painted
+        // > normally.
+        if let StackingContextFragments::Root = &stacking_context.fragment {
+            self.handler.visit_box_for_root_background(&state);
+        }
+
+        // > Step 4: If root is a block-level box, paint a block’s decorations given root
+        // > and canvas.
+        let root_fragment = stacking_context.fragment();
+        if let Some(root_fragment) = root_fragment &&
+            !root_fragment.is_inline_box()
+        {
+            self.handle_box(&state, root_fragment);
+        }
+
+        // > Step 5: For each of root’s positioned descendants with negative (non-zero) z-index
+        // > values, sort those descendants by z-index order (most negative first) then tree
+        // > order, and paint a stacking context given each descendant and canvas.
+        let mut children = stacking_context.children.iter().peekable();
+        while children.peek().is_some_and(|child| child.z_index < 0) {
+            self.traverse_stacking_context(
+                &state,
+                children.next().expect("Should have a value due to peek."),
+            );
+        }
+
+        if let Some(root_fragment) = root_fragment {
+            self.traverse_stacking_context_inner(&state, root_fragment);
+        }
+
+        // > Step 9: For each of root’s positioned descendants with z-index: auto or
+        // > z-index: 0, in tree order:
+        // >   ↪ descendant has z-index: auto
+        // >     Paint a stacking container given the descendant and canvas.
+        // >   ↪ descendant has z-index: 0
+        // >     Paint a stacking context given the descendant and canvas.
+        //
+        // > Step 10: For each of root’s positioned descendants with positive (non-zero)
+        // > z-index values, sort those descendants by z-index order (smallest first) then
+        // > tree order, and paint a stacking context given each descendant and canvas.
+        for child in children {
+            assert!(child.z_index >= 0);
+            self.traverse_stacking_context(&state, child);
+        }
+
+        // > Step 11: If the UA uses out-of-band outlines, draw all of root’s outlines
+        // > (those that it skipped drawing due to not using in-band outlines during the
+        // > current invocation of this algorithm) into canvas.
+        if old_outlines_length < self.outlines.len() {
+            for (state, outline_fragment) in &self.outlines.split_off(old_outlines_length) {
+                self.handler.visit_box_for_outline(state, outline_fragment);
+            }
+        }
+
+        self.handler
+            .leave_stacking_context(&state, stacking_context_state);
+    }
+
+    fn traverse_stacking_context_inner(&mut self, state: &TraversalState, root: &Arc<BoxFragment>) {
+        let old_float_length = self.floats.len();
+        let mut saw_inline_level_or_replaced = root.is_replaced();
+
+        // > Step 6: For each of root’s in-flow, non-positioned, block-level descendants, in
+        // > tree order, paint a block’s decorations given the descendant and canvas.
+        let inner_state = state.push_box_fragment(root);
+        for child in root.children.iter() {
+            saw_inline_level_or_replaced |=
+                self.traverse_block_level_descendants_decorations(&inner_state, child);
+        }
+
+        // Collapsed table borders are painted after block-level descendants. This isn't
+        // well specified, but is being discussed in <https://github.com/w3c/csswg-drafts/issues/11570>.
+        if root.is_table_grid_with_collapsed_borders() {
+            self.handler
+                .visit_box_for_collapsed_table_borders(state, root);
+        }
+
+        // > Step 7: For each of root’s non-positioned floating descendants, in tree order,
+        // > paint a stacking container given the descendant and canvas.
+        if old_float_length < self.floats.len() {
+            for (state, float_fragment) in &self.floats.split_off(old_float_length) {
+                self.handle_box(state, float_fragment);
+                self.traverse_stacking_context_inner(state, float_fragment);
+            }
+        }
+
+        // Step 8:
+        if root.is_inline_box() {
+            // >  ↪ If root is an inline-level box
+            // >     For each line box root is in, paint a box in a line box given root, the
+            // >     line box, and canvas.
+            self.traverse_box_in_a_line_box(state, root, true /* at_stacking_context_root */);
+        } else if saw_inline_level_or_replaced {
+            // >  ↪ Otherwise
+            // >    First for root, then for all its in-flow, non-positioned, block-level
+            // >    descendant boxes, in tree order:
+            // >    1. If the box is a replaced element, paint the replaced content into canvas,
+            // >       atomically.
+            // >    2. Otherwise, for each line box of the box, paint a box in a line box given the
+            // >       box, the line box, and canvas.
+            // >    3. If the UA uses in-band outlines, paint the outlines of the box into canvas.
+            self.traverse_line_boxes_and_replaced_for_box(
+                state, root, true, /* at_root_of_stacking_context */
+            );
+        }
+    }
+
+    /// An implementation of
+    /// <https://drafts.csswg.org/css-position-4/#paint-a-stacking-context> that only
+    /// implements the parts relevant to stacking containers. This is an optimization to
+    /// avoid work when descending into positioned container and stacking context
+    /// contents.
+    fn traverse_stacking_container(
+        &mut self,
+        state: &TraversalState,
+        root: &Arc<BoxFragment>,
+        is_block_level: bool,
+    ) {
+        let old_outlines_length = self.outlines.len();
+
+        // > Step 4: If root is a block-level box, paint a block’s decorations given root
+        // > and canvas.
+        if is_block_level {
+            self.handle_box(state, root);
+        }
+
+        // This is steps 6 through 8.
+        self.traverse_stacking_context_inner(state, root);
+
+        // > Step 11: If the UA uses out-of-band outlines, draw all of root’s outlines
+        // > (those that it skipped drawing due to not using in-band outlines during the
+        // > current invocation of this algorithm) into canvas.
+        if old_outlines_length < self.outlines.len() {
+            for (state, outline_fragment) in &self.outlines.split_off(old_outlines_length) {
+                self.handler.visit_box_for_outline(state, outline_fragment);
+            }
+        }
+    }
+
+    fn traverse_block_level_descendants_decorations(
+        &mut self,
+        state: &TraversalState,
+        fragment: &Fragment,
+    ) -> bool {
+        let mut saw_inline_level_or_replaced = false;
+
+        match fragment {
+            Fragment::Box(box_fragment) => {
+                // If this box establishes a stacking context or stacking container, do not paint
+                // it during this phase. Instead it is painted when the stacking context or container
+                // is processed.
+                if box_fragment.stacking_context_type().is_some() {
+                    return false;
+                }
+
+                // We will process inline atomics during the inline level and replaced traversal.
+                if box_fragment.is_atomic_inline_level() || box_fragment.is_flex_or_grid_item() {
+                    return true;
+                }
+
+                // Don't paint any inline boxes, but do descend into them, in case they contain floats.
+                if box_fragment.is_inline_box() {
+                    saw_inline_level_or_replaced = true;
+                } else {
+                    self.handle_box(state, box_fragment);
+                }
+
+                if box_fragment.is_replaced() {
+                    return true;
+                }
+
+                let state_for_children = state.push_box_fragment(box_fragment);
+                for child in box_fragment.children.iter() {
+                    saw_inline_level_or_replaced |= self
+                        .traverse_block_level_descendants_decorations(&state_for_children, child);
+                }
+
+                // Collapsed table borders are painted after block-level descendants. This isn't
+                // well specified, but is being discussed in <https://github.com/w3c/csswg-drafts/issues/11570>.
+                if box_fragment.is_table_grid_with_collapsed_borders() {
+                    self.handler
+                        .visit_box_for_collapsed_table_borders(state, box_fragment);
+                }
+            },
+            Fragment::Float(float_box_fragment) => {
+                if float_box_fragment.stacking_context_type().is_none() {
+                    self.floats
+                        .push((state.without_text_decorations(), float_box_fragment.clone()));
+                }
+            },
+            Fragment::Positioning(positioning_fragment) => {
+                self.handler.visit_positioning(state, positioning_fragment);
+
+                if positioning_fragment.is_line_box() {
+                    saw_inline_level_or_replaced = true;
+                }
+
+                if !positioning_fragment.children.is_empty() {
+                    let state = state.push_positioning_fragment(positioning_fragment);
+                    for child in positioning_fragment.children.iter() {
+                        saw_inline_level_or_replaced |=
+                            self.traverse_block_level_descendants_decorations(&state, child);
+                    }
+                }
+            },
+            Fragment::AbsoluteOrFixedPositioned(..) |
+            Fragment::Text(..) |
+            Fragment::Image(..) |
+            Fragment::IFrame(..) => {},
+        }
+
+        saw_inline_level_or_replaced
+    }
+
+    fn traverse_line_boxes_and_replaced_for_box(
+        &mut self,
+        state: &TraversalState,
+        fragment: &Arc<BoxFragment>,
+        at_root_of_stacking_context: bool,
+    ) {
+        let is_flex_or_grid = fragment.is_flex_or_grid_item();
+        if fragment.is_replaced() {
+            if is_flex_or_grid {
+                self.handle_box(state, fragment);
+            }
+
+            let inner_state = state.push_box_fragment(fragment);
+            self.traverse_replaced_content(&inner_state, fragment);
+            return;
+        }
+
+        if !at_root_of_stacking_context && is_flex_or_grid {
+            self.traverse_stacking_container(state, fragment, true /* is_block_level */);
+            return;
+        }
+
+        let inner_state = state.push_box_fragment(fragment);
+        for child in fragment.children.iter() {
+            self.traverse_line_boxes_and_replaced(
+                &inner_state,
+                child,
+                false, /* at_root_of_stacking_context */
+            );
+        }
+    }
+
+    fn traverse_line_boxes_and_replaced(
+        &mut self,
+        state: &TraversalState,
+        fragment: &Fragment,
+        at_root_of_stacking_context: bool,
+    ) {
+        match fragment {
+            Fragment::Box(box_fragment) => {
+                // If this box establishes a stacking context or stacking container, do not paint
+                // it during this phase. Instead it is painted when the stacking context or container
+                // is processed.
+                if box_fragment.stacking_context_type().is_some() {
+                    return;
+                }
+                self.traverse_line_boxes_and_replaced_for_box(
+                    state,
+                    box_fragment,
+                    at_root_of_stacking_context,
+                );
+            },
+            Fragment::Positioning(positioning_fragment) if positioning_fragment.is_line_box() => {
+                let state = state.push_positioning_fragment(positioning_fragment);
+                for child in &positioning_fragment.children {
+                    self.traverse_fragment_in_a_line_box(&state, child);
+                }
+            },
+            Fragment::Positioning(positioning_fragment) => {
+                if !positioning_fragment.children.is_empty() {
+                    let state = state.push_positioning_fragment(positioning_fragment);
+                    for child in &positioning_fragment.children {
+                        self.traverse_line_boxes_and_replaced(
+                            &state, child, false, /* at at_root_of_stacking_context */
+                        );
+                    }
+                }
+            },
+            Fragment::AbsoluteOrFixedPositioned(_) |
+            Fragment::Float(..) |
+            Fragment::IFrame(_) |
+            Fragment::Image(_) |
+            Fragment::Text(..) => {},
+        }
+    }
+
+    fn traverse_fragment_in_a_line_box(&mut self, state: &TraversalState, fragment: &Fragment) {
+        match fragment {
+            Fragment::Box(box_fragment) => self.traverse_box_in_a_line_box(
+                state,
+                box_fragment,
+                false, /* at_stacking_context_root */
+            ),
+            Fragment::Text(text_fragment) => {
+                // This containing block is wrong and should use the size from the parent
+                // positioning context.
+                let containing_block =
+                    PhysicalRect::new(state.origin, text_fragment.base.rect().size);
+                self.handler
+                    .visit_text(state, containing_block, text_fragment);
+            },
+            Fragment::AbsoluteOrFixedPositioned(..) | Fragment::Float(..) => {},
+            Fragment::Positioning(..) => {
+                unreachable!("Unexpected direct descendant PositioningContext of inline.")
+            },
+            Fragment::Image(..) | Fragment::IFrame(..) => {
+                unreachable!("Unexpected replaced content direct descendant of inline.")
+            },
+        }
+    }
+
+    /// <https://www.w3.org/TR/css-position-4/#paint-a-box-in-a-line-box>
+    fn traverse_box_in_a_line_box(
+        &mut self,
+        state: &TraversalState,
+        box_fragment: &Arc<BoxFragment>,
+        at_stacking_context_root: bool,
+    ) {
+        // If this box establishes a stacking context or stacking container, do not paint
+        // it during this phase. Instead it is painted when the stacking context or container
+        // is processed.
+        if !at_stacking_context_root && box_fragment.stacking_context_type().is_some() {
+            return;
+        }
+
+        // Block-in-inline split, return to block mode.
+        let is_atomic_inline_level = box_fragment.is_atomic_inline_level();
+        if !is_atomic_inline_level && !box_fragment.is_inline_box() {
+            self.traverse_line_boxes_and_replaced_for_box(
+                state,
+                box_fragment,
+                at_stacking_context_root,
+            );
+            return;
+        }
+
+        // > Step 1: Paint the backgrounds of root’s fragments that are in line box into canvas.
+        // > Step 2: Paint the borders of root’s fragments that are in line box into canvas.
+        self.handle_box(state, box_fragment);
+
+        // > Step 3:
+        //
+        // Note: The following steps are in a different order than the specification
+        // due to the way we classify fragments.
+        //
+        // > ↪ If root is an inline-level replaced element
+        // >   Paint the replaced content into canvas, atomically.
+        if box_fragment.is_replaced() {
+            let state = state.push_box_fragment(box_fragment);
+            self.traverse_replaced_content(&state, box_fragment);
+
+        // > ↪ If root is an inline-level block or table wrapper box
+        // >   Paint a stacking container given root and canvas.
+        } else if is_atomic_inline_level || box_fragment.is_flex_or_grid_item() {
+            self.traverse_stacking_container(state, box_fragment, false /* is_block_level */);
+
+        // > ↪ If root is an inline box
+        // Note: This is handled via recursion into `paint_a_fragment_in_a_line_box`.
+        } else {
+            let state = state.push_box_fragment(box_fragment);
+            for child in &box_fragment.children {
+                self.traverse_fragment_in_a_line_box(&state, child);
+            }
+        }
+    }
+
+    fn traverse_replaced_content(
+        &mut self,
+        state: &TraversalState,
+        box_fragment: &Arc<BoxFragment>,
+    ) {
+        for child in &box_fragment.children {
+            match child {
+                Fragment::Image(image_fragment) => {
+                    let containing_block =
+                        PhysicalRect::new(state.origin, box_fragment.content_rect().size);
+                    self.handler
+                        .visit_image(state, containing_block, image_fragment);
+                },
+                Fragment::IFrame(iframe_fragment) => {
+                    self.handler.visit_iframe(state, iframe_fragment);
+                },
+                Fragment::Box(box_fragment) => {
+                    self.traverse_stacking_container(
+                        &state.without_text_decorations(),
+                        box_fragment,
+                        true, /* is_block_level */
+                    );
+                },
+                _ => {},
+            }
+        }
+    }
+
+    fn handle_box(&mut self, state: &TraversalState, fragment: &Arc<BoxFragment>) {
+        if fragment.has_outline() {
+            self.outlines.push((state.clone(), fragment.clone()));
+        }
+        self.handler.visit_box(state, fragment);
+    }
+}
+
+pub(crate) trait PaintTraversalHandler {
+    type StackingContextState;
+
+    fn visit_stacking_context(
+        &mut self,
+        stacking_context: &StackingContext,
+    ) -> Self::StackingContextState;
+    fn leave_stacking_context(
+        &mut self,
+        state: &TraversalState,
+        stacking_context_state: Self::StackingContextState,
+    );
+
+    fn visit_box(&mut self, state: &TraversalState, fragment: &Arc<BoxFragment>);
+    fn visit_iframe(&mut self, _state: &TraversalState, _fragment: &Arc<IFrameFragment>) {}
+    fn visit_image(
+        &mut self,
+        _state: &TraversalState,
+        _containing_block: PhysicalRect<Au>,
+        _fragment: &Arc<ImageFragment>,
+    ) {
+    }
+    fn visit_text(
+        &mut self,
+        state: &TraversalState,
+        containing_block: PhysicalRect<Au>,
+        fragment: &Arc<TextFragment>,
+    );
+    fn visit_positioning(&mut self, _state: &TraversalState, _fragment: &Arc<PositioningFragment>) {
+    }
+
+    fn visit_box_for_root_background(&mut self, _state: &TraversalState) {}
+    fn visit_box_for_outline(&mut self, _state: &TraversalState, _fragment: &Arc<BoxFragment>) {}
+    fn visit_box_for_collapsed_table_borders(
+        &mut self,
+        _state: &TraversalState,
+        _fragment: &Arc<BoxFragment>,
+    ) {
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct TraversalState {
+    pub spatial_id: ScrollTreeNodeId,
+    pub clip_id: ClipId,
+    pub origin: PhysicalPoint<Au>,
+    pub text_decorations: Rc<Vec<FragmentTextDecoration>>,
+}
+
+impl TraversalState {
+    #[inline]
+    pub(crate) fn push_box_fragment(&self, box_fragment: &BoxFragment) -> Self {
+        let style = box_fragment.style();
+
+        // Text decorations are not propagated to atomic inline-level descendants.
+        // From https://drafts.csswg.org/css2/#lining-striking-props:
+        //
+        // > Note that text decorations are not propagated to floating and absolutely
+        // > positioned descendants, nor to the contents of atomic inline-level descendants
+        // > such as inline blocks and inline tables.
+        //
+        // Also do not propagate text decorations to floats or replaced content.
+        let mut propagated_text_decorations = self.text_decorations.clone();
+        if box_fragment.is_atomic_inline_level() ||
+            box_fragment.base.flags.contains(
+                FragmentFlags::IS_OUTSIDE_LIST_ITEM_MARKER | FragmentFlags::IS_REPLACED,
+            )
+        {
+            propagated_text_decorations = Default::default();
+        }
+
+        let text_decorations = match &style.get_text().text_decoration_line {
+            &TextDecorationLine::NONE => propagated_text_decorations,
+            line => {
+                let mut new_vector = (*propagated_text_decorations).clone();
+                let color = &style.get_inherited_text().color;
+                new_vector.push(FragmentTextDecoration {
+                    line: *line,
+                    color: style
+                        .clone_text_decoration_color()
+                        .resolve_to_absolute(color),
+                    style: style.clone_text_decoration_style(),
+                });
+                Rc::new(new_vector)
+            },
+        };
+
+        Self {
+            origin: self.origin + box_fragment.content_rect().origin.to_vector(),
+            spatial_id: box_fragment
+                .generated_scroll_tree_node_id()
+                .unwrap_or(self.spatial_id),
+            clip_id: box_fragment.generated_clip_id().unwrap_or(self.clip_id),
+            text_decorations,
+        }
+    }
+
+    pub(crate) fn without_text_decorations(&self) -> Self {
+        Self {
+            text_decorations: Default::default(),
+            ..*self
+        }
+    }
+
+    pub(crate) fn push_positioning_fragment(
+        &self,
+        positioning_fragment: &PositioningFragment,
+    ) -> Self {
+        Self {
+            origin: self.origin + positioning_fragment.base.rect().origin.to_vector(),
+            spatial_id: self.spatial_id,
+            clip_id: self.clip_id,
+            text_decorations: self.text_decorations.clone(),
+        }
+    }
+
+    pub(crate) fn push_stacking_context(&self, stacking_context: &StackingContext) -> Self {
+        Self {
+            origin: stacking_context.containing_block_origin,
+            spatial_id: stacking_context.scroll_tree_node_id,
+            clip_id: stacking_context.clip_id,
+            text_decorations: stacking_context.text_decorations.clone(),
+        }
+    }
+}

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::{Cell, RefCell};
-use std::mem;
+use std::cell::Cell;
+use std::rc::Rc;
 use std::sync::Arc;
 
 use app_units::Au;
 use embedder_traits::ViewportDetails;
 use euclid::{Point2D, Rect, SideOffsets2D, Size2D};
-use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
 use paint_api::display_list::{
     AxesScrollSensitivity, PaintDisplayListInfo, ReferenceFrameNodeInfo, ScrollableNodeInfo,
@@ -20,19 +19,14 @@ use servo_base::print_tree::PrintTree;
 use servo_config::opts::{DiagnosticsLogging, DiagnosticsLoggingOption};
 use servo_geometry::MaxRect;
 use style::Zero;
-use style::color::{AbsoluteColor, ColorSpace};
-use style::computed_values::float::T as ComputedFloat;
-use style::computed_values::mix_blend_mode::T as ComputedMixBlendMode;
+use style::color::AbsoluteColor;
 use style::computed_values::overflow_x::T as ComputedOverflow;
 use style::computed_values::position::T as ComputedPosition;
 use style::computed_values::text_decoration_style::T as TextDecorationStyle;
 use style::values::computed::angle::Angle;
-use style::values::computed::basic_shape::ClipPath;
 use style::values::computed::{ClipRectOrAuto, Length, TextDecorationLine};
 use style::values::generics::box_::{OverflowClipMarginBox, Perspective};
 use style::values::generics::transform::{self, GenericRotate, GenericScale, GenericTranslate};
-use style::values::specified::TransformStyle;
-use style::values::specified::box_::DisplayOutside;
 use style_traits::CSSPixel;
 use webrender_api::units::{LayoutPoint, LayoutRect, LayoutTransform, LayoutVector2D};
 use webrender_api::{self as wr, BorderRadius};
@@ -41,11 +35,11 @@ use wr::units::{LayoutPixel, LayoutSize};
 
 use super::ClipId;
 use super::clip::StackingContextTreeClipStore;
-use crate::display_list::conversions::{FilterToWebRender, ToWebRender};
-use crate::display_list::{BuilderForBoxFragment, DisplayListBuilder, offset_radii};
+use crate::display_list::conversions::ToWebRender;
+use crate::display_list::{BuilderForBoxFragment, offset_radii};
 use crate::fragment_tree::{
     BoxFragment, ContainingBlockCalculation, ContainingBlockManager, Fragment, FragmentFlags,
-    FragmentTree, PositioningFragment, SpecificLayoutInfo,
+    FragmentTree, PositioningFragment,
 };
 use crate::geom::{
     AuOrAuto, LengthPercentageOrAuto, PhysicalPoint, PhysicalRect, PhysicalSides, PhysicalVec,
@@ -104,21 +98,13 @@ impl ContainingBlock {
 
 pub(crate) type ContainingBlockInfo<'a> = ContainingBlockManager<'a, ContainingBlock>;
 
-#[derive(Clone, Copy, Debug, Eq, Ord, MallocSizeOf, PartialEq, PartialOrd)]
-pub(crate) enum StackingContextSection {
-    OwnBackgroundsAndBorders,
-    DescendantBackgroundsAndBorders,
-    Foreground,
-    Outline,
-}
-
 #[derive(MallocSizeOf)]
 pub(crate) struct StackingContextTree {
-    /// The root stacking context of this [`StackingContextTree`].
+    /// The root [`StackingContext`] of this [`StackingContextTree`].
     pub root_stacking_context: StackingContext,
 
     /// The information about the WebRender display list that `Paint`
-    /// consumes. This curerntly contains the out-of-band hit testing information
+    /// consumes. This currently contains the out-of-band hit testing information
     /// data structure that `Paint` uses to map hit tests to information
     /// about the item hit.
     pub paint_info: PaintDisplayListInfo,
@@ -173,7 +159,7 @@ impl StackingContextTree {
         );
 
         // We need to specify all three containing blocks here, because absolute
-        // descdendants of the root cannot share the containing block we specify
+        // descendants of the root cannot share the containing block we specify
         // for fixed descendants. In this case, they need to have the spatial
         // id of the root scroll frame, whereas fixed descendants need the
         // spatial id of the root reference frame so that they do not scroll with
@@ -185,30 +171,35 @@ impl StackingContextTree {
         };
 
         let mut stacking_context_tree = Self {
-            // This is just a temporary value that will be replaced once we have finished building the tree.
-            root_stacking_context: StackingContext::create_root(root_scroll_node_id, debug),
+            // This is just a temporary value that will be replaced once we have finished
+            // building the tree.
+            root_stacking_context: StackingContext::root(root_scroll_node_id),
             paint_info,
             clip_store: Default::default(),
         };
 
-        let mut root_stacking_context = StackingContext::create_root(root_scroll_node_id, debug);
         let text_decorations = Default::default();
-        for fragment in &fragment_tree.root_fragments {
-            fragment.build_stacking_context_tree(
+        let mut root_stacking_context = StackingContext::root(root_scroll_node_id);
+        if let Some(root_box_fragment) = fragment_tree.root_box_fragment() {
+            Fragment::Box(root_box_fragment).build_stacking_context_tree(
                 &mut stacking_context_tree,
                 &containing_block_info,
                 &mut root_stacking_context,
-                StackingContextBuildMode::SkipHoisted,
+                // The root element might be absolutely positioned and we still want
+                // to process it, if it is.
+                StackingContextBuildMode::IncludeHoisted,
                 &text_decorations,
             );
         }
+
         root_stacking_context.sort();
+        stacking_context_tree.root_stacking_context = root_stacking_context;
 
         if debug.is_enabled(DiagnosticsLoggingOption::StackingContextTree) {
-            root_stacking_context.debug_print();
+            stacking_context_tree
+                .root_stacking_context
+                .print(&mut PrintTree::new("Stacking Context Tree"));
         }
-
-        stacking_context_tree.root_stacking_context = root_stacking_context;
 
         stacking_context_tree
     }
@@ -326,607 +317,130 @@ pub(crate) struct FragmentTextDecoration {
     pub style: TextDecorationStyle,
 }
 
-/// A piece of content that directly belongs to a section of a stacking context.
-///
-/// This is generally part of a fragment, like its borders or foreground, but it
-/// can also be a stacking container that needs to be painted in fragment order.
-#[derive(MallocSizeOf)]
-pub(crate) enum StackingContextContent {
-    /// A fragment that does not generate a stacking context or stacking container.
-    Fragment {
-        scroll_node_id: ScrollTreeNodeId,
-        reference_frame_scroll_node_id: ScrollTreeNodeId,
-        clip_id: ClipId,
-        section: StackingContextSection,
-        containing_block: PhysicalRect<Au>,
-        fragment: Fragment,
-        is_hit_test_for_scrollable_overflow: bool,
-        is_collapsed_table_borders: bool,
-        #[conditional_malloc_size_of]
-        text_decorations: Arc<Vec<FragmentTextDecoration>>,
-    },
-
-    /// An index into [StackingContext::atomic_inline_stacking_containers].
-    ///
-    /// There is no section field, because these are always in [StackingContextSection::Foreground].
-    AtomicInlineStackingContainer { index: usize },
-}
-
-impl StackingContextContent {
-    pub(crate) fn section(&self) -> StackingContextSection {
-        match self {
-            Self::Fragment { section, .. } => *section,
-            Self::AtomicInlineStackingContainer { .. } => StackingContextSection::Foreground,
-        }
-    }
-
-    fn build_display_list_with_section_override(
-        &self,
-        builder: &mut DisplayListBuilder,
-        inline_stacking_containers: &[StackingContext],
-        section_override: Option<StackingContextSection>,
-    ) {
-        match self {
-            Self::Fragment {
-                scroll_node_id,
-                reference_frame_scroll_node_id,
-                clip_id,
-                section,
-                containing_block,
-                fragment,
-                is_hit_test_for_scrollable_overflow,
-                is_collapsed_table_borders,
-                text_decorations,
-            } => {
-                builder.current_scroll_node_id = *scroll_node_id;
-                builder.current_reference_frame_scroll_node_id = *reference_frame_scroll_node_id;
-                builder.current_clip_id = *clip_id;
-                fragment.build_display_list(
-                    builder,
-                    containing_block,
-                    section_override.unwrap_or(*section),
-                    *is_hit_test_for_scrollable_overflow,
-                    *is_collapsed_table_borders,
-                    text_decorations,
-                );
-            },
-            Self::AtomicInlineStackingContainer { index } => {
-                inline_stacking_containers[*index].build_display_list(builder);
-            },
-        }
-    }
-
-    fn build_display_list(
-        &self,
-        builder: &mut DisplayListBuilder,
-        inline_stacking_containers: &[StackingContext],
-    ) {
-        self.build_display_list_with_section_override(builder, inline_stacking_containers, None);
-    }
-
-    fn has_outline(&self) -> bool {
-        match self {
-            StackingContextContent::Fragment { fragment, .. } => match fragment {
-                Fragment::Box(box_fragment) | Fragment::Float(box_fragment) => {
-                    let style = box_fragment.style();
-                    let outline = style.get_outline();
-                    !outline.outline_style.none_or_hidden() && !outline.outline_width.0.is_zero()
-                },
-                _ => false,
-            },
-            StackingContextContent::AtomicInlineStackingContainer { .. } => false,
-        }
-    }
-}
-
 #[derive(Clone, Copy, Debug, Eq, MallocSizeOf, PartialEq)]
 pub(crate) enum StackingContextType {
-    RealStackingContext,
-    PositionedStackingContainer,
-    FloatStackingContainer,
-    AtomicInlineStackingContainer,
+    StackingContext,
+    StackingContainer,
+}
+
+#[derive(MallocSizeOf)]
+pub enum StackingContextFragments {
+    Root,
+    Fragment(#[conditional_malloc_size_of] Arc<BoxFragment>),
 }
 
 /// Either a stacking context or a stacking container, per the definitions in
 /// <https://drafts.csswg.org/css-position-4/#painting-order>.
 ///
-/// We use the term “real stacking context” in situations that call for a
-/// stacking context but not a stacking container.
+/// We use the term “real stacking context” in situations that call for a stacking context
+/// but not a stacking container. Only positioned stacking containers every get a
+/// `StackingContext`. The rest are handled inline during the `PaintTraversal`.
 #[derive(MallocSizeOf)]
 pub struct StackingContext {
-    /// The spatial id of this fragment. This is used to properly handle
-    /// things like preserve-3d.
-    scroll_tree_node_id: ScrollTreeNodeId,
+    /// The [`BoxFragment`] that established this stacking context. This is used to paint this
+    /// [`StackingContext`] and traverse its descendants for painting.
+    ///
+    /// This is `None` for the root stacking context.
+    pub(crate) fragment: StackingContextFragments,
 
-    /// The clip chain id of this stacking context if it has one. Used for filter clipping.
-    clip_id: Option<ClipId>,
+    /// The [`StackingContextType`] of this [`StackingContet`], which determines if it
+    /// a stacking context or a stacking container.
+    pub(crate) context_type: StackingContextType,
 
-    /// The [`BoxFragment`] that established this stacking context. We store the fragment here
-    /// rather than just the style, so that incremental layout can automatically update the style.
+    /// Child [`StackingContext`]s of this [`StackingContext`].
+    pub(crate) children: Vec<StackingContext>,
+
+    /// The offset of the containing block, used to properly paint child fragments of this
+    /// stacking context or stacking container.
+    pub(crate) containing_block_origin: PhysicalPoint<Au>,
+
+    /// The spatial id of this [`StackingContext`].
+    pub(crate) scroll_tree_node_id: ScrollTreeNodeId,
+
+    /// The clip id of this [`StackingContext`] if it has one.
+    pub(crate) clip_id: ClipId,
+
+    /// The z-index of this [`StackingContext`]. Note that `auto` is represented as 0.
+    pub(crate) z_index: i32,
+
+    /// The text decorations that apply to this [`StackingContext`] propagated via the box tree.
     #[conditional_malloc_size_of]
-    initializing_fragment: Option<Arc<BoxFragment>>,
-
-    /// The type of this stacking context. Used for collecting and sorting.
-    context_type: StackingContextType,
-
-    /// The contents that need to be painted in fragment order.
-    pub(super) contents: Vec<StackingContextContent>,
-
-    /// Stacking contexts that need to be stolen by the parent stacking context
-    /// if this is a stacking container, that is, real stacking contexts and
-    /// positioned stacking containers (where ‘z-index’ is auto).
-    /// <https://drafts.csswg.org/css-position-4/#paint-a-stacking-container>
-    /// > To paint a stacking container, given a box root and a canvas canvas:
-    /// >  1. Paint a stacking context given root and canvas, treating root as
-    /// >     if it created a new stacking context, but omitting any positioned
-    /// >     descendants or descendants that actually create a stacking context
-    /// >     (letting the parent stacking context paint them, instead).
-    pub(super) real_stacking_contexts_and_positioned_stacking_containers: Vec<StackingContext>,
-
-    /// Float stacking containers.
-    /// Separate from real_stacking_contexts_or_positioned_stacking_containers
-    /// because they should never be stolen by the parent stacking context.
-    /// <https://drafts.csswg.org/css-position-4/#paint-a-stacking-container>
-    pub(super) float_stacking_containers: Vec<StackingContext>,
-
-    /// Atomic inline stacking containers.
-    /// Separate from real_stacking_contexts_or_positioned_stacking_containers
-    /// because they should never be stolen by the parent stacking context, and
-    /// separate from float_stacking_containers so that [StackingContextContent]
-    /// can index into this vec to paint them in fragment order.
-    /// <https://drafts.csswg.org/css-position-4/#paint-a-stacking-container>
-    /// <https://drafts.csswg.org/css-position-4/#paint-a-box-in-a-line-box>
-    pub(super) atomic_inline_stacking_containers: Vec<StackingContext>,
-
-    /// Information gathered about the painting order, for [Self::debug_print].
-    debug_print_items: Option<RefCell<Vec<DebugPrintItem>>>,
-}
-
-/// Refers to one of the child contents or stacking contexts of a [StackingContext].
-#[derive(Clone, Copy, MallocSizeOf)]
-pub struct DebugPrintItem {
-    field: DebugPrintField,
-    index: usize,
-}
-
-/// Refers to one of the vecs of a [StackingContext].
-#[derive(Clone, Copy, MallocSizeOf)]
-pub enum DebugPrintField {
-    Contents,
-    RealStackingContextsAndPositionedStackingContainers,
-    FloatStackingContainers,
+    pub(crate) text_decorations: Rc<Vec<FragmentTextDecoration>>,
 }
 
 impl StackingContext {
+    fn root(scroll_tree_node_id: ScrollTreeNodeId) -> Self {
+        Self {
+            fragment: StackingContextFragments::Root,
+            context_type: StackingContextType::StackingContext,
+            children: Default::default(),
+            containing_block_origin: Default::default(),
+            scroll_tree_node_id,
+            clip_id: ClipId::INVALID,
+            z_index: 0,
+            text_decorations: Default::default(),
+        }
+    }
+
     fn create_descendant(
         &self,
+        context_type: StackingContextType,
+        containing_block_offset: PhysicalPoint<Au>,
         spatial_id: ScrollTreeNodeId,
         clip_id: ClipId,
         initializing_fragment: Arc<BoxFragment>,
-        context_type: StackingContextType,
+        text_decorations: Rc<Vec<FragmentTextDecoration>>,
     ) -> Self {
-        // WebRender has two different ways of expressing "no clip." ClipChainId::INVALID should be
-        // used for primitives, but `None` is used for stacking contexts and clip chains. We convert
-        // to the `Option<ClipId>` representation here. Just passing Some(ClipChainId::INVALID)
-        // leads to a crash.
-        let clip_id = match clip_id {
-            ClipId::INVALID => None,
-            clip_id => Some(clip_id),
-        };
+        let z_index = initializing_fragment
+            .style()
+            .effective_z_index(initializing_fragment.base.flags);
         Self {
+            fragment: StackingContextFragments::Fragment(initializing_fragment),
+            context_type,
+            containing_block_origin: containing_block_offset,
+            children: Default::default(),
             scroll_tree_node_id: spatial_id,
             clip_id,
-            initializing_fragment: Some(initializing_fragment),
-            context_type,
-            contents: vec![],
-            real_stacking_contexts_and_positioned_stacking_containers: vec![],
-            float_stacking_containers: vec![],
-            atomic_inline_stacking_containers: vec![],
-            debug_print_items: self.debug_print_items.is_some().then(|| vec![].into()),
+            z_index,
+            text_decorations,
         }
     }
 
-    fn create_root(root_scroll_node_id: ScrollTreeNodeId, debug: &DiagnosticsLogging) -> Self {
-        Self {
-            scroll_tree_node_id: root_scroll_node_id,
-            clip_id: None,
-            initializing_fragment: None,
-            context_type: StackingContextType::RealStackingContext,
-            contents: vec![],
-            real_stacking_contexts_and_positioned_stacking_containers: vec![],
-            float_stacking_containers: vec![],
-            atomic_inline_stacking_containers: vec![],
-            debug_print_items: debug
-                .is_enabled(DiagnosticsLoggingOption::StackingContextTree)
-                .then(|| vec![].into()),
+    pub(crate) fn fragment(&self) -> Option<&Arc<BoxFragment>> {
+        match &self.fragment {
+            StackingContextFragments::Root => None,
+            StackingContextFragments::Fragment(box_fragment) => Some(box_fragment),
         }
     }
 
-    /// Add a child stacking context to this stacking context.
-    fn add_stacking_context(&mut self, stacking_context: StackingContext) {
-        match stacking_context.context_type {
-            StackingContextType::RealStackingContext => {
-                &mut self.real_stacking_contexts_and_positioned_stacking_containers
-            },
-            StackingContextType::PositionedStackingContainer => {
-                &mut self.real_stacking_contexts_and_positioned_stacking_containers
-            },
-            StackingContextType::FloatStackingContainer => &mut self.float_stacking_containers,
-            StackingContextType::AtomicInlineStackingContainer => {
-                &mut self.atomic_inline_stacking_containers
-            },
-        }
-        .push(stacking_context)
+    fn sort(&mut self) {
+        self.children.sort_by_key(|child| child.z_index)
     }
 
-    pub(crate) fn z_index(&self) -> i32 {
-        self.initializing_fragment.as_ref().map_or(0, |fragment| {
-            fragment.style().effective_z_index(fragment.base.flags)
-        })
-    }
-
-    pub(crate) fn sort(&mut self) {
-        self.contents.sort_by_key(|a| a.section());
-        self.real_stacking_contexts_and_positioned_stacking_containers
-            .sort_by_key(|a| a.z_index());
-
-        debug_assert!(
-            self.real_stacking_contexts_and_positioned_stacking_containers
-                .iter()
-                .all(|c| matches!(
-                    c.context_type,
-                    StackingContextType::RealStackingContext |
-                        StackingContextType::PositionedStackingContainer
-                ))
-        );
-        debug_assert!(
-            self.float_stacking_containers
-                .iter()
-                .all(
-                    |c| c.context_type == StackingContextType::FloatStackingContainer &&
-                        c.z_index() == 0
-                )
-        );
-        debug_assert!(
-            self.atomic_inline_stacking_containers
-                .iter()
-                .all(
-                    |c| c.context_type == StackingContextType::AtomicInlineStackingContainer &&
-                        c.z_index() == 0
-                )
-        );
-    }
-
-    fn push_webrender_stacking_context_if_necessary(
-        &self,
-        builder: &mut DisplayListBuilder,
-    ) -> bool {
-        let Some(fragment) = self.initializing_fragment.as_ref() else {
-            return false;
+    fn print(&self, tree: &mut PrintTree) {
+        let fragment_string = match &self.fragment {
+            StackingContextFragments::Root => "Root".into(),
+            StackingContextFragments::Fragment(box_fragment) => format!(
+                "{:?} rect={:?}",
+                box_fragment.base.tag,
+                box_fragment.content_rect()
+            ),
         };
 
-        // WebRender only uses the stacking context to apply certain effects. If we don't
-        // actually need to create a stacking context, just avoid creating one.
-        let style = fragment.style();
-        let effects = style.get_effects();
-        let transform_style = style.get_used_transform_style();
-        if effects.filter.0.is_empty() &&
-            effects.opacity == 1.0 &&
-            effects.mix_blend_mode == ComputedMixBlendMode::Normal &&
-            !style.has_effective_transform_or_perspective(FragmentFlags::empty()) &&
-            style.get_svg().clip_path == ClipPath::None &&
-            transform_style == TransformStyle::Flat
-        {
-            return false;
+        tree.new_level(format!(
+            "{fragment_string} z-index={:?} spatial={:?} clip={:?}",
+            self.z_index, self.scroll_tree_node_id, self.clip_id
+        ));
+
+        for child in self.children.iter() {
+            child.print(tree);
         }
 
-        // Create the filter pipeline.
-        let current_color = style.clone_color();
-        let mut filters: Vec<wr::FilterOp> = effects
-            .filter
-            .0
-            .iter()
-            .map(|filter| FilterToWebRender::to_webrender(filter, &current_color))
-            .collect();
-        if effects.opacity != 1.0 {
-            filters.push(wr::FilterOp::Opacity(
-                effects.opacity.into(),
-                effects.opacity,
-            ));
-        }
-
-        // TODO(jdm): WebRender now requires us to create stacking context items
-        //            with the IS_BLEND_CONTAINER flag enabled if any children
-        //            of the stacking context have a blend mode applied.
-        //            This will require additional tracking during layout
-        //            before we start collecting stacking contexts so that
-        //            information will be available when we reach this point.
-        let spatial_id = builder.spatial_id(self.scroll_tree_node_id);
-        let clip_chain_id = self.clip_id.map(|clip_id| builder.clip_chain_id(clip_id));
-        builder.wr().push_stacking_context(
-            LayoutPoint::zero(), // origin
-            spatial_id,
-            style.get_webrender_primitive_flags(),
-            clip_chain_id,
-            transform_style.to_webrender(),
-            effects.mix_blend_mode.to_webrender(),
-            &filters,
-            &[], // filter_datas
-            &[], // filter_primitives
-            wr::RasterSpace::Screen,
-            wr::StackingContextFlags::empty(),
-            None, // snapshot
-        );
-
-        true
-    }
-
-    /// <https://drafts.csswg.org/css-backgrounds/#special-backgrounds>
-    ///
-    /// This is only called for the root `StackingContext`
-    pub(crate) fn build_canvas_background_display_list(
-        &self,
-        builder: &mut DisplayListBuilder,
-        fragment_tree: &crate::fragment_tree::FragmentTree,
-    ) {
-        let Some(root_fragment) = fragment_tree.root_fragments.iter().find(|fragment| {
-            fragment
-                .base()
-                .is_some_and(|base| base.flags.intersects(FragmentFlags::IS_ROOT_ELEMENT))
-        }) else {
-            return;
-        };
-        let root_fragment = match root_fragment {
-            Fragment::Box(box_fragment) | Fragment::Float(box_fragment) => box_fragment,
-            _ => return,
-        };
-
-        let source_style = {
-            // > For documents whose root element is an HTML HTML element or an XHTML html element
-            // > [HTML]: if the computed value of background-image on the root element is none and its
-            // > background-color is transparent, user agents must instead propagate the computed
-            // > values of the background properties from that element’s first HTML BODY or XHTML body
-            // > child element.
-            let root_fragment_style = root_fragment.style();
-            if root_fragment_style.background_is_transparent() {
-                let body_fragment = fragment_tree.body_fragment();
-                builder.paint_body_background = body_fragment.is_none();
-                body_fragment
-                    .map(|body_fragment| body_fragment.style().clone())
-                    .unwrap_or(root_fragment.style().clone())
-            } else {
-                root_fragment_style.clone()
-            }
-        };
-
-        // This can happen if the root fragment does not have a `<body>` child (either because it is
-        // `display: none` or `display: contents`) or if the `<body>`'s background is transparent.
-        if source_style.background_is_transparent() {
-            return;
-        }
-
-        // The painting area is theoretically the infinite 2D plane,
-        // but we need a rectangle with finite coordinates.
-        //
-        // If the document is smaller than the viewport (and doesn’t scroll),
-        // we still want to paint the rest of the viewport.
-        // If it’s larger, we also want to paint areas reachable after scrolling.
-        let painting_area = fragment_tree
-            .initial_containing_block
-            .union(&fragment_tree.scrollable_overflow())
-            .to_webrender();
-
-        let background_color =
-            source_style.resolve_color(&source_style.get_background().background_color);
-        if background_color.alpha > 0.0 {
-            let common = builder.common_properties(painting_area, &source_style);
-            let color = super::rgba(background_color);
-            builder.wr().push_rect(&common, painting_area, color);
-
-            // From <https://www.w3.org/TR/paint-timing/#sec-terminology>:
-            // First paint ... includes non-default background paint and the enclosing box of an iframe.
-            // The spec is vague. See also: https://github.com/w3c/paint-timing/issues/122
-            let default_background_color = servo_config::pref!(shell_background_color_rgba);
-            let default_background_color = AbsoluteColor::new(
-                ColorSpace::Srgb,
-                default_background_color[0] as f32,
-                default_background_color[1] as f32,
-                default_background_color[2] as f32,
-                default_background_color[3] as f32,
-            )
-            .into_srgb_legacy();
-            if background_color != default_background_color {
-                builder.mark_is_paintable();
-            }
-        }
-
-        let mut fragment_builder = BuilderForBoxFragment::new(
-            root_fragment,
-            &fragment_tree.initial_containing_block,
-            false, /* is_hit_test_for_scrollable_overflow */
-            false, /* is_collapsed_table_borders */
-        );
-        let painter = super::background::BackgroundPainter {
-            style: &source_style,
-            painting_area_override: Some(painting_area),
-            positioning_area_override: None,
-        };
-        fragment_builder.build_background_image(builder, &painter);
-    }
-
-    /// Build a display list from a a [`StackingContext`]. Note that this is the forward
-    /// version of the reversed stacking context walk algorithm in `hit_test.rs`. Any
-    /// changes made here should be reflected in the reverse version in that file.
-    pub(crate) fn build_display_list(&self, builder: &mut DisplayListBuilder) {
-        let pushed_context = self.push_webrender_stacking_context_if_necessary(builder);
-
-        // Properly order display items that make up a stacking context.
-        // “Steps” here refer to the steps in CSS 2.1 Appendix E.
-        // Note that “positioned descendants” is generalised to include all descendants that
-        // generate stacking contexts (csswg-drafts#2717), except in the phrase “any positioned
-        // descendants or descendants that actually create a stacking context”, where the term
-        // means positioned descendants that do not generate stacking contexts.
-
-        // Steps 1 and 2: Borders and background for the root
-        let mut content_with_outlines = Vec::new();
-        let mut contents = self.contents.iter().enumerate().peekable();
-        while contents.peek().is_some_and(|(_, child)| {
-            child.section() == StackingContextSection::OwnBackgroundsAndBorders
-        }) {
-            let (i, child) = contents.next().unwrap();
-            self.debug_push_print_item(DebugPrintField::Contents, i);
-            child.build_display_list(builder, &self.atomic_inline_stacking_containers);
-
-            if child.has_outline() {
-                content_with_outlines.push(child);
-            }
-        }
-
-        // Step 3: Stacking contexts with negative ‘z-index’
-        let mut real_stacking_contexts_and_positioned_stacking_containers = self
-            .real_stacking_contexts_and_positioned_stacking_containers
-            .iter()
-            .enumerate()
-            .peekable();
-        while real_stacking_contexts_and_positioned_stacking_containers
-            .peek()
-            .is_some_and(|(_, child)| child.z_index() < 0)
-        {
-            let (i, child) = real_stacking_contexts_and_positioned_stacking_containers
-                .next()
-                .unwrap();
-            self.debug_push_print_item(
-                DebugPrintField::RealStackingContextsAndPositionedStackingContainers,
-                i,
-            );
-            child.build_display_list(builder);
-        }
-
-        // Step 4: Block backgrounds and borders
-        while contents.peek().is_some_and(|(_, child)| {
-            child.section() == StackingContextSection::DescendantBackgroundsAndBorders
-        }) {
-            let (i, child) = contents.next().unwrap();
-            self.debug_push_print_item(DebugPrintField::Contents, i);
-            child.build_display_list(builder, &self.atomic_inline_stacking_containers);
-
-            if child.has_outline() {
-                content_with_outlines.push(child);
-            }
-        }
-
-        // Step 5: Float stacking containers
-        for (i, child) in self.float_stacking_containers.iter().enumerate() {
-            self.debug_push_print_item(DebugPrintField::FloatStackingContainers, i);
-            child.build_display_list(builder);
-        }
-
-        // Steps 6 and 7: Fragments and inline stacking containers
-        while contents
-            .peek()
-            .is_some_and(|(_, child)| child.section() == StackingContextSection::Foreground)
-        {
-            let (i, child) = contents.next().unwrap();
-            self.debug_push_print_item(DebugPrintField::Contents, i);
-            child.build_display_list(builder, &self.atomic_inline_stacking_containers);
-
-            if child.has_outline() {
-                content_with_outlines.push(child);
-            }
-        }
-
-        // Steps 8 and 9: Stacking contexts with non-negative ‘z-index’, and
-        // positioned stacking containers (where ‘z-index’ is auto)
-        for (i, child) in real_stacking_contexts_and_positioned_stacking_containers {
-            self.debug_push_print_item(
-                DebugPrintField::RealStackingContextsAndPositionedStackingContainers,
-                i,
-            );
-            child.build_display_list(builder);
-        }
-
-        // Step 10: Outline
-        for content in content_with_outlines {
-            content.build_display_list_with_section_override(
-                builder,
-                &self.atomic_inline_stacking_containers,
-                Some(StackingContextSection::Outline),
-            );
-        }
-
-        if pushed_context {
-            builder.wr().pop_stacking_context();
-        }
-    }
-
-    /// Store the fact that something was painted, if [Self::debug_print_items] is not None.
-    ///
-    /// This is used to help reconstruct the original painting order in [Self::debug_print] without
-    /// duplicating our painting order logic, since that could fall out of sync with the real logic.
-    fn debug_push_print_item(&self, field: DebugPrintField, index: usize) {
-        if let Some(items) = self.debug_print_items.as_ref() {
-            items.borrow_mut().push(DebugPrintItem { field, index });
-        }
-    }
-
-    /// Print the stacking context tree.
-    pub fn debug_print(&self) {
-        if self.debug_print_items.is_none() {
-            warn!("failed to print stacking context tree: debug_print_items was None");
-            return;
-        }
-        let mut tree = PrintTree::new("Stacking context tree");
-        self.debug_print_with_tree(&mut tree);
-    }
-
-    /// Print a subtree with the given [PrintTree], or panic if [Self::debug_print_items] is None.
-    fn debug_print_with_tree(&self, tree: &mut PrintTree) {
-        match self.context_type {
-            StackingContextType::RealStackingContext => {
-                tree.new_level(format!("{:?} z={}", self.context_type, self.z_index()));
-            },
-            StackingContextType::AtomicInlineStackingContainer => {
-                // do nothing; we print the heading with its index in DebugPrintField::Contents
-            },
-            _ => {
-                tree.new_level(format!("{:?}", self.context_type));
-            },
-        }
-        for DebugPrintItem { field, index } in
-            self.debug_print_items.as_ref().unwrap().borrow().iter()
-        {
-            match field {
-                DebugPrintField::Contents => match self.contents[*index] {
-                    StackingContextContent::Fragment { section, .. } => {
-                        tree.add_item(format!("{section:?}"));
-                    },
-                    StackingContextContent::AtomicInlineStackingContainer { index } => {
-                        tree.new_level(format!("AtomicInlineStackingContainer #{index}"));
-                        self.atomic_inline_stacking_containers[index].debug_print_with_tree(tree);
-                        tree.end_level();
-                    },
-                },
-                DebugPrintField::RealStackingContextsAndPositionedStackingContainers => {
-                    self.real_stacking_contexts_and_positioned_stacking_containers[*index]
-                        .debug_print_with_tree(tree);
-                },
-                DebugPrintField::FloatStackingContainers => {
-                    self.float_stacking_containers[*index].debug_print_with_tree(tree);
-                },
-            }
-        }
-        match self.context_type {
-            StackingContextType::AtomicInlineStackingContainer => {
-                // do nothing; we print the heading with its index in DebugPrintField::Contents
-            },
-            _ => {
-                tree.end_level();
-            },
-        }
+        tree.end_level();
     }
 }
 
-#[derive(PartialEq)]
+#[derive(Clone, Copy, PartialEq)]
 pub(crate) enum StackingContextBuildMode {
     IncludeHoisted,
     SkipHoisted,
@@ -939,7 +453,7 @@ impl Fragment {
         containing_block_info: &ContainingBlockInfo,
         stacking_context: &mut StackingContext,
         mode: StackingContextBuildMode,
-        text_decorations: &Arc<Vec<FragmentTextDecoration>>,
+        text_decorations: &Rc<Vec<FragmentTextDecoration>>,
     ) {
         let containing_block = containing_block_info.get_containing_block_for_fragment(self);
         let cumulative_containing_block = containing_block
@@ -1001,23 +515,7 @@ impl Fragment {
                     text_decorations,
                 );
             },
-            Fragment::Text(_) | Fragment::Image(_) | Fragment::IFrame(_) => {
-                stacking_context
-                    .contents
-                    .push(StackingContextContent::Fragment {
-                        section: StackingContextSection::Foreground,
-                        scroll_node_id: containing_block.scroll_node_id,
-                        reference_frame_scroll_node_id: containing_block_info
-                            .for_absolute_and_fixed_descendants
-                            .scroll_node_id,
-                        clip_id: containing_block.clip_id,
-                        containing_block: containing_block.rect,
-                        fragment: fragment_clone,
-                        is_hit_test_for_scrollable_overflow: false,
-                        is_collapsed_table_borders: false,
-                        text_decorations: text_decorations.clone(),
-                    });
-            },
+            Fragment::Text(_) | Fragment::Image(_) | Fragment::IFrame(_) => {},
         }
     }
 }
@@ -1038,42 +536,19 @@ struct OverflowFrameData {
 }
 
 impl BoxFragment {
-    fn get_stacking_context_type(&self) -> Option<StackingContextType> {
+    pub(crate) fn stacking_context_type(&self) -> Option<StackingContextType> {
         let flags = self.base.flags;
         let style = self.style();
         if style.establishes_stacking_context(flags) {
-            return Some(StackingContextType::RealStackingContext);
+            return Some(StackingContextType::StackingContext);
         }
 
         let box_style = &style.get_box();
         if box_style.position != ComputedPosition::Static {
-            return Some(StackingContextType::PositionedStackingContainer);
-        }
-
-        if box_style.float != ComputedFloat::None {
-            return Some(StackingContextType::FloatStackingContainer);
-        }
-
-        // Flex and grid items are painted like inline blocks.
-        // <https://drafts.csswg.org/css-flexbox-1/#painting>
-        // <https://drafts.csswg.org/css-grid/#z-order>
-        if self.is_atomic_inline_level() || flags.contains(FragmentFlags::IS_FLEX_OR_GRID_ITEM) {
-            return Some(StackingContextType::AtomicInlineStackingContainer);
+            return Some(StackingContextType::StackingContainer);
         }
 
         None
-    }
-
-    fn get_stacking_context_section(&self) -> StackingContextSection {
-        if self.get_stacking_context_type().is_some() {
-            return StackingContextSection::OwnBackgroundsAndBorders;
-        }
-
-        if self.style().get_box().display.outside() == DisplayOutside::Inline {
-            return StackingContextSection::Foreground;
-        }
-
-        StackingContextSection::DescendantBackgroundsAndBorders
     }
 
     fn build_stacking_context_tree(
@@ -1083,7 +558,7 @@ impl BoxFragment {
         containing_block: &ContainingBlock,
         containing_block_info: &ContainingBlockInfo,
         parent_stacking_context: &mut StackingContext,
-        text_decorations: &Arc<Vec<FragmentTextDecoration>>,
+        text_decorations: &Rc<Vec<FragmentTextDecoration>>,
     ) {
         self.build_stacking_context_tree_maybe_creating_reference_frame(
             fragment,
@@ -1102,7 +577,7 @@ impl BoxFragment {
         containing_block: &ContainingBlock,
         containing_block_info: &ContainingBlockInfo,
         parent_stacking_context: &mut StackingContext,
-        text_decorations: &Arc<Vec<FragmentTextDecoration>>,
+        text_decorations: &Rc<Vec<FragmentTextDecoration>>,
     ) {
         let reference_frame_data =
             match self.reference_frame_data_if_necessary(&containing_block.rect) {
@@ -1181,67 +656,76 @@ impl BoxFragment {
         containing_block: &ContainingBlock,
         containing_block_info: &ContainingBlockInfo,
         parent_stacking_context: &mut StackingContext,
-        text_decorations: &Arc<Vec<FragmentTextDecoration>>,
+        text_decorations: &Rc<Vec<FragmentTextDecoration>>,
     ) {
-        let context_type = match self.get_stacking_context_type() {
-            Some(context_type) => context_type,
-            None => {
-                self.build_stacking_context_tree_for_children(
-                    fragment,
-                    stacking_context_tree,
-                    containing_block,
-                    containing_block_info,
-                    parent_stacking_context,
-                    text_decorations,
-                );
-                return;
-            },
+        let Some(stacking_context_type) = self.stacking_context_type() else {
+            self.build_stacking_context_tree_for_children(
+                stacking_context_tree,
+                containing_block,
+                containing_block_info,
+                parent_stacking_context,
+                text_decorations,
+            );
+            return;
         };
 
-        if context_type == StackingContextType::AtomicInlineStackingContainer {
-            // Push a dummy fragment that indicates when the new stacking context should be painted.
-            parent_stacking_context.contents.push(
-                StackingContextContent::AtomicInlineStackingContainer {
-                    index: parent_stacking_context
-                        .atomic_inline_stacking_containers
-                        .len(),
-                },
-            );
-        }
+        let new_scroll_frame_size = containing_block_info
+            .for_non_absolute_descendants
+            .scroll_frame_size;
+        let spatial_id = self.build_sticky_frame_if_necessary(
+            stacking_context_tree,
+            containing_block.scroll_node_id,
+            &containing_block.rect,
+            &new_scroll_frame_size,
+        );
 
-        // `clip-path` needs to be applied before filters and creates a stacking context, so it can be
-        // applied directly to the stacking context itself.
-        // before
-        let stacking_context_clip_id = stacking_context_tree
+        let clip_id = self.build_clip_frame_if_necessary(
+            stacking_context_tree,
+            spatial_id.unwrap_or(containing_block.scroll_node_id),
+            containing_block.clip_id,
+            &containing_block.rect,
+        );
+
+        let style = self.style();
+        let clip_id = stacking_context_tree
             .clip_store
             .add_for_clip_path(
-                &self.style().get_svg().clip_path,
-                containing_block.scroll_node_id,
-                containing_block.clip_id,
-                BuilderForBoxFragment::new(
-                    self,
-                    &containing_block.rect,
-                    false, /* is_hit_test_for_scrollable_overflow */
-                    false, /* is_collapsed_table_borders */
-                ),
+                &style.get_svg().clip_path,
+                spatial_id.unwrap_or(containing_block.scroll_node_id),
+                clip_id.unwrap_or(containing_block.clip_id),
+                BuilderForBoxFragment::new(self, containing_block.rect.origin),
             )
-            .unwrap_or(containing_block.clip_id);
+            .or(clip_id);
 
-        let box_fragment = match fragment {
-            Fragment::Box(ref box_fragment) | Fragment::Float(ref box_fragment) => {
-                box_fragment.clone()
-            },
-            _ => unreachable!("Should never try to make stacking context for non-BoxFragment"),
+        let containing_block = if clip_id.is_some() || spatial_id.is_some() {
+            if let Some(clip_id) = clip_id {
+                self.set_generated_clip_id(clip_id);
+            }
+            if let Some(spatial_id) = spatial_id {
+                self.set_generated_scroll_tree_node_id(spatial_id);
+            }
+            &ContainingBlock {
+                scroll_node_id: spatial_id.unwrap_or(containing_block.scroll_node_id),
+                clip_id: clip_id.unwrap_or(containing_block.clip_id),
+                ..*containing_block
+            }
+        } else {
+            containing_block
         };
 
+        let box_fragment = fragment
+            .retrieve_box_fragment()
+            .expect("Should never try to make stacking context for non-BoxFragment")
+            .clone();
         let mut child_stacking_context = parent_stacking_context.create_descendant(
+            stacking_context_type,
+            containing_block.rect.origin,
             containing_block.scroll_node_id,
-            stacking_context_clip_id,
+            containing_block.clip_id,
             box_fragment,
-            context_type,
+            text_decorations.clone(),
         );
         self.build_stacking_context_tree_for_children(
-            fragment,
             stacking_context_tree,
             containing_block,
             containing_block_info,
@@ -1250,109 +734,44 @@ impl BoxFragment {
         );
 
         let mut stolen_children = vec![];
-        if context_type != StackingContextType::RealStackingContext {
-            stolen_children = mem::replace(
-                &mut child_stacking_context
-                    .real_stacking_contexts_and_positioned_stacking_containers,
-                stolen_children,
-            );
+        if stacking_context_type != StackingContextType::StackingContext {
+            stolen_children =
+                std::mem::replace(&mut child_stacking_context.children, stolen_children);
+        } else {
+            child_stacking_context.sort();
         }
 
-        child_stacking_context.sort();
-        parent_stacking_context.add_stacking_context(child_stacking_context);
         parent_stacking_context
-            .real_stacking_contexts_and_positioned_stacking_containers
+            .children
+            .push(child_stacking_context);
+        parent_stacking_context
+            .children
             .append(&mut stolen_children);
     }
 
     fn build_stacking_context_tree_for_children(
         &self,
-        fragment: Fragment,
         stacking_context_tree: &mut StackingContextTree,
         containing_block: &ContainingBlock,
         containing_block_info: &ContainingBlockInfo,
         stacking_context: &mut StackingContext,
-        text_decorations: &Arc<Vec<FragmentTextDecoration>>,
+        text_decorations: &Rc<Vec<FragmentTextDecoration>>,
     ) {
-        let mut new_scroll_node_id = containing_block.scroll_node_id;
-        let mut new_clip_id = containing_block.clip_id;
-        let mut new_scroll_frame_size = containing_block_info
-            .for_non_absolute_descendants
-            .scroll_frame_size;
-
-        if let Some(scroll_node_id) = self.build_sticky_frame_if_necessary(
-            stacking_context_tree,
-            new_scroll_node_id,
-            &containing_block.rect,
-            &new_scroll_frame_size,
-        ) {
-            new_scroll_node_id = scroll_node_id;
-        }
-
-        if let Some(clip_id) = self.build_clip_frame_if_necessary(
-            stacking_context_tree,
-            new_scroll_node_id,
-            new_clip_id,
-            &containing_block.rect,
-        ) {
-            new_clip_id = clip_id;
-        }
-
         let style = self.style();
-        if let Some(clip_id) = stacking_context_tree.clip_store.add_for_clip_path(
-            &style.get_svg().clip_path,
-            new_scroll_node_id,
-            new_clip_id,
-            BuilderForBoxFragment::new(
-                self,
-                &containing_block.rect,
-                false, /* is_hit_test_for_scrollable_overflow */
-                false, /* is_collapsed_table_borders */
-            ),
-        ) {
-            new_clip_id = clip_id;
-        }
-
         let establishes_containing_block_for_all_descendants =
             style.establishes_containing_block_for_all_descendants(self.base.flags);
         let establishes_containing_block_for_absolute_descendants =
             style.establishes_containing_block_for_absolute_descendants(self.base.flags);
 
-        let reference_frame_scroll_node_id_for_fragments =
-            if establishes_containing_block_for_all_descendants {
-                new_scroll_node_id
-            } else {
-                containing_block_info
-                    .for_absolute_and_fixed_descendants
-                    .scroll_node_id
-            };
-
-        let mut add_fragment = |section| {
-            stacking_context
-                .contents
-                .push(StackingContextContent::Fragment {
-                    scroll_node_id: new_scroll_node_id,
-                    reference_frame_scroll_node_id: reference_frame_scroll_node_id_for_fragments,
-                    clip_id: new_clip_id,
-                    section,
-                    containing_block: containing_block.rect,
-                    fragment: fragment.clone(),
-                    is_hit_test_for_scrollable_overflow: false,
-                    is_collapsed_table_borders: false,
-                    text_decorations: text_decorations.clone(),
-                });
-        };
-
-        let section = self.get_stacking_context_section();
-        add_fragment(section);
-
-        // Spatial tree node that will affect the transform of the fragment. Note that the next frame,
-        // scroll frame, does not affect the transform of the fragment but affect the transform of it
-        // children.
+        let mut new_scroll_node_id = containing_block.scroll_node_id;
         *self.spatial_tree_node.borrow_mut() = Some(new_scroll_node_id);
 
         // We want to build the scroll frame after the background and border, because
         // they shouldn't scroll with the rest of the box content.
+        let mut new_scroll_frame_size = containing_block_info
+            .for_non_absolute_descendants
+            .scroll_frame_size;
+        let mut new_clip_id = containing_block.clip_id;
         if let Some(overflow_frame_data) = self.build_overflow_frame_if_necessary(
             stacking_context_tree,
             new_scroll_node_id,
@@ -1360,23 +779,12 @@ impl BoxFragment {
             &containing_block.rect,
         ) {
             new_clip_id = overflow_frame_data.clip_id;
+            self.set_generated_clip_id(new_clip_id);
+
             if let Some(scroll_frame_data) = overflow_frame_data.scroll_frame_data {
                 new_scroll_node_id = scroll_frame_data.scroll_tree_node_id;
                 new_scroll_frame_size = Some(scroll_frame_data.scroll_frame_rect.size());
-                stacking_context
-                    .contents
-                    .push(StackingContextContent::Fragment {
-                        scroll_node_id: new_scroll_node_id,
-                        reference_frame_scroll_node_id:
-                            reference_frame_scroll_node_id_for_fragments,
-                        clip_id: new_clip_id,
-                        section,
-                        containing_block: containing_block.rect,
-                        fragment: fragment.clone(),
-                        is_hit_test_for_scrollable_overflow: true,
-                        is_collapsed_table_borders: false,
-                        text_decorations: text_decorations.clone(),
-                    });
+                self.set_generated_scroll_tree_node_id(new_scroll_node_id);
             }
         }
 
@@ -1446,7 +854,7 @@ impl BoxFragment {
                         .resolve_to_absolute(color),
                     style: style.clone_text_decoration_style(),
                 });
-                new_text_decoration = Arc::new(new_vector);
+                new_text_decoration = Rc::new(new_vector);
                 &new_text_decoration
             },
         };
@@ -1459,25 +867,6 @@ impl BoxFragment {
                 StackingContextBuildMode::SkipHoisted,
                 text_decorations,
             );
-        }
-
-        if matches!(
-            self.specific_layout_info().as_deref(),
-            Some(SpecificLayoutInfo::TableGridWithCollapsedBorders(_))
-        ) {
-            stacking_context
-                .contents
-                .push(StackingContextContent::Fragment {
-                    scroll_node_id: new_scroll_node_id,
-                    reference_frame_scroll_node_id: reference_frame_scroll_node_id_for_fragments,
-                    clip_id: new_clip_id,
-                    section,
-                    containing_block: containing_block.rect,
-                    fragment: fragment.clone(),
-                    is_hit_test_for_scrollable_overflow: false,
-                    is_collapsed_table_borders: true,
-                    text_decorations: text_decorations.clone(),
-                });
         }
     }
 
@@ -1549,7 +938,7 @@ impl BoxFragment {
             // https://drafts.csswg.org/css-overflow-3/#corner-clipping
             let radii;
             if overflow.x == ComputedOverflow::Clip && overflow.y == ComputedOverflow::Clip {
-                let builder = BuilderForBoxFragment::new(self, containing_block_rect, false, false);
+                let builder = BuilderForBoxFragment::new(self, containing_block_rect.origin);
                 let mut offsets_from_border = SideOffsets2D::new_all_same(clip_margin_offset);
                 match overflow_clip_margin.visual_box {
                     OverflowClipMarginBox::ContentBox => {
@@ -1592,7 +981,7 @@ impl BoxFragment {
             .to_webrender();
 
         let clip_id = stacking_context_tree.clip_store.add(
-            BuilderForBoxFragment::new(self, containing_block_rect, false, false).border_radius,
+            BuilderForBoxFragment::new(self, containing_block_rect.origin).border_radius,
             scroll_frame_rect,
             parent_scroll_node_id,
             parent_clip_id,
@@ -1661,7 +1050,7 @@ impl BoxFragment {
             offsets.bottom.map(|v| v.to_used_value(scroll_frame_height)),
             offsets.left.map(|v| v.to_used_value(scroll_frame_width)),
         );
-        self.ensure_rare_data().resolved_sticky_insets = Some(Box::new(offsets));
+        self.set_resolved_sticky_insets(offsets);
 
         if scroll_frame_size.is_none() {
             return None;
@@ -1927,7 +1316,7 @@ impl PositioningFragment {
         containing_block: &ContainingBlock,
         containing_block_info: &ContainingBlockInfo,
         stacking_context: &mut StackingContext,
-        text_decorations: &Arc<Vec<FragmentTextDecoration>>,
+        text_decorations: &Rc<Vec<FragmentTextDecoration>>,
     ) {
         let rect = self
             .base

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -1216,6 +1216,7 @@ impl InlineFormattingContextLayout<'_> {
                 self.root_nesting_level.style.clone(),
                 physical_line_rect,
                 fragments,
+                true, /* is_line_box */
             )));
     }
 

--- a/components/layout/fragment_tree/base_fragment.rs
+++ b/components/layout/fragment_tree/base_fragment.rs
@@ -224,11 +224,14 @@ impl From<ServoLayoutNode<'_>> for BaseFragmentInfo {
             return Self::anonymous();
         }
 
+        if node.as_element().is_some_and(|element| element.is_root()) {
+            flags.insert(FragmentFlags::IS_ROOT_ELEMENT);
+        }
+
         if let Some(element) = node.as_html_element() {
             if element.is_body_element_of_html_element_root() {
                 flags.insert(FragmentFlags::IS_BODY_ELEMENT_OF_HTML_ELEMENT_ROOT);
             }
-
             match element.local_name() {
                 &local_name!("br") => {
                     flags.insert(FragmentFlags::IS_BR_ELEMENT);
@@ -240,10 +243,6 @@ impl From<ServoLayoutNode<'_>> for BaseFragmentInfo {
                     flags.insert(FragmentFlags::IS_INPUT_ELEMENT);
                 },
                 _ => {},
-            }
-
-            if element.is_root() {
-                flags.insert(FragmentFlags::IS_ROOT_ELEMENT);
             }
         };
 

--- a/components/layout/fragment_tree/box_fragment.rs
+++ b/components/layout/fragment_tree/box_fragment.rs
@@ -21,7 +21,7 @@ use style::properties::ComputedValues;
 
 use super::{BaseFragment, BaseFragmentInfo, CollapsedBlockMargins, Fragment, FragmentFlags};
 use crate::SharedStyle;
-use crate::display_list::ToWebRender;
+use crate::display_list::{ClipId, ToWebRender};
 use crate::formatting_contexts::Baselines;
 use crate::fragment_tree::ContainingBlockCalculation;
 use crate::geom::{
@@ -81,6 +81,14 @@ pub(crate) struct BoxFragmentRareData {
 
     /// Information that is specific to a layout system (e.g., grid, table, etc.).
     pub specific_layout_info: Option<SpecificLayoutInfo>,
+
+    /// If the associated [`BoxFragment`] establishes a clip via CSS this holds the
+    /// [`ClipId`] for the generated clip set during stacking context tree construction.
+    pub generated_clip_id: Option<ClipId>,
+
+    /// If the associated [`BoxFragment`] establishes a spatial node via CSS this holds the
+    /// [`ScrollTreeNodeId`] for the generated node set during stacking context tree construction.
+    pub generated_scroll_tree_node_id: Option<ScrollTreeNodeId>,
 }
 
 impl BoxFragmentRareData {
@@ -93,6 +101,8 @@ impl BoxFragmentRareData {
             Box::new(BoxFragmentRareData {
                 resolved_sticky_insets: None,
                 specific_layout_info: Some(info),
+                generated_clip_id: None,
+                generated_scroll_tree_node_id: None,
             })
         }))
     }
@@ -220,7 +230,7 @@ impl BoxFragment {
         self.background_mode = BackgroundMode::None;
     }
 
-    pub(crate) fn ensure_rare_data(&self) -> AtomicRefMut<'_, Box<BoxFragmentRareData>> {
+    fn ensure_rare_data(&self) -> AtomicRefMut<'_, Box<BoxFragmentRareData>> {
         let mut rare_data = self.rare_data.borrow_mut();
         if rare_data.is_none() {
             *rare_data = Some(Default::default());
@@ -249,6 +259,32 @@ impl BoxFragment {
         AtomicRef::filter_map(rare_data, |rare_data| {
             rare_data.as_ref()?.resolved_sticky_insets.as_ref()
         })
+    }
+
+    pub(crate) fn set_resolved_sticky_insets(&self, sticky_insets: PhysicalSides<AuOrAuto>) {
+        self.ensure_rare_data().resolved_sticky_insets = Some(sticky_insets.into());
+    }
+
+    pub(crate) fn generated_clip_id(&self) -> Option<ClipId> {
+        self.rare_data.borrow().as_ref()?.generated_clip_id
+    }
+
+    pub(crate) fn set_generated_clip_id(&self, generated_clip_id: ClipId) {
+        self.ensure_rare_data().generated_clip_id = Some(generated_clip_id);
+    }
+
+    pub(crate) fn generated_scroll_tree_node_id(&self) -> Option<ScrollTreeNodeId> {
+        self.rare_data
+            .borrow()
+            .as_ref()?
+            .generated_scroll_tree_node_id
+    }
+
+    pub(crate) fn set_generated_scroll_tree_node_id(
+        &self,
+        generated_scroll_tree_node_id: ScrollTreeNodeId,
+    ) {
+        self.ensure_rare_data().generated_scroll_tree_node_id = Some(generated_scroll_tree_node_id);
     }
 
     pub(crate) fn with_block_level_layout_info(
@@ -669,6 +705,18 @@ impl BoxFragment {
         self.style().is_atomic_inline_level(self.base.flags)
     }
 
+    /// Whether or this is a flex or grid item.
+    pub(crate) fn is_flex_or_grid_item(&self) -> bool {
+        self.base
+            .flags
+            .contains(FragmentFlags::IS_FLEX_OR_GRID_ITEM)
+    }
+
+    /// Whether or this box is for replaced content.
+    pub(crate) fn is_replaced(&self) -> bool {
+        self.base.flags.contains(FragmentFlags::IS_REPLACED)
+    }
+
     /// Whether this is a table wrapper box.
     /// <https://www.w3.org/TR/css-tables-3/#table-wrapper-box>
     pub(crate) fn is_table_wrapper(&self) -> bool {
@@ -687,6 +735,21 @@ impl BoxFragment {
             },
             _ => false,
         }
+    }
+
+    /// Whether or not this is the [`BoxFragment`] for a table grid with collapsed borders.
+    pub(crate) fn is_table_grid_with_collapsed_borders(&self) -> bool {
+        matches!(
+            self.specific_layout_info().as_deref(),
+            Some(SpecificLayoutInfo::TableGridWithCollapsedBorders(_))
+        )
+    }
+
+    /// Whether or not this [`BoxFragment`] has outlines.
+    pub(crate) fn has_outline(&self) -> bool {
+        let style = self.style();
+        let outline = style.get_outline();
+        !outline.outline_style.none_or_hidden() && !outline.outline_width.0.is_zero()
     }
 
     pub(crate) fn spatial_tree_node(&self) -> Option<ScrollTreeNodeId> {

--- a/components/layout/fragment_tree/fragment_tree.rs
+++ b/components/layout/fragment_tree/fragment_tree.rs
@@ -12,6 +12,7 @@ use servo_base::print_tree::PrintTree;
 use style::computed_values::position::T as Position;
 
 use super::{BoxFragment, ContainingBlockManager, Fragment};
+use crate::fragment_tree::FragmentFlags;
 use crate::geom::PhysicalRect;
 
 #[derive(MallocSizeOf)]
@@ -49,6 +50,26 @@ impl FragmentTree {
             initial_containing_block,
             viewport_scroll_sensitivity,
         }
+    }
+
+    /// The root fragment for this fragment tree, if the root element does not have
+    /// `display: none;`. Note that positioned elements that have the initial containing
+    /// block as their containing block are also direct children of the fragment tree
+    /// root, but they are not returned by this getter.
+    pub(crate) fn root_box_fragment(&self) -> Option<Arc<BoxFragment>> {
+        self.root_fragments
+            .iter()
+            .find_map(|root_fragment| match root_fragment {
+                Fragment::Box(box_fragment) | Fragment::Float(box_fragment)
+                    if box_fragment
+                        .base
+                        .flags
+                        .contains(FragmentFlags::IS_ROOT_ELEMENT) =>
+                {
+                    Some(box_fragment.clone())
+                },
+                _ => None,
+            })
     }
 
     pub fn print(&self) {

--- a/components/layout/fragment_tree/positioning_fragment.rs
+++ b/components/layout/fragment_tree/positioning_fragment.rs
@@ -29,6 +29,9 @@ pub(crate) struct PositioningFragment {
     /// This [`PositioningFragment`]'s containing block rectangle in coordinates relative to
     /// the initial containing block, but not taking into account any transforms.
     pub cumulative_containing_block_rect: AtomicRefCell<PhysicalRect<Au>>,
+
+    /// Whether or not this [`PositioningFragment`] is a line box.
+    is_line_box: bool,
 }
 
 impl PositioningFragment {
@@ -36,8 +39,15 @@ impl PositioningFragment {
         style: ServoArc<ComputedValues>,
         rect: PhysicalRect<Au>,
         children: Vec<Fragment>,
+        is_line_box: bool,
     ) -> Arc<Self> {
-        Self::new_with_base_fragment_info(BaseFragmentInfo::anonymous(), style, rect, children)
+        Self::new_with_base_fragment_info(
+            BaseFragmentInfo::anonymous(),
+            style,
+            rect,
+            children,
+            is_line_box,
+        )
     }
 
     pub fn new_empty(
@@ -45,7 +55,7 @@ impl PositioningFragment {
         rect: PhysicalRect<Au>,
         style: ServoArc<ComputedValues>,
     ) -> Arc<Self> {
-        Self::new_with_base_fragment_info(base_fragment_info, style, rect, Vec::new())
+        Self::new_with_base_fragment_info(base_fragment_info, style, rect, Vec::new(), false)
     }
 
     fn new_with_base_fragment_info(
@@ -53,12 +63,14 @@ impl PositioningFragment {
         style: ServoArc<ComputedValues>,
         rect: PhysicalRect<Au>,
         children: Vec<Fragment>,
+        is_line_box: bool,
     ) -> Arc<Self> {
         Arc::new(Self {
             base: BaseFragment::new(base_fragment_info, style.into(), rect),
             children,
             scrollable_overflow: Default::default(),
             cumulative_containing_block_rect: Default::default(),
+            is_line_box,
         })
     }
 
@@ -107,6 +119,10 @@ impl PositioningFragment {
                         .translate(self.base.rect().origin.to_vector()),
                 )
             })
+    }
+
+    pub(crate) fn is_line_box(&self) -> bool {
+        self.is_line_box
     }
 
     pub fn print(&self, tree: &mut PrintTree) {

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -581,13 +581,12 @@ impl Layout for LayoutThread {
     fn query_elements_from_point(
         &self,
         point: webrender_api::units::LayoutPoint,
-        flags: layout_api::ElementsFromPointFlags,
     ) -> Vec<layout_api::ElementsFromPointResult> {
         with_layout_state(|| {
             self.stacking_context_tree
                 .borrow_mut()
                 .as_mut()
-                .map(|tree| HitTest::run(tree, point, flags))
+                .map(|tree| HitTest::run(tree, point))
                 .unwrap_or_default()
         })
     }

--- a/components/layout/style_ext.rs
+++ b/components/layout/style_ext.rs
@@ -520,13 +520,19 @@ impl ComputedValuesExt for ComputedValues {
     }
 
     fn is_inline_box(&self, fragment_flags: FragmentFlags) -> bool {
-        self.get_box().display.is_inline_flow() &&
-            !fragment_flags.intersects(FragmentFlags::IS_REPLACED | FragmentFlags::IS_WIDGET)
+        (self.get_box().display.is_inline_flow() &&
+            !fragment_flags.intersects(
+                FragmentFlags::IS_REPLACED |
+                    FragmentFlags::IS_WIDGET |
+                    FragmentFlags::IS_FLEX_OR_GRID_ITEM,
+            )) ||
+            matches!(self.pseudo(), Some(PseudoElement::FirstLetter))
     }
 
     fn is_atomic_inline_level(&self, fragment_flags: FragmentFlags) -> bool {
         self.get_box().display.outside() == stylo::DisplayOutside::Inline &&
-            !self.is_inline_box(fragment_flags)
+            !self.is_inline_box(fragment_flags) &&
+            !fragment_flags.intersects(FragmentFlags::IS_FLEX_OR_GRID_ITEM)
     }
 
     /// Returns true if this is a transformable element.

--- a/components/layout/stylesheets/servo.css
+++ b/components/layout/stylesheets/servo.css
@@ -81,7 +81,6 @@ textarea:placeholder-shown::-servo-text-control-inner-editor {
 input::placeholder,
 textarea::placeholder {
   color: grey;
-  overflow: hidden;
 }
 
 input::-servo-text-control-inner-editor {

--- a/components/layout/table/layout.rs
+++ b/components/layout/table/layout.rs
@@ -2918,6 +2918,7 @@ impl TableSlotCell {
             self.context.base.style.clone(),
             vertical_align_fragment_rect.as_physical(None),
             layout.layout.fragments,
+            false, /* is_line_box */
         );
 
         // Adjust the static position of all absolute children based on the

--- a/components/script/dom/document/documentorshadowroot.rs
+++ b/components/script/dom/document/documentorshadowroot.rs
@@ -8,7 +8,6 @@ use std::fmt;
 
 use embedder_traits::UntrustedNodeAddress;
 use js::rust::HandleValue;
-use layout_api::ElementsFromPointFlags;
 use rustc_hash::FxBuildHasher;
 use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::DocumentBinding::DocumentMethods;
@@ -157,7 +156,7 @@ impl DocumentOrShadowRoot {
 
         let results = self
             .window
-            .elements_from_point_query(LayoutPoint::new(x, y), ElementsFromPointFlags::empty());
+            .elements_from_point_query(LayoutPoint::new(x, y));
         let Some(result) = results.first() else {
             return document_element;
         };
@@ -201,7 +200,7 @@ impl DocumentOrShadowRoot {
         // Step 1 and Step 3
         let nodes = self
             .window
-            .elements_from_point_query(LayoutPoint::new(x, y), ElementsFromPointFlags::FindAll);
+            .elements_from_point_query(LayoutPoint::new(x, y));
         let mut elements: Vec<DomRoot<Element>> = nodes
             .iter()
             .flat_map(|result| {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -43,11 +43,11 @@ use js::rust::{
     MutableHandleValue,
 };
 use layout_api::{
-    AxesOverflow, BoxAreaType, CSSPixelRectVec, ElementsFromPointFlags, ElementsFromPointResult,
-    FragmentType, Layout, LayoutImageDestination, PendingImage, PendingImageState,
-    PendingRasterizationImage, PhysicalSides, QueryMsg, ReflowGoal, ReflowPhasesRun, ReflowRequest,
-    ReflowRequestRestyle, ReflowStatistics, RestyleReason, ScrollContainerQueryFlags,
-    ScrollContainerResponse, TrustedNodeAddress, combine_id_with_fragment_type,
+    AxesOverflow, BoxAreaType, CSSPixelRectVec, ElementsFromPointResult, FragmentType, Layout,
+    LayoutImageDestination, PendingImage, PendingImageState, PendingRasterizationImage,
+    PhysicalSides, QueryMsg, ReflowGoal, ReflowPhasesRun, ReflowRequest, ReflowRequestRestyle,
+    ReflowStatistics, RestyleReason, ScrollContainerQueryFlags, ScrollContainerResponse,
+    TrustedNodeAddress, combine_id_with_fragment_type,
 };
 use malloc_size_of::MallocSizeOf;
 use media::WindowGLContext;
@@ -3116,10 +3116,9 @@ impl Window {
     pub(crate) fn elements_from_point_query(
         &self,
         point: LayoutPoint,
-        flags: ElementsFromPointFlags,
     ) -> Vec<ElementsFromPointResult> {
         self.layout_reflow(QueryMsg::ElementsFromPoint);
-        self.layout().query_elements_from_point(point, flags)
+        self.layout().query_elements_from_point(point)
     }
 
     pub(crate) fn query_effective_overflow(&self, node: &Node) -> Option<AxesOverflow> {
@@ -3151,7 +3150,7 @@ impl Window {
         point_in_frame: Point2D<f32, CSSPixel>,
     ) -> Option<HitTestResult> {
         let result = self
-            .elements_from_point_query(point_in_frame.cast_unit(), ElementsFromPointFlags::empty())
+            .elements_from_point_query(point_in_frame.cast_unit())
             .into_iter()
             .nth(0)?;
 

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -397,11 +397,7 @@ pub trait Layout {
         node: TrustedNodeAddress,
         point: Point2D<Au, CSSPixel>,
     ) -> Option<usize>;
-    fn query_elements_from_point(
-        &self,
-        point: LayoutPoint,
-        flags: ElementsFromPointFlags,
-    ) -> Vec<ElementsFromPointResult>;
+    fn query_elements_from_point(&self, point: LayoutPoint) -> Vec<ElementsFromPointResult>;
     fn query_effective_overflow(&self, node: TrustedNodeAddress) -> Option<AxesOverflow>;
     fn stylist_mut(&mut self) -> &mut Stylist;
 
@@ -844,14 +840,6 @@ pub struct ElementsFromPointResult {
     /// The [`Cursor`] that's defined on the item that is hit by this
     /// hit test result.
     pub cursor: Cursor,
-}
-
-bitflags! {
-    pub struct ElementsFromPointFlags: u8 {
-        /// Whether or not to find all of the items for a hit test or stop at the
-        /// first hit.
-        const FindAll = 0b00000001;
-    }
 }
 
 #[derive(Debug, Default, MallocSizeOf)]

--- a/tests/wpt/meta/css/css-masking/clip/clip-filter-order.html.ini
+++ b/tests/wpt/meta/css/css-masking/clip/clip-filter-order.html.ini
@@ -1,2 +1,0 @@
-[clip-filter-order.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13143,7 +13143,7 @@
    },
    "incremental-layout": {
     "basic-fragment-tree-layout.html": [
-     "9cdf3e36941658512926988e3d9e467cabd3087d",
+     "8ca5549a672cbc8356307a0c50a33ac0b0542693",
      [
       null,
       {}
@@ -13192,7 +13192,7 @@
      ]
     ],
     "preserved-same-formatting-context-block-layout.html": [
-     "0a370296d767cec1db6e2ce6893478506b6ee88c",
+     "ffeb8baac76aae684b13b5a4519ee5ea578bc9c9",
      [
       null,
       {}

--- a/tests/wpt/mozilla/tests/incremental-layout/basic-fragment-tree-layout.html
+++ b/tests/wpt/mozilla/tests/incremental-layout/basic-fragment-tree-layout.html
@@ -54,10 +54,11 @@ window.onload = () => {
         // - body
         // - #div1
         // - #div1 > #p1
+        // - #div1 > #p1::text("Example1") (linebox)
         // - #div1 > #p1::text("Example1")
         // - #div2
         // - #div3
-        assert_equals(result.rebuiltFragmentCount, 7, "rebuiltFragmentCount");
+        assert_equals(result.rebuiltFragmentCount, 8, "rebuiltFragmentCount");
         assert_equals(result.restyleFragmentCount, 0, "restyleFragmentCount");
     }, "Updating div1's width property rebuilds some fragments");
 
@@ -96,8 +97,9 @@ window.onload = () => {
         // - #div3
         // - #div3 > #section3
         // - #div3 > #section3 > #p3
+        // - #div3 > #p3::text("Example3") (linebox)
         // - #div3 > #p3::text("Example3")
-        assert_equals(result.rebuiltFragmentCount, 8, "rebuiltFragmentCount");
+        assert_equals(result.rebuiltFragmentCount, 9, "rebuiltFragmentCount");
         assert_equals(result.restyleFragmentCount, 0, "restyleFragmentCount");
     }, "Updating div3's width property rebuilds some fragments");
 

--- a/tests/wpt/mozilla/tests/incremental-layout/preserved-same-formatting-context-block-layout.html
+++ b/tests/wpt/mozilla/tests/incremental-layout/preserved-same-formatting-context-block-layout.html
@@ -20,8 +20,8 @@ window.onload = () => {
 
         let result = ServoTestUtils.forceLayout();
 
-        // text fragment + p1 + div + body + root
-        assert_equals(result.rebuiltFragmentCount, 5, "rebuiltFragmentCount");
+        // text fragment + linebox + p1 + div + body + root
+        assert_equals(result.rebuiltFragmentCount, 6, "rebuiltFragmentCount");
         assert_equals(result.restyleFragmentCount, 0, "restyleFragmentCount");
         // p2 + p3 + p4 + p5
         assert_equals(result.onlyDescendantsChangedCount, 0, "onlyDescendantsChangedCount");


### PR DESCRIPTION
Previously, the `StackingContextTree` held a reference to *every*
fragment in the `FragmentTree`. This made it simpler to walk backwards
or fowards through the tree and to do a single sort during
`StackingContextTree` construction.

This change switches the `StackingContextTree` to a sparse
representation. This means that only real `StackingContext`s and
positioned stacking containers have entries in the tree. Fragments are
accessed via a new `PaintTraversal` which allows for display list
construction and hit testing.

This change reduces the amount of allocation and `Arc` reference
counting traffic. The main motivation, though, is to unlock the ability
to eventually do incremental `StackingContextTree` updates.  Currently
`StackingContextTree` construction is a significant amount of the time
spent in layout.

This change has performance implications. It makes `StackingContextTree`
construction lighter, moving more work to display list building. In
practice this is a similar of work and the hope is that incremental
`StackingContextTree` construction will make it worthwhile.

On my machine, this increases the score of
`flexbox-deeply-nested-column-flow.html` from around 29k runs/s to 32k
runs/s, though this is a layout-bound microbenchmark. We will continue
to optimize both painting and stacking context tree construction.

Testing: This is covered by existing tests very thoroughly, still one
test starts to pass as we made improvements to how clipping is processed.
