### PR TITLE
pixels: Do add RGB8 images to the `Painter` animating image cache

### DIFF
--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -128,10 +128,11 @@ fn set_webrender_image_key(
         return;
     }
 
-    let (descriptor, ipc_shared_memory) = image.webrender_image_descriptor_and_data_for_frame(0);
+    let (descriptor, ipc_shared_memory, should_be_cached) =
+        image.webrender_image_descriptor_and_data_for_frame(0);
     let data = SerializableImageData::Raw(ipc_shared_memory);
 
-    paint_api.add_image(image_key, descriptor, data, image.should_animate());
+    paint_api.add_image(image_key, descriptor, data, should_be_cached);
     image.id = Some(image_key);
 }
 

--- a/components/pixels/lib.rs
+++ b/components/pixels/lib.rs
@@ -434,7 +434,10 @@ impl RasterImage {
                 (
                     WebRenderImageFormat::BGRA8,
                     GenericSharedMemory::from_bytes(&bytes),
-                    false, // The image cache will use wrong frames because we transform the frames here
+                    // As we are transforming each frame individually we cache all frames
+                    // in the painter and adjust the offset, therefore this image should not
+                    // be added to the Painter's image cache.
+                    false,
                 )
             },
             PixelFormat::K8 | PixelFormat::KA8 => {

--- a/components/pixels/lib.rs
+++ b/components/pixels/lib.rs
@@ -401,8 +401,10 @@ impl RasterImage {
         self.frames.get(index)
     }
 
-    /// Returns the image descriptor needed for webrender and transforms them if necessary.
-    /// Returns if we can cache the image or not, with true meaning we can cache it.
+    /// Returns tuple containing three items:
+    ///   - An [`ImageDescriptor`] descriptor used to describe this image to WebRender
+    ///   - A [`GenericSharedMemory`] containing the image data 
+    ///  - Whether or not this image should be cached in the `Painter` animating image cache.
     pub fn webrender_image_descriptor_and_data_for_frame(
         &self,
         frame_index: usize,

--- a/components/pixels/lib.rs
+++ b/components/pixels/lib.rs
@@ -403,7 +403,7 @@ impl RasterImage {
 
     /// Returns tuple containing three items:
     ///   - An [`ImageDescriptor`] descriptor used to describe this image to WebRender
-    ///   - A [`GenericSharedMemory`] containing the image data 
+    ///   - A [`GenericSharedMemory`] containing the image data
     ///  - Whether or not this image should be cached in the `Painter` animating image cache.
     pub fn webrender_image_descriptor_and_data_for_frame(
         &self,

--- a/components/pixels/lib.rs
+++ b/components/pixels/lib.rs
@@ -401,23 +401,27 @@ impl RasterImage {
         self.frames.get(index)
     }
 
+    /// Returns the image descriptor needed for webrender and transforms them if necessary.
+    /// Returns if we can cache the image or not, with true meaning we can cache it.
     pub fn webrender_image_descriptor_and_data_for_frame(
         &self,
         frame_index: usize,
-    ) -> (ImageDescriptor, GenericSharedMemory) {
+    ) -> (ImageDescriptor, GenericSharedMemory, bool) {
         let frame = self
             .frames
             .get(frame_index)
             .unwrap_or_else(|| panic!("Asked for a frame that did not exist: {frame_index:?}"));
 
-        let (format, data) = match self.format {
+        let (format, data, should_animate) = match self.format {
             PixelFormat::BGRA8 => (
                 WebRenderImageFormat::BGRA8,
                 GenericSharedMemory::from_bytes(&self.bytes),
+                self.should_animate(),
             ),
             PixelFormat::RGBA8 => (
                 WebRenderImageFormat::RGBA8,
                 GenericSharedMemory::from_bytes(&self.bytes),
+                self.should_animate(),
             ),
             PixelFormat::RGB8 => {
                 let frame_bytes = &self.bytes[frame.byte_range.clone()];
@@ -428,6 +432,7 @@ impl RasterImage {
                 (
                     WebRenderImageFormat::BGRA8,
                     GenericSharedMemory::from_bytes(&bytes),
+                    false, // The image cache will use wrong frames because we transform the frames here
                 )
             },
             PixelFormat::K8 | PixelFormat::KA8 => {
@@ -445,7 +450,7 @@ impl RasterImage {
             offset: frame.byte_range.start as i32,
             flags,
         };
-        (descriptor, data)
+        (descriptor, data, should_animate)
     }
 
     /// For animations the image already exists in a cache in 'Painter'. We just send the description.


### PR DESCRIPTION
PixelFormat::RGB8 images were mistakenly cached on the paint side if they are animations. For animations we use the frame data and the animation cache to generate a new image. For these images, however,  the frame data and animation cache are out of sync because of the conversion in `webrender_image_descriptor_and_data_for_frame`. This disallows the cache for this specific format. It does not seem to be the case that we ever hit this problem though.

Testing: This doesn't change behavior as animated images never create images with an RGB8 format, but does make the code more robust in case there are future changes.
