### PR TITLE
layout: Mark layout as not needing containing block calculation when building stacking context tree

### DIFF
--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -1313,7 +1313,7 @@ impl LayoutThread {
             .map(|tree| tree.paint_info.scroll_tree.scroll_offsets());
 
         // This will be done during `StackingContextTree::new` below
-        self.need_containing_block_calculation.set(true);
+        self.need_containing_block_calculation.set(false);
 
         // Build the StackingContextTree. This turns the `FragmentTree` into a
         // tree of fragments in CSS painting order and also creates all


### PR DESCRIPTION
This was a small logic bug introduced in #44911. When building the
stacking context tree we don't need to calculate containing blocks for
queries, as they are calculated during the stacking context tree
construction itself.

This seems to improve performance from ~32k runs/s to ~35k runs/s on the
`flexbox-deeply-nested-column-flow.html` benchmark (after #45208 is
applied).

Testing: This should not change observable behavior, but does improve performance.
