### PR TITLE
paint: Avoid copying image data in single-process mode

### DIFF
--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -1081,7 +1081,9 @@ impl Painter {
                     if let Some(epoch) = epoch {
                         self.frame_delayer.update_image(key, epoch);
                     }
-                    txn.update_image(key, desc, data.into(), &DirtyRect::All)
+                    let image_data =
+                        self.serializable_image_data_to_image_data_maybe_caching(key, data, false);
+                    txn.update_image(key, desc, image_data, &DirtyRect::All)
                 },
                 ImageUpdate::UpdateImageForAnimation(image_key, desc) => {
                     let Some(image) = self.animation_image_cache.get(&image_key) else {


### PR DESCRIPTION
For animating images the cache will be hit, avoiding a copy of the data.
Otherwise, the behavior should be identical.

Testing: No behavior changes, minor perf optimization.

Part of #45199

