### PR TITLE
Enable `webgl_testing_context_creation_error` for testing

### DIFF
--- a/tests/wpt/mozilla/meta/mozilla/webgl/context-creation-error.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/webgl/context-creation-error.html.ini
@@ -1,4 +1,2 @@
 [context-creation-error.html]
-  [WebGLContextEvent "webglcontextcreationerror" event]
-    expected: FAIL
-
+  prefs: ["webgl_testing_context_creation_error:true"]


### PR DESCRIPTION
Enable `webgl_testing_context_creation_error` preference for testing 

Fixes #45115
