### PR TITLE
script: ensure that theme changes trigger related media query events

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -2941,6 +2941,9 @@ impl Document {
         {
             return true;
         }
+        if self.window().has_pending_media_query_evaluation() {
+            return true;
+        }
 
         false
     }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -472,6 +472,12 @@ pub(crate) struct Window {
     /// [`VisualViewport`] dimension changed and we need to process it on the next tick.
     has_changed_visual_viewport_dimension: Cell<bool>,
 
+    /// Whether something has changed since the last "update the rendering" turn
+    /// that may affect media query results, like a theme change. Consumed
+    /// together with the `resized` signal to decide whether to re-evaluate
+    /// `MediaQueryList`s and dispatch `change` events.
+    pending_media_query_evaluation: Cell<bool>,
+
     /// <https://html.spec.whatwg.org/multipage/#last-activation-timestamp>
     #[no_trace]
     last_activation_timestamp: Cell<UserActivationTimestamp>,
@@ -3271,6 +3277,15 @@ impl Window {
         }
         self.Document()
             .add_restyle_reason(RestyleReason::ThemeChanged);
+        // The change in `prefers-color-scheme` may flip `MediaQueryList`
+        // results so we flag the next "update the rendering" turn to re-evaluate them.
+        self.pending_media_query_evaluation.set(true);
+    }
+
+    /// Returns true and clears the flag if a media-feature change has
+    /// occurred since the last call.
+    pub(crate) fn take_pending_media_query_evaluation(&self) -> bool {
+        self.pending_media_query_evaluation.replace(false)
     }
 
     pub(crate) fn get_url(&self) -> ServoUrl {
@@ -3817,6 +3832,7 @@ impl Window {
             visual_viewport: Default::default(),
             weak_script_thread,
             has_changed_visual_viewport_dimension: Default::default(),
+            pending_media_query_evaluation: Default::default(),
             last_activation_timestamp: Cell::new(UserActivationTimestamp::PositiveInfinity),
             devtools_wants_updates: Default::default(),
         });

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -3288,6 +3288,10 @@ impl Window {
         self.pending_media_query_evaluation.replace(false)
     }
 
+    pub(crate) fn has_pending_media_query_evaluation(&self) -> bool {
+        self.pending_media_query_evaluation.get()
+    }
+
     pub(crate) fn get_url(&self) -> ServoUrl {
         self.Document().url()
     }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2731,11 +2731,6 @@ impl ScriptThread {
         for load in loads.iter_mut() {
             load.theme = theme;
         }
-        // A theme change may flip `prefers-color-scheme` media query results
-        // and force a recascade. Make sure the next iteration of the script
-        // event loop runs "update the rendering" so the new theme is applied
-        // even when the page has no ongoing animations driving the tick loop.
-        self.set_needs_rendering_update();
     }
 
     fn handle_get_document_origin(

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1238,16 +1238,22 @@ impl ScriptThread {
             // > 9. For each doc of docs, run the scroll steps for doc.
             document.run_the_scroll_steps(cx);
 
-            // Media queries is only relevant when there are resizing.
-            if resized {
-                // 10. For each doc of docs, evaluate media queries and report changes for doc.
+            // > 10. For each doc of docs, evaluate media queries and report changes for doc.
+            //
+            // Resize is the most common cause, but media queries can also change because
+            // of the platform theme (`prefers-color-scheme`) or other media features.
+            // The window tracks those via `pending_media_query_evaluation`, so we only
+            // pay the cost when something has actually changed.
+            let media_features_changed = document.window().take_pending_media_query_evaluation();
+            if resized || media_features_changed {
                 document
                     .window()
                     .evaluate_media_queries_and_report_changes(cx);
-
+            }
+            if resized {
                 // https://html.spec.whatwg.org/multipage/#img-environment-changes
                 // As per the spec, this can be run at any time.
-                document.react_to_environment_changes()
+                document.react_to_environment_changes();
             }
 
             let mut realm = enter_auto_realm(cx, &*document);
@@ -2725,6 +2731,11 @@ impl ScriptThread {
         for load in loads.iter_mut() {
             load.theme = theme;
         }
+        // A theme change may flip `prefers-color-scheme` media query results
+        // and force a recascade. Make sure the next iteration of the script
+        // event loop runs "update the rendering" so the new theme is applied
+        // even when the page has no ongoing animations driving the tick loop.
+        self.set_needs_rendering_update();
     }
 
     fn handle_get_document_origin(

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -204,15 +204,19 @@ fn test_theme_change_media_query_event() {
     let delegate = Rc::new(WebViewDelegateImpl::default());
     let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
         .delegate(delegate.clone())
-        .url(Url::parse(
-            r#"data:text/html,<!DOCTYPE html><html><script>
+        .url(
+            Url::parse(
+                r#"data:text/html,<!DOCTYPE html><html><script>
             let mediaQueryChanges = 0;
             const mediaQueryList = window.matchMedia('(prefers-color-scheme: dark)');
             mediaQueryList.addEventListener('change', () => {
                 mediaQueryChanges += 1;
                 console.log(mediaQueryChanges);
             });
-            </script></html>"#).unwrap())
+            </script></html>"#,
+            )
+            .unwrap(),
+        )
         .build();
 
     // Check that we increment mediaQueryChanges each time the theme changes.

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -199,6 +199,42 @@ fn test_theme_change() {
 }
 
 #[test]
+fn test_theme_change_media_query_event() {
+    let servo_test = ServoTest::new();
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .url(Url::parse(
+            r#"data:text/html,<!DOCTYPE html><html><script>
+            let mediaQueryChanges = 0;
+            const mediaQueryList = window.matchMedia('(prefers-color-scheme: dark)');
+            mediaQueryList.addEventListener('change', () => {
+                mediaQueryChanges += 1;
+                console.log(mediaQueryChanges);
+            });
+            </script></html>"#).unwrap())
+        .build();
+
+    // Check that we increment mediaQueryChanges each time the theme changes.
+
+    show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
+    let result = evaluate_javascript(&servo_test, webview.clone(), "mediaQueryChanges");
+    assert_eq!(result, Ok(JSValue::Number(0.0)));
+
+    webview.notify_theme_change(Theme::Dark);
+
+    show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
+    let result = evaluate_javascript(&servo_test, webview.clone(), "mediaQueryChanges");
+    assert_eq!(result, Ok(JSValue::Number(1.0)));
+
+    webview.notify_theme_change(Theme::Light);
+
+    show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
+    let result = evaluate_javascript(&servo_test, webview.clone(), "mediaQueryChanges");
+    assert_eq!(result, Ok(JSValue::Number(2.0)));
+}
+
+#[test]
 fn test_cursor_change() {
     let servo_test = ServoTest::new();
     let delegate = Rc::new(WebViewDelegateImpl::default());


### PR DESCRIPTION
Currently the media queries are only re-evaluated at an rendering update turn if there is a viewport resize. This adds tracking for other sources of changes that can warrant a media query evaluation in order to trigger 'change' events.

Testing: this requires embedder changes. I tested with mine in which I can force the dark mode on/off.

