### PR TITLE
paint: Use `GenericSharedMemory::into_arc_vec` for `SerializableImageData` -> `ImageData`

### DIFF
--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -1081,9 +1081,7 @@ impl Painter {
                     if let Some(epoch) = epoch {
                         self.frame_delayer.update_image(key, epoch);
                     }
-                    let image_data =
-                        self.serializable_image_data_to_image_data_maybe_caching(key, data, false);
-                    txn.update_image(key, desc, image_data, &DirtyRect::All)
+                    txn.update_image(key, desc, data.into(), &DirtyRect::All)
                 },
                 ImageUpdate::UpdateImageForAnimation(image_key, desc) => {
                     let Some(image) = self.animation_image_cache.get(&image_key) else {

--- a/components/shared/paint/lib.rs
+++ b/components/shared/paint/lib.rs
@@ -792,7 +792,9 @@ pub enum SerializableImageData {
 impl From<SerializableImageData> for ImageData {
     fn from(value: SerializableImageData) -> Self {
         match value {
-            SerializableImageData::Raw(shared_memory) => ImageData::new(shared_memory.to_vec()),
+            SerializableImageData::Raw(shared_memory) => {
+                ImageData::Raw(shared_memory.into_arc_vec())
+            },
             SerializableImageData::External(image) => ImageData::External(image),
         }
     }


### PR DESCRIPTION
Refactor of #45211

Instead of hardcoding `serializable_image_data_to_image_data_maybe_caching` with `is_animated_image` as false,
do it in the From trait.

Testing: The `From` trait is only used once, so not changing existing behaviour. But would improve future performance.

Part of #45199