### PR TITLE
generic_channel: Avoid unnecessary GenericSharedMemory allocations

### DIFF
--- a/components/pixels/lib.rs
+++ b/components/pixels/lib.rs
@@ -416,12 +416,12 @@ impl RasterImage {
         let (format, data, should_animate) = match self.format {
             PixelFormat::BGRA8 => (
                 WebRenderImageFormat::BGRA8,
-                GenericSharedMemory::from_bytes(&self.bytes),
+                GenericSharedMemory::from_arc_vec(self.bytes.clone()),
                 self.should_animate(),
             ),
             PixelFormat::RGBA8 => (
                 WebRenderImageFormat::RGBA8,
-                GenericSharedMemory::from_bytes(&self.bytes),
+                GenericSharedMemory::from_arc_vec(self.bytes.clone()),
                 self.should_animate(),
             ),
             PixelFormat::RGB8 => {
@@ -432,7 +432,7 @@ impl RasterImage {
                 }
                 (
                     WebRenderImageFormat::BGRA8,
-                    GenericSharedMemory::from_bytes(&bytes),
+                    GenericSharedMemory::from_vec(bytes),
                     // As we are transforming each frame individually we cache all frames
                     // in the painter and adjust the offset, therefore this image should not
                     // be added to the Painter's image cache.
@@ -495,7 +495,7 @@ impl RasterImage {
             format: self.format,
             id: self.id,
             cors_status: self.cors_status,
-            bytes: Arc::new(GenericSharedMemory::from_bytes(&self.bytes)),
+            bytes: Arc::new(GenericSharedMemory::from_arc_vec(self.bytes.clone())),
             frames: self.frames.clone(),
             is_opaque: self.is_opaque,
         })

--- a/components/pixels/snapshot.rs
+++ b/components/pixels/snapshot.rs
@@ -292,7 +292,7 @@ impl Snapshot {
         let (data, byte_range) = match &self.data {
             SnapshotData::SharedMemory(data, byte_range) => (data.clone(), byte_range.clone()),
             SnapshotData::SharedVec(data, byte_range) => (
-                Arc::new(GenericSharedMemory::from_bytes(data)),
+                Arc::new(GenericSharedMemory::from_arc_vec(data.clone())),
                 byte_range.clone(),
             ),
             SnapshotData::Owned(data) => (

--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -350,8 +350,8 @@ impl Callback for TransmitBodyPromiseHandler {
         // TODO: queue a fetch task on request to process request body for request.
         let _ = self
             .bytes_sender
-            .send(BodyChunkResponse::Chunk(GenericSharedMemory::from_bytes(
-                &chunk,
+            .send(BodyChunkResponse::Chunk(GenericSharedMemory::from_vec(
+                chunk,
             )));
     }
 }

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -852,7 +852,9 @@ impl HTMLLinkElement {
             let embedder_image = embedder_traits::Image::new(
                 frame.width,
                 frame.height,
-                std::sync::Arc::new(GenericSharedMemory::from_bytes(&raster_image.bytes)),
+                std::sync::Arc::new(GenericSharedMemory::from_arc_vec(
+                    raster_image.bytes.clone(),
+                )),
                 raster_image.frames[0].byte_range.clone(),
                 format,
             );

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -352,8 +352,8 @@ impl VideoFrameRenderer for MediaFrameRenderer {
                     updates.push(ImageUpdate::UpdateImage(
                         current_frame.image_key,
                         descriptor,
-                        SerializableImageData::Raw(GenericSharedMemory::from_bytes(
-                            &frame.get_data(),
+                        SerializableImageData::Raw(GenericSharedMemory::from_arc_vec(
+                            frame.get_data(),
                         )),
                         None,
                     ));
@@ -400,8 +400,8 @@ impl VideoFrameRenderer for MediaFrameRenderer {
                         })
                     })
                     .unwrap_or_else(|| {
-                        SerializableImageData::Raw(GenericSharedMemory::from_bytes(
-                            &frame.get_data(),
+                        SerializableImageData::Raw(GenericSharedMemory::from_arc_vec(
+                            frame.get_data(),
                         ))
                     });
 
@@ -446,8 +446,8 @@ impl VideoFrameRenderer for MediaFrameRenderer {
                         })
                     })
                     .unwrap_or_else(|| {
-                        SerializableImageData::Raw(GenericSharedMemory::from_bytes(
-                            &frame.get_data(),
+                        SerializableImageData::Raw(GenericSharedMemory::from_arc_vec(
+                            frame.get_data(),
                         ))
                     });
 

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -1277,14 +1277,12 @@ impl ReadableStream {
                 .get()
                 .expect("Stream should have controller.")
                 .get_in_memory_bytes()
-                .as_deref()
-                .map(GenericSharedMemory::from_bytes),
+                .map(GenericSharedMemory::from_vec),
             Some(ControllerType::Byte(controller)) => controller
                 .get()
                 .expect("Stream should have controller.")
                 .get_in_memory_bytes()
-                .as_deref()
-                .map(GenericSharedMemory::from_bytes),
+                .map(GenericSharedMemory::from_vec),
             _ => unreachable!("Getting in-memory bytes for a stream without a controller"),
         }
     }

--- a/components/script/dom/webgl/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl/webgl2renderingcontext.rs
@@ -3185,7 +3185,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
         // If srcData is null, a buffer of sufficient size initialized to 0 is passed.
         let buff = match *src_data {
             Some(ref data) => GenericSharedMemory::from_bytes(unsafe { data.as_slice() }),
-            None => GenericSharedMemory::from_bytes(&vec![0u8; expected_byte_len as usize]),
+            None => GenericSharedMemory::from_byte(0, expected_byte_len as usize),
         };
         if buff.len() < expected_byte_len as usize {
             return {

--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -650,7 +650,7 @@ impl WebGLRenderingContext {
             1,
             size,
             TexSource::Pixels(TexPixels::new(
-                GenericSharedMemory::from_bytes(&pixels),
+                GenericSharedMemory::from_vec(pixels),
                 size,
                 PixelFormat::RGBA8,
                 None,
@@ -4633,7 +4633,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
         // If data is null, a buffer of sufficient size
         // initialized to 0 is passed.
         let buff = match *pixels {
-            None => GenericSharedMemory::from_bytes(&vec![0u8; expected_byte_length as usize]),
+            None => GenericSharedMemory::from_byte(0, expected_byte_length as usize),
             Some(ref data) => GenericSharedMemory::from_bytes(unsafe { data.as_slice() }),
         };
 

--- a/components/shared/base/generic_channel/shared_memory.rs
+++ b/components/shared/base/generic_channel/shared_memory.rs
@@ -68,6 +68,34 @@ impl GenericSharedMemory {
         }
     }
 
+    /// Build a `GenericSharedMemory` from a `Vec<u8>`
+    ///
+    /// In single-process mode this allows reusing the Vec and the only cost is
+    /// allocating a new Arc. Prefer over `Self::from_bytes` if ownership is
+    /// transferred.
+    pub fn from_vec(bytes: Vec<u8>) -> Self {
+        if servo_config::opts::get().multiprocess || servo_config::opts::get().force_ipc {
+            GenericSharedMemory(GenericSharedMemoryVariant::Ipc(
+                IpcSharedMemory::from_bytes(&bytes),
+            ))
+        } else {
+            GenericSharedMemory(GenericSharedMemoryVariant::InProcess(Arc::new(bytes)))
+        }
+    }
+
+    /// Build a `GenericSharedMemory` from an `Arc<Vec<u8>>`
+    ///
+    /// In single-process mode this allows creating shared memory without copying.
+    pub fn from_arc_vec(arc: Arc<Vec<u8>>) -> Self {
+        if servo_config::opts::get().multiprocess || servo_config::opts::get().force_ipc {
+            GenericSharedMemory(GenericSharedMemoryVariant::Ipc(
+                IpcSharedMemory::from_bytes(&arc),
+            ))
+        } else {
+            GenericSharedMemory(GenericSharedMemoryVariant::InProcess(arc))
+        }
+    }
+
     /// Free operation in single process mode.
     /// If multiple `GenericSharedmemory` point to the same value this is safe to use and only effects the value currently hold.
     pub fn into_arc_vec(self) -> Arc<Vec<u8>> {

--- a/components/shared/base/generic_channel/shared_memory.rs
+++ b/components/shared/base/generic_channel/shared_memory.rs
@@ -68,7 +68,7 @@ impl GenericSharedMemory {
         }
     }
 
-    /// Build a `GenericSharedMemory` from a `Vec<u8>`
+    /// Build a `GenericSharedMemory` from a `Vec<u8>`.
     ///
     /// In single-process mode this allows reusing the Vec and the only cost is
     /// allocating a new Arc. Prefer over `Self::from_bytes` if ownership is
@@ -83,7 +83,7 @@ impl GenericSharedMemory {
         }
     }
 
-    /// Build a `GenericSharedMemory` from an `Arc<Vec<u8>>`
+    /// Build a `GenericSharedMemory` from an `Arc<Vec<u8>>`.
     ///
     /// In single-process mode this allows creating shared memory without copying.
     pub fn from_arc_vec(arc: Arc<Vec<u8>>) -> Self {

--- a/components/webgl/webgl_thread.rs
+++ b/components/webgl/webgl_thread.rs
@@ -1260,7 +1260,7 @@ impl WebGLImpl {
                     (false, _) => SnapshotAlphaMode::Opaque,
                 };
                 sender
-                    .send((GenericSharedMemory::from_bytes(&pixels), alpha_mode))
+                    .send((GenericSharedMemory::from_vec(pixels), alpha_mode))
                     .unwrap();
             },
             WebGLCommand::ReadPixelsPP(rect, format, pixel_type, offset) => unsafe {


### PR DESCRIPTION
In single-process mode, this allows reusing an existing Arc<Vec<u8>> or Vec<u8>, skipping the need to allocate, if the existing vec could have just been passed. Cloning an existing `Arc<Vec<u8>>` is cheaper than copying the bytes into a new Vec and then `Arc`ing that.
Initial perf measurements showed a measurable (~10%) mean LCP improvement on an image heavy website (measured on ohos).

Testing: No behavior changes.
