### PR TITLE
stylo: Incorporate Respond to live preference updates in `NonCustomPropertyId::enabled_for_all_content`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7382,7 +7382,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.38.0"
-source = "git+https://github.com/servo/stylo?rev=05479131c60d6ef8e57b7c7f736d2be970fd4190#05479131c60d6ef8e57b7c7f736d2be970fd4190"
+source = "git+https://github.com/servo/stylo?rev=e63c6351f45286f23eb0cdbd451421fa1939cc07#e63c6351f45286f23eb0cdbd451421fa1939cc07"
 dependencies = [
  "bitflags 2.11.1",
  "cssparser",
@@ -9090,7 +9090,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=05479131c60d6ef8e57b7c7f736d2be970fd4190#05479131c60d6ef8e57b7c7f736d2be970fd4190"
+source = "git+https://github.com/servo/stylo?rev=e63c6351f45286f23eb0cdbd451421fa1939cc07#e63c6351f45286f23eb0cdbd451421fa1939cc07"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -9526,7 +9526,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.17.0"
-source = "git+https://github.com/servo/stylo?rev=05479131c60d6ef8e57b7c7f736d2be970fd4190#05479131c60d6ef8e57b7c7f736d2be970fd4190"
+source = "git+https://github.com/servo/stylo?rev=e63c6351f45286f23eb0cdbd451421fa1939cc07#e63c6351f45286f23eb0cdbd451421fa1939cc07"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -9582,7 +9582,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.17.0"
-source = "git+https://github.com/servo/stylo?rev=05479131c60d6ef8e57b7c7f736d2be970fd4190#05479131c60d6ef8e57b7c7f736d2be970fd4190"
+source = "git+https://github.com/servo/stylo?rev=e63c6351f45286f23eb0cdbd451421fa1939cc07#e63c6351f45286f23eb0cdbd451421fa1939cc07"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -9591,7 +9591,7 @@ dependencies = [
 [[package]]
 name = "stylo_derive"
 version = "0.17.0"
-source = "git+https://github.com/servo/stylo?rev=05479131c60d6ef8e57b7c7f736d2be970fd4190#05479131c60d6ef8e57b7c7f736d2be970fd4190"
+source = "git+https://github.com/servo/stylo?rev=e63c6351f45286f23eb0cdbd451421fa1939cc07#e63c6351f45286f23eb0cdbd451421fa1939cc07"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -9603,7 +9603,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.17.0"
-source = "git+https://github.com/servo/stylo?rev=05479131c60d6ef8e57b7c7f736d2be970fd4190#05479131c60d6ef8e57b7c7f736d2be970fd4190"
+source = "git+https://github.com/servo/stylo?rev=e63c6351f45286f23eb0cdbd451421fa1939cc07#e63c6351f45286f23eb0cdbd451421fa1939cc07"
 dependencies = [
  "bitflags 2.11.1",
  "stylo_malloc_size_of",
@@ -9612,7 +9612,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.17.0"
-source = "git+https://github.com/servo/stylo?rev=05479131c60d6ef8e57b7c7f736d2be970fd4190#05479131c60d6ef8e57b7c7f736d2be970fd4190"
+source = "git+https://github.com/servo/stylo?rev=e63c6351f45286f23eb0cdbd451421fa1939cc07#e63c6351f45286f23eb0cdbd451421fa1939cc07"
 dependencies = [
  "app_units",
  "cssparser",
@@ -9629,7 +9629,7 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.17.0"
-source = "git+https://github.com/servo/stylo?rev=05479131c60d6ef8e57b7c7f736d2be970fd4190#05479131c60d6ef8e57b7c7f736d2be970fd4190"
+source = "git+https://github.com/servo/stylo?rev=e63c6351f45286f23eb0cdbd451421fa1939cc07#e63c6351f45286f23eb0cdbd451421fa1939cc07"
 dependencies = [
  "toml",
 ]
@@ -9637,7 +9637,7 @@ dependencies = [
 [[package]]
 name = "stylo_traits"
 version = "0.17.0"
-source = "git+https://github.com/servo/stylo?rev=05479131c60d6ef8e57b7c7f736d2be970fd4190#05479131c60d6ef8e57b7c7f736d2be970fd4190"
+source = "git+https://github.com/servo/stylo?rev=e63c6351f45286f23eb0cdbd451421fa1939cc07#e63c6351f45286f23eb0cdbd451421fa1939cc07"
 dependencies = [
  "app_units",
  "bitflags 2.11.1",
@@ -10058,7 +10058,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.4.0"
-source = "git+https://github.com/servo/stylo?rev=05479131c60d6ef8e57b7c7f736d2be970fd4190#05479131c60d6ef8e57b7c7f736d2be970fd4190"
+source = "git+https://github.com/servo/stylo?rev=e63c6351f45286f23eb0cdbd451421fa1939cc07#e63c6351f45286f23eb0cdbd451421fa1939cc07"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -10071,7 +10071,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=05479131c60d6ef8e57b7c7f736d2be970fd4190#05479131c60d6ef8e57b7c7f736d2be970fd4190"
+source = "git+https://github.com/servo/stylo?rev=e63c6351f45286f23eb0cdbd451421fa1939cc07#e63c6351f45286f23eb0cdbd451421fa1939cc07"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,13 +213,13 @@ rustls-platform-verifier = "0.7.0"
 sea-query = { version = "=1.0.0-rc.31", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = { version = "=0.8.0-rc.15" }
 sec1 = "0.7"
-selectors = { git = "https://github.com/servo/stylo", rev = "05479131c60d6ef8e57b7c7f736d2be970fd4190" }
+selectors = { git = "https://github.com/servo/stylo", rev = "e63c6351f45286f23eb0cdbd451421fa1939cc07" }
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
 serde_json = "1.0"
 serde_test = "1.0"
-servo_arc = { git = "https://github.com/servo/stylo", rev = "05479131c60d6ef8e57b7c7f736d2be970fd4190" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "e63c6351f45286f23eb0cdbd451421fa1939cc07" }
 sha1 = "0.10"
 sha2 = "0.10"
 sha3 = "0.10"
@@ -229,12 +229,12 @@ smallvec = { version = "1.15", features = ["serde", "union"] }
 speexdsp-resampler = "0.1.0"
 string_cache = "0.9"
 strum = { version = "0.28", features = ["derive"] }
-stylo = { git = "https://github.com/servo/stylo", rev = "05479131c60d6ef8e57b7c7f736d2be970fd4190" }
-stylo_atoms = { git = "https://github.com/servo/stylo", rev = "05479131c60d6ef8e57b7c7f736d2be970fd4190" }
-stylo_dom = { git = "https://github.com/servo/stylo", rev = "05479131c60d6ef8e57b7c7f736d2be970fd4190" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "05479131c60d6ef8e57b7c7f736d2be970fd4190" }
-stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "05479131c60d6ef8e57b7c7f736d2be970fd4190" }
-stylo_traits = { git = "https://github.com/servo/stylo", rev = "05479131c60d6ef8e57b7c7f736d2be970fd4190" }
+stylo = { git = "https://github.com/servo/stylo", rev = "e63c6351f45286f23eb0cdbd451421fa1939cc07" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "e63c6351f45286f23eb0cdbd451421fa1939cc07" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "e63c6351f45286f23eb0cdbd451421fa1939cc07" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "e63c6351f45286f23eb0cdbd451421fa1939cc07" }
+stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "e63c6351f45286f23eb0cdbd451421fa1939cc07" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "e63c6351f45286f23eb0cdbd451421fa1939cc07" }
 surfman = { version = "0.12.1", features = ["chains"] }
 swapper = "0.1"
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -24,8 +24,8 @@ use servo::{
     ContextMenuAction, ContextMenuElementInformation, ContextMenuElementInformationFlags,
     ContextMenuItem, CreateNewWebViewRequest, Cursor, EmbedderControl, InputEvent, InputMethodType,
     JSValue, LoadStatus, MouseButton, MouseButtonAction, MouseButtonEvent, MouseLeftViewportEvent,
-    MouseMoveEvent, RenderingContext, Scroll, SimpleDialog, Theme, WebView, WebViewBuilder,
-    WebViewDelegate, WebViewPoint, WebViewVector,
+    MouseMoveEvent, PrefValue, RenderingContext, Scroll, SimpleDialog, Theme, WebView,
+    WebViewBuilder, WebViewDelegate, WebViewPoint, WebViewVector,
 };
 use servo_config::prefs::Preferences;
 use servo_url::ServoUrl;
@@ -1036,5 +1036,41 @@ fn test_console_log_and_error_ordering() {
         messages[1].1.contains("DocumentFragment") || messages[1].1.contains("querySelector"),
         "Expected second message to contain error info, got: {:?}",
         messages[1].1
+    );
+}
+
+#[test]
+fn test_preferences_change() {
+    let servo_test = ServoTest::new();
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+
+    let test_page = Url::parse(
+        "data:text/html,\
+        <div style=\"display: grid;\">\
+            <div id=target style=\"grid-column: 1;\">three</div>\
+        </div>",
+    )
+    .expect("Data URL failed to build");
+
+    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .url(test_page.clone())
+        .build();
+    show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
+    let _ = evaluate_javascript(
+        &servo_test,
+        webview.clone(),
+        "target.style.gridColumn = \"3\";",
+    );
+
+    servo_test
+        .servo()
+        .set_preference("layout_grid_enabled", PrefValue::Bool(true));
+
+    webview.reload();
+
+    let result = assert_eq!(
+        Ok(JSValue::String("3".into())),
+        evaluate_javascript(&servo_test, webview, "target.style.gridColumn = \"3\";")
     );
 }


### PR DESCRIPTION
This change incorporates a fix from Stylo dealing with live preference
changes.

Stylo PR: servo/stylo#375

Testing: A unit test is added verifying this fix.
Fixes: #45107
