### PR TITLE
script: Use safe variants of `jsstr_to_string` and `latin1_to_string`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5112,9 +5112,9 @@ dependencies = [
 
 [[package]]
 name = "mozjs"
-version = "0.15.14"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ae3dcd73fd1aa7ab08c33c128d27243d07574874338b902872802c2b1d4b7d4"
+checksum = "50cd64afbbf78b296765b823bdebc9e70024604881a0b1d9e41eb873fab95bbd"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ inventory = "0.3.24"
 ipc-channel = "0.22"
 itertools = "0.14"
 jni = "0.22"
-js = { package = "mozjs", version = "=0.15.14", default-features = false, features = ["intl", "libz-sys"] }
+js = { package = "mozjs", version = "=0.16.0", default-features = false, features = ["intl", "libz-sys"] }
 keyboard-types = { version = "0.8.3", features = ["serde", "webdriver"] }
 kurbo = { version = "0.13.1", features = ["euclid"] }
 libc = "0.2"

--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -403,7 +403,7 @@ pub(crate) fn javascript_error_info_from_error_info(
             return None;
         }
         let stack_string = NonNull::new(stack_value.to_string())?;
-        Some(unsafe { jsstr_to_string(cx.raw_cx(), stack_string) })
+        Some(unsafe { jsstr_to_string(cx, stack_string) })
     };
 
     JavaScriptErrorInfo {

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -165,7 +165,7 @@ impl Console {
 #[expect(unsafe_code)]
 fn handle_value_to_string(cx: &mut JSContext, value: HandleValue) -> DOMString {
     match std::ptr::NonNull::new(unsafe { JS_ValueToSource(cx, value) }) {
-        Some(js_str) => unsafe { jsstr_to_string(cx.raw_cx(), js_str) }.into(),
+        Some(js_str) => unsafe { jsstr_to_string(cx, js_str) }.into(),
         None => "<error converting value to string>".into(),
     }
 }
@@ -183,7 +183,7 @@ fn console_argument_from_handle_value(
     ) -> Result<DebuggerValue, ()> {
         if handle_value.is_string() {
             let js_string = ptr::NonNull::new(handle_value.to_string()).unwrap();
-            let dom_string = unsafe { jsstr_to_string(cx.raw_cx(), js_string) };
+            let dom_string = unsafe { jsstr_to_string(cx, js_string) };
             return Ok(DebuggerValue::StringValue(dom_string));
         }
 
@@ -331,11 +331,10 @@ fn console_object_from_handle_value(
             let Some(js_string) = NonNull::new(js_string.get()) else {
                 continue;
             };
-            unsafe { jsstr_to_string(cx.raw_cx(), js_string) }
+            unsafe { jsstr_to_string(cx, js_string) }
         } else if id.is_symbol() || id.is_int() {
             rooted!(&in(cx) let mut key_value = UndefinedValue());
-            let raw_id: jsapi::HandleId = id.handle().into();
-            if !unsafe { JS_IdToValue(cx, *raw_id.ptr, key_value.handle_mut()) } {
+            if !unsafe { JS_IdToValue(cx, id.handle().get(), key_value.handle_mut()) } {
                 continue;
             }
             handle_value_to_string(cx, key_value.handle()).to_string()
@@ -379,10 +378,9 @@ fn console_object_from_handle_value(
                 JS_GetFunctionDisplayId(cx, fun.handle(), display_name.handle_mut());
                 arity = JS_GetFunctionArity(fun.get());
             }
-            let name =
-                ptr::NonNull::new(*name).map(|name| unsafe { jsstr_to_string(cx.raw_cx(), name) });
+            let name = ptr::NonNull::new(*name).map(|name| unsafe { jsstr_to_string(cx, name) });
             let display_name = ptr::NonNull::new(*display_name)
-                .map(|display_name| unsafe { jsstr_to_string(cx.raw_cx(), display_name) });
+                .map(|display_name| unsafe { jsstr_to_string(cx, display_name) });
 
             // TODO: We should get the actual argument names from the function
             // It's not trivial since we can't access the debugger API here
@@ -424,7 +422,7 @@ fn console_object_from_handle_value(
 pub(crate) fn stringify_handle_value(cx: &mut JSContext, message: HandleValue) -> DOMString {
     if message.is_string() {
         let jsstr = std::ptr::NonNull::new(message.to_string()).unwrap();
-        return unsafe { jsstr_to_string(cx.raw_cx(), jsstr).into() };
+        return unsafe { jsstr_to_string(cx, jsstr) }.into();
     }
     fn stringify_object_from_handle_value(
         cx: &mut JSContext,
@@ -554,15 +552,13 @@ fn maybe_stringify_dom_object(cx: &mut JSContext, value: HandleValue) -> Option<
     if !is_dom_class {
         return None;
     }
-    rooted!(&in(cx) let class_name = unsafe { ToString( cx.raw_cx(), value) });
+    rooted!(&in(cx) let class_name = unsafe { ToString(cx, value) });
     let Some(class_name) = NonNull::new(class_name.get()) else {
         return Some("<error converting DOM object to string>".into());
     };
-    let class_name = unsafe {
-        jsstr_to_string(cx.raw_cx(), class_name)
-            .replace("[object ", "")
-            .replace("]", "")
-    };
+    let class_name = unsafe { jsstr_to_string(cx, class_name) }
+        .replace("[object ", "")
+        .replace("]", "");
     let mut repr = format!("{} ", class_name);
     rooted!(&in(cx) let mut value = value.get());
 
@@ -607,7 +603,7 @@ fn apply_sprintf_substitutions(cx: &mut JSContext, messages: &[HandleValue]) -> 
     debug_assert!(!messages.is_empty() && messages[0].is_string());
 
     let js_string = ptr::NonNull::new(messages[0].to_string()).unwrap();
-    let format_string = unsafe { jsstr_to_string(cx.raw_cx(), js_string) };
+    let format_string = unsafe { jsstr_to_string(cx, js_string) };
 
     let mut result = String::new();
     let mut arg_index = 1usize;
@@ -987,7 +983,7 @@ fn get_js_stack(cx: &mut JSContext) -> Vec<StackFrame> {
             );
         }
         let function_name = if let Some(nonnull_result) = ptr::NonNull::new(*result) {
-            unsafe { jsstr_to_string(cx.raw_cx(), nonnull_result) }
+            unsafe { jsstr_to_string(cx, nonnull_result) }
         } else {
             "<anonymous>".into()
         };
@@ -1004,7 +1000,7 @@ fn get_js_stack(cx: &mut JSContext) -> Vec<StackFrame> {
             );
         }
         let filename = if let Some(nonnull_result) = ptr::NonNull::new(*result) {
-            unsafe { jsstr_to_string(cx.raw_cx(), nonnull_result) }
+            unsafe { jsstr_to_string(cx, nonnull_result) }
         } else {
             "<anonymous>".into()
         };

--- a/components/script/dom/dommatrixreadonly.rs
+++ b/components/script/dom/dommatrixreadonly.rs
@@ -875,9 +875,9 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
         let mut to_string = |f: f64| {
             rooted!(&in(cx) let rooted_value = jsval::DoubleValue(f));
             let serialization =
-                std::ptr::NonNull::new(unsafe { ToString(cx.raw_cx(), rooted_value.handle()) })
+                std::ptr::NonNull::new(unsafe { ToString(cx, rooted_value.handle()) })
                     .expect("Pointer cannot be null");
-            unsafe { jsstr_to_string(cx.raw_cx(), serialization) }
+            unsafe { jsstr_to_string(cx, serialization) }
         };
 
         // Step 2. Let string be the empty string.

--- a/components/script/dom/dommatrixreadonly.rs
+++ b/components/script/dom/dommatrixreadonly.rs
@@ -848,7 +848,7 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
 
     // https://drafts.fxtf.org/geometry/#dommatrixreadonly-stringification-behavior
     #[expect(unsafe_code)]
-    fn Stringifier(&self) -> Fallible<DOMString> {
+    fn Stringifier(&self, cx: &mut js::context::JSContext) -> Fallible<DOMString> {
         // Step 1. If one or more of m11 element through m44 element are a non-finite value,
         // then throw an "InvalidStateError" DOMException.
         let mat = self.matrix.borrow();
@@ -872,16 +872,12 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
             return Err(error::Error::InvalidState(None));
         }
 
-        let cx = GlobalScope::get_cx();
-        let to_string = |f: f64| {
-            let value = jsval::DoubleValue(f);
-
-            unsafe {
-                rooted!(in(*cx) let mut rooted_value = value);
-                let serialization = std::ptr::NonNull::new(ToString(*cx, rooted_value.handle()))
+        let mut to_string = |f: f64| {
+            rooted!(&in(cx) let rooted_value = jsval::DoubleValue(f));
+            let serialization =
+                std::ptr::NonNull::new(unsafe { ToString(cx.raw_cx(), rooted_value.handle()) })
                     .expect("Pointer cannot be null");
-                jsstr_to_string(*cx, serialization)
-            }
+            unsafe { jsstr_to_string(cx.raw_cx(), serialization) }
         };
 
         // Step 2. Let string be the empty string.

--- a/components/script/dom/encoding/textencoderstream.rs
+++ b/components/script/dom/encoding/textencoderstream.rs
@@ -9,11 +9,9 @@ use std::ptr::{self, NonNull};
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::conversions::latin1_to_string;
-use js::jsapi::{
-    JS_DeprecatedStringHasLatin1Chars, JS_GetTwoByteStringCharsAndLength, JSObject, JSType,
-};
+use js::jsapi::{JS_DeprecatedStringHasLatin1Chars, JSObject, JSType};
 use js::jsval::UndefinedValue;
-use js::rust::wrappers2::{JS_IsExceptionPending, ToPrimitive};
+use js::rust::wrappers2::{JS_GetTwoByteStringCharsAndLength, JS_IsExceptionPending, ToPrimitive};
 use js::rust::{
     HandleObject as SafeHandleObject, HandleValue as SafeHandleValue,
     MutableHandleValue as SafeMutableHandleValue, ToString,
@@ -224,7 +222,7 @@ pub(crate) fn encode_and_enqueue_a_chunk(
     jsval_to_primitive(cx, global, chunk, rval.handle_mut())?;
 
     assert!(!rval.is_object());
-    rooted!(&in(cx) let jsstr = unsafe { ToString(cx.raw_cx(), rval.handle()) });
+    rooted!(&in(cx) let jsstr = unsafe { ToString(cx, rval.handle()) });
     if jsstr.is_null() {
         unsafe {
             if !JS_IsExceptionPending(cx) {
@@ -243,11 +241,10 @@ pub(crate) fn encode_and_enqueue_a_chunk(
     let input = unsafe {
         if JS_DeprecatedStringHasLatin1Chars(*jsstr) {
             let s = NonNull::new(*jsstr).expect("jsstr cannot be null");
-            ConvertedInput::String(latin1_to_string(cx.raw_cx(), s))
+            ConvertedInput::String(latin1_to_string(cx, s))
         } else {
             let mut len = 0;
-            let data =
-                JS_GetTwoByteStringCharsAndLength(cx.raw_cx(), std::ptr::null(), *jsstr, &mut len);
+            let data = JS_GetTwoByteStringCharsAndLength(cx, *jsstr, &mut len);
             let maybe_ill_formed_code_units = std::slice::from_raw_parts(data, len);
             ConvertedInput::CodeUnits(maybe_ill_formed_code_units)
         }

--- a/components/script/indexeddb.rs
+++ b/components/script/indexeddb.rs
@@ -262,7 +262,7 @@ pub fn convert_value_to_key(
     if input.is_string() {
         // 3.1. Return a new key with type string and value input.
         let string_ptr = std::ptr::NonNull::new(input.to_string()).unwrap();
-        let key = unsafe { jsstr_to_string(cx.raw_cx(), string_ptr) };
+        let key = unsafe { jsstr_to_string(cx, string_ptr) };
         return Ok(ConversionResult::Valid(IndexedDBKeyType::String(key)));
     }
 

--- a/components/script/module_loading.rs
+++ b/components/script/module_loading.rs
@@ -165,7 +165,7 @@ fn inner_module_loading(
                 continue_module_loading(cx, state, Err(error));
             } else {
                 let specifier =
-                    unsafe { jsstr_to_string(cx.raw_cx(), std::ptr::NonNull::new(jsstr).unwrap()) };
+                    unsafe { jsstr_to_string(cx, std::ptr::NonNull::new(jsstr).unwrap()) };
                 let module_type = unsafe { GetRequestedModuleType(cx, module_handle, index) };
 
                 let realm = CurrentRealm::assert(cx);

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -904,7 +904,7 @@ pub(crate) unsafe extern "C" fn host_import_module_dynamically(
 
     let jsstr = unsafe { GetModuleRequestSpecifier(cx, Handle::from_raw(specifier)) };
     let module_type = unsafe { GetModuleRequestType(cx, Handle::from_raw(specifier)) };
-    let specifier = unsafe { jsstr_to_string(cx.raw_cx(), NonNull::new(jsstr).unwrap()) };
+    let specifier = unsafe { jsstr_to_string(cx, NonNull::new(jsstr).unwrap()) };
 
     let mut realm = CurrentRealm::assert(cx);
     let payload = Payload::PromiseRecord(promise);
@@ -1005,7 +1005,7 @@ unsafe extern "C" fn HostResolveImportedModule(
     let jsstr = unsafe { GetModuleRequestSpecifier(cx, Handle::from_raw(specifier)) };
     let module_type = unsafe { GetModuleRequestType(cx, Handle::from_raw(specifier)) };
 
-    let specifier = unsafe { jsstr_to_string(cx.raw_cx(), NonNull::new(jsstr).unwrap()) };
+    let specifier = unsafe { jsstr_to_string(cx, NonNull::new(jsstr).unwrap()) };
     let url = ModuleTree::resolve_module_specifier(
         &global_scope,
         module_data,
@@ -1127,8 +1127,8 @@ unsafe extern "C" fn import_meta_resolve(cx: *mut RawJSContext, argc: u32, vp: *
     let specifier = unsafe {
         let value = HandleValue::from_raw(args.get(0));
 
-        match NonNull::new(ToString(cx.raw_cx(), value)) {
-            Some(jsstr) => jsstr_to_string(cx.raw_cx(), jsstr).into(),
+        match NonNull::new(ToString(cx, value)) {
+            Some(jsstr) => jsstr_to_string(cx, jsstr).into(),
             None => return false,
         }
     };

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -505,10 +505,10 @@ unsafe extern "C" fn promise_rejection_tracker(
 }
 
 #[expect(unsafe_code)]
-fn safely_convert_null_to_string(cx: &mut js::context::JSContext, str_: HandleString) -> DOMString {
+fn safely_convert_null_to_string(cx: &js::context::JSContext, str_: HandleString) -> DOMString {
     DOMString::from(match std::ptr::NonNull::new(*str_) {
         None => "".to_owned(),
-        Some(str_) => unsafe { jsstr_to_string(cx.raw_cx(), str_) },
+        Some(str_) => unsafe { jsstr_to_string(cx, str_) },
     })
 }
 

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -350,11 +350,11 @@ fn object_has_to_json_property(
 #[expect(unsafe_code)]
 /// <https://w3c.github.io/webdriver/#dfn-collection>
 fn is_arguments_object(cx: &mut JSContext, value: HandleValue) -> bool {
-    rooted!(&in(cx) let class_name = unsafe { ToString(cx.raw_cx(), value) });
+    rooted!(&in(cx) let class_name = unsafe { ToString(cx, value) });
     let Some(class_name) = NonNull::new(class_name.get()) else {
         return false;
     };
-    let class_name = unsafe { jsstr_to_string(cx.raw_cx(), class_name) };
+    let class_name = unsafe { jsstr_to_string(cx, class_name) };
     class_name == "[object Arguments]"
 }
 
@@ -402,7 +402,7 @@ fn jsval_to_webdriver_inner(
         Ok(JSValue::Number(val.to_number()))
     } else if val.get().is_string() {
         let string = NonNull::new(val.to_string()).expect("Should have a non-Null String");
-        let string = unsafe { jsstr_to_string(cx.raw_cx(), string) };
+        let string = unsafe { jsstr_to_string(cx, string) };
         Ok(JSValue::String(string))
     } else if val.get().is_object() {
         rooted!(&in(cx) let object = match FromJSValConvertible::safe_from_jsval(cx, val, ()).unwrap() {

--- a/components/script/window_named_properties.rs
+++ b/components/script/window_named_properties.rs
@@ -122,7 +122,7 @@ unsafe extern "C" fn get_own_property_descriptor(
     }
 
     let s = if id.is_string() {
-        unsafe { jsstr_to_string(cx.raw_cx_no_gc(), NonNull::new(id.to_string()).unwrap()) }
+        unsafe { jsstr_to_string(&cx, NonNull::new(id.to_string()).unwrap()) }
     } else if id.is_int() {
         // If the property key is an integer index, convert it to a String too.
         // For indexed access on the window object, which may shadow this, see

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -330,7 +330,7 @@ DOMInterfaces = {
 },
 
 'DOMMatrixReadOnly': {
-    'cx': ['TransformPoint'],
+    'cx': ['Stringifier', 'TransformPoint'],
     'canGc': ['Multiply', 'Inverse', 'Scale', 'Translate', 'Rotate', 'RotateFromVector','FlipY', 'ScaleNonUniform', 'Scale3d', 'RotateAxisAngle', 'SkewX', 'SkewY', 'FlipX', 'FromFloat32Array', 'FromFloat64Array', 'FromMatrix', 'ToFloat32Array', 'ToFloat64Array'],
 },
 

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -6437,7 +6437,7 @@ class CGDOMJSProxyHandler_defineProperty(CGAbstractExternMethod):
             set += dedent(
                 """
                 if !<D as DomHelpers<D>>::is_platform_object_same_origin(cx, proxy) {
-                    return proxyhandler::report_cross_origin_denial::<D>(cx, id, "define");
+                    return proxyhandler::report_cross_origin_denial::<D>(cx, Handle::from_raw(id), "define");
                 }
 
                 // Safe to enter the Realm of proxy now.
@@ -6499,7 +6499,7 @@ class CGDOMJSProxyHandler_delete(CGAbstractExternMethod):
             set += dedent(
                 """
                 if !<D as DomHelpers<D>>::is_platform_object_same_origin(cx, proxy) {
-                    return proxyhandler::report_cross_origin_denial::<D>(cx, id, "delete");
+                    return proxyhandler::report_cross_origin_denial::<D>(cx, Handle::from_raw(id), "delete");
                 }
 
                 // Safe to enter the Realm of proxy now.

--- a/components/script_bindings/conversions.rs
+++ b/components/script_bindings/conversions.rs
@@ -151,14 +151,14 @@ impl FromJSValConvertible for USVString {
         value: HandleValue,
         _: (),
     ) -> Result<ConversionResult<USVString>, ()> {
-        let Some(jsstr) = ptr::NonNull::new(unsafe { ToString(cx.raw_cx(), value) }) else {
+        let Some(jsstr) = ptr::NonNull::new(unsafe { ToString(cx, value) }) else {
             debug!("ToString failed");
             return Err(());
         };
 
         // FIXME(ajeffrey): Convert directly from DOMString to USVString
         Ok(ConversionResult::Success(USVString(unsafe {
-            jsstr_to_string(cx.raw_cx(), jsstr)
+            jsstr_to_string(cx, jsstr)
         })))
     }
 }
@@ -197,7 +197,7 @@ impl FromJSValConvertible for ByteString {
         _option: (),
     ) -> Result<ConversionResult<ByteString>, ()> {
         unsafe {
-            let string = ToString(cx.raw_cx(), value);
+            let string = ToString(cx, value);
             if string.is_null() {
                 debug!("ToString failed");
                 return Err(());
@@ -444,14 +444,11 @@ where
 /// integer.
 ///
 /// Handling of invalid UTF-16 in strings depends on the relevant option.
-///
-/// # Safety
-/// - cx must point to a non-null, valid JSContext instance.
-pub fn jsid_to_string(cx: &mut js::context::JSContext, id: HandleId) -> Option<DOMString> {
+pub fn jsid_to_string(cx: &js::context::JSContext, id: HandleId) -> Option<DOMString> {
     let id_raw = *id;
     if id_raw.is_string() {
         let jsstr = ptr::NonNull::new(id_raw.to_string()).unwrap();
-        return Some(unsafe { jsstr_to_string(cx.raw_cx(), jsstr) }.into());
+        return Some(unsafe { jsstr_to_string(cx, jsstr) }.into());
     }
 
     if id_raw.is_int() {

--- a/components/script_bindings/domstring.rs
+++ b/components/script_bindings/domstring.rs
@@ -13,9 +13,10 @@ use std::sync::LazyLock;
 use std::{fmt, slice, str};
 
 use html5ever::{LocalName, Namespace};
+use js::context::{JSContext, RawJSContext};
 use js::conversions::{ToJSValConvertible, jsstr_to_string};
 use js::gc::{HandleValue, MutableHandleValue};
-use js::jsapi::{Heap, JS_GetLatin1StringCharsAndLength, JSContext, JSString};
+use js::jsapi::{Heap, JS_GetLatin1StringCharsAndLength, JSString};
 use js::jsval::StringValue;
 use js::rust::{Runtime, Trace};
 use malloc_size_of::MallocSizeOfOps;
@@ -131,11 +132,10 @@ impl DOMStringType {
     fn ensure_rust_string(&mut self) -> &mut String {
         let new_string = match self {
             DOMStringType::Rust(string) => return string,
-            DOMStringType::JSString(rooted_traceable_box) => unsafe {
-                jsstr_to_string(
-                    Runtime::get().expect("JS runtime has shut down").as_ptr(),
-                    NonNull::new(rooted_traceable_box.get()).unwrap(),
-                )
+            DOMStringType::JSString(rooted_traceable_box) => {
+                let cx = unsafe { JSContext::get_from_thread() };
+                let cx = cx.as_ref().expect("JS runtime has shut down");
+                unsafe { jsstr_to_string(cx, NonNull::new(rooted_traceable_box.get()).unwrap()) }
             },
             #[cfg(test)]
             DOMStringType::Latin1Vec(items) => {
@@ -315,10 +315,10 @@ impl DOMString {
     /// Creates the string from js. If the string can be encoded in latin1, just take the reference
     /// to the JSString. Otherwise do the conversion to utf8 now.
     pub fn from_js_string(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         value: HandleValue,
     ) -> Result<DOMString, DOMStringErrorType> {
-        let string_ptr = unsafe { js::rust::ToString(cx.raw_cx(), value) };
+        let string_ptr = unsafe { js::rust::ToString(cx, value) };
         if string_ptr.is_null() {
             debug!("ToString failed");
             Err(DOMStringErrorType::JSConversionError)
@@ -330,7 +330,7 @@ impl DOMString {
             } else {
                 // We need to convert the string anyway as it is not just latin1
                 DOMStringType::Rust(unsafe {
-                    jsstr_to_string(cx.raw_cx(), ptr::NonNull::new(string_ptr).unwrap())
+                    jsstr_to_string(cx, NonNull::new(string_ptr).unwrap())
                 })
             };
             Ok(DOMString(RefCell::new(inner)))
@@ -346,15 +346,12 @@ impl DOMString {
 
     /// Debug the current  state of the string without modifying it.
     #[expect(unused)]
-    fn debug_js(&self) {
+    fn debug_js(&self, cx: &JSContext) {
         match *self.0.borrow() {
             DOMStringType::Rust(ref s) => info!("Rust String ({})", s),
             DOMStringType::JSString(ref rooted_traceable_box) => {
                 let s = unsafe {
-                    jsstr_to_string(
-                        Runtime::get().expect("JS runtime has shut down").as_ptr(),
-                        ptr::NonNull::new(rooted_traceable_box.get()).unwrap(),
-                    )
+                    jsstr_to_string(cx, NonNull::new(rooted_traceable_box.get()).unwrap())
                 };
                 info!("JSString ({})", s);
             },
@@ -770,7 +767,7 @@ impl Extend<char> for DOMString {
 }
 
 impl ToJSValConvertible for DOMString {
-    unsafe fn to_jsval(&self, cx: *mut JSContext, mut rval: MutableHandleValue) {
+    unsafe fn to_jsval(&self, cx: *mut RawJSContext, mut rval: MutableHandleValue) {
         let val = self.0.borrow();
         match *val {
             DOMStringType::Rust(ref s) => unsafe {

--- a/components/script_bindings/proxyhandler.rs
+++ b/components/script_bindings/proxyhandler.rs
@@ -26,6 +26,9 @@ use js::rust::wrappers::{
     AppendToIdVector, JS_AlreadyHasOwnPropertyById, JS_NewObjectWithGivenProto,
     SetDataPropertyDescriptor,
 };
+use js::rust::wrappers2::{
+    JS_IdToValue, JS_IsExceptionPending, JS_ValueToSource, RUST_JSID_IS_VOID,
+};
 use js::rust::{
     Handle, HandleId, HandleObject, HandleValue, IntoHandle, MutableHandle, MutableHandleObject,
 };
@@ -220,20 +223,20 @@ pub fn set_property_descriptor(
     *is_none = false;
 }
 
-pub(crate) fn id_to_source(cx: SafeJSContext, id: RawHandleId) -> Option<DOMString> {
+fn id_to_source(cx: &mut js::context::JSContext, id: HandleId) -> Option<DOMString> {
     unsafe {
-        if js::glue::RUST_JSID_IS_VOID(id) {
+        if RUST_JSID_IS_VOID(id) {
             return None;
         }
-        rooted!(in(*cx) let mut value = UndefinedValue());
-        rooted!(in(*cx) let mut jsstr = ptr::null_mut::<jsapi::JSString>());
-        jsapi::JS_IdToValue(*cx, id.get(), value.handle_mut().into())
+        rooted!(&in(cx) let mut value = UndefinedValue());
+        rooted!(&in(cx) let mut jsstr = ptr::null_mut::<jsapi::JSString>());
+        JS_IdToValue(cx, id.get(), value.handle_mut())
             .then(|| {
-                jsstr.set(jsapi::JS_ValueToSource(*cx, value.handle().into()));
+                jsstr.set(JS_ValueToSource(cx, value.handle()));
                 jsstr.get()
             })
             .and_then(ptr::NonNull::new)
-            .map(|jsstr| jsstr_to_string(*cx, jsstr).into())
+            .map(|jsstr| jsstr_to_string(cx.raw_cx(), jsstr).into())
     }
 }
 
@@ -542,10 +545,10 @@ pub(crate) fn is_cross_origin_object<D: DomTypes>(cx: SafeJSContext, obj: RawHan
 /// "Throw a `SecurityError` DOMException".
 pub(crate) fn report_cross_origin_denial<D: DomTypes>(
     cx: &mut CurrentRealm,
-    id: RawHandleId,
+    id: HandleId,
     access: &str,
 ) -> bool {
-    if let Some(id) = id_to_source(cx.into(), id) {
+    if let Some(id) = id_to_source(cx, id) {
         debug!(
             "permission denied to {} property {} on cross-origin object",
             access,
@@ -555,7 +558,7 @@ pub(crate) fn report_cross_origin_denial<D: DomTypes>(
         debug!("permission denied to {} on cross-origin object", access);
     }
     unsafe {
-        if !js::rust::wrappers2::JS_IsExceptionPending(cx) {
+        if !JS_IsExceptionPending(cx) {
             let global = D::GlobalScope::from_current_realm(cx);
             // TODO: include `id` and `access` in the exception message
             <D as DomHelpers<D>>::throw_dom_exception(cx, &global, Error::Security(None));
@@ -707,7 +710,7 @@ pub(crate) fn cross_origin_get<D: DomTypes>(
     rooted!(&in(cx) let mut getter = ptr::null_mut::<JSObject>());
     get_getter_object(&descriptor, getter.handle_mut().into());
     if getter.get().is_null() {
-        return report_cross_origin_denial::<D>(cx, id.into_handle(), "get");
+        return report_cross_origin_denial::<D>(cx, id, "get");
     }
 
     rooted!(&in(cx) let mut getter_jsval = UndefinedValue());
@@ -770,7 +773,7 @@ pub(crate) unsafe fn cross_origin_set<D: DomTypes>(
     get_setter_object(&descriptor, setter.handle_mut().into());
     if setter.get().is_null() {
         // > 4. Throw a "SecurityError" DOMException.
-        return report_cross_origin_denial::<D>(cx, id.into_handle(), "set");
+        return report_cross_origin_denial::<D>(cx, id, "set");
     }
 
     rooted!(&in(cx) let mut setter_jsval = UndefinedValue());
@@ -829,6 +832,8 @@ pub(crate) fn cross_origin_property_fallback<D: DomTypes>(
         );
         return true;
     }
+
+    let id = unsafe { Handle::from_raw(id) };
 
     // > 2. Throw a `SecurityError` `DOMException`.
     report_cross_origin_denial::<D>(cx, id, "access")

--- a/components/script_bindings/proxyhandler.rs
+++ b/components/script_bindings/proxyhandler.rs
@@ -236,7 +236,7 @@ fn id_to_source(cx: &mut js::context::JSContext, id: HandleId) -> Option<DOMStri
                 jsstr.get()
             })
             .and_then(ptr::NonNull::new)
-            .map(|jsstr| jsstr_to_string(cx.raw_cx(), jsstr).into())
+            .map(|jsstr| jsstr_to_string(cx, jsstr).into())
     }
 }
 

--- a/components/script_bindings/utils.rs
+++ b/components/script_bindings/utils.rs
@@ -611,8 +611,7 @@ unsafe fn generic_call<D: DomTypes, const EXCEPTION_TO_REJECTION: bool>(
             // FIXME: `Handle<jsid>` could have a default constructor
             //        like `Handle<Value>::null`
             rooted!(&in(*realm) let mut void_jsid: js::jsapi::jsid);
-            let result =
-                report_cross_origin_denial::<D>(&mut realm, void_jsid.handle().into(), "call");
+            let result = report_cross_origin_denial::<D>(&mut realm, void_jsid.handle(), "call");
             return if EXCEPTION_TO_REJECTION {
                 exception_to_promise(cx.raw_cx(), args.rval(), can_gc)
             } else {

--- a/components/script_bindings/utils.rs
+++ b/components/script_bindings/utils.rs
@@ -223,9 +223,9 @@ pub(crate) fn find_enum_value<'a, T>(
     v: HandleValue,
     pairs: &'a [(&'static str, T)],
 ) -> Result<(Option<&'a T>, DOMString), ()> {
-    match ptr::NonNull::new(unsafe { ToString(cx.raw_cx(), v) }) {
+    match ptr::NonNull::new(unsafe { ToString(cx, v) }) {
         Some(jsstr) => {
-            let search = unsafe { jsstr_to_string(cx.raw_cx(), jsstr).into() };
+            let search = unsafe { jsstr_to_string(cx, jsstr) }.into();
             Ok((
                 pairs
                     .iter()


### PR DESCRIPTION
Companion PR to https://github.com/servo/mozjs/pull/718, switch to `jsstr_to_string_safe` and `latin1_to_string_safe` where possible.

Testing: It compiles
Part of #40600
