### PR TITLE
script: Move Validateable to JSContext and related

### DIFF
--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -956,7 +956,7 @@ pub(crate) fn upgrade_element(
         // We know this element is is form-associated, so we can use the implementation of
         // `FormControl` for HTMLElement, which makes that assumption.
         // Step 9.1: Reset the form owner of element
-        html_element.reset_form_owner(CanGc::from_cx(cx));
+        html_element.reset_form_owner(cx);
         if let Some(form) = html_element.form_owner() {
             // Even though the tree hasn't structurally mutated,
             // HTMLCollections need to be invalidated.

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -1101,14 +1101,24 @@ impl Document {
     }
 
     /// Remove any existing association between the provided id and any elements in this document.
-    pub(crate) fn unregister_element_id(&self, to_unregister: &Element, id: Atom, can_gc: CanGc) {
+    pub(crate) fn unregister_element_id(
+        &self,
+        cx: &mut js::context::JSContext,
+        to_unregister: &Element,
+        id: Atom,
+    ) {
         self.document_or_shadow_root
             .unregister_named_element(&self.id_map, to_unregister, &id);
-        self.reset_form_owner_for_listeners(&id, can_gc);
+        self.reset_form_owner_for_listeners(cx, &id);
     }
 
     /// Associate an element present in this document with the provided id.
-    pub(crate) fn register_element_id(&self, element: &Element, id: Atom, can_gc: CanGc) {
+    pub(crate) fn register_element_id(
+        &self,
+        cx: &mut js::context::JSContext,
+        element: &Element,
+        id: Atom,
+    ) {
         let root = self.GetDocumentElement().expect(
             "The element is in the document, so there must be a document \
              element.",
@@ -1119,7 +1129,7 @@ impl Document {
             &id,
             DomRoot::from_ref(root.upcast::<Node>()),
         );
-        self.reset_form_owner_for_listeners(&id, can_gc);
+        self.reset_form_owner_for_listeners(cx, &id);
     }
 
     /// Remove any existing association between the provided name and any elements in this document.
@@ -4207,14 +4217,14 @@ impl Document {
         self.fullscreen_element.set(element);
     }
 
-    fn reset_form_owner_for_listeners(&self, id: &Atom, can_gc: CanGc) {
+    fn reset_form_owner_for_listeners(&self, cx: &mut js::context::JSContext, id: &Atom) {
         let map = self.form_id_listener_map.borrow();
         if let Some(listeners) = map.get(id) {
             for listener in listeners {
                 listener
                     .as_maybe_form_control()
                     .expect("Element must be a form control")
-                    .reset_form_owner(can_gc);
+                    .reset_form_owner(cx);
             }
         }
     }

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -4440,7 +4440,7 @@ impl VirtualMethods for Element {
                                         CanGc::from_cx(cx),
                                     );
                                 } else {
-                                    doc.unregister_element_id(self, old_value, CanGc::from_cx(cx));
+                                    doc.unregister_element_id(cx, self, old_value);
                                 }
                             }
                             if value != atom!("") {
@@ -4451,7 +4451,7 @@ impl VirtualMethods for Element {
                                         CanGc::from_cx(cx),
                                     );
                                 } else {
-                                    doc.register_element_id(self, value, CanGc::from_cx(cx));
+                                    doc.register_element_id(cx, self, value);
                                 }
                             }
                         },
@@ -4464,7 +4464,7 @@ impl VirtualMethods for Element {
                                         CanGc::from_cx(cx),
                                     );
                                 } else {
-                                    doc.unregister_element_id(self, value, CanGc::from_cx(cx));
+                                    doc.unregister_element_id(cx, self, value);
                                 }
                             }
                         },
@@ -4580,7 +4580,7 @@ impl VirtualMethods for Element {
         }
 
         if let Some(f) = self.as_maybe_form_control() {
-            f.bind_form_control_to_tree(CanGc::from_cx(cx));
+            f.bind_form_control_to_tree(cx);
         }
 
         let doc = self.owner_document();
@@ -4597,7 +4597,7 @@ impl VirtualMethods for Element {
             if let Some(shadow_root) = self.containing_shadow_root() {
                 shadow_root.register_element_id(self, id.clone(), CanGc::from_cx(cx));
             } else {
-                doc.register_element_id(self, id.clone(), CanGc::from_cx(cx));
+                doc.register_element_id(cx, self, id.clone());
             }
         }
         if let Some(ref name) = self.name_attribute() &&
@@ -4614,7 +4614,7 @@ impl VirtualMethods for Element {
             // TODO: The valid state of ancestors might be wrong if the form control element
             // has a fieldset ancestor, for instance: `<form><fieldset><input>`,
             // if `<input>` is unbound, `<form><fieldset>` should trigger a call to `update_validity()`.
-            f.unbind_form_control_from_tree(CanGc::from_cx(cx));
+            f.unbind_form_control_from_tree(cx);
         }
 
         if !context.tree_is_in_a_document_tree && !context.tree_is_in_a_shadow_tree {
@@ -4635,7 +4635,7 @@ impl VirtualMethods for Element {
                     shadow_root.unregister_element_id(self, value.clone(), CanGc::from_cx(cx));
                 }
             } else {
-                doc.unregister_element_id(self, value.clone(), CanGc::from_cx(cx));
+                doc.unregister_element_id(cx, self, value.clone());
             }
         }
         if let Some(ref value) = self.name_attribute() &&
@@ -4844,19 +4844,18 @@ impl Element {
         }
     }
 
-    pub(crate) fn is_invalid(&self, needs_update: bool, can_gc: CanGc) -> bool {
+    pub(crate) fn is_invalid(&self, cx: &mut JSContext, needs_update: bool) -> bool {
         if let Some(validatable) = self.as_maybe_validatable() {
             if needs_update {
                 validatable
-                    .validity_state(can_gc)
-                    .perform_validation_and_update(ValidationFlags::all(), can_gc);
+                    .validity_state(cx)
+                    .perform_validation_and_update(cx, ValidationFlags::all());
             }
-            return validatable.is_instance_validatable() &&
-                !validatable.satisfies_constraints(can_gc);
+            return validatable.is_instance_validatable() && !validatable.satisfies_constraints(cx);
         }
 
         if let Some(internals) = self.get_element_internals() {
-            return internals.is_invalid(can_gc);
+            return internals.is_invalid(cx);
         }
         false
     }

--- a/components/script/dom/elementinternals.rs
+++ b/components/script/dom/elementinternals.rs
@@ -187,10 +187,10 @@ impl ElementInternals {
         }
     }
 
-    pub(crate) fn is_invalid(&self, can_gc: CanGc) -> bool {
+    pub(crate) fn is_invalid(&self, cx: &mut JSContext) -> bool {
         self.is_target_form_associated() &&
             self.is_instance_validatable() &&
-            !self.satisfies_constraints(can_gc)
+            !self.satisfies_constraints(cx)
     }
 
     pub(crate) fn custom_states_for_layout<'a>(&'a self) -> Option<LayoutDom<'a, CustomStateSet>> {
@@ -246,10 +246,10 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
     /// <https://html.spec.whatwg.org/multipage#dom-elementinternals-setvalidity>
     fn SetValidity(
         &self,
+        cx: &mut JSContext,
         flags: &ValidityStateFlags,
         message: Option<DOMString>,
         anchor: Option<&HTMLElement>,
-        can_gc: CanGc,
     ) -> ErrorResult {
         // Step 1. Let element be this's target element.
         // Step 2: If element is not a form-associated custom element, then throw a "NotSupportedError" DOMException.
@@ -271,8 +271,8 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
 
         // Step 4: For each entry `flag` → `value` of `flags`, set element's validity flag with the name
         // `flag` to `value`.
-        self.validity_state(can_gc).update_invalid_flags(bits);
-        self.validity_state(can_gc).update_pseudo_classes(can_gc);
+        self.validity_state(cx).update_invalid_flags(bits);
+        self.validity_state(cx).update_pseudo_classes(cx);
 
         // Step 5: Set element's validation message to the empty string if message is not given
         // or all of element's validity flags are false, or to message otherwise.
@@ -329,13 +329,13 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
     }
 
     /// <https://html.spec.whatwg.org/multipage#dom-elementinternals-validity>
-    fn GetValidity(&self, can_gc: CanGc) -> Fallible<DomRoot<ValidityState>> {
+    fn GetValidity(&self, cx: &mut JSContext) -> Fallible<DomRoot<ValidityState>> {
         if !self.is_target_form_associated() {
             return Err(Error::NotSupported(Some(
                 "The target element is not a form-associated custom element".to_owned(),
             )));
         }
-        Ok(self.validity_state(can_gc))
+        Ok(self.validity_state(cx))
     }
 
     /// <https://html.spec.whatwg.org/multipage#dom-elementinternals-labels>
@@ -413,13 +413,13 @@ impl Validatable for ElementInternals {
         self.target_element.upcast::<Element>()
     }
 
-    fn validity_state(&self, can_gc: CanGc) -> DomRoot<ValidityState> {
+    fn validity_state(&self, cx: &mut JSContext) -> DomRoot<ValidityState> {
         debug_assert!(self.is_target_form_associated());
         self.validity_state.or_init(|| {
             ValidityState::new(
+                cx,
                 &self.target_element.owner_window(),
                 self.target_element.upcast(),
-                can_gc,
             )
         })
     }

--- a/components/script/dom/html/htmlbuttonelement.rs
+++ b/components/script/dom/html/htmlbuttonelement.rs
@@ -205,8 +205,8 @@ impl HTMLButtonElementMethods<crate::DomTypeHolder> for HTMLButtonElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-validity>
-    fn Validity(&self, can_gc: CanGc) -> DomRoot<ValidityState> {
-        self.validity_state(can_gc)
+    fn Validity(&self, cx: &mut JSContext) -> DomRoot<ValidityState> {
+        self.validity_state(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-checkvalidity>
@@ -220,14 +220,13 @@ impl HTMLButtonElementMethods<crate::DomTypeHolder> for HTMLButtonElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-validationmessage>
-    fn ValidationMessage(&self) -> DOMString {
-        self.validation_message()
+    fn ValidationMessage(&self, cx: &mut JSContext) -> DOMString {
+        self.validation_message(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-setcustomvalidity>
     fn SetCustomValidity(&self, cx: &mut JSContext, error: DOMString) {
-        self.validity_state(CanGc::from_cx(cx))
-            .set_custom_error_message(error);
+        self.validity_state(cx).set_custom_error_message(cx, error);
     }
 }
 
@@ -263,7 +262,7 @@ impl HTMLButtonElement {
         })
     }
 
-    fn set_type(&self, value: DOMString, can_gc: CanGc) {
+    fn set_type(&self, cx: &mut JSContext, value: DOMString) {
         let value = match value.to_ascii_lowercase().as_str() {
             "reset" => ButtonType::Reset,
             "button" => ButtonType::Button,
@@ -280,8 +279,8 @@ impl HTMLButtonElement {
             },
         };
         self.button_type.set(value);
-        self.validity_state(can_gc)
-            .perform_validation_and_update(ValidationFlags::all(), can_gc);
+        self.validity_state(cx)
+            .perform_validation_and_update(cx, ValidationFlags::all());
     }
 
     fn command_for_element(&self) -> Option<DomRoot<Element>> {
@@ -386,24 +385,24 @@ impl VirtualMethods for HTMLButtonElement {
                         el.check_ancestors_disabled_state_for_form_control();
                     },
                 }
-                self.validity_state(CanGc::from_cx(cx))
-                    .perform_validation_and_update(ValidationFlags::all(), CanGc::from_cx(cx));
+                self.validity_state(cx)
+                    .perform_validation_and_update(cx, ValidationFlags::all());
             },
-            local_name!("type") => self.set_type(attr.to_dom_string(), CanGc::from_cx(cx)),
+            local_name!("type") => self.set_type(cx, attr.to_dom_string()),
             local_name!("command") => self.set_type(
+                cx,
                 self.upcast::<Element>()
                     .get_string_attribute(&local_name!("type")),
-                CanGc::from_cx(cx),
             ),
             local_name!("commandfor") => self.set_type(
+                cx,
                 self.upcast::<Element>()
                     .get_string_attribute(&local_name!("type")),
-                CanGc::from_cx(cx),
             ),
             local_name!("form") => {
-                self.form_attribute_mutated(mutation, CanGc::from_cx(cx));
-                self.validity_state(CanGc::from_cx(cx))
-                    .perform_validation_and_update(ValidationFlags::empty(), CanGc::from_cx(cx));
+                self.form_attribute_mutated(cx, mutation);
+                self.validity_state(cx)
+                    .perform_validation_and_update(cx, ValidationFlags::empty());
             },
             _ => {},
         }
@@ -453,9 +452,9 @@ impl Validatable for HTMLButtonElement {
         self.upcast()
     }
 
-    fn validity_state(&self, can_gc: CanGc) -> DomRoot<ValidityState> {
+    fn validity_state(&self, cx: &mut JSContext) -> DomRoot<ValidityState> {
         self.validity_state
-            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast(), can_gc))
+            .or_init(|| ValidityState::new(cx, &self.owner_window(), self.upcast()))
     }
 
     fn is_instance_validatable(&self) -> bool {

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -1213,7 +1213,7 @@ impl VirtualMethods for HTMLElement {
                 self.update_assigned_access_key();
             },
             (&local_name!("form"), mutation) if self.is_form_associated_custom_element() => {
-                self.form_attribute_mutated(mutation, CanGc::from_cx(cx));
+                self.form_attribute_mutated(cx, mutation);
             },
             // Adding a "disabled" attribute disables an enabled form element.
             (&local_name!("disabled"), AttributeMutation::Set(..))

--- a/components/script/dom/html/htmlfieldsetelement.rs
+++ b/components/script/dom/html/htmlfieldsetelement.rs
@@ -27,7 +27,6 @@ use crate::dom::node::{Node, NodeTraits};
 use crate::dom::validation::Validatable;
 use crate::dom::validitystate::ValidityState;
 use crate::dom::virtualmethods::VirtualMethods;
-use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 
 #[dom_struct]
@@ -72,12 +71,12 @@ impl HTMLFieldSetElement {
         )
     }
 
-    pub(crate) fn update_validity(&self, can_gc: CanGc) {
+    pub(crate) fn update_validity(&self, cx: &mut JSContext) {
         let has_invalid_child = self
             .upcast::<Node>()
             .traverse_preorder(ShadowIncluding::No)
             .flat_map(DomRoot::downcast::<Element>)
-            .any(|element| element.is_invalid(false, can_gc));
+            .any(|element| element.is_invalid(cx, false));
 
         self.upcast::<Element>()
             .set_state(ElementState::VALID, !has_invalid_child);
@@ -119,8 +118,8 @@ impl HTMLFieldSetElementMethods<crate::DomTypeHolder> for HTMLFieldSetElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-validity>
-    fn Validity(&self, can_gc: CanGc) -> DomRoot<ValidityState> {
-        self.validity_state(can_gc)
+    fn Validity(&self, cx: &mut JSContext) -> DomRoot<ValidityState> {
+        self.validity_state(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-checkvalidity>
@@ -134,13 +133,13 @@ impl HTMLFieldSetElementMethods<crate::DomTypeHolder> for HTMLFieldSetElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-validationmessage>
-    fn ValidationMessage(&self) -> DOMString {
-        self.validation_message()
+    fn ValidationMessage(&self, cx: &mut JSContext) -> DOMString {
+        self.validation_message(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-setcustomvalidity>
-    fn SetCustomValidity(&self, error: DOMString, can_gc: CanGc) {
-        self.validity_state(can_gc).set_custom_error_message(error);
+    fn SetCustomValidity(&self, cx: &mut JSContext, error: DOMString) {
+        self.validity_state(cx).set_custom_error_message(cx, error);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-fieldset-type>
@@ -248,7 +247,7 @@ impl VirtualMethods for HTMLFieldSetElement {
                 }
             },
             local_name!("form") => {
-                self.form_attribute_mutated(mutation, CanGc::from_cx(cx));
+                self.form_attribute_mutated(cx, mutation);
             },
             _ => {},
         }
@@ -274,9 +273,9 @@ impl Validatable for HTMLFieldSetElement {
         self.upcast()
     }
 
-    fn validity_state(&self, can_gc: CanGc) -> DomRoot<ValidityState> {
+    fn validity_state(&self, cx: &mut JSContext) -> DomRoot<ValidityState> {
         self.validity_state
-            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast(), can_gc))
+            .or_init(|| ValidityState::new(cx, &self.owner_window(), self.upcast()))
     }
 
     fn is_instance_validatable(&self) -> bool {

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -700,12 +700,12 @@ impl HTMLFormElement {
         self.owner_document().encoding()
     }
 
-    pub(crate) fn update_validity(&self, can_gc: CanGc) {
+    pub(crate) fn update_validity(&self, cx: &mut JSContext) {
         let is_any_invalid = self
             .controls
             .borrow()
             .iter()
-            .any(|control| control.is_invalid(false, can_gc));
+            .any(|control| control.is_invalid(cx, false));
 
         self.upcast::<Element>()
             .set_state(ElementState::VALID, !is_any_invalid);
@@ -1158,7 +1158,7 @@ impl HTMLFormElement {
 
         for elem in unhandled_invalid_controls {
             if let Some(validatable) = elem.as_maybe_validatable() {
-                error!("Validation error: {}", validatable.validation_message());
+                error!("Validation error: {}", validatable.validation_message(cx));
             }
             if first && let Some(html_elem) = elem.downcast::<HTMLElement>() {
                 // Step 3.1: User agents may focus one of those elements in the process,
@@ -1188,7 +1188,7 @@ impl HTMLFormElement {
             .iter()
             .filter_map(|field| {
                 if let Some(element) = field.downcast::<Element>() {
-                    if element.is_invalid(true, CanGc::from_cx(cx)) {
+                    if element.is_invalid(cx, true) {
                         Some(DomRoot::from_ref(element))
                     } else {
                         None
@@ -1390,7 +1390,7 @@ impl HTMLFormElement {
         self.marked_for_reset.set(false);
     }
 
-    fn add_control<T: ?Sized + FormControl>(&self, control: &T, can_gc: CanGc) {
+    fn add_control<T: ?Sized + FormControl>(&self, cx: &mut JSContext, control: &T) {
         {
             let root = self.upcast::<Element>().root_element();
             let root = root.upcast::<Node>();
@@ -1408,10 +1408,10 @@ impl HTMLFormElement {
                 controls.push(Dom::from_ref(control_element));
             }
         }
-        self.update_validity(can_gc);
+        self.update_validity(cx);
     }
 
-    fn remove_control<T: ?Sized + FormControl>(&self, control: &T, can_gc: CanGc) {
+    fn remove_control<T: ?Sized + FormControl>(&self, cx: &mut JSContext, control: &T) {
         {
             let control = control.to_element();
             let mut controls = self.controls.borrow_mut();
@@ -1427,7 +1427,7 @@ impl HTMLFormElement {
             let mut past_names_map = self.past_names_map.borrow_mut();
             past_names_map.0.retain(|_k, v| v.0 != control);
         }
-        self.update_validity(can_gc);
+        self.update_validity(cx);
     }
 }
 
@@ -1650,16 +1650,16 @@ pub(crate) trait FormControl: DomObject<ReflectorType = ()> + NodeTraits {
     // Part of step 12.
     // '..suppress the running of the reset the form owner algorithm
     // when the parser subsequently attempts to insert the element..'
-    fn set_form_owner_from_parser(&self, form: &HTMLFormElement, can_gc: CanGc) {
+    fn set_form_owner_from_parser(&self, cx: &mut JSContext, form: &HTMLFormElement) {
         let elem = self.to_element();
         let node = elem.upcast::<Node>();
         node.set_flag(NodeFlags::PARSER_ASSOCIATED_FORM_OWNER, true);
-        form.add_control(self, can_gc);
+        form.add_control(cx, self);
         self.set_form_owner(Some(form));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#reset-the-form-owner>
-    fn reset_form_owner(&self, can_gc: CanGc) {
+    fn reset_form_owner(&self, cx: &mut JSContext) {
         let elem = self.to_element();
         let node = elem.upcast::<Node>();
         let old_owner = self.form_owner();
@@ -1698,10 +1698,10 @@ pub(crate) trait FormControl: DomObject<ReflectorType = ()> + NodeTraits {
 
         if old_owner != new_owner {
             if let Some(o) = old_owner {
-                o.remove_control(self, can_gc);
+                o.remove_control(cx, self);
             }
             if let Some(ref new_owner) = new_owner {
-                new_owner.add_control(self, can_gc);
+                new_owner.add_control(cx, self);
             }
             // https://html.spec.whatwg.org/multipage/#custom-element-reactions:reset-the-form-owner
             if let Some(html_elem) = elem.downcast::<HTMLElement>() &&
@@ -1720,7 +1720,7 @@ pub(crate) trait FormControl: DomObject<ReflectorType = ()> + NodeTraits {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#association-of-controls-and-forms>
-    fn form_attribute_mutated(&self, mutation: AttributeMutation, can_gc: CanGc) {
+    fn form_attribute_mutated(&self, cx: &mut JSContext, mutation: AttributeMutation) {
         match mutation {
             AttributeMutation::Set(..) => {
                 self.register_if_necessary();
@@ -1730,7 +1730,7 @@ pub(crate) trait FormControl: DomObject<ReflectorType = ()> + NodeTraits {
             },
         }
 
-        self.reset_form_owner(can_gc);
+        self.reset_form_owner(cx);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#association-of-controls-and-forms>
@@ -1756,7 +1756,7 @@ pub(crate) trait FormControl: DomObject<ReflectorType = ()> + NodeTraits {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#association-of-controls-and-forms>
-    fn bind_form_control_to_tree(&self, can_gc: CanGc) {
+    fn bind_form_control_to_tree(&self, cx: &mut JSContext) {
         let elem = self.to_element();
         let node = elem.upcast::<Node>();
 
@@ -1769,14 +1769,14 @@ pub(crate) trait FormControl: DomObject<ReflectorType = ()> + NodeTraits {
 
         if !must_skip_reset {
             self.form_attribute_mutated(
+                cx,
                 AttributeMutation::Set(None, AttributeMutationReason::Directly),
-                can_gc,
             );
         }
     }
 
     /// <https://html.spec.whatwg.org/multipage/#association-of-controls-and-forms>
-    fn unbind_form_control_from_tree(&self, can_gc: CanGc) {
+    fn unbind_form_control_from_tree(&self, cx: &mut JSContext) {
         let elem = self.to_element();
         let has_form_attr = elem.has_attribute(&local_name!("form"));
         let same_subtree = self
@@ -1791,7 +1791,7 @@ pub(crate) trait FormControl: DomObject<ReflectorType = ()> + NodeTraits {
         // subtree) if it appears later in the tree order. Hence invoke
         // reset from here if this control has the form attribute set.
         if !same_subtree || (self.is_listed() && has_form_attr) {
-            self.reset_form_owner(can_gc);
+            self.reset_form_owner(cx);
         }
     }
 
@@ -1849,7 +1849,7 @@ pub(crate) trait FormControl: DomObject<ReflectorType = ()> + NodeTraits {
             .form_owner()
             .is_none_or(|form| self.to_element().is_in_same_home_subtree(&*form));
         if !same_subtree {
-            self.reset_form_owner(CanGc::from_cx(cx))
+            self.reset_form_owner(cx)
         }
     }
 
@@ -1880,7 +1880,7 @@ impl VirtualMethods for HTMLFormElement {
             control
                 .as_maybe_form_control()
                 .expect("Element must be a form control")
-                .reset_form_owner(CanGc::from_cx(cx));
+                .reset_form_owner(cx);
         }
     }
 

--- a/components/script/dom/html/htmllabelelement.rs
+++ b/components/script/dom/html/htmllabelelement.rs
@@ -25,7 +25,6 @@ use crate::dom::html::htmlformelement::{FormControl, FormControlElementHelpers, 
 use crate::dom::iterators::ShadowIncluding;
 use crate::dom::node::Node;
 use crate::dom::virtualmethods::VirtualMethods;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLLabelElement {
@@ -168,7 +167,7 @@ impl VirtualMethods for HTMLLabelElement {
             .unwrap()
             .attribute_mutated(cx, attr, mutation);
         if *attr.local_name() == local_name!("form") {
-            self.form_attribute_mutated(mutation, CanGc::from_cx(cx));
+            self.form_attribute_mutated(cx, mutation);
         }
     }
 }

--- a/components/script/dom/html/htmlobjectelement.rs
+++ b/components/script/dom/html/htmlobjectelement.rs
@@ -25,7 +25,6 @@ use crate::dom::node::{Node, NodeTraits};
 use crate::dom::validation::Validatable;
 use crate::dom::validitystate::ValidityState;
 use crate::dom::virtualmethods::VirtualMethods;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLObjectElement {
@@ -113,8 +112,8 @@ impl HTMLObjectElementMethods<crate::DomTypeHolder> for HTMLObjectElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-validity>
-    fn Validity(&self, can_gc: CanGc) -> DomRoot<ValidityState> {
-        self.validity_state(can_gc)
+    fn Validity(&self, cx: &mut JSContext) -> DomRoot<ValidityState> {
+        self.validity_state(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-checkvalidity>
@@ -128,13 +127,13 @@ impl HTMLObjectElementMethods<crate::DomTypeHolder> for HTMLObjectElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-validationmessage>
-    fn ValidationMessage(&self) -> DOMString {
-        self.validation_message()
+    fn ValidationMessage(&self, cx: &mut JSContext) -> DOMString {
+        self.validation_message(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-setcustomvalidity>
-    fn SetCustomValidity(&self, error: DOMString, can_gc: CanGc) {
-        self.validity_state(can_gc).set_custom_error_message(error);
+    fn SetCustomValidity(&self, cx: &mut JSContext, error: DOMString) {
+        self.validity_state(cx).set_custom_error_message(cx, error);
     }
 }
 
@@ -143,9 +142,9 @@ impl Validatable for HTMLObjectElement {
         self.upcast()
     }
 
-    fn validity_state(&self, can_gc: CanGc) -> DomRoot<ValidityState> {
+    fn validity_state(&self, cx: &mut JSContext) -> DomRoot<ValidityState> {
         self.validity_state
-            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast(), can_gc))
+            .or_init(|| ValidityState::new(cx, &self.owner_window(), self.upcast()))
     }
 
     fn is_instance_validatable(&self) -> bool {
@@ -175,7 +174,7 @@ impl VirtualMethods for HTMLObjectElement {
                 }
             },
             local_name!("form") => {
-                self.form_attribute_mutated(mutation, CanGc::from_cx(cx));
+                self.form_attribute_mutated(cx, mutation);
             },
             _ => {},
         }

--- a/components/script/dom/html/htmloptgroupelement.rs
+++ b/components/script/dom/html/htmloptgroupelement.rs
@@ -23,7 +23,6 @@ use crate::dom::node::{BindContext, Node, UnbindContext};
 use crate::dom::validation::Validatable;
 use crate::dom::validitystate::ValidationFlags;
 use crate::dom::virtualmethods::VirtualMethods;
-use crate::script_runtime::CanGc;
 
 /// <https://html.spec.whatwg.org/multipage/#htmloptgroupelement>
 #[dom_struct]
@@ -64,11 +63,11 @@ impl HTMLOptGroupElement {
         )
     }
 
-    fn update_select_validity(&self, can_gc: CanGc) {
+    fn update_select_validity(&self, cx: &mut JSContext) {
         if let Some(select) = self.owner_select_element() {
             select
-                .validity_state(can_gc)
-                .perform_validation_and_update(ValidationFlags::all(), can_gc);
+                .validity_state(cx)
+                .perform_validation_and_update(cx, ValidationFlags::all());
         }
     }
 
@@ -144,7 +143,7 @@ impl VirtualMethods for HTMLOptGroupElement {
             super_type.bind_to_tree(cx, context);
         }
 
-        self.update_select_validity(CanGc::from_cx(cx));
+        self.update_select_validity(cx);
     }
 
     fn unbind_from_tree(&self, cx: &mut js::context::JSContext, context: &UnbindContext) {
@@ -152,8 +151,8 @@ impl VirtualMethods for HTMLOptGroupElement {
 
         if let Some(select) = context.parent.downcast::<HTMLSelectElement>() {
             select
-                .validity_state(CanGc::from_cx(cx))
-                .perform_validation_and_update(ValidationFlags::all(), CanGc::from_cx(cx));
+                .validity_state(cx)
+                .perform_validation_and_update(cx, ValidationFlags::all());
         }
     }
 }

--- a/components/script/dom/html/htmloptionelement.rs
+++ b/components/script/dom/html/htmloptionelement.rs
@@ -40,7 +40,6 @@ use crate::dom::validation::Validatable;
 use crate::dom::validitystate::ValidationFlags;
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLOptionElement {
@@ -133,11 +132,11 @@ impl HTMLOptionElement {
         }
     }
 
-    fn update_select_validity(&self, can_gc: CanGc) {
+    fn update_select_validity(&self, cx: &mut JSContext) {
         if let Some(select) = self.owner_select_element() {
             select
-                .validity_state(can_gc)
-                .perform_validation_and_update(ValidationFlags::all(), can_gc);
+                .validity_state(cx)
+                .perform_validation_and_update(cx, ValidationFlags::all());
         }
     }
 
@@ -277,7 +276,7 @@ impl HTMLOptionElementMethods<crate::DomTypeHolder> for HTMLOptionElement {
 
         option.SetDefaultSelected(cx, default_selected);
         option.set_selectedness(selected);
-        option.update_select_validity(CanGc::from_cx(cx));
+        option.update_select_validity(cx);
         Ok(option)
     }
 
@@ -377,7 +376,7 @@ impl HTMLOptionElementMethods<crate::DomTypeHolder> for HTMLOptionElement {
         self.dirtiness.set(true);
         self.set_selectedness(selected);
         self.pick_if_selected_and_reset();
-        self.update_select_validity(CanGc::from_cx(cx));
+        self.update_select_validity(cx);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-option-index>
@@ -414,7 +413,7 @@ impl VirtualMethods for HTMLOptionElement {
                         el.check_parent_disabled_state_for_option();
                     },
                 }
-                self.update_select_validity(CanGc::from_cx(cx));
+                self.update_select_validity(cx);
             },
             local_name!("selected") => {
                 let mut selectedness_changed = false;
@@ -443,7 +442,7 @@ impl VirtualMethods for HTMLOptionElement {
                     }
                 }
 
-                self.update_select_validity(CanGc::from_cx(cx));
+                self.update_select_validity(cx);
             },
             local_name!("label") => {
                 // The label of the selected option is displayed inside the select element, so we need to repaint
@@ -465,7 +464,7 @@ impl VirtualMethods for HTMLOptionElement {
             .check_parent_disabled_state_for_option();
 
         self.pick_if_selected_and_reset();
-        self.update_select_validity(CanGc::from_cx(cx));
+        self.update_select_validity(cx);
     }
 
     fn unbind_from_tree(&self, cx: &mut js::context::JSContext, context: &UnbindContext) {
@@ -477,8 +476,8 @@ impl VirtualMethods for HTMLOptionElement {
             .find_map(DomRoot::downcast::<HTMLSelectElement>)
         {
             select
-                .validity_state(CanGc::from_cx(cx))
-                .perform_validation_and_update(ValidationFlags::all(), CanGc::from_cx(cx));
+                .validity_state(cx)
+                .perform_validation_and_update(cx, ValidationFlags::all());
             select.ask_for_reset();
         }
 
@@ -525,8 +524,8 @@ impl VirtualMethods for HTMLOptionElement {
                 .find_map(DomRoot::downcast::<HTMLSelectElement>)
             {
                 select
-                    .validity_state(CanGc::from_cx(cx))
-                    .perform_validation_and_update(ValidationFlags::all(), CanGc::from_cx(cx));
+                    .validity_state(cx)
+                    .perform_validation_and_update(cx, ValidationFlags::all());
                 select.ask_for_reset();
             }
 
@@ -540,6 +539,6 @@ impl VirtualMethods for HTMLOptionElement {
         element.check_parent_disabled_state_for_option();
 
         self.pick_if_selected_and_reset();
-        self.update_select_validity(CanGc::from_cx(cx));
+        self.update_select_validity(cx);
     }
 }

--- a/components/script/dom/html/htmloutputelement.rs
+++ b/components/script/dom/html/htmloutputelement.rs
@@ -129,8 +129,8 @@ impl HTMLOutputElementMethods<crate::DomTypeHolder> for HTMLOutputElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-validity>
-    fn Validity(&self, can_gc: CanGc) -> DomRoot<ValidityState> {
-        self.validity_state(can_gc)
+    fn Validity(&self, cx: &mut JSContext) -> DomRoot<ValidityState> {
+        self.validity_state(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-checkvalidity>
@@ -144,13 +144,13 @@ impl HTMLOutputElementMethods<crate::DomTypeHolder> for HTMLOutputElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-validationmessage>
-    fn ValidationMessage(&self) -> DOMString {
-        self.validation_message()
+    fn ValidationMessage(&self, cx: &mut JSContext) -> DOMString {
+        self.validation_message(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-setcustomvalidity>
-    fn SetCustomValidity(&self, error: DOMString, can_gc: CanGc) {
-        self.validity_state(can_gc).set_custom_error_message(error);
+    fn SetCustomValidity(&self, cx: &mut JSContext, error: DOMString) {
+        self.validity_state(cx).set_custom_error_message(cx, error);
     }
 }
 
@@ -169,7 +169,7 @@ impl VirtualMethods for HTMLOutputElement {
             .unwrap()
             .attribute_mutated(cx, attr, mutation);
         if attr.local_name() == &local_name!("form") {
-            self.form_attribute_mutated(mutation, CanGc::from_cx(cx));
+            self.form_attribute_mutated(cx, mutation);
         }
     }
 }
@@ -193,9 +193,9 @@ impl Validatable for HTMLOutputElement {
         self.upcast()
     }
 
-    fn validity_state(&self, can_gc: CanGc) -> DomRoot<ValidityState> {
+    fn validity_state(&self, cx: &mut JSContext) -> DomRoot<ValidityState> {
         self.validity_state
-            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast(), can_gc))
+            .or_init(|| ValidityState::new(cx, &self.owner_window(), self.upcast()))
     }
 
     fn is_instance_validatable(&self) -> bool {

--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -721,8 +721,8 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
             opt.set_selectedness(false);
         }
 
-        self.validity_state(CanGc::from_cx(cx))
-            .perform_validation_and_update(ValidationFlags::VALUE_MISSING, CanGc::from_cx(cx));
+        self.validity_state(cx)
+            .perform_validation_and_update(cx, ValidationFlags::VALUE_MISSING);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-select-selectedindex>
@@ -767,8 +767,8 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-validity>
-    fn Validity(&self, can_gc: CanGc) -> DomRoot<ValidityState> {
-        self.validity_state(can_gc)
+    fn Validity(&self, cx: &mut JSContext) -> DomRoot<ValidityState> {
+        self.validity_state(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-checkvalidity>
@@ -782,13 +782,13 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-validationmessage>
-    fn ValidationMessage(&self) -> DOMString {
-        self.validation_message()
+    fn ValidationMessage(&self, cx: &mut JSContext) -> DOMString {
+        self.validation_message(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-setcustomvalidity>
-    fn SetCustomValidity(&self, error: DOMString, can_gc: CanGc) {
-        self.validity_state(can_gc).set_custom_error_message(error);
+    fn SetCustomValidity(&self, cx: &mut JSContext, error: DOMString) {
+        self.validity_state(cx).set_custom_error_message(cx, error);
     }
 }
 
@@ -812,11 +812,8 @@ impl VirtualMethods for HTMLSelectElement {
                 self.multiple_attribute_mutated(cx, mutation);
             },
             local_name!("required") => {
-                self.validity_state(CanGc::from_cx(cx))
-                    .perform_validation_and_update(
-                        ValidationFlags::VALUE_MISSING,
-                        CanGc::from_cx(cx),
-                    );
+                self.validity_state(cx)
+                    .perform_validation_and_update(cx, ValidationFlags::VALUE_MISSING);
             },
             local_name!("disabled") => {
                 let el = self.upcast::<Element>();
@@ -832,14 +829,11 @@ impl VirtualMethods for HTMLSelectElement {
                     },
                 }
 
-                self.validity_state(CanGc::from_cx(cx))
-                    .perform_validation_and_update(
-                        ValidationFlags::VALUE_MISSING,
-                        CanGc::from_cx(cx),
-                    );
+                self.validity_state(cx)
+                    .perform_validation_and_update(cx, ValidationFlags::VALUE_MISSING);
             },
             local_name!("form") => {
-                self.form_attribute_mutated(mutation, CanGc::from_cx(cx));
+                self.form_attribute_mutated(cx, mutation);
             },
             _ => {},
         }
@@ -927,9 +921,9 @@ impl Validatable for HTMLSelectElement {
         self.upcast()
     }
 
-    fn validity_state(&self, can_gc: CanGc) -> DomRoot<ValidityState> {
+    fn validity_state(&self, cx: &mut JSContext) -> DomRoot<ValidityState> {
         self.validity_state
-            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast(), can_gc))
+            .or_init(|| ValidityState::new(cx, &self.owner_window(), self.upcast()))
     }
 
     fn is_instance_validatable(&self) -> bool {
@@ -940,8 +934,8 @@ impl Validatable for HTMLSelectElement {
 
     fn perform_validation(
         &self,
+        _cx: &mut JSContext,
         validate_flags: ValidationFlags,
-        _can_gc: CanGc,
     ) -> ValidationFlags {
         let mut failed_flags = ValidationFlags::empty();
 

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -198,8 +198,8 @@ impl HTMLTextAreaElement {
     }
 
     fn handle_text_content_changed(&self, cx: &mut JSContext) {
-        self.validity_state(CanGc::from_cx(cx))
-            .perform_validation_and_update(ValidationFlags::all(), CanGc::from_cx(cx));
+        self.validity_state(cx)
+            .perform_validation_and_update(cx, ValidationFlags::all());
 
         let placeholder_shown =
             self.textinput.borrow().is_empty() && !self.placeholder.borrow().is_empty();
@@ -539,8 +539,8 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-validity>
-    fn Validity(&self, can_gc: CanGc) -> DomRoot<ValidityState> {
-        self.validity_state(can_gc)
+    fn Validity(&self, cx: &mut JSContext) -> DomRoot<ValidityState> {
+        self.validity_state(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-checkvalidity>
@@ -554,13 +554,13 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-validationmessage>
-    fn ValidationMessage(&self) -> DOMString {
-        self.validation_message()
+    fn ValidationMessage(&self, cx: &mut JSContext) -> DOMString {
+        self.validation_message(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-setcustomvalidity>
-    fn SetCustomValidity(&self, error: DOMString, can_gc: CanGc) {
-        self.validity_state(can_gc).set_custom_error_message(error);
+    fn SetCustomValidity(&self, cx: &mut JSContext, error: DOMString) {
+        self.validity_state(cx).set_custom_error_message(cx, error);
     }
 }
 
@@ -694,13 +694,13 @@ impl VirtualMethods for HTMLTextAreaElement {
                 }
             },
             local_name!("form") => {
-                self.form_attribute_mutated(mutation, CanGc::from_cx(cx));
+                self.form_attribute_mutated(cx, mutation);
             },
             _ => {},
         }
 
-        self.validity_state(CanGc::from_cx(cx))
-            .perform_validation_and_update(ValidationFlags::all(), CanGc::from_cx(cx));
+        self.validity_state(cx)
+            .perform_validation_and_update(cx, ValidationFlags::all());
     }
 
     fn bind_to_tree(&self, cx: &mut JSContext, context: &BindContext) {
@@ -745,8 +745,8 @@ impl VirtualMethods for HTMLTextAreaElement {
             el.check_disabled_attribute();
         }
 
-        self.validity_state(CanGc::from_cx(cx))
-            .perform_validation_and_update(ValidationFlags::all(), CanGc::from_cx(cx));
+        self.validity_state(cx)
+            .perform_validation_and_update(cx, ValidationFlags::all());
     }
 
     // The cloning steps for textarea elements must propagate the raw value
@@ -767,8 +767,8 @@ impl VirtualMethods for HTMLTextAreaElement {
             let mut textinput = el.textinput.borrow_mut();
             textinput.set_content(self.textinput.borrow().get_content());
         }
-        el.validity_state(CanGc::from_cx(cx))
-            .perform_validation_and_update(ValidationFlags::all(), CanGc::from_cx(cx));
+        el.validity_state(cx)
+            .perform_validation_and_update(cx, ValidationFlags::all());
     }
 
     fn children_changed(&self, cx: &mut JSContext, mutation: &ChildrenMutation) {
@@ -845,8 +845,8 @@ impl VirtualMethods for HTMLTextAreaElement {
             self.handle_focus_event(event);
         }
 
-        self.validity_state(CanGc::from_cx(cx))
-            .perform_validation_and_update(ValidationFlags::all(), CanGc::from_cx(cx));
+        self.validity_state(cx)
+            .perform_validation_and_update(cx, ValidationFlags::all());
 
         if let Some(super_type) = self.super_type() {
             super_type.handle_event(cx, event);
@@ -880,9 +880,9 @@ impl Validatable for HTMLTextAreaElement {
         self.upcast()
     }
 
-    fn validity_state(&self, can_gc: CanGc) -> DomRoot<ValidityState> {
+    fn validity_state(&self, cx: &mut JSContext) -> DomRoot<ValidityState> {
         self.validity_state
-            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast(), can_gc))
+            .or_init(|| ValidityState::new(cx, &self.owner_window(), self.upcast()))
     }
 
     fn is_instance_validatable(&self) -> bool {
@@ -896,8 +896,8 @@ impl Validatable for HTMLTextAreaElement {
 
     fn perform_validation(
         &self,
+        _cx: &mut JSContext,
         validate_flags: ValidationFlags,
-        _can_gc: CanGc,
     ) -> ValidationFlags {
         let mut failed_flags = ValidationFlags::empty();
 

--- a/components/script/dom/html/input_element/color_input_type.rs
+++ b/components/script/dom/html/input_element/color_input_type.rs
@@ -11,7 +11,6 @@ use markup5ever::QualName;
 use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::HTMLInputElementBinding::HTMLInputElementMethods;
 use script_bindings::root::{Dom, DomRoot};
-use script_bindings::script_runtime::CanGc;
 use style::color::{AbsoluteColor, ColorFlags, ColorSpace};
 use style::selector_parser::PseudoElement;
 use style::stylesheets::CssRuleType;
@@ -252,10 +251,10 @@ impl SpecificInputType for ColorInputType {
 
     fn unbind_from_tree(
         &self,
+        _cx: &mut JSContext,
         input: &HTMLInputElement,
         _form_owner: Option<DomRoot<HTMLFormElement>>,
         _context: &UnbindContext,
-        _can_gc: CanGc,
     ) {
         input
             .owner_document()

--- a/components/script/dom/html/input_element/input_type.rs
+++ b/components/script/dom/html/input_element/input_type.rs
@@ -6,7 +6,6 @@ use js::context::JSContext;
 use script_bindings::codegen::GenericBindings::HTMLInputElementBinding::HTMLInputElementMethods;
 use script_bindings::domstring::DOMString;
 use script_bindings::root::DomRoot;
-use script_bindings::script_runtime::CanGc;
 use stylo_atoms::Atom;
 use time::OffsetDateTime;
 
@@ -355,10 +354,10 @@ pub(crate) trait SpecificInputType {
 
     fn unbind_from_tree(
         &self,
+        _cx: &mut JSContext,
         _input: &HTMLInputElement,
         _form_owner: Option<DomRoot<HTMLFormElement>>,
         _context: &UnbindContext,
-        _can_gc: CanGc,
     ) {
     }
 }

--- a/components/script/dom/html/input_element/mod.rs
+++ b/components/script/dom/html/input_element/mod.rs
@@ -1562,7 +1562,7 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-validity>
     fn Validity(&self, cx: &mut JSContext) -> DomRoot<ValidityState> {
-        self.validity_state(CanGc::from_cx(cx))
+        self.validity_state(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-checkvalidity>
@@ -1576,14 +1576,13 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-validationmessage>
-    fn ValidationMessage(&self) -> DOMString {
-        self.validation_message()
+    fn ValidationMessage(&self, cx: &mut JSContext) -> DOMString {
+        self.validation_message(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-setcustomvalidity>
     fn SetCustomValidity(&self, cx: &mut JSContext, error: DOMString) {
-        self.validity_state(CanGc::from_cx(cx))
-            .set_custom_error_message(error);
+        self.validity_state(cx).set_custom_error_message(cx, error);
     }
 }
 
@@ -1896,8 +1895,8 @@ impl HTMLInputElement {
                 perform_radio_group_validation(cx, self, self.radio_group_name().as_ref())
             },
             _ => {
-                self.validity_state(CanGc::from_cx(cx))
-                    .perform_validation_and_update(ValidationFlags::all(), CanGc::from_cx(cx));
+                self.validity_state(cx)
+                    .perform_validation_and_update(cx, ValidationFlags::all());
             },
         }
     }
@@ -2195,7 +2194,7 @@ impl VirtualMethods for HTMLInputElement {
                 }
             },
             local_name!("form") => {
-                self.form_attribute_mutated(mutation, CanGc::from_cx(cx));
+                self.form_attribute_mutated(cx, mutation);
             },
             _ => {
                 self.input_type()
@@ -2260,15 +2259,12 @@ impl VirtualMethods for HTMLInputElement {
             el.check_disabled_attribute();
         }
 
-        self.input_type().as_specific().unbind_from_tree(
-            self,
-            form_owner,
-            context,
-            CanGc::from_cx(cx),
-        );
+        self.input_type()
+            .as_specific()
+            .unbind_from_tree(cx, self, form_owner, context);
 
-        self.validity_state(CanGc::from_cx(cx))
-            .perform_validation_and_update(ValidationFlags::all(), CanGc::from_cx(cx));
+        self.validity_state(cx)
+            .perform_validation_and_update(cx, ValidationFlags::all());
     }
 
     // This represents behavior for which the UIEvents spec and the
@@ -2396,9 +2392,9 @@ impl Validatable for HTMLInputElement {
         self.upcast()
     }
 
-    fn validity_state(&self, can_gc: CanGc) -> DomRoot<ValidityState> {
+    fn validity_state(&self, cx: &mut JSContext) -> DomRoot<ValidityState> {
         self.validity_state
-            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast(), can_gc))
+            .or_init(|| ValidityState::new(cx, &self.owner_window(), self.upcast()))
     }
 
     fn is_instance_validatable(&self) -> bool {
@@ -2420,8 +2416,8 @@ impl Validatable for HTMLInputElement {
 
     fn perform_validation(
         &self,
+        cx: &mut JSContext,
         validate_flags: ValidationFlags,
-        can_gc: CanGc,
     ) -> ValidationFlags {
         let mut failed_flags = ValidationFlags::empty();
         let value = self.Value();
@@ -2439,7 +2435,7 @@ impl Validatable for HTMLInputElement {
         }
 
         if validate_flags.contains(ValidationFlags::PATTERN_MISMATCH) &&
-            self.suffers_from_pattern_mismatch(&value, can_gc)
+            self.suffers_from_pattern_mismatch(&value, CanGc::from_cx(cx))
         {
             failed_flags.insert(ValidationFlags::PATTERN_MISMATCH);
         }

--- a/components/script/dom/html/input_element/radio_input_type.rs
+++ b/components/script/dom/html/input_element/radio_input_type.rs
@@ -8,7 +8,6 @@ use script_bindings::codegen::GenericBindings::HTMLInputElementBinding::HTMLInpu
 use script_bindings::codegen::GenericBindings::NodeBinding::NodeMethods;
 use script_bindings::domstring::DOMString;
 use script_bindings::root::DomRoot;
-use script_bindings::script_runtime::CanGc;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::NodeBinding::GetRootNodeOptions;
@@ -177,10 +176,10 @@ impl SpecificInputType for RadioInputType {
 
     fn unbind_from_tree(
         &self,
+        cx: &mut JSContext,
         input: &HTMLInputElement,
         form_owner: Option<DomRoot<HTMLFormElement>>,
         context: &UnbindContext,
-        can_gc: CanGc,
     ) {
         let root = context.parent.GetRootNode(&GetRootNodeOptions::empty());
         for r in radio_group_iter(
@@ -189,8 +188,8 @@ impl SpecificInputType for RadioInputType {
             form_owner.as_deref(),
             &root,
         ) {
-            r.validity_state(can_gc)
-                .perform_validation_and_update(ValidationFlags::all(), can_gc);
+            r.validity_state(cx)
+                .perform_validation_and_update(cx, ValidationFlags::all());
         }
     }
 }
@@ -211,8 +210,8 @@ pub(crate) fn perform_radio_group_validation(
         .GetRootNode(&GetRootNodeOptions::empty());
     let form = elem.form_owner();
     for r in radio_group_iter(elem, group, form.as_deref(), &root) {
-        r.validity_state(CanGc::from_cx(cx))
-            .perform_validation_and_update(ValidationFlags::all(), CanGc::from_cx(cx));
+        r.validity_state(cx)
+            .perform_validation_and_update(cx, ValidationFlags::all());
     }
 }
 

--- a/components/script/dom/servoparser/async_html.rs
+++ b/components/script/dom/servoparser/async_html.rs
@@ -43,7 +43,6 @@ use crate::dom::servoparser::{
     ElementAttribute, ParsingAlgorithm, attach_declarative_shadow_inner, create_element_for_token,
 };
 use crate::dom::virtualmethods::vtable_for;
-use crate::script_runtime::CanGc;
 
 type ParseNodeId = usize;
 
@@ -600,7 +599,7 @@ impl Tokenizer {
                 let control = elem.and_then(|e| e.as_maybe_form_control());
 
                 if let Some(control) = control {
-                    control.set_form_owner_from_parser(&form, CanGc::from_cx(cx));
+                    control.set_form_owner_from_parser(cx, &form);
                 }
             },
             ParseOperation::Pop { node } => {

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1761,12 +1761,16 @@ impl TreeSink for Sink {
         Dom::from_ref(pi.upcast())
     }
 
+    #[expect(unsafe_code)]
     fn associate_with_form(
         &self,
         target: &Dom<Node>,
         form: &Dom<Node>,
         nodes: (&Dom<Node>, Option<&Dom<Node>>),
     ) {
+        // TODO: https://github.com/servo/servo/issues/42839
+        let mut cx = unsafe { temp_cx() };
+        let cx = &mut cx;
         let (element, prev_element) = nodes;
         let tree_node = prev_element.map_or(element, |prev| {
             if self.has_parent_node(element) {
@@ -1787,7 +1791,7 @@ impl TreeSink for Sink {
         let control = elem.and_then(|e| e.as_maybe_form_control());
 
         if let Some(control) = control {
-            control.set_form_owner_from_parser(&form, CanGc::deprecated_note());
+            control.set_form_owner_from_parser(cx, &form);
         }
     }
 

--- a/components/script/dom/validation.rs
+++ b/components/script/dom/validation.rs
@@ -14,14 +14,13 @@ use crate::dom::html::htmldatalistelement::HTMLDataListElement;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::Node;
 use crate::dom::validitystate::{ValidationFlags, ValidityState};
-use crate::script_runtime::CanGc;
 
 /// Trait for elements with constraint validation support
 pub(crate) trait Validatable {
     fn as_element(&self) -> &Element;
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-validity>
-    fn validity_state(&self, can_gc: CanGc) -> DomRoot<ValidityState>;
+    fn validity_state(&self, cx: &mut JSContext) -> DomRoot<ValidityState>;
 
     /// <https://html.spec.whatwg.org/multipage/#candidate-for-constraint-validation>
     fn is_instance_validatable(&self) -> bool;
@@ -29,20 +28,20 @@ pub(crate) trait Validatable {
     // Check if element satisfies its constraints, excluding custom errors
     fn perform_validation(
         &self,
+        _cx: &mut JSContext,
         _validate_flags: ValidationFlags,
-        _can_gc: CanGc,
     ) -> ValidationFlags {
         ValidationFlags::empty()
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-fv-valid>
-    fn satisfies_constraints(&self, can_gc: CanGc) -> bool {
-        self.validity_state(can_gc).invalid_flags().is_empty()
+    fn satisfies_constraints(&self, cx: &mut JSContext) -> bool {
+        self.validity_state(cx).invalid_flags().is_empty()
     }
 
     /// <https://html.spec.whatwg.org/multipage/#check-validity-steps>
     fn check_validity(&self, cx: &mut JSContext) -> bool {
-        if self.is_instance_validatable() && !self.satisfies_constraints(CanGc::from_cx(cx)) {
+        if self.is_instance_validatable() && !self.satisfies_constraints(cx) {
             self.as_element()
                 .upcast::<EventTarget>()
                 .fire_cancelable_event(cx, atom!("invalid"));
@@ -59,7 +58,7 @@ pub(crate) trait Validatable {
             return true;
         }
 
-        if self.satisfies_constraints(CanGc::from_cx(cx)) {
+        if self.satisfies_constraints(cx) {
             return true;
         }
 
@@ -73,10 +72,10 @@ pub(crate) trait Validatable {
         // Step 1.2. If `report` is true, for the element,
         // report the problem, run focusing steps, scroll into view.
         if report {
-            let flags = self.validity_state(CanGc::from_cx(cx)).invalid_flags();
+            let flags = self.validity_state(cx).invalid_flags();
             println!(
                 "Validation error: {}",
-                validation_message_for_flags(&self.validity_state(CanGc::from_cx(cx)), flags)
+                validation_message_for_flags(&self.validity_state(cx), flags)
             );
             if let Some(html_elem) = self.as_element().downcast::<HTMLElement>() {
                 // Run focusing steps and scroll into view.
@@ -89,12 +88,10 @@ pub(crate) trait Validatable {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-validationmessage>
-    fn validation_message(&self) -> DOMString {
+    fn validation_message(&self, cx: &mut JSContext) -> DOMString {
         if self.is_instance_validatable() {
-            let flags = self
-                .validity_state(CanGc::deprecated_note())
-                .invalid_flags();
-            validation_message_for_flags(&self.validity_state(CanGc::deprecated_note()), flags)
+            let flags = self.validity_state(cx).invalid_flags();
+            validation_message_for_flags(&self.validity_state(cx), flags)
         } else {
             DOMString::new()
         }

--- a/components/script/dom/validitystate.rs
+++ b/components/script/dom/validitystate.rs
@@ -8,8 +8,9 @@ use std::fmt;
 use bitflags::bitflags;
 use dom_struct::dom_struct;
 use itertools::Itertools;
+use js::context::JSContext;
 use script_bindings::cell::{DomRefCell, Ref};
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use stylo_dom::ElementState;
 
 use super::bindings::codegen::Bindings::ElementInternalsBinding::ValidityStateFlags;
@@ -22,7 +23,6 @@ use crate::dom::html::htmlfieldsetelement::HTMLFieldSetElement;
 use crate::dom::html::htmlformelement::FormControlElementHelpers;
 use crate::dom::node::Node;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 /// <https://html.spec.whatwg.org/multipage/#validity-states>
 #[derive(Clone, Copy, JSTraceable, MallocSizeOf)]
@@ -91,12 +91,12 @@ impl ValidityState {
         }
     }
 
-    pub(crate) fn new(window: &Window, element: &Element, can_gc: CanGc) -> DomRoot<ValidityState> {
-        reflect_dom_object(
-            Box::new(ValidityState::new_inherited(element)),
-            window,
-            can_gc,
-        )
+    pub(crate) fn new(
+        cx: &mut JSContext,
+        window: &Window,
+        element: &Element,
+    ) -> DomRoot<ValidityState> {
+        reflect_dom_object_with_cx(Box::new(ValidityState::new_inherited(element)), window, cx)
     }
 
     // https://html.spec.whatwg.org/multipage/#custom-validity-error-message
@@ -105,9 +105,9 @@ impl ValidityState {
     }
 
     // https://html.spec.whatwg.org/multipage/#custom-validity-error-message
-    pub(crate) fn set_custom_error_message(&self, error: DOMString) {
+    pub(crate) fn set_custom_error_message(&self, cx: &mut JSContext, error: DOMString) {
         *self.custom_error_message.borrow_mut() = error;
-        self.perform_validation_and_update(ValidationFlags::CUSTOM_ERROR, CanGc::deprecated_note());
+        self.perform_validation_and_update(cx, ValidationFlags::CUSTOM_ERROR);
     }
 
     /// Given a set of [ValidationFlags], recalculate their value by performing
@@ -117,14 +117,14 @@ impl ValidityState {
     /// to reflect the existance of a custom error.
     pub(crate) fn perform_validation_and_update(
         &self,
+        cx: &mut JSContext,
         update_flags: ValidationFlags,
-        can_gc: CanGc,
     ) {
         let mut invalid_flags = self.invalid_flags.get();
         invalid_flags.remove(update_flags);
 
         if let Some(validatable) = self.element.as_maybe_validatable() {
-            let new_flags = validatable.perform_validation(update_flags, can_gc);
+            let new_flags = validatable.perform_validation(cx, update_flags);
             invalid_flags.insert(new_flags);
         }
 
@@ -136,7 +136,7 @@ impl ValidityState {
         }
 
         self.invalid_flags.set(invalid_flags);
-        self.update_pseudo_classes(can_gc);
+        self.update_pseudo_classes(cx);
     }
 
     pub(crate) fn update_invalid_flags(&self, update_flags: ValidationFlags) {
@@ -147,7 +147,7 @@ impl ValidityState {
         self.invalid_flags.get()
     }
 
-    pub(crate) fn update_pseudo_classes(&self, can_gc: CanGc) {
+    pub(crate) fn update_pseudo_classes(&self, cx: &mut JSContext) {
         if self.element.is_instance_validatable() {
             let is_valid = self.invalid_flags.get().is_empty();
             self.element.set_state(ElementState::VALID, is_valid);
@@ -160,7 +160,7 @@ impl ValidityState {
         if let Some(form_control) = self.element.as_maybe_form_control() &&
             let Some(form_owner) = form_control.form_owner()
         {
-            form_owner.update_validity(can_gc);
+            form_owner.update_validity(cx);
         }
 
         if let Some(fieldset) = self
@@ -169,7 +169,7 @@ impl ValidityState {
             .ancestors()
             .find_map(DomRoot::downcast::<HTMLFieldSetElement>)
         {
-            fieldset.update_validity(can_gc);
+            fieldset.update_validity(cx);
         }
     }
 }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -336,8 +336,8 @@ DOMInterfaces = {
 },
 
 'ElementInternals': {
-    'canGc': ['GetLabels', 'GetValidity', 'SetValidity', 'States'],
-    'cx': ['CheckValidity', 'ReportValidity'],
+    'canGc': ['GetLabels', 'States'],
+    'cx': ['CheckValidity', 'GetValidity', 'ReportValidity', 'SetValidity'],
 },
 
 'EventSource': {
@@ -461,8 +461,7 @@ DOMInterfaces = {
 },
 
 'HTMLButtonElement': {
-    'canGc': ['Validity'],
-    'cx': ['CheckValidity', 'ReportValidity', 'SetCustomValidity'],
+    'cx': ['CheckValidity', 'ReportValidity', 'SetCustomValidity', 'Validity', 'ValidationMessage'],
     'implicitCxSetters': True,
 },
 
@@ -505,8 +504,7 @@ DOMInterfaces = {
 },
 
 'HTMLFieldSetElement': {
-    'canGc': ['SetCustomValidity', 'Validity'],
-    'cx': ['CheckValidity', 'Elements', 'ReportValidity'],
+    'cx': ['CheckValidity', 'Elements', 'ReportValidity', 'SetCustomValidity', 'Validity', 'ValidationMessage'],
 },
 
 'HTMLFontElement': {
@@ -539,7 +537,7 @@ DOMInterfaces = {
 },
 
 'HTMLInputElement': {
-    'cx': ['CheckValidity', 'GetLabels', 'ReportValidity', 'SetChecked', 'SetCustomValidity', 'SetValue', 'SetValueAsNumber', 'SetValueAsDate', 'StepUp', 'StepDown', 'Validity'],
+    'cx': ['CheckValidity', 'GetLabels', 'ReportValidity', 'SetChecked', 'SetCustomValidity', 'SetValue', 'SetValueAsNumber', 'SetValueAsDate', 'StepUp', 'StepDown', 'Validity', 'ValidationMessage'],
 },
 
 'HTMLLIElement': {
@@ -568,8 +566,7 @@ DOMInterfaces = {
 },
 
 'HTMLObjectElement': {
-    'canGc': ['SetCustomValidity', 'Validity'],
-    'cx': ['CheckValidity', 'ReportValidity'],
+    'cx': ['CheckValidity', 'ReportValidity', 'SetCustomValidity', 'Validity', 'ValidationMessage'],
 },
 
 'HTMLOptionElement': {
@@ -582,8 +579,7 @@ DOMInterfaces = {
 },
 
 'HTMLOutputElement': {
-    'canGc': ['SetCustomValidity', 'Validity'],
-    'cx': ['CheckValidity', 'ReportValidity', 'SetDefaultValue', 'SetValue'],
+    'cx': ['CheckValidity', 'ReportValidity', 'SetCustomValidity', 'SetDefaultValue', 'SetValue', 'Validity', 'ValidationMessage'],
 },
 
 'HTMLPreElement': {
@@ -599,8 +595,7 @@ DOMInterfaces = {
 },
 
 'HTMLSelectElement': {
-    'canGc': ['SetCustomValidity', 'Validity'],
-    'cx': ['Add', 'CheckValidity', 'IndexedSetter', 'Remove', 'Remove_', 'ReportValidity', 'SelectedOptions', 'SetLength', 'SetSelectedIndex', 'SetValue'],
+    'cx': ['Add', 'CheckValidity', 'IndexedSetter', 'Remove', 'Remove_', 'ReportValidity', 'SelectedOptions',  'SetCustomValidity', 'SetLength', 'SetSelectedIndex', 'SetValue','Validity', 'ValidationMessage'],
 },
 
 'HTMLSlotElement': {
@@ -649,8 +644,7 @@ DOMInterfaces = {
 },
 
 'HTMLTextAreaElement': {
-    'canGc': ['SetCustomValidity', 'Validity'],
-    'cx': ['CheckValidity', 'ReportValidity', 'SetDefaultValue', 'SetValue'],
+    'cx': ['CheckValidity', 'ReportValidity', 'SetDefaultValue', 'SetValue', 'SetCustomValidity', 'Validity', 'ValidationMessage'],
 },
 
 'HTMLTitleElement': {


### PR DESCRIPTION
This is mostly a mechanical move of can_gc to JSContext for Validateable and methods spawning out from there.

This adds one workaround usage in servoparser::associate_with_form with temp_cx().

Testing: Compilation is the test.
