### PR TITLE
image: Add avif support optionally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,6 +694,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "av-data"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fca67ba5d317924c02180c576157afd54babe48a76ebc66ce6d34bb8ba08308e"
+dependencies = [
+ "byte-slice-cast",
+ "bytes",
+ "num-derive",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "av-scenechange"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -867,6 +880,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "bitreader"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "886559b1e163d56c765bc3a985febb4eee8009f625244511d8ee3c432e08c066"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1841,6 +1863,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
+name = "dav1d"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee89cb860616069c67520dcd66cacdb900b57c799f634a0eb6d91f6e2a82b61"
+dependencies = [
+ "av-data",
+ "bitflags 2.11.1",
+ "dav1d-sys",
+ "static_assertions",
+]
+
+[[package]]
+name = "dav1d-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c91aea6668645415331133ed6f8ddf0e7f40160cd97a12d59e68716a58704b"
+dependencies = [
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "dbus"
 version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2454,6 +2498,15 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fallible_collections"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88c69768c0a15262df21899142bc6df9b9b823546d4b4b9a7bc2d6c448ec6fd"
+dependencies = [
+ "hashbrown 0.13.2",
+]
 
 [[package]]
 name = "fastrand"
@@ -3548,6 +3601,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -4331,10 +4393,12 @@ dependencies = [
  "bytemuck",
  "byteorder-lite",
  "color_quant",
+ "dav1d",
  "exr",
  "gif",
  "image-webp",
  "moxcms",
+ "mp4parse",
  "num-traits",
  "png 0.18.1",
  "ravif",
@@ -5122,6 +5186,20 @@ dependencies = [
  "libz-sys",
  "tar",
  "walkdir",
+]
+
+[[package]]
+name = "mp4parse"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63a35203d3c6ce92d5251c77520acb2e57108c88728695aa883f70023624c570"
+dependencies = [
+ "bitreader",
+ "byteorder",
+ "fallible_collections",
+ "log",
+ "num-traits",
+ "static_assertions",
 ]
 
 [[package]]
@@ -7573,6 +7651,7 @@ dependencies = [
  "servo-net-traits",
  "servo-paint",
  "servo-paint-api",
+ "servo-pixels",
  "servo-profile",
  "servo-profile-traits",
  "servo-script",

--- a/components/pixels/Cargo.toml
+++ b/components/pixels/Cargo.toml
@@ -13,6 +13,9 @@ description.workspace = true
 name = "pixels"
 path = "lib.rs"
 
+[features]
+avif = ["image/avif-native"]
+
 [dependencies]
 euclid = { workspace = true }
 image = { workspace = true }

--- a/components/pixels/lib.rs
+++ b/components/pixels/lib.rs
@@ -556,6 +556,10 @@ pub fn load_from_memory(buffer: &[u8], cors_status: CorsStatus) -> Option<Raster
                 GenericImageDecoder::Ico(image_decoder) => {
                     decode_static_image(cors_status, *image_decoder)
                 },
+                #[cfg(feature = "avif")]
+                GenericImageDecoder::Avif(image_decoder) => {
+                    decode_static_image(cors_status, image_decoder)
+                },
             }
         },
     }
@@ -575,6 +579,8 @@ pub fn detect_image_format(buffer: &[u8]) -> Result<ImageFormat, &str> {
         Ok(ImageFormat::Bmp)
     } else if is_ico(buffer) {
         Ok(ImageFormat::Ico)
+    } else if is_avif(buffer) {
+        Ok(ImageFormat::Avif)
     } else {
         Err("Image Format Not Supported")
     }
@@ -697,6 +703,18 @@ fn is_ico(buffer: &[u8]) -> bool {
     buffer.starts_with(&[0x00, 0x00, 0x01, 0x00])
 }
 
+#[allow(unused)]
+fn is_avif(buffer: &[u8]) -> bool {
+    #[cfg(feature = "avif")]
+    {
+        buffer.starts_with(b"avif")
+    }
+    #[cfg(not(feature = "avif"))]
+    {
+        false
+    }
+}
+
 fn is_webp(buffer: &[u8]) -> bool {
     // https://developers.google.com/speed/webp/docs/riff_container
     // First four bytes: `RIFF`, header size 12 bytes
@@ -719,6 +737,8 @@ enum GenericImageDecoder<R: std::io::BufRead + std::io::Seek> {
     Jpeg(Box<jpeg::JpegDecoder<R>>),
     Bmp(Box<bmp::BmpDecoder<R>>),
     Ico(Box<ico::IcoDecoder<R>>),
+    #[cfg(feature = "avif")]
+    Avif(Box<image::codecs::avif::AvifDecoder<R>>),
 }
 
 fn make_decoder(
@@ -736,6 +756,10 @@ fn make_decoder(
         ImageFormat::Jpeg => GenericImageDecoder::Jpeg(Box::new(jpeg::JpegDecoder::new(reader)?)),
         ImageFormat::Bmp => GenericImageDecoder::Bmp(Box::new(bmp::BmpDecoder::new(reader)?)),
         ImageFormat::Ico => GenericImageDecoder::Ico(Box::new(ico::IcoDecoder::new(reader)?)),
+        #[cfg(feature = "avif")]
+        ImageFormat::Avif => {
+            GenericImageDecoder::Avif(Box::new(image::codecs::avif::AvifDecoder::new(reader)?))
+        },
         _ => {
             return Err(ImageError::Unsupported(
                 ImageFormatHint::Exact(format).into(),

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -19,6 +19,8 @@ crate-type = ["rlib"]
 # Note: Servoshell does not use the default features of servo, so you also
 # need to add features that should be default to ports/servoshell/Cargo.toml
 default = ["baked-in-resources", "clipboard", "js_jit"]
+# Allow to decode avif image format. Needs dav1d library.
+avif = ["pixels/avif"]
 background_hang_monitor = ["servo-background-hang-monitor/sampler"]
 # This is slightly magical, but this will also work on ohos, where `servo-default-resource` is not added,
 # which makes `baked-in-resources a no-op (as intended) on ohos (and perhaps other platforms in the future).
@@ -107,6 +109,7 @@ net_traits = { workspace = true }
 paint = { workspace = true }
 paint_api = { workspace = true }
 parking_lot = { workspace = true }
+pixels = { workspace = true }
 profile = { workspace = true }
 profile_traits = { workspace = true }
 rustc-hash = { workspace = true }


### PR DESCRIPTION
Support avif decoding optionally, depending on dav1d.

Currently disabled by default in servoshell because I am not sure how to make sure to not enable it on platforms that do not have dav1d.

Testing: *Describe the new automated tests that cover this change or explain why it doesn't require tests.*
Fixes: *Link to an issue this pull request fixes or remove this line if there is no issue.*
