### PR TITLE
net/script: Reuse allocation in create_request_body_with_content

### DIFF
--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -659,7 +659,7 @@ fn test_load_doesnt_send_request_body_on_any_redirect() {
     let (pre_server, pre_url) = make_server(pre_handler);
 
     let content = "Body on POST!";
-    let request_body = create_request_body_with_content(content);
+    let request_body = create_request_body_with_content(content.to_string());
 
     let request = RequestBuilder::new(None, pre_url.clone(), Referrer::NoReferrer)
         .body(Some(request_body))
@@ -976,7 +976,7 @@ fn test_load_sets_content_length_to_length_of_request_body() {
         };
     let (server, url) = make_server(handler);
 
-    let request_body = create_request_body_with_content(content);
+    let request_body = create_request_body_with_content(content.to_string());
 
     let request = RequestBuilder::new(None, url.clone(), Referrer::NoReferrer)
         .method(Method::POST)

--- a/components/script/dom/reporting/reportingendpoint.rs
+++ b/components/script/dom/reporting/reportingendpoint.rs
@@ -251,7 +251,7 @@ impl SendReportsToEndpoints for GlobalScope {
         // Step 3. Return the byte sequence resulting from executing serialize an
         // Infra value to JSON bytes on collection.
         Some(create_request_body_with_content(
-            &serde_json::to_string(&report_body).unwrap_or("".to_owned()),
+            serde_json::to_string(&report_body).unwrap_or_default(),
         ))
     }
 }

--- a/components/script/dom/security/cspviolationreporttask.rs
+++ b/components/script/dom/security/cspviolationreporttask.rs
@@ -74,7 +74,7 @@ impl CSPViolationReportTask {
         };
         // Step 4. Return the result of serialize an infra value to JSON bytes given «[ "csp-report" → body ]».
         Some(create_request_body_with_content(
-            &serde_json::to_string(&report_body).unwrap_or("".to_owned()),
+            serde_json::to_string(&report_body).unwrap_or_default(),
         ))
     }
 

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -1286,8 +1286,8 @@ pub fn convert_header_names_to_sorted_lowercase_set(
     ordered_set.into_iter().cloned().collect()
 }
 
-pub fn create_request_body_with_content(content: &str) -> RequestBody {
-    let content_bytes = GenericSharedMemory::from_bytes(content.as_bytes());
+pub fn create_request_body_with_content(content: String) -> RequestBody {
+    let content_bytes = GenericSharedMemory::from_vec(content.into_bytes());
     let content_len = content_bytes.len();
 
     let (chunk_request_sender, chunk_request_receiver) = ipc::channel().unwrap();


### PR DESCRIPTION
Follow-up to #45224.

Both real usages already used an owned String, which is dropped
afterwards, so we can cheaply convert it to GenericSharedMemory,
reusing the String allocation.
The tests used `str`, so adapted those to `to_string`.

If future code needs slices, then we could add a trait for `content`
which optimizes the creation of GenericSharedMemory based on
borrowed/owned + multiprocess mode. But since currently this is not
the case, just requiring String is simpler.


Testing: No behavior change
