### PR TITLE
script: Directly modify `IFrameCollection` on tree changes

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -2721,19 +2721,13 @@ impl Document {
     /// A reference to the [`IFrameCollection`] of this [`Document`], holding information about
     /// `<iframe>`s found within it.
     pub(crate) fn iframes(&self) -> Ref<'_, IFrameCollection> {
-        self.iframes.borrow_mut().validate(self);
         self.iframes.borrow()
     }
 
     /// A mutable reference to the [`IFrameCollection`] of this [`Document`], holding information about
     /// `<iframe>`s found within it.
     pub(crate) fn iframes_mut(&self) -> RefMut<'_, IFrameCollection> {
-        self.iframes.borrow_mut().validate(self);
         self.iframes.borrow_mut()
-    }
-
-    pub(crate) fn invalidate_iframes_collection(&self) {
-        self.iframes.borrow_mut().invalidate();
     }
 
     pub(crate) fn get_dom_interactive(&self) -> Option<CrossProcessInstant> {

--- a/components/script/dom/execcommand/contenteditable/text.rs
+++ b/components/script/dom/execcommand/contenteditable/text.rs
@@ -11,6 +11,7 @@ use crate::dom::characterdata::CharacterData;
 use crate::dom::element::Element;
 use crate::dom::html::htmlbrelement::HTMLBRElement;
 use crate::dom::html::htmlimageelement::HTMLImageElement;
+use crate::dom::iterators::ShadowIncluding;
 use crate::dom::node::Node;
 use crate::dom::text::Text;
 
@@ -110,7 +111,7 @@ impl Text {
         // Step 9. Let reference be node.
         // Step 10. While reference is a descendant of ancestor:
         // Step 10.1. Let reference be the node after it in tree order, or null if there is no such node.
-        for reference in node.following_nodes(&resolved_ancestor) {
+        for reference in node.following_nodes(&resolved_ancestor, ShadowIncluding::No) {
             // Step 10.2. If reference is a block node or a br, return true.
             if reference.is_block_node() || reference.is::<HTMLBRElement>() {
                 return true;

--- a/components/script/dom/html/htmlcollection.rs
+++ b/components/script/dom/html/htmlcollection.rs
@@ -17,6 +17,7 @@ use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::trace::JSTraceable;
 use crate::dom::element::Element;
+use crate::dom::iterators::ShadowIncluding;
 use crate::dom::node::{Node, NodeTraits};
 use crate::dom::window::Window;
 
@@ -368,7 +369,7 @@ impl HTMLCollection {
         filter: &'a (dyn CollectionFilter + 'static),
     ) -> impl Iterator<Item = DomRoot<Element>> + 'a {
         after
-            .following_nodes(&self.root)
+            .following_nodes(&self.root, ShadowIncluding::No)
             .filter_map(DomRoot::downcast)
             .filter(move |element| filter.filter(element, &self.root))
     }

--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -1220,20 +1220,24 @@ impl VirtualMethods for HTMLIFrameElement {
     }
 
     fn bind_to_tree(&self, cx: &mut JSContext, context: &BindContext) {
-        if let Some(s) = self.super_type() {
-            s.bind_to_tree(cx, context);
+        if let Some(super_type) = self.super_type() {
+            super_type.bind_to_tree(cx, context);
         }
-        self.owner_document().invalidate_iframes_collection();
+
+        self.owner_document().iframes_mut().add(self);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-iframe-element:html-element-removing-steps>
     fn unbind_from_tree(&self, cx: &mut JSContext, context: &UnbindContext) {
-        self.super_type().unwrap().unbind_from_tree(cx, context);
+        if let Some(super_type) = self.super_type() {
+            super_type.unbind_from_tree(cx, context);
+        }
 
-        // The iframe HTML element removing steps, given removedNode, are to destroy a child navigable given removedNode
+        // The iframe HTML element removing steps, given removedNode, are to destroy a child
+        // navigable given removedNode
         self.destroy_child_navigable(cx);
 
-        self.owner_document().invalidate_iframes_collection();
+        self.owner_document().iframes_mut().remove(self);
     }
 }
 

--- a/components/script/dom/node/iterators.rs
+++ b/components/script/dom/node/iterators.rs
@@ -24,11 +24,20 @@ pub(crate) enum ShadowIncluding {
 pub(crate) struct FollowingNodeIterator {
     current: Option<DomRoot<Node>>,
     root: DomRoot<Node>,
+    shadow_including: ShadowIncluding,
 }
 
 impl FollowingNodeIterator {
-    pub(crate) fn new(current: Option<DomRoot<Node>>, root: DomRoot<Node>) -> Self {
-        FollowingNodeIterator { current, root }
+    pub(crate) fn new(
+        current: Option<DomRoot<Node>>,
+        root: DomRoot<Node>,
+        shadow_including: ShadowIncluding,
+    ) -> Self {
+        FollowingNodeIterator {
+            current,
+            root,
+            shadow_including,
+        }
     }
 }
 
@@ -50,7 +59,7 @@ impl FollowingNodeIterator {
             return current.GetNextSibling();
         }
 
-        for ancestor in current.inclusive_ancestors(ShadowIncluding::No) {
+        for ancestor in current.inclusive_ancestors(self.shadow_including) {
             if self.root == ancestor {
                 break;
             }

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -1010,8 +1010,16 @@ impl Node {
         SimpleNodeIterator::new(self.GetPreviousSibling(), |n| n.GetPreviousSibling())
     }
 
-    pub(crate) fn following_nodes(&self, root: &Node) -> FollowingNodeIterator {
-        FollowingNodeIterator::new(Some(DomRoot::from_ref(self)), DomRoot::from_ref(root))
+    pub(crate) fn following_nodes(
+        &self,
+        root: &Node,
+        shadow_including: ShadowIncluding,
+    ) -> FollowingNodeIterator {
+        FollowingNodeIterator::new(
+            Some(DomRoot::from_ref(self)),
+            DomRoot::from_ref(root),
+            shadow_including,
+        )
     }
 
     pub(crate) fn preceding_nodes(&self, root: &Node) -> PrecedingNodeIterator {
@@ -3470,14 +3478,19 @@ impl Node {
     }
 
     /// Compares `other` with `self` in [tree order](https://dom.spec.whatwg.org/#concept-tree-order).
-    fn compare_dom_tree_position(&self, other: &Node, common_ancestor: &Node) -> Ordering {
+    pub(crate) fn compare_dom_tree_position(
+        &self,
+        other: &Node,
+        common_ancestor: &Node,
+        shadow_including: ShadowIncluding,
+    ) -> Ordering {
         debug_assert!(
-            self.inclusive_ancestors(ShadowIncluding::No)
+            self.inclusive_ancestors(shadow_including)
                 .any(|ancestor| &*ancestor == common_ancestor)
         );
         debug_assert!(
             other
-                .inclusive_ancestors(ShadowIncluding::No)
+                .inclusive_ancestors(shadow_including)
                 .any(|ancestor| &*ancestor == common_ancestor)
         );
 
@@ -3493,11 +3506,11 @@ impl Node {
         }
 
         let my_ancestors: Vec<_> = self
-            .inclusive_ancestors(ShadowIncluding::No)
+            .inclusive_ancestors(shadow_including)
             .take_while(|ancestor| &**ancestor != common_ancestor)
             .collect();
         let other_ancestors: Vec<_> = other
-            .inclusive_ancestors(ShadowIncluding::No)
+            .inclusive_ancestors(shadow_including)
             .take_while(|ancestor| &**ancestor != common_ancestor)
             .collect();
 
@@ -4876,9 +4889,11 @@ where
     /// * any time an element is moved within the tree, it is removed from this array and re-inserted
     fn insert_pre_order(&mut self, node: &T, tree_root: &Node) {
         let Err(insertion_index) = self.binary_search_by(|candidate| {
-            candidate
-                .upcast()
-                .compare_dom_tree_position(node.upcast(), tree_root)
+            candidate.upcast().compare_dom_tree_position(
+                node.upcast(),
+                tree_root,
+                ShadowIncluding::No,
+            )
         }) else {
             // The element is already in the vector. We assume that users of this method generally
             // expect no duplicates, so there's nothing more to do.

--- a/components/script/dom/node/nodeiterator.rs
+++ b/components/script/dom/node/nodeiterator.rs
@@ -16,6 +16,7 @@ use crate::dom::bindings::codegen::Bindings::NodeIteratorBinding::NodeIteratorMe
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::root::{Dom, DomRoot, MutDom};
 use crate::dom::document::Document;
+use crate::dom::iterators::ShadowIncluding;
 use crate::dom::node::Node;
 use crate::script_runtime::CanGc;
 
@@ -129,7 +130,7 @@ impl NodeIteratorMethods<crate::DomTypeHolder> for NodeIterator {
         }
 
         // Step 3-1.
-        for following_node in node.following_nodes(&self.root_node) {
+        for following_node in node.following_nodes(&self.root_node, ShadowIncluding::No) {
             // Step 3-2.
             let result = self.accept_node(cx, &following_node)?;
 

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -346,7 +346,7 @@ impl Range {
         let document = start.owner_doc();
         let end_clone = end.clone();
         start
-            .following_nodes(document.upcast::<Node>())
+            .following_nodes(document.upcast::<Node>(), ShadowIncluding::No)
             .take_while(move |node| node != &end)
             .chain(iter::once(end_clone))
             .flat_map(move |node| node.border_boxes())
@@ -1008,7 +1008,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
         rooted_vec!(let mut contained_children);
         let ancestor = self.CommonAncestorContainer();
 
-        let mut iter = start_node.following_nodes(&ancestor);
+        let mut iter = start_node.following_nodes(&ancestor, ShadowIncluding::No);
 
         let mut next = iter.next();
         while let Some(child) = next {
@@ -1155,7 +1155,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
         // in tree order, to string.
         let ancestor = self.CommonAncestorContainer();
         let iter = start_node
-            .following_nodes(&ancestor)
+            .following_nodes(&ancestor, ShadowIncluding::No)
             .filter_map(DomRoot::downcast::<Text>);
 
         for child in iter {

--- a/components/script/iframe_collection.rs
+++ b/components/script/iframe_collection.rs
@@ -7,17 +7,17 @@ use std::default::Default;
 use embedder_traits::ViewportDetails;
 use layout_api::IFrameSizes;
 use paint_api::PinchZoomInfos;
-use rustc_hash::FxHashMap;
 use script_bindings::script_runtime::CanGc;
 use servo_base::id::BrowsingContextId;
 use servo_constellation_traits::{IFrameSizeMsg, ScriptToConstellationMessage, WindowSizeType};
 
+use crate::dom::NodeTraits;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::html::htmliframeelement::HTMLIFrameElement;
 use crate::dom::iterators::ShadowIncluding;
 use crate::dom::node::Node;
-use crate::dom::types::{Document, Window};
+use crate::dom::types::Window;
 use crate::script_thread::with_script_thread;
 
 #[derive(JSTraceable, MallocSizeOf)]
@@ -31,59 +31,57 @@ pub(crate) struct IFrame {
 #[derive(Default, JSTraceable, MallocSizeOf)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct IFrameCollection {
-    /// The `<iframe>`s in the collection.
+    /// The `<iframe>`s in the collection. These are kept in DOM tree order to ensure that
+    /// requestAnimationFrame callbacks respect that order.
     iframes: Vec<IFrame>,
-    /// When true, the collection will need to be rebuilt.
-    invalid: bool,
 }
 
 impl IFrameCollection {
     pub(crate) fn new() -> Self {
         Self {
-            iframes: vec![],
-            invalid: true,
+            iframes: Default::default(),
         }
     }
 
-    pub(crate) fn invalidate(&mut self) {
-        self.invalid = true;
-    }
+    pub(crate) fn add(&mut self, iframe_element: &HTMLIFrameElement) {
+        let iframe_node = iframe_element.upcast::<Node>();
 
-    /// Validate that the collection is up-to-date with the given [`Document`]. If it isn't up-to-date
-    /// rebuild it.
-    pub(crate) fn validate(&mut self, document: &Document) {
-        if !self.invalid {
-            return;
-        }
-        let document_node = DomRoot::from_ref(document.upcast::<Node>());
+        // During `moveBefore`, nodes are attached to the tree again without detaching
+        // them in order to preserve state. Here we remove any pre-existing entry for
+        // this iframe element from the collection and preserve its old size.
+        let size = self.remove(iframe_element);
 
-        // Preserve any old sizes, but only for `<iframe>`s that already have a
-        // BrowsingContextId and a set size.
-        let mut old_sizes: FxHashMap<_, _> = self
-            .iframes
-            .iter()
-            .filter_map(
-                |iframe| match (iframe.element.browsing_context_id(), iframe.size) {
-                    (Some(browsing_context_id), Some(size)) => Some((browsing_context_id, size)),
-                    _ => None,
-                },
+        // Look forward for the next `<iframe>` in the document in order to find the new
+        // insertion point in the DOM-ordered list of frames. This optimizes for the parser
+        // case where the `<iframe>` is likely being inserted at the end of the DOM and there
+        // are very few subsequent nodes.
+        let insertion_index = iframe_node
+            .following_nodes(
+                iframe_element.owner_document().upcast::<Node>(),
+                ShadowIncluding::Yes,
             )
-            .collect();
-
-        self.iframes = document_node
-            .traverse_preorder(ShadowIncluding::Yes)
-            .filter_map(DomRoot::downcast::<HTMLIFrameElement>)
-            .map(|element| {
-                let size = element
-                    .browsing_context_id()
-                    .and_then(|browsing_context_id| old_sizes.remove(&browsing_context_id));
-                IFrame {
-                    element: element.as_traced(),
-                    size,
-                }
+            .find_map(DomRoot::downcast::<HTMLIFrameElement>)
+            .and_then(|following_iframe| {
+                self.iframes
+                    .iter()
+                    .position(|iframe| *iframe.element == *following_iframe)
             })
-            .collect();
-        self.invalid = false;
+            .unwrap_or(self.iframes.len());
+
+        self.iframes.insert(
+            insertion_index,
+            IFrame {
+                element: Dom::from_ref(iframe_element),
+                size,
+            },
+        );
+    }
+
+    pub(crate) fn remove(&mut self, iframe_element: &HTMLIFrameElement) -> Option<ViewportDetails> {
+        self.iframes
+            .iter()
+            .position(|iframe| &*iframe.element == iframe_element)
+            .and_then(|index| self.iframes.remove(index).size)
     }
 
     pub(crate) fn get(&self, browsing_context_id: BrowsingContextId) -> Option<&IFrame> {

--- a/components/script/xpath.rs
+++ b/components/script/xpath.rs
@@ -120,11 +120,11 @@ impl xpath::Node for XPathWrapper<DomRoot<Node>> {
         let owner_document = self.0.owner_document();
         let next_non_descendant_node = self
             .0
-            .following_nodes(owner_document.upcast())
+            .following_nodes(owner_document.upcast(), ShadowIncluding::No)
             .next_skipping_children();
         let following_nodes = next_non_descendant_node
             .clone()
-            .map(|node| node.following_nodes(owner_document.upcast()))
+            .map(|node| node.following_nodes(owner_document.upcast(), ShadowIncluding::No))
             .into_iter()
             .flatten();
         next_non_descendant_node


### PR DESCRIPTION
Instead of walking the entire tree every time an `<iframe>` is attached
to the DOM, just walk forward from its insertion point to find the
subsequent `<iframe>`. Then add the new `<iframe>` before that
`<iframe>` in the list. This optimizes the case of parsing, where there
are few or no DOM elements after a freshly added `<iframe>`.

In order to do this the `FollowingNodeIterator` must gain a mode where
it traverses shadow roots (an `<iframe>` might be inside a shadow root).

In my profiling of the test case from #38289 this seems to reduce the
time that `Window::get_iframe_viewport_details_if_known` takes during
loading and showing the page from 55.8% to 37.7%.

Testing: This should not change observable behavior, so is covered by existing tests.
Fixes: Part of #38289.
