### PR TITLE
codegen: Add check for weakreferencable hierarchy and fixup the hierarchy

### DIFF
--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1004,6 +1004,7 @@ DOMInterfaces = {
 'WebGL2RenderingContext': {
     'canGc': ['MakeXRCompatible'],
     'additionalTraits': ['crate::interfaces::WebGL2RenderingContextHelpers'],
+    'weakReferenceable': True,
 },
 
 'WebGLShader': {

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -9292,6 +9292,7 @@ class GlobalGenRoots():
         allprotos = []
         topTypes = []
         hierarchy = defaultdict(list)
+        weak_referenceable: set[str] = {d.name for d in descriptors if d.weakReferenceable}
         for descriptor in descriptors:
             name = descriptor.name
             chain = descriptor.prototypeChain
@@ -9317,6 +9318,11 @@ class GlobalGenRoots():
             if downcast:
                 assert descriptor.interface.parent is not None
                 hierarchy[descriptor.interface.parent.identifier.name].append(name)
+                if descriptor.interface.parent.identifier.name in weak_referenceable and not descriptor.weakReferenceable:
+                    raise Exception(f"Interface {name} derives from "
+                                    f"{descriptor.interface.parent.identifier.name}, "
+                                    f"which is weak referenceable, so {name} must "
+                                    f"also be weak referenceable.")
 
         typeIdCode = []
 


### PR DESCRIPTION
The check does not actually catch problem from https://github.com/servo/servo/issues/45167, because this one is not part of standard webidl hierarchy. For it we should actually start using Inline attribute as written in the comments somewhere (although I am not sure reading the rest of codegen code I am not sure it does what we want)
Testing: *Describe the new automated tests that cover this change or explain why it doesn't require tests.*
Fixes: *Link to an issue this pull request fixes or remove this line if there is no issue.*
