### PR TITLE
script: Remove final usages of `CanGc` in `contenteditable/`

### DIFF
--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -963,12 +963,12 @@ impl Element {
 
     pub(crate) fn ensure_contenteditable_selection_range(
         &self,
+        cx: &mut JSContext,
         document: &Document,
-        can_gc: CanGc,
     ) -> DomRoot<Range> {
         self.ensure_rare_data()
             .contenteditable_selection_range
-            .or_init(|| Range::new_with_doc(document, None, can_gc))
+            .or_init(|| Range::new_with_doc(document, None, CanGc::from_cx(cx)))
     }
 
     /// <https://drafts.csswg.org/cssom-view/#scrolling-events>

--- a/components/script/dom/event/inputevent.rs
+++ b/components/script/dom/event/inputevent.rs
@@ -5,8 +5,9 @@
 use dom_struct::dom_struct;
 use embedder_traits::Cursor;
 use euclid::Point2D;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use style::Atom;
 use style_traits::CSSPixel;
 
@@ -20,7 +21,6 @@ use crate::dom::node::Node;
 use crate::dom::staticrange::StaticRange;
 use crate::dom::uievent::UIEvent;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct InputEvent {
@@ -33,6 +33,7 @@ pub(crate) struct InputEvent {
 impl InputEvent {
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         event_type: Atom,
@@ -43,9 +44,8 @@ impl InputEvent {
         data: Option<DOMString>,
         is_composing: bool,
         input_type: DOMString,
-        can_gc: CanGc,
     ) -> DomRoot<InputEvent> {
-        let event = reflect_dom_object_with_proto(
+        let event = reflect_dom_object_with_proto_and_cx(
             Box::new(InputEvent {
                 uievent: UIEvent::new_inherited(),
                 data,
@@ -54,7 +54,7 @@ impl InputEvent {
             }),
             window,
             proto,
-            can_gc,
+            cx,
         );
         event
             .uievent
@@ -66,13 +66,14 @@ impl InputEvent {
 impl InputEventMethods<crate::DomTypeHolder> for InputEvent {
     /// <https://w3c.github.io/uievents/#dom-inputevent-inputevent>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         event_type: DOMString,
         init: &InputEventBinding::InputEventInit,
     ) -> Fallible<DomRoot<InputEvent>> {
         let event = InputEvent::new(
+            cx,
             window,
             proto,
             event_type.into(),
@@ -83,7 +84,6 @@ impl InputEventMethods<crate::DomTypeHolder> for InputEvent {
             init.data.clone(),
             init.isComposing,
             init.inputType.clone(),
-            can_gc,
         );
         Ok(event)
     }

--- a/components/script/dom/execcommand/contenteditable/htmlelement.rs
+++ b/components/script/dom/execcommand/contenteditable/htmlelement.rs
@@ -23,7 +23,6 @@ use crate::dom::html::htmlfontelement::HTMLFontElement;
 use crate::dom::iterators::ShadowIncluding;
 use crate::dom::node::node::{Node, NodeTraits};
 use crate::dom::text::Text;
-use crate::script_runtime::CanGc;
 
 impl HTMLElement {
     pub(crate) fn local_name(&self) -> &str {
@@ -184,7 +183,7 @@ impl HTMLElement {
         };
         let range = self
             .upcast::<Element>()
-            .ensure_contenteditable_selection_range(&document, CanGc::from_cx(cx));
+            .ensure_contenteditable_selection_range(cx, &document);
         // If the current range is already associated with this contenteditable
         // element, then we shouldn't do anything. This is important when focus
         // is lost and regained, but selection was changed beforehand. In that

--- a/components/script/dom/execcommand/execcommands.rs
+++ b/components/script/dom/execcommand/execcommands.rs
@@ -18,7 +18,6 @@ use crate::dom::execcommand::commands::fontsize::maybe_normalize_pixels;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::Node;
 use crate::dom::selection::Selection;
-use crate::script_runtime::CanGc;
 
 /// <https://w3c.github.io/editing/docs/execCommand/#miscellaneous-commands>
 fn is_command_listed_in_miscellaneous_section(command_name: CommandName) -> bool {
@@ -251,6 +250,7 @@ impl DocumentExecCommandSupport for Document {
             // Step 4.2. Fire an event named "beforeinput" at affected editing host using InputEvent,
             // with its bubbles and cancelable attributes initialized to true, and its data attribute initialized to null
             let event = InputEvent::new(
+                cx,
                 window,
                 None,
                 atom!("beforeinput"),
@@ -261,7 +261,6 @@ impl DocumentExecCommandSupport for Document {
                 None,
                 false,
                 "".into(),
-                CanGc::from_cx(cx),
             );
             let event = event.upcast::<Event>();
             // Step 4.3. If the value returned by the previous step is false, return false.
@@ -298,6 +297,7 @@ impl DocumentExecCommandSupport for Document {
         // inputType attribute initialized to the mapped value of command, and its data attribute initialized to null.
         if let Some(affected_editing_host) = affected_editing_host {
             let event = InputEvent::new(
+                cx,
                 window,
                 None,
                 atom!("input"),
@@ -308,7 +308,6 @@ impl DocumentExecCommandSupport for Document {
                 None,
                 false,
                 mapped_value_of_command(command),
-                CanGc::from_cx(cx),
             );
             let event = event.upcast::<Event>();
             event.set_trusted(true);

--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -31,7 +31,6 @@ use crate::dom::mouseevent::MouseEvent;
 use crate::dom::node::{Node, NodeTraits};
 use crate::dom::types::{ClipboardEvent, UIEvent};
 use crate::drag_data_store::Kind;
-use crate::script_runtime::CanGc;
 
 #[derive(Clone, Copy, PartialEq)]
 pub enum Selection {
@@ -1146,6 +1145,7 @@ impl<T: ClipboardProvider> TextInput<T> {
                 let global = target.global();
                 let window = global.as_window();
                 let event = InputEvent::new(
+                    cx,
                     window,
                     None,
                     atom!("input"),
@@ -1156,7 +1156,6 @@ impl<T: ClipboardProvider> TextInput<T> {
                     data.map(DOMString::from),
                     is_composing.into(),
                     input_type.as_str().into(),
-                    CanGc::from_cx(cx),
                 );
                 let event = event.upcast::<Event>();
                 event.set_composed(true);

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -685,6 +685,10 @@ DOMInterfaces = {
     'canGc': ['ObjectStore']
 },
 
+'InputEvent': {
+    'cx': ['Constructor']
+},
+
 'IntersectionObserver': {
     'cx': ['Constructor', 'Thresholds']
 },


### PR DESCRIPTION
Part of #40600

Testing: it compiles
