### PR TITLE
devtools: Avoid panics when borrowing in `ActorRegistry`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7840,6 +7840,7 @@ dependencies = [
  "http 1.4.1",
  "log",
  "malloc_size_of_derive",
+ "parking_lot",
  "rand 0.9.2",
  "rustc-hash 2.1.2",
  "serde",

--- a/components/devtools/Cargo.toml
+++ b/components/devtools/Cargo.toml
@@ -15,6 +15,7 @@ path = "lib.rs"
 
 [dependencies]
 atomic_refcell = { workspace = true }
+parking_lot = { workspace = true }
 base64 = { workspace = true }
 chrono = { workspace = true }
 crossbeam-channel = { workspace = true }

--- a/components/devtools/actor.rs
+++ b/components/devtools/actor.rs
@@ -4,27 +4,23 @@
 
 use std::any::{Any, type_name};
 use std::borrow::Borrow;
-use std::cell::Cell;
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 
-use atomic_refcell::AtomicRefCell;
 use log::{debug, warn};
 use malloc_size_of::MallocSizeOf;
 use malloc_size_of_derive::MallocSizeOf;
+use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use serde::Serialize;
 use serde_json::{Map, Value, json};
 use servo_base::id::PipelineId;
 
 use crate::StreamId;
 use crate::protocol::{ClientRequest, DevtoolsConnection, JsonPacketStream};
-
-std::thread_local! {
-    static ALREADY_REGISTERING: Cell<bool> = const { Cell::new(false) };
-}
 
 /// Error replies.
 ///
@@ -162,108 +158,86 @@ impl Borrow<str> for RegisteredActor {
     }
 }
 
-#[derive(Default)]
-struct ActorRegistryType(AtomicRefCell<HashSet<RegisteredActor>>);
-
-impl MallocSizeOf for ActorRegistryType {
+impl MallocSizeOf for RegisteredActor {
     fn size_of(&self, ops: &mut malloc_size_of::MallocSizeOfOps) -> usize {
-        self.0
-            .borrow()
-            .iter()
-            .map(|wrapper| wrapper.0.size_of(ops))
-            .sum()
+        self.0.size_of(ops)
     }
 }
 
-/// A list of known, owned actors.
+#[cfg(debug_assertions)]
+thread_local! {
+    static REENTRANCY_GUARD: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+struct WriteGuard<'a>(RwLockWriteGuard<'a, ActorRegistryInner>);
+
+impl<'a> Deref for WriteGuard<'a> {
+    type Target = ActorRegistryInner;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'a> DerefMut for WriteGuard<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<'a> Drop for WriteGuard<'a> {
+    fn drop(&mut self) {
+        #[cfg(debug_assertions)]
+        REENTRANCY_GUARD.with(|cell| cell.set(false));
+    }
+}
+
 #[derive(Default, MallocSizeOf)]
-pub(crate) struct ActorRegistry {
-    actors: ActorRegistryType,
-    script_actors: AtomicRefCell<HashMap<String, String>>,
-    /// Lookup table for SourceActor names associated with a given PipelineId.
-    source_actor_names: AtomicRefCell<HashMap<PipelineId, Vec<String>>>,
-    /// Lookup table for inline source content associated with a given PipelineId.
-    inline_source_content: AtomicRefCell<HashMap<PipelineId, String>>,
+struct ActorRegistryInner {
+    actors: HashSet<RegisteredActor>,
+    script_to_actor: HashMap<String, String>,
+    actor_to_script: HashMap<String, String>,
+    source_actor_names: HashMap<PipelineId, Vec<String>>,
+    inline_source_content: HashMap<PipelineId, String>,
+}
+
+#[derive(Default, MallocSizeOf)]
+pub(crate) struct ActorRegistry(RwLock<ActorRegistryInner>);
+
+impl ActorRegistry {
+    fn read(&self) -> RwLockReadGuard<'_, ActorRegistryInner> {
+        self.0.read()
+    }
+
+    fn write(&self) -> WriteGuard<'_> {
+        #[cfg(debug_assertions)]
+        REENTRANCY_GUARD.with(|cell| {
+            assert!(
+                !cell.get(),
+                "Reentrant write operation detected on the same thread for ActorRegistry"
+            );
+            cell.set(true);
+        });
+        WriteGuard(self.0.write())
+    }
 }
 
 impl ActorRegistry {
-    pub(crate) fn cleanup(&self, stream_id: StreamId) {
-        let actors: Vec<Arc<dyn Actor>> = {
-            let guard = self.actors.0.borrow();
-            guard.iter().map(|r| r.0.clone()).collect()
-        };
-
-        for actor in actors {
-            actor.cleanup(stream_id);
-        }
-    }
-
-    pub fn register_script_actor(&self, script_id: String, actor: String) {
-        debug!("registering {} ({})", actor, script_id);
-        let mut script_actors = self.script_actors.borrow_mut();
-        script_actors.insert(script_id, actor);
-    }
-
-    pub fn script_to_actor(&self, script_id: &str) -> String {
-        if script_id.is_empty() {
-            return "".to_owned();
-        }
-        self.script_actors.borrow().get(script_id).unwrap().clone()
-    }
-
-    pub fn script_actor_registered(&self, script_id: &str) -> bool {
-        self.script_actors.borrow().contains_key(script_id)
-    }
-
-    pub fn actor_to_script(&self, actor: String) -> String {
-        for (key, value) in &*self.script_actors.borrow() {
-            if *value == actor {
-                return key.to_owned();
-            }
-        }
-        panic!("couldn't find actor named {}", actor)
-    }
-
     /// Add an actor to the registry of known actors that can receive messages.
-    pub(crate) fn register<T: Actor>(&self, actor: T) -> Arc<T> {
-        #[cfg(debug_assertions)]
-        let _guard = {
-            struct RegisterGuard;
-            impl Drop for RegisterGuard {
-                fn drop(&mut self) {
-                    ALREADY_REGISTERING.with(|in_reg| in_reg.set(false));
-                }
-            }
-            ALREADY_REGISTERING.with(|already| {
-                assert!(
-                    !already.replace(true),
-                    "ActorRegistry::register() called reentrantly on the same thread"
-                );
-            });
-            RegisterGuard
-        };
-
+    pub fn register<T: Actor>(&self, actor: T) -> Arc<T> {
         let actor = Arc::new(actor);
-        self.actors
-            .0
-            .borrow_mut()
-            .insert(RegisteredActor(actor.clone()));
-
-        #[cfg(debug_assertions)]
-        ALREADY_REGISTERING.with(|already| already.set(false));
+        self.write().actors.insert(RegisteredActor(actor.clone()));
         actor
     }
 
     /// Find an actor by registered name
     pub fn find<T: Actor>(&self, name: &str) -> DowncastableActorArc<T> {
-        let actor = {
-            let guard = self.actors.0.borrow();
-            guard
-                .get(name)
-                .expect("Should never look for a nonexistent actor")
-                .0
-                .clone()
-        }; // Read guard is dropped here!
+        let actor = self
+            .read()
+            .actors
+            .get(name)
+            .expect("Should never look for a nonexistent actor")
+            .0
+            .clone();
         DowncastableActorArc {
             actor,
             _phantom: PhantomData,
@@ -277,32 +251,29 @@ impl ActorRegistry {
 
     /// Attempt to process a message as directed by its `to` property. If the actor is not found, does not support the
     /// message, or failed to handle the message, send an error reply instead.
-    pub(crate) fn handle_message(
+    pub fn handle_message(
         &self,
         msg: &Map<String, Value>,
         stream: &mut DevtoolsConnection,
         stream_id: StreamId,
     ) -> Result<(), ()> {
-        let to = match msg.get("to") {
-            Some(to) => to.as_str().unwrap(),
-            None => {
-                log::warn!("Received unexpected message: {:?}", msg);
-                return Err(());
-            },
+        let Some(to) = msg.get("to").and_then(|v| v.as_str()) else {
+            warn!("Received unexpected message: {msg:?}");
+            return Err(());
         };
 
-        let actor = {
-            let actors_map = self.actors.0.borrow();
-            actors_map.get(to).map(|r| r.0.clone())
-        };
+        let actor = self.read().actors.get(to).map(|r| r.0.clone());
         match actor {
             None => {
                 // <https://firefox-source-docs.mozilla.org/devtools/backend/protocol.html#packets>
-                let msg = json!({ "from": to, "error": "noSuchActor" });
-                let _ = stream.write_json_packet(&msg);
+                let _ = stream.write_json_packet(&json!({ "from": to, "error": "noSuchActor" }));
             },
             Some(actor) => {
-                let msg_type = msg.get("type").unwrap().as_str().unwrap();
+                let Some(msg_type) = msg.get("type").and_then(|v| v.as_str()) else {
+                    let _ = stream
+                        .write_json_packet(&json!({ "from": to, "error": "missingParameter" }));
+                    return Ok(());
+                };
                 if let Err(error) = ClientRequest::handle(stream.clone(), to, |req| {
                     actor.handle_message(req, self, msg_type, msg, stream_id)
                 }) {
@@ -318,22 +289,48 @@ impl ActorRegistry {
         Ok(())
     }
 
-    pub fn remove(&self, name: &str) {
-        let mut guard = self.actors.0.borrow_mut();
-        guard.remove(name);
+    pub fn register_script_actor(&self, script_id: String, actor: String) {
+        debug!("Registering {} ({})", actor, script_id);
+        let mut lock = self.write();
+        lock.script_to_actor
+            .insert(script_id.clone(), actor.clone());
+        lock.actor_to_script.insert(actor, script_id);
+    }
+
+    pub fn script_to_actor(&self, script_id: &str) -> String {
+        if script_id.is_empty() {
+            return "".to_owned();
+        }
+        self.read()
+            .script_to_actor
+            .get(script_id)
+            .unwrap_or_else(|| panic!("No actor for script id {}", script_id))
+            .clone()
+    }
+
+    pub fn script_actor_registered(&self, script_id: &str) -> bool {
+        self.read().script_to_actor.contains_key(script_id)
+    }
+
+    pub fn actor_to_script(&self, actor: String) -> String {
+        self.read()
+            .actor_to_script
+            .get(&actor)
+            .unwrap_or_else(|| panic!("No script id for actor {}", actor))
+            .clone()
     }
 
     pub fn register_source_actor(&self, pipeline_id: PipelineId, actor_name: &str) {
-        self.source_actor_names
-            .borrow_mut()
+        self.write()
+            .source_actor_names
             .entry(pipeline_id)
             .or_default()
             .push(actor_name.to_owned());
     }
 
     pub fn source_actor_names_for_pipeline(&self, pipeline_id: PipelineId) -> Vec<String> {
-        self.source_actor_names
-            .borrow_mut()
+        self.read()
+            .source_actor_names
             .get(&pipeline_id)
             .cloned()
             .unwrap_or_default()
@@ -341,17 +338,17 @@ impl ActorRegistry {
 
     pub fn set_inline_source_content(&self, pipeline_id: PipelineId, content: String) {
         assert!(
-            self.inline_source_content
-                .borrow_mut()
+            self.write()
+                .inline_source_content
                 .insert(pipeline_id, content)
                 .is_none()
         );
     }
 
     pub fn inline_source_content(&self, pipeline_id: PipelineId) -> Option<String> {
-        self.inline_source_content
-            .borrow()
-            .get(&pipeline_id)
-            .cloned()
+        self.read().inline_source_content.get(&pipeline_id).cloned()
     }
+
+    // TODO: Handle removal and cleanup
+    pub(crate) fn cleanup(&self, _: StreamId) {}
 }

--- a/components/devtools/actor.rs
+++ b/components/devtools/actor.rs
@@ -82,7 +82,7 @@ pub(crate) trait Actor: Any + ActorAsAny + Send + Sync + MallocSizeOf {
         let _ = (request, registry, msg_type, msg, stream_id);
         Err(ActorError::UnrecognizedPacketType)
     }
-    fn name(&self) -> String;
+    fn name(&self) -> &str;
     fn cleanup(&self, _id: StreamId) {}
 }
 
@@ -178,10 +178,8 @@ impl ActorRegistry {
 
     /// Add an actor to the registry of known actors that can receive messages.
     pub(crate) fn register<T: Actor>(&self, actor: T) {
-        self.actors
-            .0
-            .borrow_mut()
-            .insert(actor.name(), Arc::new(actor));
+        let mut guard = self.actors.0.borrow_mut();
+        guard.insert(actor.name().into(), Arc::new(actor));
     }
 
     /// Find an actor by registered name

--- a/components/devtools/actor.rs
+++ b/components/devtools/actor.rs
@@ -3,7 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::any::{Any, type_name};
-use std::collections::HashMap;
+use std::borrow::Borrow;
+use std::collections::{HashMap, HashSet};
+use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -123,12 +125,39 @@ impl<T: 'static> std::ops::Deref for DowncastableActorArc<T> {
     }
 }
 
+#[derive(Clone)]
+struct RegisteredActor(Arc<dyn Actor>);
+
+impl PartialEq for RegisteredActor {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.name() == other.0.name()
+    }
+}
+
+impl Eq for RegisteredActor {}
+
+impl Hash for RegisteredActor {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.name().hash(state);
+    }
+}
+
+impl Borrow<str> for RegisteredActor {
+    fn borrow(&self) -> &str {
+        self.0.name()
+    }
+}
+
 #[derive(Default)]
-struct ActorRegistryType(AtomicRefCell<HashMap<String, Arc<dyn Actor>>>);
+struct ActorRegistryType(AtomicRefCell<HashSet<RegisteredActor>>);
 
 impl MallocSizeOf for ActorRegistryType {
     fn size_of(&self, ops: &mut malloc_size_of::MallocSizeOfOps) -> usize {
-        self.0.borrow().iter().map(|actor| actor.size_of(ops)).sum()
+        self.0
+            .borrow()
+            .iter()
+            .map(|wrapper| wrapper.0.size_of(ops))
+            .sum()
     }
 }
 
@@ -145,7 +174,12 @@ pub(crate) struct ActorRegistry {
 
 impl ActorRegistry {
     pub(crate) fn cleanup(&self, stream_id: StreamId) {
-        for actor in self.actors.0.borrow().values() {
+        let actors: Vec<Arc<dyn Actor>> = {
+            let guard = self.actors.0.borrow();
+            guard.iter().map(|r| r.0.clone()).collect()
+        };
+
+        for actor in actors {
             actor.cleanup(stream_id);
         }
     }
@@ -179,18 +213,19 @@ impl ActorRegistry {
     /// Add an actor to the registry of known actors that can receive messages.
     pub(crate) fn register<T: Actor>(&self, actor: T) {
         let mut guard = self.actors.0.borrow_mut();
-        guard.insert(actor.name().into(), Arc::new(actor));
+        guard.insert(RegisteredActor(Arc::new(actor)));
     }
 
     /// Find an actor by registered name
     pub fn find<T: Actor>(&self, name: &str) -> DowncastableActorArc<T> {
-        let actor = self
-            .actors
-            .0
-            .borrow()
-            .get(name)
-            .expect("Should never look for a nonexistent actor")
-            .clone();
+        let actor = {
+            let guard = self.actors.0.borrow();
+            guard
+                .get(name)
+                .expect("Should never look for a nonexistent actor")
+                .0
+                .clone()
+        }; // Read guard is dropped here!
         DowncastableActorArc {
             actor,
             _phantom: PhantomData,
@@ -220,7 +255,7 @@ impl ActorRegistry {
 
         let actor = {
             let actors_map = self.actors.0.borrow();
-            actors_map.get(to).cloned()
+            actors_map.get(to).map(|r| r.0.clone())
         };
         match actor {
             None => {
@@ -245,8 +280,9 @@ impl ActorRegistry {
         Ok(())
     }
 
-    pub fn remove(&self, name: String) {
-        self.actors.0.borrow_mut().remove(&name);
+    pub fn remove(&self, name: &str) {
+        let mut guard = self.actors.0.borrow_mut();
+        guard.remove(name);
     }
 
     pub fn register_source_actor(&self, pipeline_id: PipelineId, actor_name: &str) {

--- a/components/devtools/actor.rs
+++ b/components/devtools/actor.rs
@@ -47,6 +47,27 @@ impl ActorError {
     }
 }
 
+/// Create a name prefix for each actor type, without any counter suffix.
+pub(crate) fn base_name<T: ?Sized>() -> &'static str {
+    let prefix = type_name::<T>();
+    prefix.split("::").last().unwrap_or(prefix)
+}
+
+/// Create a unique actor name based on the type and a monotonically increasing suffix.
+pub(crate) fn new_actor_name<T: ?Sized>() -> String {
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+    let suffix = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let base = base_name::<T>();
+
+    // Firefox DevTools client requires "/workerTarget" in actor name to recognize workers
+    // <https://searchfox.org/firefox-main/source/devtools/client/fronts/watcher.js#65>
+    if base.contains("WorkerTarget") {
+        format!("/workerTarget{}", suffix)
+    } else {
+        format!("{}{}", base, suffix)
+    }
+}
+
 /// A common trait for all devtools actors that encompasses an immutable name
 /// and the ability to process messages that are directed to particular actors.
 pub(crate) trait Actor: Any + ActorAsAny + Send + Sync + MallocSizeOf {
@@ -120,7 +141,6 @@ pub(crate) struct ActorRegistry {
     source_actor_names: AtomicRefCell<HashMap<PipelineId, Vec<String>>>,
     /// Lookup table for inline source content associated with a given PipelineId.
     inline_source_content: AtomicRefCell<HashMap<PipelineId, String>>,
-    next: AtomicU32,
 }
 
 impl ActorRegistry {
@@ -154,30 +174,6 @@ impl ActorRegistry {
             }
         }
         panic!("couldn't find actor named {}", actor)
-    }
-
-    /// Create a name prefix for each actor type.
-    /// While not needed for unique ids as each actor already has a different
-    /// suffix, it can be used to visually identify actors in the logs.
-    pub fn base_name<T: Actor>() -> &'static str {
-        let prefix = type_name::<T>();
-        prefix.split("::").last().unwrap_or(prefix)
-    }
-
-    /// Create a unique name based on a monotonically increasing suffix
-    /// TODO: Merge this with `register` and don't allow to
-    /// create new names without registering an actor.
-    pub fn new_name<T: Actor>(&self) -> String {
-        let suffix = self.next.fetch_add(1, Ordering::Relaxed);
-        let base = Self::base_name::<T>();
-
-        // Firefox DevTools client requires "/workerTarget" in actor name to recognize workers
-        // <https://searchfox.org/firefox-main/source/devtools/client/fronts/watcher.js#65>
-        if base.contains("WorkerTarget") {
-            format!("/workerTarget{}", suffix)
-        } else {
-            format!("{}{}", base, suffix)
-        }
     }
 
     /// Add an actor to the registry of known actors that can receive messages.

--- a/components/devtools/actor.rs
+++ b/components/devtools/actor.rs
@@ -65,9 +65,9 @@ pub(crate) fn new_actor_name<T: ?Sized>() -> String {
     // Firefox DevTools client requires "/workerTarget" in actor name to recognize workers
     // <https://searchfox.org/firefox-main/source/devtools/client/fronts/watcher.js#65>
     if base.contains("WorkerTarget") {
-        format!("/workerTarget{}", suffix)
+        format!("/workerTarget{suffix}")
     } else {
-        format!("{}{}", base, suffix)
+        format!("{base}{suffix}")
     }
 }
 
@@ -164,6 +164,8 @@ impl MallocSizeOf for RegisteredActor {
     }
 }
 
+// Debug-only guard to prevent deadlocks. Panics if `ActorRegistry::write` is called
+// reentrantly on the same thread before the previous write guard is dropped.
 #[cfg(debug_assertions)]
 thread_local! {
     static REENTRANCY_GUARD: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
@@ -223,14 +225,14 @@ impl ActorRegistry {
 
 impl ActorRegistry {
     /// Add an actor to the registry of known actors that can receive messages.
-    pub fn register<T: Actor>(&self, actor: T) -> Arc<T> {
+    pub(crate) fn register<T: Actor>(&self, actor: T) -> Arc<T> {
         let actor = Arc::new(actor);
         self.write().actors.insert(RegisteredActor(actor.clone()));
         actor
     }
 
     /// Find an actor by registered name
-    pub fn find<T: Actor>(&self, name: &str) -> DowncastableActorArc<T> {
+    pub(crate) fn find<T: Actor>(&self, name: &str) -> DowncastableActorArc<T> {
         let actor = self
             .read()
             .actors
@@ -245,36 +247,42 @@ impl ActorRegistry {
     }
 
     /// Find an actor by registered name and return its serialization
-    pub fn encode<T: ActorEncode<S>, S: Serialize>(&self, name: &str) -> S {
+    pub(crate) fn encode<T: ActorEncode<S>, S: Serialize>(&self, name: &str) -> S {
         self.find::<T>(name).encode(self)
     }
 
     /// Attempt to process a message as directed by its `to` property. If the actor is not found, does not support the
     /// message, or failed to handle the message, send an error reply instead.
-    pub fn handle_message(
+    pub(crate) fn handle_message(
         &self,
         msg: &Map<String, Value>,
         stream: &mut DevtoolsConnection,
         stream_id: StreamId,
     ) -> Result<(), ()> {
-        let Some(to) = msg.get("to").and_then(|v| v.as_str()) else {
+        let Some(actor_name) = msg.get("to").and_then(|value| value.as_str()) else {
             warn!("Received unexpected message: {msg:?}");
             return Err(());
         };
 
-        let actor = self.read().actors.get(to).map(|r| r.0.clone());
+        let actor = self
+            .read()
+            .actors
+            .get(actor_name)
+            .map(|registered_actor| registered_actor.0.clone());
         match actor {
             None => {
                 // <https://firefox-source-docs.mozilla.org/devtools/backend/protocol.html#packets>
-                let _ = stream.write_json_packet(&json!({ "from": to, "error": "noSuchActor" }));
+                let _ = stream
+                    .write_json_packet(&json!({ "from": actor_name, "error": "noSuchActor" }));
             },
             Some(actor) => {
-                let Some(msg_type) = msg.get("type").and_then(|v| v.as_str()) else {
-                    let _ = stream
-                        .write_json_packet(&json!({ "from": to, "error": "missingParameter" }));
+                let Some(msg_type) = msg.get("type").and_then(|value| value.as_str()) else {
+                    let _ = stream.write_json_packet(
+                        &json!({ "from": actor_name, "error": "missingParameter" }),
+                    );
                     return Ok(());
                 };
-                if let Err(error) = ClientRequest::handle(stream.clone(), to, |req| {
+                if let Err(error) = ClientRequest::handle(stream.clone(), actor_name, |req| {
                     actor.handle_message(req, self, msg_type, msg, stream_id)
                 }) {
                     // <https://firefox-source-docs.mozilla.org/devtools/backend/protocol.html#error-packets>
@@ -289,38 +297,38 @@ impl ActorRegistry {
         Ok(())
     }
 
-    pub fn register_script_actor(&self, script_id: String, actor: String) {
-        debug!("Registering {} ({})", actor, script_id);
+    pub(crate) fn register_script_actor(&self, script_id: String, actor: String) {
+        debug!("Registering {actor} ({script_id})");
         let mut lock = self.write();
         lock.script_to_actor
             .insert(script_id.clone(), actor.clone());
         lock.actor_to_script.insert(actor, script_id);
     }
 
-    pub fn script_to_actor(&self, script_id: &str) -> String {
+    pub(crate) fn script_to_actor(&self, script_id: &str) -> String {
         if script_id.is_empty() {
-            return "".to_owned();
+            return String::new();
         }
         self.read()
             .script_to_actor
             .get(script_id)
-            .unwrap_or_else(|| panic!("No actor for script id {}", script_id))
+            .unwrap_or_else(|| panic!("No actor for script id {script_id}"))
             .clone()
     }
 
-    pub fn script_actor_registered(&self, script_id: &str) -> bool {
+    pub(crate) fn script_actor_registered(&self, script_id: &str) -> bool {
         self.read().script_to_actor.contains_key(script_id)
     }
 
-    pub fn actor_to_script(&self, actor: String) -> String {
+    pub(crate) fn actor_to_script(&self, actor: String) -> String {
         self.read()
             .actor_to_script
             .get(&actor)
-            .unwrap_or_else(|| panic!("No script id for actor {}", actor))
+            .unwrap_or_else(|| panic!("No script id for actor {actor}"))
             .clone()
     }
 
-    pub fn register_source_actor(&self, pipeline_id: PipelineId, actor_name: &str) {
+    pub(crate) fn register_source_actor(&self, pipeline_id: PipelineId, actor_name: &str) {
         self.write()
             .source_actor_names
             .entry(pipeline_id)
@@ -328,7 +336,7 @@ impl ActorRegistry {
             .push(actor_name.to_owned());
     }
 
-    pub fn source_actor_names_for_pipeline(&self, pipeline_id: PipelineId) -> Vec<String> {
+    pub(crate) fn source_actor_names_for_pipeline(&self, pipeline_id: PipelineId) -> Vec<String> {
         self.read()
             .source_actor_names
             .get(&pipeline_id)
@@ -336,7 +344,7 @@ impl ActorRegistry {
             .unwrap_or_default()
     }
 
-    pub fn set_inline_source_content(&self, pipeline_id: PipelineId, content: String) {
+    pub(crate) fn set_inline_source_content(&self, pipeline_id: PipelineId, content: String) {
         assert!(
             self.write()
                 .inline_source_content
@@ -345,10 +353,17 @@ impl ActorRegistry {
         );
     }
 
-    pub fn inline_source_content(&self, pipeline_id: PipelineId) -> Option<String> {
+    pub(crate) fn inline_source_content(&self, pipeline_id: PipelineId) -> Option<String> {
         self.read().inline_source_content.get(&pipeline_id).cloned()
     }
 
-    // TODO: Handle removal and cleanup
-    pub(crate) fn cleanup(&self, _: StreamId) {}
+    /// This is a no-op, we don't currently handle removals from the actor registry
+    pub(crate) fn remove(&self, _name: String) {}
+
+    pub(crate) fn cleanup(&self, stream_id: StreamId) {
+        let actors = self.read().actors.clone();
+        for actor in actors {
+            actor.0.cleanup(stream_id);
+        }
+    }
 }

--- a/components/devtools/actor.rs
+++ b/components/devtools/actor.rs
@@ -114,6 +114,15 @@ pub(crate) struct DowncastableActorArc<T> {
     _phantom: PhantomData<T>,
 }
 
+impl<T: Actor> From<Arc<T>> for DowncastableActorArc<T> {
+    fn from(actor: Arc<T>) -> Self {
+        Self {
+            actor,
+            _phantom: PhantomData,
+        }
+    }
+}
+
 impl<T: 'static> std::ops::Deref for DowncastableActorArc<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {

--- a/components/devtools/actor.rs
+++ b/components/devtools/actor.rs
@@ -4,6 +4,7 @@
 
 use std::any::{Any, type_name};
 use std::borrow::Borrow;
+use std::cell::Cell;
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
@@ -20,6 +21,10 @@ use servo_base::id::PipelineId;
 
 use crate::StreamId;
 use crate::protocol::{ClientRequest, DevtoolsConnection, JsonPacketStream};
+
+std::thread_local! {
+    static ALREADY_REGISTERING: Cell<bool> = const { Cell::new(false) };
+}
 
 /// Error replies.
 ///
@@ -211,9 +216,33 @@ impl ActorRegistry {
     }
 
     /// Add an actor to the registry of known actors that can receive messages.
-    pub(crate) fn register<T: Actor>(&self, actor: T) {
-        let mut guard = self.actors.0.borrow_mut();
-        guard.insert(RegisteredActor(Arc::new(actor)));
+    pub(crate) fn register<T: Actor>(&self, actor: T) -> Arc<T> {
+        #[cfg(debug_assertions)]
+        let _guard = {
+            struct RegisterGuard;
+            impl Drop for RegisterGuard {
+                fn drop(&mut self) {
+                    ALREADY_REGISTERING.with(|in_reg| in_reg.set(false));
+                }
+            }
+            ALREADY_REGISTERING.with(|already| {
+                assert!(
+                    !already.replace(true),
+                    "ActorRegistry::register() called reentrantly on the same thread"
+                );
+            });
+            RegisterGuard
+        };
+
+        let actor = Arc::new(actor);
+        self.actors
+            .0
+            .borrow_mut()
+            .insert(RegisteredActor(actor.clone()));
+
+        #[cfg(debug_assertions)]
+        ALREADY_REGISTERING.with(|already| already.set(false));
+        actor
     }
 
     /// Find an actor by registered name

--- a/components/devtools/actors/blackboxing.rs
+++ b/components/devtools/actors/blackboxing.rs
@@ -37,8 +37,8 @@ pub(crate) struct BlackboxingActor {
 }
 
 impl Actor for BlackboxingActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 
     fn handle_message(
@@ -89,7 +89,9 @@ impl Actor for BlackboxingActor {
             .send(control_msg)
             .map_err(|_| ActorError::Internal)?;
 
-        request.reply_final(&EmptyReplyMsg { from: self.name() })?;
+        request.reply_final(&EmptyReplyMsg {
+            from: self.name().into(),
+        })?;
         Ok(())
     }
 }
@@ -108,6 +110,8 @@ impl BlackboxingActor {
 
 impl ActorEncode<ActorMsg> for BlackboxingActor {
     fn encode(&self, _: &ActorRegistry) -> ActorMsg {
-        ActorMsg { actor: self.name() }
+        ActorMsg {
+            actor: self.name().into(),
+        }
     }
 }

--- a/components/devtools/actors/blackboxing.rs
+++ b/components/devtools/actors/blackboxing.rs
@@ -102,7 +102,7 @@ impl BlackboxingActor {
     pub fn register(registry: &ActorRegistry, browsing_context_name: String) -> Arc<Self> {
         let name = new_actor_name::<Self>();
         let actor = Self {
-            name: name.clone(),
+            name,
             browsing_context_name,
         };
         registry.register::<Self>(actor)

--- a/components/devtools/actors/blackboxing.rs
+++ b/components/devtools/actors/blackboxing.rs
@@ -6,7 +6,7 @@ use devtools_traits::{BlackboxCoverage, DevtoolScriptControlMsg};
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Deserialize;
 
-use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry, new_actor_name};
 use crate::actors::browsing_context::BrowsingContextActor;
 use crate::actors::thread::ThreadActor;
 use crate::{ActorMsg, EmptyReplyMsg};
@@ -96,7 +96,7 @@ impl Actor for BlackboxingActor {
 
 impl BlackboxingActor {
     pub fn register(registry: &ActorRegistry, browsing_context_name: String) -> String {
-        let name = registry.new_name::<Self>();
+        let name = new_actor_name::<Self>();
         let actor = Self {
             name: name.clone(),
             browsing_context_name,

--- a/components/devtools/actors/blackboxing.rs
+++ b/components/devtools/actors/blackboxing.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::sync::Arc;
+
 use devtools_traits::{BlackboxCoverage, DevtoolScriptControlMsg};
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Deserialize;
@@ -97,14 +99,13 @@ impl Actor for BlackboxingActor {
 }
 
 impl BlackboxingActor {
-    pub fn register(registry: &ActorRegistry, browsing_context_name: String) -> String {
+    pub fn register(registry: &ActorRegistry, browsing_context_name: String) -> Arc<Self> {
         let name = new_actor_name::<Self>();
         let actor = Self {
             name: name.clone(),
             browsing_context_name,
         };
-        registry.register::<Self>(actor);
-        name
+        registry.register::<Self>(actor)
     }
 }
 

--- a/components/devtools/actors/breakpoint.rs
+++ b/components/devtools/actors/breakpoint.rs
@@ -34,8 +34,8 @@ pub(crate) struct BreakpointListActor {
 }
 
 impl Actor for BreakpointListActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 
     fn handle_message(
@@ -80,11 +80,15 @@ impl Actor for BreakpointListActor {
                         .map_err(|_| ActorError::Internal)?;
                 }
 
-                let msg = EmptyReplyMsg { from: self.name() };
+                let msg = EmptyReplyMsg {
+                    from: self.name().into(),
+                };
                 request.reply_final(&msg)?
             },
             "setActiveEventBreakpoints" => {
-                let msg = EmptyReplyMsg { from: self.name() };
+                let msg = EmptyReplyMsg {
+                    from: self.name().into(),
+                };
                 request.reply_final(&msg)?
             },
             "removeBreakpoint" => {
@@ -116,7 +120,9 @@ impl Actor for BreakpointListActor {
                         .map_err(|_| ActorError::Internal)?;
                 }
 
-                let msg = EmptyReplyMsg { from: self.name() };
+                let msg = EmptyReplyMsg {
+                    from: self.name().into(),
+                };
                 request.reply_final(&msg)?
             },
             _ => return Err(ActorError::UnrecognizedPacketType),
@@ -139,6 +145,8 @@ impl BreakpointListActor {
 
 impl ActorEncode<ActorMsg> for BreakpointListActor {
     fn encode(&self, _: &ActorRegistry) -> ActorMsg {
-        ActorMsg { actor: self.name() }
+        ActorMsg {
+            actor: self.name().into(),
+        }
     }
 }

--- a/components/devtools/actors/breakpoint.rs
+++ b/components/devtools/actors/breakpoint.rs
@@ -7,7 +7,7 @@ use malloc_size_of_derive::MallocSizeOf;
 use serde::Deserialize;
 use serde_json::Map;
 
-use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry, new_actor_name};
 use crate::actors::browsing_context::BrowsingContextActor;
 use crate::actors::thread::ThreadActor;
 use crate::protocol::ClientRequest;
@@ -127,7 +127,7 @@ impl Actor for BreakpointListActor {
 
 impl BreakpointListActor {
     pub fn register(registry: &ActorRegistry, browsing_context_name: String) -> String {
-        let name = registry.new_name::<Self>();
+        let name = new_actor_name::<Self>();
         let actor = Self {
             name: name.clone(),
             browsing_context_name,

--- a/components/devtools/actors/breakpoint.rs
+++ b/components/devtools/actors/breakpoint.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::sync::Arc;
+
 use devtools_traits::DevtoolScriptControlMsg;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Deserialize;
@@ -132,14 +134,13 @@ impl Actor for BreakpointListActor {
 }
 
 impl BreakpointListActor {
-    pub fn register(registry: &ActorRegistry, browsing_context_name: String) -> String {
+    pub fn register(registry: &ActorRegistry, browsing_context_name: String) -> Arc<Self> {
         let name = new_actor_name::<Self>();
         let actor = Self {
-            name: name.clone(),
+            name,
             browsing_context_name,
         };
-        registry.register::<Self>(actor);
-        name
+        registry.register::<Self>(actor)
     }
 }
 

--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -149,8 +149,8 @@ impl ResourceAvailable for BrowsingContextActor {
 }
 
 impl Actor for BrowsingContextActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 
     fn handle_message(
@@ -164,12 +164,14 @@ impl Actor for BrowsingContextActor {
         match msg_type {
             "listFrames" => {
                 // TODO: Find out what needs to be listed here
-                let msg = EmptyReplyMsg { from: self.name() };
+                let msg = EmptyReplyMsg {
+                    from: self.name().into(),
+                };
                 request.reply_final(&msg)?
             },
             "listWorkers" => {
                 request.reply_final(&ListWorkersReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     // TODO: Find out what needs to be listed here
                     workers: vec![],
                 })?
@@ -267,7 +269,7 @@ impl BrowsingContextActor {
 
     pub(crate) fn frame_update(&self, request: &mut ClientRequest) {
         let _ = request.write_json_packet(&FrameUpdateReply {
-            from: self.name(),
+            from: self.name().into(),
             type_: "frameUpdate".into(),
             frames: vec![FrameUpdateMsg {
                 id: self.browsing_context_id.value(),
@@ -337,7 +339,7 @@ impl BrowsingContextActor {
 impl ActorEncode<BrowsingContextActorMsg> for BrowsingContextActor {
     fn encode(&self, _: &ActorRegistry) -> BrowsingContextActorMsg {
         BrowsingContextActorMsg {
-            actor: self.name(),
+            actor: self.name().into(),
             traits: BrowsingContextTraits {
                 is_browsing_context: true,
                 frames: true,

--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -6,6 +6,8 @@
 //! Connection point for remote devtools that wish to investigate a particular Browsing Context's contents.
 //! Supports dynamic attaching and detaching which control notifications of navigation, etc.
 
+use std::sync::Arc;
+
 use atomic_refcell::AtomicRefCell;
 use devtools_traits::DevtoolScriptControlMsg::{self, GetCssDatabase, SimulateColorScheme};
 use devtools_traits::DevtoolsPageInfo;
@@ -193,10 +195,10 @@ impl BrowsingContextActor {
         pipeline_id: PipelineId,
         outer_window_id: DevtoolsOuterWindowId,
         script_sender: GenericSender<DevtoolScriptControlMsg>,
-    ) -> String {
+    ) -> Arc<Self> {
         let name = new_actor_name::<BrowsingContextActor>();
 
-        let accessibility_name = AccessibilityActor::register(registry);
+        let accessibility_actor = AccessibilityActor::register(registry);
 
         let properties = (|| {
             let (properties_sender, properties_receiver) = generic_channel::channel()?;
@@ -204,21 +206,22 @@ impl BrowsingContextActor {
             properties_receiver.recv().ok()
         })()
         .unwrap_or_default();
-        let css_properties_name = CssPropertiesActor::register(registry, properties);
 
-        let inspector_name = InspectorActor::register(registry, name.clone());
+        let css_properties_actor = CssPropertiesActor::register(registry, properties);
 
-        let reflow_name = ReflowActor::register(registry);
+        let inspector_actor = InspectorActor::register(registry, name.clone());
 
-        let style_sheets_name =
+        let reflow_actor = ReflowActor::register(registry);
+
+        let style_sheets_actor =
             StyleSheetsActor::register(registry, script_sender.clone(), name.clone());
 
         let _ = TabDescriptorActor::register(registry, name.clone());
 
-        let thread_name =
+        let thread_actor =
             ThreadActor::register(registry, script_sender.clone(), Some(name.clone()));
 
-        let watcher_name = WatcherActor::register(
+        let watcher_actor = WatcherActor::register(
             registry,
             name.clone(),
             SessionContext::new(SessionContextType::BrowserElement),
@@ -228,26 +231,24 @@ impl BrowsingContextActor {
         script_chans.insert(pipeline_id, script_sender);
 
         let actor = BrowsingContextActor {
-            name: name.clone(),
+            name,
             script_chans: script_chans.into(),
             active_pipeline_id: pipeline_id.into(),
             active_outer_window_id: outer_window_id.into(),
             browser_id,
             browsing_context_id,
-            accessibility_name,
+            accessibility_name: accessibility_actor.name().into(),
             console_name,
-            css_properties_name,
-            inspector_name,
+            css_properties_name: css_properties_actor.name().into(),
+            inspector_name: inspector_actor.name().into(),
             page_info: page_info.into(),
-            reflow_name,
-            style_sheets_name,
-            thread_name,
-            watcher_name,
+            reflow_name: reflow_actor.name().into(),
+            style_sheets_name: style_sheets_actor.name().into(),
+            thread_name: thread_actor.name().into(),
+            watcher_name: watcher_actor.name().into(),
         };
 
-        registry.register::<Self>(actor);
-
-        name
+        registry.register::<Self>(actor)
     }
 
     pub(crate) fn handle_new_global(

--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -17,7 +17,7 @@ use serde_json::{Map, Value};
 use servo_base::generic_channel::{self, GenericSender, SendError};
 use servo_base::id::PipelineId;
 
-use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry, new_actor_name};
 use crate::actors::inspector::InspectorActor;
 use crate::actors::inspector::accessibility::AccessibilityActor;
 use crate::actors::inspector::css_properties::CssPropertiesActor;
@@ -192,7 +192,7 @@ impl BrowsingContextActor {
         outer_window_id: DevtoolsOuterWindowId,
         script_sender: GenericSender<DevtoolScriptControlMsg>,
     ) -> String {
-        let name = registry.new_name::<BrowsingContextActor>();
+        let name = new_actor_name::<BrowsingContextActor>();
 
         let accessibility_name = AccessibilityActor::register(registry);
 

--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -7,6 +7,7 @@
 //! inspection, JS evaluation, autocompletion) in Servo.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use atomic_refcell::AtomicRefCell;
@@ -194,15 +195,14 @@ pub(crate) struct ConsoleActor {
 }
 
 impl ConsoleActor {
-    pub fn register(registry: &ActorRegistry, name: String, root: Root) -> String {
+    pub fn register(registry: &ActorRegistry, name: String, root: Root) -> Arc<Self> {
         let actor = Self {
-            name: name.clone(),
+            name,
             root,
             cached_events: Default::default(),
             client_ready_to_receive_messages: false.into(),
         };
-        registry.register(actor);
-        name
+        registry.register::<Self>(actor)
     }
 
     fn script_chan(&self, registry: &ActorRegistry) -> GenericSender<DevtoolScriptControlMsg> {

--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -259,7 +259,7 @@ impl ConsoleActor {
         let has_exception = eval_result.has_exception;
 
         let reply = EvaluateJSReply {
-            from: self.name(),
+            from: self.name().into(),
             input,
             result: debugger_value_to_json(registry, eval_result.value),
             timestamp: get_time_stamp(),
@@ -350,8 +350,8 @@ impl ConsoleActor {
 }
 
 impl Actor for ConsoleActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 
     fn handle_message(
@@ -367,7 +367,9 @@ impl Actor for ConsoleActor {
                 self.cached_events
                     .borrow_mut()
                     .remove(&self.current_unique_id(registry));
-                let msg = EmptyReplyMsg { from: self.name() };
+                let msg = EmptyReplyMsg {
+                    from: self.name().into(),
+                };
                 request.reply_final(&msg)?
             },
 
@@ -375,7 +377,7 @@ impl Actor for ConsoleActor {
             //      http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/server/actors/webconsole.js
             "autocomplete" => {
                 let msg = AutocompleteReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     matches: vec![],
                     match_prop: "".to_owned(),
                 };
@@ -390,7 +392,7 @@ impl Actor for ConsoleActor {
             "evaluateJSAsync" => {
                 let result_id = Uuid::new_v4().to_string();
                 let early_reply = EvaluateJSAsyncReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     result_id: result_id.clone(),
                 };
                 // Emit an eager reply so that the client starts listening
@@ -405,7 +407,7 @@ impl Actor for ConsoleActor {
 
                 let reply = self.evaluate_js(registry, msg).unwrap();
                 let msg = EvaluateJSEvent {
-                    from: self.name(),
+                    from: self.name().into(),
                     type_: "evaluationResult".to_owned(),
                     input: reply.input,
                     result: reply.result,
@@ -422,7 +424,7 @@ impl Actor for ConsoleActor {
 
             "setPreferences" => {
                 let msg = SetPreferencesReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     updated: vec![],
                 };
                 request.reply_final(&msg)?

--- a/components/devtools/actors/device.rs
+++ b/components/devtools/actors/device.rs
@@ -41,8 +41,8 @@ pub(crate) struct DeviceActor {
 }
 
 impl Actor for DeviceActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
     fn handle_message(
         &self,
@@ -55,7 +55,7 @@ impl Actor for DeviceActor {
         match msg_type {
             "getDescription" => {
                 let msg = GetDescriptionReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     value: SystemInfo {
                         apptype: "servo".to_string(),
                         version: env!("CARGO_PKG_VERSION").to_string(),

--- a/components/devtools/actors/device.rs
+++ b/components/devtools/actors/device.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::sync::Arc;
+
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
@@ -74,11 +76,10 @@ impl Actor for DeviceActor {
 }
 
 impl DeviceActor {
-    pub fn register(registry: &ActorRegistry) -> String {
+    pub fn register(registry: &ActorRegistry) -> Arc<Self> {
         let name = new_actor_name::<Self>();
-        let actor = DeviceActor { name: name.clone() };
-        registry.register::<Self>(actor);
-        name
+        let actor = DeviceActor { name };
+        registry.register::<Self>(actor)
     }
 
     pub fn description() -> ActorDescription {

--- a/components/devtools/actors/device.rs
+++ b/components/devtools/actors/device.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 use serde_json::{Map, Value};
 
 use crate::StreamId;
-use crate::actor::{Actor, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorError, ActorRegistry, new_actor_name};
 use crate::protocol::{ActorDescription, ClientRequest, Method};
 
 #[derive(Serialize)]
@@ -75,7 +75,7 @@ impl Actor for DeviceActor {
 
 impl DeviceActor {
     pub fn register(registry: &ActorRegistry) -> String {
-        let name = registry.new_name::<Self>();
+        let name = new_actor_name::<Self>();
         let actor = DeviceActor { name: name.clone() };
         registry.register::<Self>(actor);
         name

--- a/components/devtools/actors/environment.rs
+++ b/components/devtools/actors/environment.rs
@@ -55,8 +55,8 @@ pub(crate) struct EnvironmentActor {
 }
 
 impl Actor for EnvironmentActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 }
 
@@ -94,7 +94,7 @@ impl ActorEncode<EnvironmentActorMsg> for EnvironmentActor {
         let environment = self.environment.borrow();
         // TODO: Change hardcoded values.
         EnvironmentActorMsg {
-            actor: self.name(),
+            actor: self.name().into(),
             type_: environment.type_.clone(),
             scope_kind: environment.scope_kind.clone(),
             parent,

--- a/components/devtools/actors/environment.rs
+++ b/components/devtools/actors/environment.rs
@@ -10,7 +10,7 @@ use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::Value;
 
-use crate::actor::{Actor, ActorEncode, ActorRegistry};
+use crate::actor::{Actor, ActorEncode, ActorRegistry, new_actor_name};
 use crate::actors::object::{ObjectActorMsg, ObjectPropertyDescriptor};
 
 #[derive(Serialize)]
@@ -73,7 +73,7 @@ impl EnvironmentActor {
             return actor_name;
         }
 
-        let environment_name = registry.new_name::<Self>();
+        let environment_name = new_actor_name::<Self>();
         let environment_actor = Self {
             name: environment_name.clone(),
             parent_name,

--- a/components/devtools/actors/frame.rs
+++ b/components/devtools/actors/frame.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::sync::Arc;
+
 use atomic_refcell::AtomicRefCell;
 use devtools_traits::{DevtoolScriptControlMsg, FrameInfo};
 use malloc_size_of_derive::MallocSizeOf;
@@ -114,20 +116,17 @@ impl FrameActor {
         registry: &ActorRegistry,
         source_name: String,
         frame_result: FrameInfo,
-    ) -> String {
-        // TODO: Get the real frame object from the debugger.
+    ) -> Arc<Self> {
         let object_name = ObjectActor::register(registry, None, "Object".to_owned(), None, None);
-
         let name = new_actor_name::<Self>();
         let actor = Self {
-            name: name.clone(),
+            name,
             object_actor: object_name,
             source_name,
             frame_result,
             current_offset: Default::default(),
         };
-        registry.register::<Self>(actor);
-        name
+        registry.register::<Self>(actor)
     }
 
     pub(crate) fn set_offset(&self, column: u32, line: u32) {

--- a/components/devtools/actors/frame.rs
+++ b/components/devtools/actors/frame.rs
@@ -66,8 +66,8 @@ pub(crate) struct FrameActor {
 }
 
 impl Actor for FrameActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 
     // https://searchfox.org/firefox-main/source/devtools/shared/specs/frame.js
@@ -87,12 +87,15 @@ impl Actor for FrameActor {
                 let source_actor = registry.find::<SourceActor>(&self.source_name);
                 source_actor
                     .script_sender
-                    .send(DevtoolScriptControlMsg::GetEnvironment(self.name(), tx))
+                    .send(DevtoolScriptControlMsg::GetEnvironment(
+                        self.name().into(),
+                        tx,
+                    ))
                     .map_err(|_| ActorError::Internal)?;
                 let environment_name = rx.recv().map_err(|_| ActorError::Internal)?;
 
                 let msg = FrameEnvironmentReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     environment: registry.encode::<EnvironmentActor, _>(&environment_name),
                 };
                 // This reply has a `type` field but it doesn't need a followup,
@@ -149,7 +152,7 @@ impl ActorEncode<FrameActorMsg> for FrameActor {
         let (column, line) = *self.current_offset.borrow();
         // <https://searchfox.org/firefox-main/source/devtools/docs/user/debugger-api/debugger.frame/index.rst>
         FrameActorMsg {
-            actor: self.name(),
+            actor: self.name().into(),
             type_: self.frame_result.type_.clone(),
             arguments: vec![],
             async_cause,

--- a/components/devtools/actors/frame.rs
+++ b/components/devtools/actors/frame.rs
@@ -10,7 +10,7 @@ use serde_json::{Map, Value};
 use servo_base::generic_channel::channel;
 
 use crate::StreamId;
-use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry, new_actor_name};
 use crate::actors::environment::{EnvironmentActor, EnvironmentActorMsg};
 use crate::actors::object::{ObjectActor, ObjectActorMsg};
 use crate::actors::source::SourceActor;
@@ -115,7 +115,7 @@ impl FrameActor {
         // TODO: Get the real frame object from the debugger.
         let object_name = ObjectActor::register(registry, None, "Object".to_owned(), None, None);
 
-        let name = registry.new_name::<Self>();
+        let name = new_actor_name::<Self>();
         let actor = Self {
             name: name.clone(),
             object_actor: object_name,

--- a/components/devtools/actors/framerate.rs
+++ b/components/devtools/actors/framerate.rs
@@ -10,7 +10,7 @@ use malloc_size_of_derive::MallocSizeOf;
 use servo_base::generic_channel::GenericSender;
 use servo_base::id::PipelineId;
 
-use crate::actor::{Actor, ActorRegistry};
+use crate::actor::{Actor, ActorRegistry, new_actor_name};
 use crate::actors::timeline::HighResolutionStamp;
 
 #[derive(MallocSizeOf)]
@@ -35,7 +35,7 @@ impl FramerateActor {
         pipeline_id: PipelineId,
         script_sender: GenericSender<DevtoolScriptControlMsg>,
     ) -> String {
-        let actor_name = registry.new_name::<Self>();
+        let actor_name = new_actor_name::<Self>();
         let mut actor = FramerateActor {
             name: actor_name.clone(),
             pipeline_id,

--- a/components/devtools/actors/framerate.rs
+++ b/components/devtools/actors/framerate.rs
@@ -23,8 +23,8 @@ pub(crate) struct FramerateActor {
 }
 
 impl Actor for FramerateActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 }
 
@@ -55,7 +55,10 @@ impl FramerateActor {
             .push(HighResolutionStamp::wrap(tick));
 
         if self.is_recording {
-            let msg = DevtoolScriptControlMsg::RequestAnimationFrame(self.pipeline_id, self.name());
+            let msg = DevtoolScriptControlMsg::RequestAnimationFrame(
+                self.pipeline_id,
+                self.name().into(),
+            );
             self.script_sender.send(msg).unwrap();
         }
     }
@@ -71,7 +74,8 @@ impl FramerateActor {
 
         self.is_recording = true;
 
-        let msg = DevtoolScriptControlMsg::RequestAnimationFrame(self.pipeline_id, self.name());
+        let msg =
+            DevtoolScriptControlMsg::RequestAnimationFrame(self.pipeline_id, self.name().into());
         self.script_sender.send(msg).unwrap();
     }
 

--- a/components/devtools/actors/inspector.rs
+++ b/components/devtools/actors/inspector.rs
@@ -4,6 +4,8 @@
 
 //! Liberally derived from the [Firefox JS implementation](http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/server/actors/inspector.js).
 
+use std::sync::Arc;
+
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{self, Map, Value};
@@ -112,23 +114,18 @@ impl Actor for InspectorActor {
 }
 
 impl InspectorActor {
-    pub fn register(registry: &ActorRegistry, browsing_context_name: String) -> String {
-        let highlighter_name = HighlighterActor::register(registry, browsing_context_name.clone());
+    pub fn register(registry: &ActorRegistry, browsing_context_name: String) -> Arc<Self> {
+        let highlighter_actor = HighlighterActor::register(registry, browsing_context_name.clone());
+        let page_style_actor = PageStyleActor::register(registry);
+        let walker_actor = WalkerActor::register(registry, browsing_context_name);
 
-        let page_style_name = PageStyleActor::register(registry);
-
-        let walker_name = WalkerActor::register(registry, browsing_context_name);
-
-        let inspector_actor = Self {
+        let actor = Self {
             name: new_actor_name::<InspectorActor>(),
-            highlighter_name,
-            page_style_name,
-            walker_name,
+            highlighter_name: highlighter_actor.name().into(),
+            page_style_name: page_style_actor.name().into(),
+            walker_name: walker_actor.name().into(),
         };
-        let inspector_name: String = inspector_actor.name().into();
 
-        registry.register(inspector_actor);
-
-        inspector_name
+        registry.register::<Self>(actor)
     }
 }

--- a/components/devtools/actors/inspector.rs
+++ b/components/devtools/actors/inspector.rs
@@ -60,8 +60,8 @@ pub(crate) struct InspectorActor {
 }
 
 impl Actor for InspectorActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 
     fn handle_message(
@@ -75,7 +75,7 @@ impl Actor for InspectorActor {
         match msg_type {
             "getPageStyle" => {
                 let msg = GetPageStyleReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     page_style: registry.encode::<PageStyleActor, _>(&self.page_style_name),
                 };
                 request.reply_final(&msg)?
@@ -83,7 +83,7 @@ impl Actor for InspectorActor {
 
             "getHighlighterByType" => {
                 let msg = GetHighlighterReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     highlighter: registry.encode::<HighlighterActor, _>(&self.highlighter_name),
                 };
                 request.reply_final(&msg)?
@@ -91,7 +91,7 @@ impl Actor for InspectorActor {
 
             "getWalker" => {
                 let msg = GetWalkerReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     walker: registry.encode::<WalkerActor, _>(&self.walker_name),
                 };
                 request.reply_final(&msg)?
@@ -99,7 +99,7 @@ impl Actor for InspectorActor {
 
             "supportsHighlighters" => {
                 let msg = SupportsHighlightersReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     value: true,
                 };
                 request.reply_final(&msg)?
@@ -125,7 +125,7 @@ impl InspectorActor {
             page_style_name,
             walker_name,
         };
-        let inspector_name = inspector_actor.name();
+        let inspector_name: String = inspector_actor.name().into();
 
         registry.register(inspector_actor);
 

--- a/components/devtools/actors/inspector.rs
+++ b/components/devtools/actors/inspector.rs
@@ -8,7 +8,7 @@ use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{self, Map, Value};
 
-use crate::actor::{Actor, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorError, ActorRegistry, new_actor_name};
 use crate::actors::inspector::highlighter::HighlighterActor;
 use crate::actors::inspector::page_style::{PageStyleActor, PageStyleMsg};
 use crate::actors::inspector::walker::{WalkerActor, WalkerMsg};
@@ -120,7 +120,7 @@ impl InspectorActor {
         let walker_name = WalkerActor::register(registry, browsing_context_name);
 
         let inspector_actor = Self {
-            name: registry.new_name::<InspectorActor>(),
+            name: new_actor_name::<InspectorActor>(),
             highlighter_name,
             page_style_name,
             walker_name,

--- a/components/devtools/actors/inspector/accessibility.rs
+++ b/components/devtools/actors/inspector/accessibility.rs
@@ -5,6 +5,8 @@
 //! The Accessibility actor is responsible for the Accessibility tab in the DevTools page. Right
 //! now it is a placeholder for future functionality.
 
+use std::sync::Arc;
+
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
@@ -92,10 +94,11 @@ impl Actor for AccessibilityActor {
                 request.reply_final(&msg)?
             },
             "getSimulator" => {
+                let simulator_actor = SimulatorActor::register(registry);
                 let msg = GetSimulatorReply {
                     from: self.name().into(),
                     simulator: ActorMsg {
-                        actor: SimulatorActor::register(registry),
+                        actor: simulator_actor.name().into(),
                     },
                 };
                 request.reply_final(&msg)?
@@ -110,10 +113,11 @@ impl Actor for AccessibilityActor {
                 request.reply_final(&msg)?
             },
             "getWalker" => {
+                let accessible_walker_actor = AccessibleWalkerActor::register(registry);
                 let msg = GetWalkerReply {
                     from: self.name().into(),
                     walker: ActorMsg {
-                        actor: AccessibleWalkerActor::register(registry),
+                        actor: accessible_walker_actor.name().into(),
                     },
                 };
                 request.reply_final(&msg)?
@@ -125,10 +129,9 @@ impl Actor for AccessibilityActor {
 }
 
 impl AccessibilityActor {
-    pub fn register(registry: &ActorRegistry) -> String {
+    pub fn register(registry: &ActorRegistry) -> Arc<Self> {
         let name = new_actor_name::<Self>();
-        let actor = Self { name: name.clone() };
-        registry.register::<Self>(actor);
-        name
+        let actor = Self { name };
+        registry.register::<Self>(actor)
     }
 }

--- a/components/devtools/actors/inspector/accessibility.rs
+++ b/components/devtools/actors/inspector/accessibility.rs
@@ -10,7 +10,7 @@ use serde::Serialize;
 use serde_json::{Map, Value};
 
 use crate::StreamId;
-use crate::actor::{Actor, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorError, ActorRegistry, new_actor_name};
 use crate::actors::inspector::accessible_walker::AccessibleWalkerActor;
 use crate::actors::inspector::simulator::SimulatorActor;
 use crate::protocol::ClientRequest;
@@ -126,7 +126,7 @@ impl Actor for AccessibilityActor {
 
 impl AccessibilityActor {
     pub fn register(registry: &ActorRegistry) -> String {
-        let name = registry.new_name::<Self>();
+        let name = new_actor_name::<Self>();
         let actor = Self { name: name.clone() };
         registry.register::<Self>(actor);
         name

--- a/components/devtools/actors/inspector/accessibility.rs
+++ b/components/devtools/actors/inspector/accessibility.rs
@@ -61,8 +61,8 @@ pub(crate) struct AccessibilityActor {
 }
 
 impl Actor for AccessibilityActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 
     /// The accesibility actor can handle the following messages:
@@ -86,14 +86,14 @@ impl Actor for AccessibilityActor {
         match msg_type {
             "bootstrap" => {
                 let msg = BootstrapReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     state: BootstrapState { enabled: false },
                 };
                 request.reply_final(&msg)?
             },
             "getSimulator" => {
                 let msg = GetSimulatorReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     simulator: ActorMsg {
                         actor: SimulatorActor::register(registry),
                     },
@@ -102,7 +102,7 @@ impl Actor for AccessibilityActor {
             },
             "getTraits" => {
                 let msg = GetTraitsReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     traits: AccessibilityTraits {
                         tabbing_order: true,
                     },
@@ -111,7 +111,7 @@ impl Actor for AccessibilityActor {
             },
             "getWalker" => {
                 let msg = GetWalkerReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     walker: ActorMsg {
                         actor: AccessibleWalkerActor::register(registry),
                     },

--- a/components/devtools/actors/inspector/accessible_walker.rs
+++ b/components/devtools/actors/inspector/accessible_walker.rs
@@ -21,7 +21,7 @@ impl AccessibleWalkerActor {
 }
 
 impl Actor for AccessibleWalkerActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 }

--- a/components/devtools/actors/inspector/accessible_walker.rs
+++ b/components/devtools/actors/inspector/accessible_walker.rs
@@ -4,7 +4,7 @@
 
 use malloc_size_of_derive::MallocSizeOf;
 
-use crate::actor::{Actor, ActorRegistry};
+use crate::actor::{Actor, ActorRegistry, new_actor_name};
 
 #[derive(MallocSizeOf)]
 pub(crate) struct AccessibleWalkerActor {
@@ -13,7 +13,7 @@ pub(crate) struct AccessibleWalkerActor {
 
 impl AccessibleWalkerActor {
     pub fn register(registry: &ActorRegistry) -> String {
-        let name = registry.new_name::<Self>();
+        let name = new_actor_name::<Self>();
         let actor = Self { name: name.clone() };
         registry.register::<Self>(actor);
         name

--- a/components/devtools/actors/inspector/accessible_walker.rs
+++ b/components/devtools/actors/inspector/accessible_walker.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::sync::Arc;
+
 use malloc_size_of_derive::MallocSizeOf;
 
 use crate::actor::{Actor, ActorRegistry, new_actor_name};
@@ -12,11 +14,10 @@ pub(crate) struct AccessibleWalkerActor {
 }
 
 impl AccessibleWalkerActor {
-    pub fn register(registry: &ActorRegistry) -> String {
+    pub fn register(registry: &ActorRegistry) -> Arc<Self> {
         let name = new_actor_name::<Self>();
-        let actor = Self { name: name.clone() };
-        registry.register::<Self>(actor);
-        name
+        let actor = Self { name };
+        registry.register::<Self>(actor)
     }
 }
 

--- a/components/devtools/actors/inspector/css_properties.rs
+++ b/components/devtools/actors/inspector/css_properties.rs
@@ -13,7 +13,7 @@ use serde::Serialize;
 use serde_json::{Map, Value};
 
 use crate::StreamId;
-use crate::actor::{Actor, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorError, ActorRegistry, new_actor_name};
 use crate::protocol::ClientRequest;
 
 #[derive(MallocSizeOf)]
@@ -61,7 +61,7 @@ impl CssPropertiesActor {
         registry: &ActorRegistry,
         properties: HashMap<String, CssDatabaseProperty>,
     ) -> String {
-        let name = registry.new_name::<Self>();
+        let name = new_actor_name::<Self>();
         let actor = Self {
             name: name.clone(),
             properties,

--- a/components/devtools/actors/inspector/css_properties.rs
+++ b/components/devtools/actors/inspector/css_properties.rs
@@ -6,6 +6,7 @@
 //! alternative names
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use devtools_traits::CssDatabaseProperty;
 use malloc_size_of_derive::MallocSizeOf;
@@ -60,13 +61,9 @@ impl CssPropertiesActor {
     pub fn register(
         registry: &ActorRegistry,
         properties: HashMap<String, CssDatabaseProperty>,
-    ) -> String {
+    ) -> Arc<Self> {
         let name = new_actor_name::<Self>();
-        let actor = Self {
-            name: name.clone(),
-            properties,
-        };
-        registry.register::<Self>(actor);
-        name
+        let actor = Self { name, properties };
+        registry.register::<Self>(actor)
     }
 }

--- a/components/devtools/actors/inspector/css_properties.rs
+++ b/components/devtools/actors/inspector/css_properties.rs
@@ -29,8 +29,8 @@ struct GetCssDatabaseReply<'a> {
 }
 
 impl Actor for CssPropertiesActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 
     /// The css properties actor can handle the following messages:
@@ -47,7 +47,7 @@ impl Actor for CssPropertiesActor {
     ) -> Result<(), ActorError> {
         match msg_type {
             "getCSSDatabase" => request.reply_final(&GetCssDatabaseReply {
-                from: self.name(),
+                from: self.name().into(),
                 properties: &self.properties,
             })?,
             _ => return Err(ActorError::UnrecognizedPacketType),

--- a/components/devtools/actors/inspector/highlighter.rs
+++ b/components/devtools/actors/inspector/highlighter.rs
@@ -29,8 +29,8 @@ struct ShowReply {
 }
 
 impl Actor for HighlighterActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 
     /// The highligher actor can handle the following messages:
@@ -62,7 +62,7 @@ impl Actor for HighlighterActor {
                     // TODO: For some reason, the client initially asks us to highlight
                     // the inspector? Investigate what this is supposed to mean.
                     let msg = ShowReply {
-                        from: self.name(),
+                        from: self.name().into(),
                         value: false,
                     };
                     return request.reply_final(&msg);
@@ -73,7 +73,7 @@ impl Actor for HighlighterActor {
                     registry,
                 );
                 let msg = ShowReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     value: true,
                 };
                 request.reply_final(&msg)?
@@ -82,7 +82,9 @@ impl Actor for HighlighterActor {
             "hide" => {
                 self.instruct_script_thread_to_highlight_node(None, registry);
 
-                let msg = EmptyReplyMsg { from: self.name() };
+                let msg = EmptyReplyMsg {
+                    from: self.name().into(),
+                };
                 request.reply_final(&msg)?
             },
 
@@ -127,6 +129,8 @@ impl HighlighterActor {
 
 impl ActorEncode<ActorMsg> for HighlighterActor {
     fn encode(&self, _: &ActorRegistry) -> ActorMsg {
-        ActorMsg { actor: self.name() }
+        ActorMsg {
+            actor: self.name().into(),
+        }
     }
 }

--- a/components/devtools/actors/inspector/highlighter.rs
+++ b/components/devtools/actors/inspector/highlighter.rs
@@ -5,6 +5,8 @@
 //! Handles highlighting selected DOM nodes in the inspector. At the moment it only replies and
 //! changes nothing on Servo's side.
 
+use std::sync::Arc;
+
 use devtools_traits::DevtoolScriptControlMsg;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
@@ -99,14 +101,13 @@ impl Actor for HighlighterActor {
 }
 
 impl HighlighterActor {
-    pub fn register(registry: &ActorRegistry, browsing_context_name: String) -> String {
+    pub fn register(registry: &ActorRegistry, browsing_context_name: String) -> Arc<Self> {
         let name = new_actor_name::<Self>();
         let actor = Self {
-            name: name.clone(),
+            name,
             browsing_context_name,
         };
-        registry.register::<Self>(actor);
-        name
+        registry.register::<Self>(actor)
     }
 
     fn instruct_script_thread_to_highlight_node(

--- a/components/devtools/actors/inspector/highlighter.rs
+++ b/components/devtools/actors/inspector/highlighter.rs
@@ -10,7 +10,7 @@ use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{self, Map, Value};
 
-use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry, base_name, new_actor_name};
 use crate::actors::browsing_context::BrowsingContextActor;
 use crate::actors::inspector::InspectorActor;
 use crate::protocol::ClientRequest;
@@ -58,7 +58,7 @@ impl Actor for HighlighterActor {
                     return Err(ActorError::BadParameterType);
                 };
 
-                if node_actor_name.starts_with(ActorRegistry::base_name::<InspectorActor>()) {
+                if node_actor_name.starts_with(base_name::<InspectorActor>()) {
                     // TODO: For some reason, the client initially asks us to highlight
                     // the inspector? Investigate what this is supposed to mean.
                     let msg = ShowReply {
@@ -98,7 +98,7 @@ impl Actor for HighlighterActor {
 
 impl HighlighterActor {
     pub fn register(registry: &ActorRegistry, browsing_context_name: String) -> String {
-        let name = registry.new_name::<Self>();
+        let name = new_actor_name::<Self>();
         let actor = Self {
             name: name.clone(),
             browsing_context_name,

--- a/components/devtools/actors/inspector/highlighter.rs
+++ b/components/devtools/actors/inspector/highlighter.rs
@@ -52,15 +52,15 @@ impl Actor for HighlighterActor {
     ) -> Result<(), ActorError> {
         match msg_type {
             "show" => {
-                let Some(node_actor) = msg.get("node") else {
+                let Some(node_name) = msg.get("node") else {
                     return Err(ActorError::MissingParameter);
                 };
 
-                let Some(node_actor_name) = node_actor.as_str() else {
+                let Some(node_name) = node_name.as_str() else {
                     return Err(ActorError::BadParameterType);
                 };
 
-                if node_actor_name.starts_with(base_name::<InspectorActor>()) {
+                if node_name.starts_with(base_name::<InspectorActor>()) {
                     // TODO: For some reason, the client initially asks us to highlight
                     // the inspector? Investigate what this is supposed to mean.
                     let msg = ShowReply {
@@ -70,10 +70,7 @@ impl Actor for HighlighterActor {
                     return request.reply_final(&msg);
                 }
 
-                self.instruct_script_thread_to_highlight_node(
-                    Some(node_actor_name.to_owned()),
-                    registry,
-                );
+                self.instruct_script_thread_to_highlight_node(Some(node_name.into()), registry);
                 let msg = ShowReply {
                     from: self.name().into(),
                     value: true,

--- a/components/devtools/actors/inspector/layout.rs
+++ b/components/devtools/actors/inspector/layout.rs
@@ -31,8 +31,8 @@ pub(crate) struct GetCurrentFlexboxReply {
 }
 
 impl Actor for LayoutInspectorActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 
     /// The layout inspector actor can handle the following messages:
@@ -51,7 +51,7 @@ impl Actor for LayoutInspectorActor {
         match msg_type {
             "getGrids" => {
                 let msg = GetGridsReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     // TODO: Actually create a list of grids
                     grids: vec![],
                 };
@@ -59,7 +59,7 @@ impl Actor for LayoutInspectorActor {
             },
             "getCurrentFlexbox" => {
                 let msg = GetCurrentFlexboxReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     // TODO: Create and return the current flexbox object
                     flexbox: None,
                 };
@@ -84,6 +84,8 @@ impl LayoutInspectorActor {
 
 impl ActorEncode<ActorMsg> for LayoutInspectorActor {
     fn encode(&self, _: &ActorRegistry) -> ActorMsg {
-        ActorMsg { actor: self.name() }
+        ActorMsg {
+            actor: self.name().into(),
+        }
     }
 }

--- a/components/devtools/actors/inspector/layout.rs
+++ b/components/devtools/actors/inspector/layout.rs
@@ -9,7 +9,7 @@ use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
-use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry, new_actor_name};
 use crate::protocol::ClientRequest;
 use crate::{ActorMsg, StreamId};
 
@@ -75,7 +75,7 @@ impl Actor for LayoutInspectorActor {
 
 impl LayoutInspectorActor {
     pub fn register(registry: &ActorRegistry) -> String {
-        let name = registry.new_name::<Self>();
+        let name = new_actor_name::<Self>();
         let actor = Self { name: name.clone() };
         registry.register::<Self>(actor);
         name

--- a/components/devtools/actors/inspector/layout.rs
+++ b/components/devtools/actors/inspector/layout.rs
@@ -5,6 +5,8 @@
 //! The layout actor informs the DevTools client of the layout properties of the document, such as
 //! grids or flexboxes. It acts as a placeholder for now.
 
+use std::sync::Arc;
+
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
@@ -74,11 +76,10 @@ impl Actor for LayoutInspectorActor {
 }
 
 impl LayoutInspectorActor {
-    pub fn register(registry: &ActorRegistry) -> String {
+    pub fn register(registry: &ActorRegistry) -> Arc<Self> {
         let name = new_actor_name::<Self>();
-        let actor = Self { name: name.clone() };
-        registry.register::<Self>(actor);
-        name
+        let actor = Self { name };
+        registry.register::<Self>(actor)
     }
 }
 

--- a/components/devtools/actors/inspector/layout.rs
+++ b/components/devtools/actors/inspector/layout.rs
@@ -71,8 +71,6 @@ impl Actor for LayoutInspectorActor {
         };
         Ok(())
     }
-
-    fn cleanup(&self, _id: StreamId) {}
 }
 
 impl LayoutInspectorActor {

--- a/components/devtools/actors/inspector/node.rs
+++ b/components/devtools/actors/inspector/node.rs
@@ -17,7 +17,7 @@ use serde::Serialize;
 use serde_json::{self, Map, Value};
 use servo_base::generic_channel;
 
-use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry, new_actor_name};
 use crate::actors::inspector::walker::WalkerActor;
 use crate::protocol::ClientRequest;
 use crate::{EmptyReplyMsg, StreamId};
@@ -264,7 +264,7 @@ impl NodeActor {
         let unique_id = &node_info.unique_id;
 
         if !registry.script_actor_registered(unique_id) {
-            let name = registry.new_name::<Self>();
+            let name = new_actor_name::<Self>();
             registry.register_script_actor(unique_id.clone(), name.clone());
 
             let actor = Self {

--- a/components/devtools/actors/inspector/node.rs
+++ b/components/devtools/actors/inspector/node.rs
@@ -17,7 +17,9 @@ use serde::Serialize;
 use serde_json::{self, Map, Value};
 use servo_base::generic_channel;
 
-use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry, new_actor_name};
+use crate::actor::{
+    Actor, ActorEncode, ActorError, ActorRegistry, DowncastableActorArc, new_actor_name,
+};
 use crate::actors::inspector::walker::WalkerActor;
 use crate::protocol::ClientRequest;
 use crate::{EmptyReplyMsg, StreamId};
@@ -262,7 +264,7 @@ impl NodeActor {
         registry: &ActorRegistry,
         walker_name: &str,
         node_info: NodeInfo,
-    ) -> String {
+    ) -> DowncastableActorArc<Self> {
         let unique_id = &node_info.unique_id;
 
         if !registry.script_actor_registered(unique_id) {
@@ -276,13 +278,12 @@ impl NodeActor {
                 node_info: AtomicRefCell::new(node_info),
             };
 
-            registry.register(actor);
-            name
+            registry.register(actor).into()
         } else {
             let name = registry.script_to_actor(unique_id);
             let actor = registry.find::<NodeActor>(&name);
             actor.update(node_info);
-            name
+            actor
         }
     }
 
@@ -330,8 +331,8 @@ impl ActorEncode<NodeActorMsg> for NodeActor {
             let mut children = rx.recv().ok()??;
 
             let child = children.pop()?;
-            let node_name = NodeActor::register_or_update(registry, &self.walker_name, child);
-            let msg = registry.encode::<NodeActor, _>(&node_name);
+            let node_actor = NodeActor::register_or_update(registry, &self.walker_name, child);
+            let msg = node_actor.encode(registry);
 
             // If the node child is not a text node, do not represent it inline.
             if msg.node_type != TEXT_NODE {

--- a/components/devtools/actors/inspector/node.rs
+++ b/components/devtools/actors/inspector/node.rs
@@ -272,7 +272,7 @@ impl NodeActor {
             registry.register_script_actor(unique_id.clone(), name.clone());
 
             let actor = Self {
-                name: name.clone(),
+                name,
                 walker_name: walker_name.into(),
                 style_rules: AtomicRefCell::new(HashMap::new()),
                 node_info: AtomicRefCell::new(node_info),

--- a/components/devtools/actors/inspector/node.rs
+++ b/components/devtools/actors/inspector/node.rs
@@ -136,8 +136,8 @@ pub(crate) struct NodeActor {
 }
 
 impl Actor for NodeActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 
     /// The node actor can handle the following messages:
@@ -177,12 +177,14 @@ impl Actor for NodeActor {
                 script_chan
                     .send(DevtoolScriptControlMsg::ModifyAttribute(
                         browsing_context_actor.pipeline_id(),
-                        registry.actor_to_script(self.name()),
+                        registry.actor_to_script(self.name().into()),
                         modifications,
                     ))
                     .map_err(|_| ActorError::Internal)?;
 
-                let reply = EmptyReplyMsg { from: self.name() };
+                let reply = EmptyReplyMsg {
+                    from: self.name().into(),
+                };
                 request.reply_final(&reply)?
             },
             "getEventListenerInfo" => {
@@ -203,7 +205,7 @@ impl Actor for NodeActor {
                 let event_listeners = rx.recv().map_err(|_| ActorError::Internal)?;
 
                 let msg = GetEventListenerInfoReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     events: event_listeners.into_iter().map(From::from).collect(),
                 };
                 request.reply_final(&msg)?
@@ -220,7 +222,7 @@ impl Actor for NodeActor {
 
                 self.update(node_info);
                 let msg = GetUniqueSelectorReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     value: self.node_info.borrow().node_name.to_lowercase(),
                 };
                 request.reply_final(&msg)?
@@ -243,7 +245,7 @@ impl Actor for NodeActor {
 
                 let xpath_selector = rx.recv().map_err(|_| ActorError::Internal)?;
                 let msg = GetXPathReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     value: xpath_selector,
                 };
                 request.reply_final(&msg)?
@@ -307,7 +309,7 @@ impl ActorEncode<NodeActorMsg> for NodeActor {
             .browsing_context_actor(registry);
         let script_chan = browsing_context.script_chan();
         let pipeline = browsing_context.pipeline_id();
-        let script_id = registry.actor_to_script(actor.clone());
+        let script_id = registry.actor_to_script(actor.into());
 
         // If a node only has a single text node as a child with a small enough text,
         // return it with this node as an `inlineTextChild`.
@@ -345,7 +347,7 @@ impl ActorEncode<NodeActorMsg> for NodeActor {
         })();
 
         NodeActorMsg {
-            actor,
+            actor: actor.into(),
             host,
             base_uri: node_info.base_uri.clone(),
             display_name: node_info.node_name.to_lowercase(),

--- a/components/devtools/actors/inspector/page_style.rs
+++ b/components/devtools/actors/inspector/page_style.rs
@@ -7,6 +7,7 @@
 
 use std::collections::HashMap;
 use std::iter::once;
+use std::sync::Arc;
 
 use devtools_traits::DevtoolScriptControlMsg::{GetLayout, GetSelectors};
 use devtools_traits::{AutoMargins, ComputedNodeLayout, MatchedRule};
@@ -129,11 +130,10 @@ impl Actor for PageStyleActor {
 }
 
 impl PageStyleActor {
-    pub fn register(registry: &ActorRegistry) -> String {
+    pub fn register(registry: &ActorRegistry) -> Arc<Self> {
         let name = new_actor_name::<Self>();
-        let actor = Self { name: name.clone() };
-        registry.register::<Self>(actor);
-        name
+        let actor = Self { name };
+        registry.register::<Self>(actor)
     }
 
     fn get_applied(
@@ -202,6 +202,8 @@ impl PageStyleActor {
                                 (matched_rule.stylesheet_index != usize::MAX)
                                     .then_some(matched_rule.clone()),
                             )
+                            .name()
+                            .into()
                         })
                         .clone();
 
@@ -252,7 +254,11 @@ impl PageStyleActor {
             .style_rules
             .borrow_mut()
             .entry(style_attribute_rule)
-            .or_insert_with(|| StyleRuleActor::register(registry, node_name.into(), None))
+            .or_insert_with(|| {
+                StyleRuleActor::register(registry, node_name.into(), None)
+                    .name()
+                    .into()
+            })
             .clone();
         let computed = registry
             .find::<StyleRuleActor>(&style_rule_name)

--- a/components/devtools/actors/inspector/page_style.rs
+++ b/components/devtools/actors/inspector/page_style.rs
@@ -95,8 +95,8 @@ pub(crate) struct PageStyleActor {
 }
 
 impl Actor for PageStyleActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 
     /// The page style actor can handle the following messages:
@@ -198,7 +198,7 @@ impl PageStyleActor {
                         .or_insert_with(|| {
                             StyleRuleActor::register(
                                 registry,
-                                node_actor.name(),
+                                node_actor.name().into(),
                                 (matched_rule.stylesheet_index != usize::MAX)
                                     .then_some(matched_rule.clone()),
                             )
@@ -224,7 +224,7 @@ impl PageStyleActor {
         .collect();
         let msg = GetAppliedReply {
             entries,
-            from: self.name(),
+            from: self.name().into(),
         };
         request.reply_final(&msg)
     }
@@ -261,7 +261,7 @@ impl PageStyleActor {
 
         let msg = GetComputedReply {
             computed,
-            from: self.name(),
+            from: self.name().into(),
         };
         request.reply_final(&msg)
     }
@@ -294,7 +294,7 @@ impl PageStyleActor {
             .map_err(|_| ActorError::Internal)?
             .ok_or(ActorError::Internal)?;
         request.reply_final(&GetLayoutReply {
-            from: self.name(),
+            from: self.name().into(),
             layout,
             auto_margins: auto_margins.into(),
         })
@@ -302,7 +302,7 @@ impl PageStyleActor {
 
     fn is_position_editable(&self, request: ClientRequest) -> Result<(), ActorError> {
         let msg = IsPositionEditableReply {
-            from: self.name(),
+            from: self.name().into(),
             value: false,
         };
         request.reply_final(&msg)
@@ -312,7 +312,7 @@ impl PageStyleActor {
 impl ActorEncode<PageStyleMsg> for PageStyleActor {
     fn encode(&self, _: &ActorRegistry) -> PageStyleMsg {
         PageStyleMsg {
-            actor: self.name(),
+            actor: self.name().into(),
             traits: HashMap::from([
                 ("fontStretchLevel4".into(), true),
                 ("fontStyleLevel4".into(), true),

--- a/components/devtools/actors/inspector/page_style.rs
+++ b/components/devtools/actors/inspector/page_style.rs
@@ -16,7 +16,7 @@ use serde_json::{self, Map, Value};
 use servo_base::generic_channel::{self};
 
 use crate::StreamId;
-use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry, new_actor_name};
 use crate::actors::inspector::node::NodeActor;
 use crate::actors::inspector::style_rule::{AppliedRule, ComputedDeclaration, StyleRuleActor};
 use crate::actors::inspector::walker::{WalkerActor, find_child};
@@ -130,7 +130,7 @@ impl Actor for PageStyleActor {
 
 impl PageStyleActor {
     pub fn register(registry: &ActorRegistry) -> String {
-        let name = registry.new_name::<Self>();
+        let name = new_actor_name::<Self>();
         let actor = Self { name: name.clone() };
         registry.register::<Self>(actor);
         name

--- a/components/devtools/actors/inspector/simulator.rs
+++ b/components/devtools/actors/inspector/simulator.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::sync::Arc;
+
 use malloc_size_of_derive::MallocSizeOf;
 
 use crate::actor::{Actor, ActorRegistry, new_actor_name};
@@ -12,11 +14,10 @@ pub(crate) struct SimulatorActor {
 }
 
 impl SimulatorActor {
-    pub fn register(registry: &ActorRegistry) -> String {
+    pub fn register(registry: &ActorRegistry) -> Arc<Self> {
         let name = new_actor_name::<Self>();
-        let actor = Self { name: name.clone() };
-        registry.register::<Self>(actor);
-        name
+        let actor = Self { name };
+        registry.register::<Self>(actor)
     }
 }
 

--- a/components/devtools/actors/inspector/simulator.rs
+++ b/components/devtools/actors/inspector/simulator.rs
@@ -21,7 +21,7 @@ impl SimulatorActor {
 }
 
 impl Actor for SimulatorActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 }

--- a/components/devtools/actors/inspector/simulator.rs
+++ b/components/devtools/actors/inspector/simulator.rs
@@ -4,7 +4,7 @@
 
 use malloc_size_of_derive::MallocSizeOf;
 
-use crate::actor::{Actor, ActorRegistry};
+use crate::actor::{Actor, ActorRegistry, new_actor_name};
 
 #[derive(MallocSizeOf)]
 pub(crate) struct SimulatorActor {
@@ -13,7 +13,7 @@ pub(crate) struct SimulatorActor {
 
 impl SimulatorActor {
     pub fn register(registry: &ActorRegistry) -> String {
-        let name = registry.new_name::<Self>();
+        let name = new_actor_name::<Self>();
         let actor = Self { name: name.clone() };
         registry.register::<Self>(actor);
         name

--- a/components/devtools/actors/inspector/style_rule.rs
+++ b/components/devtools/actors/inspector/style_rule.rs
@@ -7,6 +7,7 @@
 //! A group is either the html style attribute or one selector from one stylesheet.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use devtools_traits::DevtoolScriptControlMsg::{
     GetAttributeStyle, GetComputedStyle, GetDocumentElement, GetStylesheetStyle, ModifyRule,
@@ -147,15 +148,14 @@ impl StyleRuleActor {
         registry: &ActorRegistry,
         node: String,
         selector: Option<MatchedRule>,
-    ) -> String {
+    ) -> Arc<Self> {
         let name = new_actor_name::<Self>();
         let actor = Self {
-            name: name.clone(),
+            name,
             node_name: node,
             selector,
         };
-        registry.register::<Self>(actor);
-        name
+        registry.register::<Self>(actor)
     }
 
     pub fn applied(&self, registry: &ActorRegistry) -> Option<AppliedRule> {

--- a/components/devtools/actors/inspector/style_rule.rs
+++ b/components/devtools/actors/inspector/style_rule.rs
@@ -18,7 +18,7 @@ use serde_json::{Map, Value};
 use servo_base::generic_channel;
 
 use crate::StreamId;
-use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry, new_actor_name};
 use crate::actors::inspector::node::NodeActor;
 use crate::actors::inspector::walker::WalkerActor;
 use crate::protocol::ClientRequest;
@@ -148,7 +148,7 @@ impl StyleRuleActor {
         node: String,
         selector: Option<MatchedRule>,
     ) -> String {
-        let name = registry.new_name::<Self>();
+        let name = new_actor_name::<Self>();
         let actor = Self {
             name: name.clone(),
             node_name: node,

--- a/components/devtools/actors/inspector/style_rule.rs
+++ b/components/devtools/actors/inspector/style_rule.rs
@@ -88,8 +88,8 @@ pub(crate) struct StyleRuleActor {
 }
 
 impl Actor for StyleRuleActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 
     /// The style rule configuration actor can handle the following messages:
@@ -193,7 +193,7 @@ impl StyleRuleActor {
         let style = style_receiver.recv().ok()??;
 
         Some(AppliedRule {
-            actor: self.name(),
+            actor: self.name().into(),
             ancestor_data: self
                 .selector
                 .as_ref()
@@ -266,7 +266,7 @@ impl StyleRuleActor {
 impl ActorEncode<StyleRuleActorMsg> for StyleRuleActor {
     fn encode(&self, registry: &ActorRegistry) -> StyleRuleActorMsg {
         StyleRuleActorMsg {
-            from: self.name(),
+            from: self.name().into(),
             rule: self.applied(registry),
         }
     }

--- a/components/devtools/actors/inspector/walker.rs
+++ b/components/devtools/actors/inspector/walker.rs
@@ -12,7 +12,9 @@ use serde::Serialize;
 use serde_json::{self, Map, Value};
 use servo_base::generic_channel;
 
-use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry, DowncastableActorArc};
+use crate::actor::{
+    Actor, ActorEncode, ActorError, ActorRegistry, DowncastableActorArc, new_actor_name,
+};
 use crate::actors::browsing_context::BrowsingContextActor;
 use crate::actors::inspector::layout::LayoutInspectorActor;
 use crate::actors::inspector::node::{NodeActor, NodeActorMsg};
@@ -268,7 +270,7 @@ impl Actor for WalkerActor {
 
 impl WalkerActor {
     pub fn register(registry: &ActorRegistry, browsing_context_name: String) -> String {
-        let name = registry.new_name::<WalkerActor>();
+        let name = new_actor_name::<WalkerActor>();
         let actor = WalkerActor {
             name: name.clone(),
             mutations: AtomicRefCell::new(vec![]),

--- a/components/devtools/actors/inspector/walker.rs
+++ b/components/devtools/actors/inspector/walker.rs
@@ -4,6 +4,8 @@
 
 //! The walker actor is responsible for traversing the DOM tree in various ways to create new nodes
 
+use std::sync::Arc;
+
 use atomic_refcell::AtomicRefCell;
 use devtools_traits::DevtoolScriptControlMsg::{GetChildren, GetDocumentElement, GetRootNode};
 use devtools_traits::DomMutation;
@@ -171,9 +173,9 @@ impl Actor for WalkerActor {
                     nodes: children
                         .into_iter()
                         .map(|child| {
-                            let node_name =
+                            let node_actor =
                                 NodeActor::register_or_update(registry, &self.name, child);
-                            registry.encode::<NodeActor, _>(&node_name)
+                            node_actor.encode(registry)
                         })
                         .collect(),
                     from: self.name().into(),
@@ -199,8 +201,8 @@ impl Actor for WalkerActor {
                     .map_err(|_| ActorError::Internal)?
                     .ok_or(ActorError::Internal)?;
 
-                let node_name = NodeActor::register_or_update(registry, &self.name, node_info);
-                let node = registry.encode::<NodeActor, _>(&node_name);
+                let node_actor = NodeActor::register_or_update(registry, &self.name, node_info);
+                let node = node_actor.encode(registry);
 
                 let msg = DocumentElementReply {
                     from: self.name().into(),
@@ -209,11 +211,7 @@ impl Actor for WalkerActor {
                 request.reply_final(&msg)?
             },
             "getLayoutInspector" => {
-                // TODO: Create actual layout inspector actor
-                let layout_inspector_name = LayoutInspectorActor::register(registry);
-                let layout_inspector_actor =
-                    registry.find::<LayoutInspectorActor>(&layout_inspector_name);
-
+                let layout_inspector_actor = LayoutInspectorActor::register(registry);
                 let msg = GetLayoutInspectorReply {
                     from: self.name().into(),
                     actor: layout_inspector_actor.encode(registry),
@@ -273,15 +271,14 @@ impl Actor for WalkerActor {
 }
 
 impl WalkerActor {
-    pub fn register(registry: &ActorRegistry, browsing_context_name: String) -> String {
+    pub fn register(registry: &ActorRegistry, browsing_context_name: String) -> Arc<Self> {
         let name = new_actor_name::<WalkerActor>();
         let actor = WalkerActor {
-            name: name.clone(),
+            name,
             mutations: AtomicRefCell::new(vec![]),
             browsing_context_name,
         };
-        registry.register::<Self>(actor);
-        name
+        registry.register::<Self>(actor)
     }
 
     pub(crate) fn browsing_context_actor(
@@ -304,8 +301,8 @@ impl WalkerActor {
             .map_err(|_| ActorError::Internal)?
             .ok_or(ActorError::Internal)?;
 
-        let node_name = NodeActor::register_or_update(registry, &self.name, node_info);
-        Ok(registry.encode::<NodeActor, _>(&node_name))
+        let node_actor = NodeActor::register_or_update(registry, &self.name, node_info);
+        Ok(node_actor.encode(registry))
     }
 
     pub(crate) fn handle_dom_mutation(
@@ -397,8 +394,8 @@ pub fn find_child(
     let children = rx.recv().unwrap().ok_or(vec![])?;
 
     for child in children {
-        let node_name = NodeActor::register_or_update(registry, walker_name, child);
-        let msg = registry.encode::<NodeActor, _>(&node_name);
+        let node_actor = NodeActor::register_or_update(registry, walker_name, child);
+        let msg = node_actor.encode(registry);
 
         if compare_fn(&msg) {
             hierarchy.push(msg);

--- a/components/devtools/actors/inspector/walker.rs
+++ b/components/devtools/actors/inspector/walker.rs
@@ -113,8 +113,8 @@ struct NewMutationsNotification {
 }
 
 impl Actor for WalkerActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 
     /// The walker actor can handle the following messages:
@@ -176,12 +176,14 @@ impl Actor for WalkerActor {
                             registry.encode::<NodeActor, _>(&node_name)
                         })
                         .collect(),
-                    from: self.name(),
+                    from: self.name().into(),
                 };
                 request.reply_final(&msg)?
             },
             "clearPseudoClassLocks" => {
-                let msg = EmptyReplyMsg { from: self.name() };
+                let msg = EmptyReplyMsg {
+                    from: self.name().into(),
+                };
                 request.reply_final(&msg)?
             },
             "documentElement" => {
@@ -201,7 +203,7 @@ impl Actor for WalkerActor {
                 let node = registry.encode::<NodeActor, _>(&node_name);
 
                 let msg = DocumentElementReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     node,
                 };
                 request.reply_final(&msg)?
@@ -213,7 +215,7 @@ impl Actor for WalkerActor {
                     registry.find::<LayoutInspectorActor>(&layout_inspector_name);
 
                 let msg = GetLayoutInspectorReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     actor: layout_inspector_actor.encode(registry),
                 };
                 request.reply_final(&msg)?
@@ -221,7 +223,7 @@ impl Actor for WalkerActor {
             "getMutations" => self.handle_get_mutations(request, registry)?,
             "getOffsetParent" => {
                 let msg = GetOffsetParentReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     node: None,
                 };
                 request.reply_final(&msg)?
@@ -245,7 +247,7 @@ impl Actor for WalkerActor {
                 let node = hierarchy.pop().ok_or(ActorError::Internal)?;
 
                 let msg = QuerySelectorReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     node,
                     new_parents: hierarchy,
                 };
@@ -254,12 +256,14 @@ impl Actor for WalkerActor {
             "watchRootNode" => {
                 let msg = WatchRootNodeNotification {
                     type_: "root-available".into(),
-                    from: self.name(),
+                    from: self.name().into(),
                     node: self.root(registry)?,
                 };
                 let _ = request.write_json_packet(&msg);
 
-                let msg = EmptyReplyMsg { from: self.name() };
+                let msg = EmptyReplyMsg {
+                    from: self.name().into(),
+                };
                 request.reply_final(&msg)?
             },
             _ => return Err(ActorError::UnrecognizedPacketType),
@@ -329,7 +333,7 @@ impl WalkerActor {
         pending_mutations.push(dom_mutation);
 
         stream.write_json_packet(&NewMutationsNotification {
-            from: self.name(),
+            from: self.name().into(),
             type_: "newMutations".into(),
         })
     }
@@ -341,7 +345,7 @@ impl WalkerActor {
         registry: &ActorRegistry,
     ) -> Result<(), ActorError> {
         let msg = GetMutationsReply {
-            from: self.name(),
+            from: self.name().into(),
             mutations: self
                 .mutations
                 .borrow_mut()
@@ -427,7 +431,7 @@ pub fn find_child(
 impl ActorEncode<WalkerMsg> for WalkerActor {
     fn encode(&self, registry: &ActorRegistry) -> WalkerMsg {
         WalkerMsg {
-            actor: self.name(),
+            actor: self.name().into(),
             root: self.root(registry).unwrap(),
         }
     }

--- a/components/devtools/actors/long_string.rs
+++ b/components/devtools/actors/long_string.rs
@@ -1,6 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+use std::sync::Arc;
+
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
@@ -73,14 +75,10 @@ impl Actor for LongStringActor {
 }
 
 impl LongStringActor {
-    pub fn register(registry: &ActorRegistry, full_string: String) -> String {
+    pub fn register(registry: &ActorRegistry, full_string: String) -> Arc<Self> {
         let name = new_actor_name::<Self>();
-        let actor = Self {
-            name: name.clone(),
-            full_string,
-        };
-        registry.register::<Self>(actor);
-        name
+        let actor = Self { name, full_string };
+        registry.register::<Self>(actor)
     }
 
     pub fn long_string_obj(&self) -> LongStringObj {

--- a/components/devtools/actors/long_string.rs
+++ b/components/devtools/actors/long_string.rs
@@ -35,8 +35,8 @@ struct SubstringReply {
 }
 
 impl Actor for LongStringActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 
     fn handle_message(
@@ -61,7 +61,7 @@ impl Actor for LongStringActor {
                     .take(end - start)
                     .collect();
                 let reply = SubstringReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     substring,
                 };
                 request.reply_final(&reply)?

--- a/components/devtools/actors/long_string.rs
+++ b/components/devtools/actors/long_string.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use serde_json::{Map, Value};
 
 use crate::StreamId;
-use crate::actor::{Actor, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorError, ActorRegistry, new_actor_name};
 use crate::protocol::ClientRequest;
 
 const INITIAL_LENGTH: usize = 500;
@@ -74,7 +74,7 @@ impl Actor for LongStringActor {
 
 impl LongStringActor {
     pub fn register(registry: &ActorRegistry, full_string: String) -> String {
-        let name = registry.new_name::<Self>();
+        let name = new_actor_name::<Self>();
         let actor = Self {
             name: name.clone(),
             full_string,

--- a/components/devtools/actors/memory.rs
+++ b/components/devtools/actors/memory.rs
@@ -28,8 +28,8 @@ pub(crate) struct MemoryActor {
 }
 
 impl Actor for MemoryActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 }
 

--- a/components/devtools/actors/memory.rs
+++ b/components/devtools/actors/memory.rs
@@ -5,7 +5,7 @@
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 
-use crate::actor::{Actor, ActorRegistry};
+use crate::actor::{Actor, ActorRegistry, new_actor_name};
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -36,7 +36,7 @@ impl Actor for MemoryActor {
 impl MemoryActor {
     /// return name of actor
     pub fn create(registry: &ActorRegistry) -> String {
-        let actor_name = registry.new_name::<Self>();
+        let actor_name = new_actor_name::<Self>();
         let actor = MemoryActor {
             name: actor_name.clone(),
         };

--- a/components/devtools/actors/network_event.rs
+++ b/components/devtools/actors/network_event.rs
@@ -23,7 +23,7 @@ use serde_json::{Map, Value};
 use servo_url::ServoUrl;
 
 use crate::StreamId;
-use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry, new_actor_name};
 use crate::actors::browsing_context::BrowsingContextActor;
 use crate::actors::long_string::LongStringActor;
 use crate::network_handler::Cause;
@@ -540,7 +540,7 @@ impl NetworkEventActor {
         resource_id: u64,
         browsing_context_name: String,
     ) -> String {
-        let name = registry.new_name::<Self>();
+        let name = new_actor_name::<Self>();
         let actor = NetworkEventActor {
             name: name.clone(),
             resource_id,

--- a/components/devtools/actors/network_event.rs
+++ b/components/devtools/actors/network_event.rs
@@ -351,8 +351,8 @@ struct HeaderWrapper {
 }
 
 impl Actor for NetworkEventActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 
     fn handle_message(
@@ -372,7 +372,7 @@ impl Actor for NetworkEventActor {
                 let raw_headers = get_raw_headers(&headers);
 
                 let msg = GetRequestHeadersReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     headers,
                     header_size: raw_headers.len(),
                     raw_headers,
@@ -385,7 +385,7 @@ impl Actor for NetworkEventActor {
                 let request = request.as_ref().ok_or(ActorError::Internal)?;
 
                 let msg = GetCookiesReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     cookies: get_cookies_from_headers(
                         &request.request.headers,
                         &request.request.url,
@@ -400,7 +400,7 @@ impl Actor for NetworkEventActor {
                 let request = request.as_ref().ok_or(ActorError::Internal)?;
 
                 let msg = GetRequestPostDataReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     post_data: request.request.body.as_ref().map(|b| b.0.clone()),
                     post_data_discarded: request.request.body.is_none(),
                 };
@@ -420,7 +420,7 @@ impl Actor for NetworkEventActor {
                 let raw_headers = get_raw_headers(&list);
 
                 let msg = GetResponseHeadersReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     headers: list,
                     header_size: raw_headers.len(),
                     raw_headers,
@@ -435,7 +435,7 @@ impl Actor for NetworkEventActor {
                 let response = response.as_ref().ok_or(ActorError::Internal)?;
 
                 let msg = GetCookiesReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     cookies: get_cookies_from_headers(
                         response
                             .response
@@ -493,7 +493,7 @@ impl Actor for NetworkEventActor {
                 });
 
                 let msg = GetResponseContentReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     content,
                     content_discarded: response.response.body.is_none(),
                 };
@@ -509,7 +509,7 @@ impl Actor for NetworkEventActor {
                 let total_time = timings.total();
 
                 let msg = GetEventTimingsReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     offsets,
                     server_timings: vec![],
                     timings,
@@ -522,7 +522,7 @@ impl Actor for NetworkEventActor {
                 let security_info = &*self.security_info.borrow();
 
                 let msg = GetSecurityInfoReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     security_info: security_info.into(),
                 };
                 client_request.reply_final(&msg)?
@@ -712,7 +712,7 @@ impl ActorEncode<NetworkEventMsg> for NetworkEventActor {
             registry.find::<BrowsingContextActor>(&self.browsing_context_name);
 
         NetworkEventMsg {
-            actor: self.name(),
+            actor: self.name().into(),
             browsing_context_id: browsing_context_actor.browsing_context_id.value(),
             cause: Cause {
                 type_: request.destination.as_str().to_string(),

--- a/components/devtools/actors/network_event.rs
+++ b/components/devtools/actors/network_event.rs
@@ -5,6 +5,7 @@
 //! Liberally derived from the [Firefox JS implementation](http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/server/actors/webconsole.js).
 //! Handles interaction with the remote web console on network events (HTTP requests, responses) in Servo.
 
+use std::sync::Arc;
 use std::time::{Duration, UNIX_EPOCH};
 
 use atomic_refcell::AtomicRefCell;
@@ -467,10 +468,8 @@ impl Actor for NetworkEventActor {
                     let (encoding, text) = if mime_type.is_some() {
                         // Queue a LongStringActor for this body
                         let body_string = String::from_utf8_lossy(body).to_string();
-                        let long_string_name = LongStringActor::register(registry, body_string);
-                        let value = registry
-                            .find::<LongStringActor>(&long_string_name)
-                            .long_string_obj();
+                        let long_string_actor = LongStringActor::register(registry, body_string);
+                        let value = long_string_actor.long_string_obj();
                         (None, serde_json::to_value(value).unwrap())
                     } else {
                         let b64 = STANDARD.encode(&body.0);
@@ -539,16 +538,15 @@ impl NetworkEventActor {
         registry: &ActorRegistry,
         resource_id: u64,
         browsing_context_name: String,
-    ) -> String {
+    ) -> Arc<Self> {
         let name = new_actor_name::<Self>();
         let actor = NetworkEventActor {
-            name: name.clone(),
+            name,
             resource_id,
             browsing_context_name,
             ..Default::default()
         };
-        registry.register::<Self>(actor);
-        name
+        registry.register::<Self>(actor)
     }
 
     pub fn add_request(&self, request: HttpRequest) {

--- a/components/devtools/actors/object.rs
+++ b/components/devtools/actors/object.rs
@@ -181,14 +181,12 @@ impl Actor for ObjectActor {
                         preview.own_properties.clone().unwrap_or_default()
                     }
                 });
-                let property_iterator_name = PropertyIteratorActor::register(registry, properties);
-                let property_iterator_actor =
-                    registry.find::<PropertyIteratorActor>(&property_iterator_name);
+                let property_iterator_actor = PropertyIteratorActor::register(registry, properties);
                 let count = property_iterator_actor.count();
                 let msg = EnumReply {
                     from: self.name().into(),
                     iterator: EnumIterator {
-                        actor: property_iterator_name,
+                        actor: property_iterator_actor.name().into(),
                         type_: EnumIteratorType::PropertyIterator,
                         count,
                     },
@@ -198,11 +196,11 @@ impl Actor for ObjectActor {
             },
 
             "enumSymbols" => {
-                let symbol_iterator_name = SymbolIteratorActor::register(registry);
+                let symbol_iterator_actor = SymbolIteratorActor::register(registry);
                 let msg = EnumReply {
                     from: self.name().into(),
                     iterator: EnumIterator {
-                        actor: symbol_iterator_name,
+                        actor: symbol_iterator_actor.name().into(),
                         type_: EnumIteratorType::SymbolIterator,
                         count: 0,
                     },

--- a/components/devtools/actors/object.rs
+++ b/components/devtools/actors/object.rs
@@ -9,7 +9,7 @@ use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
-use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry, new_actor_name};
 use crate::actors::property_iterator::PropertyIteratorActor;
 use crate::actors::symbol_iterator::SymbolIteratorActor;
 use crate::protocol::ClientRequest;
@@ -233,7 +233,7 @@ impl ObjectActor {
         preview: Option<devtools_traits::ObjectPreview>,
     ) -> String {
         let Some(uuid) = uuid else {
-            let name = registry.new_name::<Self>();
+            let name = new_actor_name::<Self>();
             let actor = ObjectActor {
                 name: name.clone(),
                 _uuid: None,
@@ -245,7 +245,7 @@ impl ObjectActor {
             return name;
         };
         if !registry.script_actor_registered(&uuid) {
-            let name = registry.new_name::<Self>();
+            let name = new_actor_name::<Self>();
             let actor = ObjectActor {
                 name: name.clone(),
                 _uuid: Some(uuid.clone()),

--- a/components/devtools/actors/object.rs
+++ b/components/devtools/actors/object.rs
@@ -127,8 +127,8 @@ pub(crate) struct ObjectActor {
 }
 
 impl Actor for ObjectActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 
     // https://searchfox.org/firefox-main/source/devtools/shared/specs/object.js
@@ -186,7 +186,7 @@ impl Actor for ObjectActor {
                     registry.find::<PropertyIteratorActor>(&property_iterator_name);
                 let count = property_iterator_actor.count();
                 let msg = EnumReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     iterator: EnumIterator {
                         actor: property_iterator_name,
                         type_: EnumIteratorType::PropertyIterator,
@@ -200,7 +200,7 @@ impl Actor for ObjectActor {
             "enumSymbols" => {
                 let symbol_iterator_name = SymbolIteratorActor::register(registry);
                 let msg = EnumReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     iterator: EnumIterator {
                         actor: symbol_iterator_name,
                         type_: EnumIteratorType::SymbolIterator,
@@ -212,7 +212,7 @@ impl Actor for ObjectActor {
 
             "prototype" => {
                 let msg = PrototypeReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     prototype: self.encode(registry),
                 };
                 request.reply_final(&msg)?
@@ -267,7 +267,7 @@ impl ObjectActor {
 impl ActorEncode<ObjectActorMsg> for ObjectActor {
     fn encode(&self, registry: &ActorRegistry) -> ObjectActorMsg {
         let mut msg = ObjectActorMsg {
-            actor: self.name(),
+            actor: self.name().into(),
             type_: "object".into(),
             class: self.class.clone(),
             extensible: true,

--- a/components/devtools/actors/pause.rs
+++ b/components/devtools/actors/pause.rs
@@ -14,8 +14,8 @@ pub(crate) struct PauseActor {
 }
 
 impl Actor for PauseActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 }
 

--- a/components/devtools/actors/pause.rs
+++ b/components/devtools/actors/pause.rs
@@ -4,7 +4,7 @@
 
 use malloc_size_of_derive::MallocSizeOf;
 
-use crate::actor::{Actor, ActorRegistry};
+use crate::actor::{Actor, ActorRegistry, new_actor_name};
 
 /// Referenced by `ThreadActor` when replying to `interupt` messages.
 /// <https://searchfox.org/firefox-main/source/devtools/server/actors/thread.js#1699>
@@ -21,7 +21,7 @@ impl Actor for PauseActor {
 
 impl PauseActor {
     pub fn register(registry: &ActorRegistry) -> String {
-        let name = registry.new_name::<Self>();
+        let name = new_actor_name::<Self>();
         let actor = Self { name: name.clone() };
         registry.register::<Self>(actor);
         name

--- a/components/devtools/actors/pause.rs
+++ b/components/devtools/actors/pause.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::sync::Arc;
+
 use malloc_size_of_derive::MallocSizeOf;
 
 use crate::actor::{Actor, ActorRegistry, new_actor_name};
@@ -20,10 +22,9 @@ impl Actor for PauseActor {
 }
 
 impl PauseActor {
-    pub fn register(registry: &ActorRegistry) -> String {
+    pub fn register(registry: &ActorRegistry) -> Arc<Self> {
         let name = new_actor_name::<Self>();
-        let actor = Self { name: name.clone() };
-        registry.register::<Self>(actor);
-        name
+        let actor = Self { name };
+        registry.register::<Self>(actor)
     }
 }

--- a/components/devtools/actors/performance.rs
+++ b/components/devtools/actors/performance.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 use serde_json::{Map, Value};
 
 use crate::StreamId;
-use crate::actor::{Actor, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorError, ActorRegistry, new_actor_name};
 use crate::protocol::{ActorDescription, ClientRequest, Method};
 
 #[derive(MallocSizeOf)]
@@ -99,7 +99,7 @@ impl Actor for PerformanceActor {
 
 impl PerformanceActor {
     pub fn register(registry: &ActorRegistry) -> String {
-        let name = registry.new_name::<Self>();
+        let name = new_actor_name::<Self>();
         let actor = PerformanceActor { name: name.clone() };
         registry.register::<Self>(actor);
         name

--- a/components/devtools/actors/performance.rs
+++ b/components/devtools/actors/performance.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::sync::Arc;
+
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
@@ -98,11 +100,10 @@ impl Actor for PerformanceActor {
 }
 
 impl PerformanceActor {
-    pub fn register(registry: &ActorRegistry) -> String {
+    pub fn register(registry: &ActorRegistry) -> Arc<Self> {
         let name = new_actor_name::<Self>();
-        let actor = PerformanceActor { name: name.clone() };
-        registry.register::<Self>(actor);
-        name
+        let actor = PerformanceActor { name };
+        registry.register::<Self>(actor)
     }
 
     pub fn description() -> ActorDescription {

--- a/components/devtools/actors/performance.rs
+++ b/components/devtools/actors/performance.rs
@@ -53,8 +53,8 @@ struct SuccessMsg {
 enum Error {}
 
 impl Actor for PerformanceActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 
     fn handle_message(
@@ -68,7 +68,7 @@ impl Actor for PerformanceActor {
         match msg_type {
             "connect" => {
                 let msg = ConnectReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     traits: PerformanceTraits {
                         features: PerformanceFeatures {
                             with_markers: true,
@@ -83,7 +83,7 @@ impl Actor for PerformanceActor {
             },
             "canCurrentlyRecord" => {
                 let msg = CanCurrentlyRecordReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     value: SuccessMsg {
                         success: true,
                         errors: vec![],

--- a/components/devtools/actors/preference.rs
+++ b/components/devtools/actors/preference.rs
@@ -26,8 +26,8 @@ impl PreferenceActor {
 }
 
 impl Actor for PreferenceActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 
     fn handle_message(

--- a/components/devtools/actors/preference.rs
+++ b/components/devtools/actors/preference.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::sync::Arc;
+
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
@@ -17,11 +19,10 @@ pub(crate) struct PreferenceActor {
 }
 
 impl PreferenceActor {
-    pub fn register(registry: &ActorRegistry) -> String {
+    pub fn register(registry: &ActorRegistry) -> Arc<Self> {
         let name = new_actor_name::<Self>();
-        let actor = Self { name: name.clone() };
-        registry.register::<Self>(actor);
-        name
+        let actor = Self { name };
+        registry.register::<Self>(actor)
     }
 }
 

--- a/components/devtools/actors/preference.rs
+++ b/components/devtools/actors/preference.rs
@@ -8,7 +8,7 @@ use serde_json::{Map, Value};
 use servo_config::pref;
 
 use crate::StreamId;
-use crate::actor::{Actor, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorError, ActorRegistry, new_actor_name};
 use crate::protocol::ClientRequest;
 
 #[derive(MallocSizeOf)]
@@ -18,7 +18,7 @@ pub(crate) struct PreferenceActor {
 
 impl PreferenceActor {
     pub fn register(registry: &ActorRegistry) -> String {
-        let name = registry.new_name::<Self>();
+        let name = new_actor_name::<Self>();
         let actor = Self { name: name.clone() };
         registry.register::<Self>(actor);
         name

--- a/components/devtools/actors/process.rs
+++ b/components/devtools/actors/process.rs
@@ -11,7 +11,7 @@ use serde::Serialize;
 use serde_json::{Map, Value};
 
 use crate::StreamId;
-use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry, new_actor_name};
 use crate::actors::root::DescriptorTraits;
 use crate::protocol::ClientRequest;
 
@@ -69,7 +69,7 @@ impl Actor for ProcessActor {
 
 impl ProcessActor {
     pub fn register(registry: &ActorRegistry) -> String {
-        let name = registry.new_name::<Self>();
+        let name = new_actor_name::<Self>();
         let actor = Self { name: name.clone() };
         registry.register::<Self>(actor);
         name

--- a/components/devtools/actors/process.rs
+++ b/components/devtools/actors/process.rs
@@ -6,6 +6,8 @@
 //!
 //! [Firefox JS implementation]: https://searchfox.org/mozilla-central/source/devtools/server/actors/descriptors/process.js
 
+use std::sync::Arc;
+
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
@@ -68,11 +70,10 @@ impl Actor for ProcessActor {
 }
 
 impl ProcessActor {
-    pub fn register(registry: &ActorRegistry) -> String {
+    pub fn register(registry: &ActorRegistry) -> Arc<Self> {
         let name = new_actor_name::<Self>();
-        let actor = Self { name: name.clone() };
-        registry.register::<Self>(actor);
-        name
+        let actor = Self { name };
+        registry.register::<Self>(actor)
     }
 }
 

--- a/components/devtools/actors/process.rs
+++ b/components/devtools/actors/process.rs
@@ -37,8 +37,8 @@ pub(crate) struct ProcessActor {
 }
 
 impl Actor for ProcessActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 
     /// The process actor can handle the following messages:
@@ -55,7 +55,7 @@ impl Actor for ProcessActor {
         match msg_type {
             "listWorkers" => {
                 let reply = ListWorkersReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     workers: vec![],
                 };
                 request.reply_final(&reply)?
@@ -79,7 +79,7 @@ impl ProcessActor {
 impl ActorEncode<ProcessActorMsg> for ProcessActor {
     fn encode(&self, _: &ActorRegistry) -> ProcessActorMsg {
         ProcessActorMsg {
-            actor: self.name(),
+            actor: self.name().into(),
             id: 0,
             is_parent: true,
             is_windowless_parent: false,

--- a/components/devtools/actors/property_iterator.rs
+++ b/components/devtools/actors/property_iterator.rs
@@ -10,7 +10,7 @@ use serde::Serialize;
 use serde_json::{Map, Value};
 
 use crate::StreamId;
-use crate::actor::{Actor, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorError, ActorRegistry, new_actor_name};
 use crate::actors::object::ObjectPropertyDescriptor;
 use crate::protocol::ClientRequest;
 
@@ -29,7 +29,7 @@ pub(crate) struct PropertyIteratorActor {
 
 impl PropertyIteratorActor {
     pub fn register(registry: &ActorRegistry, properties: Vec<PropertyDescriptor>) -> String {
-        let name = registry.new_name::<Self>();
+        let name = new_actor_name::<Self>();
         let actor = Self {
             name: name.clone(),
             properties,

--- a/components/devtools/actors/property_iterator.rs
+++ b/components/devtools/actors/property_iterator.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use devtools_traits::PropertyDescriptor;
 use malloc_size_of_derive::MallocSizeOf;
@@ -28,14 +29,10 @@ pub(crate) struct PropertyIteratorActor {
 }
 
 impl PropertyIteratorActor {
-    pub fn register(registry: &ActorRegistry, properties: Vec<PropertyDescriptor>) -> String {
+    pub fn register(registry: &ActorRegistry, properties: Vec<PropertyDescriptor>) -> Arc<Self> {
         let name = new_actor_name::<Self>();
-        let actor = Self {
-            name: name.clone(),
-            properties,
-        };
-        registry.register::<Self>(actor);
-        name
+        let actor = Self { name, properties };
+        registry.register::<Self>(actor)
     }
 
     pub fn count(&self) -> u32 {

--- a/components/devtools/actors/property_iterator.rs
+++ b/components/devtools/actors/property_iterator.rs
@@ -44,8 +44,8 @@ impl PropertyIteratorActor {
 }
 
 impl Actor for PropertyIteratorActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 
     fn handle_message(
@@ -73,7 +73,7 @@ impl Actor for PropertyIteratorActor {
                 }
 
                 let reply = SliceReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     own_properties,
                 };
                 request.reply_final(&reply)?

--- a/components/devtools/actors/reflow.rs
+++ b/components/devtools/actors/reflow.rs
@@ -4,6 +4,8 @@
 
 //! This actor is used for protocol purposes, it forwards the reflow events to clients.
 
+use std::sync::Arc;
+
 use malloc_size_of_derive::MallocSizeOf;
 use serde_json::{Map, Value};
 
@@ -49,10 +51,9 @@ impl Actor for ReflowActor {
 }
 
 impl ReflowActor {
-    pub fn register(registry: &ActorRegistry) -> String {
+    pub fn register(registry: &ActorRegistry) -> Arc<Self> {
         let name = new_actor_name::<Self>();
-        let actor = Self { name: name.clone() };
-        registry.register::<Self>(actor);
-        name
+        let actor = Self { name };
+        registry.register::<Self>(actor)
     }
 }

--- a/components/devtools/actors/reflow.rs
+++ b/components/devtools/actors/reflow.rs
@@ -46,8 +46,6 @@ impl Actor for ReflowActor {
         };
         Ok(())
     }
-
-    fn cleanup(&self, _id: StreamId) {}
 }
 
 impl ReflowActor {

--- a/components/devtools/actors/reflow.rs
+++ b/components/devtools/actors/reflow.rs
@@ -17,8 +17,8 @@ pub(crate) struct ReflowActor {
 }
 
 impl Actor for ReflowActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 
     /// The reflow actor can handle the following messages:
@@ -35,7 +35,9 @@ impl Actor for ReflowActor {
         match msg_type {
             "start" => {
                 // TODO: Create an observer on "reflows" events
-                let msg = EmptyReplyMsg { from: self.name() };
+                let msg = EmptyReplyMsg {
+                    from: self.name().into(),
+                };
                 request.reply_final(&msg)?
             },
             _ => return Err(ActorError::UnrecognizedPacketType),

--- a/components/devtools/actors/reflow.rs
+++ b/components/devtools/actors/reflow.rs
@@ -7,7 +7,7 @@
 use malloc_size_of_derive::MallocSizeOf;
 use serde_json::{Map, Value};
 
-use crate::actor::{Actor, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorError, ActorRegistry, new_actor_name};
 use crate::protocol::ClientRequest;
 use crate::{EmptyReplyMsg, StreamId};
 
@@ -48,7 +48,7 @@ impl Actor for ReflowActor {
 
 impl ReflowActor {
     pub fn register(registry: &ActorRegistry) -> String {
-        let name = registry.new_name::<Self>();
+        let name = new_actor_name::<Self>();
         let actor = Self { name: name.clone() };
         registry.register::<Self>(actor);
         name

--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -352,23 +352,23 @@ impl RootActor {
     /// Registers the root actor and its global actors (those not associated with a specific target).
     pub fn register(registry: &mut ActorRegistry) {
         // Global actors
-        let device_name = DeviceActor::register(registry);
-        let performance_name = PerformanceActor::register(registry);
-        let preference_name = PreferenceActor::register(registry);
+        let device_actor = DeviceActor::register(registry);
+        let performance_actor = PerformanceActor::register(registry);
+        let preference_actor = PreferenceActor::register(registry);
 
         // Process descriptor
-        let process_name = ProcessActor::register(registry);
+        let process_actor = ProcessActor::register(registry);
 
         // Root actor
         let root_actor = Self {
             // TODO: Create an actual name for the root actor
             name: "root".into(),
             global_actors: GlobalActors {
-                device_actor: device_name,
-                perf_actor: performance_name,
-                preference_actor: preference_name,
+                device_actor: device_actor.name().into(),
+                perf_actor: performance_actor.name().into(),
+                preference_actor: preference_actor.name().into(),
             },
-            process_name,
+            process_name: process_actor.name().into(),
             active_tab: AtomicRefCell::new(None),
             tabs: AtomicRefCell::new(vec![]),
             workers: AtomicRefCell::new(vec![]),

--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -159,8 +159,9 @@ struct GetProcessResponse {
     process_descriptor: ProcessActorMsg,
 }
 
-#[derive(Default, MallocSizeOf)]
+#[derive(MallocSizeOf)]
 pub(crate) struct RootActor {
+    name: String,
     active_tab: AtomicRefCell<Option<String>>,
     global_actors: GlobalActors,
     process_name: String,
@@ -170,8 +171,8 @@ pub(crate) struct RootActor {
 }
 
 impl Actor for RootActor {
-    fn name(&self) -> String {
-        "root".to_owned()
+    fn name(&self) -> &str {
+        &self.name
     }
 
     fn handle_message(
@@ -185,7 +186,7 @@ impl Actor for RootActor {
         match msg_type {
             "connect" => {
                 let message = EmptyReplyMsg {
-                    from: "root".into(),
+                    from: self.name().into(),
                 };
                 request.reply_final(&message)?
             },
@@ -194,7 +195,7 @@ impl Actor for RootActor {
             "getProcess" => {
                 let process_descriptor = registry.encode::<ProcessActor, _>(&self.process_name);
                 let reply = GetProcessResponse {
-                    from: self.name(),
+                    from: self.name().into(),
                     process_descriptor,
                 };
                 request.reply_final(&reply)?
@@ -202,7 +203,7 @@ impl Actor for RootActor {
 
             "getRoot" => {
                 let reply = GetRootReply {
-                    from: "root".to_owned(),
+                    from: self.name().into(),
                     global_actors: self.global_actors.clone(),
                 };
                 request.reply_final(&reply)?
@@ -219,7 +220,7 @@ impl Actor for RootActor {
                 };
 
                 let reply = GetTabReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     tab,
                 };
                 request.reply_final(&reply)?
@@ -236,7 +237,7 @@ impl Actor for RootActor {
             "listProcesses" => {
                 let process_descriptor = registry.encode::<ProcessActor, _>(&self.process_name);
                 let reply = ListProcessesResponse {
-                    from: self.name(),
+                    from: self.name().into(),
                     processes: vec![process_descriptor],
                 };
                 request.reply_final(&reply)?
@@ -253,7 +254,7 @@ impl Actor for RootActor {
                         // Find correct scope url in the service worker
                         let scope = url.clone();
                         ServiceWorkerRegistrationMsg {
-                            actor: worker_actor.name(),
+                            actor: worker_actor.name().into(),
                             scope,
                             url: url.clone(),
                             registration_state: "".to_string(),
@@ -263,7 +264,7 @@ impl Actor for RootActor {
                             installing_worker: None,
                             waiting_worker: None,
                             active_worker: Some(ServiceWorkerInfo {
-                                actor: worker_actor.name(),
+                                actor: worker_actor.name().into(),
                                 url,
                                 state: 4, // activated
                                 state_text: "activated".to_string(),
@@ -275,7 +276,7 @@ impl Actor for RootActor {
                     })
                     .collect();
                 let reply = ListServiceWorkerRegistrationsReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     registrations,
                 };
                 request.reply_final(&reply)?
@@ -283,7 +284,7 @@ impl Actor for RootActor {
 
             "listTabs" => {
                 let reply = ListTabsReply {
-                    from: "root".to_owned(),
+                    from: self.name().into(),
                     tabs: self
                         .tabs
                         .borrow()
@@ -305,7 +306,7 @@ impl Actor for RootActor {
 
             "listWorkers" => {
                 let reply = ListWorkersReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     workers: self
                         .workers
                         .borrow()
@@ -318,7 +319,7 @@ impl Actor for RootActor {
 
             "protocolDescription" => {
                 let msg = ProtocolDescriptionReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     types: Types {
                         performance: PerformanceActor::description(),
                         device: DeviceActor::description(),
@@ -329,12 +330,16 @@ impl Actor for RootActor {
 
             "watchResources" => {
                 // TODO: Respond to watch resource requests
-                request.reply_final(&EmptyReplyMsg { from: self.name() })?
+                request.reply_final(&EmptyReplyMsg {
+                    from: self.name().into(),
+                })?
             },
 
             "unwatchResources" => {
                 // TODO: Respond to unwatch resource requests
-                request.reply_final(&EmptyReplyMsg { from: self.name() })?
+                request.reply_final(&EmptyReplyMsg {
+                    from: self.name().into(),
+                })?
             },
 
             _ => return Err(ActorError::UnrecognizedPacketType),
@@ -356,13 +361,18 @@ impl RootActor {
 
         // Root actor
         let root_actor = Self {
+            // TODO: Create an actual name for the root actor
+            name: "root".into(),
             global_actors: GlobalActors {
                 device_actor: device_name,
                 perf_actor: performance_name,
                 preference_actor: preference_name,
             },
             process_name,
-            ..Default::default()
+            active_tab: AtomicRefCell::new(None),
+            tabs: AtomicRefCell::new(vec![]),
+            workers: AtomicRefCell::new(vec![]),
+            service_workers: AtomicRefCell::new(vec![]),
         };
 
         registry.register(root_actor);
@@ -397,7 +407,7 @@ impl RootActor {
 impl ActorEncode<RootActorMsg> for RootActor {
     fn encode(&self, _: &ActorRegistry) -> RootActorMsg {
         RootActorMsg {
-            from: "root".to_owned(),
+            from: self.name().into(),
             application_type: "browser".to_owned(),
             traits: RootTraits {
                 sources: false,

--- a/components/devtools/actors/source.rs
+++ b/components/devtools/actors/source.rs
@@ -181,8 +181,8 @@ impl SourceActor {
 }
 
 impl Actor for SourceActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 
     fn handle_message(
@@ -197,7 +197,7 @@ impl Actor for SourceActor {
             // Client has requested contents of the source.
             "source" => {
                 let reply = SourceContentReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     content_type: self.content_type.clone(),
                     // TODO: if needed, fetch the page again, in the same way as in the original request.
                     // Fetch it from cache, even if the original request was non-idempotent (e.g. POST).
@@ -232,7 +232,7 @@ impl Actor for SourceActor {
                     .map(|location| location.line_number)
                     .collect::<BTreeSet<_>>();
                 let reply = GetBreakableLinesReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     lines,
                 };
                 request.reply_final(&reply)?
@@ -270,7 +270,7 @@ impl Actor for SourceActor {
                         .insert(location.column_number - 1);
                 }
                 let reply = GetBreakpointPositionsCompressedReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     positions,
                 };
                 request.reply_final(&reply)?

--- a/components/devtools/actors/source.rs
+++ b/components/devtools/actors/source.rs
@@ -4,6 +4,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::str::FromStr;
+use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
 use devtools_traits::DevtoolScriptControlMsg;
@@ -153,7 +154,7 @@ impl SourceActor {
         spidermonkey_id: u32,
         introduction_type: String,
         script_sender: GenericSender<DevtoolScriptControlMsg>,
-    ) -> String {
+    ) -> Arc<Self> {
         let name = new_actor_name::<Self>();
         let actor = Self {
             name: name.clone(),
@@ -165,9 +166,8 @@ impl SourceActor {
             introduction_type,
             script_sender,
         };
-        registry.register::<Self>(actor);
         registry.register_source_actor(pipeline_id, &name);
-        name
+        registry.register::<Self>(actor)
     }
 
     pub fn source_form(&self) -> SourceForm {

--- a/components/devtools/actors/source.rs
+++ b/components/devtools/actors/source.rs
@@ -15,7 +15,7 @@ use servo_base::id::PipelineId;
 use servo_url::ServoUrl;
 
 use crate::StreamId;
-use crate::actor::{Actor, ActorError, ActorRegistry, DowncastableActorArc};
+use crate::actor::{Actor, ActorError, ActorRegistry, DowncastableActorArc, new_actor_name};
 use crate::actors::breakpoint::BreakpointRequestLocation;
 use crate::protocol::ClientRequest;
 
@@ -154,7 +154,7 @@ impl SourceActor {
         introduction_type: String,
         script_sender: GenericSender<DevtoolScriptControlMsg>,
     ) -> String {
-        let name = registry.new_name::<Self>();
+        let name = new_actor_name::<Self>();
         let actor = Self {
             name: name.clone(),
             url,

--- a/components/devtools/actors/stylesheets.rs
+++ b/components/devtools/actors/stylesheets.rs
@@ -74,8 +74,8 @@ pub(crate) struct StyleSheetsActor {
 }
 
 impl Actor for StyleSheetsActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
     fn handle_message(
         &self,
@@ -91,7 +91,7 @@ impl Actor for StyleSheetsActor {
             "getStyleSheets" => {
                 let style_sheets = self.get_stylesheets_data(&browsing_context_actor);
                 let msg = GetStyleSheetsReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     style_sheets,
                 };
                 request.reply_final(&msg)?
@@ -123,7 +123,7 @@ impl Actor for StyleSheetsActor {
                 let long_string_name = LongStringActor::register(registry, css_text);
                 let long_string_actor = registry.find::<LongStringActor>(&long_string_name);
                 let msg = GetTextReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     text: long_string_actor.long_string_obj(),
                 };
                 request.reply_final(&msg)?

--- a/components/devtools/actors/stylesheets.rs
+++ b/components/devtools/actors/stylesheets.rs
@@ -1,6 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+use std::sync::Arc;
+
 use devtools_traits::DevtoolScriptControlMsg;
 use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
@@ -120,8 +122,7 @@ impl Actor for StyleSheetsActor {
                         warn!("Stylesheet fetched without text content");
                         "Error fetching CSS text".to_string()
                     });
-                let long_string_name = LongStringActor::register(registry, css_text);
-                let long_string_actor = registry.find::<LongStringActor>(&long_string_name);
+                let long_string_actor = LongStringActor::register(registry, css_text);
                 let msg = GetTextReply {
                     from: self.name().into(),
                     text: long_string_actor.long_string_obj(),
@@ -139,15 +140,14 @@ impl StyleSheetsActor {
         registry: &ActorRegistry,
         script_sender: GenericSender<DevtoolScriptControlMsg>,
         browsing_context_name: String,
-    ) -> String {
+    ) -> Arc<Self> {
         let name = new_actor_name::<Self>();
         let actor = StyleSheetsActor {
-            name: name.clone(),
+            name,
             script_sender,
             browsing_context_name,
         };
-        registry.register::<Self>(actor);
-        name
+        registry.register::<Self>(actor)
     }
 
     pub(crate) fn get_stylesheets_data(

--- a/components/devtools/actors/stylesheets.rs
+++ b/components/devtools/actors/stylesheets.rs
@@ -10,7 +10,7 @@ use servo_base::generic_channel;
 use servo_base::generic_channel::GenericSender;
 
 use crate::StreamId;
-use crate::actor::{Actor, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorError, ActorRegistry, new_actor_name};
 use crate::actors::browsing_context::BrowsingContextActor;
 use crate::actors::long_string::{LongStringActor, LongStringObj};
 use crate::protocol::ClientRequest;
@@ -140,7 +140,7 @@ impl StyleSheetsActor {
         script_sender: GenericSender<DevtoolScriptControlMsg>,
         browsing_context_name: String,
     ) -> String {
-        let name = registry.new_name::<Self>();
+        let name = new_actor_name::<Self>();
         let actor = StyleSheetsActor {
             name: name.clone(),
             script_sender,

--- a/components/devtools/actors/symbol_iterator.rs
+++ b/components/devtools/actors/symbol_iterator.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::sync::Arc;
+
 use malloc_size_of_derive::MallocSizeOf;
 
 use crate::actor::{Actor, ActorRegistry, new_actor_name};
@@ -12,11 +14,10 @@ pub(crate) struct SymbolIteratorActor {
 }
 
 impl SymbolIteratorActor {
-    pub fn register(registry: &ActorRegistry) -> String {
+    pub fn register(registry: &ActorRegistry) -> Arc<Self> {
         let name = new_actor_name::<Self>();
-        let actor = Self { name: name.clone() };
-        registry.register::<Self>(actor);
-        name
+        let actor = Self { name };
+        registry.register::<Self>(actor)
     }
 }
 

--- a/components/devtools/actors/symbol_iterator.rs
+++ b/components/devtools/actors/symbol_iterator.rs
@@ -21,7 +21,7 @@ impl SymbolIteratorActor {
 }
 
 impl Actor for SymbolIteratorActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 }

--- a/components/devtools/actors/symbol_iterator.rs
+++ b/components/devtools/actors/symbol_iterator.rs
@@ -4,7 +4,7 @@
 
 use malloc_size_of_derive::MallocSizeOf;
 
-use crate::actor::{Actor, ActorRegistry};
+use crate::actor::{Actor, ActorRegistry, new_actor_name};
 
 #[derive(MallocSizeOf)]
 pub(crate) struct SymbolIteratorActor {
@@ -13,7 +13,7 @@ pub(crate) struct SymbolIteratorActor {
 
 impl SymbolIteratorActor {
     pub fn register(registry: &ActorRegistry) -> String {
-        let name = registry.new_name::<Self>();
+        let name = new_actor_name::<Self>();
         let actor = Self { name: name.clone() };
         registry.register::<Self>(actor);
         name

--- a/components/devtools/actors/tab.rs
+++ b/components/devtools/actors/tab.rs
@@ -181,7 +181,7 @@ impl TabDescriptorActor {
         let root_actor = registry.find::<RootActor>("root");
         root_actor.tabs.borrow_mut().push(name.clone());
         let actor = Self {
-            name: name.clone(),
+            name,
             browsing_context_name,
         };
         registry.register::<Self>(actor)

--- a/components/devtools/actors/tab.rs
+++ b/components/devtools/actors/tab.rs
@@ -76,8 +76,8 @@ pub(crate) struct TabDescriptorActor {
 }
 
 impl Actor for TabDescriptorActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 
     /// The tab actor can handle the following messages:
@@ -104,18 +104,18 @@ impl Actor for TabDescriptorActor {
 
         match msg_type {
             "getTarget" => request.reply_final(&GetTargetReply {
-                from: self.name(),
-                frame: registry.encode::<BrowsingContextActor, _>(&self.browsing_context_name),
+                from: self.name().into(),
+                frame: browsing_context_actor.encode(registry),
             })?,
             "getFavicon" => {
                 // TODO: Return a favicon when available
                 request.reply_final(&GetFaviconReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     favicon: String::new(),
                 })?
             },
             "getWatcher" => request.reply_final(&GetWatcherReply {
-                from: self.name(),
+                from: self.name().into(),
                 watcher: registry.encode::<WatcherActor, _>(&browsing_context_actor.watcher_name),
             })?,
             "goBack" => {
@@ -123,14 +123,18 @@ impl Actor for TabDescriptorActor {
                     .script_chan()
                     .send(DevtoolScriptControlMsg::GoBack(pipeline))
                     .map_err(|_| ActorError::Internal)?;
-                request.reply_final(&EmptyReplyMsg { from: self.name() })?
+                request.reply_final(&EmptyReplyMsg {
+                    from: self.name().into(),
+                })?
             },
             "goForward" => {
                 browsing_context_actor
                     .script_chan()
                     .send(DevtoolScriptControlMsg::GoForward(pipeline))
                     .map_err(|_| ActorError::Internal)?;
-                request.reply_final(&EmptyReplyMsg { from: self.name() })?
+                request.reply_final(&EmptyReplyMsg {
+                    from: self.name().into(),
+                })?
             },
             "navigateTo" => {
                 if msg.get("waitForLoad").unwrap_or(&Value::Bool(false)) != &Value::Bool(false) {
@@ -148,7 +152,9 @@ impl Actor for TabDescriptorActor {
                     .send(DevtoolScriptControlMsg::NavigateTo(pipeline, url))
                     .map_err(|_| ActorError::Internal)?;
 
-                request.reply_final(&EmptyReplyMsg { from: self.name() })?
+                request.reply_final(&EmptyReplyMsg {
+                    from: self.name().into(),
+                })?
             },
             "reloadDescriptor" => {
                 // There is an extra bypassCache parameter that we don't currently use.
@@ -157,7 +163,9 @@ impl Actor for TabDescriptorActor {
                     .send(DevtoolScriptControlMsg::Reload(pipeline))
                     .map_err(|_| ActorError::Internal)?;
 
-                request.reply_final(&EmptyReplyMsg { from: self.name() })?
+                request.reply_final(&EmptyReplyMsg {
+                    from: self.name().into(),
+                })?
             },
             _ => return Err(ActorError::UnrecognizedPacketType),
         };
@@ -192,7 +200,7 @@ impl ActorEncode<TabDescriptorActorMsg> for TabDescriptorActor {
         let browsing_context_actor =
             registry.find::<BrowsingContextActor>(&self.browsing_context_name);
         TabDescriptorActorMsg {
-            actor: self.name(),
+            actor: self.name().into(),
             browser_id: browsing_context_actor.browser_id.value(),
             browsing_context_id: browsing_context_actor.browsing_context_id.value(),
             is_zombie_tab: false,

--- a/components/devtools/actors/tab.rs
+++ b/components/devtools/actors/tab.rs
@@ -9,6 +9,8 @@
 //!
 //! [Firefox JS implementation]: https://searchfox.org/mozilla-central/source/devtools/server/actors/descriptors/tab.js
 
+use std::sync::Arc;
+
 use devtools_traits::DevtoolScriptControlMsg;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
@@ -174,7 +176,7 @@ impl Actor for TabDescriptorActor {
 }
 
 impl TabDescriptorActor {
-    pub(crate) fn register(registry: &ActorRegistry, browsing_context_name: String) -> String {
+    pub(crate) fn register(registry: &ActorRegistry, browsing_context_name: String) -> Arc<Self> {
         let name = new_actor_name::<Self>();
         let root_actor = registry.find::<RootActor>("root");
         root_actor.tabs.borrow_mut().push(name.clone());
@@ -182,8 +184,7 @@ impl TabDescriptorActor {
             name: name.clone(),
             browsing_context_name,
         };
-        registry.register::<Self>(actor);
-        name
+        registry.register::<Self>(actor)
     }
 
     pub(crate) fn is_top_level_global(&self, registry: &ActorRegistry) -> bool {

--- a/components/devtools/actors/tab.rs
+++ b/components/devtools/actors/tab.rs
@@ -15,7 +15,7 @@ use serde::Serialize;
 use serde_json::{Map, Value};
 use servo_url::ServoUrl;
 
-use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry, new_actor_name};
 use crate::actors::browsing_context::{BrowsingContextActor, BrowsingContextActorMsg};
 use crate::actors::root::{DescriptorTraits, RootActor};
 use crate::actors::watcher::{WatcherActor, WatcherActorMsg};
@@ -167,7 +167,7 @@ impl Actor for TabDescriptorActor {
 
 impl TabDescriptorActor {
     pub(crate) fn register(registry: &ActorRegistry, browsing_context_name: String) -> String {
-        let name = registry.new_name::<Self>();
+        let name = new_actor_name::<Self>();
         let root_actor = registry.find::<RootActor>("root");
         root_actor.tabs.borrow_mut().push(name.clone());
         let actor = Self {

--- a/components/devtools/actors/thread.rs
+++ b/components/devtools/actors/thread.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
 use devtools_traits::{DevtoolScriptControlMsg, PauseReason};
@@ -121,17 +122,16 @@ impl ThreadActor {
         registry: &ActorRegistry,
         script_sender: GenericSender<DevtoolScriptControlMsg>,
         browsing_context_name: Option<String>,
-    ) -> String {
+    ) -> Arc<Self> {
         let name = new_actor_name::<Self>();
         let actor = ThreadActor {
-            name: name.clone(),
+            name,
             source_manager: SourceManager::new(),
             script_sender,
             frames: Default::default(),
             browsing_context_name,
         };
-        registry.register::<Self>(actor);
-        name
+        registry.register::<Self>(actor)
     }
 }
 
@@ -150,11 +150,11 @@ impl Actor for ThreadActor {
     ) -> Result<(), ActorError> {
         match msg_type {
             "attach" => {
-                let pause_name = PauseActor::register(registry);
+                let pause_actor = PauseActor::register(registry);
                 let msg = ThreadAttached {
                     from: self.name().into(),
                     type_: "paused".to_owned(),
-                    actor: pause_name,
+                    actor: pause_actor.name().into(),
                     frame: 0,
                     error: 0,
                     recording_endpoint: 0,

--- a/components/devtools/actors/thread.rs
+++ b/components/devtools/actors/thread.rs
@@ -12,7 +12,7 @@ use serde_json::{Map, Value};
 use servo_base::generic_channel::GenericSender;
 
 use super::source::{SourceManager, SourcesReply};
-use crate::actor::{Actor, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorError, ActorRegistry, new_actor_name};
 use crate::actors::browsing_context::BrowsingContextActor;
 use crate::actors::frame::{FrameActor, FrameActorMsg};
 use crate::actors::pause::PauseActor;
@@ -122,7 +122,7 @@ impl ThreadActor {
         script_sender: GenericSender<DevtoolScriptControlMsg>,
         browsing_context_name: Option<String>,
     ) -> String {
-        let name = registry.new_name::<Self>();
+        let name = new_actor_name::<Self>();
         let actor = ThreadActor {
             name: name.clone(),
             source_manager: SourceManager::new(),

--- a/components/devtools/actors/thread.rs
+++ b/components/devtools/actors/thread.rs
@@ -136,8 +136,8 @@ impl ThreadActor {
 }
 
 impl Actor for ThreadActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 
     fn handle_message(
@@ -152,7 +152,7 @@ impl Actor for ThreadActor {
             "attach" => {
                 let pause_name = PauseActor::register(registry);
                 let msg = ThreadAttached {
-                    from: self.name(),
+                    from: self.name().into(),
                     type_: "paused".to_owned(),
                     actor: pause_name,
                     frame: 0,
@@ -166,7 +166,9 @@ impl Actor for ThreadActor {
                     },
                 };
                 request.write_json_packet(&msg)?;
-                request.reply_final(&EmptyReplyMsg { from: self.name() })?
+                request.reply_final(&EmptyReplyMsg {
+                    from: self.name().into(),
+                })?
             },
 
             "resume" => {
@@ -179,11 +181,13 @@ impl Actor for ThreadActor {
                 ));
 
                 let msg = ThreadResumedReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     type_: "resumed".to_owned(),
                 };
                 request.write_json_packet(&msg)?;
-                request.reply_final(&EmptyReplyMsg { from: self.name() })?
+                request.reply_final(&EmptyReplyMsg {
+                    from: self.name().into(),
+                })?
             },
 
             "interrupt" => {
@@ -191,15 +195,19 @@ impl Actor for ThreadActor {
                     .send(DevtoolScriptControlMsg::Interrupt)
                     .map_err(|_| ActorError::Internal)?;
 
-                request.reply_final(&EmptyReplyMsg { from: self.name() })?
+                request.reply_final(&EmptyReplyMsg {
+                    from: self.name().into(),
+                })?
             },
 
-            "reconfigure" => request.reply_final(&EmptyReplyMsg { from: self.name() })?,
+            "reconfigure" => request.reply_final(&EmptyReplyMsg {
+                from: self.name().into(),
+            })?,
 
             "getAvailableEventBreakpoints" => {
                 // TODO: Send list of available event breakpoints (animation, clipboard, load...)
                 let msg = GetAvailableEventBreakpointsReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     value: vec![],
                 };
                 request.reply_final(&msg)?
@@ -209,7 +217,7 @@ impl Actor for ThreadActor {
             // <https://firefox-source-docs.mozilla.org/devtools/backend/protocol.html#loading-script-sources>
             "sources" => {
                 let msg = SourcesReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     sources: self.source_manager.source_forms(registry),
                 };
                 request.reply_final(&msg)?
@@ -241,7 +249,7 @@ impl Actor for ThreadActor {
                 // Frame actors should be registered here
                 // https://searchfox.org/firefox-main/source/devtools/server/actors/thread.js#1425
                 let msg = FramesReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     frames: result
                         .iter()
                         .map(|frame_name| registry.encode::<FrameActor, _>(frame_name))

--- a/components/devtools/actors/timeline.rs
+++ b/components/devtools/actors/timeline.rs
@@ -264,13 +264,13 @@ impl Actor for TimelineActor {
                     .unwrap();
 
                 // TODO: move this to the cleanup method.
-                // if let Some(ref actor_name) = *self.framerate_actor.borrow() {
-                //     registry.remove(actor_name);
-                // }
+                if let Some(ref actor_name) = *self.framerate_actor.borrow() {
+                    registry.remove(actor_name.clone());
+                }
 
-                // if let Some(ref actor_name) = *self.memory_actor.borrow() {
-                //     registry.remove(actor_name);
-                // }
+                if let Some(ref actor_name) = *self.memory_actor.borrow() {
+                    registry.remove(actor_name.clone());
+                }
 
                 **self.is_recording.lock().as_mut().unwrap() = false;
                 request.reply_final(&msg)?

--- a/components/devtools/actors/timeline.rs
+++ b/components/devtools/actors/timeline.rs
@@ -188,8 +188,8 @@ impl TimelineActor {
 }
 
 impl Actor for TimelineActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 
     fn handle_message(
@@ -233,7 +233,7 @@ impl Actor for TimelineActor {
                 }
 
                 let emitter = Emitter::new(
-                    self.name(),
+                    self.name().into(),
                     self.registry.clone(),
                     self.start_stamp,
                     request.stream(),
@@ -244,7 +244,7 @@ impl Actor for TimelineActor {
                 self.pull_timeline_data(rx, emitter);
 
                 let msg = StartReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     value: HighResolutionStamp::new(self.start_stamp, CrossProcessInstant::now()),
                 };
                 request.reply_final(&msg)?
@@ -252,7 +252,7 @@ impl Actor for TimelineActor {
 
             "stop" => {
                 let msg = StopReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     value: HighResolutionStamp::new(self.start_stamp, CrossProcessInstant::now()),
                 };
 
@@ -278,7 +278,7 @@ impl Actor for TimelineActor {
 
             "isRecording" => {
                 let msg = IsRecordingReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     value: *self.is_recording.lock().unwrap(),
                 };
 
@@ -337,7 +337,7 @@ impl Emitter {
             let framerate_actor = registry.find::<FramerateActor>(actor_name);
             let framerate_reply = FramerateEmitterReply {
                 type_: "framerate".to_owned(),
-                from: framerate_actor.name(),
+                from: framerate_actor.name().into(),
                 delta: HighResolutionStamp::new(self.start_stamp, end_time),
                 timestamps: framerate_actor.take_pending_ticks(),
             };
@@ -349,7 +349,7 @@ impl Emitter {
             let memory_actor = registry.find::<MemoryActor>(actor_name);
             let memory_reply = MemoryEmitterReply {
                 type_: "memory".to_owned(),
-                from: memory_actor.name(),
+                from: memory_actor.name().into(),
                 delta: HighResolutionStamp::new(self.start_stamp, end_time),
                 measurement: memory_actor.measure(),
             };

--- a/components/devtools/actors/timeline.rs
+++ b/components/devtools/actors/timeline.rs
@@ -264,13 +264,13 @@ impl Actor for TimelineActor {
                     .unwrap();
 
                 // TODO: move this to the cleanup method.
-                if let Some(ref actor_name) = *self.framerate_actor.borrow() {
-                    registry.remove(actor_name);
-                }
+                // if let Some(ref actor_name) = *self.framerate_actor.borrow() {
+                //     registry.remove(actor_name);
+                // }
 
-                if let Some(ref actor_name) = *self.memory_actor.borrow() {
-                    registry.remove(actor_name);
-                }
+                // if let Some(ref actor_name) = *self.memory_actor.borrow() {
+                //     registry.remove(actor_name);
+                // }
 
                 **self.is_recording.lock().as_mut().unwrap() = false;
                 request.reply_final(&msg)?

--- a/components/devtools/actors/timeline.rs
+++ b/components/devtools/actors/timeline.rs
@@ -265,11 +265,11 @@ impl Actor for TimelineActor {
 
                 // TODO: move this to the cleanup method.
                 if let Some(ref actor_name) = *self.framerate_actor.borrow() {
-                    registry.remove(actor_name.clone());
+                    registry.remove(actor_name);
                 }
 
                 if let Some(ref actor_name) = *self.memory_actor.borrow() {
-                    registry.remove(actor_name.clone());
+                    registry.remove(actor_name);
                 }
 
                 **self.is_recording.lock().as_mut().unwrap() = false;

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -214,8 +214,8 @@ pub(crate) struct WillNavigateMessage {
 }
 
 impl Actor for WatcherActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 
     /// The watcher actor can handle the following messages:
@@ -261,7 +261,7 @@ impl Actor for WatcherActor {
 
                 if target_type == "frame" {
                     let msg = WatchTargetsReply {
-                        from: self.name(),
+                        from: self.name().into(),
                         type_: "target-available-form".into(),
                         target: TargetActorMsg::BrowsingContext(
                             browsing_context_actor.encode(registry),
@@ -273,7 +273,7 @@ impl Actor for WatcherActor {
                 } else if target_type == "worker" {
                     for worker_name in &*root_actor.workers.borrow() {
                         let worker_msg = WatchTargetsReply {
-                            from: self.name(),
+                            from: self.name().into(),
                             type_: "target-available-form".into(),
                             target: TargetActorMsg::Worker(
                                 registry.encode::<WorkerTargetActor, _>(worker_name),
@@ -284,7 +284,7 @@ impl Actor for WatcherActor {
                 } else if target_type == "service_worker" {
                     for worker_name in &*root_actor.service_workers.borrow() {
                         let worker_msg = WatchTargetsReply {
-                            from: self.name(),
+                            from: self.name().into(),
                             type_: "target-available-form".into(),
                             target: TargetActorMsg::Worker(
                                 registry.encode::<WorkerTargetActor, _>(worker_name),
@@ -300,7 +300,9 @@ impl Actor for WatcherActor {
                 // don't count as a reply. Since every message needs to be responded, we send an
                 // extra empty packet to the devtools host to inform that we successfully received
                 // and processed the message so that it can continue
-                let msg = EmptyReplyMsg { from: self.name() };
+                let msg = EmptyReplyMsg {
+                    from: self.name().into(),
+                };
                 request.reply_final(&msg)?
             },
             "unwatchTargets" => {
@@ -402,7 +404,9 @@ impl Actor for WatcherActor {
                         _ => warn!("resource {} not handled yet", resource),
                     }
                 }
-                let msg = EmptyReplyMsg { from: self.name() };
+                let msg = EmptyReplyMsg {
+                    from: self.name().into(),
+                };
                 request.reply_final(&msg)?
             },
             "unwatchResources" => {
@@ -411,21 +415,21 @@ impl Actor for WatcherActor {
             },
             "getParentBrowsingContextID" => {
                 let msg = GetParentBrowsingContextIDReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     browsing_context_id: browsing_context_actor.browsing_context_id.value(),
                 };
                 request.reply_final(&msg)?
             },
             "getNetworkParentActor" => {
                 let msg = GetNetworkParentActorReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     network: registry.encode::<NetworkParentActor, _>(&self.network_parent_name),
                 };
                 request.reply_final(&msg)?
             },
             "getTargetConfigurationActor" => {
                 let msg = GetTargetConfigurationActorReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     configuration: registry
                         .encode::<TargetConfigurationActor, _>(&self.target_configuration_name),
                 };
@@ -433,7 +437,7 @@ impl Actor for WatcherActor {
             },
             "getThreadConfigurationActor" => {
                 let msg = GetThreadConfigurationActorReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     configuration: registry
                         .encode::<ThreadConfigurationActor, _>(&self.thread_configuration_name),
                 };
@@ -441,7 +445,7 @@ impl Actor for WatcherActor {
             },
             "getBreakpointListActor" => {
                 let msg = GetBreakpointListActorReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     breakpoint_list: registry
                         .encode::<BreakpointListActor, _>(&self.breakpoint_list_name),
                 };
@@ -449,7 +453,7 @@ impl Actor for WatcherActor {
             },
             "getBlackboxingActor" => {
                 let msg = GetBlackboxingActorReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     blackboxing: registry.encode::<BlackboxingActor, _>(&self.blackboxing_name),
                 };
                 request.reply_final(&msg)?
@@ -530,7 +534,7 @@ impl WatcherActor {
         available: bool,
     ) {
         let msg = WatchTargetsReply {
-            from: self.name(),
+            from: self.name().into(),
             type_: (if available {
                 "target-available-form"
             } else {
@@ -549,7 +553,7 @@ impl WatcherActor {
 impl ActorEncode<WatcherActorMsg> for WatcherActor {
     fn encode(&self, _: &ActorRegistry) -> WatcherActorMsg {
         WatcherActorMsg {
-            actor: self.name(),
+            actor: self.name().into(),
             traits: WatcherTraits {
                 resources: self.session_context.supported_resources.clone(),
                 targets: self.session_context.supported_targets.clone(),

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -11,6 +11,7 @@
 //! [Firefox JS implementation]: https://searchfox.org/mozilla-central/source/devtools/server/actors/descriptors/watcher.js
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use devtools_traits::get_time_stamp;
 use log::warn;
@@ -475,29 +476,27 @@ impl WatcherActor {
         registry: &ActorRegistry,
         browsing_context_name: String,
         session_context: SessionContext,
-    ) -> String {
-        let network_parent_name = NetworkParentActor::register(registry);
-        let target_configuration_name = TargetConfigurationActor::register(registry);
-        let thread_configuration_name = ThreadConfigurationActor::register(registry);
-        let breakpoint_list_name =
+    ) -> Arc<Self> {
+        let network_parent_actor = NetworkParentActor::register(registry);
+        let target_configuration_actor = TargetConfigurationActor::register(registry);
+        let thread_configuration_actor = ThreadConfigurationActor::register(registry);
+        let breakpoint_list_actor =
             BreakpointListActor::register(registry, browsing_context_name.clone());
-        let blackboxing_name = BlackboxingActor::register(registry, browsing_context_name.clone());
+        let blackboxing_actor = BlackboxingActor::register(registry, browsing_context_name.clone());
 
         let name = new_actor_name::<Self>();
         let actor = Self {
-            name: name.clone(),
+            name,
             browsing_context_name,
-            network_parent_name,
-            target_configuration_name,
-            thread_configuration_name,
-            breakpoint_list_name,
-            blackboxing_name,
+            network_parent_name: network_parent_actor.name().into(),
+            target_configuration_name: target_configuration_actor.name().into(),
+            thread_configuration_name: thread_configuration_actor.name().into(),
+            breakpoint_list_name: breakpoint_list_actor.name().into(),
+            blackboxing_name: blackboxing_actor.name().into(),
             session_context,
         };
 
-        registry.register::<Self>(actor);
-
-        name
+        registry.register::<Self>(actor)
     }
 
     pub fn emit_will_navigate<'a>(

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -24,7 +24,7 @@ use self::network_parent::NetworkParentActor;
 use super::breakpoint::BreakpointListActor;
 use super::thread::ThreadActor;
 use super::worker::WorkerTargetActorMsg;
-use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry, new_actor_name};
 use crate::actors::blackboxing::BlackboxingActor;
 use crate::actors::browsing_context::{BrowsingContextActor, BrowsingContextActorMsg};
 use crate::actors::console::ConsoleActor;
@@ -479,7 +479,7 @@ impl WatcherActor {
             BreakpointListActor::register(registry, browsing_context_name.clone());
         let blackboxing_name = BlackboxingActor::register(registry, browsing_context_name.clone());
 
-        let name = registry.new_name::<Self>();
+        let name = new_actor_name::<Self>();
         let actor = Self {
             name: name.clone(),
             browsing_context_name,

--- a/components/devtools/actors/watcher/network_parent.rs
+++ b/components/devtools/actors/watcher/network_parent.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::sync::Arc;
+
 use malloc_size_of_derive::MallocSizeOf;
 use serde_json::{Map, Value};
 
@@ -50,11 +52,10 @@ impl Actor for NetworkParentActor {
 }
 
 impl NetworkParentActor {
-    pub fn register(registry: &ActorRegistry) -> String {
+    pub fn register(registry: &ActorRegistry) -> Arc<Self> {
         let name = new_actor_name::<Self>();
-        let actor = Self { name: name.clone() };
-        registry.register::<Self>(actor);
-        name
+        let actor = Self { name };
+        registry.register::<Self>(actor)
     }
 }
 

--- a/components/devtools/actors/watcher/network_parent.rs
+++ b/components/devtools/actors/watcher/network_parent.rs
@@ -5,7 +5,7 @@
 use malloc_size_of_derive::MallocSizeOf;
 use serde_json::{Map, Value};
 
-use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry, new_actor_name};
 use crate::protocol::ClientRequest;
 use crate::{ActorMsg, EmptyReplyMsg, StreamId};
 
@@ -47,7 +47,7 @@ impl Actor for NetworkParentActor {
 
 impl NetworkParentActor {
     pub fn register(registry: &ActorRegistry) -> String {
-        let name = registry.new_name::<Self>();
+        let name = new_actor_name::<Self>();
         let actor = Self { name: name.clone() };
         registry.register::<Self>(actor);
         name

--- a/components/devtools/actors/watcher/network_parent.rs
+++ b/components/devtools/actors/watcher/network_parent.rs
@@ -15,8 +15,8 @@ pub(crate) struct NetworkParentActor {
 }
 
 impl Actor for NetworkParentActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 
     /// The network parent actor can handle the following messages:
@@ -32,11 +32,15 @@ impl Actor for NetworkParentActor {
     ) -> Result<(), ActorError> {
         match msg_type {
             "setSaveRequestAndResponseBodies" => {
-                let msg = EmptyReplyMsg { from: self.name() };
+                let msg = EmptyReplyMsg {
+                    from: self.name().into(),
+                };
                 request.reply_final(&msg)?
             },
             "setPersist" => {
-                let msg = EmptyReplyMsg { from: self.name() };
+                let msg = EmptyReplyMsg {
+                    from: self.name().into(),
+                };
                 request.reply_final(&msg)?
             },
             _ => return Err(ActorError::UnrecognizedPacketType),
@@ -56,6 +60,8 @@ impl NetworkParentActor {
 
 impl ActorEncode<ActorMsg> for NetworkParentActor {
     fn encode(&self, _: &ActorRegistry) -> ActorMsg {
-        ActorMsg { actor: self.name() }
+        ActorMsg {
+            actor: self.name().into(),
+        }
     }
 }

--- a/components/devtools/actors/watcher/target_configuration.rs
+++ b/components/devtools/actors/watcher/target_configuration.rs
@@ -13,7 +13,7 @@ use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
-use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry, new_actor_name};
 use crate::actors::browsing_context::BrowsingContextActor;
 use crate::actors::tab::TabDescriptorActor;
 use crate::protocol::ClientRequest;
@@ -106,7 +106,7 @@ impl Actor for TargetConfigurationActor {
 
 impl TargetConfigurationActor {
     pub fn register(registry: &ActorRegistry) -> String {
-        let name = registry.new_name::<Self>();
+        let name = new_actor_name::<Self>();
         let actor = Self {
             name: name.clone(),
             configuration: HashMap::new(),

--- a/components/devtools/actors/watcher/target_configuration.rs
+++ b/components/devtools/actors/watcher/target_configuration.rs
@@ -6,6 +6,7 @@
 //! This actor manages the configuration flags that the devtools host can apply to the targets.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use embedder_traits::Theme;
 use log::warn;
@@ -107,10 +108,10 @@ impl Actor for TargetConfigurationActor {
 }
 
 impl TargetConfigurationActor {
-    pub fn register(registry: &ActorRegistry) -> String {
+    pub fn register(registry: &ActorRegistry) -> Arc<Self> {
         let name = new_actor_name::<Self>();
         let actor = Self {
-            name: name.clone(),
+            name,
             configuration: HashMap::new(),
             supported_options: HashMap::from([
                 ("cacheDisabled", false),
@@ -132,8 +133,7 @@ impl TargetConfigurationActor {
                 ("useSimpleHighlightersForReducedMotion", false),
             ]),
         };
-        registry.register::<Self>(actor);
-        name
+        registry.register::<Self>(actor)
     }
 }
 

--- a/components/devtools/actors/watcher/target_configuration.rs
+++ b/components/devtools/actors/watcher/target_configuration.rs
@@ -47,8 +47,8 @@ struct JavascriptEnabledReply {
 }
 
 impl Actor for TargetConfigurationActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 
     /// The target configuration actor can handle the following messages:
@@ -88,12 +88,14 @@ impl Actor for TargetConfigurationActor {
                         warn!("No active tab for updateConfiguration");
                     }
                 }
-                let msg = EmptyReplyMsg { from: self.name() };
+                let msg = EmptyReplyMsg {
+                    from: self.name().into(),
+                };
                 request.reply_final(&msg)?
             },
             "isJavascriptEnabled" => {
                 let msg = JavascriptEnabledReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     javascript_enabled: true,
                 };
                 request.reply_final(&msg)?
@@ -138,7 +140,7 @@ impl TargetConfigurationActor {
 impl ActorEncode<TargetConfigurationActorMsg> for TargetConfigurationActor {
     fn encode(&self, _: &ActorRegistry) -> TargetConfigurationActorMsg {
         TargetConfigurationActorMsg {
-            actor: self.name(),
+            actor: self.name().into(),
             configuration: self.configuration.clone(),
             traits: TargetConfigurationTraits {
                 supported_options: self.supported_options.clone(),

--- a/components/devtools/actors/watcher/thread_configuration.rs
+++ b/components/devtools/actors/watcher/thread_configuration.rs
@@ -6,6 +6,7 @@
 //! This actor manages the configuration flags that the devtools host can apply to threads.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use malloc_size_of_derive::MallocSizeOf;
 use serde_json::{Map, Value};
@@ -51,14 +52,13 @@ impl Actor for ThreadConfigurationActor {
 }
 
 impl ThreadConfigurationActor {
-    pub fn register(registry: &ActorRegistry) -> String {
+    pub fn register(registry: &ActorRegistry) -> Arc<Self> {
         let name = new_actor_name::<Self>();
         let actor = Self {
-            name: name.clone(),
+            name,
             _configuration: HashMap::new(),
         };
-        registry.register::<Self>(actor);
-        name
+        registry.register::<Self>(actor)
     }
 }
 

--- a/components/devtools/actors/watcher/thread_configuration.rs
+++ b/components/devtools/actors/watcher/thread_configuration.rs
@@ -21,8 +21,8 @@ pub(crate) struct ThreadConfigurationActor {
 }
 
 impl Actor for ThreadConfigurationActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 
     /// The thread configuration actor can handle the following messages:
@@ -39,7 +39,9 @@ impl Actor for ThreadConfigurationActor {
         match msg_type {
             "updateConfiguration" => {
                 // TODO: Actually update configuration
-                let msg = EmptyReplyMsg { from: self.name() };
+                let msg = EmptyReplyMsg {
+                    from: self.name().into(),
+                };
                 request.reply_final(&msg)?
             },
             _ => return Err(ActorError::UnrecognizedPacketType),
@@ -62,6 +64,8 @@ impl ThreadConfigurationActor {
 
 impl ActorEncode<ActorMsg> for ThreadConfigurationActor {
     fn encode(&self, _: &ActorRegistry) -> ActorMsg {
-        ActorMsg { actor: self.name() }
+        ActorMsg {
+            actor: self.name().into(),
+        }
     }
 }

--- a/components/devtools/actors/watcher/thread_configuration.rs
+++ b/components/devtools/actors/watcher/thread_configuration.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use malloc_size_of_derive::MallocSizeOf;
 use serde_json::{Map, Value};
 
-use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry, new_actor_name};
 use crate::protocol::ClientRequest;
 use crate::{ActorMsg, EmptyReplyMsg, StreamId};
 
@@ -50,7 +50,7 @@ impl Actor for ThreadConfigurationActor {
 
 impl ThreadConfigurationActor {
     pub fn register(registry: &ActorRegistry) -> String {
-        let name = registry.new_name::<Self>();
+        let name = new_actor_name::<Self>();
         let actor = Self {
             name: name.clone(),
             _configuration: HashMap::new(),

--- a/components/devtools/actors/worker.rs
+++ b/components/devtools/actors/worker.rs
@@ -71,8 +71,8 @@ impl WorkerTargetActor {
 }
 
 impl Actor for WorkerTargetActor {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
     fn handle_message(
         &self,
@@ -85,7 +85,7 @@ impl Actor for WorkerTargetActor {
         match msg_type {
             "attach" => {
                 let msg = AttachedReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     type_: "attached".to_owned(),
                     url: self.url.as_str().to_owned(),
                 };
@@ -100,7 +100,7 @@ impl Actor for WorkerTargetActor {
 
             "connect" => {
                 let msg = ConnectReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     type_: "connected".to_owned(),
                     thread_actor: self.thread_name.clone(),
                     console_actor: self.console_name.clone(),
@@ -111,7 +111,7 @@ impl Actor for WorkerTargetActor {
 
             "detach" => {
                 let msg = DetachedReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     type_: "detached".to_string(),
                 };
                 self.cleanup(stream_id);
@@ -121,7 +121,7 @@ impl Actor for WorkerTargetActor {
 
             "getPushSubscription" => {
                 let msg = GetPushSubscriptionReply {
-                    from: self.name(),
+                    from: self.name().into(),
                     subscription: None,
                 };
                 request.reply_final(&msg)?
@@ -198,7 +198,7 @@ pub(crate) struct WorkerTargetActorMsg {
 impl ActorEncode<WorkerTargetActorMsg> for WorkerTargetActor {
     fn encode(&self, _: &ActorRegistry) -> WorkerTargetActorMsg {
         WorkerTargetActorMsg {
-            actor: self.name(),
+            actor: self.name().into(),
             console_actor: self.console_name.clone(),
             thread_actor: self.thread_name.clone(),
             id: self.worker_id.0.to_string(),

--- a/components/devtools/actors/worker.rs
+++ b/components/devtools/actors/worker.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::sync::Arc;
+
 use atomic_refcell::AtomicRefCell;
 use devtools_traits::DevtoolScriptControlMsg::WantsLiveNotifications;
 use devtools_traits::{DevtoolScriptControlMsg, WorkerId};
@@ -53,10 +55,10 @@ impl WorkerTargetActor {
         url: ServoUrl,
         worker_type: WorkerType,
         script_sender: GenericSender<DevtoolScriptControlMsg>,
-    ) -> String {
+    ) -> Arc<Self> {
         let name = new_actor_name::<Self>();
         let actor = Self {
-            name: name.clone(),
+            name,
             console_name,
             thread_name,
             worker_id,
@@ -65,8 +67,7 @@ impl WorkerTargetActor {
             script_sender,
             streams: Default::default(),
         };
-        registry.register::<Self>(actor);
-        name
+        registry.register::<Self>(actor)
     }
 }
 

--- a/components/devtools/actors/worker.rs
+++ b/components/devtools/actors/worker.rs
@@ -14,7 +14,7 @@ use servo_base::id::TEST_PIPELINE_ID;
 use servo_url::ServoUrl;
 
 use crate::StreamId;
-use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry, new_actor_name};
 use crate::protocol::{ClientRequest, JsonPacketStream};
 use crate::resource::ResourceAvailable;
 
@@ -54,7 +54,7 @@ impl WorkerTargetActor {
         worker_type: WorkerType,
         script_sender: GenericSender<DevtoolScriptControlMsg>,
     ) -> String {
-        let name = registry.new_name::<Self>();
+        let name = new_actor_name::<Self>();
         let actor = Self {
             name: name.clone(),
             console_name,

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -838,7 +838,7 @@ impl DevtoolsInstance {
         frame_actor.set_offset(frame_offset.column, frame_offset.line);
 
         let msg = ThreadInterruptedReply {
-            from: thread_actor.name(),
+            from: thread_actor.name().into(),
             type_: "paused".to_owned(),
             actor: pause_name,
             frame: frame_actor.encode(&self.registry),
@@ -873,7 +873,7 @@ impl DevtoolsInstance {
             .source_manager
             .find_source(&self.registry, &frame.url)
         {
-            Some(source_actor) => source_actor.name(),
+            Some(source_actor) => source_actor.name().into(),
             None => {
                 warn!("No source actor found for URL: {}", frame.url);
                 return;

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -40,7 +40,7 @@ use servo_base::generic_channel::{self, GenericSender};
 use servo_base::id::{BrowsingContextId, PipelineId, WebViewId};
 use servo_config::pref;
 
-use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry, new_actor_name};
 use crate::actors::browsing_context::BrowsingContextActor;
 use crate::actors::console::{ConsoleActor, ConsoleResource, DevtoolsConsoleMessage, Root};
 use crate::actors::environment::EnvironmentActor;
@@ -507,7 +507,7 @@ impl DevtoolsInstance {
         let devtools_browsing_context_id = id_map.browsing_context_id(browsing_context_id);
         let devtools_outer_window_id = id_map.outer_window_id(pipeline_id);
 
-        let console_name = self.registry.new_name::<ConsoleActor>();
+        let console_name = new_actor_name::<ConsoleActor>();
 
         let parent_actor = if let Some(id) = worker_id {
             let thread_name = ThreadActor::register(&self.registry, script_sender.clone(), None);

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -510,17 +510,17 @@ impl DevtoolsInstance {
         let console_name = new_actor_name::<ConsoleActor>();
 
         let parent_actor = if let Some(id) = worker_id {
-            let thread_name = ThreadActor::register(&self.registry, script_sender.clone(), None);
+            let thread_actor = ThreadActor::register(&self.registry, script_sender.clone(), None);
 
             let worker_type = if page_info.is_service_worker {
                 WorkerType::Service
             } else {
                 WorkerType::Dedicated
             };
-            let worker_name = WorkerTargetActor::register(
+            let worker_actor = WorkerTargetActor::register(
                 &self.registry,
                 console_name.clone(),
-                thread_name,
+                thread_actor.name().into(),
                 id,
                 page_info.url,
                 worker_type,
@@ -531,14 +531,17 @@ impl DevtoolsInstance {
                 root_actor
                     .service_workers
                     .borrow_mut()
-                    .push(worker_name.clone());
+                    .push(worker_actor.name().into());
             } else {
-                root_actor.workers.borrow_mut().push(worker_name.clone());
+                root_actor
+                    .workers
+                    .borrow_mut()
+                    .push(worker_actor.name().into());
             }
 
-            self.actor_workers.insert(id, worker_name.clone());
+            self.actor_workers.insert(id, worker_actor.name().into());
 
-            Root::DedicatedWorker(worker_name)
+            Root::DedicatedWorker(worker_actor.name().into())
         } else {
             self.pipelines.insert(pipeline_id, browsing_context_id);
             let browsing_context_name = self
@@ -555,6 +558,8 @@ impl DevtoolsInstance {
                         devtools_outer_window_id,
                         script_sender.clone(),
                     )
+                    .name()
+                    .into()
                 });
             let browsing_context_actor = self
                 .registry
@@ -710,13 +715,13 @@ impl DevtoolsInstance {
         let resource_id = self.next_resource_id;
         self.next_resource_id += 1;
 
-        let network_event_name =
+        let network_event_actor =
             NetworkEventActor::register(&self.registry, resource_id, browsing_context_name);
 
         self.actor_requests
-            .insert(request_id, network_event_name.clone());
+            .insert(request_id, network_event_actor.name().into());
 
-        network_event_name
+        network_event_actor.name().into()
     }
 
     fn handle_create_source_actor(
@@ -740,7 +745,7 @@ impl DevtoolsInstance {
         );
         let source_form = self
             .registry
-            .find::<SourceActor>(&source_actor)
+            .find::<SourceActor>(source_actor.name())
             .source_form();
 
         if let Some(worker_id) = source_info.worker_id {
@@ -755,7 +760,7 @@ impl DevtoolsInstance {
                 .clone();
             let thread_actor = self.registry.find::<ThreadActor>(&thread_actor_name);
 
-            thread_actor.source_manager.add_source(&source_actor);
+            thread_actor.source_manager.add_source(source_actor.name());
 
             let worker_actor = self.registry.find::<WorkerTargetActor>(worker_name);
 
@@ -783,7 +788,7 @@ impl DevtoolsInstance {
 
             let thread_actor_name = browsing_context_actor.thread_name.clone();
             let thread_actor = self.registry.find::<ThreadActor>(&thread_actor_name);
-            thread_actor.source_manager.add_source(&source_actor);
+            thread_actor.source_manager.add_source(source_actor.name());
 
             for stream in self.connections.lock().unwrap().values_mut() {
                 browsing_context_actor.resource_array(
@@ -832,7 +837,7 @@ impl DevtoolsInstance {
             .registry
             .find::<ThreadActor>(&browsing_context_actor.thread_name);
 
-        let pause_name = PauseActor::register(&self.registry);
+        let pause_name = PauseActor::register(&self.registry).name().into();
 
         let frame_actor = self.registry.find::<FrameActor>(&frame_offset.actor);
         frame_actor.set_offset(frame_offset.column, frame_offset.line);
@@ -880,9 +885,9 @@ impl DevtoolsInstance {
             },
         };
 
-        let frame_name = FrameActor::register(&self.registry, source_name, frame);
+        let frame_actor = FrameActor::register(&self.registry, source_name, frame);
 
-        let _ = result_sender.send(frame_name);
+        let _ = result_sender.send(frame_actor.name().into());
     }
 
     fn handle_create_environment_actor(


### PR DESCRIPTION
This patch fixes the panics when borrowing coming from `AtomicRefCell`, being replaced by `parking_lot::RwLock`. While this can introduced deadlocks instead, there are some measures taken to minimize the chance of this happening:

- Only `ActorRegistry` can access the internal locks, so we only have to worry about the functions we expose from it (`register`, `find`, ...).
- All of these functions have been changed to release the lock almost immediately, favouring `Arc` cloning instead when needed.
- The `WriteGuard` wrapper has a thread local cell that is updated when we lock for writing. If we are in debug and there is some reentrancy within the same thread, we panic. This is helpful to identify situations that could be problematic and fix them.
- Reorder some actor and name registrations to avoid nested registration to avoid borrow issues.

Besides, it includes some improvements in regards to how actors are created and managed that should help alleviate this issues, and provide a better usage:

- Actors now return an `Arc<Self>` from their register function, instead of the `name`. This allows to access fields in the actor directly without having to call `find` again just after they are registered. This `find` usage was also problematic for nested borrowing.
- Actor names are now _only_ stored in them, and their `name()` method now returns a reference to that. In the registry, we are using a `HashSet` instead of a `HashMap` now, with the hash being the name inside of the actor. This means that there is only one source of truth for actor names.
- `new_name` has been moved outside of the `ActorRegistry` since it didn't depend on it.

Testing: ./mach test-devtools[^1]
Fixes: #45055

[^1]: Plus manual stress testing navigating through different pages, loading heavy sites, and doing multiple actions in different DevTools tabs. We definitely need better testing to catch more regressions in the future.