### PR TITLE
ci: Fix windows concurrency limit

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -174,6 +174,7 @@ jobs:
       # On self-hosted windows runners sometimes OOM for Unit tests
       - name: Set CARGO_BUILD_JOBS for self-hosted runner
         if: ${{ runner.environment == 'self-hosted' }}
+        shell: bash
         run: echo "CARGO_BUILD_JOBS=-2" >> $GITHUB_ENV
       - name: Unit tests
         if: ${{ inputs.unit-tests }}


### PR DESCRIPTION
The default shell on windows is powershell, so the previous echo was uneffective and did not write to `GITHUB_ENV` at all.
This was observed e.g. on https://github.com/servo/servo/actions/runs/26690165242/job/78665075290 where the `env` of the following job did not contain CARGO_BUILD_JOBS as expected.

The step was originally added in #45100 to limit
concurrency of the windows build jobs on self-hosted runners, to prevent OOM errors.

Using bash for this step is the simple fix (we could also change the step to powershell syntax, but I prefer bash).

Testing: Not tested

