### PR TITLE
devtools: Pass correct walker name to `find_child` in `get_applied`

### DIFF
--- a/components/devtools/actors/inspector/node.rs
+++ b/components/devtools/actors/inspector/node.rs
@@ -132,7 +132,7 @@ pub(crate) struct NodeActor {
     name: String,
     pub script_chan: GenericSender<DevtoolScriptControlMsg>,
     pub pipeline: PipelineId,
-    pub walker: String,
+    pub walker_name: String,
     pub style_rules: AtomicRefCell<HashMap<MatchedRule, String>>,
 }
 
@@ -219,7 +219,7 @@ impl Actor for NodeActor {
                     registry,
                     self.script_chan.clone(),
                     self.pipeline,
-                    self.walker.clone(),
+                    self.walker_name.clone(),
                 );
 
                 let msg = GetUniqueSelectorReply {
@@ -264,7 +264,7 @@ impl NodeActor {
         script_id: String,
         script_chan: GenericSender<DevtoolScriptControlMsg>,
         pipeline: PipelineId,
-        walker: String,
+        walker_name: String,
     ) -> String {
         let name = registry.new_name::<Self>();
 
@@ -274,7 +274,7 @@ impl NodeActor {
             name: name.clone(),
             script_chan,
             pipeline,
-            walker,
+            walker_name,
             style_rules: AtomicRefCell::new(HashMap::new()),
         };
 
@@ -288,7 +288,7 @@ pub trait NodeInfoToProtocol {
         registry: &ActorRegistry,
         script_chan: GenericSender<DevtoolScriptControlMsg>,
         pipeline: PipelineId,
-        walker: String,
+        walker_name: String,
     ) -> NodeActorMsg;
 }
 
@@ -298,7 +298,7 @@ impl NodeInfoToProtocol for NodeInfo {
         registry: &ActorRegistry,
         script_chan: GenericSender<DevtoolScriptControlMsg>,
         pipeline: PipelineId,
-        walker: String,
+        walker_name: String,
     ) -> NodeActorMsg {
         let get_or_register_node_actor = |id: &str| {
             if !registry.script_actor_registered(id.to_string()) {
@@ -307,7 +307,7 @@ impl NodeInfoToProtocol for NodeInfo {
                     id.to_string(),
                     script_chan.clone(),
                     pipeline,
-                    walker.clone(),
+                    walker_name.clone(),
                 )
             } else {
                 registry.script_to_actor(id.to_string())
@@ -341,7 +341,7 @@ impl NodeInfoToProtocol for NodeInfo {
             let mut children = rx.recv().ok()??;
 
             let child = children.pop()?;
-            let msg = child.encode(registry, script_chan.clone(), pipeline, walker);
+            let msg = child.encode(registry, script_chan.clone(), pipeline, walker_name);
 
             // If the node child is not a text node, do not represent it inline.
             if msg.node_type != TEXT_NODE {

--- a/components/devtools/actors/inspector/page_style.rs
+++ b/components/devtools/actors/inspector/page_style.rs
@@ -148,12 +148,12 @@ impl PageStyleActor {
             .as_str()
             .ok_or(ActorError::BadParameterType)?;
         let node_actor = registry.find::<NodeActor>(node_name);
-        let walker = registry.find::<WalkerActor>(&node_actor.walker);
+        let walker = registry.find::<WalkerActor>(&node_actor.walker_name);
         let browsing_context_actor = walker.browsing_context_actor(registry);
         let entries: Vec<_> = find_child(
             &node_actor.script_chan,
             node_actor.pipeline,
-            node_name,
+            &node_actor.walker_name,
             registry,
             &walker.root(registry)?.actor,
             vec![],
@@ -280,7 +280,7 @@ impl PageStyleActor {
             .as_str()
             .ok_or(ActorError::BadParameterType)?;
         let node_actor = registry.find::<NodeActor>(node_name);
-        let walker = registry.find::<WalkerActor>(&node_actor.walker);
+        let walker = registry.find::<WalkerActor>(&node_actor.walker_name);
         let browsing_context_actor = walker.browsing_context_actor(registry);
         let (tx, rx) = generic_channel::channel().ok_or(ActorError::Internal)?;
         browsing_context_actor

--- a/components/devtools/actors/inspector/style_rule.rs
+++ b/components/devtools/actors/inspector/style_rule.rs
@@ -123,7 +123,7 @@ impl Actor for StyleRuleActor {
 
                 // Query the rule modification
                 let node_actor = registry.find::<NodeActor>(&self.node_name);
-                let walker = registry.find::<WalkerActor>(&node_actor.walker);
+                let walker = registry.find::<WalkerActor>(&node_actor.walker_name);
                 let browsing_context_actor = walker.browsing_context_actor(registry);
                 browsing_context_actor
                     .script_chan()
@@ -160,7 +160,7 @@ impl StyleRuleActor {
 
     pub fn applied(&self, registry: &ActorRegistry) -> Option<AppliedRule> {
         let node_actor = registry.find::<NodeActor>(&self.node_name);
-        let walker = registry.find::<WalkerActor>(&node_actor.walker);
+        let walker = registry.find::<WalkerActor>(&node_actor.walker_name);
         let browsing_context_actor = walker.browsing_context_actor(registry);
 
         let (document_sender, document_receiver) = generic_channel::channel()?;
@@ -232,7 +232,7 @@ impl StyleRuleActor {
         registry: &ActorRegistry,
     ) -> Option<HashMap<String, ComputedDeclaration>> {
         let node_actor = registry.find::<NodeActor>(&self.node_name);
-        let walker = registry.find::<WalkerActor>(&node_actor.walker);
+        let walker = registry.find::<WalkerActor>(&node_actor.walker_name);
         let browsing_context_actor = walker.browsing_context_actor(registry);
 
         let (style_sender, style_receiver) = generic_channel::channel()?;

--- a/components/devtools/actors/inspector/walker.rs
+++ b/components/devtools/actors/inspector/walker.rs
@@ -387,7 +387,7 @@ impl WalkerActor {
 pub fn find_child(
     script_chan: &GenericSender<DevtoolScriptControlMsg>,
     pipeline: PipelineId,
-    name: &str,
+    walker_name: &str,
     registry: &ActorRegistry,
     node_name: &str,
     mut hierarchy: Vec<NodeActorMsg>,
@@ -404,7 +404,7 @@ pub fn find_child(
     let children = rx.recv().unwrap().ok_or(vec![])?;
 
     for child in children {
-        let msg = child.encode(registry, script_chan.clone(), pipeline, name.into());
+        let msg = child.encode(registry, script_chan.clone(), pipeline, walker_name.into());
         if compare_fn(&msg) {
             hierarchy.push(msg);
             return Ok(hierarchy);
@@ -417,7 +417,7 @@ pub fn find_child(
         match find_child(
             script_chan,
             pipeline,
-            name,
+            walker_name,
             registry,
             &msg.actor,
             hierarchy,


### PR DESCRIPTION
Additionally, renames variables to `walker_name` to follow conventions and to prevent similar mistakes in the future.

Testing: ./mach test-devtools
Fixes: #45141
