### PR TITLE
script: Pass `&mut JSContext` to `Console::internal_warn`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,9 @@ Sessionx.vim
 # Zed
 /.zed
 
+# NeoVim
+.nvim.lua
+
 /unminified-js
 /unminified-css
 

--- a/components/script/dom/audio/analysernode.rs
+++ b/components/script/dom/audio/analysernode.rs
@@ -5,10 +5,11 @@
 use dom_struct::dom_struct;
 use ipc_channel::ipc::{self, IpcReceiver};
 use ipc_channel::router::ROUTER;
+use js::context::JSContext;
 use js::rust::{CustomAutoRooterGuard, HandleObject};
 use js::typedarray::{Float32Array, Uint8Array};
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use servo_media::audio::analyser_node::AnalysisEngine;
 use servo_media::audio::block::Block;
 use servo_media::audio::node::AudioNodeInit;
@@ -26,7 +27,6 @@ use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct AnalyserNode {
@@ -39,6 +39,7 @@ pub(crate) struct AnalyserNode {
 impl AnalyserNode {
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new_inherited(
+        cx: &mut JSContext,
         _: &Window,
         context: &BaseAudioContext,
         options: &AnalyserOptions,
@@ -69,6 +70,7 @@ impl AnalyserNode {
         };
 
         let node = AudioNode::new_inherited(
+            cx,
             AudioNodeInit::AnalyserNode(Box::new(callback)),
             context,
             node_options,
@@ -92,24 +94,24 @@ impl AnalyserNode {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         context: &BaseAudioContext,
         options: &AnalyserOptions,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<AnalyserNode>> {
-        Self::new_with_proto(window, None, context, options, can_gc)
+        Self::new_with_proto(cx, window, None, context, options)
     }
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         context: &BaseAudioContext,
         options: &AnalyserOptions,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<AnalyserNode>> {
-        let (node, recv) = AnalyserNode::new_inherited(window, context, options)?;
-        let object = reflect_dom_object_with_proto(Box::new(node), window, proto, can_gc);
+        let (node, recv) = AnalyserNode::new_inherited(cx, window, context, options)?;
+        let object = reflect_dom_object_with_proto_and_cx(Box::new(node), window, proto, cx);
         let task_source = window
             .as_global_scope()
             .task_manager()
@@ -138,13 +140,13 @@ impl AnalyserNode {
 impl AnalyserNodeMethods<crate::DomTypeHolder> for AnalyserNode {
     /// <https://webaudio.github.io/web-audio-api/#dom-analysernode-analysernode>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         context: &BaseAudioContext,
         options: &AnalyserOptions,
     ) -> Fallible<DomRoot<AnalyserNode>> {
-        AnalyserNode::new_with_proto(window, proto, context, options, can_gc)
+        AnalyserNode::new_with_proto(cx, window, proto, context, options)
     }
 
     #[expect(unsafe_code)]

--- a/components/script/dom/audio/audiobuffersourcenode.rs
+++ b/components/script/dom/audio/audiobuffersourcenode.rs
@@ -30,7 +30,6 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct AudioBufferSourceNode {
@@ -63,6 +62,7 @@ impl AudioBufferSourceNode {
         )?;
         let node_id = source_node.node().node_id();
         let playback_rate = AudioParam::new(
+            cx,
             window,
             context,
             node_id,
@@ -72,9 +72,9 @@ impl AudioBufferSourceNode {
             *options.playbackRate,
             f32::MIN,
             f32::MAX,
-            CanGc::from_cx(cx),
         );
         let detune = AudioParam::new(
+            cx,
             window,
             context,
             node_id,
@@ -84,7 +84,6 @@ impl AudioBufferSourceNode {
             *options.detune,
             f32::MIN,
             f32::MAX,
-            CanGc::from_cx(cx),
         );
         let node = AudioBufferSourceNode {
             source_node,

--- a/components/script/dom/audio/audiobuffersourcenode.rs
+++ b/components/script/dom/audio/audiobuffersourcenode.rs
@@ -6,8 +6,9 @@ use std::cell::Cell;
 use std::f32;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use servo_media::audio::buffer_source_node::{
     AudioBufferSourceNodeMessage, AudioBufferSourceNodeOptions,
 };
@@ -46,13 +47,14 @@ pub(crate) struct AudioBufferSourceNode {
 impl AudioBufferSourceNode {
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn new_inherited(
+        cx: &mut JSContext,
         window: &Window,
         context: &BaseAudioContext,
         options: &AudioBufferSourceOptions,
-        can_gc: CanGc,
     ) -> Fallible<AudioBufferSourceNode> {
         let node_options = Default::default();
         let source_node = AudioScheduledSourceNode::new_inherited(
+            cx,
             AudioNodeInit::AudioBufferSourceNode(options.convert()),
             context,
             node_options,
@@ -70,7 +72,7 @@ impl AudioBufferSourceNode {
             *options.playbackRate,
             f32::MIN,
             f32::MAX,
-            can_gc,
+            CanGc::from_cx(cx),
         );
         let detune = AudioParam::new(
             window,
@@ -82,7 +84,7 @@ impl AudioBufferSourceNode {
             *options.detune,
             f32::MIN,
             f32::MAX,
-            can_gc,
+            CanGc::from_cx(cx),
         );
         let node = AudioBufferSourceNode {
             source_node,
@@ -101,28 +103,28 @@ impl AudioBufferSourceNode {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         context: &BaseAudioContext,
         options: &AudioBufferSourceOptions,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<AudioBufferSourceNode>> {
-        Self::new_with_proto(window, None, context, options, can_gc)
+        Self::new_with_proto(cx, window, None, context, options)
     }
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn new_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         context: &BaseAudioContext,
         options: &AudioBufferSourceOptions,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<AudioBufferSourceNode>> {
-        let node = AudioBufferSourceNode::new_inherited(window, context, options, can_gc)?;
-        Ok(reflect_dom_object_with_proto(
+        let node = AudioBufferSourceNode::new_inherited(cx, window, context, options)?;
+        Ok(reflect_dom_object_with_proto_and_cx(
             Box::new(node),
             window,
             proto,
-            can_gc,
+            cx,
         ))
     }
 }
@@ -130,13 +132,13 @@ impl AudioBufferSourceNode {
 impl AudioBufferSourceNodeMethods<crate::DomTypeHolder> for AudioBufferSourceNode {
     /// <https://webaudio.github.io/web-audio-api/#dom-audiobuffersourcenode-audiobuffersourcenode>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         context: &BaseAudioContext,
         options: &AudioBufferSourceOptions,
     ) -> Fallible<DomRoot<AudioBufferSourceNode>> {
-        AudioBufferSourceNode::new_with_proto(window, proto, context, options, can_gc)
+        AudioBufferSourceNode::new_with_proto(cx, window, proto, context, options)
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-audiobuffersourcenode-buffer>

--- a/components/script/dom/audio/audiocontext.rs
+++ b/components/script/dom/audio/audiocontext.rs
@@ -5,6 +5,7 @@
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::realm::CurrentRealm;
 use js::rust::HandleObject;
 use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
@@ -255,18 +256,18 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
     /// <https://webaudio.github.io/web-audio-api/#dom-audiocontext-createmediaelementsource>
     fn CreateMediaElementSource(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         media_element: &HTMLMediaElement,
     ) -> Fallible<DomRoot<MediaElementAudioSourceNode>> {
         let global = self.global();
         let window = global.as_window();
-        MediaElementAudioSourceNode::new(window, self, media_element, cx)
+        MediaElementAudioSourceNode::new(cx, window, self, media_element)
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-audiocontext-createmediastreamsource>
     fn CreateMediaStreamSource(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         stream: &MediaStream,
     ) -> Fallible<DomRoot<MediaStreamAudioSourceNode>> {
         let global = self.global();
@@ -277,7 +278,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
     /// <https://webaudio.github.io/web-audio-api/#dom-audiocontext-createmediastreamtracksource>
     fn CreateMediaStreamTrackSource(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         track: &MediaStreamTrack,
     ) -> Fallible<DomRoot<MediaStreamTrackAudioSourceNode>> {
         let global = self.global();
@@ -288,7 +289,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
     /// <https://webaudio.github.io/web-audio-api/#dom-audiocontext-createmediastreamdestination>
     fn CreateMediaStreamDestination(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
     ) -> Fallible<DomRoot<MediaStreamAudioDestinationNode>> {
         let global = self.global();
         let window = global.as_window();

--- a/components/script/dom/audio/audiolistener.rs
+++ b/components/script/dom/audio/audiolistener.rs
@@ -5,7 +5,8 @@
 use std::f32;
 
 use dom_struct::dom_struct;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use js::context::JSContext;
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use servo_media::audio::node::AudioNodeType;
 use servo_media::audio::param::{ParamDir, ParamType};
 
@@ -19,7 +20,6 @@ use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct AudioListener {
@@ -36,10 +36,15 @@ pub(crate) struct AudioListener {
 }
 
 impl AudioListener {
-    fn new_inherited(window: &Window, context: &BaseAudioContext, can_gc: CanGc) -> AudioListener {
+    fn new_inherited(
+        cx: &mut JSContext,
+        window: &Window,
+        context: &BaseAudioContext,
+    ) -> AudioListener {
         let node = context.listener();
 
         let position_x = AudioParam::new(
+            cx,
             window,
             context,
             Some(node),
@@ -49,9 +54,9 @@ impl AudioListener {
             0.,       // default value
             f32::MIN, // min value
             f32::MAX, // max value
-            can_gc,
         );
         let position_y = AudioParam::new(
+            cx,
             window,
             context,
             Some(node),
@@ -61,9 +66,9 @@ impl AudioListener {
             0.,       // default value
             f32::MIN, // min value
             f32::MAX, // max value
-            can_gc,
         );
         let position_z = AudioParam::new(
+            cx,
             window,
             context,
             Some(node),
@@ -73,9 +78,9 @@ impl AudioListener {
             0.,       // default value
             f32::MIN, // min value
             f32::MAX, // max value
-            can_gc,
         );
         let forward_x = AudioParam::new(
+            cx,
             window,
             context,
             Some(node),
@@ -85,9 +90,9 @@ impl AudioListener {
             0.,       // default value
             f32::MIN, // min value
             f32::MAX, // max value
-            can_gc,
         );
         let forward_y = AudioParam::new(
+            cx,
             window,
             context,
             Some(node),
@@ -97,9 +102,9 @@ impl AudioListener {
             0.,       // default value
             f32::MIN, // min value
             f32::MAX, // max value
-            can_gc,
         );
         let forward_z = AudioParam::new(
+            cx,
             window,
             context,
             Some(node),
@@ -109,9 +114,9 @@ impl AudioListener {
             -1.,      // default value
             f32::MIN, // min value
             f32::MAX, // max value
-            can_gc,
         );
         let up_x = AudioParam::new(
+            cx,
             window,
             context,
             Some(node),
@@ -121,9 +126,9 @@ impl AudioListener {
             0.,       // default value
             f32::MIN, // min value
             f32::MAX, // max value
-            can_gc,
         );
         let up_y = AudioParam::new(
+            cx,
             window,
             context,
             Some(node),
@@ -133,9 +138,9 @@ impl AudioListener {
             1.,       // default value
             f32::MIN, // min value
             f32::MAX, // max value
-            can_gc,
         );
         let up_z = AudioParam::new(
+            cx,
             window,
             context,
             Some(node),
@@ -145,7 +150,6 @@ impl AudioListener {
             0.,       // default value
             f32::MIN, // min value
             f32::MAX, // max value
-            can_gc,
         );
 
         AudioListener {
@@ -164,12 +168,12 @@ impl AudioListener {
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         context: &BaseAudioContext,
-        can_gc: CanGc,
     ) -> DomRoot<AudioListener> {
-        let node = AudioListener::new_inherited(window, context, can_gc);
-        reflect_dom_object(Box::new(node), window, can_gc)
+        let node = AudioListener::new_inherited(cx, window, context);
+        reflect_dom_object_with_cx(Box::new(node), window, cx)
     }
 }
 

--- a/components/script/dom/audio/audionode.rs
+++ b/components/script/dom/audio/audionode.rs
@@ -5,6 +5,7 @@
 use std::cell::Cell;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use log::warn;
 use script_bindings::codegen::InheritTypes::{
     AudioNodeTypeId, AudioScheduledSourceNodeTypeId, EventTargetTypeId,
@@ -48,6 +49,7 @@ pub(crate) struct AudioNode {
 
 impl AudioNode {
     pub(crate) fn new_inherited(
+        cx: &mut JSContext,
         node_type: AudioNodeInit,
         context: &BaseAudioContext,
         options: UnwrappedAudioNodeOptions,
@@ -74,7 +76,7 @@ impl AudioNode {
             const MESSAGE: &str =
                 "Failed to create an AudioNode backend. The constructed AudioNode will be inert.";
             warn!("{MESSAGE}");
-            Console::internal_warn(&context.global(), MESSAGE.to_string());
+            Console::internal_warn(cx, &context.global(), MESSAGE.to_string());
         }
 
         Ok(AudioNode::new_inherited_for_id(

--- a/components/script/dom/audio/audioparam.rs
+++ b/components/script/dom/audio/audioparam.rs
@@ -6,8 +6,9 @@ use std::cell::Cell;
 use std::sync::mpsc;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use script_bindings::cformat;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use servo_media::audio::graph::NodeId;
 use servo_media::audio::node::{AudioNodeMessage, AudioNodeType};
 use servo_media::audio::param::{ParamRate, ParamType, RampKind, UserAutomationEvent};
@@ -21,7 +22,6 @@ use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct AudioParam {
@@ -70,6 +70,7 @@ impl AudioParam {
     #[allow(clippy::too_many_arguments)]
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         context: &BaseAudioContext,
         node: Option<NodeId>,
@@ -79,7 +80,6 @@ impl AudioParam {
         default_value: f32,
         min_value: f32,
         max_value: f32,
-        can_gc: CanGc,
     ) -> DomRoot<AudioParam> {
         let audio_param = AudioParam::new_inherited(
             context,
@@ -91,7 +91,7 @@ impl AudioParam {
             min_value,
             max_value,
         );
-        reflect_dom_object(Box::new(audio_param), window, can_gc)
+        reflect_dom_object_with_cx(Box::new(audio_param), window, cx)
     }
 
     fn message_node(&self, message: AudioNodeMessage) {

--- a/components/script/dom/audio/audioscheduledsourcenode.rs
+++ b/components/script/dom/audio/audioscheduledsourcenode.rs
@@ -5,6 +5,7 @@
 use std::cell::Cell;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use servo_media::audio::node::{
     AudioNodeInit, AudioNodeMessage, AudioScheduledSourceNodeMessage, OnEndedCallback,
 };
@@ -28,6 +29,7 @@ pub(crate) struct AudioScheduledSourceNode {
 impl AudioScheduledSourceNode {
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new_inherited(
+        cx: &mut JSContext,
         node_type: AudioNodeInit,
         context: &BaseAudioContext,
         options: UnwrappedAudioNodeOptions,
@@ -36,6 +38,7 @@ impl AudioScheduledSourceNode {
     ) -> Fallible<AudioScheduledSourceNode> {
         Ok(AudioScheduledSourceNode {
             node: AudioNode::new_inherited(
+                cx,
                 node_type,
                 context,
                 options,

--- a/components/script/dom/audio/baseaudiocontext.rs
+++ b/components/script/dom/audio/baseaudiocontext.rs
@@ -330,11 +330,11 @@ impl BaseAudioContextMethods<crate::DomTypeHolder> for BaseAudioContext {
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-listener>
-    fn Listener(&self, can_gc: CanGc) -> DomRoot<AudioListener> {
+    fn Listener(&self, cx: &mut JSContext) -> DomRoot<AudioListener> {
         let global = self.global();
         let window = global.as_window();
         self.listener
-            .or_init(|| AudioListener::new(window, self, can_gc))
+            .or_init(|| AudioListener::new(cx, window, self))
     }
 
     // https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-onstatechange

--- a/components/script/dom/audio/baseaudiocontext.rs
+++ b/components/script/dom/audio/baseaudiocontext.rs
@@ -341,95 +341,85 @@ impl BaseAudioContextMethods<crate::DomTypeHolder> for BaseAudioContext {
     event_handler!(statechange, GetOnstatechange, SetOnstatechange);
 
     /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createoscillator>
-    fn CreateOscillator(&self, can_gc: CanGc) -> Fallible<DomRoot<OscillatorNode>> {
+    fn CreateOscillator(&self, cx: &mut JSContext) -> Fallible<DomRoot<OscillatorNode>> {
         OscillatorNode::new(
+            cx,
             self.global().as_window(),
             self,
             &OscillatorOptions::empty(),
-            can_gc,
         )
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-creategain>
-    fn CreateGain(&self, can_gc: CanGc) -> Fallible<DomRoot<GainNode>> {
-        GainNode::new(
-            self.global().as_window(),
-            self,
-            &GainOptions::empty(),
-            can_gc,
-        )
+    fn CreateGain(&self, cx: &mut JSContext) -> Fallible<DomRoot<GainNode>> {
+        GainNode::new(cx, self.global().as_window(), self, &GainOptions::empty())
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createpanner>
-    fn CreatePanner(&self, can_gc: CanGc) -> Fallible<DomRoot<PannerNode>> {
-        PannerNode::new(
-            self.global().as_window(),
-            self,
-            &PannerOptions::empty(),
-            can_gc,
-        )
+    fn CreatePanner(&self, cx: &mut JSContext) -> Fallible<DomRoot<PannerNode>> {
+        PannerNode::new(cx, self.global().as_window(), self, &PannerOptions::empty())
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createanalyser>
-    fn CreateAnalyser(&self, can_gc: CanGc) -> Fallible<DomRoot<AnalyserNode>> {
+    fn CreateAnalyser(&self, cx: &mut JSContext) -> Fallible<DomRoot<AnalyserNode>> {
         AnalyserNode::new(
+            cx,
             self.global().as_window(),
             self,
             &AnalyserOptions::empty(),
-            can_gc,
         )
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createbiquadfilter>
-    fn CreateBiquadFilter(&self, can_gc: CanGc) -> Fallible<DomRoot<BiquadFilterNode>> {
+    fn CreateBiquadFilter(&self, cx: &mut JSContext) -> Fallible<DomRoot<BiquadFilterNode>> {
         BiquadFilterNode::new(
+            cx,
             self.global().as_window(),
             self,
             &BiquadFilterOptions::empty(),
-            can_gc,
         )
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createstereopanner>
-    fn CreateStereoPanner(&self, can_gc: CanGc) -> Fallible<DomRoot<StereoPannerNode>> {
+    fn CreateStereoPanner(&self, cx: &mut JSContext) -> Fallible<DomRoot<StereoPannerNode>> {
         StereoPannerNode::new(
+            cx,
             self.global().as_window(),
             self,
             &StereoPannerOptions::empty(),
-            can_gc,
         )
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createconstantsource>
-    fn CreateConstantSource(&self, can_gc: CanGc) -> Fallible<DomRoot<ConstantSourceNode>> {
+    fn CreateConstantSource(&self, cx: &mut JSContext) -> Fallible<DomRoot<ConstantSourceNode>> {
         ConstantSourceNode::new(
+            cx,
             self.global().as_window(),
             self,
             &ConstantSourceOptions::empty(),
-            can_gc,
         )
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createchannelmerger>
     fn CreateChannelMerger(
         &self,
+        cx: &mut JSContext,
         count: u32,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<ChannelMergerNode>> {
         let mut opts = ChannelMergerOptions::empty();
         opts.numberOfInputs = count;
-        ChannelMergerNode::new(self.global().as_window(), self, &opts, can_gc)
+        ChannelMergerNode::new(cx, self.global().as_window(), self, &opts)
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createchannelsplitter>
     fn CreateChannelSplitter(
         &self,
+        cx: &mut JSContext,
         count: u32,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<ChannelSplitterNode>> {
         let mut opts = ChannelSplitterOptions::empty();
         opts.numberOfOutputs = count;
-        ChannelSplitterNode::new(self.global().as_window(), self, &opts, can_gc)
+        ChannelSplitterNode::new(cx, self.global().as_window(), self, &opts)
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createbuffer>
@@ -458,12 +448,12 @@ impl BaseAudioContextMethods<crate::DomTypeHolder> for BaseAudioContext {
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createbuffersource>
-    fn CreateBufferSource(&self, can_gc: CanGc) -> Fallible<DomRoot<AudioBufferSourceNode>> {
+    fn CreateBufferSource(&self, cx: &mut JSContext) -> Fallible<DomRoot<AudioBufferSourceNode>> {
         AudioBufferSourceNode::new(
+            cx,
             self.global().as_window(),
             self,
             &AudioBufferSourceOptions::empty(),
-            can_gc,
         )
     }
 
@@ -590,16 +580,16 @@ impl BaseAudioContextMethods<crate::DomTypeHolder> for BaseAudioContext {
     /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createiirfilter>
     fn CreateIIRFilter(
         &self,
+        cx: &mut JSContext,
         feedforward: Vec<Finite<f64>>,
         feedback: Vec<Finite<f64>>,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<IIRFilterNode>> {
         let opts = IIRFilterOptions {
             parent: AudioNodeOptions::empty(),
             feedback,
             feedforward,
         };
-        IIRFilterNode::new(self.global().as_window(), self, &opts, can_gc)
+        IIRFilterNode::new(cx, self.global().as_window(), self, &opts)
     }
 }
 

--- a/components/script/dom/audio/biquadfilternode.rs
+++ b/components/script/dom/audio/biquadfilternode.rs
@@ -6,8 +6,9 @@ use std::cell::Cell;
 use std::f32;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use servo_media::audio::biquad_filter_node::{
     BiquadFilterNodeMessage, BiquadFilterNodeOptions, FilterType,
 };
@@ -43,10 +44,10 @@ pub(crate) struct BiquadFilterNode {
 impl BiquadFilterNode {
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new_inherited(
+        cx: &mut JSContext,
         window: &Window,
         context: &BaseAudioContext,
         options: &BiquadFilterOptions,
-        can_gc: CanGc,
     ) -> Fallible<BiquadFilterNode> {
         let node_options =
             options
@@ -55,6 +56,7 @@ impl BiquadFilterNode {
         let filter = Cell::new(options.type_);
         let options = options.convert();
         let node = AudioNode::new_inherited(
+            cx,
             AudioNodeInit::BiquadFilterNode(options),
             context,
             node_options,
@@ -71,7 +73,7 @@ impl BiquadFilterNode {
             options.gain, // default value
             f32::MIN,     // min value
             f32::MAX,     // max value
-            can_gc,
+            CanGc::from_cx(cx),
         );
         let q = AudioParam::new(
             window,
@@ -83,7 +85,7 @@ impl BiquadFilterNode {
             options.q, // default value
             f32::MIN,  // min value
             f32::MAX,  // max value
-            can_gc,
+            CanGc::from_cx(cx),
         );
         let frequency = AudioParam::new(
             window,
@@ -95,7 +97,7 @@ impl BiquadFilterNode {
             options.frequency, // default value
             f32::MIN,          // min value
             f32::MAX,          // max value
-            can_gc,
+            CanGc::from_cx(cx),
         );
         let detune = AudioParam::new(
             window,
@@ -107,7 +109,7 @@ impl BiquadFilterNode {
             options.detune, // default value
             f32::MIN,       // min value
             f32::MAX,       // max value
-            can_gc,
+            CanGc::from_cx(cx),
         );
         Ok(BiquadFilterNode {
             node,
@@ -120,28 +122,28 @@ impl BiquadFilterNode {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         context: &BaseAudioContext,
         options: &BiquadFilterOptions,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<BiquadFilterNode>> {
-        Self::new_with_proto(window, None, context, options, can_gc)
+        Self::new_with_proto(cx, window, None, context, options)
     }
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn new_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         context: &BaseAudioContext,
         options: &BiquadFilterOptions,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<BiquadFilterNode>> {
-        let node = BiquadFilterNode::new_inherited(window, context, options, can_gc)?;
-        Ok(reflect_dom_object_with_proto(
+        let node = BiquadFilterNode::new_inherited(cx, window, context, options)?;
+        Ok(reflect_dom_object_with_proto_and_cx(
             Box::new(node),
             window,
             proto,
-            can_gc,
+            cx,
         ))
     }
 }
@@ -149,13 +151,13 @@ impl BiquadFilterNode {
 impl BiquadFilterNodeMethods<crate::DomTypeHolder> for BiquadFilterNode {
     /// <https://webaudio.github.io/web-audio-api/#dom-biquadfilternode-biquadfilternode-context-options>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         context: &BaseAudioContext,
         options: &BiquadFilterOptions,
     ) -> Fallible<DomRoot<BiquadFilterNode>> {
-        BiquadFilterNode::new_with_proto(window, proto, context, options, can_gc)
+        BiquadFilterNode::new_with_proto(cx, window, proto, context, options)
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-biquadfilternode-gain>

--- a/components/script/dom/audio/biquadfilternode.rs
+++ b/components/script/dom/audio/biquadfilternode.rs
@@ -29,7 +29,6 @@ use crate::dom::bindings::codegen::Bindings::BiquadFilterNodeBinding::{
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct BiquadFilterNode {
@@ -64,6 +63,7 @@ impl BiquadFilterNode {
             1, // outputs
         )?;
         let gain = AudioParam::new(
+            cx,
             window,
             context,
             node.node_id(),
@@ -73,9 +73,9 @@ impl BiquadFilterNode {
             options.gain, // default value
             f32::MIN,     // min value
             f32::MAX,     // max value
-            CanGc::from_cx(cx),
         );
         let q = AudioParam::new(
+            cx,
             window,
             context,
             node.node_id(),
@@ -85,9 +85,9 @@ impl BiquadFilterNode {
             options.q, // default value
             f32::MIN,  // min value
             f32::MAX,  // max value
-            CanGc::from_cx(cx),
         );
         let frequency = AudioParam::new(
+            cx,
             window,
             context,
             node.node_id(),
@@ -97,9 +97,9 @@ impl BiquadFilterNode {
             options.frequency, // default value
             f32::MIN,          // min value
             f32::MAX,          // max value
-            CanGc::from_cx(cx),
         );
         let detune = AudioParam::new(
+            cx,
             window,
             context,
             node.node_id(),
@@ -109,7 +109,6 @@ impl BiquadFilterNode {
             options.detune, // default value
             f32::MIN,       // min value
             f32::MAX,       // max value
-            CanGc::from_cx(cx),
         );
         Ok(BiquadFilterNode {
             node,

--- a/components/script/dom/audio/channelmergernode.rs
+++ b/components/script/dom/audio/channelmergernode.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use servo_media::audio::channel_node::ChannelNodeOptions;
 use servo_media::audio::node::AudioNodeInit;
 
@@ -20,7 +21,6 @@ use crate::dom::bindings::codegen::Bindings::ChannelMergerNodeBinding::{
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct ChannelMergerNode {
@@ -30,6 +30,7 @@ pub(crate) struct ChannelMergerNode {
 impl ChannelMergerNode {
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new_inherited(
+        cx: &mut JSContext,
         _: &Window,
         context: &BaseAudioContext,
         options: &ChannelMergerOptions,
@@ -50,6 +51,7 @@ impl ChannelMergerNode {
 
         let num_inputs = options.numberOfInputs;
         let node = AudioNode::new_inherited(
+            cx,
             AudioNodeInit::ChannelMergerNode(options.convert()),
             context,
             node_options,
@@ -60,28 +62,28 @@ impl ChannelMergerNode {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         context: &BaseAudioContext,
         options: &ChannelMergerOptions,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<ChannelMergerNode>> {
-        Self::new_with_proto(window, None, context, options, can_gc)
+        Self::new_with_proto(cx, window, None, context, options)
     }
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn new_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         context: &BaseAudioContext,
         options: &ChannelMergerOptions,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<ChannelMergerNode>> {
-        let node = ChannelMergerNode::new_inherited(window, context, options)?;
-        Ok(reflect_dom_object_with_proto(
+        let node = ChannelMergerNode::new_inherited(cx, window, context, options)?;
+        Ok(reflect_dom_object_with_proto_and_cx(
             Box::new(node),
             window,
             proto,
-            can_gc,
+            cx,
         ))
     }
 }
@@ -89,13 +91,13 @@ impl ChannelMergerNode {
 impl ChannelMergerNodeMethods<crate::DomTypeHolder> for ChannelMergerNode {
     /// <https://webaudio.github.io/web-audio-api/#dom-channelmergernode-channelmergernode>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         context: &BaseAudioContext,
         options: &ChannelMergerOptions,
     ) -> Fallible<DomRoot<ChannelMergerNode>> {
-        ChannelMergerNode::new_with_proto(window, proto, context, options, can_gc)
+        ChannelMergerNode::new_with_proto(cx, window, proto, context, options)
     }
 }
 

--- a/components/script/dom/audio/channelsplitternode.rs
+++ b/components/script/dom/audio/channelsplitternode.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use servo_media::audio::node::AudioNodeInit;
 
 use crate::dom::audio::audionode::{AudioNode, AudioNodeOptionsHelper, MAX_CHANNEL_COUNT};
@@ -18,7 +19,6 @@ use crate::dom::bindings::codegen::Bindings::ChannelSplitterNodeBinding::{
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct ChannelSplitterNode {
@@ -28,6 +28,7 @@ pub(crate) struct ChannelSplitterNode {
 impl ChannelSplitterNode {
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new_inherited(
+        cx: &mut JSContext,
         _: &Window,
         context: &BaseAudioContext,
         options: &ChannelSplitterOptions,
@@ -50,6 +51,7 @@ impl ChannelSplitterNode {
         }
 
         let node = AudioNode::new_inherited(
+            cx,
             AudioNodeInit::ChannelSplitterNode,
             context,
             node_options,
@@ -60,28 +62,28 @@ impl ChannelSplitterNode {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         context: &BaseAudioContext,
         options: &ChannelSplitterOptions,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<ChannelSplitterNode>> {
-        Self::new_with_proto(window, None, context, options, can_gc)
+        Self::new_with_proto(cx, window, None, context, options)
     }
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn new_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         context: &BaseAudioContext,
         options: &ChannelSplitterOptions,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<ChannelSplitterNode>> {
-        let node = ChannelSplitterNode::new_inherited(window, context, options)?;
-        Ok(reflect_dom_object_with_proto(
+        let node = ChannelSplitterNode::new_inherited(cx, window, context, options)?;
+        Ok(reflect_dom_object_with_proto_and_cx(
             Box::new(node),
             window,
             proto,
-            can_gc,
+            cx,
         ))
     }
 }
@@ -89,12 +91,12 @@ impl ChannelSplitterNode {
 impl ChannelSplitterNodeMethods<crate::DomTypeHolder> for ChannelSplitterNode {
     /// <https://webaudio.github.io/web-audio-api/#dom-channelsplitternode-channelsplitternode>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         context: &BaseAudioContext,
         options: &ChannelSplitterOptions,
     ) -> Fallible<DomRoot<ChannelSplitterNode>> {
-        ChannelSplitterNode::new_with_proto(window, proto, context, options, can_gc)
+        ChannelSplitterNode::new_with_proto(cx, window, proto, context, options)
     }
 }

--- a/components/script/dom/audio/constantsourcenode.rs
+++ b/components/script/dom/audio/constantsourcenode.rs
@@ -23,7 +23,6 @@ use crate::dom::bindings::codegen::Bindings::ConstantSourceNodeBinding::{
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct ConstantSourceNode {
@@ -51,6 +50,7 @@ impl ConstantSourceNode {
         )?;
         let node_id = source_node.node().node_id();
         let offset = AudioParam::new(
+            cx,
             window,
             context,
             node_id,
@@ -60,7 +60,6 @@ impl ConstantSourceNode {
             offset,
             f32::MIN,
             f32::MAX,
-            CanGc::from_cx(cx),
         );
 
         Ok(ConstantSourceNode {

--- a/components/script/dom/audio/constantsourcenode.rs
+++ b/components/script/dom/audio/constantsourcenode.rs
@@ -5,8 +5,9 @@
 use std::f32;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use servo_media::audio::constant_source_node::ConstantSourceNodeOptions as ServoMediaConstantSourceOptions;
 use servo_media::audio::node::{AudioNodeInit, AudioNodeType};
 use servo_media::audio::param::ParamType;
@@ -33,14 +34,15 @@ pub(crate) struct ConstantSourceNode {
 impl ConstantSourceNode {
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn new_inherited(
+        cx: &mut JSContext,
         window: &Window,
         context: &BaseAudioContext,
         options: &ConstantSourceOptions,
-        can_gc: CanGc,
     ) -> Fallible<ConstantSourceNode> {
         let node_options = Default::default();
         let offset = *options.offset;
         let source_node = AudioScheduledSourceNode::new_inherited(
+            cx,
             AudioNodeInit::ConstantSourceNode(options.convert()),
             context,
             node_options, /* 2, MAX, Speakers */
@@ -58,7 +60,7 @@ impl ConstantSourceNode {
             offset,
             f32::MIN,
             f32::MAX,
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         Ok(ConstantSourceNode {
@@ -68,28 +70,28 @@ impl ConstantSourceNode {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         context: &BaseAudioContext,
         options: &ConstantSourceOptions,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<ConstantSourceNode>> {
-        Self::new_with_proto(window, None, context, options, can_gc)
+        Self::new_with_proto(cx, window, None, context, options)
     }
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn new_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         context: &BaseAudioContext,
         options: &ConstantSourceOptions,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<ConstantSourceNode>> {
-        let node = ConstantSourceNode::new_inherited(window, context, options, can_gc)?;
-        Ok(reflect_dom_object_with_proto(
+        let node = ConstantSourceNode::new_inherited(cx, window, context, options)?;
+        Ok(reflect_dom_object_with_proto_and_cx(
             Box::new(node),
             window,
             proto,
-            can_gc,
+            cx,
         ))
     }
 }
@@ -97,13 +99,13 @@ impl ConstantSourceNode {
 impl ConstantSourceNodeMethods<crate::DomTypeHolder> for ConstantSourceNode {
     /// <https://webaudio.github.io/web-audio-api/#dom-constantsourcenode-constantsourcenode>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         context: &BaseAudioContext,
         options: &ConstantSourceOptions,
     ) -> Fallible<DomRoot<ConstantSourceNode>> {
-        ConstantSourceNode::new_with_proto(window, proto, context, options, can_gc)
+        ConstantSourceNode::new_with_proto(cx, window, proto, context, options)
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-constantsourcenode-offset>

--- a/components/script/dom/audio/gainnode.rs
+++ b/components/script/dom/audio/gainnode.rs
@@ -5,8 +5,9 @@
 use std::f32;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use servo_media::audio::gain_node::GainNodeOptions;
 use servo_media::audio::node::{AudioNodeInit, AudioNodeType};
 use servo_media::audio::param::ParamType;
@@ -34,10 +35,10 @@ pub(crate) struct GainNode {
 impl GainNode {
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new_inherited(
+        cx: &mut JSContext,
         window: &Window,
         context: &BaseAudioContext,
         options: &GainOptions,
-        can_gc: CanGc,
     ) -> Fallible<GainNode> {
         let node_options =
             options
@@ -45,6 +46,7 @@ impl GainNode {
                 .unwrap_or(2, ChannelCountMode::Max, ChannelInterpretation::Speakers);
         let gain = *options.gain;
         let node = AudioNode::new_inherited(
+            cx,
             AudioNodeInit::GainNode(options.convert()),
             context,
             node_options,
@@ -61,7 +63,7 @@ impl GainNode {
             gain,     // default value
             f32::MIN, // min value
             f32::MAX, // max value
-            can_gc,
+            CanGc::from_cx(cx),
         );
         Ok(GainNode {
             node,
@@ -70,28 +72,28 @@ impl GainNode {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         context: &BaseAudioContext,
         options: &GainOptions,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<GainNode>> {
-        Self::new_with_proto(window, None, context, options, can_gc)
+        Self::new_with_proto(cx, window, None, context, options)
     }
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn new_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         context: &BaseAudioContext,
         options: &GainOptions,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<GainNode>> {
-        let node = GainNode::new_inherited(window, context, options, can_gc)?;
-        Ok(reflect_dom_object_with_proto(
+        let node = GainNode::new_inherited(cx, window, context, options)?;
+        Ok(reflect_dom_object_with_proto_and_cx(
             Box::new(node),
             window,
             proto,
-            can_gc,
+            cx,
         ))
     }
 }
@@ -99,13 +101,13 @@ impl GainNode {
 impl GainNodeMethods<crate::DomTypeHolder> for GainNode {
     /// <https://webaudio.github.io/web-audio-api/#dom-gainnode-gainnode>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         context: &BaseAudioContext,
         options: &GainOptions,
     ) -> Fallible<DomRoot<GainNode>> {
-        GainNode::new_with_proto(window, proto, context, options, can_gc)
+        GainNode::new_with_proto(cx, window, proto, context, options)
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-gainnode-gain>

--- a/components/script/dom/audio/gainnode.rs
+++ b/components/script/dom/audio/gainnode.rs
@@ -24,7 +24,6 @@ use crate::dom::bindings::codegen::Bindings::GainNodeBinding::{GainNodeMethods, 
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct GainNode {
@@ -54,6 +53,7 @@ impl GainNode {
             1, // outputs
         )?;
         let gain = AudioParam::new(
+            cx,
             window,
             context,
             node.node_id(),
@@ -63,7 +63,6 @@ impl GainNode {
             gain,     // default value
             f32::MIN, // min value
             f32::MAX, // max value
-            CanGc::from_cx(cx),
         );
         Ok(GainNode {
             node,

--- a/components/script/dom/audio/iirfilternode.rs
+++ b/components/script/dom/audio/iirfilternode.rs
@@ -6,10 +6,11 @@ use std::sync::Arc;
 
 use dom_struct::dom_struct;
 use itertools::Itertools;
+use js::context::JSContext;
 use js::gc::CustomAutoRooterGuard;
 use js::rust::HandleObject;
 use js::typedarray::Float32Array;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use servo_media::audio::iir_filter_node::{IIRFilterNode as IIRFilter, IIRFilterNodeOptions};
 use servo_media::audio::node::AudioNodeInit;
 
@@ -26,7 +27,6 @@ use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct IIRFilterNode {
@@ -38,6 +38,7 @@ pub(crate) struct IIRFilterNode {
 impl IIRFilterNode {
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new_inherited(
+        cx: &mut JSContext,
         _window: &Window,
         context: &BaseAudioContext,
         options: &IIRFilterOptions,
@@ -58,6 +59,7 @@ impl IIRFilterNode {
         let feedback = (*options.feedback).to_vec();
         let init_options = options.clone().convert();
         let node = AudioNode::new_inherited(
+            cx,
             AudioNodeInit::IIRFilterNode(init_options),
             context,
             node_options,
@@ -72,28 +74,28 @@ impl IIRFilterNode {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         context: &BaseAudioContext,
         options: &IIRFilterOptions,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<IIRFilterNode>> {
-        Self::new_with_proto(window, None, context, options, can_gc)
+        Self::new_with_proto(cx, window, None, context, options)
     }
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn new_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         context: &BaseAudioContext,
         options: &IIRFilterOptions,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<IIRFilterNode>> {
-        let node = IIRFilterNode::new_inherited(window, context, options)?;
-        Ok(reflect_dom_object_with_proto(
+        let node = IIRFilterNode::new_inherited(cx, window, context, options)?;
+        Ok(reflect_dom_object_with_proto_and_cx(
             Box::new(node),
             window,
             proto,
-            can_gc,
+            cx,
         ))
     }
 }
@@ -101,13 +103,13 @@ impl IIRFilterNode {
 impl IIRFilterNodeMethods<crate::DomTypeHolder> for IIRFilterNode {
     /// <https://webaudio.github.io/web-audio-api/#dom-iirfilternode-iirfilternode>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         context: &BaseAudioContext,
         options: &IIRFilterOptions,
     ) -> Fallible<DomRoot<IIRFilterNode>> {
-        IIRFilterNode::new_with_proto(window, proto, context, options, can_gc)
+        IIRFilterNode::new_with_proto(cx, window, proto, context, options)
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-iirfilternode-getfrequencyresponse>

--- a/components/script/dom/audio/mediaelementaudiosourcenode.rs
+++ b/components/script/dom/audio/mediaelementaudiosourcenode.rs
@@ -5,6 +5,7 @@
 use std::sync::mpsc;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use servo_media::audio::media_element_source_node::MediaElementSourceNodeMessage;
@@ -29,11 +30,12 @@ pub(crate) struct MediaElementAudioSourceNode {
 impl MediaElementAudioSourceNode {
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn new_inherited(
+        cx: &mut JSContext,
         context: &AudioContext,
         media_element: &HTMLMediaElement,
-        cx: &mut js::context::JSContext,
     ) -> Fallible<MediaElementAudioSourceNode> {
         let node = AudioNode::new_inherited(
+            cx,
             AudioNodeInit::MediaElementSourceNode,
             &context.base(),
             Default::default(),
@@ -54,23 +56,23 @@ impl MediaElementAudioSourceNode {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         context: &AudioContext,
         media_element: &HTMLMediaElement,
-        cx: &mut js::context::JSContext,
     ) -> Fallible<DomRoot<MediaElementAudioSourceNode>> {
-        Self::new_with_proto(window, None, context, media_element, cx)
+        Self::new_with_proto(cx, window, None, context, media_element)
     }
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn new_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         context: &AudioContext,
         media_element: &HTMLMediaElement,
-        cx: &mut js::context::JSContext,
     ) -> Fallible<DomRoot<MediaElementAudioSourceNode>> {
-        let node = MediaElementAudioSourceNode::new_inherited(context, media_element, cx)?;
+        let node = MediaElementAudioSourceNode::new_inherited(cx, context, media_element)?;
         Ok(reflect_dom_object_with_proto_and_cx(
             Box::new(node),
             window,
@@ -83,18 +85,18 @@ impl MediaElementAudioSourceNode {
 impl MediaElementAudioSourceNodeMethods<crate::DomTypeHolder> for MediaElementAudioSourceNode {
     /// <https://webaudio.github.io/web-audio-api/#dom-mediaelementaudiosourcenode-mediaelementaudiosourcenode>
     fn Constructor(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         context: &AudioContext,
         options: &MediaElementAudioSourceOptions,
     ) -> Fallible<DomRoot<MediaElementAudioSourceNode>> {
         MediaElementAudioSourceNode::new_with_proto(
+            cx,
             window,
             proto,
             context,
             &options.mediaElement,
-            cx,
         )
     }
 

--- a/components/script/dom/audio/mediastreamaudiodestinationnode.rs
+++ b/components/script/dom/audio/mediastreamaudiodestinationnode.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use servo_media::ServoMedia;
@@ -31,7 +32,7 @@ pub(crate) struct MediaStreamAudioDestinationNode {
 impl MediaStreamAudioDestinationNode {
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new_inherited(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         context: &AudioContext,
         options: &AudioNodeOptions,
     ) -> Fallible<MediaStreamAudioDestinationNode> {
@@ -44,6 +45,7 @@ impl MediaStreamAudioDestinationNode {
             ChannelInterpretation::Speakers,
         );
         let node = AudioNode::new_inherited(
+            cx,
             AudioNodeInit::MediaStreamDestinationNode(socket),
             context.upcast(),
             node_options,
@@ -57,7 +59,7 @@ impl MediaStreamAudioDestinationNode {
     }
 
     pub(crate) fn new(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         window: &Window,
         context: &AudioContext,
         options: &AudioNodeOptions,
@@ -67,7 +69,7 @@ impl MediaStreamAudioDestinationNode {
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn new_with_proto(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         context: &AudioContext,
@@ -88,7 +90,7 @@ impl MediaStreamAudioDestinationNodeMethods<crate::DomTypeHolder>
 {
     /// <https://webaudio.github.io/web-audio-api/#dom-mediastreamaudiodestinationnode-mediastreamaudiodestinationnode>
     fn Constructor(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         context: &AudioContext,

--- a/components/script/dom/audio/mediastreamaudiosourcenode.rs
+++ b/components/script/dom/audio/mediastreamaudiosourcenode.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use servo_media::audio::node::AudioNodeInit;
@@ -28,6 +29,7 @@ pub(crate) struct MediaStreamAudioSourceNode {
 impl MediaStreamAudioSourceNode {
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new_inherited(
+        cx: &mut JSContext,
         context: &AudioContext,
         stream: &MediaStream,
     ) -> Fallible<MediaStreamAudioSourceNode> {
@@ -38,6 +40,7 @@ impl MediaStreamAudioSourceNode {
             .ok_or(Error::InvalidState(None))?
             .id();
         let node = AudioNode::new_inherited(
+            cx,
             AudioNodeInit::MediaStreamSourceNode(track),
             context.upcast(),
             Default::default(),
@@ -51,7 +54,7 @@ impl MediaStreamAudioSourceNode {
     }
 
     pub(crate) fn new(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         window: &Window,
         context: &AudioContext,
         stream: &MediaStream,
@@ -61,13 +64,13 @@ impl MediaStreamAudioSourceNode {
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn new_with_proto(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         context: &AudioContext,
         stream: &MediaStream,
     ) -> Fallible<DomRoot<MediaStreamAudioSourceNode>> {
-        let node = MediaStreamAudioSourceNode::new_inherited(context, stream)?;
+        let node = MediaStreamAudioSourceNode::new_inherited(cx, context, stream)?;
         Ok(reflect_dom_object_with_proto_and_cx(
             Box::new(node),
             window,
@@ -80,7 +83,7 @@ impl MediaStreamAudioSourceNode {
 impl MediaStreamAudioSourceNodeMethods<crate::DomTypeHolder> for MediaStreamAudioSourceNode {
     /// <https://webaudio.github.io/web-audio-api/#dom-mediastreamaudiosourcenode-mediastreamaudiosourcenode>
     fn Constructor(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         context: &AudioContext,

--- a/components/script/dom/audio/mediastreamtrackaudiosourcenode.rs
+++ b/components/script/dom/audio/mediastreamtrackaudiosourcenode.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use servo_media::audio::node::AudioNodeInit;
@@ -27,10 +28,12 @@ pub(crate) struct MediaStreamTrackAudioSourceNode {
 impl MediaStreamTrackAudioSourceNode {
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new_inherited(
+        cx: &mut JSContext,
         context: &AudioContext,
         track: &MediaStreamTrack,
     ) -> Fallible<MediaStreamTrackAudioSourceNode> {
         let node = AudioNode::new_inherited(
+            cx,
             AudioNodeInit::MediaStreamSourceNode(track.id()),
             context.upcast(),
             Default::default(),
@@ -54,13 +57,13 @@ impl MediaStreamTrackAudioSourceNode {
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn new_with_proto(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         context: &AudioContext,
         track: &MediaStreamTrack,
     ) -> Fallible<DomRoot<MediaStreamTrackAudioSourceNode>> {
-        let node = MediaStreamTrackAudioSourceNode::new_inherited(context, track)?;
+        let node = MediaStreamTrackAudioSourceNode::new_inherited(cx, context, track)?;
         Ok(reflect_dom_object_with_proto_and_cx(
             Box::new(node),
             window,
@@ -75,7 +78,7 @@ impl MediaStreamTrackAudioSourceNodeMethods<crate::DomTypeHolder>
 {
     /// <https://webaudio.github.io/web-audio-api/#dom-mediastreamtrackaudiosourcenode-mediastreamtrackaudiosourcenode>
     fn Constructor(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         context: &AudioContext,

--- a/components/script/dom/audio/oscillatornode.rs
+++ b/components/script/dom/audio/oscillatornode.rs
@@ -31,7 +31,6 @@ use crate::dom::bindings::codegen::Bindings::OscillatorNodeBinding::{
 use crate::dom::bindings::error::{Error, ErrorResult, Fallible};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct OscillatorNode {
@@ -63,6 +62,7 @@ impl OscillatorNode {
         )?;
         let node_id = source_node.node().node_id();
         let frequency = AudioParam::new(
+            cx,
             window,
             context,
             node_id,
@@ -72,9 +72,9 @@ impl OscillatorNode {
             440.,
             f32::MIN,
             f32::MAX,
-            CanGc::from_cx(cx),
         );
         let detune = AudioParam::new(
+            cx,
             window,
             context,
             node_id,
@@ -84,7 +84,6 @@ impl OscillatorNode {
             0.,
             -440. / 2.,
             440. / 2.,
-            CanGc::from_cx(cx),
         );
         Ok(OscillatorNode {
             source_node,

--- a/components/script/dom/audio/oscillatornode.rs
+++ b/components/script/dom/audio/oscillatornode.rs
@@ -6,8 +6,9 @@ use std::cell::Cell;
 use std::f32;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use servo_media::audio::node::{AudioNodeInit, AudioNodeMessage, AudioNodeType};
 use servo_media::audio::oscillator_node::{
     OscillatorNodeMessage, OscillatorNodeOptions as ServoMediaOscillatorOptions,
@@ -43,16 +44,17 @@ pub(crate) struct OscillatorNode {
 impl OscillatorNode {
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new_inherited(
+        cx: &mut JSContext,
         window: &Window,
         context: &BaseAudioContext,
         options: &OscillatorOptions,
-        can_gc: CanGc,
     ) -> Fallible<OscillatorNode> {
         let node_options =
             options
                 .parent
                 .unwrap_or(2, ChannelCountMode::Max, ChannelInterpretation::Speakers);
         let source_node = AudioScheduledSourceNode::new_inherited(
+            cx,
             AudioNodeInit::OscillatorNode(options.convert()),
             context,
             node_options,
@@ -70,7 +72,7 @@ impl OscillatorNode {
             440.,
             f32::MIN,
             f32::MAX,
-            can_gc,
+            CanGc::from_cx(cx),
         );
         let detune = AudioParam::new(
             window,
@@ -82,7 +84,7 @@ impl OscillatorNode {
             0.,
             -440. / 2.,
             440. / 2.,
-            can_gc,
+            CanGc::from_cx(cx),
         );
         Ok(OscillatorNode {
             source_node,
@@ -93,28 +95,28 @@ impl OscillatorNode {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         context: &BaseAudioContext,
         options: &OscillatorOptions,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<OscillatorNode>> {
-        Self::new_with_proto(window, None, context, options, can_gc)
+        Self::new_with_proto(cx, window, None, context, options)
     }
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn new_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         context: &BaseAudioContext,
         options: &OscillatorOptions,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<OscillatorNode>> {
-        let node = OscillatorNode::new_inherited(window, context, options, can_gc)?;
-        Ok(reflect_dom_object_with_proto(
+        let node = OscillatorNode::new_inherited(cx, window, context, options)?;
+        Ok(reflect_dom_object_with_proto_and_cx(
             Box::new(node),
             window,
             proto,
-            can_gc,
+            cx,
         ))
     }
 }
@@ -122,13 +124,13 @@ impl OscillatorNode {
 impl OscillatorNodeMethods<crate::DomTypeHolder> for OscillatorNode {
     /// <https://webaudio.github.io/web-audio-api/#dom-oscillatornode-oscillatornode>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         context: &BaseAudioContext,
         options: &OscillatorOptions,
     ) -> Fallible<DomRoot<OscillatorNode>> {
-        OscillatorNode::new_with_proto(window, proto, context, options, can_gc)
+        OscillatorNode::new_with_proto(cx, window, proto, context, options)
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-oscillatornode-frequency>

--- a/components/script/dom/audio/pannernode.rs
+++ b/components/script/dom/audio/pannernode.rs
@@ -33,7 +33,6 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct PannerNode {
@@ -100,6 +99,7 @@ impl PannerNode {
         )?;
         let id = node.node_id();
         let position_x = AudioParam::new(
+            cx,
             window,
             context,
             id,
@@ -109,9 +109,9 @@ impl PannerNode {
             options.position_x, // default value
             f32::MIN,           // min value
             f32::MAX,           // max value
-            CanGc::from_cx(cx),
         );
         let position_y = AudioParam::new(
+            cx,
             window,
             context,
             id,
@@ -121,9 +121,9 @@ impl PannerNode {
             options.position_y, // default value
             f32::MIN,           // min value
             f32::MAX,           // max value
-            CanGc::from_cx(cx),
         );
         let position_z = AudioParam::new(
+            cx,
             window,
             context,
             id,
@@ -133,9 +133,9 @@ impl PannerNode {
             options.position_z, // default value
             f32::MIN,           // min value
             f32::MAX,           // max value
-            CanGc::from_cx(cx),
         );
         let orientation_x = AudioParam::new(
+            cx,
             window,
             context,
             id,
@@ -145,9 +145,9 @@ impl PannerNode {
             options.orientation_x, // default value
             f32::MIN,              // min value
             f32::MAX,              // max value
-            CanGc::from_cx(cx),
         );
         let orientation_y = AudioParam::new(
+            cx,
             window,
             context,
             id,
@@ -157,9 +157,9 @@ impl PannerNode {
             options.orientation_y, // default value
             f32::MIN,              // min value
             f32::MAX,              // max value
-            CanGc::from_cx(cx),
         );
         let orientation_z = AudioParam::new(
+            cx,
             window,
             context,
             id,
@@ -169,7 +169,6 @@ impl PannerNode {
             options.orientation_z, // default value
             f32::MIN,              // min value
             f32::MAX,              // max value
-            CanGc::from_cx(cx),
         );
         Ok(PannerNode {
             node,

--- a/components/script/dom/audio/pannernode.rs
+++ b/components/script/dom/audio/pannernode.rs
@@ -6,8 +6,9 @@ use std::cell::Cell;
 use std::f32;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use servo_media::audio::node::{AudioNodeInit, AudioNodeMessage, AudioNodeType};
 use servo_media::audio::panner_node::{
     DistanceModel, PannerNodeMessage, PannerNodeOptions, PanningModel,
@@ -60,10 +61,10 @@ pub(crate) struct PannerNode {
 impl PannerNode {
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new_inherited(
+        cx: &mut JSContext,
         window: &Window,
         context: &BaseAudioContext,
         options: &PannerOptions,
-        can_gc: CanGc,
     ) -> Fallible<PannerNode> {
         let node_options = options.parent.unwrap_or(
             2,
@@ -90,6 +91,7 @@ impl PannerNode {
         }
         let options = options.convert();
         let node = AudioNode::new_inherited(
+            cx,
             AudioNodeInit::PannerNode(options),
             context,
             node_options,
@@ -107,7 +109,7 @@ impl PannerNode {
             options.position_x, // default value
             f32::MIN,           // min value
             f32::MAX,           // max value
-            can_gc,
+            CanGc::from_cx(cx),
         );
         let position_y = AudioParam::new(
             window,
@@ -119,7 +121,7 @@ impl PannerNode {
             options.position_y, // default value
             f32::MIN,           // min value
             f32::MAX,           // max value
-            can_gc,
+            CanGc::from_cx(cx),
         );
         let position_z = AudioParam::new(
             window,
@@ -131,7 +133,7 @@ impl PannerNode {
             options.position_z, // default value
             f32::MIN,           // min value
             f32::MAX,           // max value
-            can_gc,
+            CanGc::from_cx(cx),
         );
         let orientation_x = AudioParam::new(
             window,
@@ -143,7 +145,7 @@ impl PannerNode {
             options.orientation_x, // default value
             f32::MIN,              // min value
             f32::MAX,              // max value
-            can_gc,
+            CanGc::from_cx(cx),
         );
         let orientation_y = AudioParam::new(
             window,
@@ -155,7 +157,7 @@ impl PannerNode {
             options.orientation_y, // default value
             f32::MIN,              // min value
             f32::MAX,              // max value
-            can_gc,
+            CanGc::from_cx(cx),
         );
         let orientation_z = AudioParam::new(
             window,
@@ -167,7 +169,7 @@ impl PannerNode {
             options.orientation_z, // default value
             f32::MIN,              // min value
             f32::MAX,              // max value
-            can_gc,
+            CanGc::from_cx(cx),
         );
         Ok(PannerNode {
             node,
@@ -189,28 +191,28 @@ impl PannerNode {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         context: &BaseAudioContext,
         options: &PannerOptions,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<PannerNode>> {
-        Self::new_with_proto(window, None, context, options, can_gc)
+        Self::new_with_proto(cx, window, None, context, options)
     }
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn new_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         context: &BaseAudioContext,
         options: &PannerOptions,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<PannerNode>> {
-        let node = PannerNode::new_inherited(window, context, options, can_gc)?;
-        Ok(reflect_dom_object_with_proto(
+        let node = PannerNode::new_inherited(cx, window, context, options)?;
+        Ok(reflect_dom_object_with_proto_and_cx(
             Box::new(node),
             window,
             proto,
-            can_gc,
+            cx,
         ))
     }
 }
@@ -218,13 +220,13 @@ impl PannerNode {
 impl PannerNodeMethods<crate::DomTypeHolder> for PannerNode {
     /// <https://webaudio.github.io/web-audio-api/#dom-pannernode-pannernode>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         context: &BaseAudioContext,
         options: &PannerOptions,
     ) -> Fallible<DomRoot<PannerNode>> {
-        PannerNode::new_with_proto(window, proto, context, options, can_gc)
+        PannerNode::new_with_proto(cx, window, proto, context, options)
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-pannernode-positionx>

--- a/components/script/dom/audio/stereopannernode.rs
+++ b/components/script/dom/audio/stereopannernode.rs
@@ -25,7 +25,6 @@ use crate::dom::bindings::codegen::Bindings::StereoPannerNodeBinding::{
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct StereoPannerNode {
@@ -63,6 +62,7 @@ impl StereoPannerNode {
         )?;
         let node_id = source_node.node().node_id();
         let pan = AudioParam::new(
+            cx,
             window,
             context,
             node_id,
@@ -72,7 +72,6 @@ impl StereoPannerNode {
             pan,
             -1.,
             1.,
-            CanGc::from_cx(cx),
         );
 
         Ok(StereoPannerNode {

--- a/components/script/dom/audio/stereopannernode.rs
+++ b/components/script/dom/audio/stereopannernode.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use servo_media::audio::node::{AudioNodeInit, AudioNodeType};
 use servo_media::audio::param::ParamType;
 use servo_media::audio::stereo_panner::StereoPannerOptions as ServoMediaStereoPannerOptions;
@@ -35,10 +36,10 @@ pub(crate) struct StereoPannerNode {
 impl StereoPannerNode {
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new_inherited(
+        cx: &mut JSContext,
         window: &Window,
         context: &BaseAudioContext,
         options: &StereoPannerOptions,
-        can_gc: CanGc,
     ) -> Fallible<StereoPannerNode> {
         let node_options = options.parent.unwrap_or(
             2,
@@ -53,6 +54,7 @@ impl StereoPannerNode {
         }
         let pan = *options.pan;
         let source_node = AudioScheduledSourceNode::new_inherited(
+            cx,
             AudioNodeInit::StereoPannerNode(options.convert()),
             context,
             node_options,
@@ -70,7 +72,7 @@ impl StereoPannerNode {
             pan,
             -1.,
             1.,
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         Ok(StereoPannerNode {
@@ -80,28 +82,28 @@ impl StereoPannerNode {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         context: &BaseAudioContext,
         options: &StereoPannerOptions,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<StereoPannerNode>> {
-        Self::new_with_proto(window, None, context, options, can_gc)
+        Self::new_with_proto(cx, window, None, context, options)
     }
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn new_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         context: &BaseAudioContext,
         options: &StereoPannerOptions,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<StereoPannerNode>> {
-        let node = StereoPannerNode::new_inherited(window, context, options, can_gc)?;
-        Ok(reflect_dom_object_with_proto(
+        let node = StereoPannerNode::new_inherited(cx, window, context, options)?;
+        Ok(reflect_dom_object_with_proto_and_cx(
             Box::new(node),
             window,
             proto,
-            can_gc,
+            cx,
         ))
     }
 }
@@ -109,13 +111,13 @@ impl StereoPannerNode {
 impl StereoPannerNodeMethods<crate::DomTypeHolder> for StereoPannerNode {
     /// <https://webaudio.github.io/web-audio-api/#dom-stereopannernode-stereopannernode>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         context: &BaseAudioContext,
         options: &StereoPannerOptions,
     ) -> Fallible<DomRoot<StereoPannerNode>> {
-        StereoPannerNode::new_with_proto(window, proto, context, options, can_gc)
+        StereoPannerNode::new_with_proto(cx, window, proto, context, options)
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-stereopannernode-pan>

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -157,11 +157,7 @@ impl Console {
     }
 
     // Directly logs a string message, without processing the message
-    // TODO: https://github.com/servo/servo/issues/45202
-    #[expect(unsafe_code)]
-    pub(crate) fn internal_warn(global: &GlobalScope, message: String) {
-        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
-        let cx = &mut cx;
+    pub(crate) fn internal_warn(cx: &mut JSContext, global: &GlobalScope, message: String) {
         Console::send_string_message(cx, global, ConsoleLogLevel::Warn, message);
     }
 }
@@ -841,9 +837,9 @@ impl consoleMethods<crate::DomTypeHolder> for Console {
     }
 
     /// <https://console.spec.whatwg.org/#countreset>
-    fn CountReset(global: &GlobalScope, label: DOMString) {
+    fn CountReset(cx: &mut JSContext, global: &GlobalScope, label: DOMString) {
         if global.reset_console_count(&label).is_err() {
-            Self::internal_warn(global, format!("Counter “{label}” doesn’t exist."))
+            Self::internal_warn(cx, global, format!("Counter “{label}” doesn’t exist."))
         }
     }
 }

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -1008,8 +1008,12 @@ impl HTMLScriptElement {
                 ScriptType::ImportMap => {
                     // Step 32.1 Let result be the result of creating an import map
                     // parse result given source text and base URL.
-                    let import_map_result =
-                        parse_an_import_map_string(global, Rc::clone(&text_rc), base_url.clone());
+                    let import_map_result = parse_an_import_map_string(
+                        cx,
+                        global,
+                        Rc::clone(&text_rc),
+                        base_url.clone(),
+                    );
                     let script = Script::ImportMap(ScriptOrigin::internal(
                         text_rc,
                         base_url,

--- a/components/script/dom/performance/performanceobserver.rs
+++ b/components/script/dom/performance/performanceobserver.rs
@@ -142,7 +142,11 @@ impl PerformanceObserverMethods<crate::DomTypeHolder> for PerformanceObserver {
     }
 
     /// <https://w3c.github.io/performance-timeline/#dom-performanceobserver-observe()>
-    fn Observe(&self, options: &PerformanceObserverInit) -> Fallible<()> {
+    fn Observe(
+        &self,
+        cx: &mut js::context::JSContext,
+        options: &PerformanceObserverInit,
+    ) -> Fallible<()> {
         // Step 1 is self
 
         // Step 2 is self.global()
@@ -192,7 +196,7 @@ impl PerformanceObserverMethods<crate::DomTypeHolder> for PerformanceObserver {
 
             // Step 6.3
             if entry_types.is_empty() {
-                Console::internal_warn(&self.global(), NO_VALID_ENTRY_TYPE.to_string());
+                Console::internal_warn(cx, &self.global(), NO_VALID_ENTRY_TYPE.to_string());
                 return Ok(());
             }
 
@@ -206,7 +210,7 @@ impl PerformanceObserverMethods<crate::DomTypeHolder> for PerformanceObserver {
         } else if let Some(entry_type) = &options.type_ {
             // Step 7.2
             let Ok(entry_type) = EntryType::try_from(&*entry_type.str()) else {
-                Console::internal_warn(&self.global(), NO_VALID_ENTRY_TYPE.to_string());
+                Console::internal_warn(cx, &self.global(), NO_VALID_ENTRY_TYPE.to_string());
                 return Ok(());
             };
 

--- a/components/script/dom/security/sanitizer.rs
+++ b/components/script/dom/security/sanitizer.rs
@@ -776,7 +776,7 @@ impl SanitizerMethods<crate::DomTypeHolder> for Sanitizer {
     }
 
     /// <https://wicg.github.io/sanitizer-api/#dom-sanitizer-allowelement>
-    fn AllowElement(&self, element: SanitizerElementWithAttributes) -> bool {
+    fn AllowElement(&self, cx: &mut JSContext, element: SanitizerElementWithAttributes) -> bool {
         // Step 1. Let configuration be this’s configuration.
         let mut configuration = self.configuration.borrow_mut();
 
@@ -939,6 +939,7 @@ impl SanitizerMethods<crate::DomTypeHolder> for Sanitizer {
                 // Step 5.1.1. The user agent may report a warning to the console that this
                 // operation is not supported.
                 Console::internal_warn(
+                    cx,
                     &self.global(),
                     "Do not support adding an element with attributes to a sanitizer \
                         whose configuration[\"elements\"] does not exist."

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -1691,7 +1691,7 @@ pub(crate) fn register_import_map(
     match result {
         Ok(new_import_map) => {
             // Step 2. Merge existing and new import maps, given global and result's import map.
-            merge_existing_and_new_import_maps(global, new_import_map);
+            merge_existing_and_new_import_maps(cx, global, new_import_map);
         },
         Err(exception) => {
             let mut realm = enter_auto_realm(cx, global);
@@ -1706,7 +1706,11 @@ pub(crate) fn register_import_map(
 }
 
 /// <https://html.spec.whatwg.org/multipage/#merge-existing-and-new-import-maps>
-fn merge_existing_and_new_import_maps(global: &GlobalScope, new_import_map: ImportMap) {
+fn merge_existing_and_new_import_maps(
+    cx: &mut JSContext,
+    global: &GlobalScope,
+    new_import_map: ImportMap,
+) {
     // Step 1. Let newImportMapScopes be a deep copy of newImportMap's scopes.
     let new_import_map_scopes = new_import_map.scopes;
 
@@ -1744,7 +1748,11 @@ fn merge_existing_and_new_import_maps(global: &GlobalScope, new_import_map: Impo
                     {
                         // The user agent may report a warning to the console indicating the ignored rule.
                         // They may choose to avoid reporting if the rule is identical to an existing one.
-                        Console::internal_warn(global, format!("Ignored rule: {key} -> {val:?}."));
+                        Console::internal_warn(
+                            cx,
+                            global,
+                            format!("Ignored rule: {key} -> {val:?}."),
+                        );
                         // Remove scopeImports[specifierKey].
                         false
                     } else {
@@ -1759,6 +1767,7 @@ fn merge_existing_and_new_import_maps(global: &GlobalScope, new_import_map: Impo
             // set oldImportMap's scopes[scopePrefix] to the result of
             // merging module specifier maps, given scopeImports and oldImportMap's scopes[scopePrefix].
             let merged_module_specifier_map = merge_module_specifier_maps(
+                cx,
                 global,
                 scope_imports,
                 &old_import_map.scopes[&scope_prefix],
@@ -1778,7 +1787,7 @@ fn merge_existing_and_new_import_maps(global: &GlobalScope, new_import_map: Impo
         if old_import_map.integrity.contains_key(url) {
             // Step 5.1.1 The user agent may report a warning to the console indicating the ignored rule.
             // They may choose to avoid reporting if the rule is identical to an existing one.
-            Console::internal_warn(global, format!("Ignored rule: {url} -> {integrity}."));
+            Console::internal_warn(cx, global, format!("Ignored rule: {url} -> {integrity}."));
             // Step 5.1.2 Continue.
             continue;
         }
@@ -1800,7 +1809,11 @@ fn merge_existing_and_new_import_maps(global: &GlobalScope, new_import_map: Impo
             if record.specifier.starts_with(specifier) {
                 // The user agent may report a warning to the console indicating the ignored rule.
                 // They may choose to avoid reporting if the rule is identical to an existing one.
-                Console::internal_warn(global, format!("Ignored rule: {specifier} -> {val:?}."));
+                Console::internal_warn(
+                    cx,
+                    global,
+                    format!("Ignored rule: {specifier} -> {val:?}."),
+                );
                 // Remove newImportMapImports[specifier].
                 false
             } else {
@@ -1812,7 +1825,7 @@ fn merge_existing_and_new_import_maps(global: &GlobalScope, new_import_map: Impo
     // Step 7. Set oldImportMap's imports to the result of merge module specifier maps,
     // given newImportMapImports and oldImportMap's imports.
     let merged_module_specifier_map =
-        merge_module_specifier_maps(global, new_import_map_imports, &old_import_map.imports);
+        merge_module_specifier_maps(cx, global, new_import_map_imports, &old_import_map.imports);
     old_import_map.imports = merged_module_specifier_map;
 
     // https://html.spec.whatwg.org/multipage/#the-resolution-algorithm
@@ -1824,6 +1837,7 @@ fn merge_existing_and_new_import_maps(global: &GlobalScope, new_import_map: Impo
 
 /// <https://html.spec.whatwg.org/multipage/#merge-module-specifier-maps>
 fn merge_module_specifier_maps(
+    cx: &mut JSContext,
     global: &GlobalScope,
     new_map: ModuleSpecifierMap,
     old_map: &ModuleSpecifierMap,
@@ -1837,7 +1851,7 @@ fn merge_module_specifier_maps(
         if old_map.contains_key(&specifier) {
             // Step 2.1.1 The user agent may report a warning to the console indicating the ignored rule.
             // They may choose to avoid reporting if the rule is identical to an existing one.
-            Console::internal_warn(global, format!("Ignored rule: {specifier} -> {url:?}."));
+            Console::internal_warn(cx, global, format!("Ignored rule: {specifier} -> {url:?}."));
 
             // Step 2.1.2 Continue.
             continue;
@@ -1852,6 +1866,7 @@ fn merge_module_specifier_maps(
 
 /// <https://html.spec.whatwg.org/multipage/#parse-an-import-map-string>
 pub(crate) fn parse_an_import_map_string(
+    cx: &mut JSContext,
     global: &GlobalScope,
     input: Rc<DOMString>,
     base_url: ServoUrl,
@@ -1881,7 +1896,7 @@ pub(crate) fn parse_an_import_map_string(
         // Step 4.2 Set sortedAndNormalizedImports to the result of sorting and
         // normalizing a module specifier map given parsed["imports"] and baseURL.
         sorted_and_normalized_imports =
-            sort_and_normalize_module_specifier_map(global, imports, &base_url);
+            sort_and_normalize_module_specifier_map(cx, global, imports, &base_url);
     }
 
     // Step 5. Let sortedAndNormalizedScopes be an empty ordered map.
@@ -1897,7 +1912,7 @@ pub(crate) fn parse_an_import_map_string(
         };
         // Step 6.2 Set sortedAndNormalizedScopes to the result of sorting and
         // normalizing scopes given parsed["scopes"] and baseURL.
-        sorted_and_normalized_scopes = sort_and_normalize_scopes(global, scopes, &base_url)?;
+        sorted_and_normalized_scopes = sort_and_normalize_scopes(cx, global, scopes, &base_url)?;
     }
 
     // Step 7. Let normalizedIntegrity be an empty ordered map.
@@ -1913,7 +1928,7 @@ pub(crate) fn parse_an_import_map_string(
         };
         // Step 8.2 Set normalizedIntegrity to the result of normalizing
         // a module integrity map given parsed["integrity"] and baseURL.
-        normalized_integrity = normalize_module_integrity_map(global, integrity, &base_url);
+        normalized_integrity = normalize_module_integrity_map(cx, global, integrity, &base_url);
     }
 
     // Step 9. If parsed's keys contains any items besides "imports", "scopes", or "integrity",
@@ -1922,6 +1937,7 @@ pub(crate) fn parse_an_import_map_string(
     parsed.retain(|k, _| !matches!(k.as_str(), "imports" | "scopes" | "integrity"));
     if !parsed.is_empty() {
         Console::internal_warn(
+            cx,
             global,
             "Invalid top-level key was present in the import map.
                 Only \"imports\", \"scopes\", and \"integrity\" are allowed."
@@ -1939,6 +1955,7 @@ pub(crate) fn parse_an_import_map_string(
 
 /// <https://html.spec.whatwg.org/multipage/#sorting-and-normalizing-a-module-specifier-map>
 fn sort_and_normalize_module_specifier_map(
+    cx: &mut JSContext,
     global: &GlobalScope,
     original_map: &JsonMap<String, JsonValue>,
     base_url: &ServoUrl,
@@ -1951,7 +1968,7 @@ fn sort_and_normalize_module_specifier_map(
         // Step 2.1 Let normalized_specifier_key be the result of
         // normalizing a specifier key given specifier_key and base_url.
         let Some(normalized_specifier_key) =
-            normalize_specifier_key(global, specifier_key, base_url)
+            normalize_specifier_key(cx, global, specifier_key, base_url)
         else {
             // Step 2.2 If normalized_specifier_key is null, then continue.
             continue;
@@ -1961,7 +1978,7 @@ fn sort_and_normalize_module_specifier_map(
         let JsonValue::String(value) = value else {
             // Step 2.3.1 The user agent may report a warning to the console
             // indicating that addresses need to be strings.
-            Console::internal_warn(global, "Addresses need to be strings.".to_string());
+            Console::internal_warn(cx, global, "Addresses need to be strings.".to_string());
 
             // Step 2.3.2 Set normalized[normalized_specifier_key] to null.
             normalized.insert(normalized_specifier_key, None);
@@ -1977,6 +1994,7 @@ fn sort_and_normalize_module_specifier_map(
             // Step 2.5.1. The user agent may report a warning to the console
             // indicating that the address was invalid.
             Console::internal_warn(
+                cx,
                 global,
                 format!("Value failed to resolve to module specifier: {value}"),
             );
@@ -1994,6 +2012,7 @@ fn sort_and_normalize_module_specifier_map(
             // indicating that an invalid address was given for the specifier key specifierKey;
             // since specifierKey ends with a slash, the address needs to as well.
             Console::internal_warn(
+                cx,
                 global,
                 format!(
                     "Invalid address for specifier key '{specifier_key}': {address_url}.
@@ -2019,6 +2038,7 @@ fn sort_and_normalize_module_specifier_map(
 
 /// <https://html.spec.whatwg.org/multipage/#sorting-and-normalizing-scopes>
 fn sort_and_normalize_scopes(
+    cx: &mut JSContext,
     global: &GlobalScope,
     original_map: &JsonMap<String, JsonValue>,
     base_url: &ServoUrl,
@@ -2043,6 +2063,7 @@ fn sort_and_normalize_scopes(
             // Step 2.3.1 The user agent may report a warning
             // to the console that the scope prefix URL was not parseable.
             Console::internal_warn(
+                cx,
                 global,
                 format!("Scope prefix URL was not parseable: {scope_prefix}"),
             );
@@ -2056,7 +2077,7 @@ fn sort_and_normalize_scopes(
         // Step 2.5 Set normalized[normalizedScopePrefix] to the result of sorting and
         // normalizing a module specifier map given potentialSpecifierMap and baseURL.
         let normalized_specifier_map =
-            sort_and_normalize_module_specifier_map(global, potential_specifier_map, base_url);
+            sort_and_normalize_module_specifier_map(cx, global, potential_specifier_map, base_url);
         normalized.insert(normalized_scope_prefix, normalized_specifier_map);
     }
 
@@ -2068,6 +2089,7 @@ fn sort_and_normalize_scopes(
 
 /// <https://html.spec.whatwg.org/multipage/#normalizing-a-module-integrity-map>
 fn normalize_module_integrity_map(
+    cx: &mut JSContext,
     global: &GlobalScope,
     original_map: &JsonMap<String, JsonValue>,
     base_url: &ServoUrl,
@@ -2086,6 +2108,7 @@ fn normalize_module_integrity_map(
             // Step 2.2.1 The user agent may report a warning
             // to the console indicating that the key failed to resolve.
             Console::internal_warn(
+                cx,
                 global,
                 format!("Key failed to resolve to module specifier: {key}"),
             );
@@ -2098,6 +2121,7 @@ fn normalize_module_integrity_map(
             // Step 2.3.1 The user agent may report a warning
             // to the console indicating that integrity metadata values need to be strings.
             Console::internal_warn(
+                cx,
                 global,
                 "Integrity metadata values need to be strings.".to_string(),
             );
@@ -2115,6 +2139,7 @@ fn normalize_module_integrity_map(
 
 /// <https://html.spec.whatwg.org/multipage/#normalizing-a-specifier-key>
 fn normalize_specifier_key(
+    cx: &mut JSContext,
     global: &GlobalScope,
     specifier_key: &str,
     base_url: &ServoUrl,
@@ -2124,6 +2149,7 @@ fn normalize_specifier_key(
         // step 1.1 The user agent may report a warning to the console
         // indicating that specifier keys may not be the empty string.
         Console::internal_warn(
+            cx,
             global,
             "Specifier keys may not be the empty string.".to_string(),
         );

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -51,8 +51,8 @@ DOMInterfaces = {
 
 'BaseAudioContext': {
     'inRealms': ['DecodeAudioData', 'Resume', 'ParseFromString', 'GetBounds', 'GetClientRects'],
-    'canGc': ['Resume', 'DecodeAudioData', 'Destination', 'Listener'],
-    'cx': ['CreateBuffer', 'CreateGain', 'CreateOscillator', 'CreatePanner', 'CreateStereoPanner', 'CreateBiquadFilter', 'CreateIIRFilter', 'CreateAnalyser', 'CreateConstantSource', 'CreateChannelMerger', 'CreateChannelSplitter', 'CreateBufferSource'],
+    'canGc': ['Resume', 'DecodeAudioData', 'Destination'],
+    'cx': ['CreateBuffer', 'CreateGain', 'CreateOscillator', 'CreatePanner', 'CreateStereoPanner', 'CreateBiquadFilter', 'CreateIIRFilter', 'CreateAnalyser', 'CreateConstantSource', 'CreateChannelMerger', 'CreateChannelSplitter', 'CreateBufferSource', 'Listener'],
 },
 
 'BiquadFilterNode': {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -28,12 +28,20 @@ DOMInterfaces = {
     'weakReferenceable': True,
 },
 
+'AnalyserNode': {
+    'cx': ['Constructor'],
+},
+
 'Attr': {
     'implicitCxSetters': True,
 },
 
 'AudioBuffer': {
     'cx': ['Constructor', 'CopyToChannel', 'GetChannelData'],
+},
+
+'AudioBufferSourceNode': {
+    'cx': ['Constructor'],
 },
 
 'AudioContext': {
@@ -43,8 +51,12 @@ DOMInterfaces = {
 
 'BaseAudioContext': {
     'inRealms': ['DecodeAudioData', 'Resume', 'ParseFromString', 'GetBounds', 'GetClientRects'],
-    'canGc': ['CreateChannelMerger', 'CreateOscillator', 'CreateStereoPanner', 'CreateGain', 'CreateIIRFilter', 'CreateBiquadFilter', 'CreateBufferSource', 'CreateAnalyser', 'CreatePanner', 'CreateChannelSplitter', 'CreateConstantSource', 'Resume', 'DecodeAudioData', 'Destination', 'Listener'],
-    'cx': ['CreateBuffer'],
+    'canGc': ['Resume', 'DecodeAudioData', 'Destination', 'Listener'],
+    'cx': ['CreateBuffer', 'CreateGain', 'CreateOscillator', 'CreatePanner', 'CreateStereoPanner', 'CreateBiquadFilter', 'CreateIIRFilter', 'CreateAnalyser', 'CreateConstantSource', 'CreateChannelMerger', 'CreateChannelSplitter', 'CreateBufferSource'],
+},
+
+'BiquadFilterNode': {
+    'cx': ['Constructor'],
 },
 
 'Blob': {
@@ -96,6 +108,14 @@ DOMInterfaces = {
     'canGc': ['CreateImageData', 'GetImageData', 'CreateImageData_',],
 },
 
+'ChannelMergerNode': {
+    'cx': ['Constructor'],
+},
+
+'ChannelSplitterNode': {
+    'cx': ['Constructor'],
+},
+
 'CharacterData': {
     'cx': ['After', 'AppendData', 'Before', 'DeleteData', 'InsertData', 'Remove', 'ReplaceData', 'ReplaceWith', 'SetData'],
 },
@@ -122,7 +142,11 @@ DOMInterfaces = {
 },
 
 'console': {
-    'cx': ['Log', 'Debug', 'Info', 'Warn', 'Error', 'Trace', 'Assert', 'TimeLog', 'Group', 'GroupCollapsed', 'Time', 'TimeEnd', 'Count'],
+    'cx': ['Log', 'Debug', 'Info', 'Warn', 'Error', 'Trace', 'Assert', 'TimeLog', 'Group', 'GroupCollapsed', 'Time', 'TimeEnd', 'Count', 'CountReset'],
+},
+
+'ConstantSourceNode': {
+    'cx': ['Constructor'],
 },
 
 'CookieStore': {
@@ -373,6 +397,10 @@ DOMInterfaces = {
 },
 
 'FormData': {
+    'cx': ['Constructor'],
+},
+
+'GainNode': {
     'cx': ['Constructor'],
 },
 
@@ -685,6 +713,10 @@ DOMInterfaces = {
     'canGc': ['ObjectStore']
 },
 
+'IIRFilterNode': {
+    'cx': ['Constructor'],
+},
+
 'InputEvent': {
     'cx': ['Constructor']
 },
@@ -819,12 +851,20 @@ DOMInterfaces = {
     'cx': ['CreateImageData', 'CreateImageData_', 'GetImageData', 'GetTransform', 'MeasureText', 'CreateLinearGradient', 'CreatePattern', 'CreateRadialGradient'],
 },
 
+'OscillatorNode': {
+    'cx': ['Constructor'],
+},
+
 'PaintRenderingContext2D': {
     'cx': ['CreateLinearGradient', 'CreatePattern', 'CreateRadialGradient', 'GetTransform'],
 },
 
 'PaintWorkletGlobalScope': {
     'cx': ['RegisterPaint'],
+},
+
+'PannerNode': {
+    'cx': ['Constructor'],
 },
 
 'Performance': {
@@ -837,6 +877,7 @@ DOMInterfaces = {
 
 'PerformanceObserver': {
     'canGc': ['SupportedEntryTypes'],
+    'cx': ['Observe'],
 },
 
 'Permissions': {
@@ -883,7 +924,7 @@ DOMInterfaces = {
 },
 
 'Sanitizer': {
-    'cx': ['Constructor'],
+    'cx': ['Constructor', 'AllowElement'],
 },
 
 'Selection': {
@@ -919,6 +960,10 @@ DOMInterfaces = {
 
 'StaticRange': {
     'weakReferenceable': True,
+},
+
+'StereoPannerNode': {
+    'cx': ['Constructor'],
 },
 
 'StorageManager': {


### PR DESCRIPTION
- Pass `&mut JSContext` to `Console::internal_warn`
- Pass `&mut JSContext` to callers and remove `CanGc` argument from callers.
- Add `.nvim.lua` to gitignore to support project specific settings for neovim.

Testing: These changes should already be tested by existing tests.
Fixes: #45202 
