### PR TITLE
net: Fix an image cache leak on reloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8344,6 +8344,7 @@ dependencies = [
  "servo-url",
  "servo_arc",
  "sha2",
+ "smallvec",
  "time",
  "tokio",
  "tokio-rustls",

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -74,6 +74,7 @@ servo-tracing = { workspace = true }
 servo-url = { workspace = true }
 servo_arc = { workspace = true }
 sha2 = { workspace = true }
+smallvec = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true, features = ["fs", "macros", "rt-multi-thread", "sync"] }
 tokio-rustls = { workspace = true }

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -1184,6 +1184,10 @@ impl ImageCache for ImageCacheImpl {
         store.insert_keys_and_load_images(image_keys);
     }
 
+    fn clear(&self) {
+        self.store.lock().clear();
+    }
+
     fn get_broken_image_icon(&self) -> Option<Arc<RasterImage>> {
         let store = self.store.lock();
         store
@@ -1202,9 +1206,10 @@ impl ImageCache for ImageCacheImpl {
     }
 }
 
-impl Drop for ImageCacheStore {
-    fn drop(&mut self) {
-        let image_updates = self
+impl ImageCacheStore {
+    /// Clear the image cache.
+    fn clear(&mut self) {
+        let deletions: smallvec::SmallVec<_> = self
             .completed_loads
             .values()
             .filter_map(|load| match &load.image_response {
@@ -1218,9 +1223,30 @@ impl Drop for ImageCacheStore {
                     .values()
                     .filter_map(|task| task.result.as_ref()?.id.map(ImageUpdate::DeleteImage)),
             )
+            .chain(
+                self.broken_image_icon_image
+                    .get()
+                    .and_then(|icon| icon.as_ref())
+                    .and_then(|icon| icon.id)
+                    .map(ImageUpdate::DeleteImage),
+            )
             .collect();
-        self.paint_api
-            .update_images(self.webview_id.into(), image_updates);
+        if !deletions.is_empty() {
+            self.paint_api
+                .update_images(self.webview_id.into(), deletions);
+        }
+        // Clear these fields, since `clear()` will be called multiple times,
+        // explicitly on pipeline close, and again on Drop (as a safeguard,
+        // since we could forget to explicitly clear).
+        self.completed_loads.clear();
+        self.rasterized_vector_images.clear();
+        let _ = self.broken_image_icon_image.take();
+    }
+}
+
+impl Drop for ImageCacheStore {
+    fn drop(&mut self) {
+        self.clear();
     }
 }
 

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -484,6 +484,9 @@ impl ImageCacheStore {
     fn set_key_and_finish_load(&mut self, pending_image: PendingKey, image_key: WebRenderImageKey) {
         match pending_image {
             PendingKey::RasterImage((pending_id, mut raster_image)) => {
+                if self.pending_loads.get_by_key_mut(&pending_id).is_none() {
+                    return;
+                }
                 set_webrender_image_key(&self.paint_api, &mut raster_image, image_key);
                 self.complete_load(pending_id, LoadResult::LoadedRasterImage(raster_image));
             },

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -484,6 +484,8 @@ impl ImageCacheStore {
     fn set_key_and_finish_load(&mut self, pending_image: PendingKey, image_key: WebRenderImageKey) {
         match pending_image {
             PendingKey::RasterImage((pending_id, mut raster_image)) => {
+                // We can have concurrent sync and async loads for the same image, so if it's
+                // not pending anymore we early return since the async result will be ignored in that case.
                 if self.pending_loads.get_by_key_mut(&pending_id).is_none() {
                     return;
                 }
@@ -491,6 +493,14 @@ impl ImageCacheStore {
                 self.complete_load(pending_id, LoadResult::LoadedRasterImage(raster_image));
             },
             PendingKey::Svg((pending_id, mut raster_image, requested_size)) => {
+                // We can have concurrent sync and async loads for the same image, so if it's
+                // not pending anymore we early return since the async result will be ignored in that case.
+                if !self
+                    .rasterized_vector_images
+                    .contains_key(&(pending_id, requested_size))
+                {
+                    return;
+                }
                 set_webrender_image_key(&self.paint_api, &mut raster_image, image_key);
                 self.complete_load_svg(raster_image, pending_id, requested_size);
             },

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3221,6 +3221,10 @@ impl ScriptThread {
                 window.discard_browsing_context();
             }
 
+            // Clear the image cache now, instead of waiting for the Window to be
+            // garbage collected. See servo/servo#45239.
+            window.image_cache().clear();
+
             debug!("{pipeline_id}: Clearing JavaScript runtime");
             window.clear_js_runtime();
         }

--- a/components/shared/net/image_cache.rs
+++ b/components/shared/net/image_cache.rs
@@ -241,4 +241,7 @@ pub trait ImageCache: Sync + Send {
 
     /// Fills the image cache with a batch of keys.
     fn fill_key_cache_with_batch_of_keys(&self, image_keys: Vec<ImageKey>);
+
+    /// Clear the image cache.
+    fn clear(&self);
 }


### PR DESCRIPTION
Eagerly clear the image cache on pipeline exit. Previously the image cached would only be cleared once the last reference was dropped, which depends on SM GC (via window). 
This also clears the broken image, which previously was missed in the drop implementation.

The biggest contributor to the leak on servo.org was in `set_key_and_finish_load`, where didn't check first if the load was still pending or already completed. In the latter case calling `set_webrender_image_key` would result in a leak (since `self.complete_load` early returns in that case).
This can happen, because we can have two concurrent decods for a single image
- [async decode](https://github.com/servo/servo/blob/c2a3dbc1384b1e2e155a653ca7d42cf3660fe0c6/components/net/image_cache.rs#L1152)
- [sync decoding](https://github.com/servo/servo/blob/c2a3dbc1384b1e2e155a653ca7d42cf3660fe0c6/components/net/image_cache.rs#L867)

https://github.com/servo/servo/blob/c2a3dbc1384b1e2e155a653ca7d42cf3660fe0c6/components/net/image_cache.rs#L901-L903

The main issue was that we didn't properly ignore the async result later as the comment suggests. We need to avoid calling `set_webrender_image_key`.

Testing: The changed behavior of the image cache is presumably not covered by any tests
Fixes: #45239 (Note that there is still memory leaked on every reload, just not webrender image memory). 