### PR TITLE
script: Propagate wake lock type in permission requests (#44235)

### DIFF
--- a/components/script/dom/permissions.rs
+++ b/components/script/dom/permissions.rs
@@ -5,7 +5,7 @@
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
-use embedder_traits::{self, AllowOrDeny, EmbedderMsg, PermissionFeature};
+use embedder_traits::{self, AllowOrDeny, EmbedderMsg, PermissionFeature, WakeLockType};
 use js::conversions::ConversionResult;
 use js::jsapi::JSObject;
 use js::jsval::{ObjectValue, UndefinedValue};
@@ -407,7 +407,9 @@ impl Convert<PermissionFeature> for PermissionName {
             PermissionName::Background_sync => PermissionFeature::BackgroundSync,
             PermissionName::Bluetooth => PermissionFeature::Bluetooth,
             PermissionName::Persistent_storage => PermissionFeature::PersistentStorage,
-            PermissionName::Screen_wake_lock => PermissionFeature::ScreenWakeLock,
+            PermissionName::Screen_wake_lock => {
+                PermissionFeature::ScreenWakeLock(WakeLockType::Screen)
+            },
         }
     }
 }

--- a/components/script/dom/wakelock/wakelock.rs
+++ b/components/script/dom/wakelock/wakelock.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::cell::Cell;
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
@@ -11,6 +12,7 @@ use js::realm::CurrentRealm;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use servo_constellation_traits::ScriptToConstellationMessage;
 
+use crate::conversions::Convert;
 use crate::dom::bindings::codegen::Bindings::DocumentBinding::{
     DocumentMethods, DocumentVisibilityState,
 };
@@ -29,12 +31,14 @@ use crate::script_runtime::CanGc;
 #[dom_struct]
 pub(crate) struct WakeLock {
     reflector_: Reflector,
+    type_: Cell<WakeLockType>,
 }
 
 impl WakeLock {
     pub(crate) fn new_inherited() -> Self {
         Self {
             reflector_: Reflector::new(),
+            type_: Cell::new(WakeLockType::Screen),
         }
     }
 
@@ -45,7 +49,7 @@ impl WakeLock {
 
 impl WakeLockMethods<crate::DomTypeHolder> for WakeLock {
     /// <https://w3c.github.io/screen-wake-lock/#the-request-method>
-    fn Request(&self, cx: &mut CurrentRealm, _type_: WakeLockType) -> Rc<Promise> {
+    fn Request(&self, cx: &mut CurrentRealm, type_: WakeLockType) -> Rc<Promise> {
         let global = GlobalScope::from_current_realm(cx);
         let promise = Promise::new_in_realm(cx);
 
@@ -79,9 +83,14 @@ impl WakeLockMethods<crate::DomTypeHolder> for WakeLock {
             return promise;
         };
 
+        self.type_.set(type_);
         let task_source = global.task_manager().dom_manipulation_task_source();
         let callback = callback_promise(&promise, self, task_source);
-        global.send_to_embedder(EmbedderMsg::RequestWakeLockPermission(webview_id, callback));
+        global.send_to_embedder(EmbedderMsg::RequestWakeLockPermission(
+            webview_id,
+            callback,
+            self.type_.get().convert(),
+        ));
 
         promise
     }
@@ -91,6 +100,7 @@ impl RoutedPromiseListener<AllowOrDeny> for WakeLock {
     /// <https://w3c.github.io/screen-wake-lock/#the-request-method>
     fn handle_response(&self, cx: &mut JSContext, response: AllowOrDeny, promise: &Rc<Promise>) {
         let can_gc = CanGc::from_cx(cx);
+
         match response {
             // Step 7a. If permission is denied, reject with NotAllowedError.
             AllowOrDeny::Deny => {
@@ -105,14 +115,20 @@ impl RoutedPromiseListener<AllowOrDeny> for WakeLock {
             AllowOrDeny::Allow => {
                 let global = self.global();
                 global.as_window().send_to_constellation(
-                    ScriptToConstellationMessage::AcquireWakeLock(
-                        embedder_traits::WakeLockType::Screen,
-                    ),
+                    ScriptToConstellationMessage::AcquireWakeLock(self.type_.get().convert()),
                 );
 
-                let sentinel = WakeLockSentinel::new(cx, &global, WakeLockType::Screen);
+                let sentinel = WakeLockSentinel::new(cx, &global, self.type_.get());
                 promise.resolve_native(&sentinel, can_gc);
             },
+        }
+    }
+}
+
+impl Convert<embedder_traits::WakeLockType> for WakeLockType {
+    fn convert(self) -> embedder_traits::WakeLockType {
+        match self {
+            WakeLockType::Screen => embedder_traits::WakeLockType::Screen,
         }
     }
 }

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -592,10 +592,10 @@ impl ServoInner {
                         .request_permission(webview, permission_request);
                 }
             },
-            EmbedderMsg::RequestWakeLockPermission(webview_id, callback) => {
+            EmbedderMsg::RequestWakeLockPermission(webview_id, callback, type_) => {
                 if let Some(webview) = self.get_webview_handle(webview_id) {
                     let permission_request = PermissionRequest {
-                        requested_feature: PermissionFeature::ScreenWakeLock,
+                        requested_feature: PermissionFeature::ScreenWakeLock(type_),
                         allow_deny_request: AllowOrDenyRequest::new_from_callback(
                             callback,
                             AllowOrDeny::Deny,

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -485,7 +485,7 @@ pub enum EmbedderMsg {
     /// Async permission request for screen wake lock. The callback is invoked
     /// with the user's decision, which resolves or rejects the pending promise
     /// without blocking the script thread.
-    RequestWakeLockPermission(WebViewId, GenericCallback<AllowOrDeny>),
+    RequestWakeLockPermission(WebViewId, GenericCallback<AllowOrDeny>, WakeLockType),
     /// Report the status of Devtools Server with a token that can be used to bypass the permission prompt.
     OnDevtoolsStarted(Result<u16, ()>, String),
     /// Ask the user to allow a devtools client to connect.
@@ -600,7 +600,7 @@ pub enum PermissionFeature {
     BackgroundSync,
     Bluetooth,
     PersistentStorage,
-    ScreenWakeLock,
+    ScreenWakeLock(WakeLockType),
 }
 
 /// Used to specify the kind of input method editor appropriate to edit a field.


### PR DESCRIPTION
Earlier implementation of WakeLock ignored the requested WakeLockType. 
This change fixes it.
Fixes: #44235 
