### PR TITLE
devtools: Only add debuggee if devtools enabled

### DIFF
--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -471,6 +471,7 @@ impl DedicatedWorkerGlobalScope {
                 }
 
                 let worker_id = init.worker_id;
+                let devtools_enabled = init.to_devtools_sender.is_some();
                 let global = DedicatedWorkerGlobalScope::new(
                     init,
                     webview_id,
@@ -493,12 +494,14 @@ impl DedicatedWorkerGlobalScope {
                     &debugger_global,
                     cx,
                 );
-                debugger_global.fire_add_debuggee(
-                    cx,
-                    global.upcast(),
-                    pipeline_id,
-                    Some(worker_id),
-                );
+                if devtools_enabled {
+                    debugger_global.fire_add_debuggee(
+                        cx,
+                        global.upcast(),
+                        pipeline_id,
+                        Some(worker_id),
+                    );
+                }
                 let scope = global.upcast::<WorkerGlobalScope>();
                 let global_scope = global.upcast::<GlobalScope>();
 

--- a/components/script/dom/workers/serviceworkerglobalscope.rs
+++ b/components/script/dom/workers/serviceworkerglobalscope.rs
@@ -384,6 +384,7 @@ impl ServiceWorkerGlobalScope {
                 let devtools_mpsc_port = devtools_receiver.route_preserving_errors();
 
                 let resource_threads_sender = init.resource_threads.sender();
+                let devtools_enabled = init.to_devtools_sender.is_some();
                 let global = ServiceWorkerGlobalScope::new(
                     init,
                     script_url.clone(),
@@ -405,12 +406,14 @@ impl ServiceWorkerGlobalScope {
                 let worker_scope = global.upcast::<WorkerGlobalScope>();
                 let global_scope = global.upcast::<GlobalScope>();
 
-                debugger_global.fire_add_debuggee(
-                    cx,
-                    global_scope,
-                    pipeline_id,
-                    Some(worker_scope.worker_id()),
-                );
+                if devtools_enabled {
+                    debugger_global.fire_add_debuggee(
+                        cx,
+                        global_scope,
+                        pipeline_id,
+                        Some(worker_scope.worker_id()),
+                    );
+                }
 
                 let referrer = referrer_url
                     .map(Referrer::ReferrerUrl)

--- a/components/script/dom/workers/sharedworkerglobalscope.rs
+++ b/components/script/dom/workers/sharedworkerglobalscope.rs
@@ -379,6 +379,7 @@ impl SharedWorkerGlobalScope {
                 let devtools_mpsc_port = from_devtools_receiver.route_preserving_errors();
 
                 let worker_id = init.worker_id;
+                let devtools_enabled = init.to_devtools_sender.is_some();
                 // Creating the worker global scope initializes its name (step 8)
                 // and, for shared workers, its type (step 10.3 of run a worker).
                 let global = SharedWorkerGlobalScope::new(
@@ -403,7 +404,14 @@ impl SharedWorkerGlobalScope {
                 );
                 let scope = global.upcast::<WorkerGlobalScope>();
                 let global_scope = global.upcast::<GlobalScope>();
-                debugger_global.fire_add_debuggee(cx, global_scope, pipeline_id, Some(worker_id));
+                if devtools_enabled {
+                    debugger_global.fire_add_debuggee(
+                        cx,
+                        global_scope,
+                        pipeline_id,
+                        Some(worker_id),
+                    );
+                }
 
                 let fetch_client = ModuleFetchClient {
                     insecure_requests_policy,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3489,8 +3489,14 @@ impl ScriptThread {
             incomplete.theme,
             self.this.clone(),
         );
-        self.debugger_global
-            .fire_add_debuggee(cx, window.upcast(), incomplete.pipeline_id, None);
+        if self.senders.devtools_server_sender.is_some() {
+            self.debugger_global.fire_add_debuggee(
+                cx,
+                window.upcast(),
+                incomplete.pipeline_id,
+                None,
+            );
+        }
 
         let mut realm = enter_auto_realm(cx, &*window);
         let cx = &mut realm;


### PR DESCRIPTION
If devtools are not enabled we can skip this, since it should be only overhead. 
It seems that `fire_add_debuggee` is currently a leak source, since there is no place where we remove debuggees again. 
This isn't exactly a fix for the leak, but if devtools are off, then we avoid the problem by not adding a debuggee.

Testing: Not tested
Fixes: Part of #45262