### PR TITLE
webgpu: Use SecureContext on namespaces

### DIFF
--- a/components/script_bindings/webidls/WebGPU.webidl
+++ b/components/script_bindings/webidls/WebGPU.webidl
@@ -199,7 +199,7 @@ dictionary GPUBufferDescriptor : GPUObjectDescriptorBase {
 };
 
 typedef [EnforceRange] unsigned long GPUBufferUsageFlags;
-[Exposed=(Window, Worker), /*SecureContext,*/ Pref="dom_webgpu_enabled"]
+[Exposed=(Window, Worker), SecureContext, Pref="dom_webgpu_enabled"]
 namespace GPUBufferUsage {
     const GPUFlagsConstant MAP_READ      = 0x0001;
     const GPUFlagsConstant MAP_WRITE     = 0x0002;
@@ -214,7 +214,7 @@ namespace GPUBufferUsage {
 };
 
 typedef [EnforceRange] unsigned long GPUMapModeFlags;
-[Exposed=(Window, Worker), /*SecureContext,*/ Pref="dom_webgpu_enabled"]
+[Exposed=(Window, Worker), SecureContext, Pref="dom_webgpu_enabled"]
 namespace GPUMapMode {
     const GPUFlagsConstant READ  = 0x0001;
     const GPUFlagsConstant WRITE = 0x0002;

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -14426,7 +14426,7 @@
      ]
     ],
     "interfaces.worker.js": [
-     "36767a33a8b3399145044ef7ae3121d158abf915",
+     "5acb874e8d8467ac450fb9569ee1a51c8cf7a7b1",
      [
       "mozilla/interfaces.worker.html",
       {}

--- a/tests/wpt/mozilla/tests/mozilla/interfaces.worker.js
+++ b/tests/wpt/mozilla/tests/mozilla/interfaces.worker.js
@@ -39,8 +39,6 @@ test_interfaces([
   "FileReaderSync",
   "FinalizationRegistry",
   "FormData",
-  "GPUBufferUsage",
-  "GPUMapMode",
   "Headers",
   "History",
   "IDBCursor",

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/idl/exposed.http.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/idl/exposed.http.html.ini
@@ -1,3 +1,3 @@
 [exposed.http.html]
   expected:
-    if os == "linux" and not debug: ERROR
+    if os == "linux" and not debug: TIMEOUT


### PR DESCRIPTION
This is now possible due to #45104. The test in CTS is actually bad. If there is no error it does not report done so WPT considered it as timeout. FF also has this same result: https://searchfox.org/firefox-main/source/testing/web-platform/mozilla/meta/webgpu/cts/idl/exposed.http.html.ini

Testing: WebGPU CTS
