### PR TITLE
deps: Bump `sha3` to 0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -146,7 +146,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -422,7 +422,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "password-hash",
 ]
 
@@ -869,7 +869,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1217,7 +1217,7 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -1291,7 +1291,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
  "zeroize",
 ]
@@ -1437,6 +1437,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "content-security-policy"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1562,6 +1568,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1669,6 +1684,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array 0.4.12",
+]
+
+[[package]]
+name = "cshake"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6250a2d96a09edbe8e75ed29c87d05512ee2cbb24c7e8c684657f7930ffd3c6"
+dependencies = [
+ "digest 0.11.3",
+ "keccak 0.2.0",
+ "sponge-cursor",
+]
+
+[[package]]
 name = "cssparser"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1720,7 +1755,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "fiat-crypto",
  "rustc_version",
@@ -1829,7 +1864,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "der_derive",
  "pem-rfc7468",
  "zeroize",
@@ -1884,9 +1919,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
- "const-oid",
- "crypto-common",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -2051,7 +2096,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -2152,7 +2197,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -3634,7 +3679,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3717,6 +3762,15 @@ name = "hybrid-array"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891d15931895091dea5c47afa5b3c9a01ba634b311919fd4d41388fa0e3d76af"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
@@ -4565,7 +4619,17 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -4953,12 +5017,12 @@ version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac4a46643af2001eafebcc37031fc459eb72d45057aac5d7a15b00046a2ad6db"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "hybrid-array 0.3.1",
  "num-traits",
  "pkcs8",
  "rand_core 0.6.4",
- "sha3",
+ "sha3 0.10.8",
  "signature",
 ]
 
@@ -4971,7 +5035,7 @@ dependencies = [
  "hybrid-array 0.2.3",
  "kem",
  "rand_core 0.6.4",
- "sha3",
+ "sha3 0.10.8",
 ]
 
 [[package]]
@@ -6344,7 +6408,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -6365,7 +6429,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -6928,8 +6992,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -7273,6 +7337,12 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -8548,11 +8618,12 @@ dependencies = [
  "content-security-policy",
  "cookie 0.18.1",
  "crossbeam-channel",
+ "cshake",
  "cssparser",
  "ctr",
  "data-url",
  "der",
- "digest",
+ "digest 0.10.7",
  "ecdsa",
  "elliptic-curve",
  "encoding_rs",
@@ -8598,6 +8669,7 @@ dependencies = [
  "rustc-hash 2.1.2",
  "sec1",
  "selectors",
+ "seq-macro",
  "serde",
  "serde_json",
  "servo-background-hang-monitor-api",
@@ -8636,7 +8708,7 @@ dependencies = [
  "servo_arc",
  "sha1",
  "sha2",
- "sha3",
+ "sha3 0.12.0",
  "smallvec",
  "strum",
  "stylo",
@@ -8649,6 +8721,7 @@ dependencies = [
  "tendril",
  "time",
  "tracing",
+ "turboshake",
  "unicode-bidi",
  "unicode-script",
  "url",
@@ -9028,8 +9101,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -9045,8 +9118,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -9055,8 +9128,19 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest",
- "keccak",
+ "digest 0.10.7",
+ "keccak 0.1.6",
+]
+
+[[package]]
+name = "sha3"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
+dependencies = [
+ "digest 0.11.3",
+ "keccak 0.2.0",
+ "sponge-cursor",
 ]
 
 [[package]]
@@ -9090,7 +9174,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -9275,6 +9359,12 @@ dependencies = [
  "base64ct",
  "der",
 ]
+
+[[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
 
 [[package]]
 name = "stable_deref_trait"
@@ -10196,6 +10286,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "turboshake"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f892c6904b0bd5a9241eac848347abcbbbd2b9f3892bad23ac3e6efab8d6f06a"
+dependencies = [
+ "digest 0.11.3",
+ "keccak 0.2.0",
+ "sponge-cursor",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10340,7 +10441,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ content-security-policy = { version = "0.8.0", features = ["serde"] }
 cookie = { package = "cookie", version = "0.18" }
 criterion = "0.8"
 crossbeam-channel = "0.5"
+cshake = "0.2"
 cssparser = { version = "0.37", features = ["serde"] }
 ctr = "0.9.2"
 data-url = "0.3"
@@ -214,6 +215,7 @@ sea-query = { version = "=1.0.0-rc.31", default-features = false, features = ["b
 sea-query-rusqlite = { version = "=0.8.0-rc.15" }
 sec1 = "0.7"
 selectors = { git = "https://github.com/servo/stylo", rev = "d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f" }
+seq-macro = "0.3.6"
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
@@ -222,7 +224,7 @@ serde_test = "1.0"
 servo_arc = { git = "https://github.com/servo/stylo", rev = "d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f" }
 sha1 = "0.10"
 sha2 = "0.10"
-sha3 = "0.10"
+sha3 = "0.12"
 signal-hook-registry = "1.4.8"
 skrifa = "0.42.1"
 smallvec = { version = "1.15", features = ["serde", "union"] }
@@ -255,6 +257,7 @@ tracing = "0.1.44"
 tracing-perfetto = "0.1.5"
 tracing-subscriber = "0.3.23"
 tungstenite = "0.29"
+turboshake = "0.7"
 unicode-bidi = "0.3.18"
 unicode-properties = { version = "0.1.4", features = ["emoji"] }
 unicode-script = "0.5"

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -61,6 +61,7 @@ cipher = { workspace = true }
 content-security-policy = { workspace = true }
 cookie = { workspace = true }
 crossbeam-channel = { workspace = true }
+cshake = { workspace = true }
 cssparser = { workspace = true }
 ctr = { workspace = true }
 data-url = { workspace = true }
@@ -128,6 +129,7 @@ script_bindings = { workspace = true }
 script_traits = { workspace = true }
 sec1 = { workspace = true }
 selectors = { workspace = true }
+seq-macro = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["preserve_order"] }
 servo-background-hang-monitor-api = { workspace = true }
@@ -158,6 +160,7 @@ tendril = { workspace = true }
 time = { workspace = true }
 timers = { workspace = true }
 tracing = { workspace = true, optional = true }
+turboshake = { workspace = true }
 unicode-bidi = { workspace = true }
 unicode-script = { workspace = true }
 url = { workspace = true }

--- a/components/script/dom/webcrypto/subtlecrypto/cshake_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/cshake_operation.rs
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use digest::{ExtendableOutput, Update};
-use sha3::{CShake128, CShake128Core, CShake256, CShake256Core};
+use cshake::digest::{ExtendableOutput, Update};
+use cshake::{CShake128, CShake256};
 
 use crate::dom::bindings::error::Error;
 use crate::dom::subtlecrypto::{CryptoAlgorithm, SubtleCShakeParams};
@@ -36,18 +36,17 @@ pub(crate) fn digest(
     //     parameter, functionName as the N input parameter, and customization as the S input
     //     parameter.
     // Step 5. If performing the operation results in an error, then throw an OperationError.
-    let result = match normalized_algorithm.name {
+    let mut result = vec![0u8; output_length.div_ceil(8) as usize];
+    match normalized_algorithm.name {
         CryptoAlgorithm::CShake128 => {
-            let core = CShake128Core::new_with_function_name(function_name, customization);
-            let mut hasher = CShake128::from_core(core);
+            let mut hasher = CShake128::new_with_function_name(function_name, customization);
             hasher.update(message);
-            hasher.finalize_boxed(output_length as usize / 8).to_vec()
+            hasher.finalize_xof_into(&mut result);
         },
         CryptoAlgorithm::CShake256 => {
-            let core = CShake256Core::new_with_function_name(function_name, customization);
-            let mut hasher = CShake256::from_core(core);
+            let mut hasher = CShake256::new_with_function_name(function_name, customization);
             hasher.update(message);
-            hasher.finalize_boxed(output_length as usize / 8).to_vec()
+            hasher.finalize_xof_into(&mut result);
         },
         algorithm_name => {
             return Err(Error::NotSupported(Some(format!(
@@ -55,8 +54,15 @@ pub(crate) fn digest(
                 algorithm_name.as_str()
             ))));
         },
-    };
+    }
 
     // Step 6. Return a byte sequence containing result.
+    if !output_length.is_multiple_of(8) {
+        // Clean excess bits in the last byte of result.
+        let mask = u8::MAX << (8 - output_length % 8);
+        if let Some(last_byte) = result.last_mut() {
+            *last_byte &= mask;
+        }
+    }
     Ok(result)
 }

--- a/components/script/dom/webcrypto/subtlecrypto/sha3_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/sha3_operation.rs
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use sha3::{Digest, Sha3_256, Sha3_384, Sha3_512};
+use sha3::digest::Digest;
+use sha3::{Sha3_256, Sha3_384, Sha3_512};
 
 use crate::dom::bindings::error::Error;
 use crate::dom::subtlecrypto::{CryptoAlgorithm, SubtleAlgorithm};

--- a/components/script/dom/webcrypto/subtlecrypto/turboshake_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/turboshake_operation.rs
@@ -2,8 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use digest::{ExtendableOutput, Update};
-use sha3::{TurboShake128, TurboShake128Core, TurboShake256, TurboShake256Core};
+use seq_macro::seq;
+use turboshake::digest::{ExtendableOutput, Update};
+use turboshake::{CTurboShake128, CTurboShake256};
 
 use crate::dom::bindings::error::Error;
 use crate::dom::subtlecrypto::{CryptoAlgorithm, SubtleTurboShakeParams};
@@ -47,18 +48,27 @@ pub(crate) fn digest(
     //     of [RFC9861] using message as the M input parameter, domainSeparation as the D input
     //     parameter, and outputLength divided by 8 as the L input parameter.
     // Step 6. If performing the operation results in an error, then throw an OperationError.
-    let result = match normalized_algorithm.name {
+    let mut result = vec![0u8; output_length as usize / 8];
+    match normalized_algorithm.name {
         CryptoAlgorithm::TurboShake128 => {
-            let core = TurboShake128Core::new(domain_separation);
-            let mut hasher = TurboShake128::from_core(core);
-            hasher.update(message);
-            hasher.finalize_boxed(output_length as usize / 8).to_vec()
+            seq!(DS in 0x01..=0x7f {
+                match domain_separation {
+                    #(
+                        DS => hash_message::<CTurboShake128<DS>>(message, &mut result),
+                    )*
+                    _ => unreachable!("Step 4 guarantees domainSeparation lies in 0x01..=0x7f"),
+                }
+            });
         },
         CryptoAlgorithm::TurboShake256 => {
-            let core = TurboShake256Core::new(domain_separation);
-            let mut hasher = TurboShake256::from_core(core);
-            hasher.update(message);
-            hasher.finalize_boxed(output_length as usize / 8).to_vec()
+            seq!(DS in 0x01..=0x7f {
+                match domain_separation {
+                    #(
+                        DS => hash_message::<CTurboShake256<DS>>(message, &mut result),
+                    )*
+                    _ => unreachable!("Step 4 guarantees domainSeparation lies in 0x01..=0x7f"),
+                }
+            });
         },
         algorithm_name => {
             return Err(Error::NotSupported(Some(format!(
@@ -66,8 +76,14 @@ pub(crate) fn digest(
                 algorithm_name.as_str()
             ))));
         },
-    };
+    }
 
     // Step 7. Return result.
     Ok(result)
+}
+
+fn hash_message<T: ExtendableOutput + Update + Default>(message: &[u8], result: &mut [u8]) {
+    let mut hasher = T::default();
+    hasher.update(message);
+    hasher.finalize_xof_into(result);
 }

--- a/deny.toml
+++ b/deny.toml
@@ -195,6 +195,17 @@ skip = [
     "roxmltree",
     "tiny-skia",
     "tiny-skia-path",
+
+    # Duplicated by RustCrypto crates. We are upgrading RustCrypto
+    # dependencies in multiple rounds (issue #42206). During the
+    # upgrading process, we might have some duplicated dependencies due
+    # to partial upgrade, temporarily.
+    "const-oid",
+    "cpufeatures",
+    "crypto-common",
+    "digest",
+    "keccak",
+    "sha3",
 ]
 
 # github.com organizations to allow git sources for


### PR DESCRIPTION
Bump `sha3` from 0.10 to 0.12.

The cSHAKE and TurboSHAKE functionalities are moved away from the `sha3` crate to their individual crates `cshake` and `turboshake`. We add them to our dependency tree accordingly.

Moreover, in the new `turboshake` crate, the domain separation is specified via a const generic, instead of a regular function parameter. To support all 127 domain separations, we use the `seq!` macro from the `seq-macro` crate to generate `match` arms for them.

Testing: Covered by existing WPT tests in `WebCrypto` subdirectory
Fixes: Part of #42206