### PR TITLE
fonts/layout: Stabilize glyph positions across viewport resizes

### DIFF
--- a/components/fonts/platform/freetype/font.rs
+++ b/components/fonts/platform/freetype/font.rs
@@ -9,9 +9,10 @@ use app_units::Au;
 use euclid::default::{Point2D, Rect, Size2D};
 use fonts_traits::{FontIdentifier, FontTemplateDescriptor, LocalFontIdentifier};
 use freetype_sys::{
-    FT_F26Dot6, FT_Get_Char_Index, FT_Get_Kerning, FT_GlyphSlot, FT_KERNING_DEFAULT,
-    FT_LOAD_DEFAULT, FT_LOAD_NO_HINTING, FT_Load_Glyph, FT_Size_Metrics, FT_SizeRec, FT_UInt,
-    FT_ULong, FT_Vector,
+    FT_F26Dot6, FT_Fixed, FT_GLYPH_FORMAT_OUTLINE, FT_Get_Char_Index, FT_Get_Kerning, FT_GlyphSlot,
+    FT_GlyphSlot_Embolden, FT_KERNING_DEFAULT, FT_LOAD_DEFAULT, FT_LOAD_NO_HINTING, FT_Load_Glyph,
+    FT_Long, FT_MulFix, FT_Outline_Embolden, FT_Size_Metrics, FT_SizeRec, FT_UInt, FT_ULong,
+    FT_Vector,
 };
 use log::debug;
 use memmap2::Mmap;
@@ -34,6 +35,20 @@ const SEMI_BOLD_U16: u16 = Weight::SEMI_BOLD.value() as u16;
 /// Convert FreeType-style 26.6 fixed point to an [`f64`].
 fn fixed_26_dot_6_to_float(fixed: FT_F26Dot6) -> f64 {
     fixed as f64 / 64.0
+}
+
+/// Convert FreeType-style 16.16 fixed point to an [`f64`].
+/// This is the method described here:
+/// From <https://stackoverflow.com/questions/8638792/how-to-convert-packed-integer-16-16-fixed-point-to-float>.
+fn fixed_16_dot_16_to_float(fixed: FT_Fixed) -> f64 {
+    fixed as f64 / 65536.0
+}
+
+/// Convert an [`f64`] to a FreeType-style 16.16 fixed point.
+/// This is the inverse of the method described here:
+/// <https://stackoverflow.com/questions/8638792/how-to-convert-packed-integer-16-16-fixed-point-to-float>.
+fn float_to_fixed_16_dot_16(float: f64) -> FT_Fixed {
+    (float * 65536.0).round() as FT_Fixed
 }
 
 #[derive(Debug)]
@@ -193,7 +208,7 @@ impl PlatformFontMethods for PlatformFont {
         let load_flags = face.glyph_load_flags();
         let result = unsafe { FT_Load_Glyph(face.as_ptr(), glyph as FT_UInt, load_flags) };
         if 0 != result {
-            debug!("Unable to load glyph {}. reason: {:?}", glyph, result);
+            debug!("Unable to load glyph {glyph}: {result:?}");
             return None;
         }
 
@@ -207,8 +222,24 @@ impl PlatformFontMethods for PlatformFont {
             mozilla_glyphslot_embolden_less(slot);
         }
 
-        let advance = unsafe { (*slot).metrics.horiAdvance };
-        Some(fixed_26_dot_6_to_float(advance) * self.unscalable_font_metrics_scale())
+        // There are two kinds of horizontal metrics that FreeType provides:
+        //  - FT_GlyphMetrics.horiAdvance: This is the horizontal distance in 26.6 floating
+        //    point used to increment the pen position when drawing glyphs. According to
+        //    the FreeType documentation this is normally rounded to integer pixel coordinates
+        //    by the font driver.
+        //  - FT_GlyphSlotRec.linearHoriAdavnce: This is similar to `horiAdvance`, but is a
+        //    "16.16 fixed-point number that gives the value of the original glyph advance
+        //    width in 1/65536 of pixels."
+        //
+        // As we are laying out in floating point, we do not want glyph advance to be snapped
+        // to pixel boundaries. This value is only available if the font is scalable.
+        let advance = if !face.scalable() {
+            fixed_26_dot_6_to_float(unsafe { (*slot).metrics.horiAdvance })
+        } else {
+            fixed_16_dot_16_to_float(unsafe { (*slot).linearHoriAdvance })
+        };
+
+        Some(advance * self.unscalable_font_metrics_scale())
     }
 
     fn metrics(&self) -> FontMetrics {
@@ -447,10 +478,6 @@ impl std::fmt::Debug for FreeTypeFaceTableProviderData {
 // Custom version of FT_GlyphSlot_Embolden to be less aggressive with outline
 // fonts than the default implementation in FreeType.
 fn mozilla_glyphslot_embolden_less(slot: FT_GlyphSlot) {
-    use freetype_sys::{
-        FT_GLYPH_FORMAT_OUTLINE, FT_GlyphSlot_Embolden, FT_Long, FT_MulFix, FT_Outline_Embolden,
-    };
-
     if slot.is_null() {
         return;
     }
@@ -465,8 +492,7 @@ fn mozilla_glyphslot_embolden_less(slot: FT_GlyphSlot) {
 
     let face_ = unsafe { &*slot_.face };
 
-    // FT_GlyphSlot_Embolden uses a divisor of 24 here; we'll be only half as
-    // bold.
+    // FT_GlyphSlot_Embolden uses a divisor of 24 here; we'll be only half as bold.
     let size_ = unsafe { &*face_.size };
     let strength = unsafe { FT_MulFix(face_.units_per_EM as FT_Long, size_.metrics.y_scale) / 48 };
     unsafe { FT_Outline_Embolden(&raw mut slot_.outline, strength) };
@@ -483,4 +509,6 @@ fn mozilla_glyphslot_embolden_less(slot: FT_GlyphSlot) {
     slot_.metrics.horiAdvance += strength;
     slot_.metrics.vertAdvance += strength;
     slot_.metrics.horiBearingY += strength;
+
+    slot_.linearHoriAdvance += float_to_fixed_16_dot_16(fixed_26_dot_6_to_float(strength));
 }

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -809,6 +809,7 @@ impl Fragment {
             baseline_origin,
             fragment.justification_adjustment,
             include_whitespace,
+            builder.device_pixel_ratio,
         );
 
         if glyphs.is_empty() && !fragment.is_empty_for_text_cursor {
@@ -1936,34 +1937,45 @@ fn rgba(color: AbsoluteColor) -> wr::ColorF {
 
 fn glyphs(
     shaped_text_slices: &[Arc<ShapedTextSlice>],
-    mut baseline_origin: PhysicalPoint<Au>,
+    baseline_origin: PhysicalPoint<Au>,
     justification_adjustment: Au,
     include_whitespace: bool,
+    device_pixel_ratio: Scale<f32, StyloCSSPixel, StyloDevicePixel>,
 ) -> (Vec<GlyphInstance>, Au) {
     let mut glyphs = vec![];
     let mut largest_advance = Au::zero();
 
+    // In order to produce stable display list text layout as the canvas resizes, snap
+    // the text to the nearest device pixel. If WebRender is also snapping text, this
+    // means that when the origin changes by less than a pixel (such as when resizing
+    // the WebView), each glyph of the text is laid out consistently and only the origin
+    // is changing. Otherwise, different glyphs might snap to different pixels as the
+    // origin moves by subpixel amounts.
+    let mut current_position = PhysicalPoint::new(
+        Au::from_f32_px(baseline_origin.x.to_nearest_pixel(device_pixel_ratio.get())),
+        Au::from_f32_px(baseline_origin.y.to_nearest_pixel(device_pixel_ratio.get())),
+    )
+    .to_untyped();
+
     for shaped_text_slice in shaped_text_slices {
         for glyph in shaped_text_slice.glyphs() {
             if !shaped_text_slice.is_whitespace() || include_whitespace {
-                let glyph_offset = glyph.offset().unwrap_or(Point2D::zero());
-                let point = LayoutPoint::new(
-                    baseline_origin.x.to_f32_px() + glyph_offset.x.to_f32_px(),
-                    baseline_origin.y.to_f32_px() + glyph_offset.y.to_f32_px(),
-                );
+                let glyph_offset = glyph.offset().unwrap_or(Point2D::zero()).to_vector();
                 let glyph_instance = GlyphInstance {
                     index: glyph.id(),
-                    point,
+                    point: (current_position + glyph_offset)
+                        .map(Au::to_f32_px)
+                        .cast_unit(),
                 };
                 glyphs.push(glyph_instance);
             }
 
             if glyph.char_is_word_separator() {
-                baseline_origin.x += justification_adjustment;
+                current_position.x += justification_adjustment;
             }
 
             let advance = glyph.advance();
-            baseline_origin.x += advance;
+            current_position.x += advance;
             largest_advance.max_assign(advance);
         }
     }


### PR DESCRIPTION
There are two issues that are causing text to jump around when the
WebView is resizing:

1. Servo was using rounded glyph advances from FreeType. As Servo uses
   subpixel layout, this means that glyph advances were losing precision
   as soon as they were read.
2. Text origin was not snapped to device pixels. This means that when
   WebRender quantized glyph positions themselves, the final distance
   between each glyph in a run depended on the origin of the run. By
   snapping the origin, we ensure that the only change between each
   layout is to the run origin and the inter-glyph distance does not
   change.

Testing: Unfortunately, it is very difficult to test this issue as it is really
only visible when resizing the viewport and each individual display list
rasterization doesn't show it.
Fixes: #4564.
