### PR TITLE
libservo: Add documentation for more public types.

### DIFF
--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -519,8 +519,8 @@ impl WebView {
         traversal_id
     }
 
-    /// Ask the [`WebView`] to scroll web content. Note that positive scroll offsets reveal more
-    /// content on the bottom and right of the page.
+    /// Ask the [`WebView`] to scroll the scrollable area under `point` to the
+    /// given `scroll` destination.
     pub fn notify_scroll_event(&self, scroll: Scroll, point: WebViewPoint) {
         self.inner()
             .servo

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -90,6 +90,10 @@ impl PermissionRequest {
     }
 }
 
+/// A type used for communicating an allow-or-deny decision from the embedder
+/// to Servo. This is used as a part of requests from Servo to the embedder
+/// to perform certain actions and the request can either be allowed or denied
+/// by the embedder.
 pub struct AllowOrDenyRequest(IpcResponder<AllowOrDeny>, ServoErrorSender);
 
 impl AllowOrDenyRequest {
@@ -115,12 +119,14 @@ impl AllowOrDenyRequest {
         )
     }
 
+    /// Allow the action requested by Servo.
     pub fn allow(mut self) {
         if let Err(error) = self.0.send(AllowOrDeny::Allow) {
             self.1.raise_response_send_error(error);
         }
     }
 
+    /// Deny the action requested by Servo.
     pub fn deny(mut self) {
         if let Err(error) = self.0.send(AllowOrDeny::Deny) {
             self.1.raise_response_send_error(error);
@@ -128,10 +134,18 @@ impl AllowOrDenyRequest {
     }
 }
 
+/// A request to register or unregister a custom handler for a scheme.
+/// See <https://html.spec.whatwg.org/multipage/#custom-handlers>
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProtocolHandlerRegistration {
+    /// The scheme for which the hander is being registered or unregistered.
     pub scheme: String,
+    /// The URL to navigate to when loading resources for the given 'scheme'.
+    /// The string "%s" in this URL is used as a placeholder. It will be replaced
+    /// by the URL of the resource to be handled.
     pub url: Url,
+    /// Whether this request is for a new registration or unregistering
+    /// a previously registered handler.
     pub register_or_unregister: RegisterOrUnregister,
 }
 
@@ -449,16 +463,21 @@ impl SelectElement {
 
     /// Set the options that are selected.
     ///
+    /// `selected_options` is a vector of indices into the array returned by [`Self::options`].
+    ///
     /// If other options have previously been selected, this set of options
     /// will replace them.
     pub fn select(&mut self, selected_options: Vec<usize>) {
         self.select_element_request.selected_options = selected_options
     }
 
+    /// Get the currently selected options, represented by indices into the array
+    /// returned by [`Self::options`].
     pub fn selected_options(&self) -> Vec<usize> {
         self.select_element_request.selected_options.clone()
     }
 
+    /// Whether this `<select>` supports selecting multiple options.
     pub fn allow_select_multiple(&self) -> bool {
         self.select_element_request.allow_select_multiple
     }
@@ -856,12 +875,17 @@ impl PromptDialog {
     }
 }
 
+/// A request from Servo to embedder to open a new auxiliary [`WebView`], typically
+/// triggered by page content calling DOM APIs like `window.open()`.
+///
+/// Refer to the documentation of [`WebViewDelegate::request_create_new`] for more information.
 pub struct CreateNewWebViewRequest {
     pub(crate) servo: Servo,
     pub(crate) responder: IpcResponder<Option<NewWebViewDetails>>,
 }
 
 impl CreateNewWebViewRequest {
+    /// Returns a [`WebViewBuilder`] that can be used to create a new auxiliary [`WebView`].
     pub fn builder(self, rendering_context: Rc<dyn RenderingContext>) -> WebViewBuilder {
         WebViewBuilder::new_for_create_request(&self.servo, rendering_context, self.responder)
     }
@@ -986,6 +1010,7 @@ pub trait WebViewDelegate {
     /// reading a cached value or querying the user for permission via the user interface.
     fn request_permission(&self, _webview: WebView, _request: PermissionRequest) {}
 
+    /// Request that the embedder supply credentials to use for HTTP authentication.
     fn request_authentication(
         &self,
         _webview: WebView,

--- a/components/shared/embedder/embedder_controls.rs
+++ b/components/shared/embedder/embedder_controls.rs
@@ -160,7 +160,7 @@ pub struct FilePickerRequest {
     pub accept_current_paths_for_testing: bool,
 }
 
-/// Response from the embedder to an [`EmbedderControlRequest`].
+/// Request to the embedder to display a control for a `<select>` element.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct SelectElementRequest {
     pub options: Vec<SelectElementOptionOrOptgroup>,
@@ -168,6 +168,7 @@ pub struct SelectElementRequest {
     pub allow_select_multiple: bool,
 }
 
+/// Response from the embedder to an [`EmbedderControlRequest`].
 #[derive(Debug, Deserialize, Serialize)]
 pub enum EmbedderControlResponse {
     SelectElement(Vec<usize>),

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -64,6 +64,7 @@ pub enum WebViewPoint {
 }
 
 impl WebViewPoint {
+    #[doc(hidden)]
     pub fn as_device_point(&self, scale: Scale<f32, CSSPixel, DevicePixel>) -> DevicePoint {
         match self {
             Self::Device(point) => *point,
@@ -100,6 +101,7 @@ pub enum WebViewRect {
 }
 
 impl WebViewRect {
+    #[doc(hidden)]
     pub fn as_device_rect(&self, scale: Scale<f32, CSSPixel, DevicePixel>) -> DeviceRect {
         match self {
             Self::Device(rect) => *rect,
@@ -129,6 +131,9 @@ impl From<Box2D<f32, CSSPixel>> for WebViewRect {
     }
 }
 
+/// A 2D vector in a `WebView`, either expressed in device pixels or page pixels.
+/// Page pixels are CSS pixels, which take into account device pixel scale,
+/// page zoom, and pinch zoom.
 #[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
 pub enum WebViewVector {
     Device(DeviceVector2D),
@@ -136,6 +141,7 @@ pub enum WebViewVector {
 }
 
 impl WebViewVector {
+    #[doc(hidden)]
     pub fn as_device_vector(&self, scale: Scale<f32, CSSPixel, DevicePixel>) -> DeviceVector2D {
         match self {
             Self::Device(vector) => *vector,
@@ -162,10 +168,15 @@ impl From<Vector2D<f32, CSSPixel>> for WebViewVector {
     }
 }
 
+/// Represents the destination of a scroll operation.
 #[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
 pub enum Scroll {
+    /// An offset to scroll by, with positive offsets revealing more content on the bottom
+    /// and right of the scrollable area.
     Delta(WebViewVector),
+    /// Scroll to the start of the scrollable area.
     Start,
+    /// Scroll to the end of the scrollable area.
     End,
 }
 
@@ -283,11 +294,12 @@ pub trait RefreshDriver {
     fn observe_next_frame(&self, start_frame_callback: Box<dyn Fn() + Send + 'static>);
 }
 
+/// Credentials to use in an HTTP authentication challenge.
 #[derive(Debug, Default, Deserialize, PartialEq, Serialize)]
 pub struct AuthenticationResponse {
-    /// Username for http request authentication
+    /// Username for HTTP request authentication
     pub username: String,
-    /// Password for http request authentication
+    /// Password for HTTP request authentication
     pub password: String,
 }
 
@@ -305,13 +317,16 @@ pub enum RegisterOrUnregister {
     Unregister,
 }
 
+/// A request from Servo to embedder to register or unregister a custom
+/// protocol handler for a scheme, typically triggered by web content.
+/// See <https://html.spec.whatwg.org/multipage/#custom-handlers>
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ProtocolHandlerUpdateRegistration {
-    /// The scheme for the protocol handler
+    /// The scheme for the protocol handler.
     pub scheme: String,
-    /// The URL to navigate to when handling requests for scheme
+    /// The URL to navigate to when handling requests for scheme.
     pub url: ServoUrl,
-    /// Whether this update is to register or unregister the protocol handler
+    /// Whether this update is to register or unregister the protocol handler.
     pub register_or_unregister: RegisterOrUnregister,
 }
 
@@ -354,6 +369,7 @@ impl TraversalId {
     }
 }
 
+/// The pixel format of the buffer representing a raster image.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize, MallocSizeOf)]
 pub enum PixelFormat {
     /// Luminance channel only
@@ -381,6 +397,12 @@ pub struct Image {
 }
 
 impl Image {
+    /// Creates a new [`Image`] with the given `width` and `height`.
+    ///
+    /// `data` is a shared memory block containing the pixel data of one or more image frames, in
+    /// the given `format`.
+    ///
+    /// `range` is the byte offset within `data` that is the start of the first frame.
     pub fn new(
         width: u32,
         height: u32,
@@ -403,6 +425,7 @@ impl Image {
     }
 }
 
+/// The severity level of a message logged by page content.
 #[derive(Clone, Debug, Deserialize, Serialize, MallocSizeOf)]
 #[serde(rename_all = "lowercase")]
 pub enum ConsoleLogLevel {
@@ -427,9 +450,12 @@ impl From<ConsoleLogLevel> for log::Level {
     }
 }
 
+/// Information about a single Bluetooth device.
 #[derive(Clone, Deserialize, Serialize)]
 pub struct BluetoothDeviceDescription {
+    /// The unique address of this device.
     pub address: String,
+    /// A human-readable name for this device.
     pub name: String,
 }
 
@@ -1000,6 +1026,7 @@ impl Display for FocusSequenceNumber {
 #[derive(Clone, Copy, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct JavaScriptEvaluationId(pub usize);
 
+/// A JavaScript value produced by evaluation of a script.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub enum JSValue {
     Undefined,
@@ -1015,6 +1042,7 @@ pub enum JSValue {
     Object(HashMap<String, JSValue>),
 }
 
+/// Information about a JavaScript error that occured during the evaluation of a script.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct JavaScriptErrorInfo {
     pub message: String,


### PR DESCRIPTION
Adds documentation for types defined in `embedder_traits` and `webview_delegate`.

Testing: No testing is needed as there are no code changes.