### PR TITLE
devtools: Improvements for `NodeActor`

### DIFF
--- a/components/devtools/actor.rs
+++ b/components/devtools/actor.rs
@@ -136,15 +136,15 @@ impl ActorRegistry {
         script_actors.insert(script_id, actor);
     }
 
-    pub fn script_to_actor(&self, script_id: String) -> String {
+    pub fn script_to_actor(&self, script_id: &str) -> String {
         if script_id.is_empty() {
             return "".to_owned();
         }
-        self.script_actors.borrow().get(&script_id).unwrap().clone()
+        self.script_actors.borrow().get(script_id).unwrap().clone()
     }
 
-    pub fn script_actor_registered(&self, script_id: String) -> bool {
-        self.script_actors.borrow().contains_key(&script_id)
+    pub fn script_actor_registered(&self, script_id: &str) -> bool {
+        self.script_actors.borrow().contains_key(script_id)
     }
 
     pub fn actor_to_script(&self, actor: String) -> String {

--- a/components/devtools/actors/inspector/node.rs
+++ b/components/devtools/actors/inspector/node.rs
@@ -15,10 +15,10 @@ use devtools_traits::{
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{self, Map, Value};
-use servo_base::generic_channel::{self, GenericSender};
-use servo_base::id::PipelineId;
+use servo_base::generic_channel;
 
-use crate::actor::{Actor, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
+use crate::actors::inspector::walker::WalkerActor;
 use crate::protocol::ClientRequest;
 use crate::{EmptyReplyMsg, StreamId};
 
@@ -70,7 +70,7 @@ struct AttrMsg {
     value: String,
 }
 
-#[derive(Clone, Serialize)]
+#[derive(Clone, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct NodeActorMsg {
     pub actor: String,
@@ -130,10 +130,9 @@ pub(crate) struct NodeActorMsg {
 #[derive(MallocSizeOf)]
 pub(crate) struct NodeActor {
     name: String,
-    pub script_chan: GenericSender<DevtoolScriptControlMsg>,
-    pub pipeline: PipelineId,
     pub walker_name: String,
     pub style_rules: AtomicRefCell<HashMap<MatchedRule, String>>,
+    node_info: AtomicRefCell<NodeInfo>,
 }
 
 impl Actor for NodeActor {
@@ -155,6 +154,12 @@ impl Actor for NodeActor {
         msg: &Map<String, Value>,
         _id: StreamId,
     ) -> Result<(), ActorError> {
+        let browsing_context_actor = registry
+            .find::<WalkerActor>(&self.walker_name)
+            .browsing_context_actor(registry);
+        let script_chan = browsing_context_actor.script_chan();
+        let pipeline_id = browsing_context_actor.pipeline_id();
+
         match msg_type {
             "modifyAttributes" => {
                 let mods = msg
@@ -169,9 +174,9 @@ impl Actor for NodeActor {
                     })
                     .collect();
 
-                self.script_chan
+                script_chan
                     .send(DevtoolScriptControlMsg::ModifyAttribute(
-                        self.pipeline,
+                        browsing_context_actor.pipeline_id(),
                         registry.actor_to_script(self.name()),
                         modifications,
                     ))
@@ -188,9 +193,9 @@ impl Actor for NodeActor {
                     .ok_or(ActorError::BadParameterType)?;
 
                 let (tx, rx) = generic_channel::channel().ok_or(ActorError::Internal)?;
-                self.script_chan
+                script_chan
                     .send(DevtoolScriptControlMsg::GetEventListenerInfo(
-                        self.pipeline,
+                        pipeline_id,
                         registry.actor_to_script(target.to_owned()),
                         tx,
                     ))
@@ -205,26 +210,18 @@ impl Actor for NodeActor {
             },
             "getUniqueSelector" => {
                 let (tx, rx) = generic_channel::channel().unwrap();
-                self.script_chan
-                    .send(DevtoolScriptControlMsg::GetDocumentElement(
-                        self.pipeline,
-                        tx,
-                    ))
+                script_chan
+                    .send(DevtoolScriptControlMsg::GetDocumentElement(pipeline_id, tx))
                     .unwrap();
-                let doc_elem_info = rx
+                let node_info = rx
                     .recv()
                     .map_err(|_| ActorError::Internal)?
                     .ok_or(ActorError::Internal)?;
-                let node = doc_elem_info.encode(
-                    registry,
-                    self.script_chan.clone(),
-                    self.pipeline,
-                    self.walker_name.clone(),
-                );
 
+                self.update(node_info);
                 let msg = GetUniqueSelectorReply {
                     from: self.name(),
-                    value: node.display_name,
+                    value: self.node_info.borrow().node_name.to_lowercase(),
                 };
                 request.reply_final(&msg)?
             },
@@ -236,9 +233,9 @@ impl Actor for NodeActor {
                     .ok_or(ActorError::BadParameterType)?;
 
                 let (tx, rx) = generic_channel::channel().unwrap();
-                self.script_chan
+                script_chan
                     .send(DevtoolScriptControlMsg::GetXPath(
-                        self.pipeline,
+                        pipeline_id,
                         registry.actor_to_script(target.to_owned()),
                         tx,
                     ))
@@ -259,74 +256,64 @@ impl Actor for NodeActor {
 }
 
 impl NodeActor {
-    pub fn register(
+    pub fn register_or_update(
         registry: &ActorRegistry,
-        script_id: String,
-        script_chan: GenericSender<DevtoolScriptControlMsg>,
-        pipeline: PipelineId,
-        walker_name: String,
+        walker_name: &str,
+        node_info: NodeInfo,
     ) -> String {
-        let name = registry.new_name::<Self>();
+        let unique_id = &node_info.unique_id;
 
-        registry.register_script_actor(script_id, name.clone());
+        if !registry.script_actor_registered(unique_id) {
+            let name = registry.new_name::<Self>();
+            registry.register_script_actor(unique_id.clone(), name.clone());
 
-        let actor = Self {
-            name: name.clone(),
-            script_chan,
-            pipeline,
-            walker_name,
-            style_rules: AtomicRefCell::new(HashMap::new()),
-        };
+            let actor = Self {
+                name: name.clone(),
+                walker_name: walker_name.into(),
+                style_rules: AtomicRefCell::new(HashMap::new()),
+                node_info: AtomicRefCell::new(node_info),
+            };
 
-        registry.register(actor);
-        name
+            registry.register(actor);
+            name
+        } else {
+            let name = registry.script_to_actor(unique_id);
+            let actor = registry.find::<NodeActor>(&name);
+            actor.update(node_info);
+            name
+        }
+    }
+
+    fn update(&self, node_info: NodeInfo) {
+        *self.node_info.borrow_mut() = node_info;
     }
 }
-pub trait NodeInfoToProtocol {
-    fn encode(
-        self,
-        registry: &ActorRegistry,
-        script_chan: GenericSender<DevtoolScriptControlMsg>,
-        pipeline: PipelineId,
-        walker_name: String,
-    ) -> NodeActorMsg;
-}
 
-impl NodeInfoToProtocol for NodeInfo {
-    fn encode(
-        self,
-        registry: &ActorRegistry,
-        script_chan: GenericSender<DevtoolScriptControlMsg>,
-        pipeline: PipelineId,
-        walker_name: String,
-    ) -> NodeActorMsg {
-        let get_or_register_node_actor = |id: &str| {
-            if !registry.script_actor_registered(id.to_string()) {
-                NodeActor::register(
-                    registry,
-                    id.to_string(),
-                    script_chan.clone(),
-                    pipeline,
-                    walker_name.clone(),
-                )
+impl ActorEncode<NodeActorMsg> for NodeActor {
+    fn encode(&self, registry: &ActorRegistry) -> NodeActorMsg {
+        let node_info = self.node_info.borrow();
+
+        let actor = self.name();
+        let host = node_info.host.as_ref().and_then(|host_id| {
+            if registry.script_actor_registered(host_id) {
+                Some(registry.script_to_actor(host_id))
             } else {
-                registry.script_to_actor(id.to_string())
+                None
             }
-        };
+        });
 
-        let actor = get_or_register_node_actor(&self.unique_id);
-        let host = self
-            .host
-            .as_ref()
-            .map(|host_id| get_or_register_node_actor(host_id));
+        let browsing_context = registry
+            .find::<WalkerActor>(&self.walker_name)
+            .browsing_context_actor(registry);
+        let script_chan = browsing_context.script_chan();
+        let pipeline = browsing_context.pipeline_id();
+        let script_id = registry.actor_to_script(actor.clone());
 
-        let name = registry.actor_to_script(actor.clone());
-
-        // If a node only has a single text node as a child whith a small enough text,
+        // If a node only has a single text node as a child with a small enough text,
         // return it with this node as an `inlineTextChild`.
         let inline_text_child = (|| {
             // TODO: Also return if this node is a flex element.
-            if self.num_children != 1 || self.node_name == "SLOT" {
+            if node_info.num_children != 1 || node_info.node_name == "SLOT" {
                 return None;
             }
 
@@ -334,14 +321,15 @@ impl NodeInfoToProtocol for NodeInfo {
             script_chan
                 .send(DevtoolScriptControlMsg::GetChildren(
                     pipeline,
-                    name.clone(),
+                    script_id.clone(),
                     tx,
                 ))
                 .unwrap();
             let mut children = rx.recv().ok()??;
 
             let child = children.pop()?;
-            let msg = child.encode(registry, script_chan.clone(), pipeline, walker_name);
+            let node_name = NodeActor::register_or_update(registry, &self.walker_name, child);
+            let msg = registry.encode::<NodeActor, _>(&node_name);
 
             // If the node child is not a text node, do not represent it inline.
             if msg.node_type != TEXT_NODE {
@@ -359,46 +347,37 @@ impl NodeInfoToProtocol for NodeInfo {
         NodeActorMsg {
             actor,
             host,
-            base_uri: self.base_uri,
-            causes_overflow: false,
-            container_type: None,
-            display_name: self.node_name.clone().to_lowercase(),
-            display_type: self.display,
+            base_uri: node_info.base_uri.clone(),
+            display_name: node_info.node_name.to_lowercase(),
+            display_type: node_info.display.clone(),
             inline_text_child,
-            is_after_pseudo_element: false,
-            is_anonymous: false,
-            is_before_pseudo_element: false,
-            is_direct_shadow_host_child: None,
-            is_displayed: self.is_displayed,
+            is_displayed: node_info.is_displayed,
             is_in_html_document: Some(true),
-            is_marker_pseudo_element: false,
-            is_native_anonymous: false,
-            is_scrollable: false,
-            is_shadow_host: self.is_shadow_host,
-            is_shadow_root: self.shadow_root_mode.is_some(),
-            is_top_level_document: self.is_top_level_document,
-            node_name: self.node_name,
-            node_type: self.node_type,
-            node_value: self.node_value,
-            num_children: self.num_children,
-            parent: registry.script_to_actor(self.parent.clone()),
-            shadow_root_mode: self
+            is_shadow_host: node_info.is_shadow_host,
+            is_shadow_root: node_info.shadow_root_mode.is_some(),
+            is_top_level_document: node_info.is_top_level_document,
+            node_name: node_info.node_name.clone(),
+            node_type: node_info.node_type,
+            node_value: node_info.node_value.clone(),
+            num_children: node_info.num_children,
+            parent: registry.script_to_actor(&node_info.parent),
+            shadow_root_mode: node_info
                 .shadow_root_mode
                 .as_ref()
                 .map(ShadowRootMode::to_string),
-            traits: HashMap::new(),
-            attrs: self
+            attrs: node_info
                 .attrs
-                .into_iter()
+                .iter()
                 .map(|attr| AttrMsg {
-                    name: attr.name,
-                    value: attr.value,
+                    name: attr.name.clone(),
+                    value: attr.value.clone(),
                 })
                 .collect(),
-            name: self.doctype_name,
-            public_id: self.doctype_public_identifier,
-            system_id: self.doctype_system_identifier,
-            has_event_listeners: self.has_event_listeners,
+            name: node_info.doctype_name.clone(),
+            public_id: node_info.doctype_public_identifier.clone(),
+            system_id: node_info.doctype_system_identifier.clone(),
+            has_event_listeners: node_info.has_event_listeners,
+            ..Default::default()
         }
     }
 }

--- a/components/devtools/actors/inspector/page_style.rs
+++ b/components/devtools/actors/inspector/page_style.rs
@@ -151,8 +151,6 @@ impl PageStyleActor {
         let walker = registry.find::<WalkerActor>(&node_actor.walker_name);
         let browsing_context_actor = walker.browsing_context_actor(registry);
         let entries: Vec<_> = find_child(
-            &node_actor.script_chan,
-            node_actor.pipeline,
             &node_actor.walker_name,
             registry,
             &walker.root(registry)?.actor,

--- a/components/devtools/actors/inspector/walker.rs
+++ b/components/devtools/actors/inspector/walker.rs
@@ -6,17 +6,16 @@
 
 use atomic_refcell::AtomicRefCell;
 use devtools_traits::DevtoolScriptControlMsg::{GetChildren, GetDocumentElement, GetRootNode};
-use devtools_traits::{DevtoolScriptControlMsg, DomMutation};
+use devtools_traits::DomMutation;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{self, Map, Value};
-use servo_base::generic_channel::{self, GenericSender};
-use servo_base::id::PipelineId;
+use servo_base::generic_channel;
 
 use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry, DowncastableActorArc};
 use crate::actors::browsing_context::BrowsingContextActor;
 use crate::actors::inspector::layout::LayoutInspectorActor;
-use crate::actors::inspector::node::{NodeActorMsg, NodeInfoToProtocol};
+use crate::actors::inspector::node::{NodeActor, NodeActorMsg};
 use crate::protocol::{ClientRequest, DevtoolsConnection, JsonPacketStream};
 use crate::{ActorMsg, EmptyReplyMsg, StreamId};
 
@@ -170,12 +169,9 @@ impl Actor for WalkerActor {
                     nodes: children
                         .into_iter()
                         .map(|child| {
-                            child.encode(
-                                registry,
-                                browsing_context_actor.script_chan(),
-                                browsing_context_actor.pipeline_id(),
-                                self.name(),
-                            )
+                            let node_name =
+                                NodeActor::register_or_update(registry, &self.name, child);
+                            registry.encode::<NodeActor, _>(&node_name)
                         })
                         .collect(),
                     from: self.name(),
@@ -194,16 +190,13 @@ impl Actor for WalkerActor {
                     .script_chan()
                     .send(GetDocumentElement(browsing_context_actor.pipeline_id(), tx))
                     .map_err(|_| ActorError::Internal)?;
-                let doc_elem_info = rx
+                let node_info = rx
                     .recv()
                     .map_err(|_| ActorError::Internal)?
                     .ok_or(ActorError::Internal)?;
-                let node = doc_elem_info.encode(
-                    registry,
-                    browsing_context_actor.script_chan(),
-                    browsing_context_actor.pipeline_id(),
-                    self.name(),
-                );
+
+                let node_name = NodeActor::register_or_update(registry, &self.name, node_info);
+                let node = registry.encode::<NodeActor, _>(&node_name);
 
                 let msg = DocumentElementReply {
                     from: self.name(),
@@ -242,15 +235,9 @@ impl Actor for WalkerActor {
                     .ok_or(ActorError::MissingParameter)?
                     .as_str()
                     .ok_or(ActorError::BadParameterType)?;
-                let mut hierarchy = find_child(
-                    &browsing_context_actor.script_chan(),
-                    browsing_context_actor.pipeline_id(),
-                    &self.name,
-                    registry,
-                    node_name,
-                    vec![],
-                    |msg| msg.display_name == selector,
-                )
+                let mut hierarchy = find_child(&self.name, registry, node_name, vec![], |msg| {
+                    msg.display_name == selector
+                })
                 .map_err(|_| ActorError::Internal)?;
                 hierarchy.reverse();
                 let node = hierarchy.pop().ok_or(ActorError::Internal)?;
@@ -306,16 +293,13 @@ impl WalkerActor {
             .script_chan()
             .send(GetRootNode(pipeline, tx))
             .map_err(|_| ActorError::Internal)?;
-        let root_node = rx
+        let node_info = rx
             .recv()
             .map_err(|_| ActorError::Internal)?
             .ok_or(ActorError::Internal)?;
-        Ok(root_node.encode(
-            registry,
-            browsing_context_actor.script_chan(),
-            pipeline,
-            self.name(),
-        ))
+
+        let node_name = NodeActor::register_or_update(registry, &self.name, node_info);
+        Ok(registry.encode::<NodeActor, _>(&node_name))
     }
 
     pub(crate) fn handle_dom_mutation(
@@ -370,7 +354,7 @@ impl WalkerActor {
                             attribute_name,
                             new_value,
                         },
-                        target: registry.script_to_actor(node),
+                        target: registry.script_to_actor(&node),
                         type_: "attributes".to_owned(),
                     },
                 })
@@ -385,14 +369,17 @@ impl WalkerActor {
 /// If it is found, returns a list with the child and all of its ancestors.
 /// TODO: Investigate how to cache this to some extent.
 pub fn find_child(
-    script_chan: &GenericSender<DevtoolScriptControlMsg>,
-    pipeline: PipelineId,
     walker_name: &str,
     registry: &ActorRegistry,
     node_name: &str,
     mut hierarchy: Vec<NodeActorMsg>,
     compare_fn: impl Fn(&NodeActorMsg) -> bool + Clone,
 ) -> Result<Vec<NodeActorMsg>, Vec<NodeActorMsg>> {
+    let walker = registry.find::<WalkerActor>(walker_name);
+    let browsing_context = walker.browsing_context_actor(registry);
+    let script_chan = browsing_context.script_chan();
+    let pipeline = browsing_context.pipeline_id();
+
     let (tx, rx) = generic_channel::channel().unwrap();
     script_chan
         .send(GetChildren(
@@ -404,7 +391,9 @@ pub fn find_child(
     let children = rx.recv().unwrap().ok_or(vec![])?;
 
     for child in children {
-        let msg = child.encode(registry, script_chan.clone(), pipeline, walker_name.into());
+        let node_name = NodeActor::register_or_update(registry, walker_name, child);
+        let msg = registry.encode::<NodeActor, _>(&node_name);
+
         if compare_fn(&msg) {
             hierarchy.push(msg);
             return Ok(hierarchy);
@@ -415,8 +404,6 @@ pub fn find_child(
         }
 
         match find_child(
-            script_chan,
-            pipeline,
             walker_name,
             registry,
             &msg.actor,

--- a/components/devtools/actors/object.rs
+++ b/components/devtools/actors/object.rs
@@ -244,7 +244,7 @@ impl ObjectActor {
             registry.register(actor);
             return name;
         };
-        if !registry.script_actor_registered(uuid.clone()) {
+        if !registry.script_actor_registered(&uuid) {
             let name = registry.new_name::<Self>();
             let actor = ObjectActor {
                 name: name.clone(),
@@ -259,7 +259,7 @@ impl ObjectActor {
 
             name
         } else {
-            registry.script_to_actor(uuid)
+            registry.script_to_actor(&uuid)
         }
     }
 }

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -208,14 +208,14 @@ pub struct EvaluateJSReply {
     pub has_exception: bool,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, MallocSizeOf, Serialize)]
 pub struct AttrInfo {
     pub namespace: String,
     pub name: String,
     pub value: String,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, MallocSizeOf, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NodeInfo {
     pub unique_id: String,
@@ -588,7 +588,7 @@ pub struct CssDatabaseProperty {
     pub subproperties: Vec<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, MallocSizeOf, Serialize)]
 pub enum ShadowRootMode {
     Open,
     Closed,


### PR DESCRIPTION
Get the pipeline id and script channel through the watcher actor.

Implement the `ActorEncode` trait for `NodeActor` instead of an `encode` function in `NodeInfo`. Additionaly, split the registration logic for new nodes from the `encode` function to `register_or_update` in `NodeActor`.

Avoid String clonning whenever possible.

Clean up `NodeActorMsg` construction by using `Default` for certain fields. Ideally we could reuse the `NodeInfo` directly with a serde flatten annotation, but there are some fields that need special treatment. We might get away with a special serializer function for these fields.

Testing: ./mach test-devtools
Followup to #45250
