### PR TITLE
Fix building on RISC-V

### DIFF
--- a/components/constellation/Cargo.toml
+++ b/components/constellation/Cargo.toml
@@ -67,5 +67,5 @@ webgpu = { workspace = true, optional = true }
 webgpu_traits = { workspace = true, optional = true }
 webxr-api = { workspace = true }
 
-[target.'cfg(any(target_os="macos", all(not(target_os = "windows"), not(target_os = "ios"), not(target_os="android"), not(target_env="ohos"), not(target_arch="arm"), not(target_arch="aarch64"))))'.dependencies]
+[target.'cfg(any(target_os="macos", all(not(target_os = "windows"), not(target_os = "ios"), not(target_os="android"), not(target_env="ohos"), not(target_arch="arm"), not(target_arch="aarch64"), not(target_arch="riscv32"), not(target_arch="riscv64"))))'.dependencies]
 gaol = { workspace = true }

--- a/components/constellation/sandboxing.rs
+++ b/components/constellation/sandboxing.rs
@@ -13,7 +13,9 @@ use std::{env, process};
         not(target_os = "android"),
         not(target_env = "ohos"),
         not(target_arch = "arm"),
-        not(target_arch = "aarch64")
+        not(target_arch = "aarch64"),
+        not(target_arch = "riscv32"),
+        not(target_arch = "riscv64")
     )
 ))]
 use gaol::profile::{Operation, PathPattern, Profile};
@@ -99,7 +101,9 @@ pub fn content_process_sandbox_profile() -> Profile {
     not(target_os = "android"),
     not(target_env = "ohos"),
     not(target_arch = "arm"),
-    not(target_arch = "aarch64")
+    not(target_arch = "aarch64"),
+    not(target_arch = "riscv32"),
+    not(target_arch = "riscv64")
 ))]
 pub fn content_process_sandbox_profile() -> Profile {
     use std::path::PathBuf;
@@ -130,6 +134,8 @@ pub fn content_process_sandbox_profile() -> Profile {
     target_os = "android",
     target_env = "ohos",
     target_arch = "arm",
+    target_arch = "riscv32",
+    target_arch = "riscv64",
 
     // exclude apple arm devices
     all(target_arch = "aarch64", not(target_os = "macos"))
@@ -144,7 +150,9 @@ pub fn content_process_sandbox_profile() {
     target_os = "android",
     target_env = "ohos",
     target_arch = "arm",
-    target_arch = "aarch64"
+    target_arch = "aarch64",
+    target_arch = "riscv32",
+    target_arch = "riscv64"
 ))]
 pub fn spawn_multiprocess(content: UnprivilegedContent) -> Result<Process, IpcError> {
     use ipc_channel::ipc::{IpcOneShotServer, IpcSender};
@@ -175,7 +183,9 @@ pub fn spawn_multiprocess(content: UnprivilegedContent) -> Result<Process, IpcEr
     not(target_os = "android"),
     not(target_env = "ohos"),
     not(target_arch = "arm"),
-    not(target_arch = "aarch64")
+    not(target_arch = "aarch64"),
+    not(target_arch = "riscv32"),
+    not(target_arch = "riscv64")
 ))]
 pub fn spawn_multiprocess(content: UnprivilegedContent) -> Result<Process, IpcError> {
     use gaol::sandbox::{self, Sandbox, SandboxMethods};

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -155,7 +155,7 @@ webxr = { workspace = true, optional = true }
 arboard = { workspace = true, optional = true }
 webxr = { workspace = true, optional = true, features = ["glwindow", "headless"] }
 
-[target.'cfg(all(not(target_os = "windows"), not(target_os = "ios"), not(target_os = "android"), not(target_env = "ohos"), not(target_arch = "arm"), not(target_arch = "aarch64")))'.dependencies]
+[target.'cfg(all(not(target_os = "windows"), not(target_os = "ios"), not(target_os = "android"), not(target_env = "ohos"), not(target_arch = "arm"), not(target_arch = "aarch64"), not(target_arch="riscv32"), not(target_arch="riscv64")))'.dependencies]
 gaol = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -18,6 +18,8 @@ use fonts::SystemFontService;
     not(target_os = "android"),
     not(target_arch = "arm"),
     not(target_arch = "aarch64"),
+    not(target_arch = "riscv32"),
+    not(target_arch = "riscv64"),
     not(target_env = "ohos"),
 ))]
 use gaol::sandbox::{ChildSandbox, ChildSandboxMethods};
@@ -56,6 +58,8 @@ use servo_config::{opts, pref, prefs};
     not(target_os = "android"),
     not(target_arch = "arm"),
     not(target_arch = "aarch64"),
+    not(target_arch = "riscv32"),
+    not(target_arch = "riscv64"),
     not(target_env = "ohos"),
 ))]
 use servo_constellation::content_process_sandbox_profile;
@@ -1365,6 +1369,8 @@ pub fn run_content_process(token: String) {
     not(target_os = "android"),
     not(target_arch = "arm"),
     not(target_arch = "aarch64"),
+    not(target_arch = "riscv32"),
+    not(target_arch = "riscv64"),
     not(target_env = "ohos"),
 ))]
 fn create_sandbox() {
@@ -1379,10 +1385,12 @@ fn create_sandbox() {
     target_os = "android",
     target_arch = "arm",
     target_arch = "aarch64",
+    target_arch = "riscv32",
+    target_arch = "riscv64",
     target_env = "ohos",
 ))]
 fn create_sandbox() {
-    panic!("Sandboxing is not supported on Windows, iOS, ARM targets and android.");
+    panic!("Sandboxing is not supported on Windows, iOS, ARM, RISC-V targets and android.");
 }
 
 struct DefaultEventLoopWaker;


### PR DESCRIPTION
This change fixes building servo on RISC-V platform by disabling gaol sandbox, similar to the arm and aarch64 targets.

Testing: No new automated tests that cover this change, since it possibly requires new hardware.  
I tested manually on a SpacemiT K1-based development board and a QEMU-emulated riscv64 machine. For the K1 board, building was fine but servo complains about graphic driver when launching. For the QEMU-emulated riscv64 machine, building was fine and it successfully opens the front page of the servo website.

