### PR TITLE
deps: Upgrade surfman to `0.12.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9607,9 +9607,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surfman"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef75eb0dee43eda6435d2cde8cb12d21f791aca0c73a2fb74113afd864a041d"
+checksum = "a2f5e8af3ca54762c5f3854f9fddc88134bc3e996c2938624a71e28ede83f218"
 dependencies = [
  "bitflags 2.11.1",
  "cfg_aliases",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -237,7 +237,7 @@ stylo_dom = { git = "https://github.com/servo/stylo", rev = "d7e4d965d515b55b8d2
 stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f" }
 stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f" }
 stylo_traits = { git = "https://github.com/servo/stylo", rev = "d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f" }
-surfman = { version = "0.12.1", features = ["chains"] }
+surfman = { version = "0.12.2", features = ["chains"] }
 swapper = "0.1"
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"


### PR DESCRIPTION

Testing: This is just a dependency upgrade, so doesn't need a test.
Fixes: #30332
