### PR TITLE
layout: Preserve active `display: contents` when handling anonymous table parts

### DIFF
--- a/components/layout/table/construct.rs
+++ b/components/layout/table/construct.rs
@@ -70,8 +70,26 @@ impl AnonymousTableContent<'_> {
         }
     }
 
-    fn contents_are_whitespace_only(contents: &[Self]) -> bool {
-        contents.iter().all(|content| content.is_whitespace_only())
+    // If all contents are whitespace only, it removes them except for unclosed
+    // EnterDisplayContents, and returns true. Otherwise, it returns false.
+    fn remove_whitespace_only(contents: &mut Vec<Self>) -> bool {
+        if !contents.iter().all(Self::is_whitespace_only) {
+            return false;
+        }
+        let mut enter_display_contents = vec![];
+        for content in contents.drain(..) {
+            match content {
+                AnonymousTableContent::EnterDisplayContents(_) => {
+                    enter_display_contents.push(content);
+                },
+                AnonymousTableContent::LeaveDisplayContents => {
+                    enter_display_contents.pop();
+                },
+                _ => {},
+            }
+        }
+        std::mem::swap(contents, &mut enter_display_contents);
+        true
     }
 }
 
@@ -692,12 +710,9 @@ impl<'style, 'dom> TableBuilderTraversal<'style, 'dom> {
     }
 
     fn finish_anonymous_row_if_needed(&mut self) {
-        if AnonymousTableContent::contents_are_whitespace_only(&self.current_anonymous_row_content)
-        {
-            self.current_anonymous_row_content.clear();
+        if AnonymousTableContent::remove_whitespace_only(&mut self.current_anonymous_row_content) {
             return;
         }
-
         let row_content = std::mem::take(&mut self.current_anonymous_row_content);
         let anonymous_info = self
             .info
@@ -706,6 +721,7 @@ impl<'style, 'dom> TableBuilderTraversal<'style, 'dom> {
         let mut row_builder =
             TableRowBuilder::new(self, &anonymous_info, self.current_propagated_data);
 
+        let mut enter_display_contents = vec![];
         for cell_content in row_content {
             match cell_content {
                 AnonymousTableContent::Element {
@@ -719,14 +735,18 @@ impl<'style, 'dom> TableBuilderTraversal<'style, 'dom> {
                 AnonymousTableContent::Text(info, text) => {
                     row_builder.handle_text(&info, text);
                 },
-                AnonymousTableContent::EnterDisplayContents(styles) => {
-                    row_builder.enter_display_contents(styles)
+                AnonymousTableContent::EnterDisplayContents(ref styles) => {
+                    row_builder.enter_display_contents(styles.clone());
+                    enter_display_contents.push(cell_content);
                 },
-                AnonymousTableContent::LeaveDisplayContents => row_builder.leave_display_contents(),
+                AnonymousTableContent::LeaveDisplayContents => {
+                    row_builder.leave_display_contents();
+                    enter_display_contents.pop();
+                },
             }
         }
-
         row_builder.finish();
+        self.current_anonymous_row_content = enter_display_contents;
 
         let style = anonymous_info.style.clone();
         let table_row = ArcRefCell::new(TableTrack {
@@ -980,9 +1000,7 @@ impl<'style, 'builder, 'dom, 'a> TableRowGroupBuilder<'style, 'builder, 'dom, 'a
     }
 
     fn finish_anonymous_row_if_needed(&mut self) {
-        if AnonymousTableContent::contents_are_whitespace_only(&self.current_anonymous_row_content)
-        {
-            self.current_anonymous_row_content.clear();
+        if AnonymousTableContent::remove_whitespace_only(&mut self.current_anonymous_row_content) {
             return;
         }
 
@@ -998,6 +1016,7 @@ impl<'style, 'builder, 'dom, 'a> TableRowGroupBuilder<'style, 'builder, 'dom, 'a
         let mut row_builder =
             TableRowBuilder::new(self.table_traversal, &anonymous_info, self.propagated_data);
 
+        let mut enter_display_contents = vec![];
         for cell_content in row_content {
             match cell_content {
                 AnonymousTableContent::Element {
@@ -1011,12 +1030,17 @@ impl<'style, 'builder, 'dom, 'a> TableRowGroupBuilder<'style, 'builder, 'dom, 'a
                 AnonymousTableContent::Text(info, text) => {
                     row_builder.handle_text(&info, text);
                 },
-                AnonymousTableContent::EnterDisplayContents(styles) => {
-                    row_builder.enter_display_contents(styles)
+                AnonymousTableContent::EnterDisplayContents(ref styles) => {
+                    row_builder.enter_display_contents(styles.clone());
+                    enter_display_contents.push(cell_content);
                 },
-                AnonymousTableContent::LeaveDisplayContents => row_builder.leave_display_contents(),
+                AnonymousTableContent::LeaveDisplayContents => {
+                    row_builder.leave_display_contents();
+                    enter_display_contents.pop();
+                },
             }
         }
+        self.current_anonymous_row_content = enter_display_contents;
 
         row_builder.finish();
 
@@ -1131,9 +1155,7 @@ impl<'style, 'builder, 'dom, 'a> TableRowBuilder<'style, 'builder, 'dom, 'a> {
     }
 
     fn finish_current_anonymous_cell_if_needed(&mut self) {
-        if AnonymousTableContent::contents_are_whitespace_only(&self.current_anonymous_cell_content)
-        {
-            self.current_anonymous_cell_content.clear();
+        if AnonymousTableContent::remove_whitespace_only(&mut self.current_anonymous_cell_content) {
             return;
         }
 
@@ -1145,6 +1167,7 @@ impl<'style, 'builder, 'dom, 'a> TableRowBuilder<'style, 'builder, 'dom, 'a> {
         let propagated_data = self.propagated_data.disallowing_percentage_table_columns();
         let mut builder = BlockContainerBuilder::new(context, &anonymous_info, propagated_data);
 
+        let mut enter_display_contents = vec![];
         for cell_content in self.current_anonymous_cell_content.drain(..) {
             match cell_content {
                 AnonymousTableContent::Element {
@@ -1158,12 +1181,17 @@ impl<'style, 'builder, 'dom, 'a> TableRowBuilder<'style, 'builder, 'dom, 'a> {
                 AnonymousTableContent::Text(info, text) => {
                     builder.handle_text(&info, text);
                 },
-                AnonymousTableContent::EnterDisplayContents(styles) => {
-                    builder.enter_display_contents(styles)
+                AnonymousTableContent::EnterDisplayContents(ref styles) => {
+                    builder.enter_display_contents(styles.clone());
+                    enter_display_contents.push(cell_content);
                 },
-                AnonymousTableContent::LeaveDisplayContents => builder.leave_display_contents(),
+                AnonymousTableContent::LeaveDisplayContents => {
+                    builder.leave_display_contents();
+                    enter_display_contents.pop();
+                },
             }
         }
+        self.current_anonymous_cell_content = enter_display_contents;
 
         let block_container = builder.finish();
         let new_table_cell = ArcRefCell::new(TableSlotCell {

--- a/tests/wpt/tests/css/css-tables/display-contents-001-ref.html
+++ b/tests/wpt/tests/css/css-tables/display-contents-001-ref.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<div style="font: 25px/1 Ahem; color: green">
+  XXX<br>
+  X<br>
+  X
+</div>

--- a/tests/wpt/tests/css/css-tables/display-contents-001.html
+++ b/tests/wpt/tests/css/css-tables/display-contents-001.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>CSS Test: `display: contents` inside table</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/css-tables-3/#fixup">
+<link rel="help" href="https://www.w3.org/TR/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-001-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<meta name="assert" content="
+  The contents of the table (anonymous or not) should inherit the green color from the
+  element with `display: contents`.
+">
+
+<div style="display: table; font: 25px/1 Ahem; color: red">
+  <div style="display: contents; color: green">
+    X
+    <div style="display: table-cell">X</div>
+    X
+    <div style="display: table-row">X</div>
+    X
+  </div>
+</div>

--- a/tests/wpt/tests/css/css-tables/display-contents-002.html
+++ b/tests/wpt/tests/css/css-tables/display-contents-002.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<title>CSS Test: `display: contents` inside table</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/css-tables-3/#fixup">
+<link rel="help" href="https://www.w3.org/TR/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-001-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<meta name="assert" content="
+  The contents of the table (anonymous or not) should inherit the green color from the
+  element with `display: contents`.
+">
+
+<div style="display: table; font: 25px/1 Ahem; color: red">
+  <div style="display: table-row-group">
+    <div style="display: contents; color: green">
+      X
+      <div style="display: table-cell">X</div>
+      X
+      <div style="display: table-row">X</div>
+      X
+    </div>
+  </div>
+</div>

--- a/tests/wpt/tests/css/css-tables/display-contents-003-ref.html
+++ b/tests/wpt/tests/css/css-tables/display-contents-003-ref.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<div style="font: 25px/1 Ahem; color: green">
+  XXX<br>
+  &nbsp;&nbsp;X<br>
+  &nbsp;&nbsp;X
+</div>

--- a/tests/wpt/tests/css/css-tables/display-contents-003.html
+++ b/tests/wpt/tests/css/css-tables/display-contents-003.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<title>CSS Test: `display: contents` inside table</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/css-tables-3/#fixup">
+<link rel="help" href="https://www.w3.org/TR/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-003-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<meta name="assert" content="
+  The contents of the table (anonymous or not) should inherit the green color from the
+  element with `display: contents`.
+">
+
+<div style="display: table; font: 25px/1 Ahem; color: red">
+  <div style="display: table-row">
+    <div style="display: contents; color: green">
+      X
+      <div style="display: table-cell">X</div>
+      X
+      <div style="display: table-row">X</div>
+      X
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
We weren't handling `display: contents` elements properly when dealing with contents inside tables that may need to be wrapped inside anonymous containers.

This could result in calling `leave_display_contents()` without having used `enter_display_contents()` beforehand, thus breaking the assumption that all inline formatting context should have at least one shared inline style.

Now we make sure to preserve unclosed `AnonymousTableContent::EnterDisplayContents` for later.

Testing: Adding new reftests
Fixes: #45085
Fixes: #45172