### PR TITLE
Skip Unicode Line Breaking algorithm when unused

### DIFF
--- a/components/fonts/glyph.rs
+++ b/components/fonts/glyph.rs
@@ -464,6 +464,19 @@ impl ShapedText {
             }
         })
     }
+
+    /// Creates a `ShapedTextSlice` for the entire `ShapedText`, for `text-wrap-mode: nowrap`
+    pub fn slice_full_nowrap(self: &Arc<Self>, is_whitespace: bool) -> Arc<ShapedTextSlice> {
+        Arc::new(ShapedTextSlice {
+            shaped_text: self.clone(),
+            glyph_range: 0..self.glyph_count(),
+            total_advance: self.total_advance,
+            character_count: self.character_count,
+            is_whitespace,
+            ends_with_whitespace: false, // unused with TextWrapMode::Nowrap
+            total_word_separators: self.total_word_separators,
+        })
+    }
 }
 
 impl ShapedGlyph {

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -74,7 +74,7 @@ pub mod line;
 mod line_breaker;
 pub mod text_run;
 
-use std::cell::{OnceCell, RefCell};
+use std::cell::{LazyCell, OnceCell, RefCell};
 use std::mem;
 use std::rc::Rc;
 use std::sync::{Arc, OnceLock};
@@ -1916,7 +1916,8 @@ impl InlineFormattingContext {
             })
         };
 
-        let mut new_linebreaker = LineBreaker::new(text_content.as_str(), options);
+        let mut new_linebreaker =
+            LazyCell::new(|| LineBreaker::new(text_content.as_str(), options));
         for item in &mut builder.inline_items {
             match item {
                 InlineItem::TextRun(text_run) => {

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::cell::LazyCell;
 use std::mem;
 use std::ops::Range;
 use std::sync::Arc;
@@ -20,6 +21,7 @@ use style::Zero;
 use style::computed_values::font_kerning::T as FontKerning;
 use style::computed_values::font_variant_position::T as FontVariantPosition;
 use style::computed_values::text_rendering::T as TextRendering;
+use style::computed_values::text_wrap_mode::T as TextWrapMode;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
 use style::computed_values::word_break::T as WordBreak;
 use style::properties::ComputedValues;
@@ -267,16 +269,10 @@ impl TextRunSegment {
         &mut self,
         parent_style: &ComputedValues,
         formatting_context_text: &str,
-        linebreaker: &mut LineBreaker,
+        linebreaker: &mut LazyCell<LineBreaker, impl FnOnce() -> LineBreaker>,
         old_text_run_item: Option<TextRunItem>,
     ) {
-        // Gather the linebreaks that apply to this segment from the inline formatting context's collection
-        // of line breaks. Also add a simulated break at the end of the segment in order to ensure the final
-        // piece of text is processed.
         let range = self.byte_range.clone();
-        let linebreaks = linebreaker.advance_to_linebreaks_in_range(self.byte_range.clone());
-        let linebreak_iter = linebreaks.iter().chain(std::iter::once(&range.end));
-
         let options: ShapingOptions = (&*self.info).into();
         let shaped_text = old_text_run_item
             .and_then(|old_text_run_item| {
@@ -293,6 +289,25 @@ impl TextRunSegment {
                     .font
                     .shape_text(&formatting_context_text[range.clone()], &options)
             });
+
+        match parent_style.get_inherited_text().text_wrap_mode {
+            TextWrapMode::Nowrap => {
+                // Since this `TextRunSegment` is unbreakable,
+                // return early with a single `ShapedTextSlice` for the entire segment
+                let is_whitespace = formatting_context_text.chars().all(char_is_whitespace);
+                self.runs.push(shaped_text.slice_full_nowrap(is_whitespace));
+                return;
+            },
+            TextWrapMode::Wrap => {
+                // Break the segment into slices at soft wrap/break opportunities below
+            },
+        }
+
+        // Gather the linebreaks that apply to this segment from the inline formatting context's collection
+        // of line breaks. Also add a simulated break at the end of the segment in order to ensure the final
+        // piece of text is processed.
+        let linebreaks = linebreaker.advance_to_linebreaks_in_range(self.byte_range.clone());
+        let linebreak_iter = linebreaks.iter().chain(std::iter::once(&range.end));
 
         let mut shaped_text_slicer = ShapedTextSlicer::new(shaped_text);
 
@@ -471,7 +486,7 @@ impl TextRun {
         &mut self,
         formatting_context_text: &str,
         layout_context: &LayoutContext,
-        linebreaker: &mut LineBreaker,
+        linebreaker: &mut LazyCell<LineBreaker, impl FnOnce() -> LineBreaker>,
         bidi_levels: &BidiLevels,
     ) {
         let parent_style = self.inline_styles.style.borrow().clone();


### PR DESCRIPTION
With CSS `text-wrap-mode: nowrap` (or, before CSS Text Level 4, `white-space: pre`) white space characters never create a soft break opportunity

Testing: this PR is meant not to change any observable behavior, which WPT should check

