### PR TITLE
servoshell: Rely on egui to know when widgets are animating

### DIFF
--- a/ports/servoshell/desktop/gui.rs
+++ b/ports/servoshell/desktop/gui.rs
@@ -607,7 +607,6 @@ impl Gui {
                     pos2(0.0, available_rect.max.y),
                 )
                 .show(|ui| ui.add(Label::new(status_text.clone()).extend()));
-                window.set_needs_repaint();
             }
 
             window.repaint_webviews();
@@ -626,6 +625,12 @@ impl Gui {
                 });
             }
         });
+
+        // If any egui widget requested a repaint, also request a repaint for our
+        // containing window. This allows egui widget to animate on their own.
+        if self.context.egui_ctx.has_requested_repaint() {
+            window.set_needs_repaint();
+        }
 
         let adapter = self
             .context

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -502,12 +502,7 @@ impl HeadedWindow {
         // cursor too, when all dialogs close. In general, we need a better cursor
         // management strategy.
         self.set_cursor(Cursor::Default);
-
-        let length = dialogs.len();
         dialogs.retain_mut(callback);
-        if length != dialogs.len() {
-            window.set_needs_repaint();
-        }
     }
 
     fn add_dialog(&self, webview_id: WebViewId, dialog: Dialog) {
@@ -862,17 +857,8 @@ impl PlatformWindow for HeadedWindow {
         self.gui.borrow_mut().update_webview_data(window)
     }
 
-    fn request_repaint(&self, window: &ServoShellWindow) {
+    fn request_repaint(&self, _: &ServoShellWindow) {
         self.winit_window.request_redraw();
-
-        // FIXME: This is a workaround for dialogs, which do not seem to animate, unless we
-        // constantly repaint the egui scene.
-        if window
-            .active_webview()
-            .is_some_and(|webview| self.has_active_dialog_for_webview(webview.id()))
-        {
-            window.set_needs_repaint();
-        }
     }
 
     fn request_resize(&self, _: &WebView, new_outer_size: DeviceIntSize) -> Option<DeviceIntSize> {


### PR DESCRIPTION
Instead of using the hack where we try to detect if any potential egui
animating widget is visible in order to continuously trigger repaints,
just rely on egui internal tracking of whether a widget has requested a
repaint. This should allow us to paint a great deal less when any widget
is open and remove the old hack entirely.

Testing: There isn't really testing at this level of servoshell.
