### PR TITLE
tests: Fix warning about unused variable in webview tests

### DIFF
--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -1069,7 +1069,7 @@ fn test_preferences_change() {
 
     webview.reload();
 
-    let result = assert_eq!(
+    assert_eq!(
         Ok(JSValue::String("3".into())),
         evaluate_javascript(&servo_test, webview, "target.style.gridColumn = \"3\";")
     );


### PR DESCRIPTION
assert_eq!() returns `()`, so no point in assigning it.

Spotted by chance in https://github.com/servo/servo/actions/runs/26772640858/job/78915907148

Testing: Part of a unit-test.

