### PR TITLE
webgpu: rename `*Image*` -> `*Texel*`

### DIFF
--- a/components/script/dom/webgpu/gpucommandencoder.rs
+++ b/components/script/dom/webgpu/gpucommandencoder.rs
@@ -14,7 +14,7 @@ use wgpu_core::command as wgpu_com;
 use crate::conversions::{Convert, TryConvert};
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUCommandBufferDescriptor, GPUCommandEncoderDescriptor, GPUCommandEncoderMethods,
-    GPUComputePassDescriptor, GPUExtent3D, GPUImageCopyBuffer, GPUImageCopyTexture,
+    GPUComputePassDescriptor, GPUExtent3D, GPUTexelCopyBufferInfo, GPUImageCopyTexture,
     GPURenderPassDescriptor, GPUSize64,
 };
 use crate::dom::bindings::error::Fallible;
@@ -277,7 +277,7 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-copybuffertotexture>
     fn CopyBufferToTexture(
         &self,
-        source: &GPUImageCopyBuffer,
+        source: &GPUTexelCopyBufferInfo,
         destination: &GPUImageCopyTexture,
         copy_size: GPUExtent3D,
     ) -> Fallible<()> {
@@ -300,7 +300,7 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
     fn CopyTextureToBuffer(
         &self,
         source: &GPUImageCopyTexture,
-        destination: &GPUImageCopyBuffer,
+        destination: &GPUTexelCopyBufferInfo,
         copy_size: GPUExtent3D,
     ) -> Fallible<()> {
         self.droppable

--- a/components/script/dom/webgpu/gpucommandencoder.rs
+++ b/components/script/dom/webgpu/gpucommandencoder.rs
@@ -14,7 +14,7 @@ use wgpu_core::command as wgpu_com;
 use crate::conversions::{Convert, TryConvert};
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUCommandBufferDescriptor, GPUCommandEncoderDescriptor, GPUCommandEncoderMethods,
-    GPUComputePassDescriptor, GPUExtent3D, GPUTexelCopyBufferInfo, GPUImageCopyTexture,
+    GPUComputePassDescriptor, GPUExtent3D, GPUTexelCopyBufferInfo, GPUTexelCopyTextureInfo,
     GPURenderPassDescriptor, GPUSize64,
 };
 use crate::dom::bindings::error::Fallible;
@@ -278,7 +278,7 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
     fn CopyBufferToTexture(
         &self,
         source: &GPUTexelCopyBufferInfo,
-        destination: &GPUImageCopyTexture,
+        destination: &GPUTexelCopyTextureInfo,
         copy_size: GPUExtent3D,
     ) -> Fallible<()> {
         self.droppable
@@ -299,7 +299,7 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-copybuffertotexture>
     fn CopyTextureToBuffer(
         &self,
-        source: &GPUImageCopyTexture,
+        source: &GPUTexelCopyTextureInfo,
         destination: &GPUTexelCopyBufferInfo,
         copy_size: GPUExtent3D,
     ) -> Fallible<()> {
@@ -321,8 +321,8 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
     /// <https://gpuweb.github.io/gpuweb/#GPUCommandEncoder-copyTextureToTexture>
     fn CopyTextureToTexture(
         &self,
-        source: &GPUImageCopyTexture,
-        destination: &GPUImageCopyTexture,
+        source: &GPUTexelCopyTextureInfo,
+        destination: &GPUTexelCopyTextureInfo,
         copy_size: GPUExtent3D,
     ) -> Fallible<()> {
         self.droppable

--- a/components/script/dom/webgpu/gpucommandencoder.rs
+++ b/components/script/dom/webgpu/gpucommandencoder.rs
@@ -14,8 +14,8 @@ use wgpu_core::command as wgpu_com;
 use crate::conversions::{Convert, TryConvert};
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUCommandBufferDescriptor, GPUCommandEncoderDescriptor, GPUCommandEncoderMethods,
-    GPUComputePassDescriptor, GPUExtent3D, GPUTexelCopyBufferInfo, GPUTexelCopyTextureInfo,
-    GPURenderPassDescriptor, GPUSize64,
+    GPUComputePassDescriptor, GPUExtent3D, GPURenderPassDescriptor, GPUSize64,
+    GPUTexelCopyBufferInfo, GPUTexelCopyTextureInfo,
 };
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::reflector::DomGlobal;

--- a/components/script/dom/webgpu/gpuconvert.rs
+++ b/components/script/dom/webgpu/gpuconvert.rs
@@ -17,7 +17,7 @@ use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUAddressMode, GPUBindGroupEntry, GPUBindGroupLayoutEntry, GPUBindingResource,
     GPUBlendComponent, GPUBlendFactor, GPUBlendOperation, GPUBufferBindingType, GPUColor,
     GPUCompareFunction, GPUCullMode, GPUExtent3D, GPUFilterMode, GPUFrontFace, GPUTexelCopyBufferInfo,
-    GPUImageCopyTexture, GPUTexelCopyBufferLayout, GPUIndexFormat, GPULoadOp, GPUMipmapFilterMode,
+    GPUTexelCopyTextureInfo, GPUTexelCopyBufferLayout, GPUIndexFormat, GPULoadOp, GPUMipmapFilterMode,
     GPUObjectDescriptorBase, GPUOrigin3D, GPUPrimitiveState, GPUPrimitiveTopology,
     GPUProgrammableStage, GPUSamplerBindingType, GPUStencilOperation, GPUStorageTextureAccess,
     GPUStoreOp, GPUTextureAspect, GPUTextureDescriptor, GPUTextureDimension, GPUTextureFormat,
@@ -495,7 +495,7 @@ impl TryConvert<wgpu_types::Origin3d> for &GPUOrigin3D {
     }
 }
 
-impl TryConvert<wgpu_com::TexelCopyTextureInfo> for &GPUImageCopyTexture {
+impl TryConvert<wgpu_com::TexelCopyTextureInfo> for &GPUTexelCopyTextureInfo {
     type Error = Error;
 
     fn try_convert(self) -> Result<wgpu_com::TexelCopyTextureInfo, Self::Error> {

--- a/components/script/dom/webgpu/gpuconvert.rs
+++ b/components/script/dom/webgpu/gpuconvert.rs
@@ -16,7 +16,7 @@ use crate::conversions::{Convert, TryConvert};
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUAddressMode, GPUBindGroupEntry, GPUBindGroupLayoutEntry, GPUBindingResource,
     GPUBlendComponent, GPUBlendFactor, GPUBlendOperation, GPUBufferBindingType, GPUColor,
-    GPUCompareFunction, GPUCullMode, GPUExtent3D, GPUFilterMode, GPUFrontFace, GPUImageCopyBuffer,
+    GPUCompareFunction, GPUCullMode, GPUExtent3D, GPUFilterMode, GPUFrontFace, GPUTexelCopyBufferInfo,
     GPUImageCopyTexture, GPUTexelCopyBufferLayout, GPUIndexFormat, GPULoadOp, GPUMipmapFilterMode,
     GPUObjectDescriptorBase, GPUOrigin3D, GPUPrimitiveState, GPUPrimitiveTopology,
     GPUProgrammableStage, GPUSamplerBindingType, GPUStencilOperation, GPUStorageTextureAccess,
@@ -458,7 +458,7 @@ impl Convert<wgpu_types::StencilOperation> for GPUStencilOperation {
     }
 }
 
-impl Convert<wgpu_com::TexelCopyBufferInfo> for &GPUImageCopyBuffer {
+impl Convert<wgpu_com::TexelCopyBufferInfo> for &GPUTexelCopyBufferInfo {
     fn convert(self) -> wgpu_com::TexelCopyBufferInfo {
         wgpu_com::TexelCopyBufferInfo {
             buffer: self.buffer.id().0,

--- a/components/script/dom/webgpu/gpuconvert.rs
+++ b/components/script/dom/webgpu/gpuconvert.rs
@@ -17,7 +17,7 @@ use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUAddressMode, GPUBindGroupEntry, GPUBindGroupLayoutEntry, GPUBindingResource,
     GPUBlendComponent, GPUBlendFactor, GPUBlendOperation, GPUBufferBindingType, GPUColor,
     GPUCompareFunction, GPUCullMode, GPUExtent3D, GPUFilterMode, GPUFrontFace, GPUImageCopyBuffer,
-    GPUImageCopyTexture, GPUImageDataLayout, GPUIndexFormat, GPULoadOp, GPUMipmapFilterMode,
+    GPUImageCopyTexture, GPUTexelCopyBufferLayout, GPUIndexFormat, GPULoadOp, GPUMipmapFilterMode,
     GPUObjectDescriptorBase, GPUOrigin3D, GPUPrimitiveState, GPUPrimitiveTopology,
     GPUProgrammableStage, GPUSamplerBindingType, GPUStencilOperation, GPUStorageTextureAccess,
     GPUStoreOp, GPUTextureAspect, GPUTextureDescriptor, GPUTextureDimension, GPUTextureFormat,
@@ -247,7 +247,7 @@ impl TryConvert<wgpu_types::Extent3d> for &GPUExtent3D {
     }
 }
 
-impl Convert<wgpu_types::TexelCopyBufferLayout> for &GPUImageDataLayout {
+impl Convert<wgpu_types::TexelCopyBufferLayout> for &GPUTexelCopyBufferLayout {
     fn convert(self) -> wgpu_types::TexelCopyBufferLayout {
         wgpu_types::TexelCopyBufferLayout {
             offset: self.offset as wgpu_types::BufferAddress,

--- a/components/script/dom/webgpu/gpuconvert.rs
+++ b/components/script/dom/webgpu/gpuconvert.rs
@@ -16,12 +16,12 @@ use crate::conversions::{Convert, TryConvert};
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUAddressMode, GPUBindGroupEntry, GPUBindGroupLayoutEntry, GPUBindingResource,
     GPUBlendComponent, GPUBlendFactor, GPUBlendOperation, GPUBufferBindingType, GPUColor,
-    GPUCompareFunction, GPUCullMode, GPUExtent3D, GPUFilterMode, GPUFrontFace, GPUTexelCopyBufferInfo,
-    GPUTexelCopyTextureInfo, GPUTexelCopyBufferLayout, GPUIndexFormat, GPULoadOp, GPUMipmapFilterMode,
-    GPUObjectDescriptorBase, GPUOrigin3D, GPUPrimitiveState, GPUPrimitiveTopology,
-    GPUProgrammableStage, GPUSamplerBindingType, GPUStencilOperation, GPUStorageTextureAccess,
-    GPUStoreOp, GPUTextureAspect, GPUTextureDescriptor, GPUTextureDimension, GPUTextureFormat,
-    GPUTextureSampleType, GPUTextureViewDimension, GPUVertexFormat,
+    GPUCompareFunction, GPUCullMode, GPUExtent3D, GPUFilterMode, GPUFrontFace, GPUIndexFormat,
+    GPULoadOp, GPUMipmapFilterMode, GPUObjectDescriptorBase, GPUOrigin3D, GPUPrimitiveState,
+    GPUPrimitiveTopology, GPUProgrammableStage, GPUSamplerBindingType, GPUStencilOperation,
+    GPUStorageTextureAccess, GPUStoreOp, GPUTexelCopyBufferInfo, GPUTexelCopyBufferLayout,
+    GPUTexelCopyTextureInfo, GPUTextureAspect, GPUTextureDescriptor, GPUTextureDimension,
+    GPUTextureFormat, GPUTextureSampleType, GPUTextureViewDimension, GPUVertexFormat,
 };
 use crate::dom::bindings::codegen::UnionTypes::GPUTextureOrGPUTextureView;
 use crate::dom::bindings::error::{Error, Fallible};

--- a/components/script/dom/webgpu/gpuqueue.rs
+++ b/components/script/dom/webgpu/gpuqueue.rs
@@ -12,7 +12,7 @@ use webgpu_traits::{WebGPU, WebGPUQueue, WebGPURequest};
 
 use crate::conversions::{Convert, TryConvert};
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
-    GPUExtent3D, GPUImageCopyTexture, GPUImageDataLayout, GPUQueueMethods, GPUSize64,
+    GPUExtent3D, GPUImageCopyTexture, GPUTexelCopyBufferLayout, GPUQueueMethods, GPUSize64,
 };
 use crate::dom::bindings::codegen::UnionTypes::ArrayBufferViewOrArrayBuffer as BufferSource;
 use crate::dom::bindings::error::{Error, Fallible};
@@ -169,7 +169,7 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
         &self,
         destination: &GPUImageCopyTexture,
         data: BufferSource,
-        data_layout: &GPUImageDataLayout,
+        data_layout: &GPUTexelCopyBufferLayout,
         size: GPUExtent3D,
     ) -> Fallible<()> {
         let (bytes, len) = match data {

--- a/components/script/dom/webgpu/gpuqueue.rs
+++ b/components/script/dom/webgpu/gpuqueue.rs
@@ -12,7 +12,7 @@ use webgpu_traits::{WebGPU, WebGPUQueue, WebGPURequest};
 
 use crate::conversions::{Convert, TryConvert};
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
-    GPUExtent3D, GPUImageCopyTexture, GPUTexelCopyBufferLayout, GPUQueueMethods, GPUSize64,
+    GPUExtent3D, GPUTexelCopyTextureInfo, GPUTexelCopyBufferLayout, GPUQueueMethods, GPUSize64,
 };
 use crate::dom::bindings::codegen::UnionTypes::ArrayBufferViewOrArrayBuffer as BufferSource;
 use crate::dom::bindings::error::{Error, Fallible};
@@ -167,7 +167,7 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuqueue-writetexture>
     fn WriteTexture(
         &self,
-        destination: &GPUImageCopyTexture,
+        destination: &GPUTexelCopyTextureInfo,
         data: BufferSource,
         data_layout: &GPUTexelCopyBufferLayout,
         size: GPUExtent3D,

--- a/components/script/dom/webgpu/gpuqueue.rs
+++ b/components/script/dom/webgpu/gpuqueue.rs
@@ -12,7 +12,7 @@ use webgpu_traits::{WebGPU, WebGPUQueue, WebGPURequest};
 
 use crate::conversions::{Convert, TryConvert};
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
-    GPUExtent3D, GPUTexelCopyTextureInfo, GPUTexelCopyBufferLayout, GPUQueueMethods, GPUSize64,
+    GPUExtent3D, GPUQueueMethods, GPUSize64, GPUTexelCopyBufferLayout, GPUTexelCopyTextureInfo,
 };
 use crate::dom::bindings::codegen::UnionTypes::ArrayBufferViewOrArrayBuffer as BufferSource;
 use crate::dom::bindings::error::{Error, Fallible};

--- a/components/script_bindings/webidls/WebGPU.webidl
+++ b/components/script_bindings/webidls/WebGPU.webidl
@@ -875,7 +875,7 @@ dictionary GPUTexelCopyTextureInfo {
     GPUTextureAspect aspect = "all";
 };
 
-dictionary GPUTexelCopyTextureInfoTagged : GPUTexelCopyTextureInfo {
+dictionary GPUCopyExternalImageDestInfo : GPUTexelCopyTextureInfo {
     //GPUPredefinedColorSpace colorSpace = "srgb"; //TODO
     boolean premultipliedAlpha = false;
 };
@@ -1125,7 +1125,7 @@ interface GPUQueue {
     //[Throws]
     //undefined copyExternalImageToTexture(
     //  GPUImageCopyExternalImage source,
-    //  GPUTexelCopyTextureInfoTagged destination,
+    //  GPUCopyExternalImageDestInfo destination,
     //  GPUExtent3D copySize);
 };
 GPUQueue includes GPUObjectBase;

--- a/components/script_bindings/webidls/WebGPU.webidl
+++ b/components/script_bindings/webidls/WebGPU.webidl
@@ -864,7 +864,7 @@ dictionary GPUTexelCopyBufferLayout {
     GPUSize32 rowsPerImage;
 };
 
-dictionary GPUImageCopyBuffer : GPUTexelCopyBufferLayout {
+dictionary GPUTexelCopyBufferInfo : GPUTexelCopyBufferLayout {
     required GPUBuffer buffer;
 };
 
@@ -909,14 +909,14 @@ interface GPUCommandEncoder {
 
     [Throws]
     undefined copyBufferToTexture(
-        GPUImageCopyBuffer source,
+        GPUTexelCopyBufferInfo source,
         GPUImageCopyTexture destination,
         GPUExtent3D copySize);
 
     [Throws]
     undefined copyTextureToBuffer(
         GPUImageCopyTexture source,
-        GPUImageCopyBuffer destination,
+        GPUTexelCopyBufferInfo destination,
         GPUExtent3D copySize);
 
     [Throws]

--- a/components/script_bindings/webidls/WebGPU.webidl
+++ b/components/script_bindings/webidls/WebGPU.webidl
@@ -868,14 +868,14 @@ dictionary GPUTexelCopyBufferInfo : GPUTexelCopyBufferLayout {
     required GPUBuffer buffer;
 };
 
-dictionary GPUImageCopyTexture {
+dictionary GPUTexelCopyTextureInfo {
     required GPUTexture texture;
     GPUIntegerCoordinate mipLevel = 0;
     GPUOrigin3D origin;
     GPUTextureAspect aspect = "all";
 };
 
-dictionary GPUImageCopyTextureTagged : GPUImageCopyTexture {
+dictionary GPUTexelCopyTextureInfoTagged : GPUTexelCopyTextureInfo {
     //GPUPredefinedColorSpace colorSpace = "srgb"; //TODO
     boolean premultipliedAlpha = false;
 };
@@ -910,25 +910,25 @@ interface GPUCommandEncoder {
     [Throws]
     undefined copyBufferToTexture(
         GPUTexelCopyBufferInfo source,
-        GPUImageCopyTexture destination,
+        GPUTexelCopyTextureInfo destination,
         GPUExtent3D copySize);
 
     [Throws]
     undefined copyTextureToBuffer(
-        GPUImageCopyTexture source,
+        GPUTexelCopyTextureInfo source,
         GPUTexelCopyBufferInfo destination,
         GPUExtent3D copySize);
 
     [Throws]
     undefined copyTextureToTexture(
-        GPUImageCopyTexture source,
-        GPUImageCopyTexture destination,
+        GPUTexelCopyTextureInfo source,
+        GPUTexelCopyTextureInfo destination,
         GPUExtent3D copySize);
 
     /*
     undefined copyImageBitmapToTexture(
         GPUImageBitmapCopyView source,
-        GPUImageCopyTexture destination,
+        GPUTexelCopyTextureInfo destination,
         GPUExtent3D copySize);
     */
 
@@ -1117,7 +1117,7 @@ interface GPUQueue {
 
     [Throws]
     undefined writeTexture(
-      GPUImageCopyTexture destination,
+      GPUTexelCopyTextureInfo destination,
       BufferSource data,
       GPUTexelCopyBufferLayout dataLayout,
       GPUExtent3D size);
@@ -1125,7 +1125,7 @@ interface GPUQueue {
     //[Throws]
     //undefined copyExternalImageToTexture(
     //  GPUImageCopyExternalImage source,
-    //  GPUImageCopyTextureTagged destination,
+    //  GPUTexelCopyTextureInfoTagged destination,
     //  GPUExtent3D copySize);
 };
 GPUQueue includes GPUObjectBase;

--- a/components/script_bindings/webidls/WebGPU.webidl
+++ b/components/script_bindings/webidls/WebGPU.webidl
@@ -858,13 +858,13 @@ dictionary GPUVertexAttribute {
     required GPUIndex32 shaderLocation;
 };
 
-dictionary GPUImageDataLayout {
+dictionary GPUTexelCopyBufferLayout {
     GPUSize64 offset = 0;
     GPUSize32 bytesPerRow;
     GPUSize32 rowsPerImage;
 };
 
-dictionary GPUImageCopyBuffer : GPUImageDataLayout {
+dictionary GPUImageCopyBuffer : GPUTexelCopyBufferLayout {
     required GPUBuffer buffer;
 };
 
@@ -1119,7 +1119,7 @@ interface GPUQueue {
     undefined writeTexture(
       GPUImageCopyTexture destination,
       BufferSource data,
-      GPUImageDataLayout dataLayout,
+      GPUTexelCopyBufferLayout dataLayout,
       GPUExtent3D size);
 
     //[Throws]

--- a/components/script_bindings/webidls/WebGPU.webidl
+++ b/components/script_bindings/webidls/WebGPU.webidl
@@ -896,9 +896,9 @@ dictionary GPUCommandBufferDescriptor : GPUObjectDescriptorBase {
 
 [Exposed=(Window, Worker), SecureContext, Pref="dom_webgpu_enabled"]
 interface GPUCommandEncoder {
-    GPUComputePassEncoder beginComputePass(optional GPUComputePassDescriptor descriptor = {});
     [Throws]
     GPURenderPassEncoder beginRenderPass(GPURenderPassDescriptor descriptor);
+    GPUComputePassEncoder beginComputePass(optional GPUComputePassDescriptor descriptor = {});
 
     undefined copyBufferToBuffer(
         GPUBuffer source,


### PR DESCRIPTION
The spec and wgpu did the renames two years ago and we are doing them now. Reviewable per commit.

Testing: No functional change (renames are internal to engine to better match the spec and wgpu), but I did WebGPU CTS run anyway: https://github.com/sagudev/servo/actions/runs/26769139889
