### PR TITLE
canvas: Batch `Canvas2dMsg`; base: Add `GenericBufferedSender`

### DIFF
--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -290,6 +290,11 @@ impl CanvasPaintThread {
                 self.canvas(canvas_id).update_image_rendering(canvas_epoch);
             },
             CanvasCommand::PopClips(clips) => self.canvas(canvas_id).pop_clips(clips),
+            CanvasCommand::ProcessBatchMessages(messages) => {
+                for message in messages {
+                    self.process_command(message, canvas_id);
+                }
+            },
         }
     }
 

--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -304,10 +304,11 @@ impl CanvasState {
     /// into a single `ProcessBatchMessages` to preserve ordering and avoid
     /// two separate sends.
     pub(super) fn send_canvas_command_immediate(&self, msg: CanvasCommand) {
-        self.buffered_sender.send_immediate(msg).unwrap();
         if !self.is_paintable() {
+            self.buffered_sender.flush().unwrap();
             return;
         }
+        self.buffered_sender.send_immediate(msg).unwrap();
     }
 
     /// Updates WR image and blocks on completion

--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -273,6 +273,7 @@ impl CanvasState {
     }
 
     pub(super) fn set_image_key(&self, image_key: ImageKey) {
+        // Flushing is not required for correctness, but optimization heuristics for heavy command.
         self.send_canvas_command_immediate(CanvasCommand::SetImageKey(image_key));
     }
 
@@ -328,7 +329,7 @@ impl CanvasState {
 
         // Step 2. Resize the output bitmap to the new width and height.
         self.size.replace(adjust_canvas_size(size));
-
+        // Flushing is not required for correctness, but optimization heuristics for heavy command.
         self.send_canvas_command_immediate(CanvasCommand::Recreate(Some(self.size.get())));
     }
 
@@ -341,7 +342,7 @@ impl CanvasState {
         }
 
         // Step 1. Clear canvas's bitmap to transparent black.
-
+        // Flushing is not required for correctness, but optimization heuristics for heavy command.
         self.send_canvas_command_immediate(CanvasCommand::Recreate(None));
     }
 
@@ -1976,6 +1977,7 @@ impl CanvasState {
 
         // Step 7.
         let snapshot = imagedata.get_snapshot_rect(Rect::new(src_rect.origin, dst_rect.size));
+        // Flushing is not required for correctness, but optimization heuristics for heavy command.
         self.send_canvas_command_immediate(CanvasCommand::PutImageData(
             dst_rect,
             snapshot.to_shared(),

--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -23,7 +23,7 @@ use net_traits::request::CorsSettings;
 use pixels::{Snapshot, SnapshotAlphaMode, SnapshotPixelFormat};
 use script_bindings::cell::DomRefCell;
 use servo_arc::Arc as ServoArc;
-use servo_base::generic_channel::GenericSender;
+use servo_base::generic_channel::GenericBufferedSender;
 use servo_base::{Epoch, generic_channel};
 use servo_canvas_traits::canvas::{
     CanvasCommand, CanvasFont, CanvasId, CanvasMsg, CompositionOptions, CompositionOrBlending,
@@ -82,6 +82,10 @@ use crate::script_runtime::CanGc;
 
 const HANGING_BASELINE_DEFAULT: f64 = 0.8;
 const IDEOGRAPHIC_BASELINE_DEFAULT: f64 = 0.5;
+/// Maximum number of buffered canvas commands before an automatic flush is triggered.
+/// A lower value keeps the paint thread fed with work (better parallelism),
+/// while a higher value improves batching efficiency (fewer channel operations, lower power).
+const BUFFER_SIZE: usize = 16;
 
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 #[derive(Clone, JSTraceable, MallocSizeOf)]
@@ -197,8 +201,6 @@ impl CanvasContextState {
 #[derive(JSTraceable, MallocSizeOf)]
 pub(super) struct CanvasState {
     #[no_trace]
-    canvas_thread_sender: GenericSender<CanvasMsg>,
-    #[no_trace]
     canvas_id: CanvasId,
     #[no_trace]
     size: Cell<Size2D<u64>>,
@@ -220,6 +222,10 @@ pub(super) struct CanvasState {
     /// <https://html.spec.whatwg.org/multipage/#current-default-path>
     #[no_trace]
     current_default_path: DomRefCell<Path>,
+    /// Buffered sender for batching canvas commands.
+    #[ignore_malloc_size_of = "GenericBufferedSender"]
+    #[no_trace]
+    pub(super) buffered_sender: GenericBufferedSender<CanvasMsg, CanvasCommand>,
 }
 
 impl CanvasState {
@@ -246,7 +252,6 @@ impl CanvasState {
             global.origin().immutable().clone()
         };
         Some(CanvasState {
-            canvas_thread_sender,
             canvas_id,
             size: Cell::new(size),
             state: DomRefCell::new(CanvasContextState::new()),
@@ -257,11 +262,16 @@ impl CanvasState {
             saved_states: DomRefCell::new(Vec::new()),
             origin,
             current_default_path: DomRefCell::new(Path::new()),
+            buffered_sender: GenericBufferedSender::new(
+                canvas_thread_sender,
+                Box::new(move |cmds| (canvas_id, CanvasCommand::ProcessBatchMessages(cmds))),
+                BUFFER_SIZE,
+            ),
         })
     }
 
     pub(super) fn set_image_key(&self, image_key: ImageKey) {
-        self.send_canvas_command(CanvasCommand::SetImageKey(image_key));
+        self.send_canvas_command_immediate(CanvasCommand::SetImageKey(image_key));
     }
 
     pub(super) fn get_missing_image_urls(&self) -> &DomRefCell<Vec<ServoUrl>> {
@@ -284,10 +294,18 @@ impl CanvasState {
         if !self.is_paintable() {
             return;
         }
+        self.buffered_sender.send(msg).unwrap();
+    }
 
-        self.canvas_thread_sender
-            .send((self.get_canvas_id(), msg))
-            .unwrap()
+    /// Send a canvas command immediately.
+    /// If there are buffered commands, they are combined with this message
+    /// into a single `ProcessBatchMessages` to preserve ordering and avoid
+    /// two separate sends.
+    pub(super) fn send_canvas_command_immediate(&self, msg: CanvasCommand) {
+        if !self.is_paintable() {
+            return;
+        }
+        self.buffered_sender.send_immediate(msg).unwrap();
     }
 
     /// Updates WR image and blocks on completion
@@ -296,12 +314,7 @@ impl CanvasState {
             return false;
         }
 
-        self.canvas_thread_sender
-            .send((
-                self.get_canvas_id(),
-                CanvasCommand::UpdateImage(canvas_epoch),
-            ))
-            .unwrap();
+        self.send_canvas_command_immediate(CanvasCommand::UpdateImage(canvas_epoch));
         true
     }
 
@@ -313,12 +326,7 @@ impl CanvasState {
         // Step 2. Resize the output bitmap to the new width and height.
         self.size.replace(adjust_canvas_size(size));
 
-        self.canvas_thread_sender
-            .send((
-                self.get_canvas_id(),
-                CanvasCommand::Recreate(Some(self.size.get())),
-            ))
-            .unwrap();
+        self.send_canvas_command_immediate(CanvasCommand::Recreate(Some(self.size.get())));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#reset-the-rendering-context-to-its-default-state>
@@ -330,9 +338,8 @@ impl CanvasState {
         }
 
         // Step 1. Clear canvas's bitmap to transparent black.
-        self.canvas_thread_sender
-            .send((self.get_canvas_id(), CanvasCommand::Recreate(None)))
-            .unwrap();
+
+        self.send_canvas_command_immediate(CanvasCommand::Recreate(None));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#reset-the-rendering-context-to-its-default-state>
@@ -683,7 +690,8 @@ impl CanvasState {
         if let Some(context) = canvas.context() {
             match *context {
                 OffscreenRenderingContext::Context2d(ref context) => {
-                    context.send_canvas_command(CanvasCommand::DrawImageInOther(
+                    self.buffered_sender.flush().unwrap();
+                    context.send_canvas_command_immediate(CanvasCommand::DrawImageInOther(
                         self.get_canvas_id(),
                         dest_rect,
                         source_rect,
@@ -793,7 +801,8 @@ impl CanvasState {
         if let Some(context) = canvas.context() {
             match *context {
                 RenderingContext::Context2d(ref context) => {
-                    context.send_canvas_command(CanvasCommand::DrawImageInOther(
+                    self.buffered_sender.flush().unwrap();
+                    context.send_canvas_command_immediate(CanvasCommand::DrawImageInOther(
                         self.get_canvas_id(),
                         dest_rect,
                         source_rect,
@@ -823,8 +832,9 @@ impl CanvasState {
                         return Err(Error::InvalidState(None));
                     };
                     match *context {
-                        OffscreenRenderingContext::Context2d(ref context) => context
-                            .send_canvas_command(CanvasCommand::DrawImageInOther(
+                        OffscreenRenderingContext::Context2d(ref context) => {
+                            self.buffered_sender.flush().unwrap();
+                            context.send_canvas_command_immediate(CanvasCommand::DrawImageInOther(
                                 self.get_canvas_id(),
                                 dest_rect,
                                 source_rect,
@@ -832,7 +842,8 @@ impl CanvasState {
                                 self.state.borrow().shadow_options(),
                                 self.state.borrow().composition_options(),
                                 self.state.borrow().transform,
-                            )),
+                            ));
+                        },
                         OffscreenRenderingContext::BitmapRenderer(ref context) => {
                             let Some(snapshot) = context.get_image_data() else {
                                 return Ok(());
@@ -1869,7 +1880,10 @@ impl CanvasState {
 
         let data = if self.is_paintable() {
             let (sender, receiver) = generic_channel::channel().unwrap();
-            self.send_canvas_command(CanvasCommand::GetImageData(Some(read_rect), sender));
+            self.send_canvas_command_immediate(CanvasCommand::GetImageData(
+                Some(read_rect),
+                sender,
+            ));
 
             let mut snapshot = receiver.recv().unwrap().to_owned();
             snapshot.transform(
@@ -1959,7 +1973,10 @@ impl CanvasState {
 
         // Step 7.
         let snapshot = imagedata.get_snapshot_rect(Rect::new(src_rect.origin, dst_rect.size));
-        self.send_canvas_command(CanvasCommand::PutImageData(dst_rect, snapshot.to_shared()));
+        self.send_canvas_command_immediate(CanvasCommand::PutImageData(
+            dst_rect,
+            snapshot.to_shared(),
+        ));
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-drawimage
@@ -2513,10 +2530,8 @@ impl CanvasState {
 
 impl Drop for CanvasState {
     fn drop(&mut self) {
-        if let Err(err) = self
-            .canvas_thread_sender
-            .send((self.canvas_id, CanvasCommand::Destroy))
-        {
+        // Flush any buffered commands before closing the canvas.
+        if let Err(err) = self.buffered_sender.send_immediate(CanvasCommand::Destroy) {
             warn!("Could not close canvas: {}", err)
         }
     }

--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -85,6 +85,8 @@ const IDEOGRAPHIC_BASELINE_DEFAULT: f64 = 0.5;
 /// Maximum number of buffered canvas commands before an automatic flush is triggered.
 /// A lower value keeps the paint thread fed with work (better parallelism),
 /// while a higher value improves batching efficiency (fewer channel operations, lower power).
+///
+/// See https://github.com/servo/servo/pull/45301 for measurements.
 const BUFFER_SIZE: usize = 16;
 
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]

--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -86,7 +86,7 @@ const IDEOGRAPHIC_BASELINE_DEFAULT: f64 = 0.5;
 /// A lower value keeps the paint thread fed with work (better parallelism),
 /// while a higher value improves batching efficiency (fewer channel operations, lower power).
 ///
-/// See https://github.com/servo/servo/pull/45301 for measurements.
+/// See <https://github.com/servo/servo/pull/45301> for measurements.
 const BUFFER_SIZE: usize = 16;
 
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
@@ -306,9 +306,9 @@ impl CanvasState {
     pub(super) fn send_canvas_command_immediate(&self, msg: CanvasCommand) {
         if !self.is_paintable() {
             self.buffered_sender.flush().unwrap();
-            return;
+        } else {
+            self.buffered_sender.send_immediate(msg).unwrap();
         }
-        self.buffered_sender.send_immediate(msg).unwrap();
     }
 
     /// Updates WR image and blocks on completion

--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -302,10 +302,10 @@ impl CanvasState {
     /// into a single `ProcessBatchMessages` to preserve ordering and avoid
     /// two separate sends.
     pub(super) fn send_canvas_command_immediate(&self, msg: CanvasCommand) {
+        self.buffered_sender.send_immediate(msg).unwrap();
         if !self.is_paintable() {
             return;
         }
-        self.buffered_sender.send_immediate(msg).unwrap();
     }
 
     /// Updates WR image and blocks on completion

--- a/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
@@ -110,6 +110,10 @@ impl CanvasRenderingContext2D {
         self.canvas_state.send_canvas_command(msg)
     }
 
+    pub(crate) fn send_canvas_command_immediate(&self, msg: CanvasCommand) {
+        self.canvas_state.send_canvas_command_immediate(msg)
+    }
+
     pub(crate) fn set_image_key(&self, image_key: ImageKey) {
         self.canvas_state.set_image_key(image_key);
     }
@@ -149,7 +153,7 @@ impl CanvasContext for CanvasRenderingContext2D {
 
         let (sender, receiver) = generic_channel::channel().unwrap();
         self.canvas_state
-            .send_canvas_command(CanvasCommand::GetImageData(None, sender));
+            .send_canvas_command_immediate(CanvasCommand::GetImageData(None, sender));
         Some(receiver.recv().unwrap().to_owned())
     }
 

--- a/components/script/dom/canvas/2d/offscreencanvasrenderingcontext2d.rs
+++ b/components/script/dom/canvas/2d/offscreencanvasrenderingcontext2d.rs
@@ -70,8 +70,8 @@ impl OffscreenCanvasRenderingContext2D {
         })
     }
 
-    pub(crate) fn send_canvas_command(&self, msg: CanvasCommand) {
-        self.context.send_canvas_command(msg)
+    pub(crate) fn send_canvas_command_immediate(&self, msg: CanvasCommand) {
+        self.context.send_canvas_command_immediate(msg)
     }
 }
 

--- a/components/shared/base/generic_channel/buffered.rs
+++ b/components/shared/base/generic_channel/buffered.rs
@@ -1,0 +1,110 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::cell::RefCell;
+use std::mem;
+
+use serde::Serialize;
+
+use super::{GenericSender, SendResult};
+
+/// A buffered sender that collects individual messages (`U`) and sends them
+/// as a single batched message (`T`) via a user-provided packing closure.
+///
+/// The buffer is flushed automatically when it reaches `max_buffer` items,
+/// or explicitly via [`flush`](GenericBufferedSender::flush).
+/// [`send_immediate`](GenericBufferedSender::send_immediate)
+/// combines the current buffer contents with the new message into a single
+/// packed message, ensuring ordering without an extra flush step.
+pub struct GenericBufferedSender<T, U>
+where
+    T: Serialize,
+{
+    sender: GenericSender<T>,
+    buffer: RefCell<Vec<U>>,
+    buffering: Box<dyn Fn(Vec<U>) -> T>,
+    max_buffer: usize,
+}
+
+impl<T: Serialize, U> GenericBufferedSender<T, U> {
+    /// Create a new buffered sender.
+    ///
+    /// * `sender` — the underlying `GenericSender<T>` that delivers packed messages.
+    /// * `buffering` — closure that packs a `Vec<U>` into a single `T`.
+    /// * `max_buffer` — automatic flush is triggered when the buffer reaches this size.
+    pub fn new(
+        sender: GenericSender<T>,
+        buffering: Box<dyn Fn(Vec<U>) -> T>,
+        max_buffer: usize,
+    ) -> Self {
+        Self {
+            sender,
+            buffer: RefCell::new(Vec::new()),
+            buffering,
+            max_buffer,
+        }
+    }
+
+    /// Returns `true` if the buffer contains no pending messages.
+    pub fn is_empty(&self) -> bool {
+        self.buffer.borrow().is_empty()
+    }
+
+    /// Returns the number of pending messages in the buffer.
+    pub fn len(&self) -> usize {
+        self.buffer.borrow().len()
+    }
+
+    /// Change the auto-flush threshold.
+    pub fn set_max_buffer(&mut self, max: usize) {
+        self.max_buffer = max;
+    }
+
+    /// Buffer a message for later batched delivery.
+    ///
+    /// If the buffer reaches `max_buffer` items an automatic flush is triggered.
+    pub fn send(&self, msg: U) -> SendResult {
+        if self.buffer.borrow().len() + 1 >= self.max_buffer {
+            self.send_immediate(msg)
+        } else {
+            self.buffer.borrow_mut().push(msg);
+            Ok(())
+        }
+    }
+
+    /// Deliver a message immediately, combining it with any
+    /// buffered messages into a single packed `T`.
+    pub fn send_immediate(&self, msg: U) -> SendResult {
+        let mut buffer = self.buffer.borrow_mut();
+        buffer.push(msg);
+        let msgs = mem::take(&mut *buffer);
+        drop(buffer);
+        let packed = (self.buffering)(msgs);
+        self.sender.send(packed)
+    }
+
+    /// Flush all buffered messages by packing them into a single `T` and
+    /// sending it.
+    pub fn flush(&self) -> SendResult {
+        let mut buffer = self.buffer.borrow_mut();
+        if buffer.is_empty() {
+            return Ok(());
+        }
+        let msgs = mem::take(&mut *buffer);
+        drop(buffer);
+        let packed = (self.buffering)(msgs);
+        self.sender.send(packed)
+    }
+}
+
+impl<T: Serialize, U> Drop for GenericBufferedSender<T, U> {
+    fn drop(&mut self) {
+        // Best-effort flush on drop. Ignore send failures.
+        if !self.buffer.borrow().is_empty() {
+            let msgs = mem::take(&mut *self.buffer.borrow_mut());
+            let packed = (self.buffering)(msgs);
+            let _ = self.sender.send(packed);
+        }
+    }
+}

--- a/components/shared/base/generic_channel/mod.rs
+++ b/components/shared/base/generic_channel/mod.rs
@@ -29,6 +29,8 @@ pub use oneshot::{GenericOneshotReceiver, GenericOneshotSender, oneshot};
 pub use shared_memory::GenericSharedMemory;
 mod generic_channelset;
 pub use generic_channelset::{GenericReceiverSet, GenericSelectionResult};
+mod buffered;
+pub use buffered::GenericBufferedSender;
 
 /// Cache for being in Ipc Mode
 static USE_IPC: OnceLock<bool> = OnceLock::new();

--- a/components/shared/canvas/canvas.rs
+++ b/components/shared/canvas/canvas.rs
@@ -526,6 +526,7 @@ pub enum CanvasCommand {
         Transform2D<f64>,
     ),
     UpdateImage(Option<Epoch>),
+    ProcessBatchMessages(Vec<CanvasCommand>),
 }
 
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]


### PR DESCRIPTION
This reduces the power per frame by 23% on ohos, when using batch size 16 + smallvec.
This is measured as the power of entire device, so actual reduction is huge.

There is a tradeoff between FPS and power consumption:
For example in #45199,
Buffer size is chosen to be 16 after tested with several params, as avg 
FPS would reduce by about 0.5, for every double of the size.
Power consumption also greatly reduced.


| Buffer | no-cache | 8 | 16 | 128 | 16 smallvec |
| :--- | :--- | :--- | :--- | :--- | :--- |
| FPS | 32.55 | 31.5 | 31.23 | 28.7 | 31.57 |
| power | 1138.95 | 1001.8 | 910.4 | 651 | 897.27 |
| power/frame | 34.97052993 | 31.78626678 | 29.12337385 | 22.68835034 | 28.4133 |

mate 60 Pro, measured with 1 minute, each repeated 3 times and averaged. Power is measured when plugged in with 100% battery.

This reduces Canvas2dMsg per frame from 333 to 21.

We also add `GenericBufferedSender`.

Testing: Covered by existing tests. Many of the flushes are needed to ensure correctness.

Part of #45199