### PR TITLE
generic channel: Add `send_warn` / `send_ignore` helpers

### DIFF
--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -533,9 +533,7 @@ impl ResourceChannelManager {
             CoreResourceMsg::GetCookieStringForUrl(url, consumer, source) => {
                 let mut cookie_jar = http_state.cookie_jar.write();
                 cookie_jar.remove_expired_cookies_for_url(&url);
-                consumer
-                    .send(cookie_jar.cookies_for_url(&url, source))
-                    .unwrap();
+                consumer.send_ignore(cookie_jar.cookies_for_url(&url, source));
             },
             CoreResourceMsg::GetCookiesForUrl(url, consumer, source) => {
                 let mut cookie_jar = http_state.cookie_jar.write();
@@ -544,7 +542,7 @@ impl ResourceChannelManager {
                     .cookies_data_for_url(&url, source)
                     .map(Serde)
                     .collect();
-                consumer.send(cookies).unwrap();
+                consumer.send_ignore(cookies);
             },
             CoreResourceMsg::GetCookieDataForUrlAsync(cookie_store_id, url, name) => {
                 let mut cookie_jar = http_state.cookie_jar.write();
@@ -622,13 +620,11 @@ impl ResourceChannelManager {
             CoreResourceMsg::ListCookies(sender) => {
                 let mut cookie_jar = http_state.cookie_jar.write();
                 cookie_jar.remove_all_expired_cookies();
-                let _ = sender.send(cookie_jar.cookie_site_descriptors());
+                sender.send_ignore(cookie_jar.cookie_site_descriptors());
             },
             CoreResourceMsg::GetHistoryState(history_state_id, consumer) => {
                 let history_states = http_state.history_states.read();
-                consumer
-                    .send(history_states.get(&history_state_id).cloned())
-                    .unwrap();
+                consumer.send_ignore(history_states.get(&history_state_id).cloned());
             },
             CoreResourceMsg::SetHistoryState(history_state_id, structured_data) => {
                 let mut history_states = http_state.history_states.write();
@@ -641,12 +637,12 @@ impl ResourceChannelManager {
                 }
             },
             CoreResourceMsg::GetCacheEntries(sender) => {
-                let _ = sender.send(http_state.http_cache.cache_entry_descriptors());
+                sender.send_ignore(http_state.http_cache.cache_entry_descriptors());
             },
             CoreResourceMsg::ClearCache(sender) => {
                 http_state.http_cache.clear();
                 if let Some(sender) = sender {
-                    let _ = sender.send(());
+                    sender.send_ignore(());
                 }
             },
             CoreResourceMsg::ToFileManager(msg) => self.resource_manager.filemanager.handle(msg),
@@ -666,7 +662,7 @@ impl ResourceChannelManager {
                             .sum()
                     })
                     .unwrap_or_default();
-                let _ = sender.send(total);
+                sender.send_ignore(total);
             },
             CoreResourceMsg::Exit(sender) => {
                 if let Some(ref config_dir) = self.config_dir {

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -533,7 +533,7 @@ impl ResourceChannelManager {
             CoreResourceMsg::GetCookieStringForUrl(url, consumer, source) => {
                 let mut cookie_jar = http_state.cookie_jar.write();
                 cookie_jar.remove_expired_cookies_for_url(&url);
-                consumer.send_ignore(cookie_jar.cookies_for_url(&url, source));
+                consumer.send_or_ignore(cookie_jar.cookies_for_url(&url, source));
             },
             CoreResourceMsg::GetCookiesForUrl(url, consumer, source) => {
                 let mut cookie_jar = http_state.cookie_jar.write();
@@ -542,7 +542,7 @@ impl ResourceChannelManager {
                     .cookies_data_for_url(&url, source)
                     .map(Serde)
                     .collect();
-                consumer.send_ignore(cookies);
+                consumer.send_or_ignore(cookies);
             },
             CoreResourceMsg::GetCookieDataForUrlAsync(cookie_store_id, url, name) => {
                 let mut cookie_jar = http_state.cookie_jar.write();
@@ -620,11 +620,11 @@ impl ResourceChannelManager {
             CoreResourceMsg::ListCookies(sender) => {
                 let mut cookie_jar = http_state.cookie_jar.write();
                 cookie_jar.remove_all_expired_cookies();
-                sender.send_ignore(cookie_jar.cookie_site_descriptors());
+                sender.send_or_ignore(cookie_jar.cookie_site_descriptors());
             },
             CoreResourceMsg::GetHistoryState(history_state_id, consumer) => {
                 let history_states = http_state.history_states.read();
-                consumer.send_ignore(history_states.get(&history_state_id).cloned());
+                consumer.send_or_ignore(history_states.get(&history_state_id).cloned());
             },
             CoreResourceMsg::SetHistoryState(history_state_id, structured_data) => {
                 let mut history_states = http_state.history_states.write();
@@ -637,12 +637,12 @@ impl ResourceChannelManager {
                 }
             },
             CoreResourceMsg::GetCacheEntries(sender) => {
-                sender.send_ignore(http_state.http_cache.cache_entry_descriptors());
+                sender.send_or_ignore(http_state.http_cache.cache_entry_descriptors());
             },
             CoreResourceMsg::ClearCache(sender) => {
                 http_state.http_cache.clear();
                 if let Some(sender) = sender {
-                    sender.send_ignore(());
+                    sender.send_or_ignore(());
                 }
             },
             CoreResourceMsg::ToFileManager(msg) => self.resource_manager.filemanager.handle(msg),
@@ -662,7 +662,7 @@ impl ResourceChannelManager {
                             .sum()
                     })
                     .unwrap_or_default();
-                sender.send_ignore(total);
+                sender.send_or_ignore(total);
             },
             CoreResourceMsg::Exit(sender) => {
                 if let Some(ref config_dir) = self.config_dir {

--- a/components/shared/base/generic_channel/buffered.rs
+++ b/components/shared/base/generic_channel/buffered.rs
@@ -4,6 +4,7 @@
 
 use std::cell::RefCell;
 use std::mem;
+use std::panic::Location;
 
 use serde::Serialize;
 
@@ -73,6 +74,19 @@ impl<T: Serialize, U> GenericBufferedSender<T, U> {
         }
     }
 
+    #[inline]
+    #[track_caller]
+    /// Buffer a message for later batched delivery.
+    ///
+    /// If the buffer reaches `max_buffer` items an automatic flush is triggered.
+    /// Errors on automatic flush are logged.
+    pub fn send_or_warn(&self, msg: U) {
+        if let Err(error) = self.send(msg) {
+            let location = Location::caller();
+            log::warn!("Failed to send buffered messages due to `{error}` at {location:?}");
+        }
+    }
+
     /// Deliver a message immediately, combining it with any
     /// buffered messages into a single packed `T`.
     pub fn send_immediate(&self, msg: U) -> SendResult {
@@ -82,6 +96,21 @@ impl<T: Serialize, U> GenericBufferedSender<T, U> {
         drop(buffer);
         let packed = (self.buffering)(msgs);
         self.sender.send(packed)
+    }
+
+    #[inline]
+    #[track_caller]
+    /// Deliver a message immediately, combining it with any
+    /// buffered messages into a single packed `T`.
+    ///
+    /// Errors are logged.
+    pub fn send_immediate_or_warn(&self, msg: U) {
+        if let Err(error) = self.send_immediate(msg) {
+            let location = Location::caller();
+            log::warn!(
+                "Failed to send (immediate) buffered messages due to `{error}` at {location:?}"
+            );
+        }
     }
 
     /// Flush all buffered messages by packing them into a single `T` and
@@ -95,6 +124,17 @@ impl<T: Serialize, U> GenericBufferedSender<T, U> {
         drop(buffer);
         let packed = (self.buffering)(msgs);
         self.sender.send(packed)
+    }
+
+    #[inline]
+    #[track_caller]
+    /// Flush all buffered messages by packing them into a single `T` and sending it.
+    /// Errors are logged
+    pub fn flush_or_warn(&self) {
+        if let Err(error) = self.flush() {
+            let location = Location::caller();
+            log::warn!("Failed to flush buffered messages due to `{error}` at {location:?}");
+        }
     }
 }
 

--- a/components/shared/base/generic_channel/mod.rs
+++ b/components/shared/base/generic_channel/mod.rs
@@ -7,6 +7,7 @@
 use std::fmt;
 use std::fmt::Display;
 use std::marker::PhantomData;
+use std::panic::Location;
 use std::sync::OnceLock;
 use std::time::Duration;
 
@@ -55,9 +56,11 @@ where
     ///
     /// In cases where channel closure is possible (because the receiver does not exist anymore),
     /// this convenience method can be used to ignore the result and log the error as a warning.
-    fn send_or_warn(&self, message: T, error_context: &str) {
+    #[track_caller]
+    fn send_or_warn(&self, message: T) {
         if let Err(error) = self.send(message) {
-            log::warn!("{error_context}: {error}");
+            let location = Location::caller();
+            log::warn!("Failed to send msg due to `{error}` at {location:?}");
         }
     }
 
@@ -233,9 +236,10 @@ impl<T: Serialize> GenericSender<T> {
     /// In cases where channel closure is possible (because the receiver does not exist anymore),
     /// this convenience method can be used to ignore the result and log the error as a warning.
     #[inline]
-    pub fn send_or_warn(&self, msg: T, error_context: &str) {
+    pub fn send_or_warn(&self, msg: T) {
         if let Err(error) = self.send(msg) {
-            log::warn!("{error_context}: {error}");
+            let location = Location::caller();
+            log::warn!("Failed to send msg due to `{error}` at {location:?}");
         }
     }
 

--- a/components/shared/base/generic_channel/mod.rs
+++ b/components/shared/base/generic_channel/mod.rs
@@ -50,6 +50,26 @@ where
 {
     /// send message T
     fn send(&self, _: T) -> SendResult;
+
+    /// Send a message T and log any error (instead of returning it).
+    ///
+    /// In cases where channel closure is possible (because the receiver does not exist anymore),
+    /// this convenience method can be used to ignore the result and log the error as a warning.
+    fn send_warn(&self, message: T, error_context: &str) {
+        if let Err(error) = self.send(message) {
+            log::warn!("{error_context}: {error}");
+        }
+    }
+
+    /// Send a message T and ignore the result
+    ///
+    /// In cases where channel closure is expected to happen intermittently, and the sender
+    /// doesn't care about the result, this is a short form for `let _ = GenericSend::send();`,
+    /// which makes the intent clearer.
+    fn send_ignore(&self, message: T) {
+        let _ = self.send(message);
+    }
+
     /// get underlying sender
     fn sender(&self) -> GenericSender<T>;
 }
@@ -206,6 +226,27 @@ impl<T: Serialize> GenericSender<T> {
                 sender.send(Ok(msg)).map_err(|_| SendError::Disconnected)
             },
         }
+    }
+
+    /// Send a message T and log any error (instead of returning it).
+    ///
+    /// In cases where channel closure is possible (because the receiver does not exist anymore),
+    /// this convenience method can be used to ignore the result and log the error as a warning.
+    #[inline]
+    pub fn send_warn(&self, msg: T, error_context: &str) {
+        if let Err(error) = self.send(msg) {
+            log::warn!("{error_context}: {error}");
+        }
+    }
+
+    /// Send a message T and ignore the result
+    ///
+    /// In cases where channel closure is expected to happen intermittently, and the sender
+    /// doesn't care about the result, this is a short form for `let _ = GenericSender::send();`,
+    /// which makes the intent clearer.
+    #[inline]
+    pub fn send_ignore(&self, msg: T) {
+        let _ = self.send(msg);
     }
 }
 

--- a/components/shared/base/generic_channel/mod.rs
+++ b/components/shared/base/generic_channel/mod.rs
@@ -55,7 +55,7 @@ where
     ///
     /// In cases where channel closure is possible (because the receiver does not exist anymore),
     /// this convenience method can be used to ignore the result and log the error as a warning.
-    fn send_warn(&self, message: T, error_context: &str) {
+    fn send_or_warn(&self, message: T, error_context: &str) {
         if let Err(error) = self.send(message) {
             log::warn!("{error_context}: {error}");
         }
@@ -66,7 +66,7 @@ where
     /// In cases where channel closure is expected to happen intermittently, and the sender
     /// doesn't care about the result, this is a short form for `let _ = GenericSend::send();`,
     /// which makes the intent clearer.
-    fn send_ignore(&self, message: T) {
+    fn send_or_ignore(&self, message: T) {
         let _ = self.send(message);
     }
 
@@ -233,7 +233,7 @@ impl<T: Serialize> GenericSender<T> {
     /// In cases where channel closure is possible (because the receiver does not exist anymore),
     /// this convenience method can be used to ignore the result and log the error as a warning.
     #[inline]
-    pub fn send_warn(&self, msg: T, error_context: &str) {
+    pub fn send_or_warn(&self, msg: T, error_context: &str) {
         if let Err(error) = self.send(msg) {
             log::warn!("{error_context}: {error}");
         }
@@ -245,7 +245,7 @@ impl<T: Serialize> GenericSender<T> {
     /// doesn't care about the result, this is a short form for `let _ = GenericSender::send();`,
     /// which makes the intent clearer.
     #[inline]
-    pub fn send_ignore(&self, msg: T) {
+    pub fn send_or_ignore(&self, msg: T) {
         let _ = self.send(msg);
     }
 }

--- a/components/shared/base/generic_channel/oneshot.rs
+++ b/components/shared/base/generic_channel/oneshot.rs
@@ -4,6 +4,7 @@
 
 use std::fmt;
 use std::marker::PhantomData;
+use std::panic::Location;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -27,6 +28,22 @@ impl<T: Serialize> GenericOneshotSender<T> {
                 sender.send(Ok(msg)).map_err(|_| SendError::Disconnected)
             },
         }
+    }
+
+    #[inline]
+    #[track_caller]
+    /// Send a message across the channel or log a warning if it fails
+    pub fn send_or_warn(self, msg: T) {
+        if let Err(error) = self.send(msg) {
+            let location = Location::caller();
+            log::warn!("Failed to send msg due to `{error}` at {location:?}");
+        }
+    }
+
+    #[inline]
+    /// Send a message across the channel, ignoring the result.
+    pub fn send_or_ignore(self, msg: T) {
+        let _ = self.send(msg);
     }
 }
 

--- a/ports/servoshell/webdriver.rs
+++ b/ports/servoshell/webdriver.rs
@@ -147,10 +147,7 @@ impl RunningAppState {
                 },
                 WebDriverCommandMsg::IsWebViewOpen(webview_id, sender) => {
                     let context = self.webview_by_id(webview_id);
-
-                    if let Err(error) = sender.send(context.is_some()) {
-                        warn!("Failed to send response of IsWebViewOpen: {error}");
-                    }
+                    sender.send_or_warn(context.is_some());
                 },
                 WebDriverCommandMsg::IsBrowsingContextOpen(..) => {
                     self.servo().execute_webdriver_command(msg);


### PR DESCRIPTION
As part of tackling #40744, we should reduce the amount of `unwrap()` we do on send / receive operations, since channel closures can happen (think e.g. the user closes a tab / window, while some request was still in-flight).
Obviously it depends on the specific channel usage if this should be expected or not, but I believe there are many cases in servo where we currently unwrap, but shouldn't be. 
I'm thinking that adding helper functions like `send_warn`, might ease the transition, since it keeps the diff smaller and reduces the amount of boilerplate `if let Err(e) ....` or `.inspect_err()`. 
In cases where the channel being closed is fine `send_or_ignore` should probably be used, although when changing large parts of code perhaps defaulting to `send_or_warn` might be easier than figuring out if the warning message should be added or is just noise.

This PR is mainly a first example, to add APIs and get consuses. Porting can be done in focused follow-up PRs, perhaps as part of a less-complex issue.

Testing: This adds a helper method to ignore / log errors, which is something that can also be done manually already. Hence more of a refactor and no need for explicit tests.
