### PR TITLE
script: Return rejected promises from CredentialsContainer methods

### DIFF
--- a/components/script/dom/credentialmanagement/credentialscontainer.rs
+++ b/components/script/dom/credentialmanagement/credentialscontainer.rs
@@ -52,15 +52,21 @@ impl CredentialsContainer {
         assert!(global.is_secure_context());
         // Step 3. Let document be settings’s relevant global object's associated Document.
         let document = global.as_window().Document();
+
+        let p = Promise::new_in_realm(cx);
+        let can_gc = CanGc::from_cx(cx);
         // Step 4. If document is not fully active, then return a promise rejected with an "InvalidStateError" DOMException.
         if !document.is_fully_active() {
-            return Err(Error::InvalidState(None));
+            p.reject_error(Error::InvalidState(None), can_gc);
+            return Ok(p);
         }
         // Step 5. If options.signal is aborted, then return a promise rejected with options.signal’s abort reason.
         if options.signal.as_ref().is_some_and(|s| s.aborted()) {
-            return Err(Error::Abort(None));
+            p.reject_error(Error::Abort(None), can_gc);
+            return Ok(p);
         }
-        Err(Error::NotSupported(None))
+        p.reject_error(Error::NotSupported(None), can_gc);
+        Ok(p)
     }
 
     /// <https://www.w3.org/TR/credential-management-1/#abstract-opdef-store-a-credential>
@@ -73,11 +79,16 @@ impl CredentialsContainer {
         let global = GlobalScope::from_current_realm(cx);
         // Step 2. Assert: settings is a secure context.
         assert!(global.is_secure_context());
+
+        let p = Promise::new_in_realm(cx);
+        let can_gc = CanGc::from_cx(cx);
         // Step 3. If settings’s relevant global object's associated Document is not fully active, then return a promise rejected with an "InvalidStateError" DOMException.
         if !global.as_window().Document().is_fully_active() {
-            return Err(Error::InvalidState(None));
+            p.reject_error(Error::InvalidState(None), can_gc);
+            return Ok(p);
         }
-        Err(Error::NotSupported(None))
+        p.reject_error(Error::NotSupported(None), can_gc);
+        Ok(p)
     }
 
     /// <https://www.w3.org/TR/credential-management-1/#abstract-opdef-create-a-credential>
@@ -93,11 +104,16 @@ impl CredentialsContainer {
         // Step 3. Let global be settings’ global object.
         // Step 4. Let document be the relevant global object’s associated Document.
         let document = global.as_window().Document();
+
+        let p = Promise::new_in_realm(cx);
+        let can_gc = CanGc::from_cx(cx);
         // Step 5. If document is not fully active, then return a promise rejected with an "InvalidStateError" DOMException.
         if !document.is_fully_active() {
-            return Err(Error::InvalidState(None));
+            p.reject_error(Error::InvalidState(None), can_gc);
+            return Ok(p);
         }
-        Err(Error::NotSupported(None))
+        p.reject_error(Error::NotSupported(None), can_gc);
+        Ok(p)
     }
 }
 
@@ -126,7 +142,9 @@ impl CredentialsContainerMethods<DomTypeHolder> for CredentialsContainer {
     }
 
     /// <https://www.w3.org/TR/credential-management-1/#dom-credentialscontainer-preventsilentaccess>
-    fn PreventSilentAccess(&self) -> Fallible<Rc<Promise>> {
-        Err(Error::NotSupported(None))
+    fn PreventSilentAccess(&self, cx: &mut CurrentRealm) -> Fallible<Rc<Promise>> {
+        let p = Promise::new_in_realm(cx);
+        p.reject_error(Error::NotSupported(None), CanGc::from_cx(cx));
+        Ok(p)
     }
 }

--- a/components/script/dom/credentialmanagement/credentialscontainer.rs
+++ b/components/script/dom/credentialmanagement/credentialscontainer.rs
@@ -53,20 +53,20 @@ impl CredentialsContainer {
         // Step 3. Let document be settings’s relevant global object's associated Document.
         let document = global.as_window().Document();
 
-        let p = Promise::new_in_realm(cx);
+        let promise = Promise::new_in_realm(cx);
         let can_gc = CanGc::from_cx(cx);
         // Step 4. If document is not fully active, then return a promise rejected with an "InvalidStateError" DOMException.
         if !document.is_fully_active() {
-            p.reject_error(Error::InvalidState(None), can_gc);
-            return Ok(p);
+            promise.reject_error(Error::InvalidState(None), can_gc);
+            return Ok(promise);
         }
         // Step 5. If options.signal is aborted, then return a promise rejected with options.signal’s abort reason.
         if options.signal.as_ref().is_some_and(|s| s.aborted()) {
-            p.reject_error(Error::Abort(None), can_gc);
-            return Ok(p);
+            promise.reject_error(Error::Abort(None), can_gc);
+            return Ok(promise);
         }
-        p.reject_error(Error::NotSupported(None), can_gc);
-        Ok(p)
+        promise.reject_error(Error::NotSupported(None), can_gc);
+        Ok(promise)
     }
 
     /// <https://www.w3.org/TR/credential-management-1/#abstract-opdef-store-a-credential>
@@ -80,15 +80,15 @@ impl CredentialsContainer {
         // Step 2. Assert: settings is a secure context.
         assert!(global.is_secure_context());
 
-        let p = Promise::new_in_realm(cx);
+        let promise = Promise::new_in_realm(cx);
         let can_gc = CanGc::from_cx(cx);
         // Step 3. If settings’s relevant global object's associated Document is not fully active, then return a promise rejected with an "InvalidStateError" DOMException.
         if !global.as_window().Document().is_fully_active() {
-            p.reject_error(Error::InvalidState(None), can_gc);
-            return Ok(p);
+            promise.reject_error(Error::InvalidState(None), can_gc);
+            return Ok(promise);
         }
-        p.reject_error(Error::NotSupported(None), can_gc);
-        Ok(p)
+        promise.reject_error(Error::NotSupported(None), can_gc);
+        Ok(promise)
     }
 
     /// <https://www.w3.org/TR/credential-management-1/#abstract-opdef-create-a-credential>
@@ -105,15 +105,15 @@ impl CredentialsContainer {
         // Step 4. Let document be the relevant global object’s associated Document.
         let document = global.as_window().Document();
 
-        let p = Promise::new_in_realm(cx);
+        let promise = Promise::new_in_realm(cx);
         let can_gc = CanGc::from_cx(cx);
         // Step 5. If document is not fully active, then return a promise rejected with an "InvalidStateError" DOMException.
         if !document.is_fully_active() {
-            p.reject_error(Error::InvalidState(None), can_gc);
-            return Ok(p);
+            promise.reject_error(Error::InvalidState(None), can_gc);
+            return Ok(promise);
         }
-        p.reject_error(Error::NotSupported(None), can_gc);
-        Ok(p)
+        promise.reject_error(Error::NotSupported(None), can_gc);
+        Ok(promise)
     }
 }
 
@@ -143,8 +143,8 @@ impl CredentialsContainerMethods<DomTypeHolder> for CredentialsContainer {
 
     /// <https://www.w3.org/TR/credential-management-1/#dom-credentialscontainer-preventsilentaccess>
     fn PreventSilentAccess(&self, cx: &mut CurrentRealm) -> Fallible<Rc<Promise>> {
-        let p = Promise::new_in_realm(cx);
-        p.reject_error(Error::NotSupported(None), CanGc::from_cx(cx));
-        Ok(p)
+        let promise = Promise::new_in_realm(cx);
+        promise.reject_error(Error::NotSupported(None), CanGc::from_cx(cx));
+        Ok(promise)
     }
 }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -819,7 +819,7 @@ DOMInterfaces = {
 },
 
 'CredentialsContainer': {
-    'realm': ['Get', 'Store', 'Create'],
+    'realm': ['Get', 'Store', 'Create', 'PreventSilentAccess'],
 },
 
 'WakeLock': {


### PR DESCRIPTION
Currently CredentialsContainer methods throw exception synchronously whereas the spec requires it to return rejected promises. This PR fixes it.

Testing: It should be covered by existing tests.
Fixes: #44326 
