### PR TITLE
script: Introduce `Promise::reject_error_with_cx`

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -704,9 +704,9 @@ pub(crate) fn consume_body<T: BodyMixin + DomObject>(
 
     // If object is unusable, then return a promise rejected with a TypeError.
     if object.is_unusable() {
-        promise.reject_error(
+        promise.reject_error_with_cx(
+            cx,
             Error::Type(c"The body's stream is disturbed or locked".to_owned()),
-            CanGc::from_cx(cx),
         );
         return promise;
     }
@@ -751,7 +751,7 @@ pub(crate) fn consume_body<T: BodyMixin + DomObject>(
     let reader = match stream.acquire_default_reader(CanGc::from_cx(cx)) {
         Ok(r) => r,
         Err(e) => {
-            promise.reject_error(e, CanGc::from_cx(cx));
+            promise.reject_error_with_cx(cx, e);
             return promise;
         },
     };
@@ -813,7 +813,7 @@ fn resolve_result_promise(
                 },
             };
         },
-        Err(err) => promise.reject_error(err, CanGc::from_cx(cx)),
+        Err(err) => promise.reject_error_with_cx(cx, err),
     }
 }
 

--- a/components/script/dom/audio/audiocontext.rs
+++ b/components/script/dom/audio/audiocontext.rs
@@ -148,7 +148,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
 
         // Step 2.
         if self.context.control_thread_state() == ProcessingState::Closed {
-            promise.reject_error(Error::InvalidState(None), CanGc::from_cx(cx));
+            promise.reject_error_with_cx(cx, Error::InvalidState(None));
             return promise;
         }
 
@@ -188,7 +188,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
                     .dom_manipulation_task_source()
                     .queue(task!(suspend_error: move |cx| {
                         let promise = trusted_promise.root();
-                        promise.reject_error(Error::Type(c"Something went wrong".to_owned()), CanGc::from_cx(cx));
+                        promise.reject_error_with_cx(cx, Error::Type(c"Something went wrong".to_owned()));
                     }));
             },
         };
@@ -204,7 +204,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
 
         // Step 2.
         if self.context.control_thread_state() == ProcessingState::Closed {
-            promise.reject_error(Error::InvalidState(None), CanGc::from_cx(cx));
+            promise.reject_error_with_cx(cx, Error::InvalidState(None));
             return promise;
         }
 
@@ -244,7 +244,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
                     .dom_manipulation_task_source()
                     .queue(task!(suspend_error: move |cx| {
                         let promise = trusted_promise.root();
-                        promise.reject_error(Error::Type(c"Something went wrong".to_owned()), CanGc::from_cx(cx));
+                        promise.reject_error_with_cx(cx, Error::Type(c"Something went wrong".to_owned()));
                     }));
             },
         };

--- a/components/script/dom/audio/baseaudiocontext.rs
+++ b/components/script/dom/audio/baseaudiocontext.rs
@@ -559,7 +559,7 @@ impl BaseAudioContextMethods<crate::DomTypeHolder> for BaseAudioContext {
                             let _ = callback.Call__(cx, &exception, ExceptionHandling::Report);
                         }
                         let error = cformat!("Audio decode error {:?}", error);
-                        resolver.promise.reject_error(Error::Type(error), CanGc::from_cx(cx));
+                        resolver.promise.reject_error_with_cx(cx, Error::Type(error));
                     }));
                 })
                 .build();

--- a/components/script/dom/bindings/refcounted.rs
+++ b/components/script/dom/bindings/refcounted.rs
@@ -139,7 +139,7 @@ impl TrustedPromise {
         let this = self;
         task!(reject_promise: move |cx| {
             debug!("Rejecting promise.");
-            this.root().reject_error(error, CanGc::from_cx(cx));
+            this.root().reject_error_with_cx(cx, error);
         })
     }
 

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -327,7 +327,7 @@ impl BlobMethods<crate::DomTypeHolder> for Blob {
                     promise.resolve_native(&text, CanGc::from_cx(cx));
                 },
                 Err(e) => {
-                    promise.reject_error(e, CanGc::from_cx(cx));
+                    promise.reject_error_with_cx(cx, e);
                 },
             }),
         );
@@ -346,7 +346,7 @@ impl BlobMethods<crate::DomTypeHolder> for Blob {
         let reader = match stream.and_then(|s| s.acquire_default_reader(CanGc::from_cx(cx))) {
             Ok(reader) => reader,
             Err(error) => {
-                promise.reject_error(error, CanGc::from_cx(cx));
+                promise.reject_error_with_cx(cx, error);
                 return promise;
             },
         };
@@ -389,7 +389,7 @@ impl BlobMethods<crate::DomTypeHolder> for Blob {
         let reader = match stream.and_then(|s| s.acquire_default_reader(CanGc::from_cx(cx))) {
             Ok(r) => r,
             Err(e) => {
-                p.reject_error(e, CanGc::from_cx(cx));
+                p.reject_error_with_cx(cx, e);
                 return p;
             },
         };

--- a/components/script/dom/bluetooth/bluetooth.rs
+++ b/components/script/dom/bluetooth/bluetooth.rs
@@ -134,7 +134,7 @@ where
             Ok(response) => self.receiver.root().handle_response(cx, response, &promise),
             // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetooth-requestdevice
             // Step 3 - 4.
-            Err(error) => promise.reject_error(error.convert(), CanGc::from_cx(cx)),
+            Err(error) => promise.reject_error_with_cx(cx, error.convert()),
         }
     }
 }
@@ -183,7 +183,7 @@ impl Bluetooth {
         if let Some(filters) = filters {
             // Step 2.1.
             if filters.is_empty() {
-                p.reject_error(Type(FILTER_EMPTY_ERROR.to_owned()), CanGc::from_cx(cx));
+                p.reject_error_with_cx(cx, Type(FILTER_EMPTY_ERROR.to_owned()));
                 return;
             }
 
@@ -196,7 +196,7 @@ impl Bluetooth {
                     // Step 2.4.2.
                     Ok(f) => uuid_filters.push(f),
                     Err(e) => {
-                        p.reject_error(e, CanGc::from_cx(cx));
+                        p.reject_error_with_cx(cx, e);
                         return;
                     },
                 }
@@ -210,7 +210,7 @@ impl Bluetooth {
             let uuid = match BluetoothUUID::service(opt_service.clone()) {
                 Ok(u) => String::from(u),
                 Err(e) => {
-                    p.reject_error(e, CanGc::from_cx(cx));
+                    p.reject_error_with_cx(cx, e);
                     return;
                 },
             };
@@ -233,7 +233,7 @@ impl Bluetooth {
         if let PermissionState::Denied =
             descriptor_permission_state(PermissionName::Bluetooth, None)
         {
-            return p.reject_error(Error::NotFound(None), CanGc::from_cx(cx));
+            return p.reject_error_with_cx(cx, Error::NotFound(None));
         }
 
         // Note: Step 3, 6 - 8 are implemented in
@@ -306,13 +306,13 @@ where
         let canonicalized = match uuid_canonicalizer(u) {
             Ok(canonicalized_uuid) => String::from(canonicalized_uuid),
             Err(e) => {
-                p.reject_error(e, CanGc::from_cx(cx));
+                p.reject_error_with_cx(cx, e);
                 return p;
             },
         };
         // Step 2.
         if uuid_is_blocklisted(canonicalized.as_ref(), Blocklist::All) {
-            p.reject_error(Security(None), CanGc::from_cx(cx));
+            p.reject_error_with_cx(cx, Security(None));
             return p;
         }
         Some(canonicalized)
@@ -322,7 +322,7 @@ where
 
     // Step 3 - 4.
     if !connected {
-        p.reject_error(Network(None), CanGc::from_cx(cx));
+        p.reject_error_with_cx(cx, Network(None));
         return p;
     }
 
@@ -544,7 +544,7 @@ impl BluetoothMethods<crate::DomTypeHolder> for Bluetooth {
         if (option.filters.is_some() && option.acceptAllDevices) ||
             (option.filters.is_none() && !option.acceptAllDevices)
         {
-            p.reject_error(Error::Type(OPTIONS_ERROR.to_owned()), CanGc::from_cx(cx));
+            p.reject_error_with_cx(cx, Error::Type(OPTIONS_ERROR.to_owned()));
             return p;
         }
 
@@ -691,7 +691,7 @@ impl PermissionAlgorithm for Bluetooth {
                 for filter in filters {
                     match canonicalize_filter(filter) {
                         Ok(f) => scan_filters.push(f),
-                        Err(error) => return promise.reject_error(error, CanGc::from_cx(cx)),
+                        Err(error) => return promise.reject_error_with_cx(cx, error),
                     }
                 }
 
@@ -712,7 +712,7 @@ impl PermissionAlgorithm for Bluetooth {
                 match receiver.recv().unwrap() {
                     Ok(true) => (),
                     Ok(false) => continue,
-                    Err(error) => return promise.reject_error(error.convert(), CanGc::from_cx(cx)),
+                    Err(error) => return promise.reject_error_with_cx(cx, error.convert()),
                 };
             }
 
@@ -741,7 +741,7 @@ impl PermissionAlgorithm for Bluetooth {
     ) {
         // Step 1.
         if descriptor.filters.is_some() == descriptor.acceptAllDevices {
-            return promise.reject_error(Error::Type(OPTIONS_ERROR.to_owned()), CanGc::from_cx(cx));
+            return promise.reject_error_with_cx(cx, Error::Type(OPTIONS_ERROR.to_owned()));
         }
 
         // Step 2.

--- a/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
@@ -161,13 +161,13 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
 
         // Step 1.
         if uuid_is_blocklisted(&self.uuid.str(), Blocklist::Reads) {
-            p.reject_error(Security(None), CanGc::from_cx(cx));
+            p.reject_error_with_cx(cx, Security(None));
             return p;
         }
 
         // Step 2.
         if !self.Service().Device().get_gatt(cx).Connected() {
-            p.reject_error(Network(None), CanGc::from_cx(cx));
+            p.reject_error_with_cx(cx, Network(None));
             return p;
         }
 
@@ -175,7 +175,7 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
 
         // Step 5.1.
         if !self.Properties().Read() {
-            p.reject_error(NotSupported(None), CanGc::from_cx(cx));
+            p.reject_error_with_cx(cx, NotSupported(None));
             return p;
         }
 
@@ -198,7 +198,7 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
 
         // Step 1.
         if uuid_is_blocklisted(&self.uuid.str(), Blocklist::Writes) {
-            p.reject_error(Security(None), CanGc::from_cx(cx));
+            p.reject_error_with_cx(cx, Security(None));
             return p;
         }
 
@@ -209,13 +209,13 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
         };
 
         if vec.len() > MAXIMUM_ATTRIBUTE_LENGTH {
-            p.reject_error(InvalidModification(None), CanGc::from_cx(cx));
+            p.reject_error_with_cx(cx, InvalidModification(None));
             return p;
         }
 
         // Step 4.
         if !self.Service().Device().get_gatt(cx).Connected() {
-            p.reject_error(Network(None), CanGc::from_cx(cx));
+            p.reject_error_with_cx(cx, Network(None));
             return p;
         }
 
@@ -226,7 +226,7 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
             self.Properties().WriteWithoutResponse() ||
             self.Properties().AuthenticatedSignedWrites())
         {
-            p.reject_error(NotSupported(None), CanGc::from_cx(cx));
+            p.reject_error_with_cx(cx, NotSupported(None));
             return p;
         }
 
@@ -249,19 +249,19 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
 
         // Step 1.
         if uuid_is_blocklisted(&self.uuid.str(), Blocklist::Reads) {
-            p.reject_error(Security(None), CanGc::from_cx(cx));
+            p.reject_error_with_cx(cx, Security(None));
             return p;
         }
 
         // Step 2.
         if !self.Service().Device().get_gatt(cx).Connected() {
-            p.reject_error(Network(None), CanGc::from_cx(cx));
+            p.reject_error_with_cx(cx, Network(None));
             return p;
         }
 
         // Step 5.
         if !(self.Properties().Notify() || self.Properties().Indicate()) {
-            p.reject_error(NotSupported(None), CanGc::from_cx(cx));
+            p.reject_error_with_cx(cx, NotSupported(None));
             return p;
         }
 

--- a/components/script/dom/bluetooth/bluetoothremotegattdescriptor.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattdescriptor.rs
@@ -103,7 +103,7 @@ impl BluetoothRemoteGATTDescriptorMethods<crate::DomTypeHolder> for BluetoothRem
 
         // Step 1.
         if uuid_is_blocklisted(&self.uuid.str(), Blocklist::Reads) {
-            p.reject_error(Security(None), CanGc::from_cx(cx));
+            p.reject_error_with_cx(cx, Security(None));
             return p;
         }
 
@@ -115,7 +115,7 @@ impl BluetoothRemoteGATTDescriptorMethods<crate::DomTypeHolder> for BluetoothRem
             .get_gatt(cx)
             .Connected()
         {
-            p.reject_error(Network(None), CanGc::from_cx(cx));
+            p.reject_error_with_cx(cx, Network(None));
             return p;
         }
 
@@ -139,7 +139,7 @@ impl BluetoothRemoteGATTDescriptorMethods<crate::DomTypeHolder> for BluetoothRem
 
         // Step 1.
         if uuid_is_blocklisted(&self.uuid.str(), Blocklist::Writes) {
-            p.reject_error(Security(None), CanGc::from_cx(cx));
+            p.reject_error_with_cx(cx, Security(None));
             return p;
         }
 
@@ -149,7 +149,7 @@ impl BluetoothRemoteGATTDescriptorMethods<crate::DomTypeHolder> for BluetoothRem
             ArrayBufferViewOrArrayBuffer::ArrayBuffer(ab) => ab.to_vec(),
         };
         if vec.len() > MAXIMUM_ATTRIBUTE_LENGTH {
-            p.reject_error(InvalidModification(None), CanGc::from_cx(cx));
+            p.reject_error_with_cx(cx, InvalidModification(None));
             return p;
         }
 
@@ -161,7 +161,7 @@ impl BluetoothRemoteGATTDescriptorMethods<crate::DomTypeHolder> for BluetoothRem
             .get_gatt(cx)
             .Connected()
         {
-            p.reject_error(Network(None), CanGc::from_cx(cx));
+            p.reject_error_with_cx(cx, Network(None));
             return p;
         }
 

--- a/components/script/dom/bluetooth/bluetoothremotegattserver.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattserver.rs
@@ -165,9 +165,9 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTServer {
                 // Step 5.2.3
                 if self.Device().is_represented_device_null() {
                     if let Err(e) = self.Device().garbage_collect_the_connection(cx) {
-                        return promise.reject_error(e, CanGc::from_cx(cx));
+                        return promise.reject_error_with_cx(cx, e);
                     }
-                    return promise.reject_error(Error::Network(None), CanGc::from_cx(cx));
+                    return promise.reject_error_with_cx(cx, Error::Network(None));
                 }
 
                 // Step 5.2.4.

--- a/components/script/dom/canvas/imagebitmap.rs
+++ b/components/script/dom/canvas/imagebitmap.rs
@@ -344,7 +344,7 @@ impl ImageBitmap {
                 task!(reject_promise: move |cx| {
                     let promise = trusted_promise.root();
 
-                    promise.reject_error(Error::InvalidState(None), CanGc::from_cx(cx));
+                    promise.reject_error_with_cx(cx, Error::InvalidState(None));
                 }),
             );
         };

--- a/components/script/dom/canvas/offscreencanvas.rs
+++ b/components/script/dom/canvas/offscreencanvas.rs
@@ -516,7 +516,7 @@ impl OffscreenCanvasMethods<crate::DomTypeHolder> for OffscreenCanvas {
         // then return a promise rejected with an "InvalidStateError"
         // DOMException.
         if let Some(OffscreenRenderingContext::Detached) = *self.context.borrow() {
-            promise.reject_error(Error::InvalidState(None), CanGc::from_cx(cx));
+            promise.reject_error_with_cx(cx, Error::InvalidState(None));
             return promise;
         }
 
@@ -524,7 +524,7 @@ impl OffscreenCanvasMethods<crate::DomTypeHolder> for OffscreenCanvas {
         // output bitmap's origin-clean flag is set to false, then return a
         // promise rejected with a "SecurityError" DOMException.
         if !self.origin_is_clean() {
-            promise.reject_error(Error::Security(None), CanGc::from_cx(cx));
+            promise.reject_error_with_cx(cx, Error::Security(None));
             return promise;
         }
 
@@ -532,13 +532,13 @@ impl OffscreenCanvasMethods<crate::DomTypeHolder> for OffscreenCanvas {
         // dimension or its vertical dimension is zero), then return a promise
         // rejected with an "IndexSizeError" DOMException.
         if self.Width() == 0 || self.Height() == 0 {
-            promise.reject_error(Error::IndexSize(None), CanGc::from_cx(cx));
+            promise.reject_error_with_cx(cx, Error::IndexSize(None));
             return promise;
         }
 
         // Step 4. Let bitmap be a copy of this's bitmap.
         let Some(mut snapshot) = self.get_image_data() else {
-            promise.reject_error(Error::InvalidState(None), CanGc::from_cx(cx));
+            promise.reject_error_with_cx(cx, Error::InvalidState(None));
             return promise;
         };
 
@@ -565,7 +565,7 @@ impl OffscreenCanvasMethods<crate::DomTypeHolder> for OffscreenCanvas {
                 if snapshot.encode_for_mime_type(&image_type, quality, &mut encoded).is_err() {
                     // Step 7.2.1. If file is null, then reject result with an
                     // "EncodingError" DOMException.
-                    promise.reject_error(Error::Encoding(None), CanGc::from_cx(cx));
+                    promise.reject_error_with_cx(cx, Error::Encoding(None));
                     return;
                 };
 

--- a/components/script/dom/clipboard/clipboard.rs
+++ b/components/script/dom/clipboard/clipboard.rs
@@ -72,8 +72,7 @@ impl Callback for RepresentationDataPromiseRejectionHandler {
     fn callback(&self, cx: &mut CurrentRealm, _v: SafeHandleValue) {
         // Reject p with "NotFoundError" DOMException in realm.
         // Return p.
-        self.promise
-            .reject_error(Error::NotFound(None), CanGc::from_cx(cx));
+        self.promise.reject_error_with_cx(cx, Error::NotFound(None));
     }
 }
 

--- a/components/script/dom/clipboard/clipboarditem.rs
+++ b/components/script/dom/clipboard/clipboarditem.rs
@@ -90,8 +90,7 @@ impl Callback for RepresentationDataPromiseRejectionHandler {
     /// Substeps of 8.1.2.2 If representationDataPromise was rejected, then:
     fn callback(&self, cx: &mut CurrentRealm, _v: SafeHandleValue) {
         // 1. Reject p with "NotFoundError" DOMException in realm.
-        self.promise
-            .reject_error(Error::NotFound(None), CanGc::from_cx(cx));
+        self.promise.reject_error_with_cx(cx, Error::NotFound(None));
     }
 }
 

--- a/components/script/dom/cookiestore.rs
+++ b/components/script/dom/cookiestore.rs
@@ -195,7 +195,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
-            p.reject_error(Error::Security(None), CanGc::from_cx(cx));
+            p.reject_error_with_cx(cx, Error::Security(None));
             return p;
         }
 
@@ -236,7 +236,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
-            p.reject_error(Error::Security(None), CanGc::from_cx(cx));
+            p.reject_error_with_cx(cx, Error::Security(None));
             return p;
         }
 
@@ -246,10 +246,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         // 5. If options is empty, then return a promise rejected with a TypeError.
         // "is empty" is not strictly defined anywhere in the spec but the only value we require here is "url"
         if options.url.is_none() && options.name.is_none() {
-            p.reject_error(
-                Error::Type(c"Options cannot be empty".to_owned()),
-                CanGc::from_cx(cx),
-            );
+            p.reject_error_with_cx(cx, Error::Type(c"Options cannot be empty".to_owned()));
             return p;
         }
 
@@ -267,10 +264,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
                     .as_ref()
                     .is_ok_and(|parsed| !parsed.is_equal_excluding_fragments(&creation_url))
             {
-                p.reject_error(
-                    Error::Type(c"URL does not match context".to_owned()),
-                    CanGc::from_cx(cx),
-                );
+                p.reject_error_with_cx(cx, Error::Type(c"URL does not match context".to_owned()));
                 return p;
             }
 
@@ -280,10 +274,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
                 .as_ref()
                 .is_ok_and(|parsed| creation_url.origin() != parsed.origin())
             {
-                p.reject_error(
-                    Error::Type(c"Not same origin".to_owned()),
-                    CanGc::from_cx(cx),
-                );
+                p.reject_error_with_cx(cx, Error::Type(c"Not same origin".to_owned()));
                 return p;
             }
 
@@ -324,7 +315,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
-            p.reject_error(Error::Security(None), CanGc::from_cx(cx));
+            p.reject_error_with_cx(cx, Error::Security(None));
             return p;
         }
         // 4. Let url be settings’s creation URL.
@@ -365,7 +356,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
-            p.reject_error(Error::Security(None), CanGc::from_cx(cx));
+            p.reject_error_with_cx(cx, Error::Security(None));
             return p;
         }
 
@@ -386,10 +377,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
                     .as_ref()
                     .is_ok_and(|parsed| !parsed.is_equal_excluding_fragments(&creation_url))
             {
-                p.reject_error(
-                    Error::Type(c"URL does not match context".to_owned()),
-                    CanGc::from_cx(cx),
-                );
+                p.reject_error_with_cx(cx, Error::Type(c"URL does not match context".to_owned()));
                 return p;
             }
 
@@ -399,10 +387,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
                 .as_ref()
                 .is_ok_and(|parsed| creation_url.origin() != parsed.origin())
             {
-                p.reject_error(
-                    Error::Type(c"Not same origin".to_owned()),
-                    CanGc::from_cx(cx),
-                );
+                p.reject_error_with_cx(cx, Error::Type(c"Not same origin".to_owned()));
                 return p;
             }
 
@@ -444,7 +429,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
-            p.reject_error(Error::Security(None), CanGc::from_cx(cx));
+            p.reject_error_with_cx(cx, Error::Security(None));
             return p;
         }
 
@@ -461,10 +446,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         let creation_url = global.creation_url();
         let Some(cookie) = CookieStore::set_a_cookie(&creation_url, &properties) else {
             // If r is failure, then reject p with a TypeError and abort these steps.
-            p.reject_error(
-                Error::Type(c"Invalid cookie".to_owned()),
-                CanGc::from_cx(cx),
-            );
+            p.reject_error_with_cx(cx, Error::Type(c"Invalid cookie".to_owned()));
             return p;
         };
 
@@ -501,7 +483,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
-            p.reject_error(Error::Security(None), CanGc::from_cx(cx));
+            p.reject_error_with_cx(cx, Error::Security(None));
             return p;
         }
 
@@ -511,10 +493,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         // 6.1. Let r be the result of running set a cookie with url, options["name"], options["value"],
         // options["expires"], options["domain"], options["path"], options["sameSite"], and options["partitioned"].
         let Some(cookie) = CookieStore::set_a_cookie(&creation_url, options) else {
-            p.reject_error(
-                Error::Type(c"Invalid cookie".to_owned()),
-                CanGc::from_cx(cx),
-            );
+            p.reject_error_with_cx(cx, Error::Type(c"Invalid cookie".to_owned()));
             return p;
         };
 
@@ -551,7 +530,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
-            p.reject_error(Error::Security(None), CanGc::from_cx(cx));
+            p.reject_error_with_cx(cx, Error::Security(None));
             return p;
         }
 
@@ -587,7 +566,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
-            p.reject_error(Error::Security(None), CanGc::from_cx(cx));
+            p.reject_error_with_cx(cx, Error::Security(None));
             return p;
         }
 

--- a/components/script/dom/css/fontface.rs
+++ b/components/script/dom/css/fontface.rs
@@ -601,7 +601,7 @@ impl FontFaceMethods<crate::DomTypeHolder> for FontFace {
                             // [[FontStatusPromise]] with a DOMException whose name is "NetworkError"
                             // and set font face’s status attribute to "error".
                             font_face.status.set(FontFaceLoadStatus::Error);
-                            font_face.font_status_promise.reject_error(Error::Network(None), CanGc::from_cx(cx));
+                            font_face.font_status_promise.reject_error_with_cx(cx, Error::Network(None));
                         }
                         Some(template) => {
                             // Step 5.2. Otherwise, font face now represents the loaded font;

--- a/components/script/dom/fullscreen/lib.rs
+++ b/components/script/dom/fullscreen/lib.rs
@@ -312,10 +312,8 @@ impl TaskOnce for ElementPerformFullscreenEnter {
             document
                 .upcast::<EventTarget>()
                 .fire_event(cx, atom!("fullscreenerror"));
-            promise.reject_error(
-                Error::Type(c"fullscreen is not connected".to_owned()),
-                CanGc::from_cx(cx),
-            );
+            promise
+                .reject_error_with_cx(cx, Error::Type(c"fullscreen is not connected".to_owned()));
             return;
         }
 

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -1417,7 +1417,7 @@ impl HTMLImageElement {
             .dom_manipulation_task_source()
             .queue(task!(reject_image_decode_promises: move |cx| {
                 for trusted_promise in trusted_image_decode_promises {
-                    trusted_promise.root().reject_error(Error::Encoding(None), CanGc::from_cx(cx));
+                    trusted_promise.root().reject_error_with_cx(cx, Error::Encoding(None));
                 }
             }));
     }

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -3126,7 +3126,7 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
             .get()
             .is_some_and(|e| e.Code() == MEDIA_ERR_SRC_NOT_SUPPORTED)
         {
-            promise.reject_error(Error::NotSupported(None), CanGc::from_cx(cx));
+            promise.reject_error_with_cx(cx, Error::NotSupported(None));
             return promise;
         }
 

--- a/components/script/dom/indexeddb/idbfactory.rs
+++ b/components/script/dom/indexeddb/idbfactory.rs
@@ -624,7 +624,7 @@ impl IDBFactoryMethods<crate::DomTypeHolder> for IDBFactory {
             Some(storage_key) => storage_key,
             None => {
                 let p = Promise::new(&global, CanGc::from_cx(cx));
-                p.reject_error(Error::Security(None), CanGc::from_cx(cx));
+                p.reject_error_with_cx(cx, Error::Security(None));
                 return p;
             },
         };

--- a/components/script/dom/permissions.rs
+++ b/components/script/dom/permissions.rs
@@ -108,7 +108,7 @@ impl Permissions {
         let root_desc = match Permissions::create_descriptor(cx, permissionDesc) {
             Ok(descriptor) => descriptor,
             Err(error) => {
-                p.reject_error(error, CanGc::from_cx(cx));
+                p.reject_error_with_cx(cx, error);
                 return p;
             },
         };
@@ -123,7 +123,7 @@ impl Permissions {
                 let bluetooth_desc = match Bluetooth::create_descriptor(cx, permissionDesc) {
                     Ok(descriptor) => descriptor,
                     Err(error) => {
-                        p.reject_error(error, CanGc::from_cx(cx));
+                        p.reject_error_with_cx(cx, error);
                         return p;
                     },
                 };

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -248,6 +248,19 @@ impl Promise {
         self.reject(cx, v.handle(), can_gc);
     }
 
+    pub(crate) fn reject_error_with_cx(&self, cx: &mut JSContext, error: Error) {
+        let mut realm = enter_auto_realm(cx, self);
+        let cx = &mut realm.current_realm();
+        rooted!(&in(cx) let mut v = UndefinedValue());
+        error.to_jsval(
+            cx.into(),
+            &self.global(),
+            v.handle_mut(),
+            CanGc::from_cx(cx),
+        );
+        self.reject(cx.into(), v.handle(), CanGc::from_cx(cx));
+    }
+
     #[expect(unsafe_code)]
     pub(crate) fn reject(&self, cx: SafeJSContext, value: HandleValue, _can_gc: CanGc) {
         unsafe {

--- a/components/script/dom/storagemanager.rs
+++ b/components/script/dom/storagemanager.rs
@@ -115,10 +115,7 @@ impl StorageManagerEstimateResponseHandler {
                         promise.resolve_native(&estimate, CanGc::from_cx(cx));
                     },
                     Err(message) => {
-                        promise.reject_error(
-                            StorageManager::type_error_from_string(message),
-                            CanGc::from_cx(cx),
-                        );
+                        promise.reject_error_with_cx(cx, StorageManager::type_error_from_string(message));
                     },
                 }
             }));

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -2196,10 +2196,7 @@ impl ReadableStreamMethods<crate::DomTypeHolder> for ReadableStream {
             // If ! IsReadableStreamLocked(this) is true,
             // return a promise rejected with a TypeError exception.
             let promise = Promise::new2(cx, &global);
-            promise.reject_error(
-                Error::Type(c"stream is locked".to_owned()),
-                CanGc::from_cx(cx),
-            );
+            promise.reject_error_with_cx(cx, Error::Type(c"stream is locked".to_owned()));
             promise
         } else {
             // Return ! ReadableStreamCancel(this, reason).
@@ -2247,10 +2244,7 @@ impl ReadableStreamMethods<crate::DomTypeHolder> for ReadableStream {
         if self.is_locked() {
             // return a promise rejected with a TypeError exception.
             let promise = Promise::new2(cx, &global);
-            promise.reject_error(
-                Error::Type(c"Source stream is locked".to_owned()),
-                CanGc::from_cx(cx),
-            );
+            promise.reject_error_with_cx(cx, Error::Type(c"Source stream is locked".to_owned()));
             return promise;
         }
 
@@ -2258,10 +2252,8 @@ impl ReadableStreamMethods<crate::DomTypeHolder> for ReadableStream {
         if destination.is_locked() {
             // return a promise rejected with a TypeError exception.
             let promise = Promise::new2(cx, &global);
-            promise.reject_error(
-                Error::Type(c"Destination stream is locked".to_owned()),
-                CanGc::from_cx(cx),
-            );
+            promise
+                .reject_error_with_cx(cx, Error::Type(c"Destination stream is locked".to_owned()));
             return promise;
         }
 

--- a/components/script/dom/stream/readablestreambyobreader.rs
+++ b/components/script/dom/stream/readablestreambyobreader.rs
@@ -428,18 +428,15 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
 
         // If view.[[ByteLength]] is 0, return a promise rejected with a TypeError exception.
         if view.byte_length() == 0 {
-            promise.reject_error(
-                Error::Type(c"view byte length is 0".to_owned()),
-                CanGc::from_cx(cx),
-            );
+            promise.reject_error_with_cx(cx, Error::Type(c"view byte length is 0".to_owned()));
             return promise;
         }
         // If view.[[ViewedArrayBuffer]].[[ArrayBufferByteLength]] is 0,
         // return a promise rejected with a TypeError exception.
         if view.viewed_buffer_array_byte_length(cx.into()) == 0 {
-            promise.reject_error(
+            promise.reject_error_with_cx(
+                cx,
                 Error::Type(c"viewed buffer byte length is 0".to_owned()),
-                CanGc::from_cx(cx),
             );
             return promise;
         }
@@ -447,16 +444,13 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
         // If ! IsDetachedBuffer(view.[[ViewedArrayBuffer]]) is true,
         // return a promise rejected with a TypeError exception.
         if view.is_detached_buffer(cx.into()) {
-            promise.reject_error(
-                Error::Type(c"view is detached".to_owned()),
-                CanGc::from_cx(cx),
-            );
+            promise.reject_error_with_cx(cx, Error::Type(c"view is detached".to_owned()));
             return promise;
         }
 
         // If options["min"] is 0, return a promise rejected with a TypeError exception.
         if min == 0 {
-            promise.reject_error(Error::Type(c"min is 0".to_owned()), CanGc::from_cx(cx));
+            promise.reject_error_with_cx(cx, Error::Type(c"min is 0".to_owned()));
             return promise;
         }
 
@@ -464,9 +458,9 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
         if view.has_typed_array_name() {
             // If options["min"] > view.[[ArrayLength]], return a promise rejected with a RangeError exception.
             if min > (view.get_typed_array_length() as u64) {
-                promise.reject_error(
+                promise.reject_error_with_cx(
+                    cx,
                     Error::Range(c"min is greater than array length".to_owned()),
-                    CanGc::from_cx(cx),
                 );
                 return promise;
             }
@@ -474,9 +468,9 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
             // Otherwise (i.e., it is a DataView),
             // If options["min"] > view.[[ByteLength]], return a promise rejected with a RangeError exception.
             if min > (view.byte_length() as u64) {
-                promise.reject_error(
+                promise.reject_error_with_cx(
+                    cx,
                     Error::Range(c"min is greater than byte length".to_owned()),
-                    CanGc::from_cx(cx),
                 );
                 return promise;
             }
@@ -484,9 +478,9 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
 
         // If this.[[stream]] is undefined, return a promise rejected with a TypeError exception.
         if self.stream.get().is_none() {
-            promise.reject_error(
+            promise.reject_error_with_cx(
+                cx,
                 Error::Type(c"min is greater than byte length".to_owned()),
-                CanGc::from_cx(cx),
             );
             return promise;
         }

--- a/components/script/dom/stream/readablestreamgenericreader.rs
+++ b/components/script/dom/stream/readablestreamgenericreader.rs
@@ -149,10 +149,7 @@ pub(crate) trait ReadableStreamGenericReader {
             // If this.[[stream]] is undefined,
             // return a promise rejected with a TypeError exception.
             let promise = Promise::new2(cx, global);
-            promise.reject_error(
-                Error::Type(c"stream is undefined".to_owned()),
-                CanGc::from_cx(cx),
-            );
+            promise.reject_error_with_cx(cx, Error::Type(c"stream is undefined".to_owned()));
             promise
         } else {
             // Return ! ReadableStreamReaderGenericCancel(this, reason).

--- a/components/script/dom/stream/transformstreamdefaultcontroller.rs
+++ b/components/script/dom/stream/transformstreamdefaultcontroller.rs
@@ -233,7 +233,7 @@ impl TransformStreamDefaultController {
                         )
                         .unwrap_or_else(|e| {
                             let p = Promise::new2(cx, global);
-                            p.reject_error(e, CanGc::from_cx(cx));
+                            p.reject_error_with_cx(cx, e);
                             p
                         })
                 } else {
@@ -385,7 +385,7 @@ impl TransformStreamDefaultController {
                         .Call_(cx, &this_object.handle(), chunk, ExceptionHandling::Rethrow)
                         .unwrap_or_else(|e| {
                             let p = Promise::new2(cx, global);
-                            p.reject_error(e, CanGc::from_cx(cx));
+                            p.reject_error_with_cx(cx, e);
                             p
                         })
                 } else {
@@ -465,7 +465,7 @@ impl TransformStreamDefaultController {
                         .Call_(cx, &this_object.handle(), self, ExceptionHandling::Rethrow)
                         .unwrap_or_else(|e| {
                             let p = Promise::new2(cx, global);
-                            p.reject_error(e, CanGc::from_cx(cx));
+                            p.reject_error_with_cx(cx, e);
                             p
                         })
                 } else {

--- a/components/script/dom/stream/underlyingsourcecontainer.rs
+++ b/components/script/dom/stream/underlyingsourcecontainer.rs
@@ -194,7 +194,7 @@ impl UnderlyingSourceContainer {
                 // If result is an abrupt completion,
                 if let Err(error) = result {
                     // Return a promise rejected with result.[[Value]].
-                    promise.reject_error(error, CanGc::from_cx(cx));
+                    promise.reject_error_with_cx(cx, error);
                 } else {
                     // Otherwise, return a promise resolved with undefined.
                     promise.resolve_native(&(), CanGc::from_cx(cx));

--- a/components/script/dom/stream/writablestream.rs
+++ b/components/script/dom/stream/writablestream.rs
@@ -745,10 +745,8 @@ impl WritableStream {
         if self.is_closed() || self.is_errored() {
             // return a promise rejected with a TypeError exception.
             let promise = Promise::new2(cx, global);
-            promise.reject_error(
-                Error::Type(c"Stream is closed or errored.".to_owned()),
-                CanGc::from_cx(cx),
-            );
+            promise
+                .reject_error_with_cx(cx, Error::Type(c"Stream is closed or errored.".to_owned()));
             return promise;
         }
 
@@ -1080,10 +1078,7 @@ impl WritableStreamMethods<crate::DomTypeHolder> for WritableStream {
         if self.is_locked() {
             // return a promise rejected with a TypeError exception.
             let promise = Promise::new2(cx, &global);
-            promise.reject_error(
-                Error::Type(c"Stream is locked.".to_owned()),
-                CanGc::from_cx(cx),
-            );
+            promise.reject_error_with_cx(cx, Error::Type(c"Stream is locked.".to_owned()));
             return promise;
         }
 
@@ -1099,10 +1094,7 @@ impl WritableStreamMethods<crate::DomTypeHolder> for WritableStream {
         if self.is_locked() {
             // return a promise rejected with a TypeError exception.
             let promise = Promise::new2(cx, &global);
-            promise.reject_error(
-                Error::Type(c"Stream is locked.".to_owned()),
-                CanGc::from_cx(cx),
-            );
+            promise.reject_error_with_cx(cx, Error::Type(c"Stream is locked.".to_owned()));
             return promise;
         }
 
@@ -1110,9 +1102,9 @@ impl WritableStreamMethods<crate::DomTypeHolder> for WritableStream {
         if self.close_queued_or_in_flight() {
             // return a promise rejected with a TypeError exception.
             let promise = Promise::new2(cx, &global);
-            promise.reject_error(
+            promise.reject_error_with_cx(
+                cx,
                 Error::Type(c"Stream has closed queued or in-flight".to_owned()),
-                CanGc::from_cx(cx),
             );
             return promise;
         }

--- a/components/script/dom/stream/writablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/writablestreamdefaultcontroller.rs
@@ -614,7 +614,7 @@ impl WritableStreamDefaultController {
                 };
                 result.unwrap_or_else(|e| {
                     let promise = Promise::new(global, CanGc::from_cx(cx));
-                    promise.reject_error(e, CanGc::from_cx(cx));
+                    promise.reject_error_with_cx(cx, e);
                     promise
                 })
             },
@@ -632,7 +632,7 @@ impl WritableStreamDefaultController {
 
                 // If result is an abrupt completion, return a promise rejected with result.[[Value]]
                 if let Err(error) = result {
-                    promise.reject_error(error, CanGc::from_cx(cx));
+                    promise.reject_error_with_cx(cx, error);
                 } else {
                     // Otherwise, return a promise resolved with undefined.
                     promise.resolve_native(&(), CanGc::from_cx(cx));
@@ -687,7 +687,7 @@ impl WritableStreamDefaultController {
                 };
                 result.unwrap_or_else(|e| {
                     let promise = Promise::new2(cx, global);
-                    promise.reject_error(e, CanGc::from_cx(cx));
+                    promise.reject_error_with_cx(cx, e);
                     promise
                 })
             },
@@ -761,7 +761,7 @@ impl WritableStreamDefaultController {
                 };
                 result.unwrap_or_else(|e| {
                     let promise = Promise::new2(cx, global);
-                    promise.reject_error(e, CanGc::from_cx(cx));
+                    promise.reject_error_with_cx(cx, e);
                     promise
                 })
             },

--- a/components/script/dom/stream/writablestreamdefaultwriter.rs
+++ b/components/script/dom/stream/writablestreamdefaultwriter.rs
@@ -293,9 +293,9 @@ impl WritableStreamDefaultWriter {
             .is_some_and(|current_stream| current_stream == stream)
         {
             let promise = Promise::new2(cx, global);
-            promise.reject_error(
+            promise.reject_error_with_cx(
+                cx,
                 Error::Type(c"Stream is not equal to writer stream".to_owned()),
-                CanGc::from_cx(cx),
             );
             return promise;
         }
@@ -317,9 +317,9 @@ impl WritableStreamDefaultWriter {
             // return a promise rejected with a TypeError exception
             // indicating that the stream is closing or closed
             let promise = Promise::new2(cx, global);
-            promise.reject_error(
+            promise.reject_error_with_cx(
+                cx,
                 Error::Type(c"Stream has been closed, or has close queued or in-flight".to_owned()),
-                CanGc::from_cx(cx),
             );
             return promise;
         }
@@ -456,10 +456,7 @@ impl WritableStreamDefaultWriterMethods<crate::DomTypeHolder> for WritableStream
         if self.stream.get().is_none() {
             // return a promise rejected with a TypeError exception.
             let promise = Promise::new2(cx, &global);
-            promise.reject_error(
-                Error::Type(c"Stream is undefined".to_owned()),
-                CanGc::from_cx(cx),
-            );
+            promise.reject_error_with_cx(cx, Error::Type(c"Stream is undefined".to_owned()));
             return promise;
         }
 
@@ -476,19 +473,16 @@ impl WritableStreamDefaultWriterMethods<crate::DomTypeHolder> for WritableStream
         let Some(stream) = self.stream.get() else {
             // If stream is undefined,
             // return a promise rejected with a TypeError exception.
-            promise.reject_error(
-                Error::Type(c"Stream is undefined".to_owned()),
-                CanGc::from_cx(cx),
-            );
+            promise.reject_error_with_cx(cx, Error::Type(c"Stream is undefined".to_owned()));
             return promise;
         };
 
         // If ! WritableStreamCloseQueuedOrInFlight(stream) is true
         if stream.close_queued_or_in_flight() {
             // return a promise rejected with a TypeError exception.
-            promise.reject_error(
+            promise.reject_error_with_cx(
+                cx,
                 Error::Type(c"Stream has closed queued or in-flight".to_owned()),
-                CanGc::from_cx(cx),
             );
             return promise;
         }
@@ -522,10 +516,7 @@ impl WritableStreamDefaultWriterMethods<crate::DomTypeHolder> for WritableStream
         if self.stream.get().is_none() {
             // return a promise rejected with a TypeError exception.
             let promise = Promise::new2(cx, &global);
-            promise.reject_error(
-                Error::Type(c"Stream is undefined".to_owned()),
-                CanGc::from_cx(cx),
-            );
+            promise.reject_error_with_cx(cx, Error::Type(c"Stream is undefined".to_owned()));
             return promise;
         }
 

--- a/components/script/dom/wakelock/wakelock.rs
+++ b/components/script/dom/wakelock/wakelock.rs
@@ -72,9 +72,9 @@ impl WakeLockMethods<crate::DomTypeHolder> for WakeLock {
         // Step 4. Obtain permission for "screen-wake-lock".
         // <https://w3c.github.io/screen-wake-lock/#dfn-obtain-permission>
         let Some(webview_id) = global.webview_id() else {
-            promise.reject_error(
+            promise.reject_error_with_cx(
+                cx,
                 Error::NotAllowed(Some("Unable to obtain WakeLock permission.".to_string())),
-                CanGc::from_cx(cx),
             );
             return promise;
         };

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -218,7 +218,7 @@ impl SubtleCrypto {
                     CanGc::from_cx(cx),
                 ) {
                     Ok(_) => promise.resolve_native(&*array_buffer_ptr, CanGc::from_cx(cx)),
-                    Err(_) => promise.reject_error(Error::JSFailed, CanGc::from_cx(cx)),
+                    Err(_) => promise.reject_error_with_cx(cx, Error::JSFailed),
                 }
             }));
     }
@@ -322,7 +322,7 @@ impl SubtleCrypto {
             .crypto_task_source()
             .queue(task!(reject_error: move |cx| {
                 let promise = trusted_promise.root();
-                promise.reject_error(error, CanGc::from_cx(cx));
+                promise.reject_error_with_cx(cx, error);
             }));
     }
 
@@ -381,7 +381,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             Ok(normalized_algorithm) => normalized_algorithm,
             Err(error) => {
                 let promise = Promise::new_in_realm(cx);
-                promise.reject_error(error, CanGc::from_cx(cx));
+                promise.reject_error_with_cx(cx, error);
                 return promise;
             },
         };
@@ -468,7 +468,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             Ok(normalized_algorithm) => normalized_algorithm,
             Err(error) => {
                 let promise = Promise::new_in_realm(cx);
-                promise.reject_error(error, CanGc::from_cx(cx));
+                promise.reject_error_with_cx(cx, error);
                 return promise;
             },
         };
@@ -555,7 +555,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             Ok(normalized_algorithm) => normalized_algorithm,
             Err(error) => {
                 let promise = Promise::new_in_realm(cx);
-                promise.reject_error(error, CanGc::from_cx(cx));
+                promise.reject_error_with_cx(cx, error);
                 return promise;
             },
         };
@@ -642,7 +642,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             Ok(algorithm) => algorithm,
             Err(error) => {
                 let promise = Promise::new_in_realm(cx);
-                promise.reject_error(error, CanGc::from_cx(cx));
+                promise.reject_error_with_cx(cx, error);
                 return promise;
             },
         };
@@ -732,7 +732,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             Ok(normalized_algorithm) => normalized_algorithm,
             Err(error) => {
                 let promise = Promise::new_in_realm(cx);
-                promise.reject_error(error, CanGc::from_cx(cx));
+                promise.reject_error_with_cx(cx, error);
                 return promise;
             },
         };
@@ -801,7 +801,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
         {
             Ok(normalized_algorithm) => normalized_algorithm,
             Err(error) => {
-                promise.reject_error(error, CanGc::from_cx(cx));
+                promise.reject_error_with_cx(cx, error);
                 return promise;
             },
         };
@@ -908,7 +908,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
         {
             Ok(normalized_algorithm) => normalized_algorithm,
             Err(error) => {
-                promise.reject_error(error, CanGc::from_cx(cx));
+                promise.reject_error_with_cx(cx, error);
                 return promise;
             },
         };
@@ -921,7 +921,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             match normalize_algorithm::<ImportKeyOperation>(cx, &derived_key_type) {
                 Ok(normalized_algorithm) => normalized_algorithm,
                 Err(error) => {
-                    promise.reject_error(error, CanGc::from_cx(cx));
+                    promise.reject_error_with_cx(cx, error);
                     return promise;
                 },
             };
@@ -934,7 +934,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             match normalize_algorithm::<GetKeyLengthOperation>(cx, &derived_key_type) {
                 Ok(normalized_algorithm) => normalized_algorithm,
                 Err(error) => {
-                    promise.reject_error(error, CanGc::from_cx(cx));
+                    promise.reject_error_with_cx(cx, error);
                     return promise;
                 },
             };
@@ -1055,7 +1055,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
         {
             Ok(normalized_algorithm) => normalized_algorithm,
             Err(error) => {
-                promise.reject_error(error, CanGc::from_cx(cx));
+                promise.reject_error_with_cx(cx, error);
                 return promise;
             },
         };
@@ -1135,7 +1135,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             Ok(algorithm) => algorithm,
             Err(error) => {
                 let promise = Promise::new_in_realm(cx);
-                promise.reject_error(error, CanGc::from_cx(cx));
+                promise.reject_error_with_cx(cx, error);
                 return promise;
             },
         };
@@ -1150,9 +1150,9 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                         // Step 4.1. If the keyData parameter passed to the importKey() method is
                         // not a JsonWebKey dictionary, throw a TypeError.
                         let promise = Promise::new_in_realm(cx);
-                        promise.reject_error(
+                        promise.reject_error_with_cx(
+                            cx,
                             Error::Type(c"The keyData type does not match the format".to_owned()),
-                            CanGc::from_cx(cx),
                         );
                         return promise;
                     },
@@ -1169,7 +1169,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                             Ok(stringified) => Zeroizing::new(stringified.as_bytes().to_vec()),
                             Err(error) => {
                                 let promise = Promise::new_in_realm(cx);
-                                promise.reject_error(error, CanGc::from_cx(cx));
+                                promise.reject_error_with_cx(cx, error);
                                 return promise;
                             },
                         }
@@ -1183,9 +1183,9 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                     // JsonWebKey dictionary, throw a TypeError.
                     ArrayBufferViewOrArrayBufferOrJsonWebKey::JsonWebKey(_) => {
                         let promise = Promise::new_in_realm(cx);
-                        promise.reject_error(
+                        promise.reject_error_with_cx(
+                            cx,
                             Error::Type(c"The keyData type does not match the format".to_owned()),
-                            CanGc::from_cx(cx),
                         );
                         return promise;
                     },
@@ -1377,7 +1377,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 Ok(algorithm) => WrapKeyAlgorithmOrEncryptAlgorithm::EncryptAlgorithm(algorithm),
                 Err(error) => {
                     let promise = Promise::new_in_realm(cx);
-                    promise.reject_error(error, CanGc::from_cx(cx));
+                    promise.reject_error_with_cx(cx, error);
                     return promise;
                 },
             }
@@ -1555,7 +1555,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 Ok(algorithm) => UnwrapKeyAlgorithmOrDecryptAlgorithm::DecryptAlgorithm(algorithm),
                 Err(error) => {
                     let promise = Promise::new_in_realm(cx);
-                    promise.reject_error(error, CanGc::from_cx(cx));
+                    promise.reject_error_with_cx(cx, error);
                     return promise;
                 },
             }
@@ -1569,7 +1569,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 Ok(algorithm) => algorithm,
                 Err(error) => {
                     let promise = Promise::new_in_realm(cx);
-                    promise.reject_error(error, CanGc::from_cx(cx));
+                    promise.reject_error_with_cx(cx, error);
                     return promise;
                 },
             };
@@ -1731,7 +1731,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             match normalize_algorithm::<EncapsulateOperation>(cx, &encapsulation_algorithm) {
                 Ok(algorithm) => algorithm,
                 Err(error) => {
-                    promise.reject_error(error, CanGc::from_cx(cx));
+                    promise.reject_error_with_cx(cx, error);
                     return promise;
                 },
             };
@@ -1744,7 +1744,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             match normalize_algorithm::<ImportKeyOperation>(cx, &shared_key_algorithm) {
                 Ok(algorithm) => algorithm,
                 Err(error) => {
-                    promise.reject_error(error, CanGc::from_cx(cx));
+                    promise.reject_error_with_cx(cx, error);
                     return promise;
                 },
             };
@@ -1872,7 +1872,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             match normalize_algorithm::<EncapsulateOperation>(cx, &encapsulation_algorithm) {
                 Ok(algorithm) => algorithm,
                 Err(error) => {
-                    promise.reject_error(error, CanGc::from_cx(cx));
+                    promise.reject_error_with_cx(cx, error);
                     return promise;
                 },
             };
@@ -1966,7 +1966,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 Ok(normalized_algorithm) => normalized_algorithm,
                 Err(error) => {
                     let promise = Promise::new_in_realm(cx);
-                    promise.reject_error(error, CanGc::from_cx(cx));
+                    promise.reject_error_with_cx(cx, error);
                     return promise;
                 },
             };
@@ -1980,7 +1980,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 Ok(normalized_algorithm) => normalized_algorithm,
                 Err(error) => {
                     let promise = Promise::new_in_realm(cx);
-                    promise.reject_error(error, CanGc::from_cx(cx));
+                    promise.reject_error_with_cx(cx, error);
                     return promise;
                 },
             };
@@ -2103,7 +2103,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 Ok(normalized_algorithm) => normalized_algorithm,
                 Err(error) => {
                     let promise = Promise::new_in_realm(cx);
-                    promise.reject_error(error, CanGc::from_cx(cx));
+                    promise.reject_error_with_cx(cx, error);
                     return promise;
                 },
             };
@@ -2207,7 +2207,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             Ok(normalized_algorithm) => normalized_algorithm,
             Err(error) => {
                 let promise = Promise::new_in_realm(cx);
-                promise.reject_error(error, CanGc::from_cx(cx));
+                promise.reject_error_with_cx(cx, error);
                 return promise;
             },
         };

--- a/components/script/dom/webgpu/gpuadapter.rs
+++ b/components/script/dom/webgpu/gpuadapter.rs
@@ -309,7 +309,7 @@ impl RoutedPromiseListener<WebGPUDeviceResponse> for GPUAdapter {
                     "{}",
                     wgpu_core::instance::RequestDeviceError::LimitsExceeded(l)
                 );
-                promise.reject_error(Error::Operation(None), CanGc::from_cx(cx))
+                promise.reject_error_with_cx(cx, Error::Operation(None))
             },
             // 3. user agent otherwise cannot fulfill the request
             (device_id, queue_id, Err(RequestDeviceError::Other(e))) => {

--- a/components/script/dom/webgpu/gpudevice.rs
+++ b/components/script/dom/webgpu/gpudevice.rs
@@ -639,9 +639,7 @@ impl RoutedPromiseListener<WebGPUPoppedErrorScopeResponse> for GPUDevice {
             Ok(None) | Err(PopError::Lost) => {
                 promise.resolve_native(&None::<Option<GPUError>>, CanGc::from_cx(cx))
             },
-            Err(PopError::Empty) => {
-                promise.reject_error(Error::Operation(None), CanGc::from_cx(cx))
-            },
+            Err(PopError::Empty) => promise.reject_error_with_cx(cx, Error::Operation(None)),
             Ok(Some(error)) => {
                 let error = GPUError::from_error(&self.global(), error, CanGc::from_cx(cx));
                 promise.resolve_native(&error, CanGc::from_cx(cx));

--- a/components/script/dom/workers/serviceworkercontainer.rs
+++ b/components/script/dom/workers/serviceworkercontainer.rs
@@ -90,7 +90,7 @@ impl ServiceWorkerContainer {
                     );
                 },
                 JobError::SecurityError => {
-                    promise.reject_error(Error::Security(None), CanGc::from_cx(cx));
+                    promise.reject_error_with_cx(cx, Error::Security(None));
                 },
             },
             // <https://w3c.github.io/ServiceWorker/#resolve-job-promise>

--- a/components/script/dom/workers/serviceworkerregistration.rs
+++ b/components/script/dom/workers/serviceworkerregistration.rs
@@ -223,9 +223,9 @@ impl ServiceWorkerRegistrationMethods<crate::DomTypeHolder> for ServiceWorkerReg
         // Step 4: Invoke Schedule Job with job.
         // Note: done in the container.
         let Some(storage_key) = global.obtain_storage_key() else {
-            promise.reject_error(
+            promise.reject_error_with_cx(
+                cx,
                 Error::Type(c"Failed to obtain a storage key".to_owned()),
-                CanGc::from_cx(cx),
             );
             return promise;
         };

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -228,7 +228,7 @@ pub(crate) fn Fetch(
     let request_object = match Request::Constructor(cx, global, None, input, init) {
         Err(e) => {
             response.error_stream(cx, e.clone());
-            promise.reject_error(e, CanGc::from_cx(cx));
+            promise.reject_error_with_cx(cx, e);
             return promise;
         },
         Ok(r) => r,
@@ -565,10 +565,8 @@ impl FetchResponseListener for FetchContext {
             // Step 12.3. If response is a network error, then reject
             // p with a TypeError and abort these steps.
             Err(error) => {
-                promise.reject_error(
-                    Error::Type(cformat!("Network error: {:?}", error)),
-                    CanGc::from_cx(cx),
-                );
+                promise
+                    .reject_error_with_cx(cx, Error::Type(cformat!("Network error: {:?}", error)));
                 self.fetch_promise = Some(TrustedPromise::new(promise));
                 let response = self.response_object.root();
                 response.set_type(DOMResponseType::Error, CanGc::from_cx(cx));


### PR DESCRIPTION
This allows for a gradual migration to pass in `cx`, to avoid having to do a big bang change across all code.

All call-sides were automatically migrated using the following regex replacement:

Before:

```
.reject_error\([ \n]*(.+),[ \n]+CanGc::from_cx\(cx\),?[ \n]*\);
```

After:

```
.reject_error_with_cx(cx, $1);
```

Part of #40600

Testing: it compiles