### PR TITLE
script: Introduce `Promise::{resolve,reject}_native_with_cx`

### DIFF
--- a/components/script/dom/audio/audiocontext.rs
+++ b/components/script/dom/audio/audiocontext.rs
@@ -36,7 +36,6 @@ use crate::dom::mediastream::MediaStream;
 use crate::dom::mediastreamtrack::MediaStreamTrack;
 use crate::dom::promise::Promise;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct AudioContext {
@@ -154,7 +153,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
 
         // Step 3.
         if self.context.State() == AudioContextState::Suspended {
-            promise.resolve_native(&(), CanGc::from_cx(cx));
+            promise.resolve_native_with_cx(cx, &());
             return promise;
         }
 
@@ -169,7 +168,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
                         let base_context = base_context.root();
                         let context = context.root();
                         let promise = trusted_promise.root();
-                        promise.resolve_native(&(), CanGc::from_cx(cx));
+                        promise.resolve_native_with_cx(cx, &());
                         if base_context.State() != AudioContextState::Suspended {
                             base_context.set_state_attribute(AudioContextState::Suspended);
                             context.global().task_manager().dom_manipulation_task_source().queue_simple_event(
@@ -210,7 +209,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
 
         // Step 3.
         if self.context.State() == AudioContextState::Closed {
-            promise.resolve_native(&(), CanGc::from_cx(cx));
+            promise.resolve_native_with_cx(cx, &());
             return promise;
         }
 
@@ -225,7 +224,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
                         let base_context = base_context.root();
                         let context = context.root();
                         let promise = trusted_promise.root();
-                        promise.resolve_native(&(), CanGc::from_cx(cx));
+                        promise.resolve_native_with_cx(cx, &());
                         if base_context.State() != AudioContextState::Closed {
                             base_context.set_state_attribute(AudioContextState::Closed);
                             context.global().task_manager().dom_manipulation_task_source().queue_simple_event(

--- a/components/script/dom/audio/baseaudiocontext.rs
+++ b/components/script/dom/audio/baseaudiocontext.rs
@@ -541,7 +541,7 @@ impl BaseAudioContextMethods<crate::DomTypeHolder> for BaseAudioContext {
                         if let Some(callback) = resolver.success_callback {
                             let _ = callback.Call__(cx, &buffer, ExceptionHandling::Report);
                         }
-                        resolver.promise.resolve_native(&buffer, CanGc::from_cx(cx));
+                        resolver.promise.resolve_native_with_cx(cx, &buffer);
                     }));
                 })
                 .error(move |error| {

--- a/components/script/dom/audio/offlineaudiocontext.rs
+++ b/components/script/dom/audio/offlineaudiocontext.rs
@@ -202,7 +202,7 @@ impl OfflineAudioContextMethods<crate::DomTypeHolder> for OfflineAudioContext {
                     (*this.pending_rendering_promise.borrow_mut())
                         .take()
                         .unwrap()
-                        .resolve_native(&buffer, CanGc::from_cx(cx));
+                        .resolve_native_with_cx(cx, &buffer);
                     let global = &this.global();
                     let window = global.as_window();
                     let event = OfflineAudioCompletionEvent::new(window,

--- a/components/script/dom/bindings/refcounted.rs
+++ b/components/script/dom/bindings/refcounted.rs
@@ -32,7 +32,6 @@ use std::sync::{Arc, Weak};
 use js::jsapi::JSTracer;
 use rustc_hash::FxHashMap;
 use script_bindings::reflector::{DomObject, Reflector};
-use script_bindings::script_runtime::CanGc;
 
 use crate::dom::bindings::conversions::ToJSValConvertible;
 use crate::dom::bindings::error::Error;
@@ -151,7 +150,7 @@ impl TrustedPromise {
         let this = self;
         task!(resolve_promise: move |cx| {
             debug!("Resolving promise.");
-            this.root().resolve_native(&value, CanGc::from_cx(cx));
+            this.root().resolve_native_with_cx(cx, &value);
         })
     }
 }

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -324,7 +324,7 @@ impl BlobMethods<crate::DomTypeHolder> for Blob {
                 Ok(b) => {
                     let (text, _) = UTF_8.decode_with_bom_removal(&b);
                     let text = DOMString::from(text);
-                    promise.resolve_native(&text, CanGc::from_cx(cx));
+                    promise.resolve_native_with_cx(cx, &text);
                 },
                 Err(e) => {
                     promise.reject_error_with_cx(cx, e);
@@ -367,7 +367,7 @@ impl BlobMethods<crate::DomTypeHolder> for Blob {
                     CanGc::from_cx(cx),
                 )
                 .expect("Converting input to ArrayBufferU8 should never fail");
-                success_promise.resolve_native(&array_buffer, CanGc::from_cx(cx));
+                success_promise.resolve_native_with_cx(cx, &array_buffer);
             }),
             Rc::new(move |cx, value| {
                 failure_promise.reject(cx.into(), value, CanGc::from_cx(cx));
@@ -408,7 +408,7 @@ impl BlobMethods<crate::DomTypeHolder> for Blob {
                     CanGc::from_cx(cx),
                 )
                 .expect("Converting input to uint8 array should never fail");
-                p_success.resolve_native(&arr, CanGc::from_cx(cx));
+                p_success.resolve_native_with_cx(cx, &arr);
             }),
             Rc::new(move |cx, v| {
                 p_failure.reject(cx.into(), v, CanGc::from_cx(cx));

--- a/components/script/dom/bluetooth/bluetooth.rs
+++ b/components/script/dom/bluetooth/bluetooth.rs
@@ -588,7 +588,7 @@ impl AsyncBluetoothListener for Bluetooth {
             BluetoothResponse::RequestDevice(device) => {
                 let mut device_instance_map = self.device_instance_map.borrow_mut();
                 if let Some(existing_device) = device_instance_map.get(&device.id) {
-                    return promise.resolve_native(&**existing_device, CanGc::from_cx(cx));
+                    return promise.resolve_native_with_cx(cx, &**existing_device);
                 }
                 let bt_device = BluetoothDevice::new(
                     cx,
@@ -608,12 +608,12 @@ impl AsyncBluetoothListener for Bluetooth {
                     });
                 // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetooth-requestdevice
                 // Step 5.
-                promise.resolve_native(&bt_device, CanGc::from_cx(cx));
+                promise.resolve_native_with_cx(cx, &bt_device);
             },
             // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetooth-getavailability
             // Step 2 - 3.
             BluetoothResponse::GetAvailability(is_available) => {
-                promise.resolve_native(&is_available, CanGc::from_cx(cx));
+                promise.resolve_native_with_cx(cx, &is_available);
             },
             _ => promise.reject_error(
                 Error::Type(c"Something went wrong...".to_owned()),
@@ -657,7 +657,7 @@ impl PermissionAlgorithm for Bluetooth {
         // Step 3.
         if let PermissionState::Denied = status.get_state() {
             status.set_devices(Vec::new());
-            return promise.resolve_native(status, CanGc::from_cx(cx));
+            return promise.resolve_native_with_cx(cx, status);
         }
 
         // Step 4.
@@ -729,7 +729,7 @@ impl PermissionAlgorithm for Bluetooth {
 
         // https://w3c.github.io/permissions/#dom-permissions-query
         // Step 7.
-        promise.resolve_native(status, CanGc::from_cx(cx));
+        promise.resolve_native_with_cx(cx, status);
     }
 
     /// <https://webbluetoothcg.github.io/web-bluetooth/#request-the-bluetooth-permission>

--- a/components/script/dom/bluetooth/bluetoothdevice.rs
+++ b/components/script/dom/bluetooth/bluetoothdevice.rs
@@ -349,7 +349,7 @@ impl AsyncBluetoothListener for BluetoothDevice {
                 // Step 3.1.
                 self.watching_advertisements.set(true);
                 // Step 3.2.
-                promise.resolve_native(&(), CanGc::from_cx(cx));
+                promise.resolve_native_with_cx(cx, &());
             },
             _ => promise.reject_error(
                 Error::Type(c"Something went wrong...".to_owned()),

--- a/components/script/dom/bluetooth/bluetoothpermissionresult.rs
+++ b/components/script/dom/bluetooth/bluetoothpermissionresult.rs
@@ -118,7 +118,7 @@ impl AsyncBluetoothListener for BluetoothPermissionResult {
 
                     // https://w3c.github.io/permissions/#dom-permissions-request
                     // Step 8.
-                    return promise.resolve_native(self, CanGc::from_cx(cx));
+                    return promise.resolve_native_with_cx(cx, self);
                 }
                 let bt_device = BluetoothDevice::new(
                     cx,
@@ -141,7 +141,7 @@ impl AsyncBluetoothListener for BluetoothPermissionResult {
 
                 // https://w3c.github.io/permissions/#dom-permissions-request
                 // Step 8.
-                promise.resolve_native(self, CanGc::from_cx(cx));
+                promise.resolve_native_with_cx(cx, self);
             },
             _ => promise.reject_error(
                 Error::Type(c"Something went wrong...".to_owned()),

--- a/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
@@ -320,10 +320,8 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTCharacteristic {
             // Step 7.
             BluetoothResponse::GetDescriptors(descriptors_vec, single) => {
                 if single {
-                    promise.resolve_native(
-                        &device.get_or_create_descriptor(cx, &descriptors_vec[0], self),
-                        CanGc::from_cx(cx),
-                    );
+                    let descriptor = device.get_or_create_descriptor(cx, &descriptors_vec[0], self);
+                    promise.resolve_native_with_cx(cx, &descriptor);
                     return;
                 }
                 let mut descriptors = vec![];
@@ -331,7 +329,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTCharacteristic {
                     let bt_descriptor = device.get_or_create_descriptor(cx, &descriptor, self);
                     descriptors.push(bt_descriptor);
                 }
-                promise.resolve_native(&descriptors, CanGc::from_cx(cx));
+                promise.resolve_native_with_cx(cx, &descriptors);
             },
             // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-readvalue
             BluetoothResponse::ReadValue(result) => {
@@ -347,7 +345,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTCharacteristic {
                     .fire_bubbling_event(cx, atom!("characteristicvaluechanged"));
 
                 // Step 5.5.4.
-                promise.resolve_native(&value, CanGc::from_cx(cx));
+                promise.resolve_native_with_cx(cx, &value);
             },
             // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-writevalue
             BluetoothResponse::WriteValue(result) => {
@@ -358,7 +356,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTCharacteristic {
                 *self.value.borrow_mut() = Some(ByteString::new(result));
 
                 // Step 7.5.3.
-                promise.resolve_native(&(), CanGc::from_cx(cx));
+                promise.resolve_native_with_cx(cx, &());
             },
             // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-startnotifications
             // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-stopnotifications
@@ -368,7 +366,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTCharacteristic {
 
                 // (StartNotification) Step 11.
                 // (StopNotification)  Step 5.
-                promise.resolve_native(self, CanGc::from_cx(cx));
+                promise.resolve_native_with_cx(cx, self);
             },
             _ => promise.reject_error(
                 Error::Type(c"Something went wrong...".to_owned()),

--- a/components/script/dom/bluetooth/bluetoothremotegattdescriptor.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattdescriptor.rs
@@ -198,7 +198,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTDescriptor {
                 *self.value.borrow_mut() = Some(value.clone());
 
                 // Step 5.4.3.
-                promise.resolve_native(&value, CanGc::from_cx(cx));
+                promise.resolve_native_with_cx(cx, &value);
             },
             // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattdescriptor-writevalue
             BluetoothResponse::WriteValue(result) => {
@@ -210,7 +210,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTDescriptor {
 
                 // Step 7.4.3.
                 // TODO: Resolve promise with undefined instead of a value.
-                promise.resolve_native(&(), CanGc::from_cx(cx));
+                promise.resolve_native_with_cx(cx, &());
             },
             _ => promise.reject_error(
                 Error::Type(c"Something went wrong...".to_owned()),

--- a/components/script/dom/bluetooth/bluetoothremotegattserver.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattserver.rs
@@ -174,17 +174,15 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTServer {
                 self.connected.set(connected);
 
                 // Step 5.2.5.
-                promise.resolve_native(self, CanGc::from_cx(cx));
+                promise.resolve_native_with_cx(cx, self);
             },
             // https://webbluetoothcg.github.io/web-bluetooth/#getgattchildren
             // Step 7.
             BluetoothResponse::GetPrimaryServices(services_vec, single) => {
                 let device = self.Device();
                 if single {
-                    promise.resolve_native(
-                        &device.get_or_create_service(cx, &services_vec[0], self),
-                        CanGc::from_cx(cx),
-                    );
+                    let descriptor = device.get_or_create_service(cx, &services_vec[0], self);
+                    promise.resolve_native_with_cx(cx, &descriptor);
                     return;
                 }
                 let mut services = vec![];
@@ -192,7 +190,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTServer {
                     let bt_service = device.get_or_create_service(cx, &service, self);
                     services.push(bt_service);
                 }
-                promise.resolve_native(&services, CanGc::from_cx(cx));
+                promise.resolve_native_with_cx(cx, &services);
             },
             _ => promise.reject_error(
                 Error::Type(c"Something went wrong...".to_owned()),

--- a/components/script/dom/bluetooth/bluetoothremotegattservice.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattservice.rs
@@ -186,10 +186,9 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTService {
             // Step 7.
             BluetoothResponse::GetCharacteristics(characteristics_vec, single) => {
                 if single {
-                    promise.resolve_native(
-                        &device.get_or_create_characteristic(cx, &characteristics_vec[0], self),
-                        CanGc::from_cx(cx),
-                    );
+                    let characteristic =
+                        device.get_or_create_characteristic(cx, &characteristics_vec[0], self);
+                    promise.resolve_native_with_cx(cx, &characteristic);
                     return;
                 }
                 let mut characteristics = vec![];
@@ -198,24 +197,23 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTService {
                         device.get_or_create_characteristic(cx, &characteristic, self);
                     characteristics.push(bt_characteristic);
                 }
-                promise.resolve_native(&characteristics, CanGc::from_cx(cx));
+                promise.resolve_native_with_cx(cx, &characteristics);
             },
             // https://webbluetoothcg.github.io/web-bluetooth/#getgattchildren
             // Step 7.
             BluetoothResponse::GetIncludedServices(services_vec, single) => {
                 let gatt_server = device.get_gatt(cx);
                 if single {
-                    return promise.resolve_native(
-                        &device.get_or_create_service(cx, &services_vec[0], &gatt_server),
-                        CanGc::from_cx(cx),
-                    );
+                    let characteristic =
+                        device.get_or_create_service(cx, &services_vec[0], &gatt_server);
+                    return promise.resolve_native_with_cx(cx, &characteristic);
                 }
                 let mut services = vec![];
                 for service in services_vec {
                     let bt_service = device.get_or_create_service(cx, &service, &gatt_server);
                     services.push(bt_service);
                 }
-                promise.resolve_native(&services, CanGc::from_cx(cx));
+                promise.resolve_native_with_cx(cx, &services);
             },
             _ => promise.reject_error(
                 Error::Type(c"Something went wrong...".to_owned()),

--- a/components/script/dom/canvas/imagebitmap.rs
+++ b/components/script/dom/canvas/imagebitmap.rs
@@ -330,7 +330,7 @@ impl ImageBitmap {
                         let promise = trusted_promise.root();
                         let image_bitmap = trusted_image_bitmap.root();
 
-                        promise.resolve_native(&image_bitmap, CanGc::from_cx(cx));
+                        promise.resolve_native_with_cx(cx, &image_bitmap);
                     }),
                 );
             };

--- a/components/script/dom/canvas/offscreencanvas.rs
+++ b/components/script/dom/canvas/offscreencanvas.rs
@@ -574,7 +574,7 @@ impl OffscreenCanvasMethods<crate::DomTypeHolder> for OffscreenCanvas {
                 let blob_impl = BlobImpl::new_from_bytes(encoded, image_type.as_mime_type());
                 let blob = Blob::new(cx, &this.global(), blob_impl);
 
-                promise.resolve_native(&blob, CanGc::from_cx(cx));
+                promise.resolve_native_with_cx(cx, &blob);
             }));
 
         // Step 8. Return result.

--- a/components/script/dom/clipboard/clipboard.rs
+++ b/components/script/dom/clipboard/clipboard.rs
@@ -169,7 +169,7 @@ impl ClipboardMethods<crate::DomTypeHolder> for Clipboard {
                 write_blobs_and_option_to_the_clipboard(global.as_window(), item_list, option);
 
                 // Step 3.3.6 Resolve p.
-                promise.resolve_native(&(), CanGc::from_cx(cx));
+                promise.resolve_native_with_cx(cx, &());
             }),
         );
 

--- a/components/script/dom/clipboard/clipboarditem.rs
+++ b/components/script/dom/clipboard/clipboarditem.rs
@@ -66,7 +66,7 @@ impl Callback for RepresentationDataPromiseFulfillmentHandler {
             );
 
             // 1.3 Resolve p with blobData.
-            self.promise.resolve_native(&blob_data, CanGc::from_cx(cx));
+            self.promise.resolve_native_with_cx(cx, &blob_data);
         }
         // 2. If v is a Blob, then follow the below steps:
         else if DomRoot::<Blob>::safe_from_jsval(cx.into(), v, (), CanGc::from_cx(cx))

--- a/components/script/dom/css/cssstylesheet.rs
+++ b/components/script/dom/css/cssstylesheet.rs
@@ -516,7 +516,7 @@ impl CSSStyleSheetMethods<crate::DomTypeHolder> for CSSStyleSheet {
                 sheet.disallow_modification.set(false);
 
                 // Step 4.5. Resolve promise with sheet.
-                trusted_promise.root().resolve_native(&sheet, CanGc::from_cx(cx));
+                trusted_promise.root().resolve_native_with_cx(cx, &sheet);
             }));
 
         Ok(promise)

--- a/components/script/dom/css/fontface.rs
+++ b/components/script/dom/css/fontface.rs
@@ -610,7 +610,7 @@ impl FontFaceMethods<crate::DomTypeHolder> for FontFace {
                             font_face.status.set(FontFaceLoadStatus::Loaded);
                             let old_template = font_face.template.borrow_mut().replace((family_name, template));
                             debug_assert!(old_template.is_none(), "FontFace's template must be intialized only once");
-                            font_face.font_status_promise.resolve_native(&font_face, CanGc::from_cx(cx));
+                            font_face.font_status_promise.resolve_native_with_cx(cx, &font_face);
                         }
                     }
 

--- a/components/script/dom/css/fontfaceset.rs
+++ b/components/script/dom/css/fontfaceset.rs
@@ -23,7 +23,6 @@ use crate::dom::fontface::FontFace;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 /// <https://drafts.csswg.org/css-font-loading/#FontFaceSet-interface>
 #[dom_struct]
@@ -80,7 +79,7 @@ impl FontFaceSet {
         if self.promise.is_fulfilled() {
             return false;
         }
-        self.promise.resolve_native(self, CanGc::from_cx(cx));
+        self.promise.resolve_native_with_cx(cx, self);
         true
     }
 
@@ -188,7 +187,7 @@ impl FontFaceSetMethods<crate::DomTypeHolder> for FontFaceSet {
                 // TODO: Step 4.2. Resolve promise with the result of waiting for all of the
                 // [[FontStatusPromise]]s of each font face in the font face list, in order.
                 let matched_fonts = Vec::<&FontFace>::new();
-                promise.resolve_native(&matched_fonts, CanGc::from_cx(cx));
+                promise.resolve_native_with_cx(cx, &matched_fonts);
             }));
 
         // Step 2. Return promise. Complete the rest of these steps asynchronously.

--- a/components/script/dom/fullscreen/lib.rs
+++ b/components/script/dom/fullscreen/lib.rs
@@ -331,7 +331,7 @@ impl TaskOnce for ElementPerformFullscreenEnter {
 
         // Step 14.
         // > Resolve promise with undefined.
-        promise.resolve_native(&(), CanGc::from_cx(cx));
+        promise.resolve_native_with_cx(cx, &());
     }
 }
 
@@ -372,6 +372,6 @@ impl TaskOnce for ElementPerformFullscreenExit {
 
         // Step 16
         // > Resolve promise with undefined.
-        self.promise.root().resolve_native(&(), CanGc::from_cx(cx));
+        self.promise.root().resolve_native_with_cx(cx, &());
     }
 }

--- a/components/script/dom/gamepad/gamepadhapticactuator.rs
+++ b/components/script/dom/gamepad/gamepadhapticactuator.rs
@@ -203,7 +203,7 @@ impl GamepadHapticActuatorMethods<crate::DomTypeHolder> for GamepadHapticActuato
                 task!(preempt_promise: move |cx| {
                     let promise = trusted_promise.root();
                     let message = DOMString::from("preempted");
-                    promise.resolve_native(&message, CanGc::from_cx(cx));
+                    promise.resolve_native_with_cx(cx, &message);
                 }),
             );
         }
@@ -267,7 +267,7 @@ impl GamepadHapticActuatorMethods<crate::DomTypeHolder> for GamepadHapticActuato
                 task!(preempt_promise: move |cx| {
                     let promise = trusted_promise.root();
                     let message = DOMString::from("preempted");
-                    promise.resolve_native(&message, CanGc::from_cx(cx));
+                    promise.resolve_native_with_cx(cx, &message);
                 }),
             );
         }
@@ -338,7 +338,7 @@ impl GamepadHapticActuator {
                     }
                     let promise = trusted_promise.root();
                     let message = DOMString::from("complete");
-                    promise.resolve_native(&message, CanGc::from_cx(cx));
+                    promise.resolve_native_with_cx(cx, &message);
                 })
             );
         }
@@ -358,7 +358,7 @@ impl GamepadHapticActuator {
                     return;
                 };
                 let message = DOMString::from("preempted");
-                promise.resolve_native(&message, CanGc::from_cx(cx));
+                promise.resolve_native_with_cx(cx, &message);
             }),
         );
 

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -1390,7 +1390,7 @@ impl HTMLImageElement {
             .dom_manipulation_task_source()
             .queue(task!(fulfill_image_decode_promises: move |cx| {
                 for trusted_promise in trusted_image_decode_promises {
-                    trusted_promise.root().resolve_native(&(), CanGc::from_cx(cx));
+                    trusted_promise.root().resolve_native_with_cx(cx, &());
                 }
             }));
     }

--- a/components/script/dom/indexeddb/idbfactory.rs
+++ b/components/script/dom/indexeddb/idbfactory.rs
@@ -657,7 +657,7 @@ impl IDBFactoryMethods<crate::DomTypeHolder> for IDBFactory {
                         rooted!(&in(cx) let mut rval = UndefinedValue());
                         error
                             .to_jsval(cx.into(), &promise.global(), rval.handle_mut(), CanGc::from_cx(cx));
-                        promise.reject_native(&rval.handle(), CanGc::from_cx(cx));
+                        promise.reject_native_with_cx(cx, &rval.handle());
                     },
                     Ok(info_list) => {
                         let info_list: Vec<IDBDatabaseInfo> = info_list
@@ -667,7 +667,7 @@ impl IDBFactoryMethods<crate::DomTypeHolder> for IDBFactory {
                                 version: Some(info.version),
                         })
                         .collect();
-                        promise.resolve_native(&info_list, CanGc::from_cx(cx));
+                        promise.resolve_native_with_cx(cx, &info_list);
                 },
             }
             }));

--- a/components/script/dom/media/mediadevices.rs
+++ b/components/script/dom/media/mediadevices.rs
@@ -70,7 +70,7 @@ impl MediaDevicesMethods<crate::DomTypeHolder> for MediaDevices {
             stream.add_track(&track);
         }
 
-        p.resolve_native(&stream, CanGc::from_cx(cx));
+        p.resolve_native_with_cx(cx, &stream);
         p
     }
 
@@ -107,7 +107,7 @@ impl MediaDevicesMethods<crate::DomTypeHolder> for MediaDevices {
             })
             .unwrap_or_default();
 
-        p.resolve_native(&result_list, CanGc::from_cx(cx));
+        p.resolve_native_with_cx(cx, &result_list);
 
         // Step 3.
         p

--- a/components/script/dom/notification.rs
+++ b/components/script/dom/notification.rs
@@ -431,7 +431,7 @@ impl NotificationMethods<crate::DomTypeHolder> for Notification {
                 }
 
                 // Step 3.2.2: Resolve promise with permissionState.
-                promise.resolve_native(&notification_permission, CanGc::from_cx(cx));
+                promise.resolve_native_with_cx(cx, &notification_permission);
             }),
         );
 

--- a/components/script/dom/permissions.rs
+++ b/components/script/dom/permissions.rs
@@ -164,14 +164,14 @@ impl Permissions {
                         // (Request) Step 7. The default algorithm always resolve
 
                         // (Request) Step 8.
-                        p.resolve_native(&status, CanGc::from_cx(cx));
+                        p.resolve_native_with_cx(cx, &status);
                     },
                     Operation::Query => {
                         // (Query) Step 6.
                         Permissions::permission_query(cx, &p, &root_desc, &status);
 
                         // (Query) Step 7.
-                        p.resolve_native(&status, CanGc::from_cx(cx));
+                        p.resolve_native_with_cx(cx, &status);
                     },
 
                     Operation::Revoke => {

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -220,6 +220,17 @@ impl Promise {
         self.resolve(cx, v.handle(), can_gc);
     }
 
+    pub(crate) fn resolve_native_with_cx<T>(&self, cx: &mut JSContext, val: &T)
+    where
+        T: SafeToJSValConvertible,
+    {
+        let mut realm = enter_auto_realm(cx, self);
+        let cx = &mut realm.current_realm();
+        rooted!(&in(cx) let mut v = UndefinedValue());
+        val.safe_to_jsval(cx.into(), v.handle_mut(), CanGc::from_cx(cx));
+        self.resolve(cx.into(), v.handle(), CanGc::from_cx(cx));
+    }
+
     #[expect(unsafe_code)]
     pub(crate) fn resolve(&self, cx: SafeJSContext, value: HandleValue, _can_gc: CanGc) {
         unsafe {
@@ -238,6 +249,17 @@ impl Promise {
         rooted!(in(*cx) let mut v = UndefinedValue());
         val.safe_to_jsval(cx, v.handle_mut(), can_gc);
         self.reject(cx, v.handle(), can_gc);
+    }
+
+    pub(crate) fn reject_native_with_cx<T>(&self, cx: &mut JSContext, val: &T)
+    where
+        T: SafeToJSValConvertible,
+    {
+        let mut realm = enter_auto_realm(cx, self);
+        let cx = &mut realm.current_realm();
+        rooted!(&in(cx) let mut v = UndefinedValue());
+        val.safe_to_jsval(cx.into(), v.handle_mut(), CanGc::from_cx(cx));
+        self.reject(cx.into(), v.handle(), CanGc::from_cx(cx));
     }
 
     pub(crate) fn reject_error(&self, error: Error, can_gc: CanGc) {
@@ -654,13 +676,13 @@ pub(crate) fn wait_for_all_promise(
     // Let successSteps be the following steps, given results:
     let success_steps = Rc::new(move |cx: &mut JSContext, results: Vec<HandleValue>| {
         // Resolve promise with results.
-        success_promise.resolve_native(&results, CanGc::from_cx(cx));
+        success_promise.resolve_native_with_cx(cx, &results);
     });
 
     // Let failureSteps be the following steps, given reason:
     let failure_steps = Rc::new(move |cx: &mut JSContext, reason: HandleValue| {
         // Reject promise with reason.
-        failure_promise.reject_native(&reason, CanGc::from_cx(cx));
+        failure_promise.reject_native_with_cx(cx, &reason);
     });
 
     // Wait for all with promises, given successSteps and failureSteps.

--- a/components/script/dom/servointernals.rs
+++ b/components/script/dom/servointernals.rs
@@ -204,7 +204,7 @@ impl RoutedPromiseListener<MemoryReportResult> for ServoInternals {
     ) {
         let stringified = serde_json::to_string(&response.results)
             .unwrap_or_else(|_| "{ error: \"failed to create memory report\"}".to_owned());
-        promise.resolve_native(&stringified, CanGc::from_cx(cx));
+        promise.resolve_native_with_cx(cx, &stringified);
     }
 }
 

--- a/components/script/dom/storagemanager.rs
+++ b/components/script/dom/storagemanager.rs
@@ -112,7 +112,7 @@ impl StorageManagerEstimateResponseHandler {
                         let mut estimate = StorageEstimate::empty();
                         estimate.usage = Some(usage);
                         estimate.quota = Some(quota);
-                        promise.resolve_native(&estimate, CanGc::from_cx(cx));
+                        promise.resolve_native_with_cx(cx, &estimate);
                     },
                     Err(message) => {
                         promise.reject_error_with_cx(cx, StorageManager::type_error_from_string(message));

--- a/components/script/dom/stream/byteteereadintorequest.rs
+++ b/components/script/dom/stream/byteteereadintorequest.rs
@@ -170,7 +170,7 @@ impl ByteTeeReadIntoRequest {
                     self.stream
                         .cancel(cx, &self.stream.global(), error_value.handle());
                 self.cancel_promise
-                    .resolve_native(&cancel_result, CanGc::from_cx(cx));
+                    .resolve_native_with_cx(cx, &cancel_result);
 
                 // Return.
                 return Ok(());
@@ -276,7 +276,7 @@ impl ByteTeeReadIntoRequest {
 
         // If byobCanceled is false or otherCanceled is false, resolve cancelPromise with undefined.
         if !byob_canceled || !other_canceled {
-            self.cancel_promise.resolve_native(&(), CanGc::from_cx(cx));
+            self.cancel_promise.resolve_native_with_cx(cx, &());
         }
 
         Ok(())

--- a/components/script/dom/stream/byteteereadrequest.rs
+++ b/components/script/dom/stream/byteteereadrequest.rs
@@ -148,7 +148,7 @@ impl ByteTeeReadRequest {
                 .stream
                 .cancel(cx, &self.stream.global(), error_value.handle());
             self.cancel_promise
-                .resolve_native(&cancel_result, CanGc::from_cx(cx));
+                .resolve_native_with_cx(cx, &cancel_result);
         };
 
         // Prepare per branch chunks ahead of the spec enqueue steps.
@@ -254,7 +254,7 @@ impl ByteTeeReadRequest {
 
         // If canceled1 is false or canceled2 is false, resolve cancelPromise with undefined.
         if !self.canceled_1.get() || !self.canceled_2.get() {
-            self.cancel_promise.resolve_native(&(), CanGc::from_cx(cx));
+            self.cancel_promise.resolve_native_with_cx(cx, &());
         }
 
         Ok(())

--- a/components/script/dom/stream/byteteeunderlyingsource.rs
+++ b/components/script/dom/stream/byteteeunderlyingsource.rs
@@ -483,6 +483,6 @@ impl ByteTeeUnderlyingSource {
 
         // Resolve cancelPromise with cancelResult.
         self.cancel_promise
-            .resolve_native(&cancel_result, CanGc::from_cx(cx));
+            .resolve_native_with_cx(cx, &cancel_result);
     }
 }

--- a/components/script/dom/stream/defaultteereadrequest.rs
+++ b/components/script/dom/stream/defaultteereadrequest.rs
@@ -199,7 +199,7 @@ impl DefaultTeeReadRequest {
         }
         // If canceled_1 is false or canceled_2 is false, resolve cancelPromise with undefined.
         if !self.canceled_1.get() || !self.canceled_2.get() {
-            self.cancel_promise.resolve_native(&(), CanGc::from_cx(cx));
+            self.cancel_promise.resolve_native_with_cx(cx, &());
         }
     }
     /// <https://streams.spec.whatwg.org/#read-request-error-steps>

--- a/components/script/dom/stream/defaultteeunderlyingsource.rs
+++ b/components/script/dom/stream/defaultteeunderlyingsource.rs
@@ -200,6 +200,6 @@ impl DefaultTeeUnderlyingSource {
 
         // Resolve cancelPromise with cancelResult.
         self.cancel_promise
-            .resolve_native(&cancel_result, CanGc::from_cx(cx));
+            .resolve_native_with_cx(cx, &cancel_result);
     }
 }

--- a/components/script/dom/stream/readablebytestreamcontroller.rs
+++ b/components/script/dom/stream/readablebytestreamcontroller.rs
@@ -1841,7 +1841,7 @@ impl ReadableByteStreamController {
             .call_cancel_algorithm(cx, global, reason)
             .unwrap_or_else(|| {
                 let promise = Promise::new2(cx, global);
-                promise.resolve_native(&(), CanGc::from_cx(cx));
+                promise.resolve_native_with_cx(cx, &());
                 Ok(promise)
             });
 
@@ -1849,7 +1849,7 @@ impl ReadableByteStreamController {
             rooted!(&in(cx) let mut rval = UndefinedValue());
             error.to_jsval(cx.into(), global, rval.handle_mut(), CanGc::from_cx(cx));
             let promise = Promise::new2(cx, global);
-            promise.reject_native(&rval.handle(), CanGc::from_cx(cx));
+            promise.reject_native_with_cx(cx, &rval.handle());
             promise
         });
 

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -745,10 +745,10 @@ impl PipeTo {
             error.set(shutdown_error.get());
             // If error was given, reject promise with error.
             self.result_promise
-                .reject_native(&error.handle(), CanGc::from_cx(cx));
+                .reject_native_with_cx(cx, &error.handle());
         } else {
             // Otherwise, resolve promise with undefined.
-            self.result_promise.resolve_native(&(), CanGc::from_cx(cx));
+            self.result_promise.resolve_native_with_cx(cx, &());
         }
     }
 }
@@ -766,7 +766,7 @@ impl Callback for SourceCancelPromiseFulfillmentHandler {
     /// <https://streams.spec.whatwg.org/#readable-stream-cancel>.
     /// An implementation of <https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled>
     fn callback(&self, cx: &mut CurrentRealm, _v: SafeHandleValue) {
-        self.result.resolve_native(&(), CanGc::from_cx(cx));
+        self.result.resolve_native_with_cx(cx, &());
     }
 }
 
@@ -783,7 +783,7 @@ impl Callback for SourceCancelPromiseRejectionHandler {
     /// <https://streams.spec.whatwg.org/#readable-stream-cancel>.
     /// An implementation of <https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled>
     fn callback(&self, cx: &mut CurrentRealm, v: SafeHandleValue) {
-        self.result.reject_native(&v, CanGc::from_cx(cx));
+        self.result.reject_native_with_cx(cx, &v);
     }
 }
 
@@ -1627,7 +1627,7 @@ impl ReadableStream {
             let promise = Promise::new2(cx, global);
             rooted!(&in(cx) let mut rval = UndefinedValue());
             self.stored_error.safe_to_jsval(cx, rval.handle_mut());
-            promise.reject_native(&rval.handle(), CanGc::from_cx(cx));
+            promise.reject_native_with_cx(cx, &rval.handle());
             return promise;
         }
         // Perform ! ReadableStreamClose(stream).

--- a/components/script/dom/stream/readablestreambyobreader.rs
+++ b/components/script/dom/stream/readablestreambyobreader.rs
@@ -170,7 +170,7 @@ impl Callback for ByteTeeClosedPromiseRejectionHandler {
 
         // If canceled1 is false or canceled2 is false, resolve cancelPromise with undefined.
         if !self.canceled_1.get() || !self.canceled_2.get() {
-            self.cancel_promise.resolve_native(&(), CanGc::from_cx(cx));
+            self.cancel_promise.resolve_native_with_cx(cx, &());
         }
     }
 }

--- a/components/script/dom/stream/readablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/readablestreamdefaultcontroller.rs
@@ -577,7 +577,7 @@ impl ReadableStreamDefaultController {
             .call_cancel_algorithm(cx, global, reason)
             .unwrap_or_else(|| {
                 let promise = Promise::new2(cx, global);
-                promise.resolve_native(&(), CanGc::from_cx(cx));
+                promise.resolve_native_with_cx(cx, &());
                 Ok(promise)
             });
         let promise = result.unwrap_or_else(|error| {
@@ -585,7 +585,7 @@ impl ReadableStreamDefaultController {
 
             error.to_jsval(cx.into(), global, rval.handle_mut(), CanGc::from_cx(cx));
             let promise = Promise::new2(cx, global);
-            promise.reject_native(&rval.handle(), CanGc::from_cx(cx));
+            promise.reject_native_with_cx(cx, &rval.handle());
             promise
         });
 

--- a/components/script/dom/stream/readablestreamdefaultreader.rs
+++ b/components/script/dom/stream/readablestreamdefaultreader.rs
@@ -153,7 +153,7 @@ impl ReadRequest {
                         // Spec note: Avoid direct recursion; queue into a microtask.
                         // Resolving the promise will queue a microtask to call into the native handler.
                         let tick = Promise::new(&global, CanGc::from_cx(cx));
-                        tick.resolve_native(&(), CanGc::from_cx(cx));
+                        tick.resolve_native_with_cx(cx, &());
 
                         let handler = PromiseNativeHandler::new(
                             &global,
@@ -289,7 +289,7 @@ impl Callback for ByteTeeClosedPromiseRejectionHandler {
 
         // If canceled1 is false or canceled2 is false, resolve cancelPromise with undefined.
         if !self.canceled_1.get() || !self.canceled_2.get() {
-            self.cancel_promise.resolve_native(&(), CanGc::from_cx(cx));
+            self.cancel_promise.resolve_native_with_cx(cx, &());
         }
     }
 }
@@ -320,7 +320,7 @@ impl Callback for DefaultTeeClosedPromiseRejectionHandler {
 
         // If canceled_1 is false or canceled_2 is false, resolve cancelPromise with undefined.
         if !self.canceled_1.get() || !self.canceled_2.get() {
-            self.cancel_promise.resolve_native(&(), CanGc::from_cx(cx));
+            self.cancel_promise.resolve_native_with_cx(cx, &());
         }
     }
 }
@@ -395,9 +395,7 @@ impl ReadableStreamDefaultReader {
     /// <https://streams.spec.whatwg.org/#readable-stream-close>
     pub(crate) fn close(&self, cx: &mut js::context::JSContext) {
         // Resolve reader.[[closedPromise]] with undefined.
-        self.closed_promise
-            .borrow()
-            .resolve_native(&(), CanGc::from_cx(cx));
+        self.closed_promise.borrow().resolve_native_with_cx(cx, &());
         // If reader implements ReadableStreamDefaultReader,
         // Let readRequests be reader.[[readRequests]].
         let mut read_requests = self.take_read_requests();
@@ -424,9 +422,7 @@ impl ReadableStreamDefaultReader {
     /// <https://streams.spec.whatwg.org/#readable-stream-error>
     pub(crate) fn error(&self, cx: &mut js::context::JSContext, e: SafeHandleValue) {
         // Reject reader.[[closedPromise]] with e.
-        self.closed_promise
-            .borrow()
-            .reject_native(&e, CanGc::from_cx(cx));
+        self.closed_promise.borrow().reject_native_with_cx(cx, &e);
 
         // Set reader.[[closedPromise]].[[PromiseIsHandled]] to true.
         self.closed_promise.borrow().set_promise_is_handled();

--- a/components/script/dom/stream/transformstream.rs
+++ b/components/script/dom/stream/transformstream.rs
@@ -187,7 +187,7 @@ impl Callback for CancelPromiseFulfillment {
             self.controller
                 .get_finish_promise()
                 .expect("finish promise is not set")
-                .reject_native(&error.handle(), CanGc::from_cx(cx));
+                .reject_native_with_cx(cx, &error.handle());
         } else {
             // Otherwise:
             // Perform ! ReadableStreamDefaultControllerError(readable.[[controller]], reason).
@@ -201,7 +201,7 @@ impl Callback for CancelPromiseFulfillment {
             self.controller
                 .get_finish_promise()
                 .expect("finish promise is not set")
-                .resolve_native(&(), CanGc::from_cx(cx));
+                .resolve_native_with_cx(cx, &());
         }
     }
 }
@@ -273,7 +273,7 @@ impl Callback for SourceCancelPromiseFulfillment {
             self.stream.unblock_write(global, CanGc::from_cx(cx));
 
             // Resolve controller.[[finishPromise]] with undefined.
-            finish_promise.resolve_native(&(), CanGc::from_cx(cx));
+            finish_promise.resolve_native_with_cx(cx, &());
         }
     }
 }
@@ -342,7 +342,7 @@ impl Callback for FlushPromiseFulfillment {
             self.readable.get_default_controller().close(cx);
 
             // Resolve controller.[[finishPromise]] with undefined.
-            finish_promise.resolve_native(&(), CanGc::from_cx(cx));
+            finish_promise.resolve_native_with_cx(cx, &());
         }
     }
 }
@@ -1041,10 +1041,10 @@ impl TransformStreamMethods<crate::DomTypeHolder> for TransformStream {
             } else {
                 Promise::new_resolved(global, cx.into(), result.get(), CanGc::from_cx(cx))
             };
-            start_promise.resolve_native(&promise, CanGc::from_cx(cx));
+            start_promise.resolve_native_with_cx(cx, &promise);
         } else {
             // Otherwise, resolve startPromise with undefined.
-            start_promise.resolve_native(&(), CanGc::from_cx(cx));
+            start_promise.resolve_native_with_cx(cx, &());
         };
 
         Ok(stream)

--- a/components/script/dom/stream/underlyingsourcecontainer.rs
+++ b/components/script/dom/stream/underlyingsourcecontainer.rs
@@ -197,7 +197,7 @@ impl UnderlyingSourceContainer {
                     promise.reject_error_with_cx(cx, error);
                 } else {
                     // Otherwise, return a promise resolved with undefined.
-                    promise.resolve_native(&(), CanGc::from_cx(cx));
+                    promise.resolve_native_with_cx(cx, &());
                 }
                 Some(Ok(promise))
             },

--- a/components/script/dom/stream/writablestream.rs
+++ b/components/script/dom/stream/writablestream.rs
@@ -65,8 +65,7 @@ struct AbortAlgorithmFulfillmentHandler {
 impl Callback for AbortAlgorithmFulfillmentHandler {
     fn callback(&self, cx: &mut CurrentRealm, _v: SafeHandleValue) {
         // Resolve abortRequest’s promise with undefined.
-        self.abort_request_promise
-            .resolve_native(&(), CanGc::from_cx(cx));
+        self.abort_request_promise.resolve_native_with_cx(cx, &());
 
         // Perform ! WritableStreamRejectCloseAndClosedPromiseIfNeeded(stream).
         self.stream
@@ -91,7 +90,7 @@ impl Callback for AbortAlgorithmRejectionHandler {
     fn callback(&self, cx: &mut CurrentRealm, reason: SafeHandleValue) {
         // Reject abortRequest’s promise with reason.
         self.abort_request_promise
-            .reject_native(&reason, CanGc::from_cx(cx));
+            .reject_native_with_cx(cx, &reason);
 
         // Perform ! WritableStreamRejectCloseAndClosedPromiseIfNeeded(stream).
         self.stream
@@ -560,7 +559,7 @@ impl WritableStream {
         };
 
         // Reject stream.[[inFlightCloseRequest]] with error.
-        in_flight_close_request.reject_native(&error, CanGc::from_cx(cx));
+        in_flight_close_request.reject_native_with_cx(cx, &error);
 
         // Set stream.[[inFlightCloseRequest]] to undefined.
         // Done above with `take`.
@@ -574,7 +573,7 @@ impl WritableStream {
             // Reject stream.[[pendingAbortRequest]]'s promise with error.
             pending_abort_request
                 .promise
-                .reject_native(&error, CanGc::from_cx(cx));
+                .reject_native_with_cx(cx, &error);
 
             // Set stream.[[pendingAbortRequest]] to undefined.
             // Done above with `take`.
@@ -597,7 +596,7 @@ impl WritableStream {
         };
 
         // Reject stream.[[inFlightWriteRequest]] with error.
-        in_flight_write_request.reject_native(&error, CanGc::from_cx(cx));
+        in_flight_write_request.reject_native_with_cx(cx, &error);
 
         // Set stream.[[inFlightWriteRequest]] to undefined.
         // Done above with `take`.
@@ -1170,7 +1169,7 @@ impl CrossRealmTransformWritable {
         // If backpressurePromise is not undefined,
         if let Some(promise) = backpressure_promise {
             // Resolve backpressurePromise with undefined.
-            promise.resolve_native(&(), CanGc::from_cx(cx));
+            promise.resolve_native_with_cx(cx, &());
 
             // Set backpressurePromise to undefined.
             // Done above with `take`.

--- a/components/script/dom/stream/writablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/writablestreamdefaultcontroller.rs
@@ -635,7 +635,7 @@ impl WritableStreamDefaultController {
                     promise.reject_error_with_cx(cx, error);
                 } else {
                     // Otherwise, return a promise resolved with undefined.
-                    promise.resolve_native(&(), CanGc::from_cx(cx));
+                    promise.resolve_native_with_cx(cx, &());
                 }
                 promise
             },

--- a/components/script/dom/stream/writablestreamdefaultwriter.rs
+++ b/components/script/dom/stream/writablestreamdefaultwriter.rs
@@ -161,7 +161,7 @@ impl WritableStreamDefaultWriter {
     ) {
         self.closed_promise
             .borrow()
-            .reject_native(error, CanGc::from_cx(cx));
+            .reject_native_with_cx(cx, error);
     }
 
     pub(crate) fn set_close_promise_is_handled(&self) {
@@ -307,7 +307,7 @@ impl WritableStreamDefaultWriter {
             rooted!(&in(cx) let mut error = UndefinedValue());
             stream.get_stored_error(error.handle_mut());
             let promise = Promise::new2(cx, global);
-            promise.reject_native(&error.handle(), CanGc::from_cx(cx));
+            promise.reject_native_with_cx(cx, &error.handle());
             return promise;
         }
 
@@ -330,7 +330,7 @@ impl WritableStreamDefaultWriter {
             rooted!(&in(cx) let mut error = UndefinedValue());
             stream.get_stored_error(error.handle_mut());
             let promise = Promise::new2(cx, global);
-            promise.reject_native(&error.handle(), CanGc::from_cx(cx));
+            promise.reject_native_with_cx(cx, &error.handle());
             return promise;
         }
 
@@ -398,7 +398,7 @@ impl WritableStreamDefaultWriter {
         if stream.close_queued_or_in_flight() || stream.is_closed() {
             // return a promise resolved with undefined.
             let promise = Promise::new2(cx, global);
-            promise.resolve_native(&(), CanGc::from_cx(cx));
+            promise.resolve_native_with_cx(cx, &());
             return promise;
         }
 
@@ -408,7 +408,7 @@ impl WritableStreamDefaultWriter {
             rooted!(&in(cx) let mut error = UndefinedValue());
             stream.get_stored_error(error.handle_mut());
             let promise = Promise::new2(cx, global);
-            promise.reject_native(&error.handle(), CanGc::from_cx(cx));
+            promise.reject_native_with_cx(cx, &error.handle());
             return promise;
         }
 

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -256,7 +256,7 @@ impl SubtleCrypto {
                         rooted!(&in(cx) let mut rval = UndefinedValue());
                         jwk.safe_to_jsval(cx.into(), rval.handle_mut(), CanGc::from_cx(cx));
                         rooted!(&in(cx) let mut object = rval.to_object());
-                        promise.resolve_native(&*object, CanGc::from_cx(cx));
+                        promise.resolve_native_with_cx(cx, &*object);
                     },
                     Err(error) => {
                         subtle.reject_promise_with_error(promise, error);
@@ -277,7 +277,7 @@ impl SubtleCrypto {
             .queue(task!(resolve_key: move |cx| {
                 let key = trusted_key.root();
                 let promise = trusted_promise.root();
-                promise.resolve_native(&key, CanGc::from_cx(cx));
+                promise.resolve_native_with_cx(cx, &key);
             }));
     }
 
@@ -296,7 +296,7 @@ impl SubtleCrypto {
                     publicKey: trusted_public_key.map(|trusted_key| trusted_key.root()),
                 };
                 let promise = trusted_promise.root();
-                promise.resolve_native(&key_pair, CanGc::from_cx(cx));
+                promise.resolve_native_with_cx(cx, &key_pair);
             }));
     }
 
@@ -309,7 +309,7 @@ impl SubtleCrypto {
             .crypto_task_source()
             .queue(task!(resolve_bool: move |cx| {
                 let promise = trusted_promise.root();
-                promise.resolve_native(&result, CanGc::from_cx(cx));
+                promise.resolve_native_with_cx(cx, &result);
             }));
     }
 
@@ -338,7 +338,7 @@ impl SubtleCrypto {
         self.global().task_manager().crypto_task_source().queue(
             task!(resolve_encapsulated_key: move |cx| {
                 let promise = trusted_promise.root();
-                promise.resolve_native(&encapsulated_key, CanGc::from_cx(cx));
+                promise.resolve_native_with_cx(cx, &encapsulated_key);
             }),
         );
     }
@@ -355,7 +355,7 @@ impl SubtleCrypto {
         self.global().task_manager().crypto_task_source().queue(
             task!(resolve_encapsulated_bits: move |cx| {
                 let promise = trusted_promise.root();
-                promise.resolve_native(&encapsulated_bits, CanGc::from_cx(cx));
+                promise.resolve_native_with_cx(cx, &encapsulated_bits);
             }),
         );
     }

--- a/components/script/dom/webgpu/gpu.rs
+++ b/components/script/dom/webgpu/gpu.rs
@@ -125,15 +125,15 @@ impl RoutedPromiseListener<WebGPUAdapterResponse> for GPU {
                     adapter.adapter_id,
                     CanGc::from_cx(cx),
                 );
-                promise.resolve_native(&adapter, CanGc::from_cx(cx));
+                promise.resolve_native_with_cx(cx, &adapter);
             },
             Some(Err(e)) => {
                 warn!("Could not get GPUAdapter ({:?})", e);
-                promise.resolve_native(&None::<GPUAdapter>, CanGc::from_cx(cx));
+                promise.resolve_native_with_cx(cx, &None::<GPUAdapter>);
             },
             None => {
                 warn!("Couldn't get a response, because WebGPU is disabled");
-                promise.resolve_native(&None::<GPUAdapter>, CanGc::from_cx(cx));
+                promise.resolve_native_with_cx(cx, &None::<GPUAdapter>);
             },
         }
     }

--- a/components/script/dom/webgpu/gpuadapter.rs
+++ b/components/script/dom/webgpu/gpuadapter.rs
@@ -293,7 +293,7 @@ impl RoutedPromiseListener<WebGPUDeviceResponse> for GPUAdapter {
                     CanGc::from_cx(cx),
                 );
                 self.global().add_gpu_device(&device);
-                promise.resolve_native(&device, CanGc::from_cx(cx));
+                promise.resolve_native_with_cx(cx, &device);
             },
             // 1. If features are not supported reject promise with a TypeError.
             (_, _, Err(RequestDeviceError::UnsupportedFeature(f))) => promise.reject_error(
@@ -331,7 +331,7 @@ impl RoutedPromiseListener<WebGPUDeviceResponse> for GPUAdapter {
                 );
                 // 2. Lose the device(device, "unknown").
                 device.lose(GPUDeviceLostReason::Unknown, e);
-                promise.resolve_native(&device, CanGc::from_cx(cx));
+                promise.resolve_native_with_cx(cx, &device);
             },
         }
     }

--- a/components/script/dom/webgpu/gpudevice.rs
+++ b/components/script/dom/webgpu/gpudevice.rs
@@ -642,7 +642,7 @@ impl RoutedPromiseListener<WebGPUPoppedErrorScopeResponse> for GPUDevice {
             Err(PopError::Empty) => promise.reject_error_with_cx(cx, Error::Operation(None)),
             Ok(Some(error)) => {
                 let error = GPUError::from_error(&self.global(), error, CanGc::from_cx(cx));
-                promise.resolve_native(&error, CanGc::from_cx(cx));
+                promise.resolve_native_with_cx(cx, &error);
             },
         }
     }

--- a/components/script/dom/webgpu/gpuqueue.rs
+++ b/components/script/dom/webgpu/gpuqueue.rs
@@ -234,6 +234,6 @@ impl RoutedPromiseListener<()> for GPUQueue {
         _response: (),
         promise: &Rc<Promise>,
     ) {
-        promise.resolve_native(&(), CanGc::from_cx(cx));
+        promise.resolve_native_with_cx(cx, &());
     }
 }

--- a/components/script/dom/webgpu/gpushadermodule.rs
+++ b/components/script/dom/webgpu/gpushadermodule.rs
@@ -165,6 +165,6 @@ impl RoutedPromiseListener<Option<ShaderCompilationInfo>> for GPUShaderModule {
         promise: &Rc<Promise>,
     ) {
         let info = GPUCompilationInfo::from(&self.global(), response, CanGc::from_cx(cx));
-        promise.resolve_native(&info, CanGc::from_cx(cx));
+        promise.resolve_native_with_cx(cx, &info);
     }
 }

--- a/components/script/dom/webxr/xrsession.rs
+++ b/components/script/dom/webxr/xrsession.rs
@@ -284,7 +284,7 @@ impl XRSession {
                 // Step 6 is happening n the XR session
                 // https://immersive-web.github.io/webxr/#dom-xrsession-end step 3
                 for promise in self.end_promises.borrow_mut().drain(..) {
-                    promise.resolve_native(&(), CanGc::from_cx(cx));
+                    promise.resolve_native_with_cx(cx, &());
                 }
                 // Step 7
                 let event = XRSessionEvent::new(
@@ -913,7 +913,7 @@ impl XRSessionMethods<crate::DomTypeHolder> for XRSession {
             //
             // However, if end_promises is empty, then all end() promises have already resolved,
             // so the session has completely shut down and we should not queue up more promises
-            p.resolve_native(&(), CanGc::from_cx(cx));
+            p.resolve_native_with_cx(cx, &());
             return p;
         }
         self.end_promises.borrow_mut().push(p.clone());
@@ -1083,7 +1083,7 @@ impl XRSessionMethods<crate::DomTypeHolder> for XRSession {
                     let session = this.root();
                     session.apply_nominal_framerate(cx, message.unwrap());
                     if let Some(promise) = session.update_framerate_promise.borrow_mut().take() {
-                        promise.resolve_native(&(), CanGc::from_cx(cx));
+                        promise.resolve_native_with_cx(cx, &());
                     };
                 }));
             })

--- a/components/script/dom/workers/serviceworkercontainer.rs
+++ b/components/script/dom/workers/serviceworkercontainer.rs
@@ -97,7 +97,7 @@ impl ServiceWorkerContainer {
             JobResult::ResolvePromise(value) => {
                 match value {
                     JobResultValue::Unregister(success) => {
-                        promise.resolve_native(&success, CanGc::from_cx(cx));
+                        promise.resolve_native_with_cx(cx, &success);
                     },
                     JobResultValue::Register(value) => {
                         let ServiceWorkerRegistrationInfo {
@@ -125,7 +125,7 @@ impl ServiceWorkerContainer {
                         // TODO Step 2.3: Else, set convertedValue to value, in equivalentJob’s client’s Realm.
 
                         // Step 2.4: Resolve equivalentJob’s job promise with convertedValue.
-                        promise.resolve_native(&*registration, CanGc::from_cx(cx));
+                        promise.resolve_native_with_cx(cx, &*registration);
                     },
                 }
             },
@@ -145,7 +145,7 @@ impl ServiceWorkerContainer {
 
         // Step 8.2: If registration is null, resolve promise with undefined and abort these steps.
         let Some(info) = registration_info else {
-            promise.resolve_native(&(), CanGc::from_cx(cx));
+            promise.resolve_native_with_cx(cx, &());
             return;
         };
 
@@ -160,7 +160,7 @@ impl ServiceWorkerContainer {
             info.active_worker,
             CanGc::from_cx(cx),
         );
-        promise.resolve_native(&*registration, CanGc::from_cx(cx));
+        promise.resolve_native_with_cx(cx, &*registration);
     }
 
     fn handle_algorithm_result(&self, cx: &mut JSContext, result: ServiceWorkerAlgorithmResult) {

--- a/components/script/dom/workers/serviceworkerregistration.rs
+++ b/components/script/dom/workers/serviceworkerregistration.rs
@@ -205,14 +205,14 @@ impl ServiceWorkerRegistrationMethods<crate::DomTypeHolder> for ServiceWorkerReg
         let promise = Promise::new(&self.global(), CanGc::from_cx(cx));
 
         let Some(worker) = self.get_newest_worker() else {
-            promise.resolve_native(&true, CanGc::from_cx(cx));
+            promise.resolve_native_with_cx(cx, &true);
             return promise;
         };
 
         let global = self.global();
         let Some(window) = global.downcast::<Window>() else {
             // Worker navigator does not have a service woker container yet.
-            promise.resolve_native(&false, CanGc::from_cx(cx));
+            promise.resolve_native_with_cx(cx, &false);
             return promise;
         };
         let service_worker_container = window.Navigator().ServiceWorker();

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -618,7 +618,7 @@ impl FetchResponseListener for FetchContext {
         }
 
         // Step 12.5. Resolve p with responseObject.
-        promise.resolve_native(&self.response_object.root(), CanGc::from_cx(cx));
+        promise.resolve_native_with_cx(cx, &self.response_object.root());
         self.fetch_promise = Some(TrustedPromise::new(promise));
     }
 

--- a/components/script/module_loading.rs
+++ b/components/script/module_loading.rs
@@ -222,7 +222,7 @@ fn inner_module_loading(
         // Note: mozjs defaults to the unlinked status.
 
         // c. Perform ! Call(state.[[PromiseCapability]].[[Resolve]], undefined, « undefined »).
-        state.promise.resolve_native(&(), CanGc::from_cx(cx));
+        state.promise.resolve_native_with_cx(cx, &());
     }
 
     // Step 6. Return unused.

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -625,7 +625,7 @@ impl Callback for QueueTaskHandler {
 
         global.task_manager().networking_task_source().queue(
             task!(continue_module_loading: move |cx| {
-                promise.root().resolve_native(&(), CanGc::from_cx(cx));
+                promise.root().resolve_native_with_cx(cx, &());
             }),
         );
     }
@@ -751,7 +751,7 @@ impl FetchResponseListener for ModuleContext {
         if let (Err(error), _) | (_, Err(error)) = (response.as_ref(), self.status.as_ref()) {
             error!("Fetching module script failed {:?}", error);
             global.set_module_map(self.module_request, ModuleStatus::Loaded(None));
-            return promise.resolve_native(&(), CanGc::from_cx(cx));
+            return promise.resolve_native_with_cx(cx, &());
         }
 
         let metadata = self.metadata.take().unwrap();
@@ -830,7 +830,7 @@ impl FetchResponseListener for ModuleContext {
         }
         // Step 8. Set moduleMap[(url, moduleType)] to moduleScript, and run onComplete given moduleScript.
         global.set_module_map(self.module_request, ModuleStatus::Loaded(module_script));
-        promise.resolve_native(&(), CanGc::from_cx(cx));
+        promise.resolve_native_with_cx(cx, &());
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {


### PR DESCRIPTION
This allows for a gradual migration to pass in `cx`, to avoid having to do a big bang change across all code.

All call-sides were automatically migrated using the following regex replacement:

Before:

```
.reject_native\([ \n]*(.+),[ \n]+CanGc::from_cx\(cx\),?[ \n]*\);
.resolve_native\([ \n]*(.+),[ \n]+CanGc::from_cx\(cx\),?[ \n]*\);
```

After:

```
.reject_native_with_cx(cx, $1);
.resolve_native_with_cx(cx, $1);
```

Part of #40600

Testing: it compiles