### PR TITLE
script: Remove all `CanGc` usages from `module_loading`

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -292,7 +292,7 @@ impl TransmitBodyConnectHandler {
                 }));
 
                 let handler =
-                    PromiseNativeHandler::new(&global, promise_handler.take().map(|h| Box::new(h) as Box<_>), rejection_handler.take().map(|h| Box::new(h) as Box<_>), CanGc::from_cx(cx));
+                    PromiseNativeHandler::new(cx, &global, promise_handler.take().map(|h| Box::new(h) as Box<_>), rejection_handler.take().map(|h| Box::new(h) as Box<_>));
 
                 let mut realm = enter_auto_realm(cx, &*global);
                 let realm = &mut realm.current_realm();
@@ -740,7 +740,7 @@ pub(crate) fn consume_body<T: BodyMixin + DomObject>(
     if stream.is_errored() {
         rooted!(&in(cx) let mut stored_error = UndefinedValue());
         stream.get_stored_error(stored_error.handle_mut());
-        promise.reject(cx.into(), stored_error.handle(), CanGc::from_cx(cx));
+        promise.reject_with_cx(cx, stored_error.handle());
         return promise;
     }
 
@@ -781,7 +781,7 @@ pub(crate) fn consume_body<T: BodyMixin + DomObject>(
             );
         }),
         Rc::new(move |cx, v| {
-            error_promise.reject(cx.into(), v, CanGc::from_cx(cx));
+            error_promise.reject_with_cx(cx, v);
         }),
     );
 

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -370,7 +370,7 @@ impl BlobMethods<crate::DomTypeHolder> for Blob {
                 success_promise.resolve_native_with_cx(cx, &array_buffer);
             }),
             Rc::new(move |cx, value| {
-                failure_promise.reject(cx.into(), value, CanGc::from_cx(cx));
+                failure_promise.reject_with_cx(cx, value);
             }),
         );
 
@@ -411,7 +411,7 @@ impl BlobMethods<crate::DomTypeHolder> for Blob {
                 p_success.resolve_native_with_cx(cx, &arr);
             }),
             Rc::new(move |cx, v| {
-                p_failure.reject(cx.into(), v, CanGc::from_cx(cx));
+                p_failure.reject_with_cx(cx, v);
             }),
         );
         p

--- a/components/script/dom/clipboard/clipboard.rs
+++ b/components/script/dom/clipboard/clipboard.rs
@@ -48,7 +48,7 @@ impl Callback for RepresentationDataPromiseFulfillmentHandler {
         // If v is a DOMString, then follow the below steps:
         // Resolve p with v.
         // Return p.
-        self.promise.resolve(cx.into(), v, CanGc::from_cx(cx));
+        self.promise.resolve_with_cx(cx, v);
 
         // NOTE: Since we ask text from arboard, v can't be a Blob
         // If v is a Blob, then follow the below steps:
@@ -226,10 +226,10 @@ impl RoutedPromiseListener<Result<String, String>> for Clipboard {
             promise: promise.clone(),
         });
         let handler = PromiseNativeHandler::new(
+            cx,
             &global,
             Some(fulfillment_handler),
             Some(rejection_handler),
-            CanGc::from_cx(cx),
         );
         let mut realm = enter_auto_realm(cx, &*global);
         let cx = &mut realm.current_realm();

--- a/components/script/dom/clipboard/clipboarditem.rs
+++ b/components/script/dom/clipboard/clipboarditem.rs
@@ -73,7 +73,7 @@ impl Callback for RepresentationDataPromiseFulfillmentHandler {
             .is_ok_and(|result| result.get_success_value().is_some())
         {
             // 2.1 Resolve p with v.
-            self.promise.resolve(cx.into(), v, CanGc::from_cx(cx));
+            self.promise.resolve_with_cx(cx, v);
         }
     }
 }
@@ -297,10 +297,10 @@ impl ClipboardItemMethods<crate::DomTypeHolder> for ClipboardItem {
                     Box::new(RepresentationDataPromiseRejectionHandler { promise: p.clone() });
 
                 let handler = PromiseNativeHandler::new(
+                    realm,
                     &global,
                     Some(fulfillment_handler),
                     Some(rejection_handler),
-                    CanGc::from_cx(realm),
                 );
                 representation_data_promise.append_native_handler(realm, &handler);
 

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -20,19 +20,21 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::conversions::{ConversionResult, FromJSValConvertibleRc};
 use js::jsapi::{
-    AddRawValueRoot, CallArgs, GetFunctionNativeReserved, Heap, JS_ClearPendingException,
-    JS_GetFunctionObject, JS_NewFunction, JSAutoRealm, JSContext as RawJSContext, JSObject,
-    PromiseState, PromiseUserInputEventHandlingState, RemoveRawValueRoot,
-    SetFunctionNativeReserved,
+    AddRawValueRoot, CallArgs, GetFunctionNativeReserved, Heap, JS_GetFunctionObject,
+    JS_NewFunction, JSAutoRealm, JSContext as RawJSContext, JSObject, PromiseState,
+    PromiseUserInputEventHandlingState, RemoveRawValueRoot, SetFunctionNativeReserved,
 };
 use js::jsval::{Int32Value, JSVal, NullValue, ObjectValue, UndefinedValue};
 use js::realm::{AutoRealm, CurrentRealm};
 use js::rust::wrappers::{
     CallOriginalPromiseReject, CallOriginalPromiseResolve, GetPromiseIsHandled, GetPromiseState,
-    IsPromiseObject, NewPromiseObject, RejectPromise, ResolvePromise, SetAnyPromiseIsHandled,
+    IsPromiseObject, NewPromiseObject, SetAnyPromiseIsHandled,
     SetPromiseUserInputEventHandlingState,
 };
-use js::rust::wrappers2::{AddPromiseReactions, NewFunctionWithReserved};
+use js::rust::wrappers2::{
+    AddPromiseReactions, JS_ClearPendingException, NewFunctionWithReserved, RejectPromise,
+    ResolvePromise,
+};
 use js::rust::{HandleObject, HandleValue, MutableHandleObject, Runtime};
 use script_bindings::conversions::SafeToJSValConvertible;
 use script_bindings::reflector::{DomObject, MutDomObject, Reflector};
@@ -228,14 +230,23 @@ impl Promise {
         let cx = &mut realm.current_realm();
         rooted!(&in(cx) let mut v = UndefinedValue());
         val.safe_to_jsval(cx.into(), v.handle_mut(), CanGc::from_cx(cx));
-        self.resolve(cx.into(), v.handle(), CanGc::from_cx(cx));
+        self.resolve_with_cx(cx, v.handle());
     }
 
     #[expect(unsafe_code)]
     pub(crate) fn resolve(&self, cx: SafeJSContext, value: HandleValue, _can_gc: CanGc) {
         unsafe {
-            if !ResolvePromise(*cx, self.promise_obj(), value) {
-                JS_ClearPendingException(*cx);
+            if !js::rust::wrappers::ResolvePromise(*cx, self.promise_obj(), value) {
+                js::jsapi::JS_ClearPendingException(*cx);
+            }
+        }
+    }
+
+    #[expect(unsafe_code)]
+    pub(crate) fn resolve_with_cx(&self, cx: &mut JSContext, value: HandleValue) {
+        unsafe {
+            if !ResolvePromise(cx, self.promise_obj(), value) {
+                JS_ClearPendingException(cx);
             }
         }
     }
@@ -259,7 +270,7 @@ impl Promise {
         let cx = &mut realm.current_realm();
         rooted!(&in(cx) let mut v = UndefinedValue());
         val.safe_to_jsval(cx.into(), v.handle_mut(), CanGc::from_cx(cx));
-        self.reject(cx.into(), v.handle(), CanGc::from_cx(cx));
+        self.reject_with_cx(cx, v.handle());
     }
 
     pub(crate) fn reject_error(&self, error: Error, can_gc: CanGc) {
@@ -280,14 +291,23 @@ impl Promise {
             v.handle_mut(),
             CanGc::from_cx(cx),
         );
-        self.reject(cx.into(), v.handle(), CanGc::from_cx(cx));
+        self.reject_with_cx(cx, v.handle());
     }
 
     #[expect(unsafe_code)]
     pub(crate) fn reject(&self, cx: SafeJSContext, value: HandleValue, _can_gc: CanGc) {
         unsafe {
-            if !RejectPromise(*cx, self.promise_obj(), value) {
-                JS_ClearPendingException(*cx);
+            if !js::rust::wrappers::RejectPromise(*cx, self.promise_obj(), value) {
+                js::jsapi::JS_ClearPendingException(*cx);
+            }
+        }
+    }
+
+    #[expect(unsafe_code)]
+    pub(crate) fn reject_with_cx(&self, cx: &mut JSContext, value: HandleValue) {
+        unsafe {
+            if !RejectPromise(cx, self.promise_obj(), value) {
+                JS_ClearPendingException(cx);
             }
         }
     }
@@ -645,6 +665,7 @@ fn wait_for_all(
 
         // Perform PerformPromiseThen(promise, fulfillmentHandler, rejectionHandler).
         let handler = PromiseNativeHandler::new(
+            cx,
             global,
             Some(Box::new(WaitForAllFulfillmentHandler {
                 success_steps: success_steps.clone(),
@@ -653,7 +674,6 @@ fn wait_for_all(
                 fulfilled_count: fulfilled_count.clone(),
             })),
             Some(Box::new(rejection_handler.clone())),
-            CanGc::from_cx(cx),
         );
         promise.append_native_handler(cx, &handler);
 

--- a/components/script/dom/promisenativehandler.rs
+++ b/components/script/dom/promisenativehandler.rs
@@ -3,15 +3,15 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::realm::CurrentRealm;
 use js::rust::HandleValue;
 use malloc_size_of::MallocSizeOf;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::trace::JSTraceable;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::CanGc;
 
 /// Types that implement the `Callback` trait follow the same rooting requirements
 /// as types that use the `#[dom_struct]` attribute.
@@ -30,19 +30,19 @@ pub(crate) struct PromiseNativeHandler {
 
 impl PromiseNativeHandler {
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         resolve: Option<Box<dyn Callback>>,
         reject: Option<Box<dyn Callback>>,
-        can_gc: CanGc,
     ) -> DomRoot<PromiseNativeHandler> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(PromiseNativeHandler {
                 reflector: Reflector::new(),
                 resolve,
                 reject,
             }),
             global,
-            can_gc,
+            cx,
         )
     }
 

--- a/components/script/dom/stream/readablebytestreamcontroller.rs
+++ b/components/script/dom/stream/readablebytestreamcontroller.rs
@@ -1641,6 +1641,7 @@ impl ReadableByteStreamController {
 
         if let Some(underlying_source) = self.underlying_source.get() {
             let handler = PromiseNativeHandler::new(
+                cx,
                 &global,
                 Some(Box::new(PullAlgorithmFulfillmentHandler {
                     controller: Dom::from_ref(&rooted_controller),
@@ -1648,7 +1649,6 @@ impl ReadableByteStreamController {
                 Some(Box::new(PullAlgorithmRejectionHandler {
                     controller: Dom::from_ref(&rooted_controller),
                 })),
-                CanGc::from_cx(cx),
             );
 
             let mut realm = enter_auto_realm(cx, &*global);
@@ -1783,6 +1783,7 @@ impl ReadableByteStreamController {
 
             // Upon fulfillment of startPromise, Upon rejection of startPromise with reason r,
             let handler = PromiseNativeHandler::new(
+                cx,
                 global,
                 Some(Box::new(StartAlgorithmFulfillmentHandler {
                     controller: Dom::from_ref(&rooted_byte_controller),
@@ -1790,7 +1791,6 @@ impl ReadableByteStreamController {
                 Some(Box::new(StartAlgorithmRejectionHandler {
                     controller: Dom::from_ref(&rooted_byte_controller),
                 })),
-                CanGc::from_cx(cx),
             );
             let mut realm = enter_auto_realm(cx, global);
             let cx = &mut realm.current_realm();

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -380,10 +380,10 @@ impl PipeTo {
             self.read_chunk(cx, global);
         } else {
             let handler = PromiseNativeHandler::new(
+                cx,
                 global,
                 Some(Box::new(self.clone())),
                 Some(Box::new(self.clone())),
-                CanGc::from_cx(cx),
             );
             ready_promise.append_native_handler(cx, &handler);
 
@@ -400,10 +400,10 @@ impl PipeTo {
         *self.state.borrow_mut() = PipeToState::PendingRead;
         let chunk_promise = self.reader.Read(cx);
         let handler = PromiseNativeHandler::new(
+            cx,
             global,
             Some(Box::new(self.clone())),
             Some(Box::new(self.clone())),
-            CanGc::from_cx(cx),
         );
         chunk_promise.append_native_handler(cx, &handler);
 
@@ -447,10 +447,10 @@ impl PipeTo {
         promise: Rc<Promise>,
     ) {
         let handler = PromiseNativeHandler::new(
+            cx,
             global,
             Some(Box::new(self.clone())),
             Some(Box::new(self.clone())),
-            CanGc::from_cx(cx),
         );
         promise.append_native_handler(cx, &handler);
     }
@@ -710,10 +710,10 @@ impl PipeTo {
         // Upon fulfillment of p, finalize, passing along originalError if it was given.
         // Upon rejection of p with reason newError, finalize with newError.
         let handler = PromiseNativeHandler::new(
+            cx,
             global,
             Some(Box::new(self.clone())),
             Some(Box::new(self.clone())),
-            CanGc::from_cx(cx),
         );
         promise.append_native_handler(cx, &handler);
         *self.shutdown_action_promise.borrow_mut() = Some(promise);
@@ -1674,10 +1674,10 @@ impl ReadableStream {
             result: result_promise.clone(),
         });
         let handler = PromiseNativeHandler::new(
+            cx,
             &global,
             Some(fulfillment_handler),
             Some(rejection_handler),
-            CanGc::from_cx(cx),
         );
         let mut realm = enter_auto_realm(cx, &*global);
         let cx = &mut realm.current_realm();

--- a/components/script/dom/stream/readablestreambyobreader.rs
+++ b/components/script/dom/stream/readablestreambyobreader.rs
@@ -375,6 +375,7 @@ impl ReadableStreamBYOBReader {
 
         let global = self.global();
         let handler = PromiseNativeHandler::new(
+            cx,
             &global,
             None,
             Some(Box::new(ByteTeeClosedPromiseRejectionHandler {
@@ -386,7 +387,6 @@ impl ReadableStreamBYOBReader {
                 reader_version,
                 expected_version,
             })),
-            CanGc::from_cx(cx),
         );
 
         let mut realm = enter_auto_realm(cx, &*global);

--- a/components/script/dom/stream/readablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/readablestreamdefaultcontroller.rs
@@ -434,6 +434,7 @@ impl ReadableStreamDefaultController {
 
             // Upon fulfillment of startPromise, Upon rejection of startPromise with reason r,
             let handler = PromiseNativeHandler::new(
+                cx,
                 global,
                 Some(Box::new(StartAlgorithmFulfillmentHandler {
                     controller: Dom::from_ref(&rooted_default_controller),
@@ -441,7 +442,6 @@ impl ReadableStreamDefaultController {
                 Some(Box::new(StartAlgorithmRejectionHandler {
                     controller: Dom::from_ref(&rooted_default_controller),
                 })),
-                CanGc::from_cx(cx),
             );
             let mut realm = enter_auto_realm(cx, global);
             let cx = &mut realm.current_realm();
@@ -530,6 +530,7 @@ impl ReadableStreamDefaultController {
             return;
         };
         let handler = PromiseNativeHandler::new(
+            cx,
             &global,
             Some(Box::new(PullAlgorithmFulfillmentHandler {
                 controller: Dom::from_ref(&rooted_default_controller),
@@ -537,7 +538,6 @@ impl ReadableStreamDefaultController {
             Some(Box::new(PullAlgorithmRejectionHandler {
                 controller: Dom::from_ref(&rooted_default_controller),
             })),
-            CanGc::from_cx(cx),
         );
 
         let mut realm = enter_auto_realm(cx, &*global);

--- a/components/script/dom/stream/readablestreamdefaultreader.rs
+++ b/components/script/dom/stream/readablestreamdefaultreader.rs
@@ -156,13 +156,13 @@ impl ReadRequest {
                         tick.resolve_native_with_cx(cx, &());
 
                         let handler = PromiseNativeHandler::new(
+                            cx,
                             &global,
                             Some(Box::new(ContinueReadMicrotask {
                                 reader: Dom::from_ref(reader),
                                 request: self.clone(),
                             })),
                             None,
-                            CanGc::from_cx(cx),
                         );
 
                         let mut realm = enter_auto_realm(cx, &*global);
@@ -522,6 +522,7 @@ impl ReadableStreamDefaultReader {
 
         let global = self.global();
         let handler = PromiseNativeHandler::new(
+            cx,
             &global,
             None,
             Some(Box::new(ByteTeeClosedPromiseRejectionHandler {
@@ -533,7 +534,6 @@ impl ReadableStreamDefaultReader {
                 reader_version,
                 expected_version,
             })),
-            CanGc::from_cx(cx),
         );
 
         let mut realm = enter_auto_realm(cx, &*global);
@@ -560,6 +560,7 @@ impl ReadableStreamDefaultReader {
 
         let global = self.global();
         let handler = PromiseNativeHandler::new(
+            cx,
             &global,
             None,
             Some(Box::new(DefaultTeeClosedPromiseRejectionHandler {
@@ -569,7 +570,6 @@ impl ReadableStreamDefaultReader {
                 canceled_2,
                 cancel_promise,
             })),
-            CanGc::from_cx(cx),
         );
 
         let mut realm = enter_auto_realm(cx, &*global);

--- a/components/script/dom/stream/transformstream.rs
+++ b/components/script/dom/stream/transformstream.rs
@@ -75,8 +75,7 @@ impl Callback for TransformBackPressureChangePromiseFulfillment {
         if self.writable.is_erroring() {
             rooted!(&in(cx) let mut error = UndefinedValue());
             self.writable.get_stored_error(error.handle_mut());
-            self.result_promise
-                .reject(cx.into(), error.handle(), CanGc::from_cx(cx));
+            self.result_promise.reject_with_cx(cx, error.handle());
             return;
         }
 
@@ -98,6 +97,7 @@ impl Callback for TransformBackPressureChangePromiseFulfillment {
         // PerformTransformFulfillment and PerformTransformRejection do not need
         // to be rooted because they only contain an Rc.
         let handler = PromiseNativeHandler::new(
+            cx,
             &self.writable.global(),
             Some(Box::new(PerformTransformFulfillment {
                 result_promise: self.result_promise.clone(),
@@ -105,7 +105,6 @@ impl Callback for TransformBackPressureChangePromiseFulfillment {
             Some(Box::new(PerformTransformRejection {
                 result_promise: self.result_promise.clone(),
             })),
-            CanGc::from_cx(cx),
         );
 
         let mut realm = enter_auto_realm(cx, &*self.writable.global());
@@ -227,7 +226,7 @@ impl Callback for CancelPromiseRejection {
         self.controller
             .get_finish_promise()
             .expect("finish promise is not set")
-            .reject(cx.into(), v, CanGc::from_cx(cx));
+            .reject_with_cx(cx, v);
     }
 }
 
@@ -259,7 +258,7 @@ impl Callback for SourceCancelPromiseFulfillment {
         if self.writeable.is_errored() {
             rooted!(&in(cx) let mut error = UndefinedValue());
             self.writeable.get_stored_error(error.handle_mut());
-            finish_promise.reject(cx.into(), error.handle(), CanGc::from_cx(cx));
+            finish_promise.reject_with_cx(cx, error.handle());
         } else {
             // Otherwise:
             // Perform ! WritableStreamDefaultControllerErrorIfNeeded(writable.[[controller]], reason).
@@ -307,7 +306,7 @@ impl Callback for SourceCancelPromiseRejection {
         self.controller
             .get_finish_promise()
             .expect("finish promise is not set")
-            .reject(cx.into(), v, CanGc::from_cx(cx));
+            .reject_with_cx(cx, v);
     }
 }
 
@@ -335,7 +334,7 @@ impl Callback for FlushPromiseFulfillment {
         if self.readable.is_errored() {
             rooted!(&in(cx) let mut error = UndefinedValue());
             self.readable.get_stored_error(error.handle_mut());
-            finish_promise.reject(cx.into(), error.handle(), CanGc::from_cx(cx));
+            finish_promise.reject_with_cx(cx, error.handle());
         } else {
             // Otherwise:
             // Perform ! ReadableStreamDefaultControllerClose(readable.[[controller]]).
@@ -369,7 +368,7 @@ impl Callback for FlushPromiseRejection {
         self.controller
             .get_finish_promise()
             .expect("finish promise is not set")
-            .reject(cx.into(), v, CanGc::from_cx(cx));
+            .reject_with_cx(cx, v);
     }
 }
 
@@ -686,12 +685,12 @@ impl TransformStream {
             }));
 
             let handler = PromiseNativeHandler::new(
+                cx,
                 global,
                 fulfillment_handler.take().map(|h| Box::new(h) as Box<_>),
                 Some(Box::new(BackpressureChangeRejection {
                     result_promise: result_promise.clone(),
                 })),
-                CanGc::from_cx(cx),
             );
             let mut realm = enter_auto_realm(cx, global);
             let realm = &mut realm.current_realm();
@@ -736,6 +735,7 @@ impl TransformStream {
 
         // React to cancelPromise:
         let handler = PromiseNativeHandler::new(
+            cx,
             global,
             Some(Box::new(CancelPromiseFulfillment {
                 readable: Dom::from_ref(&readable),
@@ -746,7 +746,6 @@ impl TransformStream {
                 readable: Dom::from_ref(&readable),
                 controller: Dom::from_ref(&controller),
             })),
-            CanGc::from_cx(cx),
         );
         let mut realm = enter_auto_realm(cx, global);
         let cx = &mut realm.current_realm();
@@ -793,6 +792,7 @@ impl TransformStream {
 
         // React to flushPromise:
         let handler = PromiseNativeHandler::new(
+            cx,
             global,
             Some(Box::new(FlushPromiseFulfillment {
                 readable: Dom::from_ref(&readable),
@@ -802,7 +802,6 @@ impl TransformStream {
                 readable: Dom::from_ref(&readable),
                 controller: Dom::from_ref(&controller),
             })),
-            CanGc::from_cx(cx),
         );
 
         let mut realm = enter_auto_realm(cx, global);
@@ -850,6 +849,7 @@ impl TransformStream {
 
         // React to cancelPromise:
         let handler = PromiseNativeHandler::new(
+            cx,
             global,
             Some(Box::new(SourceCancelPromiseFulfillment {
                 writeable: Dom::from_ref(&writable),
@@ -862,7 +862,6 @@ impl TransformStream {
                 controller: Dom::from_ref(&controller),
                 stream: Dom::from_ref(self),
             })),
-            CanGc::from_cx(cx),
         );
 
         // Return controller.[[finishPromise]].

--- a/components/script/dom/stream/transformstreamdefaultcontroller.rs
+++ b/components/script/dom/stream/transformstreamdefaultcontroller.rs
@@ -190,10 +190,10 @@ impl TransformStreamDefaultController {
         }));
 
         let handler = PromiseNativeHandler::new(
+            cx,
             global,
             None,
             reject_handler.take().map(|h| Box::new(h) as Box<_>),
-            CanGc::from_cx(cx),
         );
         let mut realm = enter_auto_realm(cx, global);
         let realm = &mut realm.current_realm();

--- a/components/script/dom/stream/writablestream.rs
+++ b/components/script/dom/stream/writablestream.rs
@@ -277,7 +277,7 @@ impl WritableStream {
         let write_requests = mem::take(&mut *self.write_requests.borrow_mut());
         for request in write_requests {
             // Reject writeRequest with storedError.
-            request.reject(cx.into(), stored_error.handle(), CanGc::from_cx(cx));
+            request.reject_with_cx(cx, stored_error.handle());
         }
 
         // Set stream.[[writeRequests]] to an empty list.
@@ -299,11 +299,9 @@ impl WritableStream {
             // If abortRequest’s was already erroring is true,
             if pending_abort_request.was_already_erroring {
                 // Reject abortRequest’s promise with storedError.
-                pending_abort_request.promise.reject(
-                    cx.into(),
-                    stored_error.handle(),
-                    CanGc::from_cx(cx),
-                );
+                pending_abort_request
+                    .promise
+                    .reject_with_cx(cx, stored_error.handle());
 
                 // Perform ! WritableStreamRejectCloseAndClosedPromiseIfNeeded(stream).
                 self.reject_close_and_closed_promise_if_needed(cx);
@@ -330,10 +328,10 @@ impl WritableStream {
             }));
 
             let handler = PromiseNativeHandler::new(
+                cx,
                 global,
                 fulfillment_handler.take().map(|h| Box::new(h) as Box<_>),
                 rejection_handler.take().map(|h| Box::new(h) as Box<_>),
-                CanGc::from_cx(cx),
             );
 
             let mut realm = enter_auto_realm(cx, global);

--- a/components/script/dom/stream/writablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/writablestreamdefaultcontroller.rs
@@ -501,10 +501,10 @@ impl WritableStreamDefaultController {
         }));
 
         let handler = PromiseNativeHandler::new(
+            cx,
             global,
             fulfillment_handler.take().map(|h| Box::new(h) as Box<_>),
             rejection_handler.take().map(|h| Box::new(h) as Box<_>),
-            CanGc::from_cx(cx),
         );
         let mut realm = enter_auto_realm(cx, global);
         let cx = &mut realm.current_realm();
@@ -714,10 +714,10 @@ impl WritableStreamDefaultController {
                     result_promise: result_promise.clone(),
                 }));
                 let handler = PromiseNativeHandler::new(
+                    cx,
                     global,
                     fulfillment_handler.take().map(|h| Box::new(h) as Box<_>),
                     None,
-                    CanGc::from_cx(cx),
                 );
                 let mut realm = enter_auto_realm(cx, global);
                 let realm = &mut realm.current_realm();
@@ -824,10 +824,10 @@ impl WritableStreamDefaultController {
 
         // Attach handlers to the promise.
         let handler = PromiseNativeHandler::new(
+            cx,
             global,
             fulfillment_handler.take().map(|h| Box::new(h) as Box<_>),
             rejection_handler.take().map(|h| Box::new(h) as Box<_>),
-            CanGc::from_cx(cx),
         );
         let mut realm = enter_auto_realm(cx, global);
         let realm = &mut realm.current_realm();
@@ -916,10 +916,10 @@ impl WritableStreamDefaultController {
 
         // Attach handlers to the promise.
         let handler = PromiseNativeHandler::new(
+            cx,
             global,
             fulfillment_handler.take().map(|h| Box::new(h) as Box<_>),
             rejection_handler.take().map(|h| Box::new(h) as Box<_>),
-            CanGc::from_cx(cx),
         );
         let mut realm = enter_auto_realm(cx, global);
         let realm = &mut realm.current_realm();

--- a/components/script/dom/testing/testbinding.rs
+++ b/components/script/dom/testing/testbinding.rs
@@ -1066,10 +1066,10 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
     ) -> Rc<Promise> {
         let global = self.global();
         let handler = PromiseNativeHandler::new(
+            realm,
             &global,
             resolve.map(SimpleHandler::new_boxed),
             reject.map(SimpleHandler::new_boxed),
-            CanGc::from_cx(realm),
         );
 
         let p = Promise::new_in_realm(realm);

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -185,7 +185,7 @@ fn abort_fetch_call(
     cx: &mut js::context::JSContext,
 ) {
     // Step 1. Reject promise with error.
-    promise.reject(cx.into(), abort_reason, CanGc::from_cx(cx));
+    promise.reject_with_cx(cx, abort_reason);
     // Step 2. If request’s body is non-null and is readable, then cancel request’s body with error.
     if let Some(body) = request.body() &&
         body.is_readable()

--- a/components/script/module_loading.rs
+++ b/components/script/module_loading.rs
@@ -38,7 +38,7 @@ use crate::script_module::{
     ModuleFetchClient, ModuleHandler, ModuleObject, ModuleTree, RethrowError, ScriptFetchOptions,
     fetch_a_single_module_script, gen_type_error, module_script_from_reference_private,
 };
-use crate::script_runtime::{CanGc, IntroductionType};
+use crate::script_runtime::IntroductionType;
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct OnRejectedHandler {
@@ -49,7 +49,7 @@ struct OnRejectedHandler {
 impl Callback for OnRejectedHandler {
     fn callback(&self, cx: &mut CurrentRealm, v: HandleValue) {
         // a. Perform ! Call(promiseCapability.[[Reject]], undefined, « reason »).
-        self.promise.reject(cx.into(), v, CanGc::from_cx(cx));
+        self.promise.reject_with_cx(cx, v);
     }
 }
 
@@ -250,9 +250,7 @@ fn continue_module_loading(
             state.is_loading.set(false);
 
             // b. Perform ! Call(state.[[PromiseCapability]].[[Reject]], undefined, « moduleCompletion.[[Value]] »).
-            state
-                .promise
-                .reject(cx.into(), exception.handle(), CanGc::from_cx(cx));
+            state.promise.reject_with_cx(cx, exception.handle());
         },
     }
 
@@ -299,7 +297,7 @@ fn continue_dynamic_import(
     // Step 1. If moduleCompletion is an abrupt completion, then
     if let Err(exception) = module_completion {
         // a. Perform ! Call(promiseCapability.[[Reject]], undefined, « moduleCompletion.[[Value]] »).
-        promise.reject(cx.into(), exception.handle(), CanGc::from_cx(cx));
+        promise.reject_with_cx(cx, exception.handle());
 
         // b. Return unused.
         return;
@@ -341,7 +339,7 @@ fn continue_dynamic_import(
             if !link {
                 // i. Perform ! Call(promiseCapability.[[Reject]], undefined, « link.[[Value]] »).
                 let exception = RethrowError::from_pending_exception(cx);
-                inner_promise.reject(cx.into(), exception.handle(), CanGc::from_cx(cx));
+                inner_promise.reject_with_cx(cx, exception.handle());
 
                 // ii. Return NormalCompletion(undefined).
                 return;
@@ -354,7 +352,7 @@ fn continue_dynamic_import(
 
             if !rval.is_object() {
                 let error = RethrowError::from_pending_exception(cx);
-                return inner_promise.reject(cx.into(), error.handle(), CanGc::from_cx(cx));
+                return inner_promise.reject_with_cx(cx, error.handle());
             }
 
             rooted!(&in(cx) let evaluate_promise = rval.to_object());
@@ -371,18 +369,15 @@ fn continue_dynamic_import(
                     rooted!(&in(cx) let namespace = ObjectValue(rval.get()));
 
                     // ii. Perform ! Call(promiseCapability.[[Resolve]], undefined, « namespace »).
-                    fulfilled_promise.resolve(cx.into(), namespace.handle(), CanGc::from_cx(cx));
+                    fulfilled_promise.resolve_with_cx(cx, namespace.handle());
 
                     // iii. Return NormalCompletion(undefined).
             })));
 
             // f. Perform PerformPromiseThen(evaluatePromise, onFulfilled, onRejected).
-            let handler = PromiseNativeHandler::new(
-                &global_scope,
+            let handler = PromiseNativeHandler::new(cx, &global_scope,
                 Some(on_fulfilled),
-                Some(Box::new(OnRejectedHandler { promise: inner_promise })),
-                CanGc::from_cx(cx),
-            );
+                Some(Box::new(OnRejectedHandler { promise: inner_promise })));
             evaluate_promise.append_native_handler(cx, &handler);
 
             // g. Return unused.
@@ -394,10 +389,10 @@ fn continue_dynamic_import(
     run_a_callback::<DomTypeHolder, _>(&*global, || {
         // Step 8. Perform PerformPromiseThen(loadPromise, linkAndEvaluate, onRejected).
         let handler = PromiseNativeHandler::new(
+            cx,
             &global,
             Some(link_and_evaluate),
             Some(Box::new(OnRejectedHandler { promise })),
-            CanGc::from_cx(cx),
         );
         load_promise.append_native_handler(cx, &handler);
     });

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -1446,10 +1446,10 @@ fn fetch_the_descendants_and_link_module_script(
         })));
 
     let handler = PromiseNativeHandler::new(
+        cx,
         global,
         Some(loading_promise_fulfillment),
         Some(loading_promise_rejection),
-        CanGc::from_cx(cx),
     );
 
     run_a_callback::<DomTypeHolder, _>(global, || {
@@ -1507,7 +1507,7 @@ pub(crate) fn fetch_a_single_module_script(
         }),
     ));
 
-    let handler = PromiseNativeHandler::new(global, Some(handler), None, CanGc::from_cx(cx));
+    let handler = PromiseNativeHandler::new(cx, global, Some(handler), None);
 
     let mut realm = enter_auto_realm(cx, global);
     let cx = &mut realm.current_realm();
@@ -1525,10 +1525,10 @@ pub(crate) fn fetch_a_single_module_script(
             // Append an handler to the existing pending fetch, once resolved it will queue a task
             // to run onComplete.
             let continue_loading_handler = PromiseNativeHandler::new(
+                cx,
                 global,
                 Some(Box::new(QueueTaskHandler { promise })),
                 None,
-                CanGc::from_cx(cx),
             );
 
             // be careful of a borrow hazard here (do not hold a RefCell over a possible GC pause)


### PR DESCRIPTION
This migrates three API's to the `_with_cx` pattern: `reject,resolve` and `PromiseNativeHandler`.

All call-sides were automatically migrated using the following regex replacement:

Before:

```
.reject\([ \n]*(.+),[ \n]+CanGc::from_cx\(cx\),?[ \n]*\);
.resolve\([ \n]*(.+),[ \n]+CanGc::from_cx\(cx\),?[ \n]*\);
PromiseNativeHandler::new\([ \n]*([^;]+),[ \n]*CanGc::from_cx\(cx\),?[ \n]*\);
```

After:

```
.reject_with_cx(cx, $1);
.resolve_with_cx(cx, $1);
PromiseNativeHandler::new(cx, $1);
```

Part of #40600

Testing: it compiles