### PR TITLE
webdriver: Fix race condition in synchronous script execution with Promise

### DIFF
--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -2064,12 +2064,20 @@ impl Handler {
         // new Function() and then takes the resulting function and executes
         // it with a vec of arguments.
         let script = format!(
-            r#"(function(__wd_eid) {{
-                (async function() {{
-                    {func_body}
-                }})({})
-                .then((v) => {{ if (window.__wd_eid === __wd_eid) window.webdriverCallback(v); }})
-                .catch((r) => {{ if (window.__wd_eid === __wd_eid) window.webdriverException(r); }});
+            r#"(async function(__wd_eid) {{
+                try {{
+                    let result = (async function() {{
+                        {func_body}
+                    }})({});
+                    let value = await result;
+                    if (window.__wd_eid === __wd_eid) {{
+                        window.webdriverCallback(value);
+                    }}
+                }} catch (err) {{
+                    if (window.__wd_eid === __wd_eid) {{
+                        window.webdriverException(err);
+                    }}
+                }}
             }})(window.__wd_eid = (window.__wd_eid || 0) + 1);"#,
             args_string.join(", ")
         );

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -2064,22 +2064,17 @@ impl Handler {
         // new Function() and then takes the resulting function and executes
         // it with a vec of arguments.
         let script = format!(
-            r#"(async function() {{
-                try {{
-                    let result = (async function() {{
-                        {func_body}
-                    }})({});
-                    let value = await result;
-                    window.webdriverCallback(value);
-                }} catch (err) {{
-                    window.webdriverException(err);
-                }}
-            }})();"#,
+            r#"(function(__wd_eid) {{
+                (async function() {{
+                    {func_body}
+                }})({})
+                .then((v) => {{ if (window.__wd_eid === __wd_eid) window.webdriverCallback(v); }})
+                .catch((r) => {{ if (window.__wd_eid === __wd_eid) window.webdriverException(r); }});
+            }})(window.__wd_eid = (window.__wd_eid || 0) + 1);"#,
             args_string.join(", ")
         );
 
         debug!("{}", script);
-
         // Step 2. If session's current browsing context is no longer open,
         // return error with error code no such window.
         self.verify_browsing_context_is_open(self.browsing_context_id()?)?;


### PR DESCRIPTION
When a test https://github.com/servo/servo/blob/ce51bfa517a38300b2035fd73ba5e6272b7f809a/tests/wpt/tests/webdriver/tests/classic/execute_script/promise.py#L42-L52 timeout, we move on to other tests.
However, the promise is only resolved after 1 second.
At that point, we are running another test. The original generic receiver was gone, but `webdriverCallback` would respond with new https://github.com/servo/servo/blob/ce51bfa517a38300b2035fd73ba5e6272b7f809a/components/script/dom/window.rs#L363. 

That explains the mysterious result `null` in #44455. We fix this by identifier `__wd_eid` in the script.

Testing: Earlier this fails about 10% chance. Now always pass https://github.com/servo/servo/blob/main/tests/wpt/tests/webdriver/tests/classic/execute_script/promise.py.
Fixes: #44455
