### PR TITLE
layout: Lazily build `BuilderForBoxFragment` for clip paths and `BuilderForBoxFragment::border_radius`

### DIFF
--- a/components/layout/display_list/clip.rs
+++ b/components/layout/display_list/clip.rs
@@ -111,11 +111,11 @@ impl StackingContextTreeClipStore {
             Some(self.add(
                 match geometry_box {
                     ShapeBox::MarginBox => compute_margin_box_radius(
-                        fragment_builder.border_radius,
+                        fragment_builder.border_radius(),
                         layout_rect.size(),
                         fragment_builder.fragment,
                     ),
-                    _ => fragment_builder.border_radius,
+                    _ => fragment_builder.border_radius(),
                 },
                 layout_rect,
                 parent_scroll_node_id,

--- a/components/layout/display_list/clip.rs
+++ b/components/layout/display_list/clip.rs
@@ -14,6 +14,8 @@ use webrender_api::BorderRadius;
 use webrender_api::units::{LayoutRect, LayoutSideOffsets, LayoutSize};
 
 use super::{BuilderForBoxFragment, compute_margin_box_radius, normalize_radii};
+use crate::fragment_tree::BoxFragment;
+use crate::geom::PhysicalPoint;
 
 /// An identifier for a clip used during StackingContextTree construction. This is a simple index in
 /// a [`ClipStore`]s vector of clips.
@@ -77,7 +79,8 @@ impl StackingContextTreeClipStore {
         clip_path: &ClipPath,
         parent_scroll_node_id: ScrollTreeNodeId,
         parent_clip_chain_id: ClipId,
-        fragment_builder: BuilderForBoxFragment,
+        box_fragment: &BoxFragment,
+        containing_block_origin: PhysicalPoint<Au>,
     ) -> Option<ClipId> {
         let geometry_box = match clip_path {
             ClipPath::Shape(_, ShapeGeometryBox::ShapeBox(shape_box)) => *shape_box,
@@ -86,6 +89,7 @@ impl StackingContextTreeClipStore {
             ClipPath::Box(ShapeGeometryBox::ElementDependent) => ShapeBox::BorderBox,
             _ => return None,
         };
+        let fragment_builder = BuilderForBoxFragment::new(box_fragment, containing_block_origin);
         let layout_rect = match geometry_box {
             ShapeBox::BorderBox => fragment_builder.border_rect,
             ShapeBox::ContentBox => *fragment_builder.content_rect(),

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -1327,7 +1327,7 @@ struct BuilderForBoxFragment<'a> {
     margin_rect: OnceCell<units::LayoutRect>,
     padding_rect: OnceCell<units::LayoutRect>,
     content_rect: OnceCell<units::LayoutRect>,
-    border_radius: wr::BorderRadius,
+    border_radius: OnceCell<wr::BorderRadius>,
     border_edge_clip_chain_id: RefCell<Option<ClipChainId>>,
     padding_edge_clip_chain_id: RefCell<Option<ClipChainId>>,
     content_edge_clip_chain_id: RefCell<Option<ClipChainId>>,
@@ -1342,7 +1342,7 @@ impl<'a> BuilderForBoxFragment<'a> {
             fragment,
             containing_block_origin,
             border_rect: border_rect.to_webrender(),
-            border_radius: fragment.border_radius(),
+            border_radius: OnceCell::new(),
             margin_rect: OnceCell::new(),
             padding_rect: OnceCell::new(),
             content_rect: OnceCell::new(),
@@ -1350,6 +1350,12 @@ impl<'a> BuilderForBoxFragment<'a> {
             padding_edge_clip_chain_id: RefCell::new(None),
             content_edge_clip_chain_id: RefCell::new(None),
         }
+    }
+
+    fn border_radius(&self) -> BorderRadius {
+        *self
+            .border_radius
+            .get_or_init(|| self.fragment.border_radius())
     }
 
     fn content_rect(&self) -> &units::LayoutRect {
@@ -1391,7 +1397,7 @@ impl<'a> BuilderForBoxFragment<'a> {
 
         let maybe_clip = builder.maybe_create_clip(
             state,
-            self.border_radius,
+            self.border_radius(),
             self.border_rect,
             force_clip_creation,
         );
@@ -1409,7 +1415,7 @@ impl<'a> BuilderForBoxFragment<'a> {
             return Some(clip);
         }
 
-        let radii = offset_radii(self.border_radius, -self.fragment.border.to_webrender());
+        let radii = offset_radii(self.border_radius(), -self.fragment.border.to_webrender());
         let maybe_clip =
             builder.maybe_create_clip(state, radii, *self.padding_rect(), force_clip_creation);
         *self.padding_edge_clip_chain_id.borrow_mut() = maybe_clip;
@@ -1427,7 +1433,7 @@ impl<'a> BuilderForBoxFragment<'a> {
         }
 
         let radii = offset_radii(
-            self.border_radius,
+            self.border_radius(),
             -(self.fragment.border + self.fragment.padding).to_webrender(),
         );
         let maybe_clip =
@@ -1913,7 +1919,7 @@ impl<'a> BuilderForBoxFragment<'a> {
             right: self.build_border_side(style_color.right),
             bottom: self.build_border_side(style_color.bottom),
             left: self.build_border_side(style_color.left),
-            radius: self.border_radius,
+            radius: self.border_radius(),
             do_aa: true,
         });
         let common = builder.common_properties(state, self.border_rect, &style);
@@ -2076,7 +2082,7 @@ impl<'a> BuilderForBoxFragment<'a> {
             right: side,
             bottom: side,
             left: side,
-            radius: offset_radii(self.border_radius, SideOffsets2D::new_all_same(offset)),
+            radius: offset_radii(self.border_radius(), SideOffsets2D::new_all_same(offset)),
             do_aa: true,
         });
         builder
@@ -2126,7 +2132,7 @@ impl<'a> BuilderForBoxFragment<'a> {
                 rgba(style.resolve_color(&box_shadow.base.color)),
                 blur,
                 spread,
-                self.border_radius,
+                self.border_radius(),
                 clip_mode,
             );
         }

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -693,7 +693,8 @@ impl BoxFragment {
                 &style.get_svg().clip_path,
                 spatial_id.unwrap_or(containing_block.scroll_node_id),
                 clip_id.unwrap_or(containing_block.clip_id),
-                BuilderForBoxFragment::new(self, containing_block.rect.origin),
+                self,
+                containing_block.rect.origin,
             )
             .or(clip_id);
 

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -950,7 +950,7 @@ impl BoxFragment {
                     },
                     OverflowClipMarginBox::BorderBox => {},
                 };
-                radii = offset_radii(builder.border_radius, offsets_from_border);
+                radii = offset_radii(builder.border_radius(), offsets_from_border);
             } else if overflow.x != ComputedOverflow::Clip {
                 let max = LayoutRect::max_rect();
                 overflow_clip_rect.min.x = max.min.x;
@@ -982,7 +982,7 @@ impl BoxFragment {
             .to_webrender();
 
         let clip_id = stacking_context_tree.clip_store.add(
-            BuilderForBoxFragment::new(self, containing_block_rect.origin).border_radius,
+            BuilderForBoxFragment::new(self, containing_block_rect.origin).border_radius(),
             scroll_frame_rect,
             parent_scroll_node_id,
             parent_clip_id,


### PR DESCRIPTION
* `add_for_clip_path` took a `BuilderForBoxFragment` but didn’t used it for the common case of `clip-path: none`. Instead take as parameters what’s needed for `BuilderForBoxFragment::new` and call it when needed.
* `BuilderForBoxFragment::new` materialized its `border_radius` field that isn’t always used. Make it a `OnceCell`.

Testing: existing test should show no behavior change
