### PR TITLE
devtools: Run tests in parallel

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -37,6 +37,7 @@ Mako == 1.3.12
 
 # For devtools tests.
 geckordp == 1.0.3
+pytest-xdist == 3.8.0
 
 # For Python static type checking
 pyrefly == 0.63.1

--- a/python/servo/devtools_tests/conftest.py
+++ b/python/servo/devtools_tests/conftest.py
@@ -114,32 +114,19 @@ def _start_web_servers(config):
             if utils.LOG_REQUESTS:
                 return super().log_message(format, *args)
 
-    def server_thread(i):
-        # There may be client sockets still open in TIME_WAIT state from previous tests, and they may stay open for
-        # some minutes. Set SO_REUSEADDR to avoid bind failure with EADDRINUSE in these cases.
-        # <https://stackoverflow.com/questions/14388706>
-        socketserver.TCPServer.allow_reuse_address = True
-
-        # Listen on all IPv4 interfaces.
-        port = utils.WEB_SERVERS[i]
-        web_server = socketserver.TCPServer((utils.SERVER_ADDRESS, port), Handler)
-
-        web_servers.append(web_server)
-        web_server.serve_forever()
+    # There may be client sockets still open in TIME_WAIT state from previous tests, and they may stay open for
+    # some minutes. Set SO_REUSEADDR to avoid bind failure with EADDRINUSE in these cases.
+    # <https://stackoverflow.com/questions/14388706>
+    socketserver.TCPServer.allow_reuse_address = True
 
     # Start a web server for the test.
-    for i in range(len(utils.WEB_SERVERS)):
-        thread = Thread(target=server_thread, args=[i])
+    for port in utils.WEB_SERVERS:
+        web_servers.append(socketserver.TCPServer((utils.SERVER_ADDRESS, port), Handler))
+
+    for server in web_servers:
+        thread = Thread(target=server.serve_forever)
         web_server_threads.append(thread)
         thread.start()
-
-    for port in utils.WEB_SERVERS:
-        for _ in range(int(CONNECTION_TIMEOUT / WAIT_BETWEEN_ATTEMPTS)):
-            try:
-                with socket.create_connection((utils.SERVER_ADDRESS, port)):
-                    break
-            except Exception:
-                time.sleep(WAIT_BETWEEN_ATTEMPTS)
 
 
 def _stop_web_servers():

--- a/python/servo/devtools_tests/conftest.py
+++ b/python/servo/devtools_tests/conftest.py
@@ -186,7 +186,7 @@ def run_servoshell(servo_binary, devtools_port):
     if process:
         process.terminate()
         try:
-            process.wait(timeout=2)
+            process.wait(timeout=CONNECTION_TIMEOUT)
         except TimeoutExpired:
             print("Warning: servoshell did not terminate", file=sys.stderr)
             process.kill()

--- a/python/servo/devtools_tests/conftest.py
+++ b/python/servo/devtools_tests/conftest.py
@@ -14,7 +14,6 @@ import socketserver
 import subprocess
 import sys
 import time
-from concurrent.futures import Future
 from subprocess import TimeoutExpired
 from threading import Thread
 
@@ -25,10 +24,26 @@ from . import utils
 WAIT_BETWEEN_ATTEMPTS = 1 / 8  # seconds
 CONNECTION_TIMEOUT = 5  # seconds
 
+web_servers = []
+web_server_threads = []
+
 
 def pytest_addoption(parser):
     parser.addoption("--servo-binary", help="Path to the servoshell binary")
     parser.addoption("--script-path", help="Path to the servo python library")
+
+
+def pytest_sessionstart(session: pytest.Session):
+    if hasattr(session.config, "workerinput"):
+        return
+    # The web servers for the test files need to be started before we spawn the workers running the tests
+    _start_web_servers(session.config)
+
+
+def pytest_sessionfinish(session: pytest.Session):
+    if hasattr(session.config, "workerinput"):
+        return
+    _stop_web_servers()
 
 
 @pytest.fixture(scope="session")
@@ -40,23 +55,60 @@ def servo_binary(request):
 
 
 @pytest.fixture(scope="session")
-def script_path(request):
-    path = request.config.getoption("--script-path")
+def test_dir(request):
+    return _test_dir(request.config)
+
+
+def _test_dir(config):
+    path = config.getoption("--script-path")
     if not path:
         pytest.fail("The --script-path option must be specified")
-    return path
+    return os.path.join(path, "devtools_tests")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def devtools_port(worker_id):
+    base_port = 6000
+    if worker_id == "master":
+        return base_port
+
+    worker_num = int(worker_id.replace("gw", ""))
+    port = base_port + worker_num
+
+    # Set the thread local port in utils, which is used by the Devtools class
+    # This avoid having to pass it as a parameter in every invocation of connect
+    utils.DEVTOOLS_PORT = port
+
+    return port
 
 
 @pytest.fixture(scope="session")
-def web_server_urls(script_path):
-    test_dir = os.path.join(script_path, "devtools_tests")
-    base_urls = [Future() for _ in range(len(utils.WEB_SERVERS))]
-    web_servers = [None for _ in range(len(utils.WEB_SERVERS))]
-    web_server_threads = [None for _ in range(len(utils.WEB_SERVERS))]
+def web_server_urls(worker_id):
+    base_urls = [f"http://{utils.SERVER_ADDRESS}:{port}" for port in utils.WEB_SERVERS]
+
+    # For workers other than the one starting the web servers, we want to poll until they are available
+    if worker_id != "master":
+        for port in utils.WEB_SERVERS:
+            for _ in range(int(CONNECTION_TIMEOUT / WAIT_BETWEEN_ATTEMPTS)):
+                try:
+                    with socket.create_connection((utils.SERVER_ADDRESS, port)):
+                        break
+                except Exception:
+                    time.sleep(WAIT_BETWEEN_ATTEMPTS)
+            else:
+                raise TimeoutError(f"Couldn't connect to web server at {utils.SERVER_ADDRESS}:{port}")
+
+    return base_urls
+
+
+def _start_web_servers(config):
+    if web_servers:
+        return
+    directory = _test_dir(config)
 
     class Handler(http.server.SimpleHTTPRequestHandler):
         def __init__(self, *args, **kwargs):
-            super().__init__(*args, directory=test_dir, **kwargs)
+            super().__init__(*args, directory=directory, **kwargs)
 
         def log_message(self, format, *args):
             if utils.LOG_REQUESTS:
@@ -72,20 +124,25 @@ def web_server_urls(script_path):
         port = utils.WEB_SERVERS[i]
         web_server = socketserver.TCPServer((utils.SERVER_ADDRESS, port), Handler)
 
-        base_urls[i].set_result(f"http://{utils.SERVER_ADDRESS}:{port}")
-        web_servers[i] = web_server
+        web_servers.append(web_server)
         web_server.serve_forever()
 
     # Start a web server for the test.
     for i in range(len(utils.WEB_SERVERS)):
         thread = Thread(target=server_thread, args=[i])
-        web_server_threads[i] = thread
+        web_server_threads.append(thread)
         thread.start()
 
-    # Return the urls for the servers.
-    yield [url.result(1) for url in base_urls]
+    for port in utils.WEB_SERVERS:
+        for _ in range(int(CONNECTION_TIMEOUT / WAIT_BETWEEN_ATTEMPTS)):
+            try:
+                with socket.create_connection((utils.SERVER_ADDRESS, port)):
+                    break
+            except Exception:
+                time.sleep(WAIT_BETWEEN_ATTEMPTS)
 
-    # Stop the servers and the threads.
+
+def _stop_web_servers():
     for server in web_servers:
         if server:
             server.shutdown()
@@ -96,7 +153,7 @@ def web_server_urls(script_path):
 
 
 @pytest.fixture
-def run_servoshell(servo_binary):
+def run_servoshell(servo_binary, devtools_port):
     process = None
 
     def run(*, url):
@@ -106,13 +163,13 @@ def run_servoshell(servo_binary):
         os.environ["RUST_LOG"] = "error,devtools=warn"
 
         # Run servoshell.
-        process = subprocess.Popen([servo_binary, "--headless", f"--devtools={utils.DEVTOOLS_PORT}", url])
+        process = subprocess.Popen([servo_binary, "--headless", f"--devtools={devtools_port}", url])
 
         # Try to connect to the devtools server.
-        for attempt in range(int(CONNECTION_TIMEOUT / WAIT_BETWEEN_ATTEMPTS)):
+        for _ in range(int(CONNECTION_TIMEOUT / WAIT_BETWEEN_ATTEMPTS)):
             print(".", end="", file=sys.stderr)
             try:
-                with socket.create_connection((utils.SERVER_ADDRESS, utils.DEVTOOLS_PORT)) as stream:
+                with socket.create_connection((utils.SERVER_ADDRESS, devtools_port)) as stream:
                     stream.recv(4096)  # FIXME: geckordp workaround
                     stream.shutdown(socket.SHUT_RDWR)
                 print("+", end="", file=sys.stderr, flush=True)
@@ -120,7 +177,7 @@ def run_servoshell(servo_binary):
             except Exception:
                 time.sleep(WAIT_BETWEEN_ATTEMPTS)
         raise TimeoutError(
-            f"Couldn't connect to the devtools server at {utils.SERVER_ADDRESS}:{utils.DEVTOOLS_PORT} in {CONNECTION_TIMEOUT}s"
+            f"Couldn't connect to the devtools server at {utils.SERVER_ADDRESS}:{devtools_port} in {CONNECTION_TIMEOUT}s"
         )
 
     yield run
@@ -129,7 +186,7 @@ def run_servoshell(servo_binary):
     if process:
         process.terminate()
         try:
-            process.wait(timeout=CONNECTION_TIMEOUT)
+            process.wait(timeout=2)
         except TimeoutExpired:
             print("Warning: servoshell did not terminate", file=sys.stderr)
             process.kill()

--- a/python/servo/devtools_tests/test_debugger_tab.py
+++ b/python/servo/devtools_tests/test_debugger_tab.py
@@ -708,15 +708,15 @@ class TestDebuggerTab:
         expected_content = 'console.log("external classic");\n'
         assert_source_content(Source("srcScript", f"{web_server_urls[0]}/sources/classic.js"), expected_content)
 
-    def test_source_content_html_file(self, run_servoshell, web_server_urls, script_path):
+    def test_source_content_html_file(self, run_servoshell, web_server_urls, test_dir):
         run_servoshell(url=f"{web_server_urls[0]}/sources/test.html")
-        expected_content = open(os.path.join(script_path, "devtools_tests/sources/test.html")).read()
+        expected_content = open(os.path.join(test_dir, "sources/test.html")).read()
         assert_source_content(Source("inlineScript", f"{web_server_urls[0]}/sources/test.html"), expected_content)
 
-    def test_source_content_with_inline_module_import_external(self, run_servoshell, web_server_urls, script_path):
+    def test_source_content_with_inline_module_import_external(self, run_servoshell, web_server_urls, test_dir):
         run_servoshell(url=f"{web_server_urls[0]}/sources_content_with_inline_module_import_external/test.html")
         expected_content = open(
-            os.path.join(script_path, "devtools_tests", "sources_content_with_inline_module_import_external/test.html")
+            os.path.join(test_dir, "sources_content_with_inline_module_import_external/test.html")
         ).read()
         assert_source_content(
             Source(
@@ -748,11 +748,9 @@ class TestDebuggerTab:
 
     # Test case that uses XMLHttpRequest#responseXML and would actually need the HTML parser
     # (innerHTML has a fast path for values that don't contain b'&' | b'\0' | b'<' | b'\r')
-    def test_source_content_inline_script_with_responsexml(self, run_servoshell, web_server_urls, script_path):
+    def test_source_content_inline_script_with_responsexml(self, run_servoshell, web_server_urls, test_dir):
         run_servoshell(url=f"{web_server_urls[0]}/sources_content_with_responsexml/test.html")
-        expected_content = open(
-            os.path.join(script_path, "devtools_tests/sources_content_with_responsexml/test.html")
-        ).read()
+        expected_content = open(os.path.join(test_dir, "sources_content_with_responsexml/test.html")).read()
         assert_source_content(
             Source("inlineScript", f"{web_server_urls[0]}/sources_content_with_responsexml/test.html"),
             expected_content,

--- a/python/servo/devtools_tests/utils.py
+++ b/python/servo/devtools_tests/utils.py
@@ -22,8 +22,8 @@ from geckordp.rdp_client import RDPClient
 
 # Set this to true to log requests in the internal web servers.
 LOG_REQUESTS = False
-# The devtools server will be served at 6000.
-DEVTOOLS_PORT = 6000
+# The devtools server will be served at 6000 (plus the worker index if running in parallel mode).
+DEVTOOLS_PORT: int = 6000
 # Other web servers.
 WEB_SERVERS = [10000, 10001]
 SERVER_ADDRESS = "127.0.0.1"

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -416,8 +416,14 @@ class MachCommands(CommandBase):
 
     @Command("test-devtools", description="Run tests for devtools.", category="testing")
     @CommandArgument("test_names", nargs=argparse.REMAINDER, help="Only run tests that match these patterns")
+    @CommandArgument(
+        "-N",
+        "--num-threads",
+        default="auto",
+        help="Number of parallel workers: auto, logical, or a number; 0 to disable",
+    )
     @CommandBase.common_command_arguments(binary_selection=True)
-    def test_devtools(self, servo_binary: str, test_names: list[str], **kwargs: Any) -> int:
+    def test_devtools(self, servo_binary: str, test_names: list[str], num_threads: str, **kwargs: Any) -> int:
         import pytest
 
         args = [
@@ -426,6 +432,8 @@ class MachCommands(CommandBase):
             servo_binary,
             "--script-path",
             SCRIPT_PATH,
+            "-n",
+            num_threads,
             "-v",
         ]
         if test_names:

--- a/uv.lock
+++ b/uv.lock
@@ -469,6 +469,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "flake8"
 version = "6.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -711,6 +720,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -1297,6 +1315,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "ply"
 version = "3.8"
 source = { registry = "https://pypi.org/simple" }
@@ -1511,6 +1538,34 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/0c/ca7d4f2bc3c17dac9c3da9956d8baa5c4fe4c4e4996ead9b55273b0ee20a/pyrefly-0.63.1-py3-none-win32.whl", hash = "sha256:a9a45d3fc563f02cdca4681e899a775561bd71e923d6ac4a8979d93d7c2aff2a", size = 12086212, upload-time = "2026-04-29T05:59:45.021Z" },
     { url = "https://files.pythonhosted.org/packages/97/b5/1f6373e1fcefca3414baeed4209ecab2f4beb7849a2508517d73e78034ce/pyrefly-0.63.1-py3-none-win_amd64.whl", hash = "sha256:c6470a8eedae0e46d94667fd958cd008f9c2599aa3e6f2f43b6f4e6e87863cc3", size = 12934616, upload-time = "2026-04-29T05:59:48.146Z" },
     { url = "https://files.pythonhosted.org/packages/e9/ab/116efd46872f88cec697133d0430ce28affcc7247ebdff71429422a3a42b/pyrefly-0.63.1-py3-none-win_arm64.whl", hash = "sha256:b54b068a77341bc50604fb9bd4d0cf37fb74c09fb92344645c596813cc53950a", size = 12434930, upload-time = "2026-04-29T05:59:50.462Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.3.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891, upload-time = "2025-03-02T12:54:54.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634, upload-time = "2025-03-02T12:54:52.069Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]
@@ -1769,6 +1824,7 @@ dependencies = [
     { name = "pycodestyle" },
     { name = "pyflakes" },
     { name = "pyrefly" },
+    { name = "pytest-xdist" },
     { name = "pyyaml" },
     { name = "redo" },
     { name = "requests" },
@@ -1817,6 +1873,7 @@ requires-dist = [
     { name = "pycodestyle", marker = "python_full_version >= '3.9'", specifier = "==2.11.1" },
     { name = "pyflakes", marker = "python_full_version >= '3.9'", specifier = "==3.1.0" },
     { name = "pyrefly", specifier = "==0.63.1" },
+    { name = "pytest-xdist", specifier = "==3.8.0" },
     { name = "pyyaml", specifier = "==6.0.1" },
     { name = "redo", specifier = "==3.0.0" },
     { name = "requests" },


### PR DESCRIPTION
Enabled by default, creates multiple workers based on thread count and run multiple tests at once. Each thread uses a different devtools port, but the web server for test files is shared.

Can still be run in single process mode with `-N 0`. The same flag let's users customize the thread number. The default value is "auto".

Unlike #45327, this patch does add a small dependency on [`pytest-xdist`](https://pypi.org/project/pytest-xdist/). This extension is officially maintained by `pytest` and it is the recommended way of adding parallelism to tests. Given the substantial improvement in test time, I believe it is worth it.

**Before:** 75 tests in 117.16s
**After:** 75 tests 16.27s (using 8 workers)

Testing: `./mach test-devtools` runs without changes
Part of: #44256
Depends on: #45327
