### PR TITLE
 ci: Track RAM usage in scenarios tests on host

### DIFF
--- a/etc/ci/scenario/README.md
+++ b/etc/ci/scenario/README.md
@@ -49,7 +49,7 @@ UV_PROJECT=etc/ci/scenario uv run --active etc/ci/scenario/memory_usage_plotter.
 ```
 
 # Running blink-perf-test
-There is actually another runner of blink-perf-test present in the codebase, but I guess the current one is more general and might be better because it hadles more issues. Thus, this `blink-perf-test` is primarely made for running on OHOS.
+There is actually another runner of blink-perf-test present in the codebase, the current one is more general and handles more issues. Thus, this `blink-perf-test` is primarely made for running on OHOS.
 But as this `blink-perf-test` is now also has access to the memory loggin, the scope of it also now includes `linux` and `macos`
 So, as usual, to run:
 ```bash

--- a/etc/ci/scenario/README.md
+++ b/etc/ci/scenario/README.md
@@ -47,3 +47,17 @@ or when the script is run in a standalone mode you can do `-h` to see whats ther
 ```bash
 UV_PROJECT=etc/ci/scenario uv run --active etc/ci/scenario/memory_usage_plotter.py -h
 ```
+
+# Running blink-perf-test
+There is actually another runner of blink-perf-test present in the codebase, but I guess the current one is more general and might be better because it hadles more issues. Thus, this `blink-perf-test` is primarely made for running on OHOS.
+But as this `blink-perf-test` is now also has access to the memory loggin, the scope of it also now includes `linux` and `macos`
+So, as usual, to run:
+```bash
+UV_PROJECT=etc/ci/scenario uv run --active etc/ci/scenario/blink_perf_test.py -h
+```
+
+To check if works, there is a `single-test` mode, and extra `-mve` would also add more info to the output.
+```bash
+UV_PROJECT=etc/ci/scenario uv run --active etc/ci/scenario/blink_perf_test.py -mves
+```
+Will produce both `results.json` and `blink_perf_test_logs.csv` that would include bench of the run and memory info.

--- a/etc/ci/scenario/README.md
+++ b/etc/ci/scenario/README.md
@@ -1,0 +1,49 @@
+# How to run scenarios
+The directory has both scenarios that could be run and common files used by scenarios. To run a scenario:
+```bash
+uv run etc/ci/scenario/servo_test_open_page_servo_plot.py
+```
+## available arguments
+- `--target-os` has `linux`, `macos` and `ohos` as current options
+- `
+
+or, if required, do
+```bash
+UV_PROJECT=etc/ci/scenario uv run --active etc/ci/scenario/servo_test_open_page_servo_plot.py
+```
+
+# How to develop scenarios
+## Python type checking
+Currently, due to a `pyproject.toml` in the root of servo, the default `./mach test-tidy` does not fully check current directory (`etc/ci/scenario`).
+It is crucial to currently manually check the Python scripts in this directory using
+```bash
+uv run --active pyrefly check etc/ci/scenario/
+```
+
+# Adding scenarios to CI
+## Mitmproxy
+Mitmproxy currently requires `CI=1` env to run
+## Target binary
+Current default binary is defined in the `common_function_for_servo_test.py` as
+```python
+DEFAULT_SERVO_BIN_PATH = "./target/release/servoshell"
+```
+But could be overriden by passing `--servo-bin` arg to the scenario
+
+# Using memory_usage_plotter
+There are three intended uses for the `memory_usage_plotter.py`
+1. It is included in the scenarios and can log the memory (to the `.csv`) when running the scenario or even plot in place without leaving `.csv`.
+1. Can be used to convert already existing `.csv` into a rendered plot image.
+1. To track the memory of already running servo process without explicit scenario `operator()`.
+
+## Notable options or arguments
+The script has a `MemoryLoggingOptions` that could be imported and used to set all the options.
+```Python
+memory_logging_options = MemoryLoggingOptions(
+    log_to_file=True, plot=True, pre_time=2, post_time=5, verbose=True, reset_tab=True
+)
+```
+or when the script is run in a standalone mode you can do `-h` to see whats there
+```bash
+UV_PROJECT=etc/ci/scenario uv run --active etc/ci/scenario/memory_usage_plotter.py -h
+```

--- a/etc/ci/scenario/blink_perf_test.py
+++ b/etc/ci/scenario/blink_perf_test.py
@@ -17,6 +17,7 @@ import sys
 import re
 import json
 import argparse
+from contextlib import nullcontext
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from types import TracebackType
 from hdc_py.hdc import HarmonyDeviceConnector, HarmonyDevicePerfMode  # type: ignore[import-untyped]
@@ -29,22 +30,21 @@ from dataclasses import dataclass
 import threading
 import csv
 from typing import Any, Dict, Optional, Type
-from common_function_for_servo_test import create_driver, setup_hdc_forward, stop_servo, close_usb_popup
+from common_function_for_servo_test import (
+    ABOUT_BLANK,
+    DEFAULT_SERVO_BIN_PATH,
+    HostOptions,
+    RunTestOptions,
+    WEBDRIVER_PORT,
+    close_usb_popup,
+    create_driver,
+    setup_hdc_forward,
+    start_servo,
+    stop_servo,
+)
 
 
-class PortMapResult(Enum):
-    SUCCESSFUL = (1,)
-    PORT_EXISTS = (2,)
-    FORWARD_FAILED = (3,)
-
-    def is_success(self) -> bool:
-        return self == PortMapResult.SUCCESSFUL or self == PortMapResult.PORT_EXISTS
-
-
-WEBDRIVER_PORT = 7000
 BLINK_PERF_FILES_SERVE_PORT = random.randrange(7150, 9000)
-SERVO_URL = f"http://127.0.0.1:{WEBDRIVER_PORT}"
-ABOUT_BLANK = "about:blank"
 DIRECTORY = "tests/blink_perf_tests/perf_tests"
 
 # Tests we will skip because they are currently broken.
@@ -135,6 +135,7 @@ class LocalFileServe:
         tb: TracebackType | None,
     ) -> None:
         if self.local_server is not None:
+            self.local_server.shutdown()
             self.local_server.server_close()
 
 
@@ -155,17 +156,18 @@ def run_single_test(
         before_get = time.perf_counter()
         driver.get(url)
         after_get = time.perf_counter()
-        if cli_args.page_loading_timeout is None:
+        page_loading_timeout = cli_args.page_loading_timeout
+        if page_loading_timeout is None:
             special_case_time = next(
                 (value for s, value in tests_that_take_extra_time_to_load if test_file_name in s), None
             )
             if special_case_time is not None:
-                cli_args.page_loading_timeout = special_case_time
+                page_loading_timeout = special_case_time
             else:
-                cli_args.page_loading_timeout = 2
-        if after_get - before_get > cli_args.page_loading_timeout:
+                page_loading_timeout = 2
+        if after_get - before_get > page_loading_timeout:
             raise TimeoutError(
-                f"Page loading took {(after_get - before_get):.2f}s (> {cli_args.page_loading_timeout}s limit)"
+                f"Page loading took {(after_get - before_get):.2f}s (> {page_loading_timeout}s limit)"
             )
         print(f">>> Page loading took {(after_get - before_get):.2f}s")
 
@@ -174,7 +176,7 @@ def run_single_test(
         max_line: Optional[float] = None
         unit: Optional[str] = None
         start_time, latest_time = time.perf_counter(), 0.0
-        while latest_time - start_time < 60:
+        while latest_time - start_time < MAX_WAIT_TIME:
             try:
                 element = driver.find_element(By.ID, "log")
                 latest_time = time.perf_counter()
@@ -336,8 +338,9 @@ def verbose_print(str_to_print: str, is_verbose: bool = False) -> None:
         print(str_to_print)
 
 
-def run_tests(port: int, cli_args: argparse.Namespace) -> None:
+def run_tests(port: int, cli_args: argparse.Namespace, hdc: Optional[HarmonyDeviceConnector]) -> None:
     skip_until = cli_args.skip_until
+    target_os = cli_args.target_os
 
     final_result: dict[str, dict[str, Any]] = {}
     csv_file, csv_writer = None, None
@@ -357,11 +360,25 @@ def run_tests(port: int, cli_args: argparse.Namespace) -> None:
                     if filePath in skipped_tests:
                         continue
                     print("Starting new servo instance...")
-                    cmd_str = f"aa start -a EntryAbility -b org.servo.servo -U {ABOUT_BLANK} --psn=--webdriver --psn=--pref=session_history_max_length=1"
-                    hdc.cmd(cmd_str, timeout=10)
+                    servo_process = start_servo(
+                        RunTestOptions(
+                            test_fn=lambda: None,
+                            test_name=filePath,
+                            target_os=target_os,
+                            session_history_max_length=1,
+                            url=ABOUT_BLANK,
+                            resolved_servo_bin_path=cli_args.servo_bin,
+                        )
+                    )
                     try:
-                        with HarmonyDevicePerfMode(screen_timeout_seconds=2 * 60 * 60):
-                            close_usb_popup(hdc)
+                        with (
+                            HarmonyDevicePerfMode(screen_timeout_seconds=2 * 60 * 60)
+                            if target_os == HostOptions.OHOS
+                            else nullcontext()
+                        ):
+                            if target_os == HostOptions.OHOS:
+                                assert hdc is not None
+                                close_usb_popup(hdc)
                             try:
                                 webdriver = create_driver(timeout=1)
                             except RuntimeError as exc:
@@ -427,7 +444,7 @@ def run_tests(port: int, cli_args: argparse.Namespace) -> None:
                             if csv_writer and csv_file:
                                 csv_file.flush()
                     finally:
-                        stop_servo()
+                        stop_servo(target_os, servo_process)
         print(f"final_result {final_result}")
     finally:
         if csv_file:
@@ -454,6 +471,18 @@ def get_memory_report_str(driver: webdriver.Remote) -> MemoryReport | ParseError
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--target-os",
+        type=HostOptions.from_str,
+        choices=tuple(option.value for option in HostOptions),
+        default=HostOptions.OHOS,
+        help="Where Servo should run: connected OpenHarmony device or local host",
+    )
+    parser.add_argument(
+        "--servo-bin",
+        default=DEFAULT_SERVO_BIN_PATH,
+        help="Path to the servoshell binary used for local runs",
+    )
     parser.add_argument(
         "-m",
         "--memory-report",
@@ -488,17 +517,23 @@ if __name__ == "__main__":
         help="Pages should load very fast, but if takes longer (than default 2s or specified), the result parsing is skipped",
     )
     args = parser.parse_args()
-    hdc = HarmonyDeviceConnector()
+    hdc = HarmonyDeviceConnector() if args.target_os == HostOptions.OHOS else None
     try:
         print("Stopping potential old servo instance ...")
-        stop_servo()
-        setup_hdc_forward(webdriver_port=WEBDRIVER_PORT, host_service_port=BLINK_PERF_FILES_SERVE_PORT)
+        stop_servo(args.target_os)
+        setup_hdc_forward(
+            webdriver_port=WEBDRIVER_PORT,
+            host_service_port=BLINK_PERF_FILES_SERVE_PORT,
+            target_os=args.target_os,
+        )
         with LocalFileServe(BLINK_PERF_FILES_SERVE_PORT):
-            run_tests(BLINK_PERF_FILES_SERVE_PORT, cli_args=args)
+            run_tests(BLINK_PERF_FILES_SERVE_PORT, cli_args=args, hdc=hdc)
     except Exception as e:
         print(f"Test failed with error: {e} (exception: {type(e)})")
-        hdc.screenshot("Blink_perf_test_error.jpg")
-        stop_servo()
+        if args.target_os == HostOptions.OHOS:
+            assert hdc is not None
+            hdc.screenshot("Blink_perf_test_error.jpg")
+        stop_servo(args.target_os)
         sys.exit(1)
     print("\033[32mTest Succeeded.\033[0m")
-    stop_servo()
+    stop_servo(args.target_os)

--- a/etc/ci/scenario/blink_perf_test.py
+++ b/etc/ci/scenario/blink_perf_test.py
@@ -166,9 +166,7 @@ def run_single_test(
             else:
                 page_loading_timeout = 2
         if after_get - before_get > page_loading_timeout:
-            raise TimeoutError(
-                f"Page loading took {(after_get - before_get):.2f}s (> {page_loading_timeout}s limit)"
-            )
+            raise TimeoutError(f"Page loading took {(after_get - before_get):.2f}s (> {page_loading_timeout}s limit)")
         print(f">>> Page loading took {(after_get - before_get):.2f}s")
 
         avg_line: Optional[float] = None

--- a/etc/ci/scenario/blink_perf_test.py
+++ b/etc/ci/scenario/blink_perf_test.py
@@ -378,7 +378,7 @@ def run_tests(port: int, cli_args: argparse.Namespace, hdc: Optional[HarmonyDevi
                                 assert hdc is not None
                                 close_usb_popup(hdc)
                             try:
-                                webdriver = create_driver(timeout=1)
+                                webdriver = create_driver()
                             except RuntimeError as exc:
                                 print(f"Failed to create webdriver for {filePath}: {exc}")
                                 if csv_writer:

--- a/etc/ci/scenario/blink_perf_test.py
+++ b/etc/ci/scenario/blink_perf_test.py
@@ -72,7 +72,7 @@ tests_that_hang_memory_report = [
 ]
 
 ### `tests_that_take_extra_time_to_load` tests take several seconds to load instead of default 0.05s - 2s
-# can be overriden using `--page_loading_timeout` (in seconds)
+# can be overriden using `--page-loading-timeout` (in seconds)
 tests_that_take_extra_time_to_load = [
     ("subtree-detaching.html", 20),
     ("abspos.html", 5),
@@ -385,6 +385,9 @@ def run_tests(port: int, cli_args: argparse.Namespace, hdc: Optional[HarmonyDevi
                                 print(f"Failed to create webdriver for {filePath}: {exc}")
                                 if csv_writer:
                                     csv_writer.writerow([filePath, "driver_start_failed"])
+                                if cli_args.single_test:
+                                    write_file(final_result)
+                                    return
                                 continue
 
                             try:
@@ -445,6 +448,9 @@ def run_tests(port: int, cli_args: argparse.Namespace, hdc: Optional[HarmonyDevi
                                 csv_file.flush()
                     finally:
                         stop_servo(target_os, servo_process)
+                    if cli_args.single_test:
+                        write_file(final_result)
+                        return
         print(f"final_result {final_result}")
     finally:
         if csv_file:
@@ -505,7 +511,7 @@ if __name__ == "__main__":
         help="Executes only first test. Can be used with --skip-until to run only one specific test",
     )
     parser.add_argument(
-        "--skip_until",
+        "--skip-until",
         type=str,
         default=None,
         help="Skips all tests until the specified one, and if --single-test is not set, continues until the end.",

--- a/etc/ci/scenario/common_function_for_servo_test.py
+++ b/etc/ci/scenario/common_function_for_servo_test.py
@@ -333,8 +333,7 @@ def start_servo(
         )
     if options.session_history_max_length is not None:
         command.append(f"--pref=session_history_max_length={options.session_history_max_length}")
-    if options.url != ABOUT_BLANK:
-        command.append(options.url)
+    command.append(options.url)
     return subprocess.Popen(command)
 
 

--- a/etc/ci/scenario/common_function_for_servo_test.py
+++ b/etc/ci/scenario/common_function_for_servo_test.py
@@ -351,7 +351,7 @@ def stop_servo(target_os: HostOptions, servo_process: subprocess.Popen[bytes] | 
             servo_process.kill()
             servo_process.wait(timeout=10)
     else:
-        subprocess.run(["pkill", "-x", "servoshell"], capture_output=True, text=True, timeout=10)
+        print("No tracked local Servo process to stop; skipping cleanup.")
     print("Stop Test Application successful!")
 
 

--- a/etc/ci/scenario/common_function_for_servo_test.py
+++ b/etc/ci/scenario/common_function_for_servo_test.py
@@ -30,7 +30,7 @@ from PIL import Image
 from selenium import webdriver
 from selenium.webdriver.common.options import ArgOptions
 from selenium.webdriver.remote.webelement import WebElement
-from urllib3.exceptions import ProtocolError
+from urllib3.exceptions import MaxRetryError, NewConnectionError, ProtocolError
 
 WEBDRIVER_PORT = random.randrange(9001, 9900)
 MITMPROXY_PORT = random.randrange(7150, 9000)
@@ -221,7 +221,7 @@ def create_driver(timeout: int = 10) -> webdriver.Remote:
     while driver is None and time.time() - start_time < timeout:
         try:
             driver = webdriver.Remote(command_executor=SERVO_URL, options=options)
-        except (ConnectionError, ProtocolError):
+        except (ConnectionError, MaxRetryError, NewConnectionError, ProtocolError):
             time.sleep(0.2)
         except Exception as e:
             print(f"Unexpected exception when creating webdriver: {e}, {type(e)}")

--- a/etc/ci/scenario/common_function_for_servo_test.py
+++ b/etc/ci/scenario/common_function_for_servo_test.py
@@ -308,7 +308,9 @@ def start_servo(
 ) -> subprocess.Popen[bytes] | None:
     if options.target_os == HostOptions.OHOS:
         hdc = HarmonyDeviceConnector()
-        cmd_str = f"aa start -a EntryAbility -b {SERVO_PACKAGE_NAME} -U {options.url} --psn=--webdriver={WEBDRIVER_PORT}"
+        cmd_str = (
+            f"aa start -a EntryAbility -b {SERVO_PACKAGE_NAME} -U {options.url} --psn=--webdriver={WEBDRIVER_PORT}"
+        )
         if options.use_mitmproxy.should_servo_proxy():
             cmd_str += (
                 f" --psn=--pref=network_https_proxy_uri=http://127.0.0.1:{MITMPROXY_PORT}"

--- a/etc/ci/scenario/common_function_for_servo_test.py
+++ b/etc/ci/scenario/common_function_for_servo_test.py
@@ -9,6 +9,7 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+import argparse
 import enum
 import os
 import pathlib
@@ -17,10 +18,12 @@ import shutil
 import subprocess
 import sys
 import time
+from contextlib import nullcontext
+from dataclasses import dataclass
 from decimal import Decimal
 from enum import Enum
 from types import TracebackType
-from typing import Callable, Optional, Self, Type
+from typing import TYPE_CHECKING, Callable, Optional, Self, Type
 
 from hdc_py.hdc import HarmonyDeviceConnector, HarmonyDevicePerfMode
 from PIL import Image
@@ -29,11 +32,51 @@ from selenium.webdriver.common.options import ArgOptions
 from selenium.webdriver.remote.webelement import WebElement
 from urllib3.exceptions import ProtocolError
 
-WEBDRIVER_PORT = 7000
+WEBDRIVER_PORT = random.randrange(9001, 9900)
 MITMPROXY_PORT = random.randrange(7150, 9000)
 SERVO_URL = f"http://127.0.0.1:{WEBDRIVER_PORT}"
 ABOUT_BLANK = "about:blank"
 MITMPROXY_VERSION = "12.2.1"
+DEFAULT_SERVO_BIN_PATH = "./target/release/servoshell"
+SERVO_PACKAGE_NAME = "org.servo.servo"
+SCENARIO_TARGET_OS_ENV_VAR = "SERVO_SCENARIO_TARGET_OS"
+
+if TYPE_CHECKING:
+    from memory_usage_plotter import MemoryLoggingOptions
+
+
+class HostOptions(str, Enum):
+    LINUX = "linux"
+    OHOS = "ohos"
+    MACOS = "macos"
+
+    @classmethod
+    def from_str(cls, value: str) -> "HostOptions":
+        for option in cls:
+            if option.value == value:
+                return option
+        raise ValueError(f"Unsupported host option: {value}")
+
+
+def get_target_os_from_environment() -> HostOptions:
+    return HostOptions.from_str(os.environ.get(SCENARIO_TARGET_OS_ENV_VAR, HostOptions.OHOS.value))
+
+
+def common_args_from_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument(
+        "--target-os",
+        type=HostOptions.from_str,
+        choices=tuple(option.value for option in HostOptions),
+        default=HostOptions.OHOS,
+    )
+    parser.add_argument(
+        "--servo-bin",
+        default=DEFAULT_SERVO_BIN_PATH,
+        help="Path to the servoshell binary used for local runs",
+    )
+    args, _ = parser.parse_known_args()
+    return args
 
 
 class MitmProxyRunType(enum.Enum):
@@ -48,6 +91,19 @@ class MitmProxyRunType(enum.Enum):
 
     def should_servo_proxy(self) -> bool:
         return self == MitmProxyRunType.REPLAY or self == MitmProxyRunType.RECORD or self == MitmProxyRunType.FORWARD
+
+
+@dataclass
+class RunTestOptions:
+    test_fn: Callable[[], None]
+    test_name: str
+    target_os: HostOptions = HostOptions.OHOS
+    use_mitmproxy: MitmProxyRunType = MitmProxyRunType.NOPROXY
+    dump_file: pathlib.Path = pathlib.Path("/tmp/mitmproxy-dump")
+    memory_logging_options: Optional["MemoryLoggingOptions"] = None
+    session_history_max_length: int | None = None
+    url: str = ABOUT_BLANK
+    resolved_servo_bin_path: str = DEFAULT_SERVO_BIN_PATH
 
 
 class MitmProxy:
@@ -214,12 +270,18 @@ def port_forward(port: int | str, reverse: bool) -> PortMapResult:
 
 
 def setup_hdc_forward(
-    timeout: int = 5, webdriver_port: int = WEBDRIVER_PORT, host_service_port: int = MITMPROXY_PORT
+    timeout: int = 5,
+    webdriver_port: int = WEBDRIVER_PORT,
+    host_service_port: int = MITMPROXY_PORT,
+    target_os: HostOptions = HostOptions.OHOS,
 ) -> None:
     """
     set hdc forward
     :return: If successful, return driver; If failed, return False
     """
+    if target_os != HostOptions.OHOS:
+        return
+
     for v in ("HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy"):
         os.environ.pop(v, None)
 
@@ -241,11 +303,54 @@ def setup_hdc_forward(
     raise TimeoutError("HDC port forwarding timed out")
 
 
-def stop_servo() -> None:
+def start_servo(
+    options: RunTestOptions,
+) -> subprocess.Popen[bytes] | None:
+    if options.target_os == HostOptions.OHOS:
+        hdc = HarmonyDeviceConnector()
+        cmd_str = f"aa start -a EntryAbility -b {SERVO_PACKAGE_NAME} -U {options.url} --psn=--webdriver={WEBDRIVER_PORT}"
+        if options.use_mitmproxy.should_servo_proxy():
+            cmd_str += (
+                f" --psn=--pref=network_https_proxy_uri=http://127.0.0.1:{MITMPROXY_PORT}"
+                f" --psn=--pref=network_http_proxy_uri=http://127.0.0.1:{MITMPROXY_PORT}"
+                " --psn=--ignore-certificate-errors"
+            )
+        if options.session_history_max_length is not None:
+            cmd_str += f" --psn=--pref=session_history_max_length={options.session_history_max_length}"
+        hdc.cmd(cmd_str, timeout=10)
+        return None
+
+    command = [options.resolved_servo_bin_path, f"--webdriver={WEBDRIVER_PORT}"]
+    if options.use_mitmproxy.should_servo_proxy():
+        command.extend(
+            [
+                f"--pref=network_https_proxy_uri=http://127.0.0.1:{MITMPROXY_PORT}",
+                f"--pref=network_http_proxy_uri=http://127.0.0.1:{MITMPROXY_PORT}",
+                "--ignore-certificate-errors",
+            ]
+        )
+    if options.session_history_max_length is not None:
+        command.append(f"--pref=session_history_max_length={options.session_history_max_length}")
+    if options.url != ABOUT_BLANK:
+        command.append(options.url)
+    return subprocess.Popen(command)
+
+
+def stop_servo(target_os: HostOptions, servo_process: subprocess.Popen[bytes] | None = None) -> None:
     """stop servo application"""
     print("Prepare to stop Test Application...")
-    cmd = ["hdc", "shell", "aa force-stop org.servo.servo"]
-    subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+    if target_os == HostOptions.OHOS:
+        cmd = ["hdc", "shell", f"aa force-stop {SERVO_PACKAGE_NAME}"]
+        subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+    elif servo_process is not None:
+        servo_process.terminate()
+        try:
+            servo_process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            servo_process.kill()
+            servo_process.wait(timeout=10)
+    else:
+        subprocess.run(["pkill", "-x", "servoshell"], capture_output=True, text=True, timeout=10)
     print("Stop Test Application successful!")
 
 
@@ -349,47 +454,63 @@ def close_usb_popup(hdc: HarmonyDeviceConnector) -> None:
 # We always load "about:blank" first, and then use
 # WebDriver to load target url so that it is blocked until fully loaded.
 def run_test(
-    test_fn: Callable[[], None],
-    test_name: str,
+    options_or_test_fn: RunTestOptions | Callable[[], None],
+    test_name: str | None = None,
     use_mitmproxy: MitmProxyRunType = MitmProxyRunType.NOPROXY,
     session_history_max_length: int | None = None,
     url: Optional[str] = None,
 ) -> None:
-    if os.environ.get("CI") and use_mitmproxy == MitmProxyRunType.NOPROXY:
+    if isinstance(options_or_test_fn, RunTestOptions):
+        options = options_or_test_fn
+    else:
+        if test_name is None:
+            raise ValueError("test_name is required")
+        args = common_args_from_args()
+        options = RunTestOptions(
+            test_fn=options_or_test_fn,
+            test_name=test_name,
+            target_os=args.target_os,
+            use_mitmproxy=use_mitmproxy,
+            session_history_max_length=session_history_max_length,
+            url=url if url is not None else ABOUT_BLANK,
+            resolved_servo_bin_path=args.servo_bin,
+        )
+
+    if options.memory_logging_options is not None:
+        options.memory_logging_options.target_os = options.target_os
+    if os.environ.get("CI") and options.use_mitmproxy == MitmProxyRunType.NOPROXY:
         # if we are in CI and nobody overrode our mitmproxy type we want to replay.
         print("Setting mitmproxy replay")
-        use_mitmproxy = MitmProxyRunType.REPLAY
+        options.use_mitmproxy = MitmProxyRunType.REPLAY
 
-    dump_file = pathlib.Path("/tmp/mitmproxy-dump")
-    if use_mitmproxy == MitmProxyRunType.REPLAY and not dump_file.is_file():
-        print(f"Dump file {dump_file} did not exist. We will abort")
+    if options.use_mitmproxy == MitmProxyRunType.REPLAY and not options.dump_file.is_file():
+        print(f"Dump file {options.dump_file} did not exist. We will abort")
         return
-    resolved_url = url if url is not None else ABOUT_BLANK
-    hdc = HarmonyDeviceConnector()
+    hdc = HarmonyDeviceConnector() if options.target_os == HostOptions.OHOS else None
+    servo_process: subprocess.Popen[bytes] | None = None
+    os.environ[SCENARIO_TARGET_OS_ENV_VAR] = options.target_os.value
     try:
         print("Stopping potential old servo instance ...")
-        stop_servo()
+        stop_servo(options.target_os)
 
-        setup_hdc_forward()
-        with MitmProxy(use_mitmproxy, dump_file, MITMPROXY_PORT):
+        setup_hdc_forward(target_os=options.target_os)
+        with MitmProxy(options.use_mitmproxy, options.dump_file, MITMPROXY_PORT):
             print("Starting new servo instance...")
             time.sleep(5)
-            cmd_str = f"aa start -a EntryAbility -b org.servo.servo -U {resolved_url} --psn=--webdriver"
-            if use_mitmproxy.should_servo_proxy():
-                cmd_str += f" --psn=--pref=network_https_proxy_uri=http://127.0.0.1:{str(MITMPROXY_PORT)} --psn=--pref=network_http_proxy_uri=http://127.0.0.1:{MITMPROXY_PORT} --psn=--ignore-certificate-errors"
-                if session_history_max_length is not None:
-                    cmd_str += f" --psn=--pref=session_history_max_length={str(session_history_max_length)} "
-            hdc.cmd(
-                cmd_str,
-                timeout=10,
-            )
-            with HarmonyDevicePerfMode():
-                close_usb_popup(hdc)
-                test_fn()
+            servo_process = start_servo(options)
+            with HarmonyDevicePerfMode() if options.target_os == HostOptions.OHOS else nullcontext():
+                if options.target_os == HostOptions.OHOS:
+                    assert hdc is not None
+                    close_usb_popup(hdc)
+                options.test_fn()
     except Exception as e:
-        print(f"Scenario test `{test_name}` failed with error: {e} (exception: {type(e)})")
-        hdc.screenshot(f"servo_scenario_{test_name}_error.jpg")
-        stop_servo()
+        print(f"Scenario test `{options.test_name}` failed with error: {e} (exception: {type(e)})")
+        if options.target_os == HostOptions.OHOS:
+            assert hdc is not None
+            hdc.screenshot(f"servo_scenario_{options.test_name}_error.jpg")
+        stop_servo(options.target_os, servo_process)
         sys.exit(1)
+    finally:
+        os.environ.pop(SCENARIO_TARGET_OS_ENV_VAR, None)
     print("\033[32mTest Succeeded.\033[0m")
-    stop_servo()
+    stop_servo(options.target_os, servo_process)

--- a/etc/ci/scenario/memory_usage_plotter.py
+++ b/etc/ci/scenario/memory_usage_plotter.py
@@ -11,6 +11,7 @@
 
 from io import TextIOWrapper
 import argparse
+import os
 import threading
 import time
 import csv
@@ -26,7 +27,7 @@ from selenium.webdriver.remote.webdriver import WebDriver
 import sys
 from hdc_py.hdc import HarmonyDeviceConnector  # type: ignore[import-untyped]
 from types import TracebackType
-from common_function_for_servo_test import create_driver
+from common_function_for_servo_test import HostOptions, create_driver, get_target_os_from_environment
 
 PACKAGE_NAME = "org.servo.servo"
 
@@ -47,6 +48,7 @@ class MemoryLoggingOptions:
     mode: str = "collect"
     reset_tab: Optional[str | bool] = None
     create_own_webdriver: bool = False
+    target_os: Optional[HostOptions] = None
 
 
 @dataclass
@@ -80,19 +82,7 @@ class MemoryInfo:
     __repr__ = __str__
 
 
-def get_memory_info(pid: int) -> Optional[MemoryInfo]:
-    cmd = ["hdc", "shell", "cat", f"/proc/{pid}/status"]
-
-    try:
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-    except subprocess.CalledProcessError:
-        return None
-
+def parse_memory_info(status_text: str) -> MemoryInfo:
     fields = {
         "VmRSS": 0,
         "VmHWM": 0,
@@ -103,7 +93,7 @@ def get_memory_info(pid: int) -> Optional[MemoryInfo]:
         "RssShmem": 0,
     }
 
-    for line in result.stdout.splitlines():
+    for line in status_text.splitlines():
         for key in fields:
             if line.startswith(key + ":"):
                 parts = line.split()
@@ -119,6 +109,54 @@ def get_memory_info(pid: int) -> Optional[MemoryInfo]:
         rss_file_kb=fields["RssFile"],
         rss_shmem_kb=fields["RssShmem"],
     )
+
+
+def get_memory_info(pid: int, target_os: HostOptions) -> Optional[MemoryInfo]:
+    if target_os == HostOptions.OHOS:
+        cmd = ["hdc", "shell", "cat", f"/proc/{pid}/status"]
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        except subprocess.CalledProcessError:
+            return None
+        return parse_memory_info(result.stdout)
+
+    if target_os == HostOptions.LINUX:
+        status_path = Path(f"/proc/{pid}/status")
+        if not status_path.is_file():
+            return None
+        return parse_memory_info(status_path.read_text(encoding="utf-8"))
+
+    if target_os == HostOptions.MACOS:
+        try:
+            result = subprocess.run(
+                ["ps", "-o", "rss=,vsz=", "-p", str(pid)],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        except subprocess.CalledProcessError:
+            return None
+        values = result.stdout.split()
+        if len(values) < 2:
+            return None
+        rss_kb = int(values[0])
+        vsz_kb = int(values[1])
+        return MemoryInfo(
+            vm_rss_kb=rss_kb,
+            vm_hwm_kb=rss_kb,
+            vm_size_kb=vsz_kb,
+            vm_swap_kb=0,
+            rss_anon_kb=0,
+            rss_file_kb=0,
+            rss_shmem_kb=0,
+        )
+
+    return None
 
 
 class InvalidInputFile(Exception):
@@ -137,13 +175,27 @@ def raise_if_input_invalid(file_path: str) -> None:
         raise InvalidInputFile("Invalid CSV header")
 
 
-def pidof(package_name: str, hdc: HarmonyDeviceConnector) -> List[int]:
-    completed_process = hdc.cmd("pidof " + package_name, capture_output=True, encoding="utf-8")
-    output = str(completed_process.stdout)
-    if not output:
-        return []
+def pidof(package_name: str, target_os: HostOptions, hdc: Optional[HarmonyDeviceConnector] = None) -> List[int]:
+    if target_os == HostOptions.OHOS:
+        if hdc is None:
+            raise ValueError("HDC connector is required for OHOS PID lookup")
+        completed_process = hdc.cmd("pidof " + package_name, capture_output=True, encoding="utf-8")
+        output = str(completed_process.stdout)
+        if not output:
+            return []
+        return [int(pid) for pid in output.split() if pid.isdigit()]
 
-    return [int(pid) for pid in output.split() if pid.isdigit()]
+    process_name = os.path.basename(package_name)
+    try:
+        completed_process = subprocess.run(
+            ["pgrep", "-x", process_name],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        return []
+    return [int(pid) for pid in completed_process.stdout.split() if pid.isdigit()]
 
 
 @dataclass(slots=True)
@@ -176,8 +228,8 @@ def load_memory_log(path: str) -> MemoryLog:
 
             sample = MemorySample(
                 timestamp=float(row["timestamp"]),
-                RSS_MB=float(row["rss (kb)"]),
-                Swap_MB=float(row["swap (kb)"]),
+                RSS_MB=float(row["rss (mb)"]),
+                Swap_MB=float(row["swap (mb)"]),
                 event_name=event,
             )
 
@@ -207,6 +259,7 @@ class NonBlockingMemoryLogging:
         self.driver: Optional[WebDriver] = None
         self.hdc: Optional[HarmonyDeviceConnector] = None
         self.csv_file: Optional[TextIOWrapper] = None
+        self.target_os = self.options.target_os or get_target_os_from_environment()
         if self.options.create_own_webdriver:
             self.driver = create_driver(timeout=1)
 
@@ -225,7 +278,7 @@ class NonBlockingMemoryLogging:
         if self.options.log_to_file:
             self.csv_file = open(self.options.file_name + ".csv", "w", newline="", encoding="utf-8")
             self.writer = csv.writer(self.csv_file)
-            self.writer.writerow(["timestamp", "rss (kb)", "swap (kb)", "event"])
+            self.writer.writerow(["timestamp", "rss (mb)", "swap (mb)", "event"])
         self._stop_event = threading.Event()
         self._thread = threading.Thread(
             target=self._run,
@@ -251,8 +304,10 @@ class NonBlockingMemoryLogging:
     def start(self) -> None:
         if self.options.pid is None:
             try:
-                self.hdc = HarmonyDeviceConnector()
-                self.options.pid = get_servo_pid(PACKAGE_NAME, self.hdc)
+                if self.target_os == HostOptions.OHOS:
+                    self.hdc = HarmonyDeviceConnector()
+                package_name = PACKAGE_NAME if self.target_os == HostOptions.OHOS else "servoshell"
+                self.options.pid = get_servo_pid(package_name, self.target_os, self.hdc)
             except (MoreThanOneInstanceOfServo, ProcessLookupError) as e:
                 print(f"Failed to get servo PID: {e}")
             else:
@@ -294,7 +349,7 @@ class NonBlockingMemoryLogging:
         if self.options.pid is None:
             return
 
-        memory_point = get_memory_info(self.options.pid)
+        memory_point = get_memory_info(self.options.pid, self.target_os)
         if memory_point is None:
             return
 
@@ -377,8 +432,10 @@ class MoreThanOneInstanceOfServo(Exception):
     pass
 
 
-def get_servo_pid(package_name: str, hdc: HarmonyDeviceConnector) -> int | None:
-    pids = pidof(package_name, hdc)
+def get_servo_pid(
+    package_name: str, target_os: HostOptions, hdc: Optional[HarmonyDeviceConnector] = None
+) -> int | None:
+    pids = pidof(package_name, target_os, hdc)
     if not pids:
         raise ProcessLookupError(f"No running instances of {package_name}")
     if len(pids) > 1:
@@ -389,6 +446,13 @@ def get_servo_pid(package_name: str, hdc: HarmonyDeviceConnector) -> int | None:
 if __name__ == "__main__":
     default_options = MemoryLoggingOptions()
     parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--target-os",
+        type=HostOptions.from_str,
+        choices=tuple(option.value for option in HostOptions),
+        default=HostOptions.OHOS,
+        help="Where Servo should run: connected OpenHarmony device or local host",
+    )
     parser.add_argument(
         "-v",
         "--verbose",


### PR DESCRIPTION
This PR is based on https://github.com/servo/servo/pull/43808 but is a cleaner version that includes https://github.com/servo/servo/pull/45204.

The PR adds HostOptions to scenarios and plotter, and fixes some bugs on related files:
- `memory_usage_plotter` now support linux
- `common_function_for_servo_test` shares a lot with scenarios and plotter
- `blink_perf_test` now also supports linux

Testing: 
to run plotter on its own
```bash
UV_PROJECT=etc/ci/scenario uv run --active etc/ci/scenario/memory_usage_plotter.py -h
```
to run plotter enabled scenario
```bash
UV_PROJECT=etc/ci/scenario uv run --active etc/ci/scenario/servo_test_open_page_servo_plot.py --target-os=linux
```
to run `blink_perf_test`
```
UV_PROJECT=etc/ci/scenario uv run --active etc/ci/scenario/blink_perf_test.py --target-os=linux -sme
```

I've also added README.md specific to the folder that has more context for future contributors to the scenarios
