### PR TITLE
script: Remove all `CanGc` usages from `bluetooth`

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -802,12 +802,12 @@ fn resolve_result_promise(
     match pkg_data_results {
         Ok(results) => {
             match results {
-                FetchedData::Text(s) => promise.resolve_native(&USVString(s), CanGc::from_cx(cx)),
-                FetchedData::Json(j) => promise.resolve_native(&j, CanGc::from_cx(cx)),
-                FetchedData::BlobData(b) => promise.resolve_native(&b, CanGc::from_cx(cx)),
-                FetchedData::FormData(f) => promise.resolve_native(&f, CanGc::from_cx(cx)),
-                FetchedData::Bytes(b) => promise.resolve_native(&b, CanGc::from_cx(cx)),
-                FetchedData::ArrayBuffer(a) => promise.resolve_native(&a, CanGc::from_cx(cx)),
+                FetchedData::Text(s) => promise.resolve_native_with_cx(cx, &USVString(s)),
+                FetchedData::Json(j) => promise.resolve_native_with_cx(cx, &j),
+                FetchedData::BlobData(b) => promise.resolve_native_with_cx(cx, &b),
+                FetchedData::FormData(f) => promise.resolve_native_with_cx(cx, &f),
+                FetchedData::Bytes(b) => promise.resolve_native_with_cx(cx, &b),
+                FetchedData::ArrayBuffer(a) => promise.resolve_native_with_cx(cx, &a),
                 FetchedData::JSException(e) => {
                     promise.reject_native(&e.handle(), CanGc::from_cx(cx))
                 },

--- a/components/script/dom/bluetooth/bluetooth.rs
+++ b/components/script/dom/bluetooth/bluetooth.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use script_bindings::reflector::{DomObject, reflect_dom_object};
+use script_bindings::reflector::{DomObject, reflect_dom_object_with_cx};
 use servo_base::generic_channel::{GenericCallback, GenericSender};
 use servo_bluetooth_traits::{BluetoothError, BluetoothRequest, GATTType};
 use servo_bluetooth_traits::{BluetoothResponse, BluetoothResponseResult};
@@ -11,6 +11,7 @@ use servo_bluetooth_traits::scanfilter::{BluetoothScanfilter, BluetoothScanfilte
 use servo_bluetooth_traits::scanfilter::{RequestDeviceoptions, ServiceUUIDSequence};
 use js::realm::CurrentRealm;
 use script_bindings::cformat;
+use js::context::JSContext;
 use crate::conversions::Convert;
 use script_bindings::cell::{Ref, DomRefCell};
 use crate::dom::bindings::codegen::Bindings::BluetoothBinding::BluetoothDataFilterInit;
@@ -34,7 +35,6 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::permissions::{descriptor_permission_state, PermissionAlgorithm};
 use crate::dom::promise::Promise;
-use crate::script_runtime::CanGc;
 use crate::task::TaskOnce;
 use dom_struct::dom_struct;
 use js::conversions::ConversionResult;
@@ -113,19 +113,14 @@ struct BluetoothContext<T: AsyncBluetoothListener + DomObject> {
 }
 
 pub(crate) trait AsyncBluetoothListener {
-    fn handle_response(
-        &self,
-        cx: &mut js::context::JSContext,
-        result: BluetoothResponse,
-        promise: &Rc<Promise>,
-    );
+    fn handle_response(&self, cx: &mut JSContext, result: BluetoothResponse, promise: &Rc<Promise>);
 }
 
 impl<T> BluetoothContext<T>
 where
     T: AsyncBluetoothListener + DomObject,
 {
-    fn response(&mut self, cx: &mut js::context::JSContext, response: BluetoothResponseResult) {
+    fn response(&mut self, cx: &mut JSContext, response: BluetoothResponseResult) {
         let promise = self.promise.take().expect("bt promise is missing").root();
 
         // JSAutoRealm needs to be manually made.
@@ -154,8 +149,8 @@ impl Bluetooth {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<Bluetooth> {
-        reflect_dom_object(Box::new(Bluetooth::new_inherited()), global, can_gc)
+    pub(crate) fn new(cx: &mut JSContext, global: &GlobalScope) -> DomRoot<Bluetooth> {
+        reflect_dom_object_with_cx(Box::new(Bluetooth::new_inherited()), global, cx)
     }
 
     fn get_bluetooth_thread(&self) -> GenericSender<BluetoothRequest> {
@@ -169,7 +164,7 @@ impl Bluetooth {
     /// <https://webbluetoothcg.github.io/web-bluetooth/#request-bluetooth-devices>
     fn request_bluetooth_devices(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         p: &Rc<Promise>,
         filters: &Option<Vec<BluetoothLEScanFilterInit>>,
         optional_services: &[BluetoothServiceUUID],
@@ -267,7 +262,7 @@ pub(crate) fn response_async<T: AsyncBluetoothListener + DomObject + 'static>(
         where
             T: AsyncBluetoothListener + DomObject,
         {
-            fn run_once(self, cx: &mut js::context::JSContext) {
+            fn run_once(self, cx: &mut JSContext) {
                 let mut context = self.context.lock().unwrap();
                 context.response(cx, self.action);
             }
@@ -578,7 +573,7 @@ impl BluetoothMethods<crate::DomTypeHolder> for Bluetooth {
 impl AsyncBluetoothListener for Bluetooth {
     fn handle_response(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         response: BluetoothResponse,
         promise: &Rc<Promise>,
     ) {
@@ -615,10 +610,9 @@ impl AsyncBluetoothListener for Bluetooth {
             BluetoothResponse::GetAvailability(is_available) => {
                 promise.resolve_native_with_cx(cx, &is_available);
             },
-            _ => promise.reject_error(
-                Error::Type(c"Something went wrong...".to_owned()),
-                CanGc::from_cx(cx),
-            ),
+            _ => {
+                promise.reject_error_with_cx(cx, Error::Type(c"Something went wrong...".to_owned()))
+            },
         }
     }
 }
@@ -628,7 +622,7 @@ impl PermissionAlgorithm for Bluetooth {
     type Status = BluetoothPermissionResult;
 
     fn create_descriptor(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         permission_descriptor_obj: *mut JSObject,
     ) -> Result<BluetoothPermissionDescriptor, Error> {
         rooted!(&in(cx) let mut property = UndefinedValue());
@@ -644,7 +638,7 @@ impl PermissionAlgorithm for Bluetooth {
 
     /// <https://webbluetoothcg.github.io/web-bluetooth/#query-the-bluetooth-permission>
     fn permission_query(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         promise: &Rc<Promise>,
         descriptor: &BluetoothPermissionDescriptor,
         status: &BluetoothPermissionResult,
@@ -670,7 +664,7 @@ impl PermissionAlgorithm for Bluetooth {
             .bluetooth_extra_permission_data()
             .get_allowed_devices();
 
-        let bluetooth = status.get_bluetooth();
+        let bluetooth = status.get_bluetooth(cx);
         let device_map = bluetooth.get_device_map().borrow();
 
         // Step 6.
@@ -734,7 +728,7 @@ impl PermissionAlgorithm for Bluetooth {
 
     /// <https://webbluetoothcg.github.io/web-bluetooth/#request-the-bluetooth-permission>
     fn permission_request(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         promise: &Rc<Promise>,
         descriptor: &BluetoothPermissionDescriptor,
         status: &BluetoothPermissionResult,
@@ -746,7 +740,7 @@ impl PermissionAlgorithm for Bluetooth {
 
         // Step 2.
         let sender = response_async(promise, status);
-        let bluetooth = status.get_bluetooth();
+        let bluetooth = status.get_bluetooth(cx);
         bluetooth.request_bluetooth_devices(
             cx,
             promise,
@@ -760,7 +754,7 @@ impl PermissionAlgorithm for Bluetooth {
 
     /// <https://webbluetoothcg.github.io/web-bluetooth/#revoke-bluetooth-access>
     fn permission_revoke(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         _descriptor: &BluetoothPermissionDescriptor,
         status: &BluetoothPermissionResult,
     ) {
@@ -771,7 +765,7 @@ impl PermissionAlgorithm for Bluetooth {
             .bluetooth_extra_permission_data()
             .get_allowed_devices();
         // Step 2.
-        let bluetooth = status.get_bluetooth();
+        let bluetooth = status.get_bluetooth(cx);
         let device_map = bluetooth.get_device_map().borrow();
         for (id, device) in device_map.iter() {
             let id = DOMString::from(id.clone());

--- a/components/script/dom/bluetooth/bluetoothadvertisingevent.rs
+++ b/components/script/dom/bluetooth/bluetoothadvertisingevent.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use stylo_atoms::Atom;
@@ -52,7 +53,7 @@ impl BluetoothAdvertisingEvent {
 
     #[expect(clippy::too_many_arguments)]
     fn new(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
         type_: Atom,
@@ -84,7 +85,7 @@ impl BluetoothAdvertisingEventMethods<crate::DomTypeHolder> for BluetoothAdverti
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothadvertisingevent-bluetoothadvertisingevent
     #[expect(non_snake_case)]
     fn Constructor(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         type_: DOMString,

--- a/components/script/dom/bluetooth/bluetoothcharacteristicproperties.rs
+++ b/components/script/dom/bluetooth/bluetoothcharacteristicproperties.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 
 use crate::dom::bindings::codegen::Bindings::BluetoothCharacteristicPropertiesBinding::BluetoothCharacteristicPropertiesMethods;
@@ -54,7 +55,7 @@ impl BluetoothCharacteristicProperties {
 
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         broadcast: bool,
         read: bool,

--- a/components/script/dom/bluetooth/bluetoothdevice.rs
+++ b/components/script/dom/bluetooth/bluetoothdevice.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::realm::CurrentRealm;
 use profile_traits::generic_channel;
 use script_bindings::cell::DomRefCell;
@@ -34,7 +35,6 @@ use crate::dom::bluetoothremotegattservice::BluetoothRemoteGATTService;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
-use crate::script_runtime::CanGc;
 
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 #[derive(JSTraceable, MallocSizeOf)]
@@ -78,7 +78,7 @@ impl BluetoothDevice {
     }
 
     pub(crate) fn new(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         id: DOMString,
         name: Option<DOMString>,
@@ -91,10 +91,7 @@ impl BluetoothDevice {
         )
     }
 
-    pub(crate) fn get_gatt(
-        &self,
-        cx: &mut js::context::JSContext,
-    ) -> DomRoot<BluetoothRemoteGATTServer> {
+    pub(crate) fn get_gatt(&self, cx: &mut JSContext) -> DomRoot<BluetoothRemoteGATTServer> {
         self.gatt
             .or_init(|| BluetoothRemoteGATTServer::new(cx, &self.global(), self))
     }
@@ -105,7 +102,7 @@ impl BluetoothDevice {
 
     pub(crate) fn get_or_create_service(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         service: &BluetoothServiceMsg,
         server: &BluetoothRemoteGATTServer,
     ) -> DomRoot<BluetoothRemoteGATTService> {
@@ -128,7 +125,7 @@ impl BluetoothDevice {
 
     pub(crate) fn get_or_create_characteristic(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         characteristic: &BluetoothCharacteristicMsg,
         service: &BluetoothRemoteGATTService,
     ) -> DomRoot<BluetoothRemoteGATTCharacteristic> {
@@ -179,7 +176,7 @@ impl BluetoothDevice {
 
     pub(crate) fn get_or_create_descriptor(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         descriptor: &BluetoothDescriptorMsg,
         characteristic: &BluetoothRemoteGATTCharacteristic,
     ) -> DomRoot<BluetoothRemoteGATTDescriptor> {
@@ -207,7 +204,7 @@ impl BluetoothDevice {
     }
 
     // https://webbluetoothcg.github.io/web-bluetooth/#clean-up-the-disconnected-device
-    pub(crate) fn clean_up_disconnected_device(&self, cx: &mut js::context::JSContext) {
+    pub(crate) fn clean_up_disconnected_device(&self, cx: &mut JSContext) {
         // Step 1.
         self.get_gatt(cx).set_connected(false);
 
@@ -242,10 +239,7 @@ impl BluetoothDevice {
     }
 
     // https://webbluetoothcg.github.io/web-bluetooth/#garbage-collect-the-connection
-    pub(crate) fn garbage_collect_the_connection(
-        &self,
-        cx: &mut js::context::JSContext,
-    ) -> ErrorResult {
+    pub(crate) fn garbage_collect_the_connection(&self, cx: &mut JSContext) -> ErrorResult {
         // Step 1: TODO: Check if other systems using this device.
 
         // Step 2.
@@ -282,10 +276,7 @@ impl BluetoothDeviceMethods<crate::DomTypeHolder> for BluetoothDevice {
     }
 
     /// <https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-gatt>
-    fn GetGatt(
-        &self,
-        cx: &mut js::context::JSContext,
-    ) -> Option<DomRoot<BluetoothRemoteGATTServer>> {
+    fn GetGatt(&self, cx: &mut JSContext) -> Option<DomRoot<BluetoothRemoteGATTServer>> {
         // Step 1.
         if self
             .global()
@@ -339,7 +330,7 @@ impl BluetoothDeviceMethods<crate::DomTypeHolder> for BluetoothDevice {
 impl AsyncBluetoothListener for BluetoothDevice {
     fn handle_response(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         response: BluetoothResponse,
         promise: &Rc<Promise>,
     ) {
@@ -351,10 +342,9 @@ impl AsyncBluetoothListener for BluetoothDevice {
                 // Step 3.2.
                 promise.resolve_native_with_cx(cx, &());
             },
-            _ => promise.reject_error(
-                Error::Type(c"Something went wrong...".to_owned()),
-                CanGc::from_cx(cx),
-            ),
+            _ => {
+                promise.reject_error_with_cx(cx, Error::Type(c"Something went wrong...".to_owned()))
+            },
         }
     }
 }

--- a/components/script/dom/bluetooth/bluetoothpermissionresult.rs
+++ b/components/script/dom/bluetooth/bluetoothpermissionresult.rs
@@ -5,8 +5,9 @@
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object;
+use script_bindings::reflector::reflect_dom_object_with_cx;
 use servo_base::generic_channel::GenericSender;
 use servo_bluetooth_traits::{BluetoothRequest, BluetoothResponse};
 
@@ -26,7 +27,6 @@ use crate::dom::bluetoothdevice::BluetoothDevice;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::permissionstatus::PermissionStatus;
 use crate::dom::promise::Promise;
-use crate::script_runtime::CanGc;
 
 // https://webbluetoothcg.github.io/web-bluetooth/#bluetoothpermissionresult
 #[dom_struct]
@@ -47,19 +47,19 @@ impl BluetoothPermissionResult {
     }
 
     pub(crate) fn new(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         status: &PermissionStatus,
     ) -> DomRoot<BluetoothPermissionResult> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(BluetoothPermissionResult::new_inherited(status)),
             global,
-            CanGc::from_cx(cx),
+            cx,
         )
     }
 
-    pub(crate) fn get_bluetooth(&self) -> DomRoot<Bluetooth> {
-        self.global().as_window().Navigator().Bluetooth()
+    pub(crate) fn get_bluetooth(&self, cx: &mut JSContext) -> DomRoot<Bluetooth> {
+        self.global().as_window().Navigator().Bluetooth(cx)
     }
 
     pub(crate) fn get_bluetooth_thread(&self) -> GenericSender<BluetoothRequest> {
@@ -100,7 +100,7 @@ impl BluetoothPermissionResultMethods<crate::DomTypeHolder> for BluetoothPermiss
 impl AsyncBluetoothListener for BluetoothPermissionResult {
     fn handle_response(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         response: BluetoothResponse,
         promise: &Rc<Promise>,
     ) {
@@ -109,7 +109,7 @@ impl AsyncBluetoothListener for BluetoothPermissionResult {
             // Step 3, 11, 13 - 14.
             BluetoothResponse::RequestDevice(device) => {
                 self.set_state(PermissionState::Granted);
-                let bluetooth = self.get_bluetooth();
+                let bluetooth = self.get_bluetooth(cx);
                 let mut device_instance_map = bluetooth.get_device_map().borrow_mut();
                 if let Some(existing_device) = device_instance_map.get(&device.id) {
                     // https://webbluetoothcg.github.io/web-bluetooth/#request-the-bluetooth-permission
@@ -143,10 +143,9 @@ impl AsyncBluetoothListener for BluetoothPermissionResult {
                 // Step 8.
                 promise.resolve_native_with_cx(cx, self);
             },
-            _ => promise.reject_error(
-                Error::Type(c"Something went wrong...".to_owned()),
-                CanGc::from_cx(cx),
-            ),
+            _ => {
+                promise.reject_error_with_cx(cx, Error::Type(c"Something went wrong...".to_owned()))
+            },
         }
     }
 }

--- a/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
@@ -5,6 +5,7 @@
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::realm::CurrentRealm;
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::reflect_dom_object_with_cx;
@@ -31,7 +32,6 @@ use crate::dom::bluetoothuuid::{BluetoothDescriptorUUID, BluetoothUUID};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
-use crate::script_runtime::CanGc;
 
 // Maximum length of an attribute value.
 // https://www.bluetooth.org/DocMan/handlers/DownloadDoc.ashx?doc_id=286439 (Vol. 3, page 2169)
@@ -66,7 +66,7 @@ impl BluetoothRemoteGATTCharacteristic {
     }
 
     pub(crate) fn new(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         service: &BluetoothRemoteGATTService,
         uuid: DOMString,
@@ -310,7 +310,7 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
 impl AsyncBluetoothListener for BluetoothRemoteGATTCharacteristic {
     fn handle_response(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         response: BluetoothResponse,
         promise: &Rc<Promise>,
     ) {
@@ -368,10 +368,9 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTCharacteristic {
                 // (StopNotification)  Step 5.
                 promise.resolve_native_with_cx(cx, self);
             },
-            _ => promise.reject_error(
-                Error::Type(c"Something went wrong...".to_owned()),
-                CanGc::from_cx(cx),
-            ),
+            _ => {
+                promise.reject_error_with_cx(cx, Error::Type(c"Something went wrong...".to_owned()))
+            },
         }
     }
 }

--- a/components/script/dom/bluetooth/bluetoothremotegattdescriptor.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattdescriptor.rs
@@ -5,6 +5,7 @@
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::realm::CurrentRealm;
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
@@ -27,7 +28,6 @@ use crate::dom::bluetoothremotegattcharacteristic::{
 };
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
-use crate::script_runtime::CanGc;
 
 // http://webbluetoothcg.github.io/web-bluetooth/#bluetoothremotegattdescriptor
 #[dom_struct]
@@ -55,7 +55,7 @@ impl BluetoothRemoteGATTDescriptor {
     }
 
     pub(crate) fn new(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         characteristic: &BluetoothRemoteGATTCharacteristic,
         uuid: DOMString,
@@ -183,7 +183,7 @@ impl BluetoothRemoteGATTDescriptorMethods<crate::DomTypeHolder> for BluetoothRem
 impl AsyncBluetoothListener for BluetoothRemoteGATTDescriptor {
     fn handle_response(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         response: BluetoothResponse,
         promise: &Rc<Promise>,
     ) {
@@ -212,10 +212,9 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTDescriptor {
                 // TODO: Resolve promise with undefined instead of a value.
                 promise.resolve_native_with_cx(cx, &());
             },
-            _ => promise.reject_error(
-                Error::Type(c"Something went wrong...".to_owned()),
-                CanGc::from_cx(cx),
-            ),
+            _ => {
+                promise.reject_error_with_cx(cx, Error::Type(c"Something went wrong...".to_owned()))
+            },
         }
     }
 }

--- a/components/script/dom/bluetooth/bluetoothremotegattserver.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattserver.rs
@@ -6,6 +6,7 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::realm::CurrentRealm;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use servo_base::generic_channel::GenericSender;
@@ -21,7 +22,6 @@ use crate::dom::bluetoothdevice::BluetoothDevice;
 use crate::dom::bluetoothuuid::{BluetoothServiceUUID, BluetoothUUID};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
-use crate::script_runtime::CanGc;
 
 // https://webbluetoothcg.github.io/web-bluetooth/#bluetoothremotegattserver
 #[dom_struct]
@@ -41,7 +41,7 @@ impl BluetoothRemoteGATTServer {
     }
 
     pub(crate) fn new(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         device: &BluetoothDevice,
     ) -> DomRoot<BluetoothRemoteGATTServer> {
@@ -97,7 +97,7 @@ impl BluetoothRemoteGATTServerMethods<crate::DomTypeHolder> for BluetoothRemoteG
     }
 
     /// <https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattserver-disconnect>
-    fn Disconnect(&self, cx: &mut js::context::JSContext) -> ErrorResult {
+    fn Disconnect(&self, cx: &mut JSContext) -> ErrorResult {
         // TODO: Step 1: Implement activeAlgorithms internal slot for BluetoothRemoteGATTServer.
 
         // Step 2.
@@ -155,7 +155,7 @@ impl BluetoothRemoteGATTServerMethods<crate::DomTypeHolder> for BluetoothRemoteG
 impl AsyncBluetoothListener for BluetoothRemoteGATTServer {
     fn handle_response(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         response: BluetoothResponse,
         promise: &Rc<Promise>,
     ) {
@@ -192,10 +192,9 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTServer {
                 }
                 promise.resolve_native_with_cx(cx, &services);
             },
-            _ => promise.reject_error(
-                Error::Type(c"Something went wrong...".to_owned()),
-                CanGc::from_cx(cx),
-            ),
+            _ => {
+                promise.reject_error_with_cx(cx, Error::Type(c"Something went wrong...".to_owned()))
+            },
         }
     }
 }

--- a/components/script/dom/bluetooth/bluetoothremotegattservice.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattservice.rs
@@ -5,6 +5,7 @@
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::realm::CurrentRealm;
 use script_bindings::reflector::reflect_dom_object_with_cx;
 use servo_bluetooth_traits::{BluetoothResponse, GATTType};
@@ -20,7 +21,6 @@ use crate::dom::bluetoothuuid::{BluetoothCharacteristicUUID, BluetoothServiceUUI
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
-use crate::script_runtime::CanGc;
 
 // https://webbluetoothcg.github.io/web-bluetooth/#bluetoothremotegattservice
 #[dom_struct]
@@ -50,7 +50,7 @@ impl BluetoothRemoteGATTService {
 
     #[expect(non_snake_case)]
     pub(crate) fn new(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         device: &BluetoothDevice,
         uuid: DOMString,
@@ -176,7 +176,7 @@ impl BluetoothRemoteGATTServiceMethods<crate::DomTypeHolder> for BluetoothRemote
 impl AsyncBluetoothListener for BluetoothRemoteGATTService {
     fn handle_response(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         response: BluetoothResponse,
         promise: &Rc<Promise>,
     ) {
@@ -215,10 +215,9 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTService {
                 }
                 promise.resolve_native_with_cx(cx, &services);
             },
-            _ => promise.reject_error(
-                Error::Type(c"Something went wrong...".to_owned()),
-                CanGc::from_cx(cx),
-            ),
+            _ => {
+                promise.reject_error_with_cx(cx, Error::Type(c"Something went wrong...".to_owned()))
+            },
         }
     }
 }

--- a/components/script/dom/bluetooth/testrunner.rs
+++ b/components/script/dom/bluetooth/testrunner.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use profile_traits::generic_channel;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use servo_base::generic_channel::GenericSender;
 use servo_bluetooth_traits::BluetoothRequest;
 
@@ -15,7 +16,6 @@ use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::CanGc;
 
 // https://webbluetoothcg.github.io/web-bluetooth/tests#test-runner
 #[dom_struct]
@@ -30,8 +30,8 @@ impl TestRunner {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<TestRunner> {
-        reflect_dom_object(Box::new(TestRunner::new_inherited()), global, can_gc)
+    pub(crate) fn new(cx: &mut JSContext, global: &GlobalScope) -> DomRoot<TestRunner> {
+        reflect_dom_object_with_cx(Box::new(TestRunner::new_inherited()), global, cx)
     }
 
     fn get_bluetooth_thread(&self) -> GenericSender<BluetoothRequest> {

--- a/components/script/dom/cookiestore.rs
+++ b/components/script/dom/cookiestore.rs
@@ -191,7 +191,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         let origin = global.origin();
 
         // 5. Let p be a new promise.
-        let p = Promise::new(&global, CanGc::from_cx(cx));
+        let p = Promise::new2(cx, &global);
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
@@ -232,7 +232,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         let origin = global.origin();
 
         // 7. Let p be a new promise.
-        let p = Promise::new(&global, CanGc::from_cx(cx));
+        let p = Promise::new2(cx, &global);
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
@@ -311,7 +311,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         let origin = global.origin();
 
         // 5. Let p be a new promise.
-        let p = Promise::new(&global, CanGc::from_cx(cx));
+        let p = Promise::new2(cx, &global);
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
@@ -352,7 +352,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         let origin = global.origin();
 
         // 6. Let p be a new promise.
-        let p = Promise::new(&global, CanGc::from_cx(cx));
+        let p = Promise::new2(cx, &global);
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
@@ -425,7 +425,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         let origin = global.origin();
 
         // 9. Let p be a new promise.
-        let p = Promise::new(&global, CanGc::from_cx(cx));
+        let p = Promise::new2(cx, &global);
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
@@ -479,7 +479,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         let origin = global.origin();
 
         // 5. Let p be a new promise.
-        let p = Promise::new(&global, CanGc::from_cx(cx));
+        let p = Promise::new2(cx, &global);
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
@@ -526,7 +526,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         let origin = global.origin();
 
         // 5. Let p be a new promise.
-        let p = Promise::new(&global, CanGc::from_cx(cx));
+        let p = Promise::new2(cx, &global);
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
@@ -562,7 +562,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         let origin = global.origin();
 
         // 5. Let p be a new promise.
-        let p = Promise::new(&global, CanGc::from_cx(cx));
+        let p = Promise::new2(cx, &global);
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {

--- a/components/script/dom/indexeddb/idbfactory.rs
+++ b/components/script/dom/indexeddb/idbfactory.rs
@@ -623,14 +623,14 @@ impl IDBFactoryMethods<crate::DomTypeHolder> for IDBFactory {
         let storage_key = match global.obtain_storage_key() {
             Some(storage_key) => storage_key,
             None => {
-                let p = Promise::new(&global, CanGc::from_cx(cx));
+                let p = Promise::new2(cx, &global);
                 p.reject_error_with_cx(cx, Error::Security(None));
                 return p;
             },
         };
 
         // Step 3: Let p be a new promise.
-        let p = Promise::new(&global, CanGc::from_cx(cx));
+        let p = Promise::new2(cx, &global);
 
         // Note: the option is required to pass the promise to a task from within the generic callback,
         // see #41356

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -366,9 +366,9 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
 
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-navigator-bluetooth
     #[cfg(feature = "bluetooth")]
-    fn Bluetooth(&self) -> DomRoot<Bluetooth> {
+    fn Bluetooth(&self, cx: &mut js::context::JSContext) -> DomRoot<Bluetooth> {
         self.bluetooth
-            .or_init(|| Bluetooth::new(&self.global(), CanGc::deprecated_note()))
+            .or_init(|| Bluetooth::new(cx, &self.global()))
     }
 
     /// <https://www.w3.org/TR/credential-management-1/#framework-credential-management>

--- a/components/script/dom/notification.rs
+++ b/components/script/dom/notification.rs
@@ -404,7 +404,7 @@ impl NotificationMethods<crate::DomTypeHolder> for Notification {
         permission_callback: Option<Rc<NotificationPermissionCallback>>,
     ) -> Rc<Promise> {
         // Step 2: Let promise be a new promise in this’s relevant Realm.
-        let promise = Promise::new(global, CanGc::from_cx(cx));
+        let promise = Promise::new2(cx, global);
 
         // TODO: Step 3: Run these steps in parallel:
         // Step 3.1: Let permissionState be the result of requesting permission to use "notifications".
@@ -714,7 +714,7 @@ fn request_notification_permission(
     cx: &mut JSContext,
     global: &GlobalScope,
 ) -> NotificationPermission {
-    let promise = &Promise::new(global, CanGc::from_cx(cx));
+    let promise = &Promise::new2(cx, global);
     let descriptor = PermissionDescriptor {
         name: PermissionName::Notifications,
     };

--- a/components/script/dom/storagemanager.rs
+++ b/components/script/dom/storagemanager.rs
@@ -75,11 +75,8 @@ impl StorageManagerBooleanResponseHandler {
             .queue(task!(storage_manager_boolean_response: move |cx| {
                 let promise = trusted_promise.root();
                 match result {
-                    Ok(value) => promise.resolve_native(&value, CanGc::from_cx(cx)),
-                    Err(message) => promise.reject_error(
-                        StorageManager::type_error_from_string(message),
-                        CanGc::from_cx(cx),
-                    ),
+                    Ok(value) => promise.resolve_native_with_cx(cx, &value),
+                    Err(message) => promise.reject_error_with_cx(cx, StorageManager::type_error_from_string(message)),
                 }
             }));
     }

--- a/components/script/dom/stream/readablestreamdefaultreader.rs
+++ b/components/script/dom/stream/readablestreamdefaultreader.rs
@@ -152,7 +152,7 @@ impl ReadRequest {
                         // Step 3. Read-loop given reader, bytes, successSteps, and failureSteps.
                         // Spec note: Avoid direct recursion; queue into a microtask.
                         // Resolving the promise will queue a microtask to call into the native handler.
-                        let tick = Promise::new(&global, CanGc::from_cx(cx));
+                        let tick = Promise::new2(cx, &global);
                         tick.resolve_native_with_cx(cx, &());
 
                         let handler = PromiseNativeHandler::new(

--- a/components/script/dom/stream/writablestream.rs
+++ b/components/script/dom/stream/writablestream.rs
@@ -878,10 +878,7 @@ impl WritableStream {
         // Note: other algorithms defined in the controller at call site.
 
         // Let backpressurePromise be a new promise.
-        let backpressure_promise = Rc::new(RefCell::new(Some(Promise::new(
-            &global,
-            CanGc::from_cx(cx),
-        ))));
+        let backpressure_promise = Rc::new(RefCell::new(Some(Promise::new2(cx, &global))));
 
         // Let controller be a new WritableStreamDefaultController.
         let controller = WritableStreamDefaultController::new(

--- a/components/script/dom/stream/writablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/writablestreamdefaultcontroller.rs
@@ -613,7 +613,7 @@ impl WritableStreamDefaultController {
                     ))
                 };
                 result.unwrap_or_else(|e| {
-                    let promise = Promise::new(global, CanGc::from_cx(cx));
+                    let promise = Promise::new2(cx, global);
                     promise.reject_error_with_cx(cx, e);
                     promise
                 })
@@ -628,7 +628,7 @@ impl WritableStreamDefaultController {
                 // Disentangle port.
                 global.disentangle_port(cx, port);
 
-                let promise = Promise::new(global, CanGc::from_cx(cx));
+                let promise = Promise::new2(cx, global);
 
                 // If result is an abrupt completion, return a promise rejected with result.[[Value]]
                 if let Err(error) = result {

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -217,7 +217,7 @@ impl SubtleCrypto {
                     array_buffer_ptr.handle_mut(),
                     CanGc::from_cx(cx),
                 ) {
-                    Ok(_) => promise.resolve_native(&*array_buffer_ptr, CanGc::from_cx(cx)),
+                    Ok(_) => promise.resolve_native_with_cx(cx, &*array_buffer_ptr),
                     Err(_) => promise.reject_error_with_cx(cx, Error::JSFailed),
                 }
             }));

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2181,9 +2181,9 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     }
 
     #[cfg(feature = "bluetooth")]
-    fn TestRunner(&self) -> DomRoot<TestRunner> {
+    fn TestRunner(&self, cx: &mut js::context::JSContext) -> DomRoot<TestRunner> {
         self.test_runner
-            .or_init(|| TestRunner::new(self.upcast(), CanGc::deprecated_note()))
+            .or_init(|| TestRunner::new(cx, self.upcast()))
     }
 
     fn RunningAnimationCount(&self) -> u32 {

--- a/components/script/dom/windowclient.rs
+++ b/components/script/dom/windowclient.rs
@@ -7,7 +7,6 @@ use std::rc::Rc;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use script_bindings::codegen::GenericBindings::WindowClientBinding::WindowClientMethods;
-use script_bindings::script_runtime::CanGc;
 use script_bindings::str::USVString;
 
 use crate::dom::bindings::reflector::DomGlobal;
@@ -23,12 +22,12 @@ impl WindowClientMethods<crate::DomTypeHolder> for WindowClient {
     /// <https://w3c.github.io/ServiceWorker/#dom-windowclient-focus>
     fn Focus(&self, cx: &mut JSContext) -> Rc<Promise> {
         // TODO: Implement
-        Promise::new(&self.global(), CanGc::from_cx(cx))
+        Promise::new2(cx, &self.global())
     }
 
     /// <https://w3c.github.io/ServiceWorker/#dom-windowclient-navigate>
     fn Navigate(&self, cx: &mut JSContext, _url: USVString) -> Rc<Promise> {
         // TODO: Implement
-        Promise::new(&self.global(), CanGc::from_cx(cx))
+        Promise::new2(cx, &self.global())
     }
 }

--- a/components/script/dom/workers/serviceworkerregistration.rs
+++ b/components/script/dom/workers/serviceworkerregistration.rs
@@ -202,7 +202,7 @@ impl ServiceWorkerRegistrationMethods<crate::DomTypeHolder> for ServiceWorkerReg
         // Note: `self` is the registration.
 
         // Step 2: Let promise be a new promise.
-        let promise = Promise::new(&self.global(), CanGc::from_cx(cx));
+        let promise = Promise::new2(cx, &self.global());
 
         let Some(worker) = self.get_newest_worker() else {
             promise.resolve_native_with_cx(cx, &true);

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -815,7 +815,7 @@ DOMInterfaces = {
 
 'Navigator': {
     'inRealms': ['GetVRDisplays'],
-    'cx': ['Clipboard', 'Languages', 'SendBeacon', 'Storage', 'UserActivation', 'WakeLock'],
+    'cx': ['Bluetooth', 'Clipboard', 'Languages', 'SendBeacon', 'Storage', 'UserActivation', 'WakeLock'],
 },
 
 'CredentialsContainer': {
@@ -1098,6 +1098,7 @@ DOMInterfaces = {
         'SetTimeout',
         'Stop',
         'StructuredClone',
+        'TestRunner',
         'TrustedTypes',
         'WebdriverException',
     ]


### PR DESCRIPTION
Also unify all imports of `JSContext`.

All call-sides were automatically migrated using the following regex replacement (previous regexes had a `;` at the end):

Before:

```
Promise::new\([ \n]*(.+),[ \n]+CanGc::from_cx\(cx\),?[ \n]*\)
.reject_error\([ \n]*(.+),[ \n]+CanGc::from_cx\(cx\),?[ \n]*\)
.resolve_native\([ \n]*(.+),[ \n]+CanGc::from_cx\(cx\),?[ \n]*\)
.reject_native\([ \n]*(.+),[ \n]+CanGc::from_cx\(cx\),?[ \n]*\)
```

After:

```
Promise::new2(cx, $1)
.reject_error_with_cx(cx, $1)
.resolve_native_with_cx(cx, $1)
.reject_native_with_cx(cx, $1)
```

Part of #40600

Testing: it compiles