### PR TITLE
Upgrade Android Gradle Plugin to the latest 8.x version

### DIFF
--- a/support/android/apk/build.gradle.kts
+++ b/support/android/apk/build.gradle.kts
@@ -1,5 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.7.0" apply false
-    id("com.android.library") version "8.7.0" apply false
+    id("com.android.application") version "8.13.2" apply false
+    id("com.android.library") version "8.13.2" apply false
 }


### PR DESCRIPTION
Upgrades Android Gradle Plugin to 8.13.2, which is the latest 8.x version at the time of writing. Android Gradle Plugin 9.x is available, but requires a larger refactor. Upgrading to the latest 8.x version in a separate commit to mitigate potential for issues.

Testing: It's a dependency upgrade, so if the existing tests pass, all should be well.