### PR TITLE
android: stop hardcoding the app name in manifest

### DIFF
--- a/support/android/apk/servoapp/src/main/AndroidManifest.xml
+++ b/support/android/apk/servoapp/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
-    <application android:label="Servo" android:icon="@mipmap/servo">
+    <application android:label="@string/app_name" android:icon="@mipmap/servo">
         <activity android:name=".MainActivity"
             android:configChanges="density|keyboardHidden|navigation|orientation|screenSize|uiMode"
             android:exported="true"


### PR DESCRIPTION
It's normal to reference the strings from `strings.xml` instead of hardcoding them in case we want to localise them (however unlikely it is in this case with it being the app name). A more tangible benefit is that one would look for the app's name in `strings.xml` and expect it to refer to the app's name.

Testing: Ran app on device and observed that the app is still called "Servo".