### PR TITLE
android: remove unused app name string

### DIFF
--- a/support/android/apk/servoview/src/main/res/values/strings.xml
+++ b/support/android/apk/servoview/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">servoview</string>
-</resources>


### PR DESCRIPTION
The `servoview` module is a library module, not an app module, so there's no need for an `app_name` string (and it makes sense why it's unused).

Testing: Since this code is unused, there's nothing to test. Just ran the app locally.