### PR TITLE
tests: Enable ServiceWorker in `dom` tests

### DIFF
--- a/tests/wpt/meta/dom/__dir__.ini
+++ b/tests/wpt/meta/dom/__dir__.ini
@@ -1,0 +1,3 @@
+prefs: [
+  "dom_serviceworker_enabled:true",
+]

--- a/tests/wpt/meta/dom/idlharness.any.js.ini
+++ b/tests/wpt/meta/dom/idlharness.any.js.ini
@@ -1,5 +1,4 @@
 [idlharness.any.serviceworker.html]
-  expected: ERROR
 
 [idlharness.any.sharedworker.html]
   expected: ERROR


### PR DESCRIPTION
Ran the test 50 times and all DOM tests 3 times with consistent results.

Testing: Just enabling the pref, WPT will cover this.
Fixes: Part of #45331.