### PR TITLE
android: rely on default source set config for app

### DIFF
--- a/support/android/apk/servoapp/build.gradle.kts
+++ b/support/android/apk/servoapp/build.gradle.kts
@@ -42,12 +42,6 @@ android {
         }
     }
 
-    sourceSets {
-        named("main") {
-            java.srcDirs("src/main/java")
-        }
-    }
-
     val signingKeyInfo = getSigningKeyInfo()
 
     if (signingKeyInfo != null) {


### PR DESCRIPTION
Per [the docs](https://developer.android.com/build/build-variants#configure-sourcesets), the "default directory is `src/main/java`", so explicitly setting it again is redundant.

Testing: Ran app.