### PR TITLE
docs: Update dead book links

### DIFF
--- a/docs/COMMAND_LINE_ARGS.md
+++ b/docs/COMMAND_LINE_ARGS.md
@@ -2,6 +2,6 @@
 
 Moved to the Servo book:
 
-- [Running servoshell](https://book.servo.org/running-servoshell.html)
+- [Running servoshell](https://book.servo.org/trying/running-servoshell.html)
 - Hacking on Servo
-  - [Running servoshell](https://book.servo.org/hacking/running-servoshell.html)
+  - [Running servoshell](https://book.servo.org/building/building.html#running-servoshell)

--- a/docs/HACKING_QUICKSTART.md
+++ b/docs/HACKING_QUICKSTART.md
@@ -2,4 +2,4 @@
 
 Moved to the Servo book:
 
-- [Hacking on Servo](https://book.servo.org/hacking/mach.html)
+- [Hacking on Servo](https://book.servo.org/building/building.html#mach)

--- a/docs/ORGANIZATION.md
+++ b/docs/ORGANIZATION.md
@@ -3,4 +3,4 @@
 Moved to the Servo book:
 
 - Servo’s architecture
-  - [Directory structure](https://book.servo.org/architecture/directory-structure.html)
+  - [Project structure](https://book.servo.org/design-documentation/project-structure.html)

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -2,5 +2,5 @@
 
 Moved to the Servo book:
 
-- Pre-book docs
-  - [docs/STYLE_GUIDE.md](https://book.servo.org/old/STYLE_GUIDE.html)
+- Contributing
+  - [Style guide](https://book.servo.org/contributing/style-guide.html)

--- a/docs/components/style.md
+++ b/docs/components/style.md
@@ -3,4 +3,4 @@
 Moved to the Servo book:
 
 - Servo’s architecture
-  - [Style](https://book.servo.org/architecture/style.html)
+  - [Style](https://book.servo.org/design-documentation/style.html)

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -3,4 +3,4 @@
 Moved to the Servo book:
 
 - Hacking on Servo
-  - [Debugging](https://book.servo.org/hacking/debugging.html)
+  - [Debugging](https://book.servo.org/contributing/debugging/index.html)

--- a/tests/wpt/README.md
+++ b/tests/wpt/README.md
@@ -3,4 +3,4 @@
 Moved to the Servo book:
 
 - Hacking on Servo
-  - [Automated testing](https://book.servo.org/hacking/testing.html)
+  - [Automated testing](https://book.servo.org/contributing/testing.html)


### PR DESCRIPTION
Fixes the dead book links in the `docs` folder and `tests/wpt/README.md`.

Testing: Not needed: only documentation changes.
