### PR TITLE
config: Skip preference update without changes

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -40,6 +40,12 @@ pub fn add_observer(observer: Box<dyn PreferencesObserver>) {
 /// Update the values of the global preferences for the current process. This also notifies the
 /// observers previously added using [`add_observer`].
 pub fn set(preferences: Preferences) {
+    // Get list of changes, returning early if the preferences haven't changed.
+    let changed = preferences.diff(&PREFERENCES.read().unwrap());
+    if changed.is_empty() {
+        return;
+    }
+
     // Map between Stylo preference names and Servo preference names as the This should be
     // kept in sync with components/script/dom/bindings/codegen/run.py which generates the
     // DOM CSS style accessors.
@@ -63,8 +69,6 @@ pub fn set(preferences: Preferences) {
         "layout.variable_fonts.enabled",
         preferences.layout_variable_fonts_enabled
     );
-
-    let changed = preferences.diff(&PREFERENCES.read().unwrap());
 
     *PREFERENCES.write().unwrap() = preferences;
 


### PR DESCRIPTION
Currently the global preferences update requires acquiring a static lock twice to update the preferences, even if the preferences haven't changed at all.

While there is no *cheap* way to call this function, it seems like ignoring the second lock should at least speed this function up a little bit when no work is needed anyway.

---

I was somewhat hesitant to send this PR since it's pretty noisy for arguably next to zero benefit, but I think if I was to review this code originally, it's something I definitely would have brought up myself.

Feel free to just discard if you don't feel like looking into this, but I think it should just be a 'free' speedup with almost no code complexity impact?
