### PR TITLE
layout: do not union ICB when calculating scrollable overflow of Fragment Tree.

### DIFF
--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -126,15 +126,16 @@ impl StackingContextTree {
         debug: &DiagnosticsLogging,
     ) -> Self {
         let scrollable_overflow = fragment_tree.scrollable_overflow();
-        let scrollable_overflow = LayoutSize::from_untyped(Size2D::new(
-            scrollable_overflow.size.width.to_f32_px(),
-            scrollable_overflow.size.height.to_f32_px(),
+        let scroll_area = scrollable_overflow.union(&fragment_tree.initial_containing_block);
+        let scroll_area = LayoutSize::from_untyped(Size2D::new(
+            scroll_area.size.width.to_f32_px(),
+            scroll_area.size.height.to_f32_px(),
         ));
 
         let viewport_size = viewport_details.layout_size();
         let paint_info = PaintDisplayListInfo::new(
             viewport_details,
-            scrollable_overflow,
+            scroll_area,
             pipeline_id,
             // This epoch is set when the WebRender display list is built. For now use a dummy value.
             Default::default(),

--- a/components/layout/fragment_tree/fragment_tree.rs
+++ b/components/layout/fragment_tree/fragment_tree.rs
@@ -102,7 +102,7 @@ impl FragmentTree {
         let scrollable_overflow =
             self.root_fragments
                 .iter()
-                .fold(self.initial_containing_block, |overflow, fragment| {
+                .fold(euclid::Rect::default(), |overflow, fragment| {
                     // Scrollable overflow should be accumulated in the block that
                     // establishes the containing block for the element. Thus, fixed
                     // positioned fragments whose containing block is the initial

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -187,7 +187,9 @@ pub fn process_node_scroll_area_request(
             .first()
             .map(|fragment| fragment.scrolling_area(layout_thread))
             .unwrap_or_default(),
-        None => tree.scrollable_overflow(),
+        None => tree
+            .scrollable_overflow()
+            .union(&tree.initial_containing_block),
     };
 
     Rect::new(


### PR DESCRIPTION
Do not union ICB when calculating scrollable overflow of Fragment Tree. 

Testing: Should not change any test result of existing WPT as this is a layout internal struct.
Fixes: https://github.com/servo/servo/issues/45177
