### PR TITLE
Select Dialog: add show `<select>` element function for OHOS/Android

### DIFF
--- a/ports/servoshell/egl/android/mod.rs
+++ b/ports/servoshell/egl/android/mod.rs
@@ -26,7 +26,7 @@ use raw_window_handle::{
 pub use servo::MediaSessionPlaybackState;
 use servo::{
     self, DevicePixel, EventLoopWaker, InputMethodControl, LoadStatus, MediaSessionActionType,
-    MouseButton, PrefValue,
+    MouseButton, PrefValue, SelectElement, WebViewId,
 };
 
 use super::app::{App, AppInitOptions};
@@ -853,6 +853,8 @@ impl HostTrait for HostCallbacks {
             })
             .unwrap();
     }
+
+    fn on_show_select_element(&self, _webview_id: WebViewId, _prompt: SelectElement) {}
 
     fn on_panic(&self, _reason: String, _backtrace: Option<String>) {}
 }

--- a/ports/servoshell/egl/app.rs
+++ b/ports/servoshell/egl/app.rs
@@ -180,7 +180,7 @@ impl PlatformWindow for EmbeddedPlatformWindow {
         )
     }
 
-    fn show_embedder_control(&self, _: WebViewId, embedder_control: EmbedderControl) {
+    fn show_embedder_control(&self, webview_id: WebViewId, embedder_control: EmbedderControl) {
         let control_id = embedder_control.id();
         match embedder_control {
             EmbedderControl::InputMethod(input_method_control)
@@ -188,6 +188,9 @@ impl PlatformWindow for EmbeddedPlatformWindow {
             {
                 self.visible_input_methods.borrow_mut().push(control_id);
                 self.host.on_ime_show(input_method_control);
+            },
+            EmbedderControl::SelectElement(prompt) => {
+                self.host.on_show_select_element(webview_id, prompt);
             },
             EmbedderControl::SimpleDialog(SimpleDialog::Alert(alert_dialog)) => {
                 self.host.show_alert(alert_dialog.message().into());

--- a/ports/servoshell/egl/host_trait.rs
+++ b/ports/servoshell/egl/host_trait.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use servo::{InputMethodControl, LoadStatus, MediaSessionPlaybackState};
+use servo::{InputMethodControl, LoadStatus, MediaSessionPlaybackState, SelectElement, WebViewId};
 
 /// Callbacks implemented by embedder. Called by our RunningAppState, generally on behalf of Servo.
 pub trait HostTrait {
@@ -38,6 +38,8 @@ pub trait HostTrait {
     fn on_media_session_playback_state_change(&self, state: MediaSessionPlaybackState);
     /// Called when the media session position state is set.
     fn on_media_session_set_position_state(&self, duration: f64, position: f64, playback_rate: f64);
+    /// Called when a `<select>` element is clicked.
+    fn on_show_select_element(&self, webview_id: WebViewId, prompt: SelectElement);
     /// Called when we get a panic message from constellation
     fn on_panic(&self, reason: String, backtrace: Option<String>);
 }

--- a/ports/servoshell/egl/ohos/mod.rs
+++ b/ports/servoshell/egl/ohos/mod.rs
@@ -87,7 +87,7 @@ use raw_window_handle::{
 };
 use servo::{
     self, DevicePixel, EventLoopWaker, InputMethodControl, InputMethodType, LoadStatus,
-    MediaSessionPlaybackState, PrefValue, Zero,
+    MediaSessionPlaybackState, PrefValue, SelectElement, WebViewId, Zero,
 };
 use xcomponent_sys::{
     OH_NativeXComponent, OH_NativeXComponent_Callback, OH_NativeXComponent_GetKeyEvent,
@@ -1234,6 +1234,8 @@ impl HostTrait for HostCallbacks {
     ) {
         warn!("on_media_session_set_position_state not implemented");
     }
+
+    fn on_show_select_element(&self, _webview_id: WebViewId, _prompt: SelectElement) {}
 
     fn on_panic(&self, reason: String, backtrace: Option<String>) {
         error!("Panic: {reason},");


### PR DESCRIPTION
Add new function in `servoshell` to handle showing `<select>` popup menu in OHOS/Android. Currently the function still does nothing so no visible changes yet.

Testing: Compiled for `aarch64-unknown-linux-ohos` target. No regression in existing behavior. `<select>` popups remain hidden on OHOS/Android until the native dialog implementation lands in a follow-up.
Fixes: #44295 
