### PR TITLE
webdriver: Fix race condition in asynchronous script execution

### DIFF
--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -2117,16 +2117,24 @@ impl Handler {
 
         let joined_args = args_string.join(", ");
         let script = format!(
-            r#"(function() {{
-                new Promise(function(resolve, reject) {{
-                  (async function() {{
-                    {function_body}
-                  }})({joined_args})
-                    .catch(reject)
-              }})
-              .then((v) => window.webdriverCallback(v), (r) => window.webdriverException(r))
-              .catch((r) => window.webdriverException(r));
-            }})();"#,
+            r#"(async function(__wd_eid) {{
+                try {{
+                    let result = new Promise(function(resolve, reject) {{
+                      (async function() {{
+                        {function_body}
+                      }})({joined_args})
+                        .catch(reject)
+                    }});
+                    let value = await result;
+                    if (window.__wd_eid === __wd_eid) {{
+                        window.webdriverCallback(value);
+                    }}
+                }} catch (err) {{
+                    if (window.__wd_eid === __wd_eid) {{
+                        window.webdriverException(err);
+                    }}
+                }}
+            }})(window.__wd_eid = (window.__wd_eid || 0) + 1);"#,
         );
         debug!("{}", script);
 


### PR DESCRIPTION
Similar to #45330. We fix it by identifier `__wd_eid` in the script.

Testing: Now always pass the intermittent test.
Fixes: #45198.
