### PR TITLE
deps: Bump `hkdf`, `sha1`, `sha2` and `digest`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1469,7 +1469,7 @@ dependencies = [
  "percent-encoding",
  "regex",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "url",
 ]
 
@@ -1969,6 +1969,7 @@ dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -2238,7 +2239,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "hkdf",
+ "hkdf 0.12.4",
  "pem-rfc7468",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
@@ -2418,7 +2419,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2989,7 +2990,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3616,7 +3617,7 @@ dependencies = [
  "http 1.4.1",
  "httpdate",
  "mime",
- "sha1",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -3707,7 +3708,16 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -3717,6 +3727,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -6071,7 +6090,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -6083,7 +6102,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -6097,7 +6116,7 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
  "rand_core 0.6.4",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -6971,7 +6990,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -7040,8 +7059,8 @@ dependencies = [
  "pkcs1",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sha1",
- "sha2",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
  "signature 2.2.0",
  "spki 0.7.3",
  "subtle",
@@ -7112,7 +7131,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7169,7 +7188,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8414,7 +8433,6 @@ dependencies = [
  "futures",
  "futures-core",
  "futures-util",
- "generic-array",
  "headers",
  "http 1.4.1",
  "http-body-util",
@@ -8453,7 +8471,7 @@ dependencies = [
  "servo-tracing",
  "servo-url",
  "servo_arc",
- "sha2",
+ "sha2 0.11.0",
  "smallvec",
  "time",
  "tokio",
@@ -8664,7 +8682,7 @@ dependencies = [
  "ctr",
  "data-url",
  "der 0.7.10",
- "digest 0.10.7",
+ "digest 0.11.3",
  "ecdsa",
  "elliptic-curve",
  "encoding_rs",
@@ -8672,7 +8690,7 @@ dependencies = [
  "flate2",
  "glow",
  "headers",
- "hkdf",
+ "hkdf 0.13.0",
  "html5ever",
  "http 1.4.1",
  "httparse",
@@ -8748,8 +8766,10 @@ dependencies = [
  "servo-webxr-api",
  "servo-xpath",
  "servo_arc",
- "sha1",
- "sha2",
+ "sha1 0.10.6",
+ "sha1 0.11.0",
+ "sha2 0.10.9",
+ "sha2 0.11.0",
  "sha3 0.12.0",
  "smallvec",
  "strum",
@@ -9148,6 +9168,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9162,6 +9193,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -9831,7 +9873,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10354,7 +10396,7 @@ dependencies = [
  "rand 0.9.2",
  "rustls",
  "rustls-pki-types",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
 ]
 
@@ -11368,7 +11410,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ cssparser = { version = "0.37", features = ["serde"] }
 ctr = "0.9.2"
 data-url = "0.3"
 der = { version = "0.7", features = ["alloc", "derive"] }
-digest = "0.10"
+digest = "0.11"
 dirs = "6.0"
 dpi = "0.1"
 dwrote = "0.11.5"
@@ -95,7 +95,6 @@ futures-core = { version = "0.3", default-features = false }
 futures-intrusive = "0.5"
 futures-util = { version = "0.3", default-features = false }
 gaol = "0.2.1"
-generic-array = "0.14"
 gilrs = "0.11.1"
 gleam = "0.15"
 glib = "0.22"
@@ -119,7 +118,7 @@ harfbuzz-sys = "0.6.1"
 headers = "0.4"
 hilog = "0.2.2"
 hitrace = { version = "0.2.0", features = ["api-19", "tracing-rs"] }
-hkdf = "0.12"
+hkdf = "0.13"
 html5ever = "0.39"
 http = "1.4"
 http-body-util = "0.1"
@@ -223,8 +222,10 @@ serde_core = "1.0.226"
 serde_json = "1.0"
 serde_test = "1.0"
 servo_arc = { git = "https://github.com/servo/stylo", rev = "d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f" }
-sha1 = "0.10"
-sha2 = "0.10"
+sha1 = "0.11"
+sha1_0_10 = { package = "sha1", version = "0.10" }
+sha2 = "0.11"
+sha2_0_10 = { package = "sha2", version = "0.10" }
 sha3 = "0.12"
 signal-hook-registry = "1.4.8"
 skrifa = "0.42.1"

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -37,7 +37,6 @@ fst = { workspace = true }
 futures = { workspace = true }
 futures-core = { workspace = true }
 futures-util = { workspace = true }
-generic-array = { workspace = true }
 headers = { workspace = true }
 http = { workspace = true }
 http-body-util = { workspace = true }

--- a/components/net/subresource_integrity.rs
+++ b/components/net/subresource_integrity.rs
@@ -7,7 +7,6 @@ use std::str::Split;
 use std::sync::LazyLock;
 
 use base64::Engine;
-use generic_array::ArrayLength;
 use net_traits::response::{Response, ResponseBody, ResponseType};
 use parking_lot::MutexGuard;
 use regex::Regex;
@@ -135,10 +134,7 @@ pub fn get_strongest_metadata(integrity_metadata_list: Vec<SriEntry>) -> Vec<Sri
 }
 
 /// <https://w3c.github.io/webappsec-subresource-integrity/#apply-algorithm-to-response>
-fn apply_algorithm_to_response<S: ArrayLength<u8>, D: Digest<OutputSize = S>>(
-    body: MutexGuard<ResponseBody>,
-    mut hasher: D,
-) -> String {
+fn apply_algorithm_to_response<D: Digest>(body: MutexGuard<ResponseBody>, mut hasher: D) -> String {
     if let ResponseBody::Done(ref vec) = *body {
         hasher.update(vec);
         let response_digest = hasher.finalize(); // Now hash

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -145,7 +145,9 @@ servo-tracing = { workspace = true }
 servo-url = { workspace = true }
 servo_arc = { workspace = true }
 sha1 = { workspace = true }
+sha1_0_10 = { workspace = true }
 sha2 = { workspace = true }
+sha2_0_10 = { workspace = true }
 sha3 = { workspace = true }
 smallvec = { workspace = true }
 storage_traits = { workspace = true }

--- a/components/script/dom/webcrypto/subtlecrypto/ecdsa_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ecdsa_operation.rs
@@ -50,11 +50,16 @@ pub(crate) fn sign(
     // Step 3. Let M be the result of performing the digest operation specified by hashAlgorithm
     // using message.
     let m = match hash_algorithm.name() {
-        CryptoAlgorithm::Sha1 => Sha1::new_with_prefix(message).finalize().to_vec(),
-        CryptoAlgorithm::Sha256 => Sha256::new_with_prefix(message).finalize().to_vec(),
-        CryptoAlgorithm::Sha384 => Sha384::new_with_prefix(message).finalize().to_vec(),
-        CryptoAlgorithm::Sha512 => Sha512::new_with_prefix(message).finalize().to_vec(),
-        _ => return Err(Error::NotSupported(None)),
+        CryptoAlgorithm::Sha1 => Sha1::digest(message).to_vec(),
+        CryptoAlgorithm::Sha256 => Sha256::digest(message).to_vec(),
+        CryptoAlgorithm::Sha384 => Sha384::digest(message).to_vec(),
+        CryptoAlgorithm::Sha512 => Sha512::digest(message).to_vec(),
+        hash_algorithm_name => {
+            return Err(Error::NotSupported(Some(format!(
+                "Unsupported hash algorithm for ECDSA: {}",
+                hash_algorithm_name.as_str()
+            ))));
+        },
     };
 
     // Step 4. Let d be the ECDSA private key associated with key.

--- a/components/script/dom/webcrypto/subtlecrypto/rsa_oaep_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/rsa_oaep_operation.rs
@@ -5,8 +5,8 @@
 use js::context::JSContext;
 use pkcs8::rand_core::OsRng;
 use rsa::Oaep;
-use sha1::Sha1;
-use sha2::{Sha256, Sha384, Sha512};
+use sha1_0_10::Sha1;
+use sha2_0_10::{Sha256, Sha384, Sha512};
 
 use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::{
     CryptoKeyMethods, CryptoKeyPair, KeyType, KeyUsage,

--- a/components/script/dom/webcrypto/subtlecrypto/rsa_pss_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/rsa_pss_operation.rs
@@ -6,8 +6,8 @@ use js::context::JSContext;
 use pkcs8::rand_core::OsRng;
 use rsa::pss::{Signature, SigningKey, VerifyingKey};
 use rsa::signature::{RandomizedSigner, SignatureEncoding, Verifier};
-use sha1::Sha1;
-use sha2::{Sha256, Sha384, Sha512};
+use sha1_0_10::Sha1;
+use sha2_0_10::{Sha256, Sha384, Sha512};
 
 use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::{
     CryptoKeyMethods, CryptoKeyPair, KeyType, KeyUsage,

--- a/components/script/dom/webcrypto/subtlecrypto/rsassa_pkcs1_v1_5_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/rsassa_pkcs1_v1_5_operation.rs
@@ -5,8 +5,8 @@
 use js::context::JSContext;
 use rsa::pkcs1v15::{Signature, SigningKey, VerifyingKey};
 use rsa::signature::{SignatureEncoding, Signer, Verifier};
-use sha1::Sha1;
-use sha2::{Sha256, Sha384, Sha512};
+use sha1_0_10::Sha1;
+use sha2_0_10::{Sha256, Sha384, Sha512};
 
 use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::{
     CryptoKeyMethods, CryptoKeyPair, KeyType, KeyUsage,

--- a/deny.toml
+++ b/deny.toml
@@ -200,6 +200,10 @@ skip = [
     "spki",
     "signature",
     "block-buffer",
+    "hkdf",
+    "hmac",
+    "sha1",
+    "sha2",
 ]
 
 # github.com organizations to allow git sources for


### PR DESCRIPTION
Bump `hkdf` from 0.12.4 to 0.13.0.
Bump `sha1` from 0.10.9 to 0.11.0.
Bump `sha2` from 0.10.9 to 0.11.0.
Bump `digest` from 0.10.7 to 0.11.3.

The `generic-array` crate is no longer in use, so we remove it from our dependency tree.

We have not yet bumped the `rsa` from 0.9 to 0.10, so the implementation of the operations of RSASSA-PKCS1-v1_5, RSA-PSS and RSA-OAEP still rely on the previous version (0.10) of `sha1` and `sha2`. We temporarily keep them in `Cargo.toml` with aliases `sha1_0_10` and `sha2_0_10` so that we can call them by these aliases, until we bump the `rsa` crate.

Testing: Covered by existing WPT tests in `WebCrypto` subdirectory
Fixes: Part of #42206
