### PR TITLE
script: expose static attributes of webidl namespace to javascript

### DIFF
--- a/components/script/dom/testing/testbinding.rs
+++ b/components/script/dom/testing/testbinding.rs
@@ -72,7 +72,7 @@ impl TestBinding {
         }
     }
 
-    fn new(
+    pub(crate) fn new(
         cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,

--- a/components/script/dom/testing/testns.rs
+++ b/components/script/dom/testing/testns.rs
@@ -4,11 +4,12 @@
 
 // check-tidy: no specs after this line
 
-use crate::dom::bindings::codegen::Bindings::TestBindingBinding::TestNS_Binding;
-use crate::dom::globalscope::GlobalScope; 
-use crate::dom::testbinding::TestBinding;
-use crate::dom::bindings::root::DomRoot;
 use js::context::JSContext;
+
+use crate::dom::bindings::codegen::Bindings::TestBindingBinding::TestNS_Binding;
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::globalscope::GlobalScope;
+use crate::dom::testbinding::TestBinding;
 
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct TestNS(());

--- a/components/script/dom/testing/testns.rs
+++ b/components/script/dom/testing/testns.rs
@@ -4,5 +4,17 @@
 
 // check-tidy: no specs after this line
 
+use crate::dom::bindings::codegen::Bindings::TestBindingBinding::TestNS_Binding;
+use crate::dom::globalscope::GlobalScope; 
+use crate::dom::testbinding::TestBinding;
+use crate::dom::bindings::root::DomRoot;
+use js::context::JSContext;
+
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct TestNS(());
+
+impl TestNS_Binding::TestNSMethods<crate::DomTypeHolder> for TestNS {
+    fn TestAttribute(cx: &mut JSContext, global_scope: &GlobalScope) -> DomRoot<TestBinding> {
+        TestBinding::new(cx, global_scope, None)
+    }
+}

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1146,6 +1146,10 @@ DOMInterfaces = {
     'realm': ['PromiseNativeHandler'],
 },
 
+'TestNS': {
+    'cx': ['TestAttribute'],
+},
+
 'TestWorklet': {
     'cx': ['Constructor'],
     'realm': ['AddModule'],

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -3724,11 +3724,18 @@ class CGCreateInterfaceObjectsMethod(CGAbstractMethod):
         else:
             methods = "&[]"
 
+        if self.properties.static_attrs.length():
+            attrs = f"{self.properties.static_attrs.variableName()}.get()"
+        else:
+            attrs = "&[]"
         if self.descriptor.interface.hasConstants():
             constants = "sConstants.get()"
         else:
             constants = "&[]"
 
+        # TODO: used for checking right values are being passed
+        # if self.descriptor.interface.identifier.name == "CSS":
+        #   raise ValueError(attrs)
 
         if self.descriptor.interface.isNamespace():
             return CGGeneric(f"""
@@ -3737,6 +3744,7 @@ class CGCreateInterfaceObjectsMethod(CGAbstractMethod):
                     static_methods: {methods},
                     constructor_name: PrototypeList::Constructor::{MakeNativeName(self.descriptor.interface.identifier.name)},
                     namespace_object_class: &NAMESPACE_OBJECT_CLASS,
+                    properties: {attrs},
                     constants: {constants},
                     name: c"{self.descriptor.interface.identifier.name}",
                 }};

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -3729,6 +3729,7 @@ class CGCreateInterfaceObjectsMethod(CGAbstractMethod):
         else:
             constants = "&[]"
 
+
         if self.descriptor.interface.isNamespace():
             if self.properties.static_attrs.length():
                 attrs = f"{self.properties.static_attrs.variableName()}.get()"

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -3724,27 +3724,24 @@ class CGCreateInterfaceObjectsMethod(CGAbstractMethod):
         else:
             methods = "&[]"
 
-        if self.properties.static_attrs.length():
-            attrs = f"{self.properties.static_attrs.variableName()}.get()"
-        else:
-            attrs = "&[]"
         if self.descriptor.interface.hasConstants():
             constants = "sConstants.get()"
         else:
             constants = "&[]"
 
-        # TODO: used for checking right values are being passed
-        # if self.descriptor.interface.identifier.name == "CSS":
-        #   raise ValueError(attrs)
-
         if self.descriptor.interface.isNamespace():
+            if self.properties.static_attrs.length():
+                attrs = f"{self.properties.static_attrs.variableName()}.get()"
+            else:
+                attrs = "&[]"
+
             return CGGeneric(f"""
                 let init = NamespaceInit {{
                     is_proto_hack: {rust_bool(self.descriptor.interface.getExtendedAttribute("ProtoObjectHack") is not None)},
                     static_methods: {methods},
                     constructor_name: PrototypeList::Constructor::{MakeNativeName(self.descriptor.interface.identifier.name)},
                     namespace_object_class: &NAMESPACE_OBJECT_CLASS,
-                    properties: {attrs},
+                    attributes: {attrs},
                     constants: {constants},
                     name: c"{self.descriptor.interface.identifier.name}",
                 }};

--- a/components/script_bindings/constructor.rs
+++ b/components/script_bindings/constructor.rs
@@ -72,7 +72,7 @@ pub(crate) struct NamespaceInit {
     pub(crate) namespace_object_class: &'static NamespaceObjectClass,
     pub(crate) constructor_name: PrototypeList::Constructor,
     pub(crate) constants: &'static [Guard<&'static [ConstantSpec]>],
-    pub(crate) properties: &'static [Guard<&'static [JSPropertySpec]>],
+    pub(crate) attributes: &'static [Guard<&'static [JSPropertySpec]>],
     pub(crate) name: &'static CStr,
 }
 
@@ -106,7 +106,7 @@ pub(crate) unsafe fn create_namespace_interface_objects<D: DomTypes>(
         proto.handle(),
         init.namespace_object_class,
         init.static_methods,
-        init.properties,
+        init.attributes,
         init.constants,
         init.name,
         namespace.handle_mut(),

--- a/components/script_bindings/constructor.rs
+++ b/components/script_bindings/constructor.rs
@@ -6,7 +6,7 @@ use std::ffi::CStr;
 use std::ptr;
 
 use js::gc::RootedGuard;
-use js::jsapi::{CallArgs, JSFunctionSpec, JSObject};
+use js::jsapi::{CallArgs, JSFunctionSpec, JSObject, JSPropertySpec};
 use js::rooted;
 use js::rust::HandleObject;
 use js::rust::wrappers2::{GetRealmObjectPrototype, JS_NewPlainObject};
@@ -72,6 +72,7 @@ pub(crate) struct NamespaceInit {
     pub(crate) namespace_object_class: &'static NamespaceObjectClass,
     pub(crate) constructor_name: PrototypeList::Constructor,
     pub(crate) constants: &'static [Guard<&'static [ConstantSpec]>],
+    pub(crate) properties: &'static [Guard<&'static [JSPropertySpec]>],
     pub(crate) name: &'static CStr,
 }
 
@@ -105,6 +106,7 @@ pub(crate) unsafe fn create_namespace_interface_objects<D: DomTypes>(
         proto.handle(),
         init.namespace_object_class,
         init.static_methods,
+        init.properties,
         init.constants,
         init.name,
         namespace.handle_mut(),

--- a/components/script_bindings/namespace.rs
+++ b/components/script_bindings/namespace.rs
@@ -44,7 +44,7 @@ pub(crate) fn create_namespace_object<D: DomTypes>(
     proto: HandleObject,
     class: &'static NamespaceObjectClass,
     methods: &[Guard<&'static [JSFunctionSpec]>],
-    properties: &[Guard<&'static [JSPropertySpec]>],
+    attributes: &[Guard<&'static [JSPropertySpec]>],
     constants: &[Guard<&'static [ConstantSpec]>],
     name: &CStr,
     mut rval: MutableHandleObject,
@@ -55,7 +55,7 @@ pub(crate) fn create_namespace_object<D: DomTypes>(
         proto,
         &class.0,
         methods,
-        properties,
+        attributes,
         constants,
         rval.reborrow(),
     );

--- a/components/script_bindings/namespace.rs
+++ b/components/script_bindings/namespace.rs
@@ -8,7 +8,7 @@ use std::ffi::CStr;
 use std::ptr;
 
 use js::context::JSContext;
-use js::jsapi::{JSClass, JSFunctionSpec};
+use js::jsapi::{JSClass, JSFunctionSpec, JSPropertySpec};
 use js::rust::{HandleObject, MutableHandleObject};
 
 use crate::DomTypes;
@@ -44,6 +44,7 @@ pub(crate) fn create_namespace_object<D: DomTypes>(
     proto: HandleObject,
     class: &'static NamespaceObjectClass,
     methods: &[Guard<&'static [JSFunctionSpec]>],
+    properties: &[Guard<&'static [JSPropertySpec]>],
     constants: &[Guard<&'static [ConstantSpec]>],
     name: &CStr,
     mut rval: MutableHandleObject,
@@ -54,7 +55,7 @@ pub(crate) fn create_namespace_object<D: DomTypes>(
         proto,
         &class.0,
         methods,
-        &[],
+        properties,
         constants,
         rval.reborrow(),
     );

--- a/components/script_bindings/webidls/TestBinding.webidl
+++ b/components/script_bindings/webidls/TestBinding.webidl
@@ -627,6 +627,7 @@ callback callbackWithOnlyOneOptionalArg = Promise<undefined> (optional any reaso
 namespace TestNS {
     const unsigned long ONE   = 1;
     const unsigned long TWO   = 0x2;
+    [SameObject] readonly attribute TestBinding testAttribute;
 };
 
 typedef Promise<undefined> PromiseUndefined;

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -14656,7 +14656,7 @@
      ]
     ],
     "ns.any.js": [
-     "05087872b02abdeeb48c21ee9ec037b3a1483c03",
+     "8fa275c14fdfc9e162285477aaa9f97849e7a363",
      [
       "mozilla/ns.any.html",
       {

--- a/tests/wpt/mozilla/tests/mozilla/ns.any.js
+++ b/tests/wpt/mozilla/tests/mozilla/ns.any.js
@@ -1,6 +1,10 @@
 // META: title=Namespace bindings
 
-test(function () {
-    assert_equals(TestNS.ONE, 1);
-    assert_equals(TestNS.TWO, 2);
+test(function() {
+  assert_equals(TestNS.ONE, 1);
+  assert_equals(TestNS.TWO, 2);
 }, "Namespace constants");
+
+test(function() {
+  assert_true(TestNS.testAttribute instanceof TestBinding, "Should be TestBinding");
+}, "Namespace attributes");

--- a/tests/wpt/mozilla/tests/mozilla/ns.any.js
+++ b/tests/wpt/mozilla/tests/mozilla/ns.any.js
@@ -1,10 +1,10 @@
 // META: title=Namespace bindings
 
-test(function() {
-  assert_equals(TestNS.ONE, 1);
-  assert_equals(TestNS.TWO, 2);
+test(function () {
+    assert_equals(TestNS.ONE, 1);
+    assert_equals(TestNS.TWO, 2);
 }, "Namespace constants");
 
-test(function() {
-  assert_true(TestNS.testAttribute instanceof TestBinding, "Should be TestBinding");
+test(function () {
+    assert_true(TestNS.testAttribute instanceof TestBinding, "Should be TestBinding");
 }, "Namespace attributes");


### PR DESCRIPTION
Fix codegen.py to extract the static attributes from the WebIDL namespace definition and pass them to the method that creates the JS namespace object.

Testing: Added a new test case for attributes in the existing test for WebIDL namespaces.
Fixes: #45297
