### PR TITLE
devtools: Redesign Debugger vlaue to use deserialization

### DIFF
--- a/components/default-resources/resources/debugger.js
+++ b/components/default-resources/resources/debugger.js
@@ -80,58 +80,54 @@ addEventListener("addDebuggee", event => {
 
 // Convert debuggee value to property descriptor value
 // <https://searchfox.org/firefox-main/source/devtools/server/actors/object/utils.js#116>
-function createValueGrip(value, depth, previewState) {
+function createValueGrip(value, depth) {
     switch (typeof value) {
         case "undefined":
-            return { valueType: "undefined" };
+            return "VoidValue";
         case "boolean":
-            return { valueType: "boolean", booleanValue: value };
+            return { BooleanValue: value };
         case "number":
             if (value === Infinity) {
-                return { valueType: "Infinity" };
+                return { NumberValue: "Infinity" };
             } else if (value === -Infinity) {
-                return { valueType: "-Infinity" };
+                return { NumberValue: "-Infinity" };
             } else if (Number.isNaN(value)) {
-                return { valueType: "NaN" };
+                return { NumberValue: "NaN" };
             } else if (Object.is(value, -0)) {
-                return { valueType: "-0" };
+                return { NumberValue: "-0" };
             }
-            return { valueType: "number", numberValue: value };
+            return { NumberValue: value };
         case "string":
-            return { valueType: "string", stringValue: value };
+            return { StringValue: value };
         case "object":
             // <https://searchfox.org/firefox-main/source/devtools/server/actors/object/utils.js#153>
             if (value === null) {
-                return { valueType: "null" };
+                return "NullValue";
             }
             if (value.optimizedOut || value.uninitialized || value.missingArguments) {
-                return { valueType: "null" };
+                return "NullValue";
             }
             // TODO: handle typed arrays and storage independently
             const ownPropertyLength = value.getOwnPropertyNamesLength();
+            const objectValue = {
+                class: value.class,
+                ownPropertyLength: Number.isFinite(ownPropertyLength) ? ownPropertyLength : undefined,
+            };
             // Debugger.Object - get preview using registered previewers
             // <https://firefox-source-docs.mozilla.org/devtools-user/debugger-api/debugger.object/index.html>
-            const preview = getPreview(value, depth + 1, previewState);
-            let previewId = undefined;
+            const preview = getPreview(value, depth + 1);
             if (preview) {
-                previewState.push(preview);
-                previewId = previewState.length - 1;
+                objectValue.preview = preview;
             }
-            return {
-                valueType: "object",
-                objectClass: value.class,
-                ownPropertyLength: Number.isFinite(ownPropertyLength) ? ownPropertyLength : undefined,
-                preview: getPreview(value, depth),
-                previewId,
-            };
+            return { ObjectValue: objectValue };
         default:
-            return { valueType: "string", stringValue: String(value) };
+            return { StringValue: String(value) };
     }
 }
 
 // Extract own properties from a debuggee object
 // <https://firefox-source-docs.mozilla.org/devtools-user/debugger-api/debugger.object/index.html#function-properties-of-the-debugger-object-prototype>
-function extractOwnProperties(obj, depth, previewState) {
+function extractOwnProperties(obj, depth) {
     const ownProperties = [];
     let totalLength = 0;
 
@@ -153,16 +149,16 @@ function extractOwnProperties(obj, depth, previewState) {
                     enumerable: desc.enumerable ?? false,
                     writable: desc.writable ?? false,
                     isAccessor: desc.get !== undefined || desc.set !== undefined,
-                    value: createValueGrip(undefined, depth + 1, previewState),
+                    value: createValueGrip(undefined, depth + 1),
                 };
 
                 if (desc.value !== undefined) {
-                    prop.value = createValueGrip(desc.value, depth + 1, previewState);
+                    prop.value = createValueGrip(desc.value, depth + 1);
                 } else if (desc.get) {
                     try {
                         const result = desc.get.call(obj);
                         if (result && "return" in result) {
-                            prop.value = createValueGrip(result.return, depth + 1, previewState);
+                            prop.value = createValueGrip(result.return, depth + 1);
                         }
                     } catch (e) { }
                 }
@@ -181,8 +177,8 @@ function extractOwnProperties(obj, depth, previewState) {
 const previewers = {};
 
 // <https://searchfox.org/mozilla-central/source/devtools/server/actors/object/previewers.js#125>
-previewers.Function = [ function FunctionPreviewer(obj, depth, previewState) {
-    let function_details = {
+previewers.Function = [ function FunctionPreviewer(obj, depth) {
+    let functionDetails = {
         name: obj.name,
         displayName: obj.displayName,
         parameterNames: obj.parameterNames ? obj.parameterNames: [],
@@ -190,12 +186,12 @@ previewers.Function = [ function FunctionPreviewer(obj, depth, previewState) {
         isGenerator: obj.isGeneratorFunction,
     }
 
-    let preview = { kind: "Object", function: function_details };
+    let preview = { kind: "Object", function: functionDetails };
     if (depth > 1) {
         return undefined;
     }
 
-    const { ownProperties, ownPropertiesLength } = extractOwnProperties(obj, depth, previewState);
+    const { ownProperties, ownPropertiesLength } = extractOwnProperties(obj, depth);
     preview.ownProperties = ownProperties;
     preview.ownPropertiesLength = ownPropertiesLength;
 
@@ -203,7 +199,7 @@ previewers.Function = [ function FunctionPreviewer(obj, depth, previewState) {
 } ];
 
 // <https://searchfox.org/mozilla-central/source/devtools/server/actors/object/previewers.js#172>
-previewers.Array = [ function ArrayPreviewer(obj, depth, previewState) {
+previewers.Array = [ function ArrayPreviewer(obj, depth) {
     const lengthDescriptor = obj.getOwnPropertyDescriptor("length");
     const arrayLength = lengthDescriptor ? lengthDescriptor.value : 0;
 
@@ -216,7 +212,7 @@ previewers.Array = [ function ArrayPreviewer(obj, depth, previewState) {
         try {
             const desc = obj.getOwnPropertyDescriptor(i);
             if (desc && desc.value !== undefined) {
-                preview.items.push(createValueGrip(desc.value, depth + 1, previewState));
+                preview.items.push(createValueGrip(desc.value, depth + 1));
             }
         } catch (e) {
             // For now skip properties that throw on access
@@ -228,26 +224,26 @@ previewers.Array = [ function ArrayPreviewer(obj, depth, previewState) {
 
 // Generic fallback for object previewer
 // <https://searchfox.org/mozilla-central/source/devtools/server/actors/object/previewers.js#856>
-previewers.Object = [ function ObjectPreviewer(obj, depth, previewState) {
+previewers.Object = [ function ObjectPreviewer(obj, depth) {
     let preview = { kind: "Object" };
     if (depth > 1) {
        return undefined;
     }
 
-    const { ownProperties, ownPropertiesLength } = extractOwnProperties(obj, depth, previewState);
+    const { ownProperties, ownPropertiesLength } = extractOwnProperties(obj, depth);
     preview.ownProperties = ownProperties;
     preview.ownPropertiesLength = ownPropertiesLength;
 
     return preview;
 } ];
 
-function getPreview(obj, depth, previewState) {
+function getPreview(obj, depth) {
     const className = obj.class;
 
     // <https://searchfox.org/mozilla-central/source/devtools/server/actors/object.js#295>
     const typePreviewers = previewers[className] || previewers.Object;
     for (const previewer of typePreviewers) {
-        const result = previewer(obj, depth, previewState);
+        const result = previewer(obj, depth);
         if (result) return result;
     }
 
@@ -258,7 +254,6 @@ function getPreview(obj, depth, previewState) {
 // See executeInGlobal() at <https://firefox-source-docs.mozilla.org/devtools-user/debugger-api/debugger.object/index.html#function-properties-of-the-debugger-object-prototype>
 addEventListener("eval", event => {
     const {code, pipelineId, workerId, frameActorId} = event;
-    const previewState = [];
 
     let completionValue;
     if (frameActorId) {
@@ -281,7 +276,7 @@ addEventListener("eval", event => {
     if (completionValue === null) {
         resultValue = {
             completionType: "terminated",
-            value: createValueGrip(undefined, 0, previewState),
+            value: createValueGrip(undefined, 0),
             hasException: false,
         };
     } else if ("throw" in completionValue) {
@@ -291,20 +286,22 @@ addEventListener("eval", event => {
         // let value = dbg.adoptDebuggeeValue(completionValue.throw);
         resultValue = {
             completionType: "throw",
-            value: createValueGrip(completionValue.throw, 0, previewState),
+            value: createValueGrip(completionValue.throw, 0),
             hasException: true,
         };
     } else if ("return" in completionValue) {
         resultValue = {
             completionType: "return",
-            value: createValueGrip(completionValue.return, 0, previewState),
+            value: createValueGrip(completionValue.return, 0),
             hasException: false,
         };
     }
 
-    resultValue.previews = previewState;
-
-    evalResult(event, resultValue);
+    evalResult(event, {
+        completionType: resultValue.completionType,
+        serializedValue: JSON.stringify(resultValue.value),
+        hasException: resultValue.hasException,
+    });
 });
 
 addEventListener("getPossibleBreakpoints", event => {
@@ -604,11 +601,11 @@ function createEnvironmentActor(environment) {
         parent = createEnvironmentActor(environment.parent);
     }
 
+    let bindingVariables = [];
     if (environment.type == "declarative") {
-        const { bindingVariables, previewState } = buildBindings(environment);
-        info.bindingVariables = bindingVariables;
-        info.previews = previewState;
+        bindingVariables = buildBindings(environment);
     }
+    info.serializedBindings = JSON.stringify(bindingVariables);
 
     let actor = environmentsToEnvironmentActors.get(environment);
     actor = registerEnvironmentActor(info, parent, actor);
@@ -617,7 +614,6 @@ function createEnvironmentActor(environment) {
 }
 
 function buildBindings(environment) {
-    const previewState = [];
     const bindingVariables = [];
     for (const name of environment.names()) {
         const value = environment.getVariable(name);
@@ -630,12 +626,12 @@ function buildBindings(environment) {
                 (value.optimizedOut || value.uninitialized || value.missingArguments)
             ),
             isAccessor: false,
-            value: createValueGrip(value, 0, previewState),
+            value: createValueGrip(value, 0),
         };
 
         bindingVariables.push(property);
     }
-    return { bindingVariables, previewState };
+    return bindingVariables;
 }
 
 // Get a `Debugger.Environment` instance within which evaluation is taking place.

--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -22,16 +22,12 @@ use servo_constellation_traits::ScriptToConstellationChan;
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
 use storage_traits::StorageThreads;
 
-use crate::dom::bindings::codegen::Bindings::DebuggerEvalEventBinding::DebuggerValue;
-use crate::dom::bindings::codegen::Bindings::DebuggerEvalEventBinding::GenericBindings::ObjectPreview;
 use crate::dom::bindings::codegen::Bindings::DebuggerGetEnvironmentEventBinding::EnvironmentInfo;
 use crate::dom::bindings::codegen::Bindings::DebuggerGlobalScopeBinding;
 use crate::dom::bindings::codegen::Bindings::DebuggerInterruptEventBinding::{
     FrameInfo, FrameOffset, PauseReason,
 };
-use crate::dom::bindings::codegen::GenericBindings::DebuggerEvalEventBinding::{
-    EvalResult, PropertyDescriptor,
-};
+use crate::dom::bindings::codegen::GenericBindings::DebuggerEvalEventBinding::EvalResult;
 use crate::dom::bindings::codegen::GenericBindings::DebuggerGetPossibleBreakpointsEventBinding::RecommendedBreakpointLocation;
 use crate::dom::bindings::codegen::GenericBindings::DebuggerGlobalScopeBinding::{
     DebuggerGlobalScopeMethods, NotifyNewSource, PipelineIdInit,
@@ -528,10 +524,22 @@ impl DebuggerGlobalScopeMethods<crate::DomTypeHolder> for DebuggerGlobalScope {
             .take()
             .expect("Guaranteed by Self::fire_eval()");
 
-        let previews = result.previews.as_deref();
+        let has_exception = result.hasException.unwrap_or(false);
+        let value = match serde_json::from_str::<devtools_traits::DebuggerValue>(
+            &result.serializedValue.str(),
+        ) {
+            Ok(value) => value,
+            Err(error) => {
+                warn!("Failed to parse serialized debugger eval value: {error}");
+                devtools_traits::DebuggerValue::StringValue(
+                    "failed to parse eval result".to_string(),
+                )
+            },
+        };
+
         let reply = EvaluateJSReply {
-            value: parse_debugger_value(&result.value, previews),
-            has_exception: result.hasException.unwrap_or(false),
+            value,
+            has_exception,
         };
 
         let _ = sender.send(reply);
@@ -616,18 +624,20 @@ impl DebuggerGlobalScopeMethods<crate::DomTypeHolder> for DebuggerGlobalScope {
         let chan = self.upcast::<GlobalScope>().devtools_chan()?;
         let (tx, rx) = channel::<String>().unwrap();
 
-        let previews = environment.previews.as_deref();
+        let binding_variables = match serde_json::from_str::<Vec<devtools_traits::PropertyDescriptor>>(
+            &environment.serializedBindings.str(),
+        ) {
+            Ok(binding_variables) => binding_variables,
+            Err(error) => {
+                warn!("Failed to parse serialized debugger environment bindings: {error}");
+                return None;
+            },
+        };
         let environment = devtools_traits::EnvironmentInfo {
             type_: environment.type_.clone().map(String::from),
             scope_kind: environment.scopeKind.clone().map(String::from),
             function_display_name: environment.functionDisplayName.clone().map(String::from),
-            binding_variables: environment
-                .bindingVariables
-                .as_deref()
-                .into_iter()
-                .flatten()
-                .map(|property| parse_property_descriptor(property, previews))
-                .collect(),
+            binding_variables,
         };
 
         let msg = ScriptToDevtoolsControlMsg::CreateEnvironmentActor(
@@ -648,99 +658,5 @@ impl DebuggerGlobalScopeMethods<crate::DomTypeHolder> for DebuggerGlobalScope {
             .expect("Guaranteed by Self::fire_get_environment()");
 
         let _ = sender.send(environment_actor_id.into());
-    }
-}
-
-fn parse_property_descriptor(
-    property: &PropertyDescriptor,
-    previews: Option<&[ObjectPreview]>,
-) -> devtools_traits::PropertyDescriptor {
-    devtools_traits::PropertyDescriptor {
-        name: property.name.to_string(),
-        value: parse_debugger_value(&property.value, previews),
-        configurable: property.configurable,
-        enumerable: property.enumerable,
-        writable: property.writable,
-        is_accessor: property.isAccessor,
-    }
-}
-
-fn parse_object_preview(
-    preview_id: Option<usize>,
-    previews: Option<&[ObjectPreview]>,
-) -> Option<devtools_traits::ObjectPreview> {
-    let preview_id = preview_id?;
-    let preview = previews?.get(preview_id)?;
-    Some(devtools_traits::ObjectPreview {
-        kind: preview.kind.clone().into(),
-        own_properties: preview.ownProperties.as_ref().map(|properties| {
-            properties
-                .iter()
-                .map(|property| parse_property_descriptor(property, previews))
-                .collect()
-        }),
-        own_properties_length: preview.ownPropertiesLength,
-        function: preview
-            .function
-            .as_ref()
-            .map(|fields| devtools_traits::FunctionPreview {
-                name: fields.name.as_ref().map(|s| s.to_string()),
-                display_name: fields.displayName.as_ref().map(|s| s.to_string()),
-                parameter_names: fields
-                    .parameterNames
-                    .iter()
-                    .map(|p| p.to_string())
-                    .collect(),
-                is_async: fields.isAsync,
-                is_generator: fields.isGenerator,
-            }),
-        array_length: preview.arrayLength,
-        items: preview.items.as_ref().map(|items| {
-            items
-                .iter()
-                .map(|item| parse_debugger_value(item, previews))
-                .collect()
-        }),
-    })
-}
-
-fn parse_debugger_value(
-    value: &DebuggerValue,
-    previews: Option<&[ObjectPreview]>,
-) -> devtools_traits::DebuggerValue {
-    use devtools_traits::DebuggerValue::*;
-    match &*value.valueType.str() {
-        "undefined" => VoidValue,
-        "null" => NullValue,
-        "boolean" => BooleanValue(value.booleanValue.unwrap_or(false)),
-        "Infinity" => NumberValue(f64::INFINITY),
-        "-Infinity" => NumberValue(f64::NEG_INFINITY),
-        "NaN" => NumberValue(f64::NAN),
-        "-0" => NumberValue(-0.0),
-        "number" => {
-            let num = value.numberValue.map(|f| *f).unwrap_or(0.0);
-            NumberValue(num)
-        },
-        "string" => StringValue(
-            value
-                .stringValue
-                .as_ref()
-                .map(|s| s.to_string())
-                .unwrap_or_default(),
-        ),
-        "object" => {
-            let class = value
-                .objectClass
-                .as_ref()
-                .map(|s| s.to_string())
-                .unwrap_or_else(|| "Object".to_string());
-            ObjectValue {
-                uuid: uuid::Uuid::new_v4().to_string(),
-                class,
-                own_property_length: value.ownPropertyLength,
-                preview: parse_object_preview(value.previewId.map(|m| m as usize), previews),
-            }
-        },
-        _ => unreachable!(),
     }
 }

--- a/components/script_bindings/webidls/DebuggerEvalEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerEvalEvent.webidl
@@ -17,46 +17,7 @@ partial interface DebuggerGlobalScope {
 };
 
 dictionary EvalResult {
-    required DebuggerValue value;
-    sequence<ObjectPreview> previews;
+    required DOMString serializedValue;
     required DOMString completionType;
     boolean hasException;
-};
-
-dictionary PropertyDescriptor {
-    required DOMString name;
-    required DebuggerValue value;
-    required boolean configurable;
-    required boolean enumerable;
-    required boolean writable;
-    required boolean isAccessor;
-};
-
-dictionary DebuggerValue {
-    required DOMString valueType;
-    boolean booleanValue;
-    double numberValue;
-    DOMString stringValue;
-    DOMString objectClass;
-    unsigned long ownPropertyLength;
-    unsigned long previewId;
-};
-
-dictionary ObjectPreview {
-    required DOMString kind;
-    sequence<PropertyDescriptor> ownProperties;
-    unsigned long ownPropertiesLength;
-    unsigned long arrayLength;
-    sequence<DebuggerValue> items;
-    FunctionPreview function;
-};
-
-// Function-specific metadata
-// <https://searchfox.org/mozilla-central/source/devtools/server/actors/object/previewers.js>
-dictionary FunctionPreview {
-    DOMString name;
-    DOMString displayName;
-    required sequence<DOMString> parameterNames;
-    boolean isAsync;
-    boolean isGenerator;
 };

--- a/components/script_bindings/webidls/DebuggerGetEnvironmentEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerGetEnvironmentEvent.webidl
@@ -24,6 +24,5 @@ dictionary EnvironmentInfo {
     DOMString type_;
     DOMString scopeKind;
     DOMString functionDisplayName;
-    sequence<PropertyDescriptor> bindingVariables;
-    sequence<ObjectPreview> previews;
+    required DOMString serializedBindings;
 };

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -31,6 +31,7 @@ use net_traits::http_status::HttpStatus;
 use net_traits::request::Destination;
 use net_traits::{DebugVec, TlsSecurityInfo};
 use profile_traits::mem::ReportsChan;
+use serde::de::{Error, Visitor};
 use serde::{Deserialize, Serialize};
 use servo_base::cross_process_instant::CrossProcessInstant;
 use servo_base::generic_channel::GenericSender;
@@ -158,6 +159,7 @@ pub enum DomMutation {
 }
 
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ObjectPreview {
     pub kind: String,
     pub own_properties: Option<Vec<PropertyDescriptor>>,
@@ -168,6 +170,7 @@ pub struct ObjectPreview {
 }
 
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct FunctionPreview {
     pub name: Option<String>,
     pub display_name: Option<String>,
@@ -176,14 +179,61 @@ pub struct FunctionPreview {
     pub is_generator: Option<bool>,
 }
 
+fn debugger_value_uuid() -> String {
+    Uuid::new_v4().to_string()
+}
+
+struct DebuggerNumberVisitor;
+
+impl Visitor<'_> for DebuggerNumberVisitor {
+    type Value = f64;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a debugger value number")
+    }
+
+    fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E> {
+        Ok(value)
+    }
+
+    fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E> {
+        Ok(value as f64)
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> {
+        Ok(value as f64)
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        value.parse().map_err(E::custom)
+    }
+}
+
+fn deserialize_debugger_number<'de, D>(deserializer: D) -> Result<f64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    // `DebuggerValue` is also sent over Servo IPC, not only through debugger.js.
+    if !deserializer.is_human_readable() {
+        return f64::deserialize(deserializer);
+    }
+
+    deserializer.deserialize_any(DebuggerNumberVisitor)
+}
+
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
+#[serde(rename_all_fields = "camelCase")]
 pub enum DebuggerValue {
     VoidValue,
     NullValue,
     BooleanValue(bool),
-    NumberValue(f64),
+    NumberValue(#[serde(deserialize_with = "deserialize_debugger_number")] f64),
     StringValue(String),
     ObjectValue {
+        #[serde(default = "debugger_value_uuid")]
         uuid: String,
         class: String,
         own_property_length: Option<u32>,
@@ -193,6 +243,7 @@ pub enum DebuggerValue {
 
 /// <https://searchfox.org/mozilla-central/source/devtools/server/actors/object/property-iterator.js#51>
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PropertyDescriptor {
     pub name: String,
     pub value: DebuggerValue,
@@ -203,6 +254,7 @@ pub struct PropertyDescriptor {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct EvaluateJSReply {
     pub value: DebuggerValue,
     pub has_exception: bool,


### PR DESCRIPTION
In this change we redesign debugger values for `eval` and `getEnvironment` to use serde deserialization directly.

Previously debugger.js built a separate WebIDL-based value shape and passed object previews alongside values. DebuggerGlobalScope then had to parse that intermediate shape and convert it into the DebuggerValue shape from `devtools_traits` before devtools could use it.

Now debugger.js serializes eval results and environment bindings as DebuggerValue and PropertyDescriptor-shaped JSON. DebuggerGlobalScope deserializes those values directly into the `devtools_traits` types used by devtools.

Object previews now live inside `DebuggerValue::ObjectValue` instead of being passed through a separate preview list. This removes the preview id logic and makes eval results, environment bindings, object properties, and array items use the same value path.

The serde deserialization for DebuggerValue handles the JavaScript number values that JSON cannot represent directly, such as NaN, Infinity, and -0.

Testing: Current tests should test this
Fixes: Part of ?

**DevTools Preview before vs after this change**

With current changes
<img width="6339" height="9459" alt="after" src="https://github.com/user-attachments/assets/91f8c844-abea-420e-a5e7-79c30fa89e7f" />
Before this PR:
<img width="6339" height="9459" alt="shapes at 26-06-04 12 58 31" src="https://github.com/user-attachments/assets/3accf93e-8183-4570-ab69-0b034ebf782a" />
