### PR TITLE
release: Use published stylo version for 0.2 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7312,7 +7312,8 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.37.0"
-source = "git+https://github.com/servo/stylo?rev=fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe#fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cfaaa6035167f0e604e42723c7650d59ee269ef220d7bbe0565602c8a0173b9"
 dependencies = [
  "bitflags 2.11.1",
  "cssparser",
@@ -9017,7 +9018,8 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe#fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -9443,8 +9445,9 @@ dependencies = [
 
 [[package]]
 name = "stylo"
-version = "0.16.0"
-source = "git+https://github.com/servo/stylo?rev=fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe#fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe"
+version = "0.16.1-servo-0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d60185059c9ef62c1e788e4620041f9552d74f3013c8513581846349a900b5cc"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -9499,8 +9502,9 @@ dependencies = [
 
 [[package]]
 name = "stylo_atoms"
-version = "0.16.0"
-source = "git+https://github.com/servo/stylo?rev=fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe#fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe"
+version = "0.16.1-servo-0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a66d6e19725524519863a1eddbe45ccf96670bd7a7d99a4f31f132ca8d84a3f4"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -9508,8 +9512,9 @@ dependencies = [
 
 [[package]]
 name = "stylo_derive"
-version = "0.16.0"
-source = "git+https://github.com/servo/stylo?rev=fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe#fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe"
+version = "0.16.1-servo-0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0463f9cbe2e26fd27dbb8fece4ec6c5c629359a5e8a43c11b3a21be71415198a"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -9520,8 +9525,9 @@ dependencies = [
 
 [[package]]
 name = "stylo_dom"
-version = "0.16.0"
-source = "git+https://github.com/servo/stylo?rev=fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe#fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe"
+version = "0.16.1-servo-0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2021a960930142ee298fdbb76a1b4a0a099fd38ae942126553dcc1ba4ffcf02"
 dependencies = [
  "bitflags 2.11.1",
  "stylo_malloc_size_of",
@@ -9529,8 +9535,9 @@ dependencies = [
 
 [[package]]
 name = "stylo_malloc_size_of"
-version = "0.16.0"
-source = "git+https://github.com/servo/stylo?rev=fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe#fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe"
+version = "0.16.1-servo-0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0518bf48a679e56a4e1b86085744b21ffbf972614c1d1c410a62206ac5586ecc"
 dependencies = [
  "app_units",
  "cssparser",
@@ -9546,13 +9553,15 @@ dependencies = [
 
 [[package]]
 name = "stylo_static_prefs"
-version = "0.16.0"
-source = "git+https://github.com/servo/stylo?rev=fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe#fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe"
+version = "0.16.1-servo-0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "770afdf3b46dfd288b223bd2e66d1fbbc393fdb6c6aaff97728e27be33368161"
 
 [[package]]
 name = "stylo_traits"
-version = "0.16.0"
-source = "git+https://github.com/servo/stylo?rev=fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe#fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe"
+version = "0.16.1-servo-0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d4fb2129d8091bdbc391dadc58b650bb52a0d8edc22b6526fbaad57f7e49037"
 dependencies = [
  "app_units",
  "bitflags 2.11.1",
@@ -9974,7 +9983,8 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?rev=fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe#fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eab187810ca1e6aaa4c97a06492aac9ade2ffae6a301fd2aac103656f5a69edb"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -9987,7 +9997,8 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe#fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ba1f5563024b63bb6acb4558452d9ba737518c1d11fcc1861febe98d1e31cf4"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,12 +166,12 @@ rustls-platform-verifier = "0.7.0"
 sea-query = { version = "=1.0.0-rc.31", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = { version = "=0.8.0-rc.15" }
 sec1 = "0.7"
-selectors = { git = "https://github.com/servo/stylo", rev = "fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe" }
+selectors = { version = "0.37.0" }
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
 serde_json = "1.0"
-servo_arc = { git = "https://github.com/servo/stylo", rev = "fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe" }
+servo_arc = { version = "0.4.3" }
 sha1 = "0.10"
 sha2 = "0.10"
 sha3 = "0.10"
@@ -180,12 +180,12 @@ skrifa = "0.37.0"
 smallvec = { version = "1.15", features = ["serde", "union"] }
 string_cache = "0.9"
 strum = { version = "0.28", features = ["derive"] }
-stylo = { git = "https://github.com/servo/stylo", rev = "fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe" }
-stylo_atoms = { git = "https://github.com/servo/stylo", rev = "fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe" }
-stylo_dom = { git = "https://github.com/servo/stylo", rev = "fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe" }
-stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe" }
-stylo_traits = { git = "https://github.com/servo/stylo", rev = "fee56b9ed5c6ccc62296186e9c5f1311ea62fbfe" }
+stylo = { version = "=0.16.1-servo-0.2" }
+stylo_atoms = { version = "=0.16.1-servo-0.2" }
+stylo_dom = { version = "=0.16.1-servo-0.2" }
+stylo_malloc_size_of = { version = "=0.16.1-servo-0.2" }
+stylo_static_prefs = { version = "=0.16.1-servo-0.2" }
+stylo_traits = { version = "=0.16.1-servo-0.2" }
 surfman = { version = "0.12.0", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"

--- a/deny.toml
+++ b/deny.toml
@@ -221,9 +221,3 @@ skip = [
     "vello_common",
     "vello_cpu",
 ]
-
-# github.com organizations to allow git sources for
-[sources.allow-org]
-github = [
-    "servo",
-]


### PR DESCRIPTION
We published a new version of stylo (0.16.1-servo-0.2) to crates.io, since 0.17 was already released after the last rebase. The prerelease syntax avoids breaking existing users of the 0.16 branch, since the stylo release does contain breaking changes compared to 0.16. This version matches the previous git-pinned version of stylo, and is just released to crates.io in order to allow publishing servo to crates.io.

Testing: This PR doesn't change any code, it simply uses a crates.io release based on the same git hash.

