### PR TITLE
script: Re-initialize fulfilled `document.fonts.ready` when a web font starts loading

### DIFF
--- a/components/script/dom/css/cssgroupingrule.rs
+++ b/components/script/dom/css/cssgroupingrule.rs
@@ -102,6 +102,6 @@ impl CSSGroupingRuleMethods<crate::DomTypeHolder> for CSSGroupingRule {
 
     /// <https://drafts.csswg.org/cssom/#dom-cssgroupingrule-deleterule>
     fn DeleteRule(&self, cx: &mut JSContext, index: u32) -> ErrorResult {
-        self.rulelist(cx).remove_rule(index)
+        self.rulelist(cx).remove_rule(cx, index)
     }
 }

--- a/components/script/dom/css/csskeyframesrule.rs
+++ b/components/script/dom/css/csskeyframesrule.rs
@@ -128,7 +128,7 @@ impl CSSKeyframesRuleMethods<crate::DomTypeHolder> for CSSKeyframesRule {
         };
 
         if let Ok(rule) = rule {
-            self.css_rule.parent_stylesheet().will_modify();
+            self.css_rule.parent_stylesheet().will_modify(cx);
 
             {
                 let mut guard = self.css_rule.shared_lock().write();
@@ -147,7 +147,7 @@ impl CSSKeyframesRuleMethods<crate::DomTypeHolder> for CSSKeyframesRule {
     /// <https://drafts.csswg.org/css-animations/#dom-csskeyframesrule-deleterule>
     fn DeleteRule(&self, cx: &mut JSContext, selector: DOMString) {
         if let Some(idx) = self.find_rule(&selector) {
-            let _ = self.rulelist(cx).remove_rule(idx as u32);
+            let _ = self.rulelist(cx).remove_rule(cx, idx as u32);
         }
     }
 
@@ -176,11 +176,11 @@ impl CSSKeyframesRuleMethods<crate::DomTypeHolder> for CSSKeyframesRule {
     }
 
     /// <https://drafts.csswg.org/css-animations/#dom-csskeyframesrule-name>
-    fn SetName(&self, value: DOMString) -> ErrorResult {
+    fn SetName(&self, cx: &mut JSContext, value: DOMString) -> ErrorResult {
         // Spec deviation: https://github.com/w3c/csswg-drafts/issues/801
         // Setting this property to a CSS-wide keyword or `none` does not throw,
         // it stores a value that serializes as a quoted string.
-        self.css_rule.parent_stylesheet().will_modify();
+        self.css_rule.parent_stylesheet().will_modify(cx);
         let name = KeyframesName::from_ident(&value.str());
         let mut guard = self.css_rule.shared_lock().write();
         self.keyframes_rule.borrow().write_with(&mut guard).name = name;

--- a/components/script/dom/css/cssrulelist.rs
+++ b/components/script/dom/css/cssrulelist.rs
@@ -110,7 +110,7 @@ impl CSSRuleList {
         containing_rule_types: CssRuleTypes,
         parse_relative_rule_type: Option<CssRuleType>,
     ) -> Fallible<u32> {
-        self.parent_stylesheet.will_modify();
+        self.parent_stylesheet.will_modify(cx);
         let css_rules = if let RulesSource::Rules(rules) = &*self.rules.borrow() {
             rules.clone()
         } else {
@@ -159,7 +159,7 @@ impl CSSRuleList {
         }
 
         let parent_stylesheet = &*self.parent_stylesheet;
-        parent_stylesheet.will_modify();
+        parent_stylesheet.will_modify(cx);
         let dom_rule = CSSRule::new_specific(cx, window, parent_stylesheet, new_rule);
         self.dom_rules
             .borrow_mut()
@@ -169,8 +169,8 @@ impl CSSRuleList {
     }
 
     /// In case of a keyframe rule, index must be valid.
-    pub(crate) fn remove_rule(&self, index: u32) -> ErrorResult {
-        self.parent_stylesheet.will_modify();
+    pub(crate) fn remove_rule(&self, cx: &mut JSContext, index: u32) -> ErrorResult {
+        self.parent_stylesheet.will_modify(cx);
 
         let index = index as usize;
         let mut guard = self.parent_stylesheet.shared_lock().write();

--- a/components/script/dom/css/cssstyledeclaration.rs
+++ b/components/script/dom/css/cssstyledeclaration.rs
@@ -124,7 +124,7 @@ impl CSSStyleOwner {
                 result
             },
             CSSStyleOwner::CSSRule(ref rule, ref pdb) => {
-                rule.parent_stylesheet().will_modify();
+                rule.parent_stylesheet().will_modify(cx);
                 let result = {
                     let mut guard = rule.shared_lock().write();
                     f(&mut *pdb.borrow().write_with(&mut guard), &mut changed)

--- a/components/script/dom/css/cssstylerule.rs
+++ b/components/script/dom/css/cssstylerule.rs
@@ -143,7 +143,7 @@ impl CSSStyleRuleMethods<crate::DomTypeHolder> for CSSStyleRule {
     }
 
     /// <https://drafts.csswg.org/cssom/#dom-cssstylerule-selectortext>
-    fn SetSelectorText(&self, value: DOMString) {
+    fn SetSelectorText(&self, cx: &mut JSContext, value: DOMString) {
         let value = value.str();
         let Ok(mut selector) = ({
             let guard = self.css_grouping_rule.shared_lock().read();
@@ -168,7 +168,7 @@ impl CSSStyleRuleMethods<crate::DomTypeHolder> for CSSStyleRule {
         }) else {
             return;
         };
-        self.css_grouping_rule.parent_stylesheet().will_modify();
+        self.css_grouping_rule.parent_stylesheet().will_modify(cx);
         // This mirrors what we do in CSSStyleOwner::mutate_associated_block.
         let mut guard = self.css_grouping_rule.shared_lock().write();
         mem::swap(

--- a/components/script/dom/css/cssstylesheet.rs
+++ b/components/script/dom/css/cssstylesheet.rs
@@ -260,7 +260,7 @@ impl CSSStyleSheet {
         }
     }
 
-    pub(crate) fn will_modify(&self) {
+    pub(crate) fn will_modify(&self, cx: &mut JSContext) {
         let Some(node) = self.owner_node.get() else {
             return;
         };
@@ -269,7 +269,7 @@ impl CSSStyleSheet {
             return;
         };
 
-        node.will_modify_stylesheet();
+        node.will_modify_stylesheet(cx);
     }
 
     pub(crate) fn update_style_stylesheet(
@@ -306,12 +306,12 @@ impl CSSStyleSheet {
     }
 
     /// <https://drafts.csswg.org/cssom/#dom-cssstylesheet-replacesync> Steps 2+
-    fn do_replace_sync(&self, text: USVString) {
+    fn do_replace_sync(&self, cx: &mut JSContext, text: USVString) {
         // Step 2. Let rules be the result of running parse a stylesheet’s contents from text.
         let global = self.global();
         let window = global.as_window();
 
-        self.will_modify();
+        self.will_modify(cx);
 
         let _span = profile_traits::trace_span!("ParseStylesheet").entered();
         let sheet = self.style_stylesheet();
@@ -432,7 +432,7 @@ impl CSSStyleSheetMethods<crate::DomTypeHolder> for CSSStyleSheet {
                 "This method can only be called on modifiable style sheets".to_string(),
             )));
         }
-        self.rulelist(cx).remove_rule(index)
+        self.rulelist(cx).remove_rule(cx, index)
     }
 
     /// <https://drafts.csswg.org/cssom/#dom-cssstylesheet-rules>
@@ -510,7 +510,7 @@ impl CSSStyleSheetMethods<crate::DomTypeHolder> for CSSStyleSheet {
                 let sheet = trusted_sheet.root();
 
                 // Step 4.1..4.3
-                sheet.do_replace_sync(text);
+                sheet.do_replace_sync(cx, text);
 
                 // Step 4.4. Unset sheet’s disallow modification flag.
                 sheet.disallow_modification.set(false);
@@ -523,7 +523,7 @@ impl CSSStyleSheetMethods<crate::DomTypeHolder> for CSSStyleSheet {
     }
 
     /// <https://drafts.csswg.org/cssom/#dom-cssstylesheet-replacesync>
-    fn ReplaceSync(&self, text: USVString) -> Result<(), Error> {
+    fn ReplaceSync(&self, cx: &mut js::context::JSContext, text: USVString) -> Result<(), Error> {
         // Step 1. If the constructed flag is not set, or the disallow modification flag is set,
         // throw a NotAllowedError DOMException.
         if !self.is_constructed() || self.disallow_modification() {
@@ -536,7 +536,7 @@ impl CSSStyleSheetMethods<crate::DomTypeHolder> for CSSStyleSheet {
                 "This method can only be called on modifiable style sheets".to_string(),
             )));
         }
-        self.do_replace_sync(text);
+        self.do_replace_sync(cx, text);
         Ok(())
     }
 }

--- a/components/script/dom/css/fontface.rs
+++ b/components/script/dom/css/fontface.rs
@@ -8,6 +8,7 @@ use std::rc::Rc;
 use cssparser::{Parser, ParserInput};
 use dom_struct::dom_struct;
 use fonts::{FontContext, FontContextWebFontMethods, FontTemplate, LowercaseFontFamilyName};
+use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
@@ -185,11 +186,11 @@ impl ParseErrorReporter for FontFaceErrorReporter {
 impl FontFace {
     /// Construct a [`FontFace`] to be used in the case of failure in parsing the
     /// font face descriptors.
-    fn new_failed_font_face(global: &GlobalScope, can_gc: CanGc) -> Self {
-        let font_status_promise = Promise::new(global, can_gc);
+    fn new_failed_font_face(cx: &mut JSContext, global: &GlobalScope) -> Self {
+        let font_status_promise = Promise::new2(cx, global);
         // If any of them fail to parse correctly, reject font face’s [[FontStatusPromise]] with a
         // DOMException named "SyntaxError"
-        font_status_promise.reject_error(Error::Syntax(None), can_gc);
+        font_status_promise.reject_error_with_cx(cx, Error::Syntax(None));
 
         // set font face’s corresponding attributes to the empty string, and set font face’s status
         // attribute to "error"
@@ -221,11 +222,11 @@ impl FontFace {
     /// If `source` is none then the `FontFace` is being constructed from an `ArrayBuffer`.
     /// The `ArrayBuffer` itself is not relevant for this function.
     fn new_inherited(
+        cx: &mut JSContext,
         global: &GlobalScope,
         family_name: DOMString,
         source: Option<&DOMString>,
         descriptors: &FontFaceDescriptors,
-        can_gc: CanGc,
     ) -> Self {
         // Step 1. Parse the family argument, and the members of the descriptors argument,
         // according to the grammars of the corresponding descriptors of the CSS @font-face rule If
@@ -238,11 +239,11 @@ impl FontFace {
             // [[FontStatusPromise]] with a DOMException named "SyntaxError", set font face’s
             // corresponding attributes to the empty string, and set font face’s status attribute
             // to "error".
-            return Self::new_failed_font_face(global, can_gc);
+            return Self::new_failed_font_face(cx, global);
         };
 
         // Set its internal [[FontStatusPromise]] slot to a fresh pending Promise object.
-        let font_status_promise = Promise::new(global, can_gc);
+        let font_status_promise = Promise::new2(cx, global);
 
         let sources = parsed_font_face_rule.descriptors.src.clone();
 
@@ -268,12 +269,12 @@ impl FontFace {
 
     /// <https://drafts.csswg.org/css-font-loading/#font-face-constructor>
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
         font_family: DOMString,
         source: StringOrArrayBufferViewOrArrayBuffer,
         descriptors: &FontFaceDescriptors,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
         let url_source = if let StringOrArrayBufferViewOrArrayBuffer::String(source) = &source {
             Some(source)
@@ -283,15 +284,15 @@ impl FontFace {
 
         let font_face_rule = reflect_dom_object_with_proto(
             Box::new(Self::new_inherited(
+                cx,
                 global,
                 font_family,
                 url_source,
                 descriptors,
-                can_gc,
             )),
             global,
             proto,
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         // Step 2. If the source argument was a BufferSource, set font face’s internal
@@ -312,11 +313,11 @@ impl FontFace {
             .task_manager()
             .font_loading_task_source()
             .queue(task!(
-                load_font_from_arraybuffer: move || {
+                load_font_from_arraybuffer: move |cx| {
                     let font_face_rule = trusted_font_face_rule.root();
                     let global = trusted_global.root();
 
-                    font_face_rule.load_from_data(&global, font_face_bytes);
+                    font_face_rule.load_from_data(cx, &global, font_face_bytes);
                 }
             ));
 
@@ -324,7 +325,7 @@ impl FontFace {
     }
 
     /// Step 3 of <https://drafts.csswg.org/css-font-loading/#font-face-constructor>
-    fn load_from_data(&self, global: &GlobalScope, data: Vec<u8>) {
+    fn load_from_data(&self, cx: &mut JSContext, global: &GlobalScope, data: Vec<u8>) {
         let parsed_font_face_rule = self.font_face_rule(global);
 
         // Step 3.1 Set font face’s status attribute to "loading".
@@ -332,7 +333,7 @@ impl FontFace {
 
         // Step 3.2 For each FontFaceSet font face is in:
         if let Some(font_face_set) = self.font_face_set.get() {
-            font_face_set.handle_font_face_status_changed(self);
+            font_face_set.handle_font_face_status_changed(cx, self);
         }
 
         // Asynchronously, attempt to parse the data in it as a font. When this is completed,
@@ -357,7 +358,7 @@ impl FontFace {
                 // Remove font face from the FontFaceSet’s [[LoadingFonts]] list.
                 // If font was the last item in that list (and so the list is now empty),
                 // switch the FontFaceSet to loaded.
-                font_face_set.handle_font_face_status_changed(self);
+                font_face_set.handle_font_face_status_changed(cx, self);
             }
         } else {
             // Step 2. Otherwise, reject font face’s [[FontStatusPromise]] with a DOMException named "SyntaxError"
@@ -372,17 +373,13 @@ impl FontFace {
                 // Remove font face from the FontFaceSet’s [[LoadingFonts]] list.
                 // If font was the last item in that list (and so the list is now empty),
                 // switch the FontFaceSet to loaded.
-                font_face_set.handle_font_face_status_changed(self);
+                font_face_set.handle_font_face_status_changed(cx, self);
             }
         }
     }
 
     pub(super) fn set_associated_font_face_set(&self, font_face_set: &FontFaceSet) {
         self.font_face_set.set(Some(font_face_set));
-    }
-
-    pub(super) fn loaded(&self) -> bool {
-        self.status.get() == FontFaceLoadStatus::Loaded
     }
 
     pub(super) fn template(&self) -> Option<(LowercaseFontFamilyName, FontTemplate)> {
@@ -566,7 +563,7 @@ impl FontFaceMethods<crate::DomTypeHolder> for FontFace {
     /// load. For fonts constructed from a buffer source, or fonts that are already loading or
     /// loaded, it does nothing.
     /// <https://drafts.csswg.org/css-font-loading/#font-face-load>
-    fn Load(&self) -> Rc<Promise> {
+    fn Load(&self, cx: &mut JSContext) -> Rc<Promise> {
         let Some(sources) = self.urls.borrow_mut().take() else {
             // Step 2. If font face’s [[Urls]] slot is null, or its status attribute is anything
             // other than "unloaded", return font face’s [[FontStatusPromise]] and abort these
@@ -620,7 +617,7 @@ impl FontFaceMethods<crate::DomTypeHolder> for FontFace {
                         // This implements steps 5.1.1, 5.1.2, 5.2.1 and 5.2.2 - these
                         // take care of changing the status of the `FontFaceSet` in which this
                         // `FontFace` is a member, for both failed and successful load.
-                        font_face_set.handle_font_face_status_changed(&font_face);
+                        font_face_set.handle_font_face_status_changed(cx, &font_face);
                     }
                 }));
             },
@@ -648,6 +645,14 @@ impl FontFaceMethods<crate::DomTypeHolder> for FontFace {
         // Step 3. Set font face’s status attribute to "loading", return font face’s
         // [[FontStatusPromise]], and continue executing the rest of this algorithm asynchronously.
         self.status.set(FontFaceLoadStatus::Loading);
+
+        // See <https://github.com/w3c/csswg-drafts/issues/13235>:
+        // All browsers switch the FontFaceSet to loading, but this is currently missing
+        // from the specification.
+        if let Some(font_face_set) = self.font_face_set.get() {
+            font_face_set.handle_font_face_status_changed(cx, self);
+        }
+
         self.font_status_promise.clone()
     }
 
@@ -658,14 +663,14 @@ impl FontFaceMethods<crate::DomTypeHolder> for FontFace {
 
     /// <https://drafts.csswg.org/css-font-loading/#font-face-constructor>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         family: DOMString,
         source: UnionTypes::StringOrArrayBufferViewOrArrayBuffer,
         descriptors: &FontFaceDescriptors,
     ) -> DomRoot<FontFace> {
         let global = window.as_global_scope();
-        FontFace::new(global, proto, family, source, descriptors, can_gc)
+        FontFace::new(cx, global, proto, family, source, descriptors)
     }
 }

--- a/components/script/dom/css/fontfaceset.rs
+++ b/components/script/dom/css/fontfaceset.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::cell::RefCell;
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
@@ -9,6 +10,9 @@ use fonts::FontContextWebFontMethods;
 use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
+use script_bindings::codegen::GenericBindings::FontFaceBinding::{
+    FontFaceLoadStatus, FontFaceMethods,
+};
 use script_bindings::like::Setlike;
 use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 
@@ -31,7 +35,7 @@ pub(crate) struct FontFaceSet {
 
     /// <https://drafts.csswg.org/css-font-loading/#dom-fontfaceset-readypromise-slot>
     #[conditional_malloc_size_of]
-    promise: Rc<Promise>,
+    promise: RefCell<Rc<Promise>>,
 
     set_entries: DomRefCell<Vec<Dom<FontFace>>>,
 }
@@ -40,7 +44,7 @@ impl FontFaceSet {
     fn new_inherited(cx: &mut JSContext, global: &GlobalScope) -> Self {
         FontFaceSet {
             target: EventTarget::new_inherited(),
-            promise: Promise::new2(cx, global),
+            promise: Promise::new2(cx, global).into(),
             set_entries: Default::default(),
         }
     }
@@ -58,33 +62,40 @@ impl FontFaceSet {
         )
     }
 
-    pub(super) fn handle_font_face_status_changed(&self, font_face: &FontFace) {
-        if font_face.loaded() {
-            let Some(window) = DomRoot::downcast::<Window>(self.global()) else {
-                return;
-            };
+    pub(super) fn handle_font_face_status_changed(&self, cx: &mut JSContext, font_face: &FontFace) {
+        match font_face.Status() {
+            FontFaceLoadStatus::Loading => {
+                self.switch_to_loading(cx);
+            },
+            FontFaceLoadStatus::Loaded => {
+                let Some(window) = DomRoot::downcast::<Window>(self.global()) else {
+                    return;
+                };
 
-            let (family_name, template) = font_face
-                .template()
-                .expect("A loaded web font should have a template");
-            window
-                .font_context()
-                .add_template_to_font_context(family_name, template);
-            window.Document().dirty_all_nodes();
+                let (family_name, template) = font_face
+                    .template()
+                    .expect("A loaded web font should have a template");
+                window
+                    .font_context()
+                    .add_template_to_font_context(family_name, template);
+                window.Document().dirty_all_nodes();
+            },
+            _ => {},
         }
     }
 
     /// Fulfill the font ready promise, returning true if it was not already fulfilled beforehand.
     pub(crate) fn fulfill_ready_promise_if_needed(&self, cx: &mut JSContext) -> bool {
-        if self.promise.is_fulfilled() {
+        let promise = self.promise.borrow().clone();
+        if promise.is_fulfilled() {
             return false;
         }
-        self.promise.resolve_native_with_cx(cx, self);
+        promise.resolve_native_with_cx(cx, self);
         true
     }
 
     pub(crate) fn waiting_to_fullfill_promise(&self) -> bool {
-        !self.promise.is_fulfilled()
+        !self.promise.borrow().is_fulfilled()
     }
 
     fn contains_face(&self, target: &FontFace) -> bool {
@@ -103,16 +114,34 @@ impl FontFaceSet {
         set_entries.remove(index);
         true
     }
+
+    /// <https://drafts.csswg.org/css-font-loading/#switch-the-fontfaceset-to-loading>
+    pub(crate) fn switch_to_loading(&self, cx: &mut JSContext) {
+        // Step 1. Let font face set be the given FontFaceSet.
+        // Note: This is self.
+
+        // Step 2. Set the status attribute of font face set to "loading".
+        // TODO: Implement the FontFaceSet status attribute.
+
+        // Step 3. If font face set’s [[ReadyPromise]] slot currently holds a fulfilled
+        // promise, replace it with a fresh pending promise.
+        if self.promise.borrow().is_fulfilled() {
+            *self.promise.borrow_mut() = Promise::new2(cx, &self.global());
+        }
+
+        // Step 4. Queue a task to fire a font load event named loading at font face set.
+        // TODO: Implement support for font loading events.
+    }
 }
 
 impl FontFaceSetMethods<crate::DomTypeHolder> for FontFaceSet {
     /// <https://drafts.csswg.org/css-font-loading/#dom-fontfaceset-ready>
     fn Ready(&self) -> Rc<Promise> {
-        self.promise.clone()
+        self.promise.borrow().clone()
     }
 
     /// <https://drafts.csswg.org/css-font-loading/#dom-fontfaceset-add>
-    fn Add(&self, font_face: &FontFace) -> DomRoot<FontFaceSet> {
+    fn Add(&self, cx: &mut JSContext, font_face: &FontFace) -> DomRoot<FontFaceSet> {
         // Step 1. If font is already in the FontFaceSet’s set entries,
         // skip to the last step of this algorithm immediately.
         if self.contains_face(font_face) {
@@ -129,7 +158,7 @@ impl FontFaceSetMethods<crate::DomTypeHolder> for FontFaceSet {
         // Step 4. If font’s status attribute is "loading":
         // Step 4.1 If the FontFaceSet’s [[LoadingFonts]] list is empty, switch the FontFaceSet to loading.
         // Step 4.2 Append font to the FontFaceSet’s [[LoadingFonts]] list.
-        self.handle_font_face_status_changed(font_face);
+        self.handle_font_face_status_changed(cx, font_face);
 
         // Step 5. Return the FontFaceSet.
         DomRoot::from_ref(self)
@@ -158,12 +187,7 @@ impl FontFaceSetMethods<crate::DomTypeHolder> for FontFaceSet {
     }
 
     /// <https://drafts.csswg.org/css-font-loading/#dom-fontfaceset-load>
-    fn Load(
-        &self,
-        cx: &mut js::context::JSContext,
-        _font: DOMString,
-        _text: DOMString,
-    ) -> Rc<Promise> {
+    fn Load(&self, cx: &mut JSContext, _font: DOMString, _text: DOMString) -> Rc<Promise> {
         // Step 1. Let font face set be the FontFaceSet object this method was called on. Let
         // promise be a newly-created promise object.
         let promise = Promise::new2(cx, &self.global());

--- a/components/script/dom/css/stylesheetlist.rs
+++ b/components/script/dom/css/stylesheetlist.rs
@@ -40,22 +40,33 @@ impl StyleSheetListOwner {
         }
     }
 
-    pub(crate) fn add_owned_stylesheet(&self, owner_node: &Element, sheet: Arc<Stylesheet>) {
+    pub(crate) fn add_owned_stylesheet(
+        &self,
+        cx: &mut js::context::JSContext,
+        owner_node: &Element,
+        sheet: Arc<Stylesheet>,
+    ) {
         match *self {
-            StyleSheetListOwner::Document(ref doc) => doc.add_owned_stylesheet(owner_node, sheet),
+            StyleSheetListOwner::Document(ref doc) => {
+                doc.add_owned_stylesheet(cx, owner_node, sheet)
+            },
             StyleSheetListOwner::ShadowRoot(ref shadow_root) => {
-                shadow_root.add_owned_stylesheet(owner_node, sheet)
+                shadow_root.add_owned_stylesheet(cx, owner_node, sheet)
             },
         }
     }
 
-    pub(crate) fn append_constructed_stylesheet(&self, cssom_stylesheet: &CSSStyleSheet) {
+    pub(crate) fn append_constructed_stylesheet(
+        &self,
+        cx: &mut js::context::JSContext,
+        cssom_stylesheet: &CSSStyleSheet,
+    ) {
         match *self {
             StyleSheetListOwner::Document(ref doc) => {
-                doc.append_constructed_stylesheet(cssom_stylesheet)
+                doc.append_constructed_stylesheet(cx, cssom_stylesheet)
             },
             StyleSheetListOwner::ShadowRoot(ref shadow_root) => {
-                shadow_root.append_constructed_stylesheet(cssom_stylesheet)
+                shadow_root.append_constructed_stylesheet(cx, cssom_stylesheet)
             },
         }
     }

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -25,7 +25,6 @@ use embedder_traits::{
     AllowOrDeny, AnimationState, CustomHandlersAutomationMode, EmbedderMsg, Image, LoadStatus,
 };
 use encoding_rs::{Encoding, UTF_8};
-use fonts::WebFontDocumentContext;
 use html5ever::{LocalName, Namespace, QualName, local_name, ns};
 use hyper_serde::Serde;
 use js::realm::CurrentRealm;
@@ -4293,7 +4292,12 @@ impl Document {
     ///
     /// <https://drafts.csswg.org/cssom/#documentorshadowroot-final-css-style-sheets>
     #[cfg_attr(crown, expect(crown::unrooted_must_root))] // Owner needs to be rooted already necessarily.
-    pub(crate) fn add_owned_stylesheet(&self, owner_node: &Element, sheet: Arc<Stylesheet>) {
+    pub(crate) fn add_owned_stylesheet(
+        &self,
+        cx: &mut js::context::JSContext,
+        owner_node: &Element,
+        sheet: Arc<Stylesheet>,
+    ) {
         let stylesheets = &mut *self.stylesheets.borrow_mut();
 
         // FIXME(stevennovaryo): This is almost identical with the one in ShadowRoot::add_stylesheet.
@@ -4313,12 +4317,10 @@ impl Document {
             .cloned();
 
         if self.has_browsing_context() {
-            let document_context = self.window.web_font_context();
-
-            self.window.layout_mut().add_stylesheet(
+            self.add_stylesheet_to_stylist(
+                cx,
                 sheet.clone(),
                 insertion_point.as_ref().map(|s| s.sheet.clone()),
-                &document_context,
             );
         }
 
@@ -4336,7 +4338,11 @@ impl Document {
     ///
     /// <https://drafts.csswg.org/cssom/#documentorshadowroot-final-css-style-sheets>
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
-    pub(crate) fn append_constructed_stylesheet(&self, cssom_stylesheet: &CSSStyleSheet) {
+    pub(crate) fn append_constructed_stylesheet(
+        &self,
+        cx: &mut js::context::JSContext,
+        cssom_stylesheet: &CSSStyleSheet,
+    ) {
         debug_assert!(cssom_stylesheet.is_constructed());
 
         let stylesheets = &mut *self.stylesheets.borrow_mut();
@@ -4349,10 +4355,10 @@ impl Document {
             .cloned();
 
         if self.has_browsing_context() {
-            self.window.layout_mut().add_stylesheet(
+            self.add_stylesheet_to_stylist(
+                cx,
                 sheet.clone(),
                 insertion_point.as_ref().map(|s| s.sheet.clone()),
-                &self.window.web_font_context(),
             );
         }
 
@@ -4365,15 +4371,38 @@ impl Document {
         );
     }
 
+    fn switch_font_face_set_to_loading_if_needed(&self, cx: &mut js::context::JSContext) {
+        if self.window.font_context().web_fonts_still_loading() != 0 &&
+            let Some(font_face_set) = self.fonts.get()
+        {
+            font_face_set.switch_to_loading(cx);
+        }
+    }
+
     /// Given a stylesheet, load all web fonts from it in Layout.
     pub(crate) fn load_web_fonts_from_stylesheet(
         &self,
+        cx: &mut js::context::JSContext,
         stylesheet: &Arc<Stylesheet>,
-        document_context: &WebFontDocumentContext,
     ) {
         self.window
             .layout()
-            .load_web_fonts_from_stylesheet(stylesheet, document_context);
+            .load_web_fonts_from_stylesheet(stylesheet, &self.window.web_font_context());
+        self.switch_font_face_set_to_loading_if_needed(cx);
+    }
+
+    pub(crate) fn add_stylesheet_to_stylist(
+        &self,
+        cx: &mut js::context::JSContext,
+        stylesheet: Arc<Stylesheet>,
+        before_stylesheet: Option<Arc<Stylesheet>>,
+    ) {
+        self.window.layout_mut().add_stylesheet(
+            stylesheet,
+            before_stylesheet,
+            &self.window.web_font_context(),
+        );
+        self.switch_font_face_set_to_loading_if_needed(cx);
     }
 
     /// Remove a stylesheet owned by `owner` from the list of document sheets.
@@ -6483,16 +6512,14 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     /// <https://drafts.csswg.org/cssom/#dom-documentorshadowroot-adoptedstylesheets>
     fn SetAdoptedStyleSheets(
         &self,
-        context: JSContext,
+        cx: &mut js::context::JSContext,
         val: HandleValue,
-        can_gc: CanGc,
     ) -> ErrorResult {
         let result = DocumentOrShadowRoot::set_adopted_stylesheet_from_jsval(
-            context,
+            cx,
             self.adopted_stylesheets.borrow_mut().as_mut(),
             val,
             &StyleSheetListOwner::Document(Dom::from_ref(self)),
-            can_gc,
         );
 
         // If update is successful, clear the FrozenArray cache.

--- a/components/script/dom/document/documentorshadowroot.rs
+++ b/components/script/dom/document/documentorshadowroot.rs
@@ -7,13 +7,14 @@ use std::ffi::c_void;
 use std::fmt;
 
 use embedder_traits::UntrustedNodeAddress;
+use js::context::JSContext;
 use js::rust::HandleValue;
 use rustc_hash::FxBuildHasher;
 use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::DocumentBinding::DocumentMethods;
 use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
 use script_bindings::error::{Error, ErrorResult};
-use script_bindings::script_runtime::{CanGc, JSContext};
+use script_bindings::script_runtime::CanGc;
 use servo_arc::Arc;
 use servo_config::pref;
 use style::media_queries::MediaList;
@@ -374,6 +375,7 @@ impl DocumentOrShadowRoot {
     // TODO: Handle duplicated adoptedstylesheet correctly, Stylo is preventing duplicates inside a
     //       Stylesheet Set. But this is not ideal. https://bugzilla.mozilla.org/show_bug.cgi?id=1978755
     fn set_adopted_stylesheet(
+        cx: &mut JSContext,
         adopted_stylesheets: &mut Vec<Dom<CSSStyleSheet>>,
         incoming_stylesheets: &[Dom<CSSStyleSheet>],
         owner: &StyleSheetListOwner,
@@ -432,7 +434,7 @@ impl DocumentOrShadowRoot {
                 sheet.add_adopter(owner.clone());
             }
 
-            owner.append_constructed_stylesheet(sheet);
+            owner.append_constructed_stylesheet(cx, sheet);
         }
 
         *adopted_stylesheets = incoming_stylesheets.to_vec();
@@ -443,20 +445,24 @@ impl DocumentOrShadowRoot {
     /// Set adoptedStylesheet given a js value by converting and passing the converted
     /// values to the inner [DocumentOrShadowRoot::set_adopted_stylesheet].
     pub(crate) fn set_adopted_stylesheet_from_jsval(
-        context: JSContext,
+        cx: &mut JSContext,
         adopted_stylesheets: &mut Vec<Dom<CSSStyleSheet>>,
         incoming_value: HandleValue,
         owner: &StyleSheetListOwner,
-        can_gc: CanGc,
     ) -> ErrorResult {
-        let maybe_stylesheets =
-            Vec::<DomRoot<CSSStyleSheet>>::safe_from_jsval(context, incoming_value, (), can_gc);
+        let maybe_stylesheets = Vec::<DomRoot<CSSStyleSheet>>::safe_from_jsval(
+            cx.into(),
+            incoming_value,
+            (),
+            CanGc::from_cx(cx),
+        );
 
         match maybe_stylesheets {
             Ok(ConversionResult::Success(stylesheets)) => {
                 rooted_vec!(let stylesheets <- stylesheets.iter().map(|s| s.as_traced()));
 
                 DocumentOrShadowRoot::set_adopted_stylesheet(
+                    cx,
                     adopted_stylesheets,
                     &stylesheets,
                     owner,

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -177,7 +177,11 @@ impl HTMLLinkElement {
     // FIXME(emilio): These methods are duplicated with
     // HTMLStyleElement::set_stylesheet.
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
-    pub(crate) fn set_stylesheet(&self, new_stylesheet: Arc<Stylesheet>) {
+    pub(crate) fn set_stylesheet(
+        &self,
+        cx: &mut js::context::JSContext,
+        new_stylesheet: Arc<Stylesheet>,
+    ) {
         let owner = self.stylesheet_list_owner();
         if let Some(old_stylesheet) = self.stylesheet.borrow_mut().replace(new_stylesheet.clone()) {
             owner.remove_stylesheet(
@@ -185,7 +189,7 @@ impl HTMLLinkElement {
                 &old_stylesheet,
             );
         }
-        owner.add_owned_stylesheet(self.upcast(), new_stylesheet);
+        owner.add_owned_stylesheet(cx, self.upcast(), new_stylesheet);
     }
 
     pub(crate) fn get_stylesheet(&self) -> Option<Arc<Stylesheet>> {

--- a/components/script/dom/html/htmlstyleelement.rs
+++ b/components/script/dom/html/htmlstyleelement.rs
@@ -80,7 +80,7 @@ impl HTMLStyleElement {
     }
 
     pub(crate) fn new(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
@@ -103,7 +103,7 @@ impl HTMLStyleElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#update-a-style-block>
-    pub(crate) fn update_a_style_block(&self) {
+    pub(crate) fn update_a_style_block(&self, cx: &mut JSContext) {
         // Step 1. Let element be the style element.
         //
         // That's self
@@ -210,7 +210,7 @@ impl HTMLStyleElement {
 
         // Finally, update our stylesheet, regardless of which scenario we ran into
         self.clean_stylesheet_ownership();
-        self.set_stylesheet(sheet, cache_key);
+        self.set_stylesheet(cx, sheet, cache_key);
     }
 
     // FIXME(emilio): This is duplicated with HTMLLinkElement::set_stylesheet.
@@ -219,23 +219,24 @@ impl HTMLStyleElement {
     // this function has a bit difference with `HTMLLinkElement::set_stylesheet` now.
     pub(crate) fn set_stylesheet(
         &self,
+        cx: &mut JSContext,
         s: Arc<Stylesheet>,
         cache_key: Option<StylesheetContentsCacheKey>,
     ) {
         *self.stylesheet.borrow_mut() = Some(s.clone());
         *self.stylesheetcontents_cache_key.borrow_mut() = cache_key;
         self.stylesheet_list_owner()
-            .add_owned_stylesheet(self.upcast(), s);
+            .add_owned_stylesheet(cx, self.upcast(), s);
     }
 
-    pub(crate) fn will_modify_stylesheet(&self) {
+    pub(crate) fn will_modify_stylesheet(&self, cx: &mut JSContext) {
         if let Some(stylesheet_with_owned_contents) = self.create_owned_contents_stylesheet() {
             self.remove_stylesheet();
             if let Some(cssom_stylesheet) = self.cssom_stylesheet.get() {
                 let guard = stylesheet_with_owned_contents.shared_lock.read();
                 cssom_stylesheet.update_style_stylesheet(&stylesheet_with_owned_contents, &guard);
             }
-            self.set_stylesheet(stylesheet_with_owned_contents, None);
+            self.set_stylesheet(cx, stylesheet_with_owned_contents, None);
         }
     }
 
@@ -324,7 +325,7 @@ impl VirtualMethods for HTMLStyleElement {
         // https://html.spec.whatwg.org/multipage/#update-a-style-block
         // > The element is not on the stack of open elements of an HTML parser or XML parser, and its children changed steps run.
         if !self.in_stack_of_open_elements.get() {
-            self.update_a_style_block();
+            self.update_a_style_block(cx);
         }
     }
 
@@ -334,7 +335,7 @@ impl VirtualMethods for HTMLStyleElement {
         // https://html.spec.whatwg.org/multipage/#update-a-style-block
         // > The element is not on the stack of open elements of an HTML parser or XML parser, and it becomes connected or disconnected.
         if !self.in_stack_of_open_elements.get() {
-            self.update_a_style_block();
+            self.update_a_style_block(cx);
         }
     }
 
@@ -344,7 +345,7 @@ impl VirtualMethods for HTMLStyleElement {
 
         // https://html.spec.whatwg.org/multipage/#update-a-style-block
         // > The element is popped off the stack of open elements of an HTML parser or XML parser.
-        self.update_a_style_block();
+        self.update_a_style_block(cx);
     }
 
     fn unbind_from_tree(&self, cx: &mut js::context::JSContext, context: &UnbindContext) {
@@ -355,7 +356,7 @@ impl VirtualMethods for HTMLStyleElement {
         // https://html.spec.whatwg.org/multipage/#update-a-style-block
         // > The element is not on the stack of open elements of an HTML parser or XML parser, and it becomes connected or disconnected.
         if !self.in_stack_of_open_elements.get() {
-            self.update_a_style_block();
+            self.update_a_style_block(cx);
         }
     }
 
@@ -383,7 +384,7 @@ impl VirtualMethods for HTMLStyleElement {
                 return;
             }
             self.remove_stylesheet();
-            self.update_a_style_block();
+            self.update_a_style_block(cx);
         } else if attr.name() == "media" &&
             let Some(ref stylesheet) = *self.stylesheet.borrow_mut()
         {

--- a/components/script/dom/media/medialist.rs
+++ b/components/script/dom/media/medialist.rs
@@ -156,8 +156,8 @@ impl MediaListMethods<crate::DomTypeHolder> for MediaList {
     }
 
     /// <https://drafts.csswg.org/cssom/#dom-medialist-mediatext>
-    fn SetMediaText(&self, value: DOMString) {
-        self.parent_stylesheet.will_modify();
+    fn SetMediaText(&self, cx: &mut JSContext, value: DOMString) {
+        self.parent_stylesheet.will_modify(cx);
         let global = self.global();
         let mut guard = self.shared_lock().write();
         let media_queries_borrowed = self.media_queries.borrow();
@@ -193,7 +193,7 @@ impl MediaListMethods<crate::DomTypeHolder> for MediaList {
     }
 
     /// <https://drafts.csswg.org/cssom/#dom-medialist-appendmedium>
-    fn AppendMedium(&self, medium: DOMString) {
+    fn AppendMedium(&self, cx: &mut JSContext, medium: DOMString) {
         // Step 1
         let global = self.global();
         let medium = medium.str();
@@ -218,7 +218,7 @@ impl MediaListMethods<crate::DomTypeHolder> for MediaList {
             }
         }
         // Step 4
-        self.parent_stylesheet.will_modify();
+        self.parent_stylesheet.will_modify(cx);
         let mut guard = self.shared_lock().write();
         self.media_queries
             .borrow()
@@ -229,7 +229,7 @@ impl MediaListMethods<crate::DomTypeHolder> for MediaList {
     }
 
     /// <https://drafts.csswg.org/cssom/#dom-medialist-deletemedium>
-    fn DeleteMedium(&self, medium: DOMString) {
+    fn DeleteMedium(&self, cx: &mut JSContext, medium: DOMString) {
         // Step 1
         let global = self.global();
         let medium = medium.str();
@@ -239,7 +239,7 @@ impl MediaListMethods<crate::DomTypeHolder> for MediaList {
             return;
         }
         // Step 3
-        self.parent_stylesheet.will_modify();
+        self.parent_stylesheet.will_modify(cx);
         let m_serialized = m.unwrap().to_css_string();
         let mut guard = self.shared_lock().write();
         let media_queries_borrowed = self.media_queries.borrow();

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -202,7 +202,12 @@ impl ShadowRoot {
     ///
     /// <https://drafts.csswg.org/cssom/#documentorshadowroot-final-css-style-sheets>
     #[cfg_attr(crown, expect(crown::unrooted_must_root))] // Owner needs to be rooted already necessarily.
-    pub(crate) fn add_owned_stylesheet(&self, owner_node: &Element, sheet: Arc<Stylesheet>) {
+    pub(crate) fn add_owned_stylesheet(
+        &self,
+        cx: &mut js::context::JSContext,
+        owner_node: &Element,
+        sheet: Arc<Stylesheet>,
+    ) {
         let stylesheets = &mut self.author_styles.borrow_mut().stylesheets;
 
         // FIXME(stevennovaryo): This is almost identical with the one in Document::add_stylesheet.
@@ -221,10 +226,7 @@ impl ShadowRoot {
             .cloned();
 
         if self.document.has_browsing_context() {
-            let document_context = self.window.web_font_context();
-            self.window
-                .layout_mut()
-                .load_web_fonts_from_stylesheet(&sheet, &document_context);
+            self.document.load_web_fonts_from_stylesheet(cx, &sheet);
         }
 
         DocumentOrShadowRoot::add_stylesheet(
@@ -238,7 +240,11 @@ impl ShadowRoot {
 
     /// Append a constructed stylesheet to the back of shadow root stylesheet set.
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
-    pub(crate) fn append_constructed_stylesheet(&self, cssom_stylesheet: &CSSStyleSheet) {
+    pub(crate) fn append_constructed_stylesheet(
+        &self,
+        cx: &mut js::context::JSContext,
+        cssom_stylesheet: &CSSStyleSheet,
+    ) {
         debug_assert!(cssom_stylesheet.is_constructed());
 
         let stylesheets = &mut self.author_styles.borrow_mut().stylesheets;
@@ -247,10 +253,7 @@ impl ShadowRoot {
         let insertion_point = stylesheets.iter().last().cloned();
 
         if self.document.has_browsing_context() {
-            let document_context = self.window.web_font_context();
-            self.window
-                .layout_mut()
-                .load_web_fonts_from_stylesheet(&sheet, &document_context);
+            self.document.load_web_fonts_from_stylesheet(cx, &sheet);
         }
 
         DocumentOrShadowRoot::add_stylesheet(
@@ -593,16 +596,14 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
     /// <https://drafts.csswg.org/cssom/#dom-documentorshadowroot-adoptedstylesheets>
     fn SetAdoptedStyleSheets(
         &self,
-        context: JSContext,
+        cx: &mut js::context::JSContext,
         val: HandleValue,
-        can_gc: CanGc,
     ) -> ErrorResult {
         let result = DocumentOrShadowRoot::set_adopted_stylesheet_from_jsval(
-            context,
+            cx,
             self.adopted_stylesheets.borrow_mut().as_mut(),
             val,
             &StyleSheetListOwner::ShadowRoot(Dom::from_ref(self)),
-            can_gc,
         );
 
         // If update is successful, clear the FrozenArray cache.

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -284,16 +284,12 @@ impl StylesheetContext {
                 //
                 // Note that even in the failure case, we should create an empty stylesheet.
                 // That's why `set_stylesheet` also removes the previous stylesheet
-                link.set_stylesheet(stylesheet);
+                link.set_stylesheet(cx, stylesheet);
             },
             StylesheetContextSource::Import(import_rule) => {
-                // Construct a new WebFontDocumentContext for the stylesheet
-                let window = element.owner_window();
-                let document_context = window.web_font_context();
-
                 // Layout knows about this stylesheet, because Stylo added it to the Stylist,
                 // but Layout doesn't know about any new web fonts that it contains.
-                document.load_web_fonts_from_stylesheet(&stylesheet, &document_context);
+                document.load_web_fonts_from_stylesheet(cx, &stylesheet);
 
                 let mut guard = document.style_shared_author_lock().write();
                 import_rule.write_with(&mut guard).stylesheet = ImportSheet::Sheet(stylesheet);

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -174,7 +174,7 @@ DOMInterfaces = {
 },
 
 'CSSKeyframesRule': {
-    'cx': ['AppendRule', 'CssRules', 'DeleteRule', 'FindRule'],
+    'cx': ['AppendRule', 'CssRules', 'DeleteRule', 'FindRule', 'SetName'],
 },
 
 'CSSLayerStatementRule': {
@@ -194,12 +194,20 @@ DOMInterfaces = {
 },
 
 'CSSStyleRule': {
-    'cx': ['Style'],
+    'cx': ['SetSelectorText', 'Style'],
 },
 
 'CSSStyleSheet': {
     'realm': ['Replace'],
-    'cx': ['AddRule', 'DeleteRule', 'GetCssRules', 'GetRules', 'InsertRule', 'RemoveRule'],
+    'cx': [
+        'AddRule',
+        'DeleteRule',
+        'GetCssRules',
+        'GetRules',
+        'InsertRule',
+        'ReplaceSync',
+        'RemoveRule'
+    ],
 },
 
 'Crypto': {
@@ -242,7 +250,7 @@ DOMInterfaces = {
 
 'Document': {
     'additionalTraits': ["crate::interfaces::DocumentHelpers"],
-    'canGc': ['CreateRange', 'ExitFullscreen', 'StyleSheets', 'Implementation', 'CreateNodeIterator', 'GetElementsByName', 'AdoptedStyleSheets', 'SetAdoptedStyleSheets'],
+    'canGc': ['CreateRange', 'ExitFullscreen', 'StyleSheets', 'Implementation', 'CreateNodeIterator', 'GetElementsByName', 'AdoptedStyleSheets'],
     'cx': [
         'AdoptNode',
         'Append',
@@ -294,6 +302,7 @@ DOMInterfaces = {
         'Children',
         'GetSelection',
         'NamedGetter',
+        'SetAdoptedStyleSheets',
         'SetBgColor',
         'SetFgColor',
     ],
@@ -392,8 +401,12 @@ DOMInterfaces = {
     'canGc': ['ReadAsArrayBuffer'],
 },
 
+'FontFace': {
+    'cx': ['Constructor', 'Load'],
+},
+
 'FontFaceSet': {
-    'cx': ['Load'],
+    'cx': ['Add', 'Load'],
 },
 
 'FormData': {
@@ -751,6 +764,14 @@ DOMInterfaces = {
     'cx': ['Constructor'],
 },
 
+'MediaList': {
+    'cx': [
+        'AppendMedium',
+        'DeleteMedium',
+        'SetMediaText',
+    ],
+},
+
 'MediaStreamAudioSourceNode': {
     'cx': ['Constructor'],
 },
@@ -954,8 +975,15 @@ DOMInterfaces = {
 },
 
 'ShadowRoot': {
-    'canGc': ['AdoptedStyleSheets', 'SetAdoptedStyleSheets'],
-    'cx': ['GetHTML', 'GetInnerHTML', 'SetHTMLUnsafe', 'SetHTML', 'SetInnerHTML'],
+    'canGc': ['AdoptedStyleSheets'],
+    'cx': [
+        'GetHTML',
+        'GetInnerHTML',
+        'SetAdoptedStyleSheets',
+        'SetHTMLUnsafe',
+        'SetHTML',
+        'SetInnerHTML',
+    ],
 },
 
 'StaticRange': {

--- a/tests/wpt/meta/css/css-fonts/generic-family-keywords-001.html.ini
+++ b/tests/wpt/meta/css/css-fonts/generic-family-keywords-001.html.ini
@@ -31,6 +31,3 @@
 
   [@font-face matching for quoted and unquoted math]
     expected: [FAIL, PASS]
-
-  [@font-face matching for quoted and unquoted generic(fangsong)]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/generic-family-keywords-003.html.ini
+++ b/tests/wpt/meta/css/css-fonts/generic-family-keywords-003.html.ini
@@ -8,25 +8,13 @@
   [@font-face matching for quoted and unquoted sans-serif (drawing text in a canvas)]
     expected: FAIL
 
-  [@font-face matching for quoted and unquoted generic(kai) (drawing text in a canvas)]
-    expected: FAIL
-
   [@font-face matching for quoted and unquoted ui-sans-serif (drawing text in a canvas)]
-    expected: FAIL
-
-  [@font-face matching for quoted and unquoted ui-serif (drawing text in a canvas)]
     expected: FAIL
 
   [@font-face matching for quoted and unquoted cursive (drawing text in a canvas)]
     expected: FAIL
 
-  [@font-face matching for quoted and unquoted fantasy (drawing text in a canvas)]
-    expected: FAIL
-
   [@font-face matching for quoted and unquoted monospace (drawing text in a canvas)]
-    expected: FAIL
-
-  [@font-face matching for quoted and unquoted system-ui (drawing text in a canvas)]
     expected: FAIL
 
   [@font-face matching for quoted and unquoted math (drawing text in a canvas)]
@@ -36,7 +24,4 @@
     expected: FAIL
 
   [@font-face matching for quoted and unquoted generic(khmer-mul) (drawing text in a canvas)]
-    expected: FAIL
-
-  [@font-face matching for quoted and unquoted generic(nastaliq) (drawing text in a canvas)]
     expected: FAIL

--- a/tests/wpt/meta/fetch/metadata/generated/css-font-face.https.sub.tentative.html.ini
+++ b/tests/wpt/meta/fetch/metadata/generated/css-font-face.https.sub.tentative.html.ini
@@ -1,51 +1,6 @@
 [css-font-face.https.sub.tentative.html]
-  [sec-fetch-site - Cross-site]
-    expected: FAIL
-
-  [sec-fetch-site - Same site]
-    expected: FAIL
-
-  [sec-fetch-site - Same-Origin -> Cross-Site -> Same-Origin redirect]
-    expected: FAIL
-
   [sec-fetch-site - Same-Origin -> Same-Site -> Same-Origin redirect]
     expected: FAIL
 
-  [sec-fetch-site - Cross-Site -> Same Origin]
-    expected: FAIL
-
-  [sec-fetch-site - Cross-Site -> Same-Site]
-    expected: FAIL
-
-  [sec-fetch-site - Cross-Site -> Cross-Site]
-    expected: FAIL
-
-  [sec-fetch-site - Same-Origin -> Same Origin]
-    expected: FAIL
-
-  [sec-fetch-site - Same-Origin -> Same-Site]
-    expected: FAIL
-
-  [sec-fetch-site - Same-Origin -> Cross-Site]
-    expected: FAIL
-
   [sec-fetch-site - Same-Site -> Same Origin]
-    expected: FAIL
-
-  [sec-fetch-site - Same-Site -> Same-Site]
-    expected: FAIL
-
-  [sec-fetch-site - Same-Site -> Cross-Site]
-    expected: FAIL
-
-  [sec-fetch-user]
-    expected: FAIL
-
-  [sec-fetch-storage-access - Cross-site]
-    expected: FAIL
-
-  [sec-fetch-mode]
-    expected: FAIL
-
-  [sec-fetch-storage-access - Same site]
     expected: FAIL

--- a/tests/wpt/meta/fetch/metadata/generated/css-font-face.sub.tentative.html.ini
+++ b/tests/wpt/meta/fetch/metadata/generated/css-font-face.sub.tentative.html.ini
@@ -43,12 +43,3 @@
 
   [sec-fetch-site - HTTPS downgrade-upgrade]
     expected: [FAIL, PASS]
-
-  [sec-fetch-storage-access - Not sent to non-trustworthy same-origin destination]
-    expected: FAIL
-
-  [sec-fetch-storage-access - Not sent to non-trustworthy same-site destination]
-    expected: FAIL
-
-  [sec-fetch-storage-access - Not sent to non-trustworthy cross-site destination]
-    expected: FAIL

--- a/tests/wpt/meta/preload/preload-resource-match.https.html.ini
+++ b/tests/wpt/meta/preload/preload-resource-match.https.html.ini
@@ -1,0 +1,3 @@
+[preload-resource-match.https.html]
+  [Loading font (same-origin) with link (same-origin) should reuse the preloaded response]
+    expected: FAIL


### PR DESCRIPTION
This change adds an initial implementation of the "switch the
FontFaceSet to loading" steps from the CSS Font Loading specification.
The only thing it does is to reset `document.fonts.ready` so that it can
be waited on again. In addition, this is called when the addition of a
stylesheet or the DOM modification of a `FontFace` or `FontFaceSet`
triggers more font loading. The goal here is to reduce flakiness in the
CSS font loading tests.

Testing: This causes some tests to pass and one to fail (due to missing preload support -- so this is progression actually). The main goal here though is to remove a lot of flakiness.
Fixes: #37467.
Fixes: #40929.
Fixes: #32732.
Fixes: #34624.
