### PR TITLE
android: localise git ignoring of `.gradle`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,9 +43,6 @@ webrender-captures/
 *.iws
 *.iml
 
-## Gradle
-.gradle
-
 ## VSCode
 .vscode
 !/.vscode/extensions.json

--- a/support/android/apk/.gitignore
+++ b/support/android/apk/.gitignore
@@ -1,3 +1,4 @@
+.gradle/
 /assets/
 /bin/
 /gen/

--- a/support/android/apk/buildSrc/.gitignore
+++ b/support/android/apk/buildSrc/.gitignore
@@ -1,2 +1,1 @@
-.gradle/
 build/


### PR DESCRIPTION
I found it confusing that the `support/android/apk/.gradle` was getting gitignored, but wasn't listed in `support/android/apk/.gitignore`, particularly since all the other Gradle related things that should be gitignored were in `support/android/apk/.gitignore`.

Testing: Made sure that all `.gradle`s were still gitignored.
