### PR TITLE
media: Add required feature to servo-media-derive

### DIFF
--- a/components/media/servo-media-derive/Cargo.toml
+++ b/components/media/servo-media-derive/Cargo.toml
@@ -17,4 +17,4 @@ path = "lib.rs"
 [dependencies]
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
-syn = { workspace = true }
+syn = { workspace = true, features = ["proc-macro"] }


### PR DESCRIPTION
During regular servo workspace builds, this feature is already enabled via feature unification. The build fails however when building this crate standalone, since it depends on the feature. Discovered during workspace publish dry-run.

Testing: Standalone builds of crates are not covered in CI. 

