### PR TITLE
script: Using `Fallible<ImportMap>` instead of `ScriptOrigin` in `Script` enum

### DIFF
--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -352,7 +352,7 @@ pub(crate) type ScriptResult = Result<Script, ()>;
 pub(crate) enum Script {
     Classic(ClassicScript),
     Module(#[conditional_malloc_size_of] Rc<ModuleTree>),
-    ImportMap(ScriptOrigin),
+    ImportMap(Fallible<ImportMap>),
 }
 
 /// The context required for asynchronously loading an external script source.
@@ -1014,14 +1014,7 @@ impl HTMLScriptElement {
                         Rc::clone(&text_rc),
                         base_url.clone(),
                     );
-                    let script = Script::ImportMap(ScriptOrigin::internal(
-                        text_rc,
-                        base_url,
-                        options,
-                        script_type,
-                        self.global().unminified_js_dir(),
-                        import_map_result,
-                    ));
+                    let script = Script::ImportMap(import_map_result);
 
                     // Step 34.3
                     self.execute(cx, Ok(script));
@@ -1110,9 +1103,9 @@ impl HTMLScriptElement {
                 self.owner_global()
                     .run_a_module_script(cx, module_tree, false);
             },
-            Script::ImportMap(script) => {
+            Script::ImportMap(import_map) => {
                 // Step 6."importmap".1. Register an import map given el's relevant global object and el's result.
-                register_import_map(cx, &self.owner_global(), script.import_map);
+                register_import_map(cx, &self.owner_global(), import_map);
             },
         }
 

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -348,7 +348,6 @@ pub(crate) type ScriptResult = Result<Script, ()>;
 
 // TODO merge classic and module scripts
 #[derive(JSTraceable, MallocSizeOf)]
-#[expect(clippy::large_enum_variant)]
 pub(crate) enum Script {
     Classic(ClassicScript),
     Module(#[conditional_malloc_size_of] Rc<ModuleTree>),
@@ -1008,12 +1007,8 @@ impl HTMLScriptElement {
                 ScriptType::ImportMap => {
                     // Step 32.1 Let result be the result of creating an import map
                     // parse result given source text and base URL.
-                    let import_map_result = parse_an_import_map_string(
-                        cx,
-                        global,
-                        Rc::clone(&text_rc),
-                        base_url.clone(),
-                    );
+                    let import_map_result =
+                        parse_an_import_map_string(cx, global, Rc::clone(&text_rc), base_url);
                     let script = Script::ImportMap(import_map_result);
 
                     // Step 34.3


### PR DESCRIPTION
Using `Fallible<ImportMap>` instead of `ScriptOrigin` in enum `Script` in components/script/dom/htmlscriptelement.rs. Other fields provided by `ScriptOrigin` are not used when processing import maps.


Testing: No change in behavior. 
Fixes: #45321 
