### PR TITLE
android: remove redundant disablement of density splits

### DIFF
--- a/support/android/apk/servoapp/build.gradle.kts
+++ b/support/android/apk/servoapp/build.gradle.kts
@@ -34,9 +34,6 @@ android {
     }
 
     splits {
-        density {
-            isEnable = false
-        }
         abi {
             isEnable = false
         }

--- a/support/android/apk/servoview/build.gradle.kts
+++ b/support/android/apk/servoview/build.gradle.kts
@@ -35,9 +35,6 @@ android {
     }
 
     splits {
-        density {
-            isEnable = false
-        }
         abi {
             isEnable = false
         }


### PR DESCRIPTION
Per [the docs](https://web.archive.org/web/20260104035242/https://developer.android.com/build/configure-apk-splits#configure-density-split), density splits are disabled by default.

The Wayback Machine had to be used for the documentation link above, since the option `android.splits.density.*` was completely removed in Android Gradle Plugin 9, meaning the latest documentation won't refer to this configuration block anymore.

Testing: Ran app.