### PR TITLE
fonts: Support `font-feature-settings` in `@font-face` rule descriptor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7368,7 +7368,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.38.0"
-source = "git+https://github.com/simonwuelker/stylo?branch=font-tag-debug#ea769a652823e5bbe2deb9f628be254f9ba3a819"
+source = "git+https://github.com/servo/stylo?rev=e06a7e6a164fa41f1e6eb49a01100b2a88e0ac1f#e06a7e6a164fa41f1e6eb49a01100b2a88e0ac1f"
 dependencies = [
  "bitflags 2.11.1",
  "cssparser",
@@ -9089,7 +9089,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/simonwuelker/stylo?branch=font-tag-debug#ea769a652823e5bbe2deb9f628be254f9ba3a819"
+source = "git+https://github.com/servo/stylo?rev=e06a7e6a164fa41f1e6eb49a01100b2a88e0ac1f#e06a7e6a164fa41f1e6eb49a01100b2a88e0ac1f"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -9585,8 +9585,8 @@ dependencies = [
 
 [[package]]
 name = "stylo"
-version = "0.17.0"
-source = "git+https://github.com/simonwuelker/stylo?branch=font-tag-debug#ea769a652823e5bbe2deb9f628be254f9ba3a819"
+version = "0.18.0"
+source = "git+https://github.com/servo/stylo?rev=e06a7e6a164fa41f1e6eb49a01100b2a88e0ac1f#e06a7e6a164fa41f1e6eb49a01100b2a88e0ac1f"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -9641,8 +9641,8 @@ dependencies = [
 
 [[package]]
 name = "stylo_atoms"
-version = "0.17.0"
-source = "git+https://github.com/simonwuelker/stylo?branch=font-tag-debug#ea769a652823e5bbe2deb9f628be254f9ba3a819"
+version = "0.18.0"
+source = "git+https://github.com/servo/stylo?rev=e06a7e6a164fa41f1e6eb49a01100b2a88e0ac1f#e06a7e6a164fa41f1e6eb49a01100b2a88e0ac1f"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -9650,8 +9650,8 @@ dependencies = [
 
 [[package]]
 name = "stylo_derive"
-version = "0.17.0"
-source = "git+https://github.com/simonwuelker/stylo?branch=font-tag-debug#ea769a652823e5bbe2deb9f628be254f9ba3a819"
+version = "0.18.0"
+source = "git+https://github.com/servo/stylo?rev=e06a7e6a164fa41f1e6eb49a01100b2a88e0ac1f#e06a7e6a164fa41f1e6eb49a01100b2a88e0ac1f"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -9662,8 +9662,8 @@ dependencies = [
 
 [[package]]
 name = "stylo_dom"
-version = "0.17.0"
-source = "git+https://github.com/simonwuelker/stylo?branch=font-tag-debug#ea769a652823e5bbe2deb9f628be254f9ba3a819"
+version = "0.18.0"
+source = "git+https://github.com/servo/stylo?rev=e06a7e6a164fa41f1e6eb49a01100b2a88e0ac1f#e06a7e6a164fa41f1e6eb49a01100b2a88e0ac1f"
 dependencies = [
  "bitflags 2.11.1",
  "stylo_malloc_size_of",
@@ -9671,8 +9671,8 @@ dependencies = [
 
 [[package]]
 name = "stylo_malloc_size_of"
-version = "0.17.0"
-source = "git+https://github.com/simonwuelker/stylo?branch=font-tag-debug#ea769a652823e5bbe2deb9f628be254f9ba3a819"
+version = "0.18.0"
+source = "git+https://github.com/servo/stylo?rev=e06a7e6a164fa41f1e6eb49a01100b2a88e0ac1f#e06a7e6a164fa41f1e6eb49a01100b2a88e0ac1f"
 dependencies = [
  "app_units",
  "cssparser",
@@ -9688,16 +9688,16 @@ dependencies = [
 
 [[package]]
 name = "stylo_static_prefs"
-version = "0.17.0"
-source = "git+https://github.com/simonwuelker/stylo?branch=font-tag-debug#ea769a652823e5bbe2deb9f628be254f9ba3a819"
+version = "0.18.0"
+source = "git+https://github.com/servo/stylo?rev=e06a7e6a164fa41f1e6eb49a01100b2a88e0ac1f#e06a7e6a164fa41f1e6eb49a01100b2a88e0ac1f"
 dependencies = [
  "toml",
 ]
 
 [[package]]
 name = "stylo_traits"
-version = "0.17.0"
-source = "git+https://github.com/simonwuelker/stylo?branch=font-tag-debug#ea769a652823e5bbe2deb9f628be254f9ba3a819"
+version = "0.18.0"
+source = "git+https://github.com/servo/stylo?rev=e06a7e6a164fa41f1e6eb49a01100b2a88e0ac1f#e06a7e6a164fa41f1e6eb49a01100b2a88e0ac1f"
 dependencies = [
  "app_units",
  "bitflags 2.11.1",
@@ -10118,7 +10118,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.4.0"
-source = "git+https://github.com/simonwuelker/stylo?branch=font-tag-debug#ea769a652823e5bbe2deb9f628be254f9ba3a819"
+source = "git+https://github.com/servo/stylo?rev=e06a7e6a164fa41f1e6eb49a01100b2a88e0ac1f#e06a7e6a164fa41f1e6eb49a01100b2a88e0ac1f"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -10131,7 +10131,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/simonwuelker/stylo?branch=font-tag-debug#ea769a652823e5bbe2deb9f628be254f9ba3a819"
+source = "git+https://github.com/servo/stylo?rev=e06a7e6a164fa41f1e6eb49a01100b2a88e0ac1f#e06a7e6a164fa41f1e6eb49a01100b2a88e0ac1f"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7368,7 +7368,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.38.0"
-source = "git+https://github.com/servo/stylo?rev=d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f#d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f"
+source = "git+https://github.com/simonwuelker/stylo?branch=font-tag-debug#ea769a652823e5bbe2deb9f628be254f9ba3a819"
 dependencies = [
  "bitflags 2.11.1",
  "cssparser",
@@ -9089,7 +9089,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f#d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f"
+source = "git+https://github.com/simonwuelker/stylo?branch=font-tag-debug#ea769a652823e5bbe2deb9f628be254f9ba3a819"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -9586,7 +9586,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.17.0"
-source = "git+https://github.com/servo/stylo?rev=d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f#d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f"
+source = "git+https://github.com/simonwuelker/stylo?branch=font-tag-debug#ea769a652823e5bbe2deb9f628be254f9ba3a819"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -9642,7 +9642,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.17.0"
-source = "git+https://github.com/servo/stylo?rev=d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f#d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f"
+source = "git+https://github.com/simonwuelker/stylo?branch=font-tag-debug#ea769a652823e5bbe2deb9f628be254f9ba3a819"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -9651,7 +9651,7 @@ dependencies = [
 [[package]]
 name = "stylo_derive"
 version = "0.17.0"
-source = "git+https://github.com/servo/stylo?rev=d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f#d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f"
+source = "git+https://github.com/simonwuelker/stylo?branch=font-tag-debug#ea769a652823e5bbe2deb9f628be254f9ba3a819"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -9663,7 +9663,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.17.0"
-source = "git+https://github.com/servo/stylo?rev=d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f#d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f"
+source = "git+https://github.com/simonwuelker/stylo?branch=font-tag-debug#ea769a652823e5bbe2deb9f628be254f9ba3a819"
 dependencies = [
  "bitflags 2.11.1",
  "stylo_malloc_size_of",
@@ -9672,7 +9672,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.17.0"
-source = "git+https://github.com/servo/stylo?rev=d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f#d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f"
+source = "git+https://github.com/simonwuelker/stylo?branch=font-tag-debug#ea769a652823e5bbe2deb9f628be254f9ba3a819"
 dependencies = [
  "app_units",
  "cssparser",
@@ -9689,7 +9689,7 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.17.0"
-source = "git+https://github.com/servo/stylo?rev=d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f#d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f"
+source = "git+https://github.com/simonwuelker/stylo?branch=font-tag-debug#ea769a652823e5bbe2deb9f628be254f9ba3a819"
 dependencies = [
  "toml",
 ]
@@ -9697,7 +9697,7 @@ dependencies = [
 [[package]]
 name = "stylo_traits"
 version = "0.17.0"
-source = "git+https://github.com/servo/stylo?rev=d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f#d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f"
+source = "git+https://github.com/simonwuelker/stylo?branch=font-tag-debug#ea769a652823e5bbe2deb9f628be254f9ba3a819"
 dependencies = [
  "app_units",
  "bitflags 2.11.1",
@@ -10118,7 +10118,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.4.0"
-source = "git+https://github.com/servo/stylo?rev=d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f#d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f"
+source = "git+https://github.com/simonwuelker/stylo?branch=font-tag-debug#ea769a652823e5bbe2deb9f628be254f9ba3a819"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -10131,7 +10131,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f#d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f"
+source = "git+https://github.com/simonwuelker/stylo?branch=font-tag-debug#ea769a652823e5bbe2deb9f628be254f9ba3a819"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -214,14 +214,14 @@ rustls-platform-verifier = "0.7.0"
 sea-query = { version = "=1.0.0-rc.31", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = { version = "=0.8.0-rc.15" }
 sec1 = "0.7"
-selectors = { git = "https://github.com/servo/stylo", rev = "d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f" }
+selectors = { git = "https://github.com/servo/stylo", rev = "e06a7e6a164fa41f1e6eb49a01100b2a88e0ac1f" }
 seq-macro = "0.3.6"
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
 serde_json = "1.0"
 serde_test = "1.0"
-servo_arc = { git = "https://github.com/servo/stylo", rev = "d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "e06a7e6a164fa41f1e6eb49a01100b2a88e0ac1f" }
 sha1 = "0.11"
 sha1_0_10 = { package = "sha1", version = "0.10" }
 sha2 = "0.11"
@@ -233,12 +233,12 @@ smallvec = { version = "1.15", features = ["serde", "union"] }
 speexdsp-resampler = "0.1.0"
 string_cache = "0.9"
 strum = { version = "0.28", features = ["derive"] }
-stylo = { git = "https://github.com/servo/stylo", rev = "d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f" }
-stylo_atoms = { git = "https://github.com/servo/stylo", rev = "d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f" }
-stylo_dom = { git = "https://github.com/servo/stylo", rev = "d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f" }
-stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f" }
-stylo_traits = { git = "https://github.com/servo/stylo", rev = "d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f" }
+stylo = { git = "https://github.com/servo/stylo", rev = "e06a7e6a164fa41f1e6eb49a01100b2a88e0ac1f" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "e06a7e6a164fa41f1e6eb49a01100b2a88e0ac1f" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "e06a7e6a164fa41f1e6eb49a01100b2a88e0ac1f" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "e06a7e6a164fa41f1e6eb49a01100b2a88e0ac1f" }
+stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "e06a7e6a164fa41f1e6eb49a01100b2a88e0ac1f" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "e06a7e6a164fa41f1e6eb49a01100b2a88e0ac1f" }
 surfman = { version = "0.12.2", features = ["chains"] }
 swapper = "0.1"
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
@@ -450,15 +450,15 @@ codegen-units = 1
 #
 # Or for Stylo:
 #
-[patch."https://github.com/servo/stylo"]
-selectors = { git="https://github.com/simonwuelker/stylo", branch="font-tag-debug" }
-servo_arc = { git="https://github.com/simonwuelker/stylo", branch="font-tag-debug" }
-stylo = {git="https://github.com/simonwuelker/stylo", branch="font-tag-debug" }
-stylo_atoms = { git="https://github.com/simonwuelker/stylo", branch="font-tag-debug" }
-stylo_dom = { git="https://github.com/simonwuelker/stylo", branch="font-tag-debug" }
-stylo_malloc_size_of = { git="https://github.com/simonwuelker/stylo", branch="font-tag-debug" }
-stylo_static_prefs = { git="https://github.com/simonwuelker/stylo", branch="font-tag-debug" }
-stylo_traits = {git="https://github.com/simonwuelker/stylo", branch="font-tag-debug" }
+# [patch."https://github.com/servo/stylo"]
+# selectors = { path = "../stylo/selectors" }
+# servo_arc = { path = "../stylo/servo_arc" }
+# stylo = { path = "../stylo/style" }
+# stylo_atoms = { path = "../stylo/stylo_atoms" }
+# stylo_dom = { path = "../stylo/stylo_dom" }
+# stylo_malloc_size_of = { path = "../stylo/malloc_size_of" }
+# stylo_static_prefs = { path = "../stylo/stylo_static_prefs" }
+# stylo_traits = { path = "../stylo/style_traits" }
 #
 # Or for another Git dependency:
 #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -450,15 +450,15 @@ codegen-units = 1
 #
 # Or for Stylo:
 #
-# [patch."https://github.com/servo/stylo"]
-# selectors = { path = "../stylo/selectors" }
-# servo_arc = { path = "../stylo/servo_arc" }
-# stylo = { path = "../stylo/style" }
-# stylo_atoms = { path = "../stylo/stylo_atoms" }
-# stylo_dom = { path = "../stylo/stylo_dom" }
-# stylo_malloc_size_of = { path = "../stylo/malloc_size_of" }
-# stylo_static_prefs = { path = "../stylo/stylo_static_prefs" }
-# stylo_traits = { path = "../stylo/style_traits" }
+[patch."https://github.com/servo/stylo"]
+selectors = { git="https://github.com/simonwuelker/stylo", branch="font-tag-debug" }
+servo_arc = { git="https://github.com/simonwuelker/stylo", branch="font-tag-debug" }
+stylo = {git="https://github.com/simonwuelker/stylo", branch="font-tag-debug" }
+stylo_atoms = { git="https://github.com/simonwuelker/stylo", branch="font-tag-debug" }
+stylo_dom = { git="https://github.com/simonwuelker/stylo", branch="font-tag-debug" }
+stylo_malloc_size_of = { git="https://github.com/simonwuelker/stylo", branch="font-tag-debug" }
+stylo_static_prefs = { git="https://github.com/simonwuelker/stylo", branch="font-tag-debug" }
+stylo_traits = {git="https://github.com/simonwuelker/stylo", branch="font-tag-debug" }
 #
 # Or for another Git dependency:
 #

--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -466,9 +466,11 @@ impl Font {
             self.shape_text_fast(text, options)
         } else {
             debug!("shape_text: Using Harfbuzz.");
-            self.shaper
-                .get_or_init(|| Shaper::new(self))
-                .shape_text(text, options)
+            self.shaper.get_or_init(|| Shaper::new(self)).shape_text(
+                text,
+                options,
+                self.template.borrow().font_face_rule.as_ref(),
+            )
         };
 
         let shaped_text = Arc::new(glyphs);

--- a/components/fonts/shapers/harfbuzz.rs
+++ b/components/fonts/shapers/harfbuzz.rs
@@ -28,6 +28,7 @@ use harfbuzz_sys::{
 };
 use num_traits::Zero;
 use read_fonts::types::Tag;
+use style::font_face::FontFaceRule;
 
 use super::{
     GlyphShapingResult, ShapedGlyph, compute_used_font_features, unicode_script_to_iso15924_tag,
@@ -247,6 +248,7 @@ impl Shaper {
         &self,
         text: &str,
         options: &ShapingOptions,
+        font_face_rule: Option<&FontFaceRule>,
     ) -> HarfbuzzGlyphShapingResult {
         unsafe {
             let hb_buffer: *mut hb_buffer_t = hb_buffer_create();
@@ -279,7 +281,7 @@ impl Shaper {
             );
             hb_buffer_set_language(hb_buffer, hb_language);
 
-            let mut features: Vec<_> = compute_used_font_features(options)
+            let mut features: Vec<_> = compute_used_font_features(options, font_face_rule)
                 .map(|(tag, value)| hb_feature_t {
                     tag: u32::from_be_bytes(tag.to_be_bytes()),
                     value,
@@ -298,8 +300,17 @@ impl Shaper {
         }
     }
 
-    pub(crate) fn shape_text(&self, text: &str, options: &ShapingOptions) -> ShapedText {
-        ShapedText::with_shaped_glyph_data(text, options, &self.shaped_glyph_data(text, options))
+    pub(crate) fn shape_text(
+        &self,
+        text: &str,
+        options: &ShapingOptions,
+        font_face_rule: Option<&FontFaceRule>,
+    ) -> ShapedText {
+        ShapedText::with_shaped_glyph_data(
+            text,
+            options,
+            &self.shaped_glyph_data(text, options, font_face_rule),
+        )
     }
 
     pub(crate) fn baseline(&self) -> Option<FontBaseline> {

--- a/components/fonts/shapers/mod.rs
+++ b/components/fonts/shapers/mod.rs
@@ -10,6 +10,7 @@ pub(crate) use harfbuzz::Shaper;
 use read_fonts::types::Tag;
 use rustc_hash::FxHashMap;
 use style::computed_values::font_variant_position::T as FontVariantPosition;
+use style::font_face::FontFaceRule;
 use style::values::computed::{FontVariantEastAsian, FontVariantLigatures, FontVariantNumeric};
 
 use crate::{
@@ -56,17 +57,41 @@ pub(crate) trait GlyphShapingResult {
     fn iter(&self) -> impl Iterator<Item = ShapedGlyph>;
 }
 
-fn compute_used_font_features(options: &ShapingOptions) -> impl Iterator<Item = (Tag, u32)> {
+/// Determine which OpenType features are applied for the font.
+///
+/// The order of precedence is specified in <https://drafts.csswg.org/css-fonts-4/#apply-font-matching-variations>.
+fn compute_used_font_features(
+    options: &ShapingOptions,
+    font_face_rule: Option<&FontFaceRule>,
+) -> impl Iterator<Item = (Tag, u32)> {
     let mut features = FxHashMap::default();
 
     let mut add_feature = |tag, value| {
         features.entry(tag).insert_entry(value);
     };
 
-    if options.ligatures == FontVariantLigatures::NORMAL {
-        add_feature(LIGA, 1);
-        add_feature(CLIG, 1);
-    } else if options.ligatures == FontVariantLigatures::NONE {
+    // Step 1. Font features enabled by default are applied, including features required
+    // for a given script. See § 7.1 Default features for a description of these.
+    add_feature(LIGA, 1);
+    add_feature(CLIG, 1);
+
+    // Step 7. If the font is defined via an @font-face rule, the font features implied
+    // by the font-feature-settings descriptor in the @font-face rule are applied.
+    if let Some(font_feature_settings) =
+        font_face_rule.and_then(|rule| rule.descriptors.font_feature_settings.as_ref())
+    {
+        for feature_setting in font_feature_settings.0.iter() {
+            add_feature(
+                Tag::from_u32(feature_setting.tag.0),
+                feature_setting.value.value() as u32,
+            )
+        }
+    }
+
+    // Step 10. Font features implied by the value of the font-variant property,
+    // the related font-variant subproperties and any other CSS property that uses
+    // OpenType features (e.g. the font-kerning property) are applied.
+    if options.ligatures == FontVariantLigatures::NONE {
         add_feature(LIGA, 0);
         add_feature(CLIG, 0);
         add_feature(DLIG, 0);
@@ -205,6 +230,7 @@ fn compute_used_font_features(options: &ShapingOptions) -> impl Iterator<Item = 
         add_feature(KERN, 0);
     }
 
+    // Step 13. Font features implied by the value of font-feature-settings property are applied.
     for feature_setting in options.feature_settings.0.iter() {
         add_feature(
             Tag::from_u32(feature_setting.tag.0),

--- a/components/fonts/shapers/mod.rs
+++ b/components/fonts/shapers/mod.rs
@@ -59,7 +59,8 @@ pub(crate) trait GlyphShapingResult {
 
 /// Determine which OpenType features are applied for the font.
 ///
-/// The order of precedence is specified in <https://drafts.csswg.org/css-fonts-4/#apply-font-matching-variations>.
+/// The order of precedence for resolving font-specific font feature properties is specified in
+/// <https://drafts.csswg.org/css-fonts-4/#apply-font-matching-variations>.
 fn compute_used_font_features(
     options: &ShapingOptions,
     font_face_rule: Option<&FontFaceRule>,

--- a/tests/wpt/meta/css/css-fonts/font-feature-settings-descriptor-02.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-feature-settings-descriptor-02.html.ini
@@ -1,2 +1,0 @@
-[font-feature-settings-descriptor-02.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/font-feature-settings-descriptor-binary.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-feature-settings-descriptor-binary.html.ini
@@ -1,2 +1,0 @@
-[font-feature-settings-descriptor-binary.html]
-  expected: FAIL


### PR DESCRIPTION
Additionally, this bumps stylo to https://github.com/servo/stylo/pull/382. I can do that in a seperate PR if preferred, but the change is so small that it doesn't feel like its worth the effort.

Testing: New tests start to pass