### PR TITLE
android: remove redundant disablement of abi splits

### DIFF
--- a/support/android/apk/servoapp/build.gradle.kts
+++ b/support/android/apk/servoapp/build.gradle.kts
@@ -33,12 +33,6 @@ android {
         }
     }
 
-    splits {
-        abi {
-            isEnable = false
-        }
-    }
-
     val signingKeyInfo = getSigningKeyInfo()
 
     if (signingKeyInfo != null) {

--- a/support/android/apk/servoview/build.gradle.kts
+++ b/support/android/apk/servoview/build.gradle.kts
@@ -34,13 +34,6 @@ android {
         }
     }
 
-    splits {
-        abi {
-            isEnable = false
-        }
-    }
-
-
     buildTypes {
         // Default debug and release build types are used as templates
         debug {


### PR DESCRIPTION
Per [the docs](https://developer.android.com/build/configure-apk-splits#configure-abi-split), abi splits are disabled by default.

Testing: Ran app.