### PR TITLE
layout: Require `AccessibilityUpdate` to remove nodes from `AccessibilityTree`

### DIFF
--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -207,13 +207,39 @@ impl AccessibilityTree {
         node.clone()
     }
 
-    /// Remove the node with the given ID from the cache and return it, if it exists.
-    fn remove_node(&mut self, id: NodeId) -> Option<ArcRefCell<AccessibilityNode>> {
-        let node = self.nodes.remove(&id)?;
-        if let Some(opaque_node) = node.borrow().opaque_node {
-            self.opaque_node_to_id.remove(&opaque_node);
+    /// Consume the [`AccessibilityUpdate`] by deleting all nodes it detected as being removed from
+    /// the tree.
+    fn remove_stale_nodes(&mut self, mut update: AccessibilityUpdate) {
+        for id in update
+            .tree_changes
+            .drain()
+            .filter_map(|(id, change)| match change {
+                TreeChange::PendingMove => {
+                    unreachable!(
+                        "Pending move found for node id {id:?} when draining tree state changes"
+                    );
+                },
+                TreeChange::Removed => Some(id),
+                _ => None,
+            })
+        {
+            if let Some(node) = self.nodes.remove(&id) &&
+                let Some(opaque_node) = node.borrow().opaque_node
+            {
+                self.opaque_node_to_id.remove(&opaque_node);
+            }
         }
-        Some(node)
+
+        if self
+            .debug
+            .is_enabled(DiagnosticsLoggingOption::AccessibilityTree)
+        {
+            self.print();
+        }
+
+        if pref!(expensive_accessibility_test_assertions_enabled) {
+            self.assert_integrity();
+        }
     }
 
     fn existing_id_for_opaque(&self, opaque: OpaqueNode) -> Option<&NodeId> {
@@ -573,26 +599,9 @@ impl AccessibilityUpdate {
             return None;
         }
 
-        for id in self
-            .tree_changes
-            .drain()
-            .filter_map(|(id, change)| match change {
-                TreeChange::PendingMove => {
-                    unreachable!(
-                        "Pending move found for node id {id:?} when draining tree state changes"
-                    );
-                },
-                TreeChange::Removed => Some(id),
-                _ => None,
-            })
-        {
-            tree.remove_node(id);
-        }
-
         let accesskit_tree = accesskit::Tree::new(root_node_id);
         let tree_update = accesskit::TreeUpdate {
-            nodes: self
-                .changed_nodes
+            nodes: std::mem::take(&mut self.changed_nodes)
                 .into_iter()
                 .map(|id| {
                     (
@@ -606,16 +615,7 @@ impl AccessibilityUpdate {
             tree_id: tree.tree_id,
         };
 
-        if tree
-            .debug
-            .is_enabled(DiagnosticsLoggingOption::AccessibilityTree)
-        {
-            tree.print();
-        }
-
-        if pref!(expensive_accessibility_test_assertions_enabled) {
-            tree.assert_integrity();
-        }
+        tree.remove_stale_nodes(self);
 
         Some(tree_update)
     }

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -193,13 +193,13 @@ impl AccessibilityTree {
         dom_node: &ServoLayoutNode<'_>,
     ) -> ArcRefCell<AccessibilityNode> {
         let id = self.id_for_opaque(dom_node.opaque());
-        let node = self.assert_node_for_id(id);
+        let node = self.assert_node_for_id(&id);
         assert!(node.borrow().opaque_node == Some(dom_node.opaque()));
         node
     }
 
-    fn assert_node_for_id(&self, id: NodeId) -> ArcRefCell<AccessibilityNode> {
-        let Some(node) = self.nodes.get(&id) else {
+    fn assert_node_for_id(&self, id: &NodeId) -> ArcRefCell<AccessibilityNode> {
+        let Some(node) = self.nodes.get(id) else {
             panic!("{id:?} does not exist in tree");
         };
         node.clone()
@@ -245,7 +245,7 @@ impl AccessibilityTree {
                 "Tree contains {node_id:?} in multiple places"
             );
             // If this fails, then the tree has dangling references.
-            let node = self.assert_node_for_id(node_id);
+            let node = self.assert_node_for_id(&node_id);
             let node = node.borrow();
             node_ids.extend(node.children().iter().rev());
         }
@@ -260,7 +260,7 @@ impl AccessibilityTree {
         };
 
         let mut print_tree = PrintTree::new("Accessibility Tree");
-        let node = self.assert_node_for_id(root_node_id);
+        let node = self.assert_node_for_id(&root_node_id);
         node.borrow().print(self, &mut print_tree);
         print_tree.end_level();
     }
@@ -326,7 +326,7 @@ impl AccessibilityNode {
             let old_children = self.children();
             for old_child_id in old_children {
                 if !new_children.contains(old_child_id) {
-                    let removed_child = tree.assert_node_for_id(*old_child_id);
+                    let removed_child = tree.assert_node_for_id(old_child_id);
                     removed_child.borrow().set_subtree_state_change(
                         TreeChange::Removed,
                         tree,
@@ -336,7 +336,7 @@ impl AccessibilityNode {
             }
             for new_child_id in new_children.iter() {
                 if !newly_created.contains(new_child_id) && !old_children.contains(new_child_id) {
-                    let moved_child = tree.assert_node_for_id(*new_child_id);
+                    let moved_child = tree.assert_node_for_id(new_child_id);
                     moved_child.borrow().set_subtree_state_change(
                         TreeChange::PendingMove,
                         tree,
@@ -375,7 +375,7 @@ impl AccessibilityNode {
         update.set_tree_state_change(self.id, change);
 
         for child_id in self.children().iter() {
-            let child = tree.assert_node_for_id(*child_id);
+            let child = tree.assert_node_for_id(child_id);
             // `new_change` might be different per node, if only some nodes were moved elsewhere.
             child
                 .borrow()
@@ -409,7 +409,7 @@ impl AccessibilityNode {
         let mut children = VecDeque::from_iter(self.children().iter().copied());
         let mut text = String::new();
         while let Some(child_id) = children.pop_front() {
-            let child = tree.assert_node_for_id(child_id);
+            let child = tree.assert_node_for_id(&child_id);
             let child = child.borrow();
             match child.role() {
                 Role::TextRun => {
@@ -436,7 +436,7 @@ impl AccessibilityNode {
         print_tree.new_level(format!("{self:?}"));
 
         for child_id in self.children() {
-            let child = tree.assert_node_for_id(*child_id);
+            let child = tree.assert_node_for_id(child_id);
             child.borrow().print(tree, print_tree);
         }
         print_tree.end_level();
@@ -591,7 +591,7 @@ impl AccessibilityUpdate {
                 .map(|id| {
                     (
                         id,
-                        tree.assert_node_for_id(id).borrow().accesskit_node.clone(),
+                        tree.assert_node_for_id(&id).borrow().accesskit_node.clone(),
                     )
                 })
                 .collect(),
@@ -636,11 +636,11 @@ fn test_accessibility_update_add_some_nodes_twice() {
     let mut update = AccessibilityUpdate::new();
 
     {
-        let node_3 = tree.assert_node_for_id(NodeId(3));
+        let node_3 = tree.assert_node_for_id(&NodeId(3));
         let mut node_3 = node_3.borrow_mut();
-        let node_4 = tree.assert_node_for_id(NodeId(4));
+        let node_4 = tree.assert_node_for_id(&NodeId(4));
         let mut node_4 = node_4.borrow_mut();
-        let node_5 = tree.assert_node_for_id(NodeId(5));
+        let node_5 = tree.assert_node_for_id(&NodeId(5));
         let mut node_5 = node_5.borrow_mut();
 
         update.add(&mut node_5);

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -181,19 +181,21 @@ impl AccessibilityTree {
     }
 
     fn node_for_dom_node(
-        &mut self,
+        &self,
         dom_node: &ServoLayoutNode<'_>,
     ) -> Option<ArcRefCell<AccessibilityNode>> {
-        let id = self.id_for_opaque(dom_node.opaque());
-        self.nodes.get(&id).cloned()
+        let id = self.existing_id_for_opaque(dom_node.opaque())?;
+        self.nodes.get(id).cloned()
     }
 
     fn assert_node_for_dom_node(
-        &mut self,
+        &self,
         dom_node: &ServoLayoutNode<'_>,
     ) -> ArcRefCell<AccessibilityNode> {
-        let id = self.id_for_opaque(dom_node.opaque());
-        let node = self.assert_node_for_id(&id);
+        let Some(id) = self.existing_id_for_opaque(dom_node.opaque()) else {
+            panic!("Node {dom_node:?} not found in accessibility tree.");
+        };
+        let node = self.assert_node_for_id(id);
         assert!(node.borrow().opaque_node == Some(dom_node.opaque()));
         node
     }
@@ -212,6 +214,10 @@ impl AccessibilityTree {
             self.opaque_node_to_id.remove(&opaque_node);
         }
         Some(node)
+    }
+
+    fn existing_id_for_opaque(&self, opaque: OpaqueNode) -> Option<&NodeId> {
+        self.opaque_node_to_id.get(&opaque)
     }
 
     fn id_for_opaque(&mut self, opaque: OpaqueNode) -> NodeId {


### PR DESCRIPTION
Previously `remove_node()` could be called without an `AccessibilityUpdate`, and we depended on it only being called from `AccessibilityUpdate::finalize()`.

This change replaces `remove_node()` with `remove_stale_nodes()` which consumes the `AccessibilityUpdate` and removes all nodes it detected as removed from the tree.

This means we can state that any tree-mutating method must take an `AccessibilityUpdate` - removing nodes can now only happen by consuming the `AccessibilityUpdate`, so it must wait until the update is being finalized.

Testing: No change to behaviour.
Fixes: Part of #4344