### PR TITLE
script: Pass `&mut JSContext` to `Condition::Func`

### DIFF
--- a/components/script/dom/canvas/offscreencanvas.rs
+++ b/components/script/dom/canvas/offscreencanvas.rs
@@ -247,10 +247,8 @@ impl OffscreenCanvas {
         cx: &mut js::context::JSContext,
         options: HandleValue,
     ) -> Option<DomRoot<WebGL2RenderingContext>> {
-        if !WebGL2RenderingContext::is_webgl2_enabled(
-            cx.into(),
-            self.global().reflector().get_jsobject(),
-        ) {
+        if !WebGL2RenderingContext::is_webgl2_enabled(cx, self.global().reflector().get_jsobject())
+        {
             return None;
         }
         if let Some(ctx) = self.context() {

--- a/components/script/dom/html/htmlcanvaselement.rs
+++ b/components/script/dom/html/htmlcanvaselement.rs
@@ -291,10 +291,8 @@ impl HTMLCanvasElement {
         cx: &mut js::context::JSContext,
         options: HandleValue,
     ) -> Option<DomRoot<WebGL2RenderingContext>> {
-        if !WebGL2RenderingContext::is_webgl2_enabled(
-            cx.into(),
-            self.global().reflector().get_jsobject(),
-        ) {
+        if !WebGL2RenderingContext::is_webgl2_enabled(cx, self.global().reflector().get_jsobject())
+        {
             return None;
         }
         if let Some(ctx) = self.context() {

--- a/components/script/dom/servointernals.rs
+++ b/components/script/dom/servointernals.rs
@@ -8,6 +8,7 @@ use dom_struct::dom_struct;
 use js::gc::MutableHandleValue;
 use js::jsapi::Heap;
 use js::jsval::UndefinedValue;
+use js::realm::CurrentRealm;
 use js::rust::HandleObject;
 use profile_traits::mem::MemoryReportResult;
 use script_bindings::conversions::SafeToJSValConvertible;
@@ -25,7 +26,7 @@ use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
-use crate::realms::{AlreadyInRealm, InRealm};
+use crate::realms::InRealm;
 use crate::routed_promise::{RoutedPromiseListener, callback_promise};
 use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
@@ -211,14 +212,11 @@ impl RoutedPromiseListener<MemoryReportResult> for ServoInternals {
 impl ServoInternalsHelpers for ServoInternals {
     /// The navigator.servo api is exposed to about: pages except about:blank, as
     /// well as any URLs provided by embedders that register new protocol handlers.
-    #[expect(unsafe_code)]
-    fn is_servo_internal(cx: JSContext, _global: HandleObject) -> bool {
-        unsafe {
-            let in_realm_proof = AlreadyInRealm::assert_for_cx(cx);
-            let global_scope = GlobalScope::from_context(*cx, InRealm::Already(&in_realm_proof));
-            let url = global_scope.get_url();
-            (url.scheme() == "about" && url.as_str() != "about:blank") ||
-                ScriptThread::is_servo_privileged(url)
-        }
+    fn is_servo_internal(cx: &mut js::context::JSContext, _global: HandleObject) -> bool {
+        let realm = CurrentRealm::assert(cx);
+        let global_scope = GlobalScope::from_current_realm(&realm);
+        let url = global_scope.get_url();
+        (url.scheme() == "about" && url.as_str() != "about:blank") ||
+            ScriptThread::is_servo_privileged(url)
     }
 }

--- a/components/script/dom/testing/testbinding.rs
+++ b/components/script/dom/testing/testbinding.rs
@@ -1187,10 +1187,10 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
 }
 
 impl TestBinding {
-    pub(crate) fn condition_satisfied(_: SafeJSContext, _: HandleObject) -> bool {
+    pub(crate) fn condition_satisfied(_: &mut JSContext, _: HandleObject) -> bool {
         true
     }
-    pub(crate) fn condition_unsatisfied(_: SafeJSContext, _: HandleObject) -> bool {
+    pub(crate) fn condition_unsatisfied(_: &mut JSContext, _: HandleObject) -> bool {
         false
     }
 }
@@ -1211,10 +1211,10 @@ impl TestBindingCallback {
 }
 
 impl TestBindingHelpers for TestBinding {
-    fn condition_satisfied(cx: SafeJSContext, global: HandleObject) -> bool {
+    fn condition_satisfied(cx: &mut JSContext, global: HandleObject) -> bool {
         Self::condition_satisfied(cx, global)
     }
-    fn condition_unsatisfied(cx: SafeJSContext, global: HandleObject) -> bool {
+    fn condition_unsatisfied(cx: &mut JSContext, global: HandleObject) -> bool {
         Self::condition_unsatisfied(cx, global)
     }
 }

--- a/components/script/dom/webgl/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl/webgl2renderingcontext.rs
@@ -199,7 +199,10 @@ impl WebGL2RenderingContext {
     }
 
     #[expect(unsafe_code)]
-    pub(crate) fn is_webgl2_enabled(_cx: JSContext, global: HandleObject) -> bool {
+    pub(crate) fn is_webgl2_enabled(
+        _cx: &mut js::context::JSContext,
+        global: HandleObject,
+    ) -> bool {
         if pref!(dom_webgl2_enabled) {
             return true;
         }
@@ -4975,7 +4978,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
 }
 
 impl WebGL2RenderingContextHelpers for WebGL2RenderingContext {
-    fn is_webgl2_enabled(cx: JSContext, global: HandleObject) -> bool {
+    fn is_webgl2_enabled(cx: &mut js::context::JSContext, global: HandleObject) -> bool {
         Self::is_webgl2_enabled(cx, global)
     }
 }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2410,11 +2410,11 @@ impl Window {
     // https://heycam.github.io/webidl/#named-properties-object
     // https://html.spec.whatwg.org/multipage/#named-access-on-the-window-object
     pub(crate) fn create_named_properties_object(
-        cx: SafeJSContext,
+        cx: &mut JSContext,
         proto: HandleObject,
         object: MutableHandleObject,
     ) {
-        window_named_properties::create(cx, proto, object)
+        window_named_properties::create(cx.into(), proto, object)
     }
 
     pub(crate) fn current_event(&self) -> Option<DomRoot<Event>> {
@@ -4023,7 +4023,7 @@ unsafe extern "C" fn dump_js_stack(cx: *mut RawJSContext) {
 
 impl WindowHelpers for Window {
     fn create_named_properties_object(
-        cx: SafeJSContext,
+        cx: &mut JSContext,
         proto: HandleObject,
         object: MutableHandleObject,
     ) {

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -3262,7 +3262,7 @@ class CGConstructorEnabled(CGAbstractMethod):
         func = iface.getExtendedAttribute("Func")
         if func:
             assert isinstance(func, list) and len(func) == 1
-            conditions.append(f"D::{func[0]}(cx.into(), aObj)")
+            conditions.append(f"D::{func[0]}(cx, aObj)")
 
         secure = iface.getExtendedAttribute("SecureContext")
         if secure:
@@ -3285,8 +3285,8 @@ def InitLegacyUnforgeablePropertiesOnHolder(descriptor: Descriptor, properties: 
     """
     unforgeables = []
 
-    defineLegacyUnforgeableAttrs = "define_guarded_properties::<D>(cx.into(), unforgeable_holder.handle(), %s, global);"
-    defineLegacyUnforgeableMethods = "define_guarded_methods::<D>(cx.into(), unforgeable_holder.handle(), %s, global);"
+    defineLegacyUnforgeableAttrs = "define_guarded_properties::<D>(cx, unforgeable_holder.handle(), %s, global);"
+    defineLegacyUnforgeableMethods = "define_guarded_methods::<D>(cx, unforgeable_holder.handle(), %s, global);"
 
     unforgeableMembers = [
         (defineLegacyUnforgeableAttrs, properties.unforgeable_attrs),
@@ -3415,7 +3415,7 @@ class CGWrapGlobalMethod(CGAbstractMethod):
             ("define_guarded_methods", self.properties.methods),
             ("define_guarded_constants", self.properties.consts)
         ]
-        members = [f"{function}::<D>(cx.into(), obj.handle(), {array.variableName()}.get(), obj.handle());"
+        members = [f"{function}::<D>(cx, obj.handle(), {array.variableName()}.get(), obj.handle());"
                    for (function, array) in pairs if array.length() > 0]
         membersStr = "\n".join(members)
         name = self.descriptor.name
@@ -3676,7 +3676,7 @@ let global = incumbent_global.reflector().get_jsobject();\n"""
                     let conditions = ${conditions};
                     let is_satisfied = conditions.iter().any(|c|
                          c.is_satisfied::<D>(
-                           cx.into(),
+                           cx,
                            HandleObject::from_raw(obj),
                            global));
                     if is_satisfied {
@@ -3778,7 +3778,7 @@ assert!(!prototype_proto.is_null());""")]
             assert not self.haveUnscopables
             code.append(CGGeneric(f"""
 rooted!(&in(cx) let mut prototype_proto_proto = prototype_proto.get());
-D::{name}::create_named_properties_object(cx.into(), prototype_proto_proto.handle(), prototype_proto.handle_mut());
+D::{name}::create_named_properties_object(cx, prototype_proto_proto.handle(), prototype_proto.handle_mut());
 assert!(!prototype_proto.is_null());"""))
 
         properties = {
@@ -3807,7 +3807,7 @@ assert!(!prototype_proto.is_null());"""))
 
         code.append(CGGeneric(f"""
 rooted!(&in(cx) let mut prototype = ptr::null_mut::<JSObject>());
-create_interface_prototype_object::<D>(cx.into(),
+create_interface_prototype_object::<D>(cx,
                                   global,
                                   prototype_proto.handle(),
                                   &PrototypeClass,
@@ -3843,7 +3843,7 @@ assert!((*cache)[PrototypeList::ID::{proto_properties['id']} as usize].is_null()
 assert!(!interface_proto.is_null());
 
 rooted!(&in(cx) let mut interface = ptr::null_mut::<JSObject>());
-create_noncallback_interface_object::<D>(cx.into(),
+create_noncallback_interface_object::<D>(cx,
                                     global,
                                     interface_proto.handle(),
                                     INTERFACE_OBJECT_CLASS.get(),
@@ -3930,7 +3930,7 @@ assert!((*cache)[PrototypeList::Constructor::{properties['id']} as usize].is_nul
                 specs.append(CGGeneric(f"({hook}::<D> as ConstructorClassHook, {name}, {length})"))
             values = CGIndenter(CGList(specs, "\n"), 4)
             code.append(CGWrapper(values, pre=f"{decl} = [\n", post="\n];"))
-            code.append(CGGeneric("create_named_constructors(cx.into(), global, &named_constructors, prototype.handle());"))
+            code.append(CGGeneric("create_named_constructors(cx, global, &named_constructors, prototype.handle());"))
 
         if self.descriptor.hasLegacyUnforgeableMembers:
             # We want to use the same JSClass and prototype as the object we'll

--- a/components/script_bindings/constant.rs
+++ b/components/script_bindings/constant.rs
@@ -6,13 +6,12 @@
 
 use std::ffi::CStr;
 
+use js::context::JSContext;
 use js::jsapi::{JSPROP_ENUMERATE, JSPROP_PERMANENT, JSPROP_READONLY};
 use js::jsval::{BooleanValue, DoubleValue, Int32Value, JSVal, NullValue, UInt32Value};
 use js::rooted;
 use js::rust::HandleObject;
-use js::rust::wrappers::JS_DefineProperty;
-
-use crate::script_runtime::JSContext;
+use js::rust::wrappers2::JS_DefineProperty;
 
 /// Representation of an IDL constant.
 #[derive(Clone)]
@@ -54,12 +53,12 @@ impl ConstantSpec {
 
 /// Defines constants on `obj`.
 /// Fails on JSAPI failure.
-pub fn define_constants(cx: JSContext, obj: HandleObject, constants: &[ConstantSpec]) {
+pub fn define_constants(cx: &mut JSContext, obj: HandleObject, constants: &[ConstantSpec]) {
     for spec in constants {
-        rooted!(in(*cx) let value = spec.get_value());
+        rooted!(&in(cx) let value = spec.get_value());
         unsafe {
             assert!(JS_DefineProperty(
-                *cx,
+                cx,
                 obj,
                 spec.name.as_ptr(),
                 value.handle(),

--- a/components/script_bindings/constructor.rs
+++ b/components/script_bindings/constructor.rs
@@ -100,7 +100,7 @@ pub(crate) unsafe fn create_namespace_interface_objects<D: DomTypes>(
     assert!(!proto.is_null());
     rooted!(&in(cx) let mut namespace = ptr::null_mut::<JSObject>());
     create_namespace_object::<D>(
-        cx.into(),
+        cx,
         global,
         proto.handle(),
         init.namespace_object_class,
@@ -125,7 +125,7 @@ pub(crate) unsafe fn create_callback_interface_objects<D: DomTypes>(
 ) {
     rooted!(&in(cx) let mut interface = ptr::null_mut::<JSObject>());
     create_callback_interface_object::<D>(
-        cx.into(),
+        cx,
         global,
         init.constants,
         init.name,

--- a/components/script_bindings/guard.rs
+++ b/components/script_bindings/guard.rs
@@ -4,6 +4,8 @@
 
 //! Machinery to conditionally expose things.
 
+use js::context::JSContext;
+use js::realm::CurrentRealm;
 use js::rust::HandleObject;
 use servo_config::prefs::get;
 
@@ -11,8 +13,6 @@ use crate::DomTypes;
 use crate::codegen::Globals::Globals;
 use crate::interface::is_exposed_in;
 use crate::interfaces::GlobalScopeHelpers;
-use crate::realms::{AlreadyInRealm, InRealm};
-use crate::script_runtime::JSContext;
 
 /// A container with a list of conditions.
 pub(crate) struct Guard<T: Clone + Copy> {
@@ -31,7 +31,7 @@ impl<T: Clone + Copy> Guard<T> {
     /// The passed handle is the object on which the value may be exposed.
     pub(crate) fn expose<D: DomTypes>(
         &self,
-        cx: JSContext,
+        cx: &mut JSContext,
         obj: HandleObject,
         global: HandleObject,
     ) -> Option<T> {
@@ -61,7 +61,7 @@ impl<T: Clone + Copy> Guard<T> {
 #[derive(Clone, Copy)]
 pub(crate) enum Condition {
     /// The condition is satisfied if the function returns true.
-    Func(fn(JSContext, HandleObject) -> bool),
+    Func(fn(&mut JSContext, HandleObject) -> bool),
     /// The condition is satisfied if the preference is set.
     Pref(&'static str),
     // The condition is satisfied if the interface is exposed in the global.
@@ -71,17 +71,15 @@ pub(crate) enum Condition {
     Satisfied,
 }
 
-fn is_secure_context<D: DomTypes>(cx: JSContext) -> bool {
-    unsafe {
-        let in_realm_proof = AlreadyInRealm::assert_for_cx(JSContext::from_ptr(*cx));
-        D::GlobalScope::from_context(*cx, InRealm::Already(&in_realm_proof)).is_secure_context()
-    }
+fn is_secure_context<D: DomTypes>(cx: &mut JSContext) -> bool {
+    let realm = CurrentRealm::assert(cx);
+    D::GlobalScope::from_current_realm(&realm).is_secure_context()
 }
 
 impl Condition {
     pub(crate) fn is_satisfied<D: DomTypes>(
         &self,
-        cx: JSContext,
+        cx: &mut JSContext,
         obj: HandleObject,
         global: HandleObject,
     ) -> bool {

--- a/components/script_bindings/interface.rs
+++ b/components/script_bindings/interface.rs
@@ -13,20 +13,20 @@ use js::glue::UncheckedUnwrapObject;
 use js::jsapi::JS::CompartmentIterResult;
 use js::jsapi::{
     CallArgs, CheckedUnwrapStatic, Compartment, CompartmentSpecifier, GetNonCCWObjectGlobal,
-    GetRealmGlobalOrNull, GetWellKnownSymbol, HandleObject as RawHandleObject,
-    IsSharableCompartment, IsSystemCompartment, JS_AtomizeAndPinString, JS_GetFunctionObject,
-    JS_IterateCompartments, JS_NewFunction, JS_NewGlobalObject, JS_NewObject, JS_NewStringCopyN,
-    JS_SetReservedSlot, JS_SetTrustedPrincipals, JSAutoRealm, JSClass, JSClassOps, JSContext,
-    JSFUN_CONSTRUCTOR, JSFunctionSpec, JSObject, JSPROP_ENUMERATE, JSPROP_PERMANENT,
-    JSPROP_READONLY, JSPROP_RESOLVING, JSPropertySpec, JSString, JSTracer, ObjectOps,
-    OnNewGlobalHookOption, SymbolCode, TrueHandleValue, Value, jsid,
+    GetRealmGlobalOrNull, HandleObject as RawHandleObject, IsSharableCompartment,
+    IsSystemCompartment, JS_GetFunctionObject, JS_IterateCompartments, JS_NewGlobalObject,
+    JS_NewObject, JS_NewStringCopyN, JS_SetReservedSlot, JS_SetTrustedPrincipals, JSAutoRealm,
+    JSClass, JSClassOps, JSContext, JSFUN_CONSTRUCTOR, JSFunctionSpec, JSObject, JSPROP_ENUMERATE,
+    JSPROP_PERMANENT, JSPROP_READONLY, JSPROP_RESOLVING, JSPropertySpec, JSString, JSTracer,
+    ObjectOps, OnNewGlobalHookOption, SymbolCode, TrueHandleValue, Value, jsid,
 };
 use js::jsval::{JSVal, NullValue, PrivateValue};
 use js::realm::AutoRealm;
-use js::rust::wrappers::{
-    JS_DefineProperty, JS_DefineProperty3, JS_DefineProperty4, JS_DefineProperty5,
-    JS_DefinePropertyById5, JS_FireOnNewGlobalObject, JS_LinkConstructorAndPrototype,
-    JS_NewObjectWithGivenProto, RUST_SYMBOL_TO_JSID,
+use js::rust::wrappers::{JS_FireOnNewGlobalObject, RUST_SYMBOL_TO_JSID};
+use js::rust::wrappers2::{
+    GetWellKnownSymbol, JS_AtomizeAndPinString, JS_DefineProperty, JS_DefineProperty3,
+    JS_DefineProperty4, JS_DefineProperty5, JS_DefinePropertyById5, JS_LinkConstructorAndPrototype,
+    JS_NewFunction, JS_NewObjectWithGivenProto,
 };
 use js::rust::{
     HandleObject, HandleValue, MutableHandleObject, RealmOptions, define_methods,
@@ -231,7 +231,7 @@ fn select_compartment(cx: SafeJSContext, options: &mut RealmOptions) {
 
 /// Create and define the interface object of a callback interface.
 pub(crate) fn create_callback_interface_object<D: DomTypes>(
-    cx: SafeJSContext,
+    cx: &mut js::context::JSContext,
     global: HandleObject,
     constants: &[Guard<&[ConstantSpec]>],
     name: &CStr,
@@ -239,7 +239,7 @@ pub(crate) fn create_callback_interface_object<D: DomTypes>(
 ) {
     assert!(!constants.is_empty());
     unsafe {
-        rval.set(JS_NewObject(*cx, ptr::null()));
+        rval.set(JS_NewObject(cx.raw_cx(), ptr::null()));
     }
     assert!(!rval.is_null());
     define_guarded_constants::<D>(cx, rval.handle(), constants, global);
@@ -250,7 +250,7 @@ pub(crate) fn create_callback_interface_object<D: DomTypes>(
 /// Create the interface prototype object of a non-callback interface.
 #[expect(clippy::too_many_arguments)]
 pub(crate) fn create_interface_prototype_object<D: DomTypes>(
-    cx: SafeJSContext,
+    cx: &mut js::context::JSContext,
     global: HandleObject,
     proto: HandleObject,
     class: &'static JSClass,
@@ -272,17 +272,17 @@ pub(crate) fn create_interface_prototype_object<D: DomTypes>(
     );
 
     if !unscopable_names.is_empty() {
-        rooted!(in(*cx) let mut unscopable_obj = ptr::null_mut::<JSObject>());
+        rooted!(&in(cx) let mut unscopable_obj = ptr::null_mut::<JSObject>());
         create_unscopable_object(cx, unscopable_names, unscopable_obj.handle_mut());
         unsafe {
-            let unscopable_symbol = GetWellKnownSymbol(*cx, SymbolCode::unscopables);
+            let unscopable_symbol = GetWellKnownSymbol(cx, SymbolCode::unscopables);
             assert!(!unscopable_symbol.is_null());
 
-            rooted!(in(*cx) let mut unscopable_id: jsid);
+            rooted!(&in(cx) let mut unscopable_id: jsid);
             RUST_SYMBOL_TO_JSID(unscopable_symbol, unscopable_id.handle_mut());
 
             assert!(JS_DefinePropertyById5(
-                *cx,
+                cx,
                 rval.handle(),
                 unscopable_id.handle(),
                 unscopable_obj.handle(),
@@ -295,7 +295,7 @@ pub(crate) fn create_interface_prototype_object<D: DomTypes>(
 /// Create and define the interface object of a non-callback interface.
 #[expect(clippy::too_many_arguments)]
 pub(crate) fn create_noncallback_interface_object<D: DomTypes>(
-    cx: SafeJSContext,
+    cx: &mut js::context::JSContext,
     global: HandleObject,
     proto: HandleObject,
     class: &'static NonCallbackInterfaceObjectClass,
@@ -320,7 +320,7 @@ pub(crate) fn create_noncallback_interface_object<D: DomTypes>(
     );
     unsafe {
         assert!(JS_LinkConstructorAndPrototype(
-            *cx,
+            cx,
             rval.handle(),
             interface_prototype_object
         ));
@@ -338,22 +338,22 @@ pub(crate) fn create_noncallback_interface_object<D: DomTypes>(
 
 /// Create and define the named constructors of a non-callback interface.
 pub(crate) fn create_named_constructors(
-    cx: SafeJSContext,
+    cx: &mut js::context::JSContext,
     global: HandleObject,
     named_constructors: &[(ConstructorClassHook, &CStr, u32)],
     interface_prototype_object: HandleObject,
 ) {
-    rooted!(in(*cx) let mut constructor = ptr::null_mut::<JSObject>());
+    rooted!(&in(cx) let mut constructor = ptr::null_mut::<JSObject>());
 
     for &(native, name, arity) in named_constructors {
         unsafe {
-            let fun = JS_NewFunction(*cx, Some(native), arity, JSFUN_CONSTRUCTOR, name.as_ptr());
+            let fun = JS_NewFunction(cx, Some(native), arity, JSFUN_CONSTRUCTOR, name.as_ptr());
             assert!(!fun.is_null());
             constructor.set(JS_GetFunctionObject(fun));
             assert!(!constructor.is_null());
 
             assert!(JS_DefineProperty3(
-                *cx,
+                cx,
                 constructor.handle(),
                 c"prototype".as_ptr(),
                 interface_prototype_object,
@@ -368,7 +368,7 @@ pub(crate) fn create_named_constructors(
 /// Create a new object with a unique type.
 #[expect(clippy::too_many_arguments)]
 pub(crate) fn create_object<D: DomTypes>(
-    cx: SafeJSContext,
+    cx: &mut js::context::JSContext,
     global: HandleObject,
     proto: HandleObject,
     class: &'static JSClass,
@@ -378,7 +378,7 @@ pub(crate) fn create_object<D: DomTypes>(
     mut rval: MutableHandleObject,
 ) {
     unsafe {
-        rval.set(JS_NewObjectWithGivenProto(*cx, class, proto));
+        rval.set(JS_NewObjectWithGivenProto(cx, class, proto));
     }
     assert!(!rval.is_null());
     define_guarded_methods::<D>(cx, rval.handle(), methods, global);
@@ -388,7 +388,7 @@ pub(crate) fn create_object<D: DomTypes>(
 
 /// Conditionally define constants on an object.
 pub(crate) fn define_guarded_constants<D: DomTypes>(
-    cx: SafeJSContext,
+    cx: &mut js::context::JSContext,
     obj: HandleObject,
     constants: &[Guard<&[ConstantSpec]>],
     global: HandleObject,
@@ -402,7 +402,7 @@ pub(crate) fn define_guarded_constants<D: DomTypes>(
 
 /// Conditionally define methods on an object.
 pub(crate) fn define_guarded_methods<D: DomTypes>(
-    cx: SafeJSContext,
+    cx: &mut js::context::JSContext,
     obj: HandleObject,
     methods: &[Guard<&'static [JSFunctionSpec]>],
     global: HandleObject,
@@ -410,7 +410,7 @@ pub(crate) fn define_guarded_methods<D: DomTypes>(
     for guard in methods {
         if let Some(specs) = guard.expose::<D>(cx, obj, global) {
             unsafe {
-                define_methods(*cx, obj, specs).unwrap();
+                define_methods(cx.raw_cx(), obj, specs).unwrap();
             }
         }
     }
@@ -418,7 +418,7 @@ pub(crate) fn define_guarded_methods<D: DomTypes>(
 
 /// Conditionally define properties on an object.
 pub(crate) fn define_guarded_properties<D: DomTypes>(
-    cx: SafeJSContext,
+    cx: &mut js::context::JSContext,
     obj: HandleObject,
     properties: &[Guard<&'static [JSPropertySpec]>],
     global: HandleObject,
@@ -426,7 +426,7 @@ pub(crate) fn define_guarded_properties<D: DomTypes>(
     for guard in properties {
         if let Some(specs) = guard.expose::<D>(cx, obj, global) {
             unsafe {
-                define_properties(*cx, obj, specs).unwrap();
+                define_properties(cx.raw_cx(), obj, specs).unwrap();
             }
         }
     }
@@ -445,14 +445,14 @@ pub(crate) fn is_exposed_in(object: HandleObject, globals: Globals) -> bool {
 /// Define a property with a given name on the global object. Should be called
 /// through the resolve hook.
 pub(crate) fn define_on_global_object(
-    cx: SafeJSContext,
+    cx: &mut js::context::JSContext,
     global: HandleObject,
     name: &CStr,
     obj: HandleObject,
 ) {
     unsafe {
         assert!(JS_DefineProperty3(
-            *cx,
+            cx,
             global,
             name.as_ptr(),
             obj,
@@ -487,19 +487,23 @@ unsafe extern "C" fn fun_to_string_hook(
     ret
 }
 
-fn create_unscopable_object(cx: SafeJSContext, names: &[&CStr], mut rval: MutableHandleObject) {
+fn create_unscopable_object(
+    cx: &mut js::context::JSContext,
+    names: &[&CStr],
+    mut rval: MutableHandleObject,
+) {
     assert!(!names.is_empty());
     assert!(rval.is_null());
     unsafe {
         rval.set(JS_NewObjectWithGivenProto(
-            *cx,
+            cx,
             ptr::null(),
             HandleObject::null(),
         ));
         assert!(!rval.is_null());
         for &name in names {
             assert!(JS_DefineProperty(
-                *cx,
+                cx,
                 rval.handle(),
                 name.as_ptr(),
                 HandleValue::from_raw(TrueHandleValue),
@@ -509,12 +513,12 @@ fn create_unscopable_object(cx: SafeJSContext, names: &[&CStr], mut rval: Mutabl
     }
 }
 
-fn define_name(cx: SafeJSContext, obj: HandleObject, name: &CStr) {
+fn define_name(cx: &mut js::context::JSContext, obj: HandleObject, name: &CStr) {
     unsafe {
-        rooted!(in(*cx) let name = JS_AtomizeAndPinString(*cx, name.as_ptr()));
+        rooted!(&in(cx) let name = JS_AtomizeAndPinString(cx, name.as_ptr()));
         assert!(!name.is_null());
         assert!(JS_DefineProperty4(
-            *cx,
+            cx,
             obj,
             c"name".as_ptr(),
             name.handle(),
@@ -523,10 +527,10 @@ fn define_name(cx: SafeJSContext, obj: HandleObject, name: &CStr) {
     }
 }
 
-fn define_length(cx: SafeJSContext, obj: HandleObject, length: i32) {
+fn define_length(cx: &mut js::context::JSContext, obj: HandleObject, length: i32) {
     unsafe {
         assert!(JS_DefineProperty5(
-            *cx,
+            cx,
             obj,
             c"length".as_ptr(),
             length,

--- a/components/script_bindings/interfaces.rs
+++ b/components/script_bindings/interfaces.rs
@@ -5,6 +5,7 @@
 use std::cell::RefCell;
 use std::thread::LocalKey;
 
+use js::context::JSContext;
 use js::glue::JSPrincipalsCallbacks;
 use js::jsapi::{CallArgs, HandleObject as RawHandleObject, JSContext as RawJSContext, JSObject};
 use js::realm::CurrentRealm;
@@ -18,7 +19,7 @@ use crate::error::Error;
 use crate::realms::InRealm;
 use crate::reflector::{DomObject, DomObjectWrap};
 use crate::root::DomRoot;
-use crate::script_runtime::{CanGc, JSContext};
+use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 use crate::settings_stack::StackEntry;
 use crate::utils::ProtoOrIfaceArray;
 
@@ -28,21 +29,21 @@ use crate::utils::ProtoOrIfaceArray;
 /// <https://github.com/mozilla/gecko-dev/blob/3fd619f47/dom/bindings/WebIDLGlobalNameHash.h#L24>
 pub struct Interface {
     /// Define the JS object for this interface on the given global.
-    pub define: fn(&mut js::context::JSContext, HandleObject),
+    pub define: fn(&mut JSContext, HandleObject),
     /// Returns true if this interface's conditions are met for the given global.
-    pub enabled: fn(&mut js::context::JSContext, HandleObject) -> bool,
+    pub enabled: fn(&mut JSContext, HandleObject) -> bool,
 }
 
 /// Operations that must be invoked from the generated bindings.
 pub trait DomHelpers<D: DomTypes> {
-    fn throw_dom_exception(cx: &mut js::context::JSContext, global: &D::GlobalScope, result: Error);
+    fn throw_dom_exception(cx: &mut JSContext, global: &D::GlobalScope, result: Error);
 
     fn call_html_constructor<T: DerivedFrom<D::Element> + DomObject>(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         args: &CallArgs,
         global: &D::GlobalScope,
         proto_id: PrototypeList::ID,
-        creator: unsafe fn(&mut js::context::JSContext, HandleObject, *mut ProtoOrIfaceArray),
+        creator: unsafe fn(&mut JSContext, HandleObject, *mut ProtoOrIfaceArray),
     ) -> bool;
 
     fn settings_stack() -> &'static LocalKey<RefCell<Vec<StackEntry<D>>>>;
@@ -54,7 +55,7 @@ pub trait DomHelpers<D: DomTypes> {
     fn interface_map() -> &'static phf::Map<&'static [u8], Interface>;
 
     fn push_new_element_queue();
-    fn pop_current_element_queue(cx: &mut js::context::JSContext);
+    fn pop_current_element_queue(cx: &mut JSContext);
 
     fn reflect_dom_object<T, U>(obj: Box<T>, global: &U, can_gc: CanGc) -> DomRoot<T>
     where
@@ -71,7 +72,7 @@ pub trait GlobalScopeHelpers<D: DomTypes> {
     /// # Safety
     /// `cx` must point to a valid, non-null RawJSContext.
     unsafe fn from_context(cx: *mut RawJSContext, realm: InRealm) -> DomRoot<D::GlobalScope>;
-    fn get_cx() -> JSContext;
+    fn get_cx() -> SafeJSContext;
     /// # Safety
     /// `obj` must point to a valid, non-null JSObject.
     unsafe fn from_object(obj: *mut JSObject) -> DomRoot<D::GlobalScope>;
@@ -81,7 +82,7 @@ pub trait GlobalScopeHelpers<D: DomTypes> {
 
     fn incumbent() -> Option<DomRoot<D::GlobalScope>>;
 
-    fn perform_a_microtask_checkpoint(&self, cx: &mut js::context::JSContext);
+    fn perform_a_microtask_checkpoint(&self, cx: &mut JSContext);
 
     fn get_url(&self) -> ServoUrl;
 
@@ -93,21 +94,21 @@ pub trait DocumentHelpers {
 }
 
 pub trait ServoInternalsHelpers {
-    fn is_servo_internal(cx: JSContext, global: HandleObject) -> bool;
+    fn is_servo_internal(cx: &mut JSContext, global: HandleObject) -> bool;
 }
 
 pub trait TestBindingHelpers {
-    fn condition_satisfied(cx: JSContext, global: HandleObject) -> bool;
-    fn condition_unsatisfied(cx: JSContext, global: HandleObject) -> bool;
+    fn condition_satisfied(cx: &mut JSContext, global: HandleObject) -> bool;
+    fn condition_unsatisfied(cx: &mut JSContext, global: HandleObject) -> bool;
 }
 
 pub trait WebGL2RenderingContextHelpers {
-    fn is_webgl2_enabled(cx: JSContext, global: HandleObject) -> bool;
+    fn is_webgl2_enabled(cx: &mut JSContext, global: HandleObject) -> bool;
 }
 
 pub trait WindowHelpers {
     fn create_named_properties_object(
-        cx: JSContext,
+        cx: &mut JSContext,
         proto: HandleObject,
         object: MutableHandleObject,
     );

--- a/components/script_bindings/namespace.rs
+++ b/components/script_bindings/namespace.rs
@@ -7,6 +7,7 @@
 use std::ffi::CStr;
 use std::ptr;
 
+use js::context::JSContext;
 use js::jsapi::{JSClass, JSFunctionSpec};
 use js::rust::{HandleObject, MutableHandleObject};
 
@@ -14,7 +15,6 @@ use crate::DomTypes;
 use crate::constant::ConstantSpec;
 use crate::guard::Guard;
 use crate::interface::{create_object, define_on_global_object};
-use crate::script_runtime::JSContext;
 
 /// The class of a namespace object.
 #[derive(Clone, Copy)]
@@ -39,7 +39,7 @@ impl NamespaceObjectClass {
 /// Create a new namespace object.
 #[expect(clippy::too_many_arguments)]
 pub(crate) fn create_namespace_object<D: DomTypes>(
-    cx: JSContext,
+    cx: &mut JSContext,
     global: HandleObject,
     proto: HandleObject,
     class: &'static NamespaceObjectClass,


### PR DESCRIPTION
The condition is used in `.webidl` to determine whether an
interface should be available or not. This function is used
as guard, hence we need to update quite a few places to the
new `JSContext`. Overall, we now use a lot more `wrappers2`
than before.

Part of #40600

Testing: it compiles