### PR TITLE
layout: Have `NodeExt::with_layout_box_base_including_pseudos` take `FnMut`

### DIFF
--- a/components/layout/dom.rs
+++ b/components/layout/dom.rs
@@ -98,19 +98,19 @@ impl InnerDOMLayoutData {
         }
     }
 
-    fn with_layout_box_base(&self, callback: impl Fn(&LayoutBoxBase)) {
+    fn with_layout_box_base(&self, callback: impl FnMut(&LayoutBoxBase)) {
         if let Some(data) = self.self_box.borrow().as_ref() {
             data.with_base(callback);
         }
     }
 
-    fn with_layout_box_base_including_pseudos(&self, callback: impl Fn(&LayoutBoxBase)) {
-        self.with_layout_box_base(&callback);
+    fn with_layout_box_base_including_pseudos(&self, mut callback: impl FnMut(&LayoutBoxBase)) {
+        self.with_layout_box_base(&mut callback);
         for pseudo_layout_data in self.pseudo_boxes.iter() {
             pseudo_layout_data
                 .data
                 .borrow()
-                .with_layout_box_base(&callback);
+                .with_layout_box_base(&mut callback);
         }
     }
 }
@@ -347,7 +347,7 @@ pub(crate) trait NodeExt<'dom> {
     fn rendering_type(&self) -> NodeRenderingType;
 
     fn fragments_for_pseudo(&self, pseudo_element: Option<PseudoElement>) -> Vec<Fragment>;
-    fn with_layout_box_base_including_pseudos(&self, callback: impl Fn(&LayoutBoxBase));
+    fn with_layout_box_base_including_pseudos(&self, callback: impl FnMut(&LayoutBoxBase));
 
     fn repair_style(&self, context: &SharedStyleContext);
 
@@ -543,7 +543,7 @@ impl<'dom> NodeExt<'dom> for ServoLayoutNode<'dom> {
         }
     }
 
-    fn with_layout_box_base_including_pseudos(&self, callback: impl Fn(&LayoutBoxBase)) {
+    fn with_layout_box_base_including_pseudos(&self, callback: impl FnMut(&LayoutBoxBase)) {
         if let Some(inner_layout_data) = self.inner_layout_data() {
             inner_layout_data.with_layout_box_base_including_pseudos(callback);
         }

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -308,14 +308,12 @@ pub(crate) fn compute_damage_and_rebuild_box_tree_inner(
             // to run fragment tree layout in this subtree due to an ancestor, this node, or a
             // descendant changing style. In that case, we ask the `LayoutBoxBase` to clear
             // any cached information that cannot be used.
-            let extra_layout_damage_for_parent = Cell::new(LayoutDamage::empty());
+            let mut extra_layout_damage_for_parent = LayoutDamage::empty();
             node.with_layout_box_base_including_pseudos(|base| {
-                extra_layout_damage_for_parent.set(
-                    extra_layout_damage_for_parent.get() |
-                        base.add_damage(element_damage, damage_from_children, damage_from_parent),
-                );
+                extra_layout_damage_for_parent |=
+                    base.add_damage(element_damage, damage_from_children, damage_from_parent);
             });
-            layout_damage_for_parent.insert(extra_layout_damage_for_parent.get());
+            layout_damage_for_parent.insert(extra_layout_damage_for_parent);
         } else if (damage_from_children | element_damage)
             .contains(LayoutDamage::RecalculateOverflow)
         {


### PR DESCRIPTION
This makes `NodeExt::with_layout_box_base_including_pseudos` take a
`FnMut` which allows callers to mutate data passed to the callback. This
allows removing the usage of a `Cell` from the damage propagation
traversal.


Testing: This change should not change behavior in an observable way, so should be covered by existing tests.
