### PR TITLE
script: Drop pending image-cache callbacks

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2497,6 +2497,10 @@ impl Window {
         self.as_global_scope()
             .task_manager()
             .cancel_all_tasks_and_ignore_future_tasks();
+
+        // Callbacks may contain `Trusted` references, which are rooted and would
+        // prevent the window from being GCed.
+        self.pending_image_callbacks.borrow_mut().clear();
     }
 
     /// <https://drafts.csswg.org/cssom-view/#dom-window-scroll>


### PR DESCRIPTION
This is one cycle that that prevents the Window from being GCed by SM.
The pending_image_callbacks are also removed / dropped when the requests are fulfilled, but this is inherently racy and repeatedly reloading a page in quick succession is a good way to trigger pending image callbacks on pipeline destroy.

Testing: Not tested. It's not clear how to add a test that asserts a window is GCed (and this fix is not sufficient).
Fixes: Part of #45262
