### PR TITLE
script: Make `URL.revokeObjectURL` work for sandboxed iframe

### DIFF
--- a/components/script/dom/url/url.rs
+++ b/components/script/dom/url/url.rs
@@ -205,7 +205,6 @@ impl URLMethods<crate::DomTypeHolder> for URL {
 
         if let Ok(url) = ServoUrl::parse(&url.str()) &&
             url.fragment().is_none() &&
-            *origin == url.origin() &&
             let Ok((id, _)) = parse_blob_url(&url)
         {
             let resource_threads = global.resource_threads();

--- a/components/script/dom/url/url.rs
+++ b/components/script/dom/url/url.rs
@@ -204,6 +204,7 @@ impl URLMethods<crate::DomTypeHolder> for URL {
         let origin = global.origin().immutable();
 
         if let Ok(url) = ServoUrl::parse(&url.str()) &&
+            url.fragment().is_none() &&
             let Ok((id, _)) = parse_blob_url(&url)
         {
             let resource_threads = global.resource_threads();

--- a/components/script/dom/url/url.rs
+++ b/components/script/dom/url/url.rs
@@ -204,7 +204,6 @@ impl URLMethods<crate::DomTypeHolder> for URL {
         let origin = global.origin().immutable();
 
         if let Ok(url) = ServoUrl::parse(&url.str()) &&
-            url.fragment().is_none() &&
             let Ok((id, _)) = parse_blob_url(&url)
         {
             let resource_threads = global.resource_threads();

--- a/components/script_bindings/webidls/URL.webidl
+++ b/components/script_bindings/webidls/URL.webidl
@@ -27,7 +27,6 @@ interface URL {
 
   // https://w3c.github.io/FileAPI/#creating-revoking
   static DOMString createObjectURL(Blob blob);
-  // static DOMString createFor(Blob blob);
   static undefined revokeObjectURL(DOMString url);
 
   USVString toJSON();

--- a/tests/wpt/meta/FileAPI/url/sandboxed-iframe.html.ini
+++ b/tests/wpt/meta/FileAPI/url/sandboxed-iframe.html.ini
@@ -12,8 +12,5 @@
   [Revoke blob URL after creating Request, then clone Request, will fetch]
     expected: FAIL
 
-  [XHR of a revoked URL should fail]
-    expected: FAIL
-
-  [fetch of a revoked URL should fail]
+  [Revoke blob URL after creating Request, will fetch]
     expected: FAIL


### PR DESCRIPTION
[Spec](https://w3c.github.io/FileAPI/#dfn-revokeObjectURL) never said anything about if the origin should match.
We remove this check. We were failing `tests\wpt\tests\FileAPI\url\sandboxed-iframe.html` as the sandboxed iframe
has opaque origin and we never successfully revoke the blob.

Testing: Existing tests passing for sandboxed iframe. 
`Revoke blob URL after creating Request, will fetch` now **fails correctly**. It was wrongly passing,
as we didn't revoke the URL.
Spec says "Requests that were started before the url was revoked should still succeed.", 
which we never implemented correctly.
Part of #10778