### PR TITLE
servoshell: fix selection of options in multiple select

### DIFF
--- a/ports/servoshell/desktop/dialog.rs
+++ b/ports/servoshell/desktop/dialog.rs
@@ -506,15 +506,11 @@ impl Dialog {
 
                     if clickable_area.clicked() && !option.is_disabled {
                         if allow_multiple {
-                            if let Some(pos) =
-                                selected_options.iter().position(|id| *id == option.id)
-                            {
-                                selected_options.remove(pos);
-                            }
                             if let Some(position) =
                                 selected_options.iter().position(|id| *id == option.id)
                             {
                                 selected_options.remove(position);
+                            } else {
                                 selected_options.push(option.id);
                             }
                         } else {


### PR DESCRIPTION
Currently it is not possible to select options in a select element with the multiple attribute due to a merging error that broke the code which inserts options into the list of selected options. This pull request fixes that.

Testing: Currently we lack the infrastructure to test servoshell GUI.