### PR TITLE
layout: Refactor damage propagation traversal

### DIFF
--- a/components/layout/layout_box_base.rs
+++ b/components/layout/layout_box_base.rs
@@ -29,6 +29,7 @@ use crate::fragment_tree::{
 use crate::geom::LogicalSides1D;
 use crate::positioned::{PositioningContext, relative_adjustement};
 use crate::sizing::{ComputeInlineContentSizes, InlineContentSizesResult, SizeConstraint};
+use crate::traversal::ElementDamageSet;
 use crate::{ConstraintSpace, ContainingBlock, ContainingBlockSize};
 
 /// A box tree node that handles containing information about style and the original DOM
@@ -151,15 +152,12 @@ impl LayoutBoxBase {
         self.parent_box.as_ref().and_then(WeakLayoutBox::upgrade)
     }
 
-    pub(crate) fn add_damage(
-        &self,
-        element_damage: LayoutDamage,
-        damage_from_children: LayoutDamage,
-        damage_from_parent: LayoutDamage,
-    ) -> LayoutDamage {
-        let only_descendants_changed = !element_damage.contains(LayoutDamage::Relayout) &&
-            !damage_from_parent.contains(LayoutDamage::Relayout) &&
-            !damage_from_children.contains(LayoutDamage::LayoutAffectedByInflowDescendant) &&
+    pub(crate) fn add_damage(&self, damage_set: &ElementDamageSet) -> LayoutDamage {
+        let only_descendants_changed = !damage_set.on_element.contains(LayoutDamage::Relayout) &&
+            !damage_set.from_parent.contains(LayoutDamage::Relayout) &&
+            !damage_set
+                .from_children
+                .contains(LayoutDamage::LayoutAffectedByInflowDescendant) &&
             self.fragments.borrow().iter().all(|fragment| {
                 fragment
                     .base()
@@ -169,13 +167,15 @@ impl LayoutBoxBase {
             .store(only_descendants_changed, Ordering::Relaxed);
         self.clear_fragments_and_dirty_fragment_cache();
 
-        if !element_damage.is_empty() ||
-            damage_from_children.contains(LayoutDamage::RecomputeInlineContentSizes)
+        if !damage_set.on_element.is_empty() ||
+            damage_set
+                .from_children
+                .contains(LayoutDamage::RecomputeInlineContentSizes)
         {
             *self.cached_inline_content_size.borrow_mut() = None;
         }
 
-        let mut damage_for_parent = element_damage | damage_from_children;
+        let mut damage_for_parent = damage_set.on_element | damage_set.from_children;
 
         // When a block container has a mix of inline-level and block-level contents, the
         // inline-level ones are wrapped inside an anonymous block associated with the
@@ -189,7 +189,7 @@ impl LayoutBoxBase {
         // and we can keep the cache.
         damage_for_parent.set(
             LayoutDamage::RecomputeInlineContentSizes,
-            !element_damage.is_empty() ||
+            !damage_set.on_element.is_empty() ||
                 (!self.base_fragment_info.is_anonymous() &&
                     self.outer_inline_content_sizes_depend_on_content
                         .load(Ordering::Relaxed)),

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::Cell;
 use std::sync::Arc;
 
 use layout_api::{
@@ -147,18 +146,14 @@ pub(crate) fn compute_damage_and_rebuild_box_tree(
         } else if needs_fragment_tree_rebuild {
             // Reconstruction has already run or was not necessary, so we just need to
             // ensure that fragment tree layout does not reuse any cached fragments.
-            let new_damage_for_ancestors = Cell::new(LayoutDamage::empty());
+            let mut new_damage_for_ancestors = LayoutDamage::empty();
             parent_node.with_layout_box_base_including_pseudos(|base| {
-                new_damage_for_ancestors.set(
-                    new_damage_for_ancestors.get() |
-                        base.add_damage(
-                            Default::default(),
-                            damage_for_ancestors,
-                            LayoutDamage::empty(),
-                        ),
-                );
+                new_damage_for_ancestors |= base.add_damage(&ElementDamageSet::from_children(
+                    parent_node,
+                    damage_for_ancestors,
+                ));
             });
-            damage_for_ancestors = new_damage_for_ancestors.get();
+            damage_for_ancestors = new_damage_for_ancestors;
 
             // If doing a fragment tree layout, we also need to apply the LAYOUT_AFFECTED_BY_INFLOW_DESCENDANT
             // damage flag, unless this node is out of flow. In that case our ancestors are rebuilt, but
@@ -195,8 +190,8 @@ pub(crate) fn compute_damage_and_rebuild_box_tree_inner(
     node: ServoLayoutNode<'_>,
     damage_from_parent: LayoutDamage,
 ) -> LayoutDamage {
-    // Don't do any kind of damage propagation or box tree constuction for non-Element nodes,
-    // such as text and comments.
+    // Don't do any kind of damage propagation or box tree construction for non-Element
+    // nodes, such as text and comments.
     let Some(element) = node.as_element() else {
         return damage_from_parent;
     };
@@ -217,136 +212,244 @@ pub(crate) fn compute_damage_and_rebuild_box_tree_inner(
         dangerous_style_element.unset_dirty_descendants();
     };
 
-    let mut element_and_parent_damage = element_damage | damage_from_parent;
     if is_display_none {
         node.unset_all_boxes();
-        return element_and_parent_damage;
+        return element_damage | damage_from_parent;
     }
 
-    // Children only receive layout mode damage from their parents, except when an ancestor
-    // needs to be completely rebuilt. In that case, descendants are rebuilt down to the
-    // first independent formatting context, which should isolate that tree from further
-    // box damage.
-    let mut damage_for_children = element_and_parent_damage.only_layout_modes();
-    let rebuild_children = element_damage.contains(LayoutDamage::BoxDamage) ||
-        (damage_from_parent.contains(LayoutDamage::BoxDamage) &&
-            !node.isolates_damage_for_damage_propagation());
-    if rebuild_children {
-        damage_for_children.insert(LayoutDamage::BoxDamage);
-    } else if element_and_parent_damage.contains(LayoutDamage::Relayout) &&
-        !element_damage.contains(LayoutDamage::Relayout) &&
-        node.isolates_damage_for_damage_propagation()
-    {
-        // If not rebuilding the boxes for this node, but fragments need to be rebuilt
-        // only because of an ancestor, fragment layout caches should still be valid when
-        // crossing down into new independent formatting contexts.
-        damage_for_children.remove(LayoutDamage::Relayout);
-        element_and_parent_damage.remove(LayoutDamage::Relayout);
+    let mut damage_set = ElementDamageSet {
+        node,
+        from_parent: damage_from_parent,
+        on_element: element_damage,
+        from_children: LayoutDamage::empty(),
+    };
+
+    // Depending on the incoming damage, it can be isolated, meaning that some damage
+    // doesn't get passed down to children.
+    let damage_for_children = damage_set.isolate_incoming_damage();
+
+    // Propagate damage to children and gather the resulting damage into `from_children`.
+    damage_set.propagate_damage_to_children(
+        layout_context,
+        has_dirty_descendants,
+        damage_for_children,
+    );
+
+    // Apply the calculated damage to this element (perhaps triggering box tree layout),
+    // and propagate resulting damage to ancestors.
+    damage_set.apply_damage(layout_context)
+}
+
+enum BoxDamageAction {
+    RebuildAncestor,
+    TryRebuild,
+    InvalidateFragmentCache,
+    InvalidateScrollableOverflow,
+    None,
+}
+
+impl BoxDamageAction {
+    fn preserves_boxes(&self) -> bool {
+        matches!(
+            self,
+            Self::InvalidateFragmentCache | Self::InvalidateScrollableOverflow | Self::None
+        )
+    }
+}
+
+pub(crate) struct ElementDamageSet<'a> {
+    node: ServoLayoutNode<'a>,
+    pub from_parent: LayoutDamage,
+    pub on_element: LayoutDamage,
+    pub from_children: LayoutDamage,
+}
+
+impl<'a> ElementDamageSet<'a> {
+    fn from_children(node: ServoLayoutNode<'a>, from_children: LayoutDamage) -> Self {
+        Self {
+            node,
+            from_parent: LayoutDamage::empty(),
+            on_element: LayoutDamage::empty(),
+            from_children,
+        }
     }
 
-    let mut damage_from_children = LayoutDamage::empty();
+    /// Given the damage on the element and damage from parents, determine which damage
+    /// should be passed to children, returning that value.
+    fn isolate_incoming_damage(&mut self) -> LayoutDamage {
+        // Children only receive layout mode damage from their parents, except when an ancestor
+        // needs to be completely rebuilt. In that case, descendants are rebuilt down to the
+        // first independent formatting context, which should isolate that tree from further
+        // box damage.
+        let mut damage_for_children = (self.on_element | self.from_parent).only_layout_modes();
+        let rebuild_children = self.on_element.contains(LayoutDamage::BoxDamage) ||
+            (self.from_parent.contains(LayoutDamage::BoxDamage) &&
+                !self.node.isolates_damage_for_damage_propagation());
 
-    // Propagate damage into children, but only if:
-    //  1. There is a descendant that was dirty / possibly restyled.
-    //  2. We detected that we need to rebuild child boxes.
-    //  3. An ancestor will be laid out and children need to have their fragment caches cleared.
-    //
-    // In other situations, such as when layout will not run at all or when we are
-    // guaranteed that children are undamaged, we can skip traversing children entirely.
-    if has_dirty_descendants ||
-        rebuild_children ||
-        damage_for_children.contains(LayoutDamage::Relayout)
-    {
-        for child in node.flat_tree_children() {
-            if child.is_element() {
-                damage_from_children |= compute_damage_and_rebuild_box_tree_inner(
-                    layout_context,
-                    child,
-                    damage_for_children,
-                );
+        if rebuild_children {
+            damage_for_children.insert(LayoutDamage::BoxDamage);
+        } else if self.from_parent.contains(LayoutDamage::Relayout) &&
+            !self.on_element.contains(LayoutDamage::Relayout) &&
+            self.node.isolates_damage_for_damage_propagation()
+        {
+            // If not rebuilding the boxes for this node, but fragments need to be laid out
+            // only because of an ancestor, fragment layout caches should still be valid when
+            // crossing down into new independent formatting contexts.
+            damage_for_children.remove(LayoutDamage::Relayout);
+            self.from_parent.remove(LayoutDamage::Relayout);
+        }
+
+        damage_for_children
+    }
+
+    /// Given the damage the damage to children and whether or not this element had any
+    /// dirty descendants, conditionally propagated damage to children and set the resulting
+    /// damage from children on this [`ElementDamageSet`].
+    fn propagate_damage_to_children(
+        &mut self,
+        layout_context: &LayoutContext<'_>,
+        has_dirty_descendants: bool,
+        damage_for_children: LayoutDamage,
+    ) {
+        // Propagate damage into children, but only if:
+        //  1. There is a descendant that was dirty / possibly restyled.
+        //  2. We detected that we need to rebuild child boxes.
+        //  3. An ancestor will be laid out and children need to have their fragment caches cleared.
+        //
+        // In other situations, such as when layout will not run at all or when we are
+        // guaranteed that children are undamaged, we can skip traversing children entirely.
+        if has_dirty_descendants ||
+            damage_for_children.intersects(LayoutDamage::BoxDamage | LayoutDamage::Relayout)
+        {
+            for child in self.node.flat_tree_children() {
+                if child.is_element() {
+                    self.from_children |= compute_damage_and_rebuild_box_tree_inner(
+                        layout_context,
+                        child,
+                        damage_for_children,
+                    );
+                }
             }
         }
     }
 
-    // Only propagate up layout phases and whether layout affects inflow descendants from
-    // children. Other types of damage can be propagated from children but via the
-    // `LayoutBoxBase::add_damage` return value.
-    let mut layout_damage_for_parent = element_and_parent_damage |
-        (damage_from_children &
-            (LayoutDamage::Relayout | LayoutDamage::LayoutAffectedByInflowDescendant));
+    /// Given the damage from this element, the parent, and children, determine what action to
+    /// take for this element's boxes and return the damage that should be propagated to parents.
+    fn apply_damage(&self, layout_context: &LayoutContext<'_>) -> LayoutDamage {
+        // Only propagate up layout phases and whether layout affects inflow descendants from
+        // children. Other types of damage can be propagated from children but via the
+        // `LayoutBoxBase::add_damage` return value.
+        let forwarded_damage = (self.from_parent | self.on_element | self.from_children)
+            .only_layout_modes() |
+            (self.from_children | LayoutDamage::LayoutAffectedByInflowDescendant);
 
-    let element_or_ancestors_need_rebuild =
-        element_and_parent_damage.contains(LayoutDamage::DescendantHasBoxDamage);
-    let descendant_needs_rebuild =
-        damage_from_children.contains(LayoutDamage::DescendantHasBoxDamage);
-    if element_or_ancestors_need_rebuild || descendant_needs_rebuild {
-        if damage_from_parent.contains(LayoutDamage::DescendantHasBoxDamage) ||
-            !node.rebuild_box_tree_from_independent_formatting_context(layout_context)
-        {
-            // In this case:
-            //  - an ancestor needs to be completely rebuilt, or
-            //  - a descendant needs to be rebuilt, but we are still propagating the rebuild
-            //    damage to an independent formatting context with a compatible box level.
-            //
-            // This means that this box is no longer valid and also needs to be rebuilt
-            // (perhaps some of its descendants do not though). In this case, unset all existing
-            // boxes for the node and ensure that the appropriate rebuild-type damage
-            // propagates up the tree.
-            node.unset_all_boxes();
-            layout_damage_for_parent
-                .insert(LayoutDamage::DescendantHasBoxDamage | LayoutDamage::Relayout);
-        } else {
-            // In this case, we have rebuilt the box tree from this point and we do not
-            // have to propagate rebuild box tree damage up the tree any further.
-            layout_damage_for_parent.remove(LayoutDamage::BoxDamage);
-            layout_damage_for_parent
-                .insert(LayoutDamage::Relayout | LayoutDamage::RecomputeInlineContentSizes);
-        }
-    } else {
-        if (element_and_parent_damage | damage_from_children).contains(LayoutDamage::Relayout) {
-            // In this case, this node's boxes are preserved! It's possible that we still need
-            // to run fragment tree layout in this subtree due to an ancestor, this node, or a
-            // descendant changing style. In that case, we ask the `LayoutBoxBase` to clear
-            // any cached information that cannot be used.
-            let mut extra_layout_damage_for_parent = LayoutDamage::empty();
-            node.with_layout_box_base_including_pseudos(|base| {
-                extra_layout_damage_for_parent |=
-                    base.add_damage(element_damage, damage_from_children, damage_from_parent);
-            });
-            layout_damage_for_parent.insert(extra_layout_damage_for_parent);
-        } else if (damage_from_children | element_damage)
-            .contains(LayoutDamage::RecalculateOverflow)
-        {
-            // In this case the node's fragments are preserved, but it or one of its descendants
-            // had scrollable overflow damage, which means that scrollable overflow should be
-            // cleared. This causes it to be recalculated the next time it's queried.
-            node.with_layout_box_base_including_pseudos(|base| {
-                base.clear_scrollable_overflow_all_on_fragments();
-            });
-        }
+        let invalidate_for_rebuild = || {
+            self.node.unset_all_boxes();
+            LayoutDamage::DescendantHasBoxDamage | LayoutDamage::Relayout
+        };
+
+        let action = self.box_damage_action();
+        let mut damage_for_parent = match action {
+            BoxDamageAction::TryRebuild => {
+                if self
+                    .node
+                    .rebuild_box_tree_from_independent_formatting_context(layout_context)
+                {
+                    // In this case, we have rebuilt the box tree from this point and we do not
+                    // have to propagate rebuild box tree damage up the tree any further.
+                    LayoutDamage::Relayout | LayoutDamage::RecomputeInlineContentSizes
+                } else {
+                    // A descendant needs to be rebuilt, but couldn't be rebuilt here,
+                    // because this node was an not a rebuild-compatible independent
+                    // formatting context. In this case do the same thing as if we needed
+                    // to rebuild an ancestor.
+                    invalidate_for_rebuild()
+                }
+            },
+            BoxDamageAction::RebuildAncestor => {
+                // In this case an ancestor needs to be completely rebuilt.
+                //
+                // This means that this box is no longer valid and also needs to be rebuilt
+                // (perhaps some of its descendants do not though). In this case, unset all existing
+                // boxes for the node and ensure that the appropriate rebuild-type damage
+                // propagates up the tree.
+                invalidate_for_rebuild()
+            },
+            BoxDamageAction::InvalidateFragmentCache => {
+                // In this case, this node's boxes are preserved! It's possible that we still need
+                // to run fragment tree layout in this subtree due to an ancestor, this node, or a
+                // descendant changing style. In that case, we ask the `LayoutBoxBase` to clear
+                // any cached information that cannot be used.
+                let mut damage_for_parent = forwarded_damage;
+                self.node.with_layout_box_base_including_pseudos(|base| {
+                    damage_for_parent |= base.add_damage(self);
+                });
+                damage_for_parent
+            },
+            BoxDamageAction::InvalidateScrollableOverflow => {
+                // In this case the node's fragments are preserved, but it or one of its descendants
+                // had scrollable overflow damage, which means that scrollable overflow should be
+                // cleared. This causes it to be recalculated the next time it's queried.
+                self.node.with_layout_box_base_including_pseudos(|base| {
+                    base.clear_scrollable_overflow_all_on_fragments();
+                });
+                forwarded_damage
+            },
+            BoxDamageAction::None => forwarded_damage,
+        };
 
         // The box is preserved. Whether or not we run fragment tree layout, we need to
         // update any preserved layout data structures' style references, if *this*
         // element's style has changed.
-        if !element_damage.is_empty() {
-            node.repair_style(&layout_context.style_context);
+        if !self.on_element.is_empty() && action.preserves_boxes() {
+            self.node.repair_style(&layout_context.style_context);
         }
+
+        // If doing a fragment tree layout, we also need to apply the LAYOUT_AFFECTED_BY_INFLOW_DESCENDANT
+        // damage flag, unless this node is out of flow. In that case our ancestors are rebuilt, but
+        // their resulting fragments should be equivalent to the previous ones.
+        if !damage_for_parent.contains(LayoutDamage::DescendantHasBoxDamage) {
+            if self.on_element.contains(LayoutDamage::Relayout) {
+                damage_for_parent.insert(LayoutDamage::LayoutAffectedByInflowDescendant);
+            }
+
+            if damage_for_parent.contains(LayoutDamage::LayoutAffectedByInflowDescendant) &&
+                self.node.is_absolutely_positioned()
+            {
+                damage_for_parent.remove(LayoutDamage::LayoutAffectedByInflowDescendant);
+            }
+        }
+
+        damage_for_parent
     }
 
-    // If doing a fragment tree layout, we also need to apply the LAYOUT_AFFECTED_BY_INFLOW_DESCENDANT
-    // damage flag, unless this node is out of flow. In that case our ancestors are rebuilt, but
-    // their resulting fragments should be equivalent to the previous ones.
-    if !layout_damage_for_parent.contains(LayoutDamage::DescendantHasBoxDamage) {
-        if element_damage.contains(LayoutDamage::Relayout) {
-            layout_damage_for_parent.insert(LayoutDamage::LayoutAffectedByInflowDescendant);
-        }
-
-        if layout_damage_for_parent.contains(LayoutDamage::LayoutAffectedByInflowDescendant) &&
-            node.is_absolutely_positioned()
+    fn box_damage_action(&self) -> BoxDamageAction {
+        // When a parent box is going to be reconstructed, that overrides everything else.
+        if self
+            .from_parent
+            .contains(LayoutDamage::DescendantHasBoxDamage)
         {
-            layout_damage_for_parent.remove(LayoutDamage::LayoutAffectedByInflowDescendant);
+            return BoxDamageAction::RebuildAncestor;
         }
-    }
 
-    layout_damage_for_parent
+        // When this element or one of its descendants needs to be reconstructed, try to
+        // rebuild it here. If that fails, an ancestor box will be reconstructed instead.
+        let element_and_children_damage = self.on_element | self.from_children;
+        if element_and_children_damage.contains(LayoutDamage::DescendantHasBoxDamage) {
+            return BoxDamageAction::TryRebuild;
+        }
+
+        // If this element needs a new fragment layout, then invalidate fragment caches.
+        if (self.from_parent | element_and_children_damage).contains(LayoutDamage::Relayout) {
+            return BoxDamageAction::InvalidateFragmentCache;
+        }
+
+        // If the scrollable overflow of this element has changed, invalidate the
+        // scrollable overflow.
+        if element_and_children_damage.contains(LayoutDamage::RecalculateOverflow) {
+            return BoxDamageAction::InvalidateScrollableOverflow;
+        }
+
+        BoxDamageAction::None
+    }
 }


### PR DESCRIPTION
The damage propagation traversal was a mess of sphaghetti code, so this
change makes it a bit more understandable, by splitting it into three
phases:

1. Damage isolation: Where damage from ancestors and the element is
   limited before propagating to children.
2. Propagation of damage to children.
3. Application of damage to the element's boxes and calculation of
   damage to propagate to parents.

Testing: This should not change behavior so should be covered by existing tests.
