### PR TITLE
script: Move SVG cache invalidation so it works on subtree mutation

### DIFF
--- a/components/script/dom/svg/svgsvgelement.rs
+++ b/components/script/dom/svg/svgsvgelement.rs
@@ -155,13 +155,12 @@ impl SVGSVGElement {
         }
     }
 
-    fn invalidate_cached_serialized_subtree(&self) {
+    fn invalidate_cached_serialized_subtree_and_rasterization_result(&self) {
         let owner_window = self.owner_window();
         owner_window
             .image_cache()
             .evict_rasterized_image(&self.uuid);
-        let data_url = self.cached_serialized_data_url.borrow().clone();
-        if let Some(Ok(url)) = data_url {
+        if let Some(Ok(url)) = &*self.cached_serialized_data_url.borrow() {
             owner_window.layout_mut().remove_cached_image(&url);
             owner_window.image_cache().evict_completed_image(
                 &url,
@@ -213,7 +212,7 @@ impl VirtualMethods for SVGSVGElement {
             .unwrap()
             .attribute_mutated(cx, attr, mutation);
 
-        self.invalidate_cached_serialized_subtree();
+        self.invalidate_cached_serialized_subtree_and_rasterization_result();
     }
 
     fn attribute_affects_presentational_hints(&self, attr: AttrRef<'_>) -> bool {
@@ -264,7 +263,7 @@ impl VirtualMethods for SVGSVGElement {
             super_type.children_changed(cx, mutation);
         }
 
-        self.invalidate_cached_serialized_subtree();
+        self.invalidate_cached_serialized_subtree_and_rasterization_result();
     }
 
     fn unbind_from_tree(&self, cx: &mut js::context::JSContext, context: &UnbindContext<'_>) {
@@ -272,6 +271,6 @@ impl VirtualMethods for SVGSVGElement {
             s.unbind_from_tree(cx, context);
         }
 
-        self.invalidate_cached_serialized_subtree();
+        self.invalidate_cached_serialized_subtree_and_rasterization_result();
     }
 }

--- a/components/script/dom/svg/svgsvgelement.rs
+++ b/components/script/dom/svg/svgsvgelement.rs
@@ -161,9 +161,9 @@ impl SVGSVGElement {
             .image_cache()
             .evict_rasterized_image(&self.uuid);
         if let Some(Ok(url)) = &*self.cached_serialized_data_url.borrow() {
-            owner_window.layout_mut().remove_cached_image(&url);
+            owner_window.layout_mut().remove_cached_image(url);
             owner_window.image_cache().evict_completed_image(
-                &url,
+                url,
                 owner_window.origin().immutable(),
                 &None,
             );

--- a/components/script/dom/svg/svgsvgelement.rs
+++ b/components/script/dom/svg/svgsvgelement.rs
@@ -156,6 +156,20 @@ impl SVGSVGElement {
     }
 
     fn invalidate_cached_serialized_subtree(&self) {
+        let owner_window = self.owner_window();
+        owner_window
+            .image_cache()
+            .evict_rasterized_image(&self.uuid);
+        let data_url = self.cached_serialized_data_url.borrow().clone();
+        if let Some(Ok(url)) = data_url {
+            owner_window.layout_mut().remove_cached_image(&url);
+            owner_window.image_cache().evict_completed_image(
+                &url,
+                owner_window.origin().immutable(),
+                &None,
+            );
+        }
+
         *self.cached_serialized_data_url.borrow_mut() = None;
         self.upcast::<Node>().dirty(NodeDamage::Other);
     }
@@ -257,19 +271,7 @@ impl VirtualMethods for SVGSVGElement {
         if let Some(s) = self.super_type() {
             s.unbind_from_tree(cx, context);
         }
-        let owner_window = self.owner_window();
-        self.owner_window()
-            .image_cache()
-            .evict_rasterized_image(&self.uuid);
-        let data_url = self.cached_serialized_data_url.borrow().clone();
-        if let Some(Ok(url)) = data_url {
-            owner_window.layout_mut().remove_cached_image(&url);
-            owner_window.image_cache().evict_completed_image(
-                &url,
-                owner_window.origin().immutable(),
-                &None,
-            );
-        }
+
         self.invalidate_cached_serialized_subtree();
     }
 }


### PR DESCRIPTION
SVG cache invalidation was moved to the `invalidate_cached_serialized_subtree` method so the cache is properly cleared when there is a subtree modification. Previously, this did not occur and changing an SVG element to have different attributes caused the original, unmodified SVG to not render.

Testing: I wanted some feedback here: I can't figure out how to write a good test for this for a number of reasons:
1. I'm not sure where to put this test in WPT: I didn't find any similar tests.
2. This bug is timing-specific: if you update the attributes too quickly, the previous version of the SVG properly leaves the cache and the issue does not arise. It is easy to test manually or with `setTimeout`, but I'm not sure how to wait for the SVG to fully render in an automated environment.
3. In automated testing environments, the previous version of Servo encounters a test timeout: likely because the last paint never finishes. I don't know if we care about how a test would perform on older Servo versions, so please let me know about this.
4. This is a very Servo-specific bug due to the way Servo is currently rendering SVGs using a library.

Please let me know if you can think of a good way to test this. Thanks!

Fixes: https://github.com/servo/servo/issues/45396
