### PR TITLE
webgpu: Support "core" stuff and other `GPURequestAdapterOptions`

### DIFF
--- a/components/script/dom/webgpu/gpu.rs
+++ b/components/script/dom/webgpu/gpu.rs
@@ -6,6 +6,7 @@ use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::jsapi::HandleObject;
+use js::realm::CurrentRealm;
 use script_bindings::reflector::{Reflector, reflect_dom_object};
 use servo_constellation_traits::ScriptToConstellationMessage;
 use webgpu_traits::WebGPUAdapterResponse;
@@ -22,7 +23,6 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 use crate::dom::webgpu::gpuadapter::GPUAdapter;
-use crate::realms::InRealm;
 use crate::routed_promise::{RoutedPromiseListener, callback_promise};
 use crate::script_runtime::CanGc;
 
@@ -51,13 +51,12 @@ impl GPUMethods<crate::DomTypeHolder> for GPU {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpu-requestadapter>
     fn RequestAdapter(
         &self,
+        cx: &mut CurrentRealm,
         options: &GPURequestAdapterOptions,
-        comp: InRealm,
-        can_gc: CanGc,
     ) -> Rc<Promise> {
         let global = &self.global();
         // 1. Let promise be a new promise.
-        let promise = Promise::new_in_current_realm(comp, can_gc);
+        let promise = Promise::new_in_realm(cx);
         let task_source = global.task_manager().dom_manipulation_task_source();
         let callback = callback_promise(&promise, self, task_source);
 
@@ -85,7 +84,7 @@ impl GPUMethods<crate::DomTypeHolder> for GPU {
                 // and wgpu does not support "compatibility" yet so we return core for now
             },
             _ => {
-                promise.resolve_native(&None::<GPUAdapter>, can_gc);
+                promise.resolve_native_with_cx(cx, &None::<GPUAdapter>);
                 return promise;
             },
         }
@@ -102,7 +101,7 @@ impl GPUMethods<crate::DomTypeHolder> for GPU {
             ))
             .is_err()
         {
-            promise.reject_error(Error::Operation(None), can_gc);
+            promise.reject_error_with_cx(cx, Error::Operation(None));
         }
         // 4. Return promise
         promise
@@ -119,9 +118,12 @@ impl GPUMethods<crate::DomTypeHolder> for GPU {
     }
 
     /// <https://www.w3.org/TR/webgpu/#dom-gpu-wgsllanguagefeatures>
-    fn WgslLanguageFeatures(&self, can_gc: CanGc) -> DomRoot<WGSLLanguageFeatures> {
+    fn WgslLanguageFeatures(
+        &self,
+        cx: &mut js::context::JSContext,
+    ) -> DomRoot<WGSLLanguageFeatures> {
         self.wgsl_language_features
-            .or_init(|| WGSLLanguageFeatures::new(&self.global(), None, can_gc))
+            .or_init(|| WGSLLanguageFeatures::new(cx, &self.global(), None))
     }
 }
 

--- a/components/script/dom/webgpu/gpu.rs
+++ b/components/script/dom/webgpu/gpu.rs
@@ -56,6 +56,7 @@ impl GPUMethods<crate::DomTypeHolder> for GPU {
         can_gc: CanGc,
     ) -> Rc<Promise> {
         let global = &self.global();
+        // 1. Let promise be a new promise.
         let promise = Promise::new_in_current_realm(comp, can_gc);
         let task_source = global.task_manager().dom_manipulation_task_source();
         let callback = callback_promise(&promise, self, task_source);
@@ -67,6 +68,27 @@ impl GPUMethods<crate::DomTypeHolder> for GPU {
         };
         let ids = global.wgpu_id_hub().create_adapter_id();
 
+        // 3. Issue the initialization steps on the Device timeline of this
+
+        /*
+        We do some steps here to avoid IPC round-trips
+        1. options.featureLevel must be a feature level string.
+        If any are unmet
+            Let adapter be null, issue the resolution steps on contentTimeline, and return.
+        If adapter is null:
+            Resolve promise with null.
+        */
+        match &*options.featureLevel.str() {
+            "core" => {},
+            "compatibility" => {
+                // Set options.featureLevel to "compatibility" if the user agent chooses to support it, or "core" if not.
+                // and wgpu does not support "compatibility" yet so we return core for now
+            },
+            _ => {
+                promise.resolve_native(&None::<GPUAdapter>, can_gc);
+                return promise;
+            },
+        }
         let script_to_constellation_chan = global.script_to_constellation_chan();
         if script_to_constellation_chan
             .send(ScriptToConstellationMessage::RequestAdapter(
@@ -82,6 +104,7 @@ impl GPUMethods<crate::DomTypeHolder> for GPU {
         {
             promise.reject_error(Error::Operation(None), can_gc);
         }
+        // 4. Return promise
         promise
     }
 

--- a/components/script/dom/webgpu/gpusupportedfeatures.rs
+++ b/components/script/dom/webgpu/gpusupportedfeatures.rs
@@ -40,6 +40,8 @@ impl GPUSupportedFeatures {
         can_gc: CanGc,
     ) -> DomRoot<GPUSupportedFeatures> {
         let mut set = IndexSet::new();
+        // everything that wgpu currently does is considered as part of "core"
+        set.insert(GPUFeatureName::Core_features_and_limits);
         if features.contains(Features::DEPTH_CLIP_CONTROL) {
             set.insert(GPUFeatureName::Depth_clip_control);
         }
@@ -127,6 +129,8 @@ impl GPUSupportedFeaturesMethods<crate::DomTypeHolder> for GPUSupportedFeatures 
 
 pub(crate) fn gpu_to_wgt_feature(feature: GPUFeatureName) -> Option<Features> {
     match feature {
+        // everything that wgpu currently does is considered as part of "core"
+        GPUFeatureName::Core_features_and_limits => Some(Features::empty()),
         GPUFeatureName::Depth_clip_control => Some(Features::DEPTH_CLIP_CONTROL),
         GPUFeatureName::Depth32float_stencil8 => Some(Features::DEPTH32FLOAT_STENCIL8),
         GPUFeatureName::Texture_compression_bc => Some(Features::TEXTURE_COMPRESSION_BC),

--- a/components/script/dom/webgpu/wgsllanguagefeatures.rs
+++ b/components/script/dom/webgpu/wgsllanguagefeatures.rs
@@ -6,17 +6,17 @@
 
 use dom_struct::dom_struct;
 use indexmap::IndexSet;
+use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
 use script_bindings::like::Setlike;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
 use wgpu_core::naga::front::wgsl::ImplementedLanguageExtension;
 
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::WGSLLanguageFeaturesMethods;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct WGSLLanguageFeatures {
@@ -28,22 +28,22 @@ pub struct WGSLLanguageFeatures {
 
 impl WGSLLanguageFeatures {
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
         let set = ImplementedLanguageExtension::all()
             .iter()
             .map(|le| le.to_ident().into())
             .collect();
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(Self {
                 reflector: Reflector::new(),
                 internal: DomRefCell::new(set),
             }),
             global,
             proto,
-            can_gc,
+            cx,
         )
     }
 }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -422,8 +422,8 @@ DOMInterfaces = {
 },
 
 'GPU': {
-    'inRealms': ['RequestAdapter'],
-    'canGc': ['RequestAdapter', 'WgslLanguageFeatures'],
+    'realm': ['RequestAdapter'],
+    'cx': ['WgslLanguageFeatures'],
 },
 
 'GPUAdapter': {

--- a/components/script_bindings/webidls/WebGPU.webidl
+++ b/components/script_bindings/webidls/WebGPU.webidl
@@ -91,8 +91,10 @@ interface GPU {
 };
 
 dictionary GPURequestAdapterOptions {
+    DOMString featureLevel = "core";
     GPUPowerPreference powerPreference;
     boolean forceFallbackAdapter = false;
+    boolean xrCompatible = false;
 };
 
 enum GPUPowerPreference {
@@ -115,6 +117,7 @@ dictionary GPUDeviceDescriptor : GPUObjectDescriptorBase {
 };
 
 enum GPUFeatureName {
+    "core-features-and-limits",
     "depth-clip-control",
     "depth32float-stencil8",
     "texture-compression-bc",


### PR DESCRIPTION
Per spec it is valid to always return core device even if worse (read "compatibility") was requested: https://www.w3.org/TR/webgpu/#feature-level-string
similarly also goes for `xrCompatible` field: https://www.w3.org/TR/webgpu/#dom-gpurequestadapteroptions-xrcompatible

Firefox does the same.

Testing: Covered by WebGPU CTS tests
