### PR TITLE
android: remove product flavor as only one

### DIFF
--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -178,17 +178,13 @@ class PackageCommands(CommandBase):
             # Inform the android build of where `libservoshell.so` is located.
             env["SERVO_TARGET_DIR"] = target_dir
 
-            flavor_name = "Basic"
-            if flavor is not None:
-                flavor_name = flavor.title()
-
             dir_to_resources = path.join(self.get_top_dir(), "target", "android", "resources")
             if path.exists(dir_to_resources):
                 delete(dir_to_resources)
 
             copy_packaged_resources(dir_to_root, dir_to_resources)
 
-            variant = ":assemble" + flavor_name + arch_string + build_type_string
+            variant = ":assemble" + arch_string + build_type_string
             apk_task_name = ":servoapp" + variant
             aar_task_name = ":servoview" + variant
             argv = ["./gradlew", "--no-daemon", apk_task_name, aar_task_name]

--- a/support/android/apk/servoapp/build.gradle.kts
+++ b/support/android/apk/servoapp/build.gradle.kts
@@ -25,14 +25,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
-    // Share all of that with servoview
-    flavorDimensions.add("default")
-
-    productFlavors {
-        register("basic") {
-        }
-    }
-
     val signingKeyInfo = getSigningKeyInfo()
 
     if (signingKeyInfo != null) {
@@ -124,7 +116,7 @@ android {
 
     project.afterEvaluate {
         android.applicationVariants.forEach { variant ->
-            val pattern = Pattern.compile("^[\\w\\d]+([A-Z][\\w\\d]+)(Debug|Release)")
+            val pattern = Pattern.compile("^([\\w\\d]+)(Debug|Release)")
             val matcher = pattern.matcher(variant.name)
             if (!matcher.find()) {
                 throw GradleException("Invalid variant name for output: " + variant.name)

--- a/support/android/apk/servoview/build.gradle.kts
+++ b/support/android/apk/servoview/build.gradle.kts
@@ -27,13 +27,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
-    flavorDimensions.add("default")
-
-    productFlavors {
-        register("basic") {
-        }
-    }
-
     buildTypes {
         // Default debug and release build types are used as templates
         debug {
@@ -137,8 +130,8 @@ android {
         // as to prevent concurrent modification exceptions due to creating a new task
         // while iterating
         tasks.mapNotNull { compileTask -> // mapNotNull acts as our filter, null results are dropped
-            // This matches the task `mergeBasicArmv7DebugJniLibFolders`.
-            val pattern = Pattern.compile("^merge[A-Z]\\w+([A-Z]\\w+)(Debug|Release)JniLibFolders")
+            // This matches the task `mergeArmv7DebugJniLibFolders`.
+            val pattern = Pattern.compile("^merge([A-Z]\\w+)(Debug|Release)JniLibFolders")
             val matcher = pattern.matcher(compileTask.name)
             if (matcher.find())
                 compileTask to matcher.group(1)
@@ -162,7 +155,7 @@ android {
         }
 
         android.libraryVariants.forEach { variant ->
-            val pattern = Pattern.compile("^[\\w\\d]+([A-Z][\\w\\d]+)(Debug|Release)")
+            val pattern = Pattern.compile("^([\\w\\d]+)(Debug|Release)")
             val matcher = pattern.matcher(variant.name)
             if (!matcher.find()) {
                 throw GradleException("Invalid variant name for output: " + variant.name)


### PR DESCRIPTION
There were other product flavors before, but they were removed in d7de206dbd459e8c8bf121f73755d12569c6cc55. Since there is only one product flavor now, there isn't much utility to it. Removing it makes the Gradle tasks a tad less verbose, and simplifies the regex needed to parse those Gradle tasks.

Testing: Ran app