### PR TITLE
script: replace Castable:downcast::<Type>().is_some() with Castable:is::<Type>()

### DIFF
--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -1359,8 +1359,7 @@ impl<'dom> LayoutDom<'dom, Element> {
 
         // Aspect ratio when providing both width and height.
         // https://html.spec.whatwg.org/multipage/#attributes-for-embedded-content-and-images
-        if (self.downcast::<HTMLImageElement>().is_some() ||
-            self.downcast::<HTMLVideoElement>().is_some()) &&
+        if (self.is::<HTMLImageElement>() || self.is::<HTMLVideoElement>()) &&
             let LengthOrPercentageOrAuto::Length(width) = width &&
             let LengthOrPercentageOrAuto::Length(height) = height
         {
@@ -2485,7 +2484,7 @@ impl Element {
             return false;
         }
         // Step 2: If element is a script element, then for each attribute of element’s attribute list:
-        if self.downcast::<HTMLScriptElement>().is_some() {
+        if self.is::<HTMLScriptElement>() {
             for attr in self.attrs().borrow().iter() {
                 // Step 2.1: If attribute’s name contains an ASCII case-insensitive match
                 // for "<script" or "<style", return "Not Nonceable".

--- a/components/script/dom/event/eventtarget.rs
+++ b/components/script/dom/event/eventtarget.rs
@@ -1006,7 +1006,7 @@ impl EventTarget {
         }
 
         // The get the parent algorithm for an IDBDatabase returns null.
-        if self.downcast::<IDBDatabase>().is_some() {
+        if self.is::<IDBDatabase>() {
             return None;
         }
 

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -3210,14 +3210,11 @@ impl GlobalScope {
         match self.top_level_creation_url() {
             None => {
                 // Workers and worklets don't have a top-level creation URL
-                assert!(
-                    self.downcast::<WorkerGlobalScope>().is_some() ||
-                        self.downcast::<WorkletGlobalScope>().is_some()
-                );
+                assert!(self.is::<WorkerGlobalScope>() || self.is::<WorkletGlobalScope>());
                 true
             },
             Some(top_level_creation_url) => {
-                assert!(self.downcast::<Window>().is_some());
+                assert!(self.is::<Window>());
                 // Step 2. If the result of Is url potentially trustworthy?
                 // given environment's top-level creation URL is "Potentially Trustworthy", then return true.
                 // Step 3. Return false.
@@ -3233,7 +3230,7 @@ impl GlobalScope {
 
     /// <https://www.w3.org/TR/CSP/#get-csp-of-object>
     pub(crate) fn get_csp_list(&self) -> Option<CspList> {
-        if self.downcast::<Window>().is_some() || self.downcast::<WorkerGlobalScope>().is_some() {
+        if self.is::<Window>() || self.is::<WorkerGlobalScope>() {
             return self.policy_container().csp_list;
         }
         // TODO: Worklet global scopes.

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -2066,8 +2066,7 @@ impl Node {
             return false;
         }
         // > and either it is an HTML element, or it is an svg or math element, or it is not an Element and its parent is an HTML element.
-        html_element.is_some() ||
-            (!self.is::<Element>() && parent.downcast::<HTMLElement>().is_some())
+        html_element.is_some() || (!self.is::<Element>() && parent.is::<HTMLElement>())
     }
 }
 

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -378,7 +378,7 @@ impl FetchResponseListener for StylesheetContext {
         let element = self.element.root();
 
         // https://html.spec.whatwg.org/multipage/#link-type-stylesheet:process-the-linked-resource
-        if element.downcast::<HTMLLinkElement>().is_some() {
+        if element.is::<HTMLLinkElement>() {
             // Step 1. If the resource's Content-Type metadata is not text/css, then set success to false.
             let is_css = MimeClassifier::is_css(
                 &metadata.resource_content_type_metadata(LoadContext::Style, &self.data),


### PR DESCRIPTION
Replace script instances of downcast::<Type>().is_some() with is::<Type>() to avoid casting the objects.

Testing: No behavior change so existing tests suffice
Fixes: [#45406](https://github.com/servo/servo/issues/45406)
