### PR TITLE
fonts: Improve embedder font preferences

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -94,10 +94,10 @@ macro_rules! pref {
 /// [experimental features documentation](https://book.servo.org/design-documentation/experimental-features.html).
 #[derive(Clone, Deserialize, Serialize, ServoPreferences)]
 pub struct Preferences {
-    pub fonts_default: String,
-    pub fonts_serif: String,
-    pub fonts_sans_serif: String,
-    pub fonts_monospace: String,
+    pub fonts_default: FontFamilyPref,
+    pub fonts_serif: FontFamilyPref,
+    pub fonts_sans_serif: FontFamilyPref,
+    pub fonts_monospace: FontFamilyPref,
     pub fonts_default_size: i64,
     pub fonts_default_monospace_size: i64,
     /// The amount of time that a half cycle of a text caret blink takes in milliseconds.
@@ -447,12 +447,12 @@ impl Preferences {
             dom_visual_viewport_enabled: false,
             accessibility_enabled: false,
             expensive_accessibility_test_assertions_enabled: false,
-            fonts_default: String::new(),
+            fonts_default: FontFamilyPref::None,
             fonts_default_monospace_size: 13,
             fonts_default_size: 16,
-            fonts_monospace: String::new(),
-            fonts_sans_serif: String::new(),
-            fonts_serif: String::new(),
+            fonts_monospace: FontFamilyPref::Monospace,
+            fonts_sans_serif: FontFamilyPref::SansSerif,
+            fonts_serif: FontFamilyPref::Serif,
             gfx_precache_shaders: false,
             gfx_text_antialiasing_enabled: true,
             gfx_subpixel_text_antialiasing_enabled: true,
@@ -614,6 +614,54 @@ impl UserAgentPlatform {
             UserAgentPlatform::Ios => format!(
                 "Mozilla/5.0 (iPhone; CPU iPhone OS 18_6 like Mac OS X; rv:140.0) Servo/{SERVO_VERSION} Firefox/140.0"
             ),
+        }
+    }
+}
+
+/// Embedder-defined font family.
+#[derive(Deserialize, Serialize, Clone, PartialEq, Eq, Debug)]
+pub enum FontFamilyPref {
+    /// No font preference, the font will be picked based on context.
+    None,
+    /// Pick the system's recommended Serif font.
+    Serif,
+    /// Pick the system's recommended Sans-Serif font.
+    SansSerif,
+    /// Pick the system's recommended Monospace font.
+    Monospace,
+    /// Select a specific font family.
+    ///
+    /// This does not perform font fallback on all platforms. If font fallback is not
+    /// supported and no family match can be found, the fallback font will be used
+    /// instead.
+    Other(String),
+}
+
+impl TryFrom<PrefValue> for FontFamilyPref {
+    type Error = String;
+
+    fn try_from(pref: PrefValue) -> Result<Self, Self::Error> {
+        match pref {
+            PrefValue::Str(s) => match s.as_str() {
+                "" => Ok(Self::None),
+                "style=serif" => Ok(Self::Serif),
+                "style=sans-serif" => Ok(Self::SansSerif),
+                "style=mono" => Ok(Self::Monospace),
+                _ => Ok(Self::Other(s)),
+            },
+            _ => Err(format!("Cannot convert {pref:?} to FontFamilyPref")),
+        }
+    }
+}
+
+impl From<FontFamilyPref> for PrefValue {
+    fn from(font: FontFamilyPref) -> Self {
+        match font {
+            FontFamilyPref::None => PrefValue::Str(String::new()),
+            FontFamilyPref::Serif => PrefValue::Str(String::from("style=serif")),
+            FontFamilyPref::SansSerif => PrefValue::Str(String::from("style=sans-serif")),
+            FontFamilyPref::Monospace => PrefValue::Str(String::from("style=mono")),
+            FontFamilyPref::Other(family) => PrefValue::Str(family),
         }
     }
 }

--- a/components/fonts/platform/freetype/font_list.rs
+++ b/components/fonts/platform/freetype/font_list.rs
@@ -233,9 +233,26 @@ pub(crate) fn default_system_generic_font_family(
         GenericFontFamily::SystemUi => c"sans-serif",
     };
 
-    let generic_name_ptr = generic_string.as_ptr();
+    system_font_family(generic_string).unwrap_or_else(|| {
+        match generic {
+            GenericFontFamily::None | GenericFontFamily::Serif => "Noto Serif",
+            GenericFontFamily::SansSerif => "Noto Sans",
+            GenericFontFamily::Monospace => "Deja Vu Sans Mono",
+            GenericFontFamily::Cursive => "Comic Sans MS",
+            GenericFontFamily::Fantasy => "Impact",
+            GenericFontFamily::SystemUi => "Noto Sans",
+        }
+        .into()
+    })
+}
+
+/// Attempt to get the canonical name for a font or font pattern.
+pub(crate) fn system_font_family(pattern: &CStr) -> Option<LowercaseFontFamilyName> {
+    let mut name = None;
+
+    let pattern_ptr = pattern.as_ptr();
     unsafe {
-        let pattern = FcNameParse(generic_name_ptr as *mut FcChar8);
+        let pattern = FcNameParse(pattern_ptr as *mut FcChar8);
         FcConfigSubstitute(ptr::null_mut(), pattern, FcMatchPattern);
         FcDefaultSubstitute(pattern);
 
@@ -255,25 +272,14 @@ pub(crate) fn default_system_generic_font_family(
                 .expect("Font family name contains invalid UTF-8")
                 .to_owned();
 
-            FcPatternDestroy(family_match);
-            FcPatternDestroy(pattern);
-
-            return family_name.into();
+            name = Some(family_name.into());
         }
 
         FcPatternDestroy(family_match);
         FcPatternDestroy(pattern);
     }
 
-    match generic {
-        GenericFontFamily::None | GenericFontFamily::Serif => "Noto Serif",
-        GenericFontFamily::SansSerif => "Noto Sans",
-        GenericFontFamily::Monospace => "Deja Vu Sans Mono",
-        GenericFontFamily::Cursive => "Comic Sans MS",
-        GenericFontFamily::Fantasy => "Impact",
-        GenericFontFamily::SystemUi => "Noto Sans",
-    }
-    .into()
+    name
 }
 
 fn font_style_from_fontconfig_pattern(pattern: *mut FcPattern) -> Option<FontStyle> {

--- a/components/fonts/system_font_service.rs
+++ b/components/fonts/system_font_service.rs
@@ -5,6 +5,8 @@
 use std::borrow::ToOwned;
 use std::cell::OnceCell;
 use std::collections::HashMap;
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
+use std::ffi::CString;
 use std::thread;
 
 use app_units::Au;
@@ -23,12 +25,13 @@ use rustc_hash::FxHashMap;
 use servo_base::generic_channel::{self, GenericReceiver};
 use servo_base::id::PainterId;
 use servo_config::pref;
+use servo_config::prefs::FontFamilyPref;
 use style::values::computed::font::{GenericFontFamily, SingleFontFamily};
 use webrender_api::{FontInstanceFlags, FontInstanceKey, FontKey, FontVariation};
 
 use crate::font_store::FontStore;
 use crate::platform::font_list::{
-    default_system_generic_font_family, for_each_available_family, for_each_variation,
+    self, default_system_generic_font_family, for_each_available_family, for_each_variation,
 };
 
 #[derive(Default, MallocSizeOf)]
@@ -331,21 +334,41 @@ impl SystemFontService {
 
         resolved_font
             .get_or_init(|| {
-                // First check whether the font is set in the preferences.
-                let family_name = match generic {
-                    GenericFontFamily::None => pref!(fonts_default),
+                // Get the configured font for this style.
+                let family = match generic {
                     GenericFontFamily::Serif => pref!(fonts_serif),
                     GenericFontFamily::SansSerif => pref!(fonts_sans_serif),
                     GenericFontFamily::Monospace => pref!(fonts_monospace),
-                    _ => String::new(),
+                    _ => pref!(fonts_default),
                 };
 
-                if !family_name.is_empty() {
-                    return family_name.into();
-                }
+                let style = match family {
+                    FontFamilyPref::None => *generic,
+                    FontFamilyPref::Serif => GenericFontFamily::Serif,
+                    FontFamilyPref::SansSerif => GenericFontFamily::SansSerif,
+                    FontFamilyPref::Monospace => GenericFontFamily::Monospace,
+                    FontFamilyPref::Other(family) if family.is_empty() => *generic,
+                    FontFamilyPref::Other(family) => {
+                        // Attempt to load font as pattern through fontconfig on Linux.
+                        #[cfg(any(
+                            target_os = "linux",
+                            target_os = "android",
+                            target_os = "freebsd"
+                        ))]
+                        {
+                            if let Some(family) = CString::new(&*family).ok().and_then(|c_family| {
+                                font_list::system_font_family(c_family.as_c_str())
+                            }) {
+                                return family;
+                            }
+                        }
 
-                // Otherwise ask the platform for the default family for the generic font.
-                default_system_generic_font_family(*generic)
+                        return family.into();
+                    },
+                };
+
+                // Load the default system font for the selected style.
+                default_system_generic_font_family(style)
             })
             .clone()
     }

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -58,7 +58,7 @@ pub use resources;
 pub use servo_base::generic_channel::GenericSender;
 pub use servo_base::id::WebViewId;
 pub use servo_config::opts::{DiagnosticsLogging, DiagnosticsLoggingOption, Opts, OutputOptions};
-pub use servo_config::prefs::{PrefValue, Preferences, UserAgentPlatform};
+pub use servo_config::prefs::{FontFamilyPref, PrefValue, Preferences, UserAgentPlatform};
 pub use servo_config::{opts, pref, prefs};
 pub use servo_geometry::{
     DeviceIndependentIntRect, DeviceIndependentPixel, convert_rect_to_css_pixel,

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -17,6 +17,8 @@ use bpaf::*;
 use euclid::Size2D;
 use log::warn;
 use serde_json::Value;
+#[cfg(test)]
+use servo::FontFamilyPref;
 use servo::user_contents::UserStyleSheet;
 use servo::{
     DeviceIndependentPixel, DiagnosticsLogging, DiagnosticsLoggingOption, Opts, OutputOptions,
@@ -816,7 +818,10 @@ fn test_parse_pref_from_command_line() {
 
     // Test string.
     let preferences = test_parse_pref("fonts_default=Lucida");
-    assert_eq!(preferences.fonts_default, "Lucida");
+    assert_eq!(
+        preferences.fonts_default,
+        FontFamilyPref::Other("Lucida".into())
+    );
 
     // Test with no value (defaults to true).
     let preferences = test_parse_pref("dom_bluetooth_enabled");


### PR DESCRIPTION
Currently the font preferences set by an embedder were plain strings, which were then directly used to find a font in the internal fonts list. This is problematic because it does not provide any pattern matching for inputs like "sans", causing font loading to fail.

To ensure common font styles like sans, sans-serif, and monospace can be loaded properly, without exact font matching, the preferences now accept an enum. This enum allows either using a predefined alias, which all platforms already have a well-defined fallback implementation for, or the usual free-form text family.

On non-Linux platforms, the generic text-based font family is treated as an exact font match, the same way it behaved before. On Linux, the existing fontconfig code uses the input as a pattern to look up the font family with fontconfig, providing the expected system font fallback.

This changes nothing about the fact that a website without any `font-family` configured will pick the `fonts_serif` font by default, rather than using `fonts_default`, however it does allow just alias serif fonts to use sans fonts instead.

Closes: https://github.com/servo/servo/issues/45394

---

Honestly I'm not entirely sure whether this is a horrible hack, or a nice stop-gap to get most functionality on all platforms while implementing the full range of expected behavior on Linux. I'm in no position to implement the full font fallback on other platforms and the existing code also does not seem to make use of system font fallback on macos/Windows, so I think it might be fine as-is?

There  probably is a simpler alternative to this patch which keeps the existing `String` value for the preferences and just adds the linux-specific branch to do fallback, but I figured I should at least *try* to provide a solution for all supported platforms.