### PR TITLE
script: Properly unregister moved elements from `name` and `id` maps during moveBefore

### DIFF
--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -2783,6 +2783,44 @@ impl Element {
                     custom_element_definition.has_attribute_changed_callback()
                 })
     }
+
+    pub(crate) fn register_current_id_and_name_attribute(&self, cx: &mut JSContext) {
+        if let Some(shadow_root) = self.containing_shadow_root() {
+            if let Some(ref id) = *self.id_attribute.borrow() {
+                shadow_root.register_element_id(self, id, CanGc::from_cx(cx));
+            }
+        } else {
+            let document = self.owner_document();
+            if let Some(ref id) = *self.id_attribute.borrow() {
+                document.register_element_id(cx, self, id);
+            }
+            if let Some(ref name) = self.name_attribute() {
+                document.register_element_name(self, name);
+            }
+        }
+    }
+
+    pub(crate) fn unregister_current_id_and_name_attribute(&self, cx: &mut JSContext) {
+        if let Some(shadow_root) = self.containing_shadow_root() {
+            // Only unregister the element id if the node was disconnected from it's
+            // shadow root (as opposed to the whole shadow tree being disconnected as a
+            // whole)
+            if self.upcast::<Node>().is_in_a_shadow_tree() {
+                return;
+            }
+            if let Some(ref id) = *self.id_attribute.borrow() {
+                shadow_root.unregister_element_id(id);
+            }
+        } else {
+            let document = self.owner_document();
+            if let Some(ref id) = *self.id_attribute.borrow() {
+                document.unregister_element_id(cx, id);
+            }
+            if let Some(ref name) = self.name_attribute() {
+                document.unregister_element_name(name);
+            }
+        }
+    }
 }
 
 impl ElementMethods<crate::DomTypeHolder> for Element {
@@ -4655,8 +4693,6 @@ impl VirtualMethods for Element {
             f.bind_form_control_to_tree(cx);
         }
 
-        let doc = self.owner_document();
-
         if let Some(ref shadow_root) = self.shadow_root() {
             shadow_root.bind_to_tree(cx, context);
         }
@@ -4665,18 +4701,7 @@ impl VirtualMethods for Element {
             return;
         }
 
-        if let Some(ref id) = *self.id_attribute.borrow() {
-            if let Some(shadow_root) = self.containing_shadow_root() {
-                shadow_root.register_element_id(self, id, CanGc::from_cx(cx));
-            } else {
-                doc.register_element_id(cx, self, id);
-            }
-        }
-        if let Some(ref name) = self.name_attribute() &&
-            self.containing_shadow_root().is_none()
-        {
-            doc.register_element_name(self, name);
-        }
+        self.register_current_id_and_name_attribute(cx);
     }
 
     fn unbind_from_tree(&self, cx: &mut JSContext, context: &UnbindContext) {
@@ -4699,22 +4724,8 @@ impl VirtualMethods for Element {
         if fullscreen.as_deref() == Some(self) {
             doc.exit_fullscreen(CanGc::from_cx(cx));
         }
-        if let Some(ref value) = *self.id_attribute.borrow() {
-            if let Some(ref shadow_root) = self.containing_shadow_root() {
-                // Only unregister the element id if the node was disconnected from it's shadow root
-                // (as opposed to the whole shadow tree being disconnected as a whole)
-                if !self.upcast::<Node>().is_in_a_shadow_tree() {
-                    shadow_root.unregister_element_id(value);
-                }
-            } else {
-                doc.unregister_element_id(cx, value);
-            }
-        }
-        if let Some(ref value) = self.name_attribute() &&
-            self.containing_shadow_root().is_none()
-        {
-            doc.unregister_element_name(value);
-        }
+
+        self.unregister_current_id_and_name_attribute(cx);
     }
 
     fn children_changed(&self, cx: &mut JSContext, mutation: &ChildrenMutation) {

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -426,7 +426,7 @@ impl Node {
         }
     }
 
-    pub(crate) fn complete_move_subtree(root: &Node) {
+    pub(crate) fn complete_move_subtree(cx: &mut JSContext, root: &Node) {
         // Flags that reset when a node is moved
         const RESET_FLAGS: NodeFlags = NodeFlags::IS_IN_A_DOCUMENT_TREE
             .union(NodeFlags::IS_CONNECTED)
@@ -437,6 +437,12 @@ impl Node {
         for node in root.traverse_preorder(ShadowIncluding::No) {
             node.set_flag(RESET_FLAGS | NodeFlags::IS_IN_SHADOW_TREE, false);
             node.clean_up_style_and_layout_data();
+
+            // Unregister the `id` and `name` attributes for this node. Note that they
+            // will be re-registered when added to the tree again.
+            if let Some(element) = node.downcast::<Element>() {
+                element.unregister_current_id_and_name_attribute(cx);
+            }
 
             // Make sure that we don't accidentally initialize the rare data for this node
             // by setting it to None
@@ -506,7 +512,7 @@ impl Node {
         Self::complete_remove_subtree(cx, child, &context);
     }
 
-    fn move_child(&self, child: &Node) {
+    fn move_child(&self, cx: &mut JSContext, child: &Node) {
         assert!(child.parent_node.get().as_deref() == Some(self));
         self.note_dirty_descendants();
 
@@ -514,7 +520,7 @@ impl Node {
         child.next_sibling.set(None);
         child.parent_node.set(None);
         self.children_count.set(self.children_count.get() - 1);
-        Self::complete_move_subtree(child)
+        Self::complete_move_subtree(cx, child)
     }
 
     pub(crate) fn to_untrusted_node_address(&self) -> UntrustedNodeAddress {
@@ -1399,7 +1405,7 @@ impl Node {
         );
 
         // Step 13. Remove node from oldParent’s children.
-        old_parent.move_child(node);
+        old_parent.move_child(cx, node);
 
         // Step 14. If node is assigned, then run assign slottables for node’s assigned slot.
         if let Some(slot) = node.assigned_slot() {

--- a/tests/wpt/meta/dom/nodes/moveBefore/moveBefore-id-map.html.ini
+++ b/tests/wpt/meta/dom/nodes/moveBefore/moveBefore-id-map.html.ini
@@ -1,9 +1,0 @@
-[moveBefore-id-map.html]
-  [moveBefore() correctly updates id map when moving into shadow root]
-    expected: FAIL
-
-  [moveBefore() correctly updates window map when moving id-mapped element into shadow root]
-    expected: FAIL
-
-  [moveBefore() correctly updates id map when moving between shadow roots]
-    expected: FAIL

--- a/tests/wpt/meta/dom/nodes/moveBefore/moveBefore-name-map.html.ini
+++ b/tests/wpt/meta/dom/nodes/moveBefore/moveBefore-name-map.html.ini
@@ -1,3 +1,0 @@
-[moveBefore-name-map.html]
-  [moveBefore() correctly updates window map]
-    expected: FAIL


### PR DESCRIPTION
The previous code was adding new entries in the maps for the moved
elements, but not removing the old entries. This change fixes that
issue.

Testing: This causes two WPT tests to start passing.
Fixes: #44140.
