### PR TITLE
script: return `Err` if `JS_SetPrototype` failed

### DIFF
--- a/components/script/dom/bindings/constructor.rs
+++ b/components/script/dom/bindings/constructor.rs
@@ -247,7 +247,9 @@ fn html_constructor(
             return Err(());
         }
 
-        JS_SetPrototype(cx, element.handle(), prototype.handle());
+        if !JS_SetPrototype(cx, element.handle(), prototype.handle()) {
+            return Err(());
+        }
 
         result.safe_to_jsval(
             cx.into(),


### PR DESCRIPTION
When constructing html elements the return value of `JS_SetPrototype` was ignored, now instead of silently continuing, return Err(()).

Testing: Covered by existing tests, no crash observed on a debug-mozjs build with `./mach test-wpt /custom-elements/prevent-extensions-crash.html --repeat-until-unexpected`
Fixes: #44579
