### PR TITLE
devtools: Keep `ArrayLike` preview for nested arrays

### DIFF
--- a/components/default-resources/resources/debugger.js
+++ b/components/default-resources/resources/debugger.js
@@ -203,11 +203,12 @@ previewers.Array = [ function ArrayPreviewer(obj, depth) {
     const lengthDescriptor = obj.getOwnPropertyDescriptor("length");
     const arrayLength = lengthDescriptor ? lengthDescriptor.value : 0;
 
-    let preview = { kind: "ArrayLike", arrayLength, items: [] };
+    let preview = { kind: "ArrayLike", arrayLength };
     if (depth > 1) {
-        return undefined;
+        return preview;
     }
 
+    preview.items = [];
     for (let i = 0; i < arrayLength; i++) {
         try {
             const desc = obj.getOwnPropertyDescriptor(i);


### PR DESCRIPTION
Keep ArrayLike preview for nested arrays.

Testing: `./mach test-devtools` passes
Fixes: Part of #39858 

**Before Fix and After Fix**
<img width="305" height="250" alt="image" src="https://github.com/user-attachments/assets/df1f2f35-224f-472d-ad42-87e1a0566dfb" /> <img width="322" height="250" alt="image" src="https://github.com/user-attachments/assets/b766f126-53b7-4f93-9cb6-702f840647cd" />
