### PR TITLE
script: Complete porting `CustomElementRegistryMethods` to `&mut JSContext`

### DIFF
--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -432,9 +432,9 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
         // Steps 14.1 - 14.2: Get the value of the prototype.
         rooted!(&in(cx) let mut prototype = UndefinedValue());
         {
-            // let _realm = AutoRealm::new_from_handle(cx, constructor.handle());
+            let mut realm = AutoRealm::new_from_handle(cx, constructor.handle());
             if let Err(error) =
-                self.check_prototype(cx, constructor.handle(), prototype.handle_mut())
+                self.check_prototype(&mut realm, constructor.handle(), prototype.handle_mut())
             {
                 self.element_definition_is_running.set(false);
                 return Err(error);
@@ -448,8 +448,8 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
         // if one of the callback getters throws an exception.
         rooted!(&in(cx) let proto_object = prototype.to_object());
         let mut callbacks = {
-            // let _realm = AutoRealm::new_from_handle(cx, proto_object.handle());
-            match self.get_callbacks(cx, proto_object.handle()) {
+            let mut realm = AutoRealm::new_from_handle(cx, proto_object.handle());
+            match self.get_callbacks(&mut realm, proto_object.handle()) {
                 Ok(callbacks) => callbacks,
                 Err(error) => {
                     self.element_definition_is_running.set(false);
@@ -461,8 +461,8 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
         // Step 14.5: Handle the case where with `attributeChangedCallback` on `lifecycleCallbacks`
         // is not null.
         let observed_attributes = if callbacks.attribute_changed_callback.is_some() {
-            // let _realm = AutoRealm::new_from_handle(cx, constructor.handle());
-            match self.get_attributes(cx, constructor.handle(), c"observedAttributes") {
+            let mut realm = AutoRealm::new_from_handle(cx, constructor.handle());
+            match self.get_attributes(&mut realm, constructor.handle(), c"observedAttributes") {
                 Ok(attributes) => attributes,
                 Err(error) => {
                     self.element_definition_is_running.set(false);
@@ -475,8 +475,8 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
 
         // Steps 14.6 - 14.10: Handle `disabledFeatures`.
         let (disable_internals, disable_shadow) = {
-            // let _realm = AutoRealm::new_from_handle(cx, constructor.handle());
-            match self.get_attributes(cx, constructor.handle(), c"disabledFeatures") {
+            let mut realm = AutoRealm::new_from_handle(cx, constructor.handle());
+            match self.get_attributes(&mut realm, constructor.handle(), c"disabledFeatures") {
                 Ok(sequence) => (
                     sequence.iter().any(|s| *s == "internals"),
                     sequence.iter().any(|s| *s == "shadow"),
@@ -490,8 +490,8 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
 
         // Step 14.11 - 14.12: Handle `formAssociated`.
         let form_associated = {
-            // let _realm = AutoRealm::new_from_handle(cx, constructor.handle());
-            match self.get_form_associated_value(cx, constructor.handle()) {
+            let mut realm = AutoRealm::new_from_handle(cx, constructor.handle());
+            match self.get_form_associated_value(&mut realm, constructor.handle()) {
                 Ok(flag) => flag,
                 Err(error) => {
                     self.element_definition_is_running.set(false);
@@ -502,11 +502,13 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
 
         // Steps 14.13: Add the `formAssociated` callbacks.
         if form_associated {
-            // let _realm = AutoRealm::new_from_handle(cx, proto_object.handle());
+            let mut realm = AutoRealm::new_from_handle(cx, proto_object.handle());
             unsafe {
-                if let Err(error) =
-                    self.add_form_associated_callbacks(cx, proto_object.handle(), &mut callbacks)
-                {
+                if let Err(error) = self.add_form_associated_callbacks(
+                    &mut realm,
+                    proto_object.handle(),
+                    &mut callbacks,
+                ) {
                     self.element_definition_is_running.set(false);
                     return Err(error);
                 }

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -562,7 +562,7 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
                 constructor.handle_mut(),
                 CanGc::from_cx(cx),
             );
-            promise.resolve_native(&constructor.get(), CanGc::from_cx(cx));
+            promise.resolve_native_with_cx(cx, &constructor.get());
         }
         Ok(())
     }
@@ -596,14 +596,12 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
         // Step 1
         if !is_valid_custom_element_name(&name) {
             let promise = Promise::new_in_realm(realm);
-            promise.reject_native(
-                &DOMException::new(
-                    self.window.as_global_scope(),
-                    DOMErrorName::SyntaxError,
-                    CanGc::from_cx(realm),
-                ),
+            let error = DOMException::new(
+                self.window.as_global_scope(),
+                DOMErrorName::SyntaxError,
                 CanGc::from_cx(realm),
             );
+            promise.reject_native_with_cx(realm, &error);
             return promise;
         }
 
@@ -616,7 +614,7 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
                 CanGc::from_cx(realm),
             );
             let promise = Promise::new_in_realm(realm);
-            promise.resolve_native(&constructor.get(), CanGc::from_cx(realm));
+            promise.resolve_native_with_cx(realm, &constructor.get());
             return promise;
         }
 

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -10,12 +10,13 @@ use std::{mem, ptr};
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Namespace, Prefix, ns};
+use js::context::JSContext;
 use js::glue::UnwrapObjectStatic;
 use js::jsapi::{HandleValueArray, Heap, IsCallable, IsConstructor, JSAutoRealm, JSObject};
 use js::jsval::{BooleanValue, JSVal, NullValue, ObjectValue, UndefinedValue};
 use js::realm::AutoRealm;
-use js::rust::wrappers::{Construct1, JS_GetProperty};
-use js::rust::wrappers2::SameValue;
+use js::rust::wrappers::Construct1;
+use js::rust::wrappers2::{JS_GetProperty, SameValue};
 use js::rust::{HandleObject, MutableHandleValue};
 use rustc_hash::FxBuildHasher;
 use script_bindings::cell::DomRefCell;
@@ -53,7 +54,7 @@ use crate::dom::promise::Promise;
 use crate::dom::window::Window;
 use crate::microtask::Microtask;
 use crate::realms::{InRealm, enter_auto_realm};
-use crate::script_runtime::{CanGc, JSContext};
+use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 
 /// <https://dom.spec.whatwg.org/#concept-element-custom-element-state>
@@ -177,17 +178,13 @@ impl CustomElementRegistry {
     #[expect(unsafe_code)]
     fn check_prototype(
         &self,
+        cx: &mut JSContext,
         constructor: HandleObject,
         mut prototype: MutableHandleValue,
     ) -> ErrorResult {
         unsafe {
             // Step 10.1
-            if !JS_GetProperty(
-                *GlobalScope::get_cx(),
-                constructor,
-                c"prototype".as_ptr(),
-                prototype.reborrow(),
-            ) {
+            if !JS_GetProperty(cx, constructor, c"prototype".as_ptr(), prototype.reborrow()) {
                 return Err(Error::JSFailed);
             }
 
@@ -204,10 +201,11 @@ impl CustomElementRegistry {
     /// <https://html.spec.whatwg.org/multipage/#dom-customelementregistry-define>
     /// This function includes both steps 14.3 and 14.4 which add the callbacks to a map and
     /// process them.
-    #[expect(unsafe_code)]
-    unsafe fn get_callbacks(&self, prototype: HandleObject) -> Fallible<LifecycleCallbacks> {
-        let cx = GlobalScope::get_cx();
-
+    fn get_callbacks(
+        &self,
+        cx: &mut JSContext,
+        prototype: HandleObject,
+    ) -> Fallible<LifecycleCallbacks> {
         // Step 4
         Ok(LifecycleCallbacks {
             connected_callback: get_callback(cx, prototype, c"connectedCallback")?,
@@ -228,17 +226,16 @@ impl CustomElementRegistry {
     #[expect(unsafe_code)]
     unsafe fn add_form_associated_callbacks(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         prototype: HandleObject,
         callbacks: &mut LifecycleCallbacks,
     ) -> ErrorResult {
         callbacks.form_associated_callback =
-            get_callback(cx.into(), prototype, c"formAssociatedCallback")?;
-        callbacks.form_reset_callback = get_callback(cx.into(), prototype, c"formResetCallback")?;
-        callbacks.form_disabled_callback =
-            get_callback(cx.into(), prototype, c"formDisabledCallback")?;
+            get_callback(cx, prototype, c"formAssociatedCallback")?;
+        callbacks.form_reset_callback = get_callback(cx, prototype, c"formResetCallback")?;
+        callbacks.form_disabled_callback = get_callback(cx, prototype, c"formDisabledCallback")?;
         callbacks.form_state_restore_callback =
-            get_callback(cx.into(), prototype, c"formStateRestoreCallback")?;
+            get_callback(cx, prototype, c"formStateRestoreCallback")?;
 
         Ok(())
     }
@@ -246,19 +243,12 @@ impl CustomElementRegistry {
     #[expect(unsafe_code)]
     fn get_attributes(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         constructor: HandleObject,
         name: &CStr,
     ) -> Fallible<Vec<DOMString>> {
         rooted!(&in(cx) let mut attributes = UndefinedValue());
-        if unsafe {
-            !JS_GetProperty(
-                cx.raw_cx(),
-                constructor,
-                name.as_ptr(),
-                attributes.handle_mut(),
-            )
-        } {
+        if unsafe { !JS_GetProperty(cx, constructor, name.as_ptr(), attributes.handle_mut()) } {
             return Err(Error::JSFailed);
         }
 
@@ -284,13 +274,13 @@ impl CustomElementRegistry {
     #[expect(unsafe_code)]
     fn get_form_associated_value(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         constructor: HandleObject,
     ) -> Fallible<bool> {
         rooted!(&in(cx) let mut form_associated_value = UndefinedValue());
         if unsafe {
             !JS_GetProperty(
-                cx.raw_cx(),
+                cx,
                 constructor,
                 c"formAssociated".as_ptr(),
                 form_associated_value.handle_mut(),
@@ -321,19 +311,14 @@ impl CustomElementRegistry {
 /// Step 14.4: Get `callbackValue` for all `callbackName` in `lifecycleCallbacks`.
 #[expect(unsafe_code)]
 fn get_callback(
-    cx: JSContext,
+    cx: &mut JSContext,
     prototype: HandleObject,
     name: &CStr,
 ) -> Fallible<Option<Rc<Function>>> {
-    rooted!(in(*cx) let mut callback = UndefinedValue());
+    rooted!(&in(cx) let mut callback = UndefinedValue());
     unsafe {
         // Step 10.4.1
-        if !JS_GetProperty(
-            *cx,
-            prototype,
-            name.as_ptr() as *const _,
-            callback.handle_mut(),
-        ) {
+        if !JS_GetProperty(cx, prototype, name.as_ptr(), callback.handle_mut()) {
             return Err(Error::JSFailed);
         }
 
@@ -344,7 +329,7 @@ fn get_callback(
                     c"Lifecycle callback is not callable".to_owned(),
                 ));
             }
-            Ok(Some(Function::new(cx, callback.to_object())))
+            Ok(Some(Function::new(cx.into(), callback.to_object())))
         } else {
             Ok(None)
         }
@@ -356,7 +341,7 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
     /// <https://html.spec.whatwg.org/multipage/#dom-customelementregistry-define>
     fn Define(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         name: DOMString,
         constructor_: Rc<CustomElementConstructor>,
         options: &ElementDefinitionOptions,
@@ -448,7 +433,9 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
         rooted!(&in(cx) let mut prototype = UndefinedValue());
         {
             // let _realm = AutoRealm::new_from_handle(cx, constructor.handle());
-            if let Err(error) = self.check_prototype(constructor.handle(), prototype.handle_mut()) {
+            if let Err(error) =
+                self.check_prototype(cx, constructor.handle(), prototype.handle_mut())
+            {
                 self.element_definition_is_running.set(false);
                 return Err(error);
             }
@@ -462,8 +449,7 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
         rooted!(&in(cx) let proto_object = prototype.to_object());
         let mut callbacks = {
             // let _realm = AutoRealm::new_from_handle(cx, proto_object.handle());
-            let callbacks = unsafe { self.get_callbacks(proto_object.handle()) };
-            match callbacks {
+            match self.get_callbacks(cx, proto_object.handle()) {
                 Ok(callbacks) => callbacks,
                 Err(error) => {
                     self.element_definition_is_running.set(false);
@@ -580,12 +566,12 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-customelementregistry-get>
-    fn Get(&self, cx: JSContext, name: DOMString, mut retval: MutableHandleValue) {
+    fn Get(&self, cx: &mut JSContext, name: DOMString, mut retval: MutableHandleValue) {
         match self.definitions.borrow().get(&LocalName::from(name)) {
             Some(definition) => {
                 definition
                     .constructor
-                    .safe_to_jsval(cx, retval, CanGc::deprecated_note())
+                    .safe_to_jsval(cx.into(), retval, CanGc::from_cx(cx))
             },
             None => retval.set(UndefinedValue()),
         }
@@ -839,7 +825,7 @@ impl CustomElementDefinition {
 
 /// <https://html.spec.whatwg.org/multipage/#concept-upgrade-an-element>
 pub(crate) fn upgrade_element(
-    cx: &mut js::context::JSContext,
+    cx: &mut JSContext,
     definition: Rc<CustomElementDefinition>,
     element: &Element,
 ) {
@@ -957,7 +943,7 @@ pub(crate) fn upgrade_element(
 /// Steps 9.1-9.4
 #[expect(unsafe_code)]
 fn run_upgrade_constructor(
-    cx: &mut js::context::JSContext,
+    cx: &mut JSContext,
     definition: &CustomElementDefinition,
     element: &Element,
 ) -> ErrorResult {
@@ -1053,7 +1039,7 @@ pub(crate) enum CustomElementReaction {
 
 impl CustomElementReaction {
     /// <https://html.spec.whatwg.org/multipage/#invoke-custom-element-reactions>
-    pub(crate) fn invoke(&self, cx: &mut js::context::JSContext, element: &Element) {
+    pub(crate) fn invoke(&self, cx: &mut JSContext, element: &Element) {
         // Step 2.1
         match *self {
             CustomElementReaction::Upgrade(ref definition) => {
@@ -1124,7 +1110,7 @@ impl CustomElementReactionStack {
         self.stack.borrow_mut().push(ElementQueue::new());
     }
 
-    pub(crate) fn pop_current_element_queue(&self, cx: &mut js::context::JSContext) {
+    pub(crate) fn pop_current_element_queue(&self, cx: &mut JSContext) {
         rooted_vec!(let mut stack);
         mem::swap(&mut *stack, &mut *self.stack.borrow_mut());
 
@@ -1139,7 +1125,7 @@ impl CustomElementReactionStack {
 
     /// <https://html.spec.whatwg.org/multipage/#enqueue-an-element-on-the-appropriate-element-queue>
     /// Step 4
-    pub(crate) fn invoke_backup_element_queue(&self, cx: &mut js::context::JSContext) {
+    pub(crate) fn invoke_backup_element_queue(&self, cx: &mut JSContext) {
         // Step 4.1
         self.backup_queue.invoke_reactions(cx);
 
@@ -1358,7 +1344,7 @@ impl ElementQueue {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#invoke-custom-element-reactions>
-    fn invoke_reactions(&self, cx: &mut js::context::JSContext) {
+    fn invoke_reactions(&self, cx: &mut JSContext) {
         // Steps 1-2
         while let Some(element) = self.next_element() {
             element.invoke_reactions(cx)

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -14,7 +14,7 @@ use js::context::JSContext;
 use js::glue::UnwrapObjectStatic;
 use js::jsapi::{HandleValueArray, Heap, IsCallable, IsConstructor, JSAutoRealm, JSObject};
 use js::jsval::{BooleanValue, JSVal, NullValue, ObjectValue, UndefinedValue};
-use js::realm::AutoRealm;
+use js::realm::{AutoRealm, CurrentRealm};
 use js::rust::wrappers::Construct1;
 use js::rust::wrappers2::{JS_GetProperty, SameValue};
 use js::rust::{HandleObject, MutableHandleValue};
@@ -53,7 +53,7 @@ use crate::dom::node::{Node, NodeTraits};
 use crate::dom::promise::Promise;
 use crate::dom::window::Window;
 use crate::microtask::Microtask;
-use crate::realms::{InRealm, enter_auto_realm};
+use crate::realms::enter_auto_realm;
 use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 
@@ -588,43 +588,45 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-customelementregistry-whendefined>
-    fn WhenDefined(&self, name: DOMString, comp: InRealm, can_gc: CanGc) -> Rc<Promise> {
+    fn WhenDefined(&self, realm: &mut CurrentRealm, name: DOMString) -> Rc<Promise> {
         let name = LocalName::from(name);
 
         // Step 1
         if !is_valid_custom_element_name(&name) {
-            let promise = Promise::new_in_current_realm(comp, can_gc);
+            let promise = Promise::new_in_realm(realm);
             promise.reject_native(
                 &DOMException::new(
                     self.window.as_global_scope(),
                     DOMErrorName::SyntaxError,
-                    can_gc,
+                    CanGc::from_cx(realm),
                 ),
-                can_gc,
+                CanGc::from_cx(realm),
             );
             return promise;
         }
 
         // Step 2
         if let Some(definition) = self.definitions.borrow().get(&LocalName::from(&*name)) {
-            let cx = GlobalScope::get_cx();
-            rooted!(in(*cx) let mut constructor = UndefinedValue());
-            definition
-                .constructor
-                .safe_to_jsval(cx, constructor.handle_mut(), can_gc);
-            let promise = Promise::new_in_current_realm(comp, can_gc);
-            promise.resolve_native(&constructor.get(), can_gc);
+            rooted!(&in(*realm) let mut constructor = UndefinedValue());
+            definition.constructor.safe_to_jsval(
+                realm.into(),
+                constructor.handle_mut(),
+                CanGc::from_cx(realm),
+            );
+            let promise = Promise::new_in_realm(realm);
+            promise.resolve_native(&constructor.get(), CanGc::from_cx(realm));
             return promise;
         }
 
         // Steps 3, 4, 5, 6
         let existing_promise = self.when_defined.borrow().get(&name).cloned();
         existing_promise.unwrap_or_else(|| {
-            let promise = Promise::new_in_current_realm(comp, can_gc);
+            let promise = Promise::new_in_realm(realm);
             self.when_defined.borrow_mut().insert(name, promise.clone());
             promise
         })
     }
+
     /// <https://html.spec.whatwg.org/multipage/#dom-customelementregistry-upgrade>
     fn Upgrade(&self, node: &Node) {
         // Spec says to make a list first and then iterate the list, but

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -244,30 +244,31 @@ impl CustomElementRegistry {
     }
 
     #[expect(unsafe_code)]
-    fn get_observed_attributes(
+    fn get_attributes(
         &self,
         cx: &mut js::context::JSContext,
         constructor: HandleObject,
+        name: &CStr,
     ) -> Fallible<Vec<DOMString>> {
-        rooted!(&in(cx) let mut observed_attributes = UndefinedValue());
+        rooted!(&in(cx) let mut attributes = UndefinedValue());
         if unsafe {
             !JS_GetProperty(
                 cx.raw_cx(),
                 constructor,
-                c"observedAttributes".as_ptr(),
-                observed_attributes.handle_mut(),
+                name.as_ptr(),
+                attributes.handle_mut(),
             )
         } {
             return Err(Error::JSFailed);
         }
 
-        if observed_attributes.is_undefined() {
+        if attributes.is_undefined() {
             return Ok(Vec::new());
         }
 
         let conversion = SafeFromJSValConvertible::safe_from_jsval(
             cx.into(),
-            observed_attributes.handle(),
+            attributes.handle(),
             StringificationBehavior::Default,
             CanGc::from_cx(cx),
         );
@@ -310,43 +311,6 @@ impl CustomElementRegistry {
         );
         match conversion {
             Ok(ConversionResult::Success(flag)) => Ok(flag),
-            Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into_owned())),
-            _ => Err(Error::JSFailed),
-        }
-    }
-
-    /// <https://html.spec.whatwg.org/multipage/#dom-customelementregistry-define>
-    /// Step 14.7: Get `disabledFeatures` value
-    #[expect(unsafe_code)]
-    fn get_disabled_features(
-        &self,
-        cx: &mut js::context::JSContext,
-        constructor: HandleObject,
-    ) -> Fallible<Vec<DOMString>> {
-        rooted!(&in(cx) let mut disabled_features = UndefinedValue());
-        if unsafe {
-            !JS_GetProperty(
-                cx.raw_cx(),
-                constructor,
-                c"disabledFeatures".as_ptr(),
-                disabled_features.handle_mut(),
-            )
-        } {
-            return Err(Error::JSFailed);
-        }
-
-        if disabled_features.is_undefined() {
-            return Ok(Vec::new());
-        }
-
-        let conversion = SafeFromJSValConvertible::safe_from_jsval(
-            cx.into(),
-            disabled_features.handle(),
-            StringificationBehavior::Default,
-            CanGc::from_cx(cx),
-        );
-        match conversion {
-            Ok(ConversionResult::Success(attributes)) => Ok(attributes),
             Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into_owned())),
             _ => Err(Error::JSFailed),
         }
@@ -512,7 +476,7 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
         // is not null.
         let observed_attributes = if callbacks.attribute_changed_callback.is_some() {
             // let _realm = AutoRealm::new_from_handle(cx, constructor.handle());
-            match self.get_observed_attributes(cx, constructor.handle()) {
+            match self.get_attributes(cx, constructor.handle(), c"observedAttributes") {
                 Ok(attributes) => attributes,
                 Err(error) => {
                     self.element_definition_is_running.set(false);
@@ -526,7 +490,7 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
         // Steps 14.6 - 14.10: Handle `disabledFeatures`.
         let (disable_internals, disable_shadow) = {
             // let _realm = AutoRealm::new_from_handle(cx, constructor.handle());
-            match self.get_disabled_features(cx, constructor.handle()) {
+            match self.get_attributes(cx, constructor.handle(), c"disabledFeatures") {
                 Ok(sequence) => (
                     sequence.iter().any(|s| *s == "internals"),
                     sequence.iter().any(|s| *s == "shadow"),

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -228,17 +228,17 @@ impl CustomElementRegistry {
     #[expect(unsafe_code)]
     unsafe fn add_form_associated_callbacks(
         &self,
+        cx: &mut js::context::JSContext,
         prototype: HandleObject,
         callbacks: &mut LifecycleCallbacks,
     ) -> ErrorResult {
-        let cx = self.window.get_cx();
-
         callbacks.form_associated_callback =
-            get_callback(cx, prototype, c"formAssociatedCallback")?;
-        callbacks.form_reset_callback = get_callback(cx, prototype, c"formResetCallback")?;
-        callbacks.form_disabled_callback = get_callback(cx, prototype, c"formDisabledCallback")?;
+            get_callback(cx.into(), prototype, c"formAssociatedCallback")?;
+        callbacks.form_reset_callback = get_callback(cx.into(), prototype, c"formResetCallback")?;
+        callbacks.form_disabled_callback =
+            get_callback(cx.into(), prototype, c"formDisabledCallback")?;
         callbacks.form_state_restore_callback =
-            get_callback(cx, prototype, c"formStateRestoreCallback")?;
+            get_callback(cx.into(), prototype, c"formStateRestoreCallback")?;
 
         Ok(())
     }
@@ -246,14 +246,13 @@ impl CustomElementRegistry {
     #[expect(unsafe_code)]
     fn get_observed_attributes(
         &self,
+        cx: &mut js::context::JSContext,
         constructor: HandleObject,
-        can_gc: CanGc,
     ) -> Fallible<Vec<DOMString>> {
-        let cx = GlobalScope::get_cx();
-        rooted!(in(*cx) let mut observed_attributes = UndefinedValue());
+        rooted!(&in(cx) let mut observed_attributes = UndefinedValue());
         if unsafe {
             !JS_GetProperty(
-                *cx,
+                cx.raw_cx(),
                 constructor,
                 c"observedAttributes".as_ptr(),
                 observed_attributes.handle_mut(),
@@ -267,10 +266,10 @@ impl CustomElementRegistry {
         }
 
         let conversion = SafeFromJSValConvertible::safe_from_jsval(
-            cx,
+            cx.into(),
             observed_attributes.handle(),
             StringificationBehavior::Default,
-            can_gc,
+            CanGc::from_cx(cx),
         );
         match conversion {
             Ok(ConversionResult::Success(attributes)) => Ok(attributes),
@@ -284,14 +283,13 @@ impl CustomElementRegistry {
     #[expect(unsafe_code)]
     fn get_form_associated_value(
         &self,
+        cx: &mut js::context::JSContext,
         constructor: HandleObject,
-        can_gc: CanGc,
     ) -> Fallible<bool> {
-        let cx = self.window.get_cx();
-        rooted!(in(*cx) let mut form_associated_value = UndefinedValue());
+        rooted!(&in(cx) let mut form_associated_value = UndefinedValue());
         if unsafe {
             !JS_GetProperty(
-                *cx,
+                cx.raw_cx(),
                 constructor,
                 c"formAssociated".as_ptr(),
                 form_associated_value.handle_mut(),
@@ -305,10 +303,10 @@ impl CustomElementRegistry {
         }
 
         let conversion = SafeFromJSValConvertible::safe_from_jsval(
-            cx,
+            cx.into(),
             form_associated_value.handle(),
             (),
-            can_gc,
+            CanGc::from_cx(cx),
         );
         match conversion {
             Ok(ConversionResult::Success(flag)) => Ok(flag),
@@ -322,14 +320,13 @@ impl CustomElementRegistry {
     #[expect(unsafe_code)]
     fn get_disabled_features(
         &self,
+        cx: &mut js::context::JSContext,
         constructor: HandleObject,
-        can_gc: CanGc,
     ) -> Fallible<Vec<DOMString>> {
-        let cx = self.window.get_cx();
-        rooted!(in(*cx) let mut disabled_features = UndefinedValue());
+        rooted!(&in(cx) let mut disabled_features = UndefinedValue());
         if unsafe {
             !JS_GetProperty(
-                *cx,
+                cx.raw_cx(),
                 constructor,
                 c"disabledFeatures".as_ptr(),
                 disabled_features.handle_mut(),
@@ -343,10 +340,10 @@ impl CustomElementRegistry {
         }
 
         let conversion = SafeFromJSValConvertible::safe_from_jsval(
-            cx,
+            cx.into(),
             disabled_features.handle(),
             StringificationBehavior::Default,
-            can_gc,
+            CanGc::from_cx(cx),
         );
         match conversion {
             Ok(ConversionResult::Success(attributes)) => Ok(attributes),
@@ -395,18 +392,17 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
     /// <https://html.spec.whatwg.org/multipage/#dom-customelementregistry-define>
     fn Define(
         &self,
+        cx: &mut js::context::JSContext,
         name: DOMString,
         constructor_: Rc<CustomElementConstructor>,
         options: &ElementDefinitionOptions,
-        can_gc: CanGc,
     ) -> ErrorResult {
-        let cx = GlobalScope::get_cx();
-        rooted!(in(*cx) let constructor = constructor_.callback());
+        rooted!(&in(cx) let constructor = constructor_.callback());
         let name = LocalName::from(name);
 
         // Step 1. If IsConstructor(constructor) is false, then throw a TypeError.
         // We must unwrap the constructor as all wrappers are constructable if they are callable.
-        rooted!(in(*cx) let unwrapped_constructor = unsafe { UnwrapObjectStatic(constructor.get()) });
+        rooted!(&in(cx) let unwrapped_constructor = unsafe { UnwrapObjectStatic(constructor.get()) });
 
         if unwrapped_constructor.is_null() {
             // We do not have permission to access the unwrapped constructor.
@@ -485,9 +481,9 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
         // `observedAttributes` with default values, but this is done later.
 
         // Steps 14.1 - 14.2: Get the value of the prototype.
-        rooted!(in(*cx) let mut prototype = UndefinedValue());
+        rooted!(&in(cx) let mut prototype = UndefinedValue());
         {
-            let _ac = JSAutoRealm::new(*cx, constructor.get());
+            // let _realm = AutoRealm::new_from_handle(cx, constructor.handle());
             if let Err(error) = self.check_prototype(constructor.handle(), prototype.handle_mut()) {
                 self.element_definition_is_running.set(false);
                 return Err(error);
@@ -499,9 +495,9 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
         // we know whether this definition is going to be form-associated,
         // but the order of operations is specified and it's observable
         // if one of the callback getters throws an exception.
-        rooted!(in(*cx) let proto_object = prototype.to_object());
+        rooted!(&in(cx) let proto_object = prototype.to_object());
         let mut callbacks = {
-            let _ac = JSAutoRealm::new(*cx, proto_object.get());
+            // let _realm = AutoRealm::new_from_handle(cx, proto_object.handle());
             let callbacks = unsafe { self.get_callbacks(proto_object.handle()) };
             match callbacks {
                 Ok(callbacks) => callbacks,
@@ -515,8 +511,8 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
         // Step 14.5: Handle the case where with `attributeChangedCallback` on `lifecycleCallbacks`
         // is not null.
         let observed_attributes = if callbacks.attribute_changed_callback.is_some() {
-            let _ac = JSAutoRealm::new(*cx, constructor.get());
-            match self.get_observed_attributes(constructor.handle(), can_gc) {
+            // let _realm = AutoRealm::new_from_handle(cx, constructor.handle());
+            match self.get_observed_attributes(cx, constructor.handle()) {
                 Ok(attributes) => attributes,
                 Err(error) => {
                     self.element_definition_is_running.set(false);
@@ -529,8 +525,8 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
 
         // Steps 14.6 - 14.10: Handle `disabledFeatures`.
         let (disable_internals, disable_shadow) = {
-            let _ac = JSAutoRealm::new(*cx, constructor.get());
-            match self.get_disabled_features(constructor.handle(), can_gc) {
+            // let _realm = AutoRealm::new_from_handle(cx, constructor.handle());
+            match self.get_disabled_features(cx, constructor.handle()) {
                 Ok(sequence) => (
                     sequence.iter().any(|s| *s == "internals"),
                     sequence.iter().any(|s| *s == "shadow"),
@@ -544,8 +540,8 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
 
         // Step 14.11 - 14.12: Handle `formAssociated`.
         let form_associated = {
-            let _ac = JSAutoRealm::new(*cx, constructor.get());
-            match self.get_form_associated_value(constructor.handle(), can_gc) {
+            // let _realm = AutoRealm::new_from_handle(cx, constructor.handle());
+            match self.get_form_associated_value(cx, constructor.handle()) {
                 Ok(flag) => flag,
                 Err(error) => {
                     self.element_definition_is_running.set(false);
@@ -556,10 +552,10 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
 
         // Steps 14.13: Add the `formAssociated` callbacks.
         if form_associated {
-            let _ac = JSAutoRealm::new(*cx, proto_object.get());
+            // let _realm = AutoRealm::new_from_handle(cx, proto_object.handle());
             unsafe {
                 if let Err(error) =
-                    self.add_form_associated_callbacks(proto_object.handle(), &mut callbacks)
+                    self.add_form_associated_callbacks(cx, proto_object.handle(), &mut callbacks)
                 {
                     self.element_definition_is_running.set(false);
                     return Err(error);
@@ -608,11 +604,13 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
         // Step 16, 16.3
         let promise = self.when_defined.borrow_mut().remove(&name);
         if let Some(promise) = promise {
-            rooted!(in(*cx) let mut constructor = UndefinedValue());
-            definition
-                .constructor
-                .safe_to_jsval(cx, constructor.handle_mut(), can_gc);
-            promise.resolve_native(&constructor.get(), can_gc);
+            rooted!(&in(cx) let mut constructor = UndefinedValue());
+            definition.constructor.safe_to_jsval(
+                cx.into(),
+                constructor.handle_mut(),
+                CanGc::from_cx(cx),
+            );
+            promise.resolve_native(&constructor.get(), CanGc::from_cx(cx));
         }
         Ok(())
     }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -221,7 +221,8 @@ DOMInterfaces = {
 
 'CustomElementRegistry': {
     'inRealms': ['WhenDefined'],
-    'canGc': ['Define', 'WhenDefined'],
+    'canGc': ['WhenDefined'],
+    'cx': ['Define']
 },
 
 'DataTransfer': {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -220,9 +220,8 @@ DOMInterfaces = {
 },
 
 'CustomElementRegistry': {
-    'inRealms': ['WhenDefined'],
-    'canGc': ['WhenDefined'],
-    'cx': ['Define', 'Get']
+    'cx': ['Define', 'Get'],
+    'realm': ['WhenDefined']
 },
 
 'DataTransfer': {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -222,7 +222,7 @@ DOMInterfaces = {
 'CustomElementRegistry': {
     'inRealms': ['WhenDefined'],
     'canGc': ['WhenDefined'],
-    'cx': ['Define']
+    'cx': ['Define', 'Get']
 },
 
 'DataTransfer': {


### PR DESCRIPTION
Reviewable per commit

Testing: It compiles
Part of #42638 
