### PR TITLE
android: upgrade Android Gradle Plugin to latest version

### DIFF
--- a/support/android/apk/build.gradle.kts
+++ b/support/android/apk/build.gradle.kts
@@ -1,5 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.13.2" apply false
-    id("com.android.library") version "8.13.2" apply false
+    id("com.android.application") version "9.2.1" apply false
+    id("com.android.library") version "9.2.1" apply false
 }

--- a/support/android/apk/gradle.properties
+++ b/support/android/apk/gradle.properties
@@ -11,11 +11,5 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-# AndroidX package structure to make it clearer which packages are bundled with the
-# Android operating system, and which are packaged with your app's APK
-# https://developer.android.com/topic/libraries/support-library/androidx-rn
-android.useAndroidX=true
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true
+android.newDsl=false
+android.r8.proguardAndroidTxt.disallowed=false


### PR DESCRIPTION
A minimal upgrade to AGP 9.x. Some Gradle properties have been deleted as they are [now the default](https://developer.android.com/build/releases/agp-9-0-0-release-notes). The two new Gradle properties have been added as they require minimal changes (in the case of `android.r8.proguardAndroidTxt.disallowed=false`) or extensive changes (in the case of `android.newDsl=false`). These can be done separately from this upgrade.

Testing: Ran app