### PR TITLE
android: move Gradle blocks to correct scope

### DIFF
--- a/support/android/apk/servoapp/build.gradle.kts
+++ b/support/android/apk/servoapp/build.gradle.kts
@@ -4,13 +4,13 @@ plugins {
     id("com.android.application")
 }
 
+layout.buildDirectory = File(rootDir.absolutePath, "/../../../target/android/gradle/servoapp")
+
 android {
     compileSdk = 34
     buildToolsVersion = "34.0.0"
 
     namespace = "org.servo.servoshell"
-
-    layout.buildDirectory = File(rootDir.absolutePath, "/../../../target/android/gradle/servoapp")
 
     defaultConfig {
         applicationId = "org.servo.servoshell"
@@ -104,37 +104,37 @@ android {
             }
         }
     }
+}
 
-    // Ignore default "debug" and "release" build types
-    androidComponents {
-        beforeVariants {
-            if (it.buildType == "release" || it.buildType == "debug") {
-                it.enable = false
-            }
+// Ignore default "debug" and "release" build types
+androidComponents {
+    beforeVariants {
+        if (it.buildType == "release" || it.buildType == "debug") {
+            it.enable = false
         }
     }
+}
 
-    project.afterEvaluate {
-        android.applicationVariants.forEach { variant ->
-            val pattern = Pattern.compile("^([\\w\\d]+)(Debug|Release)")
-            val matcher = pattern.matcher(variant.name)
-            if (!matcher.find()) {
-                throw GradleException("Invalid variant name for output: " + variant.name)
-            }
-            val arch = matcher.group(1)
-            val debug = variant.name.contains("Debug")
-            val finalFolder = getTargetDir(debug, arch)
-            val finalFile = File(finalFolder, "servoapp.apk")
-            variant.outputs.forEach { output ->
-                val copyAndRenameAPKTask =
-                    project.task<Copy>("copyAndRename${variant.name.capitalize()}APK") {
-                        from(output.outputFile.parent)
-                        into(finalFolder)
-                        include(output.outputFile.name)
-                        rename(output.outputFile.name, finalFile.name)
-                    }
-                variant.assembleProvider.get().finalizedBy(copyAndRenameAPKTask)
-            }
+project.afterEvaluate {
+    android.applicationVariants.forEach { variant ->
+        val pattern = Pattern.compile("^([\\w\\d]+)(Debug|Release)")
+        val matcher = pattern.matcher(variant.name)
+        if (!matcher.find()) {
+            throw GradleException("Invalid variant name for output: " + variant.name)
+        }
+        val arch = matcher.group(1)
+        val debug = variant.name.contains("Debug")
+        val finalFolder = getTargetDir(debug, arch)
+        val finalFile = File(finalFolder, "servoapp.apk")
+        variant.outputs.forEach { output ->
+            val copyAndRenameAPKTask =
+                project.task<Copy>("copyAndRename${variant.name.capitalize()}APK") {
+                    from(output.outputFile.parent)
+                    into(finalFolder)
+                    include(output.outputFile.name)
+                    rename(output.outputFile.name, finalFile.name)
+                }
+            variant.assembleProvider.get().finalizedBy(copyAndRenameAPKTask)
         }
     }
 }

--- a/support/android/apk/servoview/build.gradle.kts
+++ b/support/android/apk/servoview/build.gradle.kts
@@ -4,25 +4,30 @@ plugins {
     id("com.android.library")
 }
 
+layout.buildDirectory = File(rootDir.absolutePath, "/../../../target/android/gradle/servoview")
+
 android {
     compileSdk = 33
     buildToolsVersion = "34.0.0"
 
     namespace = "org.servo.servoview"
 
-    layout.buildDirectory = File(rootDir.absolutePath, "/../../../target/android/gradle/servoview")
-
     ndkPath = getNdkDir()
+
+    defaultConfig.versionCode = generatedVersionCode
+    defaultConfig.versionName = "0.0.1" // TODO: Parse Servo"s TOML and add git SHA.
 
     defaultConfig {
         minSdk = 30
-        lint.targetSdk = 33
-        defaultConfig.versionCode = generatedVersionCode
-        defaultConfig.versionName = "0.0.1" // TODO: Parse Servo"s TOML and add git SHA.
     }
 
+    lint {
+        targetSdk = 33
+    }
+
+    compileOptions.incremental = false
+
     compileOptions {
-        compileOptions.incremental = false
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
@@ -98,83 +103,82 @@ android {
             jniLibs.srcDirs(getJniLibsPath(false, "x64"))
         }
     }
+}
 
-    // Ignore default "debug" and "release" build types
-    androidComponents {
-        beforeVariants {
-            if (it.buildType == "release" || it.buildType == "debug") {
-                it.enable = false
-            }
-        }
-    }
-
-    // Call our custom NDK Build task using flavor parameters.
-    // This step is needed because the Android Gradle Plugin system"s
-    // integration with native C/C++ shared objects (based on the
-    // `android.externalNativeBuild` dsl object) assumes that we
-    // actually execute compiler commands to produced the shared
-    // objects. We already have the libservoshell.so produced by rustc.
-    // We could simply copy the .so to the `sourceSet.jniLibs` folder
-    // to make AGP bundle it with the APK, but this doesn't copy the STL
-    // (libc++_shared.so) as well. So we use ndk-build as a glorified
-    // `cp` command to copy the libservoshell.so from target/<arch>
-    // to target/android and crucially also include libc++_shared.so
-    // as well.
-    //
-    // FIXME(mukilan): According to the AGP docs, we should not be
-    // relying on task names used by the plugin system to hook into
-    // the build process, but instead we should use officially supported
-    // extension points such as `androidComponents.beforeVariants`
-    project.afterEvaluate {
-        // we filter entries first in order to abstract to a new list
-        // as to prevent concurrent modification exceptions due to creating a new task
-        // while iterating
-        tasks.mapNotNull { compileTask -> // mapNotNull acts as our filter, null results are dropped
-            // This matches the task `mergeArmv7DebugJniLibFolders`.
-            val pattern = Pattern.compile("^merge([A-Z]\\w+)(Debug|Release)JniLibFolders")
-            val matcher = pattern.matcher(compileTask.name)
-            if (matcher.find())
-                compileTask to matcher.group(1)
-            else null
-        }.forEach { (compileTask, arch) ->
-            val ndkBuildTask = tasks.create<Exec>("ndkbuild" + compileTask.name) {
-                val debug = compileTask.name.contains("Debug")
-                commandLine(
-                    getNdkDir() + "/ndk-build",
-                    "APP_BUILD_SCRIPT=../jni/Android.mk",
-                    "NDK_APPLICATION_MK=../jni/Application.mk",
-                    "NDK_LIBS_OUT=" + getJniLibsPath(debug, arch),
-                    "NDK_DEBUG=" + if (debug) "1" else "0",
-                    "APP_ABI=" + getNDKAbi(arch),
-                    "NDK_LOG=1",
-                    "SERVO_TARGET_DIR=" + getNativeTargetDir(debug, arch)
-                )
-            }
-
-            compileTask.dependsOn(ndkBuildTask)
-        }
-
-        android.libraryVariants.forEach { variant ->
-            val pattern = Pattern.compile("^([\\w\\d]+)(Debug|Release)")
-            val matcher = pattern.matcher(variant.name)
-            if (!matcher.find()) {
-                throw GradleException("Invalid variant name for output: " + variant.name)
-            }
-            val arch = matcher.group(1)
-            val debug = variant.name.contains("Debug")
-            val finalFolder = getTargetDir(debug, arch)
-            val finalFile = File(finalFolder, "servoview.aar")
-            variant.outputs.forEach { output ->
-                val copyAndRenameAARTask =
-                    project.task<Copy>("copyAndRename${variant.name.capitalize()}AAR") {
-                        from(output.outputFile.parent)
-                        into(finalFolder)
-                        include(output.outputFile.name)
-                        rename(output.outputFile.name, finalFile.name)
-                    }
-                variant.assembleProvider.get().finalizedBy(copyAndRenameAARTask)
-            }
+// Ignore default "debug" and "release" build types
+androidComponents {
+    beforeVariants {
+        if (it.buildType == "release" || it.buildType == "debug") {
+            it.enable = false
         }
     }
 }
 
+// Call our custom NDK Build task using flavor parameters.
+// This step is needed because the Android Gradle Plugin system"s
+// integration with native C/C++ shared objects (based on the
+// `android.externalNativeBuild` dsl object) assumes that we
+// actually execute compiler commands to produced the shared
+// objects. We already have the libservoshell.so produced by rustc.
+// We could simply copy the .so to the `sourceSet.jniLibs` folder
+// to make AGP bundle it with the APK, but this doesn't copy the STL
+// (libc++_shared.so) as well. So we use ndk-build as a glorified
+// `cp` command to copy the libservoshell.so from target/<arch>
+// to target/android and crucially also include libc++_shared.so
+// as well.
+//
+// FIXME(mukilan): According to the AGP docs, we should not be
+// relying on task names used by the plugin system to hook into
+// the build process, but instead we should use officially supported
+// extension points such as `androidComponents.beforeVariants`
+project.afterEvaluate {
+    // we filter entries first in order to abstract to a new list
+    // as to prevent concurrent modification exceptions due to creating a new task
+    // while iterating
+    tasks.mapNotNull { compileTask -> // mapNotNull acts as our filter, null results are dropped
+        // This matches the task `mergeArmv7DebugJniLibFolders`.
+        val pattern = Pattern.compile("^merge([A-Z]\\w+)(Debug|Release)JniLibFolders")
+        val matcher = pattern.matcher(compileTask.name)
+        if (matcher.find())
+            compileTask to matcher.group(1)
+        else null
+    }.forEach { (compileTask, arch) ->
+        val ndkBuildTask = tasks.create<Exec>("ndkbuild" + compileTask.name) {
+            val debug = compileTask.name.contains("Debug")
+            commandLine(
+                getNdkDir() + "/ndk-build",
+                "APP_BUILD_SCRIPT=../jni/Android.mk",
+                "NDK_APPLICATION_MK=../jni/Application.mk",
+                "NDK_LIBS_OUT=" + getJniLibsPath(debug, arch),
+                "NDK_DEBUG=" + if (debug) "1" else "0",
+                "APP_ABI=" + getNDKAbi(arch),
+                "NDK_LOG=1",
+                "SERVO_TARGET_DIR=" + getNativeTargetDir(debug, arch)
+            )
+        }
+
+        compileTask.dependsOn(ndkBuildTask)
+    }
+
+    android.libraryVariants.forEach { variant ->
+        val pattern = Pattern.compile("^([\\w\\d]+)(Debug|Release)")
+        val matcher = pattern.matcher(variant.name)
+        if (!matcher.find()) {
+            throw GradleException("Invalid variant name for output: " + variant.name)
+        }
+        val arch = matcher.group(1)
+        val debug = variant.name.contains("Debug")
+        val finalFolder = getTargetDir(debug, arch)
+        val finalFile = File(finalFolder, "servoview.aar")
+        variant.outputs.forEach { output ->
+            val copyAndRenameAARTask =
+                project.task<Copy>("copyAndRename${variant.name.capitalize()}AAR") {
+                    from(output.outputFile.parent)
+                    into(finalFolder)
+                    include(output.outputFile.name)
+                    rename(output.outputFile.name, finalFile.name)
+                }
+            variant.assembleProvider.get().finalizedBy(copyAndRenameAARTask)
+        }
+    }
+}


### PR DESCRIPTION
Some of these blocks are needlessly nested in other components, making reading these scripts a bit hard at times. For example, nesting the `layout` block in `android` might make one think that the `layout` is related to how Android works specifically, when it's really just a generic Gradle thing.

Some of these Gradle block moves are surprising! Like `compileOptions.incremental` can't just go into the `compileOptions` block as `incremental`, as one would usually expect. Instead, the `compileOptions` property has type `com.android.build.gradle.internal.CompileOptions` whereas the lambda receiver for the function `compileOptions` has type `com.android.build.api.dsl.CompileOptions`. A similar thing can be said for `defaultConfig`. Gradle configs can really test one's sanity sometimes :joy: 

Instead of painstakingly going through each block to see in which scope it belongs, I just went through the scripts and chucked a `this.` in front of all the DSL functions. If it's in the correct scope, the `this.` won't cause a compiler error, and if it's not, it will since it should be referenced via `this@myRealScopeParent`. I then just moved all these failing blocks to their respective `myRealScopeParent`.

Testing: Ran app.
