### PR TITLE
wpt(pointerevents): Fix intermittency from touch-generated compatibility mouse event in `pointerevent_setpointercapture_pointerup_touch.html`

### DIFF
--- a/tests/wpt/tests/pointerevents/pointerevent_setpointercapture_pointerup_touch.html
+++ b/tests/wpt/tests/pointerevents/pointerevent_setpointercapture_pointerup_touch.html
@@ -39,12 +39,23 @@
             }
 
             window.onload = function() {
+                let pointerdown_count = 0;
                 on_event(target0, 'pointerdown', function(e) {
+                    pointerdown_count++;
+                    assert_less_than_equal(pointerdown_count, 2);
                     detected_pointertypes[e.pointerType] = true;
-                    event_log.push('pointerdown@target0');
-                    test_pointerEvent.step(function () {
-                        assert_equals(e.pointerType, "touch", "Test should be run using a touch as input");
-                    });
+                    if (pointerdown_count === 1) {
+                        event_log.push('pointerdown@target0');
+                        test_pointerEvent.step(function () {
+                            assert_equals(e.pointerType, "touch",
+                                "First pointerdown should be touch");
+                        });
+                    } else if (pointerdown_count === 2) {
+                        test_pointerEvent.step(function () {
+                            assert_equals(e.pointerType, "mouse",
+                                "Second pointerdown (compatibility) should be mouse");
+                        });
+                    }
                 });
 
                 on_event(target0, 'gotpointercapture', function(e) {


### PR DESCRIPTION
Safari is also intermittent on this with same failure as we have: `!EQ("touch", "mouse")` [^1] . When the mouse compatibility event  from touch  generates a corresponding pointerdown of type mouse,  it is likely that the test hasn't fully exited yet due to timing with `.done`, and the listener triggered again.

We fix this by considering all possible cases.

Testing: Running for 10 mins without intermittency.
Fixes: https://github.com/servo/servo/issues/45444

[^1]: https://wpt.fyi/results/pointerevents/pointerevent_setpointercapture_pointerup_touch.html?run_id=5093659057061888&run_id=5121307573485568&run_id=5152622649802752&run_id=5379888461905920
