### PR TITLE
android: remove explicit disablement of incremental compilation

### DIFF
--- a/support/android/apk/servoview/build.gradle.kts
+++ b/support/android/apk/servoview/build.gradle.kts
@@ -25,8 +25,6 @@ android {
         targetSdk = 33
     }
 
-    compileOptions.incremental = false
-
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
As mentioned in 76205572c3fc267d2f106e2df43e7fa1faeef547, this `compileOptions` is in the namespace `com.android.build.gradle.internal`, making it an internal API. We shouldn't use this API because:

1. It's internal, so can break at any moment.
2. It _does_ break when we switch off of the legacy DSL (i.e., deleting `android.newDsl=false` in `gradle.properties`).
3. There's no clear reason why it was disabled in the first place (see e8af185a3d78ab8a578fa9ced616050c46bf4d14).

Because of those points, we should just delete it and use whatever the default is. I couldn't figure out _what_ the default is, as the KDoc for it doesn't say, and nor is it really mentioned online anywhere. Perhaps it's under-documented because it's an internal API.

Testing: Ran app.