### PR TITLE
android: opt in to optimized R8 config

### DIFF
--- a/support/android/apk/gradle.properties
+++ b/support/android/apk/gradle.properties
@@ -12,4 +12,3 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 android.newDsl=false
-android.r8.proguardAndroidTxt.disallowed=false

--- a/support/android/apk/servoview/build.gradle.kts
+++ b/support/android/apk/servoview/build.gradle.kts
@@ -40,7 +40,7 @@ android {
             signingConfig =
                 signingConfigs.getByName("debug") // Change this to sign with a production key
             isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android.txt"))
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
         }
 
         val debug = getByName("debug")


### PR DESCRIPTION
Deleting `android.r8.proguardAndroidTxt.disallowed=false` in `gradle.properties` makes `android.r8.proguardAndroidTxt.disallowed=true` by default. Doing this and assembling the project causes the following error:

```
`getDefaultProguardFile('proguard-android.txt')` is no longer supported since it includes `-dontoptimize`, which prevents R8 from performing many optimizations. Instead use `getDefaultProguardFile('proguard-android-optimize.txt)`, and if needed, temporarily use `-dontoptimize` in a custom keep rule file while fixing breakages.
```

Here we just apply the suggested fix.

Testing: Ran release version of app and tapped around. An over optimisation by R8 would cause the app to crash, which it didn't.
