### PR TITLE
Fix canvas memory growth by reporting 2D canvas native backing memory to SM

### DIFF
--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -272,6 +272,10 @@ impl CanvasState {
         self.canvas_id
     }
 
+    pub(super) fn bitmap_dimensions(&self) -> Size2D<u64> {
+        self.size.get()
+    }
+
     pub(super) fn is_paintable(&self) -> bool {
         !self.size.get().is_empty()
     }

--- a/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
@@ -47,7 +47,8 @@ pub(crate) struct CanvasRenderingContext2D {
 }
 
 impl CanvasRenderingContext2D {
-    const RGBA8_BYTES_PER_PIXEL: usize = 4; // 4 bytes per RGBA pixel
+    const BYTES_PER_RGBA8_PIXEL: usize = 4;
+    /// We have two bitmap buffers one in Canvas Paint Thread and one for WebRender
     const ASSOCIATED_MEMORY_BUFFER_COUNT: usize = 2;
 
     fn associated_memory_size(size: Size2D<u64>) -> usize {

--- a/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::cell::Cell;
+
 use dom_struct::dom_struct;
 use euclid::default::Size2D;
 use js::context::JSContext;
@@ -44,9 +46,27 @@ pub(crate) struct CanvasRenderingContext2D {
     reflector_: Reflector<AssociatedMemory>,
     canvas: HTMLCanvasElementOrOffscreenCanvas,
     canvas_state: CanvasState,
+    associated_memory_buffer_count: Cell<usize>,
 }
 
 impl CanvasRenderingContext2D {
+    fn associated_memory_size(size: Size2D<u32>, buffer_count: usize) -> usize {
+        (size.width as usize)
+            .saturating_mul(size.height as usize)
+            .saturating_mul(4) // RGBA 4 byytes per pixel
+            .saturating_mul(buffer_count)
+    }
+
+    pub(crate) fn update_associated_memory_size(&self) {
+        self.reflector_.update_memory_size(
+            self,
+            Self::associated_memory_size(
+                <Self as CanvasContext>::size(self),
+                self.associated_memory_buffer_count.get(),
+            ),
+        );
+    }
+
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new_inherited(
         global: &GlobalScope,
@@ -59,6 +79,7 @@ impl CanvasRenderingContext2D {
             reflector_: Reflector::new(),
             canvas,
             canvas_state,
+            associated_memory_buffer_count: Cell::new(1),
         })
     }
 
@@ -73,7 +94,11 @@ impl CanvasRenderingContext2D {
             HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(Dom::from_ref(canvas)),
             size,
         )
-        .map(|context| reflect_dom_object(Box::new(context), global, can_gc))
+        .map(|context| {
+            let context = reflect_dom_object(Box::new(context), global, can_gc);
+            context.update_associated_memory_size();
+            context
+        })
     }
 
     pub(crate) fn take_missing_image_urls(&self) -> Vec<ServoUrl> {
@@ -90,6 +115,8 @@ impl CanvasRenderingContext2D {
 
     pub(crate) fn set_image_key(&self, image_key: ImageKey) {
         self.canvas_state.set_image_key(image_key);
+        self.associated_memory_buffer_count.set(2);
+        self.update_associated_memory_size();
     }
 
     pub(crate) fn update_rendering(&self, canvas_epoch: Epoch) -> bool {
@@ -112,8 +139,7 @@ impl CanvasContext for CanvasRenderingContext2D {
     }
 
     fn resize(&self) {
-        self.reflector_
-            .update_memory_size(self, self.size().cast::<usize>().area());
+        self.update_associated_memory_size();
         self.canvas_state.set_bitmap_dimensions(self.size().cast());
     }
 

--- a/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::Cell;
-
 use dom_struct::dom_struct;
 use euclid::default::Size2D;
 use js::context::JSContext;
@@ -46,24 +44,23 @@ pub(crate) struct CanvasRenderingContext2D {
     reflector_: Reflector<AssociatedMemory>,
     canvas: HTMLCanvasElementOrOffscreenCanvas,
     canvas_state: CanvasState,
-    associated_memory_buffer_count: Cell<usize>,
 }
 
 impl CanvasRenderingContext2D {
-    fn associated_memory_size(size: Size2D<u64>, buffer_count: usize) -> usize {
+    const RGBA8_BYTES_PER_PIXEL: usize = 4; // 4 bytes per RGBA pixel
+    const ASSOCIATED_MEMORY_BUFFER_COUNT: usize = 2;
+
+    fn associated_memory_size(size: Size2D<u64>) -> usize {
         (size.width as usize)
             .saturating_mul(size.height as usize)
-            .saturating_mul(4) // RGBA 4 byytes per pixel
-            .saturating_mul(buffer_count)
+            .saturating_mul(Self::RGBA8_BYTES_PER_PIXEL)
+            .saturating_mul(Self::ASSOCIATED_MEMORY_BUFFER_COUNT)
     }
 
     pub(crate) fn update_associated_memory_size(&self) {
         self.reflector_.update_memory_size(
             self,
-            Self::associated_memory_size(
-                self.canvas_state.bitmap_dimensions(),
-                self.associated_memory_buffer_count.get(),
-            ),
+            Self::associated_memory_size(self.canvas_state.bitmap_dimensions()),
         );
     }
 
@@ -79,7 +76,6 @@ impl CanvasRenderingContext2D {
             reflector_: Reflector::new(),
             canvas,
             canvas_state,
-            associated_memory_buffer_count: Cell::new(1),
         })
     }
 
@@ -115,8 +111,6 @@ impl CanvasRenderingContext2D {
 
     pub(crate) fn set_image_key(&self, image_key: ImageKey) {
         self.canvas_state.set_image_key(image_key);
-        self.associated_memory_buffer_count.set(2);
-        self.update_associated_memory_size();
     }
 
     pub(crate) fn update_rendering(&self, canvas_epoch: Epoch) -> bool {

--- a/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
@@ -47,7 +47,7 @@ pub(crate) struct CanvasRenderingContext2D {
 }
 
 impl CanvasRenderingContext2D {
-    const BYTES_PER_RGBA8_PIXEL: usize = 4;
+    const RGBA8_BYTES_PER_PIXEL: usize = 4;
     /// We have two bitmap buffers one in Canvas Paint Thread and one for WebRender
     const ASSOCIATED_MEMORY_BUFFER_COUNT: usize = 2;
 

--- a/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
@@ -50,7 +50,7 @@ pub(crate) struct CanvasRenderingContext2D {
 }
 
 impl CanvasRenderingContext2D {
-    fn associated_memory_size(size: Size2D<u32>, buffer_count: usize) -> usize {
+    fn associated_memory_size(size: Size2D<u64>, buffer_count: usize) -> usize {
         (size.width as usize)
             .saturating_mul(size.height as usize)
             .saturating_mul(4) // RGBA 4 byytes per pixel
@@ -61,7 +61,7 @@ impl CanvasRenderingContext2D {
         self.reflector_.update_memory_size(
             self,
             Self::associated_memory_size(
-                <Self as CanvasContext>::size(self),
+                self.canvas_state.bitmap_dimensions(),
                 self.associated_memory_buffer_count.get(),
             ),
         );
@@ -139,8 +139,8 @@ impl CanvasContext for CanvasRenderingContext2D {
     }
 
     fn resize(&self) {
-        self.update_associated_memory_size();
         self.canvas_state.set_bitmap_dimensions(self.size().cast());
+        self.update_associated_memory_size();
     }
 
     fn reset_bitmap(&self) {

--- a/components/script/dom/canvas/2d/offscreencanvasrenderingcontext2d.rs
+++ b/components/script/dom/canvas/2d/offscreencanvasrenderingcontext2d.rs
@@ -63,7 +63,11 @@ impl OffscreenCanvasRenderingContext2D {
             HTMLCanvasElementOrOffscreenCanvas::OffscreenCanvas(Dom::from_ref(canvas)),
             size,
         )
-        .map(|context| reflect_dom_object(Box::new(context), global, can_gc))
+        .map(|context| {
+            let context = reflect_dom_object(Box::new(context), global, can_gc);
+            context.context.update_associated_memory_size();
+            context
+        })
     }
 
     pub(crate) fn send_canvas_command(&self, msg: CanvasCommand) {


### PR DESCRIPTION
CanvasRenderingContext2D already uses associated_memory, but initial canvas memory was not reported after object reflection, and resize accounting only used pixel area instead of byte size. This caused SM to underestimate memory pressure for large canvas workloadds, delaying GC and keeping old canvas resources alive.

Before : <img width="943" height="141" alt="Screenshot 2026-06-07 at 3 25 58 PM" src="https://github.com/user-attachments/assets/6e8eaaad-cb02-48ad-a895-d21670357326" />


After: <img width="965" height="170" alt="Screenshot 2026-06-07 at 4 26 22 PM" src="https://github.com/user-attachments/assets/35e89632-195c-431d-9baa-2bd70f1a36b6" />  

Fixes: #45369