### PR TITLE
paint/servoshell: Optimize resizing so that it is free of tearing and drift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2419,7 +2419,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2990,7 +2990,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3889,7 +3889,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -7131,7 +7131,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7188,7 +7188,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9723,9 +9723,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surfman"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2f5e8af3ca54762c5f3854f9fddc88134bc3e996c2938624a71e28ede83f218"
+checksum = "15317532328e0f6e5da2abad68391297621ddf66810e5819e92271318cc08feb"
 dependencies = [
  "bitflags 2.11.1",
  "cfg_aliases",
@@ -9874,7 +9874,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11411,7 +11411,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -291,11 +291,6 @@ impl Painter {
     }
 
     pub(crate) fn perform_updates(&mut self) {
-        // The WebXR thread may make a different context current
-        if let Err(err) = self.rendering_context.make_current() {
-            warn!("Failed to make the rendering context current: {:?}", err);
-        }
-
         let mut need_zoom = false;
         let scroll_offset_updates: Vec<_> = self
             .webview_renderers

--- a/components/shared/paint/rendering_context.rs
+++ b/components/shared/paint/rendering_context.rs
@@ -188,42 +188,22 @@ impl SurfmanRenderingContext {
         SwapChain::create_attached(device, context, SurfaceAccess::GPUOnly)
     }
 
-    fn resize_surface(&self, size: PhysicalSize<u32>) -> Result<(), Error> {
+    fn resize_bound_surface(&self, size: PhysicalSize<u32>) -> Result<(), Error> {
         if size.width == 0 || size.height == 0 {
             log::error!("Unable to resize to size under 1x1 ({size:?} provided)");
             return Err(Error::Failed);
         }
 
         let size = Size2D::new(size.width as i32, size.height as i32);
-        let device = &mut self.device.borrow_mut();
-        let context = &mut self.context.borrow_mut();
-
-        let mut surface = device.unbind_surface_from_context(context)?.unwrap();
-        device.resize_surface(context, &mut surface, size)?;
-        device
-            .bind_surface_to_context(context, surface)
-            .map_err(|(err, mut surface)| {
-                let _ = device.destroy_surface(context, &mut surface);
-                err
-            })
+        self.device
+            .borrow()
+            .resize_bound_surface(&mut self.context.borrow_mut(), size)
     }
 
     fn present_bound_surface(&self) -> Result<(), Error> {
-        let device = &self.device.borrow();
-        let context = &mut self.context.borrow_mut();
-
-        let mut surface = device
-            .unbind_surface_from_context(context)?
-            // todo: proper error type. This probably should be done in surfman.
-            .ok_or(Error::Failed)
-            .inspect_err(|_| log::error!("Unable to present bound surface: no surface bound"))?;
-        device.present_surface(context, &mut surface)?;
-        device
-            .bind_surface_to_context(context, surface)
-            .map_err(|(err, mut surface)| {
-                let _ = device.destroy_surface(context, &mut surface);
-                err
-            })
+        self.device
+            .borrow()
+            .present_bound_surface(&mut self.context.borrow_mut())
     }
 
     #[expect(dead_code)]
@@ -562,7 +542,7 @@ impl RenderingContext for WindowRenderingContext {
     }
 
     fn resize(&self, size: PhysicalSize<u32>) {
-        match self.surfman_context.resize_surface(size) {
+        match self.surfman_context.resize_bound_surface(size) {
             Ok(..) => self.size.set(size),
             Err(error) => warn!("Error resizing surface: {error:?}"),
         }

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -538,9 +538,20 @@ impl HeadedWindow {
         window: Rc<ServoShellWindow>,
         event: WindowEvent,
     ) {
-        if event == WindowEvent::RedrawRequested {
-            // WARNING: do not defer painting or presenting to some later tick of the event
-            // loop or servoshell may become unresponsive! (servo#30312)
+        // Handle resize events first, so that any subsequent redrawing draws onto a buffer of the
+        // correct size.
+        let mut resized = false;
+        if let WindowEvent::Resized(new_inner_size) = event &&
+            self.inner_size.get() != new_inner_size
+        {
+            self.inner_size.set(new_inner_size);
+            self.window_rendering_context.resize(new_inner_size);
+            resized = true;
+        }
+
+        // If requested to redraw or resized, repaint as soon as possible, so that new buffer
+        // contents are available to the window manager.
+        if event == WindowEvent::RedrawRequested || resized {
             let mut gui = self.gui.borrow_mut();
             gui.update(&state, &window, self);
             gui.paint(&self.winit_window);
@@ -621,10 +632,6 @@ impl HeadedWindow {
                     .borrow_mut()
                     .on_window_event(&self.winit_window, event);
 
-                if let WindowEvent::Resized(_) = event {
-                    self.rebuild_user_interface(&state, &window);
-                }
-
                 if let WindowEvent::Focused(true) = event {
                     state.handle_focused(window.clone());
                 }
@@ -649,140 +656,126 @@ impl HeadedWindow {
             },
         }
 
-        if !consumed {
-            // Make sure to handle early resize events even when there are no webviews yet
-            if let WindowEvent::Resized(new_inner_size) = event &&
-                self.inner_size.get() != new_inner_size
-            {
-                self.inner_size.set(new_inner_size);
-                // This should always be set to inner size
-                // because we are resizing `SurfmanRenderingContext`.
-                // See https://github.com/servo/servo/issues/38369#issuecomment-3138378527
-                self.window_rendering_context.resize(new_inner_size);
-            }
+        if !consumed && let Some(webview) = window.active_webview() {
+            match event {
+                WindowEvent::KeyboardInput { event, .. } => {
+                    self.handle_keyboard_input(state, &window, event)
+                },
+                WindowEvent::ModifiersChanged(modifiers) => {
+                    self.modifiers_state.set(modifiers.state())
+                },
+                WindowEvent::MouseInput { state, button, .. } => {
+                    self.handle_mouse_button_event(&webview, button, state);
+                },
+                WindowEvent::CursorMoved { position, .. } => {
+                    self.handle_mouse_move_event(&webview, position);
+                },
+                WindowEvent::CursorLeft { .. } => {
+                    let webview_rect: Rect<_, _> = webview.size().into();
+                    if webview_rect.contains(self.webview_relative_mouse_point.get()) {
+                        webview.notify_input_event(InputEvent::MouseLeftViewport(
+                            MouseLeftViewportEvent::default(),
+                        ));
+                    }
+                },
+                WindowEvent::MouseWheel { delta, .. } => {
+                    let (delta_x, delta_y, mode) = match delta {
+                        MouseScrollDelta::LineDelta(delta_x, delta_y) => (
+                            (delta_x * LINE_WIDTH) as f64,
+                            (delta_y * LINE_HEIGHT) as f64,
+                            WheelMode::DeltaPixel,
+                        ),
+                        MouseScrollDelta::PixelDelta(delta) => {
+                            (delta.x, delta.y, WheelMode::DeltaPixel)
+                        },
+                    };
 
-            if let Some(webview) = window.active_webview() {
-                match event {
-                    WindowEvent::KeyboardInput { event, .. } => {
-                        self.handle_keyboard_input(state, &window, event)
-                    },
-                    WindowEvent::ModifiersChanged(modifiers) => {
-                        self.modifiers_state.set(modifiers.state())
-                    },
-                    WindowEvent::MouseInput { state, button, .. } => {
-                        self.handle_mouse_button_event(&webview, button, state);
-                    },
-                    WindowEvent::CursorMoved { position, .. } => {
-                        self.handle_mouse_move_event(&webview, position);
-                    },
-                    WindowEvent::CursorLeft { .. } => {
-                        let webview_rect: Rect<_, _> = webview.size().into();
-                        if webview_rect.contains(self.webview_relative_mouse_point.get()) {
-                            webview.notify_input_event(InputEvent::MouseLeftViewport(
-                                MouseLeftViewportEvent::default(),
-                            ));
-                        }
-                    },
-                    WindowEvent::MouseWheel { delta, .. } => {
-                        let (delta_x, delta_y, mode) = match delta {
-                            MouseScrollDelta::LineDelta(delta_x, delta_y) => (
-                                (delta_x * LINE_WIDTH) as f64,
-                                (delta_y * LINE_HEIGHT) as f64,
-                                WheelMode::DeltaPixel,
-                            ),
-                            MouseScrollDelta::PixelDelta(delta) => {
-                                (delta.x, delta.y, WheelMode::DeltaPixel)
+                    // Create wheel event before snapping to the major axis of movement
+                    let delta = WheelDelta {
+                        x: delta_x,
+                        y: delta_y,
+                        z: 0.0,
+                        mode,
+                    };
+                    let point = self.webview_relative_mouse_point.get();
+                    webview.notify_input_event(InputEvent::Wheel(WheelEvent::new(
+                        delta,
+                        point.into(),
+                    )));
+                },
+                WindowEvent::Touch(touch) => {
+                    webview.notify_input_event(InputEvent::Touch(TouchEvent::new(
+                        winit_phase_to_touch_event_type(touch.phase),
+                        TouchId(touch.id as i32),
+                        DevicePoint::new(touch.location.x as f32, touch.location.y as f32).into(),
+                    )));
+                },
+                WindowEvent::PinchGesture { delta, .. } => {
+                    webview.adjust_pinch_zoom(
+                        delta as f32 + 1.0,
+                        self.webview_relative_mouse_point.get(),
+                    );
+                },
+                WindowEvent::CloseRequested => {
+                    window.schedule_close();
+                },
+                WindowEvent::ThemeChanged(theme) => {
+                    webview.notify_theme_change(match theme {
+                        winit::window::Theme::Light => Theme::Light,
+                        winit::window::Theme::Dark => Theme::Dark,
+                    });
+                },
+                WindowEvent::Ime(ime) => match ime {
+                    Ime::Enabled => {
+                        webview.notify_input_event(InputEvent::Ime(ImeEvent::Composition(
+                            servo::CompositionEvent {
+                                state: servo::CompositionState::Start,
+                                data: String::new(),
                             },
-                        };
-
-                        // Create wheel event before snapping to the major axis of movement
-                        let delta = WheelDelta {
-                            x: delta_x,
-                            y: delta_y,
-                            z: 0.0,
-                            mode,
-                        };
-                        let point = self.webview_relative_mouse_point.get();
-                        webview.notify_input_event(InputEvent::Wheel(WheelEvent::new(
-                            delta,
-                            point.into(),
                         )));
                     },
-                    WindowEvent::Touch(touch) => {
-                        webview.notify_input_event(InputEvent::Touch(TouchEvent::new(
-                            winit_phase_to_touch_event_type(touch.phase),
-                            TouchId(touch.id as i32),
-                            DevicePoint::new(touch.location.x as f32, touch.location.y as f32)
-                                .into(),
+                    Ime::Preedit(text, _) => {
+                        webview.notify_input_event(InputEvent::Ime(ImeEvent::Composition(
+                            servo::CompositionEvent {
+                                state: servo::CompositionState::Update,
+                                data: text,
+                            },
                         )));
                     },
-                    WindowEvent::PinchGesture { delta, .. } => {
-                        webview.adjust_pinch_zoom(
-                            delta as f32 + 1.0,
-                            self.webview_relative_mouse_point.get(),
-                        );
+                    Ime::Commit(text) => {
+                        webview.notify_input_event(InputEvent::Ime(ImeEvent::Composition(
+                            servo::CompositionEvent {
+                                state: servo::CompositionState::End,
+                                data: text,
+                            },
+                        )));
                     },
-                    WindowEvent::CloseRequested => {
-                        window.schedule_close();
-                    },
-                    WindowEvent::ThemeChanged(theme) => {
-                        webview.notify_theme_change(match theme {
-                            winit::window::Theme::Light => Theme::Light,
-                            winit::window::Theme::Dark => Theme::Dark,
-                        });
-                    },
-                    WindowEvent::Ime(ime) => match ime {
-                        Ime::Enabled => {
-                            webview.notify_input_event(InputEvent::Ime(ImeEvent::Composition(
-                                servo::CompositionEvent {
-                                    state: servo::CompositionState::Start,
-                                    data: String::new(),
-                                },
-                            )));
-                        },
-                        Ime::Preedit(text, _) => {
-                            webview.notify_input_event(InputEvent::Ime(ImeEvent::Composition(
-                                servo::CompositionEvent {
-                                    state: servo::CompositionState::Update,
-                                    data: text,
-                                },
-                            )));
-                        },
-                        Ime::Commit(text) => {
-                            webview.notify_input_event(InputEvent::Ime(ImeEvent::Composition(
-                                servo::CompositionEvent {
-                                    state: servo::CompositionState::End,
-                                    data: text,
-                                },
-                            )));
-                        },
-                        Ime::Disabled => {
-                            // There are two reasons we receive this message from winit:
-                            //
-                            // 1. The user dismissed the IME. In that case we want to inform Servo
-                            //    so it can unfocus the current editable element.
-                            // 2. Servo changed focus and requested that we dismiss the IME, which
-                            //    in turn triggers this message. We know this is the case when we don't
-                            //    expect any IME to be open and shouldn't send any more messages to
-                            //    Servo as it might cause unexpected blurring of the newly focused
-                            //    element.
-                            if self.visible_input_method.take().is_some() {
-                                webview.notify_input_event(InputEvent::Ime(ImeEvent::Dismissed));
-                            }
-                        },
-                    },
-                    WindowEvent::DroppedFile(dropped_file) => {
-                        if let Ok(url) = Url::from_file_path(&dropped_file) {
-                            webview.load(url);
-                        } else {
-                            log::error!(
-                                "Failed to create URL for dropped file ({})",
-                                dropped_file.display()
-                            );
+                    Ime::Disabled => {
+                        // There are two reasons we receive this message from winit:
+                        //
+                        // 1. The user dismissed the IME. In that case we want to inform Servo
+                        //    so it can unfocus the current editable element.
+                        // 2. Servo changed focus and requested that we dismiss the IME, which
+                        //    in turn triggers this message. We know this is the case when we don't
+                        //    expect any IME to be open and shouldn't send any more messages to
+                        //    Servo as it might cause unexpected blurring of the newly focused
+                        //    element.
+                        if self.visible_input_method.take().is_some() {
+                            webview.notify_input_event(InputEvent::Ime(ImeEvent::Dismissed));
                         }
                     },
-                    _ => {},
-                }
+                },
+                WindowEvent::DroppedFile(dropped_file) => {
+                    if let Ok(url) = Url::from_file_path(&dropped_file) {
+                        webview.load(url);
+                    } else {
+                        log::error!(
+                            "Failed to create URL for dropped file ({})",
+                            dropped_file.display()
+                        );
+                    }
+                },
+                _ => {},
             }
         }
     }
@@ -849,10 +842,6 @@ impl PlatformWindow for HeadedWindow {
         self.device_pixel_ratio_override
             .map(Scale::new)
             .unwrap_or_else(|| self.device_hidpi_scale_factor())
-    }
-
-    fn rebuild_user_interface(&self, state: &RunningAppState, window: &ServoShellWindow) {
-        self.gui.borrow_mut().update(state, window, self);
     }
 
     fn update_user_interface_state(&self, _: &RunningAppState, window: &ServoShellWindow) -> bool {

--- a/ports/servoshell/egl/app.rs
+++ b/ports/servoshell/egl/app.rs
@@ -78,8 +78,6 @@ impl PlatformWindow for EmbeddedPlatformWindow {
         false
     }
 
-    fn rebuild_user_interface(&self, _: &RunningAppState, _: &ServoShellWindow) {}
-
     #[cfg_attr(
         not(all(feature = "tracing", feature = "tracing-hitrace")),
         expect(unused_variables)

--- a/ports/servoshell/window.rs
+++ b/ports/servoshell/window.rs
@@ -384,11 +384,6 @@ pub(crate) trait PlatformWindow {
     fn hidpi_scale_factor(&self) -> Scale<f32, DeviceIndependentPixel, DevicePixel>;
     #[cfg_attr(any(target_os = "android", target_env = "ohos"), expect(dead_code))]
     fn get_fullscreen(&self) -> bool;
-    /// Request that the `Window` rebuild its user interface, if it has one. This should
-    /// not repaint, but should prepare the user interface for painting when it is
-    /// actually requested.
-    #[cfg_attr(any(target_os = "android", target_env = "ohos"), expect(dead_code))]
-    fn rebuild_user_interface(&self, _: &RunningAppState, _: &ServoShellWindow) {}
     /// Inform the `Window` that the state of a `WebView` has changed and that it should
     /// do an incremental update of user interface state. Returns `true` if the user
     /// interface actually changed and a rebuild  and repaint is needed, `false` otherwise.


### PR DESCRIPTION
This change improves resizing in Servo by:

1. Eliminating `eglMakeCurrent` churn during resizes using new surfman
   API (`Device::resize_bound_surface` and
   `Device::present_bound_surface`). This can interfere with the resize
   lifecycle on Wayland and ANGLE. In addition, not switching contexts
   should make things faster.
3. Remove an extra `make_current` for WebXR in
   `Painter::perform_updates`. This isn't necessary as we already call
   `make_current` only when necessary to render a particular `Painter`'s
   contents now. In addition, it introduces the same issues solved by #1
   when there are multiple windows.
2. Eagerly repaint servoshell contents during resizing. This prevents a
   gap in between the time the window is resized and contents are
   repainted. Without eager resizing, the window manager tends to scale
   a too small / too large window surface, leading to distortion while resizing.

In order to review this PR, it's suggested to turn off whitepace in the
diff.

Testing: Unfortuantely there isn't a good way to test this, but the results are obvious when resizing the Servo window.
Fixes: #30827.
