### PR TITLE
script: Deduplicate JS property retrieval with get_property helpers

### DIFF
--- a/components/script/dom/bindings/conversions.rs
+++ b/components/script/dom/bindings/conversions.rs
@@ -40,7 +40,7 @@ pub(crate) use js::conversions::{
 };
 use js::jsapi::{JSContext as RawJSContext, JSObject};
 use js::jsval::UndefinedValue;
-use js::rust::wrappers2::{JS_GetProperty, JS_HasProperty, JS_IsExceptionPending};
+use js::rust::wrappers2::JS_GetProperty;
 use js::rust::{HandleObject, MutableHandleValue};
 pub(crate) use script_bindings::conversions::{is_dom_proxy, *};
 use script_bindings::reflector::DomObject;
@@ -79,21 +79,11 @@ pub(crate) fn get_property_jsval(
     name: &ffi::CStr,
     rval: MutableHandleValue,
 ) -> Fallible<()> {
-    let mut found = false;
-    unsafe {
-        if !JS_HasProperty(cx, object, name.as_ptr(), &mut found) || !found {
-            if JS_IsExceptionPending(cx) {
-                return Err(Error::JSFailed);
-            }
-            return Ok(());
-        }
-
-        if !JS_GetProperty(cx, object, name.as_ptr(), rval) {
-            return Err(Error::JSFailed);
-        }
-
-        Ok(())
+    if unsafe { !JS_GetProperty(cx, object, name.as_ptr(), rval) } {
+        return Err(Error::JSFailed);
     }
+
+    Ok(())
 }
 
 /// Get a property from a JS object, and convert it to a Rust value.

--- a/components/script/dom/bindings/conversions.rs
+++ b/components/script/dom/bindings/conversions.rs
@@ -88,10 +88,10 @@ pub(crate) fn get_property_jsval(
             return Ok(());
         }
 
-        JS_GetProperty(cx, object, name.as_ptr(), rval);
-        if JS_IsExceptionPending(cx) {
+        if !JS_GetProperty(cx, object, name.as_ptr(), rval) {
             return Err(Error::JSFailed);
         }
+
         Ok(())
     }
 }
@@ -106,19 +106,17 @@ pub(crate) fn get_property<T>(
 where
     T: FromJSValConvertible,
 {
-    debug!("Getting property {:?}.", name);
     rooted!(&in(cx) let mut result = UndefinedValue());
-
     get_property_jsval(cx, object, name, result.handle_mut())?;
+
     if result.is_undefined() {
-        debug!("No property {:?}.", name);
         return Ok(None);
     }
-    debug!("Converting property {:?}.", name);
+
     let value = T::safe_from_jsval(cx, result.handle(), option);
     match value {
         Ok(ConversionResult::Success(value)) => Ok(Some(value)),
-        Ok(ConversionResult::Failure(_)) => Ok(None),
+        Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into_owned())),
         Err(()) => Err(Error::JSFailed),
     }
 }

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -34,7 +34,7 @@ use crate::dom::bindings::codegen::Bindings::CustomElementRegistryBinding::{
 use crate::dom::bindings::codegen::Bindings::ElementBinding::ElementMethods;
 use crate::dom::bindings::codegen::Bindings::FunctionBinding::Function;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::Window_Binding::WindowMethods;
-use crate::dom::bindings::conversions::{ConversionResult, StringificationBehavior};
+use crate::dom::bindings::conversions::{ConversionResult, StringificationBehavior, get_property};
 use crate::dom::bindings::error::{
     Error, ErrorResult, Fallible, report_pending_exception, throw_dom_exception,
 };
@@ -239,72 +239,6 @@ impl CustomElementRegistry {
 
         Ok(())
     }
-
-    #[expect(unsafe_code)]
-    fn get_attributes(
-        &self,
-        cx: &mut JSContext,
-        constructor: HandleObject,
-        name: &CStr,
-    ) -> Fallible<Vec<DOMString>> {
-        rooted!(&in(cx) let mut attributes = UndefinedValue());
-        if unsafe { !JS_GetProperty(cx, constructor, name.as_ptr(), attributes.handle_mut()) } {
-            return Err(Error::JSFailed);
-        }
-
-        if attributes.is_undefined() {
-            return Ok(Vec::new());
-        }
-
-        let conversion = SafeFromJSValConvertible::safe_from_jsval(
-            cx.into(),
-            attributes.handle(),
-            StringificationBehavior::Default,
-            CanGc::from_cx(cx),
-        );
-        match conversion {
-            Ok(ConversionResult::Success(attributes)) => Ok(attributes),
-            Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into_owned())),
-            _ => Err(Error::JSFailed),
-        }
-    }
-
-    /// <https://html.spec.whatwg.org/multipage/#dom-customelementregistry-define>
-    /// Step 14.11: Get the value of `formAssociated`.
-    #[expect(unsafe_code)]
-    fn get_form_associated_value(
-        &self,
-        cx: &mut JSContext,
-        constructor: HandleObject,
-    ) -> Fallible<bool> {
-        rooted!(&in(cx) let mut form_associated_value = UndefinedValue());
-        if unsafe {
-            !JS_GetProperty(
-                cx,
-                constructor,
-                c"formAssociated".as_ptr(),
-                form_associated_value.handle_mut(),
-            )
-        } {
-            return Err(Error::JSFailed);
-        }
-
-        if form_associated_value.is_undefined() {
-            return Ok(false);
-        }
-
-        let conversion = SafeFromJSValConvertible::safe_from_jsval(
-            cx.into(),
-            form_associated_value.handle(),
-            (),
-            CanGc::from_cx(cx),
-        );
-        match conversion {
-            Ok(ConversionResult::Success(flag)) => Ok(flag),
-            Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into_owned())),
-            _ => Err(Error::JSFailed),
-        }
-    }
 }
 
 /// <https://html.spec.whatwg.org/multipage/#dom-customelementregistry-define>
@@ -460,10 +394,16 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
 
         // Step 14.5: Handle the case where with `attributeChangedCallback` on `lifecycleCallbacks`
         // is not null.
-        let observed_attributes = if callbacks.attribute_changed_callback.is_some() {
+        let observed_attributes: Vec<DOMString> = if callbacks.attribute_changed_callback.is_some()
+        {
             let mut realm = AutoRealm::new_from_handle(cx, constructor.handle());
-            match self.get_attributes(&mut realm, constructor.handle(), c"observedAttributes") {
-                Ok(attributes) => attributes,
+            match get_property(
+                &mut realm,
+                constructor.handle(),
+                c"observedAttributes",
+                StringificationBehavior::Default,
+            ) {
+                Ok(attributes) => attributes.unwrap_or_default(),
                 Err(error) => {
                     self.element_definition_is_running.set(false);
                     return Err(error);
@@ -476,11 +416,19 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
         // Steps 14.6 - 14.10: Handle `disabledFeatures`.
         let (disable_internals, disable_shadow) = {
             let mut realm = AutoRealm::new_from_handle(cx, constructor.handle());
-            match self.get_attributes(&mut realm, constructor.handle(), c"disabledFeatures") {
-                Ok(sequence) => (
-                    sequence.iter().any(|s| *s == "internals"),
-                    sequence.iter().any(|s| *s == "shadow"),
-                ),
+            match get_property::<Vec<DOMString>>(
+                &mut realm,
+                constructor.handle(),
+                c"disabledFeatures",
+                StringificationBehavior::Default,
+            ) {
+                Ok(sequence) => {
+                    let sequence = sequence.unwrap_or_default();
+                    (
+                        sequence.iter().any(|s| *s == "internals"),
+                        sequence.iter().any(|s| *s == "shadow"),
+                    )
+                },
                 Err(error) => {
                     self.element_definition_is_running.set(false);
                     return Err(error);
@@ -489,10 +437,10 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
         };
 
         // Step 14.11 - 14.12: Handle `formAssociated`.
-        let form_associated = {
+        let form_associated: bool = {
             let mut realm = AutoRealm::new_from_handle(cx, constructor.handle());
-            match self.get_form_associated_value(&mut realm, constructor.handle()) {
-                Ok(flag) => flag,
+            match get_property(&mut realm, constructor.handle(), c"formAssociated", ()) {
+                Ok(flag) => flag.unwrap_or_default(),
                 Err(error) => {
                     self.element_definition_is_running.set(false);
                     return Err(error);

--- a/components/script/dom/stream/bytelengthqueuingstrategy.rs
+++ b/components/script/dom/stream/bytelengthqueuingstrategy.rs
@@ -16,10 +16,10 @@ use crate::dom::bindings::codegen::Bindings::FunctionBinding::Function;
 use crate::dom::bindings::codegen::Bindings::QueuingStrategyBinding::{
     ByteLengthQueuingStrategyMethods, QueuingStrategyInit,
 };
+use crate::dom::bindings::conversions::get_property_jsval;
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::DomRoot;
-use crate::dom::bindings::utils::get_dictionary_property;
 use crate::dom::types::GlobalScope;
 use crate::native_fn;
 use crate::script_runtime::CanGc;
@@ -115,14 +115,8 @@ fn byte_length_queuing_strategy_size(cx: &mut js::context::JSContext, args: Call
     rooted!(&in(cx) let object = chunk.to_object());
 
     // Return ? O.[[Get]](P, V).
-    match get_dictionary_property(cx, object.handle(), c"byteLength", unsafe {
+    get_property_jsval(cx, object.handle(), c"byteLength", unsafe {
         MutableHandleValue::from_raw(args.rval())
-    }) {
-        Ok(true) => true,
-        Ok(false) => {
-            args.rval().set(UndefinedValue());
-            true
-        },
-        Err(()) => false,
-    }
+    })
+    .is_ok()
 }

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -37,7 +37,7 @@ use crate::dom::abortsignal::{AbortAlgorithm, AbortSignal};
 use crate::dom::bindings::codegen::Bindings::ReadableStreamDefaultReaderBinding::ReadableStreamDefaultReaderMethods;
 use crate::dom::bindings::codegen::Bindings::ReadableStreamDefaultControllerBinding::ReadableStreamDefaultController_Binding::ReadableStreamDefaultControllerMethods;
 use crate::dom::bindings::codegen::Bindings::UnderlyingSourceBinding::UnderlyingSource as JsUnderlyingSource;
-use crate::dom::bindings::conversions::{ConversionBehavior, ConversionResult};
+use crate::dom::bindings::conversions::{ConversionBehavior, ConversionResult, get_property, get_property_jsval};
 use crate::dom::bindings::error::{Error, ErrorToJsval, Fallible};
 use crate::dom::bindings::codegen::GenericBindings::WritableStreamDefaultWriterBinding::WritableStreamDefaultWriter_Binding::WritableStreamDefaultWriterMethods;
 use crate::dom::stream::writablestream::WritableStream;
@@ -46,7 +46,6 @@ use crate::dom::bindings::reflector::DomGlobal;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use crate::dom::bindings::root::{DomRoot, MutNullableDom, Dom};
 use crate::dom::bindings::trace::RootedTraceableBox;
-use crate::dom::bindings::utils::get_dictionary_property;
 use crate::dom::stream::byteteeunderlyingsource::{ByteTeeCancelAlgorithm, ByteTeePullAlgorithm, ByteTeeUnderlyingSource};
 use crate::dom::stream::countqueuingstrategy::{extract_high_water_mark, extract_size_algorithm};
 use crate::dom::stream::readablestreamgenericreader::ReadableStreamGenericReader;
@@ -424,15 +423,13 @@ impl PipeTo {
         if chunk.is_object() {
             rooted!(&in(cx) let object = chunk.to_object());
             rooted!(&in(cx) let mut bytes = UndefinedValue());
-            let has_value =
-                get_dictionary_property(cx, object.handle(), c"value", bytes.handle_mut())
-                    .expect("Chunk should have a value.");
-            if has_value {
-                // Write the chunk.
-                let write_promise = self.writer.write(cx, global, bytes.handle());
-                self.pending_writes.borrow_mut().push_back(write_promise);
-                return true;
-            }
+            get_property_jsval(cx, object.handle(), c"value", bytes.handle_mut())
+                .expect("Chunk should have a value.");
+
+            // Write the chunk.
+            let write_promise = self.writer.write(cx, global, bytes.handle());
+            self.pending_writes.borrow_mut().push_back(write_promise);
+            return true;
         }
         false
     }
@@ -2331,22 +2328,21 @@ pub(crate) fn get_type_and_value_from_message(
     rooted!(&in(cx) let data_object = data.to_object());
 
     // Let type be ! Get(data, "type").
-    rooted!(&in(cx) let mut type_ = UndefinedValue());
-    get_dictionary_property(cx, data_object.handle(), c"type", type_.handle_mut())
-        .expect("Getting the type should not fail.");
+    let type_ = get_property::<DOMString>(
+        cx,
+        data_object.handle(),
+        c"type",
+        StringificationBehavior::Empty,
+    );
 
     // Let value be ! Get(data, "value").
-    get_dictionary_property(cx, data_object.handle(), c"value", value)
+    get_property_jsval(cx, data_object.handle(), c"value", value)
         .expect("Getting the value should not fail.");
 
     // Assert: type is a String.
-    let result = DOMString::safe_from_jsval(cx, type_.handle(), StringificationBehavior::Empty)
-        .expect("The type of the message should be a string");
-    let ConversionResult::Success(type_string) = result else {
-        unreachable!("The type of the message should be a string");
-    };
-
-    type_string
+    type_
+        .expect("The type of the message should be a string")
+        .expect("Property should be present")
 }
 
 impl js::gc::Rootable for CrossRealmTransformReadable {}
@@ -2435,16 +2431,8 @@ pub(crate) fn get_read_promise_done(
     }
 
     rooted!(&in(cx) let object = v.to_object());
-    rooted!(&in(cx) let mut done = UndefinedValue());
-    match get_dictionary_property(cx, object.handle(), c"done", done.handle_mut()) {
-        Ok(true) => match bool::safe_from_jsval(cx, done.handle(), ()) {
-            Ok(ConversionResult::Success(val)) => Ok(val),
-            Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into_owned())),
-            _ => Err(Error::Type(c"Unknown format for done property.".to_owned())),
-        },
-        Ok(false) => Err(Error::Type(c"Promise has no done property.".to_owned())),
-        Err(()) => Err(Error::JSFailed),
-    }
+    get_property::<bool>(cx, object.handle(), c"done", ())?
+        .ok_or(Error::Type(c"Promise has no done property.".to_owned()))
 }
 
 /// Get the `value` property of an object that a read promise resolved to.
@@ -2459,18 +2447,13 @@ pub(crate) fn get_read_promise_bytes(
     }
 
     rooted!(&in(cx) let object = v.to_object());
-    rooted!(&in(cx) let mut bytes = UndefinedValue());
-    match get_dictionary_property(cx, object.handle(), c"value", bytes.handle_mut()) {
-        Ok(true) => {
-            match Vec::<u8>::safe_from_jsval(cx, bytes.handle(), ConversionBehavior::EnforceRange) {
-                Ok(ConversionResult::Success(val)) => Ok(val),
-                Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into_owned())),
-                _ => Err(Error::Type(c"Unknown format for bytes read.".to_owned())),
-            }
-        },
-        Ok(false) => Err(Error::Type(c"Promise has no value property.".to_owned())),
-        Err(()) => Err(Error::JSFailed),
-    }
+    get_property::<Vec<u8>>(
+        cx,
+        object.handle(),
+        c"value",
+        ConversionBehavior::EnforceRange,
+    )?
+    .ok_or(Error::Type(c"Promise has no value property.".to_owned()))
 }
 
 /// Convert a raw stream `chunk` JS value to `Vec<u8>`.

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -36,7 +36,7 @@ use std::str::FromStr;
 
 use base64ct::{Base64UrlUnpadded, Encoding};
 use dom_struct::dom_struct;
-use js::conversions::{ConversionBehavior, ConversionResult};
+use js::conversions::{ConversionBehavior, ConversionResult, FromJSValConvertible};
 use js::jsapi::{Heap, JSObject};
 use js::jsval::UndefinedValue;
 use js::realm::CurrentRealm;
@@ -66,7 +66,7 @@ use crate::dom::bindings::codegen::UnionTypes::{
     ArrayBufferViewOrArrayBuffer, ArrayBufferViewOrArrayBufferOrJsonWebKey, ObjectOrString,
 };
 use crate::dom::bindings::conversions::{
-    SafeFromJSValConvertible, SafeToJSValConvertible, StringificationBehavior,
+    SafeToJSValConvertible, StringificationBehavior, get_property,
 };
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::refcounted::{Trusted, TrustedPromise};
@@ -74,7 +74,6 @@ use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::{DOMString, serialize_jsval_to_json_utf8};
 use crate::dom::bindings::trace::RootedTraceableBox;
-use crate::dom::bindings::utils::get_dictionary_property;
 use crate::dom::cryptokey::{CryptoKey, CryptoKeyOrCryptoKeyPair};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
@@ -3976,31 +3975,17 @@ impl SafeToJSValConvertible for SubtleEncapsulatedBits {
 }
 
 /// Helper to retrieve an optional paramter from WebIDL dictionary.
-fn get_optional_parameter<T: SafeFromJSValConvertible>(
+fn get_optional_parameter<T: FromJSValConvertible>(
     cx: &mut js::context::JSContext,
     object: HandleObject,
     parameter: &std::ffi::CStr,
     option: T::Config,
 ) -> Fallible<Option<T>> {
-    rooted!(&in(cx) let mut rval = UndefinedValue());
-    if get_dictionary_property(cx, object, parameter, rval.handle_mut())
-        .map_err(|_| Error::JSFailed)? &&
-        !rval.is_undefined()
-    {
-        let conversion_result =
-            T::safe_from_jsval(cx.into(), rval.handle(), option, CanGc::from_cx(cx))
-                .map_err(|_| Error::JSFailed)?;
-        match conversion_result {
-            ConversionResult::Success(value) => Ok(Some(value)),
-            ConversionResult::Failure(error) => Err(Error::Type(error.into())),
-        }
-    } else {
-        Ok(None)
-    }
+    get_property::<T>(cx, object, parameter, option)
 }
 
 /// Helper to retrieve a required paramter from WebIDL dictionary.
-fn get_required_parameter<T: SafeFromJSValConvertible>(
+fn get_required_parameter<T: FromJSValConvertible>(
     cx: &mut js::context::JSContext,
     object: HandleObject,
     parameter: &std::ffi::CStr,
@@ -4011,35 +3996,18 @@ fn get_required_parameter<T: SafeFromJSValConvertible>(
 }
 
 /// Helper to retrieve an optional paramter, in RootedTraceableBox, from WebIDL dictionary.
-fn get_optional_parameter_in_box<T: SafeFromJSValConvertible + Trace>(
+fn get_optional_parameter_in_box<T: FromJSValConvertible + Trace>(
     cx: &mut js::context::JSContext,
     object: HandleObject,
     parameter: &std::ffi::CStr,
     option: T::Config,
 ) -> Fallible<Option<RootedTraceableBox<T>>> {
-    rooted!(&in(cx) let mut rval = UndefinedValue());
-    if get_dictionary_property(cx, object, parameter, rval.handle_mut())
-        .map_err(|_| Error::JSFailed)? &&
-        !rval.is_undefined()
-    {
-        let conversion_result: ConversionResult<T> = SafeFromJSValConvertible::safe_from_jsval(
-            cx.into(),
-            rval.handle(),
-            option,
-            CanGc::from_cx(cx),
-        )
-        .map_err(|_| Error::JSFailed)?;
-        match conversion_result {
-            ConversionResult::Success(value) => Ok(Some(RootedTraceableBox::new(value))),
-            ConversionResult::Failure(error) => Err(Error::Type(error.into())),
-        }
-    } else {
-        Ok(None)
-    }
+    get_property::<T>(cx, object, parameter, option)
+        .map(|option| option.map(RootedTraceableBox::new))
 }
 
 /// Helper to retrieve a required paramter, in RootedTraceableBox, from WebIDL dictionary.
-fn get_required_parameter_in_box<T: SafeFromJSValConvertible + Trace>(
+fn get_required_parameter_in_box<T: FromJSValConvertible + Trace>(
     cx: &mut js::context::JSContext,
     object: HandleObject,
     parameter: &std::ffi::CStr,

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -3456,12 +3456,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleAesGcmParams {
             name: algorithm_name,
             iv: get_required_buffer_source(cx, object, c"iv")?,
             additional_data: get_optional_buffer_source(cx, object, c"additionalData")?,
-            tag_length: get_optional_parameter(
-                cx,
-                object,
-                c"tagLength",
-                ConversionBehavior::EnforceRange,
-            )?,
+            tag_length: get_property(cx, object, c"tagLength", ConversionBehavior::EnforceRange)?,
         })
     }
 }
@@ -3492,12 +3487,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleHmacImportParams {
         Ok(SubtleHmacImportParams {
             name: algorithm_name,
             hash: normalize_algorithm::<DigestOperation>(cx, &hash)?,
-            length: get_optional_parameter(
-                cx,
-                object,
-                c"length",
-                ConversionBehavior::EnforceRange,
-            )?,
+            length: get_property(cx, object, c"length", ConversionBehavior::EnforceRange)?,
         })
     }
 }
@@ -3580,12 +3570,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleHmacKeyGenParams {
         Ok(SubtleHmacKeyGenParams {
             name: algorithm_name,
             hash: normalize_algorithm::<DigestOperation>(cx, &hash)?,
-            length: get_optional_parameter(
-                cx,
-                object,
-                c"length",
-                ConversionBehavior::EnforceRange,
-            )?,
+            length: get_property(cx, object, c"length", ConversionBehavior::EnforceRange)?,
         })
     }
 }
@@ -3718,12 +3703,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleAeadParams {
             name: algorithm_name,
             iv: get_required_buffer_source(cx, object, c"iv")?,
             additional_data: get_optional_buffer_source(cx, object, c"additionalData")?,
-            tag_length: get_optional_parameter(
-                cx,
-                object,
-                c"tagLength",
-                ConversionBehavior::EnforceRange,
-            )?,
+            tag_length: get_property(cx, object, c"tagLength", ConversionBehavior::EnforceRange)?,
         })
     }
 }
@@ -3819,7 +3799,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleTurboShakeParams {
                 c"outputLength",
                 ConversionBehavior::EnforceRange,
             )?,
-            domain_separation: get_optional_parameter(
+            domain_separation: get_property(
                 cx,
                 object,
                 c"domainSeparation",
@@ -3908,12 +3888,7 @@ impl<'a> TryFromWithCxAndName<HandleObject<'a>> for SubtleArgon2Params {
                 c"passes",
                 ConversionBehavior::EnforceRange,
             )?,
-            version: get_optional_parameter(
-                cx,
-                object,
-                c"version",
-                ConversionBehavior::EnforceRange,
-            )?,
+            version: get_property(cx, object, c"version", ConversionBehavior::EnforceRange)?,
             secret_value: get_optional_buffer_source(cx, object, c"secretValue")?,
             associated_data: get_optional_buffer_source(cx, object, c"associatedData")?,
         })
@@ -3974,16 +3949,6 @@ impl SafeToJSValConvertible for SubtleEncapsulatedBits {
     }
 }
 
-/// Helper to retrieve an optional paramter from WebIDL dictionary.
-fn get_optional_parameter<T: FromJSValConvertible>(
-    cx: &mut js::context::JSContext,
-    object: HandleObject,
-    parameter: &std::ffi::CStr,
-    option: T::Config,
-) -> Fallible<Option<T>> {
-    get_property::<T>(cx, object, parameter, option)
-}
-
 /// Helper to retrieve a required paramter from WebIDL dictionary.
 fn get_required_parameter<T: FromJSValConvertible>(
     cx: &mut js::context::JSContext,
@@ -3991,19 +3956,8 @@ fn get_required_parameter<T: FromJSValConvertible>(
     parameter: &std::ffi::CStr,
     option: T::Config,
 ) -> Fallible<T> {
-    get_optional_parameter(cx, object, parameter, option)?
+    get_property::<T>(cx, object, parameter, option)?
         .ok_or(Error::Type(c"Missing required parameter".into()))
-}
-
-/// Helper to retrieve an optional paramter, in RootedTraceableBox, from WebIDL dictionary.
-fn get_optional_parameter_in_box<T: FromJSValConvertible + Trace>(
-    cx: &mut js::context::JSContext,
-    object: HandleObject,
-    parameter: &std::ffi::CStr,
-    option: T::Config,
-) -> Fallible<Option<RootedTraceableBox<T>>> {
-    get_property::<T>(cx, object, parameter, option)
-        .map(|option| option.map(RootedTraceableBox::new))
 }
 
 /// Helper to retrieve a required paramter, in RootedTraceableBox, from WebIDL dictionary.
@@ -4013,7 +3967,8 @@ fn get_required_parameter_in_box<T: FromJSValConvertible + Trace>(
     parameter: &std::ffi::CStr,
     option: T::Config,
 ) -> Fallible<RootedTraceableBox<T>> {
-    get_optional_parameter_in_box(cx, object, parameter, option)?
+    get_property::<T>(cx, object, parameter, option)?
+        .map(RootedTraceableBox::new)
         .ok_or(Error::Type(c"Missing required parameter".into()))
 }
 
@@ -4025,8 +3980,7 @@ fn get_optional_buffer_source(
     object: HandleObject,
     parameter: &std::ffi::CStr,
 ) -> Fallible<Option<Vec<u8>>> {
-    let buffer_source =
-        get_optional_parameter::<ArrayBufferViewOrArrayBuffer>(cx, object, parameter, ())?;
+    let buffer_source = get_property::<ArrayBufferViewOrArrayBuffer>(cx, object, parameter, ())?;
     match buffer_source {
         Some(ArrayBufferViewOrArrayBuffer::ArrayBufferView(view)) => Ok(Some(view.to_vec())),
         Some(ArrayBufferViewOrArrayBuffer::ArrayBuffer(buffer)) => Ok(Some(buffer.to_vec())),

--- a/components/script/indexeddb.rs
+++ b/components/script/indexeddb.rs
@@ -30,9 +30,7 @@ use crate::dom::bindings::conversions::{
 };
 use crate::dom::bindings::error::Error;
 use crate::dom::bindings::str::DOMString;
-use crate::dom::bindings::utils::{
-    define_dictionary_property, get_dictionary_property, has_own_property,
-};
+use crate::dom::bindings::utils::{define_dictionary_property, has_own_property};
 use crate::dom::blob::Blob;
 use crate::dom::file::File;
 use crate::dom::idbkeyrange::IDBKeyRange;
@@ -631,16 +629,12 @@ pub(crate) fn evaluate_key_path_on_value(
                 }
 
                 // Let value be ! Get(value, identifier).
-                match get_dictionary_property(
+                get_property_jsval(
                     cx,
                     object.handle(),
                     identifier_name.as_c_str(),
                     current_value.handle_mut(),
-                ) {
-                    Ok(true) => {},
-                    Ok(false) => return Ok(EvaluationResult::Failure),
-                    Err(()) => return Err(Error::JSFailed),
-                }
+                )?;
 
                 // If value is undefined, return failure.
                 if current_value.get().is_undefined() {
@@ -712,16 +706,12 @@ pub(crate) fn can_inject_key_into_value(
         }
 
         // Step 3.4. Set value to ? Get(value, identifier).
-        match get_dictionary_property(
+        get_property_jsval(
             cx,
             current_object.handle(),
             identifier_name.as_c_str(),
             current_value.handle_mut(),
-        ) {
-            Ok(true) => {},
-            Ok(false) => return Ok(false),
-            Err(()) => return Err(Error::JSFailed),
-        }
+        )?;
     }
 
     // Step 4. Return true if value is an Object or an Array, and false otherwise.
@@ -789,16 +779,12 @@ pub(crate) fn inject_key_into_value(
         }
 
         // Step 4.3 Let value be ! Get(value, identifier).
-        match get_dictionary_property(
+        get_property_jsval(
             cx,
             current_object.handle(),
             identifier_name.as_c_str(),
             current_value.handle_mut(),
-        ) {
-            Ok(true) => {},
-            Ok(false) => return Ok(false),
-            Err(()) => return Err(Error::JSFailed),
-        }
+        )?;
 
         // Step 5 "Assert: value is an Object or an Array."
         if !current_value.is_object() {

--- a/components/script_bindings/utils.rs
+++ b/components/script_bindings/utils.rs
@@ -241,8 +241,7 @@ pub(crate) fn find_enum_value<'a, T>(
 /// Get the property with name `property` from `object`.
 /// Returns `Err(())` on JSAPI failure (there is a pending exception), and
 /// `Ok(false)` if there was no property with the given name.
-#[allow(clippy::result_unit_err)]
-pub fn get_dictionary_property(
+pub(crate) fn get_dictionary_property(
     cx: &mut js::context::JSContext,
     object: HandleObject,
     property: &CStr,


### PR DESCRIPTION
Around the codebase there was different code that called `JS_GetProperty` and then optionally convert it to a rust value, this is now consolidated all around `get_property_jsval` and `get_property`.
Reviewable per commit.

Testing: Covered by existing tests.
