### PR TITLE
fix: silence test-tidy pyrefly false positive on Github(auth=)

### DIFF
--- a/etc/ci/upload_nightly.py
+++ b/etc/ci/upload_nightly.py
@@ -63,7 +63,7 @@ def upload_to_github_release(platform: str, package: str, package_hash: str, git
 
     extension = path.basename(package).partition(".")[2]
     auth = Auth.Token(os.environ["RELEASE_REPO_TOKEN"])
-    g = Github(auth=auth)
+    g = Github(auth=auth)  # pyrefly: ignore[bad-keyword-argument]
     nightly_repo = g.get_repo(os.environ["RELEASE_REPO"])
     release = nightly_repo.get_release(github_release_id)
 


### PR DESCRIPTION
## Summary
Silences a `test-tidy` pyrefly false positive on `Github(auth=auth)` in the nightly upload script.

## Why this matters
Reported in #45423: pyrefly flags `Github(auth=...)` as a `bad-keyword-argument` even though it is the documented PyGithub constructor, so `./mach test-tidy` fails on an otherwise-correct call. A targeted `# pyrefly: ignore[bad-keyword-argument]` suppresses just this false positive without disabling the check elsewhere.

## Changes
- Add a scoped `# pyrefly: ignore[bad-keyword-argument]` on the `Github(auth=auth)` line in `etc/ci/upload_nightly.py`.

## Testing
`./mach test-tidy` no longer reports the false positive on this line.

Fixes #45423

AI was used for assistance.
