### PR TITLE
devtools: Set the selected tab correctly

### DIFF
--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -17,6 +17,7 @@ use serde::Serialize;
 use serde_json::{Map, Value};
 
 use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
+use crate::actors::browsing_context::BrowsingContextActor;
 use crate::actors::device::DeviceActor;
 use crate::actors::performance::PerformanceActor;
 use crate::actors::preference::PreferenceActor;
@@ -283,22 +284,34 @@ impl Actor for RootActor {
             },
 
             "listTabs" => {
+                let top_level_tabs: Vec<_> = self
+                    .tabs
+                    .borrow()
+                    .iter()
+                    .filter(|&tab_name| {
+                        registry
+                            .find::<TabDescriptorActor>(tab_name)
+                            .is_top_level_global(registry)
+                    })
+                    .cloned()
+                    .collect();
+
+                // Ensure a tab is always selected
+                let active_tab_name = self.active_tab.borrow().clone();
+                let some_active_tab = active_tab_name
+                    .as_ref()
+                    .is_some_and(|name| top_level_tabs.contains(name));
+                if let Some(first_tab) = top_level_tabs.first() &&
+                    !some_active_tab
+                {
+                    *self.active_tab.borrow_mut() = Some(first_tab.clone());
+                }
+
                 let reply = ListTabsReply {
                     from: self.name().into(),
-                    tabs: self
-                        .tabs
-                        .borrow()
+                    tabs: top_level_tabs
                         .iter()
-                        .filter_map(|tab_descriptor_name| {
-                            let tab_descriptor_actor =
-                                registry.find::<TabDescriptorActor>(tab_descriptor_name);
-                            // Filter out iframes and workers
-                            if tab_descriptor_actor.is_top_level_global(registry) {
-                                Some(tab_descriptor_actor.encode(registry))
-                            } else {
-                                None
-                            }
-                        })
+                        .map(|tab_name| registry.encode::<TabDescriptorActor, _>(tab_name))
                         .collect(),
                 };
                 request.reply_final(&reply)?
@@ -383,20 +396,23 @@ impl RootActor {
         registry: &ActorRegistry,
         browser_id: u32,
     ) -> Option<TabDescriptorActorMsg> {
-        let mut tab_msg = self
+        let tab_descriptor_actor = self
             .tabs
             .borrow()
             .iter()
-            .map(|tab_descriptor_name| {
-                registry.encode::<TabDescriptorActor, _>(tab_descriptor_name)
-            })
-            .find(|tab_descriptor_actor| tab_descriptor_actor.browser_id() == browser_id);
+            .map(|tab_descriptor_name| registry.find::<TabDescriptorActor>(tab_descriptor_name))
+            .find(|tab_descriptor_actor| {
+                let browsing_context = registry
+                    .find::<BrowsingContextActor>(&tab_descriptor_actor.browsing_context_name);
+                browsing_context.browser_id.value() == browser_id
+            });
 
-        if let Some(ref mut msg) = tab_msg {
-            msg.selected = true;
-            *self.active_tab.borrow_mut() = Some(msg.actor());
+        if let Some(tab_descriptor_actor) = tab_descriptor_actor {
+            *self.active_tab.borrow_mut() = Some(tab_descriptor_actor.name().to_owned());
+            Some(registry.encode::<TabDescriptorActor, _>(tab_descriptor_actor.name()))
+        } else {
+            None
         }
-        tab_msg
     }
 
     pub fn active_tab(&self) -> Option<String> {

--- a/components/devtools/actors/tab.rs
+++ b/components/devtools/actors/tab.rs
@@ -42,16 +42,6 @@ pub(crate) struct TabDescriptorActorMsg {
     url: String,
 }
 
-impl TabDescriptorActorMsg {
-    pub fn browser_id(&self) -> u32 {
-        self.browser_id
-    }
-
-    pub fn actor(&self) -> String {
-        self.actor.clone()
-    }
-}
-
 #[derive(Serialize)]
 struct GetTargetReply {
     from: String,
@@ -200,13 +190,14 @@ impl ActorEncode<TabDescriptorActorMsg> for TabDescriptorActor {
     fn encode(&self, registry: &ActorRegistry) -> TabDescriptorActorMsg {
         let browsing_context_actor =
             registry.find::<BrowsingContextActor>(&self.browsing_context_name);
+        let root_actor = registry.find::<RootActor>("root");
         TabDescriptorActorMsg {
             actor: self.name().into(),
             browser_id: browsing_context_actor.browser_id.value(),
             browsing_context_id: browsing_context_actor.browsing_context_id.value(),
             is_zombie_tab: false,
             outer_window_id: browsing_context_actor.outer_window_id().value(),
-            selected: false,
+            selected: root_actor.active_tab().as_deref() == Some(self.name()),
             title: browsing_context_actor.title(),
             traits: DescriptorTraits {
                 watcher: true,

--- a/python/servo/devtools_tests/test_connection.py
+++ b/python/servo/devtools_tests/test_connection.py
@@ -1,0 +1,26 @@
+# Copyright 2013 The Servo Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from geckordp.actors.root import RootActor
+
+from .utils import Devtools
+
+
+class TestConnection:
+    def test_selected_tab(self, run_servoshell):
+        run_servoshell(url="data:text/html,<h1>Test</h1>")
+
+        with Devtools.connect() as devtools:
+            root = RootActor(devtools.client)
+            tabs = root.list_tabs()
+
+            assert len(tabs) >= 1
+
+            selected_tabs = [tab for tab in tabs if tab.get("selected")]
+            assert len(selected_tabs) == 1


### PR DESCRIPTION
Fix the `selected` field when serializing tabs. There should always be a selected tab, otherwise we run into issues. This is a prequiste for running [geckordp tests](https://github.com/jpramosi/geckordp/tree/master/tests) on servo, since it expects one tab to be selected.

Testing: New `test_selected_tab` test
Part of: #44256
