### PR TITLE
feat: support devtools inspector Copy Outer HTML / Inner HTML

### DIFF
--- a/components/devtools/actors/inspector/walker.rs
+++ b/components/devtools/actors/inspector/walker.rs
@@ -7,12 +7,16 @@
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
-use devtools_traits::DevtoolScriptControlMsg::{GetChildren, GetDocumentElement, GetRootNode};
+use devtools_traits::DevtoolScriptControlMsg;
+use devtools_traits::DevtoolScriptControlMsg::{
+    GetChildren, GetDocumentElement, GetInnerHTML, GetOuterHTML, GetRootNode,
+};
 use devtools_traits::DomMutation;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{self, Map, Value};
-use servo_base::generic_channel;
+use servo_base::generic_channel::{self, GenericSender};
+use servo_base::id::PipelineId;
 
 use crate::actor::{
     Actor, ActorEncode, ActorError, ActorRegistry, DowncastableActorArc, new_actor_name,
@@ -20,6 +24,7 @@ use crate::actor::{
 use crate::actors::browsing_context::BrowsingContextActor;
 use crate::actors::inspector::layout::LayoutInspectorActor;
 use crate::actors::inspector::node::{NodeActor, NodeActorMsg};
+use crate::actors::long_string::{LongStringActor, LongStringObj};
 use crate::protocol::{ClientRequest, DevtoolsConnection, JsonPacketStream};
 use crate::{ActorMsg, EmptyReplyMsg, StreamId};
 
@@ -58,6 +63,12 @@ struct ChildrenReply {
     has_last: bool,
     nodes: Vec<NodeActorMsg>,
     from: String,
+}
+
+#[derive(Serialize)]
+struct GetHtmlReply {
+    from: String,
+    value: LongStringObj,
 }
 
 #[derive(Serialize)]
@@ -129,9 +140,13 @@ impl Actor for WalkerActor {
     ///
     /// - `getLayoutInspector`: Returns the Layout inspector actor, placeholder
     ///
+    /// - `innerHTML`: Returns the serialized HTML descendants of the specified node
+    ///
     /// - `getMutations`: Returns the list of attribute changes since it was last called
     ///
     /// - `getOffsetParent`: Placeholder
+    ///
+    /// - `outerHTML`: Returns the serialized HTML of the specified node
     ///
     /// - `querySelector`: Recursively looks for the specified selector in the tree, reutrning the
     ///   node and its ascendents
@@ -218,6 +233,7 @@ impl Actor for WalkerActor {
                 };
                 request.reply_final(&msg)?
             },
+            "innerHTML" => self.handle_get_html(request, registry, msg, GetInnerHTML)?,
             "getMutations" => self.handle_get_mutations(request, registry)?,
             "getOffsetParent" => {
                 let msg = GetOffsetParentReply {
@@ -226,6 +242,7 @@ impl Actor for WalkerActor {
                 };
                 request.reply_final(&msg)?
             },
+            "outerHTML" => self.handle_get_html(request, registry, msg, GetOuterHTML)?,
             "querySelector" => {
                 let selector = msg
                     .get("selector")
@@ -303,6 +320,42 @@ impl WalkerActor {
 
         let node_actor = NodeActor::register_or_update(registry, &self.name, node_info);
         Ok(node_actor.encode(registry))
+    }
+
+    fn handle_get_html(
+        &self,
+        request: ClientRequest,
+        registry: &ActorRegistry,
+        msg: &Map<String, Value>,
+        get_html: fn(PipelineId, String, GenericSender<Option<String>>) -> DevtoolScriptControlMsg,
+    ) -> Result<(), ActorError> {
+        let target = msg
+            .get("node")
+            .ok_or(ActorError::MissingParameter)?
+            .as_str()
+            .ok_or(ActorError::BadParameterType)?;
+        let Some((tx, rx)) = generic_channel::channel() else {
+            return Err(ActorError::Internal);
+        };
+        let browsing_context_actor = self.browsing_context_actor(registry);
+        browsing_context_actor
+            .script_chan()
+            .send(get_html(
+                browsing_context_actor.pipeline_id(),
+                registry.actor_to_script(target.into()),
+                tx,
+            ))
+            .map_err(|_| ActorError::Internal)?;
+        let html = rx
+            .recv()
+            .map_err(|_| ActorError::Internal)?
+            .unwrap_or_default();
+        let long_string_actor = LongStringActor::register(registry, html);
+        let msg = GetHtmlReply {
+            from: self.name().into(),
+            value: long_string_actor.long_string_obj(),
+        };
+        request.reply_final(&msg)
     }
 
     pub(crate) fn handle_dom_mutation(

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -36,6 +36,7 @@ use crate::dom::bindings::codegen::Bindings::ElementBinding::ElementMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLElementBinding::HTMLElementMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeConstants;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
+use crate::dom::bindings::codegen::UnionTypes::TrustedHTMLOrNullIsEmptyString;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
@@ -344,6 +345,47 @@ pub(crate) fn handle_get_children(
     children.extend(children_iter);
 
     reply.send(Some(children)).unwrap();
+}
+
+fn trusted_html_to_string(html: TrustedHTMLOrNullIsEmptyString) -> String {
+    match html {
+        TrustedHTMLOrNullIsEmptyString::NullIsEmptyString(html) => String::from(html),
+        TrustedHTMLOrNullIsEmptyString::TrustedHTML(html) => html.to_string(),
+    }
+}
+
+pub(crate) fn handle_get_outer_html(
+    cx: &mut JSContext,
+    state: &DevtoolsState,
+    pipeline: PipelineId,
+    node_id: &str,
+    reply: GenericSender<Option<String>>,
+) {
+    let html = state.find_node_by_unique_id(pipeline, node_id).map(|node| {
+        node.downcast::<Element>()
+            .and_then(|element| element.outer_html(cx).ok())
+            .map(String::from)
+            .or_else(|| node.GetTextContent().map(String::from))
+            .unwrap_or_default()
+    });
+    reply.send(html).unwrap();
+}
+
+pub(crate) fn handle_get_inner_html(
+    cx: &mut JSContext,
+    state: &DevtoolsState,
+    pipeline: PipelineId,
+    node_id: &str,
+    reply: GenericSender<Option<String>>,
+) {
+    let html = state.find_node_by_unique_id(pipeline, node_id).map(|node| {
+        node.downcast::<Element>()
+            .and_then(|element| element.GetInnerHTML(cx).ok())
+            .map(trusted_html_to_string)
+            .or_else(|| node.GetTextContent().map(String::from))
+            .unwrap_or_default()
+    });
+    reply.send(html).unwrap();
 }
 
 pub(crate) fn handle_get_attribute_style(

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2171,6 +2171,12 @@ impl ScriptThread {
             DevtoolScriptControlMsg::GetChildren(id, node_id, reply) => {
                 devtools::handle_get_children(cx, &self.devtools_state, id, &node_id, reply)
             },
+            DevtoolScriptControlMsg::GetOuterHTML(id, node_id, reply) => {
+                devtools::handle_get_outer_html(cx, &self.devtools_state, id, &node_id, reply)
+            },
+            DevtoolScriptControlMsg::GetInnerHTML(id, node_id, reply) => {
+                devtools::handle_get_inner_html(cx, &self.devtools_state, id, &node_id, reply)
+            },
             DevtoolScriptControlMsg::GetAttributeStyle(id, node_id, reply) => {
                 devtools::handle_get_attribute_style(cx, &self.devtools_state, id, &node_id, reply)
             },

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -394,6 +394,10 @@ pub enum DevtoolScriptControlMsg {
     GetDocumentElement(PipelineId, GenericSender<Option<NodeInfo>>),
     /// Retrieve the details of the child nodes of the given node in the given pipeline.
     GetChildren(PipelineId, String, GenericSender<Option<Vec<NodeInfo>>>),
+    /// Retrieve the outer HTML of the given node in the given pipeline.
+    GetOuterHTML(PipelineId, String, GenericSender<Option<String>>),
+    /// Retrieve the inner HTML of the given node in the given pipeline.
+    GetInnerHTML(PipelineId, String, GenericSender<Option<String>>),
     /// Retrieve the CSS style properties defined in the attribute tag for the given node.
     GetAttributeStyle(PipelineId, String, GenericSender<Option<Vec<NodeStyle>>>),
     /// Retrieve the CSS style properties defined in an stylesheet for the given selector.


### PR DESCRIPTION
## Summary
The devtools inspector's Copy -> Outer HTML and Copy -> Inner HTML context-menu items now return the node's serialized HTML instead of an empty string.

## Why this matters
Reported in #45448. @jdm (MEMBER) diagnosed the root cause: the inspector walker actor never implemented the `outerHTML` / `innerHTML` actor messages the devtools client sends for those menu actions, so they always returned empty. These messages are part of the Firefox walker spec.

## Changes
- Add `GetOuterHTML` / `GetInnerHTML` script-control messages and dispatch them from `script_thread`.
- Implement `handle_get_outer_html` / `handle_get_inner_html` in the script devtools module, resolving the actor id to a node and serializing via the existing `outerHTML` / `innerHTML` IDL attributes.
- Handle the `outerHTML` / `innerHTML` actor messages in the inspector walker and reply with the serialized string.

## Testing
Exercised the inspector Copy menu against element, text, and empty nodes; Copy Outer/Inner HTML return the expected serialization.

Fixes #45448

AI was used for assistance.
