### PR TITLE
script: Add ReflectorRoot registry to break cycles

### DIFF
--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -58,6 +58,7 @@ use rustc_hash::{FxBuildHasher, FxHashMap};
 use script_bindings::cell::{DomRefCell, RefMut};
 use script_bindings::interfaces::GlobalScopeHelpers;
 use script_bindings::reflector::DomObject;
+use script_bindings::reflector_root::WeakReflectorRoot;
 use script_bindings::settings_stack::run_a_script;
 use servo_base::generic_channel;
 use servo_base::generic_channel::{GenericCallback, GenericSend};
@@ -292,6 +293,11 @@ pub(crate) struct GlobalScope {
     /// The mechanism by which time-outs and intervals are scheduled.
     /// <https://html.spec.whatwg.org/multipage/#timers>
     timers: OnceCell<OneshotTimers>,
+
+    /// Weak references to the [`ReflectorRoot`]s created in this global.
+    /// Allows us to release perma roots on teardown and break cycles.
+    #[no_trace]
+    rooted_reflectors: DomRefCell<Vec<WeakReflectorRoot>>,
 
     /// The origin of the globalscope
     #[no_trace]
@@ -848,6 +854,7 @@ impl GlobalScope {
             resolved_module_set: Default::default(),
             font_context,
             fetch_group: Default::default(),
+            rooted_reflectors: DomRefCell::new(Vec::new()),
         }
     }
 
@@ -872,6 +879,32 @@ impl GlobalScope {
 
     fn timers(&self) -> &OneshotTimers {
         self.timers.get_or_init(|| OneshotTimers::new(self))
+    }
+
+    pub(crate) fn register_reflector_root(&self, root: WeakReflectorRoot) {
+        let mut roots = self.rooted_reflectors.borrow_mut();
+        if roots.len() == roots.capacity() {
+            roots.retain(|weak| weak.live());
+        }
+        roots.push(root);
+    }
+
+    /// Release (unroot) all registered `ReflectorRoot`s
+    ///
+    /// This may be called when the ReflectorRoot objects are still alive.
+    /// The Reflector can then be garbage collected, as soon as nothing else traces to it.
+    ///
+    /// # Safety
+    ///
+    /// This may only be called on teardown, when it is certain that nothing can
+    /// dereference the reflector anymore.
+    #[expect(unsafe_code)]
+    pub(crate) unsafe fn release_reflector_roots(&self) {
+        let roots = std::mem::take(&mut *self.rooted_reflectors.borrow_mut());
+        for weak in roots {
+            // SAFETY: The caller guarantees that this is only called on teardown.
+            unsafe { weak.release() }
+        }
     }
 
     pub(crate) fn font_context(&self) -> Option<&Arc<FontContext>> {
@@ -3638,5 +3671,9 @@ impl GlobalScopeHelpers<crate::DomTypeHolder> for GlobalScope {
 
     fn is_secure_context(&self) -> bool {
         self.is_secure_context()
+    }
+
+    fn register_reflector_root(&self, root: WeakReflectorRoot) {
+        self.register_reflector_root(root)
     }
 }

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -96,7 +96,6 @@ impl Promise {
     }
 
     #[expect(unsafe_code)]
-    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new_with_js_promise(obj: HandleObject, mut cx: SafeJSContext) -> Rc<Promise> {
         // SAFETY: callers pass a valid promise object.
         unsafe { assert!(IsPromiseObject(obj)) };

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -20,9 +20,9 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::conversions::{ConversionResult, FromJSValConvertibleRc};
 use js::jsapi::{
-    AddRawValueRoot, CallArgs, GetFunctionNativeReserved, Heap, JS_GetFunctionObject,
-    JS_NewFunction, JSAutoRealm, JSContext as RawJSContext, JSObject, PromiseState,
-    PromiseUserInputEventHandlingState, RemoveRawValueRoot, SetFunctionNativeReserved,
+    CallArgs, GetFunctionNativeReserved, Heap, JS_GetFunctionObject, JS_NewFunction, JSAutoRealm,
+    JSContext as RawJSContext, JSObject, PromiseState, PromiseUserInputEventHandlingState,
+    SetFunctionNativeReserved,
 };
 use js::jsval::{Int32Value, JSVal, NullValue, ObjectValue, UndefinedValue};
 use js::realm::{AutoRealm, CurrentRealm};
@@ -35,9 +35,10 @@ use js::rust::wrappers2::{
     AddPromiseReactions, JS_ClearPendingException, NewFunctionWithReserved, RejectPromise,
     ResolvePromise,
 };
-use js::rust::{HandleObject, HandleValue, MutableHandleObject, Runtime};
+use js::rust::{HandleObject, HandleValue, MutableHandleObject};
 use script_bindings::conversions::SafeToJSValConvertible;
 use script_bindings::reflector::{DomObject, MutDomObject, Reflector};
+use script_bindings::reflector_root::ReflectorRoot;
 use script_bindings::settings_stack::run_a_script;
 
 use crate::DomTypeHolder;
@@ -56,48 +57,7 @@ use crate::script_thread::ScriptThread;
 #[cfg_attr(crown, crown::unrooted_must_root_lint::allow_unrooted_in_rc)]
 pub(crate) struct Promise {
     reflector: Reflector,
-    /// Since Promise values are natively reference counted without the knowledge of
-    /// the SpiderMonkey GC, an explicit root for the reflector is stored while any
-    /// native instance exists. This ensures that the reflector will never be GCed
-    /// while native code could still interact with its native representation.
-    #[ignore_malloc_size_of = "SM handles JS values"]
-    permanent_js_root: Heap<JSVal>,
-}
-
-/// Private helper to enable adding new methods to `Rc<Promise>`.
-trait PromiseHelper {
-    fn initialize(&self, cx: SafeJSContext);
-}
-
-impl PromiseHelper for Rc<Promise> {
-    #[expect(unsafe_code)]
-    fn initialize(&self, cx: SafeJSContext) {
-        let obj = self.reflector().get_jsobject();
-        self.permanent_js_root.set(ObjectValue(*obj));
-        unsafe {
-            assert!(AddRawValueRoot(
-                *cx,
-                self.permanent_js_root.get_unsafe(),
-                c"Promise::root".as_ptr(),
-            ));
-        }
-    }
-}
-
-// Promise objects are stored inside Rc values, so Drop is run when the last Rc is dropped,
-// rather than when SpiderMonkey runs a GC. This makes it safe to interact with the JS engine unlike
-// Drop implementations for other DOM types.
-impl Drop for Promise {
-    #[expect(unsafe_code)]
-    fn drop(&mut self) {
-        unsafe {
-            let object = self.permanent_js_root.get().to_object();
-            assert!(!object.is_null());
-            if let Some(cx) = Runtime::get() {
-                RemoveRawValueRoot(cx.as_ptr(), self.permanent_js_root.get_unsafe());
-            }
-        }
-    }
+    root: ReflectorRoot,
 }
 
 impl Promise {
@@ -137,18 +97,22 @@ impl Promise {
 
     #[expect(unsafe_code)]
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
-    pub(crate) fn new_with_js_promise(obj: HandleObject, cx: SafeJSContext) -> Rc<Promise> {
-        unsafe {
-            assert!(IsPromiseObject(obj));
-            let promise = Promise {
-                reflector: Reflector::new(),
-                permanent_js_root: Heap::default(),
-            };
-            let promise = Rc::new(promise);
-            promise.init_reflector_without_associated_memory(obj.get());
-            promise.initialize(cx);
-            promise
-        }
+    pub(crate) fn new_with_js_promise(obj: HandleObject, mut cx: SafeJSContext) -> Rc<Promise> {
+        // SAFETY: callers pass a valid promise object.
+        unsafe { assert!(IsPromiseObject(obj)) };
+        let promise = Rc::new(Promise {
+            reflector: Reflector::new(),
+            root: ReflectorRoot::new(&mut cx, ObjectValue(*obj), c"Promise::root"),
+        });
+        // SAFETY: `obj` is a valid promise object, asserted above.
+        unsafe { promise.init_reflector_without_associated_memory(obj.get()) };
+        // Register the root weakly with the owning global so it can be unrooted if the
+        // global is torn down before this promise drops, which can be necessary to
+        // clean up despite cycles.
+        promise
+            .global()
+            .register_reflector_root(promise.root.get_weak());
+        promise
     }
 
     #[expect(unsafe_code)]

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2467,6 +2467,7 @@ impl Window {
         self.document.get().is_some()
     }
 
+    #[expect(unsafe_code)]
     pub(crate) fn clear_js_runtime(&self) {
         self.as_global_scope()
             .remove_web_messaging_and_dedicated_workers_infra();
@@ -2501,6 +2502,10 @@ impl Window {
         // Callbacks may contain `Trusted` references, which are rooted and would
         // prevent the window from being GCed.
         self.pending_image_callbacks.borrow_mut().clear();
+
+        // SAFETY: This is at the end of `clear_js_runtime()`, so nothing can
+        // dereference the reflectors we unroot here.
+        unsafe { self.as_global_scope().release_reflector_roots() };
     }
 
     /// <https://drafts.csswg.org/cssom-view/#dom-window-scroll>

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -421,9 +421,14 @@ impl WorkerGlobalScope {
     }
 
     /// Clear various items when the worker event-loop shuts-down.
+    #[expect(unsafe_code)]
     pub(crate) fn clear_js_runtime(&self) {
         self.upcast::<GlobalScope>()
             .remove_web_messaging_and_dedicated_workers_infra();
+
+        // SAFETY: The runtime is destroyed after this step,
+        // nothing should be able to access the reflectors anymore.
+        unsafe { self.globalscope.release_reflector_roots() }
 
         // Drop the runtime.
         let runtime = self.runtime.borrow_mut().take();

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -751,10 +751,16 @@ impl WorkletThread {
     }
 
     /// Process a control message.
+    #[expect(unsafe_code)]
     fn process_control(&mut self, control: WorkletControl, cx: &mut js::context::JSContext) {
         match control {
             WorkletControl::ExitWorklet(worklet_id) => {
-                self.global_scopes.remove(&worklet_id);
+                if let Some(global) = self.global_scopes.remove(&worklet_id) {
+                    // SAFETY: The worklet has exited. Tasks arriving for it after this
+                    // point can't find the worklet_id in `global_scopes` and are dropped,
+                    // so nothing can dereference the reflectors we unroot here.
+                    unsafe { global.upcast::<GlobalScope>().release_reflector_roots() };
+                }
             },
             WorkletControl::FetchAndInvokeAWorkletScript {
                 webview_id,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3234,10 +3234,6 @@ impl ScriptThread {
 
             debug!("{pipeline_id}: Clearing JavaScript runtime");
             window.clear_js_runtime();
-
-            // SAFETY: This is after `clear_js_runtime()`, so nothing can
-            // dereference the reflectors we unroot here.
-            unsafe { window.as_global_scope().release_reflector_roots() };
         }
 
         // Prevent any further work for this Pipeline.

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3234,6 +3234,10 @@ impl ScriptThread {
 
             debug!("{pipeline_id}: Clearing JavaScript runtime");
             window.clear_js_runtime();
+
+            // SAFETY: This is after `clear_js_runtime()`, so nothing can
+            // dereference the reflectors we unroot here.
+            unsafe { window.as_global_scope().release_reflector_roots() };
         }
 
         // Prevent any further work for this Pipeline.

--- a/components/script_bindings/callback.rs
+++ b/components/script_bindings/callback.rs
@@ -8,10 +8,10 @@ use std::default::Default;
 use std::ffi::CStr;
 use std::rc::Rc;
 
-use js::jsapi::{AddRawValueRoot, Heap, IsCallable, JSObject, RemoveRawValueRoot};
+use js::jsapi::{Heap, IsCallable, JSObject};
 use js::jsval::{JSVal, NullValue, ObjectValue, UndefinedValue};
 use js::rust::wrappers2::{EnterRealm, JS_GetProperty, JS_WrapObject, LeaveRealm};
-use js::rust::{HandleObject, MutableHandleValue, Runtime};
+use js::rust::{HandleObject, MutableHandleValue};
 
 use crate::codegen::GenericBindings::WindowBinding::Window_Binding::WindowMethods;
 use crate::error::{Error, Fallible};
@@ -19,6 +19,7 @@ use crate::inheritance::Castable;
 use crate::interfaces::{DocumentHelpers, DomHelpers, GlobalScopeHelpers};
 use crate::realms::enter_auto_realm;
 use crate::reflector::DomObject;
+use crate::reflector_root::ReflectorRoot;
 use crate::root::Dom;
 use crate::script_runtime::JSContext;
 use crate::settings_stack::{run_a_callback, run_a_script};
@@ -57,8 +58,9 @@ pub struct CallbackObject<D: DomTypes> {
     /// The underlying `JSObject`.
     #[ignore_malloc_size_of = "measured by mozjs"]
     callback: Heap<*mut JSObject>,
-    #[ignore_malloc_size_of = "measured by mozjs"]
-    permanent_js_root: Heap<JSVal>,
+    /// Holds this callback's reflector root (after `init()`).
+    /// This acts like a perma-root, but can be manually unrooted.
+    root: Option<ReflectorRoot>,
 
     /// The ["callback context"], that is, the global to use as incumbent
     /// global when calling the callback.
@@ -80,7 +82,7 @@ impl<D: DomTypes> CallbackObject<D> {
     fn new() -> Self {
         Self {
             callback: Heap::default(),
-            permanent_js_root: Heap::default(),
+            root: None,
             incumbent: D::GlobalScope::incumbent().map(|i| Dom::from_ref(&*i)),
         }
     }
@@ -90,27 +92,11 @@ impl<D: DomTypes> CallbackObject<D> {
     }
 
     #[expect(unsafe_code)]
-    unsafe fn init(&mut self, cx: JSContext, callback: *mut JSObject) {
+    unsafe fn init(&mut self, mut cx: JSContext, callback: *mut JSObject) {
         self.callback.set(callback);
-        self.permanent_js_root.set(ObjectValue(callback));
-        unsafe {
-            assert!(AddRawValueRoot(
-                *cx,
-                self.permanent_js_root.get_unsafe(),
-                c"CallbackObject::root".as_ptr()
-            ));
-        }
-    }
-}
-
-impl<D: DomTypes> Drop for CallbackObject<D> {
-    #[expect(unsafe_code)]
-    fn drop(&mut self) {
-        unsafe {
-            if let Some(cx) = Runtime::get() {
-                RemoveRawValueRoot(cx.as_ptr(), self.permanent_js_root.get_unsafe());
-            }
-        }
+        let root = ReflectorRoot::new(&mut cx, ObjectValue(callback), c"CallbackObject::root");
+        unsafe { D::GlobalScope::from_object(callback) }.register_reflector_root(root.get_weak());
+        self.root = Some(root);
     }
 }
 

--- a/components/script_bindings/callback.rs
+++ b/components/script_bindings/callback.rs
@@ -4,11 +4,10 @@
 
 //! Base classes to work with IDL callbacks.
 
-use std::default::Default;
 use std::ffi::CStr;
 use std::rc::Rc;
 
-use js::jsapi::{Heap, IsCallable, JSObject};
+use js::jsapi::{IsCallable, JSObject};
 use js::jsval::{JSVal, NullValue, ObjectValue, UndefinedValue};
 use js::rust::wrappers2::{EnterRealm, JS_GetProperty, JS_WrapObject, LeaveRealm};
 use js::rust::{HandleObject, MutableHandleValue};
@@ -55,11 +54,8 @@ pub enum ExceptionHandling {
 #[derive(JSTraceable, MallocSizeOf)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub struct CallbackObject<D: DomTypes> {
-    /// The underlying `JSObject`.
-    #[ignore_malloc_size_of = "measured by mozjs"]
-    callback: Heap<*mut JSObject>,
-    /// Holds this callback's reflector root (after `init()`).
-    /// This acts like a perma-root, but can be manually unrooted.
+    /// Holds the underlying `JSObject` (after `init()`.
+    /// This acts like a perma-root, but can be manually unrooted on global teardown.
     root: Option<ReflectorRoot>,
 
     /// The ["callback context"], that is, the global to use as incumbent
@@ -81,19 +77,23 @@ impl<D: DomTypes> CallbackObject<D> {
     #[allow(clippy::new_without_default)]
     fn new() -> Self {
         Self {
-            callback: Heap::default(),
             root: None,
             incumbent: D::GlobalScope::incumbent().map(|i| Dom::from_ref(&*i)),
         }
     }
 
+    /// Returns the underlying `JSObject`, or null before `init()` and after
+    /// the root has been released on global teardown.
     pub fn get(&self) -> *mut JSObject {
-        self.callback.get()
+        self.root
+            .as_ref()
+            .and_then(|root| root.get())
+            .and_then(|value| value.is_object().then(|| value.to_object()))
+            .unwrap_or_else(std::ptr::null_mut)
     }
 
     #[expect(unsafe_code)]
     unsafe fn init(&mut self, mut cx: JSContext, callback: *mut JSObject) {
-        self.callback.set(callback);
         let root = ReflectorRoot::new(&mut cx, ObjectValue(callback), c"CallbackObject::root");
         unsafe { D::GlobalScope::from_object(callback) }.register_reflector_root(root.get_weak());
         self.root = Some(root);
@@ -102,7 +102,7 @@ impl<D: DomTypes> CallbackObject<D> {
 
 impl<D: DomTypes> PartialEq for CallbackObject<D> {
     fn eq(&self, other: &CallbackObject<D>) -> bool {
-        self.callback.get() == other.callback.get()
+        self.get() == other.get()
     }
 }
 

--- a/components/script_bindings/interfaces.rs
+++ b/components/script_bindings/interfaces.rs
@@ -18,6 +18,7 @@ use crate::conversions::DerivedFrom;
 use crate::error::Error;
 use crate::realms::InRealm;
 use crate::reflector::{DomObject, DomObjectWrap};
+use crate::reflector_root::WeakReflectorRoot;
 use crate::root::DomRoot;
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 use crate::settings_stack::StackEntry;
@@ -87,6 +88,9 @@ pub trait GlobalScopeHelpers<D: DomTypes> {
     fn get_url(&self) -> ServoUrl;
 
     fn is_secure_context(&self) -> bool;
+
+    /// Track a `ReflectorRoot` so the perma-root can be removed when this global is torn down.
+    fn register_reflector_root(&self, root: WeakReflectorRoot);
 }
 
 pub trait DocumentHelpers {

--- a/components/script_bindings/lib.rs
+++ b/components/script_bindings/lib.rs
@@ -40,6 +40,7 @@ pub mod proxyhandler;
 pub mod realms;
 pub mod record;
 pub mod reflector;
+pub mod reflector_root;
 pub mod root;
 pub mod script_runtime;
 pub mod settings_stack;

--- a/components/script_bindings/reflector_root.rs
+++ b/components/script_bindings/reflector_root.rs
@@ -24,10 +24,13 @@ use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use crate::script_runtime::JSContext;
 
 #[derive(JSTraceable)]
+#[cfg_attr(crown, crown::unrooted_must_root_lint::allow_unrooted_interior)]
 struct ReflectorRootInternal {
     /// The rooted reflector value. While `rooted` is true an `AddRawValueRoot` registration is
     /// keyed on this cell's address, which is stable because the cell lives in a heap (`Rc`)
     /// allocation in `ReflectorRoot`.
+    /// `value` can be assumed to be rooted for the life-time, since manual unrooting is unsafe,
+    /// and requires the caller to promise that `value` will not be used after this point anymore.
     value: Heap<JSVal>,
     /// Whether `value` is rooted or not. Avoids double unroots.
     rooted: Cell<bool>,

--- a/components/script_bindings/reflector_root.rs
+++ b/components/script_bindings/reflector_root.rs
@@ -82,6 +82,18 @@ impl ReflectorRoot {
         root
     }
 
+    /// Returns a handle to the rooted value, or `None` if the root has
+    /// already been released via [`WeakReflectorRoot::release`].
+    #[expect(unsafe_code)]
+    pub fn get(&self) -> Option<HandleValue<'_>> {
+        if !self.inner.rooted.get() {
+            return None;
+        }
+        // SAFETY: The value is rooted (checked above), always holds a valid
+        // `JSVal`.
+        Some(unsafe { HandleValue::from_raw(self.inner.value.handle()) })
+    }
+
     /// Returns a weak reference to this ReflectorRoot.
     pub fn get_weak(&self) -> WeakReflectorRoot {
         WeakReflectorRoot(Rc::downgrade(&self.inner))

--- a/components/script_bindings/reflector_root.rs
+++ b/components/script_bindings/reflector_root.rs
@@ -17,8 +17,8 @@ use std::ffi::CStr;
 use std::rc::{Rc, Weak};
 
 use js::jsapi::{AddRawValueRoot, Heap, RemoveRawValueRoot};
-use js::jsval::JSVal;
-use js::rust::Runtime;
+use js::jsval::{JSVal, UndefinedValue};
+use js::rust::{HandleValue, Runtime};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 
 use crate::script_runtime::JSContext;
@@ -57,6 +57,18 @@ impl ReflectorRootInternal {
         }
         if let Some(cx) = Runtime::get() {
             unsafe { RemoveRawValueRoot(cx.as_ptr(), self.value.get_unsafe()) };
+            // Clear the value via `set()` to get a post_barrier.
+            // This prevents UB when `value` is later dropped, which also
+            // invoked a post_barrier (but is skipped for UndefinedValue)
+            // and UB for a freed value.
+            self.value.set(UndefinedValue());
+        } else {
+            // Clear the value so the `Heap` drop doesn't cause UB in mozjs.
+            // Opposed to the above `set` we don't want to run a post_barrier
+            // here, since the value would already be garbage if the runtime
+            // is gone.
+            // SAFETY: No concurrent access, safe to overwrite the garbage value.
+            unsafe { self.value.get_unsafe().write(UndefinedValue()) };
         }
     }
 }

--- a/components/script_bindings/reflector_root.rs
+++ b/components/script_bindings/reflector_root.rs
@@ -1,0 +1,129 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+//! A permanently rooted Reflector, that can be unrooted on demand.
+//!
+//! We currently still need perma-roots in some areas of servo. However, this can lead to
+//! memory leaks if the perma-rooted Object transitively references an object that holds the perma-root.
+//! To allow breaking such cycles, we add the [`ReflectorRoot`] type.
+//! It allows manually unrooting via [`ReflectorRoot::release`].
+//!
+//! [`ReflectorRoot`] internally uses an `Rc`, so besides an owned Root, which can be released on drop,
+//! we can also have a [`WeakReflectorRoot`], which can be used to manually unroot and break cycles.
+
+use std::cell::Cell;
+use std::ffi::CStr;
+use std::rc::{Rc, Weak};
+
+use js::jsapi::{AddRawValueRoot, Heap, RemoveRawValueRoot};
+use js::jsval::JSVal;
+use js::rust::Runtime;
+use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
+
+use crate::script_runtime::JSContext;
+
+#[derive(JSTraceable)]
+struct ReflectorRootInternal {
+    /// The rooted reflector value. While `rooted` is true an `AddRawValueRoot` registration is
+    /// keyed on this cell's address, which is stable because the cell lives in a heap (`Rc`)
+    /// allocation in `ReflectorRoot`.
+    value: Heap<JSVal>,
+    /// Whether `value` is rooted or not. Avoids double unroots.
+    rooted: Cell<bool>,
+}
+
+#[derive(JSTraceable)]
+pub struct ReflectorRoot {
+    inner: Rc<ReflectorRootInternal>,
+}
+
+pub struct WeakReflectorRoot(Weak<ReflectorRootInternal>);
+
+impl ReflectorRootInternal {
+    /// Remove the root.
+    ///
+    /// # Safety
+    ///
+    /// Since this makes the Object eligible for GC, this may only be called when the caller
+    /// is sure the object is not going to be used anymore.
+    #[expect(unsafe_code)]
+    unsafe fn release(&self) {
+        if !self.rooted.replace(false) {
+            return;
+        }
+        if let Some(cx) = Runtime::get() {
+            unsafe { RemoveRawValueRoot(cx.as_ptr(), self.value.get_unsafe()) };
+        }
+    }
+}
+
+impl ReflectorRoot {
+    /// Root `value` under `name`.
+    #[expect(unsafe_code)]
+    pub fn new(cx: &mut JSContext, value: JSVal, name: &CStr) -> Self {
+        let inner = Rc::new(ReflectorRootInternal {
+            value: Heap::default(),
+            rooted: Cell::new(false),
+        });
+        inner.value.set(value);
+        let root = ReflectorRoot { inner };
+        unsafe {
+            assert!(AddRawValueRoot(
+                cx.raw_cx(),
+                root.inner.value.get_unsafe(),
+                name.as_ptr()
+            ));
+        }
+        root.inner.rooted.set(true);
+        root
+    }
+
+    /// Returns a weak reference to this ReflectorRoot.
+    pub fn get_weak(&self) -> WeakReflectorRoot {
+        WeakReflectorRoot(Rc::downgrade(&self.inner))
+    }
+}
+
+impl Drop for ReflectorRoot {
+    fn drop(&mut self) {
+        // SAFETY: If the ReflectorRoot itself is dropped, then we trivially know
+        // it's safe to release the root.
+        unsafe { self.inner.release() };
+    }
+}
+
+impl WeakReflectorRoot {
+    /// Remove the root if the Reflector is still alive.
+    ///
+    /// # Safety
+    ///
+    /// Since this makes the Object eligible for GC, this may only be called when the caller
+    /// is sure the object is not going to be used anymore.
+    pub unsafe fn release(&self) {
+        if let Some(reflector_root) = self.0.upgrade() {
+            // SAFETY: The safety precondition was delegated to the caller of this method.
+            unsafe { reflector_root.release() }
+        }
+    }
+
+    /// Returns true if the weakly referenced `ReflectorRoot` is still live.
+    pub fn live(&self) -> bool {
+        self.0.strong_count() > 0
+    }
+}
+
+impl MallocSizeOf for ReflectorRoot {
+    fn size_of(&self, _ops: &mut MallocSizeOfOps) -> usize {
+        // JS Heap is tracked in `mozjs`, so only count our owned internal struct.
+        // Our `Rc` is not clonable, so we treat this as an owned heap value.
+        size_of::<ReflectorRootInternal>()
+    }
+}
+
+impl MallocSizeOf for WeakReflectorRoot {
+    fn size_of(&self, _ops: &mut MallocSizeOfOps) -> usize {
+        // Weak reference, nothing to count here.
+        0
+    }
+}


### PR DESCRIPTION
Perma-roots are tricky, since a Perma-rooted Reflector that transitivily references an Object that holds the Reflector means that we have a cycle which Spidermonkey can't collect. 
This leads to leaks, e.g. visible when reloading servo.org. 
To break such cycles, we add a new type `ReflectorRoot`, which allows manually unrooting the Reflector, if it is still alive. We achieve that with an `Rc` and a `Weak` reference, which we register with the Globalscope, so we can manually unroot on pipeline close.

Manual testing: Load servo.org, open a new tab with `about:memory`, measure. Reload the servo.org tab multiple times. Measure memory usage again and compare. After this patch the JS related increase is fixed. 

Testing: We don't have automated tests proving absence of leaks, or that memory is garbage collected.
Fixes: #45262