### PR TITLE
webgpu: Fix potential UaF in GPUBuffer

### DIFF
--- a/components/script/dom/webgpu/gpubuffer.rs
+++ b/components/script/dom/webgpu/gpubuffer.rs
@@ -185,7 +185,16 @@ impl GPUBuffer {
 
 impl Drop for GPUBuffer {
     fn drop(&mut self) {
-        self.Destroy();
+        if let Err(e) = self
+            .channel
+            .0
+            .send(WebGPURequest::DropBuffer(self.buffer.0))
+        {
+            error!(
+                "Failed to send WebGPURequest::DropBuffer({:?}) ({}) - Potential leak",
+                self.buffer.0, e
+            );
+        }
     }
 }
 


### PR DESCRIPTION
We can't destroy the buffer since it might still be used. Instead, we should send `DropBuffer`, so the buffer can be destroyed once nothing references it (as all the surrounding webgpu code seems to do).
Fixes a crash (racy) with spookyball on macos.

Testing: Unclear
Fixes: Part of #45474
