### PR TITLE
Use FastTransform from `webrender_api` rather than `webrender`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6190,8 +6190,7 @@ checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
 [[package]]
 name = "peek-poke"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef60922033e31835f6cf98b9b81b58368037b71d2a81928985cd9d0b3b3171fb"
+source = "git+https://github.com/servo/webrender?rev=82dda62fd9ad85a032028cbe456cbc3e03084ae5#82dda62fd9ad85a032028cbe456cbc3e03084ae5"
 dependencies = [
  "euclid",
  "peek-poke-derive",
@@ -6200,8 +6199,7 @@ dependencies = [
 [[package]]
 name = "peek-poke-derive"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271f78bae1e699b58c180a384a2e8d78ccbb60b853e15db92339725f3a2764d5"
+source = "git+https://github.com/servo/webrender?rev=82dda62fd9ad85a032028cbe456cbc3e03084ae5#82dda62fd9ad85a032028cbe456cbc3e03084ae5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8023,7 +8021,6 @@ dependencies = [
  "euclid",
  "malloc_size_of_derive",
  "servo-malloc-size-of",
- "webrender",
  "webrender_api",
 ]
 
@@ -8178,7 +8175,6 @@ dependencies = [
  "url",
  "urlpattern",
  "uuid",
- "webrender",
  "webrender_api",
  "wr_malloc_size_of",
 ]
@@ -11147,9 +11143,8 @@ dependencies = [
 
 [[package]]
 name = "webrender"
-version = "0.68.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a591c25221a9f8ac2ad7754659b283d912cee6c8424f0fa3777aabed3be91c16"
+version = "0.68.1"
+source = "git+https://github.com/servo/webrender?rev=82dda62fd9ad85a032028cbe456cbc3e03084ae5#82dda62fd9ad85a032028cbe456cbc3e03084ae5"
 dependencies = [
  "allocator-api2",
  "bincode",
@@ -11184,9 +11179,8 @@ dependencies = [
 
 [[package]]
 name = "webrender_api"
-version = "0.68.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb206f613b4635881065a2ff4670e656edc904af0b8729c51ce1196679fd1b6d"
+version = "0.68.1"
+source = "git+https://github.com/servo/webrender?rev=82dda62fd9ad85a032028cbe456cbc3e03084ae5#82dda62fd9ad85a032028cbe456cbc3e03084ae5"
 dependencies = [
  "app_units",
  "bitflags 2.11.1",
@@ -11205,8 +11199,7 @@ dependencies = [
 [[package]]
 name = "webrender_build"
 version = "0.68.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6165a81201892371061250bd6f08ede9ed7279842fedc4033f48582a789068"
+source = "git+https://github.com/servo/webrender?rev=82dda62fd9ad85a032028cbe456cbc3e03084ae5#82dda62fd9ad85a032028cbe456cbc3e03084ae5"
 dependencies = [
  "bitflags 2.11.1",
  "lazy_static",
@@ -11872,8 +11865,7 @@ dependencies = [
 [[package]]
 name = "wr_glyph_rasterizer"
 version = "0.68.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4fcffa889d25131fc7c6ec8a558aa7c78d6030eaa17e31695c172adcc4eb0b"
+source = "git+https://github.com/servo/webrender?rev=82dda62fd9ad85a032028cbe456cbc3e03084ae5#82dda62fd9ad85a032028cbe456cbc3e03084ae5"
 dependencies = [
  "core-foundation 0.9.4",
  "core-graphics",
@@ -11898,8 +11890,7 @@ dependencies = [
 [[package]]
 name = "wr_malloc_size_of"
 version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "482308b684f11723b200a32808094bb460b5ac4840903ccbcb78ad92a6354a1f"
+source = "git+https://github.com/servo/webrender?rev=82dda62fd9ad85a032028cbe456cbc3e03084ae5#82dda62fd9ad85a032028cbe456cbc3e03084ae5"
 dependencies = [
  "app_units",
  "euclid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -274,8 +274,8 @@ warp = "0.4.2"
 web_atoms = "0.2.4"
 webdriver = { version = "0.53.0", default-features = false }
 webpki-roots = "1.0"
-webrender = { version = "0.68", features = ["capture"] }
-webrender_api = "0.68"
+webrender = { git = "https://github.com/servo/webrender", rev = "82dda62fd9ad85a032028cbe456cbc3e03084ae5", features = ["capture"] }
+webrender_api = { git = "https://github.com/servo/webrender", rev = "82dda62fd9ad85a032028cbe456cbc3e03084ae5", features = ["deserialize"] }
 wgpu-core = "29"
 wgpu-types = "29"
 winapi = "0.3"
@@ -283,7 +283,7 @@ windows-sys = "0.61"
 winit = "0.30.13"
 winresource = "0.1"
 wio = "0.2"
-wr_malloc_size_of = "0.2.2"
+wr_malloc_size_of = { git = "https://github.com/servo/webrender", rev = "82dda62fd9ad85a032028cbe456cbc3e03084ae5" }
 x25519-dalek = { version = "2.0.1", features = ["static_secrets"] }
 xcomponent-sys = "0.3.6"
 xml = "1.1"

--- a/components/geometry/Cargo.toml
+++ b/components/geometry/Cargo.toml
@@ -18,5 +18,4 @@ app_units = { workspace = true }
 euclid = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
-webrender = { workspace = true }
 webrender_api = { workspace = true }

--- a/components/geometry/lib.rs
+++ b/components/geometry/lib.rs
@@ -8,7 +8,7 @@ use app_units::{Au, MAX_AU, MIN_AU};
 use euclid::default::{Point2D as UntypedPoint2D, Rect as UntypedRect, Size2D as UntypedSize2D};
 use euclid::{Box2D, Length, Point2D, Rect, Scale, SideOffsets2D, Size2D, Vector2D};
 use malloc_size_of_derive::MallocSizeOf;
-use webrender::FastTransform;
+use webrender_api::FastTransform;
 use webrender_api::units::{
     DeviceIntRect, DeviceIntSize, DevicePixel, FramebufferPixel, LayoutPixel, LayoutPoint,
     LayoutRect, LayoutSize,

--- a/components/malloc_size_of/Cargo.toml
+++ b/components/malloc_size_of/Cargo.toml
@@ -45,6 +45,5 @@ unicode-script = { workspace = true }
 url = { workspace = true }
 urlpattern = { workspace = true }
 uuid = { workspace = true }
-webrender = { workspace = true }
 webrender_api = { workspace = true }
 wr_malloc_size_of = { workspace = true }

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -1223,7 +1223,7 @@ macro_rules! malloc_size_of_is_webrender_malloc_size_of(
     );
 );
 
-malloc_size_of_is_webrender_malloc_size_of!(webrender::FastTransform<webrender_api::units::LayoutPixel, webrender_api::units::LayoutPixel>);
+malloc_size_of_is_webrender_malloc_size_of!(webrender_api::FastTransform<webrender_api::units::LayoutPixel, webrender_api::units::LayoutPixel>);
 malloc_size_of_is_webrender_malloc_size_of!(webrender_api::BorderRadius);
 malloc_size_of_is_webrender_malloc_size_of!(webrender_api::BorderStyle);
 malloc_size_of_is_webrender_malloc_size_of!(webrender_api::BoxShadowClipMode);


### PR DESCRIPTION
Depends on: https://github.com/servo/webrender/pull/4883

`servo-malloc-size-of` and `servo-geometry` are currently depending on `webrender` because they need the `FastTransform` type. As these crates are low in the crate graph, this means that ~50 servo crates need to recompile when modifying webrender.

This PR, moves `FastTransform` into `webrender_api` which means that`servo-malloc-size-of` and `servo-geometry` can also depend only on `webrender_api` and the only servo crates that needs to depend on `webrender` are `servo-paint` and `servo`.

No behaviour changes expected. This just moves a type to a different crates to improve incremental compile times.