### PR TITLE
script: Allow `AttributeProvider` to match case-insensitively in HTML

### DIFF
--- a/components/script/layout_dom/servo_dangerous_style_element.rs
+++ b/components/script/layout_dom/servo_dangerous_style_element.rs
@@ -89,9 +89,15 @@ impl<'dom> DangerousStyleElement<'dom> for ServoDangerousStyleElement<'dom> {
 
 impl<'dom> style::dom::AttributeProvider for ServoDangerousStyleElement<'dom> {
     fn get_attr(&self, attr: &style::LocalName, namespace: &style::Namespace) -> Option<String> {
-        self.element
-            .get_attr_val_for_layout(namespace, attr)
-            .map(Into::into)
+        // All attribute names on HTML elements in HTML docs match ASCII-case-insensitively.
+        // See note in https://html.spec.whatwg.org/multipage/#custom-data-attribute
+        if self.is_html_element_in_html_document() {
+            let attr = &style::LocalName::new(attr.to_ascii_lowercase());
+            self.element.get_attr_val_for_layout(namespace, attr)
+        } else {
+            self.element.get_attr_val_for_layout(namespace, attr)
+        }
+        .map(Into::into)
     }
 }
 

--- a/tests/wpt/meta/css/css-content/__dir__.ini
+++ b/tests/wpt/meta/css/css-content/__dir__.ini
@@ -1,0 +1,1 @@
+prefs: [layout_css_attr_enabled: true]

--- a/tests/wpt/meta/css/css-content/attr-case-sensitivity-004.html.ini
+++ b/tests/wpt/meta/css/css-content/attr-case-sensitivity-004.html.ini
@@ -1,2 +1,0 @@
-[attr-case-sensitivity-004.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-values/html-attr-case-insensitivity.html.ini
+++ b/tests/wpt/meta/css/css-values/html-attr-case-insensitivity.html.ini
@@ -1,2 +1,0 @@
-[html-attr-case-insensitivity.html]
-  expected: FAIL


### PR DESCRIPTION
`AttributeProvider` is the trait used for the modern version of `attr()` which can be used everywhere, not just in the `content` property.

This patch fixes its implementation to match attribute names on HTML elements in HTML documents in an ASCII-case-insensitive way.

Testing: The fix makes `/css/css-values/html-attr-case-insensitivity.html` pass. Additionally, the pref that controls this modern `attr()` is now enabled for `/css/css-content/`. Without the fix, these tests would then fail:
 - `/css/css-content/attr-case-sensitivity-001.html`
 - `/css/css-content/attr-case-sensitivity-002.html`

Regardless of the fix, enabling the pref also makes `/css/css-content/attr-case-sensitivity-004.html` pass.
