### PR TITLE
fonts: Compute used font features before querying shape cache

### DIFF
--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -46,6 +46,7 @@ use crate::{
     EmojiPresentationPreference, FallbackFontSelectionOptions, FontContext, FontData,
     FontDataAndIndex, FontDataError, FontIdentifier, FontTemplateDescriptor, FontTemplateRef,
     FontTemplateRefMethods, GlyphId, LocalFontIdentifier, ShapedGlyph, ShapedText, Shaper,
+    compute_used_font_features,
 };
 
 pub(crate) const AFRC: Tag = Tag::new(b"afrc");
@@ -444,20 +445,31 @@ impl ShapingOptions {
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 struct ShapeCacheEntry {
     text: String,
-    options: ShapingOptions,
+    letter_spacing: Option<Au>,
+    word_spacing: Option<Au>,
+    script: Script,
+    language: Language,
+    font_features: Box<[(Tag, u32)]>,
+    flags: ShapingFlags,
 }
 
 impl Font {
     pub fn shape_text(&self, text: &str, options: &ShapingOptions) -> Arc<ShapedText> {
+        let font_features =
+            compute_used_font_features(options, self.template.borrow().font_face_rule.as_ref())
+                .collect();
         let lookup_key = ShapeCacheEntry {
             text: text.to_owned(),
-            options: options.clone(),
+            letter_spacing: options.letter_spacing,
+            word_spacing: options.word_spacing,
+            script: options.script,
+            language: options.language,
+            flags: options.flags,
+            font_features,
         };
-        {
-            let cache = self.cached_shape_data.read();
-            if let Some(shaped_text) = cache.shaped_text.get(&lookup_key) {
-                return shaped_text.clone();
-            }
+
+        if let Some(shaped_text) = self.cached_shape_data.read().shaped_text.get(&lookup_key) {
+            return shaped_text.clone();
         }
 
         let start_time = Instant::now();
@@ -469,7 +481,7 @@ impl Font {
             self.shaper.get_or_init(|| Shaper::new(self)).shape_text(
                 text,
                 options,
-                self.template.borrow().font_face_rule.as_ref(),
+                &lookup_key.font_features,
             )
         };
 

--- a/components/fonts/shapers/harfbuzz.rs
+++ b/components/fonts/shapers/harfbuzz.rs
@@ -28,11 +28,8 @@ use harfbuzz_sys::{
 };
 use num_traits::Zero;
 use read_fonts::types::Tag;
-use style::font_face::FontFaceRule;
 
-use super::{
-    GlyphShapingResult, ShapedGlyph, compute_used_font_features, unicode_script_to_iso15924_tag,
-};
+use super::{GlyphShapingResult, ShapedGlyph, unicode_script_to_iso15924_tag};
 use crate::platform::font::FontTable;
 use crate::{
     BASE, Font, FontBaseline, FontTableMethods, GlyphId, ShapedText, ShapingFlags, ShapingOptions,
@@ -248,7 +245,7 @@ impl Shaper {
         &self,
         text: &str,
         options: &ShapingOptions,
-        font_face_rule: Option<&FontFaceRule>,
+        font_features: &[(Tag, u32)],
     ) -> HarfbuzzGlyphShapingResult {
         unsafe {
             let hb_buffer: *mut hb_buffer_t = hb_buffer_create();
@@ -281,10 +278,11 @@ impl Shaper {
             );
             hb_buffer_set_language(hb_buffer, hb_language);
 
-            let mut features: Vec<_> = compute_used_font_features(options, font_face_rule)
+            let mut features: Vec<_> = font_features
+                .iter()
                 .map(|(tag, value)| hb_feature_t {
                     tag: u32::from_be_bytes(tag.to_be_bytes()),
-                    value,
+                    value: *value,
                     start: 0,
                     end: hb_buffer_get_length(hb_buffer),
                 })
@@ -304,12 +302,12 @@ impl Shaper {
         &self,
         text: &str,
         options: &ShapingOptions,
-        font_face_rule: Option<&FontFaceRule>,
+        font_features: &[(Tag, u32)],
     ) -> ShapedText {
         ShapedText::with_shaped_glyph_data(
             text,
             options,
-            &self.shaped_glyph_data(text, options, font_face_rule),
+            &self.shaped_glyph_data(text, options, font_features),
         )
     }
 

--- a/components/fonts/shapers/mod.rs
+++ b/components/fonts/shapers/mod.rs
@@ -61,7 +61,7 @@ pub(crate) trait GlyphShapingResult {
 ///
 /// The order of precedence for resolving font-specific font feature properties is specified in
 /// <https://drafts.csswg.org/css-fonts-4/#apply-font-matching-variations>.
-fn compute_used_font_features(
+pub(crate) fn compute_used_font_features(
     options: &ShapingOptions,
     font_face_rule: Option<&FontFaceRule>,
 ) -> impl Iterator<Item = (Tag, u32)> {


### PR DESCRIPTION
Addresses concerns raised in https://github.com/servo/servo/pull/45308#discussion_r3364672804.

Computing the font features first means more work if there is a matching cache entry. That work should be negligible, and in the common case (when no `font-variant` properties are set to non-default values) then there's nothing to do.

This reduces the size of `ShapeCacheEntry` by 8 bytes immediately and avoids increasing it by another 16 bytes due to https://github.com/servo/servo/pull/45308. 

Testing: No behaviour change intended, coverd by existing tests