### PR TITLE
fonts: Measure time spent in text shaping with "servo_tracing"

### DIFF
--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -6,9 +6,7 @@ use std::borrow::ToOwned;
 use std::collections::HashMap;
 use std::hash::Hash;
 use std::ops::Deref;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock};
-use std::time::Instant;
 use std::{iter, str};
 
 use app_units::Au;
@@ -81,9 +79,6 @@ pub(crate) const TRAD: Tag = Tag::new(b"trad");
 pub(crate) const ZERO: Tag = Tag::new(b"zero");
 
 pub const LAST_RESORT_GLYPH_ADVANCE: FractionalPixel = 10.0;
-
-/// Nanoseconds spent shaping text across all layout threads.
-static TEXT_SHAPING_PERFORMANCE_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
 // PlatformFont encapsulates access to the platform's font API,
 // e.g. quartz, FreeType. It provides access to metrics and tables
@@ -448,6 +443,7 @@ struct ShapeCacheEntry {
 }
 
 impl Font {
+    #[servo_tracing::instrument(name = "Font::shape_text", skip_all)]
     pub fn shape_text(&self, text: &str, options: &ShapingOptions) -> Arc<ShapedText> {
         let lookup_key = ShapeCacheEntry {
             text: text.to_owned(),
@@ -460,7 +456,6 @@ impl Font {
             }
         }
 
-        let start_time = Instant::now();
         let glyphs = if self.can_do_fast_shaping(text, options) {
             debug!("shape_text: Using ASCII fast path.");
             self.shape_text_fast(text, options)
@@ -476,11 +471,6 @@ impl Font {
         let shaped_text = Arc::new(glyphs);
         let mut cache = self.cached_shape_data.write();
         cache.shaped_text.insert(lookup_key, shaped_text.clone());
-
-        TEXT_SHAPING_PERFORMANCE_COUNTER.fetch_add(
-            ((Instant::now() - start_time).as_nanos()) as usize,
-            Ordering::Relaxed,
-        );
 
         shaped_text
     }


### PR DESCRIPTION
Previously we were measuring the time with `std::time`, accumulating the result in a global variable. Now we use `servo_tracing` and only measure when tracing is enabled. That's how we do profiling in other parts of the project and its much more convenient.

Testing: No user-facing behavour change intended, we don't have tests for tracing macros.