### PR TITLE
mach: Use `system-certs` instead of `native-tls`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,4 +82,4 @@ project-excludes = [
 ]
 
 [tool.uv]
-native-tls = true
+system-certs = true


### PR DESCRIPTION
Update deprecated protocol.

Testing: Compilation without mentioned warning.
Fixes: #45499
