### PR TITLE
libservo: Remove unused `WebView::send_error` API.

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1418,14 +1418,6 @@ where
             EmbedderToConstellationMessage::CloseWebView(webview_id) => {
                 self.handle_close_top_level_browsing_context(webview_id);
             },
-            // Panic a top level browsing context.
-            EmbedderToConstellationMessage::SendError(webview_id, error) => {
-                warn!("Constellation got a SendError message from WebView {webview_id:?}: {error}");
-                let Some(webview_id) = webview_id else {
-                    return;
-                };
-                self.handle_panic_in_webview(webview_id, &error, &None);
-            },
             EmbedderToConstellationMessage::FocusWebView(webview_id) => {
                 self.handle_focus_web_view(webview_id);
             },

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -61,7 +61,6 @@ mod from_embedder {
                 Self::LogEntry(..) => target!("LogEntry"),
                 Self::NewWebView(..) => target!("NewWebView"),
                 Self::CloseWebView(..) => target!("CloseWebView"),
-                Self::SendError(..) => target!("SendError"),
                 Self::FocusWebView(..) => target!("FocusWebView"),
                 Self::BlurWebView => target!("BlurWebView"),
                 Self::ForwardInputEvent(_webview_id, event, ..) => event.log_target(),

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -740,16 +740,6 @@ impl WebView {
         );
     }
 
-    pub fn send_error(&self, message: String) {
-        self.inner()
-            .servo
-            .constellation_proxy()
-            .send(EmbedderToConstellationMessage::SendError(
-                Some(self.id()),
-                message,
-            ));
-    }
-
     /// Paint the contents of this [`WebView`] into its [`RenderingContext`].
     pub fn paint(&self) {
         self.inner().servo.paint().render(self.id());

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -72,8 +72,6 @@ pub enum EmbedderToConstellationMessage {
     NewWebView(ServoUrl, NewWebViewDetails),
     /// Close a top level browsing context.
     CloseWebView(WebViewId),
-    /// Panic a top level browsing context.
-    SendError(Option<WebViewId>, String),
     /// Make a webview focused. [EmbedderMsg::WebViewFocused] will be sent with
     /// the result of this operation.
     FocusWebView(WebViewId),


### PR DESCRIPTION
Based on Git history, it seems this API was originally used in the pre-delegate, message-based embedding API. The embedder used the `SendError` variant to report any IPC `send` failures when responding to requests from the engine in the form of `EmbedderMsg`s that carry a response sender.

Today, we have the various `*Request` types that hide the underlying IPC mechanism from the embedder. The requests internally use `AllowOrDenyRequest` which captures the send error and eventually reports it to the embedder as a `WebViewDelegate::notify_error` callback.

Since this `WebViewDelegate::send_error` is no longer directly used, remove that API and the `EmbedderToConstellationMessage::SendError` variant.

Testing: No testing needed as the API is not used anywhere so shouldn't cause behavioral change.