### PR TITLE
script: Switch some places to use `FromJSValConvertible`

### DIFF
--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -31,9 +31,7 @@ pub(crate) use script_bindings::error::*;
 use script_bindings::root::DomRoot;
 use script_bindings::str::DOMString;
 
-use crate::dom::bindings::conversions::{
-    ConversionResult, SafeFromJSValConvertible, root_from_object,
-};
+use crate::dom::bindings::conversions::{ConversionResult, FromJSValConvertible, root_from_object};
 use crate::dom::bindings::str::USVString;
 use crate::dom::domexception::{DOMErrorName, DOMException};
 use crate::dom::globalscope::GlobalScope;
@@ -321,17 +319,18 @@ impl ErrorInfo {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#extract-error>
-    pub(crate) fn from_value(value: HandleValue, cx: SafeJSContext, can_gc: CanGc) -> ErrorInfo {
+    pub(crate) fn from_value(cx: &mut JSContext, value: HandleValue) -> ErrorInfo {
         if value.is_object() {
-            rooted!(in(*cx) let object = value.to_object());
-            if let Some(info) = ErrorInfo::from_object(object.handle(), cx) {
+            rooted!(&in(cx) let object = value.to_object());
+            if let Some(info) = ErrorInfo::from_object(object.handle(), cx.into()) {
                 return info;
             }
         }
 
-        match USVString::safe_from_jsval(cx, value, (), can_gc) {
+        match USVString::safe_from_jsval(cx, value, ()) {
             Ok(ConversionResult::Success(USVString(string))) => {
-                let scripted_caller = unsafe { describe_scripted_caller(*cx) }.unwrap_or_default();
+                let scripted_caller =
+                    unsafe { describe_scripted_caller(cx.raw_cx()) }.unwrap_or_default();
                 ErrorInfo {
                     message: format!("uncaught exception: {}", string),
                     filename: scripted_caller.filename,

--- a/components/script/dom/create.rs
+++ b/components/script/dom/create.rs
@@ -175,10 +175,10 @@ fn create_html_element(
                     // TODO(jdm) Pass proto to create_element?
                     // Steps 4.1.1-4.1.11
                     return match definition.create_element(
+                        cx,
                         document,
                         prefix.clone(),
                         registry.clone(),
-                        CanGc::from_cx(cx),
                     ) {
                         Ok(element) => {
                             element.set_custom_element_definition(definition.clone());

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -5,22 +5,23 @@
 use std::cell::Cell;
 use std::collections::VecDeque;
 use std::ffi::CStr;
+use std::ptr::NonNull;
 use std::rc::Rc;
 use std::{mem, ptr};
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Namespace, Prefix, ns};
 use js::context::JSContext;
+use js::conversions::FromJSValConvertible;
 use js::glue::UnwrapObjectStatic;
 use js::jsapi::{HandleValueArray, Heap, IsCallable, IsConstructor, JSAutoRealm, JSObject};
 use js::jsval::{BooleanValue, JSVal, NullValue, ObjectValue, UndefinedValue};
 use js::realm::{AutoRealm, CurrentRealm};
-use js::rust::wrappers::Construct1;
-use js::rust::wrappers2::{JS_GetProperty, SameValue};
+use js::rust::wrappers2::{Construct1, JS_GetProperty, SameValue};
 use js::rust::{HandleObject, MutableHandleValue};
 use rustc_hash::FxBuildHasher;
 use script_bindings::cell::DomRefCell;
-use script_bindings::conversions::{SafeFromJSValConvertible, SafeToJSValConvertible};
+use script_bindings::conversions::SafeToJSValConvertible;
 use script_bindings::reflector::{DomObject, Reflector, reflect_dom_object};
 use script_bindings::settings_stack::{run_a_callback, run_a_script};
 use style::attr::AttrValue;
@@ -692,28 +693,28 @@ impl CustomElementDefinition {
     #[expect(unsafe_code)]
     pub(crate) fn create_element(
         &self,
+        cx: &mut JSContext,
         document: &Document,
         prefix: Option<Prefix>,
         registry: Option<DomRoot<CustomElementRegistry>>,
-        // This function can cause GC through AutoEntryScript::Drop, but we can't pass a CanGc there
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<Element>> {
         let window = document.window();
-        let cx = GlobalScope::get_cx();
+
         // Step 5.1.1. Let C be definition’s constructor.
-        rooted!(in(*cx) let constructor = ObjectValue(self.constructor.callback()));
-        rooted!(in(*cx) let mut element = ptr::null_mut::<JSObject>());
+        rooted!(&in(cx) let constructor = ObjectValue(self.constructor.callback()));
+        rooted!(&in(cx) let mut element = ptr::null_mut::<JSObject>());
         {
             // Go into the constructor's realm
-            let _ac = JSAutoRealm::new(*cx, self.constructor.callback());
+            let mut realm = AutoRealm::new(cx, NonNull::new(self.constructor.callback()).unwrap());
+            let cx = &mut realm;
+
             // Step 5.3.1. Set result to the result of constructing C, with no arguments.
             // https://webidl.spec.whatwg.org/#construct-a-callback-function
             run_a_script::<DomTypeHolder, _>(window.upcast(), || {
                 run_a_callback::<DomTypeHolder, _>(window.upcast(), || {
                     let args = HandleValueArray::empty();
-                    if unsafe {
-                        !Construct1(*cx, constructor.handle(), &args, element.handle_mut())
-                    } {
+                    if unsafe { !Construct1(cx, constructor.handle(), &args, element.handle_mut()) }
+                    {
                         Err(Error::JSFailed)
                     } else {
                         Ok(())
@@ -722,9 +723,9 @@ impl CustomElementDefinition {
             })?;
         }
 
-        rooted!(in(*cx) let element_val = ObjectValue(element.get()));
+        rooted!(&in(cx) let element_val = ObjectValue(element.get()));
         let element: DomRoot<Element> =
-            match SafeFromJSValConvertible::safe_from_jsval(cx, element_val.handle(), (), can_gc) {
+            match FromJSValConvertible::safe_from_jsval(cx, element_val.handle(), ()) {
                 Ok(ConversionResult::Success(element)) => element,
                 Ok(ConversionResult::Failure(..)) => {
                     return Err(Error::Type(
@@ -911,7 +912,7 @@ fn run_upgrade_constructor(
         }
 
         // Go into the constructor's realm
-        let mut realm = AutoRealm::new(cx, std::ptr::NonNull::new(constructor.callback()).unwrap());
+        let mut realm = AutoRealm::new(cx, NonNull::new(constructor.callback()).unwrap());
         let cx = &mut *realm;
 
         let args = HandleValueArray::empty();
@@ -924,7 +925,7 @@ fn run_upgrade_constructor(
             run_a_callback::<DomTypeHolder, _>(window.upcast(), || {
                 if unsafe {
                     !Construct1(
-                        cx.raw_cx(),
+                        cx,
                         constructor_val.handle(),
                         &args,
                         construct_result.handle_mut(),

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2786,7 +2786,7 @@ impl GlobalScope {
         // Handled in `report_an_error`
 
         // Step 2. Let errorInfo be the result of extracting error information from exception.
-        let error_info = ErrorInfo::from_value(error, cx.into(), CanGc::from_cx(cx));
+        let error_info = ErrorInfo::from_value(cx, error);
 
         // Step 3. Let script be a script found in an implementation-defined way, or null.
         // This should usually be the running script (most notably during run a classic script).

--- a/components/script/dom/stream/compressionstream.rs
+++ b/components/script/dom/stream/compressionstream.rs
@@ -11,6 +11,7 @@ use brotli::CompressorWriter as BrotliEncoder;
 use dom_struct::dom_struct;
 use flate2::Compression;
 use flate2::write::{DeflateEncoder, GzEncoder, ZlibEncoder};
+use js::context::JSContext;
 use js::jsapi::JSObject;
 use js::jsval::UndefinedValue;
 use js::rust::{HandleObject as SafeHandleObject, HandleValue as SafeHandleValue};
@@ -23,14 +24,14 @@ use crate::dom::bindings::codegen::Bindings::CompressionStreamBinding::{
     CompressionFormat, CompressionStreamMethods,
 };
 use crate::dom::bindings::codegen::UnionTypes::ArrayBufferViewOrArrayBuffer;
-use crate::dom::bindings::conversions::{SafeFromJSValConvertible, SafeToJSValConvertible};
+use crate::dom::bindings::conversions::{FromJSValConvertible, SafeToJSValConvertible};
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::stream::transformstreamdefaultcontroller::TransformerType;
 use crate::dom::types::{
     GlobalScope, ReadableStream, TransformStream, TransformStreamDefaultController, WritableStream,
 };
-use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
+use crate::script_runtime::CanGc;
 
 pub(crate) const BROTLI_BUFFER_SIZE: usize = 4096;
 const BROTLI_QUALITIY_LEVEL: u32 = 5;
@@ -63,7 +64,7 @@ impl CompressionStream {
     }
 
     fn new_with_proto(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<SafeHandleObject>,
         transform: &TransformStream,
@@ -81,7 +82,7 @@ impl CompressionStream {
 impl CompressionStreamMethods<crate::DomTypeHolder> for CompressionStream {
     /// <https://compression.spec.whatwg.org/#dom-compressionstream-compressionstream>
     fn Constructor(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<SafeHandleObject>,
         format: CompressionFormat,
@@ -123,14 +124,14 @@ impl CompressionStreamMethods<crate::DomTypeHolder> for CompressionStream {
 
 /// <https://compression.spec.whatwg.org/#compress-and-enqueue-a-chunk>
 pub(crate) fn compress_and_enqueue_a_chunk(
-    cx: &mut js::context::JSContext,
+    cx: &mut JSContext,
     global: &GlobalScope,
     cs: &CompressionStream,
     chunk: SafeHandleValue,
     controller: &TransformStreamDefaultController,
 ) -> Fallible<()> {
     // Step 1. If chunk is not a BufferSource type, then throw a TypeError.
-    let chunk = convert_chunk_to_vec(cx.into(), chunk, CanGc::from_cx(cx))?;
+    let chunk = convert_chunk_to_vec(cx, chunk)?;
 
     // Step 2. Let buffer be the result of compressing chunk with cs’s format and context.
     // NOTE: In our implementation, the enum type of context already indicates the format.
@@ -165,7 +166,7 @@ pub(crate) fn compress_and_enqueue_a_chunk(
 
 /// <https://compression.spec.whatwg.org/#compress-flush-and-enqueue>
 pub(crate) fn compress_flush_and_enqueue(
-    cx: &mut js::context::JSContext,
+    cx: &mut JSContext,
     global: &GlobalScope,
     cs: &CompressionStream,
     controller: &TransformStreamDefaultController,
@@ -315,12 +316,11 @@ impl CompressionContext {
 }
 
 pub(crate) fn convert_chunk_to_vec(
-    cx: SafeJSContext,
+    cx: &mut JSContext,
     chunk: SafeHandleValue,
-    can_gc: CanGc,
 ) -> Result<Vec<u8>, Error> {
-    let conversion_result = ArrayBufferViewOrArrayBuffer::safe_from_jsval(cx, chunk, (), can_gc)
-        .map_err(|_| {
+    let conversion_result =
+        ArrayBufferViewOrArrayBuffer::safe_from_jsval(cx, chunk, ()).map_err(|_| {
             Error::Type(c"Unable to convert chunk into ArrayBuffer or ArrayBufferView".to_owned())
         })?;
     let buffer_source = conversion_result.get_success_value().ok_or_else(|| {

--- a/components/script/dom/stream/decompressionstream.rs
+++ b/components/script/dom/stream/decompressionstream.rs
@@ -126,7 +126,7 @@ pub(crate) fn decompress_and_enqueue_a_chunk(
     controller: &TransformStreamDefaultController,
 ) -> Fallible<()> {
     // Step 1. If chunk is not a BufferSource type, then throw a TypeError.
-    let chunk = convert_chunk_to_vec(cx.into(), chunk, CanGc::from_cx(cx))?;
+    let chunk = convert_chunk_to_vec(cx, chunk)?;
 
     // Step 2. Let buffer be the result of decompressing chunk with ds’s format and context. If
     // this results in an error, then throw a TypeError.

--- a/components/script/dom/webxr/xrsystem.rs
+++ b/components/script/dom/webxr/xrsystem.rs
@@ -8,6 +8,8 @@ use std::rc::Rc;
 use dom_struct::dom_struct;
 use ipc_channel::ipc::{self as ipc_crate, IpcReceiver};
 use ipc_channel::router::ROUTER;
+use js::context::JSContext;
+use js::realm::CurrentRealm;
 use profile_traits::generic_callback::GenericCallback as ProfileGenericCallback;
 use profile_traits::ipc;
 use script_bindings::cell::DomRefCell;
@@ -20,7 +22,7 @@ use crate::conversions::Convert;
 use crate::dom::bindings::codegen::Bindings::XRSystemBinding::{
     XRSessionInit, XRSessionMode, XRSystemMethods,
 };
-use crate::dom::bindings::conversions::{ConversionResult, SafeFromJSValConvertible};
+use crate::dom::bindings::conversions::{ConversionResult, FromJSValConvertible};
 use crate::dom::bindings::error::Error;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::{Trusted, TrustedPromise};
@@ -29,12 +31,10 @@ use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::gamepad::Gamepad;
-use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 use crate::dom::window::Window;
 use crate::dom::xrsession::XRSession;
 use crate::dom::xrtest::XRTest;
-use crate::realms::InRealm;
 use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 
@@ -158,14 +158,13 @@ impl XRSystemMethods<crate::DomTypeHolder> for XRSystem {
     /// <https://immersive-web.github.io/webxr/#dom-xr-requestsession>
     fn RequestSession(
         &self,
+        realm: &mut CurrentRealm,
         mode: XRSessionMode,
         init: RootedTraceableBox<XRSessionInit>,
-        comp: InRealm,
-        can_gc: CanGc,
     ) -> Rc<Promise> {
         let global = self.global();
         let window = global.as_window();
-        let promise = Promise::new_in_current_realm(comp, can_gc);
+        let promise = Promise::new_in_realm(realm);
 
         if mode != XRSessionMode::Inline {
             if !ScriptThread::is_user_interacting() {
@@ -174,13 +173,13 @@ impl XRSystemMethods<crate::DomTypeHolder> for XRSystem {
                         "The dom.webxr.unsafe-assume-user-intent preference assumes user intent to enter WebXR."
                     );
                 } else {
-                    promise.reject_error(Error::Security(None), can_gc);
+                    promise.reject_error_with_cx(realm, Error::Security(None));
                     return promise;
                 }
             }
 
             if self.pending_or_active_session() {
-                promise.reject_error(Error::InvalidState(None), can_gc);
+                promise.reject_error_with_cx(realm, Error::InvalidState(None));
                 return promise;
             }
 
@@ -189,12 +188,11 @@ impl XRSystemMethods<crate::DomTypeHolder> for XRSystem {
 
         let mut required_features = vec![];
         let mut optional_features = vec![];
-        let cx = GlobalScope::get_cx();
 
         if let Some(ref r) = init.requiredFeatures {
             for feature in r {
                 if let Ok(ConversionResult::Success(s)) =
-                    String::safe_from_jsval(cx, feature.handle(), (), can_gc)
+                    String::safe_from_jsval(realm, feature.handle(), ())
                 {
                     required_features.push(s)
                 } else {
@@ -202,7 +200,7 @@ impl XRSystemMethods<crate::DomTypeHolder> for XRSystem {
                     if mode != XRSessionMode::Inline {
                         self.pending_immersive_session.set(false);
                     }
-                    promise.reject_error(Error::NotSupported(None), can_gc);
+                    promise.reject_error_with_cx(realm, Error::NotSupported(None));
                     return promise;
                 }
             }
@@ -211,7 +209,7 @@ impl XRSystemMethods<crate::DomTypeHolder> for XRSystem {
         if let Some(ref o) = init.optionalFeatures {
             for feature in o {
                 if let Ok(ConversionResult::Success(s)) =
-                    String::safe_from_jsval(cx, feature.handle(), (), can_gc)
+                    String::safe_from_jsval(realm, feature.handle(), ())
                 {
                     optional_features.push(s)
                 } else {
@@ -256,8 +254,8 @@ impl XRSystemMethods<crate::DomTypeHolder> for XRSystem {
                     error!("requestSession callback given incorrect payload");
                     return;
                 };
-                task_source.queue(task!(request_session: move || {
-                    this.root().session_obtained(message, trusted.root(), mode, frame_receiver, CanGc::deprecated_note());
+                task_source.queue(task!(request_session: move |cx| {
+                    this.root().session_obtained(cx, message, trusted.root(), mode, frame_receiver);
                 }));
             }),
         );
@@ -277,11 +275,11 @@ impl XRSystemMethods<crate::DomTypeHolder> for XRSystem {
 impl XRSystem {
     fn session_obtained(
         &self,
+        cx: &mut JSContext,
         response: Result<Session, XRError>,
         promise: Rc<Promise>,
         mode: XRSessionMode,
         frame_receiver: IpcReceiver<Frame>,
-        can_gc: CanGc,
     ) {
         let session = match response {
             Ok(session) => session,
@@ -290,7 +288,7 @@ impl XRSystem {
                 if mode != XRSessionMode::Inline {
                     self.pending_immersive_session.set(false);
                 }
-                promise.reject_error(Error::NotSupported(None), can_gc);
+                promise.reject_error_with_cx(cx, Error::NotSupported(None));
                 return;
             },
         };
@@ -299,7 +297,7 @@ impl XRSystem {
             session,
             mode,
             frame_receiver,
-            CanGc::deprecated_note(),
+            CanGc::from_cx(cx),
         );
         if mode == XRSessionMode::Inline {
             self.active_inline_sessions
@@ -308,7 +306,7 @@ impl XRSystem {
         } else {
             self.set_active_immersive_session(&session);
         }
-        promise.resolve_native(&session, can_gc);
+        promise.resolve_native_with_cx(cx, &session);
         // https://github.com/immersive-web/webxr/issues/961
         // This must be called _after_ the promise is resolved
         session.setup_initial_inputs();

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1833,7 +1833,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     fn WebdriverException(&self, cx: &mut JSContext, value: HandleValue) {
         let webdriver_script_sender = self.webdriver_script_chan.borrow_mut().take();
         if let Some(webdriver_script_sender) = webdriver_script_sender {
-            let error_info = ErrorInfo::from_value(value, cx.into(), CanGc::from_cx(cx));
+            let error_info = ErrorInfo::from_value(cx, value);
             let _ = webdriver_script_sender.send(Err(
                 JavaScriptEvaluationError::EvaluationFailure(Some(
                     javascript_error_info_from_error_info(cx, &error_info, value),

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1331,8 +1331,8 @@ DOMInterfaces = {
 },
 
 'XRSystem': {
-    'inRealms': ['RequestSession'],
-    'canGc': ['RequestSession', 'IsSessionSupported'],
+    'canGc': ['IsSessionSupported'],
+    'realm': ['RequestSession'],
 },
 
 'XRTest': {


### PR DESCRIPTION
More propagation of `&mut JSContext` and replace some usages of wrapper trait `SafeFromJSValConvertible` with `FromJSValConvertible`.

Testing: It compiles
Part of #40600 
