### PR TITLE
layout: Remove unnecessary clone for get_lang_for_layout

### DIFF
--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -53,7 +53,7 @@ use style::values::computed::Overflow;
 use style::values::generics::NonNegative;
 use style::values::generics::position::PreferredRatio;
 use style::values::generics::ratio::Ratio;
-use style::values::{AtomIdent, CSSFloat, GenericAtomIdent, computed, specified};
+use style::values::{AtomIdent, AtomString, CSSFloat, GenericAtomIdent, computed, specified};
 use style::{ArcSlice, CaseSensitivityExt, dom_apis, thread_state};
 use style_traits::CSSPixel;
 use stylo_atoms::Atom;
@@ -1540,14 +1540,14 @@ impl<'dom> LayoutDom<'dom, Element> {
         None
     }
 
-    pub(crate) fn get_lang_for_layout(self) -> String {
+    pub(crate) fn get_lang_for_layout(self) -> AtomString {
         let mut current_node = Some(self.upcast::<Node>());
         while let Some(node) = current_node {
             current_node = node.composed_parent_node_ref();
             match node.downcast::<Element>() {
                 Some(elem) => {
                     if let Some(attr) = elem.get_lang_attr_val_for_layout() {
-                        return attr.to_owned();
+                        return AtomString::from(attr);
                     }
                 },
                 None => continue,
@@ -1555,7 +1555,7 @@ impl<'dom> LayoutDom<'dom, Element> {
         }
         // TODO: Check meta tags for a pragma-set default language
         // TODO: Check HTTP Content-Language header
-        String::new()
+        AtomString::from("")
     }
 
     #[inline]

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -1555,7 +1555,7 @@ impl<'dom> LayoutDom<'dom, Element> {
         }
         // TODO: Check meta tags for a pragma-set default language
         // TODO: Check HTTP Content-Language header
-        AtomString::from("")
+        AtomString::default()
     }
 
     #[inline]

--- a/components/script/layout_dom/servo_dangerous_style_element.rs
+++ b/components/script/layout_dom/servo_dangerous_style_element.rs
@@ -418,7 +418,7 @@ impl<'dom> style::dom::TElement for ServoDangerousStyleElement<'dom> {
         let element_lang = match override_lang {
             Some(Some(lang)) => lang,
             Some(None) => AtomString::default(),
-            None => AtomString::from(&*self.element.get_lang_for_layout()),
+            None => self.element.get_lang_for_layout(),
         };
         extended_filtering(&element_lang, value)
     }


### PR DESCRIPTION
This removes an unnecessary string creation/clone for get_lang_for_layout.

get_lang_for_layout is only read by match_element_lang which creates an AtomString. Directly returning an AtomString from the returned &str is more efficient than creating a String in between.

Testing: The output is exactly the same, so no need for extra tests.
