### PR TITLE
tests: enable service workers for the html suite

### DIFF
--- a/tests/wpt/meta/html/__dir__.ini
+++ b/tests/wpt/meta/html/__dir__.ini
@@ -1,0 +1,3 @@
+prefs: [
+  "dom_serviceworker_enabled:true",
+]

--- a/tests/wpt/meta/html/anonymous-iframe/worker-cookies.tentative.https.window.js.ini
+++ b/tests/wpt/meta/html/anonymous-iframe/worker-cookies.tentative.https.window.js.ini
@@ -2,15 +2,12 @@
   [Worker spawned from credentialless iframe can't access global cookies]
     expected: FAIL
 
+
 [worker-cookies.tentative.https.window.html?worker=dedicated_worker]
   [Worker spawned from credentialless iframe can't access global cookies]
     expected: FAIL
 
+
 [worker-cookies.tentative.https.window.html?worker=service_worker]
-  expected: TIMEOUT
-
   [Worker spawned from credentialless iframe can't access global cookies]
-    expected: NOTRUN
-
-  [Worker spawned from normal iframe can access global cookies]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/back-forward-cache/service-worker-client-postmessage.https.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/back-forward-cache/service-worker-client-postmessage.https.html.ini
@@ -1,3 +1,4 @@
 [service-worker-client-postmessage.https.html]
+  expected: TIMEOUT
   [Client.postMessage while a controlled page is in BFCache]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/browsing-the-web/back-forward-cache/service-worker-clients-claim.https.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/back-forward-cache/service-worker-clients-claim.https.html.ini
@@ -1,3 +1,4 @@
 [service-worker-clients-claim.https.html]
+  expected: TIMEOUT
   [Clients.claim() evicts pages that would be affected from BFCache]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/browsing-the-web/back-forward-cache/service-worker-clients-matchall.https.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/back-forward-cache/service-worker-clients-matchall.https.html.ini
@@ -1,3 +1,4 @@
 [service-worker-clients-matchall.https.html]
+  expected: TIMEOUT
   [Clients.matchAll() should not list pages in BFCache]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/browsing-the-web/back-forward-cache/service-worker-controlled-after-restore.https.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/back-forward-cache/service-worker-controlled-after-restore.https.html.ini
@@ -1,3 +1,4 @@
 [service-worker-controlled-after-restore.https.html]
+  expected: TIMEOUT
   [Pages should remain controlled after restored from BFCache]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/browsing-the-web/back-forward-cache/service-worker-unregister.https.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/back-forward-cache/service-worker-unregister.https.html.ini
@@ -1,3 +1,4 @@
 [service-worker-unregister.https.html]
+  expected: TIMEOUT
   [Unregister service worker while a controlled page is in BFCache]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/origin/api/origin-from-extendablemessageevent.any.js.ini
+++ b/tests/wpt/meta/html/browsers/origin/api/origin-from-extendablemessageevent.any.js.ini
@@ -1,2 +1,3 @@
 [origin-from-extendablemessageevent.any.serviceworker.html]
-  expected: ERROR
+  [Posted `ExtendableMessageEvent` objects have origins.]
+    expected: FAIL

--- a/tests/wpt/meta/html/browsers/origin/api/origin-from-global.any.js.ini
+++ b/tests/wpt/meta/html/browsers/origin/api/origin-from-global.any.js.ini
@@ -1,5 +1,7 @@
 [origin-from-global.any.serviceworker.html]
-  expected: ERROR
+  [Origin.from(globalThis) is a tuple origin.]
+    expected: FAIL
+
 
 [origin-from-global.any.worker.html]
   [Origin.from(globalThis) is a tuple origin.]

--- a/tests/wpt/meta/html/document-isolation-policy/credentialless-service-worker.https.tentative.window.js.ini
+++ b/tests/wpt/meta/html/document-isolation-policy/credentialless-service-worker.https.tentative.window.js.ini
@@ -1,12 +1,3 @@
 [credentialless-service-worker.https.tentative.window.html]
-  [fetch same-origin]
-    expected: FAIL
-
-  [fetch same-origin + credentialless worker]
-    expected: FAIL
-
-  [fetch cross-origin]
-    expected: FAIL
-
   [fetch cross-origin + credentialless worker]
     expected: FAIL

--- a/tests/wpt/meta/html/document-isolation-policy/isolate-and-require-corp-load-from-cache-storage.tentative.https.html.ini
+++ b/tests/wpt/meta/html/document-isolation-policy/isolate-and-require-corp-load-from-cache-storage.tentative.https.html.ini
@@ -1,87 +1,88 @@
 [isolate-and-require-corp-load-from-cache-storage.tentative.https.html]
+  expected: TIMEOUT
   [setting up]
-    expected: FAIL
+    expected: TIMEOUT
 
   [Fetch cross-origin cors   from service-worker and CacheStorage.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch cross-origin no-cors   from service-worker and CacheStorage.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch same-origin cors   from service-worker and CacheStorage.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch same-origin no-cors   from service-worker and CacheStorage.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch same-origin cors cors-disabled corp-cross-origin from network and CacheStorage.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch same-origin cors cors-disabled corp-same-origin from network and CacheStorage.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch same-origin cors cors-disabled corp-undefined from network and CacheStorage.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch same-origin cors cors-enabled corp-cross-origin from network and CacheStorage.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch same-origin cors cors-enabled corp-same-origin from network and CacheStorage.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch same-origin cors cors-enabled corp-undefined from network and CacheStorage.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch same-origin no-cors cors-disabled corp-cross-origin from network and CacheStorage.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch same-origin no-cors cors-disabled corp-same-origin from network and CacheStorage.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch same-origin no-cors cors-disabled corp-undefined from network and CacheStorage.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch same-origin no-cors cors-enabled corp-cross-origin from network and CacheStorage.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch same-origin no-cors cors-enabled corp-same-origin from network and CacheStorage.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch same-origin no-cors cors-enabled corp-undefined from network and CacheStorage.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch cross-origin cors cors-disabled corp-cross-origin from network and CacheStorage.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch cross-origin cors cors-disabled corp-same-origin from network and CacheStorage.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch cross-origin cors cors-disabled corp-undefined from network and CacheStorage.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch cross-origin cors cors-enabled corp-cross-origin from network and CacheStorage.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch cross-origin cors cors-enabled corp-same-origin from network and CacheStorage.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch cross-origin cors cors-enabled corp-undefined from network and CacheStorage.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch cross-origin no-cors cors-disabled corp-cross-origin from network and CacheStorage.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch cross-origin no-cors cors-disabled corp-same-origin from network and CacheStorage.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch cross-origin no-cors cors-disabled corp-undefined from network and CacheStorage.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch cross-origin no-cors cors-enabled corp-cross-origin from network and CacheStorage.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch cross-origin no-cors cors-enabled corp-same-origin from network and CacheStorage.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch cross-origin no-cors cors-enabled corp-undefined from network and CacheStorage.]
-    expected: FAIL
+    expected: NOTRUN

--- a/tests/wpt/meta/html/document-isolation-policy/service-worker-coep-credentialless-proxy.https.tentative.window.js.ini
+++ b/tests/wpt/meta/html/document-isolation-policy/service-worker-coep-credentialless-proxy.https.tentative.window.js.ini
@@ -1,3 +1,4 @@
 [service-worker-coep-credentialless-proxy.https.tentative.window.html]
+  expected: TIMEOUT
   [COEP:credentialless ServiceWorker]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/document-isolation-policy/service-worker-coep-none-proxy.https.tentative.window.js.ini
+++ b/tests/wpt/meta/html/document-isolation-policy/service-worker-coep-none-proxy.https.tentative.window.js.ini
@@ -1,3 +1,4 @@
 [service-worker-coep-none-proxy.https.tentative.window.html]
+  expected: TIMEOUT
   [COEP:unsafe-none ServiceWorker]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.js.ini
+++ b/tests/wpt/meta/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.js.ini
@@ -4,11 +4,12 @@
 
 
 [messagechannel.any.serviceworker.html]
-  expected: ERROR
+  expected: CRASH
 
 [messagechannel.any.sharedworker.html]
   [Growable SharedArrayBuffer]
     expected: FAIL
+
 
 [messagechannel.any.html]
   [Growable SharedArrayBuffer]

--- a/tests/wpt/meta/html/semantics/embedded-content/the-img-element/list-of-available-images-matching.https.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-img-element/list-of-available-images-matching.https.html.ini
@@ -1,2 +1,10 @@
 [list-of-available-images-matching.https.html]
-  expected: ERROR
+  expected: TIMEOUT
+  [registering service worker]
+    expected: TIMEOUT
+
+  [list of available images tuple-matching logic]
+    expected: NOTRUN
+
+  [unregistering service worker]
+    expected: NOTRUN

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/json-module/json-module-service-worker-test.https.html.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/json-module/json-module-service-worker-test.https.html.ini
@@ -1,9 +1,7 @@
 [json-module-service-worker-test.https.html]
+  expected: TIMEOUT
   [Trying to register a service worker with a top-level JSON Module should fail]
     expected: FAIL
 
   [JSON Module dynamic import should not load within the context of a service worker]
-    expected: FAIL
-
-  [Javascript importing JSON Module should load within the context of a service worker]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/dynamic-import/microtasks/serviceworker.any.js.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/dynamic-import/microtasks/serviceworker.any.js.ini
@@ -1,2 +1,3 @@
 [serviceworker.any.serviceworker.html]
-  expected: ERROR
+  [import() should not drain the microtask queue if it fails because it's used in a ServiceWorker]
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/import-meta/import-meta-object.any.js.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/import-meta/import-meta-object.any.js.ini
@@ -1,2 +1,2 @@
 [import-meta-object.any.serviceworker-module.html]
-  expected: ERROR
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/import-meta/import-meta-resolve.any.js.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/import-meta/import-meta-resolve.any.js.ini
@@ -1,2 +1,2 @@
 [import-meta-resolve.any.serviceworker-module.html]
-  expected: ERROR
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/import-meta/import-meta-url.any.js.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/import-meta/import-meta-url.any.js.ini
@@ -1,2 +1,2 @@
 [import-meta-url.any.serviceworker-module.html]
-  expected: ERROR
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/text-module/service-worker-test.https.html.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/text-module/service-worker-test.https.html.ini
@@ -1,9 +1,7 @@
 [service-worker-test.https.html]
+  expected: TIMEOUT
   [Trying to register a service worker with a top-level text module should fail]
     expected: FAIL
 
   [Text module dynamic import should not load within the context of a service worker]
-    expected: FAIL
-
-  [Javascript importing text module should load within the context of a service worker]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/webappapis/microtask-queuing/queue-microtask-exceptions.any.js.ini
+++ b/tests/wpt/meta/html/webappapis/microtask-queuing/queue-microtask-exceptions.any.js.ini
@@ -1,2 +1,0 @@
-[queue-microtask-exceptions.any.serviceworker.html]
-  expected: ERROR

--- a/tests/wpt/meta/html/webappapis/microtask-queuing/queue-microtask.any.js.ini
+++ b/tests/wpt/meta/html/webappapis/microtask-queuing/queue-microtask.any.js.ini
@@ -1,2 +1,0 @@
-[queue-microtask.any.serviceworker.html]
-  expected: ERROR

--- a/tests/wpt/meta/html/webappapis/scripting/events/messageevent-constructor.https.html.ini
+++ b/tests/wpt/meta/html/webappapis/scripting/events/messageevent-constructor.https.html.ini
@@ -1,3 +1,4 @@
 [messageevent-constructor.https.html]
+  expected: TIMEOUT
   [Passing ServiceWorker for source member]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-agent-formalism/requires-failure.https.any.js.ini
+++ b/tests/wpt/meta/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-agent-formalism/requires-failure.https.any.js.ini
@@ -4,4 +4,5 @@
 
 
 [requires-failure.https.any.serviceworker.html]
-  expected: ERROR
+  [[[CanBlock\]\] in a ServiceWorkerGlobalScope]
+    expected: FAIL

--- a/tests/wpt/meta/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/promise-rejection-events.serviceworker.https.html.ini
+++ b/tests/wpt/meta/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/promise-rejection-events.serviceworker.https.html.ini
@@ -1,3 +1,4 @@
 [promise-rejection-events.serviceworker.https.html]
+  expected: TIMEOUT
   [Service worker setup]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/webappapis/system-state-and-capabilities/the-navigator-object/protocol-handler-fragment.https.html.ini
+++ b/tests/wpt/meta/html/webappapis/system-state-and-capabilities/the-navigator-object/protocol-handler-fragment.https.html.ini
@@ -1,3 +1,4 @@
 [protocol-handler-fragment.https.html]
+  expected: TIMEOUT
   [registerProtocolHandler() and a handler with %s in the fragment]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/webappapis/system-state-and-capabilities/the-navigator-object/protocol-handler-path.https.html.ini
+++ b/tests/wpt/meta/html/webappapis/system-state-and-capabilities/the-navigator-object/protocol-handler-path.https.html.ini
@@ -1,3 +1,4 @@
 [protocol-handler-path.https.html]
+  expected: TIMEOUT
   [registerProtocolHandler() and a handler with %s in the path]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/webappapis/system-state-and-capabilities/the-navigator-object/protocol-handler-query.https.html.ini
+++ b/tests/wpt/meta/html/webappapis/system-state-and-capabilities/the-navigator-object/protocol-handler-query.https.html.ini
@@ -1,3 +1,4 @@
 [protocol-handler-query.https.html]
+  expected: TIMEOUT
   [registerProtocolHandler() and a handler with %s in the query]
-    expected: FAIL
+    expected: TIMEOUT


### PR DESCRIPTION
Enable dom_serviceworker_enabled for the html WPT suite

Testing: WPT html (5 runs)
Fixes: Part of #45331

