### PR TITLE
layout: reduce redundant atomic style borrows (4% faster layout)

### DIFF
--- a/components/layout/display_list/background.rs
+++ b/components/layout/display_list/background.rs
@@ -123,7 +123,7 @@ impl<'a> BackgroundPainter<'a> {
     ) -> wr::CommonItemProperties {
         let clip = self.clip(fragment_builder, builder, state, layer_index);
         let style = fragment_builder.fragment.style();
-        let mut common = builder.common_properties(state, painting_area, &style);
+        let mut common = builder.common_properties(state, painting_area, style);
         if let Some(clip_chain_id) = clip {
             common.clip_chain_id = clip_chain_id;
         }

--- a/components/layout/display_list/clip.rs
+++ b/components/layout/display_list/clip.rs
@@ -91,7 +91,8 @@ impl StackingContextTreeClipStore {
             ClipPath::Box(ShapeGeometryBox::ElementDependent) => ShapeBox::BorderBox,
             _ => return None,
         };
-        let fragment_builder = BuilderForBoxFragment::new(box_fragment, containing_block_origin);
+        let fragment = box_fragment.with_style();
+        let fragment_builder = BuilderForBoxFragment::new(&fragment, containing_block_origin);
         let layout_rect = match geometry_box {
             ShapeBox::BorderBox => fragment_builder.border_rect,
             ShapeBox::ContentBox => *fragment_builder.content_rect(),

--- a/components/layout/display_list/clip.rs
+++ b/components/layout/display_list/clip.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cell::LazyCell;
+use std::sync::Arc;
 
 use app_units::Au;
 use malloc_size_of_derive::MallocSizeOf;
@@ -81,7 +82,7 @@ impl StackingContextTreeClipStore {
         clip_path: &ClipPath,
         parent_scroll_node_id: ScrollTreeNodeId,
         parent_clip_chain_id: ClipId,
-        box_fragment: &BoxFragment,
+        box_fragment: &Arc<BoxFragment>,
         containing_block_origin: PhysicalPoint<Au>,
     ) -> Option<ClipId> {
         let geometry_box = match clip_path {

--- a/components/layout/display_list/clip.rs
+++ b/components/layout/display_list/clip.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cell::LazyCell;
-use std::sync::Arc;
 
 use app_units::Au;
 use malloc_size_of_derive::MallocSizeOf;
@@ -17,7 +16,7 @@ use webrender_api::BorderRadius;
 use webrender_api::units::{LayoutPoint, LayoutRect, LayoutSideOffsets, LayoutSize};
 
 use super::{BuilderForBoxFragment, compute_margin_box_radius};
-use crate::fragment_tree::BoxFragment;
+use crate::fragment_tree::BoxFragmentWithStyle;
 use crate::geom::PhysicalPoint;
 
 /// An identifier for a clip used during StackingContextTree construction. This is a simple index in
@@ -82,7 +81,7 @@ impl StackingContextTreeClipStore {
         clip_path: &ClipPath,
         parent_scroll_node_id: ScrollTreeNodeId,
         parent_clip_chain_id: ClipId,
-        box_fragment: &Arc<BoxFragment>,
+        box_fragment: &BoxFragmentWithStyle<'_>,
         containing_block_origin: PhysicalPoint<Au>,
     ) -> Option<ClipId> {
         let geometry_box = match clip_path {
@@ -92,8 +91,7 @@ impl StackingContextTreeClipStore {
             ClipPath::Box(ShapeGeometryBox::ElementDependent) => ShapeBox::BorderBox,
             _ => return None,
         };
-        let fragment = box_fragment.with_style();
-        let fragment_builder = BuilderForBoxFragment::new(&fragment, containing_block_origin);
+        let fragment_builder = BuilderForBoxFragment::new(box_fragment, containing_block_origin);
         let layout_rect = match geometry_box {
             ShapeBox::BorderBox => fragment_builder.border_rect,
             ShapeBox::ContentBox => *fragment_builder.content_rect(),

--- a/components/layout/display_list/hit_test.rs
+++ b/components/layout/display_list/hit_test.rs
@@ -23,7 +23,7 @@ use webrender_api::units::{LayoutPoint, LayoutRect, LayoutSize, RectExt};
 use crate::display_list::clip::{Clip, ClipId};
 use crate::display_list::paint_traversal::{PaintTraversal, PaintTraversalHandler};
 use crate::display_list::{StackingContext, StackingContextTree, ToWebRender, TraversalState};
-use crate::fragment_tree::{BoxFragment, Fragment, FragmentFlags, TextFragment};
+use crate::fragment_tree::{BoxFragmentWithStyle, Fragment, FragmentFlags, TextFragment};
 use crate::geom::PhysicalRect;
 
 pub(crate) struct HitTest<'a> {
@@ -121,8 +121,8 @@ impl PaintTraversalHandler for HitTest<'_> {
 
     fn visit_stacking_context(&mut self, _: &StackingContext) -> Self::StackingContextState {}
     fn leave_stacking_context(&mut self, _: &TraversalState, _: Self::StackingContextState) {}
-    fn visit_box(&mut self, state: &TraversalState, fragment: &Arc<BoxFragment>) {
-        Fragment::Box(fragment.clone()).hit_test(state, self);
+    fn visit_box(&mut self, state: &TraversalState, fragment: &BoxFragmentWithStyle<'_>) {
+        Fragment::Box(fragment.box_fragment.clone()).hit_test(state, self);
     }
     fn visit_text(
         &mut self,

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -679,7 +679,7 @@ impl PaintTraversalHandler for DisplayListBuilder<'_> {
         }
     }
 
-    fn visit_box(&mut self, state: &TraversalState, fragment: &Arc<BoxFragment>) {
+    fn visit_box(&mut self, state: &TraversalState, fragment: &BoxFragmentWithStyle<'_>) {
         fragment.base.visit_fragment(self);
 
         if let Some(mut inspector_highlight) = self.inspector_highlight.take() &&
@@ -689,12 +689,11 @@ impl PaintTraversalHandler for DisplayListBuilder<'_> {
             self.inspector_highlight = Some(inspector_highlight);
         }
 
-        let fragment = fragment.with_style();
         if fragment.style().get_inherited_box().visibility != Visibility::Visible {
             return;
         };
 
-        BuilderForBoxFragment::new(&fragment, state.origin).build(self, state)
+        BuilderForBoxFragment::new(fragment, state.origin).build(self, state)
     }
 
     fn visit_iframe(&mut self, state: &TraversalState, fragment: &Arc<IFrameFragment>) {

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -898,13 +898,12 @@ impl PaintTraversalHandler for DisplayListBuilder<'_> {
     fn visit_box_for_collapsed_table_borders(
         &mut self,
         state: &TraversalState,
-        fragment: &Arc<BoxFragment>,
+        fragment: &BoxFragmentWithStyle<'_>,
     ) {
-        let fragment = fragment.with_style();
         if fragment.style().get_inherited_box().visibility != Visibility::Visible {
             return;
         };
-        BuilderForBoxFragment::new(&fragment, state.origin)
+        BuilderForBoxFragment::new(fragment, state.origin)
             .build_collapsed_table_borders(self, state)
     }
 }

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -60,9 +60,9 @@ use crate::display_list::conversions::FilterToWebRender;
 pub(crate) use crate::display_list::conversions::ToWebRender;
 use crate::display_list::paint_traversal::{PaintTraversal, PaintTraversalHandler, TraversalState};
 use crate::fragment_tree::{
-    BackgroundMode, BaseFragment, BoxFragment, ContainingBlockCalculation, Fragment, FragmentFlags,
-    FragmentStatus, FragmentTree, IFrameFragment, ImageFragment, PositioningFragment,
-    SpecificLayoutInfo, Tag, TextFragment,
+    BackgroundMode, BaseFragment, BoxFragment, BoxFragmentWithStyle, ContainingBlockCalculation,
+    Fragment, FragmentFlags, FragmentStatus, FragmentTree, IFrameFragment, ImageFragment,
+    PositioningFragment, SpecificLayoutInfo, Tag, TextFragment,
 };
 use crate::geom::{
     LengthPercentageOrAuto, PhysicalPoint, PhysicalRect, PhysicalSides, PhysicalSize,
@@ -689,11 +689,12 @@ impl PaintTraversalHandler for DisplayListBuilder<'_> {
             self.inspector_highlight = Some(inspector_highlight);
         }
 
+        let fragment = fragment.with_style();
         if fragment.style().get_inherited_box().visibility != Visibility::Visible {
             return;
         };
 
-        BuilderForBoxFragment::new(fragment, state.origin).build(self, state)
+        BuilderForBoxFragment::new(&fragment, state.origin).build(self, state)
     }
 
     fn visit_iframe(&mut self, state: &TraversalState, fragment: &Arc<IFrameFragment>) {
@@ -813,6 +814,7 @@ impl PaintTraversalHandler for DisplayListBuilder<'_> {
         let Some(fragment) = self.fragment_tree.root_box_fragment() else {
             return;
         };
+        let fragment = fragment.with_style();
 
         let source_style = {
             // > For documents whose root element is an HTML HTML element or an XHTML html element
@@ -887,10 +889,11 @@ impl PaintTraversalHandler for DisplayListBuilder<'_> {
     }
 
     fn visit_box_for_outline(&mut self, state: &TraversalState, fragment: &Arc<BoxFragment>) {
+        let fragment = fragment.with_style();
         if fragment.style().get_inherited_box().visibility != Visibility::Visible {
             return;
         };
-        BuilderForBoxFragment::new(fragment, state.origin).build_outline(self, state)
+        BuilderForBoxFragment::new(&fragment, state.origin).build_outline(self, state)
     }
 
     fn visit_box_for_collapsed_table_borders(
@@ -898,10 +901,11 @@ impl PaintTraversalHandler for DisplayListBuilder<'_> {
         state: &TraversalState,
         fragment: &Arc<BoxFragment>,
     ) {
+        let fragment = fragment.with_style();
         if fragment.style().get_inherited_box().visibility != Visibility::Visible {
             return;
         };
-        BuilderForBoxFragment::new(fragment, state.origin)
+        BuilderForBoxFragment::new(&fragment, state.origin)
             .build_collapsed_table_borders(self, state)
     }
 }
@@ -1307,7 +1311,7 @@ impl Fragment {
 }
 
 struct BuilderForBoxFragment<'a> {
-    fragment: &'a BoxFragment,
+    fragment: &'a BoxFragmentWithStyle<'a>,
     containing_block_origin: PhysicalPoint<Au>,
     border_rect: units::LayoutRect,
     margin_rect: OnceCell<units::LayoutRect>,
@@ -1320,7 +1324,10 @@ struct BuilderForBoxFragment<'a> {
 }
 
 impl<'a> BuilderForBoxFragment<'a> {
-    fn new(fragment: &'a BoxFragment, containing_block_origin: PhysicalPoint<Au>) -> Self {
+    fn new(
+        fragment: &'a BoxFragmentWithStyle<'a>,
+        containing_block_origin: PhysicalPoint<Au>,
+    ) -> Self {
         let border_rect = fragment
             .border_rect()
             .translate(containing_block_origin.to_vector());
@@ -1482,7 +1489,7 @@ impl<'a> BuilderForBoxFragment<'a> {
             .paint_info
             .external_scroll_id_for_scroll_tree_node(state.spatial_id);
 
-        let mut common = builder.common_properties(state, rect, &self.fragment.style());
+        let mut common = builder.common_properties(state, rect, self.fragment.style());
         if let Some(clip_chain_id) = self.border_edge_clip(builder, state, false) {
             common.clip_chain_id = clip_chain_id;
         }
@@ -1574,7 +1581,7 @@ impl<'a> BuilderForBoxFragment<'a> {
         }
 
         let painter = BackgroundPainter {
-            style: &self.fragment.style(),
+            style: self.fragment.style(),
             painting_area_override: None,
             positioning_area_override: None,
         };
@@ -1832,7 +1839,7 @@ impl<'a> BuilderForBoxFragment<'a> {
             return;
         };
         let mut common =
-            builder.common_properties(state, units::LayoutRect::default(), &self.fragment.style());
+            builder.common_properties(state, units::LayoutRect::default(), self.fragment.style());
         let radius = wr::BorderRadius::default();
         let mut column_sum = Au::zero();
         for (x, column_size) in table_info.track_sizes.x.iter().enumerate() {
@@ -1919,7 +1926,7 @@ impl<'a> BuilderForBoxFragment<'a> {
             radius: self.border_radius(),
             do_aa: true,
         });
-        let common = builder.common_properties(state, self.border_rect, &style);
+        let common = builder.common_properties(state, self.border_rect, style);
         builder
             .wr()
             .push_border(&common, self.border_rect, border_widths, details)
@@ -1947,7 +1954,7 @@ impl<'a> BuilderForBoxFragment<'a> {
         let border_image_repeat = &border_style_struct.border_image_repeat;
         let border_image_fill = border_style_struct.border_image_slice.fill;
         let border_image_slice = &border_style_struct.border_image_slice.offsets;
-        let common = builder.common_properties(state, border_image_area.to_box2d(), &style);
+        let common = builder.common_properties(state, border_image_area.to_box2d(), style);
 
         let stops = Vec::new();
         let mut width = border_image_size.width;
@@ -1998,7 +2005,7 @@ impl<'a> BuilderForBoxFragment<'a> {
                 NinePatchBorderSource::Image(key, image_rendering)
             },
             Ok(ResolvedImage::Gradient(gradient)) => {
-                match gradient::build(&style, gradient, border_image_size, builder) {
+                match gradient::build(style, gradient, border_image_size, builder) {
                     WebRenderGradient::Linear(gradient) => {
                         NinePatchBorderSource::Gradient(gradient)
                     },
@@ -2077,7 +2084,7 @@ impl<'a> BuilderForBoxFragment<'a> {
             offset.max(-self.border_rect.width() / 2.0 + width),
             offset.max(-self.border_rect.height() / 2.0 + width),
         );
-        let common = builder.common_properties(state, outline_rect, &style);
+        let common = builder.common_properties(state, outline_rect, style);
         let widths = SideOffsets2D::new_all_same(width);
         let border_style = match outline.outline_style {
             // TODO: treating 'auto' as 'solid' is allowed by the spec,
@@ -2151,7 +2158,7 @@ impl<'a> BuilderForBoxFragment<'a> {
                     BoxShadowClipMode::Outset => spread,
                 }),
             );
-            let common = builder.common_properties(state, clip_rect, &style);
+            let common = builder.common_properties(state, clip_rect, style);
             builder.wr().push_box_shadow(
                 &common,
                 rect,

--- a/components/layout/display_list/paint_traversal.rs
+++ b/components/layout/display_list/paint_traversal.rs
@@ -536,9 +536,7 @@ pub(crate) struct TraversalState {
 }
 
 impl TraversalState {
-    #[inline]
-    pub(crate) fn push_box_fragment(&self, box_fragment: &Arc<BoxFragment>) -> Self {
-        let box_fragment = box_fragment.with_style();
+    pub(crate) fn push_box_fragment(&self, box_fragment: &BoxFragmentWithStyle<'_>) -> Self {
         let style = box_fragment.style();
 
         // Text decorations are not propagated to atomic inline-level descendants.

--- a/components/layout/display_list/paint_traversal.rs
+++ b/components/layout/display_list/paint_traversal.rs
@@ -172,10 +172,9 @@ impl<'a, Handler: PaintTraversalHandler> PaintTraversal<'a, Handler> {
     fn traverse_stacking_container(
         &mut self,
         state: &TraversalState,
-        root: &Arc<BoxFragment>,
+        root: &BoxFragmentWithStyle<'_>,
         is_block_level: bool,
     ) {
-        let root = &root.with_style();
         let old_outlines_length = self.outlines.len();
 
         // > Step 4: If root is a block-level box, paint a block’s decorations given root
@@ -455,7 +454,7 @@ impl<'a, Handler: PaintTraversalHandler> PaintTraversal<'a, Handler> {
                 Fragment::LayoutRoot(layout_root_fragment) => {
                     self.traverse_stacking_container(
                         &state.without_text_decorations(),
-                        &layout_root_fragment.inner_box_fragment(),
+                        &layout_root_fragment.inner_box_fragment().with_style(),
                         true, /* is_block_level */
                     );
                 },
@@ -471,7 +470,7 @@ impl<'a, Handler: PaintTraversalHandler> PaintTraversal<'a, Handler> {
                 Fragment::Box(box_fragment) => {
                     self.traverse_stacking_container(
                         &state.without_text_decorations(),
-                        box_fragment,
+                        &box_fragment.with_style(),
                         true, /* is_block_level */
                     );
                 },

--- a/components/layout/display_list/paint_traversal.rs
+++ b/components/layout/display_list/paint_traversal.rs
@@ -61,7 +61,7 @@ impl<'a, Handler: PaintTraversalHandler> PaintTraversal<'a, Handler> {
         // > and canvas.
         let root_fragment = stacking_context.fragment();
         if let Some(root_fragment) = root_fragment &&
-            !root_fragment.is_inline_box()
+            !root_fragment.with_style().is_inline_box()
         {
             self.handle_box(&state, root_fragment);
         }
@@ -110,6 +110,7 @@ impl<'a, Handler: PaintTraversalHandler> PaintTraversal<'a, Handler> {
     }
 
     fn traverse_stacking_context_inner(&mut self, state: &TraversalState, root: &Arc<BoxFragment>) {
+        let root = &root.with_style();
         let old_float_length = self.floats.len();
         let mut saw_inline_level_or_replaced = root.is_replaced();
 
@@ -205,6 +206,7 @@ impl<'a, Handler: PaintTraversalHandler> PaintTraversal<'a, Handler> {
                 );
             },
             Fragment::Box(box_fragment) => {
+                let box_fragment = &box_fragment.with_style();
                 // If this box establishes a stacking context or stacking container, do not paint
                 // it during this phase. Instead it is painted when the stacking context or container
                 // is processed.
@@ -387,6 +389,7 @@ impl<'a, Handler: PaintTraversalHandler> PaintTraversal<'a, Handler> {
         box_fragment: &Arc<BoxFragment>,
         at_stacking_context_root: bool,
     ) {
+        let box_fragment = &box_fragment.with_style();
         // If this box establishes a stacking context or stacking container, do not paint
         // it during this phase. Instead it is painted when the stacking context or container
         // is processed.
@@ -529,7 +532,8 @@ pub(crate) struct TraversalState {
 
 impl TraversalState {
     #[inline]
-    pub(crate) fn push_box_fragment(&self, box_fragment: &BoxFragment) -> Self {
+    pub(crate) fn push_box_fragment(&self, box_fragment: &Arc<BoxFragment>) -> Self {
+        let box_fragment = box_fragment.with_style();
         let style = box_fragment.style();
 
         // Text decorations are not propagated to atomic inline-level descendants.

--- a/components/layout/display_list/paint_traversal.rs
+++ b/components/layout/display_list/paint_traversal.rs
@@ -499,7 +499,7 @@ pub(crate) trait PaintTraversalHandler {
         stacking_context_state: Self::StackingContextState,
     );
 
-    fn visit_box(&mut self, state: &TraversalState, fragment: &Arc<BoxFragment>);
+    fn visit_box(&mut self, state: &TraversalState, fragment: &BoxFragmentWithStyle<'_>);
     fn visit_iframe(&mut self, _state: &TraversalState, _fragment: &Arc<IFrameFragment>) {}
     fn visit_image(
         &mut self,

--- a/components/layout/display_list/paint_traversal.rs
+++ b/components/layout/display_list/paint_traversal.rs
@@ -366,7 +366,7 @@ impl<'a, Handler: PaintTraversalHandler> PaintTraversal<'a, Handler> {
             },
             Fragment::Box(box_fragment) => self.traverse_box_in_a_line_box(
                 state,
-                box_fragment,
+                &box_fragment.with_style(),
                 false, /* at_stacking_context_root */
             ),
             Fragment::Text(text_fragment) => {
@@ -391,10 +391,9 @@ impl<'a, Handler: PaintTraversalHandler> PaintTraversal<'a, Handler> {
     fn traverse_box_in_a_line_box(
         &mut self,
         state: &TraversalState,
-        box_fragment: &Arc<BoxFragment>,
+        box_fragment: &BoxFragmentWithStyle<'_>,
         at_stacking_context_root: bool,
     ) {
-        let box_fragment = &box_fragment.with_style();
         // If this box establishes a stacking context or stacking container, do not paint
         // it during this phase. Instead it is painted when the stacking context or container
         // is processed.

--- a/components/layout/display_list/paint_traversal.rs
+++ b/components/layout/display_list/paint_traversal.rs
@@ -110,8 +110,11 @@ impl<'a, Handler: PaintTraversalHandler> PaintTraversal<'a, Handler> {
             .leave_stacking_context(&state, stacking_context_state);
     }
 
-    fn traverse_stacking_context_inner(&mut self, state: &TraversalState, root: &Arc<BoxFragment>) {
-        let root = &root.with_style();
+    fn traverse_stacking_context_inner(
+        &mut self,
+        state: &TraversalState,
+        root: &BoxFragmentWithStyle<'_>,
+    ) {
         let old_float_length = self.floats.len();
         let mut saw_inline_level_or_replaced = root.is_replaced();
 

--- a/components/layout/display_list/paint_traversal.rs
+++ b/components/layout/display_list/paint_traversal.rs
@@ -13,8 +13,8 @@ use crate::display_list::{
     ClipId, FragmentTextDecoration, StackingContext, StackingContextFragments,
 };
 use crate::fragment_tree::{
-    BoxFragment, Fragment, FragmentFlags, IFrameFragment, ImageFragment, PositioningFragment,
-    TextFragment,
+    BoxFragment, BoxFragmentWithStyle, Fragment, FragmentFlags, IFrameFragment, ImageFragment,
+    PositioningFragment, TextFragment,
 };
 use crate::geom::{PhysicalPoint, PhysicalRect};
 
@@ -60,8 +60,9 @@ impl<'a, Handler: PaintTraversalHandler> PaintTraversal<'a, Handler> {
         // > Step 4: If root is a block-level box, paint a block’s decorations given root
         // > and canvas.
         let root_fragment = stacking_context.fragment();
-        if let Some(root_fragment) = root_fragment &&
-            !root_fragment.with_style().is_inline_box()
+        let root_fragment = root_fragment.as_ref().map(|f| f.with_style());
+        if let Some(root_fragment) = &root_fragment &&
+            !root_fragment.is_inline_box()
         {
             self.handle_box(&state, root_fragment);
         }
@@ -77,7 +78,7 @@ impl<'a, Handler: PaintTraversalHandler> PaintTraversal<'a, Handler> {
             );
         }
 
-        if let Some(root_fragment) = root_fragment {
+        if let Some(root_fragment) = &root_fragment {
             self.traverse_stacking_context_inner(&state, root_fragment);
         }
 
@@ -133,6 +134,7 @@ impl<'a, Handler: PaintTraversalHandler> PaintTraversal<'a, Handler> {
         // > paint a stacking container given the descendant and canvas.
         if old_float_length < self.floats.len() {
             for (state, float_fragment) in &self.floats.split_off(old_float_length) {
+                let float_fragment = &float_fragment.with_style();
                 self.handle_box(state, float_fragment);
                 self.traverse_stacking_context_inner(state, float_fragment);
             }
@@ -170,6 +172,7 @@ impl<'a, Handler: PaintTraversalHandler> PaintTraversal<'a, Handler> {
         root: &Arc<BoxFragment>,
         is_block_level: bool,
     ) {
+        let root = &root.with_style();
         let old_outlines_length = self.outlines.len();
 
         // > Step 4: If root is a block-level box, paint a block’s decorations given root
@@ -279,6 +282,7 @@ impl<'a, Handler: PaintTraversalHandler> PaintTraversal<'a, Handler> {
         fragment: &Arc<BoxFragment>,
         at_root_of_stacking_context: bool,
     ) {
+        let fragment = &fragment.with_style();
         let is_flex_or_grid = fragment.is_flex_or_grid_item();
         if fragment.is_replaced() {
             if is_flex_or_grid {
@@ -473,9 +477,10 @@ impl<'a, Handler: PaintTraversalHandler> PaintTraversal<'a, Handler> {
         }
     }
 
-    fn handle_box(&mut self, state: &TraversalState, fragment: &Arc<BoxFragment>) {
+    fn handle_box(&mut self, state: &TraversalState, fragment: &BoxFragmentWithStyle<'_>) {
         if fragment.has_outline() {
-            self.outlines.push((state.clone(), fragment.clone()));
+            self.outlines
+                .push((state.clone(), fragment.box_fragment.clone()));
         }
         self.handler.visit_box(state, fragment);
     }

--- a/components/layout/display_list/paint_traversal.rs
+++ b/components/layout/display_list/paint_traversal.rs
@@ -60,7 +60,9 @@ impl<'a, Handler: PaintTraversalHandler> PaintTraversal<'a, Handler> {
         // > Step 4: If root is a block-level box, paint a block’s decorations given root
         // > and canvas.
         let root_fragment = stacking_context.fragment();
-        let root_fragment = root_fragment.as_ref().map(|f| f.with_style());
+        let root_fragment = root_fragment
+            .as_ref()
+            .map(|root_fragment| root_fragment.with_style());
         if let Some(root_fragment) = &root_fragment &&
             !root_fragment.is_inline_box()
         {

--- a/components/layout/display_list/paint_traversal.rs
+++ b/components/layout/display_list/paint_traversal.rs
@@ -281,10 +281,9 @@ impl<'a, Handler: PaintTraversalHandler> PaintTraversal<'a, Handler> {
     fn traverse_line_boxes_and_replaced_for_box(
         &mut self,
         state: &TraversalState,
-        fragment: &Arc<BoxFragment>,
+        fragment: &BoxFragmentWithStyle<'_>,
         at_root_of_stacking_context: bool,
     ) {
-        let fragment = &fragment.with_style();
         let is_flex_or_grid = fragment.is_flex_or_grid_item();
         if fragment.is_replaced() {
             if is_flex_or_grid {
@@ -332,7 +331,7 @@ impl<'a, Handler: PaintTraversalHandler> PaintTraversal<'a, Handler> {
                 }
                 self.traverse_line_boxes_and_replaced_for_box(
                     state,
-                    box_fragment,
+                    &box_fragment.with_style(),
                     at_root_of_stacking_context,
                 );
             },

--- a/components/layout/display_list/paint_traversal.rs
+++ b/components/layout/display_list/paint_traversal.rs
@@ -522,7 +522,7 @@ pub(crate) trait PaintTraversalHandler {
     fn visit_box_for_collapsed_table_borders(
         &mut self,
         _state: &TraversalState,
-        _fragment: &Arc<BoxFragment>,
+        _fragment: &BoxFragmentWithStyle<'_>,
     ) {
     }
 }

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -40,8 +40,8 @@ use super::clip::StackingContextTreeClipStore;
 use crate::display_list::conversions::ToWebRender;
 use crate::display_list::{BuilderForBoxFragment, offset_radii};
 use crate::fragment_tree::{
-    BoxFragment, ContainingBlockCalculation, ContainingBlockManager, Fragment, FragmentFlags,
-    FragmentTree, PositioningFragment,
+    BoxFragment, BoxFragmentWithStyle, ContainingBlockCalculation, ContainingBlockManager,
+    Fragment, FragmentFlags, FragmentTree, PositioningFragment,
 };
 use crate::geom::{
     AuOrAuto, LengthPercentageOrAuto, PhysicalPoint, PhysicalRect, PhysicalSides, PhysicalVec,
@@ -779,7 +779,7 @@ impl BoxFragment {
             .for_non_absolute_descendants
             .scroll_frame_size;
         let mut new_clip_id = containing_block.clip_id;
-        if let Some(overflow_frame_data) = self.build_overflow_frame_if_necessary(
+        if let Some(overflow_frame_data) = with_style.build_overflow_frame_if_necessary(
             stacking_context_tree,
             new_scroll_node_id,
             new_clip_id,
@@ -910,16 +910,17 @@ impl BoxFragment {
             parent_clip_id,
         ))
     }
+}
 
+impl BoxFragmentWithStyle<'_> {
     fn build_overflow_frame_if_necessary(
-        self: &Arc<Self>,
+        &self,
         stacking_context_tree: &mut StackingContextTree,
         parent_scroll_node_id: ScrollTreeNodeId,
         parent_clip_id: ClipId,
         containing_block_rect: &PhysicalRect<Au>,
     ) -> Option<OverflowFrameData> {
-        let with_style = self.with_style();
-        let style = with_style.style();
+        let style = self.style();
         let overflow = style.effective_overflow(self.base.flags);
 
         if overflow.x == ComputedOverflow::Visible && overflow.y == ComputedOverflow::Visible {
@@ -946,7 +947,7 @@ impl BoxFragment {
             // https://drafts.csswg.org/css-overflow-3/#corner-clipping
             let radii;
             if overflow.x == ComputedOverflow::Clip && overflow.y == ComputedOverflow::Clip {
-                let builder = BuilderForBoxFragment::new(&with_style, containing_block_rect.origin);
+                let builder = BuilderForBoxFragment::new(self, containing_block_rect.origin);
                 let mut offsets_from_border = SideOffsets2D::new_all_same(clip_margin_offset);
                 match overflow_clip_margin.visual_box {
                     OverflowClipMarginBox::ContentBox => {
@@ -989,7 +990,7 @@ impl BoxFragment {
             .to_webrender();
 
         let clip_id = stacking_context_tree.clip_store.add(
-            BuilderForBoxFragment::new(&with_style, containing_block_rect.origin).border_radius(),
+            BuilderForBoxFragment::new(self, containing_block_rect.origin).border_radius(),
             scroll_frame_rect,
             parent_scroll_node_id,
             parent_clip_id,
@@ -1009,7 +1010,7 @@ impl BoxFragment {
         let scroll_tree_node_id = stacking_context_tree.define_scroll_frame(
             parent_scroll_node_id,
             external_scroll_id,
-            with_style.scrollable_overflow().to_webrender(),
+            self.scrollable_overflow().to_webrender(),
             scroll_frame_rect,
             sensitivity,
         );
@@ -1022,7 +1023,9 @@ impl BoxFragment {
             }),
         })
     }
+}
 
+impl BoxFragment {
     fn build_sticky_frame_if_necessary(
         &self,
         stacking_context_tree: &mut StackingContextTree,

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -662,8 +662,10 @@ impl BoxFragment {
         parent_stacking_context: &mut StackingContext,
         text_decorations: &Rc<Vec<FragmentTextDecoration>>,
     ) {
+        let with_style = &self.with_style();
+        let style = with_style.style();
         let Some(stacking_context_type) = self.stacking_context_type() else {
-            self.build_stacking_context_tree_for_children(
+            with_style.build_stacking_context_tree_for_children(
                 stacking_context_tree,
                 containing_block,
                 containing_block_info,
@@ -683,15 +685,13 @@ impl BoxFragment {
             &new_scroll_frame_size,
         );
 
-        let clip_id = self.build_clip_frame_if_necessary(
+        let clip_id = with_style.build_clip_frame_if_necessary(
             stacking_context_tree,
             spatial_id.unwrap_or(containing_block.scroll_node_id),
             containing_block.clip_id,
             &containing_block.rect,
         );
 
-        let with_style = &self.with_style();
-        let style = with_style.style();
         let clip_id = stacking_context_tree
             .clip_store
             .add_for_clip_path(
@@ -731,7 +731,7 @@ impl BoxFragment {
             box_fragment,
             text_decorations.clone(),
         );
-        self.build_stacking_context_tree_for_children(
+        with_style.build_stacking_context_tree_for_children(
             stacking_context_tree,
             containing_block,
             containing_block_info,
@@ -754,17 +754,18 @@ impl BoxFragment {
             .children
             .append(&mut stolen_children);
     }
+}
 
+impl BoxFragmentWithStyle<'_> {
     fn build_stacking_context_tree_for_children(
-        self: &Arc<Self>,
+        &self,
         stacking_context_tree: &mut StackingContextTree,
         containing_block: &ContainingBlock,
         containing_block_info: &ContainingBlockInfo,
         stacking_context: &mut StackingContext,
         text_decorations: &Rc<Vec<FragmentTextDecoration>>,
     ) {
-        let with_style = self.with_style();
-        let style = with_style.style();
+        let style = self.style();
         let establishes_containing_block_for_all_descendants =
             style.establishes_containing_block_for_all_descendants(self.base.flags);
         let establishes_containing_block_for_absolute_descendants =
@@ -779,7 +780,7 @@ impl BoxFragment {
             .for_non_absolute_descendants
             .scroll_frame_size;
         let mut new_clip_id = containing_block.clip_id;
-        if let Some(overflow_frame_data) = with_style.build_overflow_frame_if_necessary(
+        if let Some(overflow_frame_data) = self.build_overflow_frame_if_necessary(
             stacking_context_tree,
             new_scroll_node_id,
             new_clip_id,
@@ -839,7 +840,7 @@ impl BoxFragment {
         // > Note that text decorations are not propagated to floating and absolutely
         // > positioned descendants, nor to the contents of atomic inline-level descendants
         // > such as inline blocks and inline tables.
-        let text_decorations = match with_style.is_atomic_inline_level() ||
+        let text_decorations = match self.is_atomic_inline_level() ||
             self.base
                 .flags
                 .contains(FragmentFlags::IS_OUTSIDE_LIST_ITEM_MARKER)
@@ -910,9 +911,7 @@ impl BoxFragment {
             parent_clip_id,
         ))
     }
-}
 
-impl BoxFragmentWithStyle<'_> {
     fn build_overflow_frame_if_necessary(
         &self,
         stacking_context_tree: &mut StackingContextTree,

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -556,7 +556,7 @@ impl BoxFragment {
     }
 
     fn build_stacking_context_tree(
-        &self,
+        self: &Arc<Self>,
         fragment: Fragment,
         stacking_context_tree: &mut StackingContextTree,
         containing_block: &ContainingBlock,
@@ -575,7 +575,7 @@ impl BoxFragment {
     }
 
     fn build_stacking_context_tree_maybe_creating_reference_frame(
-        &self,
+        self: &Arc<Self>,
         fragment: Fragment,
         stacking_context_tree: &mut StackingContextTree,
         containing_block: &ContainingBlock,
@@ -654,7 +654,7 @@ impl BoxFragment {
     }
 
     fn build_stacking_context_tree_maybe_creating_stacking_context(
-        &self,
+        self: &Arc<Self>,
         fragment: Fragment,
         stacking_context_tree: &mut StackingContextTree,
         containing_block: &ContainingBlock,
@@ -755,7 +755,7 @@ impl BoxFragment {
     }
 
     fn build_stacking_context_tree_for_children(
-        &self,
+        self: &Arc<Self>,
         stacking_context_tree: &mut StackingContextTree,
         containing_block: &ContainingBlock,
         containing_block_info: &ContainingBlockInfo,
@@ -910,7 +910,7 @@ impl BoxFragment {
     }
 
     fn build_overflow_frame_if_necessary(
-        &self,
+        self: &Arc<Self>,
         stacking_context_tree: &mut StackingContextTree,
         parent_scroll_node_id: ScrollTreeNodeId,
         parent_clip_id: ClipId,

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -762,7 +762,8 @@ impl BoxFragment {
         stacking_context: &mut StackingContext,
         text_decorations: &Rc<Vec<FragmentTextDecoration>>,
     ) {
-        let style = self.style();
+        let with_style = self.with_style();
+        let style = with_style.style();
         let establishes_containing_block_for_all_descendants =
             style.establishes_containing_block_for_all_descendants(self.base.flags);
         let establishes_containing_block_for_absolute_descendants =
@@ -837,7 +838,7 @@ impl BoxFragment {
         // > Note that text decorations are not propagated to floating and absolutely
         // > positioned descendants, nor to the contents of atomic inline-level descendants
         // > such as inline blocks and inline tables.
-        let text_decorations = match self.is_atomic_inline_level() ||
+        let text_decorations = match with_style.is_atomic_inline_level() ||
             self.base
                 .flags
                 .contains(FragmentFlags::IS_OUTSIDE_LIST_ITEM_MARKER)

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -690,14 +690,15 @@ impl BoxFragment {
             &containing_block.rect,
         );
 
-        let style = self.style();
+        let with_style = &self.with_style();
+        let style = with_style.style();
         let clip_id = stacking_context_tree
             .clip_store
             .add_for_clip_path(
                 &style.get_svg().clip_path,
                 spatial_id.unwrap_or(containing_block.scroll_node_id),
                 clip_id.unwrap_or(containing_block.clip_id),
-                self,
+                with_style,
                 containing_block.rect.origin,
             )
             .or(clip_id);

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -1008,7 +1008,7 @@ impl BoxFragment {
         let scroll_tree_node_id = stacking_context_tree.define_scroll_frame(
             parent_scroll_node_id,
             external_scroll_id,
-            self.scrollable_overflow().to_webrender(),
+            with_style.scrollable_overflow().to_webrender(),
             scroll_frame_rect,
             sensitivity,
         );

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -916,7 +916,8 @@ impl BoxFragment {
         parent_clip_id: ClipId,
         containing_block_rect: &PhysicalRect<Au>,
     ) -> Option<OverflowFrameData> {
-        let style = self.style();
+        let with_style = self.with_style();
+        let style = with_style.style();
         let overflow = style.effective_overflow(self.base.flags);
 
         if overflow.x == ComputedOverflow::Visible && overflow.y == ComputedOverflow::Visible {
@@ -943,7 +944,7 @@ impl BoxFragment {
             // https://drafts.csswg.org/css-overflow-3/#corner-clipping
             let radii;
             if overflow.x == ComputedOverflow::Clip && overflow.y == ComputedOverflow::Clip {
-                let builder = BuilderForBoxFragment::new(self, containing_block_rect.origin);
+                let builder = BuilderForBoxFragment::new(&with_style, containing_block_rect.origin);
                 let mut offsets_from_border = SideOffsets2D::new_all_same(clip_margin_offset);
                 match overflow_clip_margin.visual_box {
                     OverflowClipMarginBox::ContentBox => {
@@ -986,7 +987,7 @@ impl BoxFragment {
             .to_webrender();
 
         let clip_id = stacking_context_tree.clip_store.add(
-            BuilderForBoxFragment::new(self, containing_block_rect.origin).border_radius(),
+            BuilderForBoxFragment::new(&with_style, containing_block_rect.origin).border_radius(),
             scroll_frame_rect,
             parent_scroll_node_id,
             parent_clip_id,

--- a/components/layout/fragment_tree/box_fragment.rs
+++ b/components/layout/fragment_tree/box_fragment.rs
@@ -319,137 +319,12 @@ impl BoxFragment {
         self
     }
 
-    /// Get the scrollable overflow for this [`BoxFragment`] relative to its containing
-    /// block, recalculating scrollable overflow when necessary, for instance after a
-    /// style change.
-    pub(crate) fn scrollable_overflow(self: &Arc<Self>) -> PhysicalRect<Au> {
-        if self
-            .scrollable_overflow_is_up_to_date
-            .load(Ordering::Acquire)
-        {
-            self.scrollable_overflow.get()
-        } else {
-            let rect = self.calculate_scrollable_overflow();
-            self.scrollable_overflow.set(rect);
-            self.scrollable_overflow_is_up_to_date
-                .store(true, Ordering::Release);
-            rect
-        }
-    }
-
     /// Clear the scrollable overflow on this [`BoxFragment`]. This is called
     /// during damage propagation when a fragment is preserved, itself or one of its
     /// descendants has scrollable overflow damage.
     pub(crate) fn clear_scrollable_overflow(&self) {
         self.scrollable_overflow_is_up_to_date
             .store(false, Ordering::Release);
-    }
-
-    /// This is an implementation of:
-    /// - <https://drafts.csswg.org/css-overflow-3/#scrollable>.
-    /// - <https://drafts.csswg.org/cssom-view/#scrolling-area>
-    fn calculate_scrollable_overflow(self: &Arc<Self>) -> PhysicalRect<Au> {
-        // Fragments with `IS_COLLAPSED` (currently only table cells that are part of
-        // table tracks with `visibility: collapse`) should not contribute to scrollable
-        // overflow. This behavior matches Chrome, but not Firefox.
-        // See https://github.com/w3c/csswg-drafts/issues/12689
-        if self.base.flags.contains(FragmentFlags::IS_COLLAPSED) {
-            return Rect::zero();
-        }
-
-        let with_style = self.with_style();
-        let physical_padding_rect = self.padding_rect();
-        let content_origin = self.base.rect().origin.to_vector();
-
-        // > The scrollable overflow area is the union of:
-        // > * The scroll container’s own padding box.
-        // > * All line boxes directly contained by the scroll container.
-        // > * The border boxes of all boxes for which it is the containing block and
-        // >   whose border boxes are positioned not wholly in the unreachable
-        // >   scrollable overflow region, accounting for transforms by projecting
-        // >   each box onto the plane of the element that establishes its 3D
-        // >   rendering context.
-        // > * The margin areas of grid item and flex item boxes for which the box
-        // >   establishes a containing block.
-        // > * The scrollable overflow areas of all of the above boxes (including zero-area
-        // >   boxes and accounting for transforms as described above), provided they
-        // >   themselves have overflow: visible (i.e. do not themselves trap the overflow)
-        // >   and that scrollable overflow is not already clipped (e.g. by the clip property
-        // >   or the contain property).
-        // > * Additional padding added to the scrollable overflow rectangle as necessary
-        //     to enable scroll positions that satisfy the requirements of both place-content:
-        //     start and place-content: end alignment.
-        //
-        // TODO(mrobinson): Below we are handling the border box and the scrollable
-        // overflow together, but from the specification it seems that if the border
-        // box of an item is in the "wholly unreachable scrollable overflow region", but
-        // its scrollable overflow is not, it should also be excluded.
-        let mut scrollable_overflow =
-            self.children
-                .iter()
-                .fold(physical_padding_rect, |acc, child| {
-                    let scrollable_overflow_from_child = child
-                        .scrollable_overflow_for_parent()
-                        .translate(content_origin);
-
-                    // Note that this doesn't just exclude the wholly unreachable
-                    // scrollable overflow area from the rectangle, but also clips it.
-                    // This makes the resulting value more like the "scroll area" rather
-                    // than the "scrollable overflow."
-                    let scrollable_overflow_from_child = with_style
-                        .clip_wholly_unreachable_scrollable_overflow(
-                            scrollable_overflow_from_child,
-                            physical_padding_rect,
-                        );
-
-                    acc.union(&scrollable_overflow_from_child)
-                });
-
-        // From <https://drafts.csswg.org/css-overflow-3/#scrollable>:
-        // > Additional padding added to the scrollable overflow rectangle as necessary to
-        // > enable scroll positions that satisfy the requirements of both place-content:
-        // > start and place-content: end alignment.
-        //
-        // Whether we should include additional padding to the scrollable overflow to satisfy
-        // the requirements of `place-content: start` and `place-content: end` for boxes that
-        // establish scroll containers. Note: This padding is different from the CSS concept
-        // of padding. See <https://github.com/w3c/csswg-drafts/issues/129>.
-        //
-        // TODO: For input elements, we also disable the padding in the inline direction, as we
-        // do not have a way to scroll the textual input element in inline direction yet.
-        let should_include_additional_padding = with_style
-            .style()
-            .establishes_scroll_container(self.base.flags) &&
-            !self.base.flags.intersects(FragmentFlags::IS_INPUT_ELEMENT);
-
-        if should_include_additional_padding {
-            scrollable_overflow = self
-                .children
-                .iter()
-                .fold(scrollable_overflow, |acc, child| {
-                    let Some(padding_contribution) =
-                        child.scrollable_overflow_padding_contribution_for_parent()
-                    else {
-                        return acc;
-                    };
-
-                    let padding_contribution = padding_contribution
-                        .translate(content_origin)
-                        .outer_rect(self.padding);
-
-                    // Applying padding could also cause the rectangle to overflow to
-                    // the wholly unreachable scrollable overflow, clipping the overflow
-                    // here prevents this.
-                    let padding_contribution = with_style
-                        .clip_wholly_unreachable_scrollable_overflow(
-                            padding_contribution,
-                            physical_padding_rect,
-                        );
-
-                    acc.union(&padding_contribution)
-                });
-        }
-        scrollable_overflow
     }
 
     #[inline]
@@ -518,6 +393,7 @@ impl BoxFragment {
     }
 
     pub(crate) fn print(self: &Arc<Self>, tree: &mut PrintTree) {
+        let with_style = self.with_style();
         tree.new_level(format!(
             "Box\
                 \nbase={:?}\
@@ -533,58 +409,15 @@ impl BoxFragment {
             self.padding_rect(),
             self.border_rect(),
             self.margin,
-            self.scrollable_overflow(),
+            with_style.scrollable_overflow(),
             self.baselines,
-            self.style().effective_overflow(self.base.flags),
+            with_style.style().effective_overflow(self.base.flags),
         ));
 
         for child in &self.children {
             child.print(tree);
         }
         tree.end_level();
-    }
-
-    pub(crate) fn scrollable_overflow_for_parent(self: &Arc<Self>) -> PhysicalRect<Au> {
-        let style = self.style();
-        let mut overflow = self.border_rect();
-        if !style.establishes_scroll_container(self.base.flags) {
-            // https://www.w3.org/TR/css-overflow-3/#scrollable
-            // Only include the scrollable overflow of a child box if it has overflow: visible.
-            let scrollable_overflow = self.scrollable_overflow();
-            let bottom_right = PhysicalPoint::new(
-                overflow.max_x().max(scrollable_overflow.max_x()),
-                overflow.max_y().max(scrollable_overflow.max_y()),
-            );
-
-            let overflow_style = style.effective_overflow(self.base.flags);
-            if overflow_style.y == ComputedOverflow::Visible {
-                overflow.origin.y = overflow.origin.y.min(scrollable_overflow.origin.y);
-                overflow.size.height = bottom_right.y - overflow.origin.y;
-            }
-
-            if overflow_style.x == ComputedOverflow::Visible {
-                overflow.origin.x = overflow.origin.x.min(scrollable_overflow.origin.x);
-                overflow.size.width = bottom_right.x - overflow.origin.x;
-            }
-        }
-
-        if !style.has_effective_transform_or_perspective(self.base.flags) {
-            return overflow;
-        }
-
-        // <https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-region>
-        // > ...accounting for transforms by projecting each box onto the plane of
-        // > the element that establishes its 3D rendering context. [CSS3-TRANSFORMS]
-        // Both boxes and its scrollable overflow (if it is included) should be transformed accordingly.
-        //
-        // TODO(stevennovaryo): We are supposed to handle perspective transform and 3d
-        // contexts, but it is yet to happen.
-        self.calculate_transform_matrix(&self.border_rect())
-            .and_then(|transform| {
-                transform.outer_transformed_rect(&overflow.to_webrender().to_rect())
-            })
-            .map(|transformed_rect| f32_rect_to_au_rect(transformed_rect).cast_unit())
-            .unwrap_or(overflow)
     }
 
     pub(crate) fn calculate_resolved_insets_if_positioned(
@@ -758,6 +591,170 @@ impl<'a> BoxFragmentWithStyle<'a> {
             false => scrollable_overflow_box.to_rect(),
             true => Rect::zero(),
         }
+    }
+
+    pub(crate) fn scrollable_overflow_for_parent(&self) -> PhysicalRect<Au> {
+        let style = self.style();
+        let mut overflow = self.border_rect();
+        if !style.establishes_scroll_container(self.base.flags) {
+            // https://www.w3.org/TR/css-overflow-3/#scrollable
+            // Only include the scrollable overflow of a child box if it has overflow: visible.
+            let scrollable_overflow = self.scrollable_overflow();
+            let bottom_right = PhysicalPoint::new(
+                overflow.max_x().max(scrollable_overflow.max_x()),
+                overflow.max_y().max(scrollable_overflow.max_y()),
+            );
+
+            let overflow_style = style.effective_overflow(self.base.flags);
+            if overflow_style.y == ComputedOverflow::Visible {
+                overflow.origin.y = overflow.origin.y.min(scrollable_overflow.origin.y);
+                overflow.size.height = bottom_right.y - overflow.origin.y;
+            }
+
+            if overflow_style.x == ComputedOverflow::Visible {
+                overflow.origin.x = overflow.origin.x.min(scrollable_overflow.origin.x);
+                overflow.size.width = bottom_right.x - overflow.origin.x;
+            }
+        }
+
+        if !style.has_effective_transform_or_perspective(self.base.flags) {
+            return overflow;
+        }
+
+        // <https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-region>
+        // > ...accounting for transforms by projecting each box onto the plane of
+        // > the element that establishes its 3D rendering context. [CSS3-TRANSFORMS]
+        // Both boxes and its scrollable overflow (if it is included) should be transformed accordingly.
+        //
+        // TODO(stevennovaryo): We are supposed to handle perspective transform and 3d
+        // contexts, but it is yet to happen.
+        self.calculate_transform_matrix(&self.border_rect())
+            .and_then(|transform| {
+                transform.outer_transformed_rect(&overflow.to_webrender().to_rect())
+            })
+            .map(|transformed_rect| f32_rect_to_au_rect(transformed_rect).cast_unit())
+            .unwrap_or(overflow)
+    }
+
+    /// Get the scrollable overflow for this [`BoxFragment`] relative to its containing
+    /// block, recalculating scrollable overflow when necessary, for instance after a
+    /// style change.
+    pub(crate) fn scrollable_overflow(&self) -> PhysicalRect<Au> {
+        if self
+            .scrollable_overflow_is_up_to_date
+            .load(Ordering::Acquire)
+        {
+            self.scrollable_overflow.get()
+        } else {
+            let rect = self.calculate_scrollable_overflow();
+            self.scrollable_overflow.set(rect);
+            self.scrollable_overflow_is_up_to_date
+                .store(true, Ordering::Release);
+            rect
+        }
+    }
+    /// This is an implementation of:
+    /// - <https://drafts.csswg.org/css-overflow-3/#scrollable>.
+    /// - <https://drafts.csswg.org/cssom-view/#scrolling-area>
+    fn calculate_scrollable_overflow(&self) -> PhysicalRect<Au> {
+        // Fragments with `IS_COLLAPSED` (currently only table cells that are part of
+        // table tracks with `visibility: collapse`) should not contribute to scrollable
+        // overflow. This behavior matches Chrome, but not Firefox.
+        // See https://github.com/w3c/csswg-drafts/issues/12689
+        if self.base.flags.contains(FragmentFlags::IS_COLLAPSED) {
+            return Rect::zero();
+        }
+
+        let physical_padding_rect = self.padding_rect();
+        let content_origin = self.base.rect().origin.to_vector();
+
+        // > The scrollable overflow area is the union of:
+        // > * The scroll container’s own padding box.
+        // > * All line boxes directly contained by the scroll container.
+        // > * The border boxes of all boxes for which it is the containing block and
+        // >   whose border boxes are positioned not wholly in the unreachable
+        // >   scrollable overflow region, accounting for transforms by projecting
+        // >   each box onto the plane of the element that establishes its 3D
+        // >   rendering context.
+        // > * The margin areas of grid item and flex item boxes for which the box
+        // >   establishes a containing block.
+        // > * The scrollable overflow areas of all of the above boxes (including zero-area
+        // >   boxes and accounting for transforms as described above), provided they
+        // >   themselves have overflow: visible (i.e. do not themselves trap the overflow)
+        // >   and that scrollable overflow is not already clipped (e.g. by the clip property
+        // >   or the contain property).
+        // > * Additional padding added to the scrollable overflow rectangle as necessary
+        //     to enable scroll positions that satisfy the requirements of both place-content:
+        //     start and place-content: end alignment.
+        //
+        // TODO(mrobinson): Below we are handling the border box and the scrollable
+        // overflow together, but from the specification it seems that if the border
+        // box of an item is in the "wholly unreachable scrollable overflow region", but
+        // its scrollable overflow is not, it should also be excluded.
+        let mut scrollable_overflow =
+            self.children
+                .iter()
+                .fold(physical_padding_rect, |acc, child| {
+                    let scrollable_overflow_from_child = child
+                        .scrollable_overflow_for_parent()
+                        .translate(content_origin);
+
+                    // Note that this doesn't just exclude the wholly unreachable
+                    // scrollable overflow area from the rectangle, but also clips it.
+                    // This makes the resulting value more like the "scroll area" rather
+                    // than the "scrollable overflow."
+                    let scrollable_overflow_from_child = self
+                        .clip_wholly_unreachable_scrollable_overflow(
+                            scrollable_overflow_from_child,
+                            physical_padding_rect,
+                        );
+
+                    acc.union(&scrollable_overflow_from_child)
+                });
+
+        // From <https://drafts.csswg.org/css-overflow-3/#scrollable>:
+        // > Additional padding added to the scrollable overflow rectangle as necessary to
+        // > enable scroll positions that satisfy the requirements of both place-content:
+        // > start and place-content: end alignment.
+        //
+        // Whether we should include additional padding to the scrollable overflow to satisfy
+        // the requirements of `place-content: start` and `place-content: end` for boxes that
+        // establish scroll containers. Note: This padding is different from the CSS concept
+        // of padding. See <https://github.com/w3c/csswg-drafts/issues/129>.
+        //
+        // TODO: For input elements, we also disable the padding in the inline direction, as we
+        // do not have a way to scroll the textual input element in inline direction yet.
+        let should_include_additional_padding =
+            self.style().establishes_scroll_container(self.base.flags) &&
+                !self.base.flags.intersects(FragmentFlags::IS_INPUT_ELEMENT);
+
+        if should_include_additional_padding {
+            scrollable_overflow = self
+                .children
+                .iter()
+                .fold(scrollable_overflow, |acc, child| {
+                    let Some(padding_contribution) =
+                        child.scrollable_overflow_padding_contribution_for_parent()
+                    else {
+                        return acc;
+                    };
+
+                    let padding_contribution = padding_contribution
+                        .translate(content_origin)
+                        .outer_rect(self.padding);
+
+                    // Applying padding could also cause the rectangle to overflow to
+                    // the wholly unreachable scrollable overflow, clipping the overflow
+                    // here prevents this.
+                    let padding_contribution = self.clip_wholly_unreachable_scrollable_overflow(
+                        padding_contribution,
+                        physical_padding_rect,
+                    );
+
+                    acc.union(&padding_contribution)
+                });
+        }
+        scrollable_overflow
     }
 
     /// Whether this is a non-replaced inline-level box whose inner display type is `flow`.

--- a/components/layout/fragment_tree/box_fragment.rs
+++ b/components/layout/fragment_tree/box_fragment.rs
@@ -153,25 +153,6 @@ pub(crate) struct BoxFragment {
     pub spatial_tree_node: AtomicOptionScrollTreeNodeId,
 }
 
-/// Contains `&Arc<BoxFragment>` and dereferences to it so it can mostly
-/// be used in the same ways, except the `.style()` method is shadowed to use an existing
-/// `atomic_refcell::AtomicRef` that lives as long as `BoxFragmentWithStyle`.
-///
-/// Compared to calling `BoxFragment::style()` repeatedly, this reduce the number of atomic
-/// increments and decrements on `ArcRefCell`’s borrow counter.
-pub(crate) struct BoxFragmentWithStyle<'a> {
-    pub(crate) box_fragment: &'a Arc<BoxFragment>,
-    pub(crate) style: AtomicRef<'a, ServoArc<ComputedValues>>,
-}
-
-impl std::ops::Deref for BoxFragmentWithStyle<'_> {
-    type Target = Arc<BoxFragment>;
-
-    fn deref(&self) -> &Self::Target {
-        self.box_fragment
-    }
-}
-
 impl BoxFragment {
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
@@ -547,15 +528,28 @@ impl BoxFragment {
     }
 }
 
+/// Contains `&Arc<BoxFragment>` and dereferences to it so it can mostly
+/// be used in the same ways, except the `.style()` method is shadowed to use an existing
+/// `atomic_refcell::AtomicRef` that lives as long as `BoxFragmentWithStyle`.
+///
+/// Compared to calling `BoxFragment::style()` repeatedly, this reduce the number of atomic
+/// increments and decrements on `ArcRefCell`’s borrow counter.
+pub(crate) struct BoxFragmentWithStyle<'a> {
+    pub(crate) box_fragment: &'a Arc<BoxFragment>,
+    pub(crate) style: AtomicRef<'a, ServoArc<ComputedValues>>,
+}
+
+impl std::ops::Deref for BoxFragmentWithStyle<'_> {
+    type Target = Arc<BoxFragment>;
+
+    fn deref(&self) -> &Self::Target {
+        self.box_fragment
+    }
+}
+
 impl<'a> BoxFragmentWithStyle<'a> {
     pub(crate) fn style(&self) -> &ServoArc<ComputedValues> {
         &self.style
-    }
-
-    /// Calling this is redundant, you already have a `BoxFragmentWithStyle`
-    #[expect(dead_code)]
-    pub(crate) fn with_style(&self) -> &Self {
-        self
     }
 
     /// Return the clipped scrollable overflow based on its scroll origin, determined by

--- a/components/layout/fragment_tree/box_fragment.rs
+++ b/components/layout/fragment_tree/box_fragment.rs
@@ -701,17 +701,6 @@ impl BoxFragment {
         )
     }
 
-    pub(crate) fn has_collapsed_borders(&self) -> bool {
-        match self.specific_layout_info().as_deref() {
-            Some(SpecificLayoutInfo::TableCellWithCollapsedBorders) => true,
-            Some(SpecificLayoutInfo::TableGridWithCollapsedBorders(_)) => true,
-            Some(SpecificLayoutInfo::TableWrapper) => {
-                self.style().get_inherited_table().border_collapse == BorderCollapse::Collapse
-            },
-            _ => false,
-        }
-    }
-
     /// Whether or not this is the [`BoxFragment`] for a table grid with collapsed borders.
     pub(crate) fn is_table_grid_with_collapsed_borders(&self) -> bool {
         matches!(
@@ -788,5 +777,16 @@ impl<'a> BoxFragmentWithStyle<'a> {
     /// <https://drafts.csswg.org/css-display-3/#atomic-inline>
     pub(crate) fn is_atomic_inline_level(&self) -> bool {
         self.style().is_atomic_inline_level(self.base.flags)
+    }
+
+    pub(crate) fn has_collapsed_borders(&self) -> bool {
+        match self.specific_layout_info().as_deref() {
+            Some(SpecificLayoutInfo::TableCellWithCollapsedBorders) => true,
+            Some(SpecificLayoutInfo::TableGridWithCollapsedBorders(_)) => true,
+            Some(SpecificLayoutInfo::TableWrapper) => {
+                self.style().get_inherited_table().border_collapse == BorderCollapse::Collapse
+            },
+            _ => false,
+        }
     }
 }

--- a/components/layout/fragment_tree/box_fragment.rs
+++ b/components/layout/fragment_tree/box_fragment.rs
@@ -160,8 +160,8 @@ pub(crate) struct BoxFragment {
 /// Compared to calling `BoxFragment::style()` repeatedly, this reduce the number of atomic
 /// increments and decrements on `ArcRefCell`’s borrow counter.
 pub(crate) struct BoxFragmentWithStyle<'a> {
-    box_fragment: &'a Arc<BoxFragment>,
-    style: AtomicRef<'a, ServoArc<ComputedValues>>,
+    pub(crate) box_fragment: &'a Arc<BoxFragment>,
+    pub(crate) style: AtomicRef<'a, ServoArc<ComputedValues>>,
 }
 
 impl std::ops::Deref for BoxFragmentWithStyle<'_> {
@@ -680,18 +680,6 @@ impl BoxFragment {
         convert_to_au_or_auto(PhysicalSides::new(top, right, bottom, left))
     }
 
-    /// Whether this is a non-replaced inline-level box whose inner display type is `flow`.
-    /// <https://drafts.csswg.org/css-display-3/#inline-box>
-    pub(crate) fn is_inline_box(&self) -> bool {
-        self.style().is_inline_box(self.base.flags)
-    }
-
-    /// Whether this is an atomic inline-level box.
-    /// <https://drafts.csswg.org/css-display-3/#atomic-inline>
-    pub(crate) fn is_atomic_inline_level(&self) -> bool {
-        self.style().is_atomic_inline_level(self.base.flags)
-    }
-
     /// Whether or this is a flex or grid item.
     pub(crate) fn is_flex_or_grid_item(&self) -> bool {
         self.base
@@ -788,5 +776,17 @@ impl<'a> BoxFragmentWithStyle<'a> {
             false => scrollable_overflow_box.to_rect(),
             true => Rect::zero(),
         }
+    }
+
+    /// Whether this is a non-replaced inline-level box whose inner display type is `flow`.
+    /// <https://drafts.csswg.org/css-display-3/#inline-box>
+    pub(crate) fn is_inline_box(&self) -> bool {
+        self.style().is_inline_box(self.base.flags)
+    }
+
+    /// Whether this is an atomic inline-level box.
+    /// <https://drafts.csswg.org/css-display-3/#atomic-inline>
+    pub(crate) fn is_atomic_inline_level(&self) -> bool {
+        self.style().is_atomic_inline_level(self.base.flags)
     }
 }

--- a/components/layout/fragment_tree/box_fragment.rs
+++ b/components/layout/fragment_tree/box_fragment.rs
@@ -152,6 +152,25 @@ pub(crate) struct BoxFragment {
     pub spatial_tree_node: AtomicOptionScrollTreeNodeId,
 }
 
+/// Constructed from `&BoxFragment` and dereferences to it so it can mostly
+/// be used in the same ways, except the `.style()` method is shadowed to use an existing
+/// `atomic_refcell::AtomicRef` that lives as long as `BoxFragmentWithStyle`.
+///
+/// Compared to calling `BoxFragment::style()` repeatedly, this reduce the number of atomic
+/// increments and decrements on `ArcRefCell`’s borrow counter.
+pub(crate) struct BoxFragmentWithStyle<'a> {
+    box_fragment: &'a BoxFragment,
+    style: AtomicRef<'a, ServoArc<ComputedValues>>,
+}
+
+impl std::ops::Deref for BoxFragmentWithStyle<'_> {
+    type Target = BoxFragment;
+
+    fn deref(&self) -> &Self::Target {
+        self.box_fragment
+    }
+}
+
 impl BoxFragment {
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
@@ -189,6 +208,13 @@ impl BoxFragment {
 
     pub(crate) fn style<'a>(&'a self) -> AtomicRef<'a, ServoArc<ComputedValues>> {
         self.base.style()
+    }
+
+    pub(crate) fn with_style(&self) -> BoxFragmentWithStyle<'_> {
+        BoxFragmentWithStyle {
+            box_fragment: self,
+            style: self.style(),
+        }
     }
 
     /// Get the baselines for this [`BoxFragment`] if they are compatible with the given [`WritingMode`].
@@ -752,5 +778,11 @@ impl BoxFragment {
 
     pub(crate) fn spatial_tree_node(&self) -> Option<ScrollTreeNodeId> {
         self.spatial_tree_node.get()
+    }
+}
+
+impl<'a> BoxFragmentWithStyle<'a> {
+    pub(crate) fn style(&self) -> &ServoArc<ComputedValues> {
+        &self.style
     }
 }

--- a/components/layout/fragment_tree/box_fragment.rs
+++ b/components/layout/fragment_tree/box_fragment.rs
@@ -552,6 +552,12 @@ impl<'a> BoxFragmentWithStyle<'a> {
         &self.style
     }
 
+    /// Calling this is redundant, you already have a `BoxFragmentWithStyle`
+    #[expect(dead_code)]
+    pub(crate) fn with_style(&self) -> &Self {
+        self
+    }
+
     /// Return the clipped scrollable overflow based on its scroll origin, determined by
     /// overflow direction. Return [`None`] if the scrollable overflow from child is wholly
     /// unreachable. For an element, the clip rect is the padding rect and for viewport,

--- a/components/layout/fragment_tree/box_fragment.rs
+++ b/components/layout/fragment_tree/box_fragment.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cell::LazyCell;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use app_units::{Au, MAX_AU, MIN_AU};
@@ -152,19 +153,19 @@ pub(crate) struct BoxFragment {
     pub spatial_tree_node: AtomicOptionScrollTreeNodeId,
 }
 
-/// Constructed from `&BoxFragment` and dereferences to it so it can mostly
+/// Contains `&Arc<BoxFragment>` and dereferences to it so it can mostly
 /// be used in the same ways, except the `.style()` method is shadowed to use an existing
 /// `atomic_refcell::AtomicRef` that lives as long as `BoxFragmentWithStyle`.
 ///
 /// Compared to calling `BoxFragment::style()` repeatedly, this reduce the number of atomic
 /// increments and decrements on `ArcRefCell`’s borrow counter.
 pub(crate) struct BoxFragmentWithStyle<'a> {
-    box_fragment: &'a BoxFragment,
+    box_fragment: &'a Arc<BoxFragment>,
     style: AtomicRef<'a, ServoArc<ComputedValues>>,
 }
 
 impl std::ops::Deref for BoxFragmentWithStyle<'_> {
-    type Target = BoxFragment;
+    type Target = Arc<BoxFragment>;
 
     fn deref(&self) -> &Self::Target {
         self.box_fragment
@@ -210,7 +211,7 @@ impl BoxFragment {
         self.base.style()
     }
 
-    pub(crate) fn with_style(&self) -> BoxFragmentWithStyle<'_> {
+    pub(crate) fn with_style(self: &Arc<Self>) -> BoxFragmentWithStyle<'_> {
         BoxFragmentWithStyle {
             box_fragment: self,
             style: self.style(),
@@ -321,7 +322,7 @@ impl BoxFragment {
     /// Get the scrollable overflow for this [`BoxFragment`] relative to its containing
     /// block, recalculating scrollable overflow when necessary, for instance after a
     /// style change.
-    pub(crate) fn scrollable_overflow(&self) -> PhysicalRect<Au> {
+    pub(crate) fn scrollable_overflow(self: &Arc<Self>) -> PhysicalRect<Au> {
         if self
             .scrollable_overflow_is_up_to_date
             .load(Ordering::Acquire)
@@ -347,7 +348,7 @@ impl BoxFragment {
     /// This is an implementation of:
     /// - <https://drafts.csswg.org/css-overflow-3/#scrollable>.
     /// - <https://drafts.csswg.org/cssom-view/#scrolling-area>
-    fn calculate_scrollable_overflow(&self) -> PhysicalRect<Au> {
+    fn calculate_scrollable_overflow(self: &Arc<Self>) -> PhysicalRect<Au> {
         // Fragments with `IS_COLLAPSED` (currently only table cells that are part of
         // table tracks with `visibility: collapse`) should not contribute to scrollable
         // overflow. This behavior matches Chrome, but not Firefox.
@@ -516,7 +517,7 @@ impl BoxFragment {
             .intersects(FragmentFlags::IS_BODY_ELEMENT_OF_HTML_ELEMENT_ROOT)
     }
 
-    pub(crate) fn print(&self, tree: &mut PrintTree) {
+    pub(crate) fn print(self: &Arc<Self>, tree: &mut PrintTree) {
         tree.new_level(format!(
             "Box\
                 \nbase={:?}\
@@ -543,7 +544,7 @@ impl BoxFragment {
         tree.end_level();
     }
 
-    pub(crate) fn scrollable_overflow_for_parent(&self) -> PhysicalRect<Au> {
+    pub(crate) fn scrollable_overflow_for_parent(self: &Arc<Self>) -> PhysicalRect<Au> {
         let style = self.style();
         let mut overflow = self.border_rect();
         if !style.establishes_scroll_container(self.base.flags) {

--- a/components/layout/fragment_tree/box_fragment.rs
+++ b/components/layout/fragment_tree/box_fragment.rs
@@ -709,13 +709,6 @@ impl BoxFragment {
         )
     }
 
-    /// Whether or not this [`BoxFragment`] has outlines.
-    pub(crate) fn has_outline(&self) -> bool {
-        let style = self.style();
-        let outline = style.get_outline();
-        !outline.outline_style.none_or_hidden() && !outline.outline_width.0.is_zero()
-    }
-
     pub(crate) fn spatial_tree_node(&self) -> Option<ScrollTreeNodeId> {
         self.spatial_tree_node.get()
     }
@@ -788,5 +781,12 @@ impl<'a> BoxFragmentWithStyle<'a> {
             },
             _ => false,
         }
+    }
+
+    /// Whether or not this [`BoxFragment`] has outlines.
+    pub(crate) fn has_outline(&self) -> bool {
+        let style = self.style();
+        let outline = style.get_outline();
+        !outline.outline_style.none_or_hidden() && !outline.outline_width.0.is_zero()
     }
 }

--- a/components/layout/fragment_tree/box_fragment.rs
+++ b/components/layout/fragment_tree/box_fragment.rs
@@ -356,6 +356,7 @@ impl BoxFragment {
             return Rect::zero();
         }
 
+        let with_style = self.with_style();
         let physical_padding_rect = self.padding_rect();
         let content_origin = self.base.rect().origin.to_vector();
 
@@ -394,7 +395,7 @@ impl BoxFragment {
                     // scrollable overflow area from the rectangle, but also clips it.
                     // This makes the resulting value more like the "scroll area" rather
                     // than the "scrollable overflow."
-                    let scrollable_overflow_from_child = self
+                    let scrollable_overflow_from_child = with_style
                         .clip_wholly_unreachable_scrollable_overflow(
                             scrollable_overflow_from_child,
                             physical_padding_rect,
@@ -415,9 +416,10 @@ impl BoxFragment {
         //
         // TODO: For input elements, we also disable the padding in the inline direction, as we
         // do not have a way to scroll the textual input element in inline direction yet.
-        let should_include_additional_padding =
-            self.style().establishes_scroll_container(self.base.flags) &&
-                !self.base.flags.intersects(FragmentFlags::IS_INPUT_ELEMENT);
+        let should_include_additional_padding = with_style
+            .style()
+            .establishes_scroll_container(self.base.flags) &&
+            !self.base.flags.intersects(FragmentFlags::IS_INPUT_ELEMENT);
 
         if should_include_additional_padding {
             scrollable_overflow = self
@@ -437,10 +439,11 @@ impl BoxFragment {
                     // Applying padding could also cause the rectangle to overflow to
                     // the wholly unreachable scrollable overflow, clipping the overflow
                     // here prevents this.
-                    let padding_contribution = self.clip_wholly_unreachable_scrollable_overflow(
-                        padding_contribution,
-                        physical_padding_rect,
-                    );
+                    let padding_contribution = with_style
+                        .clip_wholly_unreachable_scrollable_overflow(
+                            padding_contribution,
+                            physical_padding_rect,
+                        );
 
                     acc.union(&padding_contribution)
                 });
@@ -581,47 +584,6 @@ impl BoxFragment {
             })
             .map(|transformed_rect| f32_rect_to_au_rect(transformed_rect).cast_unit())
             .unwrap_or(overflow)
-    }
-
-    /// Return the clipped scrollable overflow based on its scroll origin, determined by
-    /// overflow direction. Return [`None`] if the scrollable overflow from child is wholly
-    /// unreachable. For an element, the clip rect is the padding rect and for viewport,
-    /// it is the initial containing block.
-    pub(crate) fn clip_wholly_unreachable_scrollable_overflow(
-        &self,
-        scrollable_overflow_from_child: PhysicalRect<Au>,
-        clipping_rect: PhysicalRect<Au>,
-    ) -> PhysicalRect<Au> {
-        // From <https://drafts.csswg.org/css-overflow/#unreachable-scrollable-overflow-region>:
-        // > Unless otherwise adjusted (e.g. by content alignment [css-align-3]), the area
-        // > beyond the scroll origin in either axis is considered the unreachable scrollable
-        // > overflow region: content rendered here is not accessible to the reader, see § 2.2
-        // > Scrollable Overflow. A scroll container is said to be scrolled to its scroll
-        // > origin when its scroll origin coincides with the corresponding corner of its
-        // > scrollport. This scroll position, the scroll origin position, usually, but not
-        // > always, coincides with the initial scroll position.
-        let scrolling_direction = self.style().overflow_direction();
-        let mut clipping_box = clipping_rect.to_box2d();
-        if scrolling_direction.rightward {
-            clipping_box.max.x = MAX_AU;
-        } else {
-            clipping_box.min.x = MIN_AU;
-        }
-
-        if scrolling_direction.downward {
-            clipping_box.max.y = MAX_AU;
-        } else {
-            clipping_box.min.y = MIN_AU;
-        }
-
-        let scrollable_overflow_box = scrollable_overflow_from_child
-            .to_box2d()
-            .intersection_unchecked(&clipping_box);
-
-        match scrollable_overflow_box.is_negative() {
-            false => scrollable_overflow_box.to_rect(),
-            true => Rect::zero(),
-        }
     }
 
     pub(crate) fn calculate_resolved_insets_if_positioned(
@@ -784,5 +746,46 @@ impl BoxFragment {
 impl<'a> BoxFragmentWithStyle<'a> {
     pub(crate) fn style(&self) -> &ServoArc<ComputedValues> {
         &self.style
+    }
+
+    /// Return the clipped scrollable overflow based on its scroll origin, determined by
+    /// overflow direction. Return [`None`] if the scrollable overflow from child is wholly
+    /// unreachable. For an element, the clip rect is the padding rect and for viewport,
+    /// it is the initial containing block.
+    pub(crate) fn clip_wholly_unreachable_scrollable_overflow(
+        &self,
+        scrollable_overflow_from_child: PhysicalRect<Au>,
+        clipping_rect: PhysicalRect<Au>,
+    ) -> PhysicalRect<Au> {
+        // From <https://drafts.csswg.org/css-overflow/#unreachable-scrollable-overflow-region>:
+        // > Unless otherwise adjusted (e.g. by content alignment [css-align-3]), the area
+        // > beyond the scroll origin in either axis is considered the unreachable scrollable
+        // > overflow region: content rendered here is not accessible to the reader, see § 2.2
+        // > Scrollable Overflow. A scroll container is said to be scrolled to its scroll
+        // > origin when its scroll origin coincides with the corresponding corner of its
+        // > scrollport. This scroll position, the scroll origin position, usually, but not
+        // > always, coincides with the initial scroll position.
+        let scrolling_direction = self.style().overflow_direction();
+        let mut clipping_box = clipping_rect.to_box2d();
+        if scrolling_direction.rightward {
+            clipping_box.max.x = MAX_AU;
+        } else {
+            clipping_box.min.x = MIN_AU;
+        }
+
+        if scrolling_direction.downward {
+            clipping_box.max.y = MAX_AU;
+        } else {
+            clipping_box.min.y = MIN_AU;
+        }
+
+        let scrollable_overflow_box = scrollable_overflow_from_child
+            .to_box2d()
+            .intersection_unchecked(&clipping_box);
+
+        match scrollable_overflow_box.is_negative() {
+            false => scrollable_overflow_box.to_rect(),
+            true => Rect::zero(),
+        }
     }
 }

--- a/components/layout/fragment_tree/fragment.rs
+++ b/components/layout/fragment_tree/fragment.rs
@@ -183,7 +183,7 @@ impl Fragment {
             || self.scrollable_overflow_for_parent(),
             |box_fragment| {
                 box_fragment.offset_by_containing_block(
-                    &box_fragment.scrollable_overflow(),
+                    &box_fragment.with_style().scrollable_overflow(),
                     layout_thread.into(),
                 )
             },
@@ -212,7 +212,7 @@ impl Fragment {
                 layout_root.inner().scrollable_overflow_for_parent()
             },
             Fragment::Box(fragment) | Fragment::Float(fragment) => {
-                fragment.scrollable_overflow_for_parent()
+                fragment.with_style().scrollable_overflow_for_parent()
             },
             Fragment::Positioning(fragment) => fragment.scrollable_overflow_for_parent(),
             Fragment::AbsoluteOrFixedPositionedPlaceholder(_) |

--- a/components/layout/fragment_tree/fragment.rs
+++ b/components/layout/fragment_tree/fragment.rs
@@ -291,6 +291,7 @@ impl Fragment {
         let Some(fragment) = self.retrieve_box_fragment() else {
             return Rect::zero();
         };
+        let fragment = fragment.with_style();
 
         // https://drafts.csswg.org/cssom-view/#dom-element-clienttop
         // " If the element has no associated CSS layout box or if the

--- a/components/layout/fragment_tree/fragment_tree.rs
+++ b/components/layout/fragment_tree/fragment_tree.rs
@@ -117,10 +117,12 @@ impl FragmentTree {
 
         // Ensure that scrollable overflow that is unreachable is not included in the final
         // rectangle. See <https://drafts.csswg.org/css-overflow/#scrolling-direction>.
-        first_root_fragment.clip_wholly_unreachable_scrollable_overflow(
-            scrollable_overflow,
-            self.initial_containing_block,
-        )
+        first_root_fragment
+            .with_style()
+            .clip_wholly_unreachable_scrollable_overflow(
+                scrollable_overflow,
+                self.initial_containing_block,
+            )
     }
 
     pub(crate) fn find<T>(

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -104,7 +104,7 @@ pub(crate) fn process_box_area_request(
             !exclude_transform_and_inline ||
                 fragment
                     .retrieve_box_fragment()
-                    .is_none_or(|fragment| !fragment.is_inline_box())
+                    .is_none_or(|fragment| !fragment.with_style().is_inline_box())
         })
         .filter_map(|node| node.cumulative_box_area_rect(area, layout_thread.into()))
         .peekable();
@@ -433,7 +433,7 @@ fn resolved_size_should_be_used_value(fragment: &Fragment) -> bool {
         Fragment::LayoutRoot(layout_root) => {
             resolved_size_should_be_used_value(&layout_root.inner())
         },
-        Fragment::Box(box_fragment) => !box_fragment.is_inline_box(),
+        Fragment::Box(box_fragment) => !box_fragment.with_style().is_inline_box(),
         Fragment::Float(_) |
         Fragment::Positioning(_) |
         Fragment::AbsoluteOrFixedPositionedPlaceholder(_) |


### PR DESCRIPTION
`BoxFragment` (indirectly) owns an `Arc<AtomicRefCell<ComputedStyle>>`. To access `&ComputedStyle`, the `AtomicRefCell` must increment an atomic borrow counter and return a guard that decrements the counter when dropped. Layout code accesses the style in many places, but repeatedly borrowing and unborrowing the refcell creates additional traffic of the atomic borrow counter which may have some performance cost.

The new `BoxFragmentWithStyle<'_>` struct packages a `&BoxFragment` with an already-borrowed guard for the style, so using it to repeatedly access the style is free.

Latter commits use this new type in increasingly more places.

This PR makes `blink_perf_tests/flexbox-deeply-nested-column-flow.html` 4% faster: https://github.com/servo/servo/pull/45511#issuecomment-4667247354

Testing: expecting no behavior change or different outcome for existing tests