### PR TITLE
devtools: Fix crash caused by anonymous debugger frame

### DIFF
--- a/components/default-resources/resources/debugger.js
+++ b/components/default-resources/resources/debugger.js
@@ -325,7 +325,7 @@ function createFrameActor(frame, pipelineId) {
         frameActorId = registerFrameActor(pipelineId, {
             // TODO: Some properties throw if terminated is true
             // TODO: arguments: frame.arguments,
-            displayName: frame.script.displayName,
+            displayName: frame.script.displayName ?? null,
             onStack: frame.onStack,
             oldest: frame.older == null,
             terminated: frame.terminated,

--- a/components/devtools/actors/frame.rs
+++ b/components/devtools/actors/frame.rs
@@ -48,7 +48,7 @@ pub(crate) struct FrameActorMsg {
     type_: String,
     arguments: Vec<Value>,
     async_cause: Option<String>,
-    display_name: String,
+    display_name: Option<String>,
     oldest: bool,
     state: FrameState,
     this: ObjectActorMsg,
@@ -155,7 +155,6 @@ impl ActorEncode<FrameActorMsg> for FrameActor {
             type_: self.frame_result.type_.clone(),
             arguments: vec![],
             async_cause,
-            // TODO: Should be optional
             display_name: self.frame_result.display_name.clone(),
             this: registry.encode::<ObjectActor, _>(&self.object_actor),
             oldest: self.frame_result.oldest,

--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -592,7 +592,7 @@ impl DebuggerGlobalScopeMethods<crate::DomTypeHolder> for DebuggerGlobalScope {
         let (tx, rx) = channel::<String>().unwrap();
 
         let frame = devtools_traits::FrameInfo {
-            display_name: result.displayName.clone().into(),
+            display_name: result.displayName.clone().map(String::from),
             on_stack: result.onStack,
             oldest: result.oldest,
             terminated: result.terminated,

--- a/components/script_bindings/webidls/DebuggerInterruptEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerInterruptEvent.webidl
@@ -24,7 +24,7 @@ dictionary PauseReason {
 };
 
 dictionary FrameInfo {
-    required DOMString displayName;
+    required DOMString? displayName;
     required boolean onStack;
     required boolean oldest;
     required boolean terminated;

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -678,7 +678,7 @@ pub struct RecommendedBreakpointLocation {
 
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub struct FrameInfo {
-    pub display_name: String,
+    pub display_name: Option<String>,
     pub on_stack: bool,
     pub oldest: bool,
     pub terminated: bool,


### PR DESCRIPTION
Debugger frames do not always have a script display name. Anonymous frames, timer callbacks, and some generated frames can have `frame.script.displayName` as `undefined`.

For example:
```sh
// anonymous frame
(() => debugger)();

// named frame
function servo() {
  debugger;
}
```


Testing: current tests are passing, also manually tested
Fixes:  #44621 and part of #36027
