### PR TITLE
Revert webgl1/webgl2 rendering context reflector merge

### DIFF
--- a/components/script/dom/webgl/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl/webgl2renderingcontext.rs
@@ -18,7 +18,7 @@ use js::typedarray::{ArrayBufferView, CreateWith, Float32, Int32Array, Uint32, U
 use pixels::{Alpha, Snapshot};
 use script_bindings::conversions::SafeToJSValConvertible;
 use script_bindings::interfaces::WebGL2RenderingContextHelpers;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use servo_base::generic_channel::{self, GenericSharedMemory};
 use servo_canvas_traits::webgl::WebGLError::*;
 use servo_canvas_traits::webgl::{
@@ -44,7 +44,7 @@ use crate::dom::bindings::codegen::UnionTypes::{
 };
 use crate::dom::bindings::error::{ErrorResult, Fallible};
 use crate::dom::bindings::reflector::DomGlobal;
-use crate::dom::bindings::root::{DomRoot, MutNullableDom};
+use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 #[cfg(feature = "webxr")]
@@ -95,9 +95,10 @@ impl IndexedBinding {
     }
 }
 
-#[dom_struct(associated_memory)] // no need to report size here as it is reported as part of WebGLRenderingContext
+#[dom_struct] // no need to report size here as it is reported as part of WebGLRenderingContext
 pub(crate) struct WebGL2RenderingContext {
-    base: WebGLRenderingContext,
+    reflector_: Reflector,
+    base: Dom<WebGLRenderingContext>,
     occlusion_query: MutNullableDom<WebGLQuery>,
     primitives_query: MutNullableDom<WebGLQuery>,
     samplers: Box<[MutNullableDom<WebGLSampler>]>,
@@ -131,37 +132,32 @@ struct ReadPixelsSizes {
 
 impl WebGL2RenderingContext {
     fn new_inherited(
+        cx: &mut js::context::JSContext,
         window: &Window,
         canvas: &RootedHTMLCanvasElementOrOffscreenCanvas,
         size: Size2D<u32>,
         attrs: GLContextAttributes,
     ) -> Option<WebGL2RenderingContext> {
-        let ctx_data =
-            WebGLRenderingContext::create_context_data(window, WebGLVersion::WebGL2, size, attrs)
-                .ok()?;
+        let base =
+            WebGLRenderingContext::new(cx, window, canvas, WebGLVersion::WebGL2, size, attrs)?;
 
-        let limits = &ctx_data.limits;
-        let samplers = (0..limits.max_combined_texture_image_units)
+        let samplers = (0..base.limits().max_combined_texture_image_units)
             .map(|_| Default::default())
             .collect::<Vec<_>>()
             .into();
-        let indexed_uniform_buffer_bindings = (0..limits.max_uniform_buffer_bindings)
+        let indexed_uniform_buffer_bindings = (0..base.limits().max_uniform_buffer_bindings)
             .map(|_| IndexedBinding::new())
             .collect::<Vec<_>>()
             .into();
-        let indexed_transform_feedback_buffer_bindings = (0..limits
-            .max_transform_feedback_separate_attribs)
-            .map(|_| IndexedBinding::new())
-            .collect::<Vec<_>>()
-            .into();
+        let indexed_transform_feedback_buffer_bindings =
+            (0..base.limits().max_transform_feedback_separate_attribs)
+                .map(|_| IndexedBinding::new())
+                .collect::<Vec<_>>()
+                .into();
 
         Some(WebGL2RenderingContext {
-            base: WebGLRenderingContext::new_inherited(
-                canvas,
-                WebGLVersion::WebGL2,
-                size,
-                ctx_data,
-            ),
+            reflector_: Reflector::new(),
+            base: Dom::from_ref(&*base),
             occlusion_query: MutNullableDom::new(None),
             primitives_query: MutNullableDom::new(None),
             samplers,
@@ -190,7 +186,7 @@ impl WebGL2RenderingContext {
         size: Size2D<u32>,
         attrs: GLContextAttributes,
     ) -> Option<DomRoot<WebGL2RenderingContext>> {
-        WebGL2RenderingContext::new_inherited(window, canvas, size, attrs)
+        WebGL2RenderingContext::new_inherited(cx, window, canvas, size, attrs)
             .map(|ctx| reflect_dom_object_with_cx(Box::new(ctx), window, cx))
     }
 
@@ -328,7 +324,7 @@ impl WebGL2RenderingContext {
     }
 
     pub(crate) fn base_context(&self) -> DomRoot<WebGLRenderingContext> {
-        DomRoot::from_ref(&self.base)
+        DomRoot::from_ref(&*self.base)
     }
 
     fn bound_buffer(&self, target: u32) -> WebGLResult<Option<DomRoot<WebGLBuffer>>> {
@@ -2898,7 +2894,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
             return retval.set(NullValue())
         );
 
-        let triple = (&self.base, program.id(), location.id());
+        let triple = (&*self.base, program.id(), location.id());
 
         match location.type_() {
             constants::UNSIGNED_INT => retval.set(UInt32Value(uniform_get(

--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -30,9 +30,9 @@ use servo_base::{Epoch, generic_channel};
 use servo_canvas_traits::webgl::WebGLError::*;
 use servo_canvas_traits::webgl::{
     AlphaTreatment, GLContextAttributes, GLLimits, GlType, Parameter, SizedDataType, TexDataType,
-    TexFormat, TexParameter, WebGLCommand, WebGLCommandBacktrace, WebGLContextId,
-    WebGLCreateContextResult, WebGLError, WebGLFramebufferBindingRequest, WebGLMsg, WebGLMsgSender,
-    WebGLProgramId, WebGLResult, WebGLSLVersion, WebGLVersion, YAxisTreatment, webgl_channel,
+    TexFormat, TexParameter, WebGLCommand, WebGLCommandBacktrace, WebGLContextId, WebGLError,
+    WebGLFramebufferBindingRequest, WebGLMsg, WebGLMsgSender, WebGLProgramId, WebGLResult,
+    WebGLSLVersion, WebGLVersion, YAxisTreatment, webgl_channel,
 };
 use servo_config::pref;
 use webrender_api::ImageKey;
@@ -229,12 +229,14 @@ pub(crate) struct WebGLRenderingContext {
 }
 
 impl WebGLRenderingContext {
-    pub(crate) fn create_context_data(
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
+    pub(crate) fn new_inherited(
         window: &Window,
+        canvas: HTMLCanvasElementOrOffscreenCanvas,
         webgl_version: WebGLVersion,
         size: Size2D<u32>,
         attrs: GLContextAttributes,
-    ) -> Result<WebGLCreateContextResult, String> {
+    ) -> Result<WebGLRenderingContext, String> {
         if pref!(webgl_testing_context_creation_error) {
             return Err("WebGL context creation error forced by pref `webgl.testing.context_creation_error`".into());
         }
@@ -254,58 +256,54 @@ impl WebGLRenderingContext {
                 sender,
             ))
             .unwrap();
-        receiver.recv().unwrap()
-    }
+        let result = receiver.recv().unwrap();
 
-    pub(crate) fn new_inherited(
-        canvas: &RootedHTMLCanvasElementOrOffscreenCanvas,
-        webgl_version: WebGLVersion,
-        size: Size2D<u32>,
-        ctx_data: WebGLCreateContextResult,
-    ) -> WebGLRenderingContext {
-        let max_combined_texture_image_units = ctx_data.limits.max_combined_texture_image_units;
-        let max_vertex_attribs = ctx_data.limits.max_vertex_attribs as usize;
-        WebGLRenderingContext {
-            reflector_: Reflector::new(),
-            webgl_version,
-            glsl_version: ctx_data.glsl_version,
-            limits: ctx_data.limits,
-            canvas: HTMLCanvasElementOrOffscreenCanvas::from(canvas),
-            last_error: Cell::new(None),
-            texture_packing_alignment: Cell::new(4),
-            texture_unpacking_settings: Cell::new(TextureUnpacking::CONVERT_COLORSPACE),
-            texture_unpacking_alignment: Cell::new(4),
-            bound_draw_framebuffer: MutNullableDom::new(None),
-            bound_read_framebuffer: MutNullableDom::new(None),
-            bound_buffer_array: MutNullableDom::new(None),
-            bound_renderbuffer: MutNullableDom::new(None),
-            current_program: MutNullableDom::new(None),
-            current_vertex_attribs: DomRefCell::new(
-                vec![VertexAttrib::Float(0f32, 0f32, 0f32, 1f32); max_vertex_attribs].into(),
-            ),
-            current_scissor: Cell::new((0, 0, size.width, size.height)),
-            // FIXME(#21718) The backend is allowed to choose a size smaller than
-            // what was requested
-            size: Cell::new(size),
-            current_clear_color: Cell::new((0.0, 0.0, 0.0, 0.0)),
-            extension_manager: WebGLExtensions::new(
+        result.map(|ctx_data| {
+            let max_combined_texture_image_units = ctx_data.limits.max_combined_texture_image_units;
+            let max_vertex_attribs = ctx_data.limits.max_vertex_attribs as usize;
+            Self {
+                reflector_: Reflector::new(),
                 webgl_version,
-                ctx_data.api_type,
-                ctx_data.glsl_version,
-            ),
-            capabilities: Default::default(),
-            default_vao: Default::default(),
-            current_vao: Default::default(),
-            default_vao_webgl2: Default::default(),
-            current_vao_webgl2: Default::default(),
-            textures: Textures::new(max_combined_texture_image_units),
-            api_type: ctx_data.api_type,
-            droppable: DroppableWebGLRenderingContext {
-                webgl_sender: ctx_data.sender,
-            },
-        }
+                glsl_version: ctx_data.glsl_version,
+                limits: ctx_data.limits,
+                canvas,
+                last_error: Cell::new(None),
+                texture_packing_alignment: Cell::new(4),
+                texture_unpacking_settings: Cell::new(TextureUnpacking::CONVERT_COLORSPACE),
+                texture_unpacking_alignment: Cell::new(4),
+                bound_draw_framebuffer: MutNullableDom::new(None),
+                bound_read_framebuffer: MutNullableDom::new(None),
+                bound_buffer_array: MutNullableDom::new(None),
+                bound_renderbuffer: MutNullableDom::new(None),
+                current_program: MutNullableDom::new(None),
+                current_vertex_attribs: DomRefCell::new(
+                    vec![VertexAttrib::Float(0f32, 0f32, 0f32, 1f32); max_vertex_attribs].into(),
+                ),
+                current_scissor: Cell::new((0, 0, size.width, size.height)),
+                // FIXME(#21718) The backend is allowed to choose a size smaller than
+                // what was requested
+                size: Cell::new(size),
+                current_clear_color: Cell::new((0.0, 0.0, 0.0, 0.0)),
+                extension_manager: WebGLExtensions::new(
+                    webgl_version,
+                    ctx_data.api_type,
+                    ctx_data.glsl_version,
+                ),
+                capabilities: Default::default(),
+                default_vao: Default::default(),
+                current_vao: Default::default(),
+                default_vao_webgl2: Default::default(),
+                current_vao_webgl2: Default::default(),
+                textures: Textures::new(max_combined_texture_image_units),
+                api_type: ctx_data.api_type,
+                droppable: DroppableWebGLRenderingContext {
+                    webgl_sender: ctx_data.sender,
+                },
+            }
+        })
     }
 
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new(
         cx: &mut js::context::JSContext,
         window: &Window,
@@ -314,8 +312,14 @@ impl WebGLRenderingContext {
         size: Size2D<u32>,
         attrs: GLContextAttributes,
     ) -> Option<DomRoot<WebGLRenderingContext>> {
-        let ctx_data = match Self::create_context_data(window, webgl_version, size, attrs) {
-            Ok(data) => data,
+        match WebGLRenderingContext::new_inherited(
+            window,
+            HTMLCanvasElementOrOffscreenCanvas::from(canvas),
+            webgl_version,
+            size,
+            attrs,
+        ) {
+            Ok(ctx) => Some(reflect_dom_object_with_cx(Box::new(ctx), window, cx)),
             Err(msg) => {
                 error!("Couldn't create WebGLRenderingContext: {}", msg);
                 let event = WebGLContextEvent::new(
@@ -334,20 +338,9 @@ impl WebGLRenderingContext {
                         event.upcast::<Event>().fire(cx, canvas.upcast());
                     },
                 }
-                return None;
+                None
             },
-        };
-
-        Some(reflect_dom_object_with_cx(
-            Box::new(WebGLRenderingContext::new_inherited(
-                canvas,
-                webgl_version,
-                size,
-                ctx_data,
-            )),
-            window,
-            cx,
-        ))
+        }
     }
 
     pub(crate) fn set_image_key(&self, image_key: ImageKey) {

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -2706,8 +2706,6 @@ class CGAssertInheritance(CGThing):
             #
             # FIXME *RenderingContext2D should use Inline
             parentName = "crate::dom::canvasrenderingcontext2d::CanvasRenderingContext2D"
-        if selfName == "WebGL2RenderingContext":
-            parentName = "crate::dom::webgl::webglrenderingcontext::WebGLRenderingContext"
         args = {
             "parentName": parentName,
             "selfName": selfName,

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -169,6 +169,15 @@
       {}
      ]
     ],
+    "webgl": {
+     "weak-reference-crash.html": [
+      "e557c86a1ad014bd96b8370ab5306dd2342d0cdb",
+      [
+       null,
+       {}
+      ]
+     ]
+    },
     "window-resizeTo-not-permitted-crash.html": [
      "7b6a67ff81436a91048bdb627f303f7fab2762f7",
      [

--- a/tests/wpt/mozilla/tests/mozilla/webgl/weak-reference-crash.html
+++ b/tests/wpt/mozilla/tests/mozilla/webgl/weak-reference-crash.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<script>
+  onload = _=>
+    document.createElement("canvas").getContext("webgl2").createProgram();
+</script>
+<iframe srcdoc="about:blank"></iframe>


### PR DESCRIPTION
This reverts the changes from #45095 because they introduced multiple regressions for unclear benefit. WebGL 1 rendering contexts are weak referenceable, but WebGL 2 contexts are not, so sharing the reflector leads to unexpected behaviour from the JS bindings.

Testing: New crash test added.
Fixes: #45167
Fixes: #45501
