### PR TITLE
android: Remove magic `android-toolchains` directory handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 /.servobuild
 /.wpt
 /.vs
-/android-toolchains
 /target
 /tests/wpt/reftests-report/report.html
 /python/_virtualenv*

--- a/etc/run_in_headless_android_emulator.py
+++ b/etc/run_in_headless_android_emulator.py
@@ -85,10 +85,6 @@ def tool_path(directory, bin_name):
         if os.path.exists(path):
             return path
 
-    path = os.path.join(os.path.dirname(__file__), "..", "android-toolchains", "sdk", directory, bin_name)
-    if os.path.exists(path):
-        return path
-
     return bin_name
 
 

--- a/python/servo/platform/build_target.py
+++ b/python/servo/platform/build_target.py
@@ -132,12 +132,6 @@ class AndroidTarget(CrossBuildTarget):
         if config["android"]["ndk"]:
             env["ANDROID_NDK_ROOT"] = config["android"]["ndk"]
 
-        toolchains = path.join(topdir, "android-toolchains")
-        for kind in ["sdk", "ndk"]:
-            default = os.path.join(toolchains, kind)
-            if os.path.isdir(default):
-                env.setdefault(f"ANDROID_{kind.upper()}_ROOT", default)
-
         if "IN_NIX_SHELL" in env and ("ANDROID_NDK_ROOT" not in env or "ANDROID_SDK_ROOT" not in env):
             print("Please set SERVO_ANDROID_BUILD=1 when starting the Nix shell to include the Android SDK/NDK.")
             sys.exit(1)


### PR DESCRIPTION
When digging through the Python build script for Android, I was surprised that one could specify a directory called `android-toolchains` in the root directory, have two subdirectories named `sdk` and `ndk` where you put the SDK and NDK respectively, and then one doesn't need to set the `ANDROID_SDK_ROOT` and `ANDROID_NDK_ROOT` environment variables during the Android set up.

I found this very surprising in terms of behaviour, seemingly undocumented, fragile, and perhaps needless? We're debatably saving some effort here by skipping the setting of the two environment variables, but IMO the cons heavily outweigh the pros.

Testing: Ran `env SERVO_ANDROID_BUILD=1 ./mach build --android`
