### PR TITLE
script: Stub out core interfaces of the Web Animation API

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -207,6 +207,8 @@ pub struct Preferences {
     pub dom_touch_events_legacy_apis_enabled: bool,
     /// <https://html.spec.whatwg.org/multipage/#transient-activation-duration>
     pub dom_transient_activation_duration_ms: i64,
+    // feature: Web Animations | #36950 | Web/API/Web_Animations_API
+    pub dom_web_animations_enabled: bool,
     /// Enable WebGL2 APIs.
     // feature: WebGL2 | #41394 | Web/API/WebGL2RenderingContext
     pub dom_webgl2_enabled: bool,
@@ -425,6 +427,7 @@ impl Preferences {
             dom_touch_events_legacy_apis_enabled: cfg!(target_os = "android") |
                 cfg!(target_env = "ohos"),
             dom_transient_activation_duration_ms: 5000,
+            dom_web_animations_enabled: false,
             dom_webgl2_enabled: false,
             dom_webgpu_enabled: false,
             dom_webgpu_wgpu_backend: String::new(),

--- a/components/script/dom/animations/animation.rs
+++ b/components/script/dom/animations/animation.rs
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use dom_struct::dom_struct;
+use js::context::JSContext;
+use js::rust::HandleObject;
+use script_bindings::codegen::GenericBindings::DocumentBinding::DocumentMethods;
+use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
+use script_bindings::inheritance::Castable;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::root::DomRoot;
+
+use crate::dom::animationeffect::AnimationEffect;
+use crate::dom::bindings::codegen::Bindings::AnimationBinding::AnimationMethods;
+use crate::dom::bindings::root::MutNullableDom;
+use crate::dom::eventtarget::EventTarget;
+use crate::dom::globalscope::GlobalScope;
+use crate::dom::types::AnimationTimeline;
+use crate::dom::window::Window;
+
+/// <https://drafts.csswg.org/web-animations-1/#animation>
+#[dom_struct]
+pub(crate) struct Animation {
+    event_target: EventTarget,
+
+    /// <https://drafts.csswg.org/web-animations-1/#timeline>
+    timeline: MutNullableDom<AnimationTimeline>,
+
+    /// <https://drafts.csswg.org/web-animations-1/#animation-associated-effect>
+    associated_effect: MutNullableDom<AnimationEffect>,
+}
+
+impl Animation {
+    pub(crate) fn new_inherited() -> Self {
+        Self {
+            event_target: EventTarget::new_inherited(),
+            timeline: Default::default(),
+            associated_effect: Default::default(),
+        }
+    }
+
+    fn new_with_proto_and_cx(
+        cx: &mut JSContext,
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+    ) -> DomRoot<Self> {
+        reflect_dom_object_with_proto_and_cx(Box::new(Self::new_inherited()), global, proto, cx)
+    }
+
+    pub(crate) fn new(cx: &mut JSContext, global: &GlobalScope) -> DomRoot<Self> {
+        Self::new_with_proto_and_cx(cx, global, None)
+    }
+
+    /// <https://drafts.csswg.org/web-animations-1/#animation-set-the-timeline-of-an-animation>
+    fn set_the_timeline(&self, timeline: &AnimationTimeline) {
+        // FIXME: Implement this fully
+        self.timeline.set(Some(timeline));
+    }
+
+    /// <https://drafts.csswg.org/web-animations-1/#animation-set-the-associated-effect-of-an-animation>
+    fn set_the_associated_effect(&self, effect: Option<&AnimationEffect>) {
+        // FIXME: Implement this fully
+        self.associated_effect.set(effect);
+    }
+}
+
+impl AnimationMethods<crate::DomTypeHolder> for Animation {
+    /// <https://drafts.csswg.org/web-animations-1/#dom-animation-animation>
+    fn Constructor(
+        cx: &mut JSContext,
+        window: &Window,
+        _object: Option<HandleObject>,
+        effect: Option<&AnimationEffect>,
+    ) -> DomRoot<Self> {
+        // Step 1. Let animation be a new Animation object.
+        let animation = Animation::new(cx, window.upcast());
+
+        // Step 2. Run the procedure to set the timeline of an animation on animation passing timeline
+        // as the new timeline; or, if the timeline argument is missing, passing the default document
+        // timeline of the Document associated with the Window that is the current global object.
+        // TODO: We don't suppor the timeline argument yet.
+        animation.set_the_timeline(window.Document().Timeline().upcast());
+
+        // Step 3. Run the procedure to set the associated effect of an animation on animation passing
+        // source as the new effect.
+        animation.set_the_associated_effect(effect);
+
+        animation
+    }
+}

--- a/components/script/dom/animations/animationeffect.rs
+++ b/components/script/dom/animations/animationeffect.rs
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use dom_struct::dom_struct;
+use script_bindings::reflector::Reflector;
+
+/// <https://drafts.csswg.org/web-animations-1/#animationeffect>
+#[dom_struct]
+pub(crate) struct AnimationEffect {
+    reflector: Reflector,
+}
+
+impl AnimationEffect {
+    pub(crate) fn new_inherited() -> Self {
+        Self {
+            reflector: Reflector::new(),
+        }
+    }
+}

--- a/components/script/dom/animations/keyframeeffect.rs
+++ b/components/script/dom/animations/keyframeeffect.rs
@@ -1,0 +1,110 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use dom_struct::dom_struct;
+use js::context::JSContext;
+use js::jsapi::JSObject;
+use js::rust::HandleObject;
+use script_bindings::codegen::GenericUnionTypes::UnrestrictedDoubleOrKeyframeEffectOptions;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::root::{Dom, DomRoot};
+
+use crate::dom::animationeffect::AnimationEffect;
+use crate::dom::bindings::codegen::Bindings::KeyframeEffectBinding::KeyframeEffectMethods;
+use crate::dom::bindings::root::MutNullableDom;
+use crate::dom::element::Element;
+use crate::dom::window::Window;
+
+/// <https://drafts.csswg.org/web-animations-1/#keyframeeffect>
+#[dom_struct]
+pub(crate) struct KeyframeEffect {
+    animationeffect: AnimationEffect,
+
+    /// The window that this keyframe was constructed in
+    window: Dom<Window>,
+
+    /// <https://drafts.csswg.org/web-animations-1/#effect-target-target-element>
+    // FIXME: Store a target pseudo-selector
+    // to fully match the concept of the effect target
+    //
+    // https://drafts.csswg.org/web-animations-1/#effect-target-target-pseudo-selector
+    // https://drafts.csswg.org/web-animations-1/#keyframe-effect-effect-target.
+    target_element: MutNullableDom<Element>,
+}
+
+impl KeyframeEffect {
+    pub(crate) fn new_inherited(window: &Window) -> Self {
+        Self {
+            window: Dom::from_ref(window),
+            animationeffect: AnimationEffect::new_inherited(),
+            target_element: Default::default(),
+        }
+    }
+
+    fn new_with_proto_and_cx(
+        cx: &mut JSContext,
+        window: &Window,
+        proto: Option<HandleObject>,
+    ) -> DomRoot<Self> {
+        reflect_dom_object_with_proto_and_cx(
+            Box::new(Self::new_inherited(window)),
+            window,
+            proto,
+            cx,
+        )
+    }
+
+    pub(crate) fn new(cx: &mut JSContext, window: &Window) -> DomRoot<Self> {
+        Self::new_with_proto_and_cx(cx, window, None)
+    }
+}
+
+impl KeyframeEffectMethods<crate::DomTypeHolder> for KeyframeEffect {
+    /// <https://drafts.csswg.org/web-animations-1/#dom-keyframeeffect-keyframeeffect>
+    fn Constructor(
+        cx: &mut JSContext,
+        window: &Window,
+        _: Option<HandleObject>,
+        target: Option<&Element>,
+        keyframes: *mut JSObject,
+        _options: UnrestrictedDoubleOrKeyframeEffectOptions,
+    ) -> DomRoot<KeyframeEffect> {
+        // Step 1. Create a new KeyframeEffect object, effect.
+        let effect = KeyframeEffect::new(cx, window);
+
+        // Step 2. Set the target element of effect to target.
+        effect.target_element.set(target);
+
+        // TODO: Step 3. Set the target pseudo-selector to the result corresponding to
+        // the first matching condition below:
+
+        // TODO: Step 4. Let timing input be the result corresponding to the first matching
+        // condition below:
+
+        // Step 5. Call the procedure to update the timing properties of an animation effect of
+        // effect from timing input.
+        // If that procedure causes an exception to be thrown, propagate the exception and abort this procedure.
+
+        // TODO: Step 6. If options is a KeyframeEffectOptions object, assign the composite property of effect
+        // to the corresponding value from options.
+        //
+        // When assigning this property, the error-handling defined for the corresponding setter on the
+        //  KeyframeEffect interface is applied. If the setter requires an exception to be thrown for the value
+        //  specified by options, this procedure must throw the same exception and abort all further steps.
+
+        // Step 7. Initialize the set of keyframes by performing the procedure defined for setKeyframes()
+        // passing keyframes as the input.
+        effect.SetKeyframes(cx, keyframes);
+
+        effect
+    }
+
+    /// <https://drafts.csswg.org/web-animations-1/#dom-keyframeeffect-setkeyframes>
+    fn SetKeyframes(&self, _cx: &mut JSContext, _keyframes: *mut JSObject) {
+        // > This effect’s set of keyframes is replaced with the result of performing the procedure to
+        // > process a keyframes argument. If that procedure throws an exception, this effect’s
+        // > keyframes are not modified.
+        // FIXME: Implement this.
+    }
+}

--- a/components/script/dom/animations/mod.rs
+++ b/components/script/dom/animations/mod.rs
@@ -2,5 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+pub(crate) mod animation;
+pub(crate) mod animationeffect;
 pub(crate) mod animationtimeline;
 pub(crate) mod documenttimeline;
+pub(crate) mod keyframeeffect;

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -21,7 +21,7 @@ use html5ever::serialize::TraversalScope;
 use html5ever::serialize::TraversalScope::{ChildrenOnly, IncludeNode};
 use html5ever::{LocalName, Namespace, Prefix, QualName, local_name, namespace_prefix, ns};
 use js::context::JSContext;
-use js::jsapi::Heap;
+use js::jsapi::{Heap, JSObject};
 use js::jsval::JSVal;
 use js::rust::HandleObject;
 use layout_api::{LayoutDamage, QueryMsg, ScrollContainerQueryFlags, StyleData, with_layout_state};
@@ -64,7 +64,10 @@ use xml5ever::serialize::TraversalScope::{
 
 use crate::conversions::Convert;
 use crate::dom::activation::Activatable;
+use crate::dom::animation::Animation;
+use crate::dom::animations::keyframeeffect::KeyframeEffect;
 use crate::dom::attr::{Attr, is_relevant_attribute};
+use crate::dom::bindings::codegen::Bindings::AnimationBinding::AnimationMethods;
 use crate::dom::bindings::codegen::Bindings::AttrBinding::AttrMethods;
 use crate::dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use crate::dom::bindings::codegen::Bindings::ElementBinding::{
@@ -74,6 +77,7 @@ use crate::dom::bindings::codegen::Bindings::EventHandlerBinding::EventHandlerNo
 use crate::dom::bindings::codegen::Bindings::FunctionBinding::Function;
 use crate::dom::bindings::codegen::Bindings::HTMLElementBinding::HTMLElementMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLTemplateElementBinding::HTMLTemplateElementMethods;
+use crate::dom::bindings::codegen::Bindings::KeyframeEffectBinding::KeyframeEffectMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use crate::dom::bindings::codegen::Bindings::SanitizerBinding::{
     SetHTMLOptions, SetHTMLUnsafeOptions,
@@ -88,6 +92,7 @@ use crate::dom::bindings::codegen::UnionTypes::{
     BooleanOrScrollIntoViewOptions, NodeOrString, TrustedHTMLOrNullIsEmptyString,
     TrustedHTMLOrString,
     TrustedHTMLOrTrustedScriptOrTrustedScriptURLOrString as TrustedTypeOrString,
+    UnrestrictedDoubleOrKeyframeAnimationOptions, UnrestrictedDoubleOrKeyframeEffectOptions,
 };
 use crate::dom::bindings::conversions::DerivedFrom;
 use crate::dom::bindings::domname::{
@@ -4475,6 +4480,54 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         self.ensure_rare_data()
             .part
             .or_init(|| DOMTokenList::new(cx, self, &local_name!("part"), None))
+    }
+
+    /// <https://drafts.csswg.org/web-animations-1/#dom-animatable-animate>
+    fn Animate(
+        &self,
+        cx: &mut JSContext,
+        keyframes: *mut JSObject,
+        options: UnrestrictedDoubleOrKeyframeAnimationOptions,
+    ) -> DomRoot<Animation> {
+        let window = self.owner_window();
+
+        // Step 1. Let target be the object on which this method was called.
+        let target = self;
+
+        // Step 2. Construct a new KeyframeEffect object effect in the relevant Realm
+        // of target by using the same procedure as the KeyframeEffect(target, keyframes, options)
+        // constructor, passing target as the target argument, and the keyframes and options arguments
+        //  as supplied.
+        //
+        // If the above procedure causes an exception to be thrown, propagate the exception and
+        // abort this procedure.
+        let parent_options = match options {
+            UnrestrictedDoubleOrKeyframeAnimationOptions::UnrestrictedDouble(value) => {
+                UnrestrictedDoubleOrKeyframeEffectOptions::UnrestrictedDouble(value)
+            },
+            UnrestrictedDoubleOrKeyframeAnimationOptions::KeyframeAnimationOptions(options) => {
+                UnrestrictedDoubleOrKeyframeEffectOptions::KeyframeEffectOptions(options.parent)
+            },
+        };
+        let effect =
+            KeyframeEffect::Constructor(cx, &window, None, Some(target), keyframes, parent_options);
+
+        // TODO: Step 3. If options is a KeyframeAnimationOptions object, let timeline be the timeline member of
+        // options or, if timeline member of options is missing, the default document timeline of the node document
+        // of the element on which this method was called.
+
+        // Step 4. Construct a new Animation object, animation, in the relevant Realm of target by using
+        // the same procedure as the Animation() constructor, passing effect and timeline as arguments of
+        // the same name.
+        let animation = Animation::Constructor(cx, &window, None, Some(effect.upcast()));
+
+        // TODO: Step 5. If options is a KeyframeAnimationOptions object, assign the value of the id member of options
+        // to animation’s id attribute.
+
+        // TODO: Step 6. Run the procedure to play an animation for animation with the auto-rewind flag set to true.
+
+        // Step 7. Return animation.
+        animation
     }
 }
 

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -32,6 +32,14 @@ DOMInterfaces = {
     'cx': ['Constructor'],
 },
 
+'Animation': {
+    'cx': ['Constructor']
+},
+
+'AnimationEffect': {
+    'cx': ['Constructor']
+},
+
 'Attr': {
     'implicitCxSetters': True,
 },
@@ -379,6 +387,7 @@ DOMInterfaces = {
 'Element': {
     'cx': [
         'After',
+        'Animate',
         'Append',
         'AttachShadow',
         'Before',
@@ -855,6 +864,10 @@ DOMInterfaces = {
 
 'KeyboardEvent': {
     'cx': ['Constructor'],
+},
+
+'KeyframeEffect': {
+    'cx': ['Constructor', 'SetKeyframes']
 },
 
 'LayoutResult': {

--- a/components/script_bindings/webidls/Animatable.webidl
+++ b/components/script_bindings/webidls/Animatable.webidl
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://drafts.csswg.org/web-animations-1/#the-animatable-interface-mixin
+
+interface mixin Animatable {
+    Animation           animate(object? keyframes ,
+                                optional (unrestricted double or KeyframeAnimationOptions) options = {});
+    // sequence<Animation> getAnimations(optional GetAnimationsOptions options = {});
+};
+
+dictionary KeyframeAnimationOptions : KeyframeEffectOptions {
+    DOMString id = "";
+    AnimationTimeline? timeline;
+};
+
+dictionary GetAnimationsOptions {
+    boolean subtree = false;
+    CSSOMString? pseudoElement = null;
+};

--- a/components/script_bindings/webidls/Animatable.webidl
+++ b/components/script_bindings/webidls/Animatable.webidl
@@ -5,6 +5,7 @@
 // https://drafts.csswg.org/web-animations-1/#the-animatable-interface-mixin
 
 interface mixin Animatable {
+    [Pref="dom_web_animations_enabled"]
     Animation           animate(object? keyframes ,
                                 optional (unrestricted double or KeyframeAnimationOptions) options = {});
     // sequence<Animation> getAnimations(optional GetAnimationsOptions options = {});

--- a/components/script_bindings/webidls/Animation.webidl
+++ b/components/script_bindings/webidls/Animation.webidl
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://drafts.csswg.org/web-animations-1/#animation
+
+[Exposed=Window]
+interface Animation : EventTarget {
+  constructor(optional AnimationEffect? effect = null/*,
+              optional AnimationTimeline? timeline */);
+  //          attribute DOMString                id;
+  //          attribute AnimationEffect?         effect;
+  //          attribute AnimationTimeline?       timeline;
+  //          attribute double?                  startTime;
+  //          attribute double?                  currentTime;
+  //          attribute double                   playbackRate;
+  // readonly attribute AnimationPlayState       playState;
+  // readonly attribute AnimationReplaceState    replaceState;
+  // readonly attribute boolean                  pending;
+  // readonly attribute Promise<Animation>       ready;
+  // readonly attribute Promise<Animation>       finished;
+  //          attribute EventHandler             onfinish;
+  //          attribute EventHandler             oncancel;
+  //          attribute EventHandler             onremove;
+  // undefined cancel();
+  // undefined finish();
+  // undefined play();
+  // undefined pause();
+  // undefined updatePlaybackRate(double playbackRate);
+  // undefined reverse();
+  // undefined persist();
+  // [CEReactions]
+  // undefined commitStyles();
+};

--- a/components/script_bindings/webidls/Animation.webidl
+++ b/components/script_bindings/webidls/Animation.webidl
@@ -4,7 +4,7 @@
 
 // https://drafts.csswg.org/web-animations-1/#animation
 
-[Exposed=Window]
+[Exposed=Window, Pref="dom_web_animations_enabled"]
 interface Animation : EventTarget {
   constructor(optional AnimationEffect? effect = null/*,
               optional AnimationTimeline? timeline */);

--- a/components/script_bindings/webidls/AnimationEffect.webidl
+++ b/components/script_bindings/webidls/AnimationEffect.webidl
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 // https://drafts.csswg.org/web-animations-1/#animationeffect
-[Exposed=Window]
+[Exposed=Window, Pref="dom_web_animations_enabled"]
 interface AnimationEffect {
 //     EffectTiming         getTiming();
 //     ComputedEffectTiming getComputedTiming();

--- a/components/script_bindings/webidls/AnimationEffect.webidl
+++ b/components/script_bindings/webidls/AnimationEffect.webidl
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://drafts.csswg.org/web-animations-1/#animationeffect
+[Exposed=Window]
+interface AnimationEffect {
+//     EffectTiming         getTiming();
+//     ComputedEffectTiming getComputedTiming();
+//     undefined            updateTiming(optional OptionalEffectTiming timing = {});
+};
+
+// https://drafts.csswg.org/web-animations-1/#the-effecttiming-dictionaries
+dictionary EffectTiming {
+  double                             delay = 0;
+  double                             endDelay = 0;
+  FillMode                           fill = "auto";
+  double                             iterationStart = 0.0;
+  unrestricted double                iterations = 1.0;
+  (unrestricted double or DOMString) duration = "auto";
+  PlaybackDirection                  direction = "normal";
+  DOMString                          easing = "linear";
+};
+
+dictionary OptionalEffectTiming {
+  double                             delay;
+  double                             endDelay;
+  FillMode                           fill;
+  double                             iterationStart;
+  unrestricted double                iterations;
+  (unrestricted double or DOMString) duration;
+  PlaybackDirection                  direction;
+  DOMString                          easing;
+};
+
+// https://drafts.csswg.org/web-animations-1/#the-fillmode-enumeration
+enum FillMode { "none", "forwards", "backwards", "both", "auto" };
+
+// https://drafts.csswg.org/web-animations-1/#the-playbackdirection-enumeration
+enum PlaybackDirection { "normal", "reverse", "alternate", "alternate-reverse" };

--- a/components/script_bindings/webidls/Element.webidl
+++ b/components/script_bindings/webidls/Element.webidl
@@ -176,3 +176,6 @@ partial interface Element {
 partial interface Element {
   [CEReactions, Throws] undefined setHTML(DOMString html, optional SetHTMLOptions options = {});
 };
+
+// https://drafts.csswg.org/web-animations-1/#extensions-to-the-element-interface
+Element includes Animatable;

--- a/components/script_bindings/webidls/KeyframeEffect.webidl
+++ b/components/script_bindings/webidls/KeyframeEffect.webidl
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://drafts.csswg.org/web-animations-1/#keyframeeffect
+[Exposed=Window]
+interface KeyframeEffect : AnimationEffect {
+  constructor(Element?       target,
+              object?        keyframes,
+              optional (unrestricted double or KeyframeEffectOptions) options = {});
+//   constructor(KeyframeEffect source);
+//   attribute Element?           target;
+//   attribute CSSOMString?       pseudoElement;
+//   attribute CompositeOperation composite;
+//   sequence<object> getKeyframes();
+   undefined        setKeyframes(object? keyframes);
+};
+
+// https://drafts.csswg.org/web-animations-1/#dictdef-keyframeeffectoptions
+dictionary KeyframeEffectOptions : EffectTiming {
+    CompositeOperation composite = "replace";
+    CSSOMString?       pseudoElement = null;
+};
+
+// https://drafts.csswg.org/web-animations-1/#the-compositeoperation-enumeration
+enum CompositeOperation { "replace", "add", "accumulate" };
+enum CompositeOperationOrAuto { "replace", "add", "accumulate", "auto" };
+
+// Necessary for https://drafts.csswg.org/web-animations-1/#process-a-keyframe-like-object
+dictionary BasePropertyIndexedKeyframe {
+//   (double? or sequence<double?>)                         offset = [];
+//   (DOMString or sequence<DOMString>)                     easing = [];
+//   (CompositeOperationOrAuto or sequence<CompositeOperationOrAuto>) composite = [];
+};
+dictionary BaseKeyframe {
+//   double?                  offset = null;
+//   DOMString                easing = "linear";
+//   CompositeOperationOrAuto composite = "auto";
+};

--- a/components/script_bindings/webidls/KeyframeEffect.webidl
+++ b/components/script_bindings/webidls/KeyframeEffect.webidl
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 // https://drafts.csswg.org/web-animations-1/#keyframeeffect
-[Exposed=Window]
+[Exposed=Window, Pref="dom_web_animations_enabled"]
 interface KeyframeEffect : AnimationEffect {
   constructor(Element?       target,
               object?        keyframes,


### PR DESCRIPTION
This is a first step towards implementing the API, getting all the boilerplate out of the way. The interfaces are not functional yet, because I want to keep the pull requests incremental and easy to review. My branch which contains all the work so far is at https://github.com/simonwuelker/servo/tree/web-animations.

Testing: These changes are behind a preference that is not enabled in CI yet. There's also no point in doing so, because there is no functionality to test.
Part of https://github.com/servo/servo/issues/36950
