### PR TITLE
android: remove erroneous versioning of servoview

### DIFF
--- a/support/android/apk/servoview/build.gradle.kts
+++ b/support/android/apk/servoview/build.gradle.kts
@@ -14,9 +14,6 @@ android {
 
     ndkPath = getNdkDir()
 
-    defaultConfig.versionCode = generatedVersionCode
-    defaultConfig.versionName = "0.0.1" // TODO: Parse Servo"s TOML and add git SHA.
-
     defaultConfig {
         minSdk = 30
     }


### PR DESCRIPTION
As mentioned in 76205572c3fc267d2f106e2df43e7fa1faeef547, these `defaultConfig` APIs are actually internal, so shouldn't be used. This versioning code was added in ea109d549023e01b97e510088871a351b9ec7543 to make the app publishable, but only versioning for the app module was required, not the library module.

Once/if we want the library module to be published, we wouldn't use these internal APIs as it wouldn't actually version our library. We'd probably want to use something like the Maven Publish Gradle plugin instead.

Testing: Ran app.