### PR TITLE
tools: Remove the `fake-ld.sh` scripts

### DIFF
--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -106,7 +106,7 @@ FILE_PATTERNS_TO_CHECK = [
 ]
 
 # File patterns that are ignored for all tidy and lint checks.
-FILE_PATTERNS_TO_IGNORE = ["*.#*", "*.pyc", "fake-ld.sh", "*.ogv", "*.webm", "license.html"]
+FILE_PATTERNS_TO_IGNORE = ["*.#*", "*.pyc", "*.ogv", "*.webm", "license.html"]
 
 SPEC_BASE_PATH = "components/script/dom/"
 

--- a/support/arm32/fake-ld.sh
+++ b/support/arm32/fake-ld.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
-echo /usr/bin/arm-linux-gnueabihf-ld -L/usr/lib/arm-linux-gnueabihf $*
-/usr/bin/arm-linux-gnueabihf-ld -L/usr/lib/arm-linux-gnueabihf $*

--- a/support/arm64/fake-ld.sh
+++ b/support/arm64/fake-ld.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
-echo /usr/bin/aarch64-linux-gnu-ld -L/usr/lib/aarch64-linux-gnu $*
-/usr/bin/aarch64-linux-gnu-ld -L/usr/lib/aarch64-linux-gnu $*


### PR DESCRIPTION
These scripts are currently unused in Servo, so we can just remove them.

Testing: This just removes dead code.
