### PR TITLE
android: Ensure that the entire Android build happens in the same target directory

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -124,14 +124,14 @@ jobs:
         id: upload-apk
         with:
           name: ${{ inputs.profile }}-binary-android-${{ matrix.target }}
-          path: target/android/${{ matrix.target }}/${{ inputs.profile }}/servoapp.apk
+          path: target/${{ matrix.target }}/${{ inputs.profile }}/servoapp.apk
           if-no-files-found: error
       - name: Upload AAR artifact
         uses: actions/upload-artifact@v7
         id: upload-aar
         with:
           name: ${{ inputs.profile }}-library-android-${{ matrix.target }}
-          path: target/android/${{ matrix.target }}/${{ inputs.profile }}/servoview.aar
+          path: target/${{ matrix.target }}/${{ inputs.profile }}/servoview.aar
           if-no-files-found: error
       - name: Collect artifact IDs needed by the release workflow
         if: matrix.target == 'aarch64-linux-android'

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -178,7 +178,7 @@ class PackageCommands(CommandBase):
             # Inform the android build of where `libservoshell.so` is located.
             env["SERVO_TARGET_DIR"] = target_dir
 
-            dir_to_resources = path.join(self.get_top_dir(), "target", "android", "resources")
+            dir_to_resources = path.join(self.get_top_dir(), "target", target_triple, "resources")
             if path.exists(dir_to_resources):
                 delete(dir_to_resources)
 

--- a/python/servo/platform/build_target.py
+++ b/python/servo/platform/build_target.py
@@ -258,12 +258,6 @@ class AndroidTarget(CrossBuildTarget):
         # These two variables are needed for the mozjs compilation.
         env["ANDROID_API_LEVEL"] = android_api
         env["ANDROID_NDK_HOME"] = env["ANDROID_NDK_ROOT"]
-
-        # Set output dir for gradle aar files
-        env["AAR_OUT_DIR"] = path.join(topdir, "target", "android", "aar")
-        if not os.path.exists(env["AAR_OUT_DIR"]):
-            os.makedirs(env["AAR_OUT_DIR"])
-
         env["TARGET_PKG_CONFIG_SYSROOT_DIR"] = path.join(llvm_toolchain, "sysroot")
 
     def binary_name(self) -> str:
@@ -277,7 +271,7 @@ class AndroidTarget(CrossBuildTarget):
 
     def get_package_path(self, build_type_directory: str) -> str:
         base_path = util.get_target_dir()
-        base_path = path.join(base_path, "android", self.triple())
+        base_path = path.join(base_path, self.triple())
         apk_name = "servoapp.apk"
         return path.join(base_path, build_type_directory, apk_name)
 

--- a/support/android/apk/buildSrc/src/main/kotlin/Interop.kt
+++ b/support/android/apk/buildSrc/src/main/kotlin/Interop.kt
@@ -10,7 +10,7 @@ Some functions are extensions to the Project class, as to allow access to its pu
 
 fun Project.getTargetDir(debug: Boolean, arch: String): String {
     val basePath = project.rootDir.parentFile.parentFile.parentFile.absolutePath
-    return basePath + "/target/android/" + getSubTargetDir(debug, arch)
+    return basePath + "/target/" + getSubTargetDir(debug, arch)
 }
 
 fun Project.getNativeTargetDir(debug: Boolean, arch: String): String {


### PR DESCRIPTION
Previously part of the Android build would happen in a directory like
`target/aarch64-linux-android` and another part would happen in
`target/android`. That could potentially cause issues if two different
Android builds were running at the same time. This change ensures that
the entire Android build happens in the directory with the name like
`target/aarch64-linux-android`.

In addition, the `AAR_OUT_DIR` variable is no longer set, because it is
ignored anyway.

Testing: A successful Android build is enough to test this change.
