### PR TITLE
layout: Rename `Fragment::AbsoluteOrFixedPositioned` to `Fragment::AbsoluteOrFixedPositionedPlaceholder`

### DIFF
--- a/components/layout/display_list/paint_traversal.rs
+++ b/components/layout/display_list/paint_traversal.rs
@@ -256,7 +256,7 @@ impl<'a, Handler: PaintTraversalHandler> PaintTraversal<'a, Handler> {
                     }
                 }
             },
-            Fragment::AbsoluteOrFixedPositioned(..) |
+            Fragment::AbsoluteOrFixedPositionedPlaceholder(..) |
             Fragment::Text(..) |
             Fragment::Image(..) |
             Fragment::IFrame(..) => {},
@@ -333,7 +333,7 @@ impl<'a, Handler: PaintTraversalHandler> PaintTraversal<'a, Handler> {
                     }
                 }
             },
-            Fragment::AbsoluteOrFixedPositioned(_) |
+            Fragment::AbsoluteOrFixedPositionedPlaceholder(_) |
             Fragment::Float(..) |
             Fragment::IFrame(_) |
             Fragment::Image(_) |
@@ -356,7 +356,7 @@ impl<'a, Handler: PaintTraversalHandler> PaintTraversal<'a, Handler> {
                 self.handler
                     .visit_text(state, containing_block, text_fragment);
             },
-            Fragment::AbsoluteOrFixedPositioned(..) | Fragment::Float(..) => {},
+            Fragment::AbsoluteOrFixedPositionedPlaceholder(..) | Fragment::Float(..) => {},
             Fragment::Positioning(..) => {
                 unreachable!("Unexpected direct descendant PositioningContext of inline.")
             },

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -492,7 +492,7 @@ impl Fragment {
                     text_decorations,
                 );
             },
-            Fragment::AbsoluteOrFixedPositioned(fragment) => {
+            Fragment::AbsoluteOrFixedPositionedPlaceholder(fragment) => {
                 let shared_fragment = fragment.borrow();
                 let fragment_ref = match shared_fragment.fragment.as_ref() {
                     Some(fragment_ref) => fragment_ref,

--- a/components/layout/flexbox/layout.rs
+++ b/components/layout/flexbox/layout.rs
@@ -1027,7 +1027,7 @@ impl FlexContainer {
         );
         let hoisted_fragment = hoisted_box.fragment.clone();
         positioning_context.push(hoisted_box);
-        Fragment::AbsoluteOrFixedPositioned(hoisted_fragment)
+        Fragment::AbsoluteOrFixedPositionedPlaceholder(hoisted_fragment)
     }
 
     #[inline]

--- a/components/layout/flow/inline/line.rs
+++ b/components/layout/flow/inline/line.rs
@@ -737,7 +737,7 @@ impl LineItemLayout<'_, '_> {
         let hoisted_fragment = hoisted_box.fragment.clone();
         self.current_positioning_context_mut().push(hoisted_box);
         self.current_state.fragments.push((
-            Fragment::AbsoluteOrFixedPositioned(hoisted_fragment),
+            Fragment::AbsoluteOrFixedPositionedPlaceholder(hoisted_fragment),
             LogicalRect::zero(),
         ));
     }

--- a/components/layout/flow/mod.rs
+++ b/components/layout/flow/mod.rs
@@ -934,7 +934,7 @@ impl BlockLevelBox {
                 );
                 let hoisted_fragment = hoisted_box.fragment.clone();
                 positioning_context.push(hoisted_box);
-                Fragment::AbsoluteOrFixedPositioned(hoisted_fragment)
+                Fragment::AbsoluteOrFixedPositionedPlaceholder(hoisted_fragment)
             },
             BlockLevelBox::OutOfFlowFloatBox(float_box) => Fragment::Float(
                 float_box
@@ -1989,7 +1989,7 @@ impl<'container> PlacementState<'container> {
                     self.current_margin = fragment_block_margins.end;
                 }
             },
-            Fragment::AbsoluteOrFixedPositioned(fragment) => {
+            Fragment::AbsoluteOrFixedPositionedPlaceholder(fragment) => {
                 // The alignment of absolutes in block flow layout is always "start", so the size of
                 // the static position rectangle does not matter.
                 fragment.borrow_mut().original_static_position_rect = LogicalRect {

--- a/components/layout/fragment_tree/fragment.rs
+++ b/components/layout/fragment_tree/fragment.rs
@@ -37,14 +37,12 @@ pub(crate) enum Fragment {
     /// float containing block formatting context.
     Float(#[conditional_malloc_size_of] Arc<BoxFragment>),
     Positioning(#[conditional_malloc_size_of] Arc<PositioningFragment>),
-    /// Absolute and fixed position fragments are hoisted up so that they
-    /// are children of the BoxFragment that establishes their containing
-    /// blocks, so that they can be laid out properly. When this happens
-    /// an `AbsoluteOrFixedPositioned` fragment is left at the original tree
-    /// position. This allows these hoisted fragments to be painted with
-    /// regard to their original tree order during stacking context tree /
-    /// display list construction.
-    AbsoluteOrFixedPositioned(ArcRefCell<HoistedSharedFragment>),
+    /// Absolute and fixed position fragments are hoisted up so that they are children of the
+    /// BoxFragment that establishes their containing blocks, so that they can be laid out properly.
+    /// When this happens an `AbsoluteOrFixedPositionedPlaceholder` fragment is left at the original
+    /// tree position. This allows these hoisted fragments to be painted with regard to their
+    /// original tree order during stacking context tree / display list construction.
+    AbsoluteOrFixedPositionedPlaceholder(ArcRefCell<HoistedSharedFragment>),
     Text(#[conditional_malloc_size_of] Arc<TextFragment>),
     Image(#[conditional_malloc_size_of] Arc<ImageFragment>),
     IFrame(#[conditional_malloc_size_of] Arc<IFrameFragment>),
@@ -102,7 +100,7 @@ impl Fragment {
         Some(match self {
             Fragment::Box(fragment) => &fragment.base,
             Fragment::Text(fragment) => &fragment.base,
-            Fragment::AbsoluteOrFixedPositioned(_) => return None,
+            Fragment::AbsoluteOrFixedPositionedPlaceholder(_) => return None,
             Fragment::Positioning(fragment) => &fragment.base,
             Fragment::Image(fragment) => &fragment.base,
             Fragment::IFrame(fragment) => &fragment.base,
@@ -118,7 +116,7 @@ impl Fragment {
             Fragment::Positioning(positioning_fragment) => {
                 positioning_fragment.set_containing_block(containing_block)
             },
-            Fragment::AbsoluteOrFixedPositioned(..) |
+            Fragment::AbsoluteOrFixedPositionedPlaceholder(..) |
             Fragment::Text(..) |
             Fragment::Image(..) |
             Fragment::IFrame(..) => {},
@@ -137,7 +135,7 @@ impl Fragment {
                 fragment.print(tree);
                 tree.end_level();
             },
-            Fragment::AbsoluteOrFixedPositioned(_) => {
+            Fragment::AbsoluteOrFixedPositionedPlaceholder(_) => {
                 tree.add_item("AbsoluteOrFixedPositioned".to_string());
             },
             Fragment::Positioning(fragment) => fragment.print(tree),
@@ -174,7 +172,7 @@ impl Fragment {
                 fragment.scrollable_overflow_for_parent()
             },
             Fragment::Positioning(fragment) => fragment.scrollable_overflow_for_parent(),
-            Fragment::AbsoluteOrFixedPositioned(_) |
+            Fragment::AbsoluteOrFixedPositionedPlaceholder(_) |
             Fragment::Text(..) |
             Fragment::Image(..) |
             Fragment::IFrame(..) => self.base().map(|base| base.rect()).unwrap_or_default(),
@@ -205,7 +203,7 @@ impl Fragment {
             // this measurement is concerned with the actual fragments, it's quite likely that this
             // rectangle should include that.
             Fragment::Positioning(fragment) => Some(fragment.base.rect()),
-            Fragment::AbsoluteOrFixedPositioned(_) => None,
+            Fragment::AbsoluteOrFixedPositionedPlaceholder(_) => None,
             Fragment::Text(..) | Fragment::Image(..) | Fragment::IFrame(..) => {
                 Some(self.base()?.rect())
             },
@@ -236,7 +234,7 @@ impl Fragment {
                 ))
             },
             Fragment::Text(_) |
-            Fragment::AbsoluteOrFixedPositioned(_) |
+            Fragment::AbsoluteOrFixedPositionedPlaceholder(_) |
             Fragment::Image(_) |
             Fragment::IFrame(_) => None,
         }

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -420,7 +420,7 @@ fn resolved_size_should_be_used_value(fragment: &Fragment) -> bool {
         Fragment::Box(box_fragment) => !box_fragment.is_inline_box(),
         Fragment::Float(_) |
         Fragment::Positioning(_) |
-        Fragment::AbsoluteOrFixedPositioned(_) |
+        Fragment::AbsoluteOrFixedPositionedPlaceholder(_) |
         Fragment::Image(_) |
         Fragment::IFrame(_) => true,
         Fragment::Text(_) => false,

--- a/components/layout/table/layout.rs
+++ b/components/layout/table/layout.rs
@@ -98,7 +98,7 @@ impl CellLayout {
         self.layout
             .fragments
             .iter()
-            .all(|fragment| matches!(fragment, Fragment::AbsoluteOrFixedPositioned(_)))
+            .all(|fragment| matches!(fragment, Fragment::AbsoluteOrFixedPositionedPlaceholder(_)))
     }
 }
 

--- a/components/layout/taffy/layout.rs
+++ b/components/layout/taffy/layout.rs
@@ -556,7 +556,7 @@ impl TaffyContainer {
                         );
                         let hoisted_fragment = hoisted_box.fragment.clone();
                         container_ctx.positioning_context.push(hoisted_box);
-                        Fragment::AbsoluteOrFixedPositioned(hoisted_fragment)
+                        Fragment::AbsoluteOrFixedPositionedPlaceholder(hoisted_fragment)
                     },
                 };
 


### PR DESCRIPTION
This makes it clearer that this kind of fragment is the placeholder for
the original DOM position of the hoisted absolute.

Testing: This is just a rename, so existing tests should suffice.
