### PR TITLE
script: Replace SafeFromJSValConvertible with FromJSValConvertible

### DIFF
--- a/components/script/dom/clipboard/clipboarditem.rs
+++ b/components/script/dom/clipboard/clipboarditem.rs
@@ -48,14 +48,11 @@ impl Callback for RepresentationDataPromiseFulfillmentHandler {
         // 1. If v is a DOMString, then follow the below steps:
         if v.get().is_string() {
             // 1.1 Let dataAsBytes be the result of UTF-8 encoding v.
-            let data_as_bytes = match FromJSValConvertible::safe_from_jsval(
-                cx,
-                v,
-                StringificationBehavior::Default,
-            ) {
-                Ok(ConversionResult::Success(s)) => s.as_bytes().to_owned(),
-                _ => return,
-            };
+            let data_as_bytes =
+                match DOMString::safe_from_jsval(cx, v, StringificationBehavior::Default) {
+                    Ok(ConversionResult::Success(s)) => s.as_bytes().to_owned(),
+                    _ => return,
+                };
 
             // 1.2 Let blobData be a Blob created using dataAsBytes with its type set to mimeType, serialized.
             let blob_data = Blob::new(
@@ -68,7 +65,7 @@ impl Callback for RepresentationDataPromiseFulfillmentHandler {
             self.promise.resolve_native_with_cx(cx, &blob_data);
         }
         // 2. If v is a Blob, then follow the below steps:
-        else if DomRoot::<Blob>::safe_from_jsval(cx.into(), v, (), CanGc::from_cx(cx))
+        else if DomRoot::<Blob>::safe_from_jsval(cx, v, ())
             .is_ok_and(|result| result.get_success_value().is_some())
         {
             // 2.1 Resolve p with v.

--- a/components/script/dom/clipboard/clipboarditem.rs
+++ b/components/script/dom/clipboard/clipboarditem.rs
@@ -20,7 +20,7 @@ use crate::dom::bindings::codegen::Bindings::ClipboardBinding::{
     ClipboardItemMethods, ClipboardItemOptions, PresentationStyle,
 };
 use crate::dom::bindings::conversions::{
-    ConversionResult, SafeFromJSValConvertible, StringificationBehavior,
+    ConversionResult, FromJSValConvertible, StringificationBehavior,
 };
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::frozenarray::CachedFrozenArray;
@@ -48,11 +48,10 @@ impl Callback for RepresentationDataPromiseFulfillmentHandler {
         // 1. If v is a DOMString, then follow the below steps:
         if v.get().is_string() {
             // 1.1 Let dataAsBytes be the result of UTF-8 encoding v.
-            let data_as_bytes = match DOMString::safe_from_jsval(
-                cx.into(),
+            let data_as_bytes = match FromJSValConvertible::safe_from_jsval(
+                cx,
                 v,
                 StringificationBehavior::Default,
-                CanGc::from_cx(cx),
             ) {
                 Ok(ConversionResult::Success(s)) => s.as_bytes().to_owned(),
                 _ => return,

--- a/components/script/dom/document/documentorshadowroot.rs
+++ b/components/script/dom/document/documentorshadowroot.rs
@@ -8,11 +8,11 @@ use std::fmt;
 
 use embedder_traits::UntrustedNodeAddress;
 use js::context::JSContext;
+use js::conversions::FromJSValConvertible;
 use js::rust::HandleValue;
 use script_bindings::codegen::GenericBindings::DocumentBinding::DocumentMethods;
 use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
 use script_bindings::error::{Error, ErrorResult};
-use script_bindings::script_runtime::CanGc;
 use servo_arc::Arc;
 use servo_config::pref;
 use style::media_queries::MediaList;
@@ -25,7 +25,7 @@ use crate::dom::Document;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::GetRootNodeOptions;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::Node_Binding::NodeMethods;
 use crate::dom::bindings::codegen::Bindings::ShadowRootBinding::ShadowRootMethods;
-use crate::dom::bindings::conversions::{ConversionResult, SafeFromJSValConvertible};
+use crate::dom::bindings::conversions::ConversionResult;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::root::{Dom, DomRoot};
@@ -399,12 +399,8 @@ impl DocumentOrShadowRoot {
         incoming_value: HandleValue,
         owner: &StyleSheetListOwner,
     ) -> ErrorResult {
-        let maybe_stylesheets = Vec::<DomRoot<CSSStyleSheet>>::safe_from_jsval(
-            cx.into(),
-            incoming_value,
-            (),
-            CanGc::from_cx(cx),
-        );
+        let maybe_stylesheets =
+            Vec::<DomRoot<CSSStyleSheet>>::safe_from_jsval(cx, incoming_value, ());
 
         match maybe_stylesheets {
             Ok(ConversionResult::Success(stylesheets)) => {

--- a/components/script/dom/origin.rs
+++ b/components/script/dom/origin.rs
@@ -10,7 +10,7 @@ use servo_url::{ImmutableOrigin, ServoUrl};
 
 use crate::dom::bindings::codegen::Bindings::OriginBinding::OriginMethods;
 use crate::dom::bindings::conversions::{
-    ConversionResult, SafeFromJSValConvertible, StringificationBehavior, root_from_handlevalue,
+    ConversionResult, FromJSValConvertible, StringificationBehavior, root_from_handlevalue,
 };
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::root::DomRoot;
@@ -123,11 +123,10 @@ impl OriginMethods<crate::DomTypeHolder> for Origin {
 
         // Step 2. If value is a string:
         if value.get().is_string() {
-            let s = match DOMString::safe_from_jsval(
+            let s = match FromJSValConvertible::safe_from_jsval(
                 cx,
                 value,
                 StringificationBehavior::Default,
-                can_gc,
             ) {
                 Ok(ConversionResult::Success(s)) => s,
                 _ => return Err(Error::Type(c"Failed to convert value to string".to_owned())),

--- a/components/script/dom/origin.rs
+++ b/components/script/dom/origin.rs
@@ -111,23 +111,25 @@ impl OriginMethods<crate::DomTypeHolder> for Origin {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-origin-from>
-    fn From(cx: JSContext, global: &GlobalScope, value: HandleValue) -> Fallible<DomRoot<Origin>> {
+    fn From(
+        cx: &mut js::context::JSContext,
+        global: &GlobalScope,
+        value: HandleValue,
+    ) -> Fallible<DomRoot<Origin>> {
         let can_gc = CanGc::deprecated_note();
 
         // Step 1. If value is a platform object:
         //   1. Let origin be the result of executing value's extract an origin operation.
         //   2. If origin is not null, then return a new Origin object whose origin is origin.
-        if let Some(origin) = Origin::extract_an_origin_from_platform_object(value, cx, global) {
+        if let Some(origin) =
+            Origin::extract_an_origin_from_platform_object(value, cx.into(), global)
+        {
             return Ok(Origin::new(global, None, origin, can_gc));
         }
 
         // Step 2. If value is a string:
         if value.get().is_string() {
-            let s = match FromJSValConvertible::safe_from_jsval(
-                cx,
-                value,
-                StringificationBehavior::Default,
-            ) {
+            let s = match DOMString::safe_from_jsval(cx, value, StringificationBehavior::Default) {
                 Ok(ConversionResult::Success(s)) => s,
                 _ => return Err(Error::Type(c"Failed to convert value to string".to_owned())),
             };

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -120,7 +120,7 @@ use crate::dom::bindings::codegen::Bindings::DocumentBinding::{
 use crate::dom::bindings::codegen::Bindings::NavigatorBinding::NavigatorMethods;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use crate::dom::bindings::conversions::{
-    ConversionResult, SafeFromJSValConvertible, StringificationBehavior,
+    ConversionResult, FromJSValConvertible, StringificationBehavior,
 };
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::DomGlobal;
@@ -3850,11 +3850,10 @@ impl ScriptThread {
             return None;
         }
 
-        let strval = DOMString::safe_from_jsval(
-            cx.into(),
+        let strval = FromJSValConvertible::safe_from_jsval(
+            cx,
             jsval.handle(),
             StringificationBehavior::Empty,
-            CanGc::from_cx(cx),
         );
         match strval {
             Ok(ConversionResult::Success(s)) => {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3850,11 +3850,7 @@ impl ScriptThread {
             return None;
         }
 
-        let strval = FromJSValConvertible::safe_from_jsval(
-            cx,
-            jsval.handle(),
-            StringificationBehavior::Empty,
-        );
+        let strval = DOMString::safe_from_jsval(cx, jsval.handle(), StringificationBehavior::Empty);
         match strval {
             Ok(ConversionResult::Success(s)) => {
                 // Step 11. Let response be a new response with

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1306,6 +1306,10 @@ DOMInterfaces = {
     'cx': ['Evaluate'],
 },
 
+'Origin': {
+    'cx': ['From'],
+},
+
 'XRBoundedReferenceSpace': {
     'cx': ['BoundsGeometry'],
 },

--- a/components/script_bindings/conversions.rs
+++ b/components/script_bindings/conversions.rs
@@ -78,32 +78,6 @@ pub enum StringificationBehavior {
     Empty,
 }
 
-/// A safe wrapper for `FromJSValConvertible`.
-pub trait SafeFromJSValConvertible: Sized {
-    type Config;
-
-    #[allow(clippy::result_unit_err)] // Type definition depends on mozjs
-    fn safe_from_jsval(
-        cx: SafeJSContext,
-        value: HandleValue,
-        option: Self::Config,
-        _can_gc: CanGc,
-    ) -> Result<ConversionResult<Self>, ()>;
-}
-
-impl<T: FromJSValConvertible> SafeFromJSValConvertible for T {
-    type Config = <T as FromJSValConvertible>::Config;
-
-    fn safe_from_jsval(
-        cx: SafeJSContext,
-        value: HandleValue,
-        option: Self::Config,
-        _can_gc: CanGc,
-    ) -> Result<ConversionResult<Self>, ()> {
-        unsafe { T::from_jsval(*cx, value, option) }
-    }
-}
-
 // https://heycam.github.io/webidl/#es-DOMString
 impl FromJSValConvertible for DOMString {
     type Config = StringificationBehavior;


### PR DESCRIPTION
This PR replaces the remaining DOMString-related usages of `SafeFromJSValConvertible` with direct calls to `FromJSValConvertible` where appropriate and updates the affected call sites to use the newer conversion APIs.

As part of the review process, it also:

* Updates relevant call sites to use the correct `JSContext` signatures.
* Removes obsolete `can_gc` arguments where they are no longer required.
* Removes the `SafeFromJSValConvertible` trait definition and its blanket implementation after migrating the remaining usages.

Testing: It compiles
Fixes: #45131