### PR TITLE
devtools: Report exceptions from evaluated JS.

### DIFF
--- a/components/default-resources/resources/debugger.js
+++ b/components/default-resources/resources/debugger.js
@@ -278,6 +278,7 @@ addEventListener("eval", event => {
         resultValue = {
             completionType: "terminated",
             value: createValueGrip(undefined, 0),
+            exceptionMessage: "",
             hasException: false,
         };
     } else if ("throw" in completionValue) {
@@ -285,15 +286,18 @@ addEventListener("eval", event => {
         // <https://searchfox.org/firefox-main/source/devtools/server/actors/webconsole/eval-with-debugger.js#312>
         // we probably don't need adoptDebuggeeValue, as we only have one debugger instance for now
         // let value = dbg.adoptDebuggeeValue(completionValue.throw);
+        let realError = completionValue.throw.unsafeDereference();
         resultValue = {
             completionType: "throw",
             value: createValueGrip(completionValue.throw, 0),
+            exceptionMessage: realError.message,
             hasException: true,
         };
     } else if ("return" in completionValue) {
         resultValue = {
             completionType: "return",
             value: createValueGrip(completionValue.return, 0),
+            exceptionMessage: "",
             hasException: false,
         };
     }
@@ -301,6 +305,7 @@ addEventListener("eval", event => {
     evalResult(event, {
         completionType: resultValue.completionType,
         serializedValue: JSON.stringify(resultValue.value),
+        exceptionMessage: resultValue.exceptionMessage,
         hasException: resultValue.hasException,
     });
 });

--- a/components/default-resources/resources/debugger.js
+++ b/components/default-resources/resources/debugger.js
@@ -278,7 +278,6 @@ addEventListener("eval", event => {
         resultValue = {
             completionType: "terminated",
             value: createValueGrip(undefined, 0),
-            exceptionMessage: "",
             hasException: false,
         };
     } else if ("throw" in completionValue) {
@@ -297,7 +296,6 @@ addEventListener("eval", event => {
         resultValue = {
             completionType: "return",
             value: createValueGrip(completionValue.return, 0),
-            exceptionMessage: "",
             hasException: false,
         };
     }
@@ -305,7 +303,7 @@ addEventListener("eval", event => {
     evalResult(event, {
         completionType: resultValue.completionType,
         serializedValue: JSON.stringify(resultValue.value),
-        exceptionMessage: resultValue.exceptionMessage,
+        exceptionMessage: resultValue.hasException ? resultValue.exceptionMessage : null,
         hasException: resultValue.hasException,
     });
 });

--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -140,7 +140,7 @@ struct EvaluateJSReply {
     result: Value,
     timestamp: u64,
     exception: Value,
-    exception_message: Value,
+    exception_message: String,
     has_exception: bool,
     helper_result: Value,
 }
@@ -157,7 +157,7 @@ struct EvaluateJSEvent {
     #[serde(rename = "resultID")]
     result_id: String,
     exception: Value,
-    exception_message: Value,
+    exception_message: String,
     has_exception: bool,
     helper_result: Value,
 }
@@ -257,14 +257,26 @@ impl ConsoleActor {
 
         let eval_result = port.recv().map_err(|_| ())?;
         let has_exception = eval_result.has_exception;
-
+        let (result, exception, exception_message) = if has_exception {
+            (
+                Value::Null,
+                debugger_value_to_json(registry, eval_result.value),
+                eval_result.exception_message,
+            )
+        } else {
+            (
+                debugger_value_to_json(registry, eval_result.value),
+                Value::Null,
+                String::new(),
+            )
+        };
         let reply = EvaluateJSReply {
             from: self.name().into(),
             input,
-            result: debugger_value_to_json(registry, eval_result.value),
+            result,
             timestamp: get_time_stamp(),
-            exception: Value::Null,
-            exception_message: Value::Null,
+            exception,
+            exception_message,
             has_exception,
             helper_result: Value::Null,
         };
@@ -414,7 +426,7 @@ impl Actor for ConsoleActor {
                     timestamp: reply.timestamp,
                     result_id,
                     exception: reply.exception,
-                    exception_message: reply.exception_message,
+                    exception_message: reply.exception_message.into(),
                     has_exception: reply.has_exception,
                     helper_result: reply.helper_result,
                 };

--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -140,7 +140,7 @@ struct EvaluateJSReply {
     result: Value,
     timestamp: u64,
     exception: Value,
-    exception_message: String,
+    exception_message: Option<String>,
     has_exception: bool,
     helper_result: Value,
 }
@@ -157,7 +157,7 @@ struct EvaluateJSEvent {
     #[serde(rename = "resultID")]
     result_id: String,
     exception: Value,
-    exception_message: String,
+    exception_message: Option<String>,
     has_exception: bool,
     helper_result: Value,
 }
@@ -257,17 +257,15 @@ impl ConsoleActor {
 
         let eval_result = port.recv().map_err(|_| ())?;
         let has_exception = eval_result.has_exception;
-        let (result, exception, exception_message) = if has_exception {
+        let (result, exception) = if has_exception {
             (
                 Value::Null,
                 debugger_value_to_json(registry, eval_result.value),
-                eval_result.exception_message,
             )
         } else {
             (
                 debugger_value_to_json(registry, eval_result.value),
                 Value::Null,
-                String::new(),
             )
         };
         let reply = EvaluateJSReply {
@@ -276,7 +274,7 @@ impl ConsoleActor {
             result,
             timestamp: get_time_stamp(),
             exception,
-            exception_message,
+            exception_message: eval_result.exception_message,
             has_exception,
             helper_result: Value::Null,
         };
@@ -426,7 +424,7 @@ impl Actor for ConsoleActor {
                     timestamp: reply.timestamp,
                     result_id,
                     exception: reply.exception,
-                    exception_message: reply.exception_message.into(),
+                    exception_message: reply.exception_message.map(|message| message.into()),
                     has_exception: reply.has_exception,
                     helper_result: reply.helper_result,
                 };

--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -424,7 +424,7 @@ impl Actor for ConsoleActor {
                     timestamp: reply.timestamp,
                     result_id,
                     exception: reply.exception,
-                    exception_message: reply.exception_message.map(|message| message.into()),
+                    exception_message: reply.exception_message,
                     has_exception: reply.has_exception,
                     helper_result: reply.helper_result,
                 };

--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -537,7 +537,10 @@ impl DebuggerGlobalScopeMethods<crate::DomTypeHolder> for DebuggerGlobalScope {
             },
         };
 
-        let exception_message = result.exceptionMessage.str().to_string();
+        let exception_message = result
+            .exceptionMessage
+            .as_ref()
+            .map(|message| message.str().to_string());
 
         let reply = EvaluateJSReply {
             value,

--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -537,8 +537,11 @@ impl DebuggerGlobalScopeMethods<crate::DomTypeHolder> for DebuggerGlobalScope {
             },
         };
 
+        let exception_message = result.exceptionMessage.str().to_string();
+
         let reply = EvaluateJSReply {
             value,
+            exception_message,
             has_exception,
         };
 

--- a/components/script_bindings/webidls/DebuggerEvalEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerEvalEvent.webidl
@@ -19,5 +19,6 @@ partial interface DebuggerGlobalScope {
 dictionary EvalResult {
     required DOMString serializedValue;
     required DOMString completionType;
+    required DOMString exceptionMessage;
     boolean hasException;
 };

--- a/components/script_bindings/webidls/DebuggerEvalEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerEvalEvent.webidl
@@ -19,6 +19,6 @@ partial interface DebuggerGlobalScope {
 dictionary EvalResult {
     required DOMString serializedValue;
     required DOMString completionType;
-    required DOMString exceptionMessage;
+    required DOMString? exceptionMessage;
     boolean hasException;
 };

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -257,6 +257,7 @@ pub struct PropertyDescriptor {
 #[serde(rename_all = "camelCase")]
 pub struct EvaluateJSReply {
     pub value: DebuggerValue,
+    pub exception_message: String,
     pub has_exception: bool,
 }
 

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -257,7 +257,7 @@ pub struct PropertyDescriptor {
 #[serde(rename_all = "camelCase")]
 pub struct EvaluateJSReply {
     pub value: DebuggerValue,
-    pub exception_message: String,
+    pub exception_message: Option<String>,
     pub has_exception: bool,
 }
 

--- a/python/servo/devtools_tests/test_console_tab.py
+++ b/python/servo/devtools_tests/test_console_tab.py
@@ -182,7 +182,6 @@ class TestConsoleTab:
         run_servoshell(url="data:text/html,")
 
         result = evaluate("document.head.insertBefore(document.documentElement);")
-        print(result)
         assert not result["result"]
         assert result["exception"]
         assert "Not enough arguments" in result["exceptionMessage"]

--- a/python/servo/devtools_tests/test_console_tab.py
+++ b/python/servo/devtools_tests/test_console_tab.py
@@ -17,6 +17,24 @@ from geckordp.actors.web_console import WebConsoleActor
 from .utils import Devtools
 
 
+def evaluate(js: str, timeout: float = 1) -> dict:
+    with Devtools.connect() as devtools:
+        console = WebConsoleActor(devtools.client, devtools.targets[0]["consoleActor"])
+        evaluation_result = Future()
+        result_id = ""
+
+        def on_evaluation(data):
+            assert result_id == data["resultID"]
+            evaluation_result.set_result(data)
+
+        devtools.client.add_event_listener(console.actor_id, Events.WebConsole.EVALUATION_RESULT, on_evaluation)
+
+        evaluation_result = Future()
+        result = console.evaluate_js_async(js)
+        result_id = result["resultID"]
+        return evaluation_result.result(timeout)
+
+
 def evaluate_and_capture_console_log_output(js: str, timeout: float = 1) -> dict:
     with Devtools.connect() as devtools:
         devtools.watcher.watch_resources([Resources.CONSOLE_MESSAGE])
@@ -159,3 +177,12 @@ class TestConsoleTab:
         # We don't run any assertions on the result because we don't implement previews for the window object
         # yet. The important part is that we didn't crash and didn't time out waiting for
         # a console notification (meaning we got *something*).
+
+    def test_console_throw_exception(self, run_servoshell):
+        run_servoshell(url="data:text/html,")
+
+        result = evaluate("document.head.insertBefore(document.documentElement);")
+        print(result)
+        assert not result["result"]
+        assert result["exception"]
+        assert "Not enough arguments" in result["exceptionMessage"]


### PR DESCRIPTION
The devtools expect exception data to be reported in a different field from non-exceptional values.

Testing: New unit test.
Fixes: #45449
