### PR TITLE
script: JSContextify most of webgpu

### DIFF
--- a/components/script/dom/bindings/buffer_source.rs
+++ b/components/script/dom/bindings/buffer_source.rs
@@ -13,8 +13,6 @@ use std::ptr;
 #[cfg(feature = "webgpu")]
 use std::sync::Arc;
 
-#[cfg(feature = "webgpu")]
-use js::jsapi::NewExternalArrayBuffer;
 use js::jsapi::{
     ArrayBufferClone, ArrayBufferCopyData, GetArrayBufferByteLength,
     HasDefinedArrayBufferDetachKey, Heap, IsArrayBufferObject, IsDetachedArrayBufferObject,
@@ -30,6 +28,8 @@ use js::jsapi::{
 };
 use js::jsval::{ObjectValue, UndefinedValue};
 use js::rust::wrappers::DetachArrayBuffer;
+#[cfg(feature = "webgpu")]
+use js::rust::wrappers2::NewExternalArrayBuffer;
 use js::rust::{
     CustomAutoRooterGuard, Handle, MutableHandleObject,
     MutableHandleValue as SafeMutableHandleValue,
@@ -955,7 +955,11 @@ impl DataBlock {
     }
 
     /// Returns error if requested range is already mapped
-    pub(crate) fn view(&mut self, range: Range<usize>, _can_gc: CanGc) -> Result<&DataView, ()> {
+    pub(crate) fn view(
+        &mut self,
+        cx: &mut js::context::JSContext,
+        range: Range<usize>,
+    ) -> Result<&DataView, ()> {
         if self
             .data_views
             .iter()
@@ -969,7 +973,6 @@ impl DataBlock {
             .expect("range end must be >= range start");
         assert!(range.end <= self.data.len());
 
-        let cx = GlobalScope::get_cx();
         /// `freeFunc()` must be threadsafe, should be safely callable from any thread
         /// without causing conflicts, unexpected behavior.
         unsafe extern "C" fn free_func(_contents: *mut c_void, free_user_data: *mut c_void) {
@@ -984,9 +987,9 @@ impl DataBlock {
         // until `free_func` is called. `range.start..range.end` is inside
         // the valid range of the slice.
         let data_ptr = unsafe { (**raw).as_ptr().add(range.start) };
-        rooted!(in(*cx) let object = unsafe {
+        rooted!(&in(cx) let object = unsafe {
             NewExternalArrayBuffer(
-                *cx,
+                cx,
                 range_len,
                 // FIXME(jschwe): I believe casting to a mutable pointer is unsound.
                 // We would need interior mutability.

--- a/components/script/dom/html/htmlcanvaselement.rs
+++ b/components/script/dom/html/htmlcanvaselement.rs
@@ -338,8 +338,7 @@ impl HTMLCanvasElement {
             .recv()
             .expect("Failed to get WebGPU channel")
             .map(|channel| {
-                let context =
-                    GPUCanvasContext::new(&global_scope, self, channel, CanGc::from_cx(cx));
+                let context = GPUCanvasContext::new(cx, &global_scope, self, channel);
                 self.set_rendering_context(|| RenderingContext::WebGPU(Dom::from_ref(&*context)));
                 context
             })

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -12,6 +12,8 @@ use dom_struct::dom_struct;
 use embedder_traits::{EmbedderMsg, ProtocolHandlerUpdateRegistration, RegisterOrUnregister};
 use headers::HeaderMap;
 use http::header::{self, HeaderValue};
+#[cfg(feature = "webgpu")]
+use js::context::JSContext;
 use js::rust::MutableHandleValue;
 use net_traits::blob_url_store::UrlWithBlobClaim;
 use net_traits::request::{
@@ -500,9 +502,8 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
 
     // https://gpuweb.github.io/gpuweb/#dom-navigator-gpu
     #[cfg(feature = "webgpu")]
-    fn Gpu(&self) -> DomRoot<GPU> {
-        self.gpu
-            .or_init(|| GPU::new(&self.global(), CanGc::deprecated_note()))
+    fn Gpu(&self, cx: &mut JSContext) -> DomRoot<GPU> {
+        self.gpu.or_init(|| GPU::new(cx, &self.global()))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-navigator-hardwareconcurrency>

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -114,6 +114,13 @@ impl Promise {
         Promise::new_with_js_promise(obj.handle(), cx)
     }
 
+    pub(crate) fn new_in_current_realm2(cx: &mut JSContext, _comp: InRealm) -> Rc<Promise> {
+        let cx2 = GlobalScope::get_cx();
+        rooted!(in(*cx2) let mut obj = ptr::null_mut::<JSObject>());
+        Promise::create_js_promise(cx2, obj.handle_mut(), CanGc::from_cx(cx));
+        Promise::new_with_js_promise(obj.handle(), cx2)
+    }
+
     pub(crate) fn new2(cx: &mut js::context::JSContext, global: &GlobalScope) -> Rc<Promise> {
         let mut realm = AutoRealm::new(
             cx,

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -114,13 +114,6 @@ impl Promise {
         Promise::new_with_js_promise(obj.handle(), cx)
     }
 
-    pub(crate) fn new_in_current_realm2(cx: &mut JSContext, _comp: InRealm) -> Rc<Promise> {
-        let cx2 = GlobalScope::get_cx();
-        rooted!(in(*cx2) let mut obj = ptr::null_mut::<JSObject>());
-        Promise::create_js_promise(cx2, obj.handle_mut(), CanGc::from_cx(cx));
-        Promise::new_with_js_promise(obj.handle(), cx2)
-    }
-
     pub(crate) fn new2(cx: &mut js::context::JSContext, global: &GlobalScope) -> Rc<Promise> {
         let mut realm = AutoRealm::new(
             cx,

--- a/components/script/dom/webgpu/gpu.rs
+++ b/components/script/dom/webgpu/gpu.rs
@@ -5,9 +5,10 @@
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::jsapi::HandleObject;
 use js::realm::CurrentRealm;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use servo_constellation_traits::ScriptToConstellationMessage;
 use webgpu_traits::WebGPUAdapterResponse;
 use wgpu_types::PowerPreference;
@@ -24,7 +25,6 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 use crate::dom::webgpu::gpuadapter::GPUAdapter;
 use crate::routed_promise::{RoutedPromiseListener, callback_promise};
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 #[expect(clippy::upper_case_acronyms)]
@@ -42,8 +42,8 @@ impl GPU {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<GPU> {
-        reflect_dom_object(Box::new(GPU::new_inherited()), global, can_gc)
+    pub(crate) fn new(cx: &mut JSContext, global: &GlobalScope) -> DomRoot<GPU> {
+        reflect_dom_object_with_cx(Box::new(GPU::new_inherited()), global, cx)
     }
 }
 
@@ -137,6 +137,7 @@ impl RoutedPromiseListener<WebGPUAdapterResponse> for GPU {
         match response {
             Some(Ok(adapter)) => {
                 let adapter = GPUAdapter::new(
+                    cx,
                     &self.global(),
                     adapter.channel,
                     DOMString::from(format!(
@@ -148,7 +149,6 @@ impl RoutedPromiseListener<WebGPUAdapterResponse> for GPU {
                     adapter.limits,
                     adapter.adapter_info,
                     adapter.adapter_id,
-                    CanGc::from_cx(cx),
                 );
                 promise.resolve_native_with_cx(cx, &adapter);
             },

--- a/components/script/dom/webgpu/gpuadapter.rs
+++ b/components/script/dom/webgpu/gpuadapter.rs
@@ -8,7 +8,8 @@ use dom_struct::dom_struct;
 use js::jsapi::{HandleObject, Heap, JSObject};
 use script_bindings::cformat;
 use script_bindings::like::Setlike;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::script_runtime::CanGc;
 use webgpu_traits::{
     RequestDeviceError, WebGPU, WebGPUAdapter, WebGPUDeviceResponse, WebGPURequest,
 };
@@ -30,7 +31,6 @@ use crate::dom::webgpu::gpudevice::GPUDevice;
 use crate::dom::webgpu::gpusupportedfeatures::gpu_to_wgt_feature;
 use crate::realms::InRealm;
 use crate::routed_promise::{RoutedPromiseListener, callback_promise};
-use crate::script_runtime::CanGc;
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPUAdapter {
@@ -89,6 +89,7 @@ impl GPUAdapter {
 
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         channel: WebGPU,
         name: DOMString,
@@ -97,17 +98,16 @@ impl GPUAdapter {
         limits: wgpu_types::Limits,
         info: wgpu_types::AdapterInfo,
         adapter: WebGPUAdapter,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        let features = GPUSupportedFeatures::Constructor(global, None, features, can_gc).unwrap();
-        let limits = GPUSupportedLimits::new(global, limits, can_gc);
-        let info = GPUAdapter::create_adapter_info(global, info, &features, can_gc);
-        let dom_root = reflect_dom_object(
+        let features = GPUSupportedFeatures::Constructor(cx, global, None, features).unwrap();
+        let limits = GPUSupportedLimits::new(cx, global, limits);
+        let info = GPUAdapter::create_adapter_info(cx, global, info, &features);
+        let dom_root = reflect_dom_object_with_cx(
             Box::new(GPUAdapter::new_inherited(
                 channel, name, &features, &limits, &info, adapter,
             )),
             global,
-            can_gc,
+            cx,
         );
         dom_root.extensions.set(*extensions);
         dom_root
@@ -115,10 +115,10 @@ impl GPUAdapter {
 
     /// <https://gpuweb.github.io/gpuweb/#abstract-opdef-new-adapter-info>
     fn create_adapter_info(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         info: AdapterInfo,
         features: &GPUSupportedFeatures,
-        can_gc: CanGc,
     ) -> DomRoot<GPUAdapterInfo> {
         // Step 2. If the vendor is known, set adapterInfo.vendor to the name of adapter’s vendor as
         // a normalized identifier string. To preserve privacy, the user agent may instead set
@@ -170,6 +170,7 @@ impl GPUAdapter {
 
         // Step 1. Let adapterInfo be a new GPUAdapterInfo.
         GPUAdapterInfo::new(
+            cx,
             global,
             vendor,
             architecture,
@@ -178,7 +179,6 @@ impl GPUAdapter {
             subgroup_min_size,
             subgroup_max_size,
             is_fallback_adapter,
-            can_gc,
         )
     }
 }
@@ -281,6 +281,7 @@ impl RoutedPromiseListener<WebGPUDeviceResponse> for GPUAdapter {
             // 3.1 Let device be a new device with the capabilities described by descriptor.
             (device_id, queue_id, Ok(descriptor)) => {
                 let device = GPUDevice::new(
+                    cx,
                     &self.global(),
                     self.droppable.channel.clone(),
                     self,
@@ -290,18 +291,17 @@ impl RoutedPromiseListener<WebGPUDeviceResponse> for GPUAdapter {
                     device_id,
                     queue_id,
                     descriptor.label.unwrap_or_default(),
-                    CanGc::from_cx(cx),
                 );
                 self.global().add_gpu_device(&device);
                 promise.resolve_native_with_cx(cx, &device);
             },
             // 1. If features are not supported reject promise with a TypeError.
-            (_, _, Err(RequestDeviceError::UnsupportedFeature(f))) => promise.reject_error(
+            (_, _, Err(RequestDeviceError::UnsupportedFeature(f))) => promise.reject_error_with_cx(
+                cx,
                 Error::Type(cformat!(
                     "{}",
                     wgpu_core::instance::RequestDeviceError::UnsupportedFeature(f)
                 )),
-                CanGc::from_cx(cx),
             ),
             // 2. If limits are not supported reject promise with an OperationError.
             (_, _, Err(RequestDeviceError::LimitsExceeded(l))) => {
@@ -318,6 +318,7 @@ impl RoutedPromiseListener<WebGPUDeviceResponse> for GPUAdapter {
                 // causing crashes when one tries to use it
                 // 1. Let device be a new device.
                 let device = GPUDevice::new(
+                    cx,
                     &self.global(),
                     self.droppable.channel.clone(),
                     self,
@@ -327,7 +328,6 @@ impl RoutedPromiseListener<WebGPUDeviceResponse> for GPUAdapter {
                     device_id,
                     queue_id,
                     String::new(),
-                    CanGc::from_cx(cx),
                 );
                 // 2. Lose the device(device, "unknown").
                 device.lose(GPUDeviceLostReason::Unknown, e);

--- a/components/script/dom/webgpu/gpuadapter.rs
+++ b/components/script/dom/webgpu/gpuadapter.rs
@@ -6,10 +6,10 @@ use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::jsapi::{HandleObject, Heap, JSObject};
+use js::realm::CurrentRealm;
 use script_bindings::cformat;
 use script_bindings::like::Setlike;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
-use script_bindings::script_runtime::CanGc;
 use webgpu_traits::{
     RequestDeviceError, WebGPU, WebGPUAdapter, WebGPUDeviceResponse, WebGPURequest,
 };
@@ -29,7 +29,6 @@ use crate::dom::promise::Promise;
 use crate::dom::types::{GPUAdapterInfo, GPUSupportedLimits};
 use crate::dom::webgpu::gpudevice::GPUDevice;
 use crate::dom::webgpu::gpusupportedfeatures::gpu_to_wgt_feature;
-use crate::realms::InRealm;
 use crate::routed_promise::{RoutedPromiseListener, callback_promise};
 
 #[derive(JSTraceable, MallocSizeOf)]
@@ -187,12 +186,11 @@ impl GPUAdapterMethods<crate::DomTypeHolder> for GPUAdapter {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuadapter-requestdevice>
     fn RequestDevice(
         &self,
+        cx: &mut CurrentRealm<'_>,
         descriptor: &GPUDeviceDescriptor,
-        comp: InRealm,
-        can_gc: CanGc,
     ) -> Rc<Promise> {
         // Step 2
-        let promise = Promise::new_in_current_realm(comp, can_gc);
+        let promise = Promise::new_in_realm(cx);
         let callback = callback_promise(
             &promise,
             self,
@@ -203,9 +201,9 @@ impl GPUAdapterMethods<crate::DomTypeHolder> for GPUAdapter {
             if let Some(feature) = gpu_to_wgt_feature(ext) {
                 required_features.insert(feature);
             } else {
-                promise.reject_error(
+                promise.reject_error_with_cx(
+                    cx,
                     Error::Type(cformat!("{} is not supported feature", ext.as_str())),
-                    can_gc,
                 );
                 return promise;
             }
@@ -216,7 +214,7 @@ impl GPUAdapterMethods<crate::DomTypeHolder> for GPUAdapter {
             for (limit, value) in (*limits).iter() {
                 if !set_limit(&mut required_limits, &limit.str(), *value) {
                     warn!("Unknown GPUDevice limit: {limit}");
-                    promise.reject_error(Error::Operation(None), can_gc);
+                    promise.reject_error_with_cx(cx, Error::Operation(None));
                     return promise;
                 }
             }
@@ -247,7 +245,7 @@ impl GPUAdapterMethods<crate::DomTypeHolder> for GPUAdapter {
             })
             .is_err()
         {
-            promise.reject_error(Error::Operation(None), can_gc);
+            promise.reject_error_with_cx(cx, Error::Operation(None));
         }
         // Step 5
         promise

--- a/components/script/dom/webgpu/gpuadapterinfo.rs
+++ b/components/script/dom/webgpu/gpuadapterinfo.rs
@@ -3,13 +3,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use js::context::JSContext;
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPUAdapterInfoMethods;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct GPUAdapterInfo {
@@ -47,6 +47,7 @@ impl GPUAdapterInfo {
 
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         vendor: DOMString,
         architecture: DOMString,
@@ -55,9 +56,8 @@ impl GPUAdapterInfo {
         subgroup_min_size: u32,
         subgroup_max_size: u32,
         is_fallback_adapter: bool,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(Self::new_inherited(
                 vendor,
                 architecture,
@@ -68,16 +68,17 @@ impl GPUAdapterInfo {
                 is_fallback_adapter,
             )),
             global,
-            can_gc,
+            cx,
         )
     }
 
     pub(crate) fn clone_from(
+        cx: &mut JSContext,
         global: &GlobalScope,
         info: &GPUAdapterInfo,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
         Self::new(
+            cx,
             global,
             info.vendor.clone(),
             info.architecture.clone(),
@@ -86,7 +87,6 @@ impl GPUAdapterInfo {
             info.subgroup_min_size,
             info.subgroup_max_size,
             info.is_fallback_adapter,
-            can_gc,
         )
     }
 }

--- a/components/script/dom/webgpu/gpubindgroup.rs
+++ b/components/script/dom/webgpu/gpubindgroup.rs
@@ -5,8 +5,9 @@
 use std::borrow::Cow;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{WebGPU, WebGPUBindGroup, WebGPUDevice, WebGPURequest};
 use wgpu_core::binding_model::BindGroupDescriptor;
 
@@ -18,9 +19,10 @@ use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
+use crate::dom::gpuconvert::convert_bind_group_entry;
 use crate::dom::webgpu::gpubindgrouplayout::GPUBindGroupLayout;
 use crate::dom::webgpu::gpudevice::GPUDevice;
-use crate::script_runtime::CanGc;
+
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPUBindGroup {
     #[no_trace]
@@ -75,20 +77,20 @@ impl GPUBindGroup {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         channel: WebGPU,
         bind_group: WebGPUBindGroup,
         device: WebGPUDevice,
         layout: &GPUBindGroupLayout,
         label: USVString,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(GPUBindGroup::new_inherited(
                 channel, bind_group, device, layout, label,
             )),
             global,
-            can_gc,
+            cx,
         )
     }
 }
@@ -100,14 +102,14 @@ impl GPUBindGroup {
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createbindgroup>
     pub(crate) fn create(
+        cx: &mut JSContext,
         device: &GPUDevice,
         descriptor: &GPUBindGroupDescriptor,
-        can_gc: CanGc,
     ) -> DomRoot<GPUBindGroup> {
         let entries = descriptor
             .entries
             .iter()
-            .map(|bind| bind.convert())
+            .map(|bind| convert_bind_group_entry(cx, bind))
             .collect::<Vec<_>>();
 
         let desc = BindGroupDescriptor {
@@ -130,13 +132,13 @@ impl GPUBindGroup {
         let bind_group = WebGPUBindGroup(bind_group_id);
 
         GPUBindGroup::new(
+            cx,
             &device.global(),
             device.channel(),
             bind_group,
             device.id(),
             &descriptor.layout,
             descriptor.parent.label.clone(),
-            can_gc,
         )
     }
 }

--- a/components/script/dom/webgpu/gpubindgrouplayout.rs
+++ b/components/script/dom/webgpu/gpubindgrouplayout.rs
@@ -5,8 +5,9 @@
 use std::borrow::Cow;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{WebGPU, WebGPUBindGroupLayout, WebGPURequest};
 use wgpu_core::binding_model::BindGroupLayoutDescriptor;
 
@@ -21,7 +22,6 @@ use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::webgpu::gpuconvert::convert_bind_group_layout_entry;
 use crate::dom::webgpu::gpudevice::GPUDevice;
-use crate::script_runtime::CanGc;
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPUBindGroupLayout {
@@ -70,20 +70,20 @@ impl GPUBindGroupLayout {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         channel: WebGPU,
         bind_group_layout: WebGPUBindGroupLayout,
         label: USVString,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(GPUBindGroupLayout::new_inherited(
                 channel,
                 bind_group_layout,
                 label,
             )),
             global,
-            can_gc,
+            cx,
         )
     }
 }
@@ -95,9 +95,9 @@ impl GPUBindGroupLayout {
 
     /// <https://gpuweb.github.io/gpuweb/#GPUDevice-createBindGroupLayout>
     pub(crate) fn create(
+        cx: &mut JSContext,
         device: &GPUDevice,
         descriptor: &GPUBindGroupLayoutDescriptor,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<GPUBindGroupLayout>> {
         let entries = descriptor
             .entries
@@ -130,11 +130,11 @@ impl GPUBindGroupLayout {
         let bgl = WebGPUBindGroupLayout(bind_group_layout_id);
 
         Ok(GPUBindGroupLayout::new(
+            cx,
             &device.global(),
             device.channel(),
             bgl,
             descriptor.parent.label.clone(),
-            can_gc,
         ))
     }
 }

--- a/components/script/dom/webgpu/gpubuffer.rs
+++ b/components/script/dom/webgpu/gpubuffer.rs
@@ -7,9 +7,11 @@ use std::rc::Rc;
 use std::string::String;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::typedarray::HeapArrayBuffer;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::script_runtime::CanGc;
 use script_bindings::trace::RootedTraceableBox;
 use servo_base::generic_channel::GenericSharedMemory;
 use webgpu_traits::{Mapping, WebGPU, WebGPUBuffer, WebGPURequest};
@@ -31,7 +33,6 @@ use crate::dom::promise::Promise;
 use crate::dom::webgpu::gpudevice::GPUDevice;
 use crate::realms::InRealm;
 use crate::routed_promise::{RoutedPromiseListener, callback_promise};
-use crate::script_runtime::{CanGc, JSContext};
 
 #[derive(JSTraceable, MallocSizeOf)]
 pub(crate) struct ActiveBufferMapping {
@@ -110,6 +111,7 @@ impl GPUBuffer {
 
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         channel: WebGPU,
         buffer: WebGPUBuffer,
@@ -118,14 +120,13 @@ impl GPUBuffer {
         usage: GPUFlagsConstant,
         mapping: Option<ActiveBufferMapping>,
         label: USVString,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(GPUBuffer::new_inherited(
                 channel, buffer, device, size, usage, mapping, label,
             )),
             global,
-            can_gc,
+            cx,
         )
     }
 }
@@ -137,9 +138,9 @@ impl GPUBuffer {
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createbuffer>
     pub(crate) fn create(
+        cx: &mut js::context::JSContext,
         device: &GPUDevice,
         descriptor: &GPUBufferDescriptor,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<GPUBuffer>> {
         let desc = wgpu_types::BufferDescriptor {
             label: (&descriptor.parent).convert(),
@@ -170,6 +171,7 @@ impl GPUBuffer {
         };
 
         Ok(GPUBuffer::new(
+            cx,
             &device.global(),
             device.channel(),
             buffer,
@@ -178,7 +180,6 @@ impl GPUBuffer {
             descriptor.usage,
             mapping,
             descriptor.parent.label.clone(),
-            can_gc,
         ))
     }
 }
@@ -200,11 +201,11 @@ impl Drop for GPUBuffer {
 
 impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpubuffer-unmap>
-    fn Unmap(&self) {
+    fn Unmap(&self, cx: &mut js::context::JSContext) {
         // Step 1
         let promise = self.pending_map.borrow_mut().take();
         if let Some(promise) = promise {
-            promise.reject_error(Error::Abort(None), CanGc::deprecated_note());
+            promise.reject_error_with_cx(cx, Error::Abort(None));
         }
         // Step 2
         let mut mapping = self.mapping.borrow_mut().take();
@@ -234,9 +235,9 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpubuffer-destroy>
-    fn Destroy(&self) {
+    fn Destroy(&self, cx: &mut JSContext) {
         // Step 1
-        self.Unmap();
+        self.Unmap(cx);
         // Step 2
         if let Err(e) = self
             .channel
@@ -308,10 +309,9 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpubuffer-getmappedrange>
     fn GetMappedRange(
         &self,
-        _cx: JSContext,
+        cx: &mut js::context::JSContext,
         offset: GPUSize64,
         size: Option<GPUSize64>,
-        can_gc: CanGc,
     ) -> Fallible<RootedTraceableBox<HeapArrayBuffer>> {
         let range_size = if let Some(s) = size {
             s
@@ -340,7 +340,7 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
         let rebased_offset = (offset - mapping.range.start) as usize;
         let result = mapping
             .data
-            .view(rebased_offset..rebased_offset + range_size as usize, can_gc)
+            .view(cx, rebased_offset..rebased_offset + range_size as usize)
             .map(|view| view.array_buffer())
             .map_err(|()| Error::Operation(None));
 
@@ -401,7 +401,7 @@ impl GPUBuffer {
         }
     }
 
-    fn map_success(&self, p: &Rc<Promise>, wgpu_mapping: Mapping, can_gc: CanGc) {
+    fn map_success(&self, cx: &mut js::context::JSContext, p: &Rc<Promise>, wgpu_mapping: Mapping) {
         // Step 1
         if self.pending_map.borrow().as_ref() != Some(p) {
             assert!(p.is_rejected());
@@ -423,7 +423,7 @@ impl GPUBuffer {
         match mapping {
             Err(error) => {
                 *self.pending_map.borrow_mut() = None;
-                p.reject_error(error, can_gc);
+                p.reject_error_with_cx(cx, error);
             },
             Ok(mut mapping) => {
                 // Step 5
@@ -432,7 +432,7 @@ impl GPUBuffer {
                 self.mapping.borrow_mut().replace(mapping);
                 // Step 7
                 self.pending_map.borrow_mut().take();
-                p.resolve_native(&(), can_gc);
+                p.resolve_native_with_cx(cx, &());
             },
         }
     }
@@ -446,7 +446,7 @@ impl RoutedPromiseListener<Result<Mapping, BufferAccessError>> for GPUBuffer {
         promise: &Rc<Promise>,
     ) {
         match response {
-            Ok(mapping) => self.map_success(promise, mapping, CanGc::from_cx(cx)),
+            Ok(mapping) => self.map_success(cx, promise, mapping),
             Err(_) => self.map_failure(promise, CanGc::from_cx(cx)),
         }
     }

--- a/components/script/dom/webgpu/gpubuffer.rs
+++ b/components/script/dom/webgpu/gpubuffer.rs
@@ -8,10 +8,10 @@ use std::string::String;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
+use js::realm::CurrentRealm;
 use js::typedarray::HeapArrayBuffer;
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
-use script_bindings::script_runtime::CanGc;
 use script_bindings::trace::RootedTraceableBox;
 use servo_base::generic_channel::GenericSharedMemory;
 use webgpu_traits::{Mapping, WebGPU, WebGPUBuffer, WebGPURequest};
@@ -31,7 +31,6 @@ use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 use crate::dom::webgpu::gpudevice::GPUDevice;
-use crate::realms::InRealm;
 use crate::routed_promise::{RoutedPromiseListener, callback_promise};
 
 #[derive(JSTraceable, MallocSizeOf)]
@@ -254,16 +253,15 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpubuffer-mapasync>
     fn MapAsync(
         &self,
+        cx: &mut CurrentRealm<'_>,
         mode: u32,
         offset: GPUSize64,
         size: Option<GPUSize64>,
-        comp: InRealm,
-        can_gc: CanGc,
     ) -> Rc<Promise> {
-        let promise = Promise::new_in_current_realm(comp, can_gc);
+        let promise = Promise::new_in_realm(cx);
         // Step 2
         if self.pending_map.borrow().is_some() {
-            promise.reject_error(Error::Operation(None), can_gc);
+            promise.reject_error_with_cx(cx, Error::Operation(None));
             return promise;
         }
         // Step 4
@@ -277,7 +275,7 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
                     .dispatch_error(webgpu_traits::Error::Validation(String::from(
                         "Invalid MapModeFlags",
                     )));
-                self.map_failure(&promise, can_gc);
+                self.map_failure(cx, &promise);
                 return promise;
             },
         };
@@ -299,7 +297,7 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
                 "Failed to send BufferMapAsync ({:?}) ({})",
                 self.buffer.0, e
             );
-            self.map_failure(&promise, can_gc);
+            self.map_failure(cx, &promise);
             return promise;
         }
         // Step 6
@@ -382,7 +380,7 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
 }
 
 impl GPUBuffer {
-    fn map_failure(&self, p: &Rc<Promise>, can_gc: CanGc) {
+    fn map_failure(&self, cx: &mut JSContext, p: &Rc<Promise>) {
         // Step 1
         if self.pending_map.borrow().as_ref() != Some(p) {
             assert!(p.is_rejected());
@@ -395,9 +393,9 @@ impl GPUBuffer {
         // Step 4
         let is_lost = self.device.is_lost();
         if is_lost {
-            p.reject_error(Error::Abort(None), can_gc);
+            p.reject_error_with_cx(cx, Error::Abort(None));
         } else {
-            p.reject_error(Error::Operation(None), can_gc);
+            p.reject_error_with_cx(cx, Error::Operation(None));
         }
     }
 
@@ -447,7 +445,7 @@ impl RoutedPromiseListener<Result<Mapping, BufferAccessError>> for GPUBuffer {
     ) {
         match response {
             Ok(mapping) => self.map_success(cx, promise, mapping),
-            Err(_) => self.map_failure(promise, CanGc::from_cx(cx)),
+            Err(_) => self.map_failure(cx, promise),
         }
     }
 }

--- a/components/script/dom/webgpu/gpucanvascontext.rs
+++ b/components/script/dom/webgpu/gpucanvascontext.rs
@@ -7,10 +7,11 @@ use std::cell::{Cell, RefCell};
 
 use arrayvec::ArrayVec;
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use pixels::Snapshot;
 use script_bindings::cformat;
 use script_bindings::codegen::GenericBindings::WebGPUBinding::GPUTextureFormat;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use servo_base::{Epoch, generic_channel};
 use webgpu_traits::{
     ContextConfiguration, PRESENTATION_BUFFER_COUNT, PendingTexture, WebGPU, WebGPUContextId,
@@ -35,7 +36,6 @@ use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlcanvaselement::HTMLCanvasElement;
-use crate::script_runtime::CanGc;
 
 /// <https://gpuweb.github.io/gpuweb/#supported-context-formats>
 fn supported_context_format(format: GPUTextureFormat) -> bool {
@@ -122,19 +122,19 @@ impl GPUCanvasContext {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         canvas: &HTMLCanvasElement,
         channel: WebGPU,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(GPUCanvasContext::new_inherited(
                 global,
                 HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(Dom::from_ref(canvas)),
                 channel,
             )),
             global,
-            can_gc,
+            cx,
         )
     }
 }
@@ -387,7 +387,7 @@ impl GPUCanvasContextMethods<crate::DomTypeHolder> for GPUCanvasContext {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-getcurrenttexture>
-    fn GetCurrentTexture(&self) -> Fallible<DomRoot<GPUTexture>> {
+    fn GetCurrentTexture(&self, cx: &mut JSContext) -> Fallible<DomRoot<GPUTexture>> {
         // 1. If this.[[configuration]] is null, throw an InvalidStateError and return.
         let configuration = self.configuration.borrow();
         let Some(configuration) = configuration.as_ref() else {
@@ -406,7 +406,7 @@ impl GPUCanvasContextMethods<crate::DomTypeHolder> for GPUCanvasContext {
             self.replace_drawing_buffer();
             // 4.2. Set this.[[currentTexture]] to the result of calling device.createTexture() with this.[[textureDescriptor]],
             // except with the GPUTexture’s underlying storage pointing to this.[[drawingBuffer]].
-            let current_texture = device.CreateTexture(texture_descriptor)?;
+            let current_texture = device.CreateTexture(cx, texture_descriptor)?;
             self.current_texture.set(Some(&current_texture));
 
             // The content of the texture is the content of the canvas.

--- a/components/script/dom/webgpu/gpucommandbuffer.rs
+++ b/components/script/dom/webgpu/gpucommandbuffer.rs
@@ -3,15 +3,15 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{WebGPU, WebGPUCommandBuffer, WebGPURequest};
 
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPUCommandBufferMethods;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::CanGc;
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPUCommandBuffer {
@@ -60,20 +60,20 @@ impl GPUCommandBuffer {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         channel: WebGPU,
         command_buffer: WebGPUCommandBuffer,
         label: USVString,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(GPUCommandBuffer::new_inherited(
                 channel,
                 command_buffer,
                 label,
             )),
             global,
-            can_gc,
+            cx,
         )
     }
 }

--- a/components/script/dom/webgpu/gpucommandencoder.rs
+++ b/components/script/dom/webgpu/gpucommandencoder.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{
     WebGPU, WebGPUCommandBuffer, WebGPUCommandEncoder, WebGPUComputePass, WebGPUDevice,
     WebGPURenderPass, WebGPURequest,
@@ -22,13 +23,12 @@ use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::gpuconvert::convert_load_op;
+use crate::dom::gpuconvert::{convert_load_op, convert_texture_for_wgpu_with_cx};
 use crate::dom::webgpu::gpubuffer::GPUBuffer;
 use crate::dom::webgpu::gpucommandbuffer::GPUCommandBuffer;
 use crate::dom::webgpu::gpucomputepassencoder::GPUComputePassEncoder;
 use crate::dom::webgpu::gpudevice::GPUDevice;
 use crate::dom::webgpu::gpurenderpassencoder::GPURenderPassEncoder;
-use crate::script_runtime::CanGc;
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPUCommandEncoder {
@@ -74,19 +74,19 @@ impl GPUCommandEncoder {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         channel: WebGPU,
         device: &GPUDevice,
         encoder: WebGPUCommandEncoder,
         label: USVString,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(GPUCommandEncoder::new_inherited(
                 channel, device, encoder, label,
             )),
             global,
-            can_gc,
+            cx,
         )
     }
 }
@@ -102,9 +102,9 @@ impl GPUCommandEncoder {
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createcommandencoder>
     pub(crate) fn create(
+        cx: &mut JSContext,
         device: &GPUDevice,
         descriptor: &GPUCommandEncoderDescriptor,
-        can_gc: CanGc,
     ) -> DomRoot<GPUCommandEncoder> {
         let command_encoder_id = device.global().wgpu_id_hub().create_command_encoder_id();
         device
@@ -122,12 +122,12 @@ impl GPUCommandEncoder {
         let encoder = WebGPUCommandEncoder(command_encoder_id);
 
         GPUCommandEncoder::new(
+            cx,
             &device.global(),
             device.channel(),
             device,
             encoder,
             descriptor.parent.label.clone(),
-            can_gc,
         )
     }
 }
@@ -146,6 +146,7 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-begincomputepass>
     fn BeginComputePass(
         &self,
+        cx: &mut JSContext,
         descriptor: &GPUComputePassDescriptor,
     ) -> DomRoot<GPUComputePassEncoder> {
         let compute_pass_id = self.global().wgpu_id_hub().create_compute_pass_id();
@@ -165,18 +166,19 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
         }
 
         GPUComputePassEncoder::new(
+            cx,
             &self.global(),
             self.droppable.channel.clone(),
             self,
             WebGPUComputePass(compute_pass_id),
             descriptor.parent.label.clone(),
-            CanGc::deprecated_note(),
         )
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-beginrenderpass>
     fn BeginRenderPass(
         &self,
+        cx: &mut JSContext,
         descriptor: &GPURenderPassDescriptor,
     ) -> Fallible<DomRoot<GPURenderPassEncoder>> {
         let depth_stencil_attachment = descriptor.depthStencilAttachment.as_ref().map(|ds| {
@@ -197,7 +199,7 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
                     store_op: ds.stencilStoreOp.as_ref().map(Convert::convert),
                     read_only: ds.stencilReadOnly,
                 },
-                view: ds.view.convert().0,
+                view: convert_texture_for_wgpu_with_cx(cx, &ds.view).0,
             }
         });
 
@@ -206,7 +208,10 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
             .iter()
             .map(|color| -> Fallible<_> {
                 Ok(Some(wgpu_com::RenderPassColorAttachment {
-                    resolve_target: color.resolveTarget.as_ref().map(|t| t.convert().0),
+                    resolve_target: color
+                        .resolveTarget
+                        .as_ref()
+                        .map(|t| convert_texture_for_wgpu_with_cx(cx, t).0),
                     load_op: convert_load_op(
                         &color.loadOp,
                         color
@@ -217,7 +222,7 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
                             .unwrap_or_default(),
                     ),
                     store_op: color.storeOp.convert(),
-                    view: color.view.convert().0,
+                    view: convert_texture_for_wgpu_with_cx(cx, &color.view).0,
                     depth_slice: None,
                 }))
             })
@@ -241,12 +246,12 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
         }
 
         Ok(GPURenderPassEncoder::new(
+            cx,
             &self.global(),
             self.droppable.channel.clone(),
             WebGPURenderPass(render_pass_id),
             self,
             descriptor.parent.label.clone(),
-            CanGc::deprecated_note(),
         ))
     }
 
@@ -341,7 +346,11 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-finish>
-    fn Finish(&self, descriptor: &GPUCommandBufferDescriptor) -> DomRoot<GPUCommandBuffer> {
+    fn Finish(
+        &self,
+        cx: &mut JSContext,
+        descriptor: &GPUCommandBufferDescriptor,
+    ) -> DomRoot<GPUCommandBuffer> {
         let command_buffer_id = self.global().wgpu_id_hub().create_command_buffer_id();
         self.droppable
             .channel
@@ -358,11 +367,11 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
 
         let buffer = WebGPUCommandBuffer(command_buffer_id);
         GPUCommandBuffer::new(
+            cx,
             &self.global(),
             self.droppable.channel.clone(),
             buffer,
             descriptor.parent.label.clone(),
-            CanGc::deprecated_note(),
         )
     }
 }

--- a/components/script/dom/webgpu/gpucompilationinfo.rs
+++ b/components/script/dom/webgpu/gpucompilationinfo.rs
@@ -4,7 +4,8 @@
 
 use dom_struct::dom_struct;
 use js::rust::MutableHandleValue;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::script_runtime::CanGc;
 use webgpu_traits::ShaderCompilationInfo;
 
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPUCompilationInfoMethods;
@@ -12,7 +13,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::utils::to_frozen_array;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::types::GPUCompilationMessage;
-use crate::script_runtime::{CanGc, JSContext};
+use crate::script_runtime::JSContext;
 
 #[dom_struct]
 pub(crate) struct GPUCompilationInfo {
@@ -30,27 +31,22 @@ impl GPUCompilationInfo {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         msg: Vec<DomRoot<GPUCompilationMessage>>,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_proto(Box::new(Self::new_inherited(msg)), global, None, can_gc)
+        reflect_dom_object_with_proto_and_cx(Box::new(Self::new_inherited(msg)), global, None, cx)
     }
 
     pub(crate) fn from(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         error: Option<ShaderCompilationInfo>,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        Self::new(
-            global,
-            if let Some(error) = error {
-                vec![GPUCompilationMessage::from(global, error, can_gc)]
-            } else {
-                Vec::new()
-            },
-            can_gc,
-        )
+        let msg = error
+            .map(|error| vec![GPUCompilationMessage::from(cx, global, error)])
+            .unwrap_or_default();
+        Self::new(cx, global, msg)
     }
 }
 

--- a/components/script/dom/webgpu/gpucompilationmessage.rs
+++ b/components/script/dom/webgpu/gpucompilationmessage.rs
@@ -3,7 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use js::context::JSContext;
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::ShaderCompilationInfo;
 
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
@@ -12,7 +13,6 @@ use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::types::GlobalScope;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct GPUCompilationMessage {
@@ -47,6 +47,7 @@ impl GPUCompilationMessage {
 
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         message: DOMString,
         mtype: GPUCompilationMessageType,
@@ -54,23 +55,23 @@ impl GPUCompilationMessage {
         line_pos: u64,
         offset: u64,
         length: u64,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(Self::new_inherited(
                 message, mtype, line_num, line_pos, offset, length,
             )),
             global,
-            can_gc,
+            cx,
         )
     }
 
     pub(crate) fn from(
+        cx: &mut JSContext,
         global: &GlobalScope,
         info: ShaderCompilationInfo,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
         GPUCompilationMessage::new(
+            cx,
             global,
             info.message.into(),
             GPUCompilationMessageType::Error,
@@ -78,7 +79,6 @@ impl GPUCompilationMessage {
             info.line_pos,
             info.offset,
             info.length,
-            can_gc,
         )
     }
 }

--- a/components/script/dom/webgpu/gpucomputepassencoder.rs
+++ b/components/script/dom/webgpu/gpucomputepassencoder.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{WebGPU, WebGPUComputePass, WebGPURequest};
 
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPUComputePassEncoderMethods;
@@ -15,7 +16,6 @@ use crate::dom::webgpu::gpubindgroup::GPUBindGroup;
 use crate::dom::webgpu::gpubuffer::GPUBuffer;
 use crate::dom::webgpu::gpucommandencoder::GPUCommandEncoder;
 use crate::dom::webgpu::gpucomputepipeline::GPUComputePipeline;
-use crate::script_runtime::CanGc;
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPUComputePassEncoder {
@@ -64,14 +64,14 @@ impl GPUComputePassEncoder {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         channel: WebGPU,
         parent: &GPUCommandEncoder,
         compute_pass: WebGPUComputePass,
         label: USVString,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(GPUComputePassEncoder::new_inherited(
                 channel,
                 parent,
@@ -79,7 +79,7 @@ impl GPUComputePassEncoder {
                 label,
             )),
             global,
-            can_gc,
+            cx,
         )
     }
 }

--- a/components/script/dom/webgpu/gpucomputepipeline.rs
+++ b/components/script/dom/webgpu/gpucomputepipeline.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use servo_base::generic_channel::GenericCallback;
 use webgpu_traits::{
     WebGPU, WebGPUBindGroupLayout, WebGPUComputePipeline, WebGPUComputePipelineResponse,
@@ -23,7 +24,6 @@ use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::webgpu::gpubindgrouplayout::GPUBindGroupLayout;
 use crate::dom::webgpu::gpudevice::GPUDevice;
-use crate::script_runtime::CanGc;
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPUComputePipeline {
@@ -74,20 +74,20 @@ impl GPUComputePipeline {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         compute_pipeline: WebGPUComputePipeline,
         label: USVString,
         device: &GPUDevice,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(GPUComputePipeline::new_inherited(
                 compute_pipeline,
                 label,
                 device,
             )),
             global,
-            can_gc,
+            cx,
         )
     }
 }
@@ -141,7 +141,11 @@ impl GPUComputePipelineMethods<crate::DomTypeHolder> for GPUComputePipeline {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpupipelinebase-getbindgrouplayout>
-    fn GetBindGroupLayout(&self, index: u32) -> Fallible<DomRoot<GPUBindGroupLayout>> {
+    fn GetBindGroupLayout(
+        &self,
+        cx: &mut JSContext,
+        index: u32,
+    ) -> Fallible<DomRoot<GPUBindGroupLayout>> {
         let id = self.global().wgpu_id_hub().create_bind_group_layout_id();
 
         if let Err(e) = self
@@ -159,11 +163,11 @@ impl GPUComputePipelineMethods<crate::DomTypeHolder> for GPUComputePipeline {
         }
 
         Ok(GPUBindGroupLayout::new(
+            cx,
             &self.global(),
             self.droppable.channel.clone(),
             WebGPUBindGroupLayout(id),
             USVString::default(),
-            CanGc::deprecated_note(),
         ))
     }
 }

--- a/components/script/dom/webgpu/gpuconvert.rs
+++ b/components/script/dom/webgpu/gpuconvert.rs
@@ -5,6 +5,7 @@
 use std::borrow::Cow;
 use std::num::NonZeroU64;
 
+use js::context::JSContext;
 use webgpu_traits::WebGPUTextureView;
 use wgpu_core::binding_model::{BindGroupEntry, BindingResource, BufferBinding};
 use wgpu_core::command as wgpu_com;
@@ -703,39 +704,39 @@ impl<'a> Convert<ProgrammableStageDescriptor<'a>> for &GPUProgrammableStage {
     }
 }
 
-impl Convert<WebGPUTextureView> for &GPUTextureOrGPUTextureView {
-    fn convert(self) -> WebGPUTextureView {
-        match self {
-            GPUTextureOrGPUTextureView::GPUTextureView(view) => view.id(),
-            GPUTextureOrGPUTextureView::GPUTexture(texture) => texture.get_default_view(),
-        }
+pub(crate) fn convert_texture_for_wgpu_with_cx(
+    cx: &mut JSContext,
+    texture_view: &GPUTextureOrGPUTextureView,
+) -> WebGPUTextureView {
+    match texture_view {
+        GPUTextureOrGPUTextureView::GPUTextureView(view) => view.id(),
+        GPUTextureOrGPUTextureView::GPUTexture(texture) => texture.get_default_view(cx),
     }
 }
 
-impl<'a> Convert<BindGroupEntry<'a>> for &GPUBindGroupEntry {
-    fn convert(self) -> BindGroupEntry<'a> {
-        BindGroupEntry {
-            binding: self.binding,
-            resource: match self.resource {
-                GPUBindingResource::GPUSampler(ref s) => BindingResource::Sampler(s.id().0),
-                GPUBindingResource::GPUTextureView(ref t) => BindingResource::TextureView(t.id().0),
-                GPUBindingResource::GPUTexture(ref t) => {
-                    BindingResource::TextureView(t.get_default_view().0)
-                },
-                GPUBindingResource::GPUBufferBinding(ref b) => {
-                    BindingResource::Buffer(BufferBinding {
-                        buffer: b.buffer.id().0,
-                        offset: b.offset,
-                        size: b.size,
-                    })
-                },
-                GPUBindingResource::GPUBuffer(ref b) => BindingResource::Buffer(BufferBinding {
-                    buffer: b.id().0,
-                    offset: 0,
-                    size: None,
-                }),
+pub(crate) fn convert_bind_group_entry<'a>(
+    cx: &mut JSContext,
+    bind_group: &GPUBindGroupEntry,
+) -> BindGroupEntry<'a> {
+    BindGroupEntry {
+        binding: bind_group.binding,
+        resource: match bind_group.resource {
+            GPUBindingResource::GPUSampler(ref s) => BindingResource::Sampler(s.id().0),
+            GPUBindingResource::GPUTextureView(ref t) => BindingResource::TextureView(t.id().0),
+            GPUBindingResource::GPUTexture(ref t) => {
+                BindingResource::TextureView(t.get_default_view(cx).0)
             },
-        }
+            GPUBindingResource::GPUBufferBinding(ref b) => BindingResource::Buffer(BufferBinding {
+                buffer: b.buffer.id().0,
+                offset: b.offset,
+                size: b.size,
+            }),
+            GPUBindingResource::GPUBuffer(ref b) => BindingResource::Buffer(BufferBinding {
+                buffer: b.id().0,
+                offset: 0,
+                size: None,
+            }),
+        },
     }
 }
 

--- a/components/script/dom/webgpu/gpudevice.rs
+++ b/components/script/dom/webgpu/gpudevice.rs
@@ -7,10 +7,12 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::jsapi::{HandleObject, Heap, JSObject};
 use script_bindings::cell::DomRefCell;
 use script_bindings::cformat;
-use script_bindings::reflector::reflect_dom_object;
+use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::script_runtime::CanGc;
 use webgpu_traits::{
     PopError, WebGPU, WebGPUComputePipeline, WebGPUComputePipelineResponse, WebGPUDevice,
     WebGPUPoppedErrorScopeResponse, WebGPUQueue, WebGPURenderPipeline,
@@ -66,7 +68,6 @@ use crate::dom::webgpu::gputexture::GPUTexture;
 use crate::dom::webgpu::gpuuncapturederrorevent::GPUUncapturedErrorEvent;
 use crate::realms::InRealm;
 use crate::routed_promise::{RoutedPromiseListener, callback_promise};
-use crate::script_runtime::CanGc;
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPUDevice {
@@ -150,6 +151,7 @@ impl GPUDevice {
 
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         channel: WebGPU,
         adapter: &GPUAdapter,
@@ -159,14 +161,13 @@ impl GPUDevice {
         device: WebGPUDevice,
         queue: WebGPUQueue,
         label: String,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        let queue = GPUQueue::new(global, channel.clone(), queue, can_gc);
-        let limits = GPUSupportedLimits::new(global, limits, can_gc);
-        let features = GPUSupportedFeatures::Constructor(global, None, features, can_gc).unwrap();
-        let adapter_info = GPUAdapterInfo::clone_from(global, &adapter.Info(), can_gc);
-        let lost_promise = Promise::new(global, can_gc);
-        let device = reflect_dom_object(
+        let queue = GPUQueue::new(cx, global, channel.clone(), queue);
+        let limits = GPUSupportedLimits::new(cx, global, limits);
+        let features = GPUSupportedFeatures::Constructor(cx, global, None, features).unwrap();
+        let adapter_info = GPUAdapterInfo::clone_from(cx, global, &adapter.Info());
+        let lost_promise = Promise::new2(cx, global);
+        let device = reflect_dom_object_with_cx(
             Box::new(GPUDevice::new_inherited(
                 channel,
                 adapter,
@@ -179,7 +180,7 @@ impl GPUDevice {
                 lost_promise,
             )),
             global,
-            can_gc,
+            cx,
         );
         queue.set_device(&device);
         device.extensions.set(*extensions);
@@ -218,16 +219,15 @@ impl GPUDevice {
         self.global().task_manager().webgpu_task_source().queue(
             task!(fire_uncaptured_error: move |cx| {
                 let this = this.root();
-                let error = GPUError::from_error(&this.global(), error, CanGc::from_cx(cx));
+                let error = GPUError::from_error(cx, &this.global(), error);
 
-                let event = GPUUncapturedErrorEvent::new(
+                let event = GPUUncapturedErrorEvent::new(cx,
                     &this.global(),
                     atom!("uncapturederror"),
                     &GPUUncapturedErrorEventInit {
                         error,
                         parent: EventInit::empty(),
                     },
-                    CanGc::from_cx(cx),
                 );
 
                 event.upcast::<Event>().fire(cx, this.upcast());
@@ -442,29 +442,39 @@ impl GPUDeviceMethods<crate::DomTypeHolder> for GPUDevice {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createbuffer>
-    fn CreateBuffer(&self, descriptor: &GPUBufferDescriptor) -> Fallible<DomRoot<GPUBuffer>> {
-        GPUBuffer::create(self, descriptor, CanGc::deprecated_note())
+    fn CreateBuffer(
+        &self,
+        cx: &mut JSContext,
+        descriptor: &GPUBufferDescriptor,
+    ) -> Fallible<DomRoot<GPUBuffer>> {
+        GPUBuffer::create(cx, self, descriptor)
     }
 
     /// <https://gpuweb.github.io/gpuweb/#GPUDevice-createBindGroupLayout>
     fn CreateBindGroupLayout(
         &self,
+        cx: &mut JSContext,
         descriptor: &GPUBindGroupLayoutDescriptor,
     ) -> Fallible<DomRoot<GPUBindGroupLayout>> {
-        GPUBindGroupLayout::create(self, descriptor, CanGc::deprecated_note())
+        GPUBindGroupLayout::create(cx, self, descriptor)
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createpipelinelayout>
     fn CreatePipelineLayout(
         &self,
+        cx: &mut JSContext,
         descriptor: &GPUPipelineLayoutDescriptor,
     ) -> DomRoot<GPUPipelineLayout> {
-        GPUPipelineLayout::create(self, descriptor, CanGc::deprecated_note())
+        GPUPipelineLayout::create(cx, self, descriptor)
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createbindgroup>
-    fn CreateBindGroup(&self, descriptor: &GPUBindGroupDescriptor) -> DomRoot<GPUBindGroup> {
-        GPUBindGroup::create(self, descriptor, CanGc::deprecated_note())
+    fn CreateBindGroup(
+        &self,
+        cx: &mut JSContext,
+        descriptor: &GPUBindGroupDescriptor,
+    ) -> DomRoot<GPUBindGroup> {
+        GPUBindGroup::create(cx, self, descriptor)
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createshadermodule>
@@ -472,23 +482,23 @@ impl GPUDeviceMethods<crate::DomTypeHolder> for GPUDevice {
         &self,
         descriptor: RootedTraceableBox<GPUShaderModuleDescriptor>,
         comp: InRealm,
-        can_gc: CanGc,
     ) -> DomRoot<GPUShaderModule> {
-        GPUShaderModule::create(self, descriptor, comp, can_gc)
+        GPUShaderModule::create(self, descriptor, comp, CanGc::deprecated_note())
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createcomputepipeline>
     fn CreateComputePipeline(
         &self,
+        cx: &mut JSContext,
         descriptor: &GPUComputePipelineDescriptor,
     ) -> DomRoot<GPUComputePipeline> {
         let compute_pipeline = GPUComputePipeline::create(self, descriptor, None);
         GPUComputePipeline::new(
+            cx,
             &self.global(),
             compute_pipeline,
             descriptor.parent.parent.label.clone(),
             self,
-            CanGc::deprecated_note(),
         )
     }
 
@@ -497,9 +507,8 @@ impl GPUDeviceMethods<crate::DomTypeHolder> for GPUDevice {
         &self,
         descriptor: &GPUComputePipelineDescriptor,
         comp: InRealm,
-        can_gc: CanGc,
     ) -> Rc<Promise> {
-        let promise = Promise::new_in_current_realm(comp, can_gc);
+        let promise = Promise::new_in_current_realm(comp, CanGc::deprecated_note());
         let callback = callback_promise(
             &promise,
             self,
@@ -512,34 +521,44 @@ impl GPUDeviceMethods<crate::DomTypeHolder> for GPUDevice {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createcommandencoder>
     fn CreateCommandEncoder(
         &self,
+        cx: &mut JSContext,
         descriptor: &GPUCommandEncoderDescriptor,
     ) -> DomRoot<GPUCommandEncoder> {
-        GPUCommandEncoder::create(self, descriptor, CanGc::deprecated_note())
+        GPUCommandEncoder::create(cx, self, descriptor)
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createtexture>
-    fn CreateTexture(&self, descriptor: &GPUTextureDescriptor) -> Fallible<DomRoot<GPUTexture>> {
-        GPUTexture::create(self, descriptor, CanGc::deprecated_note())
+    fn CreateTexture(
+        &self,
+        cx: &mut JSContext,
+        descriptor: &GPUTextureDescriptor,
+    ) -> Fallible<DomRoot<GPUTexture>> {
+        GPUTexture::create(cx, self, descriptor)
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createsampler>
-    fn CreateSampler(&self, descriptor: &GPUSamplerDescriptor) -> DomRoot<GPUSampler> {
-        GPUSampler::create(self, descriptor, CanGc::deprecated_note())
+    fn CreateSampler(
+        &self,
+        cx: &mut JSContext,
+        descriptor: &GPUSamplerDescriptor,
+    ) -> DomRoot<GPUSampler> {
+        GPUSampler::create(cx, self, descriptor)
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createrenderpipeline>
     fn CreateRenderPipeline(
         &self,
+        cx: &mut JSContext,
         descriptor: &GPURenderPipelineDescriptor,
     ) -> Fallible<DomRoot<GPURenderPipeline>> {
         let desc = self.parse_render_pipeline(descriptor)?;
         let render_pipeline = GPURenderPipeline::create(self, desc, None)?;
         Ok(GPURenderPipeline::new(
+            cx,
             &self.global(),
             render_pipeline,
             descriptor.parent.parent.label.clone(),
             self,
-            CanGc::deprecated_note(),
         ))
     }
 
@@ -548,10 +567,9 @@ impl GPUDeviceMethods<crate::DomTypeHolder> for GPUDevice {
         &self,
         descriptor: &GPURenderPipelineDescriptor,
         comp: InRealm,
-        can_gc: CanGc,
     ) -> Fallible<Rc<Promise>> {
         let desc = self.parse_render_pipeline(descriptor)?;
-        let promise = Promise::new_in_current_realm(comp, can_gc);
+        let promise = Promise::new_in_current_realm(comp, CanGc::deprecated_note());
         let callback = callback_promise(
             &promise,
             self,
@@ -564,9 +582,10 @@ impl GPUDeviceMethods<crate::DomTypeHolder> for GPUDevice {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createrenderbundleencoder>
     fn CreateRenderBundleEncoder(
         &self,
+        cx: &mut JSContext,
         descriptor: &GPURenderBundleEncoderDescriptor,
     ) -> Fallible<DomRoot<GPURenderBundleEncoder>> {
-        GPURenderBundleEncoder::create(self, descriptor, CanGc::deprecated_note())
+        GPURenderBundleEncoder::create(cx, self, descriptor)
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-pusherrorscope>
@@ -586,8 +605,8 @@ impl GPUDeviceMethods<crate::DomTypeHolder> for GPUDevice {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-poperrorscope>
-    fn PopErrorScope(&self, comp: InRealm, can_gc: CanGc) -> Rc<Promise> {
-        let promise = Promise::new_in_current_realm(comp, can_gc);
+    fn PopErrorScope(&self, comp: InRealm) -> Rc<Promise> {
+        let promise = Promise::new_in_current_realm(comp, CanGc::deprecated_note());
         let callback = callback_promise(
             &promise,
             self,
@@ -637,11 +656,11 @@ impl RoutedPromiseListener<WebGPUPoppedErrorScopeResponse> for GPUDevice {
     ) {
         match response {
             Ok(None) | Err(PopError::Lost) => {
-                promise.resolve_native(&None::<Option<GPUError>>, CanGc::from_cx(cx))
+                promise.resolve_native_with_cx(cx, &None::<Option<GPUError>>)
             },
             Err(PopError::Empty) => promise.reject_error_with_cx(cx, Error::Operation(None)),
             Ok(Some(error)) => {
-                let error = GPUError::from_error(&self.global(), error, CanGc::from_cx(cx));
+                let error = GPUError::from_error(cx, &self.global(), error);
                 promise.resolve_native_with_cx(cx, &error);
             },
         }
@@ -656,35 +675,33 @@ impl RoutedPromiseListener<WebGPUComputePipelineResponse> for GPUDevice {
         promise: &Rc<Promise>,
     ) {
         match response {
-            Ok(pipeline) => promise.resolve_native(
-                &GPUComputePipeline::new(
+            Ok(pipeline) => {
+                let gpu_compute_pipeline = GPUComputePipeline::new(
+                    cx,
                     &self.global(),
                     WebGPUComputePipeline(pipeline.id),
                     pipeline.label.into(),
                     self,
-                    CanGc::from_cx(cx),
-                ),
-                CanGc::from_cx(cx),
-            ),
-            Err(webgpu_traits::Error::Validation(msg)) => promise.reject_native(
-                &GPUPipelineError::new(
+                );
+                promise.resolve_native_with_cx(cx, &gpu_compute_pipeline)
+            },
+            Err(webgpu_traits::Error::Validation(msg)) => {
+                let gpu_pipeline_error = GPUPipelineError::new(
+                    cx,
                     &self.global(),
                     msg.into(),
                     GPUPipelineErrorReason::Validation,
-                    CanGc::from_cx(cx),
-                ),
-                CanGc::from_cx(cx),
-            ),
+                );
+                promise.reject_native_with_cx(cx, &gpu_pipeline_error)
+            },
             Err(webgpu_traits::Error::OutOfMemory(msg) | webgpu_traits::Error::Internal(msg)) => {
-                promise.reject_native(
-                    &GPUPipelineError::new(
-                        &self.global(),
-                        msg.into(),
-                        GPUPipelineErrorReason::Internal,
-                        CanGc::from_cx(cx),
-                    ),
-                    CanGc::from_cx(cx),
-                )
+                let gpu_pipeline_error = GPUPipelineError::new(
+                    cx,
+                    &self.global(),
+                    msg.into(),
+                    GPUPipelineErrorReason::Internal,
+                );
+                promise.reject_native_with_cx(cx, &gpu_pipeline_error)
             },
         }
     }
@@ -698,35 +715,34 @@ impl RoutedPromiseListener<WebGPURenderPipelineResponse> for GPUDevice {
         promise: &Rc<Promise>,
     ) {
         match response {
-            Ok(pipeline) => promise.resolve_native(
-                &GPURenderPipeline::new(
+            Ok(pipeline) => {
+                let gpu_pipeline = GPURenderPipeline::new(
+                    cx,
                     &self.global(),
                     WebGPURenderPipeline(pipeline.id),
                     pipeline.label.into(),
                     self,
-                    CanGc::from_cx(cx),
-                ),
-                CanGc::from_cx(cx),
-            ),
-            Err(webgpu_traits::Error::Validation(msg)) => promise.reject_native(
-                &GPUPipelineError::new(
+                );
+                promise.resolve_native_with_cx(cx, &gpu_pipeline)
+            },
+            Err(webgpu_traits::Error::Validation(msg)) => {
+                let pipeline_error = GPUPipelineError::new(
+                    cx,
                     &self.global(),
                     msg.into(),
                     GPUPipelineErrorReason::Validation,
-                    CanGc::from_cx(cx),
-                ),
-                CanGc::from_cx(cx),
-            ),
+                );
+
+                promise.reject_native_with_cx(cx, &pipeline_error)
+            },
             Err(webgpu_traits::Error::OutOfMemory(msg) | webgpu_traits::Error::Internal(msg)) => {
-                promise.reject_native(
-                    &GPUPipelineError::new(
-                        &self.global(),
-                        msg.into(),
-                        GPUPipelineErrorReason::Internal,
-                        CanGc::from_cx(cx),
-                    ),
-                    CanGc::from_cx(cx),
-                )
+                let pipeline_error = GPUPipelineError::new(
+                    cx,
+                    &self.global(),
+                    msg.into(),
+                    GPUPipelineErrorReason::Internal,
+                );
+                promise.reject_native_with_cx(cx, &pipeline_error)
             },
         }
     }

--- a/components/script/dom/webgpu/gpudevice.rs
+++ b/components/script/dom/webgpu/gpudevice.rs
@@ -9,6 +9,7 @@ use std::rc::Rc;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::jsapi::{HandleObject, Heap, JSObject};
+use js::realm::CurrentRealm;
 use script_bindings::cell::DomRefCell;
 use script_bindings::cformat;
 use script_bindings::reflector::reflect_dom_object_with_cx;
@@ -66,7 +67,6 @@ use crate::dom::webgpu::gpushadermodule::GPUShaderModule;
 use crate::dom::webgpu::gpusupportedfeatures::GPUSupportedFeatures;
 use crate::dom::webgpu::gputexture::GPUTexture;
 use crate::dom::webgpu::gpuuncapturederrorevent::GPUUncapturedErrorEvent;
-use crate::realms::InRealm;
 use crate::routed_promise::{RoutedPromiseListener, callback_promise};
 
 #[derive(JSTraceable, MallocSizeOf)]
@@ -480,10 +480,10 @@ impl GPUDeviceMethods<crate::DomTypeHolder> for GPUDevice {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createshadermodule>
     fn CreateShaderModule(
         &self,
+        cx: &mut CurrentRealm<'_>,
         descriptor: RootedTraceableBox<GPUShaderModuleDescriptor>,
-        comp: InRealm,
     ) -> DomRoot<GPUShaderModule> {
-        GPUShaderModule::create(self, descriptor, comp, CanGc::deprecated_note())
+        GPUShaderModule::create(cx, self, descriptor)
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createcomputepipeline>
@@ -505,10 +505,10 @@ impl GPUDeviceMethods<crate::DomTypeHolder> for GPUDevice {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createcomputepipelineasync>
     fn CreateComputePipelineAsync(
         &self,
+        cx: &mut CurrentRealm<'_>,
         descriptor: &GPUComputePipelineDescriptor,
-        comp: InRealm,
     ) -> Rc<Promise> {
-        let promise = Promise::new_in_current_realm(comp, CanGc::deprecated_note());
+        let promise = Promise::new_in_realm(cx);
         let callback = callback_promise(
             &promise,
             self,
@@ -565,11 +565,11 @@ impl GPUDeviceMethods<crate::DomTypeHolder> for GPUDevice {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createrenderpipelineasync>
     fn CreateRenderPipelineAsync(
         &self,
+        cx: &mut CurrentRealm<'_>,
         descriptor: &GPURenderPipelineDescriptor,
-        comp: InRealm,
     ) -> Fallible<Rc<Promise>> {
         let desc = self.parse_render_pipeline(descriptor)?;
-        let promise = Promise::new_in_current_realm(comp, CanGc::deprecated_note());
+        let promise = Promise::new_in_realm(cx);
         let callback = callback_promise(
             &promise,
             self,
@@ -605,8 +605,8 @@ impl GPUDeviceMethods<crate::DomTypeHolder> for GPUDevice {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-poperrorscope>
-    fn PopErrorScope(&self, comp: InRealm) -> Rc<Promise> {
-        let promise = Promise::new_in_current_realm(comp, CanGc::deprecated_note());
+    fn PopErrorScope(&self, cx: &mut CurrentRealm<'_>) -> Rc<Promise> {
+        let promise = Promise::new_in_realm(cx);
         let callback = callback_promise(
             &promise,
             self,

--- a/components/script/dom/webgpu/gpudevicelostinfo.rs
+++ b/components/script/dom/webgpu/gpudevicelostinfo.rs
@@ -4,6 +4,7 @@
 
 use dom_struct::dom_struct;
 use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::script_runtime::CanGc;
 
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUDeviceLostInfoMethods, GPUDeviceLostReason,
@@ -11,7 +12,6 @@ use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct GPUDeviceLostInfo {

--- a/components/script/dom/webgpu/gpuerror.rs
+++ b/components/script/dom/webgpu/gpuerror.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
 use webgpu_traits::{Error, ErrorFilter};
 
 use crate::conversions::Convert;
@@ -13,7 +14,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::types::{GPUInternalError, GPUOutOfMemoryError, GPUValidationError};
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct GPUError {
@@ -30,43 +30,51 @@ impl GPUError {
     }
 
     #[expect(dead_code)]
-    pub(crate) fn new(global: &GlobalScope, message: DOMString, can_gc: CanGc) -> DomRoot<Self> {
-        Self::new_with_proto(global, None, message, can_gc)
+    pub(crate) fn new(
+        cx: &mut JSContext,
+        global: &GlobalScope,
+        message: DOMString,
+    ) -> DomRoot<Self> {
+        Self::new_with_proto(cx, global, None, message)
     }
 
     pub(crate) fn new_with_proto(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
         message: DOMString,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(GPUError::new_inherited(message)),
             global,
             proto,
-            can_gc,
+            cx,
         )
     }
 
-    pub(crate) fn from_error(global: &GlobalScope, error: Error, can_gc: CanGc) -> DomRoot<Self> {
+    pub(crate) fn from_error(
+        cx: &mut JSContext,
+        global: &GlobalScope,
+        error: Error,
+    ) -> DomRoot<Self> {
         match error {
             Error::Validation(msg) => DomRoot::upcast(GPUValidationError::new_with_proto(
+                cx,
                 global,
                 None,
                 msg.into(),
-                can_gc,
             )),
             Error::OutOfMemory(msg) => DomRoot::upcast(GPUOutOfMemoryError::new_with_proto(
+                cx,
                 global,
                 None,
                 msg.into(),
-                can_gc,
             )),
             Error::Internal(msg) => DomRoot::upcast(GPUInternalError::new_with_proto(
+                cx,
                 global,
                 None,
                 msg.into(),
-                can_gc,
             )),
         }
     }

--- a/components/script/dom/webgpu/gpuinternalerror.rs
+++ b/components/script/dom/webgpu/gpuinternalerror.rs
@@ -3,15 +3,15 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPUInternalError_Binding::GPUInternalErrorMethods;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::types::GPUError;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct GPUInternalError {
@@ -26,16 +26,16 @@ impl GPUInternalError {
     }
 
     pub(crate) fn new_with_proto(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
         message: DOMString,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(Self::new_inherited(message)),
             global,
             proto,
-            can_gc,
+            cx,
         )
     }
 }
@@ -43,11 +43,11 @@ impl GPUInternalError {
 impl GPUInternalErrorMethods<crate::DomTypeHolder> for GPUInternalError {
     /// <https://gpuweb.github.io/gpuweb/#dom-GPUInternalError-GPUInternalError>
     fn Constructor(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         message: DOMString,
     ) -> DomRoot<Self> {
-        Self::new_with_proto(global, proto, message, can_gc)
+        Self::new_with_proto(cx, global, proto, message)
     }
 }

--- a/components/script/dom/webgpu/gpuoutofmemoryerror.rs
+++ b/components/script/dom/webgpu/gpuoutofmemoryerror.rs
@@ -3,15 +3,15 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPUOutOfMemoryError_Binding::GPUOutOfMemoryErrorMethods;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::types::GPUError;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct GPUOutOfMemoryError {
@@ -26,16 +26,16 @@ impl GPUOutOfMemoryError {
     }
 
     pub(crate) fn new_with_proto(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
         message: DOMString,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(Self::new_inherited(message)),
             global,
             proto,
-            can_gc,
+            cx,
         )
     }
 }
@@ -43,11 +43,11 @@ impl GPUOutOfMemoryError {
 impl GPUOutOfMemoryErrorMethods<crate::DomTypeHolder> for GPUOutOfMemoryError {
     /// <https://gpuweb.github.io/gpuweb/#dom-GPUOutOfMemoryError-GPUOutOfMemoryError>
     fn Constructor(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         message: DOMString,
     ) -> DomRoot<Self> {
-        Self::new_with_proto(global, proto, message, can_gc)
+        Self::new_with_proto(cx, global, proto, message)
     }
 }

--- a/components/script/dom/webgpu/gpupipelineerror.rs
+++ b/components/script/dom/webgpu/gpupipelineerror.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUPipelineErrorInit, GPUPipelineErrorMethods, GPUPipelineErrorReason,
@@ -13,7 +14,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::domexception::DOMException;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::CanGc;
 
 /// <https://gpuweb.github.io/gpuweb/#gpupipelineerror>
 #[dom_struct]
@@ -31,40 +31,40 @@ impl GPUPipelineError {
     }
 
     pub(crate) fn new_with_proto(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
         message: DOMString,
         reason: GPUPipelineErrorReason,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(Self::new_inherited(message, reason)),
             global,
             proto,
-            can_gc,
+            cx,
         )
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         message: DOMString,
         reason: GPUPipelineErrorReason,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        Self::new_with_proto(global, None, message, reason, can_gc)
+        Self::new_with_proto(cx, global, None, message, reason)
     }
 }
 
 impl GPUPipelineErrorMethods<crate::DomTypeHolder> for GPUPipelineError {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpupipelineerror-constructor>
     fn Constructor(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         message: DOMString,
         options: &GPUPipelineErrorInit,
     ) -> DomRoot<Self> {
-        Self::new_with_proto(global, proto, message, options.reason, can_gc)
+        Self::new_with_proto(cx, global, proto, message, options.reason)
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpupipelineerror-reason>

--- a/components/script/dom/webgpu/gpupipelinelayout.rs
+++ b/components/script/dom/webgpu/gpupipelinelayout.rs
@@ -5,8 +5,9 @@
 use std::borrow::Cow;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{WebGPU, WebGPUBindGroupLayout, WebGPUPipelineLayout, WebGPURequest};
 use wgpu_core::binding_model::PipelineLayoutDescriptor;
 
@@ -19,7 +20,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::webgpu::gpudevice::GPUDevice;
-use crate::script_runtime::CanGc;
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPUPipelineLayout {
@@ -72,14 +72,14 @@ impl GPUPipelineLayout {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         channel: WebGPU,
         pipeline_layout: WebGPUPipelineLayout,
         label: USVString,
         bgls: Vec<WebGPUBindGroupLayout>,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(GPUPipelineLayout::new_inherited(
                 channel,
                 pipeline_layout,
@@ -87,7 +87,7 @@ impl GPUPipelineLayout {
                 bgls,
             )),
             global,
-            can_gc,
+            cx,
         )
     }
 }
@@ -103,9 +103,9 @@ impl GPUPipelineLayout {
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createpipelinelayout>
     pub(crate) fn create(
+        cx: &mut JSContext,
         device: &GPUDevice,
         descriptor: &GPUPipelineLayoutDescriptor,
-        can_gc: CanGc,
     ) -> DomRoot<GPUPipelineLayout> {
         let bgls = descriptor
             .bindGroupLayouts
@@ -133,12 +133,12 @@ impl GPUPipelineLayout {
 
         let pipeline_layout = WebGPUPipelineLayout(pipeline_layout_id);
         GPUPipelineLayout::new(
+            cx,
             &device.global(),
             device.channel(),
             pipeline_layout,
             descriptor.parent.label.clone(),
             bgls,
-            can_gc,
         )
     }
 }

--- a/components/script/dom/webgpu/gpuqueue.rs
+++ b/components/script/dom/webgpu/gpuqueue.rs
@@ -5,8 +5,9 @@
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use servo_base::generic_channel::GenericSharedMemory;
 use webgpu_traits::{WebGPU, WebGPUQueue, WebGPURequest};
 
@@ -25,7 +26,6 @@ use crate::dom::webgpu::gpubuffer::GPUBuffer;
 use crate::dom::webgpu::gpucommandbuffer::GPUCommandBuffer;
 use crate::dom::webgpu::gpudevice::GPUDevice;
 use crate::routed_promise::{RoutedPromiseListener, callback_promise};
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct GPUQueue {
@@ -51,15 +51,15 @@ impl GPUQueue {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         channel: WebGPU,
         queue: WebGPUQueue,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(GPUQueue::new_inherited(channel, queue)),
             global,
-            can_gc,
+            cx,
         )
     }
 }
@@ -207,9 +207,9 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuqueue-onsubmittedworkdone>
-    fn OnSubmittedWorkDone(&self, can_gc: CanGc) -> Rc<Promise> {
+    fn OnSubmittedWorkDone(&self, cx: &mut JSContext) -> Rc<Promise> {
         let global = self.global();
-        let promise = Promise::new(&global, can_gc);
+        let promise = Promise::new2(cx, &global);
         let task_source = global.task_manager().dom_manipulation_task_source();
         let callback = callback_promise(&promise, self, task_source);
 

--- a/components/script/dom/webgpu/gpurenderbundle.rs
+++ b/components/script/dom/webgpu/gpurenderbundle.rs
@@ -3,15 +3,15 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{WebGPU, WebGPUDevice, WebGPURenderBundle, WebGPURequest};
 
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPURenderBundleMethods;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::CanGc;
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPURenderBundle {
@@ -64,14 +64,14 @@ impl GPURenderBundle {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         render_bundle: WebGPURenderBundle,
         device: WebGPUDevice,
         channel: WebGPU,
         label: USVString,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(GPURenderBundle::new_inherited(
                 render_bundle,
                 device,
@@ -79,7 +79,7 @@ impl GPURenderBundle {
                 label,
             )),
             global,
-            can_gc,
+            cx,
         )
     }
 }

--- a/components/script/dom/webgpu/gpurenderbundleencoder.rs
+++ b/components/script/dom/webgpu/gpurenderbundleencoder.rs
@@ -5,8 +5,9 @@
 use std::borrow::Cow;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{WebGPU, WebGPURenderBundle, WebGPURequest};
 use wgpu_core::command::{
     RenderBundleEncoder, RenderBundleEncoderDescriptor, bundle_ffi as wgpu_bundle,
@@ -27,7 +28,6 @@ use crate::dom::webgpu::gpubuffer::GPUBuffer;
 use crate::dom::webgpu::gpudevice::GPUDevice;
 use crate::dom::webgpu::gpurenderbundle::GPURenderBundle;
 use crate::dom::webgpu::gpurenderpipeline::GPURenderPipeline;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct GPURenderBundleEncoder {
@@ -58,14 +58,14 @@ impl GPURenderBundleEncoder {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         render_bundle_encoder: RenderBundleEncoder,
         device: &GPUDevice,
         channel: WebGPU,
         label: USVString,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(GPURenderBundleEncoder::new_inherited(
                 render_bundle_encoder,
                 device,
@@ -73,7 +73,7 @@ impl GPURenderBundleEncoder {
                 label,
             )),
             global,
-            can_gc,
+            cx,
         )
     }
 }
@@ -81,9 +81,9 @@ impl GPURenderBundleEncoder {
 impl GPURenderBundleEncoder {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createrenderbundleencoder>
     pub(crate) fn create(
+        cx: &mut JSContext,
         device: &GPUDevice,
         descriptor: &GPURenderBundleEncoderDescriptor,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<GPURenderBundleEncoder>> {
         let desc = RenderBundleEncoderDescriptor {
             label: (&descriptor.parent.parent).convert(),
@@ -120,12 +120,12 @@ impl GPURenderBundleEncoder {
         let render_bundle_encoder = RenderBundleEncoder::new(&desc, device.id().0).unwrap();
 
         Ok(GPURenderBundleEncoder::new(
+            cx,
             &device.global(),
             render_bundle_encoder,
             device,
             device.channel(),
             descriptor.parent.parent.label.clone(),
-            can_gc,
         ))
     }
 }
@@ -256,7 +256,11 @@ impl GPURenderBundleEncoderMethods<crate::DomTypeHolder> for GPURenderBundleEnco
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderbundleencoder-finish>
-    fn Finish(&self, descriptor: &GPURenderBundleDescriptor) -> DomRoot<GPURenderBundle> {
+    fn Finish(
+        &self,
+        cx: &mut JSContext,
+        descriptor: &GPURenderBundleDescriptor,
+    ) -> DomRoot<GPURenderBundle> {
         let desc = wgpu_types::RenderBundleDescriptor {
             label: (&descriptor.parent).convert(),
         };
@@ -275,12 +279,12 @@ impl GPURenderBundleEncoderMethods<crate::DomTypeHolder> for GPURenderBundleEnco
 
         let render_bundle = WebGPURenderBundle(render_bundle_id);
         GPURenderBundle::new(
+            cx,
             &self.global(),
             render_bundle,
             self.device.id(),
             self.channel.clone(),
             descriptor.parent.label.clone(),
-            CanGc::deprecated_note(),
         )
     }
 }

--- a/components/script/dom/webgpu/gpurenderpassencoder.rs
+++ b/components/script/dom/webgpu/gpurenderpassencoder.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{RenderCommand, WebGPU, WebGPURenderPass, WebGPURequest};
 
 use crate::conversions::TryConvert;
@@ -21,7 +22,6 @@ use crate::dom::webgpu::gpubuffer::GPUBuffer;
 use crate::dom::webgpu::gpucommandencoder::GPUCommandEncoder;
 use crate::dom::webgpu::gpurenderbundle::GPURenderBundle;
 use crate::dom::webgpu::gpurenderpipeline::GPURenderPipeline;
-use crate::script_runtime::CanGc;
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPURenderPassEncoder {
@@ -69,14 +69,14 @@ impl GPURenderPassEncoder {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         channel: WebGPU,
         render_pass: WebGPURenderPass,
         parent: &GPUCommandEncoder,
         label: USVString,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(GPURenderPassEncoder::new_inherited(
                 channel,
                 render_pass,
@@ -84,7 +84,7 @@ impl GPURenderPassEncoder {
                 label,
             )),
             global,
-            can_gc,
+            cx,
         )
     }
 

--- a/components/script/dom/webgpu/gpurenderpipeline.rs
+++ b/components/script/dom/webgpu/gpurenderpipeline.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use servo_base::generic_channel::GenericCallback;
 use webgpu_traits::{
     WebGPU, WebGPUBindGroupLayout, WebGPURenderPipeline, WebGPURenderPipelineResponse,
@@ -20,7 +21,6 @@ use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::webgpu::gpubindgrouplayout::GPUBindGroupLayout;
 use crate::dom::webgpu::gpudevice::GPUDevice;
-use crate::script_runtime::CanGc;
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPURenderPipeline {
@@ -71,20 +71,20 @@ impl GPURenderPipeline {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         render_pipeline: WebGPURenderPipeline,
         label: USVString,
         device: &GPUDevice,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(GPURenderPipeline::new_inherited(
                 render_pipeline,
                 label,
                 device,
             )),
             global,
-            can_gc,
+            cx,
         )
     }
 }
@@ -129,7 +129,11 @@ impl GPURenderPipelineMethods<crate::DomTypeHolder> for GPURenderPipeline {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpupipelinebase-getbindgrouplayout>
-    fn GetBindGroupLayout(&self, index: u32) -> Fallible<DomRoot<GPUBindGroupLayout>> {
+    fn GetBindGroupLayout(
+        &self,
+        cx: &mut JSContext,
+        index: u32,
+    ) -> Fallible<DomRoot<GPUBindGroupLayout>> {
         let id = self.global().wgpu_id_hub().create_bind_group_layout_id();
 
         if let Err(e) = self
@@ -147,11 +151,11 @@ impl GPURenderPipelineMethods<crate::DomTypeHolder> for GPURenderPipeline {
         }
 
         Ok(GPUBindGroupLayout::new(
+            cx,
             &self.global(),
             self.droppable.channel.clone(),
             WebGPUBindGroupLayout(id),
             USVString::default(),
-            CanGc::deprecated_note(),
         ))
     }
 }

--- a/components/script/dom/webgpu/gpusampler.rs
+++ b/components/script/dom/webgpu/gpusampler.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{WebGPU, WebGPUDevice, WebGPURequest, WebGPUSampler};
 use wgpu_core::resource::SamplerDescriptor;
 
@@ -17,7 +18,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::webgpu::gpudevice::GPUDevice;
-use crate::script_runtime::CanGc;
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPUSampler {
@@ -67,15 +67,15 @@ impl GPUSampler {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         channel: WebGPU,
         device: WebGPUDevice,
         compare_enable: bool,
         sampler: WebGPUSampler,
         label: USVString,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(GPUSampler::new_inherited(
                 channel,
                 device,
@@ -84,7 +84,7 @@ impl GPUSampler {
                 label,
             )),
             global,
-            can_gc,
+            cx,
         )
     }
 }
@@ -96,9 +96,9 @@ impl GPUSampler {
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createsampler>
     pub(crate) fn create(
+        cx: &mut JSContext,
         device: &GPUDevice,
         descriptor: &GPUSamplerDescriptor,
-        can_gc: CanGc,
     ) -> DomRoot<GPUSampler> {
         let sampler_id = device.global().wgpu_id_hub().create_sampler_id();
         let compare_enable = descriptor.compare.is_some();
@@ -132,13 +132,13 @@ impl GPUSampler {
         let sampler = WebGPUSampler(sampler_id);
 
         GPUSampler::new(
+            cx,
             &device.global(),
             device.channel(),
             device.id(),
             compare_enable,
             sampler,
             descriptor.parent.label.clone(),
-            can_gc,
         )
     }
 }

--- a/components/script/dom/webgpu/gpushadermodule.rs
+++ b/components/script/dom/webgpu/gpushadermodule.rs
@@ -5,9 +5,10 @@
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
+use js::realm::CurrentRealm;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
-use script_bindings::script_runtime::CanGc;
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{ShaderCompilationInfo, WebGPU, WebGPURequest, WebGPUShaderModule};
 
 use super::gpucompilationinfo::GPUCompilationInfo;
@@ -21,7 +22,6 @@ use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 use crate::dom::types::GPUDevice;
-use crate::realms::InRealm;
 use crate::routed_promise::{RoutedPromiseListener, callback_promise};
 
 #[derive(JSTraceable, MallocSizeOf)]
@@ -75,14 +75,14 @@ impl GPUShaderModule {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         channel: WebGPU,
         shader_module: WebGPUShaderModule,
         label: USVString,
         promise: Rc<Promise>,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(GPUShaderModule::new_inherited(
                 channel,
                 shader_module,
@@ -90,7 +90,7 @@ impl GPUShaderModule {
                 promise,
             )),
             global,
-            can_gc,
+            cx,
         )
     }
 }
@@ -102,20 +102,19 @@ impl GPUShaderModule {
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createshadermodule>
     pub(crate) fn create(
+        cx: &mut CurrentRealm<'_>,
         device: &GPUDevice,
         descriptor: RootedTraceableBox<GPUShaderModuleDescriptor>,
-        comp: InRealm,
-        can_gc: CanGc,
     ) -> DomRoot<GPUShaderModule> {
         let program_id = device.global().wgpu_id_hub().create_shader_module_id();
-        let promise = Promise::new_in_current_realm(comp, can_gc);
+        let promise = Promise::new_in_realm(cx);
         let shader_module = GPUShaderModule::new(
+            cx,
             &device.global(),
             device.channel(),
             WebGPUShaderModule(program_id),
             descriptor.parent.label.clone(),
             promise.clone(),
-            can_gc,
         );
         let callback = callback_promise(
             &promise,

--- a/components/script/dom/webgpu/gpushadermodule.rs
+++ b/components/script/dom/webgpu/gpushadermodule.rs
@@ -7,6 +7,7 @@ use std::rc::Rc;
 use dom_struct::dom_struct;
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::script_runtime::CanGc;
 use webgpu_traits::{ShaderCompilationInfo, WebGPU, WebGPURequest, WebGPUShaderModule};
 
 use super::gpucompilationinfo::GPUCompilationInfo;
@@ -22,7 +23,6 @@ use crate::dom::promise::Promise;
 use crate::dom::types::GPUDevice;
 use crate::realms::InRealm;
 use crate::routed_promise::{RoutedPromiseListener, callback_promise};
-use crate::script_runtime::CanGc;
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPUShaderModule {
@@ -164,7 +164,7 @@ impl RoutedPromiseListener<Option<ShaderCompilationInfo>> for GPUShaderModule {
         response: Option<ShaderCompilationInfo>,
         promise: &Rc<Promise>,
     ) {
-        let info = GPUCompilationInfo::from(&self.global(), response, CanGc::from_cx(cx));
+        let info = GPUCompilationInfo::from(cx, &self.global(), response);
         promise.resolve_native_with_cx(cx, &info);
     }
 }

--- a/components/script/dom/webgpu/gpusupportedfeatures.rs
+++ b/components/script/dom/webgpu/gpusupportedfeatures.rs
@@ -6,10 +6,11 @@
 
 use dom_struct::dom_struct;
 use indexmap::IndexSet;
+use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
 use script_bindings::like::Setlike;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
 use wgpu_types::Features;
 
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
@@ -19,7 +20,6 @@ use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct GPUSupportedFeatures {
@@ -34,10 +34,10 @@ pub(crate) struct GPUSupportedFeatures {
 
 impl GPUSupportedFeatures {
     fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
         features: Features,
-        can_gc: CanGc,
     ) -> DomRoot<GPUSupportedFeatures> {
         let mut set = IndexSet::new();
         // everything that wgpu currently does is considered as part of "core"
@@ -92,7 +92,7 @@ impl GPUSupportedFeatures {
         }
         */
 
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(GPUSupportedFeatures {
                 reflector: Reflector::new(),
                 internal: DomRefCell::new(set),
@@ -100,18 +100,18 @@ impl GPUSupportedFeatures {
             }),
             global,
             proto,
-            can_gc,
+            cx,
         )
     }
 
     #[expect(non_snake_case)]
     pub(crate) fn Constructor(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
         features: Features,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<GPUSupportedFeatures>> {
-        Ok(GPUSupportedFeatures::new(global, proto, features, can_gc))
+        Ok(GPUSupportedFeatures::new(cx, global, proto, features))
     }
 }
 

--- a/components/script/dom/webgpu/gpusupportedlimits.rs
+++ b/components/script/dom/webgpu/gpusupportedlimits.rs
@@ -4,14 +4,14 @@
 
 use GPUSupportedLimits_Binding::GPUSupportedLimitsMethods;
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use num_traits::bounds::UpperBounded;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use wgpu_types::Limits;
 
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPUSupportedLimits_Binding;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::CanGc;
 
 /// <https://gpuweb.github.io/gpuweb/#gpusupportedlimits>
 #[dom_struct]
@@ -30,8 +30,8 @@ impl GPUSupportedLimits {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope, limits: Limits, can_gc: CanGc) -> DomRoot<Self> {
-        reflect_dom_object(Box::new(Self::new_inherited(limits)), global, can_gc)
+    pub(crate) fn new(cx: &mut JSContext, global: &GlobalScope, limits: Limits) -> DomRoot<Self> {
+        reflect_dom_object_with_cx(Box::new(Self::new_inherited(limits)), global, cx)
     }
 }
 

--- a/components/script/dom/webgpu/gputexture.rs
+++ b/components/script/dom/webgpu/gputexture.rs
@@ -5,8 +5,9 @@
 use std::string::String;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{WebGPU, WebGPURequest, WebGPUTexture, WebGPUTextureView};
 use wgpu_core::resource;
 
@@ -23,7 +24,6 @@ use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::webgpu::gpudevice::GPUDevice;
 use crate::dom::webgpu::gputextureview::GPUTextureView;
-use crate::script_runtime::CanGc;
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPUTexture {
@@ -96,6 +96,7 @@ impl GPUTexture {
 
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         texture: WebGPUTexture,
         device: &GPUDevice,
@@ -107,9 +108,8 @@ impl GPUTexture {
         format: GPUTextureFormat,
         texture_usage: u32,
         label: USVString,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(GPUTexture::new_inherited(
                 texture,
                 device,
@@ -123,7 +123,7 @@ impl GPUTexture {
                 label,
             )),
             global,
-            can_gc,
+            cx,
         )
     }
 }
@@ -135,9 +135,9 @@ impl GPUTexture {
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createtexture>
     pub(crate) fn create(
+        cx: &mut JSContext,
         device: &GPUDevice,
         descriptor: &GPUTextureDescriptor,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<GPUTexture>> {
         let (desc, size) = convert_texture_descriptor(descriptor, device)?;
 
@@ -156,6 +156,7 @@ impl GPUTexture {
         let texture = WebGPUTexture(texture_id);
 
         Ok(GPUTexture::new(
+            cx,
             &device.global(),
             texture,
             device,
@@ -167,14 +168,13 @@ impl GPUTexture {
             descriptor.format,
             descriptor.usage,
             descriptor.parent.label.clone(),
-            can_gc,
         ))
     }
 
-    pub(crate) fn get_default_view(&self) -> WebGPUTextureView {
+    pub(crate) fn get_default_view(&self, cx: &mut JSContext) -> WebGPUTextureView {
         self.default_view
             .or_init(|| {
-                self.CreateView(&GPUTextureViewDescriptor::default())
+                self.CreateView(cx, &GPUTextureViewDescriptor::default())
                     .expect("Default descriptor should always be valid.")
             })
             .id()
@@ -195,6 +195,7 @@ impl GPUTextureMethods<crate::DomTypeHolder> for GPUTexture {
     /// <https://gpuweb.github.io/gpuweb/#dom-gputexture-createview>
     fn CreateView(
         &self,
+        cx: &mut JSContext,
         descriptor: &GPUTextureViewDescriptor,
     ) -> Fallible<DomRoot<GPUTextureView>> {
         let desc = if !matches!(descriptor.mipLevelCount, Some(0)) &&
@@ -246,12 +247,12 @@ impl GPUTextureMethods<crate::DomTypeHolder> for GPUTexture {
         let texture_view = WebGPUTextureView(texture_view_id);
 
         Ok(GPUTextureView::new(
+            cx,
             &self.global(),
             self.droppable.channel.clone(),
             texture_view,
             self,
             descriptor.parent.label.clone(),
-            CanGc::deprecated_note(),
         ))
     }
 

--- a/components/script/dom/webgpu/gputextureview.rs
+++ b/components/script/dom/webgpu/gputextureview.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{WebGPU, WebGPURequest, WebGPUTextureView};
 
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPUTextureViewMethods;
@@ -12,7 +13,6 @@ use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::webgpu::gputexture::GPUTexture;
-use crate::script_runtime::CanGc;
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPUTextureView {
@@ -65,14 +65,14 @@ impl GPUTextureView {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         channel: WebGPU,
         texture_view: WebGPUTextureView,
         texture: &GPUTexture,
         label: USVString,
-        can_gc: CanGc,
     ) -> DomRoot<GPUTextureView> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(GPUTextureView::new_inherited(
                 channel,
                 texture_view,
@@ -80,7 +80,7 @@ impl GPUTextureView {
                 label,
             )),
             global,
-            can_gc,
+            cx,
         )
     }
 }

--- a/components/script/dom/webgpu/gpuuncapturederrorevent.rs
+++ b/components/script/dom/webgpu/gpuuncapturederrorevent.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
@@ -16,7 +17,6 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::event::Event;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::webgpu::gpuerror::GPUError;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct GPUUncapturedErrorEvent {
@@ -34,26 +34,26 @@ impl GPUUncapturedErrorEvent {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         event_type: Atom,
         init: &GPUUncapturedErrorEventInit,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        Self::new_with_proto(global, None, event_type, init, can_gc)
+        Self::new_with_proto(cx, global, None, event_type, init)
     }
 
     fn new_with_proto(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
         event_type: Atom,
         init: &GPUUncapturedErrorEventInit,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        let event = reflect_dom_object_with_proto(
+        let event = reflect_dom_object_with_proto_and_cx(
             Box::new(GPUUncapturedErrorEvent::new_inherited(init)),
             global,
             proto,
-            can_gc,
+            cx,
         );
         event
             .event
@@ -65,13 +65,13 @@ impl GPUUncapturedErrorEvent {
 impl GPUUncapturedErrorEventMethods<crate::DomTypeHolder> for GPUUncapturedErrorEvent {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuuncapturederrorevent-gpuuncapturederrorevent>
     fn Constructor(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         event_type: DOMString,
         init: &GPUUncapturedErrorEventInit,
     ) -> DomRoot<Self> {
-        GPUUncapturedErrorEvent::new_with_proto(global, proto, event_type.into(), init, can_gc)
+        GPUUncapturedErrorEvent::new_with_proto(cx, global, proto, event_type.into(), init)
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuuncapturederrorevent-error>

--- a/components/script/dom/webgpu/gpuvalidationerror.rs
+++ b/components/script/dom/webgpu/gpuvalidationerror.rs
@@ -3,15 +3,15 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPUValidationError_Binding::GPUValidationErrorMethods;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::types::GPUError;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct GPUValidationError {
@@ -26,16 +26,16 @@ impl GPUValidationError {
     }
 
     pub(crate) fn new_with_proto(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
         message: DOMString,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(Self::new_inherited(message)),
             global,
             proto,
-            can_gc,
+            cx,
         )
     }
 }
@@ -43,11 +43,11 @@ impl GPUValidationError {
 impl GPUValidationErrorMethods<crate::DomTypeHolder> for GPUValidationError {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuvalidationerror-gpuvalidationerror>
     fn Constructor(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         message: DOMString,
     ) -> DomRoot<Self> {
-        Self::new_with_proto(global, proto, message, can_gc)
+        Self::new_with_proto(cx, global, proto, message)
     }
 }

--- a/components/script/dom/workers/workernavigator.rs
+++ b/components/script/dom/workers/workernavigator.rs
@@ -127,9 +127,8 @@ impl WorkerNavigatorMethods<crate::DomTypeHolder> for WorkerNavigator {
 
     // https://gpuweb.github.io/gpuweb/#dom-navigator-gpu
     #[cfg(feature = "webgpu")]
-    fn Gpu(&self) -> DomRoot<GPU> {
-        self.gpu
-            .or_init(|| GPU::new(&self.global(), CanGc::deprecated_note()))
+    fn Gpu(&self, cx: &mut js::context::JSContext) -> DomRoot<GPU> {
+        self.gpu.or_init(|| GPU::new(cx, &self.global()))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-navigator-hardwareconcurrency>

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -561,13 +561,12 @@ DOMInterfaces = {
 },
 
 'GPUAdapter': {
-    'inRealms': ['RequestDevice'],
+    'realm': ['RequestDevice'],
     'canGc': ['RequestDevice'],
 },
 
 'GPUBuffer': {
-    'inRealms': ['MapAsync'],
-    'canGc': ['MapAsync'],
+    'realm': ['MapAsync'],
     'cx': ['Destroy', 'GetMappedRange',  'Unmap', 'PopErrorScope'],
     'allowDropImpl': True,
 },
@@ -590,11 +589,9 @@ DOMInterfaces = {
 },
 
 'GPUDevice': {
-    'inRealms': [
-        'CreateComputePipelineAsync',
-        'CreateRenderPipelineAsync',
-        'CreateShaderModule', # Creates promise for compilation info
-        'PopErrorScope'
+    'realm': ['CreateComputePipelineAsync', 'CreateRenderPipelineAsync',
+        'CreateShaderModule', # create promise for compilation info
+        'PopErrorScope',
     ],
     'cx': [
         'CreateBuffer',

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -567,16 +567,26 @@ DOMInterfaces = {
 
 'GPUBuffer': {
     'inRealms': ['MapAsync'],
-    'canGc': ['GetMappedRange', 'MapAsync'],
+    'canGc': ['MapAsync'],
+    'cx': ['Destroy', 'GetMappedRange',  'Unmap', 'PopErrorScope'],
     'allowDropImpl': True,
 },
 
 'GPUCanvasContext': {
     'weakReferenceable': True,
+    'cx': ['GetCurrentTexture'],
+},
+
+'GPUCommandEncoder': {
+    'cx': ['BeginComputePass', 'BeginRenderPass', 'Finish'],
 },
 
 'GPUCompilationInfo': {
     'canGc': ['Messages'],
+},
+
+'GPUComputePipeline': {
+    'cx': ['GetBindGroupLayout'],
 },
 
 'GPUDevice': {
@@ -586,17 +596,51 @@ DOMInterfaces = {
         'CreateShaderModule', # Creates promise for compilation info
         'PopErrorScope'
     ],
-    'canGc': [
-        'CreateComputePipelineAsync',
-        'CreateRenderPipelineAsync',
-        'CreateShaderModule',
-        'PopErrorScope'
+    'cx': [
+        'CreateBuffer',
+        'CreateBindGroup',
+        'CreateBindGroupLayout',
+        'CreatePipelineLayout',
+        'CreateComputePipeline', 'CreateCommandEncoder',
+        'CreateTexture', 'CreateSampler', 'CreateRenderPipeline',  'CreateRenderBundleEncoder',
     ],
     'weakReferenceable': True, # for usage in GlobalScope https://github.com/servo/servo/issues/32519
 },
 
+'GPUInternalError': {
+    'cx': ['Constructor'],
+},
+
+'GPUOutOfMemoryError': {
+    'cx': ['Constructor'],
+},
+
+'GPUPipelineError': {
+    'cx': ['Constructor'],
+},
+
 'GPUQueue': {
-    'canGc': ['OnSubmittedWorkDone'],
+    'cx': ['OnSubmittedWorkDone'],
+},
+
+'GPURenderBundleEncoder': {
+    'cx': ['Finish'],
+},
+
+'GPURenderPipeline': {
+    'cx': ['GetBindGroupLayout'],
+},
+
+'GPUTexture': {
+    'cx': ['CreateView'],
+},
+
+'GPUUncapturedErrorEvent': {
+    'cx': ['Constructor'],
+},
+
+'GPUValidationError': {
+    'cx': ['Constructor'],
 },
 
 'History': {
@@ -961,7 +1005,7 @@ DOMInterfaces = {
 
 'Navigator': {
     'inRealms': ['GetVRDisplays'],
-    'cx': ['Bluetooth', 'Clipboard', 'Languages', 'SendBeacon', 'ServiceWorker', 'Storage', 'UserActivation', 'WakeLock'],
+    'cx': ['Bluetooth', 'Clipboard', 'Gpu', 'Languages', 'SendBeacon', 'ServiceWorker', 'Storage', 'UserActivation', 'WakeLock'],
 },
 
 'CredentialsContainer': {
@@ -1422,7 +1466,7 @@ DOMInterfaces = {
 
 'WorkerNavigator': {
     'canGc': ['Languages'],
-    'cx': ['Storage'],
+    'cx': ['Gpu', 'Storage'],
 },
 
 }


### PR DESCRIPTION
This moves from CanGc to JSContext for most of dom/webgpu with exceptions where complications arose.

Special care should taken to review the following:
- Promise::new_in_current_realm2,
- DataBuffer::view,
- Two Convert method were split into separate function as they require a &mut JSContext,



Testing: *Describe the new automated tests that cover this change or explain why it doesn't require tests.*
Fixes: *Link to an issue this pull request fixes or remove this line if there is no issue.*

Edit: The merged version does not have the Promise::new_in_current_realm2 as it was replaced with CurrentRealm.
