### PR TITLE
Refactor common code in Accessibility tests.

### DIFF
--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -31,15 +31,7 @@ impl TreeChangeHandler for NoOpChangeHandler {
 
 #[test]
 fn test_basic_accessibility_update() {
-    let servo_test = ServoTest::new_with_builder(|builder| {
-        let mut preferences = Preferences::default();
-        preferences.accessibility_enabled = true;
-        preferences.expensive_accessibility_test_assertions_enabled = true;
-        let mut opts = Opts::default();
-        opts.debug
-            .toggle_option(DiagnosticsLoggingOption::AccessibilityTree, true);
-        builder.preferences(preferences).opts(opts)
-    });
+    let servo_test = build_test();
 
     let delegate = Rc::new(WebViewDelegateImpl::default());
     let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
@@ -59,15 +51,7 @@ fn test_basic_accessibility_update() {
 
 #[test]
 fn test_activate_accessibility_after_layout() {
-    let servo_test = ServoTest::new_with_builder(|builder| {
-        let mut preferences = Preferences::default();
-        preferences.accessibility_enabled = true;
-        preferences.expensive_accessibility_test_assertions_enabled = true;
-        let mut opts = Opts::default();
-        opts.debug
-            .toggle_option(DiagnosticsLoggingOption::AccessibilityTree, true);
-        builder.preferences(preferences).opts(opts)
-    });
+    let servo_test = build_test();
 
     let delegate = Rc::new(WebViewDelegateImpl::default());
     let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
@@ -87,15 +71,7 @@ fn test_activate_accessibility_after_layout() {
 
 #[test]
 fn test_navigate_creates_new_accessibility_update() {
-    let servo_test = ServoTest::new_with_builder(|builder| {
-        let mut preferences = Preferences::default();
-        preferences.accessibility_enabled = true;
-        preferences.expensive_accessibility_test_assertions_enabled = true;
-        let mut opts = Opts::default();
-        opts.debug
-            .toggle_option(DiagnosticsLoggingOption::AccessibilityTree, true);
-        builder.preferences(preferences).opts(opts)
-    });
+    let servo_test = build_test();
 
     let page_1_url = Url::parse("data:text/html,<!DOCTYPE html> page 1").unwrap();
     let page_2_url = Url::parse("data:text/html,<!DOCTYPE html> page 2").unwrap();
@@ -146,15 +122,7 @@ fn test_navigate_creates_new_accessibility_update() {
 // a11y tree building, this test will break.
 #[test]
 fn test_accessibility_after_navigate_and_back() {
-    let servo_test = ServoTest::new_with_builder(|builder| {
-        let mut preferences = Preferences::default();
-        preferences.accessibility_enabled = true;
-        preferences.expensive_accessibility_test_assertions_enabled = true;
-        let mut opts = Opts::default();
-        opts.debug
-            .toggle_option(DiagnosticsLoggingOption::AccessibilityTree, true);
-        builder.preferences(preferences).opts(opts)
-    });
+    let servo_test = build_test();
 
     let page_1_url = Url::parse("data:text/html,<!DOCTYPE html> page 1").unwrap();
     let page_2_url = Url::parse("data:text/html,<!DOCTYPE html> page 2").unwrap();
@@ -219,17 +187,6 @@ fn test_accessibility_after_navigate_and_back() {
 
 #[test]
 fn test_accessibility_basic_mapping() {
-    let servo_test = ServoTest::new_with_builder(|builder| {
-        let mut preferences = Preferences::default();
-        preferences.accessibility_enabled = true;
-        preferences.expensive_accessibility_test_assertions_enabled = true;
-        let mut opts = Opts::default();
-        opts.debug
-            .toggle_option(DiagnosticsLoggingOption::AccessibilityTree, true);
-        builder.preferences(preferences).opts(opts)
-    });
-    let delegate = Rc::new(WebViewDelegateImpl::default());
-
     let mut element_role_pairs = VecDeque::from([
         ("article", Role::Article),
         ("aside", Role::Complementary),
@@ -251,18 +208,9 @@ fn test_accessibility_basic_mapping() {
     for (element, _) in element_role_pairs.iter() {
         url.push_str(format!("<{element}></{element}>").as_str());
     }
-    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
-        .delegate(delegate.clone())
-        .url(Url::parse(url.as_str()).unwrap())
-        .build();
 
-    webview.set_accessibility_active(true);
+    let (servo_test, delegate, webview, mut tree) = build_webview_and_tree(url.as_str());
 
-    let load_webview = webview.clone();
-    servo_test.spin(move || load_webview.load_status() != LoadStatus::Complete);
-
-    let updates = wait_for_min_updates(&servo_test, delegate.clone(), 2);
-    let tree = build_tree(updates);
     let root = assert_tree_structure_and_get_root_web_area(&tree);
     assert_eq!(root.children().len(), element_role_pairs.len());
     for child in root.children() {
@@ -280,28 +228,8 @@ fn test_accessibility_basic_mapping() {
 
 #[test]
 fn test_accessibility_basic_name_from_contents() {
-    let servo_test = ServoTest::new_with_builder(|builder| {
-        let mut preferences = Preferences::default();
-        preferences.accessibility_enabled = true;
-        preferences.expensive_accessibility_test_assertions_enabled = true;
-        let mut opts = Opts::default();
-        opts.debug
-            .toggle_option(DiagnosticsLoggingOption::AccessibilityTree, true);
-        builder.preferences(preferences).opts(opts)
-    });
-    let delegate = Rc::new(WebViewDelegateImpl::default());
-    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
-        .delegate(delegate.clone())
-        .url(Url::parse("data:text/html,<!DOCTYPE html><h1>Servo</h1>").unwrap())
-        .build();
-
-    webview.set_accessibility_active(true);
-
-    let load_webview = webview.clone();
-    servo_test.spin(move || load_webview.load_status() != LoadStatus::Complete);
-
-    let updates = wait_for_min_updates(&servo_test, delegate.clone(), 2);
-    let tree = build_tree(updates);
+    let url = "data:text/html,<!DOCTYPE html><h1>Servo</h1>";
+    let (servo_test, delegate, webview, mut tree) = build_webview_and_tree(url);
     let root = assert_tree_structure_and_get_root_web_area(&tree);
     let first_child = root
         .children()
@@ -313,32 +241,12 @@ fn test_accessibility_basic_name_from_contents() {
 
 #[test]
 fn test_accessibility_name_from_contents_subtree() {
-    let servo_test = ServoTest::new_with_builder(|builder| {
-        let mut preferences = Preferences::default();
-        preferences.accessibility_enabled = true;
-        preferences.expensive_accessibility_test_assertions_enabled = true;
-        let mut opts = Opts::default();
-        opts.debug
-            .toggle_option(DiagnosticsLoggingOption::AccessibilityTree, true);
-        builder.preferences(preferences).opts(opts)
-    });
     let url = "data:text/html,<!DOCTYPE html>\
                <h1>Servo aims to empower <code>developers</code> with a <em>lightweight</em>, \
                <strong>high-performance</strong> alternative for <span>embedding \
                <span>web technologies</span> in <span>applications</span></span>.</h1>";
-    let delegate = Rc::new(WebViewDelegateImpl::default());
-    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
-        .delegate(delegate.clone())
-        .url(Url::parse(url).unwrap())
-        .build();
+    let (servo_test, delegate, webview, mut tree) = build_webview_and_tree(url);
 
-    webview.set_accessibility_active(true);
-
-    let load_webview = webview.clone();
-    servo_test.spin(move || load_webview.load_status() != LoadStatus::Complete);
-
-    let updates = wait_for_min_updates(&servo_test, delegate.clone(), 2);
-    let tree = build_tree(updates);
     let root = assert_tree_structure_and_get_root_web_area(&tree);
     let heading = root
         .children()
@@ -360,32 +268,11 @@ fn test_accessibility_name_from_contents_subtree() {
 
 #[test]
 fn test_accessibility_basic_mutation() {
-    let servo_test = ServoTest::new_with_builder(|builder| {
-        let mut preferences = Preferences::default();
-        preferences.accessibility_enabled = true;
-        preferences.dom_servo_helpers_enabled = true;
-        preferences.expensive_accessibility_test_assertions_enabled = true;
-        let mut opts = Opts::default();
-        opts.debug
-            .toggle_option(DiagnosticsLoggingOption::AccessibilityTree, true);
-        builder.preferences(preferences).opts(opts)
-    });
     let url = "data:text/html,<!DOCTYPE html>\
                <h1 id='h1'>This is an h1</h1>\
                <h2 id='h2'>This is an h2</h2>";
-    let delegate = Rc::new(WebViewDelegateImpl::default());
-    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
-        .delegate(delegate.clone())
-        .url(Url::parse(url).unwrap())
-        .build();
+    let (servo_test, delegate, webview, mut tree) = build_webview_and_tree(url);
 
-    webview.set_accessibility_active(true);
-
-    let load_webview = webview.clone();
-    servo_test.spin(move || load_webview.load_status() != LoadStatus::Complete);
-
-    let updates = wait_for_min_updates(&servo_test, delegate.clone(), 2);
-    let mut tree = build_tree(updates);
     let root = assert_tree_structure_and_get_root_web_area(&tree);
     let children: Vec<_> = root.children().collect();
     assert_eq!(children.len(), 2);
@@ -418,34 +305,13 @@ fn test_accessibility_basic_mutation() {
 
 #[test]
 fn test_accessibility_with_mutation_move_nodes() {
-    let servo_test = ServoTest::new_with_builder(|builder| {
-        let mut preferences = Preferences::default();
-        preferences.accessibility_enabled = true;
-        preferences.dom_servo_helpers_enabled = true;
-        preferences.expensive_accessibility_test_assertions_enabled = true;
-        let mut opts = Opts::default();
-        opts.debug
-            .toggle_option(DiagnosticsLoggingOption::AccessibilityTree, true);
-        builder.preferences(preferences).opts(opts)
-    });
     let url = "data:text/html,<!DOCTYPE html>\
                <div id='div1'></div>\
                <h1 id='h1'>This is an h1</h1>\
                <h2 id='h2'>This is an h2</h2>\
                <div id='div2'></div>";
-    let delegate = Rc::new(WebViewDelegateImpl::default());
-    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
-        .delegate(delegate.clone())
-        .url(Url::parse(url).unwrap())
-        .build();
+    let (servo_test, delegate, webview, mut tree) = build_webview_and_tree(url);
 
-    webview.set_accessibility_active(true);
-
-    let load_webview = webview.clone();
-    servo_test.spin(move || load_webview.load_status() != LoadStatus::Complete);
-
-    let updates = wait_for_min_updates(&servo_test, delegate.clone(), 2);
-    let mut tree = build_tree(updates);
     let root = assert_tree_structure_and_get_root_web_area(&tree);
     let children: Vec<accesskit_consumer::Node> = root.children().collect();
     assert_eq!(children.len(), 4);
@@ -492,6 +358,43 @@ fn test_accessibility_with_mutation_move_nodes() {
     assert_eq!(h1.label().as_deref(), Some("This is an h1"));
     assert_eq!(h2.role(), Role::Heading);
     assert_eq!(h2.label().as_deref(), Some("This is an h2"));
+}
+
+fn build_test() -> ServoTest {
+    let servo_test = ServoTest::new_with_builder(|builder| {
+        let mut preferences = Preferences::default();
+        preferences.accessibility_enabled = true;
+        preferences.dom_servo_helpers_enabled = true;
+        preferences.expensive_accessibility_test_assertions_enabled = true;
+        let mut opts = Opts::default();
+        opts.debug
+            .toggle_option(DiagnosticsLoggingOption::AccessibilityTree, true);
+        builder.preferences(preferences).opts(opts)
+    });
+    servo_test
+}
+
+fn build_webview_and_tree(
+    url: &str,
+) -> (
+    ServoTest,
+    Rc<WebViewDelegateImpl>,
+    servo::WebView,
+    accesskit_consumer::Tree,
+) {
+    let servo_test = build_test();
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .url(Url::parse(url).unwrap())
+        .build();
+    webview.set_accessibility_active(true);
+    let load_webview = webview.clone();
+    servo_test.spin(move || load_webview.load_status() != LoadStatus::Complete);
+
+    let updates = wait_for_min_updates(&servo_test, delegate.clone(), 2);
+    let mut tree = build_tree(updates);
+    (servo_test, delegate, webview, tree)
 }
 
 fn wait_for_min_updates(


### PR DESCRIPTION
Pull common code into helper functions.

Testing: Just refactoring tests.
Fixes: Part of #4344
