### PR TITLE
servoshell: Use Window.current_monitor() in HeadedWindow.set_fullscreen to show fullscreen on current window

### DIFF
--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -931,7 +931,7 @@ impl PlatformWindow for HeadedWindow {
             .expect("No monitor detected");
         if self.fullscreen.get() != state {
             self.winit_window.set_fullscreen(if state {
-                Some(winit::window::Fullscreen::Borderless(Some(monitor.clone())))
+                Some(winit::window::Fullscreen::Borderless(Some(monitor)))
             } else {
                 None
             });

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -66,7 +66,6 @@ pub struct HeadedWindow {
     /// this headed `Window`.
     gui: RefCell<Gui>,
     screen_size: Size2D<u32, DeviceIndependentPixel>,
-    monitor: winit::monitor::MonitorHandle,
     webview_relative_mouse_point: Cell<Point2D<f32, DevicePixel>>,
     /// The inner size of the window in physical pixels which excludes OS decorations.
     /// It equals viewport size + (0, toolbar height).
@@ -201,7 +200,6 @@ impl HeadedWindow {
             webview_relative_mouse_point: Cell::new(Point2D::zero()),
             fullscreen: Cell::new(false),
             inner_size: Cell::new(inner_size),
-            monitor,
             screen_size,
             device_pixel_ratio_override: servoshell_preferences.device_pixel_ratio_override,
             xr_window_poses: RefCell::new(vec![]),
@@ -926,11 +924,14 @@ impl PlatformWindow for HeadedWindow {
     }
 
     fn set_fullscreen(&self, state: bool) {
+        let monitor = self
+            .winit_window()
+            .current_monitor()
+            .or_else(|| self.winit_window.available_monitors().nth(0))
+            .expect("No monitor detected");
         if self.fullscreen.get() != state {
             self.winit_window.set_fullscreen(if state {
-                Some(winit::window::Fullscreen::Borderless(Some(
-                    self.monitor.clone(),
-                )))
+                Some(winit::window::Fullscreen::Borderless(Some(monitor.clone())))
             } else {
                 None
             });


### PR DESCRIPTION
To ensure the servoshell window is rendered in fullscreen in current active screen, we need to get the current monitor 
on runtime every time **set_fullscreen** is run. However, currently it uses the 'monitor' field of **HeadedWindow** struct which was just defined once at app startup. This prevents servoshell running on fullscreen on other monitors apart from the one at  start. This change removes the monitor field from HeadedWindow and uses **Window.current_monitor()** in set_fullscreen function to get the current monitor at runtime and then display window on fullscreen on that monitor.

Testing: Although I am not fully certain, since this is just a small fix for servoshell, it doesn't require any additional testing methods since there aren't any tests for servoshell.

Fixes: https://github.com/servo/servo/issues/45488
