### PR TITLE
migrate reject error to reject error with cx

### DIFF
--- a/components/script/dom/clipboard/clipboarditem.rs
+++ b/components/script/dom/clipboard/clipboarditem.rs
@@ -310,7 +310,7 @@ impl ClipboardItemMethods<crate::DomTypeHolder> for ClipboardItem {
         }
 
         // Step 9 Reject p with "NotFoundError" DOMException in realm.
-        p.reject_error(Error::NotFound(None), CanGc::from_cx(realm));
+        p.reject_error_with_cx(realm, Error::NotFound(None));
 
         // Step 10 Return p.
         Ok(p)

--- a/components/script/dom/credentialmanagement/credentialscontainer.rs
+++ b/components/script/dom/credentialmanagement/credentialscontainer.rs
@@ -54,18 +54,17 @@ impl CredentialsContainer {
         let document = global.as_window().Document();
 
         let promise = Promise::new_in_realm(cx);
-        let can_gc = CanGc::from_cx(cx);
         // Step 4. If document is not fully active, then return a promise rejected with an "InvalidStateError" DOMException.
         if !document.is_fully_active() {
-            promise.reject_error(Error::InvalidState(None), can_gc);
+            promise.reject_error_with_cx(cx, Error::InvalidState(None));
             return Ok(promise);
         }
         // Step 5. If options.signal is aborted, then return a promise rejected with options.signal’s abort reason.
         if options.signal.as_ref().is_some_and(|s| s.aborted()) {
-            promise.reject_error(Error::Abort(None), can_gc);
+            promise.reject_error_with_cx(cx, Error::Abort(None));
             return Ok(promise);
         }
-        promise.reject_error(Error::NotSupported(None), can_gc);
+        promise.reject_error_with_cx(cx, Error::NotSupported(None));
         Ok(promise)
     }
 
@@ -81,13 +80,12 @@ impl CredentialsContainer {
         assert!(global.is_secure_context());
 
         let promise = Promise::new_in_realm(cx);
-        let can_gc = CanGc::from_cx(cx);
         // Step 3. If settings’s relevant global object's associated Document is not fully active, then return a promise rejected with an "InvalidStateError" DOMException.
         if !global.as_window().Document().is_fully_active() {
-            promise.reject_error(Error::InvalidState(None), can_gc);
+            promise.reject_error_with_cx(cx, Error::InvalidState(None));
             return Ok(promise);
         }
-        promise.reject_error(Error::NotSupported(None), can_gc);
+        promise.reject_error_with_cx(cx, Error::NotSupported(None));
         Ok(promise)
     }
 
@@ -106,13 +104,12 @@ impl CredentialsContainer {
         let document = global.as_window().Document();
 
         let promise = Promise::new_in_realm(cx);
-        let can_gc = CanGc::from_cx(cx);
         // Step 5. If document is not fully active, then return a promise rejected with an "InvalidStateError" DOMException.
         if !document.is_fully_active() {
-            promise.reject_error(Error::InvalidState(None), can_gc);
+            promise.reject_error_with_cx(cx, Error::InvalidState(None));
             return Ok(promise);
         }
-        promise.reject_error(Error::NotSupported(None), can_gc);
+        promise.reject_error_with_cx(cx, Error::NotSupported(None));
         Ok(promise)
     }
 }
@@ -144,7 +141,7 @@ impl CredentialsContainerMethods<DomTypeHolder> for CredentialsContainer {
     /// <https://www.w3.org/TR/credential-management-1/#dom-credentialscontainer-preventsilentaccess>
     fn PreventSilentAccess(&self, cx: &mut CurrentRealm) -> Fallible<Rc<Promise>> {
         let promise = Promise::new_in_realm(cx);
-        promise.reject_error(Error::NotSupported(None), CanGc::from_cx(cx));
+        promise.reject_error_with_cx(cx, Error::NotSupported(None));
         Ok(promise)
     }
 }

--- a/components/script/dom/css/fontface.rs
+++ b/components/script/dom/css/fontface.rs
@@ -364,7 +364,7 @@ impl FontFace {
             // Step 2. Otherwise, reject font face’s [[FontStatusPromise]] with a DOMException named "SyntaxError"
             // and set font face’s status attribute to "error".
             self.font_status_promise
-                .reject_error(Error::Syntax(None), CanGc::deprecated_note());
+                .reject_error_with_cx(cx, Error::Syntax(None));
             self.status.set(FontFaceLoadStatus::Error);
 
             // For each FontFaceSet font face is in:

--- a/components/script/dom/stream/writablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/writablestreamdefaultcontroller.rs
@@ -186,7 +186,7 @@ impl Callback for TransferBackPressurePromiseReaction {
             global.disentangle_port(cx, &self.port);
 
             // Return a promise rejected with result.[[Value]].
-            self.result_promise.reject_error(error, can_gc);
+            self.result_promise.reject_error_with_cx(cx, error);
         } else {
             // Otherwise, return a promise resolved with undefined.
             self.result_promise.resolve_native(&(), can_gc);

--- a/components/script/dom/wakelock/wakelock.rs
+++ b/components/script/dom/wakelock/wakelock.rs
@@ -58,18 +58,18 @@ impl WakeLockMethods<crate::DomTypeHolder> for WakeLock {
 
         // Step 2. If document is not fully active, reject with NotAllowedError.
         if !document.is_fully_active() {
-            promise.reject_error(Error::NotAllowed(Some(
+            promise.reject_error_with_cx(cx, Error::NotAllowed(Some(
                         "Failed to execute 'request' on 'WakeLock': The requesting page is not fully active."
-                        .to_string())), CanGc::from_cx(cx));
+                        .to_string())));
             return promise;
         }
 
         // Step 3. If document's visibility state is "hidden", reject with NotAllowedError.
         if document.VisibilityState() == DocumentVisibilityState::Hidden {
-            promise.reject_error(Error::NotAllowed(Some(
+            promise.reject_error_with_cx(cx, Error::NotAllowed(Some(
                         "Failed to execute 'request' on 'WakeLock': The requesting page is not visible."
                         .to_string()
-                        )), CanGc::from_cx(cx));
+                        )));
             return promise;
         }
 
@@ -104,11 +104,11 @@ impl RoutedPromiseListener<AllowOrDeny> for WakeLock {
         match response {
             // Step 7a. If permission is denied, reject with NotAllowedError.
             AllowOrDeny::Deny => {
-                promise.reject_error(
+                promise.reject_error_with_cx(
+                    cx,
                     Error::NotAllowed(Some(
                         "Failed to execute 'request' on 'WakeLock': Permission denied.".to_string(),
                     )),
-                    can_gc,
                 );
             },
             // Step 7b-7c. Acquire the lock and resolve with a WakeLockSentinel.

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -59,7 +59,7 @@ use crate::dom::workletglobalscope::{
 };
 use crate::fetch::{CspViolationsProcessor, load_whole_resource};
 use crate::messaging::{CommonScriptMsg, MainThreadScriptMsg};
-use crate::script_runtime::{CanGc, Runtime, ScriptThreadEventCategory};
+use crate::script_runtime::{Runtime, ScriptThreadEventCategory};
 use crate::script_thread::ScriptThread;
 use crate::task::TaskBox;
 use crate::task_source::TaskSourceName;
@@ -149,7 +149,7 @@ impl WorkletMethods<crate::DomTypeHolder> for Worklet {
             Err(err) => {
                 // Step 4.
                 debug!("URL {:?} parse error {:?}.", module_url.0, err);
-                promise.reject_error(Error::Syntax(None), CanGc::from_cx(realm));
+                promise.reject_error_with_cx(realm, Error::Syntax(None));
                 return promise;
             },
         };


### PR DESCRIPTION
I've replaced `reject_error` to `reject_error_with_cx` as asked in the issue.

As per the coments from @TimvdLippe I only added changes that had (added in context)

Testing: As discussed in the issue. I ran `./mach build` and it was successful. Hence, I concluded that my changes are fine.
Fixes: #45453 