### PR TITLE
script: Support extraction of `multiEntry` keys.

### DIFF
--- a/components/script/indexeddb.rs
+++ b/components/script/indexeddb.rs
@@ -14,8 +14,8 @@ use js::jsapi::{
 };
 use js::jsval::{DoubleValue, ObjectValue, UndefinedValue};
 use js::rust::wrappers2::{
-    GetArrayLength, IsArrayObject, JS_HasOwnPropertyById, JS_IndexToId, JS_IsIdentifier,
-    JS_NewObject, NewDateObject, ObjectIsDate, SameValue,
+    GetArrayLength, IsArrayObject, JS_GetPropertyById, JS_HasOwnPropertyById, JS_IndexToId,
+    JS_IsIdentifier, JS_NewObject, NewDateObject, ObjectIsDate, SameValue,
 };
 use js::rust::{HandleValue, MutableHandleValue};
 use js::typedarray::{ArrayBuffer, ArrayBufferView, CreateWith};
@@ -386,6 +386,75 @@ pub fn convert_value_to_key(
 
     // Otherwise, return "invalid type".
     Ok(ConversionResult::Invalid)
+}
+
+/// <https://www.w3.org/TR/IndexedDB-3/#convert-a-value-to-a-multientry-key>
+#[expect(unsafe_code)]
+pub fn convert_value_to_multientry_key(
+    cx: &mut JSContext,
+    input: HandleValue,
+) -> Result<ConversionResult, Error> {
+    // Step 1: If input is an Array exotic object, then:
+    unsafe {
+        let mut is_array = false;
+        if !IsArrayObject(cx, input, &mut is_array) {
+            return Err(Error::JSFailed);
+        }
+        if is_array {
+            rooted!(&in(cx) let object = input.to_object());
+
+            // Step 1.1: Let len be ? ToLength( ? Get(input, "length")).
+            let mut len = 0;
+            if !GetArrayLength(cx, object.handle(), &mut len) {
+                return Err(Error::JSFailed);
+            }
+
+            // Step 1.2: Let seen be a new set containing only input.
+            let seen: Vec<HandleValue> = vec![input];
+
+            // Step 1.3: Let keys be a new empty list.
+            let mut keys = vec![];
+
+            // Step 1.4: Let index be 0.
+            let mut index: u32 = 0;
+
+            // Step 1.5: While index is less than len:
+            while index < len {
+                // Step 1.5.1: Let entry be Get(input, index).
+                rooted!(&in(cx) let mut id: PropertyKey);
+                if !JS_IndexToId(cx, index, id.handle_mut()) {
+                    return Err(Error::JSFailed);
+                }
+                rooted!(&in(cx) let mut entry = UndefinedValue());
+                if !JS_GetPropertyById(cx, object.handle(), id.handle(), entry.handle_mut()) {
+                    return Err(Error::JSFailed);
+                }
+
+                // Step 1.5.2: If entry is not an abrupt completion, then:
+                if !entry.get().is_null() {
+                    // Step 1.5.2.1: Let key be the result of converting a value to a key with arguments entry and seen.
+                    // Step 1.5.2.2: If key is not "invalid value" or "invalid type" or an abrupt completion, and there
+                    // is no item in keys equal to key, then append key to keys.
+                    if let ConversionResult::Valid(key) =
+                        convert_value_to_key(cx, entry.handle(), Some(seen.clone()))? &&
+                        !keys.contains(&key)
+                    {
+                        keys.push(key);
+                    };
+                }
+
+                // Step 1.5.3: Increase index by 1.
+                index += 1;
+            }
+
+            // Step 1.6: Return a new array key with value set to keys.
+            return Ok(ConversionResult::Valid(IndexedDBKeyType::Array(keys)));
+        }
+    }
+
+    // Step 2: Otherwise, return the result of running the steps to convert a value
+    // to a key with argument input. Rethrow any exceptions.
+    convert_value_to_key(cx, input, None)
 }
 
 /// <https://www.w3.org/TR/IndexedDB-3/#convert-a-value-to-a-key-range>
@@ -819,16 +888,12 @@ pub(crate) fn extract_key(
     // Step 3. Let key be the result of running the steps to convert a value to a key with r if the
     // multiEntry flag is unset, and the result of running the steps to convert a value to a
     // multiEntry key with r otherwise. Rethrow any exceptions.
-    let key = match multi_entry {
-        Some(true) => {
-            // TODO: implement convert_value_to_multientry_key
-            unimplemented!("multiEntry keys are not yet supported");
-        },
-        _ => match convert_value_to_key(cx, r.handle(), None)? {
-            ConversionResult::Valid(key) => key,
-            // Step 4. If key is invalid, return invalid.
-            ConversionResult::Invalid => return Ok(ExtractionResult::Invalid),
-        },
+    let ConversionResult::Valid(key) = (match multi_entry {
+        Some(true) => convert_value_to_multientry_key(cx, r.handle())?,
+        _ => convert_value_to_key(cx, r.handle(), None)?,
+    }) else {
+        // Step 4. If key is invalid, return invalid.
+        return Ok(ExtractionResult::Invalid);
     };
 
     // Step 5. Return key.

--- a/components/script/indexeddb.rs
+++ b/components/script/indexeddb.rs
@@ -395,61 +395,65 @@ pub fn convert_value_to_multientry_key(
     input: HandleValue,
 ) -> Result<ConversionResult, Error> {
     // Step 1: If input is an Array exotic object, then:
+    let mut is_array = false;
     unsafe {
-        let mut is_array = false;
         if !IsArrayObject(cx, input, &mut is_array) {
             return Err(Error::JSFailed);
         }
-        if is_array {
-            rooted!(&in(cx) let object = input.to_object());
+    }
+    if is_array {
+        rooted!(&in(cx) let object = input.to_object());
 
-            // Step 1.1: Let len be ? ToLength( ? Get(input, "length")).
-            let mut len = 0;
+        // Step 1.1: Let len be ? ToLength( ? Get(input, "length")).
+        let mut len = 0;
+        unsafe {
             if !GetArrayLength(cx, object.handle(), &mut len) {
                 return Err(Error::JSFailed);
             }
+        }
 
-            // Step 1.2: Let seen be a new set containing only input.
-            let seen: Vec<HandleValue> = vec![input];
+        // Step 1.2: Let seen be a new set containing only input.
+        let seen: Vec<HandleValue> = vec![input];
 
-            // Step 1.3: Let keys be a new empty list.
-            let mut keys = vec![];
+        // Step 1.3: Let keys be a new empty list.
+        let mut keys = vec![];
 
-            // Step 1.4: Let index be 0.
-            let mut index: u32 = 0;
+        // Step 1.4: Let index be 0.
+        let mut index: u32 = 0;
 
-            // Step 1.5: While index is less than len:
-            while index < len {
-                // Step 1.5.1: Let entry be Get(input, index).
-                rooted!(&in(cx) let mut id: PropertyKey);
+        // Step 1.5: While index is less than len:
+        while index < len {
+            // Step 1.5.1: Let entry be Get(input, index).
+            rooted!(&in(cx) let mut id: PropertyKey);
+            rooted!(&in(cx) let mut entry = UndefinedValue());
+            unsafe {
                 if !JS_IndexToId(cx, index, id.handle_mut()) {
                     return Err(Error::JSFailed);
                 }
-                rooted!(&in(cx) let mut entry = UndefinedValue());
                 if !JS_GetPropertyById(cx, object.handle(), id.handle(), entry.handle_mut()) {
                     return Err(Error::JSFailed);
                 }
-
-                // Step 1.5.2: If entry is not an abrupt completion, then:
-                if !entry.get().is_null() {
-                    // Step 1.5.2.1: Let key be the result of converting a value to a key with arguments entry and seen.
-                    // Step 1.5.2.2: If key is not "invalid value" or "invalid type" or an abrupt completion, and there
-                    // is no item in keys equal to key, then append key to keys.
-                    if let ConversionResult::Valid(key) =
-                        convert_value_to_key(cx, entry.handle(), Some(seen.clone()))? &&
-                        !keys.contains(&key)
-                    {
-                        keys.push(key);
-                    };
-                }
-
-                // Step 1.5.3: Increase index by 1.
-                index += 1;
             }
 
-            // Step 1.6: Return a new array key with value set to keys.
-            return Ok(ConversionResult::Valid(IndexedDBKeyType::Array(keys)));
+            // Step 1.5.2: If entry is not an abrupt completion, then:
+            if !entry.get().is_null() {
+                // Step 1.5.2.1: Let key be the result of converting a value to a key with arguments entry and seen.
+                // Step 1.5.2.2: If key is not "invalid value" or "invalid type" or an abrupt completion, and there
+                // is no item in keys equal to key, then append key to keys.
+                if let ConversionResult::Valid(key) =
+                    convert_value_to_key(cx, entry.handle(), Some(seen.clone()))? &&
+                    !keys.contains(&key)
+                {
+                    keys.push(key);
+                };
+            }
+
+            // Step 1.5.3: Increase index by 1.
+            index += 1;
         }
+
+        // Step 1.6: Return a new array key with value set to keys.
+        return Ok(ConversionResult::Valid(IndexedDBKeyType::Array(keys)));
     }
 
     // Step 2: Otherwise, return the result of running the steps to convert a value


### PR DESCRIPTION
This PR implements the steps for handling `multiEntry` keys while extracting a key from a value.

Testing: Affected web platform tests still miss other functionality.
Fixes: #25326
