### PR TITLE
layout: Add initial support for layout roots

### DIFF
--- a/components/layout/cell.rs
+++ b/components/layout/cell.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::ops::Deref;
 use std::sync::{Arc, Weak};
 
-use atomic_refcell::AtomicRefCell;
+use atomic_refcell::{AtomicRef, AtomicRefCell};
 use malloc_size_of_derive::MallocSizeOf;
 
 #[derive(MallocSizeOf)]
@@ -91,5 +91,21 @@ impl<T> Clone for WeakRefCell<T> {
 impl<T> WeakRefCell<T> {
     pub(crate) fn upgrade(&self) -> Option<ArcRefCell<T>> {
         self.value.upgrade().map(|value| ArcRefCell { value })
+    }
+}
+
+pub(crate) enum RefOrAtomicRef<'a, T> {
+    Ref(&'a T),
+    AtomicRef(AtomicRef<'a, T>),
+}
+
+impl<T> Deref for RefOrAtomicRef<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Ref(value) => value,
+            Self::AtomicRef(value) => value.deref(),
+        }
     }
 }

--- a/components/layout/display_list/hit_test.rs
+++ b/components/layout/display_list/hit_test.rs
@@ -222,6 +222,9 @@ impl Fragment {
             };
 
         match self {
+            Fragment::LayoutRoot(layout_root_fragment) => {
+                layout_root_fragment.inner().hit_test(state, hit_test)
+            },
             Fragment::Box(box_fragment) | Fragment::Float(box_fragment) => hit_test_fragment_inner(
                 &box_fragment.style(),
                 box_fragment.border_rect(),

--- a/components/layout/display_list/paint_traversal.rs
+++ b/components/layout/display_list/paint_traversal.rs
@@ -198,6 +198,12 @@ impl<'a, Handler: PaintTraversalHandler> PaintTraversal<'a, Handler> {
         let mut saw_inline_level_or_replaced = false;
 
         match fragment {
+            Fragment::LayoutRoot(layout_root_fragment) => {
+                saw_inline_level_or_replaced = self.traverse_block_level_descendants_decorations(
+                    state,
+                    &layout_root_fragment.inner(),
+                );
+            },
             Fragment::Box(box_fragment) => {
                 // If this box establishes a stacking context or stacking container, do not paint
                 // it during this phase. Instead it is painted when the stacking context or container
@@ -304,6 +310,11 @@ impl<'a, Handler: PaintTraversalHandler> PaintTraversal<'a, Handler> {
         at_root_of_stacking_context: bool,
     ) {
         match fragment {
+            Fragment::LayoutRoot(layout_root_fragment) => self.traverse_line_boxes_and_replaced(
+                state,
+                &layout_root_fragment.inner(),
+                at_root_of_stacking_context,
+            ),
             Fragment::Box(box_fragment) => {
                 // If this box establishes a stacking context or stacking container, do not paint
                 // it during this phase. Instead it is painted when the stacking context or container
@@ -343,6 +354,9 @@ impl<'a, Handler: PaintTraversalHandler> PaintTraversal<'a, Handler> {
 
     fn traverse_fragment_in_a_line_box(&mut self, state: &TraversalState, fragment: &Fragment) {
         match fragment {
+            Fragment::LayoutRoot(layout_root_fragment) => {
+                self.traverse_fragment_in_a_line_box(state, &layout_root_fragment.inner())
+            },
             Fragment::Box(box_fragment) => self.traverse_box_in_a_line_box(
                 state,
                 box_fragment,
@@ -428,6 +442,13 @@ impl<'a, Handler: PaintTraversalHandler> PaintTraversal<'a, Handler> {
     ) {
         for child in &box_fragment.children {
             match child {
+                Fragment::LayoutRoot(layout_root_fragment) => {
+                    self.traverse_stacking_container(
+                        &state.without_text_decorations(),
+                        &layout_root_fragment.inner_box_fragment(),
+                        true, /* is_block_level */
+                    );
+                },
                 Fragment::Image(image_fragment) => {
                     let containing_block =
                         PhysicalRect::new(state.origin, box_fragment.content_rect().size);

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -278,10 +278,7 @@ impl StackingContextTree {
         fragment: &Fragment,
         point_in_viewport: PhysicalPoint<Au>,
     ) -> Option<Point2D<Au, CSSPixel>> {
-        let Fragment::Box(fragment) = fragment else {
-            return None;
-        };
-
+        let fragment = fragment.retrieve_box_fragment()?;
         let spatial_tree_node = fragment.spatial_tree_node()?;
         let transform = self
             .paint_info
@@ -491,6 +488,10 @@ impl Fragment {
                     stacking_context,
                     text_decorations,
                 );
+            },
+            Fragment::LayoutRoot(..) => {
+                // These fragments are processed at their originating
+                // `Fragment::AbsoluteOrFixedPositionedPlaceholder` position.
             },
             Fragment::AbsoluteOrFixedPositionedPlaceholder(fragment) => {
                 let shared_fragment = fragment.borrow();
@@ -1295,6 +1296,9 @@ impl BoxFragment {
         fn assign_spatial_tree_node_on_fragments(fragments: &[Fragment]) {
             for fragment in fragments.iter() {
                 match fragment {
+                    Fragment::LayoutRoot(layout_root_fragment) => layout_root_fragment
+                        .inner_box_fragment()
+                        .clear_spatial_tree_node_including_descendants(),
                     Fragment::Box(box_fragment) | Fragment::Float(box_fragment) => {
                         box_fragment.clear_spatial_tree_node_including_descendants();
                     },

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -235,7 +235,7 @@ impl BlockLevelBox {
             true, /* has_inline_parent */
         );
 
-        let Fragment::Box(fragment) = fragment else {
+        let Some(fragment) = fragment.retrieve_box_fragment() else {
             unreachable!("The fragment should be a Fragment::Box()");
         };
 
@@ -247,7 +247,7 @@ impl BlockLevelBox {
 
         layout.push_line_item_to_unbreakable_segment(LineItem::BlockLevel(
             layout.current_inline_box_identifier(),
-            fragment,
+            fragment.clone(),
         ));
 
         layout.commit_current_segment_to_line();

--- a/components/layout/flow/mod.rs
+++ b/components/layout/flow/mod.rs
@@ -1861,7 +1861,9 @@ impl<'container> PlacementState<'container> {
         self.place_fragment(fragment, sequential_layout_state);
 
         let box_fragment = match fragment {
-            Fragment::Box(box_fragment) => box_fragment,
+            Fragment::LayoutRoot(..) | Fragment::Box(..) => fragment
+                .retrieve_box_fragment()
+                .expect("Should be guaranteed by surrounding check"),
             _ => return,
         };
 
@@ -1896,7 +1898,11 @@ impl<'container> PlacementState<'container> {
         sequential_layout_state: Option<&mut SequentialLayoutState>,
     ) {
         match fragment {
-            Fragment::Box(fragment) => {
+            Fragment::LayoutRoot(..) | Fragment::Box(..) => {
+                let fragment = fragment
+                    .retrieve_box_fragment()
+                    .expect("Should be guaranteed by surrounding condition");
+
                 // If this child is a marker positioned outside of a list item, then record its
                 // size, but also ensure that it doesn't advance the block position of the placment.
                 // This ensures item content is placed next to the marker.
@@ -2015,7 +2021,7 @@ impl<'container> PlacementState<'container> {
                 );
             },
             Fragment::Positioning(_) => {},
-            _ => unreachable!(),
+            _ => unreachable!("Unexpected Fragment type encountered during flow layout"),
         }
     }
 

--- a/components/layout/fragment_tree/containing_block.rs
+++ b/components/layout/fragment_tree/containing_block.rs
@@ -51,16 +51,15 @@ pub(crate) struct ContainingBlockManager<'a, T> {
 
 impl<'a, T> ContainingBlockManager<'a, T> {
     pub(crate) fn get_containing_block_for_fragment(&self, fragment: &Fragment) -> &T {
-        if let Fragment::Box(box_fragment) = fragment {
-            match box_fragment.style().clone_position() {
-                ComputedPosition::Fixed => self.for_absolute_and_fixed_descendants,
-                ComputedPosition::Absolute => self
-                    .for_absolute_descendants
-                    .unwrap_or(self.for_absolute_and_fixed_descendants),
-                _ => self.for_non_absolute_descendants,
-            }
-        } else {
-            self.for_non_absolute_descendants
+        let Some(box_fragment) = fragment.retrieve_box_fragment() else {
+            return self.for_non_absolute_descendants;
+        };
+        match box_fragment.style().clone_position() {
+            ComputedPosition::Fixed => self.for_absolute_and_fixed_descendants,
+            ComputedPosition::Absolute => self
+                .for_absolute_descendants
+                .unwrap_or(self.for_absolute_and_fixed_descendants),
+            _ => self.for_non_absolute_descendants,
         }
     }
 

--- a/components/layout/fragment_tree/fragment.rs
+++ b/components/layout/fragment_tree/fragment.rs
@@ -5,6 +5,7 @@
 use std::sync::Arc;
 
 use app_units::Au;
+use atomic_refcell::AtomicRef;
 use euclid::{Point2D, Rect, Size2D};
 use fonts::{FontMetrics, ShapedTextSlice};
 use layout_api::BoxAreaType;
@@ -21,7 +22,7 @@ use super::{
     Tag,
 };
 use crate::SharedStyle;
-use crate::cell::ArcRefCell;
+use crate::cell::{ArcRefCell, RefOrAtomicRef};
 use crate::flow::inline::line::TextRunOffsets;
 use crate::geom::{LogicalSides, PhysicalPoint, PhysicalRect};
 use crate::layout_impl::LayoutThread;
@@ -29,6 +30,7 @@ use crate::style_ext::ComputedValuesExt;
 
 #[derive(Clone, MallocSizeOf)]
 pub(crate) enum Fragment {
+    LayoutRoot(LayoutRootFragment),
     Box(#[conditional_malloc_size_of] Arc<BoxFragment>),
     /// Floating content. A floated fragment is very similar to a normal
     /// [BoxFragment] but it isn't positioned using normal in block flow
@@ -59,6 +61,29 @@ pub(crate) struct CollapsedBlockMargins {
 pub(crate) struct CollapsedMargin {
     max_positive: Au,
     min_negative: Au,
+}
+
+#[derive(Clone, MallocSizeOf)]
+pub(crate) struct LayoutRootFragment {
+    pub fragment: ArcRefCell<HoistedSharedFragment>,
+}
+
+impl LayoutRootFragment {
+    pub(crate) fn inner(&self) -> AtomicRef<'_, Fragment> {
+        AtomicRef::map(self.fragment.borrow(), |fragment| {
+            fragment
+                .fragment
+                .as_ref()
+                .expect("Should never create LayoutRoot without a Fragment")
+        })
+    }
+
+    pub(crate) fn inner_box_fragment(&self) -> AtomicRef<'_, Arc<BoxFragment>> {
+        AtomicRef::map(self.inner(), |fragment| match fragment {
+            Fragment::Box(box_fragment) => box_fragment,
+            _ => unreachable!("Layout root should always contain box fragment"),
+        })
+    }
 }
 
 #[derive(MallocSizeOf)]
@@ -96,20 +121,27 @@ pub(crate) struct IFrameFragment {
 }
 
 impl Fragment {
-    pub fn base(&self) -> Option<&BaseFragment> {
+    pub fn base(&self) -> Option<RefOrAtomicRef<'_, BaseFragment>> {
         Some(match self {
-            Fragment::Box(fragment) => &fragment.base,
-            Fragment::Text(fragment) => &fragment.base,
+            Fragment::LayoutRoot(fragment) => RefOrAtomicRef::AtomicRef(AtomicRef::map(
+                fragment.inner_box_fragment(),
+                |box_fragment| &box_fragment.base,
+            )),
+            Fragment::Box(fragment) => RefOrAtomicRef::Ref(&fragment.base),
+            Fragment::Text(fragment) => RefOrAtomicRef::Ref(&fragment.base),
             Fragment::AbsoluteOrFixedPositionedPlaceholder(_) => return None,
-            Fragment::Positioning(fragment) => &fragment.base,
-            Fragment::Image(fragment) => &fragment.base,
-            Fragment::IFrame(fragment) => &fragment.base,
-            Fragment::Float(fragment) => &fragment.base,
+            Fragment::Positioning(fragment) => RefOrAtomicRef::Ref(&fragment.base),
+            Fragment::Image(fragment) => RefOrAtomicRef::Ref(&fragment.base),
+            Fragment::IFrame(fragment) => RefOrAtomicRef::Ref(&fragment.base),
+            Fragment::Float(fragment) => RefOrAtomicRef::Ref(&fragment.base),
         })
     }
 
     pub(crate) fn set_containing_block(&self, containing_block: &PhysicalRect<Au>) {
         match self {
+            Fragment::LayoutRoot(layout_root_fragment) => layout_root_fragment
+                .inner()
+                .set_containing_block(containing_block),
             Fragment::Box(box_fragment) | Fragment::Float(box_fragment) => {
                 box_fragment.set_containing_block(containing_block)
             },
@@ -129,6 +161,7 @@ impl Fragment {
 
     pub fn print(&self, tree: &mut PrintTree) {
         match self {
+            Fragment::LayoutRoot(layout_root_fragment) => layout_root_fragment.inner().print(tree),
             Fragment::Box(fragment) => fragment.print(tree),
             Fragment::Float(fragment) => {
                 tree.new_level("Float".to_string());
@@ -146,11 +179,14 @@ impl Fragment {
     }
 
     pub(crate) fn scrolling_area(&self, layout_thread: &LayoutThread) -> PhysicalRect<Au> {
-        match self {
-            Fragment::Box(fragment) | Fragment::Float(fragment) => fragment
-                .offset_by_containing_block(&fragment.scrollable_overflow(), layout_thread.into()),
-            _ => self.scrollable_overflow_for_parent(),
-        }
+        self.retrieve_box_fragment()
+            .map(|box_fragment| {
+                box_fragment.offset_by_containing_block(
+                    &box_fragment.scrollable_overflow(),
+                    layout_thread.into(),
+                )
+            })
+            .unwrap_or_else(|| self.scrollable_overflow_for_parent())
     }
 
     /// Clear the scrollable overflow on this [`Fragment`]. This is called during damage
@@ -158,6 +194,9 @@ impl Fragment {
     /// scrollable overflow damage.
     pub(crate) fn clear_scrollable_overflow(&self) {
         match self {
+            Fragment::LayoutRoot(fragment) => {
+                fragment.inner_box_fragment().clear_scrollable_overflow()
+            },
             Fragment::Box(fragment) | Fragment::Float(fragment) => {
                 fragment.clear_scrollable_overflow()
             },
@@ -168,6 +207,9 @@ impl Fragment {
 
     pub(crate) fn scrollable_overflow_for_parent(&self) -> PhysicalRect<Au> {
         match self {
+            Fragment::LayoutRoot(layout_root) => {
+                layout_root.inner().scrollable_overflow_for_parent()
+            },
             Fragment::Box(fragment) | Fragment::Float(fragment) => {
                 fragment.scrollable_overflow_for_parent()
             },
@@ -192,13 +234,14 @@ impl Fragment {
     ) -> Option<PhysicalRect<Au>> {
         match self {
             // TODO: This should consider the box in pre-relative-adjusted position state.
-            Fragment::Box(fragment) | Fragment::Float(fragment) => {
-                if !fragment.style().clone_position().is_absolutely_positioned() {
-                    Some(fragment.margin_rect())
-                } else {
-                    None
-                }
+            Fragment::Box(fragment) | Fragment::Float(fragment)
+                if !fragment.style().clone_position().is_absolutely_positioned() =>
+            {
+                Some(fragment.margin_rect())
             },
+            // Layout roots and absolutely positioned elements do not affect scrollable overflow
+            // for parents.
+            Fragment::Box(..) | Fragment::Float(..) | Fragment::LayoutRoot(..) => None,
             // TODO: This rectangle does not include extra size from overflowing inline items. As
             // this measurement is concerned with the actual fragments, it's quite likely that this
             // rectangle should include that.
@@ -216,6 +259,9 @@ impl Fragment {
         containing_block_computation: ContainingBlockCalculation<'_>,
     ) -> Option<PhysicalRect<Au>> {
         match self {
+            Fragment::LayoutRoot(layout_root_fragment) => layout_root_fragment
+                .inner()
+                .cumulative_box_area_rect(area, containing_block_computation),
             Fragment::Box(fragment) | Fragment::Float(fragment) => Some(match area {
                 BoxAreaType::Content => {
                     fragment.cumulative_content_box_rect(containing_block_computation)
@@ -241,30 +287,29 @@ impl Fragment {
     }
 
     pub(crate) fn client_rect(&self) -> Rect<i32, CSSPixel> {
-        let rect = match self {
-            Fragment::Box(fragment) | Fragment::Float(fragment) => {
-                // https://drafts.csswg.org/cssom-view/#dom-element-clienttop
-                // " If the element has no associated CSS layout box or if the
-                //   CSS layout box is inline, return zero." For this check we
-                // also explicitly ignore the list item portion of the display
-                // style.
-                if fragment.is_inline_box() {
-                    return Rect::zero();
-                }
+        let Some(fragment) = self.retrieve_box_fragment() else {
+            return Rect::zero();
+        };
 
-                if fragment.is_table_wrapper() {
-                    // For tables the border actually belongs to the table grid box,
-                    // so we need to include it in the dimension of the table wrapper box.
-                    let mut rect = fragment.border_rect();
-                    rect.origin = PhysicalPoint::zero();
-                    rect
-                } else {
-                    let mut rect = fragment.padding_rect();
-                    rect.origin = PhysicalPoint::new(fragment.border.left, fragment.border.top);
-                    rect
-                }
-            },
-            _ => return Rect::zero(),
+        // https://drafts.csswg.org/cssom-view/#dom-element-clienttop
+        // " If the element has no associated CSS layout box or if the
+        //   CSS layout box is inline, return zero." For this check we
+        // also explicitly ignore the list item portion of the display
+        // style.
+        if fragment.is_inline_box() {
+            return Rect::zero();
+        }
+
+        let rect = if fragment.is_table_wrapper() {
+            // For tables the border actually belongs to the table grid box,
+            // so we need to include it in the dimension of the table wrapper box.
+            let mut rect = fragment.border_rect();
+            rect.origin = PhysicalPoint::zero();
+            rect
+        } else {
+            let mut rect = fragment.padding_rect();
+            rect.origin = PhysicalPoint::new(fragment.border.left, fragment.border.top);
+            rect
         };
 
         let rect = Rect::new(
@@ -274,10 +319,16 @@ impl Fragment {
         rect.round().to_i32()
     }
 
-    pub(crate) fn children(&self) -> Option<&[Fragment]> {
+    pub(crate) fn children(&self) -> Option<RefOrAtomicRef<'_, Vec<Fragment>>> {
         match self {
-            Fragment::Box(fragment) | Fragment::Float(fragment) => Some(&fragment.children),
-            Fragment::Positioning(fragment) => Some(&fragment.children),
+            Fragment::LayoutRoot(fragment) => Some(RefOrAtomicRef::AtomicRef(AtomicRef::map(
+                fragment.inner_box_fragment(),
+                |fragment| &fragment.children,
+            ))),
+            Fragment::Box(fragment) | Fragment::Float(fragment) => {
+                Some(RefOrAtomicRef::Ref(&fragment.children))
+            },
+            Fragment::Positioning(fragment) => Some(RefOrAtomicRef::Ref(&fragment.children)),
             _ => None,
         }
     }
@@ -294,6 +345,11 @@ impl Fragment {
         }
 
         match self {
+            Fragment::LayoutRoot(layout_root_fragment) => {
+                layout_root_fragment
+                    .inner()
+                    .find(manager, level, process_func)
+            },
             Fragment::Box(fragment) | Fragment::Float(fragment) => {
                 let style = fragment.style();
                 let content_rect = fragment
@@ -334,9 +390,14 @@ impl Fragment {
         }
     }
 
-    pub(crate) fn retrieve_box_fragment(&self) -> Option<&Arc<BoxFragment>> {
+    pub(crate) fn retrieve_box_fragment(&self) -> Option<RefOrAtomicRef<'_, Arc<BoxFragment>>> {
         match self {
-            Fragment::Box(box_fragment) | Fragment::Float(box_fragment) => Some(box_fragment),
+            Fragment::LayoutRoot(layout_root_fragment) => Some(RefOrAtomicRef::AtomicRef(
+                layout_root_fragment.inner_box_fragment(),
+            )),
+            Fragment::Box(box_fragment) | Fragment::Float(box_fragment) => {
+                Some(RefOrAtomicRef::Ref(box_fragment))
+            },
             _ => None,
         }
     }

--- a/components/layout/fragment_tree/fragment.rs
+++ b/components/layout/fragment_tree/fragment.rs
@@ -179,14 +179,15 @@ impl Fragment {
     }
 
     pub(crate) fn scrolling_area(&self, layout_thread: &LayoutThread) -> PhysicalRect<Au> {
-        self.retrieve_box_fragment()
-            .map(|box_fragment| {
+        self.retrieve_box_fragment().map_or_else(
+            || self.scrollable_overflow_for_parent(),
+            |box_fragment| {
                 box_fragment.offset_by_containing_block(
                     &box_fragment.scrollable_overflow(),
                     layout_thread.into(),
                 )
-            })
-            .unwrap_or_else(|| self.scrollable_overflow_for_parent())
+            },
+        )
     }
 
     /// Clear the scrollable overflow on this [`Fragment`]. This is called during damage

--- a/components/layout/fragment_tree/fragment_tree.rs
+++ b/components/layout/fragment_tree/fragment_tree.rs
@@ -60,6 +60,18 @@ impl FragmentTree {
         self.root_fragments
             .iter()
             .find_map(|root_fragment| match root_fragment {
+                Fragment::LayoutRoot(layout_root_fragment) => {
+                    let box_fragment = layout_root_fragment.inner_box_fragment();
+                    if box_fragment
+                        .base
+                        .flags
+                        .contains(FragmentFlags::IS_ROOT_ELEMENT)
+                    {
+                        Some(box_fragment.clone())
+                    } else {
+                        None
+                    }
+                },
                 Fragment::Box(box_fragment) | Fragment::Float(box_fragment)
                     if box_fragment
                         .base
@@ -95,7 +107,7 @@ impl FragmentTree {
     /// Calculate the scrollable overflow / scrolling area for this [`FragmentTree`] according
     /// to <https://drafts.csswg.org/cssom-view/#scrolling-area>.
     fn calculate_scrollable_overflow(&self) -> PhysicalRect<Au> {
-        let Some(first_root_fragment) = self.root_fragments.first() else {
+        let Some(first_root_fragment) = self.root_box_fragment() else {
             return self.initial_containing_block;
         };
 
@@ -120,17 +132,8 @@ impl FragmentTree {
                     overflow.union(&fragment.scrollable_overflow_for_parent())
                 });
 
-        // Assuming that the first fragment is the root element, ensure that
-        // scrollable overflow that is unreachable is not included in the final
-        // rectangle. See
-        // <https://drafts.csswg.org/css-overflow/#scrolling-direction>.
-        let first_root_fragment = match first_root_fragment {
-            Fragment::Box(fragment) | Fragment::Float(fragment) => fragment,
-            _ => return scrollable_overflow,
-        };
-        if !first_root_fragment.is_root_element() {
-            return scrollable_overflow;
-        }
+        // Ensure that scrollable overflow that is unreachable is not included in the final
+        // rectangle. See <https://drafts.csswg.org/css-overflow/#scrolling-direction>.
         first_root_fragment.clip_wholly_unreachable_scrollable_overflow(
             scrollable_overflow,
             self.initial_containing_block,
@@ -153,25 +156,34 @@ impl FragmentTree {
 
     /// Find the `<body>` element's [`Fragment`], if it exists in this [`FragmentTree`].
     pub(crate) fn body_fragment(&self) -> Option<Arc<BoxFragment>> {
+        fn find_body_from_box_fragment(
+            box_fragment: &Arc<BoxFragment>,
+        ) -> Option<Arc<BoxFragment>> {
+            if box_fragment.is_body_element_of_html_element_root() {
+                return Some(box_fragment.clone());
+            }
+
+            // The fragment for the `<body>` element is typically a child of the root (though,
+            // not if it's absolutely positioned), so we need to recurse into the children of
+            // the root to find it.
+            //
+            // Additionally, recurse into any anonymous fragments, as the `<body>` fragment may
+            // have created anonymous parents (for instance by creating an inline formatting context).
+            if box_fragment.is_root_element() || box_fragment.base.is_anonymous() {
+                find_body(&box_fragment.children)
+            } else {
+                None
+            }
+        }
+
         fn find_body(children: &[Fragment]) -> Option<Arc<BoxFragment>> {
             children.iter().find_map(|fragment| {
                 match fragment {
+                    Fragment::LayoutRoot(layout_root) => {
+                        find_body_from_box_fragment(&layout_root.inner_box_fragment())
+                    },
                     Fragment::Box(box_fragment) | Fragment::Float(box_fragment) => {
-                        if box_fragment.is_body_element_of_html_element_root() {
-                            return Some(box_fragment.clone());
-                        }
-
-                        // The fragment for the `<body>` element is typically a child of the root (though,
-                        // not if it's absolutely positioned), so we need to recurse into the children of
-                        // the root to find it.
-                        //
-                        // Additionally, recurse into any anonymous fragments, as the `<body>` fragment may
-                        // have created anonymous parents (for instance by creating an inline formatting context).
-                        if box_fragment.is_root_element() || box_fragment.base.is_anonymous() {
-                            find_body(&box_fragment.children)
-                        } else {
-                            None
-                        }
+                        find_body_from_box_fragment(box_fragment)
                     },
                     Fragment::Positioning(positioning_fragment)
                         if positioning_fragment.base.is_anonymous() =>

--- a/components/layout/fragment_tree/fragment_tree.rs
+++ b/components/layout/fragment_tree/fragment_tree.rs
@@ -57,31 +57,14 @@ impl FragmentTree {
     /// block as their containing block are also direct children of the fragment tree
     /// root, but they are not returned by this getter.
     pub(crate) fn root_box_fragment(&self) -> Option<Arc<BoxFragment>> {
-        self.root_fragments
-            .iter()
-            .find_map(|root_fragment| match root_fragment {
-                Fragment::LayoutRoot(layout_root_fragment) => {
-                    let box_fragment = layout_root_fragment.inner_box_fragment();
-                    if box_fragment
-                        .base
-                        .flags
-                        .contains(FragmentFlags::IS_ROOT_ELEMENT)
-                    {
-                        Some(box_fragment.clone())
-                    } else {
-                        None
-                    }
-                },
-                Fragment::Box(box_fragment) | Fragment::Float(box_fragment)
-                    if box_fragment
-                        .base
-                        .flags
-                        .contains(FragmentFlags::IS_ROOT_ELEMENT) =>
-                {
-                    Some(box_fragment.clone())
-                },
-                _ => None,
-            })
+        self.root_fragments.iter().find_map(|root_fragment| {
+            let box_fragment = root_fragment.retrieve_box_fragment()?;
+            box_fragment
+                .base
+                .flags
+                .contains(FragmentFlags::IS_ROOT_ELEMENT)
+                .then(|| box_fragment.clone())
+        })
     }
 
     pub fn print(&self) {

--- a/components/layout/positioned.rs
+++ b/components/layout/positioned.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::mem;
+use std::sync::Arc;
 
 use app_units::Au;
 use malloc_size_of_derive::MallocSizeOf;
@@ -18,7 +19,9 @@ use crate::cell::ArcRefCell;
 use crate::context::LayoutContext;
 use crate::dom_traversal::{Contents, NodeAndStyleInfo};
 use crate::formatting_contexts::IndependentFormattingContext;
-use crate::fragment_tree::{BoxFragment, Fragment, FragmentFlags, HoistedSharedFragment};
+use crate::fragment_tree::{
+    BoxFragment, Fragment, FragmentFlags, HoistedSharedFragment, LayoutRootFragment,
+};
 use crate::geom::{
     AuOrAuto, LogicalRect, LogicalSides, LogicalSides1D, LogicalVec2, PhysicalPoint, PhysicalRect,
     PhysicalSides, PhysicalSize, PhysicalVec, ToLogical, ToLogicalWithContainingBlock,
@@ -112,6 +115,11 @@ pub(crate) struct PositioningContext {
 }
 
 impl PositioningContext {
+    #[inline]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.absolutes.is_empty()
+    }
+
     #[inline]
     pub(crate) fn new_for_layout_box_base(layout_box_base: &LayoutBoxBase) -> Option<Self> {
         Self::new_for_style_and_fragment_flags(
@@ -417,8 +425,6 @@ impl HoistedAbsolutelyPositionedBox {
                         containing_block,
                         containing_block_padding,
                     );
-
-                    hoisted_box.fragment.borrow_mut().fragment = Some(new_fragment.clone());
                     (new_fragment, new_hoisted_boxes)
                 })
                 .unzip_into_vecs(&mut new_fragments, &mut new_hoisted_boxes);
@@ -427,16 +433,13 @@ impl HoistedAbsolutelyPositionedBox {
             for_nearest_containing_block_for_all_descendants
                 .extend(new_hoisted_boxes.into_iter().flatten());
         } else {
-            fragments.extend(boxes.iter_mut().map(|box_| {
-                let new_fragment = box_.layout(
+            fragments.extend(boxes.iter_mut().map(|hoisted_box| {
+                hoisted_box.layout(
                     layout_context,
                     for_nearest_containing_block_for_all_descendants,
                     containing_block,
                     containing_block_padding,
-                );
-
-                box_.fragment.borrow_mut().fragment = Some(new_fragment.clone());
-                new_fragment
+                )
             }))
         }
     }
@@ -448,23 +451,6 @@ impl HoistedAbsolutelyPositionedBox {
         containing_block: &DefiniteContainingBlock,
         containing_block_padding: PhysicalSides<Au>,
     ) -> Fragment {
-        let cbis = containing_block.size.inline;
-        let cbbs = containing_block.size.block;
-        let containing_block_writing_mode = containing_block.style.writing_mode;
-        let absolutely_positioned_box = self.absolutely_positioned_box.borrow();
-        let context = &absolutely_positioned_box.context;
-        let style = context.style().clone();
-        let layout_style = context.layout_style();
-        let ContentBoxSizesAndPBM {
-            content_box_sizes,
-            pbm,
-            ..
-        } = layout_style.content_box_sizes_and_padding_border_margin(&containing_block.into());
-        let containing_block = &containing_block.into();
-        let is_table = layout_style.is_table();
-        let is_table_or_replaced = is_table || context.is_replaced();
-        let preferred_aspect_ratio = context.preferred_aspect_ratio(&pbm.padding_border_sums);
-
         // The static position rect was calculated assuming that the containing block would be
         // established by the content box of some ancestor, but the actual containing block is
         // established by the padding box. So we need to add the padding of that ancestor.
@@ -472,7 +458,86 @@ impl HoistedAbsolutelyPositionedBox {
             .static_position_rect()
             .outer_rect(-containing_block_padding);
         static_position_rect.size = static_position_rect.size.max(PhysicalSize::zero());
-        let static_position_rect = static_position_rect.to_logical(containing_block);
+        let fully_adjusted_static_position_rect =
+            static_position_rect.to_logical(&containing_block.into());
+
+        let absolutely_positioned_box = self.absolutely_positioned_box.borrow();
+        let independent_formatting_context = &absolutely_positioned_box.context;
+        let (box_fragment, mut positioning_context) = independent_formatting_context
+            .layout_as_absolute(
+                layout_context,
+                &fully_adjusted_static_position_rect,
+                containing_block,
+                self.resolved_alignment,
+                self.original_parent_writing_mode,
+            );
+
+        // An absolutely-positioned box can be a layout root if it does not hoist any
+        // fixed positioned boxes out of it. This condition ensures isolation from parent
+        // layout meaning that laying out the absolutely positioned box again, will not
+        // affect ancestor layout.
+        let is_layout_root = positioning_context.is_empty();
+
+        // Any hoisted boxes that remain in this positioning context are going to be hoisted
+        // up above this absolutely positioned box. These will necessarily be fixed position
+        // elements, because absolutely positioned elements form containing blocks for all
+        // other elements. If any of them have a static start position though, we need to
+        // adjust it to account for the start corner of this absolute.
+        positioning_context.adjust_static_position_of_hoisted_fragments_with_offset(
+            &box_fragment.content_rect().origin.to_vector(),
+            PositioningContextLength::zero(),
+        );
+        hoisted_absolutes_from_children.extend(positioning_context.absolutes);
+
+        let fragment = Fragment::Box(box_fragment);
+        self.fragment.borrow_mut().fragment = Some(fragment.clone());
+
+        let fragment = match is_layout_root {
+            false => fragment,
+            true => Fragment::LayoutRoot(LayoutRootFragment {
+                fragment: self.fragment.clone(),
+            }),
+        };
+
+        independent_formatting_context
+            .base
+            .set_fragment(fragment.clone());
+
+        fragment
+    }
+
+    fn static_position_rect(&self) -> PhysicalRect<Au> {
+        self.adjusted_static_position_rect
+            .unwrap_or_else(|| self.fragment.borrow().original_static_position_rect)
+    }
+
+    fn adjust_static_position_with_offset(&mut self, offset: &PhysicalVec<Au>) {
+        self.adjusted_static_position_rect = Some(self.static_position_rect().translate(*offset));
+    }
+}
+
+impl IndependentFormattingContext {
+    pub(crate) fn layout_as_absolute(
+        &self,
+        layout_context: &LayoutContext,
+        static_position_rect: &LogicalRect<Au>,
+        containing_block: &DefiniteContainingBlock,
+        resolved_alignment: LogicalVec2<AlignFlags>,
+        original_parent_writing_mode: WritingMode,
+    ) -> (Arc<BoxFragment>, PositioningContext) {
+        let cbis = containing_block.size.inline;
+        let cbbs = containing_block.size.block;
+        let containing_block_writing_mode = containing_block.style.writing_mode;
+        let style = self.style().clone();
+        let layout_style = self.layout_style();
+        let ContentBoxSizesAndPBM {
+            content_box_sizes,
+            pbm,
+            ..
+        } = layout_style.content_box_sizes_and_padding_border_margin(&containing_block.into());
+        let is_table = layout_style.is_table();
+        let is_table_or_replaced = is_table || self.is_replaced();
+        let preferred_aspect_ratio = self.preferred_aspect_ratio(&pbm.padding_border_sums);
 
         let box_offset = style.box_offsets(containing_block.style.writing_mode);
 
@@ -481,7 +546,7 @@ impl HoistedAbsolutelyPositionedBox {
         let inline_box_offsets = box_offset.inline_sides().percentages_relative_to(cbis);
         let inline_alignment = match inline_box_offsets.either_specified() {
             true => style.clone_justify_self().0,
-            false => self.resolved_alignment.inline,
+            false => resolved_alignment.inline,
         };
 
         let inline_axis_solver = AbsoluteAxisSolver {
@@ -495,7 +560,7 @@ impl HoistedAbsolutelyPositionedBox {
             box_offsets: inline_box_offsets,
             static_position_rect_axis: static_position_rect.get_axis(Direction::Inline),
             alignment: inline_alignment,
-            flip_anchor: self.original_parent_writing_mode.is_bidi_ltr() !=
+            flip_anchor: original_parent_writing_mode.is_bidi_ltr() !=
                 containing_block_writing_mode.is_bidi_ltr(),
             is_table_or_replaced,
         };
@@ -505,7 +570,7 @@ impl HoistedAbsolutelyPositionedBox {
         let block_box_offsets = box_offset.block_sides().percentages_relative_to(cbbs);
         let block_alignment = match block_box_offsets.either_specified() {
             true => style.clone_align_self().0,
-            false => self.resolved_alignment.block,
+            false => resolved_alignment.block,
         };
         let block_axis_solver = AbsoluteAxisSolver {
             axis: Direction::Block,
@@ -528,7 +593,7 @@ impl HoistedAbsolutelyPositionedBox {
         let block_stretch_size = Some(block_axis_solver.stretch_size());
         let inline_stretch_size = inline_axis_solver.stretch_size();
         let tentative_block_content_size =
-            context.tentative_block_content_size(preferred_aspect_ratio, inline_stretch_size);
+            self.tentative_block_content_size(preferred_aspect_ratio, inline_stretch_size);
         let tentative_block_size = if let Some(block_content_size) = tentative_block_content_size {
             SizeConstraint::Definite(block_axis_solver.computed_sizes.resolve(
                 Direction::Block,
@@ -551,8 +616,7 @@ impl HoistedAbsolutelyPositionedBox {
         let get_inline_content_size = || {
             let constraint_space =
                 ConstraintSpace::new(tentative_block_size, &style, preferred_aspect_ratio);
-            context
-                .inline_content_sizes(layout_context, &constraint_space)
+            self.inline_content_sizes(layout_context, &constraint_space)
                 .sizes
         };
         let inline_size = inline_axis_solver.computed_sizes.resolve(
@@ -587,7 +651,9 @@ impl HoistedAbsolutelyPositionedBox {
             block_stretch_size,
             is_table,
         );
-        let (layout, is_cached) = context.layout_and_is_cached(
+
+        let containing_block = &containing_block.into();
+        let (layout, is_cached) = self.layout_and_is_cached(
             layout_context,
             &mut positioning_context,
             &containing_block_for_children,
@@ -625,13 +691,13 @@ impl HoistedAbsolutelyPositionedBox {
         let inline_origin = inline_axis_solver.origin_for_margin_box(
             margin_rect_size.inline,
             style.writing_mode,
-            self.original_parent_writing_mode,
+            original_parent_writing_mode,
             containing_block_writing_mode,
         );
         let block_origin = block_axis_solver.origin_for_margin_box(
             margin_rect_size.block,
             style.writing_mode,
-            self.original_parent_writing_mode,
+            original_parent_writing_mode,
             containing_block_writing_mode,
         );
         let content_rect = LogicalRect {
@@ -643,33 +709,21 @@ impl HoistedAbsolutelyPositionedBox {
         }
         .as_physical(Some(containing_block));
 
-        let mut adjust_hoisted_boxes = |mut positioning_context: PositioningContext| {
-            // Any hoisted boxes that remain in this positioning context are going to be hoisted
-            // up above this absolutely positioned box. These will necessarily be fixed position
-            // elements, because absolutely positioned elements form containing blocks for all
-            // other elements. If any of them have a static start position though, we need to
-            // adjust it to account for the start corner of this absolute.
-            positioning_context.adjust_static_position_of_hoisted_fragments_with_offset(
-                &content_rect.origin.to_vector(),
-                PositioningContextLength::zero(),
-            );
-
-            hoisted_absolutes_from_children.extend(positioning_context.absolutes);
-        };
-
         if is_cached &&
-            let Some(Fragment::Box(old_fragment)) = context.base.fragments().first() &&
-            content_rect == old_fragment.content_rect()
+            let Some(old_fragment) = self.base.fragments().first() &&
+            let Some(old_box_fragment) = old_fragment
+                .retrieve_box_fragment()
+                .map(|fragment| fragment.clone()) &&
+            content_rect == old_box_fragment.content_rect()
         {
             // Drain the nested absolutes for which we are a containing block.
             // However, we are reusing the fragment, so no need to lay them out again.
-            positioning_context.forget_unhoisted_boxes(old_fragment);
-            adjust_hoisted_boxes(positioning_context);
-            return Fragment::Box(old_fragment.clone());
+            positioning_context.forget_unhoisted_boxes(&old_box_fragment);
+            return (old_box_fragment, positioning_context);
         }
 
-        let mut new_fragment = BoxFragment::new(
-            context.base_fragment_info(),
+        let mut new_box_fragment = BoxFragment::new(
+            self.base_fragment_info(),
             style,
             fragments,
             content_rect,
@@ -682,22 +736,8 @@ impl HoistedAbsolutelyPositionedBox {
         // This is an absolutely positioned element, which means it also establishes a
         // containing block for absolutes. We lay out any absolutely positioned children
         // here and pass the rest to `hoisted_absolutes_from_children.`
-        positioning_context.layout_collected_children(layout_context, &mut new_fragment);
-
-        adjust_hoisted_boxes(positioning_context);
-
-        let fragment = Fragment::Box(new_fragment.into());
-        context.base.set_fragment(fragment.clone());
-        fragment
-    }
-
-    fn static_position_rect(&self) -> PhysicalRect<Au> {
-        self.adjusted_static_position_rect
-            .unwrap_or_else(|| self.fragment.borrow().original_static_position_rect)
-    }
-
-    fn adjust_static_position_with_offset(&mut self, offset: &PhysicalVec<Au>) {
-        self.adjusted_static_position_rect = Some(self.static_position_rect().translate(*offset));
+        positioning_context.layout_collected_children(layout_context, &mut new_box_fragment);
+        (new_box_fragment.into(), positioning_context)
     }
 }
 

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -3,12 +3,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 //! Utilities for querying the layout, as needed by layout.
+use std::cell::LazyCell;
 use std::rc::Rc;
 use std::sync::Arc;
 
 use app_units::Au;
 use embedder_traits::UntrustedNodeAddress;
-use euclid::{Point2D, Rect, SideOffsets2D, Size2D};
+use euclid::{Point2D, Rect, Size2D};
 use itertools::Itertools;
 use layout_api::{
     AxesOverflow, BoxAreaType, CSSPixelRectVec, DangerousStyleElementOf, LayoutElement,
@@ -45,6 +46,7 @@ use style::values::specified::box_::DisplayInside;
 use style::values::specified::text::TextTransformCase;
 use style_traits::{CSSPixel, ParsingMode, ToCss};
 
+use crate::cell::RefOrAtomicRef;
 use crate::display_list::{StackingContextTree, au_rect_to_length_rect};
 use crate::dom::NodeExt;
 use crate::flow::inline::construct::{TextTransformation, WhitespaceCollapse, capitalize_string};
@@ -72,18 +74,20 @@ fn root_transform_for_layout_node(
 pub(crate) fn process_padding_request(node: ServoLayoutNode<'_>) -> Option<PhysicalSides> {
     let fragments = node.fragments_for_pseudo(None);
     let fragment = fragments.first()?;
-    Some(match fragment {
-        Fragment::Box(box_fragment) | Fragment::Float(box_fragment) => {
-            let padding = box_fragment.padding;
-            PhysicalSides {
-                top: padding.top,
-                left: padding.left,
-                bottom: padding.bottom,
-                right: padding.right,
-            }
-        },
-        _ => Default::default(),
-    })
+    Some(
+        fragment
+            .retrieve_box_fragment()
+            .map(|box_fragment| {
+                let padding = box_fragment.padding;
+                PhysicalSides {
+                    top: padding.top,
+                    left: padding.left,
+                    bottom: padding.bottom,
+                    right: padding.right,
+                }
+            })
+            .unwrap_or_default(),
+    )
 }
 
 pub(crate) fn process_box_area_request(
@@ -326,53 +330,48 @@ pub fn process_resolved_style_request(
     }
 
     let resolve_for_fragment = |fragment: &Fragment| {
-        let (content_rect, margins, padding, specific_layout_info) = match fragment {
-            Fragment::Box(box_fragment) | Fragment::Float(box_fragment) => {
-                if style.get_box().position != Position::Static {
-                    let resolved_insets = || {
-                        box_fragment.calculate_resolved_insets_if_positioned(layout_thread.into())
-                    };
-                    match longhand_id {
-                        LonghandId::Top => return resolved_insets().top.to_css_string(),
-                        LonghandId::Right => {
-                            return resolved_insets().right.to_css_string();
-                        },
-                        LonghandId::Bottom => {
-                            return resolved_insets().bottom.to_css_string();
-                        },
-                        LonghandId::Left => {
-                            return resolved_insets().left.to_css_string();
-                        },
-                        LonghandId::Transform => {
-                            // If we can compute the string do it, but otherwise fallback to a cruder serialization
-                            // of the value.
-                            if let Ok(string) = serialize_transform_value(Some(box_fragment)) {
-                                return string;
-                            }
-                        },
-                        _ => {},
+        if let Some(box_fragment) = fragment.retrieve_box_fragment() &&
+            style.get_box().position != Position::Static
+        {
+            let resolved_insets =
+                || box_fragment.calculate_resolved_insets_if_positioned(layout_thread.into());
+            match longhand_id {
+                LonghandId::Top => return resolved_insets().top.to_css_string(),
+                LonghandId::Right => {
+                    return resolved_insets().right.to_css_string();
+                },
+                LonghandId::Bottom => {
+                    return resolved_insets().bottom.to_css_string();
+                },
+                LonghandId::Left => {
+                    return resolved_insets().left.to_css_string();
+                },
+                LonghandId::Transform => {
+                    // If we can compute the string do it, but otherwise fallback to a cruder serialization
+                    // of the value.
+                    if let Ok(string) = serialize_transform_value(Some(&box_fragment)) {
+                        return string;
                     }
-                }
-                let content_rect = box_fragment.base.rect();
-                let margins = box_fragment.margin;
-                let padding = box_fragment.padding;
-                let specific_layout_info = box_fragment.specific_layout_info().as_deref().cloned();
-                (content_rect, margins, padding, specific_layout_info)
-            },
-            Fragment::Positioning(positioning_fragment) => (
-                positioning_fragment.base.rect(),
-                SideOffsets2D::zero(),
-                SideOffsets2D::zero(),
-                None,
-            ),
-            _ => return computed_style(Some(fragment)),
-        };
+                },
+                _ => {},
+            }
+        }
+
+        if !matches!(
+            fragment,
+            Fragment::LayoutRoot(..) | Fragment::Box(..) | Fragment::Positioning(..)
+        ) {
+            return computed_style(Some(fragment));
+        }
 
         // https://drafts.csswg.org/css-grid/#resolved-track-list
         // > The grid-template-rows and grid-template-columns properties are
         // > resolved value special case properties.
         //
         // > When an element generates a grid container box...
+        let specific_layout_info = fragment
+            .retrieve_box_fragment()
+            .and_then(|box_fragment| box_fragment.specific_layout_info().as_deref().cloned());
         if display.inside() == DisplayInside::Grid &&
             let Some(SpecificLayoutInfo::Grid(info)) = specific_layout_info &&
             let Some(value) = resolve_grid_template(&info, style, longhand_id)
@@ -387,6 +386,20 @@ pub fn process_resolved_style_request(
         //
         // However, all browsers ignore that for margin and padding properties, and resolve to a length
         // even if the property doesn't apply: https://github.com/w3c/csswg-drafts/issues/10391
+        let content_rect =
+            LazyCell::new(|| fragment.base().map(|base| base.rect()).unwrap_or_default());
+        let margins = LazyCell::new(|| {
+            fragment
+                .retrieve_box_fragment()
+                .map(|fragment| fragment.margin)
+                .unwrap_or_default()
+        });
+        let padding = LazyCell::new(|| {
+            fragment
+                .retrieve_box_fragment()
+                .map(|fragment| fragment.padding)
+                .unwrap_or_default()
+        });
         match longhand_id {
             LonghandId::Width if resolved_size_should_be_used_value(fragment) => {
                 content_rect.size.width
@@ -417,6 +430,9 @@ fn resolved_size_should_be_used_value(fragment: &Fragment) -> bool {
     // https://drafts.csswg.org/css-sizing-3/#preferred-size-properties
     // > Applies to: all elements except non-replaced inlines
     match fragment {
+        Fragment::LayoutRoot(layout_root) => {
+            resolved_size_should_be_used_value(&layout_root.inner())
+        },
         Fragment::Box(box_fragment) => !box_fragment.is_inline_box(),
         Fragment::Float(_) |
         Fragment::Positioning(_) |
@@ -436,7 +452,10 @@ fn should_honor_min_size_auto(fragment: Option<&Fragment>, style: &ComputedValue
     // <https://github.com/w3c/csswg-drafts/issues/11716>
     // However, when a box is generated and `aspect-ratio` isn't `auto`, we need to preserve
     // the automatic minimum size as `auto`.
-    let Some(Fragment::Box(box_fragment)) = fragment else {
+    if let Some(Fragment::Float(..)) = fragment {
+        return false;
+    };
+    let Some(box_fragment) = fragment.and_then(|fragment| fragment.retrieve_box_fragment()) else {
         return false;
     };
     let flags = box_fragment.base.flags;
@@ -581,6 +600,13 @@ struct OffsetParentFragments {
     grandparent: Option<Fragment>,
 }
 
+impl OffsetParentFragments {
+    fn grandparent_box_fragment(&self) -> Option<RefOrAtomicRef<'_, Arc<BoxFragment>>> {
+        self.grandparent
+            .as_ref()
+            .and_then(|grandparent| grandparent.retrieve_box_fragment())
+    }
+}
 /// <https://www.w3.org/TR/2016/WD-cssom-view-1-20160317/#dom-htmlelement-offsetparent>
 #[expect(unsafe_code)]
 fn offset_parent_fragments(node: ServoLayoutNode<'_>) -> Option<OffsetParentFragments> {
@@ -596,9 +622,11 @@ fn offset_parent_fragments(node: ServoLayoutNode<'_>) -> Option<OffsetParentFrag
     ) {
         return None;
     }
-    if matches!(
-        fragment, Fragment::Box(fragment) if fragment.style().get_box().position == Position::Fixed
-    ) {
+
+    if fragment
+        .retrieve_box_fragment()
+        .is_some_and(|fragment| fragment.style().get_box().position == Position::Fixed)
+    {
         return None;
     }
 
@@ -613,9 +641,8 @@ fn offset_parent_fragments(node: ServoLayoutNode<'_>) -> Option<OffsetParentFrag
         maybe_parent_node = unsafe { parent_node.dangerous_dom_parent() };
 
         if let Some(parent_fragment) = parent_node.fragments_for_pseudo(None).first() {
-            let parent_fragment = match parent_fragment {
-                Fragment::Box(box_fragment) | Fragment::Float(box_fragment) => box_fragment,
-                _ => continue,
+            let Some(parent_fragment) = parent_fragment.retrieve_box_fragment() else {
+                continue;
             };
 
             let grandparent_fragment =
@@ -691,7 +718,7 @@ pub fn process_offset_parent_query(
         });
     };
 
-    let parent_fragment = offset_parent_fragment.parent;
+    let parent_fragment = &offset_parent_fragment.parent;
     let parent_is_static_body_element = parent_fragment
         .base
         .flags
@@ -706,13 +733,7 @@ pub fn process_offset_parent_query(
     //    that apply to the element and its ancestors.
     //
     // We generalize this for `offsetRight` as described in the specification.
-    let grandparent_box_fragment = || match offset_parent_fragment.grandparent {
-        Some(Fragment::Box(box_fragment)) | Some(Fragment::Float(box_fragment)) => {
-            Some(box_fragment)
-        },
-        _ => None,
-    };
-
+    //
     // The spec (https://www.w3.org/TR/cssom-view-1/#extensions-to-the-htmlelement-interface)
     // says that offsetTop/offsetLeft are always relative to the padding box of the offsetParent.
     // However, in practice this is not true in major browsers in the case that the offsetParent is the body
@@ -721,7 +742,7 @@ pub fn process_offset_parent_query(
     //
     // See <https://github.com/w3c/csswg-drafts/issues/10549>.
     let parent_offset_rect = if parent_is_static_body_element {
-        if let Some(grandparent_fragment) = grandparent_box_fragment() {
+        if let Some(grandparent_fragment) = offset_parent_fragment.grandparent_box_fragment() {
             grandparent_fragment.offset_by_containing_block(
                 &grandparent_fragment.border_rect(),
                 layout_thread.into(),

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -452,9 +452,6 @@ fn should_honor_min_size_auto(fragment: Option<&Fragment>, style: &ComputedValue
     // <https://github.com/w3c/csswg-drafts/issues/11716>
     // However, when a box is generated and `aspect-ratio` isn't `auto`, we need to preserve
     // the automatic minimum size as `auto`.
-    if let Some(Fragment::Float(..)) = fragment {
-        return false;
-    };
     let Some(box_fragment) = fragment.and_then(|fragment| fragment.retrieve_box_fragment()) else {
         return false;
     };


### PR DESCRIPTION
This adds initial support for the concept of layout roots: places in the
fragment tree where fragment layout can be initiated. Currently this
only includes absolutely positioned elements that do not have any fixed
position descendants that are hoisted out of them.

This change does not implement layout that starts from these layout
roots, but lays the groundwork for that implementation.

Testing: This should not change observable behavior so should be covered by existing tests.
