### PR TITLE
Track parent IDs for accessibility nodes.

### DIFF
--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -268,6 +268,7 @@ impl AccessibilityTree {
         {
             let node = self.nodes.remove(&id);
             debug_assert!(node.is_some(), "Node for id {id:?} was already removed");
+            self.node_to_parent.remove(&id);
             if let Some(opaque_node) = self.id_to_opaque_node.remove(&id) {
                 self.opaque_node_to_id.remove(&opaque_node);
             }
@@ -361,7 +362,13 @@ impl AccessibilityTree {
         }
         // If this fails, then the tree has orphaned nodes (a leak).
         // Dangling references are already caught in the loop above.
-        assert_eq!(seen_node_ids, self.nodes.keys().copied().collect());
+        let mut known_nodes = self.nodes.keys().copied().collect();
+        assert_eq!(seen_node_ids, known_nodes);
+
+        // All node IDs other than the root node should be keys in `node_to_parent`, and no others.
+        known_nodes.remove(&root_node_id);
+        let nodes_with_parents: FxHashSet<NodeId> = self.node_to_parent.keys().copied().collect();
+        assert_eq!(nodes_with_parents, known_nodes);
     }
 
     fn print(&self) {

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 use std::collections::VecDeque;
 use std::fmt::Debug;
+use std::iter;
 use std::sync::atomic::AtomicU64;
 use std::sync::{LazyLock, atomic};
 
@@ -84,6 +85,8 @@ pub struct AccessibilityTree {
     ///
     /// This must be kept in sync with [`Self::opaque_node_to_id`].
     id_to_opaque_node: FxHashMap<NodeId, OpaqueNode>,
+    /// A map to allow retrieving a node's parent ID, if any.
+    node_to_parent: FxHashMap<NodeId, NodeId>,
     /// Sent with each [`accesskit::TreeUpdate`]. This allows this tree to be
     /// [grafted](https://docs.rs/accesskit/latest/accesskit/struct.Node.html#method.tree_id) into
     /// an application's tree.
@@ -139,6 +142,7 @@ impl AccessibilityTree {
             nodes: FxHashMap::default(),
             opaque_node_to_id: FxHashMap::default(),
             id_to_opaque_node: FxHashMap::default(),
+            node_to_parent: FxHashMap::default(),
             tree_id,
             root_node_id: None,
             embedder_epoch,
@@ -228,6 +232,18 @@ impl AccessibilityTree {
             panic!("{id:?} does not exist in tree");
         };
         node.clone()
+    }
+
+    fn parent_for_node(&self, node_id: &NodeId) -> Option<NodeId> {
+        self.node_to_parent.get(node_id).cloned()
+    }
+
+    fn set_parent_for_node(&mut self, node_id: NodeId, parent_id: Option<NodeId>) {
+        if let Some(parent_id) = parent_id {
+            self.node_to_parent.insert(node_id, parent_id);
+        } else {
+            self.node_to_parent.remove(&node_id);
+        }
     }
 
     /// Consume the [`AccessibilityUpdate`] by deleting all nodes it detected as being removed from
@@ -322,18 +338,26 @@ impl AccessibilityTree {
             return;
         };
         // Traverse the tree from the given root.
-        let mut node_ids = vec![root_node_id];
+        let mut node_ids = vec![(root_node_id, None)];
         let mut seen_node_ids = FxHashSet::default();
-        while let Some(node_id) = node_ids.pop() {
+        while let Some((node_id, parent_id)) = node_ids.pop() {
             // If this fails, then the tree is not a tree at all.
             assert!(
                 seen_node_ids.insert(node_id),
                 "Tree contains {node_id:?} in multiple places"
             );
+            assert_eq!(self.node_to_parent.get(&node_id).cloned(), parent_id);
+
             // If this fails, then the tree has dangling references.
             let node = self.assert_node_for_id(&node_id);
             let node = node.borrow();
-            node_ids.extend(node.child_ids().iter().rev());
+            node_ids.extend(
+                node.child_ids()
+                    .iter()
+                    .cloned()
+                    .rev()
+                    .zip(iter::repeat(Some(node_id))),
+            );
         }
         // If this fails, then the tree has orphaned nodes (a leak).
         // Dangling references are already caught in the loop above.
@@ -547,6 +571,9 @@ impl AccessibilityNode {
                 let removed_child = tree.assert_node_for_id(old_id);
                 let removed_child = removed_child.borrow();
                 removed_child.set_subtree_state_change(TreeChange::Removed, tree, update);
+                if tree.parent_for_node(old_id) == Some(self.id) {
+                    tree.set_parent_for_node(*old_id, None);
+                }
             }
         }
 
@@ -557,6 +584,7 @@ impl AccessibilityNode {
                 if !update.is_new(new_id) {
                     new_child.set_subtree_state_change(TreeChange::PendingMove, tree, update);
                 }
+                tree.set_parent_for_node(*new_id, Some(self.id));
             }
         }
 
@@ -659,13 +687,12 @@ impl AccessibilityUpdate {
     }
 
     fn set_tree_state_change(&mut self, node_id: NodeId, change: TreeChange) {
-        let old_change = self.tree_changes.get(&node_id);
-
         assert!(
             change != TreeChange::Moved,
             "Incoming change must never be Moved"
         );
 
+        let old_change = self.tree_changes.get(&node_id);
         let new_change = old_change
             .map(|old_change| match (old_change, change) {
                 (TreeChange::PendingMove, TreeChange::Removed) => TreeChange::Moved,


### PR DESCRIPTION
Note: draft as this may be superseded by #45798

This will allow us to propagate accessibility damage within the accessibility tree, and be more judicious about marking nodes as moved or removed.

Also modify the accessibility tree's integrity check to check correctness of parent IDs.

Testing: Modifies integrity check.
Fixes: Part of #4344