### PR TITLE
Avoid extra tree walks when removing accessibility nodes.

### DIFF
--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -239,9 +239,9 @@ impl AccessibilityTree {
             self.assert_removed_nodes_were_rooted(&update, rooted_nodes);
         }
 
-        for id in update
+        let mut ids_to_remove: Vec<NodeId> = update
             .tree_changes
-            .drain()
+            .iter()
             .filter_map(|(id, change)| match change {
                 TreeChange::PendingMove => {
                     unreachable!(
@@ -249,14 +249,24 @@ impl AccessibilityTree {
                     );
                 },
                 TreeChange::Removed => Some(id),
-                _ => None,
+                TreeChange::New => None,
+                TreeChange::Moved => None,
             })
-        {
+            .cloned()
+            .collect();
+
+        while let Some(id) = ids_to_remove.pop() {
             self.node_to_parent.remove(&id);
-            if let Some(node) = self.nodes.remove(&id) &&
-                let Some(opaque_node) = node.borrow().opaque_node
-            {
-                self.opaque_node_to_id.remove(&opaque_node);
+            if let Some(node) = self.nodes.remove(&id) {
+                let node = node.borrow();
+                if let Some(opaque_node) = node.opaque_node {
+                    self.opaque_node_to_id.remove(&opaque_node);
+                }
+                for child_id in node.children() {
+                    if !update.tree_changes.contains_key(child_id) {
+                        ids_to_remove.push(*child_id);
+                    }
+                }
             }
         }
 
@@ -430,7 +440,7 @@ impl AccessibilityNode {
         damage
     }
 
-    /// Recursively mark this subtree as having the given `TreeChange`.
+    /// Mark this subtree as having the given `TreeChange`.
     ///
     /// This is used when a node is `Moved` or `Removed`, since its entire subtree will also need to
     /// be marked accordingly. When a node is `New`, it's marked as such when it is created. We
@@ -452,15 +462,15 @@ impl AccessibilityNode {
             "New shouldn't be set recursively"
         );
 
-        update.set_tree_state_change(self.id, change);
-
-        for child_id in self.children().iter() {
-            let child = tree.assert_node_for_id(child_id);
-            // `new_change` might be different per node, if only some nodes were moved elsewhere.
-            child
-                .borrow()
-                .set_subtree_state_change(change, tree, update);
+        let mut parent_id = tree.parent_for_node(&self.id);
+        while let Some(id) = parent_id {
+            if let Some(ancestor_state_change) = update.get_tree_state_change(id) {
+                update.set_tree_state_change(self.id, ancestor_state_change);
+            }
+            parent_id = tree.parent_for_node(&id);
         }
+
+        update.set_tree_state_change(self.id, change);
     }
 
     /// Update this node's properties from its corresponding DOM node.
@@ -677,6 +687,10 @@ impl AccessibilityUpdate {
         self.changed_nodes.insert(node.id);
 
         node.updated = false;
+    }
+
+    fn get_tree_state_change(&self, node_id: NodeId) -> Option<TreeChange> {
+        self.tree_changes.get(&node_id).cloned()
     }
 
     fn set_tree_state_change(&mut self, node_id: NodeId, change: TreeChange) {

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -26,7 +26,7 @@ bitflags! {
     /// properties to need to be re-computed based on the updated values, either on the same node or
     /// on other nodes.
     #[derive(Clone, Copy, Default, Debug, Eq, PartialEq)]
-    pub struct LocalDamage: u16 {
+    struct LocalAccessibilityDamage: u16 {
         /// This node's children changed, and/or any node in its subtree changed.
         const SUBTREE_CHANGED = 0b0001;
         /// This node's computed role changed.
@@ -162,9 +162,9 @@ impl AccessibilityTree {
         node: &ArcRefCell<AccessibilityNode>,
         dom_node: &ServoLayoutNode<'_>,
         update: &mut AccessibilityUpdate,
-    ) -> LocalDamage {
+    ) -> LocalAccessibilityDamage {
         let mut node = node.borrow_mut();
-        let mut damage = LocalDamage::empty();
+        let mut damage = LocalAccessibilityDamage::empty();
 
         // TODO: read accessibility damage from DOM (right now, assume damage is complete)
         damage.insert(node.update_node_from_dom_node(dom_node));
@@ -366,8 +366,8 @@ impl AccessibilityNode {
         dom_node: &ServoLayoutNode<'dom>,
         tree: &mut AccessibilityTree,
         update: &mut AccessibilityUpdate,
-    ) -> LocalDamage {
-        let mut damage = LocalDamage::empty();
+    ) -> LocalAccessibilityDamage {
+        let mut damage = LocalAccessibilityDamage::empty();
 
         let dom_children: Vec<ServoLayoutNode> = dom_node.flat_tree_children().collect();
         let new_children: Vec<NodeId> = dom_children
@@ -377,7 +377,7 @@ impl AccessibilityNode {
 
         damage.insert(self.set_children(new_children, tree, update));
 
-        let mut damage_from_children = LocalDamage::empty();
+        let mut damage_from_children = LocalAccessibilityDamage::empty();
         for dom_child in dom_children {
             let (_, child_node) = tree.get_or_create_node(&dom_child, update);
             let child_damage =
@@ -385,7 +385,7 @@ impl AccessibilityNode {
             damage_from_children.insert(child_damage);
         }
         if !damage_from_children.is_empty() {
-            damage.insert(LocalDamage::SUBTREE_CHANGED);
+            damage.insert(LocalAccessibilityDamage::SUBTREE_CHANGED);
         }
 
         damage
@@ -425,8 +425,11 @@ impl AccessibilityNode {
     }
 
     /// Update this node's properties from its corresponding DOM node.
-    fn update_node_from_dom_node(&mut self, dom_node: &ServoLayoutNode<'_>) -> LocalDamage {
-        let mut damage = LocalDamage::empty();
+    fn update_node_from_dom_node(
+        &mut self,
+        dom_node: &ServoLayoutNode<'_>,
+    ) -> LocalAccessibilityDamage {
+        let mut damage = LocalAccessibilityDamage::empty();
         damage.insert(self.set_role(role_from_dom_node(dom_node)));
         if dom_node.type_id() == Some(LayoutNodeType::Text) {
             let text_content = dom_node.text_content();
@@ -444,12 +447,12 @@ impl AccessibilityNode {
     /// If any changes are made, add this node to the given [`AccessibilityUpdate`].
     fn update_node_local(
         &mut self,
-        damage: LocalDamage,
+        damage: LocalAccessibilityDamage,
         tree: &mut AccessibilityTree,
-    ) -> LocalDamage {
-        let mut new_damage = LocalDamage::empty();
-        if damage.contains(LocalDamage::SUBTREE_CHANGED) ||
-            damage.contains(LocalDamage::ROLE_CHANGED)
+    ) -> LocalAccessibilityDamage {
+        let mut new_damage = LocalAccessibilityDamage::empty();
+        if damage.contains(LocalAccessibilityDamage::SUBTREE_CHANGED) ||
+            damage.contains(LocalAccessibilityDamage::ROLE_CHANGED)
         {
             if let Some(text) = self.label_from_descendants(tree) {
                 new_damage.insert(self.set_label(text.as_str()));
@@ -514,9 +517,9 @@ impl AccessibilityNode {
         children: Vec<NodeId>,
         tree: &mut AccessibilityTree,
         update: &mut AccessibilityUpdate,
-    ) -> LocalDamage {
+    ) -> LocalAccessibilityDamage {
         if children == self.children() {
-            return LocalDamage::empty();
+            return LocalAccessibilityDamage::empty();
         }
         let old_children = self.children();
         for old_child_id in old_children {
@@ -542,42 +545,42 @@ impl AccessibilityNode {
         self.accesskit_node.set_children(children);
         self.updated = true;
 
-        LocalDamage::SUBTREE_CHANGED
+        LocalAccessibilityDamage::SUBTREE_CHANGED
     }
 
     fn role(&self) -> Role {
         self.accesskit_node.role()
     }
 
-    fn set_role(&mut self, role: Role) -> LocalDamage {
+    fn set_role(&mut self, role: Role) -> LocalAccessibilityDamage {
         if role == self.accesskit_node.role() {
-            return LocalDamage::empty();
+            return LocalAccessibilityDamage::empty();
         }
         self.accesskit_node.set_role(role);
         self.updated = true;
-        LocalDamage::ROLE_CHANGED
+        LocalAccessibilityDamage::ROLE_CHANGED
     }
 
     fn label(&self) -> Option<&str> {
         self.accesskit_node.label()
     }
 
-    fn set_label(&mut self, label: &str) -> LocalDamage {
+    fn set_label(&mut self, label: &str) -> LocalAccessibilityDamage {
         if Some(label) == self.accesskit_node.label() {
-            return LocalDamage::empty();
+            return LocalAccessibilityDamage::empty();
         }
         self.accesskit_node.set_label(label);
         self.updated = true;
-        LocalDamage::TEXT_CHANGED
+        LocalAccessibilityDamage::TEXT_CHANGED
     }
 
-    fn clear_label(&mut self) -> LocalDamage {
+    fn clear_label(&mut self) -> LocalAccessibilityDamage {
         if self.accesskit_node.label().is_none() {
-            return LocalDamage::empty();
+            return LocalAccessibilityDamage::empty();
         }
         self.accesskit_node.clear_label();
         self.updated = true;
-        LocalDamage::TEXT_CHANGED
+        LocalAccessibilityDamage::TEXT_CHANGED
     }
 
     fn html_tag(&self) -> Option<&str> {
@@ -596,13 +599,13 @@ impl AccessibilityNode {
         self.accesskit_node.value()
     }
 
-    fn set_value(&mut self, value: &str) -> LocalDamage {
+    fn set_value(&mut self, value: &str) -> LocalAccessibilityDamage {
         if Some(value) == self.accesskit_node.value() {
-            return LocalDamage::empty();
+            return LocalAccessibilityDamage::empty();
         }
         self.accesskit_node.set_value(value);
         self.updated = true;
-        LocalDamage::TEXT_CHANGED
+        LocalAccessibilityDamage::TEXT_CHANGED
     }
 }
 

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -7,6 +7,7 @@ use std::sync::atomic::AtomicU64;
 use std::sync::{LazyLock, atomic};
 
 use accesskit::{NodeId, Role};
+use bitflags::bitflags;
 use layout_api::{LayoutElement, LayoutNode, LayoutNodeType};
 use log::trace;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -19,6 +20,15 @@ use style::dom::OpaqueNode;
 use web_atoms::{LocalName, local_name};
 
 use crate::ArcRefCell;
+
+bitflags! {
+    #[derive(Clone, Copy, Default, Debug, Eq, PartialEq)]
+    pub struct LocalDamage: u16 {
+        const SUBTREE_CHANGED = 0b0001;
+        const ROLE_CHANGED = 0b0010;
+        const TEXT_CHANGED = 0b0100;
+    }
+}
 
 /// Changes which have occurred during the current update.
 struct AccessibilityUpdate {
@@ -146,21 +156,21 @@ impl AccessibilityTree {
         node: &ArcRefCell<AccessibilityNode>,
         dom_node: &ServoLayoutNode<'_>,
         update: &mut AccessibilityUpdate,
-    ) -> bool {
+    ) -> LocalDamage {
         let mut node = node.borrow_mut();
+        let mut damage = LocalDamage::empty();
 
         // TODO: read accessibility damage from DOM (right now, assume damage is complete)
-        let node_updated = node.update_node_from_dom_node(dom_node);
-        let any_descendant_updated = node.update_descendants_from_dom_node(dom_node, self, update);
+        damage.insert(node.update_node_from_dom_node(dom_node));
+        damage.insert(node.update_descendants_from_dom_node(dom_node, self, update));
 
-        node.update_node_local(node_updated || any_descendant_updated, self);
+        damage.insert(node.update_node_local(damage, self));
 
         if node.updated {
             update.add(&mut node);
-            return true;
         }
 
-        any_descendant_updated
+        damage
     }
 
     fn get_or_create_node(
@@ -350,8 +360,8 @@ impl AccessibilityNode {
         dom_node: &ServoLayoutNode<'dom>,
         tree: &mut AccessibilityTree,
         update: &mut AccessibilityUpdate,
-    ) -> bool {
-        let mut any_descendant_updated = false;
+    ) -> LocalDamage {
+        let mut damage = LocalDamage::empty();
 
         let dom_children: Vec<ServoLayoutNode> = dom_node.flat_tree_children().collect();
         let new_children: Vec<NodeId> = dom_children
@@ -359,15 +369,20 @@ impl AccessibilityNode {
             .map(|dom_child| tree.id_for_opaque(dom_child.opaque()))
             .collect();
 
-        any_descendant_updated |= self.set_children(new_children, tree, update);
+        damage.insert(self.set_children(new_children, tree, update));
 
+        let mut damage_from_children = LocalDamage::empty();
         for dom_child in dom_children {
             let (_, child_node) = tree.get_or_create_node(&dom_child, update);
-            any_descendant_updated |=
+            let child_damage =
                 tree.update_node_and_descendants_from_dom_node(&child_node, &dom_child, update);
+            damage_from_children.insert(child_damage);
+        }
+        if !damage_from_children.is_empty() {
+            damage.insert(LocalDamage::SUBTREE_CHANGED);
         }
 
-        any_descendant_updated
+        damage
     }
 
     /// Recursively mark this subtree as having the given `TreeChange `.
@@ -404,16 +419,17 @@ impl AccessibilityNode {
     }
 
     /// Update this node's properties from its corresponding DOM node.
-    fn update_node_from_dom_node(&mut self, dom_node: &ServoLayoutNode<'_>) -> bool {
-        self.set_role(role_from_dom_node(dom_node));
+    fn update_node_from_dom_node(&mut self, dom_node: &ServoLayoutNode<'_>) -> LocalDamage {
+        let mut damage = LocalDamage::empty();
+        damage.insert(self.set_role(role_from_dom_node(dom_node)));
         if dom_node.type_id() == Some(LayoutNodeType::Text) {
             let text_content = dom_node.text_content();
             trace!("node text content = {text_content:?}");
             // FIXME: this should take into account editing selection units (grapheme clusters?)
-            self.set_value(&text_content);
+            damage.insert(self.set_value(&text_content));
         }
 
-        false
+        damage
     }
 
     /// Update this node's properties based on changes already made to the accessibility tree.
@@ -422,20 +438,21 @@ impl AccessibilityNode {
     /// If any changes are made, add this node to the given [`AccessibilityUpdate`].
     fn update_node_local(
         &mut self,
-        self_or_descendants_updated: bool,
+        damage: LocalDamage,
         tree: &mut AccessibilityTree,
-    ) -> bool {
-        if !self_or_descendants_updated {
-            return false;
+    ) -> LocalDamage {
+        let mut new_damage = LocalDamage::empty();
+        if damage.contains(LocalDamage::SUBTREE_CHANGED) ||
+            damage.contains(LocalDamage::ROLE_CHANGED)
+        {
+            if let Some(text) = self.label_from_descendants(tree) {
+                new_damage.insert(self.set_label(text.as_str()));
+            } else {
+                new_damage.insert(self.clear_label());
+            }
         }
 
-        if let Some(text) = self.label_from_descendants(tree) {
-            self.set_label(text.as_str());
-        } else {
-            self.clear_label();
-        }
-
-        false
+        new_damage
     }
 
     fn label_from_descendants(&self, tree: &AccessibilityTree) -> Option<String> {
@@ -491,9 +508,9 @@ impl AccessibilityNode {
         children: Vec<NodeId>,
         tree: &mut AccessibilityTree,
         update: &mut AccessibilityUpdate,
-    ) -> bool {
+    ) -> LocalDamage {
         if children == self.children() {
-            return false;
+            return LocalDamage::empty();
         }
         let old_children = self.children();
         for old_child_id in old_children {
@@ -519,39 +536,42 @@ impl AccessibilityNode {
         self.accesskit_node.set_children(children);
         self.updated = true;
 
-        true
+        LocalDamage::SUBTREE_CHANGED
     }
 
     fn role(&self) -> Role {
         self.accesskit_node.role()
     }
 
-    fn set_role(&mut self, role: Role) {
+    fn set_role(&mut self, role: Role) -> LocalDamage {
         if role == self.accesskit_node.role() {
-            return;
+            return LocalDamage::empty();
         }
         self.accesskit_node.set_role(role);
         self.updated = true;
+        LocalDamage::ROLE_CHANGED
     }
 
     fn label(&self) -> Option<&str> {
         self.accesskit_node.label()
     }
 
-    fn set_label(&mut self, label: &str) {
+    fn set_label(&mut self, label: &str) -> LocalDamage {
         if Some(label) == self.accesskit_node.label() {
-            return;
+            return LocalDamage::empty();
         }
         self.accesskit_node.set_label(label);
         self.updated = true;
+        LocalDamage::TEXT_CHANGED
     }
 
-    fn clear_label(&mut self) {
+    fn clear_label(&mut self) -> LocalDamage {
         if self.accesskit_node.label().is_none() {
-            return;
+            return LocalDamage::empty();
         }
         self.accesskit_node.clear_label();
         self.updated = true;
+        LocalDamage::TEXT_CHANGED
     }
 
     fn html_tag(&self) -> Option<&str> {
@@ -570,12 +590,13 @@ impl AccessibilityNode {
         self.accesskit_node.value()
     }
 
-    fn set_value(&mut self, value: &str) {
+    fn set_value(&mut self, value: &str) -> LocalDamage {
         if Some(value) == self.accesskit_node.value() {
-            return;
+            return LocalDamage::empty();
         }
         self.accesskit_node.set_value(value);
         self.updated = true;
+        LocalDamage::TEXT_CHANGED
     }
 }
 

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -252,6 +252,7 @@ impl AccessibilityTree {
                 _ => None,
             })
         {
+            self.node_to_parent.remove(&id);
             if let Some(node) = self.nodes.remove(&id) &&
                 let Some(opaque_node) = node.borrow().opaque_node
             {

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -391,7 +391,7 @@ impl AccessibilityNode {
         damage
     }
 
-    /// Recursively mark this subtree as having the given `TreeChange `.
+    /// Recursively mark this subtree as having the given `TreeChange`.
     ///
     /// This is used when a node is `Moved` or `Removed`, since its entire subtree will also need to
     /// be marked accordingly. When a node is `New`, it's marked as such when it is created. We

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -326,7 +326,13 @@ impl AccessibilityTree {
 
         // If this fails, then the tree has orphaned nodes (a leak).
         // Dangling references are already caught in the loop above.
-        assert_eq!(seen_node_ids, self.nodes.keys().copied().collect());
+        let mut known_nodes = self.nodes.keys().copied().collect();
+        assert_eq!(seen_node_ids, known_nodes);
+
+        // All node IDs other than the root node should be keys in `node_to_parent`, and no others.
+        known_nodes.remove(&root_node_id);
+        let nodes_with_parents: FxHashSet<NodeId> = self.node_to_parent.keys().copied().collect();
+        assert_eq!(nodes_with_parents, known_nodes);
     }
 
     /// Recursively check the integrity of the subtree rooted at node for `node_id`, and check that
@@ -346,7 +352,7 @@ impl AccessibilityTree {
         let node = self.assert_node_for_id(&node_id);
         let node = node.borrow();
 
-        assert_eq!(self.node_to_parent.get(&node.id).cloned(), parent_id);
+        assert_eq!(self.parent_for_node(&node.id), parent_id);
         for child_id in node.children().iter() {
             self.assert_subtree_integrity_recursive(*child_id, Some(node_id), seen_node_ids);
         }

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -234,7 +234,7 @@ impl AccessibilityTree {
 
     /// Consume the [`AccessibilityUpdate`] by deleting all nodes it detected as being removed from
     /// the tree.
-    fn remove_stale_nodes(&mut self, mut update: AccessibilityUpdate) {
+    fn drop_removed_nodes(&mut self, mut update: AccessibilityUpdate) {
         if let Some(rooted_nodes) = std::mem::take(&mut update.rooted_nodes) {
             self.assert_removed_nodes_were_rooted(&update, rooted_nodes);
         }
@@ -743,7 +743,7 @@ impl AccessibilityUpdate {
             tree_id: tree.tree_id,
         };
 
-        tree.remove_stale_nodes(self);
+        tree.drop_removed_nodes(self);
 
         Some(tree_update)
     }

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -22,10 +22,16 @@ use web_atoms::{LocalName, local_name};
 use crate::ArcRefCell;
 
 bitflags! {
+    /// Damage which was caused by changes to the accessibility tree. These changes can cause other
+    /// properties to need to be re-computed based on the updated values, either on the same node or
+    /// on other nodes.
     #[derive(Clone, Copy, Default, Debug, Eq, PartialEq)]
     pub struct LocalDamage: u16 {
+        /// This node's children changed, and/or any node in its subtree changed.
         const SUBTREE_CHANGED = 0b0001;
+        /// This node's computed role changed.
         const ROLE_CHANGED = 0b0010;
+        /// This node's computed label or text value (for a text node) changed.
         const TEXT_CHANGED = 0b0100;
     }
 }

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -77,6 +77,8 @@ pub struct AccessibilityTree {
     /// A map to allow retrieving the [`AccessibilityNode`] which corresponds to a particular DOM
     /// node, if any.
     opaque_node_to_id: FxHashMap<OpaqueNode, NodeId>,
+    /// A map to allow retrieving a node's parent ID, if any.
+    node_to_parent: FxHashMap<NodeId, NodeId>,
     /// Sent with each [`accesskit::TreeUpdate`]. This allows this tree to be
     /// [grafted](https://docs.rs/accesskit/latest/accesskit/struct.Node.html#method.tree_id) into
     /// an application's tree.
@@ -131,6 +133,7 @@ impl AccessibilityTree {
         Self {
             nodes: FxHashMap::default(),
             opaque_node_to_id: FxHashMap::default(),
+            node_to_parent: FxHashMap::default(),
             tree_id,
             root_node_id: None,
             embedder_epoch,
@@ -146,7 +149,7 @@ impl AccessibilityTree {
         rooted_nodes: Option<FxHashSet<OpaqueNode>>,
     ) -> Option<accesskit::TreeUpdate> {
         let mut update = AccessibilityUpdate::new(rooted_nodes);
-        let (root_node_id, root_node) = self.get_or_create_node(root_dom_node, &mut update);
+        let (root_node_id, root_node) = self.get_or_create_node(root_dom_node, None, &mut update);
         self.root_node_id = Some(root_node_id);
 
         self.update_node_and_descendants_from_dom_node(&root_node, root_dom_node, &mut update);
@@ -182,12 +185,16 @@ impl AccessibilityTree {
     fn get_or_create_node(
         &mut self,
         dom_node: &ServoLayoutNode<'_>,
+        parent_id: Option<NodeId>,
         update: &mut AccessibilityUpdate,
     ) -> (NodeId, ArcRefCell<AccessibilityNode>) {
         let id = self.id_for_opaque(dom_node.opaque());
 
         let node = self.nodes.entry(id).or_insert_with(|| {
             update.set_tree_state_change(id, TreeChange::New);
+            if let Some(parent_id) = parent_id {
+                self.node_to_parent.insert(id, parent_id);
+            }
             ArcRefCell::new(AccessibilityNode::new(id))
         });
 
@@ -211,6 +218,18 @@ impl AccessibilityTree {
             panic!("{id:?} does not exist in tree");
         };
         node.clone()
+    }
+
+    fn parent_for_node(&self, node_id: &NodeId) -> Option<NodeId> {
+        self.node_to_parent.get(node_id).cloned()
+    }
+
+    fn set_parent_for_node(&mut self, node_id: NodeId, parent_id: Option<NodeId>) {
+        if let Some(parent_id) = parent_id {
+            self.node_to_parent.insert(node_id, parent_id);
+        } else {
+            self.node_to_parent.remove(&node_id);
+        }
     }
 
     /// Consume the [`AccessibilityUpdate`] by deleting all nodes it detected as being removed from
@@ -301,23 +320,36 @@ impl AccessibilityTree {
         let Some(root_node_id) = self.root_node_id else {
             return;
         };
-        // Traverse the tree from the given root.
-        let mut node_ids = vec![root_node_id];
+
         let mut seen_node_ids = FxHashSet::default();
-        while let Some(node_id) = node_ids.pop() {
-            // If this fails, then the tree is not a tree at all.
-            assert!(
-                seen_node_ids.insert(node_id),
-                "Tree contains {node_id:?} in multiple places"
-            );
-            // If this fails, then the tree has dangling references.
-            let node = self.assert_node_for_id(&node_id);
-            let node = node.borrow();
-            node_ids.extend(node.children().iter().rev());
-        }
+        self.assert_subtree_integrity_recursive(root_node_id, None, &mut seen_node_ids);
+
         // If this fails, then the tree has orphaned nodes (a leak).
         // Dangling references are already caught in the loop above.
         assert_eq!(seen_node_ids, self.nodes.keys().copied().collect());
+    }
+
+    /// Recursively check the integrity of the subtree rooted at node for `node_id`, and check that
+    /// the parent of the subtree root is `parent_id`.
+    fn assert_subtree_integrity_recursive(
+        &self,
+        node_id: NodeId,
+        parent_id: Option<NodeId>,
+        seen_node_ids: &mut std::collections::HashSet<NodeId, rustc_hash::FxBuildHasher>,
+    ) {
+        // If this fails, then the tree is not a tree at all.
+        assert!(
+            seen_node_ids.insert(node_id),
+            "Tree contains {node_id:?} in multiple places"
+        );
+        // If this fails, then the tree has dangling references.
+        let node = self.assert_node_for_id(&node_id);
+        let node = node.borrow();
+
+        assert_eq!(self.node_to_parent.get(&node.id).cloned(), parent_id);
+        for child_id in node.children().iter() {
+            self.assert_subtree_integrity_recursive(*child_id, Some(node_id), seen_node_ids);
+        }
     }
 
     fn print(&self) {
@@ -379,7 +411,7 @@ impl AccessibilityNode {
 
         let mut damage_from_children = LocalAccessibilityDamage::empty();
         for dom_child in dom_children {
-            let (_, child_node) = tree.get_or_create_node(&dom_child, update);
+            let (_, child_node) = tree.get_or_create_node(&dom_child, Some(self.id), update);
             let child_damage =
                 tree.update_node_and_descendants_from_dom_node(&child_node, &dom_child, update);
             damage_from_children.insert(child_damage);
@@ -525,20 +557,20 @@ impl AccessibilityNode {
         for old_child_id in old_children {
             if !children.contains(old_child_id) {
                 let removed_child = tree.assert_node_for_id(old_child_id);
-                removed_child
-                    .borrow()
-                    .set_subtree_state_change(TreeChange::Removed, tree, update);
+                let removed_child = removed_child.borrow_mut();
+                removed_child.set_subtree_state_change(TreeChange::Removed, tree, update);
+                if tree.parent_for_node(old_child_id) == Some(self.id) {
+                    tree.set_parent_for_node(*old_child_id, None);
+                }
             }
         }
         for new_child_id in children.iter() {
             if !old_children.contains(new_child_id) &&
                 let Some(moved_child) = tree.node_for_id(new_child_id)
             {
-                moved_child.borrow().set_subtree_state_change(
-                    TreeChange::PendingMove,
-                    tree,
-                    update,
-                );
+                let moved_child = moved_child.borrow_mut();
+                moved_child.set_subtree_state_change(TreeChange::PendingMove, tree, update);
+                tree.set_parent_for_node(*new_child_id, Some(self.id));
             }
         }
 
@@ -641,13 +673,12 @@ impl AccessibilityUpdate {
     }
 
     fn set_tree_state_change(&mut self, node_id: NodeId, change: TreeChange) {
-        let old_change = self.tree_changes.get(&node_id);
-
         assert!(
             change != TreeChange::Moved,
             "Incoming change must never be Moved"
         );
 
+        let old_change = self.tree_changes.get(&node_id);
         let new_change = old_change
             .map(|old_change| match (old_change, change) {
                 (TreeChange::PendingMove, TreeChange::Removed) => TreeChange::Moved,

--- a/components/script/dom/document/accessibility_data.rs
+++ b/components/script/dom/document/accessibility_data.rs
@@ -13,7 +13,7 @@ use crate::dom::Node;
 #[derive(Clone, Default, JSTraceable, MallocSizeOf)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct AccessibilityData {
-    /// Nodes which have been unbound from the DOM but may not yet have been removed from the
+    /// Nodes which have been removed from the DOM but may not yet have been removed from the
     /// accessibility tree. This is cleared after each reflow.
     rooted_nodes: FxHashSet<Dom<Node>>,
 }
@@ -37,6 +37,9 @@ impl AccessibilityData {
     ///   it's kept alive by strong references in its parent, child and/or sibling [`Node`]s (and in
     ///   the case of the document itself, by a strong reference in the [`Window`]). See
     ///   [`Node::first_child`], [`Node::next_sibling`], etc.
+    ///    - Note that this means we only need to root nodes which are removed from the document,
+    ///      and not their ancestors, as ancestor nodes will still be rooted via these properties as
+    ///      long as the subtree root is stored here.
     /// - After a node is removed from the tree, those strong references are removed, and it _may_
     ///   become a candidate for GC if its DOM object isn't held (directly or indirectly) in script
     ///   and it isn't immediately inserted elsewhere in the DOM.

--- a/components/script/dom/document/accessibility_data.rs
+++ b/components/script/dom/document/accessibility_data.rs
@@ -38,8 +38,8 @@ impl AccessibilityData {
     ///   the case of the document itself, by a strong reference in the [`Window`]). See
     ///   [`Node::first_child`], [`Node::next_sibling`], etc.
     ///    - Note that this means we only need to root nodes which are removed from the document,
-    ///      and not their ancestors, as ancestor nodes will still be rooted via these properties as
-    ///      long as the subtree root is stored here.
+    ///      and not their descendants, as descendant nodes will still be rooted via these
+    ///      properties as long as the subtree root is stored here.
     /// - After a node is removed from the tree, those strong references are removed, and it _may_
     ///   become a candidate for GC if its DOM object isn't held (directly or indirectly) in script
     ///   and it isn't immediately inserted elsewhere in the DOM.

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -424,6 +424,14 @@ impl Node {
                 }
             }
         }
+
+        // Make sure the node and its subtree aren't GCed until the accessibility tree has had a
+        // chance to remove them.
+        if root.owner_document().accessibility_active() {
+            root.owner_document()
+                .accessibility_data_mut()
+                .root_removed_node(cx.no_gc(), root);
+        }
     }
 
     pub(crate) fn complete_move_subtree(cx: &mut JSContext, root: &Node) {
@@ -4443,12 +4451,6 @@ impl VirtualMethods for Node {
         if !self.is_in_a_shadow_tree() && !self.ranges_is_empty() {
             self.ranges()
                 .drain_to_parent(context.parent, context.index(), self);
-        }
-
-        if self.owner_document().accessibility_active() {
-            self.owner_document()
-                .accessibility_data_mut()
-                .root_removed_node(cx.no_gc(), self);
         }
     }
 

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -398,6 +398,49 @@ fn test_accessibility_text_change() {
     );
 }
 
+#[test]
+fn test_accessibility_partial_subtree_move_and_delete() {
+    let url = "data:text/html,<!DOCTYPE html>\
+               <div id='div1'><div><h1 id='h1'>This is an h1</h1></div></div>\
+               <div id='div2'><h2 id='h2'>This is an h2</h2></div>";
+    let (servo_test, delegate, webview, mut tree) = build_webview_and_tree(url);
+
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let children: Vec<accesskit_consumer::Node> = root.children().collect();
+    assert_eq!(children.len(), 2);
+    let div1 = children[0];
+    assert_eq!(div1.role(), Role::GenericContainer);
+    let h1 = find_all_matching_nodes(div1, |node| node.role() == Role::Heading)[0];
+    assert_eq!(h1.label(), Some("This is an h1".to_owned()));
+    let div2 = children[1];
+    assert_eq!(div2.role(), Role::GenericContainer);
+    let h2 = find_all_matching_nodes(div2, |node| node.role() == Role::Heading)[0];
+    assert_eq!(h2.label(), Some("This is an h2".to_owned()));
+
+    let _ = evaluate_javascript(
+        &servo_test,
+        webview.clone(),
+        "div2.moveBefore(div1, h2);\
+         div1.remove();\
+         window.ServoTestUtils.forceAccessibilityUpdate();",
+    );
+    let mut updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
+    assert_eq!(updates.len(), 1);
+    let update = updates.pop().expect("Guaranteed by assert above");
+    tree.update_and_process_changes(update, &mut NoOpChangeHandler);
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let children: Vec<accesskit_consumer::Node> = root.children().collect();
+    assert_eq!(children.len(), 1);
+    let div2 = children[0];
+    assert_eq!(div2.role(), Role::GenericContainer);
+    let headings: Vec<accesskit_consumer::Node> = div2.children().collect();
+    assert_eq!(headings.len(), 2);
+    let h1 = headings[0];
+    assert_eq!(h1.label(), Some("This is an h1".to_owned()));
+    let h2 = headings[1];
+    assert_eq!(h2.label(), Some("This is an h2".to_owned()));
+}
+
 fn build_test() -> ServoTest {
     let servo_test = ServoTest::new_with_builder(|builder| {
         let mut preferences = Preferences::default();

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -360,6 +360,45 @@ fn test_accessibility_with_mutation_move_nodes() {
     assert_eq!(h2.label().as_deref(), Some("This is an h2"));
 }
 
+#[test]
+fn test_accessibility_text_change() {
+    let url = "data:text/html,<!DOCTYPE html>\
+               <h1 id='h1'>This is an h1</h1>";
+    let (servo_test, delegate, webview, mut tree) = build_webview_and_tree(url);
+
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let children: Vec<accesskit_consumer::Node> = root.children().collect();
+    assert_eq!(children.len(), 1);
+    let h1 = children[0];
+    assert_eq!(h1.role(), Role::Heading);
+    assert_eq!(h1.label(), Some("This is an h1".to_owned()));
+
+    let _ = evaluate_javascript(
+        &servo_test,
+        webview.clone(),
+        "h1.firstChild.appendData(', now with more text');\
+         window.ServoTestUtils.forceAccessibilityUpdate();",
+    );
+    let mut updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
+    assert_eq!(updates.len(), 1);
+    let update = updates.pop().expect("Guaranteed by assert above");
+    assert_eq!(update.nodes.len(), 2);
+    assert_eq!(update.nodes[0].1.role(), Role::TextRun);
+    assert_eq!(update.nodes[1].1.role(), Role::Heading);
+    assert_eq!(update.nodes[1].1.children().len(), 1);
+    tree.update_and_process_changes(update, &mut NoOpChangeHandler);
+    let root = assert_tree_structure_and_get_root_web_area(&tree);
+    let children: Vec<accesskit_consumer::Node> = root.children().collect();
+    assert_eq!(children.len(), 1);
+    let h1 = children[0];
+    assert_eq!(h1.role(), Role::Heading);
+    assert_eq!(
+        h1.label(),
+        Some("This is an h1, now with more text".to_owned())
+    );
+}
+
+
 fn build_test() -> ServoTest {
     let servo_test = ServoTest::new_with_builder(|builder| {
         let mut preferences = Preferences::default();

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -398,7 +398,6 @@ fn test_accessibility_text_change() {
     );
 }
 
-
 fn build_test() -> ServoTest {
     let servo_test = ServoTest::new_with_builder(|builder| {
         let mut preferences = Preferences::default();

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -401,8 +401,13 @@ fn test_accessibility_text_change() {
 #[test]
 fn test_accessibility_partial_subtree_move_and_delete() {
     let url = "data:text/html,<!DOCTYPE html>\
-               <div id='div1'><div><h1 id='h1'>This is an h1</h1></div></div>\
-               <div id='div2'><h2 id='h2'>This is an h2</h2></div>";
+               <div id='div1'>\
+                 <div id='div2'>\
+                   <h1 id='h1'>This is an h1</h1>\
+                   <p id='p'>This is a paragraph</p>\
+                 </div>\
+               </div>\
+               <div id='div3'><h2 id='h2'>This is an h2</h2></div>";
     let (servo_test, delegate, webview, mut tree) = build_webview_and_tree(url);
 
     let root = assert_tree_structure_and_get_root_web_area(&tree);
@@ -412,6 +417,10 @@ fn test_accessibility_partial_subtree_move_and_delete() {
     assert_eq!(div1.role(), Role::GenericContainer);
     let h1 = find_all_matching_nodes(div1, |node| node.role() == Role::Heading)[0];
     assert_eq!(h1.label(), Some("This is an h1".to_owned()));
+    let _p = find_all_matching_nodes(div1, |node| node.role() == Role::Paragraph)
+        .pop()
+        .expect("Should be exactly one Paragraph node");
+
     let div2 = children[1];
     assert_eq!(div2.role(), Role::GenericContainer);
     let h2 = find_all_matching_nodes(div2, |node| node.role() == Role::Heading)[0];
@@ -420,7 +429,9 @@ fn test_accessibility_partial_subtree_move_and_delete() {
     let _ = evaluate_javascript(
         &servo_test,
         webview.clone(),
-        "div2.moveBefore(div1, h2);\
+        "div3.moveBefore(div2, h2);\
+         div3.moveBefore(h1, div2);\
+         p.remove();\
          div1.remove();\
          window.ServoTestUtils.forceAccessibilityUpdate();",
     );
@@ -433,11 +444,15 @@ fn test_accessibility_partial_subtree_move_and_delete() {
     assert_eq!(children.len(), 1);
     let div2 = children[0];
     assert_eq!(div2.role(), Role::GenericContainer);
-    let headings: Vec<accesskit_consumer::Node> = div2.children().collect();
-    assert_eq!(headings.len(), 2);
-    let h1 = headings[0];
+    let children: Vec<accesskit_consumer::Node> = div2.children().collect();
+    assert_eq!(children.len(), 3);
+    let h1 = children[0];
+    assert_eq!(h1.role(), Role::Heading);
     assert_eq!(h1.label(), Some("This is an h1".to_owned()));
-    let h2 = headings[1];
+    let div2 = children[1];
+    assert_eq!(div2.role(), Role::GenericContainer);
+    let h2 = children[2];
+    assert_eq!(h2.role(), Role::Heading);
     assert_eq!(h2.label(), Some("This is an h2".to_owned()));
 }
 


### PR DESCRIPTION
Note: draft as this contains the changes from #45575 which should be reviewed and landed first.

Instead of setting the TreeChange for each node in a removed subtree, just set the TreeChange for the subtree root.

Also only root the subtree root in AccessibilityData.

Testing: Modifies the integrity check.
Fixes: Part of #4344
