### PR TITLE
layout: Incrementally update accessibility tree based on DOM changes

### DIFF
--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -30,11 +30,11 @@ bitflags! {
     #[derive(Clone, Copy, Default, Debug, Eq, PartialEq)]
     struct LocalAccessibilityDamage: u16 {
         /// This node's children changed, and/or any node in its subtree changed.
-        const SUBTREE_CHANGED = 0b0001;
+        const SubtreeChanged = 0b0001;
         /// This node's computed role changed.
-        const ROLE_CHANGED = 0b0010;
+        const RoleChanged = 0b0010;
         /// This node's computed label or text value (for a text node) changed.
-        const TEXT_CHANGED = 0b0100;
+        const TextChanged = 0b0100;
     }
 }
 
@@ -45,7 +45,7 @@ struct AccessibilityUpdate {
     /// Nodes that changed their relation to the tree within the current update.
     tree_changes: FxHashMap<NodeId, TreeChange>,
     /// Damage to nodes caused by changes in the accessibility tree.
-    local_damage: FxHashMap<NodeId, LocalAccessibilityDamage>,
+    unresolved_local_damage: FxHashMap<NodeId, LocalAccessibilityDamage>,
     /// Nodes which were removed from the DOM tree since the last reflow, which were rooted in
     /// `AccessibilityData`. Only set if `pref::expensive_accessibility_test_assertions_enabled`
     /// is set.
@@ -165,14 +165,13 @@ impl AccessibilityTree {
     ) -> Option<accesskit::TreeUpdate> {
         let mut update = AccessibilityUpdate::new(rooted_nodes);
 
-        let root_node = self.update_root(root_dom_node, &mut damage_from_dom, &mut update);
+        self.ensure_root_node(root_dom_node, &mut damage_from_dom, &mut update);
 
-        let local_damage = self.resolve_damage_from_dom_tree(damage_from_dom, &mut update);
-        self.propagate_subtree_damage_to_ancestors(local_damage, &mut update);
+        self.apply_changes_from_dom_tree(damage_from_dom, &mut update);
 
         // FIXME: This assumes any local subtree damage always propagates up to the root. This is
         // currently true, but we might be able to improve at stopping propagation.
-        self.update_node_and_descendants_local(root_node, &mut update);
+        self.resolve_local_damage_for_node_and_subtree(self.assert_root_node(), &mut update);
 
         update.finalize(self)
     }
@@ -180,49 +179,73 @@ impl AccessibilityTree {
     /// Get the node corresponding to the root DOM node, and set it as this tree's root. If the root
     /// node is newly created, which probably means this accessibility tree is newly created, append
     /// an `AccessibilityDamage::REBUILD` value for it to `damage_from_dom`.
-    fn update_root<'dom>(
+    fn ensure_root_node<'dom>(
         &mut self,
         root_dom_node: &ServoLayoutNode<'dom>,
         damage_from_dom: &mut VecDeque<(ServoLayoutNode<'dom>, AccessibilityDamage)>,
         update: &mut AccessibilityUpdate,
-    ) -> ArcRefCell<AccessibilityNode> {
+    ) {
         let (root_id, root_node) = self.get_or_create_node(root_dom_node, update);
         if update.is_new(&root_id) {
-            damage_from_dom.push_front((*root_dom_node, AccessibilityDamage::REBUILD));
+            damage_from_dom.push_front((*root_dom_node, AccessibilityDamage::Rebuild));
         }
-        self.root_node = Some(root_node.clone());
-        root_node
+        self.root_node = Some(root_node);
+    }
+
+    /// Get the root node for this tree, asserting that it has been set.
+    fn assert_root_node(&self) -> ArcRefCell<AccessibilityNode> {
+        self.root_node.clone().expect("Root node was asserted")
     }
 
     /// For each DOM node in `damage_from_dom`, update the corresponding accessibility node based on
     /// its `AccessibilityDamage`. If any [`LocalDamage`] results from the update, propagate
     /// [`LocalDamage::SUBTREE_CHANGED`] to its ancestors.
-    fn resolve_damage_from_dom_tree<'dom>(
+    fn apply_changes_from_dom_tree<'dom>(
         &mut self,
         mut damage_from_dom: VecDeque<(ServoLayoutNode<'dom>, AccessibilityDamage)>,
         update: &mut AccessibilityUpdate,
-    ) -> FxHashMap<NodeId, LocalAccessibilityDamage> {
-        let mut local_damage: FxHashMap<NodeId, LocalAccessibilityDamage> = FxHashMap::default();
-
+    ) {
         while let Some((dom_node, dom_node_damage)) = damage_from_dom.pop_front() {
-            let Some((id, node)) = self.node_for_dom_node(&dom_node) else {
+            let Some((_, node)) = self.node_for_dom_node(&dom_node) else {
                 // If we don't have a node for this DOM node yet, it will be created and populated
                 // when it's added to its parent node.
                 continue;
             };
-            let local_damage_for_node = self.update_node_and_descendants_from_dom_node(
+            self.update_node_and_descendants_from_dom_node(
                 node.clone(),
                 &dom_node,
                 dom_node_damage,
                 update,
             );
-            if !local_damage_for_node.is_empty() {
-                let existing_damage = local_damage.entry(id).or_default();
-                existing_damage.insert(local_damage_for_node);
-            }
         }
 
-        local_damage
+        self.propagate_subtree_damage_to_ancestors(update);
+    }
+
+    /// After applying changes from the DOM tree, mark the ancestors of any changed nodes with
+    /// [`LocalDamage::SubtreeChanged`].
+    fn propagate_subtree_damage_to_ancestors(&mut self, update: &mut AccessibilityUpdate) {
+        for (node_id, damage) in update.unresolved_local_damage.clone() {
+            if damage.is_empty() {
+                continue;
+            }
+            let node = self.assert_node_for_id(&node_id);
+
+            let mut parent_node = node.borrow().parent();
+            while let Some(node) = parent_node {
+                let node = node.borrow();
+                let existing_damage = update.unresolved_local_damage.entry(node.id).or_default();
+
+                // If we encounter a node which already has `SubtreeChanged` damage, we know that
+                // all of its ancestors have it too, so we can bail out early from our ancestor walk
+                if existing_damage.contains(LocalAccessibilityDamage::SubtreeChanged) {
+                    break;
+                }
+
+                existing_damage.insert(LocalAccessibilityDamage::SubtreeChanged);
+                parent_node = node.parent();
+            }
+        }
     }
 
     /// Update the given AccessibilityNode from its corresponding DOM node and
@@ -245,34 +268,42 @@ impl AccessibilityTree {
             node.update_descendants_from_dom_node(weak_node, dom_node, dom_damage, self, update),
         );
 
-        // We call this here rather than in `update_node_and_descendants_local()` as we need to add
-        // local damage from updating the node to the damage which is propagated to ancestors.
-        // This node won't be visited in `update_node_and_descendants_local()`, since we consume its
-        // local damage in `propagate_subtree_damage_to_ancestors()`.
-        local_damage.insert(node.update_node_local(local_damage));
-
         if node.updated {
             update.add(&mut node);
+        }
+
+        if !local_damage.is_empty() {
+            update
+                .unresolved_local_damage
+                .entry(node.id)
+                .or_default()
+                .insert(local_damage);
         }
 
         local_damage
     }
 
-    fn update_node_and_descendants_local(
+    /// Update the given node and, where necessary, its descendants, based on damage propagated
+    /// within the accessibility as a result of changes made based on DOM tree changes.
+    /// For example, if a node's descendants changed as a result of the DOM tree changing, its
+    /// computed text may also have changed, so it would have had
+    /// [`LocalAccessibilityDamage::SubtreeChanged`] set when changes from the DOM tree were
+    /// applied. That damage is resolved here.
+    fn resolve_local_damage_for_node_and_subtree(
         &mut self,
         node: ArcRefCell<AccessibilityNode>,
         update: &mut AccessibilityUpdate,
     ) {
         let mut node = node.borrow_mut();
-        let Some(&local_damage) = update.local_damage.get(&node.id) else {
+        let Some(&local_damage) = update.unresolved_local_damage.get(&node.id) else {
             return;
         };
 
         node.update_node_local(local_damage);
 
-        if local_damage.contains(LocalAccessibilityDamage::SUBTREE_CHANGED) {
+        if local_damage.contains(LocalAccessibilityDamage::SubtreeChanged) {
             for child in node.children() {
-                self.update_node_and_descendants_local(child.clone(), update);
+                self.resolve_local_damage_for_node_and_subtree(child.clone(), update);
             }
         }
 
@@ -280,30 +311,7 @@ impl AccessibilityTree {
             update.add(&mut node);
         }
 
-        update.local_damage.remove(&node.id);
-    }
-
-    fn propagate_subtree_damage_to_ancestors(
-        &mut self,
-        local_damage: FxHashMap<NodeId, LocalAccessibilityDamage>,
-        update: &mut AccessibilityUpdate,
-    ) {
-        for (node_id, damage) in local_damage {
-            if damage.is_empty() {
-                continue;
-            }
-            let node = self.assert_node_for_id(&node_id);
-            let mut parent_node = node.borrow().parent();
-            while let Some(node) = parent_node {
-                let node = node.borrow();
-                let existing_damage = update.local_damage.entry(node.id).or_default();
-                if existing_damage.contains(LocalAccessibilityDamage::SUBTREE_CHANGED) {
-                    break;
-                }
-                existing_damage.insert(LocalAccessibilityDamage::SUBTREE_CHANGED);
-                parent_node = node.parent();
-            }
-        }
+        update.unresolved_local_damage.remove(&node.id);
     }
 
     fn get_or_create_node(
@@ -311,7 +319,7 @@ impl AccessibilityTree {
         dom_node: &ServoLayoutNode<'_>,
         update: &mut AccessibilityUpdate,
     ) -> (NodeId, ArcRefCell<AccessibilityNode>) {
-        let id = self.id_for_opaque(dom_node.opaque());
+        let id = self.get_or_create_id_for_opaque(dom_node.opaque());
         let node = self.get_or_create_node_with_id(id, update);
 
         {
@@ -432,7 +440,7 @@ impl AccessibilityTree {
         }
     }
 
-    fn id_for_opaque(&mut self, opaque: OpaqueNode) -> NodeId {
+    fn get_or_create_id_for_opaque(&mut self, opaque: OpaqueNode) -> NodeId {
         let id = self.opaque_node_to_id.entry(opaque).or_insert_with(|| {
             static LAST_ID: AtomicU64 = AtomicU64::new(0);
             let id = LAST_ID.fetch_add(1, atomic::Ordering::SeqCst).into();
@@ -537,7 +545,7 @@ impl AccessibilityNode {
         update: &mut AccessibilityUpdate,
     ) -> LocalAccessibilityDamage {
         let mut local_damage = LocalAccessibilityDamage::empty();
-        if !dom_damage.contains(AccessibilityDamage::CHILDREN) {
+        if !dom_damage.contains(AccessibilityDamage::Children) {
             return local_damage;
         }
 
@@ -552,7 +560,7 @@ impl AccessibilityNode {
                 let child_damage = tree.update_node_and_descendants_from_dom_node(
                     child_node.clone(),
                     &dom_child,
-                    AccessibilityDamage::REBUILD,
+                    AccessibilityDamage::Rebuild,
                     update,
                 );
                 damage_from_children.insert(child_damage);
@@ -561,7 +569,7 @@ impl AccessibilityNode {
             new_child_nodes.push(child_node);
         }
         if !damage_from_children.is_empty() {
-            local_damage.insert(LocalAccessibilityDamage::SUBTREE_CHANGED);
+            local_damage.insert(LocalAccessibilityDamage::SubtreeChanged);
         }
 
         local_damage.insert(self.set_children(weak_self, new_child_ids, new_child_nodes, update));
@@ -600,7 +608,7 @@ impl AccessibilityNode {
         dom_damage: AccessibilityDamage,
     ) -> LocalAccessibilityDamage {
         let mut local_damage = LocalAccessibilityDamage::empty();
-        if !dom_damage.contains(AccessibilityDamage::SELF) {
+        if !dom_damage.contains(AccessibilityDamage::Text) {
             return local_damage;
         }
         local_damage.insert(self.set_role(role_from_dom_node(dom_node)));
@@ -623,8 +631,8 @@ impl AccessibilityNode {
         local_damage: LocalAccessibilityDamage,
     ) -> LocalAccessibilityDamage {
         let mut new_damage = LocalAccessibilityDamage::empty();
-        if local_damage.contains(LocalAccessibilityDamage::SUBTREE_CHANGED) ||
-            local_damage.contains(LocalAccessibilityDamage::ROLE_CHANGED)
+        if local_damage.contains(LocalAccessibilityDamage::SubtreeChanged) ||
+            local_damage.contains(LocalAccessibilityDamage::RoleChanged)
         {
             if let Some(text) = self.label_from_descendants() {
                 new_damage.insert(self.set_label(text.as_str()));
@@ -729,7 +737,7 @@ impl AccessibilityNode {
         self.accesskit_node.set_children(new_child_ids);
         self.updated = true;
 
-        LocalAccessibilityDamage::SUBTREE_CHANGED
+        LocalAccessibilityDamage::SubtreeChanged
     }
 
     fn role(&self) -> Role {
@@ -742,7 +750,7 @@ impl AccessibilityNode {
         }
         self.accesskit_node.set_role(role);
         self.updated = true;
-        LocalAccessibilityDamage::ROLE_CHANGED
+        LocalAccessibilityDamage::RoleChanged
     }
 
     fn label(&self) -> Option<&str> {
@@ -755,7 +763,7 @@ impl AccessibilityNode {
         }
         self.accesskit_node.set_label(label);
         self.updated = true;
-        LocalAccessibilityDamage::TEXT_CHANGED
+        LocalAccessibilityDamage::TextChanged
     }
 
     fn clear_label(&mut self) -> LocalAccessibilityDamage {
@@ -764,7 +772,7 @@ impl AccessibilityNode {
         }
         self.accesskit_node.clear_label();
         self.updated = true;
-        LocalAccessibilityDamage::TEXT_CHANGED
+        LocalAccessibilityDamage::TextChanged
     }
 
     fn html_tag(&self) -> Option<&str> {
@@ -789,7 +797,7 @@ impl AccessibilityNode {
         }
         self.accesskit_node.set_value(value);
         self.updated = true;
-        LocalAccessibilityDamage::TEXT_CHANGED
+        LocalAccessibilityDamage::TextChanged
     }
 
     fn assert_integrity(&self, expected_parent: Option<WeakRefCell<AccessibilityNode>>) {
@@ -841,7 +849,7 @@ impl AccessibilityUpdate {
         Self {
             changed_nodes: FxHashSet::default(),
             tree_changes: FxHashMap::default(),
-            local_damage: FxHashMap::default(),
+            unresolved_local_damage: FxHashMap::default(),
             rooted_nodes,
         }
     }
@@ -889,7 +897,7 @@ impl AccessibilityUpdate {
             .borrow()
             .id;
 
-        debug_assert!(self.local_damage.is_empty());
+        debug_assert!(self.unresolved_local_damage.is_empty());
 
         if self.changed_nodes.is_empty() {
             assert!(self.tree_changes.is_empty());

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -9,7 +9,7 @@ use std::sync::{LazyLock, atomic};
 
 use accesskit::{NodeId, Role};
 use bitflags::bitflags;
-use layout_api::{LayoutElement, LayoutNode, LayoutNodeType};
+use layout_api::{AccessibilityDamage, LayoutElement, LayoutNode, LayoutNodeType};
 use log::trace;
 use rustc_hash::{FxHashMap, FxHashSet};
 use script::layout_dom::ServoLayoutNode;
@@ -44,6 +44,8 @@ struct AccessibilityUpdate {
     changed_nodes: FxHashSet<NodeId>,
     /// Nodes that changed their relation to the tree within the current update.
     tree_changes: FxHashMap<NodeId, TreeChange>,
+    /// Damage to nodes caused by changes in the accessibility tree.
+    local_damage: FxHashMap<NodeId, LocalAccessibilityDamage>,
     /// Nodes which were removed from the DOM tree since the last reflow, which were rooted in
     /// `AccessibilityData`. Only set if `pref::expensive_accessibility_test_assertions_enabled`
     /// is set.
@@ -155,44 +157,153 @@ impl AccessibilityTree {
 
     /// Update this tree based on the current state of the given DOM tree, and if anything changed,
     /// return an [`accesskit::TreeUpdate`] representing what changed.
-    pub(super) fn update_tree(
+    pub(super) fn update_tree<'dom>(
         &mut self,
-        root_dom_node: &ServoLayoutNode<'_>,
+        root_dom_node: &ServoLayoutNode<'dom>,
+        mut damage_from_dom: VecDeque<(ServoLayoutNode<'dom>, AccessibilityDamage)>,
         rooted_nodes: Option<FxHashSet<OpaqueNode>>,
     ) -> Option<accesskit::TreeUpdate> {
         let mut update = AccessibilityUpdate::new(rooted_nodes);
-        let (_, root_node) = self.get_or_create_node(root_dom_node, &mut update);
-        self.root_node = Some(root_node.clone());
 
-        self.update_node_and_descendants_from_dom_node(&root_node, root_dom_node, &mut update);
+        let root_node = self.update_root(root_dom_node, &mut damage_from_dom, &mut update);
+
+        let local_damage = self.resolve_damage_from_dom_tree(damage_from_dom, &mut update);
+        self.propagate_subtree_damage_to_ancestors(local_damage, &mut update);
+
+        // FIXME: This assumes any local subtree damage always propagates up to the root. This is
+        // currently true, but we might be able to improve at stopping propagation.
+        self.update_node_and_descendants_local(root_node, &mut update);
 
         update.finalize(self)
     }
 
-    /// Update the given AccessibilityNode from its corresponding DOM node.
+    /// Get the node corresponding to the root DOM node, and set it as this tree's root. If the root
+    /// node is newly created, which probably means this accessibility tree is newly created, append
+    /// an `AccessibilityDamage::REBUILD` value for it to `damage_from_dom`.
+    fn update_root<'dom>(
+        &mut self,
+        root_dom_node: &ServoLayoutNode<'dom>,
+        damage_from_dom: &mut VecDeque<(ServoLayoutNode<'dom>, AccessibilityDamage)>,
+        update: &mut AccessibilityUpdate,
+    ) -> ArcRefCell<AccessibilityNode> {
+        let (root_id, root_node) = self.get_or_create_node(root_dom_node, update);
+        if update.is_new(&root_id) {
+            damage_from_dom.push_front((*root_dom_node, AccessibilityDamage::REBUILD));
+        }
+        self.root_node = Some(root_node.clone());
+        root_node
+    }
+
+    /// For each DOM node in `damage_from_dom`, update the corresponding accessibility node based on
+    /// its `AccessibilityDamage`. If any [`LocalDamage`] results from the update, propagate
+    /// [`LocalDamage::SUBTREE_CHANGED`] to its ancestors.
+    fn resolve_damage_from_dom_tree<'dom>(
+        &mut self,
+        mut damage_from_dom: VecDeque<(ServoLayoutNode<'dom>, AccessibilityDamage)>,
+        update: &mut AccessibilityUpdate,
+    ) -> FxHashMap<NodeId, LocalAccessibilityDamage> {
+        let mut local_damage: FxHashMap<NodeId, LocalAccessibilityDamage> = FxHashMap::default();
+
+        while let Some((dom_node, dom_node_damage)) = damage_from_dom.pop_front() {
+            let Some((id, node)) = self.node_for_dom_node(&dom_node) else {
+                // If we don't have a node for this DOM node yet, it will be created and populated
+                // when it's added to its parent node.
+                continue;
+            };
+            let local_damage_for_node = self.update_node_and_descendants_from_dom_node(
+                node.clone(),
+                &dom_node,
+                dom_node_damage,
+                update,
+            );
+            if !local_damage_for_node.is_empty() {
+                let existing_damage = local_damage.entry(id).or_default();
+                existing_damage.insert(local_damage_for_node);
+            }
+        }
+
+        local_damage
+    }
+
+    /// Update the given AccessibilityNode from its corresponding DOM node and
+    /// ['AccessibilityDamage'].
     /// If it has new children, those will be recursively populated here.
     // Any changed nodes will be added to the given [`AccessibilityUpdate`].
     fn update_node_and_descendants_from_dom_node(
         &mut self,
-        node: &ArcRefCell<AccessibilityNode>,
+        node: ArcRefCell<AccessibilityNode>,
         dom_node: &ServoLayoutNode<'_>,
+        dom_damage: AccessibilityDamage,
         update: &mut AccessibilityUpdate,
     ) -> LocalAccessibilityDamage {
         let weak_node = node.downgrade();
         let mut node = node.borrow_mut();
-        let mut damage = LocalAccessibilityDamage::empty();
+        let mut local_damage = LocalAccessibilityDamage::empty();
 
-        // TODO: read accessibility damage from DOM (right now, assume damage is complete)
-        damage.insert(node.update_node_from_dom_node(dom_node));
-        damage.insert(node.update_descendants_from_dom_node(weak_node, dom_node, self, update));
+        local_damage.insert(node.update_node_from_dom_node(dom_node, dom_damage));
+        local_damage.insert(
+            node.update_descendants_from_dom_node(weak_node, dom_node, dom_damage, self, update),
+        );
 
-        damage.insert(node.update_node_local(damage));
+        // We call this here rather than in `update_node_and_descendants_local()` as we need to add
+        // local damage from updating the node to the damage which is propagated to ancestors.
+        // This node won't be visited in `update_node_and_descendants_local()`, since we consume its
+        // local damage in `propagate_subtree_damage_to_ancestors()`.
+        local_damage.insert(node.update_node_local(local_damage));
 
         if node.updated {
             update.add(&mut node);
         }
 
-        damage
+        local_damage
+    }
+
+    fn update_node_and_descendants_local(
+        &mut self,
+        node: ArcRefCell<AccessibilityNode>,
+        update: &mut AccessibilityUpdate,
+    ) {
+        let mut node = node.borrow_mut();
+        let Some(&local_damage) = update.local_damage.get(&node.id) else {
+            return;
+        };
+
+        node.update_node_local(local_damage);
+
+        if local_damage.contains(LocalAccessibilityDamage::SUBTREE_CHANGED) {
+            for child in node.children() {
+                self.update_node_and_descendants_local(child.clone(), update);
+            }
+        }
+
+        if node.updated {
+            update.add(&mut node);
+        }
+
+        update.local_damage.remove(&node.id);
+    }
+
+    fn propagate_subtree_damage_to_ancestors(
+        &mut self,
+        local_damage: FxHashMap<NodeId, LocalAccessibilityDamage>,
+        update: &mut AccessibilityUpdate,
+    ) {
+        for (node_id, damage) in local_damage {
+            if damage.is_empty() {
+                continue;
+            }
+            let node = self.assert_node_for_id(&node_id);
+            let mut parent_node = node.borrow().parent();
+            while let Some(node) = parent_node {
+                let node = node.borrow();
+                let existing_damage = update.local_damage.entry(node.id).or_default();
+                if existing_damage.contains(LocalAccessibilityDamage::SUBTREE_CHANGED) {
+                    break;
+                }
+                existing_damage.insert(LocalAccessibilityDamage::SUBTREE_CHANGED);
+                parent_node = node.parent();
+            }
+        }
     }
 
     fn get_or_create_node(
@@ -229,6 +340,18 @@ impl AccessibilityTree {
         self.nodes.insert(id, node.clone());
 
         node
+    }
+
+    fn node_for_id(&self, id: NodeId) -> Option<ArcRefCell<AccessibilityNode>> {
+        self.nodes.get(&id).cloned()
+    }
+
+    fn node_for_dom_node(
+        &self,
+        dom_node: &ServoLayoutNode<'_>,
+    ) -> Option<(NodeId, ArcRefCell<AccessibilityNode>)> {
+        let id = self.existing_id_for_opaque(dom_node.opaque())?;
+        Some((id, self.node_for_id(id)?))
     }
 
     fn assert_node_for_id(&self, id: &NodeId) -> ArcRefCell<AccessibilityNode> {
@@ -316,8 +439,11 @@ impl AccessibilityTree {
             self.id_to_opaque_node.insert(id, opaque);
             id
         });
-
         *id
+    }
+
+    fn existing_id_for_opaque(&self, opaque: OpaqueNode) -> Option<NodeId> {
+        self.opaque_node_to_id.get(&opaque).cloned()
     }
 
     pub(crate) fn embedder_epoch(&self) -> Epoch {
@@ -406,10 +532,14 @@ impl AccessibilityNode {
         &mut self,
         weak_self: WeakRefCell<Self>,
         dom_node: &ServoLayoutNode<'dom>,
+        dom_damage: AccessibilityDamage,
         tree: &mut AccessibilityTree,
         update: &mut AccessibilityUpdate,
     ) -> LocalAccessibilityDamage {
-        let mut damage = LocalAccessibilityDamage::empty();
+        let mut local_damage = LocalAccessibilityDamage::empty();
+        if !dom_damage.contains(AccessibilityDamage::CHILDREN) {
+            return local_damage;
+        }
 
         let dom_children: Vec<ServoLayoutNode> = dom_node.flat_tree_children().collect();
 
@@ -418,18 +548,24 @@ impl AccessibilityNode {
         let mut new_child_nodes = vec![];
         for dom_child in dom_children {
             let (child_id, child_node) = tree.get_or_create_node(&dom_child, update);
-            let child_damage =
-                tree.update_node_and_descendants_from_dom_node(&child_node, &dom_child, update);
-            damage_from_children.insert(child_damage);
+            if update.is_new(&child_id) {
+                let child_damage = tree.update_node_and_descendants_from_dom_node(
+                    child_node.clone(),
+                    &dom_child,
+                    AccessibilityDamage::REBUILD,
+                    update,
+                );
+                damage_from_children.insert(child_damage);
+            }
             new_child_ids.push(child_id);
             new_child_nodes.push(child_node);
         }
         if !damage_from_children.is_empty() {
-            damage.insert(LocalAccessibilityDamage::SUBTREE_CHANGED);
+            local_damage.insert(LocalAccessibilityDamage::SUBTREE_CHANGED);
         }
 
-        damage.insert(self.set_children(weak_self, new_child_ids, new_child_nodes, update));
-        damage
+        local_damage.insert(self.set_children(weak_self, new_child_ids, new_child_nodes, update));
+        local_damage
     }
 
     /// Recursively mark this subtree as having the given `TreeChange`.
@@ -461,27 +597,34 @@ impl AccessibilityNode {
     fn update_node_from_dom_node(
         &mut self,
         dom_node: &ServoLayoutNode<'_>,
+        dom_damage: AccessibilityDamage,
     ) -> LocalAccessibilityDamage {
-        let mut damage = LocalAccessibilityDamage::empty();
-        damage.insert(self.set_role(role_from_dom_node(dom_node)));
+        let mut local_damage = LocalAccessibilityDamage::empty();
+        if !dom_damage.contains(AccessibilityDamage::SELF) {
+            return local_damage;
+        }
+        local_damage.insert(self.set_role(role_from_dom_node(dom_node)));
         if dom_node.type_id() == Some(LayoutNodeType::Text) {
             let text_content = dom_node.text_content();
             trace!("node text content = {text_content:?}");
             // FIXME: this should take into account editing selection units (grapheme clusters?)
-            damage.insert(self.set_value(&text_content));
+            local_damage.insert(self.set_value(&text_content));
         }
 
-        damage
+        local_damage
     }
 
     /// Update this node's properties based on changes already made to the accessibility tree.
     /// For example, if there were nodes added or removed in its subtree, its computed text may have
     /// changed, so that will be recomputed here.
     /// If any changes are made, add this node to the given [`AccessibilityUpdate`].
-    fn update_node_local(&mut self, damage: LocalAccessibilityDamage) -> LocalAccessibilityDamage {
+    fn update_node_local(
+        &mut self,
+        local_damage: LocalAccessibilityDamage,
+    ) -> LocalAccessibilityDamage {
         let mut new_damage = LocalAccessibilityDamage::empty();
-        if damage.contains(LocalAccessibilityDamage::SUBTREE_CHANGED) ||
-            damage.contains(LocalAccessibilityDamage::ROLE_CHANGED)
+        if local_damage.contains(LocalAccessibilityDamage::SUBTREE_CHANGED) ||
+            local_damage.contains(LocalAccessibilityDamage::ROLE_CHANGED)
         {
             if let Some(text) = self.label_from_descendants() {
                 new_damage.insert(self.set_label(text.as_str()));
@@ -529,6 +672,10 @@ impl AccessibilityNode {
             child.borrow().print(print_tree);
         }
         print_tree.end_level();
+    }
+
+    fn parent(&self) -> Option<ArcRefCell<AccessibilityNode>> {
+        self.parent_node.as_ref().and_then(|weak| weak.upgrade())
     }
 
     // TODO: use macros to generate getter/setter methods.
@@ -694,6 +841,7 @@ impl AccessibilityUpdate {
         Self {
             changed_nodes: FxHashSet::default(),
             tree_changes: FxHashMap::default(),
+            local_damage: FxHashMap::default(),
             rooted_nodes,
         }
     }
@@ -740,6 +888,8 @@ impl AccessibilityUpdate {
             .expect("AccessibilityUpdate::finalize() called but no root_node set in tree")
             .borrow()
             .id;
+
+        debug_assert!(self.local_damage.is_empty());
 
         if self.changed_nodes.is_empty() {
             assert!(self.tree_changes.is_empty());

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -20,10 +20,10 @@ use fonts::{FontContext, FontContextWebFontMethods, WebFontDocumentContext};
 use fonts_traits::StylesheetWebFontLoadFinishedCallback;
 use icu_locid::subtags::Language;
 use layout_api::{
-    AccessibilityDamage, AxesOverflow, BoxAreaType, CSSPixelRectVec, DangerousStyleNode,
-    IFrameSizes, Layout, LayoutConfig, LayoutDamage, LayoutElement, LayoutFactory, LayoutNode,
-    NodeRenderingType, OffsetParentResponse, PhysicalSides, QueryMsg, ReflowGoal, ReflowPhasesRun,
-    ReflowRequest, ReflowRequestRestyle, ReflowResult, ReflowStatistics, ScrollContainerQueryFlags,
+    AxesOverflow, BoxAreaType, CSSPixelRectVec, DangerousStyleNode, IFrameSizes, Layout,
+    LayoutConfig, LayoutDamage, LayoutElement, LayoutFactory, LayoutNode, NodeRenderingType,
+    OffsetParentResponse, PhysicalSides, QueryMsg, ReflowGoal, ReflowPhasesRun, ReflowRequest,
+    ReflowRequestRestyle, ReflowResult, ReflowStatistics, ScrollContainerQueryFlags,
     ScrollContainerResponse, TrustedNodeAddress, with_layout_state,
 };
 use log::{debug, warn};
@@ -984,26 +984,24 @@ impl LayoutThread {
         let rooted_nodes =
             std::mem::take(&mut reflow_request.rooted_nodes_for_accessibility_integrity_check);
 
-        unsafe {
-            let damage: VecDeque<(ServoLayoutNode, AccessibilityDamage)> = damage
-                .iter()
-                .map(|(address, damage)| (ServoLayoutNode::new(address), *damage))
-                .collect();
+        let damage: VecDeque<_> = damage
+            .iter()
+            .map(|(address, damage)| unsafe { (ServoLayoutNode::new(address), *damage) })
+            .collect();
 
-            if let Some(tree_update) =
-                accessibility_tree.update_tree(root_element, damage, rooted_nodes)
-            {
-                // FIXME: Handle send error. Could have a method on accessibility tree to
-                // finalise after sending, removing accessibility damage? On fail, retain damage
-                // for next reflow, as well as retaining document.needs_accessibility_update.
-                let _ = self
-                    .embedder_chan
-                    .send(EmbedderMsg::AccessibilityTreeUpdate(
-                        self.webview_id,
-                        tree_update,
-                        accessibility_tree.embedder_epoch(),
-                    ));
-            }
+        if let Some(tree_update) =
+            accessibility_tree.update_tree(root_element, damage, rooted_nodes)
+        {
+            // FIXME: Handle send error. Could have a method on accessibility tree to
+            // finalise after sending, removing accessibility damage? On fail, retain damage
+            // for next reflow, as well as retaining document.needs_accessibility_update.
+            let _ = self
+                .embedder_chan
+                .send(EmbedderMsg::AccessibilityTreeUpdate(
+                    self.webview_id,
+                    tree_update,
+                    accessibility_tree.embedder_epoch(),
+                ));
         }
         self.needs_accessibility_update.set(false);
         true

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -5,7 +5,7 @@
 #![expect(unsafe_code)]
 
 use std::cell::{Cell, OnceCell, RefCell};
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::fmt::Debug;
 use std::rc::Rc;
 use std::sync::{Arc, LazyLock};
@@ -20,10 +20,10 @@ use fonts::{FontContext, FontContextWebFontMethods, WebFontDocumentContext};
 use fonts_traits::StylesheetWebFontLoadFinishedCallback;
 use icu_locid::subtags::Language;
 use layout_api::{
-    AxesOverflow, BoxAreaType, CSSPixelRectVec, DangerousStyleNode, IFrameSizes, Layout,
-    LayoutConfig, LayoutDamage, LayoutElement, LayoutFactory, LayoutNode, NodeRenderingType,
-    OffsetParentResponse, PhysicalSides, QueryMsg, ReflowGoal, ReflowPhasesRun, ReflowRequest,
-    ReflowRequestRestyle, ReflowResult, ReflowStatistics, ScrollContainerQueryFlags,
+    AccessibilityDamage, AxesOverflow, BoxAreaType, CSSPixelRectVec, DangerousStyleNode,
+    IFrameSizes, Layout, LayoutConfig, LayoutDamage, LayoutElement, LayoutFactory, LayoutNode,
+    NodeRenderingType, OffsetParentResponse, PhysicalSides, QueryMsg, ReflowGoal, ReflowPhasesRun,
+    ReflowRequest, ReflowRequestRestyle, ReflowResult, ReflowStatistics, ScrollContainerQueryFlags,
     ScrollContainerResponse, TrustedNodeAddress, with_layout_state,
 };
 use log::{debug, warn};
@@ -976,22 +976,34 @@ impl LayoutThread {
         let Some(accessibility_tree) = accessibility_tree.as_mut() else {
             return false;
         };
+        let Some(damage) = &reflow_request.accessibility_damage else {
+            return false;
+        };
 
         let accessibility_tree = &mut *accessibility_tree;
         let rooted_nodes =
             std::mem::take(&mut reflow_request.rooted_nodes_for_accessibility_integrity_check);
 
-        if let Some(tree_update) = accessibility_tree.update_tree(root_element, rooted_nodes) {
-            // FIXME: Handle send error. Could have a method on accessibility tree to
-            // finalise after sending, removing accessibility damage? On fail, retain damage
-            // for next reflow, as well as retaining document.needs_accessibility_update.
-            let _ = self
-                .embedder_chan
-                .send(EmbedderMsg::AccessibilityTreeUpdate(
-                    self.webview_id,
-                    tree_update,
-                    accessibility_tree.embedder_epoch(),
-                ));
+        unsafe {
+            let damage: VecDeque<(ServoLayoutNode, AccessibilityDamage)> = damage
+                .iter()
+                .map(|(address, damage)| (ServoLayoutNode::new(address), *damage))
+                .collect();
+
+            if let Some(tree_update) =
+                accessibility_tree.update_tree(root_element, damage, rooted_nodes)
+            {
+                // FIXME: Handle send error. Could have a method on accessibility tree to
+                // finalise after sending, removing accessibility damage? On fail, retain damage
+                // for next reflow, as well as retaining document.needs_accessibility_update.
+                let _ = self
+                    .embedder_chan
+                    .send(EmbedderMsg::AccessibilityTreeUpdate(
+                        self.webview_id,
+                        tree_update,
+                        accessibility_tree.embedder_epoch(),
+                    ));
+            }
         }
         self.needs_accessibility_update.set(false);
         true

--- a/components/script/dom/document/accessibility_data.rs
+++ b/components/script/dom/document/accessibility_data.rs
@@ -3,12 +3,15 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use js::context::NoGC;
-use rustc_hash::FxHashSet;
+use layout_api::{AccessibilityDamage, TrustedNodeAddress};
+use rustc_hash::{FxHashMap, FxHashSet};
+use script_bindings::cell::DomRefCell;
 use script_bindings::root::Dom;
 use servo_config::pref;
 use style::dom::OpaqueNode;
 
 use crate::dom::Node;
+use crate::dom::bindings::trace::NoTrace;
 
 #[derive(Clone, Default, JSTraceable, MallocSizeOf)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
@@ -16,6 +19,10 @@ pub(crate) struct AccessibilityData {
     /// Nodes which have been unbound from the DOM but may not yet have been removed from the
     /// accessibility tree. This is cleared after each reflow.
     rooted_nodes: FxHashSet<Dom<Node>>,
+
+    /// Damage to the accessibility tree as a result of DOM mutations. This is drained and sent to
+    /// the accessibility tree during reflow.
+    pending_damage: NoTrace<DomRefCell<FxHashMap<TrustedNodeAddress, AccessibilityDamage>>>,
 }
 
 impl AccessibilityData {
@@ -75,5 +82,26 @@ impl AccessibilityData {
     /// This should only be called during reflow.
     pub(crate) fn unroot_all_removed_nodes(&mut self) {
         self.rooted_nodes.clear();
+    }
+
+    /// Track accessibility damage to the given node caused by mutations in the DOM tree.
+    pub(crate) fn add_pending_accessibility_damage_for_node(
+        &self,
+        node: &Node,
+        damage: AccessibilityDamage,
+    ) {
+        assert!(pref!(accessibility_enabled));
+
+        let map = &mut self.pending_damage.0.borrow_mut();
+        let pending_damage = map.entry(node.to_trusted_node_address()).or_default();
+        *pending_damage |= damage;
+    }
+
+    /// Drain all pending accessibility damage so that it can be passed to the accessibility tree.
+    pub(crate) fn drain_pending_accessibility_damage(
+        &mut self,
+    ) -> Vec<(TrustedNodeAddress, AccessibilityDamage)> {
+        let pending_damage = &mut self.pending_damage.0.borrow_mut();
+        pending_damage.drain().collect()
     }
 }

--- a/components/script/dom/document/accessibility_data.rs
+++ b/components/script/dom/document/accessibility_data.rs
@@ -22,7 +22,7 @@ pub(crate) struct AccessibilityData {
 
     /// Damage to the accessibility tree as a result of DOM mutations. This is drained and sent to
     /// the accessibility tree during reflow.
-    pending_damage: NoTrace<DomRefCell<FxHashMap<TrustedNodeAddress, AccessibilityDamage>>>,
+    pending_damage: DomRefCell<FxHashMap<Dom<Node>, NoTrace<AccessibilityDamage>>>,
 }
 
 impl AccessibilityData {
@@ -92,16 +92,19 @@ impl AccessibilityData {
     ) {
         assert!(pref!(accessibility_enabled));
 
-        let map = &mut self.pending_damage.0.borrow_mut();
-        let pending_damage = map.entry(node.to_trusted_node_address()).or_default();
-        *pending_damage |= damage;
+        let map = &mut self.pending_damage.borrow_mut();
+        let pending_damage = map.entry(Dom::from_ref(node)).or_default();
+        pending_damage.0 |= damage;
     }
 
     /// Drain all pending accessibility damage so that it can be passed to the accessibility tree.
     pub(crate) fn drain_pending_accessibility_damage(
         &mut self,
     ) -> Vec<(TrustedNodeAddress, AccessibilityDamage)> {
-        let pending_damage = &mut self.pending_damage.0.borrow_mut();
-        pending_damage.drain().collect()
+        let pending_damage = &mut self.pending_damage.borrow_mut();
+        pending_damage
+            .drain()
+            .map(|(node, damage)| (node.to_trusted_node_address(), damage.0))
+            .collect()
     }
 }

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -292,6 +292,9 @@ impl Node {
         assert!(new_child.parent_node.get().is_none());
         assert!(new_child.prev_sibling.get().is_none());
         assert!(new_child.next_sibling.get().is_none());
+
+        self.add_pending_accessibility_damage(AccessibilityDamage::Children);
+
         match before {
             Some(before) => {
                 assert!(before.parent_node.get().as_deref() == Some(self));
@@ -498,6 +501,7 @@ impl Node {
     fn remove_child(&self, cx: &mut JSContext, child: &Node, cached_index: Option<u32>) {
         assert!(child.parent_node.get().as_deref() == Some(self));
         self.note_dirty_descendants();
+        self.add_pending_accessibility_damage(AccessibilityDamage::Children);
 
         let prev_sibling = child.GetPreviousSibling();
         match prev_sibling {
@@ -540,6 +544,7 @@ impl Node {
     fn move_child(&self, cx: &mut JSContext, child: &Node) {
         assert!(child.parent_node.get().as_deref() == Some(self));
         self.note_dirty_descendants();
+        self.add_pending_accessibility_damage(AccessibilityDamage::Children);
 
         child.prev_sibling.set(None);
         child.next_sibling.set(None);
@@ -681,10 +686,6 @@ impl Node {
 }
 
 impl Node {
-    fn rare_data(&self) -> Ref<'_, Option<Box<NodeRareData>>> {
-        self.rare_data.borrow()
-    }
-
     fn ensure_rare_data(&self) -> RefMut<'_, Box<NodeRareData>> {
         let mut rare_data = self.rare_data.borrow_mut();
         if rare_data.is_none() {
@@ -894,7 +895,7 @@ impl Node {
                     .unwrap()
                     .dirty(NodeDamage::ContentOrHeritage);
 
-                self.add_pending_accessibility_damage(AccessibilityDamage::SELF);
+                self.add_pending_accessibility_damage(AccessibilityDamage::Text);
             },
             NodeTypeId::Element(_) => self.downcast::<Element>().unwrap().restyle(damage),
             NodeTypeId::DocumentFragment(DocumentFragmentTypeId::ShadowRoot) => self
@@ -1582,9 +1583,6 @@ impl Node {
             next: child,
         });
         MutationObserver::queue_a_mutation_record(cx, new_parent, mutation);
-
-        old_parent.add_pending_accessibility_damage(AccessibilityDamage::CHILDREN);
-        new_parent.add_pending_accessibility_damage(AccessibilityDamage::CHILDREN);
 
         Ok(())
     }
@@ -4200,7 +4198,6 @@ impl VirtualMethods for Node {
         {
             list.as_children_list().children_changed(mutation);
         }
-        self.add_pending_accessibility_damage(AccessibilityDamage::CHILDREN);
 
         self.owner_doc().content_and_heritage_changed(self);
     }

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -26,8 +26,8 @@ use js::jsapi::JSObject;
 use js::rust::HandleObject;
 use keyboard_types::Modifiers;
 use layout_api::{
-    AxesOverflow, BoxAreaType, CSSPixelRectVec, GenericLayoutData, NodeRenderingType,
-    PhysicalSides, TrustedNodeAddress, with_layout_state,
+    AccessibilityDamage, AxesOverflow, BoxAreaType, CSSPixelRectVec, GenericLayoutData,
+    NodeRenderingType, PhysicalSides, TrustedNodeAddress, with_layout_state,
 };
 use libc::{self, uintptr_t};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
@@ -665,7 +665,27 @@ impl Node {
         )
     }
 
-    pub(super) fn ensure_rare_data(&self) -> RefMut<'_, Box<NodeRareData>> {
+    fn add_pending_accessibility_damage(&self, damage: AccessibilityDamage) {
+        if !self.owner_doc().accessibility_active() {
+            return;
+        }
+
+        self.owner_doc()
+            .accessibility_data_mut()
+            .add_pending_accessibility_damage_for_node(self, damage);
+
+        self.owner_window()
+            .layout()
+            .set_needs_accessibility_update();
+    }
+}
+
+impl Node {
+    fn rare_data(&self) -> Ref<'_, Option<Box<NodeRareData>>> {
+        self.rare_data.borrow()
+    }
+
+    fn ensure_rare_data(&self) -> RefMut<'_, Box<NodeRareData>> {
         let mut rare_data = self.rare_data.borrow_mut();
         if rare_data.is_none() {
             *rare_data = Some(Default::default());
@@ -872,7 +892,9 @@ impl Node {
                 self.parent_node
                     .get()
                     .unwrap()
-                    .dirty(NodeDamage::ContentOrHeritage)
+                    .dirty(NodeDamage::ContentOrHeritage);
+
+                self.add_pending_accessibility_damage(AccessibilityDamage::SELF);
             },
             NodeTypeId::Element(_) => self.downcast::<Element>().unwrap().restyle(damage),
             NodeTypeId::DocumentFragment(DocumentFragmentTypeId::ShadowRoot) => self
@@ -1560,6 +1582,9 @@ impl Node {
             next: child,
         });
         MutationObserver::queue_a_mutation_record(cx, new_parent, mutation);
+
+        old_parent.add_pending_accessibility_damage(AccessibilityDamage::CHILDREN);
+        new_parent.add_pending_accessibility_damage(AccessibilityDamage::CHILDREN);
 
         Ok(())
     }
@@ -4175,6 +4200,7 @@ impl VirtualMethods for Node {
         {
             list.as_children_list().children_changed(mutation);
         }
+        self.add_pending_accessibility_damage(AccessibilityDamage::CHILDREN);
 
         self.owner_doc().content_and_heritage_changed(self);
     }

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -41,11 +41,11 @@ use js::rust::{
     MutableHandleValue,
 };
 use layout_api::{
-    AxesOverflow, BoxAreaType, CSSPixelRectVec, ElementsFromPointResult, FragmentType, Layout,
-    LayoutImageDestination, PendingImage, PendingImageState, PendingRasterizationImage,
-    PhysicalSides, QueryMsg, ReflowGoal, ReflowPhasesRun, ReflowRequest, ReflowRequestRestyle,
-    ReflowStatistics, RestyleReason, ScrollContainerQueryFlags, ScrollContainerResponse,
-    TrustedNodeAddress, combine_id_with_fragment_type,
+    AccessibilityDamage, AxesOverflow, BoxAreaType, CSSPixelRectVec, ElementsFromPointResult,
+    FragmentType, Layout, LayoutImageDestination, PendingImage, PendingImageState,
+    PendingRasterizationImage, PhysicalSides, QueryMsg, ReflowGoal, ReflowPhasesRun, ReflowRequest,
+    ReflowRequestRestyle, ReflowStatistics, RestyleReason, ScrollContainerQueryFlags,
+    ScrollContainerResponse, TrustedNodeAddress, combine_id_with_fragment_type,
 };
 use malloc_size_of::MallocSizeOf;
 use media::WindowGLContext;
@@ -2625,6 +2625,11 @@ impl Window {
 
         let rooted_nodes_for_accessibility_integrity_check =
             document.rooted_nodes_for_accessibility_integrity_check();
+        let mut accessibility_damage: Option<Vec<(TrustedNodeAddress, AccessibilityDamage)>> = None;
+        if self.layout().accessibility_active() {
+            let mut accessibility_data = document.accessibility_data_mut();
+            accessibility_damage = Some(accessibility_data.drain_pending_accessibility_damage());
+        }
 
         // Send new document and relevant styles to layout.
         let reflow = ReflowRequest {
@@ -2639,6 +2644,7 @@ impl Window {
             animating_images: document.image_animation_manager().animating_images(),
             highlighted_dom_node: document.highlighted_dom_node().map(|node| node.to_opaque()),
             document_context,
+            accessibility_damage,
             rooted_nodes_for_accessibility_integrity_check,
         };
 

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -284,8 +284,7 @@ fn test_accessibility_basic_mutation() {
     let _ = evaluate_javascript(
         &servo_test,
         webview.clone(),
-        "document.getElementById('h2').remove();\
-         window.ServoTestUtils.forceAccessibilityUpdate();",
+        "document.getElementById('h2').remove();",
     );
 
     let mut updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
@@ -330,8 +329,7 @@ fn test_accessibility_with_mutation_move_nodes() {
     let _ = evaluate_javascript(
         &servo_test,
         webview.clone(),
-        "div1.moveBefore(h1,null); div2.appendChild(h2);\
-         window.ServoTestUtils.forceAccessibilityUpdate();",
+        "div1.moveBefore(h1,null); div2.appendChild(h2);",
     );
 
     let mut updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
@@ -376,8 +374,7 @@ fn test_accessibility_text_change() {
     let _ = evaluate_javascript(
         &servo_test,
         webview.clone(),
-        "h1.firstChild.appendData(', now with more text');\
-         window.ServoTestUtils.forceAccessibilityUpdate();",
+        "h1.firstChild.appendData(', now with more text');",
     );
     let mut updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
     assert_eq!(updates.len(), 1);

--- a/components/shared/layout/layout_damage.rs
+++ b/components/shared/layout/layout_damage.rs
@@ -55,3 +55,14 @@ impl From<LayoutDamage> for RestyleDamage {
         RestyleDamage::from_bits_retain(layout_damage.bits())
     }
 }
+
+bitflags! {
+    #[derive(Clone, Copy, Default, Debug, Eq, PartialEq)]
+    pub struct AccessibilityDamage: u16 {
+        const SELF = 0b0001;
+        const CHILDREN = 0b0010;
+        const SUBTREE = 0b0100;
+        const REBUILD = 0b1111;
+    }
+}
+malloc_size_of::malloc_size_of_is_0!(AccessibilityDamage);

--- a/components/shared/layout/layout_damage.rs
+++ b/components/shared/layout/layout_damage.rs
@@ -59,10 +59,10 @@ impl From<LayoutDamage> for RestyleDamage {
 bitflags! {
     #[derive(Clone, Copy, Default, Debug, Eq, PartialEq)]
     pub struct AccessibilityDamage: u16 {
-        const SELF = 0b0001;
-        const CHILDREN = 0b0010;
-        const SUBTREE = 0b0100;
-        const REBUILD = 0b1111;
+        const Text = 0b0001;
+        const Children = 0b0010;
+        const Subtree = 0b0100;
+        const Rebuild = 0b1111;
     }
 }
 malloc_size_of::malloc_size_of_is_0!(AccessibilityDamage);

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -189,7 +189,6 @@ impl SVGElementData<'_> {
 /// The address of a node known to be valid. These are sent from script to layout.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub struct TrustedNodeAddress(pub *const c_void);
-malloc_size_of::malloc_size_of_is_0!(TrustedNodeAddress);
 
 #[expect(unsafe_code)]
 unsafe impl Send for TrustedNodeAddress {}

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -29,7 +29,7 @@ use bitflags::bitflags;
 use embedder_traits::{Cursor, ScriptToEmbedderChan, Theme, UntrustedNodeAddress, ViewportDetails};
 use euclid::{Point2D, Rect};
 use fonts::{FontContext, TextByteRange, WebFontDocumentContext};
-pub use layout_damage::LayoutDamage;
+pub use layout_damage::{AccessibilityDamage, LayoutDamage};
 pub use layout_dom::{
     DangerousStyleElementOf, DangerousStyleNodeOf, LayoutDomTypeBundle, LayoutElementOf,
     LayoutNodeOf,
@@ -187,8 +187,9 @@ impl SVGElementData<'_> {
 }
 
 /// The address of a node known to be valid. These are sent from script to layout.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub struct TrustedNodeAddress(pub *const c_void);
+malloc_size_of::malloc_size_of_is_0!(TrustedNodeAddress);
 
 #[expect(unsafe_code)]
 unsafe impl Send for TrustedNodeAddress {}
@@ -709,6 +710,8 @@ pub struct ReflowRequest {
     pub highlighted_dom_node: Option<OpaqueNode>,
     /// The current font context.
     pub document_context: WebFontDocumentContext,
+    /// Damage to the accessibility tree from DOM mutations.
+    pub accessibility_damage: Option<Vec<(TrustedNodeAddress, AccessibilityDamage)>>,
     /// Nodes which were removed from the DOM tree since the last reflow, which were rooted in
     /// [`AccessibilityData`]. Only set if [`pref::expensive_accessibility_test_assertions_enabled`]
     /// is set.


### PR DESCRIPTION
- Add `layout_api::AccessibilityDamage` to track specific types of DOM changes which impact the accessibility tree.
- Track these changes in `AccessibilityData`, via `add_pending_accessibility_damage_for_node()`
- Drain pending accessibility damage into `ReflowRequest` and pass in to `AccessibilityTree:update_tree()`
- Use accessibility damage from DOM to determine how to update the accessibility tree from the DOM tree, propagating and resolving damage within the tree as necessary.

Testing: Covered by existing tests.
Fixes: #45967
