### PR TITLE
ci: Run devtools tests in CI

### DIFF
--- a/.github/workflows/dispatch-workflow.yml
+++ b/.github/workflows/dispatch-workflow.yml
@@ -23,6 +23,9 @@ on:
       unit-tests:
         required: true
         type: boolean
+      devtools-tests:
+        required: true
+        type: boolean
       build-libservo:
         required: true
         type: boolean
@@ -95,6 +98,7 @@ jobs:
       wpt: ${{ inputs.wpt }}
       number-of-wpt-chunks: ${{ inputs.number-of-wpt-chunks }}
       unit-tests: ${{ inputs.unit-tests }}
+      devtools-tests: ${{ inputs.devtools-tests }}
       build-libservo: ${{ inputs.build-libservo }}
       wpt-args: ${{ inputs.wpt-args }}
       bencher: ${{ inputs.bencher }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -33,6 +33,10 @@ on:
         required: false
         default: false
         type: boolean
+      devtools-tests:
+        required: false
+        default: false
+        type: boolean
       build-libservo:
         required: false
         default: false
@@ -76,6 +80,10 @@ on:
         required: false
         type: number
       unit-tests:
+        required: false
+        default: false
+        type: boolean
+      devtools-tests:
         required: false
         default: false
         type: boolean
@@ -206,7 +214,7 @@ jobs:
           flags: unittests,unittests-linux,unittests-linux-${{ inputs.profile }}
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Devtools tests
-        if: ${{ false && inputs.unit-tests }} # FIXME #39273
+        if: ${{ inputs.devtools-tests }}
         run: ./mach test-devtools --profile ${{ inputs.profile }}
       - name: Archive build timing
         uses: actions/upload-artifact@v7

--- a/.github/workflows/mac-arm64.yml
+++ b/.github/workflows/mac-arm64.yml
@@ -179,9 +179,6 @@ jobs:
           disable_search: true
           flags: unittests,unittests-mac-arm64,unittests-mac-arm64-${{ inputs.profile }}
           token: ${{ secrets.CODECOV_TOKEN }}
-      - name: Devtools tests
-        if: ${{ false && inputs.unit-tests }} # FIXME #39273
-        run: ./mach test-devtools --profile ${{ inputs.profile }}
       - name: Build mach package
         run: ./mach package --profile ${{ inputs.profile }}
       - name: Run DMG smoketest

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -178,9 +178,6 @@ jobs:
           disable_search: true
           flags: unittests,unittests-mac,unittests-mac-${{ inputs.profile }}
           token: ${{ secrets.CODECOV_TOKEN }}
-      - name: Devtools tests
-        if: ${{ false && inputs.unit-tests }}  # FIXME #39273
-        run: ./mach test-devtools --profile ${{ inputs.profile }}
       - name: Build mach package
         run: ./mach package --profile ${{ inputs.profile }}
       - name: Run DMG smoketest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,7 @@ jobs:
       wpt: ${{ matrix.wpt }}
       profile: ${{ matrix.profile }}
       unit-tests: ${{ matrix.unit_tests }}
+      devtools-tests: ${{ matrix.devtools_tests }}
       build-libservo: ${{ matrix.build_libservo }}
       wpt-args: ${{ matrix.wpt_args }}
       build-args: ${{ matrix.build_args }}

--- a/.github/workflows/try-label.yml
+++ b/.github/workflows/try-label.yml
@@ -127,6 +127,7 @@ jobs:
       wpt: ${{ matrix.wpt }}
       profile: ${{ matrix.profile }}
       unit-tests: ${{ matrix.unit_tests }}
+      devtools-tests: ${{ matrix.devtools_tests }}
       build-libservo: ${{ matrix.build_libservo }}
       wpt-args: ${{ matrix.wpt_args }}
       build-args: ${{ matrix.build_args }}

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -24,6 +24,9 @@ on:
       unit-tests:
         required: false
         type: boolean
+      devtools-tests:
+        required: false
+        type: boolean
       bencher:
         required: false
         type: boolean
@@ -112,6 +115,7 @@ jobs:
       wpt: ${{ matrix.wpt }}
       profile: ${{ matrix.profile }}
       unit-tests: ${{ matrix.unit_tests }}
+      devtools-tests: ${{ matrix.devtools_tests }}
       build-libservo: ${{ matrix.build_libservo }}
       build-args: ${{ matrix.build_args }}
       wpt-args: ${{ matrix.wpt_args }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -203,9 +203,6 @@ jobs:
           disable_search: true
           flags: unittests,unittests-windows,unittests-windows-${{ inputs.profile }}
           token: ${{ secrets.CODECOV_TOKEN }}
-      - name: Devtools tests
-        if: ${{ false && inputs.unit-tests }}  # FIXME #39273
-        run: .\mach test-devtools --profile ${{ inputs.profile }}
       - name: Archive build timing
         uses: actions/upload-artifact@v7
         with:

--- a/python/servo/try_parser.py
+++ b/python/servo/try_parser.py
@@ -38,6 +38,7 @@ class JobConfig(object):
     wpt: bool = False
     profile: str = "checked-release"
     unit_tests: bool = False
+    devtools_tests: bool = False
     build_libservo: bool = False
     bencher: bool = False
     coverage: bool = False
@@ -58,6 +59,7 @@ class JobConfig(object):
 
         self.wpt |= other.wpt
         self.unit_tests |= other.unit_tests
+        self.devtools_tests |= other.devtools_tests
         self.build_libservo |= other.build_libservo
         self.bencher |= other.bencher
         self.coverage |= other.coverage
@@ -84,6 +86,8 @@ class JobConfig(object):
             modifier.append(self.profile.title())
         if self.unit_tests:
             modifier.append("Unit Tests")
+        if self.devtools_tests:
+            modifier.append("Devtools Tests")
         if self.build_libservo:
             modifier.append("Build libservo")
         if self.wpt:
@@ -158,6 +162,8 @@ def handle_modifier(config: Optional[JobConfig], s: str) -> Optional[JobConfig]:
     s = s.lower()
     if "unit-tests" in s:
         config.unit_tests = True
+    if "devtools" in s:
+        config.devtools_tests = True
     if "build-libservo" in s:
         config.build_libservo = True
     if "production" in s:
@@ -286,6 +292,7 @@ class TestParser(unittest.TestCase):
                         "number_of_wpt_chunks": 20,
                         "profile": "checked-release",
                         "unit_tests": True,
+                        "devtools_tests": False,
                         "build_libservo": False,
                         "workflow": "linux",
                         "wpt": False,
@@ -309,6 +316,7 @@ class TestParser(unittest.TestCase):
                         "wpt": True,
                         "profile": "checked-release",
                         "unit_tests": True,
+                        "devtools_tests": False,
                         "build_libservo": True,
                         "bencher": True,
                         "build_args": "",
@@ -323,6 +331,7 @@ class TestParser(unittest.TestCase):
                         "wpt": False,
                         "profile": "checked-release",
                         "unit_tests": True,
+                        "devtools_tests": False,
                         "build_libservo": True,
                         "bencher": False,
                         "build_args": "",
@@ -337,6 +346,7 @@ class TestParser(unittest.TestCase):
                         "wpt": False,
                         "profile": "checked-release",
                         "unit_tests": True,
+                        "devtools_tests": False,
                         "build_libservo": False,
                         "bencher": False,
                         "build_args": "",
@@ -351,6 +361,7 @@ class TestParser(unittest.TestCase):
                         "wpt": False,
                         "profile": "checked-release",
                         "unit_tests": False,
+                        "devtools_tests": False,
                         "build_libservo": False,
                         "bencher": False,
                         "build_args": "",
@@ -365,6 +376,7 @@ class TestParser(unittest.TestCase):
                         "wpt": False,
                         "profile": "checked-release",
                         "unit_tests": False,
+                        "devtools_tests": False,
                         "build_libservo": False,
                         "bencher": False,
                         "build_args": "",
@@ -379,6 +391,7 @@ class TestParser(unittest.TestCase):
                         "wpt": False,
                         "profile": "checked-release",
                         "unit_tests": False,
+                        "devtools_tests": False,
                         "build_libservo": False,
                         "bencher": False,
                         "build_args": "",
@@ -403,6 +416,7 @@ class TestParser(unittest.TestCase):
                         "name": "Linux (WPT)",
                         "number_of_wpt_chunks": 20,
                         "profile": "checked-release",
+                        "devtools_tests": False,
                         "unit_tests": False,
                         "build_libservo": False,
                         "workflow": "linux",
@@ -465,6 +479,7 @@ class TestParser(unittest.TestCase):
                         "number_of_wpt_chunks": 20,
                         "profile": "checked-release",
                         "unit_tests": False,
+                        "devtools_tests": False,
                         "build_libservo": False,
                         "workflow": "linux",
                         "wpt": False,
@@ -478,6 +493,15 @@ class TestParser(unittest.TestCase):
 
     def test_wpt_alias(self) -> None:
         self.assertDictEqual(json.loads(Config("wpt").to_json()), json.loads(Config("linux-wpt").to_json()))
+
+    def test_devtools_tests(self) -> None:
+        matrix_result = json.loads(Config("linux-devtools").to_json())["matrix"][0]
+
+        self.assertEqual(matrix_result["name"], "Linux (Devtools Tests)")
+        self.assertEqual(matrix_result["workflow"], "linux")
+        self.assertTrue(matrix_result["devtools_tests"])
+        self.assertFalse(matrix_result["unit_tests"])
+        self.assertFalse(matrix_result["wpt"])
 
 
 def run_tests() -> bool:


### PR DESCRIPTION
Not enabled by default, only run with a manual `T-linux-devtools` tag.

Testing: Runs `./mach test-devtools` on CI
Part of: #39273
Part of: #44256
