### PR TITLE
ci: Make try-label job pass 'capi' input to dispatch-workflow

### DIFF
--- a/.github/workflows/try-label.yml
+++ b/.github/workflows/try-label.yml
@@ -133,6 +133,7 @@ jobs:
       number-of-wpt-chunks: ${{ matrix.number_of_wpt_chunks }}
       bencher: ${{ matrix.bencher }}
       coverage: ${{ matrix.coverage }}
+      capi: ${{ matrix.capi }}
 
   results:
     name: Results


### PR DESCRIPTION
This was missed in #44984, so now try-label job is [broken](https://github.com/servo/servo/actions/workflows/try-label.yml) due to the missing input.

Testing: The try string parser is already tested as part of #44984. There are no tests for the try-label.yml job itself. This needs to be tested manually.
