### PR TITLE
bluetooth: Inline return_if_cached macro

### DIFF
--- a/components/bluetooth/lib.rs
+++ b/components/bluetooth/lib.rs
@@ -58,14 +58,6 @@ bitflags! {
     }
 }
 
-macro_rules! return_if_cached(
-    ($cache:expr, $key:expr) => (
-        if $cache.contains_key($key) {
-            return $cache.get($key);
-        }
-    );
-);
-
 pub trait BluetoothThreadFactory {
     fn new(embedder_proxy: EmbedderProxy) -> Self;
 }
@@ -464,10 +456,11 @@ impl BluetoothManager {
         adapter: &mut BluetoothAdapter,
         device_id: &str,
     ) -> Option<&BluetoothDevice> {
-        return_if_cached!(self.cached_devices, device_id);
+        if self.cached_devices.contains_key(device_id) {
+            return self.cached_devices.get(device_id);
+        }
         self.get_and_cache_devices(adapter).await;
-        return_if_cached!(self.cached_devices, device_id);
-        None
+        self.cached_devices.get(device_id)
     }
 
     async fn select_device(
@@ -583,11 +576,12 @@ impl BluetoothManager {
         adapter: &mut BluetoothAdapter,
         service_id: &str,
     ) -> Option<&BluetoothGATTService> {
-        return_if_cached!(self.cached_services, service_id);
+        if self.cached_services.contains_key(service_id) {
+            return self.cached_services.get(service_id);
+        }
         let device_id = self.service_to_device.get(service_id)?.clone();
         self.get_and_cache_gatt_services(adapter, &device_id).await;
-        return_if_cached!(self.cached_services, service_id);
-        None
+        self.cached_services.get(service_id)
     }
 
     fn service_is_cached(&self, service_id: &str) -> bool {
@@ -623,15 +617,16 @@ impl BluetoothManager {
         adapter: &mut BluetoothAdapter,
         characteristic_id: &str,
     ) -> Option<&BluetoothGATTCharacteristic> {
-        return_if_cached!(self.cached_characteristics, characteristic_id);
+        if self.cached_characteristics.contains_key(characteristic_id) {
+            return self.cached_characteristics.get(characteristic_id);
+        }
         let service_id = self
             .characteristic_to_service
             .get(characteristic_id)?
             .clone();
         self.get_and_cache_gatt_characteristics(adapter, &service_id)
             .await;
-        return_if_cached!(self.cached_characteristics, characteristic_id);
-        None
+        self.cached_characteristics.get(characteristic_id)
     }
 
     fn get_characteristic_properties(&self, characteristic: &BluetoothGATTCharacteristic) -> Flags {
@@ -691,15 +686,16 @@ impl BluetoothManager {
         adapter: &mut BluetoothAdapter,
         descriptor_id: &str,
     ) -> Option<&BluetoothGATTDescriptor> {
-        return_if_cached!(self.cached_descriptors, descriptor_id);
+        if self.cached_descriptors.contains_key(descriptor_id) {
+            return self.cached_descriptors.get(descriptor_id);
+        }
         let characteristic_id = self
             .descriptor_to_characteristic
             .get(descriptor_id)?
             .clone();
         self.get_and_cache_gatt_descriptors(adapter, &characteristic_id)
             .await;
-        return_if_cached!(self.cached_descriptors, descriptor_id);
-        None
+        self.cached_descriptors.get(descriptor_id)
     }
 
     // Methods


### PR DESCRIPTION
Replaces the `return_if_cached` macro at all call sites. Each function had two uses of the macro: the first cache hit check is now written inline, and the second lookup now uses the relevant `self.cache_whatever.get(key)` call directly. The trailing `None` return is removed where it is now redundant.

Testing: Existing Bluetooth tests cover this. Successfully tested locally by running  `./mach test-wpt tests/wpt/mozilla/tests/bluetooth`
Fixes: Closes #45534 
