### PR TITLE
script: Use unrooted iterators for HTMLCollections

### DIFF
--- a/components/script/dom/execcommand/basecommand.rs
+++ b/components/script/dom/execcommand/basecommand.rs
@@ -372,7 +372,7 @@ impl CommandName {
         let mut at_least_two_different_effective_values = false;
         let mut previous_effective_value: Option<DOMString> = None;
         active_range.for_each_effectively_contained_child(|node| {
-            if at_least_two_different_effective_values || !node.is_formattable() {
+            if at_least_two_different_effective_values || !node.is_formattable(cx.no_gc()) {
                 return;
             }
             if let Some(effective_command_value) = node.effective_command_value(self) {
@@ -421,7 +421,7 @@ impl CommandName {
                 let mut at_least_one_child_is_formattable = false;
                 let mut all_children_have_matching_command_values = true;
                 active_range.for_each_effectively_contained_child(|node| {
-                    if !node.is_formattable() {
+                    if !node.is_formattable(cx.no_gc()) {
                         return;
                     }
                     at_least_one_child_is_formattable = true;
@@ -468,7 +468,7 @@ impl CommandName {
                 let active_range = selection.active_range()?;
 
                 active_range
-                    .first_formattable_contained_node()
+                    .first_formattable_contained_node(cx.no_gc())
                     .unwrap_or_else(|| active_range.start_container())
                     .effective_command_value(self)
                     .unwrap_or_default()

--- a/components/script/dom/execcommand/commands/delete.rs
+++ b/components/script/dom/execcommand/commands/delete.rs
@@ -57,7 +57,7 @@ pub(crate) fn execute_delete_command(
         if offset == 0 &&
             let Some(sibling) = node.GetPreviousSibling() &&
             sibling.is_editable() &&
-            sibling.is_invisible()
+            sibling.is_invisible(cx.no_gc())
         {
             sibling.remove_self(cx);
             continue;
@@ -71,7 +71,7 @@ pub(crate) fn execute_delete_command(
                 .map(|node| node.as_rooted());
             if let Some(child) = child &&
                 child.is_editable() &&
-                child.is_invisible()
+                child.is_invisible(cx.no_gc())
             {
                 child.remove_self(cx);
                 offset -= 1;
@@ -80,7 +80,7 @@ pub(crate) fn execute_delete_command(
         }
         // Step 4.3. Otherwise, if offset is zero and node is an inline node, or if node is an invisible node,
         // set offset to the index of node, then set node to its parent.
-        if (offset == 0 && node.is_inline_node()) || node.is_invisible() {
+        if (offset == 0 && node.is_inline_node()) || node.is_invisible(cx.no_gc()) {
             offset = node.index();
             node = node.GetParentNode().expect("Must always have a parent");
             continue;
@@ -154,7 +154,7 @@ pub(crate) fn execute_delete_command(
     ) && node
         .GetParentNode()
         .and_then(|parent| parent.children_unrooted(cx.no_gc()).next())
-        .is_some_and(|first| first == &node) &&
+        .is_some_and(|first| **first == *node) &&
         offset == 0
     {
         // Step 7.1. Let items be a list of all lis that are ancestors of node.
@@ -217,7 +217,7 @@ pub(crate) fn execute_delete_command(
             .map(|node| node.as_rooted());
         if let Some(child) = child &&
             child.is_editable() &&
-            child.is_invisible()
+            child.is_invisible(cx.no_gc())
         {
             child.remove_self(cx);
             start_offset -= 1;
@@ -297,7 +297,7 @@ pub(crate) fn execute_delete_command(
         };
         // Step 16.1. If start node's child with index start offset minus one
         // is editable and invisible, remove it from start node, then subtract one from start offset.
-        if child.is_editable() && child.is_invisible() {
+        if child.is_editable() && child.is_invisible(cx.no_gc()) {
             child.remove_self(cx);
             start_offset -= 1;
         } else {

--- a/components/script/dom/execcommand/commands/fontsize.rs
+++ b/components/script/dom/execcommand/commands/fontsize.rs
@@ -131,7 +131,7 @@ pub(crate) fn value_for_fontsize_command(
     // the effective command value of the active range's start node,
     // in either case interpreted as a number of pixels.
     let command_value = active_range
-        .first_formattable_contained_node()
+        .first_formattable_contained_node(cx.no_gc())
         .unwrap_or_else(|| active_range.start_container())
         .effective_command_value(&CommandName::FontSize)?;
     // Step 3. Return the legacy font size for pixel size.

--- a/components/script/dom/execcommand/commands/insertparagraph.rs
+++ b/components/script/dom/execcommand/commands/insertparagraph.rs
@@ -398,7 +398,10 @@ pub(crate) fn execute_insert_paragraph_command(
     // Step 32. If container has no visible children,
     // call createElement("br") on the context object,
     // and append the result as the last child of container.
-    if container.children().all(|child| child.is_invisible()) {
+    if container
+        .children()
+        .all(|child| child.is_invisible(cx.no_gc()))
+    {
         let br = document.create_element(cx, "br");
         if container.AppendChild(cx, br.upcast()).is_err() {
             unreachable!("Must always be able to append");
@@ -409,7 +412,7 @@ pub(crate) fn execute_insert_paragraph_command(
     // and append the result as the last child of new container.
     if new_container_node
         .children()
-        .all(|child| child.is_invisible())
+        .all(|child| child.is_invisible(cx.no_gc()))
     {
         let br = document.create_element(cx, "br");
         if new_container_node.AppendChild(cx, br.upcast()).is_err() {

--- a/components/script/dom/execcommand/contenteditable/node.rs
+++ b/components/script/dom/execcommand/contenteditable/node.rs
@@ -7,7 +7,7 @@ use std::ops::Deref;
 
 use cssparser::color::OPAQUE;
 use html5ever::local_name;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use script_bindings::inheritance::Castable;
 use style::attr::parse_legacy_color;
 use style::values::specified::box_::DisplayOutside;
@@ -434,14 +434,16 @@ pub(crate) fn split_the_parent<'a>(cx: &mut JSContext, node_list: &'a [&'a Node]
         .children()
         .next()
         .is_some_and(|first_child| node_list.contains(&first_child.deref()));
-    let follows_line_break = first_child_is_in_node_list && original_parent.follows_a_line_break();
+    let follows_line_break =
+        first_child_is_in_node_list && original_parent.follows_a_line_break(cx.no_gc());
     // Step 5. If the last child of original parent is in node list, and original parent precedes a line break,
     // set precedes line break to true. Otherwise, set precedes line break to false.
     let last_child_is_in_node_list = original_parent
         .children()
         .last()
         .is_some_and(|last_child| node_list.contains(&last_child.deref()));
-    let precedes_line_break = last_child_is_in_node_list && original_parent.precedes_a_line_break();
+    let precedes_line_break =
+        last_child_is_in_node_list && original_parent.precedes_a_line_break(cx.no_gc());
     // Step 6. If the first child of original parent is not in node list, but its last child is:
     if !first_child_is_in_node_list && last_child_is_in_node_list {
         // Step 6.1. For each node in node list, in reverse order,
@@ -456,7 +458,7 @@ pub(crate) fn split_the_parent<'a>(cx: &mut JSContext, node_list: &'a [&'a Node]
         // call createElement("br") on the context object and insert the result immediately after the last member of node list.
         if precedes_line_break &&
             let Some(last) = node_list.last() &&
-            !last.precedes_a_line_break()
+            !last.precedes_a_line_break(cx.no_gc())
         {
             let br = context_object.create_element(cx, "br");
             if last
@@ -517,7 +519,7 @@ pub(crate) fn split_the_parent<'a>(cx: &mut JSContext, node_list: &'a [&'a Node]
     // call createElement("br") on the context object and insert the result immediately before the first member of node list.
     if follows_line_break &&
         let Some(first) = node_list.first() &&
-        !first.follows_a_line_break()
+        !first.follows_a_line_break(cx.no_gc())
     {
         let br = context_object.create_element(cx, "br");
         if first
@@ -551,7 +553,7 @@ pub(crate) fn split_the_parent<'a>(cx: &mut JSContext, node_list: &'a [&'a Node]
         // call createElement("br") on the context object and insert the result immediately after the last member of node list.
         if precedes_line_break &&
             let Some(last) = node_list.last() &&
-            !last.precedes_a_line_break()
+            !last.precedes_a_line_break(cx.no_gc())
         {
             let br = context_object.create_element(cx, "br");
             if last
@@ -592,7 +594,7 @@ where
     // and none is a br, return null and abort these steps.
     if node_list
         .iter()
-        .all(|node| node.is_invisible() && !node.is::<HTMLBRElement>())
+        .all(|node| node.is_invisible(cx.no_gc()) && !node.is::<HTMLBRElement>())
     {
         return None;
     }
@@ -612,7 +614,7 @@ where
     // Step 4. While node list's first member's previousSibling is invisible, prepend it to node list.
     while let Some(previous_of_first) = node_list.first().and_then(|last| last.GetPreviousSibling())
     {
-        if previous_of_first.is_invisible() {
+        if previous_of_first.is_invisible(cx.no_gc()) {
             node_list.insert(0, previous_of_first);
             continue;
         }
@@ -620,7 +622,7 @@ where
     }
     // Step 5. While node list's last member's nextSibling is invisible, append it to node list.
     while let Some(next_of_last) = node_list.last().and_then(|last| last.GetNextSibling()) {
-        if next_of_last.is_invisible() {
+        if next_of_last.is_invisible(cx.no_gc()) {
             node_list.push(next_of_last);
             continue;
         }
@@ -698,11 +700,11 @@ where
         if !new_parent.is_inline_node() &&
             new_parent
                 .rev_children()
-                .find(|child| child.is_visible())
+                .find(|child| child.is_visible(cx.no_gc()))
                 .is_some_and(|child| child.is_inline_node()) &&
             node_list
                 .iter()
-                .find(|node| node.is_visible())
+                .find(|node| node.is_visible(cx.no_gc()))
                 .is_some_and(|node| node.is_inline_node()) &&
             new_parent
                 .children_unrooted(cx.no_gc())
@@ -728,12 +730,12 @@ where
         if !new_parent.is_inline_node() &&
             new_parent
                 .children_unrooted(cx.no_gc())
-                .find(|child| child.is_visible())
+                .find(|child| child.is_visible(cx.no_gc()))
                 .is_some_and(|child| child.is_inline_node()) &&
             node_list
                 .iter()
                 .rev()
-                .find(|node| node.is_visible())
+                .find(|node| node.is_visible(cx.no_gc()))
                 .is_some_and(|node| node.is_inline_node()) &&
             node_list
                 .last()
@@ -1195,7 +1197,7 @@ impl Node {
             );
         }
         // Step 5. If node is invisible, abort this algorithm.
-        if self.is_invisible() {
+        if self.is_invisible(cx.no_gc()) {
             return;
         }
         // Step 6. If the effective command value of command is loosely equivalent to new value on node, abort this algorithm.
@@ -1520,7 +1522,7 @@ impl Node {
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#visible>
-    pub(crate) fn is_visible(&self) -> bool {
+    pub(crate) fn is_visible(&self, no_gc: &NoGC) -> bool {
         for parent in self.inclusive_ancestors(ShadowIncluding::No) {
             // > excluding any node with an inclusive ancestor Element whose "display" property has resolved value "none".
             if parent
@@ -1538,7 +1540,7 @@ impl Node {
         // > or a Text node that is not a collapsed whitespace node,
         if self
             .downcast::<Text>()
-            .is_some_and(|text| !text.is_collapsed_whitespace_node())
+            .is_some_and(|text| !text.is_collapsed_whitespace_node(no_gc))
         {
             return true;
         }
@@ -1553,7 +1555,7 @@ impl Node {
             return true;
         }
         for child in self.children() {
-            if child.is_visible() {
+            if child.is_visible(no_gc) {
                 return true;
             }
         }
@@ -1561,16 +1563,16 @@ impl Node {
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#invisible>
-    pub(crate) fn is_invisible(&self) -> bool {
+    pub(crate) fn is_invisible(&self, no_gc: &NoGC) -> bool {
         // > Something is invisible if it is a node that is not visible.
-        !self.is_visible()
+        !self.is_visible(no_gc)
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#formattable-node>
-    pub(crate) fn is_formattable(&self) -> bool {
+    pub(crate) fn is_formattable(&self, no_gc: &NoGC) -> bool {
         // > A formattable node is an editable visible node that is either a Text node, an img, or a br.
         self.is_editable() &&
-            self.is_visible() &&
+            self.is_visible(no_gc) &&
             (self.is::<Text>() || self.is::<HTMLImageElement>() || self.is::<HTMLBRElement>())
     }
 
@@ -1589,19 +1591,21 @@ impl Node {
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#block-start-point>
-    pub(crate) fn is_block_start_point(&self, offset: usize) -> bool {
+    pub(crate) fn is_block_start_point(&self, no_gc: &NoGC, offset: usize) -> bool {
         // > A boundary point (node, offset) is a block start point if either node's parent is null and offset is zero;
         if offset == 0 {
             return self.GetParentNode().is_none();
         }
         // > or node has a child with index offset − 1, and that child is either a visible block node or a visible br.
-        self.children().nth(offset - 1).is_some_and(|child| {
-            child.is_visible() && (child.is_block_node() || child.is::<HTMLBRElement>())
-        })
+        self.children_unrooted(no_gc)
+            .nth(offset - 1)
+            .is_some_and(|child| {
+                child.is_visible(no_gc) && (child.is_block_node() || child.is::<HTMLBRElement>())
+            })
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#block-end-point>
-    pub(crate) fn is_block_end_point(&self, offset: u32) -> bool {
+    pub(crate) fn is_block_end_point(&self, offset: u32, no_gc: &NoGC) -> bool {
         // > A boundary point (node, offset) is a block end point if either node's parent is null and offset is node's length;
         if self.GetParentNode().is_none() && offset == self.len() {
             return true;
@@ -1609,13 +1613,13 @@ impl Node {
         // > or node has a child with index offset, and that child is a visible block node.
         self.children()
             .nth(offset as usize)
-            .is_some_and(|child| child.is_visible() && child.is_block_node())
+            .is_some_and(|child| child.is_visible(no_gc) && child.is_block_node())
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#block-boundary-point>
-    pub(crate) fn is_block_boundary_point(&self, offset: u32) -> bool {
+    pub(crate) fn is_block_boundary_point(&self, no_gc: &NoGC, offset: u32) -> bool {
         // > A boundary point is a block boundary point if it is either a block start point or a block end point.
-        self.is_block_start_point(offset as usize) || self.is_block_end_point(offset)
+        self.is_block_start_point(no_gc, offset as usize) || self.is_block_end_point(offset, no_gc)
     }
 
     pub(crate) fn is_no_allowed_child_in_same_editing_host(&self) -> bool {
@@ -1742,7 +1746,7 @@ impl Node {
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#collapsed-block-prop>
-    pub(crate) fn is_collapsed_block_prop(&self) -> bool {
+    pub(crate) fn is_collapsed_block_prop(&self, no_gc: &NoGC) -> bool {
         // > A collapsed block prop is either a collapsed line break that is not an extraneous line break,
 
         // TODO: Check for collapsed line break
@@ -1760,12 +1764,12 @@ impl Node {
             return false;
         }
         let mut at_least_one_collapsed_block_prop = false;
-        for child in self.children() {
-            if child.is_collapsed_block_prop() {
+        for child in self.children_unrooted(no_gc) {
+            if child.is_collapsed_block_prop(no_gc) {
                 at_least_one_collapsed_block_prop = true;
                 continue;
             }
-            if child.is_invisible() {
+            if child.is_invisible(no_gc) {
                 continue;
             }
 
@@ -1776,12 +1780,12 @@ impl Node {
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#follows-a-line-break>
-    fn follows_a_line_break(&self) -> bool {
+    fn follows_a_line_break(&self, no_gc: &NoGC) -> bool {
         // Step 1. Let offset be zero.
         let mut offset = 0;
         // Step 2. While (node, offset) is not a block boundary point:
         let mut node = DomRoot::from_ref(self);
-        while !node.is_block_boundary_point(offset) {
+        while !node.is_block_boundary_point(no_gc, offset) {
             // Step 2.2. If offset is zero or node has no children, set offset to node's index, then set node to its parent.
             if offset == 0 || node.children_count() == 0 {
                 offset = node.index();
@@ -1793,7 +1797,7 @@ impl Node {
             let Some(child) = child else {
                 return false;
             };
-            if child.is_visible() {
+            if child.is_visible(no_gc) {
                 return false;
             }
             // Step 2.3. Otherwise, set node to its child with index offset minus one, then set offset to node's length.
@@ -1805,17 +1809,17 @@ impl Node {
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#precedes-a-line-break>
-    fn precedes_a_line_break(&self) -> bool {
+    fn precedes_a_line_break(&self, no_gc: &NoGC) -> bool {
         let mut node = DomRoot::from_ref(self);
         // Step 1. Let offset be node's length.
         let mut offset = node.len();
         // Step 2. While (node, offset) is not a block boundary point:
-        while !node.is_block_boundary_point(offset) {
+        while !node.is_block_boundary_point(no_gc, offset) {
             // Step 2.1. If node has a visible child with index offset, return false.
             if node
                 .children()
                 .nth(offset as usize)
-                .is_some_and(|child| child.is_visible())
+                .is_some_and(|child| child.is_visible(no_gc))
             {
                 return false;
             }
@@ -1921,7 +1925,7 @@ impl Node {
             // and start node's parent is in the same editing host, set start offset to start node's index,
             // then set start node to its parent.
             if start_offset == 0 &&
-                !start_node.follows_a_line_break() &&
+                !start_node.follows_a_line_break(cx.no_gc()) &&
                 let Some(parent) = start_node.GetParentNode() &&
                 parent.same_editing_host(&start_node)
             {
@@ -1951,7 +1955,7 @@ impl Node {
         // Step 5. Let length equal zero.
         let mut length = 0;
         // Step 6. Let collapse spaces be true if start offset is zero and start node follows a line break, otherwise false.
-        let mut collapse_spaces = start_offset == 0 && start_node.follows_a_line_break();
+        let mut collapse_spaces = start_offset == 0 && start_node.follows_a_line_break(cx.no_gc());
         // Step 7. Repeat the following steps:
         loop {
             // Step 7.1. If end node has a child in the same editing host with index end offset,
@@ -1967,7 +1971,7 @@ impl Node {
             // and end node does not precede a line break
             // and end node's parent is in the same editing host,
             // set end offset to one plus end node's index, then set end node to its parent.
-            if end_offset == end_node.len() && !end_node.precedes_a_line_break() {
+            if end_offset == end_node.len() && !end_node.precedes_a_line_break(cx.no_gc()) {
                 if let Some(parent) = end_node.GetParentNode() &&
                     parent.same_editing_host(&end_node)
                 {
@@ -2055,7 +2059,7 @@ impl Node {
                         text.data().len() as u32,
                         &[&'\u{0020}'],
                     ) &&
-                    end_node.precedes_a_line_break()
+                    end_node.precedes_a_line_break(cx.no_gc())
                 {
                     // Step 8.3.1. Subtract one from end offset.
                     end_offset -= 1;
@@ -2080,8 +2084,8 @@ impl Node {
         // non-breaking end is true if end offset is end node's length and end node precedes a line break, and false otherwise.
         let replacement_whitespace = Node::canonical_space_sequence(
             length,
-            start_offset == 0 && start_node.follows_a_line_break(),
-            end_offset == end_node.len() && end_node.precedes_a_line_break(),
+            start_offset == 0 && start_node.follows_a_line_break(cx.no_gc()),
+            end_offset == end_node.len() && end_node.precedes_a_line_break(cx.no_gc()),
         );
         let mut replacement_whitespace_chars = replacement_whitespace.chars();
         // Step 10. While (start node, start offset) is before (end node, end offset):
@@ -2144,7 +2148,7 @@ impl Node {
         // Step 4. While ref is invisible but not an extraneous line break,
         // and ref does not equal node's parent, set ref to the node before it in tree order.
         loop {
-            if ref_.is_invisible() &&
+            if ref_.is_invisible(cx.no_gc()) &&
                 ref_.downcast::<HTMLBRElement>()
                     .is_none_or(|br| !br.is_extraneous_line_break()) &&
                 let Some(parent) = parent.as_ref() &&
@@ -2179,7 +2183,7 @@ impl Node {
         // Step 3. While ref is invisible but not an extraneous line break, and ref does not equal node,
         // set ref to the node before it in tree order.
         loop {
-            if ref_.is_invisible() &&
+            if ref_.is_invisible(cx.no_gc()) &&
                 *ref_ != *self &&
                 ref_.downcast::<HTMLBRElement>()
                     .is_none_or(|br| !br.is_extraneous_line_break()) &&
@@ -2202,7 +2206,7 @@ impl Node {
             loop {
                 if let Some(parent) = ref_.GetParentNode() &&
                     parent.is_editable() &&
-                    parent.is_invisible()
+                    parent.is_invisible(cx.no_gc())
                 {
                     ref_ = parent;
                     continue;

--- a/components/script/dom/execcommand/contenteditable/range.rs
+++ b/components/script/dom/execcommand/contenteditable/range.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use script_bindings::inheritance::Castable;
 
 use crate::dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
@@ -68,14 +68,14 @@ impl Range {
             .unwrap_or(ancestor_container)
     }
 
-    pub(crate) fn first_formattable_contained_node(&self) -> Option<DomRoot<Node>> {
+    pub(crate) fn first_formattable_contained_node(&self, no_gc: &NoGC) -> Option<DomRoot<Node>> {
         if self.collapsed() {
             return None;
         }
 
         self.ancestor_for_effectively_contained()
             .traverse_preorder(ShadowIncluding::No)
-            .find(|child| child.is_formattable() && self.is_effectively_contained_node(child))
+            .find(|child| child.is_formattable(no_gc) && self.is_effectively_contained_node(child))
     }
 
     pub(crate) fn for_each_effectively_contained_child<Callback: FnMut(&Node)>(
@@ -120,7 +120,7 @@ impl Range {
                 .expect("Must always have a parent");
         }
         // Step 3. If (start node, start offset) is not a block start point, repeat the following steps:
-        if !start_node.is_block_start_point(start_offset as usize) {
+        if !start_node.is_block_start_point(cx.no_gc(), start_offset as usize) {
             loop {
                 // Step 3.1. If start offset is zero, set it to start node's index, then set start node to its parent.
                 if start_offset == 0 {
@@ -133,7 +133,7 @@ impl Range {
                     start_offset -= 1;
                 }
                 // Step 3.3. If (start node, start offset) is a block boundary point, break from this loop.
-                if start_node.is_block_boundary_point(start_offset) {
+                if start_node.is_block_boundary_point(cx.no_gc(), start_offset) {
                     break;
                 }
             }
@@ -159,7 +159,7 @@ impl Range {
                 .expect("Must always have a parent");
         }
         // Step 6. If (end node, end offset) is not a block end point, repeat the following steps:
-        if !end_node.is_block_end_point(end_offset) {
+        if !end_node.is_block_end_point(end_offset, cx.no_gc()) {
             loop {
                 // Step 6.1. If end offset is end node's length, set it to one plus end node's index, then set end node to its parent.
                 if end_offset == end_node.len() {
@@ -170,7 +170,7 @@ impl Range {
                     end_offset += 1;
                 }
                 // Step 6.3. If (end node, end offset) is a block boundary point, break from this loop.
-                if end_node.is_block_boundary_point(end_offset) {
+                if end_node.is_block_boundary_point(cx.no_gc(), end_offset) {
                     break;
                 }
             }
@@ -203,7 +203,7 @@ impl Range {
 
         // Step 2. Let node be the first formattable node effectively contained in the active range,
         // or null if there is none.
-        let Some(node) = self.first_formattable_contained_node() else {
+        let Some(node) = self.first_formattable_contained_node(cx.no_gc()) else {
             // Step 3. If node is null, return overrides.
             return vec![];
         };
@@ -272,7 +272,8 @@ impl Range {
     ) {
         // Step 1. Let node be the first formattable node effectively contained in the active range,
         // or null if there is none.
-        let mut first_formattable_contained_node = self.first_formattable_contained_node();
+        let mut first_formattable_contained_node =
+            self.first_formattable_contained_node(cx.no_gc());
         for override_state in overrides {
             // Step 2. If node is not null, then for each (command, override) pair in overrides, in order:
             if let Some(ref node) = first_formattable_contained_node {
@@ -365,7 +366,8 @@ impl Range {
                     },
                 }
                 // Step 2.6. Set node to the first formattable node effectively contained in the active range, if there is one.
-                first_formattable_contained_node = self.first_formattable_contained_node();
+                first_formattable_contained_node =
+                    self.first_formattable_contained_node(cx.no_gc());
             } else {
                 // Step 3. Otherwise, for each (command, override) pair in overrides, in order:
                 // Step 3.1. If override is a boolean, set the state override for command to override.

--- a/components/script/dom/execcommand/contenteditable/selection.rs
+++ b/components/script/dom/execcommand/contenteditable/selection.rs
@@ -402,7 +402,7 @@ impl Selection {
             if parent.block_node_of().is_some_and(|block_node| {
                 block_node
                     .children_unrooted(cx.no_gc())
-                    .all(|child| child.is_invisible())
+                    .all(|child| child.is_invisible(cx.no_gc()))
             }) && parent.is_editable_or_editing_host()
             {
                 let br = context_object.create_element(cx, "br");
@@ -494,7 +494,7 @@ impl Selection {
             let Some(child) = start_block.children().nth(0) else {
                 unreachable!("Must always have a single child");
             };
-            if child.is_collapsed_block_prop() {
+            if child.is_collapsed_block_prop(cx.no_gc()) {
                 assert!(child.has_parent());
                 child.remove_self(cx);
             }
@@ -508,7 +508,7 @@ impl Selection {
             loop {
                 if start_block
                     .children_unrooted(cx.no_gc())
-                    .all(|child| child != &reference_node)
+                    .all(|child| **child != *reference_node)
                 {
                     reference_node = reference_node
                         .GetParentNode()
@@ -788,7 +788,10 @@ impl Selection {
         // Passed as argument
 
         // Step 2. If there is no formattable node effectively contained in the active range:
-        if active_range.first_formattable_contained_node().is_none() {
+        if active_range
+            .first_formattable_contained_node(cx.no_gc())
+            .is_none()
+        {
             // Step 2.1. If command has inline command activated values, set the state override to true if new value is among them and false if it's not.
             let inline_command_activated_values = command.inline_command_activated_values();
             if !inline_command_activated_values.is_empty() {

--- a/components/script/dom/execcommand/contenteditable/text.rs
+++ b/components/script/dom/execcommand/contenteditable/text.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use js::context::NoGC;
 use script_bindings::cell::Ref;
 use script_bindings::inheritance::Castable;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
@@ -58,7 +59,7 @@ impl Text {
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#collapsed-whitespace-node>
-    pub(crate) fn is_collapsed_whitespace_node(&self) -> bool {
+    pub(crate) fn is_collapsed_whitespace_node(&self, no_gc: &NoGC) -> bool {
         // Step 1. If node is not a whitespace node, return false.
         if !self.is_whitespace_node() {
             return false;
@@ -111,7 +112,9 @@ impl Text {
         // Step 9. Let reference be node.
         // Step 10. While reference is a descendant of ancestor:
         // Step 10.1. Let reference be the node after it in tree order, or null if there is no such node.
-        for reference in node.following_nodes(&resolved_ancestor, ShadowIncluding::No) {
+        for reference in
+            node.following_nodes_unrooted(no_gc, &resolved_ancestor, ShadowIncluding::No)
+        {
             // Step 10.2. If reference is a block node or a br, return true.
             if reference.is_block_node() || reference.is::<HTMLBRElement>() {
                 return true;

--- a/components/script/dom/html/htmlcollection.rs
+++ b/components/script/dom/html/htmlcollection.rs
@@ -6,7 +6,8 @@ use std::cell::Cell;
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, QualName, local_name, namespace_url, ns};
-use js::context::NoGC;
+use js::context::{JSContext, NoGC};
+use script_bindings::dom::UnrootedDom;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use style::str::split_html_space_chars;
 use stylo_atoms::Atom;
@@ -31,16 +32,20 @@ pub(crate) trait CollectionFilter: JSTraceable {
 /// efficient when the collection's elements can be enumerated directly
 /// (e.g. `selectedOptions` iterating only the select's list of options).
 pub(crate) trait CollectionSource: JSTraceable {
-    fn iter<'a>(&'a self, root: &'a Node) -> Box<dyn Iterator<Item = DomRoot<Element>> + 'a>;
+    fn iter<'b>(
+        &'b self,
+        no_gc: &'b NoGC,
+        root: &'b Node,
+    ) -> Box<dyn Iterator<Item = UnrootedDom<'b, Element>> + 'b>;
 }
 
 /// How a collection enumerates its elements.
 #[derive(JSTraceable)]
 enum CollectionKind {
     /// Filter elements from a subtree traversal of the root node.
-    Filter(Box<dyn CollectionFilter + 'static>),
+    Filter(Box<dyn CollectionFilter>),
     /// Provide elements directly via a custom iterator.
-    Source(Box<dyn CollectionSource + 'static>),
+    Source(Box<dyn CollectionSource>),
 }
 
 /// An optional `u32`, using `u32::MAX` to represent None.  It would be nicer
@@ -364,36 +369,44 @@ impl HTMLCollection {
 
     /// Iterate forwards from a node, filtering by a [`CollectionFilter`].
     /// Only usable with filter-based collections for cursor optimization.
-    fn filter_iter_after<'a>(
-        &'a self,
-        after: &'a Node,
-        filter: &'a (dyn CollectionFilter + 'static),
-    ) -> impl Iterator<Item = DomRoot<Element>> + 'a {
+    fn filter_iter_after<'b>(
+        &'b self,
+        no_gc: &'b NoGC,
+        after: &'b Node,
+        filter: &'b (dyn CollectionFilter + 'static),
+    ) -> impl Iterator<Item = UnrootedDom<'b, Element>> + 'b {
         after
-            .following_nodes(&self.root, ShadowIncluding::No)
-            .filter_map(DomRoot::downcast)
+            .following_nodes_unrooted(no_gc, &self.root, ShadowIncluding::No)
+            .filter_map(UnrootedDom::downcast)
             .filter(move |element| filter.filter(element, &self.root))
     }
 
     /// Iterate backwards from a node, filtering by a [`CollectionFilter`].
     /// Only usable with filter-based collections for cursor optimization.
-    fn filter_iter_before<'a>(
+    fn filter_iter_before<'a, 'b>(
         &'a self,
+        no_gc: &'b NoGC,
         before: &'a Node,
         filter: &'a (dyn CollectionFilter + 'static),
-    ) -> impl Iterator<Item = DomRoot<Element>> + 'a {
+    ) -> impl Iterator<Item = UnrootedDom<'b, Element>> + 'a
+    where
+        'b: 'a,
+    {
         before
-            .preceding_nodes(&self.root)
-            .filter_map(DomRoot::downcast)
+            .preceding_nodes_unrooted(no_gc, &self.root)
+            .filter_map(UnrootedDom::downcast)
             .filter(move |element| filter.filter(element, &self.root))
     }
 
-    pub(crate) fn elements_iter(&self) -> Box<dyn Iterator<Item = DomRoot<Element>> + '_> {
+    pub(crate) fn elements_iter<'b>(
+        &'b self,
+        no_gc: &'b NoGC,
+    ) -> Box<dyn Iterator<Item = UnrootedDom<'b, Element>> + 'b> {
         match &self.kind {
             CollectionKind::Filter(filter) => {
-                Box::new(self.filter_iter_after(&self.root, filter.as_ref()))
+                Box::new(self.filter_iter_after(no_gc, &self.root, filter.as_ref()))
             },
-            CollectionKind::Source(source) => source.iter(&self.root),
+            CollectionKind::Source(source) => source.iter(no_gc, &self.root),
         }
     }
 
@@ -404,7 +417,7 @@ impl HTMLCollection {
 
 impl HTMLCollectionMethods<crate::DomTypeHolder> for HTMLCollection {
     /// <https://dom.spec.whatwg.org/#dom-htmlcollection-length>
-    fn Length(&self) -> u32 {
+    fn Length(&self, cx: &JSContext) -> u32 {
         self.validate_cache();
 
         if let Some(cached_length) = self.cached_length.get().to_option() {
@@ -412,14 +425,14 @@ impl HTMLCollectionMethods<crate::DomTypeHolder> for HTMLCollection {
             cached_length
         } else {
             // Cache miss, calculate the length
-            let length = self.elements_iter().count() as u32;
+            let length = self.elements_iter(cx.no_gc()).count() as u32;
             self.cached_length.set(OptionU32::some(length));
             length
         }
     }
 
     /// <https://dom.spec.whatwg.org/#dom-htmlcollection-item>
-    fn Item(&self, index: u32) -> Option<DomRoot<Element>> {
+    fn Item(&self, cx: &JSContext, index: u32) -> Option<DomRoot<Element>> {
         self.validate_cache();
 
         if let Some(element) = self.cached_cursor_element.get() {
@@ -439,16 +452,18 @@ impl HTMLCollectionMethods<crate::DomTypeHolder> for HTMLCollection {
                         let offset = index - (cached_index + 1);
                         self.set_cached_cursor(
                             index,
-                            self.filter_iter_after(&node, filter.as_ref())
-                                .nth(offset as usize),
+                            self.filter_iter_after(cx.no_gc(), &node, filter.as_ref())
+                                .nth(offset as usize)
+                                .map(|node| node.as_rooted()),
                         )
                     } else {
                         // Iterate backwards from the cursor.
                         let offset = cached_index - (index + 1);
                         self.set_cached_cursor(
                             index,
-                            self.filter_iter_before(&node, filter.as_ref())
-                                .nth(offset as usize),
+                            self.filter_iter_before(cx.no_gc(), &node, filter.as_ref())
+                                .nth(offset as usize)
+                                .map(|node| node.as_rooted()),
                         )
                     };
                 }
@@ -456,11 +471,16 @@ impl HTMLCollectionMethods<crate::DomTypeHolder> for HTMLCollection {
         }
 
         // Cache miss or source-based collection: iterate from the beginning.
-        self.set_cached_cursor(index, self.elements_iter().nth(index as usize))
+        self.set_cached_cursor(
+            index,
+            self.elements_iter(cx.no_gc())
+                .nth(index as usize)
+                .map(|node| node.as_rooted()),
+        )
     }
 
     /// <https://dom.spec.whatwg.org/#dom-htmlcollection-nameditem>
-    fn NamedItem(&self, key: DOMString) -> Option<DomRoot<Element>> {
+    fn NamedItem(&self, cx: &JSContext, key: DOMString) -> Option<DomRoot<Element>> {
         // Step 1.
         if key.is_empty() {
             return None;
@@ -469,29 +489,32 @@ impl HTMLCollectionMethods<crate::DomTypeHolder> for HTMLCollection {
         let key = Atom::from(key);
 
         // Step 2.
-        self.elements_iter().find(|elem| {
-            elem.get_id().is_some_and(|id| id == key) ||
-                (elem.namespace() == &ns!(html) && elem.get_name().is_some_and(|id| id == key))
-        })
+        self.elements_iter(cx.no_gc())
+            .find(|elem| {
+                elem.get_id().is_some_and(|id| id == key) ||
+                    (elem.namespace() == &ns!(html) &&
+                        elem.get_name().is_some_and(|id| id == key))
+            })
+            .map(|node| node.as_rooted())
     }
 
     /// <https://dom.spec.whatwg.org/#dom-htmlcollection-item>
-    fn IndexedGetter(&self, index: u32) -> Option<DomRoot<Element>> {
-        self.Item(index)
+    fn IndexedGetter(&self, cx: &JSContext, index: u32) -> Option<DomRoot<Element>> {
+        self.Item(cx, index)
     }
 
     // check-tidy: no specs after this line
-    fn NamedGetter(&self, name: DOMString) -> Option<DomRoot<Element>> {
-        self.NamedItem(name)
+    fn NamedGetter(&self, cx: &JSContext, name: DOMString) -> Option<DomRoot<Element>> {
+        self.NamedItem(cx, name)
     }
 
     /// <https://dom.spec.whatwg.org/#interface-htmlcollection>
-    fn SupportedPropertyNames(&self, _: &NoGC) -> Vec<DOMString> {
+    fn SupportedPropertyNames(&self, no_gc: &NoGC) -> Vec<DOMString> {
         // Step 1
         let mut result = vec![];
 
         // Step 2
-        for elem in self.elements_iter() {
+        for elem in self.elements_iter(no_gc) {
             // Step 2.1
             if let Some(id_atom) = elem.get_id() {
                 let id_str = DOMString::from(&*id_atom);

--- a/components/script/dom/html/htmlformcontrolscollection.rs
+++ b/components/script/dom/html/htmlformcontrolscollection.rs
@@ -60,8 +60,8 @@ impl HTMLFormControlsCollectionMethods<crate::DomTypeHolder> for HTMLFormControl
     // FIXME: This shouldn't need to be implemented here since HTMLCollection (the parent of
     // HTMLFormControlsCollection) implements Length
     /// <https://dom.spec.whatwg.org/#dom-htmlcollection-length>
-    fn Length(&self) -> u32 {
-        self.collection.Length()
+    fn Length(&self, cx: &JSContext) -> u32 {
+        self.collection.Length(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-htmlformcontrolscollection-nameditem>
@@ -72,37 +72,41 @@ impl HTMLFormControlsCollectionMethods<crate::DomTypeHolder> for HTMLFormControl
         }
 
         let name = Atom::from(name);
+        {
+            let mut filter_map = self
+                .collection
+                .elements_iter(cx.no_gc())
+                .filter_map(|elem| {
+                    if elem.get_name().is_some_and(|n| n == name) ||
+                        elem.get_id().is_some_and(|i| i == name)
+                    {
+                        Some(elem)
+                    } else {
+                        None
+                    }
+                })
+                .peekable();
 
-        let mut filter_map = self.collection.elements_iter().filter_map(|elem| {
-            if elem.get_name().is_some_and(|n| n == name) ||
-                elem.get_id().is_some_and(|i| i == name)
-            {
-                Some(elem)
-            } else {
-                None
-            }
-        });
-
-        if let Some(elem) = filter_map.next() {
-            let mut peekable = filter_map.peekable();
+            // This if is more complicated because of lifetimes.
             // Step 2
-            if peekable.peek().is_none() {
-                Some(RadioNodeListOrElement::Element(elem))
+            if filter_map.peek().is_none() {
+                return None;
             } else {
-                // Step 4-5
-                let global = self.global();
-                let window = global.as_window();
-                // There is only one way to get an HTMLCollection,
-                // specifically HTMLFormElement::Elements(),
-                // and the collection filter excludes image inputs.
-                Some(RadioNodeListOrElement::RadioNodeList(
-                    RadioNodeList::new_controls_except_image_inputs(cx, window, &self.form, &name),
-                ))
+                let elem = filter_map.next().unwrap();
+                if filter_map.peek().is_none() {
+                    return Some(RadioNodeListOrElement::Element(elem.as_rooted()));
+                }
             }
-        // Step 3
-        } else {
-            None
         }
+        // Step 4-5
+        let global = self.global();
+        let window = global.as_window();
+        // There is only one way to get an HTMLCollection,
+        // specifically HTMLFormElement::Elements(),
+        // and the collection filter excludes image inputs.
+        Some(RadioNodeListOrElement::RadioNodeList(
+            RadioNodeList::new_controls_except_image_inputs(cx, window, &self.form, &name),
+        ))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-htmlformcontrolscollection-nameditem>
@@ -120,7 +124,7 @@ impl HTMLFormControlsCollectionMethods<crate::DomTypeHolder> for HTMLFormControl
     // https://github.com/servo/servo/issues/5875
     //
     /// <https://dom.spec.whatwg.org/#dom-htmlcollection-item>
-    fn IndexedGetter(&self, index: u32) -> Option<DomRoot<Element>> {
-        self.collection.IndexedGetter(index)
+    fn IndexedGetter(&self, cx: &JSContext, index: u32) -> Option<DomRoot<Element>> {
+        self.collection.IndexedGetter(cx, index)
     }
 }

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -436,13 +436,13 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-form-length>
     fn Length(&self, cx: &mut JSContext) -> u32 {
-        self.Elements(cx).Length()
+        self.Elements(cx).Length(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-form-item>
     fn IndexedGetter(&self, cx: &mut JSContext, index: u32) -> Option<DomRoot<Element>> {
         let elements = self.Elements(cx);
-        elements.IndexedGetter(index)
+        elements.IndexedGetter(cx, index)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-form-element%3Adetermine-the-value-of-a-named-property>
@@ -454,12 +454,12 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
         // Step 1
         let mut candidates =
             RadioNodeList::new_controls_except_image_inputs(cx, &window, self, &name);
-        let mut candidates_length = candidates.Length();
+        let mut candidates_length = candidates.Length(cx);
 
         // Step 2
         if candidates_length == 0 {
             candidates = RadioNodeList::new_images(cx, &window, self, &name);
-            candidates_length = candidates.Length();
+            candidates_length = candidates.Length(cx);
         }
 
         let mut past_names_map = self.past_names_map.borrow_mut();
@@ -1228,9 +1228,9 @@ impl HTMLFormElement {
     /// 5.x substeps are mostly handled inside element-specific methods
     fn get_unclean_dataset(
         &self,
+        cx: &mut JSContext,
         submitter: Option<FormSubmitterElement>,
         encoding: Option<&'static Encoding>,
-        can_gc: CanGc,
     ) -> Vec<FormDatum> {
         let mut data_set = Vec::new();
         for child in self.controls.borrow().iter() {
@@ -1266,7 +1266,7 @@ impl HTMLFormElement {
                     },
                     HTMLElementTypeId::HTMLSelectElement => {
                         let select = child.downcast::<HTMLSelectElement>().unwrap();
-                        select.push_form_data(&mut data_set);
+                        select.push_form_data(cx.no_gc(), &mut data_set);
                     },
                     HTMLElementTypeId::HTMLTextAreaElement => {
                         let textarea = child.downcast::<HTMLTextAreaElement>().unwrap();
@@ -1283,8 +1283,9 @@ impl HTMLFormElement {
                         let custom = child.downcast::<HTMLElement>().unwrap();
                         if custom.is_form_associated_custom_element() {
                             // https://html.spec.whatwg.org/multipage/#face-entry-construction
-                            let internals =
-                                custom.upcast::<Element>().ensure_element_internals(can_gc);
+                            let internals = custom
+                                .upcast::<Element>()
+                                .ensure_element_internals(CanGc::from_cx(cx));
                             internals.perform_entry_construction(&mut data_set);
                             // Otherwise no form value has been set so there is nothing to do.
                         }
@@ -1340,7 +1341,7 @@ impl HTMLFormElement {
         self.constructing_entry_list.set(true);
 
         // Step 3-6
-        let ret = self.get_unclean_dataset(submitter, encoding, CanGc::from_cx(cx));
+        let ret = self.get_unclean_dataset(cx, submitter, encoding);
 
         let window = self.owner_window();
 
@@ -1466,7 +1467,7 @@ impl Element {
         if let Some(input_element) = self.downcast::<HTMLInputElement>() {
             input_element.reset(cx);
         } else if let Some(select_element) = self.downcast::<HTMLSelectElement>() {
-            select_element.reset();
+            select_element.reset(cx);
         } else if let Some(textarea_element) = self.downcast::<HTMLTextAreaElement>() {
             textarea_element.reset(cx);
         } else if let Some(output_element) = self.downcast::<HTMLOutputElement>() {

--- a/components/script/dom/html/htmloptionelement.rs
+++ b/components/script/dom/html/htmloptionelement.rs
@@ -7,7 +7,7 @@ use std::convert::TryInto;
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, QualName, local_name, ns};
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::rust::HandleObject;
 use style::str::{split_html_space_chars, str_join};
 use stylo_dom::ElementState;
@@ -98,22 +98,22 @@ impl HTMLOptionElement {
         self.dirtiness.set(dirtiness);
     }
 
-    fn pick_if_selected_and_reset(&self) {
+    fn pick_if_selected_and_reset(&self, no_gc: &NoGC) {
         if let Some(select) = self.owner_select_element() {
             if self.Selected() {
-                select.pick_option(self);
+                select.pick_option(no_gc, self);
             }
-            select.ask_for_reset();
+            select.ask_for_reset(no_gc);
         }
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-option-index>
-    fn index(&self) -> i32 {
+    fn index(&self, no_gc: &NoGC) -> i32 {
         let Some(owner_select) = self.owner_select_element() else {
             return 0;
         };
 
-        let Some(position) = owner_select.list_of_options().position(|n| &*n == self) else {
+        let Some(position) = owner_select.list_of_options(no_gc).position(|n| *n == self) else {
             // An option should always be in it's owner's list of options, but it's not worth a browser panic
             warn!("HTMLOptionElement called index_in_select at a select that did not contain it");
             return 0;
@@ -375,13 +375,13 @@ impl HTMLOptionElementMethods<crate::DomTypeHolder> for HTMLOptionElement {
     fn SetSelected(&self, cx: &mut JSContext, selected: bool) {
         self.dirtiness.set(true);
         self.set_selectedness(selected);
-        self.pick_if_selected_and_reset();
+        self.pick_if_selected_and_reset(cx.no_gc());
         self.update_select_validity(cx);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-option-index>
-    fn Index(&self) -> i32 {
-        self.index()
+    fn Index(&self, cx: &JSContext) -> i32 {
+        self.index(cx.no_gc())
     }
 }
 
@@ -435,7 +435,7 @@ impl VirtualMethods for HTMLOptionElement {
                 }
 
                 if selectedness_changed {
-                    self.pick_if_selected_and_reset();
+                    self.pick_if_selected_and_reset(cx.no_gc());
 
                     if let Some(select_element) = self.owner_select_element() {
                         select_element.update_shadow_tree(cx);
@@ -463,7 +463,7 @@ impl VirtualMethods for HTMLOptionElement {
         self.upcast::<Element>()
             .check_parent_disabled_state_for_option();
 
-        self.pick_if_selected_and_reset();
+        self.pick_if_selected_and_reset(cx.no_gc());
         self.update_select_validity(cx);
     }
 
@@ -478,7 +478,7 @@ impl VirtualMethods for HTMLOptionElement {
             select
                 .validity_state(cx)
                 .perform_validation_and_update(cx, ValidationFlags::all());
-            select.ask_for_reset();
+            select.ask_for_reset(cx.no_gc());
         }
 
         let node = self.upcast::<Node>();
@@ -502,8 +502,8 @@ impl VirtualMethods for HTMLOptionElement {
             .has_attribute(&local_name!("label")) &&
             let Some(owner_select) = self.owner_select_element() &&
             owner_select
-                .selected_option()
-                .is_some_and(|selected_option| self == &*selected_option)
+                .selected_option(cx.no_gc())
+                .is_some_and(|selected_option| *self == **selected_option)
         {
             owner_select.update_shadow_tree(cx);
         }
@@ -526,7 +526,7 @@ impl VirtualMethods for HTMLOptionElement {
                 select
                     .validity_state(cx)
                     .perform_validation_and_update(cx, ValidationFlags::all());
-                select.ask_for_reset();
+                select.ask_for_reset(cx.no_gc());
             }
 
             if self.upcast::<Node>().GetParentNode().is_some() {
@@ -538,7 +538,7 @@ impl VirtualMethods for HTMLOptionElement {
 
         element.check_parent_disabled_state_for_option();
 
-        self.pick_if_selected_and_reset();
+        self.pick_if_selected_and_reset(cx.no_gc());
         self.update_select_validity(cx);
     }
 }

--- a/components/script/dom/html/htmloptionscollection.rs
+++ b/components/script/dom/html/htmloptionscollection.rs
@@ -84,8 +84,8 @@ impl HTMLOptionsCollectionMethods<crate::DomTypeHolder> for HTMLOptionsCollectio
     // https://github.com/servo/servo/issues/5875
     //
     /// <https://dom.spec.whatwg.org/#dom-htmlcollection-nameditem>
-    fn NamedGetter(&self, name: DOMString) -> Option<DomRoot<Element>> {
-        self.upcast().NamedItem(name)
+    fn NamedGetter(&self, cx: &JSContext, name: DOMString) -> Option<DomRoot<Element>> {
+        self.upcast().NamedItem(cx, name)
     }
 
     /// <https://heycam.github.io/webidl/#dfn-supported-property-names>
@@ -98,8 +98,8 @@ impl HTMLOptionsCollectionMethods<crate::DomTypeHolder> for HTMLOptionsCollectio
     // https://github.com/servo/servo/issues/5875
     //
     /// <https://dom.spec.whatwg.org/#dom-htmlcollection-item>
-    fn IndexedGetter(&self, index: u32) -> Option<DomRoot<Element>> {
-        self.upcast().IndexedGetter(index)
+    fn IndexedGetter(&self, cx: &JSContext, index: u32) -> Option<DomRoot<Element>> {
+        self.upcast().IndexedGetter(cx, index)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-htmloptionscollection-setter>
@@ -111,7 +111,7 @@ impl HTMLOptionsCollectionMethods<crate::DomTypeHolder> for HTMLOptionsCollectio
     ) -> ErrorResult {
         if let Some(value) = value {
             // Step 2
-            let length = self.upcast().Length();
+            let length = self.upcast().Length(cx);
 
             // Step 3
             let n = index as i32 - length as i32;
@@ -127,7 +127,7 @@ impl HTMLOptionsCollectionMethods<crate::DomTypeHolder> for HTMLOptionsCollectio
             if n >= 0 {
                 Node::pre_insert(cx, node, &root, None).map(|_| ())
             } else {
-                let child = self.upcast().IndexedGetter(index).unwrap();
+                let child = self.upcast().IndexedGetter(cx, index).unwrap();
                 let child_node = child.upcast::<Node>();
 
                 root.ReplaceChild(cx, node, child_node).map(|_| ())
@@ -140,14 +140,14 @@ impl HTMLOptionsCollectionMethods<crate::DomTypeHolder> for HTMLOptionsCollectio
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-htmloptionscollection-length>
-    fn Length(&self) -> u32 {
-        self.upcast().Length()
+    fn Length(&self, cx: &JSContext) -> u32 {
+        self.upcast().Length(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-htmloptionscollection-length>
     fn SetLength(&self, cx: &mut JSContext, length: u32) {
         // Step 1. Let current be the number of nodes represented by the collection.
-        let current = self.upcast().Length();
+        let current = self.upcast().Length(cx);
 
         match length.cmp(&current) {
             // Step 2. If the given value is greater than current, then:
@@ -223,7 +223,7 @@ impl HTMLOptionsCollectionMethods<crate::DomTypeHolder> for HTMLOptionsCollectio
             HTMLElementOrLong::HTMLElement(element) => Some(DomRoot::upcast::<Node>(element)),
             HTMLElementOrLong::Long(index) => self
                 .upcast()
-                .IndexedGetter(index as u32)
+                .IndexedGetter(cx, index as u32)
                 .map(DomRoot::upcast::<Node>),
         });
 
@@ -242,18 +242,18 @@ impl HTMLOptionsCollectionMethods<crate::DomTypeHolder> for HTMLOptionsCollectio
 
     /// <https://html.spec.whatwg.org/multipage/#dom-htmloptionscollection-remove>
     fn Remove(&self, cx: &mut JSContext, index: i32) {
-        if let Some(element) = self.upcast().IndexedGetter(index as u32) {
+        if let Some(element) = self.upcast().IndexedGetter(cx, index as u32) {
             element.Remove(cx);
         }
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-htmloptionscollection-selectedindex>
-    fn SelectedIndex(&self) -> i32 {
+    fn SelectedIndex(&self, cx: &JSContext) -> i32 {
         self.upcast()
             .root_node()
             .downcast::<HTMLSelectElement>()
             .expect("HTMLOptionsCollection not rooted on a HTMLSelectElement")
-            .SelectedIndex()
+            .SelectedIndex(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-htmloptionscollection-selectedindex>

--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -9,6 +9,7 @@ use crate::dom::activation::Activatable;
 use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::iterators::ShadowIncluding;
 use script_bindings::cell::{DomRefCell, Ref};
+use script_bindings::dom::UnrootedDom;
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
 use crate::dom::bindings::codegen::Bindings::ElementBinding::ElementMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLCollectionBinding::HTMLCollectionMethods;
@@ -52,7 +53,7 @@ use dom_struct::dom_struct;
 use embedder_traits::{EmbedderControlRequest, SelectElementRequest};
 use embedder_traits::{SelectElementOption, SelectElementOptionOrOptgroup};
 use html5ever::{local_name, ns, LocalName, Prefix, QualName};
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::rust::HandleObject;
 use style::attr::AttrValue;
 use stylo_dom::ElementState;
@@ -105,16 +106,21 @@ impl CollectionFilter for OptionsFilter {
 /// avoiding a full subtree traversal.
 #[derive(JSTraceable, MallocSizeOf)]
 struct SelectedOptionsSource;
+
 impl CollectionSource for SelectedOptionsSource {
-    fn iter<'a>(&'a self, root: &'a Node) -> Box<dyn Iterator<Item = DomRoot<Element>> + 'a> {
+    fn iter<'b>(
+        &'b self,
+        no_gc: &'b NoGC,
+        root: &'b Node,
+    ) -> Box<dyn Iterator<Item = UnrootedDom<'b, Element>> + 'b> {
         let select = root
             .downcast::<HTMLSelectElement>()
             .expect("SelectedOptionsSource must be rooted on an HTMLSelectElement");
         Box::new(
             select
-                .list_of_options()
+                .list_of_options(no_gc)
                 .filter(|option| option.Selected())
-                .map(DomRoot::upcast::<Element>),
+                .map(UnrootedDom::upcast::<Element>),
         )
     }
 }
@@ -180,44 +186,53 @@ impl HTMLSelectElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-select-option-list>
-    pub(crate) fn list_of_options(
+    pub(crate) fn list_of_options<'b>(
         &self,
-    ) -> impl Iterator<Item = DomRoot<HTMLOptionElement>> + use<'_> {
-        self.upcast::<Node>().children().flat_map(|node| {
-            if node.is::<HTMLOptionElement>() {
-                let node = DomRoot::downcast::<HTMLOptionElement>(node).unwrap();
-                Choice3::First(iter::once(node))
-            } else if node.is::<HTMLOptGroupElement>() {
-                Choice3::Second(node.children().filter_map(DomRoot::downcast))
-            } else {
-                Choice3::Third(iter::empty())
-            }
-        })
+        no_gc: &'b NoGC,
+    ) -> impl Iterator<Item = UnrootedDom<'b, HTMLOptionElement>> + use<'b> {
+        self.upcast::<Node>()
+            .children_unrooted(no_gc)
+            .flat_map(|node| {
+                if node.is::<HTMLOptionElement>() {
+                    let node = UnrootedDom::downcast::<HTMLOptionElement>(node).unwrap();
+                    Choice3::First(iter::once(node))
+                } else if node.is::<HTMLOptGroupElement>() {
+                    Choice3::Second(
+                        node.children_unrooted(no_gc)
+                            .filter_map(UnrootedDom::downcast),
+                    )
+                } else {
+                    Choice3::Third(iter::empty())
+                }
+            })
     }
 
     /// <https://html.spec.whatwg.org/multipage/#placeholder-label-option>
-    fn get_placeholder_label_option(&self) -> Option<DomRoot<HTMLOptionElement>> {
+    fn get_placeholder_label_option(&self, no_gc: &NoGC) -> Option<DomRoot<HTMLOptionElement>> {
         if self.Required() && !self.Multiple() && self.display_size() == 1 {
-            self.list_of_options().next().filter(|node| {
-                let parent = node.upcast::<Node>().GetParentNode();
-                node.Value().is_empty() && parent.as_deref() == Some(self.upcast())
-            })
+            self.list_of_options(no_gc)
+                .next()
+                .filter(|node| {
+                    let parent = node.upcast::<Node>().GetParentNode();
+                    node.Value().is_empty() && parent.as_deref() == Some(self.upcast())
+                })
+                .map(|node| node.as_rooted())
         } else {
             None
         }
     }
 
     // https://html.spec.whatwg.org/multipage/#the-select-element:concept-form-reset-control
-    pub(crate) fn reset(&self) {
-        for opt in self.list_of_options() {
+    pub(crate) fn reset(&self, no_gc: &NoGC) {
+        for opt in self.list_of_options(no_gc) {
             opt.set_selectedness(opt.DefaultSelected());
             opt.set_dirtiness(false);
         }
-        self.ask_for_reset();
+        self.ask_for_reset(no_gc);
     }
 
     // https://html.spec.whatwg.org/multipage/#ask-for-a-reset
-    pub(crate) fn ask_for_reset(&self) {
+    pub(crate) fn ask_for_reset(&self, no_gc: &NoGC) {
         if self.Multiple() {
             return;
         }
@@ -225,7 +240,7 @@ impl HTMLSelectElement {
         let mut first_enabled: Option<DomRoot<HTMLOptionElement>> = None;
         let mut last_selected: Option<DomRoot<HTMLOptionElement>> = None;
 
-        for opt in self.list_of_options() {
+        for opt in self.list_of_options(no_gc) {
             if opt.Selected() {
                 opt.set_selectedness(false);
                 last_selected = Some(DomRoot::from_ref(&opt));
@@ -245,11 +260,11 @@ impl HTMLSelectElement {
         }
     }
 
-    pub(crate) fn push_form_data(&self, data_set: &mut Vec<FormDatum>) {
+    pub(crate) fn push_form_data(&self, no_gc: &NoGC, data_set: &mut Vec<FormDatum>) {
         if self.Name().is_empty() {
             return;
         }
-        for opt in self.list_of_options() {
+        for opt in self.list_of_options(no_gc) {
             let element = opt.upcast::<Element>();
             if opt.Selected() && element.enabled_state() {
                 data_set.push(FormDatum {
@@ -262,10 +277,10 @@ impl HTMLSelectElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#concept-select-pick
-    pub(crate) fn pick_option(&self, picked: &HTMLOptionElement) {
+    pub(crate) fn pick_option(&self, no_gc: &NoGC, picked: &HTMLOptionElement) {
         if !self.Multiple() {
             let picked = picked.upcast();
-            for opt in self.list_of_options() {
+            for opt in self.list_of_options(no_gc) {
                 if opt.upcast::<HTMLElement>() != picked {
                     opt.set_selectedness(false);
                 }
@@ -358,13 +373,13 @@ impl HTMLSelectElement {
     pub(crate) fn update_shadow_tree(&self, cx: &mut JSContext) {
         let shadow_tree = self.shadow_tree(cx);
 
-        let selected_options = self.selected_options();
+        let selected_options = self.selected_options(cx.no_gc());
         let selected_options_count = selected_options.len();
 
         let displayed_text = if selected_options_count == 1 {
             let first_selected_option = self
-                .selected_option()
-                .or_else(|| self.list_of_options().next());
+                .selected_option(cx.no_gc())
+                .or_else(|| self.list_of_options(cx.no_gc()).next());
 
             let first_selected_option_text = first_selected_option
                 .map(|option| option.displayed_label())
@@ -382,19 +397,25 @@ impl HTMLSelectElement {
             .SetData(cx, displayed_text.trim().into());
     }
 
-    pub(crate) fn selected_option(&self) -> Option<DomRoot<HTMLOptionElement>> {
-        self.list_of_options()
+    pub(crate) fn selected_option<'b>(
+        &self,
+        no_gc: &'b NoGC,
+    ) -> Option<UnrootedDom<'b, HTMLOptionElement>> {
+        self.list_of_options(no_gc)
             .find(|opt_elem| opt_elem.Selected())
-            .or_else(|| self.list_of_options().next())
+            .or_else(|| self.list_of_options(no_gc).next())
     }
 
-    pub(crate) fn selected_options(&self) -> Vec<DomRoot<HTMLOptionElement>> {
-        self.list_of_options()
+    pub(crate) fn selected_options<'b>(
+        &self,
+        no_gc: &'b NoGC,
+    ) -> Vec<UnrootedDom<'b, HTMLOptionElement>> {
+        self.list_of_options(no_gc)
             .filter(|opt_elem| opt_elem.Selected())
             .collect()
     }
 
-    pub(crate) fn show_menu(&self) {
+    pub(crate) fn show_menu(&self, no_gc: &NoGC) {
         // Collect list of optgroups and options
         let mut index = 0;
         let mut embedder_option_from_option = |option: &HTMLOptionElement| {
@@ -431,7 +452,7 @@ impl HTMLSelectElement {
             .collect();
 
         let selected_options = self
-            .list_of_options()
+            .list_of_options(no_gc)
             .enumerate()
             .filter(|(_, option)| option.Selected())
             .map(|(index, _)| index)
@@ -461,7 +482,7 @@ impl HTMLSelectElement {
         };
 
         let mut selection_did_change = false;
-        for (index, option) in self.list_of_options().enumerate() {
+        for (index, option) in self.list_of_options(cx.no_gc()).enumerate() {
             let should_be_selected = selected_values.contains(&index);
             let option_selected_did_change = option.Selected() != should_be_selected;
 
@@ -487,7 +508,7 @@ impl HTMLSelectElement {
             let mut first_enabled: Option<DomRoot<HTMLOptionElement>> = None;
             let mut first_selected: Option<DomRoot<HTMLOptionElement>> = None;
 
-            for option in self.list_of_options() {
+            for option in self.list_of_options(cx.no_gc()) {
                 if first_selected.is_none() && option.Selected() {
                     first_selected = Some(DomRoot::from_ref(&option));
                 }
@@ -650,8 +671,8 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-select-length>
-    fn Length(&self) -> u32 {
-        self.Options().Length()
+    fn Length(&self, cx: &JSContext) -> u32 {
+        self.Options().Length(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-select-length>
@@ -660,13 +681,13 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-select-item>
-    fn Item(&self, index: u32) -> Option<DomRoot<Element>> {
-        self.Options().upcast().Item(index)
+    fn Item(&self, cx: &JSContext, index: u32) -> Option<DomRoot<Element>> {
+        self.Options().upcast().Item(cx, index)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-select-item>
-    fn IndexedGetter(&self, index: u32) -> Option<DomRoot<Element>> {
-        self.Options().IndexedGetter(index)
+    fn IndexedGetter(&self, cx: &JSContext, index: u32) -> Option<DomRoot<Element>> {
+        self.Options().IndexedGetter(cx, index)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-select-setter>
@@ -680,9 +701,9 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-select-nameditem>
-    fn NamedItem(&self, name: DOMString) -> Option<DomRoot<HTMLOptionElement>> {
+    fn NamedItem(&self, cx: &JSContext, name: DOMString) -> Option<DomRoot<HTMLOptionElement>> {
         self.Options()
-            .NamedGetter(name)
+            .NamedGetter(cx, name)
             .and_then(DomRoot::downcast::<HTMLOptionElement>)
     }
 
@@ -697,8 +718,8 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-select-value>
-    fn Value(&self) -> DOMString {
-        self.list_of_options()
+    fn Value(&self, cx: &JSContext) -> DOMString {
+        self.list_of_options(cx.no_gc())
             .find(|opt_elem| opt_elem.Selected())
             .map(|opt_elem| opt_elem.Value())
             .unwrap_or_default()
@@ -706,7 +727,7 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-select-value>
     fn SetValue(&self, cx: &mut JSContext, value: DOMString) {
-        let mut opt_iter = self.list_of_options();
+        let mut opt_iter = self.list_of_options(cx.no_gc());
         // Reset until we find an <option> with a matching value
         for opt in opt_iter.by_ref() {
             if opt.Value() == value {
@@ -726,8 +747,8 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-select-selectedindex>
-    fn SelectedIndex(&self) -> i32 {
-        self.list_of_options()
+    fn SelectedIndex(&self, cx: &JSContext) -> i32 {
+        self.list_of_options(cx.no_gc())
             .enumerate()
             .filter(|(_, opt_elem)| opt_elem.Selected())
             .map(|(i, _)| i as i32)
@@ -739,20 +760,22 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
     fn SetSelectedIndex(&self, cx: &mut JSContext, index: i32) {
         let mut selection_did_change = false;
 
-        let mut opt_iter = self.list_of_options();
-        for opt in opt_iter.by_ref().take(index as usize) {
-            selection_did_change |= opt.Selected();
-            opt.set_selectedness(false);
-        }
-        if let Some(selected_option) = opt_iter.next() {
-            selection_did_change |= !selected_option.Selected();
-            selected_option.set_selectedness(true);
-            selected_option.set_dirtiness(true);
-
-            // Reset remaining <option> elements
-            for opt in opt_iter {
+        {
+            let mut opt_iter = self.list_of_options(cx.no_gc());
+            for opt in opt_iter.by_ref().take(index as usize) {
                 selection_did_change |= opt.Selected();
                 opt.set_selectedness(false);
+            }
+            if let Some(selected_option) = opt_iter.next() {
+                selection_did_change |= !selected_option.Selected();
+                selected_option.set_selectedness(true);
+                selected_option.set_dirtiness(true);
+
+                // Reset remaining <option> elements
+                for opt in opt_iter {
+                    selection_did_change |= opt.Selected();
+                    opt.set_selectedness(false);
+                }
             }
         }
 
@@ -934,7 +957,7 @@ impl Validatable for HTMLSelectElement {
 
     fn perform_validation(
         &self,
-        _cx: &mut JSContext,
+        cx: &mut JSContext,
         validate_flags: ValidationFlags,
     ) -> ValidationFlags {
         let mut failed_flags = ValidationFlags::empty();
@@ -942,10 +965,14 @@ impl Validatable for HTMLSelectElement {
         // https://html.spec.whatwg.org/multipage/#suffering-from-being-missing
         // https://html.spec.whatwg.org/multipage/#the-select-element%3Asuffering-from-being-missing
         if validate_flags.contains(ValidationFlags::VALUE_MISSING) && self.Required() {
-            let placeholder = self.get_placeholder_label_option();
-            let is_value_missing = !self
-                .list_of_options()
-                .any(|e| e.Selected() && placeholder != Some(e));
+            let placeholder = self.get_placeholder_label_option(cx.no_gc());
+            let is_value_missing = !self.list_of_options(cx.no_gc()).any(|e| {
+                e.Selected() &&
+                    placeholder
+                        .as_ref()
+                        .map(|placeholder| **placeholder != **e)
+                        .unwrap_or(true)
+            });
             failed_flags.set(ValidationFlags::VALUE_MISSING, is_value_missing);
         }
 
@@ -964,7 +991,7 @@ impl Activatable for HTMLSelectElement {
 
     fn activation_behavior(
         &self,
-        _cx: &mut js::context::JSContext,
+        cx: &mut js::context::JSContext,
         event: &Event,
         _target: &EventTarget,
     ) {
@@ -972,7 +999,7 @@ impl Activatable for HTMLSelectElement {
             return;
         }
 
-        self.show_menu();
+        self.show_menu(cx.no_gc());
     }
 }
 

--- a/components/script/dom/html/htmltableelement.rs
+++ b/components/script/dom/html/htmltableelement.rs
@@ -347,7 +347,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
     /// <https://html.spec.whatwg.org/multipage/#dom-table-insertrow>
     fn InsertRow(&self, cx: &mut JSContext, index: i32) -> Fallible<DomRoot<HTMLTableRowElement>> {
         let rows = self.Rows(cx);
-        let number_of_row_elements = rows.Length();
+        let number_of_row_elements = rows.Length(cx);
 
         if index < -1 || index > number_of_row_elements as i32 {
             return Err(Error::IndexSize(None));
@@ -391,7 +391,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
         } else if index == number_of_row_elements as i32 || index == -1 {
             // append new row to parent of last row in table
             let last_row = rows
-                .Item(number_of_row_elements - 1)
+                .Item(cx, number_of_row_elements - 1)
                 .expect("InsertRow failed to find last row in table.");
 
             let last_row_parent = last_row
@@ -406,7 +406,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
         } else {
             // insert new row before the index-th row in rows using the same parent
             let ith_row = rows
-                .Item(index as u32)
+                .Item(cx, index as u32)
                 .expect("InsertRow failed to find a row in table.");
 
             let ith_row_parent = ith_row
@@ -426,7 +426,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
     /// <https://html.spec.whatwg.org/multipage/#dom-table-deleterow>
     fn DeleteRow(&self, cx: &mut JSContext, mut index: i32) -> Fallible<()> {
         let rows = self.Rows(cx);
-        let num_rows = rows.Length() as i32;
+        let num_rows = rows.Length(cx) as i32;
 
         // Step 1: If index is less than −1 or greater than or equal to the number of elements
         // in the rows collection, then throw an "IndexSizeError".
@@ -434,7 +434,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
             return Err(Error::IndexSize(None));
         }
 
-        let num_rows = rows.Length() as i32;
+        let num_rows = rows.Length(cx) as i32;
 
         // Step 2: If index is −1, then remove the last element in the rows collection from its
         // parent, or do nothing if the rows collection is empty.
@@ -447,7 +447,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
         }
 
         // Step 3: Otherwise, remove the indexth element in the rows collection from its parent.
-        DomRoot::upcast::<Node>(rows.Item(index as u32).unwrap()).remove_self(cx);
+        DomRoot::upcast::<Node>(rows.Item(cx, index as u32).unwrap()).remove_self(cx);
 
         Ok(())
     }

--- a/components/script/dom/html/htmltablerowelement.rs
+++ b/components/script/dom/html/htmltablerowelement.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, QualName, local_name, ns};
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::rust::HandleObject;
 use style::attr::{AttrValue, LengthOrPercentageOrAuto};
 use style::color::AbsoluteColor;
@@ -68,9 +68,9 @@ impl HTMLTableRowElement {
 
     /// Determine the index for this `HTMLTableRowElement` within the given
     /// `HTMLCollection`. Returns `-1` if not found within collection.
-    fn row_index(&self, collection: DomRoot<HTMLCollection>) -> i32 {
+    fn row_index(&self, no_gc: &NoGC, collection: DomRoot<HTMLCollection>) -> i32 {
         collection
-            .elements_iter()
+            .elements_iter(no_gc)
             .position(|elem| (&elem as &Element) == self.upcast())
             .map_or(-1, |i| i as i32)
     }
@@ -138,7 +138,8 @@ impl HTMLTableRowElementMethods<crate::DomTypeHolder> for HTMLTableRowElement {
             None => return -1,
         };
         if let Some(table) = parent.downcast::<HTMLTableElement>() {
-            return self.row_index(table.Rows(cx));
+            let rows = table.Rows(cx);
+            return self.row_index(cx.no_gc(), rows);
         }
         if !parent.is::<HTMLTableSectionElement>() {
             return -1;
@@ -149,7 +150,10 @@ impl HTMLTableRowElementMethods<crate::DomTypeHolder> for HTMLTableRowElement {
         };
         grandparent
             .downcast::<HTMLTableElement>()
-            .map_or(-1, |table| self.row_index(table.Rows(cx)))
+            .map_or(-1, |table| {
+                let rows = table.Rows(cx);
+                self.row_index(cx.no_gc(), rows)
+            })
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-tr-sectionrowindex>
@@ -165,7 +169,7 @@ impl HTMLTableRowElementMethods<crate::DomTypeHolder> for HTMLTableRowElement {
         } else {
             return -1;
         };
-        self.row_index(collection)
+        self.row_index(cx.no_gc(), collection)
     }
 }
 

--- a/components/script/dom/node/iterators.rs
+++ b/components/script/dom/node/iterators.rs
@@ -89,6 +89,79 @@ impl Iterator for FollowingNodeIterator {
     }
 }
 
+pub(crate) struct UnrootedFollowingNodeIterator<'a, 'b> {
+    current: Option<UnrootedDom<'b, Node>>,
+    root: UnrootedDom<'b, Node>,
+    shadow_including: ShadowIncluding,
+    no_gc: &'b NoGC,
+    phantom: PhantomData<&'a Node>,
+}
+
+impl<'a, 'b> UnrootedFollowingNodeIterator<'a, 'b> {
+    pub(crate) fn new(
+        current: Option<UnrootedDom<'b, Node>>,
+        root: UnrootedDom<'b, Node>,
+        shadow_including: ShadowIncluding,
+        no_gc: &'b NoGC,
+    ) -> Self
+    where
+        'b: 'a,
+    {
+        UnrootedFollowingNodeIterator {
+            current,
+            root,
+            shadow_including,
+            no_gc,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, 'b> UnrootedFollowingNodeIterator<'a, 'b> {
+    fn next_skipping_children_impl(
+        &mut self,
+        current: UnrootedDom<'b, Node>,
+    ) -> Option<UnrootedDom<'b, Node>> {
+        if self.root == current {
+            self.current = None;
+            return None;
+        }
+
+        if let Some(next_sibling) = current.get_next_sibling_unrooted(self.no_gc) {
+            self.current = Some(next_sibling);
+            return current.get_next_sibling_unrooted(self.no_gc);
+        }
+
+        for ancestor in current.inclusive_ancestors(self.shadow_including) {
+            if **self.root == *ancestor {
+                break;
+            }
+            if let Some(next_sibling) = ancestor.get_next_sibling_unrooted(self.no_gc) {
+                self.current = Some(next_sibling);
+                return ancestor.get_next_sibling_unrooted(self.no_gc);
+            }
+        }
+        self.current = None;
+        None
+    }
+}
+
+impl<'a, 'b> Iterator for UnrootedFollowingNodeIterator<'a, 'b> {
+    type Item = UnrootedDom<'b, Node>;
+
+    /// <https://dom.spec.whatwg.org/#concept-tree-following>
+    fn next(&mut self) -> Option<UnrootedDom<'b, Node>> {
+        let current = self.current.take()?;
+
+        if let Some(first_child) = current.get_first_child_unrooted(self.no_gc) {
+            self.current = Some(first_child);
+            return current.get_first_child_unrooted(self.no_gc);
+        }
+
+        self.next_skipping_children_impl(current)
+    }
+}
+
 pub(crate) struct PrecedingNodeIterator {
     current: Option<DomRoot<Node>>,
     root: DomRoot<Node>,
@@ -121,6 +194,59 @@ impl Iterator for PrecedingNodeIterator {
             current.GetParentNode()
         };
         self.current.clone()
+    }
+}
+
+pub(crate) struct UnrootedPrecedingNodeIterator<'a, 'b> {
+    current: Option<UnrootedDom<'a, Node>>,
+    no_gc: &'b NoGC,
+    root: UnrootedDom<'a, Node>,
+}
+
+impl<'a, 'b> UnrootedPrecedingNodeIterator<'a, 'b> {
+    pub(crate) fn new(
+        current: Option<UnrootedDom<'a, Node>>,
+        root: UnrootedDom<'a, Node>,
+        no_gc: &'b NoGC,
+    ) -> Self {
+        UnrootedPrecedingNodeIterator {
+            current,
+            no_gc,
+            root,
+        }
+    }
+}
+
+impl<'a, 'b> Iterator for UnrootedPrecedingNodeIterator<'a, 'b>
+where
+    'b: 'a,
+{
+    type Item = UnrootedDom<'b, Node>;
+
+    /// <https://dom.spec.whatwg.org/#concept-tree-preceding>
+    fn next(&mut self) -> Option<UnrootedDom<'b, Node>> {
+        let current = self.current.take()?;
+
+        self.current = if self.root == current {
+            None
+        } else if let Some(previous_sibling) = current.get_previous_sibling_unrooted(self.no_gc) {
+            if self.root == previous_sibling {
+                None
+            } else if let Some(last_child) = previous_sibling
+                .descending_last_children_unrooted(self.no_gc)
+                .last()
+            {
+                Some(last_child)
+            } else {
+                Some(previous_sibling)
+            }
+        } else {
+            current.get_parent_node_unrooted(self.no_gc)
+        };
+
+        self.current
+            .as_ref()
+            .map(|node| UnrootedDom::from_dom((*node).clone(), self.no_gc))
     }
 }
 

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -101,7 +101,9 @@ use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::html::htmllinkelement::HTMLLinkElement;
 use crate::dom::html::htmlslotelement::{HTMLSlotElement, Slottable};
 use crate::dom::html::htmlstyleelement::HTMLStyleElement;
-use crate::dom::iterators::ShadowIncluding;
+use crate::dom::iterators::{
+    ShadowIncluding, UnrootedFollowingNodeIterator, UnrootedPrecedingNodeIterator,
+};
 use crate::dom::mutationobserver::{Mutation, MutationObserver, RegisteredObserver};
 use crate::dom::node::iterators::{
     FollowingNodeIterator, PrecedingNodeIterator, SimpleNodeIterator, TreeIterator,
@@ -1048,14 +1050,57 @@ impl Node {
         )
     }
 
+    pub(crate) fn following_nodes_unrooted<'a, 'b>(
+        &'a self,
+        no_gc: &'b NoGC,
+        root: &Node,
+        shadow_including: ShadowIncluding,
+    ) -> UnrootedFollowingNodeIterator<'a, 'b>
+    where
+        'b: 'a,
+    {
+        UnrootedFollowingNodeIterator::new(
+            Some(UnrootedDom::from_dom(Dom::from_ref(self), no_gc)),
+            UnrootedDom::from_dom(Dom::from_ref(root), no_gc),
+            shadow_including,
+            no_gc,
+        )
+    }
+
     pub(crate) fn preceding_nodes(&self, root: &Node) -> PrecedingNodeIterator {
         PrecedingNodeIterator::new(Some(DomRoot::from_ref(self)), DomRoot::from_ref(root))
+    }
+
+    pub(crate) fn preceding_nodes_unrooted<'a, 'b>(
+        &self,
+        no_gc: &'b NoGC,
+        root: &'a Node,
+    ) -> UnrootedPrecedingNodeIterator<'a, 'b>
+    where
+        'b: 'a,
+    {
+        UnrootedPrecedingNodeIterator::new(
+            Some(UnrootedDom::from_dom(Dom::from_ref(self), no_gc)),
+            UnrootedDom::from_dom(Dom::from_ref(root), no_gc),
+            no_gc,
+        )
     }
 
     /// Return an iterator that moves from `self` down the tree, choosing the last child
     /// at each step of the way.
     pub(crate) fn descending_last_children(&self) -> impl Iterator<Item = DomRoot<Node>> + use<> {
         SimpleNodeIterator::new(self.GetLastChild(), |n| n.GetLastChild())
+    }
+
+    pub(crate) fn descending_last_children_unrooted<'b>(
+        &self,
+        no_gc: &'b NoGC,
+    ) -> impl Iterator<Item = UnrootedDom<'b, Node>> {
+        UnrootedSimpleNodeIterator::new(
+            self.get_last_child_unrooted(no_gc),
+            |n, no_gc| n.get_last_child_unrooted(no_gc),
+            no_gc,
+        )
     }
 
     pub(crate) fn is_parent_of(&self, child: &Node) -> bool {
@@ -1866,8 +1911,8 @@ impl Node {
             } else {
                 let items = get_items(cx);
                 let node = match items
-                    .elements_iter()
-                    .map(DomRoot::upcast::<Node>)
+                    .elements_iter(cx.no_gc())
+                    .map(UnrootedDom::upcast::<Node>)
                     .map(Some)
                     .chain(iter::once(None))
                     .nth(index as usize)
@@ -1875,7 +1920,7 @@ impl Node {
                     None => return Err(Error::IndexSize(None)),
                     Some(node) => node,
                 };
-                self.InsertBefore(cx, tr_node, node.as_deref())?;
+                self.InsertBefore(cx, tr_node, node.map(|node| node.as_rooted()).as_deref())?;
             }
         }
 
@@ -1908,7 +1953,7 @@ impl Node {
                     None => return Ok(()),
                 }
             },
-            index => match get_items(cx).Item(index as u32) {
+            index => match get_items(cx).Item(cx, index as u32) {
                 Some(element) => element,
                 None => return Err(Error::IndexSize(None)),
             },
@@ -3241,6 +3286,10 @@ impl Node {
         no_gc: &'a NoGC,
     ) -> Option<UnrootedDom<'a, Node>> {
         self.first_child.get_unrooted(no_gc)
+    }
+
+    fn get_last_child_unrooted<'b>(&self, no_gc: &'b NoGC) -> Option<UnrootedDom<'b, Node>> {
+        self.last_child.get_unrooted(no_gc)
     }
 
     pub(crate) fn get_parent_node_unrooted<'a>(

--- a/components/script/dom/radionodelist.rs
+++ b/components/script/dom/radionodelist.rs
@@ -80,7 +80,7 @@ impl RadioNodeList {
 impl RadioNodeListMethods<crate::DomTypeHolder> for RadioNodeList {
     // https://dom.spec.whatwg.org/#dom-nodelist-length
     /// <https://github.com/servo/servo/issues/5875>
-    fn Length(&self) -> u32 {
+    fn Length(&self, _cx: &JSContext) -> u32 {
         self.node_list.Length()
     }
 

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -842,7 +842,7 @@ pub(crate) fn handle_find_elements_tag_name(
         Ok(document) => reply
             .send(Ok(document
                 .GetElementsByTagName(cx, DOMString::from(selector))
-                .elements_iter()
+                .elements_iter(cx.no_gc())
                 .map(|x| x.upcast::<Node>().unique_id(pipeline))
                 .collect::<Vec<String>>()))
             .unwrap(),
@@ -988,7 +988,7 @@ pub(crate) fn handle_find_element_elements_tag_name(
             get_known_element(documents, pipeline, element_id).map(|element| {
                 element
                     .GetElementsByTagName(cx, DOMString::from(selector))
-                    .elements_iter()
+                    .elements_iter(cx.no_gc())
                     .map(|x| x.upcast::<Node>().unique_id(pipeline))
                     .collect::<Vec<String>>()
             }),

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -672,6 +672,10 @@ DOMInterfaces = {
     'implicitCxSetters': True,
 },
 
+'HTMLCollection': {
+    'cx_no_gc': ['Length', 'Item', 'IndexedGetter', 'NamedGetter', 'NamedItem'],
+},
+
 'HTMLCanvasElement': {
     'cx': ['CaptureStream', 'GetContext', 'TransferControlToOffscreen'],
     'implicitCxSetters': True,
@@ -718,6 +722,7 @@ DOMInterfaces = {
 
 'HTMLFormControlsCollection': {
     'cx': ['NamedGetter', 'NamedItem'],
+    'cx_no_gc': ['IndexedGetter', 'Length'],
 },
 
 'HTMLFormElement': {
@@ -774,10 +779,12 @@ DOMInterfaces = {
 
 'HTMLOptionElement': {
     'cx': ['Option', 'SetSelected', 'SetText'],
+    'cx_no_gc': ['Index'],
 },
 
 'HTMLOptionsCollection': {
-    'cx': ['Add', 'IndexedSetter', 'Remove', 'SetLength', 'SetSelectedIndex']
+    'cx': ['Add', 'IndexedSetter', 'Remove', 'SetLength', 'SetSelectedIndex'],
+    'cx_no_gc': ['Length', 'NamedGetter', 'IndexedGetter', 'SelectedIndex'],
 },
 
 'HTMLOutputElement': {
@@ -798,6 +805,7 @@ DOMInterfaces = {
 
 'HTMLSelectElement': {
     'cx': ['Add', 'CheckValidity', 'IndexedSetter', 'Remove', 'Remove_', 'ReportValidity', 'SelectedOptions',  'SetCustomValidity', 'SetLength', 'SetSelectedIndex', 'SetValue','Validity', 'ValidationMessage'],
+    'cx_no_gc': ['Length', 'Item', 'NamedItem', 'IndexedGetter', 'SelectedIndex', 'Value'],
 },
 
 'HTMLSlotElement': {
@@ -1081,6 +1089,7 @@ DOMInterfaces = {
 
 'RadioNodeList': {
     'cx': ['SetValue'],
+    'cx_no_gc': ['Length'],
 },
 
 'Range': {

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -6534,7 +6534,7 @@ class CGDOMJSProxyHandler_ownPropertyKeys(CGAbstractExternMethod):
         else:
             cross_origin = "None"
         if self.descriptor.operations['IndexedGetter']:
-            if "Length" in self.descriptor.cxMethods:
+            if "Length" in self.descriptor.cxMethods or "Length" in self.descriptor.cx_no_gcMethods:
                 length = f"Some(|unwrapped_proxy: &{self.descriptor.concreteType}, cx| unwrapped_proxy.Length(cx))"
             else:
                 length = f"Some(|unwrapped_proxy: &{self.descriptor.concreteType}, _cx| unwrapped_proxy.Length())"
@@ -6578,7 +6578,7 @@ class CGDOMJSProxyHandler_getOwnEnumerablePropertyKeys(CGAbstractExternMethod):
 
     def definition_body(self) -> CGThing:
         if self.descriptor.operations['IndexedGetter']:
-            if "Length" in self.descriptor.cxMethods:
+            if "Length" in self.descriptor.cxMethods or "Length" in self.descriptor.cx_no_gcMethods:
                 length = f"Some(Box::new(|unwrapped_proxy: &{self.descriptor.concreteType}, cx| unwrapped_proxy.Length(cx)))"
             else:
                 length = f"Some(Box::new(|unwrapped_proxy: &{self.descriptor.concreteType}, _cx| unwrapped_proxy.Length()))"
@@ -7165,7 +7165,7 @@ class CGInterfaceTrait(CGThing):
             methods.extend(list(ctorMethod(ctor)))
 
         if descriptor.operations['IndexedGetter'] and not hasLength:
-            methods.append(CGGeneric("fn Length(&self) -> u32;\n"))
+            methods.append(CGGeneric("fn Length(&self, cx:&JSContext) -> u32;\n"))
 
         name = descriptor.interface.identifier.name
         self.cgRoot = CGWrapper(CGIndenter(CGList(methods, "")),

--- a/components/script_bindings/dom.rs
+++ b/components/script_bindings/dom.rs
@@ -143,9 +143,15 @@ impl<'a, T: Castable> UnrootedDom<'a, T> {
     }
 }
 
-impl<'a, T: DomObject> PartialEq<&T> for UnrootedDom<'a, T> {
-    fn eq(&self, other: &&T) -> bool {
-        self.inner == Dom::from_ref(*other)
+impl<'a, T: DomObject> PartialEq<T> for UnrootedDom<'a, T> {
+    fn eq(&self, other: &T) -> bool {
+        self.inner == other
+    }
+}
+
+impl<'a, T: DomObject> PartialEq<UnrootedDom<'a, T>> for UnrootedDom<'a, T> {
+    fn eq(&self, other: &UnrootedDom<'a, T>) -> bool {
+        self.inner == other.inner
     }
 }
 


### PR DESCRIPTION
This implements two new UnrootedIterators (PreceedingNodeIterator and FollowingNodeIterator) with the same schema as the other UnrootedIterators.
This also implements using these iterators for HTMLCollections (and their subtypes) and CollectionSource trait as well as a couple of downstream.

Special care should be given to check:
- The correctness of the new iterators from the point of iterating.
- The enum CollectioonKind not having the 'static lifetime anymore.
- HTMLFormControlsCollection::NamedItem (which had to be rewritten to make the lifetimes work).
- Bugfix in codegen.py to also check the cx._no_gcMethods for Length(cx).
- Implementation of PartialEq for UnrootedDom and UnrootedDom<T>==T

Most other changes are mechanical &JSContext adding or NoGC propagating.

Overall this seems to eliminate rooting overhead on amazon.com down from 1.8% runtime in a small unscientific test.

Testing: WPT tests should find any screwups.
