### PR TITLE
deps: Update mozjs_sys to v140.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5123,9 +5123,9 @@ dependencies = [
 
 [[package]]
 name = "mozjs"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5449c338a7e61f11841f727d944b9c49b00d4b27ceb48e1de5f90a459b1f2a8b"
+checksum = "dd8bd40dc947a6bfe93eb45ef1dc784f48cd3008fb466f63940e7d9a160bba69"
 dependencies = [
  "bindgen",
  "cc",
@@ -5138,9 +5138,9 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "140.11.0-0"
+version = "140.11.0-1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4943ebd6f18667064a7d1f1d4c41b9ded3151b562d1df12d37feb6b0ef37517"
+checksum = "5c1f9f0e5d9957edaf0f833a97edd41680c9231026dcf3fc617847e1571f377c"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5123,9 +5123,9 @@ dependencies = [
 
 [[package]]
 name = "mozjs"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cd64afbbf78b296765b823bdebc9e70024604881a0b1d9e41eb873fab95bbd"
+checksum = "5449c338a7e61f11841f727d944b9c49b00d4b27ceb48e1de5f90a459b1f2a8b"
 dependencies = [
  "bindgen",
  "cc",
@@ -5138,9 +5138,9 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "140.10.1-0"
+version = "140.11.0-0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf708f34816a335a5c019451a3776196d2c66eb7d4d950c04d4b781821e8feff"
+checksum = "e4943ebd6f18667064a7d1f1d4c41b9ded3151b562d1df12d37feb6b0ef37517"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,7 @@ inventory = "0.3.24"
 ipc-channel = "0.22"
 itertools = "0.14"
 jni = "0.22"
-js = { package = "mozjs", version = "=0.16.1", default-features = false, features = ["intl", "libz-sys"] }
+js = { package = "mozjs", version = "=0.16.2", default-features = false, features = ["intl", "libz-sys"] }
 keyboard-types = { version = "0.8.3", features = ["serde", "webdriver"] }
 kurbo = { version = "0.13.1", features = ["euclid"] }
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,7 @@ inventory = "0.3.24"
 ipc-channel = "0.22"
 itertools = "0.14"
 jni = "0.22"
-js = { package = "mozjs", version = "=0.16.0", default-features = false, features = ["intl", "libz-sys"] }
+js = { package = "mozjs", version = "=0.16.1", default-features = false, features = ["intl", "libz-sys"] }
 keyboard-types = { version = "0.8.3", features = ["serde", "webdriver"] }
 kurbo = { version = "0.13.1", features = ["euclid"] }
 libc = "0.2"


### PR DESCRIPTION
Regular mozjs update with latest ESR security fixes. 

Testing: Covered by normal tests.

