### PR TITLE
script: Refactor IDBDatabase to require a list of object store names on initialization

### DIFF
--- a/components/script/dom/indexeddb/idbdatabase.rs
+++ b/components/script/dom/indexeddb/idbdatabase.rs
@@ -55,13 +55,20 @@ pub struct IDBDatabase {
 }
 
 impl IDBDatabase {
-    pub fn new_inherited(name: DOMString, id: Uuid, version: u64) -> IDBDatabase {
+    pub fn new_inherited(
+        name: DOMString,
+        id: Uuid,
+        version: u64,
+        object_store_names: Vec<String>,
+    ) -> IDBDatabase {
         IDBDatabase {
             eventtarget: EventTarget::new_inherited(),
             name,
             id,
             version: Cell::new(version),
-            object_store_names: Default::default(),
+            object_store_names: DomRefCell::new(
+                object_store_names.into_iter().map(Into::into).collect(),
+            ),
             upgrade_transaction: Default::default(),
             close_pending: Cell::new(false),
         }
@@ -72,10 +79,16 @@ impl IDBDatabase {
         name: DOMString,
         id: Uuid,
         version: u64,
+        object_store_names: Vec<String>,
         can_gc: CanGc,
     ) -> DomRoot<IDBDatabase> {
         reflect_dom_object(
-            Box::new(IDBDatabase::new_inherited(name, id, version)),
+            Box::new(IDBDatabase::new_inherited(
+                name,
+                id,
+                version,
+                object_store_names,
+            )),
             global,
             can_gc,
         )
@@ -102,12 +115,6 @@ impl IDBDatabase {
         // Step 4. Set connection’s object store set to the set of object stores in database if database previously existed,
         // or the empty set if database was newly created.
         self.object_store_names.borrow().clone()
-    }
-
-    pub(crate) fn set_object_store_names_from_backend(&self, names: Vec<String>) {
-        // https://w3c.github.io/IndexedDB/#abort-an-upgrade-transaction
-        // Step 4. NOTE: This reverts the value of objectStoreNames returned by the IDBDatabase object.
-        *self.object_store_names.borrow_mut() = names.into_iter().map(Into::into).collect();
     }
 
     pub(crate) fn restore_object_store_names(&self, names: Vec<DOMString>) {

--- a/components/script/dom/indexeddb/idbfactory.rs
+++ b/components/script/dom/indexeddb/idbfactory.rs
@@ -277,17 +277,17 @@ impl IDBFactory {
                 let connection = request.get_or_init_connection(
                     cx,
                     &self.global(),
-                    name.clone(),
+                    name,
                     version,
+                    object_store_names,
                     upgraded,
                 );
-                connection.set_object_store_names_from_backend(object_store_names);
 
                 // Step 2.2: Otherwise,
                 // set request’s result to result,
                 // set request’s done flag,
                 // and fire an event named success at request.
-                request.dispatch_success(cx, name, version, upgraded);
+                request.dispatch_success(cx, connection);
             },
             ConnectionMsg::Upgrade {
                 name,
@@ -306,10 +306,16 @@ impl IDBFactory {
                     );
                 };
 
-                let connection = request.get_or_init_connection(cx, &global, name, version, false);
+                let connection = request.get_or_init_connection(
+                    cx,
+                    &global,
+                    name,
+                    version,
+                    object_store_names,
+                    false,
+                );
                 // https://w3c.github.io/IndexedDB/#upgrade-transaction-steps
                 // Step 3. Set transaction’s scope to connection’s object store set.
-                connection.set_object_store_names_from_backend(object_store_names);
                 request.upgrade_db_version(cx, &connection, old_version, version, transaction);
             },
             ConnectionMsg::VersionError { name, id } => {
@@ -337,8 +343,7 @@ impl IDBFactory {
                         "There should be a request to handle ConnectionMsg::VersionChange."
                     );
                 };
-                let connection =
-                    request.get_or_init_connection(cx, &global, name.clone(), version, false);
+                let connection = request.get_connection();
 
                 // Step 10.2: fire a version change event named versionchange at entry with db’s version and version.
                 connection.dispatch_versionchange(cx, old_version, Some(version));

--- a/components/script/dom/indexeddb/idbfactory.rs
+++ b/components/script/dom/indexeddb/idbfactory.rs
@@ -343,7 +343,7 @@ impl IDBFactory {
                         "There should be a request to handle ConnectionMsg::VersionChange."
                     );
                 };
-                let connection = request.get_connection();
+                let connection = request.connection();
 
                 // Step 10.2: fire a version change event named versionchange at entry with db’s version and version.
                 connection.dispatch_versionchange(cx, old_version, Some(version));

--- a/components/script/dom/indexeddb/idbopendbrequest.rs
+++ b/components/script/dom/indexeddb/idbopendbrequest.rs
@@ -128,12 +128,19 @@ impl IDBOpenDBRequest {
         self.id
     }
 
+    pub(crate) fn get_connection(&self) -> DomRoot<IDBDatabase> {
+        self.pending_connection
+            .take()
+            .expect("A connection should exist for the db.")
+    }
+
     pub(crate) fn get_or_init_connection(
         &self,
         cx: &mut JSContext,
         global: &GlobalScope,
         name: String,
         version: u64,
+        object_store_names: Vec<String>,
         upgraded: bool,
     ) -> DomRoot<IDBDatabase> {
         self.pending_connection.or_init(|| {
@@ -143,6 +150,7 @@ impl IDBOpenDBRequest {
                 name.into(),
                 self.get_id(),
                 version,
+                object_store_names,
                 CanGc::from_cx(cx),
             )
         })
@@ -281,9 +289,8 @@ impl IDBOpenDBRequest {
         matches
     }
 
-    pub fn dispatch_success(&self, cx: &mut JSContext, name: String, version: u64, upgraded: bool) {
+    pub fn dispatch_success(&self, cx: &mut JSContext, result: DomRoot<IDBDatabase>) {
         let global = self.global();
-        let result = self.get_or_init_connection(cx, &global, name, version, upgraded);
         self.idbrequest.set_ready_state_done();
 
         let mut realm = enter_auto_realm(cx, &*result);

--- a/components/script/dom/indexeddb/idbopendbrequest.rs
+++ b/components/script/dom/indexeddb/idbopendbrequest.rs
@@ -128,9 +128,9 @@ impl IDBOpenDBRequest {
         self.id
     }
 
-    pub(crate) fn get_connection(&self) -> DomRoot<IDBDatabase> {
+    pub(crate) fn connection(&self) -> DomRoot<IDBDatabase> {
         self.pending_connection
-            .take()
+            .get()
             .expect("A connection should exist for the db.")
     }
 


### PR DESCRIPTION
Previously the IDBDatabase was always initialized without the object store names. Instead, these were set right after initialization.

This PR updates the constructor to require a list of object store names in order to enforce that they are always available. 

Testing: This is just a refactor.
Fixes: #38816
