### PR TITLE
script: JSContextify Promise.reject_error in RTCPeerConnection and HTMLImageElement

### DIFF
--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -83,7 +83,6 @@ use crate::fetch::{RequestWithGlobalScope, create_a_potential_cors_request};
 use crate::microtask::{Microtask, MicrotaskRunnable};
 use crate::network_listener::{self, FetchResponseListener, ResourceTimingListener};
 use crate::realms::enter_auto_realm;
-use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 
 /// Supported image MIME types as defined by
@@ -1341,20 +1340,20 @@ impl HTMLImageElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-img-decode>
-    fn react_to_decode_image_sync_steps(&self, promise: Rc<Promise>, can_gc: CanGc) {
+    fn react_to_decode_image_sync_steps(&self, cx: &mut JSContext, promise: Rc<Promise>) {
         // Step 2.2. If any of the following are true: this's node document is not fully active; or
         // this's current request's state is broken, then reject promise with an "EncodingError"
         // DOMException.
         if !self.owner_document().is_fully_active() ||
             matches!(self.current_request.borrow().state, State::Broken)
         {
-            promise.reject_error(Error::Encoding(None), can_gc);
+            promise.reject_error_with_cx(cx, Error::Encoding(None));
         } else if matches!(
             self.current_request.borrow().state,
             State::CompletelyAvailable
         ) {
             // this doesn't follow the spec, but it's been discussed in <https://github.com/whatwg/html/issues/4217>
-            promise.resolve_native(&(), can_gc);
+            promise.resolve_native_with_cx(cx, &());
         } else if matches!(self.current_request.borrow().state, State::Unavailable) &&
             self.current_request.borrow().source_url.is_none()
         {
@@ -1362,7 +1361,7 @@ impl HTMLImageElement {
             // request's state is unavailable and current URL is empty string (<img> without "src"
             // and "srcset" attributes) then reject promise with an "EncodingError" DOMException.
             // <https://github.com/whatwg/html/issues/11769>
-            promise.reject_error(Error::Encoding(None), can_gc);
+            promise.reject_error_with_cx(cx, Error::Encoding(None));
         } else {
             self.image_decode_promises.borrow_mut().push(promise);
         }
@@ -1657,7 +1656,7 @@ impl MicrotaskRunnable for ImageElementMicrotask {
                 ref elem,
                 ref promise,
             } => {
-                elem.react_to_decode_image_sync_steps(promise.clone(), CanGc::from_cx(cx));
+                elem.react_to_decode_image_sync_steps(cx, promise.clone());
             },
         }
     }

--- a/components/script/dom/webrtc/rtcpeerconnection.rs
+++ b/components/script/dom/webrtc/rtcpeerconnection.rs
@@ -52,7 +52,7 @@ use crate::dom::rtcrtptransceiver::RTCRtpTransceiver;
 use crate::dom::rtcsessiondescription::RTCSessionDescription;
 use crate::dom::rtctrackevent::RTCTrackEvent;
 use crate::dom::window::Window;
-use crate::realms::{InRealm, enter_auto_realm};
+use crate::realms::enter_auto_realm;
 use crate::script_runtime::CanGc;
 use crate::task_source::SendableTaskSource;
 
@@ -554,24 +554,23 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
     /// <https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-addicecandidate>
     fn AddIceCandidate(
         &self,
+        current_realm: &mut CurrentRealm,
         candidate: &RTCIceCandidateInit,
-        comp: InRealm,
-        can_gc: CanGc,
     ) -> Rc<Promise> {
-        let p = Promise::new_in_current_realm(comp, can_gc);
+        let p = Promise::new_in_realm(current_realm);
         if candidate.sdpMid.is_none() && candidate.sdpMLineIndex.is_none() {
-            p.reject_error(
+            p.reject_error_with_cx(
+                current_realm,
                 Error::Type(c"one of sdpMid and sdpMLineIndex must be set".to_owned()),
-                can_gc,
             );
             return p;
         }
 
         // XXXManishearth add support for sdpMid
         if candidate.sdpMLineIndex.is_none() {
-            p.reject_error(
+            p.reject_error_with_cx(
+                current_realm,
                 Error::Type(c"servo only supports sdpMLineIndex right now".to_owned()),
-                can_gc,
             );
             return p;
         }
@@ -589,15 +588,19 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
             });
 
         // XXXManishearth add_ice_candidate should have a callback
-        p.resolve_native(&(), can_gc);
+        p.resolve_native_with_cx(current_realm, &());
         p
     }
 
     /// <https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-createoffer>
-    fn CreateOffer(&self, _options: &RTCOfferOptions, comp: InRealm, can_gc: CanGc) -> Rc<Promise> {
-        let p = Promise::new_in_current_realm(comp, can_gc);
+    fn CreateOffer(
+        &self,
+        current_realm: &mut CurrentRealm,
+        _options: &RTCOfferOptions,
+    ) -> Rc<Promise> {
+        let p = Promise::new_in_realm(current_realm);
         if self.closed.get() {
-            p.reject_error(Error::InvalidState(None), can_gc);
+            p.reject_error_with_cx(current_realm, Error::InvalidState(None));
             return p;
         }
         self.offer_promises.borrow_mut().push(p.clone());
@@ -608,13 +611,12 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
     /// <https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-createoffer>
     fn CreateAnswer(
         &self,
+        current_realm: &mut CurrentRealm,
         _options: &RTCAnswerOptions,
-        comp: InRealm,
-        can_gc: CanGc,
     ) -> Rc<Promise> {
-        let p = Promise::new_in_current_realm(comp, can_gc);
+        let p = Promise::new_in_realm(current_realm);
         if self.closed.get() {
-            p.reject_error(Error::InvalidState(None), can_gc);
+            p.reject_error_with_cx(current_realm, Error::InvalidState(None));
             return p;
         }
         self.answer_promises.borrow_mut().push(p.clone());
@@ -635,12 +637,11 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
     /// <https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-setlocaldescription>
     fn SetLocalDescription(
         &self,
+        current_realm: &mut CurrentRealm,
         desc: &RTCSessionDescriptionInit,
-        comp: InRealm,
-        can_gc: CanGc,
     ) -> Rc<Promise> {
         // XXXManishearth validate the current state
-        let p = Promise::new_in_current_realm(comp, can_gc);
+        let p = Promise::new_in_realm(current_realm);
         let this = Trusted::new(self);
         let desc: SessionDescription = desc.convert();
         let trusted_promise = TrustedPromise::new(p.clone());
@@ -656,7 +657,7 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
             .set_local_description(
                 desc.clone(),
                 Box::new(move || {
-                    task_source.queue(task!(local_description_set: move || {
+                    task_source.queue(task!(local_description_set: move |current_realm| {
                         // XXXManishearth spec actually asks for an intricate
                         // dance between pending/current local/remote descriptions
                         let this = this.root();
@@ -668,7 +669,7 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
                             &desc,
                         ).unwrap();
                         this.local_description.set(Some(&desc));
-                        trusted_promise.root().resolve_native(&(), CanGc::deprecated_note())
+                        trusted_promise.root().resolve_native_with_cx(current_realm, &())
                     }));
                 }),
             );
@@ -678,12 +679,11 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
     /// <https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-setremotedescription>
     fn SetRemoteDescription(
         &self,
+        current_realm: &mut CurrentRealm,
         desc: &RTCSessionDescriptionInit,
-        comp: InRealm,
-        can_gc: CanGc,
     ) -> Rc<Promise> {
         // XXXManishearth validate the current state
-        let p = Promise::new_in_current_realm(comp, can_gc);
+        let p = Promise::new_in_realm(current_realm);
         let this = Trusted::new(self);
         let desc: SessionDescription = desc.convert();
         let trusted_promise = TrustedPromise::new(p.clone());
@@ -699,7 +699,7 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
             .set_remote_description(
                 desc.clone(),
                 Box::new(move || {
-                    task_source.queue(task!(remote_description_set: move || {
+                    task_source.queue(task!(remote_description_set: move |current_realm| {
                         // XXXManishearth spec actually asks for an intricate
                         // dance between pending/current local/remote descriptions
                         let this = this.root();
@@ -707,11 +707,11 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
                         let desc = RTCSessionDescription::Constructor(
                             this.global().as_window(),
                             None,
-                            CanGc::deprecated_note(),
+                            CanGc::from_cx(current_realm),
                             &desc,
                         ).unwrap();
                         this.remote_description.set(Some(&desc));
-                        trusted_promise.root().resolve_native(&(), CanGc::deprecated_note())
+                        trusted_promise.root().resolve_native_with_cx(current_realm, &())
                     }));
                 }),
             );

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1100,8 +1100,7 @@ DOMInterfaces = {
 },
 
 'RTCPeerConnection': {
-    'inRealms': ['AddIceCandidate', 'CreateAnswer', 'CreateOffer', 'SetLocalDescription', 'SetRemoteDescription'],
-    'canGc': ['AddIceCandidate', 'CreateAnswer', 'CreateOffer', 'SetLocalDescription', 'SetRemoteDescription'],
+    'realm': ['AddIceCandidate', 'CreateAnswer', 'CreateOffer', 'SetLocalDescription', 'SetRemoteDescription'],
     'cx': ['Close'],
     'weakReferenceable': True,
 },


### PR DESCRIPTION
Part of JSContextifying Promsie.reject_error.
Implements the method for RTCPeerConnection and HTMLImageElement.


Testing: Compilation is the test.
Fixes: Part of https://github.com/servo/servo/issues/45453
