### PR TITLE
layout: Allow tuning Servo parallelism for both wide and deep trees

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -301,6 +301,29 @@ pub struct Preferences {
     pub layout_css_attr_enabled: bool,
     pub layout_style_sharing_cache_enabled: bool,
     pub layout_threads: i64,
+    /// The minimum number of parallelizable jobs required before turning on parallelism
+    /// for a set of jobs.
+    ///
+    /// When deciding whether or not to parallelize layout, this is the minimum number of
+    /// jobs that must be larger than [`Self::layout_parallelism_job_size_minimum`] to
+    /// turn on parallelism. An exception is when doing box tree layout, where Servo does
+    /// not know the depth of the tree. In that case any task that has more jobs than this
+    /// value will be parallelized.
+    ///
+    /// The goal of these two values is to allow tuning Servo's parallelism for both wide
+    /// and deep trees.
+    pub layout_parallelism_job_count_minimum: u64,
+    /// The minimum size of a layout job to be considered for parallelization.
+    ///
+    /// When deciding whether or not to parallelize layout, jobs greater than this size
+    /// are counted when considering the [`Self::layout_parallelism_job_count_minimum`]
+    /// threshold for turning on parallelism. Generally the size of the job is based on
+    /// the number of tasks to process in the subtree. For instance, this might be the
+    /// number of boxes to process in a box tree subtree.
+    ///
+    /// The goal of these two values is to allow tuning Servo's parallelism for both wide
+    /// and deep trees.
+    pub layout_parallelism_job_size_minimum: u64,
     pub layout_unimplemented: bool,
     // feature: Variable fonts | #38800 | Web/CSS/Guides/Fonts/Variable_fonts
     pub layout_variable_fonts_enabled: bool,
@@ -513,6 +536,8 @@ impl Preferences {
             layout_style_sharing_cache_enabled: true,
             // TODO(mrobinson): This should likely be based on the number of processors.
             layout_threads: 3,
+            layout_parallelism_job_count_minimum: 4,
+            layout_parallelism_job_size_minimum: 16,
             layout_unimplemented: false,
             layout_variable_fonts_enabled: false,
             layout_writing_mode_enabled: false,

--- a/components/layout/construct_modern.rs
+++ b/components/layout/construct_modern.rs
@@ -286,7 +286,7 @@ impl<'a, 'dom> ModernContainerBuilder<'a, 'dom> {
         self.wrap_any_text_in_anonymous_block_container();
 
         let jobs = std::mem::take(&mut self.jobs);
-        let mut children: Vec<_> = if self.context.use_rayon {
+        let mut children: Vec<_> = if self.context.should_parallelize(jobs.iter().len()) {
             jobs.into_par_iter()
                 .filter_map(|job| job.finish(&self))
                 .collect()

--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -30,8 +30,6 @@ use webrender_api::units::{DeviceIntSize, DeviceSize};
 pub(crate) type CachedImageOrError = Result<CachedImage, ResolveImageError>;
 
 pub(crate) struct LayoutContext<'a> {
-    pub use_rayon: bool,
-
     /// Bits shared by the layout and style system.
     pub style_context: SharedStyleContext<'a>,
 
@@ -47,6 +45,30 @@ pub(crate) struct LayoutContext<'a> {
 
     /// The [`PainterId`] that identifies which `RenderingContext` that this layout targets.
     pub painter_id: PainterId,
+
+    /// Whether or not parallel layout should be allowed for this layout.
+    pub allow_parallel_layout: bool,
+
+    /// The minimum number of jobs that need to be larger than
+    /// [`Self::parallelism_job_size_minimum`] in order to enable parallelism.
+    pub parallelism_job_count_minimum: usize,
+
+    /// The minimum size a job needs to be to be counted when determining if the number of
+    /// jobs exceeds [`Self::parallelism_job_count_minimum`].
+    pub parallelism_job_size_minimum: usize,
+}
+
+impl LayoutContext<'_> {
+    pub(crate) fn should_parallelize(&self, number_of_jobs: usize) -> bool {
+        self.allow_parallel_layout && number_of_jobs >= self.parallelism_job_count_minimum
+    }
+
+    pub(crate) fn should_parallelize_layout(&self, jobs: impl Iterator<Item = usize>) -> bool {
+        self.allow_parallel_layout &&
+            jobs.filter(|job| *job >= self.parallelism_job_size_minimum)
+                .count() >=
+                self.parallelism_job_count_minimum
+    }
 }
 
 pub enum ResolvedImage<'a> {

--- a/components/layout/flexbox/layout.rs
+++ b/components/layout/flexbox/layout.rs
@@ -1188,7 +1188,13 @@ fn do_initial_flex_line_layout<'items>(
     // We didn't reach the end of the last line, so add all remaining items there.
     lines.push((items, line_size_so_far));
 
-    if flex_context.layout_context.use_rayon {
+    let job_sizes = lines
+        .iter()
+        .map(|line| line.0.iter().map(FlexItem::subtree_size).sum());
+    if flex_context
+        .layout_context
+        .should_parallelize_layout(job_sizes)
+    {
         lines.par_drain(..).map(construct_line).collect()
     } else {
         lines.into_iter().map(construct_line).collect()
@@ -1225,7 +1231,10 @@ impl InitialFlexLineLayout<'_> {
         );
 
         // https://drafts.csswg.org/css-flexbox/#algo-cross-item
-        let layout_results: Vec<_> = if flex_context.layout_context.use_rayon {
+        let layout_results: Vec<_> = if flex_context
+            .layout_context
+            .should_parallelize_layout(items.iter().map(FlexItem::subtree_size))
+        {
             items
                 .par_iter()
                 .zip(&item_used_main_sizes)
@@ -1955,6 +1964,10 @@ impl FlexItem<'_> {
             self.border.cross_start +
             self.border.cross_end +
             self.padding.cross_end
+    }
+
+    fn subtree_size(&self) -> usize {
+        self.box_.independent_formatting_context.subtree_size()
     }
 
     /// Return the cross-start, cross-end, main-start, and main-end margins, with `auto` values resolved.

--- a/components/layout/flexbox/mod.rs
+++ b/components/layout/flexbox/mod.rs
@@ -148,6 +148,13 @@ impl FlexContainer {
         self.config = FlexContainerConfig::new(new_style);
         self.style = new_style.clone();
     }
+
+    pub(crate) fn subtree_size(&self) -> usize {
+        self.children
+            .iter()
+            .map(|child| child.borrow().with_base(|base| base.subtree_size()))
+            .sum()
+    }
 }
 
 #[expect(clippy::large_enum_variant)]

--- a/components/layout/flow/construct.rs
+++ b/components/layout/flow/construct.rs
@@ -292,7 +292,10 @@ impl<'dom, 'style> BlockContainerBuilder<'dom, 'style> {
         }
 
         let context = self.context;
-        let block_level_boxes = if self.context.use_rayon {
+        let block_level_boxes = if self
+            .context
+            .should_parallelize(self.block_level_boxes.len())
+        {
             self.block_level_boxes
                 .into_par_iter()
                 .map(|block_level_job| block_level_job.finish(context))
@@ -743,12 +746,12 @@ impl BlockLevelJob<'_> {
             BlockLevelCreator::SameFormattingContextBlock(intermediate_block_container) => {
                 let contents = intermediate_block_container.finish(context, info);
                 let contains_floats = contents.contains_floats();
+
+                let base = LayoutBoxBase::new(info.into(), info.style.clone());
+                base.set_subtree_size(contents.subtree_size() + 1);
+
                 ArcRefCell::new(BlockLevelBox::SameFormattingContextBlock(
-                    SameFormattingContextBlock::new(
-                        LayoutBoxBase::new(info.into(), info.style.clone()),
-                        contents,
-                        contains_floats,
-                    ),
+                    SameFormattingContextBlock::new(base, contents, contains_floats),
                 ))
             },
             BlockLevelCreator::Independent {

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -2099,6 +2099,27 @@ impl InlineFormattingContext {
         }
     }
 
+    pub(crate) fn subtree_size(&self) -> usize {
+        self.inline_items
+            .iter()
+            .map(|item| match item {
+                InlineItem::StartInlineBox(..) => 1,
+                InlineItem::EndInlineBox => 0,
+                InlineItem::TextRun(..) => 1,
+                InlineItem::OutOfFlowAbsolutelyPositionedBox(absolutely_positioned_box, _) => {
+                    absolutely_positioned_box
+                        .borrow()
+                        .context
+                        .base
+                        .subtree_size()
+                },
+                InlineItem::OutOfFlowFloatBox(..) => 1,
+                InlineItem::Atomic(..) => 1,
+                InlineItem::BlockLevel(block_level_box) => block_level_box.borrow().subtree_size(),
+            })
+            .sum()
+    }
+
     fn next_character_prevents_soft_wrap_opportunity(&self, index: usize) -> bool {
         let Some(character) = self.text_content[index..].chars().nth(1) else {
             return false;

--- a/components/layout/flow/mod.rs
+++ b/components/layout/flow/mod.rs
@@ -88,6 +88,18 @@ impl BlockContainer {
             },
         }
     }
+
+    pub(crate) fn subtree_size(&self) -> usize {
+        match self {
+            BlockContainer::BlockLevelBoxes(boxes) => boxes
+                .iter()
+                .map(|block_level_box| block_level_box.borrow().subtree_size())
+                .sum(),
+            BlockContainer::InlineFormattingContext(inline_formatting_context) => {
+                inline_formatting_context.subtree_size()
+            },
+        }
+    }
 }
 
 #[derive(Debug, MallocSizeOf)]
@@ -291,6 +303,10 @@ impl BlockLevelBox {
 
         true
     }
+
+    fn subtree_size(&self) -> usize {
+        self.with_base(|base| base.subtree_size())
+    }
 }
 
 #[derive(Clone, Copy, MallocSizeOf, PartialEq)]
@@ -409,11 +425,12 @@ impl BlockFormattingContext {
         positioning_context: &mut PositioningContext,
         containing_block: &ContainingBlock,
     ) -> IndependentFormattingContextLayoutResult {
-        let mut sequential_layout_state = if self.contains_floats || !layout_context.use_rayon {
-            Some(SequentialLayoutState::new(containing_block.size.inline))
-        } else {
-            None
-        };
+        let mut sequential_layout_state =
+            if self.contains_floats || !layout_context.allow_parallel_layout {
+                Some(SequentialLayoutState::new(containing_block.size.inline))
+            } else {
+                None
+            };
 
         // Since this is an independent formatting context, we don't ignore block margins when
         // resolving a stretch block size of the children.
@@ -610,7 +627,11 @@ fn compute_inline_content_sizes_for_block_level_boxes(
             }
             data
         };
-    let data = if layout_context.use_rayon {
+
+    let job_counts = boxes
+        .iter()
+        .map(|block_level_box| block_level_box.borrow().subtree_size());
+    let data = if layout_context.should_parallelize_layout(job_counts) {
         boxes
             .par_iter()
             .filter_map(get_box_info)

--- a/components/layout/formatting_contexts.rs
+++ b/components/layout/formatting_contexts.rs
@@ -58,6 +58,26 @@ pub(crate) enum IndependentFormattingContextContents {
     // Other layout modes go here
 }
 
+impl IndependentFormattingContextContents {
+    fn subtree_size(&self) -> usize {
+        match self {
+            IndependentFormattingContextContents::Replaced(_, widget) => widget
+                .as_ref()
+                .map_or(0, |widget| widget.borrow().subtree_size()),
+            IndependentFormattingContextContents::Flow(block_formatting_context) => {
+                block_formatting_context.contents.subtree_size()
+            },
+            IndependentFormattingContextContents::Flex(flex_container) => {
+                flex_container.subtree_size()
+            },
+            IndependentFormattingContextContents::Grid(taffy_container) => {
+                taffy_container.subtree_size()
+            },
+            IndependentFormattingContextContents::Table(table) => table.subtree_size(),
+        }
+    }
+}
+
 /// The baselines of a layout or a [`crate::fragment_tree::BoxFragment`]. Some layout
 /// uses the first and some layout uses the last.
 #[derive(Clone, Copy, Debug, Default, MallocSizeOf)]
@@ -81,6 +101,7 @@ impl IndependentFormattingContext {
         contents: IndependentFormattingContextContents,
         propagated_data: PropagatedBoxTreeData,
     ) -> Self {
+        base.set_subtree_size(contents.subtree_size() + 1);
         Self {
             base,
             contents,
@@ -130,8 +151,12 @@ impl IndependentFormattingContext {
             contents,
             propagated_data,
         );
+
+        let base = LayoutBoxBase::new(base_fragment_info, node_and_style_info.style.clone());
+        base.set_subtree_size(contents.subtree_size() + 1);
+
         Self {
-            base: LayoutBoxBase::new(base_fragment_info, node_and_style_info.style.clone()),
+            base,
             contents,
             propagated_data,
         }
@@ -561,6 +586,10 @@ impl IndependentFormattingContext {
                 contents.attached_to_tree(layout_box)
             },
         }
+    }
+
+    pub(crate) fn subtree_size(&self) -> usize {
+        self.base.subtree_size()
     }
 }
 

--- a/components/layout/layout_box_base.rs
+++ b/components/layout/layout_box_base.rs
@@ -4,7 +4,7 @@
 
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use app_units::Au;
 use atomic_refcell::AtomicRefCell;
@@ -56,6 +56,10 @@ pub(crate) struct LayoutBoxBase {
     /// layout, but cannot be reused directly.
     cached_layout_result_dirty: AtomicBool,
 
+    /// A count of the number of boxes are in this box's subtree (including itself).
+    /// This is used as a heuristic to know when to perform parallel layout.
+    subtree_size: AtomicUsize,
+
     pub fragments: AtomicRefCell<Vec<Fragment>>,
     pub parent_box: Option<WeakLayoutBox>,
     only_descendants_changed: AtomicBool,
@@ -73,10 +77,21 @@ impl LayoutBoxBase {
             outer_inline_content_sizes_depend_on_content: AtomicBool::new(true),
             cached_layout_result: AtomicRefCell::default(),
             cached_layout_result_dirty: AtomicBool::default(),
+            subtree_size: AtomicUsize::default(),
             fragments: AtomicRefCell::default(),
             parent_box: None,
             only_descendants_changed: AtomicBool::default(),
         }
+    }
+
+    /// Set the subtree size on this [`LayoutBoxBase`]. This should be done once
+    /// box construction knows how many boxes are in this box's subtree.
+    pub(crate) fn set_subtree_size(&self, size: usize) {
+        self.subtree_size.store(size, Ordering::Relaxed);
+    }
+
+    pub(crate) fn subtree_size(&self) -> usize {
+        self.subtree_size.load(Ordering::Relaxed)
     }
 
     /// Get the inline content sizes of a box tree node that extends this [`LayoutBoxBase`], fetch

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -1197,9 +1197,11 @@ impl LayoutThread {
             ),
             font_context: self.font_context.clone(),
             iframe_sizes: Mutex::default(),
-            use_rayon: rayon_pool.is_some(),
+            allow_parallel_layout: rayon_pool.is_some(),
             image_resolver: image_resolver.clone(),
             painter_id: self.webview_id.into(),
+            parallelism_job_count_minimum: pref!(layout_parallelism_job_count_minimum) as usize,
+            parallelism_job_size_minimum: pref!(layout_parallelism_job_size_minimum) as usize,
         };
 
         let restyle = reflow_request

--- a/components/layout/positioned.rs
+++ b/components/layout/positioned.rs
@@ -411,7 +411,14 @@ impl HoistedAbsolutelyPositionedBox {
         containing_block: &DefiniteContainingBlock,
         containing_block_padding: PhysicalSides<Au>,
     ) {
-        if layout_context.use_rayon {
+        let job_sizes = boxes.iter().map(|hoisted_box| {
+            hoisted_box
+                .absolutely_positioned_box
+                .borrow()
+                .context
+                .subtree_size()
+        });
+        if layout_context.should_parallelize_layout(job_sizes) {
             let mut new_fragments = Vec::new();
             let mut new_hoisted_boxes = Vec::new();
 

--- a/components/layout/table/layout.rs
+++ b/components/layout/table/layout.rs
@@ -1142,7 +1142,12 @@ impl<'a> TableLayout<'a> {
             })
         };
 
-        self.cells_laid_out = if layout_context.use_rayon {
+        let job_sizes = self
+            .table
+            .slots
+            .iter()
+            .map(|row| row.iter().map(|item| item.subtree_size()).sum::<usize>());
+        self.cells_laid_out = if layout_context.should_parallelize_layout(job_sizes) {
             self.table
                 .slots
                 .par_iter()

--- a/components/layout/table/mod.rs
+++ b/components/layout/table/mod.rs
@@ -211,6 +211,14 @@ impl Table {
                 new_style,
             );
     }
+
+    pub(crate) fn subtree_size(&self) -> usize {
+        self.slots
+            .iter()
+            .flat_map(|row| row.iter())
+            .map(TableSlot::subtree_size)
+            .sum()
+    }
 }
 
 type TableSlotCoordinates = Point2D<usize, UnknownUnit>;
@@ -296,6 +304,13 @@ impl std::fmt::Debug for TableSlot {
 impl TableSlot {
     fn new_spanned(offset: TableSlotOffset) -> Self {
         Self::Spanned(vec![offset])
+    }
+
+    pub(crate) fn subtree_size(&self) -> usize {
+        match self {
+            TableSlot::Cell(cell) => cell.borrow().context.subtree_size(),
+            TableSlot::Spanned(..) | TableSlot::Empty => 0,
+        }
     }
 }
 

--- a/components/layout/taffy/layout.rs
+++ b/components/layout/taffy/layout.rs
@@ -599,4 +599,11 @@ impl TaffyContainer {
             });
         }
     }
+
+    pub(crate) fn subtree_size(&self) -> usize {
+        self.children
+            .iter()
+            .map(|child| child.borrow().with_base(|base| base.subtree_size()))
+            .sum()
+    }
 }


### PR DESCRIPTION
This change adds two preferences:

 - `layout_parallelism_job_size_minimum`
 - `layout_parallelism_job_count_minimum`

Which allow tuning whether parallelism is enabled depending on how wide
and deep the tree of work is. During layout only jobs over the job size
are counted toward the job count threshold. The job size depends on the
number of boxes in the subtree of the box we are laying out.

Box tree construction doesn't have a good measure of the depth of the
tree, so we resort to just verifying that there are more jobs than
`layout_parallelism_job_count_minimum`. Maybe in the future this could
be based on some pre-computed DOM depth.

With the initial tuning values of 4 for job count minimum and 16 for the
job size minimum this greatly reduces the amount of time spent in the
script thread's `sched_yield`. In a lopsided flexbox case, this caused
the time spent in `sched_yield` in the script thread to drop from 29% to
14%, which means the main thread is busier and spends less time waiting.

The big win here though is that these values are now tunable, whereas
before this was an all-or-nothing setting.

Testing: This should not change layout results, it just exposes and gives a
default to performance tuning parameters, so existing tests should suffice.
