### PR TITLE
deps: Bump `rand` to 0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1230,13 +1230,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chacha20poly1305"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -6723,6 +6734,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
+ "chacha20 0.10.0",
  "getrandom 0.4.1",
  "rand_core 0.10.1",
 ]
@@ -7660,7 +7672,7 @@ dependencies = [
  "btleplug",
  "futures",
  "log",
- "rand 0.9.4",
+ "rand 0.10.1",
  "servo-base",
  "servo-bluetooth-traits",
  "servo-config",
@@ -7782,7 +7794,7 @@ dependencies = [
  "keyboard-types",
  "log",
  "parking_lot",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rustc-hash 2.1.2",
  "serde",
  "servo-background-hang-monitor",
@@ -7879,7 +7891,7 @@ dependencies = [
  "log",
  "malloc_size_of_derive",
  "parking_lot",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rustc-hash 2.1.2",
  "serde",
  "serde_json",
@@ -8271,7 +8283,7 @@ name = "servo-media-examples"
 version = "0.3.0"
 dependencies = [
  "euclid",
- "rand 0.9.4",
+ "rand 0.10.1",
  "serde",
  "servo-media",
  "servo-media-auto",
@@ -8527,7 +8539,7 @@ dependencies = [
  "num-traits",
  "parking_lot",
  "percent-encoding",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rustc-hash 2.1.2",
  "rustls-pki-types",
  "serde",
@@ -8745,7 +8757,7 @@ dependencies = [
  "phf",
  "pkcs8 0.10.2",
  "postcard",
- "rand 0.9.4",
+ "rand 0.10.1",
  "regex",
  "rsa",
  "rustc-hash 2.1.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,7 +202,7 @@ proc-macro2 = "1"
 quick_cache = { version = "0.6.18", default-features = false }
 quickcheck = "1"
 quote = "1"
-rand = "0.9"
+rand = "0.10"
 raw-window-handle = "0.6"
 rayon = "1"
 read-fonts = "0.39.2"

--- a/components/bluetooth/lib.rs
+++ b/components/bluetooth/lib.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 use bitflags::bitflags;
 use embedder_traits::{BluetoothDeviceDescription, EmbedderMsg, EmbedderProxy};
 use log::warn;
-use rand::{self, Rng};
+use rand::{self, RngExt};
 #[cfg(not(feature = "native-bluetooth"))]
 use servo_base::generic_channel::GenericReceiver;
 use servo_base::generic_channel::{self, GenericSender};

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -134,7 +134,7 @@ use profile_traits::mem::ProfilerMsg;
 use profile_traits::{mem, time};
 use rand::rngs::SmallRng;
 use rand::seq::IndexedRandom;
-use rand::{Rng, SeedableRng};
+use rand::{RngExt, SeedableRng, make_rng};
 use rustc_hash::{FxHashMap, FxHashSet};
 use script_traits::{
     ConstellationInputEvent, DiscardBrowsingContext, DocumentActivity, NewPipelineInfo,
@@ -716,7 +716,7 @@ where
                     random_pipeline_closure: random_pipeline_closure_probability.map(|probability| {
                         let rng = random_pipeline_closure_seed
                             .map(|seed| SmallRng::seed_from_u64(seed as u64))
-                            .unwrap_or_else(SmallRng::from_os_rng);
+                            .unwrap_or_else(make_rng);
                         warn!("Randomly closing pipelines using seed {random_pipeline_closure_seed:?}.");
                         (rng, probability)
                     }),

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -31,7 +31,7 @@ use log::{trace, warn};
 use malloc_size_of::MallocSizeOf;
 use malloc_size_of_derive::MallocSizeOf;
 use profile_traits::path;
-use rand::{RngCore, rng};
+use rand::{Rng, rng};
 use resource::{ResourceArrayType, ResourceAvailable};
 use rustc_hash::FxHashMap;
 use serde::Serialize;

--- a/components/script/dom/webcrypto/crypto.rs
+++ b/components/script/dom/webcrypto/crypto.rs
@@ -6,8 +6,8 @@ use dom_struct::dom_struct;
 use js::jsapi::{Heap, JSObject, Type};
 use js::rust::CustomAutoRooterGuard;
 use js::typedarray::{ArrayBufferView, ArrayBufferViewU8, HeapArrayBufferView, TypedArray};
-use rand::TryRngCore;
-use rand::rngs::OsRng;
+use rand::TryRng;
+use rand::rngs::SysRng;
 use script_bindings::reflector::{Reflector, reflect_dom_object};
 use script_bindings::trace::RootedTraceableBox;
 use uuid::Uuid;
@@ -68,7 +68,7 @@ impl CryptoMethods<crate::DomTypeHolder> for Crypto {
                 });
             }
 
-            if OsRng.try_fill_bytes(data).is_err() {
+            if SysRng.try_fill_bytes(data).is_err() {
                 return Err(Error::Operation(Some(
                     "Failed to generate random values".into(),
                 )));

--- a/components/script/dom/webcrypto/subtlecrypto/ed25519_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ed25519_operation.rs
@@ -5,8 +5,8 @@
 use aws_lc_rs::encoding::{AsBigEndian, AsDer};
 use aws_lc_rs::signature::{ED25519, Ed25519KeyPair, KeyPair, ParsedPublicKey, UnparsedPublicKey};
 use js::context::JSContext;
-use rand::TryRngCore;
-use rand::rngs::OsRng;
+use rand::TryRng;
+use rand::rngs::SysRng;
 
 use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::{
     CryptoKeyMethods, CryptoKeyPair, KeyType, KeyUsage,
@@ -102,7 +102,7 @@ pub(crate) fn generate_key(
 
     // Step 2. Generate an Ed25519 key pair, as defined in [RFC8032], section 5.1.5.
     let mut seed = vec![0u8; ED25519_SEED_LENGTH];
-    if OsRng.try_fill_bytes(&mut seed).is_err() {
+    if SysRng.try_fill_bytes(&mut seed).is_err() {
         return Err(Error::Operation(Some("Error getting random data".into())));
     }
     let key_pair = Ed25519KeyPair::from_seed_unchecked(&seed).map_err(|error| {

--- a/components/script/dom/webcrypto/subtlecrypto/hmac_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/hmac_operation.rs
@@ -5,8 +5,8 @@
 use aws_lc_rs::constant_time::verify_slices_are_equal;
 use aws_lc_rs::hmac;
 use js::context::JSContext;
-use rand::TryRngCore;
-use rand::rngs::OsRng;
+use rand::TryRng;
+use rand::rngs::SysRng;
 use script_bindings::codegen::GenericBindings::CryptoKeyBinding::CryptoKeyMethods;
 use script_bindings::domstring::DOMString;
 use zeroize::Zeroizing;
@@ -128,7 +128,7 @@ pub(crate) fn generate_key(
     // Step 3. Generate a key of length length bits.
     // Step 4. If the key generation step fails, then throw an OperationError.
     let mut key_data = vec![0; length as usize];
-    if OsRng.try_fill_bytes(&mut key_data).is_err() {
+    if SysRng.try_fill_bytes(&mut key_data).is_err() {
         return Err(Error::JSFailed);
     }
 

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -21,7 +21,7 @@ use malloc_size_of::malloc_size_of_is_0;
 use malloc_size_of_derive::MallocSizeOf;
 use mime::Mime;
 use profile_traits::mem::ReportsChan;
-use rand::{RngCore, rng};
+use rand::{Rng, rng};
 use request::RequestId;
 use rustc_hash::FxHashMap;
 use rustls_pki_types::CertificateDer;

--- a/deny.toml
+++ b/deny.toml
@@ -204,6 +204,7 @@ skip = [
     "hmac",
     "sha1",
     "sha2",
+    "chacha20",
 ]
 
 # github.com organizations to allow git sources for


### PR DESCRIPTION
Bump `rand` from 0.9.4 to 0.10.1, which is needed for #42206.

There are some breaking changes in `rand` 0.10, and our code follows:

- `rand::rngs::OsRng` is replaced with `rand::rngs::SysRng`.
- The trait `rand::Rng` is renamed to `rand::RngExt`.
- The trait `rand::RngCore` is renamed to `rand::Rng`.
- The trait `rand::TryRngCore` is renamed to `rand::TryRng`.
- The method `SeedableRng::from_os_rng` is removed. Use `rand::make_rng()` instead.

All breaking changes of `rand` 0.10: https://rust-random.github.io/book/update-0.10.html

Testing: Covered by existing tests.