### PR TITLE
deps: Remove `module-lattice` from `Cargo.toml`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8729,7 +8729,6 @@ dependencies = [
  "mime_guess",
  "ml-dsa",
  "ml-kem",
- "module-lattice",
  "mozangle",
  "mozjs",
  "nom-rfc8288",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,6 @@ mime = "0.3.13"
 mime_guess = "2.0.5"
 ml-dsa = { version = "0.1", features = ["zeroize"] }
 ml-kem = { version = "0.3", features = ["getrandom", "pkcs8", "zeroize"] }
-module-lattice = { version = "0.2", features = ["alloc"] }
 mozangle = "0.5.5"
 napi-derive-ohos = "1.2.0"
 napi-ohos = "1.2.0"

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -104,7 +104,6 @@ mime = { workspace = true }
 mime_guess = { workspace = true }
 ml-dsa = { workspace = true }
 ml-kem = { workspace = true }
-module-lattice = { workspace = true }
 net_traits = { workspace = true }
 nom-rfc8288 = { workspace = true }
 num-bigint-dig = { workspace = true }

--- a/components/script/dom/webcrypto/cryptokey.rs
+++ b/components/script/dom/webcrypto/cryptokey.rs
@@ -62,10 +62,6 @@ pub(crate) enum Handle {
     MlKem512PublicKey(ml_kem::EncapsulationKey<ml_kem::MlKem512>),
     MlKem768PublicKey(ml_kem::EncapsulationKey<ml_kem::MlKem768>),
     MlKem1024PublicKey(ml_kem::EncapsulationKey<ml_kem::MlKem1024>),
-    // Make sure the `alloc` feature of the `module-lattice` crate is enabled so that the `MaybeBox`
-    // used within the `ml_dsa::SigningKey` and `ml_dsa::VerifyingKey` is allocated on the heap
-    // rather the stack. Otherwise, these keys can easily overflow the stack.
-    // <https://docs.rs/module-lattice/0.2.3/module_lattice/struct.MaybeBox.html>
     MlDsa44PrivateKey(ml_dsa::SigningKey<ml_dsa::MlDsa44>),
     MlDsa65PrivateKey(ml_dsa::SigningKey<ml_dsa::MlDsa65>),
     MlDsa87PrivateKey(ml_dsa::SigningKey<ml_dsa::MlDsa87>),


### PR DESCRIPTION
We recently bumped `ml-dsa` from 0.1.0 to 0.1.1. https://github.com/servo/servo/commit/bcf976e3f1b7bcaffc96ffb5b30def0a6ceb78d6

Starting from `ml-dsa` 0.1.1, the `alloc` feature (enabled by default) of `ml-dsa` implies the `alloc` feature of its dependency `module-lattice`. So, we don't need to explicitly enable the `alloc` feature of `module-lattice` in our `Cargo.toml`. Furthermore, we do not use the `module-lattice` crate directly in our code. We can simply remove it from `Cargo.toml`.

Testing: Covered by existing tests.