### PR TITLE
android: Set all SDK requirements to be the same and update README

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@v4
         with:
-          packages: 'tools platform-tools platforms;android-33'
+          packages: 'tools platform-tools platforms;android-34'
       - name: Install Android NDK
         uses: nttld/setup-ndk@v1
         id: setup-ndk

--- a/README.md
+++ b/README.md
@@ -68,12 +68,12 @@ For more detailed build instructions, see the Servo Book under [Getting the Code
 - Run the following command to install the necessary components:
   ```shell
   sudo $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --install \
-   "build-tools;34.0.0" \
+   "build-tools;36.0.0" \
    "emulator" \
    "ndk;28.2.13676358" \
    "platform-tools" \
-   "platforms;android-33" \
-   "system-images;android-33;google_apis;x86_64"
+   "platforms;android-34" \
+   "system-images;android-34;google_apis;x86_64"
   ```
 - Follow the instructions above for the platform you are building on
 

--- a/support/android/apk/servoapp/build.gradle.kts
+++ b/support/android/apk/servoapp/build.gradle.kts
@@ -8,7 +8,7 @@ layout.buildDirectory = File(rootDir.absolutePath, "/../../../target/android/gra
 
 android {
     compileSdk = 34
-    buildToolsVersion = "34.0.0"
+    buildToolsVersion = "36.0.0"
 
     namespace = "org.servo.servoshell"
 

--- a/support/android/apk/servoview/build.gradle.kts
+++ b/support/android/apk/servoview/build.gradle.kts
@@ -7,8 +7,8 @@ plugins {
 layout.buildDirectory = File(rootDir.absolutePath, "/../../../target/android/gradle/servoview")
 
 android {
-    compileSdk = 33
-    buildToolsVersion = "34.0.0"
+    compileSdk = 34
+    buildToolsVersion = "36.0.0"
 
     namespace = "org.servo.servoview"
 


### PR DESCRIPTION
Recent changes to the Android version of Servo (Gradle file changes and
the UI refresh) increased the SDK and build tools version necessary to
build Servo, but the documentation wasn't updated. In addition, the SDK
update only changed on of the Gradle files. This change standardizes the
version and updates the documentation with the new version requirements.

Testing: This should not change behavior so compilation should be enough.
