### PR TITLE
ci: Make try job pass 'capi' input to dispatch-workflow

### DIFF
--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -118,6 +118,7 @@ jobs:
       number-of-wpt-chunks: ${{ matrix.number_of_wpt_chunks }}
       bencher: ${{ matrix.bencher }}
       coverage: ${{ matrix.coverage }}
+      capi: ${{ matrix.capi }}
 
   build-result:
     name: Result


### PR DESCRIPTION
This was missed in https://github.com/servo/servo/pull/44984, so now try job is [broken](https://github.com/servo/servo/actions/workflows/try-label.yml) due to the missing input.

Testing: The try string parser is already tested as part of https://github.com/servo/servo/pull/44984. There are no tests for the try job itself. This needs to be tested manually.