### PR TITLE
ci: Pass required `capi` input parameter in try job.

### DIFF
--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -118,6 +118,7 @@ jobs:
       number-of-wpt-chunks: ${{ matrix.number_of_wpt_chunks }}
       bencher: ${{ matrix.bencher }}
       coverage: ${{ matrix.coverage }}
+      capi: ${{ matrix.capi }}
 
   build-result:
     name: Result


### PR DESCRIPTION
Same as #45580. I didn't realize we had a duplicate code path for `./mach try`.