### PR TITLE
script: Make `SupportedPropertyNames` `NoGC`

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -5995,10 +5995,10 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-tree-accessors:supported-property-names>
-    fn SupportedPropertyNames(&self, cx: &mut js::context::JSContext) -> Vec<DOMString> {
+    fn SupportedPropertyNames(&self, no_gc: &NoGC) -> Vec<DOMString> {
         let mut names_with_first_named_element_map = HashMap::new();
         self.name_map
-            .for_each(cx.no_gc(), self.upcast(), |name, elements| {
+            .for_each(no_gc, self.upcast(), |name, elements| {
                 if name.is_empty() {
                     return;
                 }
@@ -6010,25 +6010,24 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
                 }
             });
 
-        self.id_map
-            .for_each(cx.no_gc(), self.upcast(), |id, elements| {
-                if id.is_empty() {
-                    return;
+        self.id_map.for_each(no_gc, self.upcast(), |id, elements| {
+            if id.is_empty() {
+                return;
+            }
+            let mut id_iter = elements
+                .iter()
+                .filter(|elem| is_named_element_with_id_attribute(elem));
+            if let Some(first) = id_iter.next() {
+                match names_with_first_named_element_map.entry(id.clone()) {
+                    Vacant(entry) => drop(entry.insert(first.as_rooted())),
+                    Occupied(mut entry) => {
+                        if first.upcast::<Node>().is_before(entry.get().upcast()) {
+                            *entry.get_mut() = first.as_rooted();
+                        }
+                    },
                 }
-                let mut id_iter = elements
-                    .iter()
-                    .filter(|elem| is_named_element_with_id_attribute(elem));
-                if let Some(first) = id_iter.next() {
-                    match names_with_first_named_element_map.entry(id.clone()) {
-                        Vacant(entry) => drop(entry.insert(first.as_rooted())),
-                        Occupied(mut entry) => {
-                            if first.upcast::<Node>().is_before(entry.get().upcast()) {
-                                *entry.get_mut() = first.as_rooted();
-                            }
-                        },
-                    }
-                }
-            });
+            }
+        });
 
         let mut names_with_first_named_element_vec: Vec<_> =
             names_with_first_named_element_map.into_iter().collect();

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -3026,10 +3026,6 @@ impl Document {
         &self.id_map
     }
 
-    pub(crate) fn name_map(&self) -> &TreeOrderedIndexMap {
-        &self.name_map
-    }
-
     /// <https://drafts.csswg.org/resize-observer/#dom-resizeobserver-resizeobserver>
     pub(crate) fn add_resize_observer(&self, resize_observer: &ResizeObserver) {
         self.resize_observers

--- a/components/script/dom/domstringmap.rs
+++ b/components/script/dom/domstringmap.rs
@@ -4,6 +4,7 @@
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, ns};
+use js::context::NoGC;
 use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use crate::dom::bindings::codegen::Bindings::DOMStringMapBinding::DOMStringMapMethods;
@@ -189,7 +190,7 @@ impl DOMStringMapMethods<crate::DomTypeHolder> for DOMStringMap {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-domstringmap-interface:supported-property-names>
-    fn SupportedPropertyNames(&self, _: &mut js::context::JSContext) -> Vec<DOMString> {
+    fn SupportedPropertyNames(&self, _: &NoGC) -> Vec<DOMString> {
         // > The supported property names on a DOMStringMap object at any instant are
         // > the names of each pair returned from getting the DOMStringMap's name-value
         // > pairs at that instant, in the order returned.

--- a/components/script/dom/html/htmlcollection.rs
+++ b/components/script/dom/html/htmlcollection.rs
@@ -6,6 +6,7 @@ use std::cell::Cell;
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, QualName, local_name, namespace_url, ns};
+use js::context::NoGC;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use style::str::split_html_space_chars;
 use stylo_atoms::Atom;
@@ -485,7 +486,7 @@ impl HTMLCollectionMethods<crate::DomTypeHolder> for HTMLCollection {
     }
 
     /// <https://dom.spec.whatwg.org/#interface-htmlcollection>
-    fn SupportedPropertyNames(&self, _: &mut js::context::JSContext) -> Vec<DOMString> {
+    fn SupportedPropertyNames(&self, _: &NoGC) -> Vec<DOMString> {
         // Step 1
         let mut result = vec![];
 

--- a/components/script/dom/html/htmldocument.rs
+++ b/components/script/dom/html/htmldocument.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use script_bindings::codegen::GenericBindings::DocumentBinding::DocumentMethods;
 use script_bindings::codegen::GenericBindings::HTMLDocumentBinding::HTMLDocumentMethods;
 use script_bindings::root::DomRoot;
@@ -25,8 +25,8 @@ impl HTMLDocumentMethods<crate::DomTypeHolder> for HTMLDocument {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-tree-accessors:supported-property-names>
-    fn SupportedPropertyNames(&self, cx: &mut js::context::JSContext) -> Vec<DOMString> {
-        self.document.SupportedPropertyNames(cx)
+    fn SupportedPropertyNames(&self, no_gc: &NoGC) -> Vec<DOMString> {
+        self.document.SupportedPropertyNames(no_gc)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-tree-accessors:dom-document-nameditem-filter>

--- a/components/script/dom/html/htmlformcontrolscollection.rs
+++ b/components/script/dom/html/htmlformcontrolscollection.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use script_bindings::reflector::reflect_dom_object_with_cx;
 use stylo_atoms::Atom;
 
@@ -111,8 +111,8 @@ impl HTMLFormControlsCollectionMethods<crate::DomTypeHolder> for HTMLFormControl
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-htmlformcontrolscollection-interface:supported-property-names>
-    fn SupportedPropertyNames(&self, cx: &mut js::context::JSContext) -> Vec<DOMString> {
-        self.collection.SupportedPropertyNames(cx)
+    fn SupportedPropertyNames(&self, no_gc: &NoGC) -> Vec<DOMString> {
+        self.collection.SupportedPropertyNames(no_gc)
     }
 
     // FIXME: This shouldn't need to be implemented here since HTMLCollection (the parent of

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -11,7 +11,7 @@ use encoding_rs::{Encoding, UTF_8};
 use headers::{ContentType, HeaderMapExt};
 use html5ever::{LocalName, Prefix, local_name};
 use http::Method;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::rust::HandleObject;
 use mime::{self, Mime};
 use net_traits::request::Referrer;
@@ -521,7 +521,7 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#the-form-element:supported-property-names
-    fn SupportedPropertyNames(&self, _: &mut JSContext) -> Vec<DOMString> {
+    fn SupportedPropertyNames(&self, _: &NoGC) -> Vec<DOMString> {
         // Step 1
         #[derive(Debug, Eq, Ord, PartialEq, PartialOrd)]
         enum SourcedNameSource {

--- a/components/script/dom/html/htmloptionscollection.rs
+++ b/components/script/dom/html/htmloptionscollection.rs
@@ -6,7 +6,7 @@ use std::cmp::Ordering;
 
 use dom_struct::dom_struct;
 use html5ever::{QualName, local_name, ns};
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use script_bindings::reflector::reflect_dom_object;
 
 use crate::dom::bindings::codegen::Bindings::ElementBinding::ElementMethods;
@@ -89,8 +89,8 @@ impl HTMLOptionsCollectionMethods<crate::DomTypeHolder> for HTMLOptionsCollectio
     }
 
     /// <https://heycam.github.io/webidl/#dfn-supported-property-names>
-    fn SupportedPropertyNames(&self, cx: &mut js::context::JSContext) -> Vec<DOMString> {
-        self.upcast().SupportedPropertyNames(cx)
+    fn SupportedPropertyNames(&self, no_gc: &NoGC) -> Vec<DOMString> {
+        self.upcast().SupportedPropertyNames(no_gc)
     }
 
     // FIXME: This shouldn't need to be implemented here since HTMLCollection (the parent of

--- a/components/script/dom/mimetypearray.rs
+++ b/components/script/dom/mimetypearray.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::NoGC;
 use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use crate::dom::bindings::codegen::Bindings::MimeTypeArrayBinding::MimeTypeArrayMethods;
@@ -57,7 +57,7 @@ impl MimeTypeArrayMethods<crate::DomTypeHolder> for MimeTypeArray {
     }
 
     /// <https://heycam.github.io/webidl/#dfn-supported-property-names>
-    fn SupportedPropertyNames(&self, _: &mut JSContext) -> Vec<DOMString> {
+    fn SupportedPropertyNames(&self, _: &NoGC) -> Vec<DOMString> {
         vec![]
     }
 }

--- a/components/script/dom/namednodemap.rs
+++ b/components/script/dom/namednodemap.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use html5ever::LocalName;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use crate::dom::attr::Attr;
@@ -112,7 +112,7 @@ impl NamedNodeMapMethods<crate::DomTypeHolder> for NamedNodeMap {
     }
 
     /// <https://heycam.github.io/webidl/#dfn-supported-property-names>
-    fn SupportedPropertyNames(&self, _: &mut JSContext) -> Vec<DOMString> {
+    fn SupportedPropertyNames(&self, _: &NoGC) -> Vec<DOMString> {
         let mut names = vec![];
         let html_element_in_html_document = self.owner.html_element_in_html_document();
         for attr in self.owner.attrs().borrow().iter() {

--- a/components/script/dom/plugin.rs
+++ b/components/script/dom/plugin.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::NoGC;
 use script_bindings::reflector::Reflector;
 
 use crate::dom::bindings::codegen::Bindings::PluginBinding::PluginMethods;
@@ -58,7 +58,7 @@ impl PluginMethods<crate::DomTypeHolder> for Plugin {
     }
 
     /// <https://heycam.github.io/webidl/#dfn-supported-property-names>
-    fn SupportedPropertyNames(&self, _: &mut JSContext) -> Vec<DOMString> {
+    fn SupportedPropertyNames(&self, _: &NoGC) -> Vec<DOMString> {
         unreachable!()
     }
 }

--- a/components/script/dom/pluginarray.rs
+++ b/components/script/dom/pluginarray.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::NoGC;
 use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use crate::dom::bindings::codegen::Bindings::PluginArrayBinding::PluginArrayMethods;
@@ -60,7 +60,7 @@ impl PluginArrayMethods<crate::DomTypeHolder> for PluginArray {
     }
 
     /// <https://heycam.github.io/webidl/#dfn-supported-property-names>
-    fn SupportedPropertyNames(&self, _: &mut JSContext) -> Vec<DOMString> {
+    fn SupportedPropertyNames(&self, _: &NoGC) -> Vec<DOMString> {
         vec![]
     }
 }

--- a/components/script/dom/storage.rs
+++ b/components/script/dom/storage.rs
@@ -1,8 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::NoGC;
 use profile_traits::generic_channel;
 use script_bindings::reflector::{Reflector, reflect_dom_object};
 use servo_base::generic_channel::{GenericSend, SendResult};
@@ -183,7 +184,7 @@ impl StorageMethods<crate::DomTypeHolder> for Storage {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-storage-interface:supported-property-names>
-    fn SupportedPropertyNames(&self, _: &mut JSContext) -> Vec<DOMString> {
+    fn SupportedPropertyNames(&self, _: &NoGC) -> Vec<DOMString> {
         let time_profiler = self.global().time_profiler_chan().clone();
         let (sender, receiver) = generic_channel::channel(time_profiler).unwrap();
 

--- a/components/script/dom/testing/testbindingproxy.rs
+++ b/components/script/dom/testing/testbindingproxy.rs
@@ -5,7 +5,7 @@
 // check-tidy: no specs after this line
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::NoGC;
 
 use crate::dom::bindings::codegen::Bindings::TestBindingProxyBinding::TestBindingProxyMethods;
 use crate::dom::bindings::str::DOMString;
@@ -20,7 +20,7 @@ impl TestBindingProxyMethods<crate::DomTypeHolder> for TestBindingProxy {
     fn Length(&self) -> u32 {
         0
     }
-    fn SupportedPropertyNames(&self, _: &mut JSContext) -> Vec<DOMString> {
+    fn SupportedPropertyNames(&self, _: &NoGC) -> Vec<DOMString> {
         vec![]
     }
     fn GetNamedItem(&self, _: DOMString) -> DOMString {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -4,9 +4,8 @@
 
 use std::borrow::ToOwned;
 use std::cell::{Cell, RefCell, RefMut};
-use std::cmp;
+use std::collections::HashSet;
 use std::collections::hash_map::Entry;
-use std::collections::{HashMap, HashSet};
 use std::default::Default;
 use std::ffi::c_void;
 use std::io::{Write, stderr, stdout};
@@ -2320,61 +2319,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-tree-accessors:supported-property-names>
     fn SupportedPropertyNames(&self, no_gc: &NoGC) -> Vec<DOMString> {
-        let document = self.Document();
-        let mut names_with_first_named_element_map = HashMap::new();
-        document
-            .name_map()
-            .for_each(no_gc, document.upcast(), |name, elements| {
-                if name.is_empty() {
-                    return;
-                }
-                let mut name_iter = elements
-                    .iter()
-                    .filter(|elem| is_named_element_with_name_attribute(elem));
-                if let Some(first) = name_iter.next() {
-                    names_with_first_named_element_map.insert(name.clone(), first.as_rooted());
-                }
-            });
-
-        document
-            .id_map()
-            .for_each(no_gc, document.upcast(), |id, elements| {
-                if id.is_empty() {
-                    return;
-                }
-                let mut id_iter = elements
-                    .iter()
-                    .filter(|elem| is_named_element_with_id_attribute(elem));
-                if let Some(first) = id_iter.next() {
-                    match names_with_first_named_element_map.entry(id.clone()) {
-                        Entry::Vacant(entry) => drop(entry.insert(first.as_rooted())),
-                        Entry::Occupied(mut entry) => {
-                            if first.upcast::<Node>().is_before(entry.get().upcast()) {
-                                *entry.get_mut() = first.as_rooted();
-                            }
-                        },
-                    }
-                }
-            });
-
-        let mut names_with_first_named_element_vec: Vec<_> =
-            names_with_first_named_element_map.into_iter().collect();
-        names_with_first_named_element_vec.sort_unstable_by(|a, b| {
-            if a.1 == b.1 {
-                // This can happen if an img has an id different from its name,
-                // spec does not say which string to put first.
-                a.0.cmp(&b.0)
-            } else if a.1.upcast::<Node>().is_before(b.1.upcast::<Node>()) {
-                cmp::Ordering::Less
-            } else {
-                cmp::Ordering::Greater
-            }
-        });
-
-        names_with_first_named_element_vec
-            .iter()
-            .map(|(k, _v)| DOMString::from(&**k))
-            .collect()
+        self.Document().SupportedPropertyNames(no_gc)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-structuredclone>

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -31,7 +31,7 @@ use embedder_traits::{
 };
 use euclid::{Point2D, Rect, Scale, Size2D, Vector2D};
 use fonts::{CspViolationHandler, FontContext, NetworkTimingHandler, WebFontDocumentContext};
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::glue::DumpJSStack;
 use js::jsapi::{GCReason, Heap, JSContext as RawJSContext, JSObject, JSPROP_ENUMERATE};
 use js::jsval::{NullValue, UndefinedValue};
@@ -2319,12 +2319,12 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-tree-accessors:supported-property-names>
-    fn SupportedPropertyNames(&self, cx: &mut JSContext) -> Vec<DOMString> {
+    fn SupportedPropertyNames(&self, no_gc: &NoGC) -> Vec<DOMString> {
         let document = self.Document();
         let mut names_with_first_named_element_map = HashMap::new();
         document
             .name_map()
-            .for_each(cx.no_gc(), document.upcast(), |name, elements| {
+            .for_each(no_gc, document.upcast(), |name, elements| {
                 if name.is_empty() {
                     return;
                 }
@@ -2338,7 +2338,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
 
         document
             .id_map()
-            .for_each(cx.no_gc(), document.upcast(), |id, elements| {
+            .for_each(no_gc, document.upcast(), |id, elements| {
                 if id.is_empty() {
                     return;
                 }

--- a/components/script/dom/xmldocument.rs
+++ b/components/script/dom/xmldocument.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 
 use data_url::mime::Mime;
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use net_traits::request::InsecureRequestsPolicy;
 use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
 use script_bindings::reflector::reflect_dom_object;
@@ -131,8 +131,8 @@ impl XMLDocumentMethods<crate::DomTypeHolder> for XMLDocument {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-tree-accessors:supported-property-names>
-    fn SupportedPropertyNames(&self, cx: &mut js::context::JSContext) -> Vec<DOMString> {
-        self.upcast::<Document>().SupportedPropertyNames(cx)
+    fn SupportedPropertyNames(&self, no_gc: &NoGC) -> Vec<DOMString> {
+        self.upcast::<Document>().SupportedPropertyNames(no_gc)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-tree-accessors:dom-document-nameditem-filter>

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -6541,7 +6541,7 @@ class CGDOMJSProxyHandler_ownPropertyKeys(CGAbstractExternMethod):
             length = "None"
 
         if self.descriptor.supportsNamedProperties():
-            properties = f"Some(|unwrapped_proxy: *const {self.descriptor.concreteType}, cx| (*unwrapped_proxy).SupportedPropertyNames(cx))"
+            properties = f"Some(|unwrapped_proxy: *const {self.descriptor.concreteType}, cx| (*unwrapped_proxy).SupportedPropertyNames(cx.no_gc()))"
         else:
             properties = "None"
 
@@ -7091,7 +7091,7 @@ class CGInterfaceTrait(CGThing):
                         # WebIDL, Second Draft, section 3.2.4.5
                         # https://heycam.github.io/webidl/#idl-named-properties
                         if operation.isNamed():
-                            yield "SupportedPropertyNames", [("cx", "&mut JSContext")], "Vec<DOMString>", False
+                            yield "SupportedPropertyNames", [("no_gc", "&NoGC")], "Vec<DOMString>", False
                     else:
                         arguments = method_arguments(descriptor, rettype, arguments,
                                                      cx_no_gc=name in descriptor.cx_no_gcMethods,

--- a/components/script_bindings/import.rs
+++ b/components/script_bindings/import.rs
@@ -7,7 +7,7 @@ pub(crate) mod base {
     pub(crate) use std::rc::Rc;
 
     #[allow(unused_imports)]
-    pub(crate) use js::context::{JSContext, RawJSContext};
+    pub(crate) use js::context::{JSContext, NoGC, RawJSContext};
     pub(crate) use js::conversions::{
         ConversionBehavior, ConversionResult, FromJSValConvertible, ToJSValConvertible,
     };


### PR DESCRIPTION
In `SupportedPropertyNames` implementations, the `cx` argument is only used by `Document` to invoke `no_gc`, thus we move the call inside bindings code.
Also clean-up the window implementation, which was the same one of document.

Testing: Covered by existing tests