### PR TITLE
layout: Adjust corner radii for inset box shadows

### DIFF
--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -2135,7 +2135,15 @@ impl<'a> BuilderForBoxFragment<'a> {
                         .inflate(extra_size_from_blur, extra_size_from_blur)
                 },
             };
-            let border_radius = self.border_radius();
+            let border_radius = match clip_mode {
+                BoxShadowClipMode::Inset => {
+                    // The `border-radius` value applies to the border box, but inset shadows
+                    // use the padding box instead. So we need to shrink the `border-radius`
+                    // by the border widths.
+                    offset_radii(self.border_radius(), -self.fragment.border.to_webrender())
+                },
+                BoxShadowClipMode::Outset => self.border_radius(),
+            };
             let shadow_radius = offset_radii(
                 border_radius,
                 SideOffsets2D::new_all_same(match clip_mode {

--- a/tests/wpt/tests/css/css-backgrounds/box-shadow-radius-002-ref.html
+++ b/tests/wpt/tests/css/css-backgrounds/box-shadow-radius-002-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>CSS Reference: Box Shadow Border Radius (Inset)</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+
+<style>
+body {
+  margin: 0;
+}
+#target {
+  width: 100px;
+  height: 100px;
+  border: 50px solid;
+  margin: 50px;
+  border-radius: 75px;
+}
+</style>
+<div id="target"></div>

--- a/tests/wpt/tests/css/css-backgrounds/box-shadow-radius-002.html
+++ b/tests/wpt/tests/css/css-backgrounds/box-shadow-radius-002.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>Box Shadow Border Radius (Inset)</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/css-backgrounds-3/#shadow-shape">
+<link rel="help" href="https://github.com/servo/servo/issues/45614">
+<link rel="match" href="box-shadow-radius-002-ref.html">
+<meta name="fuzzy" content="maxDifference=0-120; totalPixels=0-1500">
+
+<style>
+body {
+  margin: 0;
+}
+#target {
+  width: 200px;
+  height: 200px;
+  border: 50px solid transparent;
+  box-shadow: inset 0 0 0 50px;
+  border-radius: 125px;
+}
+</style>
+<div id="target"></div>


### PR DESCRIPTION
Inset box shadows refer to the padding box, not the border box. However, the value from `border-radius` needs to apply to the border box.

Therefore, we need to adjust the `border-radius` by the border sizes before applying it to the inset box shadow.

Testing: Adding new test
Fixes: #45614
