### PR TITLE
layout: Enable CSS Grid by default

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -567,7 +567,7 @@ impl Preferences {
             layout_css_attr_enabled: false,
             layout_css_ellipse_corners_enabled: false,
             layout_css_progress_function_enabled: false,
-            layout_grid_enabled: false,
+            layout_grid_enabled: true,
             layout_style_sharing_cache_enabled: true,
             // TODO(mrobinson): This should likely be based on the number of processors.
             layout_threads: 3,

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -1084,13 +1084,9 @@ fn test_preferences_change() {
     let servo_test = ServoTest::new();
     let delegate = Rc::new(WebViewDelegateImpl::default());
 
-    let test_page = Url::parse(
-        "data:text/html,\
-        <div style=\"display: grid;\">\
-            <div id=target style=\"grid-column: 1;\">three</div>\
-        </div>",
-    )
-    .expect("Data URL failed to build");
+    let test_page =
+        Url::parse("data:text/html,<div id=\"target\" style=\"backdrop-filter: sepia(1)\"></div>")
+            .expect("Data URL failed to build");
 
     let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
         .delegate(delegate.clone())
@@ -1099,6 +1095,9 @@ fn test_preferences_change() {
     show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
 
     assert_eq!(
+        // The backdrop-filter style is feature flagged by the layout.unimplemented feature,
+        // so when layout.unimplemented feature is disabled, the backdrop-filter style specified
+        // in the stylesheet won't parse and the computed value undefined
         Ok(JSValue::Array(vec![
             JSValue::String("".to_string()),
             JSValue::String("".to_string())
@@ -1106,30 +1105,32 @@ fn test_preferences_change() {
         evaluate_javascript(
             &servo_test,
             webview.clone(),
-            "let old_value = target.style.getPropertyValue('grid-column');
-            target.style.gridColumn = '3';
-            let new_value = target.style.getPropertyValue('grid-column');
+            "let old_value = target.style.getPropertyValue('backdrop-filter');
+            target.style.backdropFilter = 'sepia(1)';
+            let new_value = target.style.getPropertyValue('backdrop-filter');
             [old_value, new_value]"
         )
     );
 
     servo_test
         .servo()
-        .set_preference("layout_grid_enabled", PrefValue::Bool(true));
+        .set_preference("layout_unimplemented", PrefValue::Bool(true));
 
     webview.reload();
 
     assert_eq!(
+        // When layout.unimplemented feature is enabled, the backdrop-filter style specified in
+        // the stylesheet will parse and the computed value will be that value
         Ok(JSValue::Array(vec![
-            JSValue::String("1".to_string()),
-            JSValue::String("3".to_string())
+            JSValue::String("sepia(1)".to_string()),
+            JSValue::String("opacity(0.5)".to_string())
         ])),
         evaluate_javascript(
             &servo_test,
             webview,
-            "let old_value = target.style.getPropertyValue('grid-column');
-            target.style.gridColumn = '3';
-            let new_value = target.style.getPropertyValue('grid-column');
+            "let old_value = target.style.getPropertyValue('backdrop-filter');
+            target.style.backdropFilter = 'opacity(0.5)';
+            let new_value = target.style.getPropertyValue('backdrop-filter');
             [old_value, new_value]"
         )
     );

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -51,7 +51,6 @@ pub(crate) static EXPERIMENTAL_PREFS: &[&str] = &[
     "layout_css_progress_function_enabled",
     "layout_columns_enabled",
     "layout_container_queries_enabled",
-    "layout_grid_enabled",
     "layout_variable_fonts_enabled",
 ];
 


### PR DESCRIPTION
CSS Grid layout now has no known crashes, and test pass rates are [comparable to Flexbox](https://github.com/servo/servo/issues/34479#issuecomment-4587455201). So let's enable it by default?

Changes made:
- Flip the `layout_grid_enabled` pref for CSS Grid to be `true` by default.
- Removes the `layout_grid_enabled` from servoshell's list of experimental prefs.
- Updates a test that was relying on the `layout_grid_enabled` pref being off-by-default to use the `layout_unimplemented` pref instead.

Testing: We're already testing with the grid preference enabled.
Part of: https://github.com/servo/servo/issues/34479
