### PR TITLE
layout: Properly set IS_BLEND_CONTAINER when creating WebRender stacking contexts

### DIFF
--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -401,7 +401,7 @@ impl DisplayListBuilder<'_> {
             return false;
         }
 
-        let is_blend_container = stacking_context.children.iter().any(|child| {
+        let mut is_blend_container = stacking_context.children.iter().any(|child| {
             child.fragment().is_some_and(|fragment| {
                 fragment.style().clone_mix_blend_mode() != ComputedMixBlendMode::Normal
             })
@@ -429,12 +429,11 @@ impl DisplayListBuilder<'_> {
                 //
                 // TODO: Would it be cleaner to paint the root background at the root fragment
                 // instead of the root stacking context?
-                let needs_blend_container = is_blend_container &&
-                    !fragment.base.flags.contains(FragmentFlags::IS_ROOT_ELEMENT);
+                is_blend_container &= !fragment.base.flags.contains(FragmentFlags::IS_ROOT_ELEMENT);
 
                 // WebRender only uses the stacking context to apply certain effects. If we don't
                 // actually need to create a stacking context, just avoid creating one.
-                if !needs_blend_container &&
+                if !is_blend_container &&
                     effects.filter.0.is_empty() &&
                     effects.opacity == 1.0 &&
                     effects.mix_blend_mode == ComputedMixBlendMode::Normal &&
@@ -459,25 +458,21 @@ impl DisplayListBuilder<'_> {
                         effects.opacity,
                     ));
                 }
-
-                if needs_blend_container {
-                    stacking_context_flags.insert(StackingContextFlags::IS_BLEND_CONTAINER);
-                }
             },
-            StackingContextFragments::Root => {
-                // WebRender only needs a stacking context at the root when the root stacking
-                // context itself is a blend container. Adding the IS_BLEND_CONTAINER here seems to
-                // trigger a bug in WebRender though. It's harmless to not enable it as the root
-                // stacking context already contains all other display items.
-                if !is_blend_container {
-                    return false;
-                }
+            // WebRender only needs a stacking context at the root when the root stacking
+            // context itself is a blend container.
+            StackingContextFragments::Root if is_blend_container => {
                 transform_style = TransformStyle::Flat;
                 primitive_flags = PrimitiveFlags::empty();
                 mix_blend_mode = MixBlendMode::Normal;
                 filters = Vec::new();
             },
+            _ => return false,
         };
+
+        if is_blend_container {
+            stacking_context_flags.insert(StackingContextFlags::IS_BLEND_CONTAINER);
+        }
 
         // WebRender has two different ways of expressing "no clip." ClipChainId::INVALID
         // should be used for primitives, but `None` is used for stacking contexts and

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -33,7 +33,7 @@ use style::dom::OpaqueNode;
 use style::properties::ComputedValues;
 use style::properties::longhands::visibility::computed_value::T as Visibility;
 use style::properties::style_structs::Border;
-use style::values::computed::basic_shape::ClipPath;
+use style::values::computed::basic_shape::ClipPath as ComputedClipPath;
 use style::values::computed::{
     BorderImageSideWidth, BorderImageWidth, BorderStyle, LengthPercentage,
     NonNegativeLengthOrNumber, NumberOrPercentage, OutlineStyle,
@@ -41,7 +41,6 @@ use style::values::computed::{
 use style::values::generics::NonNegative;
 use style::values::generics::color::ColorOrAuto;
 use style::values::generics::rect::Rect as StyleRect;
-use style::values::specified::TransformStyle;
 use style::values::specified::text::TextDecorationLine;
 use style_traits::{CSSPixel as StyloCSSPixel, DevicePixel as StyloDevicePixel};
 use webrender_api::units::{
@@ -50,8 +49,9 @@ use webrender_api::units::{
 use webrender_api::{
     self as wr, BorderDetails, BorderRadius, BorderSide, BoxShadowClipMode, BuiltDisplayList,
     ClipChainId, ClipMode, ColorF, CommonItemProperties, ComplexClipRegion, GlyphInstance,
-    NinePatchBorder, NinePatchBorderSource, NormalBorder, PrimitiveFlags, PropertyBinding,
-    PropertyBindingKey, RasterSpace, SpatialId, StackingContextFlags, units,
+    MixBlendMode, NinePatchBorder, NinePatchBorderSource, NormalBorder, PrimitiveFlags,
+    PropertyBinding, PropertyBindingKey, RasterSpace, SpatialId, StackingContextFlags,
+    TransformStyle, units,
 };
 use wr::units::LayoutVector2D;
 
@@ -401,47 +401,83 @@ impl DisplayListBuilder<'_> {
             return false;
         }
 
-        let StackingContextFragments::Fragment(fragment) = &stacking_context.fragment else {
-            return false;
+        let is_blend_container = stacking_context.children.iter().any(|child| {
+            child.fragment().is_some_and(|fragment| {
+                fragment.style().clone_mix_blend_mode() != ComputedMixBlendMode::Normal
+            })
+        });
+
+        let primitive_flags;
+        let transform_style;
+        let mix_blend_mode;
+        let mut filters: Vec<_>;
+        let mut stacking_context_flags = StackingContextFlags::empty();
+        match &stacking_context.fragment {
+            StackingContextFragments::Fragment(fragment) => {
+                let style = fragment.style();
+                let effects = style.get_effects();
+
+                transform_style = style
+                    .used_transform_style(fragment.base.flags)
+                    .to_webrender();
+                mix_blend_mode = effects.mix_blend_mode.to_webrender();
+                primitive_flags = style.get_webrender_primitive_flags();
+
+                // Do not create another blend container stacking context started by the root
+                // element, because the root background is painted above of it (at the root
+                // stacking context, which sits above the root fragment).
+                //
+                // TODO: Would it be cleaner to paint the root background at the root fragment
+                // instead of the root stacking context?
+                let needs_blend_container = is_blend_container &&
+                    !fragment.base.flags.contains(FragmentFlags::IS_ROOT_ELEMENT);
+
+                // WebRender only uses the stacking context to apply certain effects. If we don't
+                // actually need to create a stacking context, just avoid creating one.
+                if !needs_blend_container &&
+                    effects.filter.0.is_empty() &&
+                    effects.opacity == 1.0 &&
+                    effects.mix_blend_mode == ComputedMixBlendMode::Normal &&
+                    !style.has_effective_transform_or_perspective(FragmentFlags::empty()) &&
+                    style.get_svg().clip_path == ComputedClipPath::None &&
+                    transform_style == TransformStyle::Flat
+                {
+                    return false;
+                }
+
+                // Create the filter pipeline.
+                let current_color = &style.get_inherited_text().color;
+                filters = effects
+                    .filter
+                    .0
+                    .iter()
+                    .map(|filter| FilterToWebRender::to_webrender(filter, current_color))
+                    .collect();
+                if effects.opacity != 1.0 {
+                    filters.push(wr::FilterOp::Opacity(
+                        effects.opacity.into(),
+                        effects.opacity,
+                    ));
+                }
+
+                if needs_blend_container {
+                    stacking_context_flags.insert(StackingContextFlags::IS_BLEND_CONTAINER);
+                }
+            },
+            StackingContextFragments::Root => {
+                // WebRender only needs a stacking context at the root when the root stacking
+                // context itself is a blend container. Adding the IS_BLEND_CONTAINER here seems to
+                // trigger a bug in WebRender though. It's harmless to not enable it as the root
+                // stacking context already contains all other display items.
+                if !is_blend_container {
+                    return false;
+                }
+                transform_style = TransformStyle::Flat;
+                primitive_flags = PrimitiveFlags::empty();
+                mix_blend_mode = MixBlendMode::Normal;
+                filters = Vec::new();
+            },
         };
-
-        // WebRender only uses the stacking context to apply certain effects. If we don't
-        // actually need to create a stacking context, just avoid creating one.
-        let style = fragment.style();
-        let effects = style.get_effects();
-        let transform_style = style.used_transform_style(fragment.base.flags);
-        if effects.filter.0.is_empty() &&
-            effects.opacity == 1.0 &&
-            effects.mix_blend_mode == ComputedMixBlendMode::Normal &&
-            !style.has_effective_transform_or_perspective(FragmentFlags::empty()) &&
-            style.get_svg().clip_path == ClipPath::None &&
-            transform_style == TransformStyle::Flat
-        {
-            return false;
-        }
-
-        // Create the filter pipeline.
-        let current_color = style.clone_color();
-        let mut filters: Vec<wr::FilterOp> = effects
-            .filter
-            .0
-            .iter()
-            .map(|filter| FilterToWebRender::to_webrender(filter, &current_color))
-            .collect();
-        if effects.opacity != 1.0 {
-            filters.push(wr::FilterOp::Opacity(
-                effects.opacity.into(),
-                effects.opacity,
-            ));
-        }
-
-        // TODO(jdm): WebRender now requires us to create stacking context items
-        //            with the IS_BLEND_CONTAINER flag enabled if any children
-        //            of the stacking context have a blend mode applied.
-        //            This will require additional tracking during layout
-        //            before we start collecting stacking contexts so that
-        //            information will be available when we reach this point.
-        let spatial_id = self.spatial_id(stacking_context.scroll_tree_node_id);
 
         // WebRender has two different ways of expressing "no clip." ClipChainId::INVALID
         // should be used for primitives, but `None` is used for stacking contexts and
@@ -451,17 +487,18 @@ impl DisplayListBuilder<'_> {
             ClipId::INVALID => None,
             clip_id => Some(self.clip_chain_id(clip_id)),
         };
+        let spatial_id = self.spatial_id(stacking_context.scroll_tree_node_id);
 
         self.wr().push_stacking_context(
             spatial_id,
-            style.get_webrender_primitive_flags(),
+            primitive_flags,
             clip_chain_id,
-            transform_style.to_webrender(),
-            effects.mix_blend_mode.to_webrender(),
+            transform_style,
+            mix_blend_mode,
             &filters,
             &[], // filter_datas
             wr::RasterSpace::Screen,
-            wr::StackingContextFlags::empty(),
+            stacking_context_flags,
             None, // snapshot
         );
 
@@ -1682,7 +1719,7 @@ impl<'a> BuilderForBoxFragment<'a> {
                 spatial_id,
                 PrimitiveFlags::empty(),
                 None,
-                webrender_api::TransformStyle::Flat,
+                TransformStyle::Flat,
                 blend_mode.to_webrender(),
                 &[],
                 &[],

--- a/tests/wpt/meta/css/compositing/mix-blend-mode/mix-blend-mode-blended-element-overflow-scroll.html.ini
+++ b/tests/wpt/meta/css/compositing/mix-blend-mode/mix-blend-mode-blended-element-overflow-scroll.html.ini
@@ -1,2 +1,0 @@
-[mix-blend-mode-blended-element-overflow-scroll.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/compositing/mix-blend-mode/mix-blend-mode-overflowing-child.html.ini
+++ b/tests/wpt/meta/css/compositing/mix-blend-mode/mix-blend-mode-overflowing-child.html.ini
@@ -1,2 +1,0 @@
-[mix-blend-mode-overflowing-child.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/compositing/mix-blend-mode/mix-blend-mode-parent-element-overflow-hidden-and-border-radius-2.html.ini
+++ b/tests/wpt/meta/css/compositing/mix-blend-mode/mix-blend-mode-parent-element-overflow-hidden-and-border-radius-2.html.ini
@@ -1,2 +1,0 @@
-[mix-blend-mode-parent-element-overflow-hidden-and-border-radius-2.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/compositing/mix-blend-mode/mix-blend-mode-parent-element-overflow-hidden-and-border-radius.html.ini
+++ b/tests/wpt/meta/css/compositing/mix-blend-mode/mix-blend-mode-parent-element-overflow-hidden-and-border-radius.html.ini
@@ -1,2 +1,0 @@
-[mix-blend-mode-parent-element-overflow-hidden-and-border-radius.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/compositing/mix-blend-mode/mix-blend-mode-parent-element-overflow-scroll.html.ini
+++ b/tests/wpt/meta/css/compositing/mix-blend-mode/mix-blend-mode-parent-element-overflow-scroll.html.ini
@@ -1,2 +1,0 @@
-[mix-blend-mode-parent-element-overflow-scroll.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/compositing/mix-blend-mode/mix-blend-mode-parent-with-3D-transform.html.ini
+++ b/tests/wpt/meta/css/compositing/mix-blend-mode/mix-blend-mode-parent-with-3D-transform.html.ini
@@ -1,0 +1,2 @@
+[mix-blend-mode-parent-with-3D-transform.html]
+    fuzzy: maxDifference=0-61;totalPixels=0-140

--- a/tests/wpt/meta/css/compositing/mix-blend-mode/mix-blend-mode-parent-with-border-radius.html.ini
+++ b/tests/wpt/meta/css/compositing/mix-blend-mode/mix-blend-mode-parent-with-border-radius.html.ini
@@ -1,2 +1,0 @@
-[mix-blend-mode-parent-with-border-radius.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/compositing/mix-blend-mode/mix-blend-mode-parent-with-text.html.ini
+++ b/tests/wpt/meta/css/compositing/mix-blend-mode/mix-blend-mode-parent-with-text.html.ini
@@ -1,2 +1,0 @@
-[mix-blend-mode-parent-with-text.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/compositing/mix-blend-mode/mix-blend-mode-rotated-clip.html.ini
+++ b/tests/wpt/meta/css/compositing/mix-blend-mode/mix-blend-mode-rotated-clip.html.ini
@@ -1,2 +1,0 @@
-[mix-blend-mode-rotated-clip.html]
-  expected: FAIL

--- a/tests/wpt/tests/css/compositing/mix-blend-mode/mix-blend-mode-root-element-transform-crash.html
+++ b/tests/wpt/tests/css/compositing/mix-blend-mode/mix-blend-mode-root-element-transform-crash.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel=help href="https://github.com/servo/servo/issues/41207">
+<style>
+  html {
+      transform: matrix3d(0,866,1,0,0,0,1,628,1,0.46,0,868,0,0,8,0.33) rotateZ(180deg);
+      -webkit-box-shadow: 1em 0em 463px;
+      mix-blend-mode: hue;
+  }
+</style>
+
+


### PR DESCRIPTION
In order to properly support `mix-blend-mode` stacking contexts that are
parents of child stacking contexts with `mix-blend-mode` in their style
need to be marked with the is `IS_BLEND_CONTAINER` StackingContextFlag.
In addition to correcting the display of `mix-blend-mode` content, this
also works around an issue where `mix-blend-mode` was causing a panic
when combined with a particular transform.

This change also works around a variety of WebRender bugs that happen when
`mix-blend-mode` is used near the root stacking context.

Testing: This change updates test results and also adds a WPT crash test.
Fixes: #42292.
