### PR TITLE
script: Use constellation event's mouse button state instead of tracking count

### DIFF
--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -170,10 +170,10 @@ pub(crate) struct DocumentEventHandler {
     click_counting_info: DomRefCell<ClickCountingInfo>,
     #[no_trace]
     last_mouse_button_down_point: Cell<Option<Point2D<f32, CSSPixel>>>,
-    /// The number of mouse buttons currently being pressed. This is used to ensure
-    /// that `pointerup` and `pointerdown` events are only sent when transitioning from
+    /// The current button state of the mouse. This is used to ensure that
+    /// `pointerup` and `pointerdown` events are only sent when transitioning from
     /// having no mouse buttons pressed to having any and vice-versa.
-    mouse_buttons_down: Cell<u32>,
+    mouse_button_state: Cell<u16>,
     /// The element that is currently hovered by the cursor.
     current_hover_target: MutNullableDom<Element>,
     /// The element that was most recently activated during a mouse button press or touch
@@ -219,7 +219,7 @@ impl DocumentEventHandler {
             coalesced_wheel_event_ids: Default::default(),
             click_counting_info: Default::default(),
             last_mouse_button_down_point: Default::default(),
-            mouse_buttons_down: Cell::new(0),
+            mouse_button_state: Cell::new(0),
             current_hover_target: Default::default(),
             current_active_element: Default::default(),
             most_recently_clicked_element: Default::default(),
@@ -944,8 +944,7 @@ impl DocumentEventHandler {
                     .set(Some(hit_test_result.point_in_frame));
 
                 // Step 6. Dispatch pointerdown event.
-                let mouse_buttons_down = self.mouse_buttons_down.get();
-                let pointer_event_name = if mouse_buttons_down == 0 {
+                let pointer_event_name = if self.mouse_button_state.get() == 0 {
                     // From <https://w3c.github.io/pointerevents/#dfn-pointerdown>
                     // > The user agent MUST fire a pointer event named pointerdown when a pointer enters
                     // > the active buttons state. For mouse, this is when the device transitions from no
@@ -974,8 +973,9 @@ impl DocumentEventHandler {
                     .map(DomRoot::upcast::<EventTarget>)
                     .unwrap_or_else(|| DomRoot::from_ref(node.upcast::<EventTarget>()));
 
-                // Increment button count before firing so setPointerCapture works in handler.
-                self.mouse_buttons_down.set(mouse_buttons_down + 1);
+                // Update button state before firing so setPointerCapture works in handler.
+                self.mouse_button_state
+                    .set(input_event.pressed_mouse_buttons);
 
                 pointer_event.upcast::<Event>().fire(cx, &pointer_target);
 
@@ -1011,8 +1011,11 @@ impl DocumentEventHandler {
             // https://w3c.github.io/pointerevents/#dfn-handle-native-mouse-up
             MouseButtonAction::Up => {
                 // Step 6. Dispatch pointerup event.
-                let mouse_buttons_down = self.mouse_buttons_down.get();
-                let pointer_event_name = if mouse_buttons_down == 1 {
+                let mouse_button_state = self.mouse_button_state.get();
+                // Exactly one button is pressed iff mouse_button_state is a power of 2
+                let exactly_one_button =
+                    mouse_button_state > 0 && (mouse_button_state & (mouse_button_state - 1)) == 0;
+                let pointer_event_name = if exactly_one_button {
                     // From <https://w3c.github.io/pointerevents/#dfn-pointerup>:
                     // > The user agent MUST fire a pointer event named pointerup when a pointer leaves
                     // > the active buttons state. For mouse, this is when the device transitions from at
@@ -1043,10 +1046,10 @@ impl DocumentEventHandler {
 
                 pointer_event.upcast::<Event>().fire(cx, &pointer_target);
 
-                // Decrement button count after firing event, so setPointerCapture/releasePointerCapture
+                // Update button state after firing event, so setPointerCapture/releasePointerCapture
                 // work during the pointerup handler (pointer is still "active").
-                self.mouse_buttons_down
-                    .set(mouse_buttons_down.saturating_sub(1));
+                self.mouse_button_state
+                    .set(input_event.pressed_mouse_buttons);
 
                 // Process pending pointer capture after decrementing button count, but skip
                 // if we just released a disconnected capture to avoid immediately re-capturing.
@@ -1056,7 +1059,7 @@ impl DocumentEventHandler {
                 }
 
                 // Implicitly release pointer capture when last button was released
-                if mouse_buttons_down == 1 {
+                if exactly_one_button {
                     self.implicit_release_pointer_capture(cx, pointer_id, "mouse", true);
                 }
 
@@ -2497,7 +2500,7 @@ impl DocumentEventHandler {
     pub(crate) fn is_active_pointer(&self, pointer_id: i32) -> bool {
         if pointer_id == PointerId::Mouse as i32 {
             // Mouse is active when buttons are down
-            self.mouse_buttons_down.get() > 0
+            self.mouse_button_state.get() > 0
         } else {
             // Touch pointers are tracked in active_pointer_ids
             self.active_pointer_ids
@@ -2686,7 +2689,7 @@ impl DocumentEventHandler {
             Point2D::new(0, 0),
             Modifiers::empty(),
             -1, // button: -1 for boundary events
-            self.mouse_buttons_down.get() as u16,
+            self.mouse_button_state.get(),
             related_target.map(|el| el.upcast::<EventTarget>()),
             None,
             pointer_id,

--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -172,10 +172,11 @@ pub(crate) struct DocumentEventHandler {
     click_counting_info: DomRefCell<ClickCountingInfo>,
     #[no_trace]
     last_mouse_button_down_point: Cell<Option<Point2D<f32, CSSPixel>>>,
-    /// The number of mouse buttons currently being pressed. This is used to ensure
-    /// that `pointerup` and `pointerdown` events are only sent when transitioning from
+    /// The current button state of the mouse. This is used to ensure that
+    /// `pointerup` and `pointerdown` events are only sent when transitioning from
     /// having no mouse buttons pressed to having any and vice-versa.
-    mouse_buttons_down_count: Cell<u32>,
+    #[no_trace]
+    mouse_button_state: Cell<MouseButtons>,
     /// The element that is currently hovered by the cursor.
     current_hover_target: MutNullableDom<Element>,
     /// The element that was most recently activated during a mouse button press or touch
@@ -224,7 +225,7 @@ impl DocumentEventHandler {
             coalesced_wheel_event_ids: Default::default(),
             click_counting_info: Default::default(),
             last_mouse_button_down_point: Default::default(),
-            mouse_buttons_down_count: Cell::new(0),
+            mouse_button_state: Cell::new(MouseButtons::empty()),
             current_hover_target: Default::default(),
             current_active_element: Default::default(),
             most_recently_clicked_element: Default::default(),
@@ -990,8 +991,7 @@ impl DocumentEventHandler {
                     .set(Some(hit_test_result.point_in_frame));
 
                 // Step 6. Dispatch pointerdown event.
-                let mouse_buttons_down = self.mouse_buttons_down_count.get();
-                let pointer_event_name = if mouse_buttons_down == 0 {
+                let pointer_event_name = if self.mouse_button_state.get().is_empty() {
                     // From <https://w3c.github.io/pointerevents/#dfn-pointerdown>
                     // > The user agent MUST fire a pointer event named pointerdown when a pointer enters
                     // > the active buttons state. For mouse, this is when the device transitions from no
@@ -1020,8 +1020,9 @@ impl DocumentEventHandler {
                     .map(DomRoot::upcast::<EventTarget>)
                     .unwrap_or_else(|| DomRoot::from_ref(node.upcast::<EventTarget>()));
 
-                // Increment button count before firing so setPointerCapture works in handler.
-                self.mouse_buttons_down_count.set(mouse_buttons_down + 1);
+                // Update button state before firing so setPointerCapture works in handler.
+                self.mouse_button_state
+                    .set(input_event.pressed_mouse_buttons);
 
                 pointer_event.upcast::<Event>().fire(cx, &pointer_target);
 
@@ -1057,8 +1058,9 @@ impl DocumentEventHandler {
             // https://w3c.github.io/pointerevents/#dfn-handle-native-mouse-up
             MouseButtonAction::Up => {
                 // Step 6. Dispatch pointerup event.
-                let mouse_buttons_down = self.mouse_buttons_down_count.get();
-                let pointer_event_name = if mouse_buttons_down == 1 {
+                let mouse_button_state = self.mouse_button_state.get();
+                let exactly_one_button = mouse_button_state.exactly_one_button_pressed();
+                let pointer_event_name = if exactly_one_button {
                     // From <https://w3c.github.io/pointerevents/#dfn-pointerup>:
                     // > The user agent MUST fire a pointer event named pointerup when a pointer leaves
                     // > the active buttons state. For mouse, this is when the device transitions from at
@@ -1089,10 +1091,10 @@ impl DocumentEventHandler {
 
                 pointer_event.upcast::<Event>().fire(cx, &pointer_target);
 
-                // Decrement button count after firing event, so setPointerCapture/releasePointerCapture
+                // Update button state after firing event, so setPointerCapture/releasePointerCapture
                 // work during the pointerup handler (pointer is still "active").
-                self.mouse_buttons_down_count
-                    .set(mouse_buttons_down.saturating_sub(1));
+                self.mouse_button_state
+                    .set(input_event.pressed_mouse_buttons);
 
                 // Process pending pointer capture after decrementing button count, but skip
                 // if we just released a disconnected capture to avoid immediately re-capturing.
@@ -1102,7 +1104,7 @@ impl DocumentEventHandler {
                 }
 
                 // Implicitly release pointer capture when last button was released
-                if mouse_buttons_down == 1 {
+                if exactly_one_button {
                     self.implicit_release_pointer_capture(cx, pointer_id, "mouse", true);
                 }
 
@@ -2557,7 +2559,7 @@ impl DocumentEventHandler {
     pub(crate) fn is_active_pointer(&self, pointer_id: i32) -> bool {
         if pointer_id == PointerId::Mouse as i32 {
             // Mouse is active when buttons are down
-            self.mouse_buttons_down_count.get() > 0
+            !self.mouse_button_state.get().is_empty()
         } else {
             // Touch pointers are tracked in active_pointer_ids
             self.active_pointer_ids
@@ -2727,13 +2729,6 @@ impl DocumentEventHandler {
         target: &Element,
         related_target: Option<&Element>,
     ) {
-        // TODO: This is wrong when the button pressed is not the primary one.
-        let mouse_buttons = if self.mouse_buttons_down_count.get() != 0 {
-            MouseButtons::Primary
-        } else {
-            MouseButtons::empty()
-        };
-
         let pointer_event = PointerEvent::new(
             cx,
             &self.window,
@@ -2747,7 +2742,7 @@ impl DocumentEventHandler {
             Point2D::new(0, 0),
             Modifiers::empty(),
             MouseButton::None,
-            mouse_buttons,
+            self.mouse_button_state.get(),
             related_target.map(|el| el.upcast::<EventTarget>()),
             None,
             pointer_id,

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -387,6 +387,14 @@ bitflags! {
     }
 }
 
+impl MouseButtons {
+    /// Returns whether exactly one button is pressed.
+    pub fn exactly_one_button_pressed(&self) -> bool {
+        // Exactly one button is pressed iff mouse_button_state is a power of 2
+        !self.is_empty() && (self.bits() & (self.bits() - 1)) == 0
+    }
+}
+
 malloc_size_of_is_0!(MouseButtons);
 
 impl TryFrom<MouseButton> for MouseButtons {

--- a/tests/wpt/tests/pointerevents/pointerevent_buttons-attribute-chorded.html
+++ b/tests/wpt/tests/pointerevents/pointerevent_buttons-attribute-chorded.html
@@ -1,0 +1,127 @@
+<!doctype html>
+<title>Pointer event `buttons` attribute on chorded button state changes</title>
+<meta name="timeout" content="long">
+<meta name="viewport" content="width=device-width">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script type="text/javascript" src="pointerevent_support.js"></script>
+<style>
+  div {
+    width: 100px;
+    height: 100px;
+    touch-action: none;
+    user-select: none;
+  }
+</style>
+<body>
+  <div id="done"></div>
+  <div id="target"></div>
+</body>
+<script>
+  "use strict";
+
+  let target = null;
+  let done = null;
+
+  promise_setup(async () => {
+    await new Promise((resolve) => {
+      window.addEventListener('load', resolve, { once: true });
+    });
+    target = document.getElementById("target");
+    done = document.getElementById("done");
+  });
+
+  function generatePointerSequence(expected, actions) {
+    const pointerSequence = [];
+    if ((expected & ButtonsBitfield.LEFT_MOUSE) > 0) {
+      pointerSequence.push(actions.ButtonType.LEFT);
+    }
+    if ((expected & ButtonsBitfield.RIGHT_MOUSE) > 0) {
+      pointerSequence.push(actions.ButtonType.RIGHT);
+    }
+    if ((expected & ButtonsBitfield.MIDDLE_MOUSE) > 0) {
+      pointerSequence.push(actions.ButtonType.MIDDLE);
+    }
+    if ((expected & ButtonsBitfield.X1_MOUSE) > 0) {
+      pointerSequence.push(actions.ButtonType.BACK);
+    }
+    if ((expected & ButtonsBitfield.X2_MOUSE) > 0) {
+      pointerSequence.push(actions.ButtonType.FORWARD);
+    }
+    return pointerSequence;
+  }
+
+  async function testButtonsBasic(expected) {
+    let max = 0;
+    const handler = (event) => (max = Math.max(max, event.buttons));
+    target.onpointerdown = handler;
+    target.onpointermove = handler;
+    const doneClickPromise = new Promise(res => (done.onclick = res));
+    let actions = new test_driver.Actions();
+    const pointerSequence = generatePointerSequence(expected, actions);
+    actions = actions.pointerMove(0, 0, { origin: target });
+    for (const button of pointerSequence) {
+      actions = actions.pointerDown({ button });
+    }
+    for (const button of pointerSequence) {
+      actions = actions.pointerUp({ button });
+    }
+    actions = actions
+      .pointerMove(0, 0, { origin: done })
+      .pointerDown()
+      .pointerUp();
+
+    await actions.send();
+    await doneClickPromise;
+
+    assert_equals(max, expected, "buttons attribute matched");
+  }
+
+  async function testButtonsCaptureBoundary(expected) {
+    let pointerId;
+    const pointerLeavePromise = new Promise(res => target.onpointerleave = (event) => res(event.buttons));
+    target.onpointerdown = (event) => {
+      pointerId = event.pointerId;
+      target.setPointerCapture(pointerId);
+    };
+    const doneClickPromise = new Promise(res => (done.onclick = res));
+    let actions = new test_driver.Actions();
+    const pointerSequence = generatePointerSequence(expected, actions);
+    let count = 0;
+    target.onpointermove = (event) => {
+      if (count === pointerSequence.length) done.setPointerCapture(pointerId);
+      count++;
+    };
+    actions = actions.pointerMove(0, 0, { origin: target });
+    for (const button of pointerSequence) {
+      actions = actions.pointerDown({ button });
+    }
+    actions = actions.pointerMove(0, 0, { origin: done });
+    await actions.send();
+
+    const output = await pointerLeavePromise;
+
+    actions = new test_driver.Actions();
+    for (const button of pointerSequence) {
+      actions = actions.pointerUp({ button });
+    }
+    actions = actions
+      .pointerMove(0, 0, { origin: done })
+      .pointerDown()
+      .pointerUp();
+
+    await actions.send();
+    await doneClickPromise;
+
+    assert_equals(output, expected, "buttons attribute matched");
+  }
+
+  promise_test((test) => testButtonsBasic(0b10101), "left mouse + middle mouse + forward mouse properly sets buttons");
+  promise_test((test) => testButtonsBasic(0b01010), "right mouse + back mouse properly sets buttons");
+
+  promise_test((test) => testButtonsCaptureBoundary(0b10101), "left mouse + middle mouse + forward mouse properly sets buttons on pointer capture boundaries");
+  promise_test((test) => testButtonsCaptureBoundary(0b01010), "right mouse + back mouse properly sets buttons on pointer capture boundaries");
+</script>


### PR DESCRIPTION
Instead of keeping track of the number of mouse buttons currently pressed from within the document event handler, we use the input event from the constellation as the source of truth for currently pressed mouse buttons. This fixes an issue where the internal count would permanently increase, preventing the firing of `pointerup`/`pointerdown` events.

This also fixes an issue where the `buttons` field of pointer capture boundary transition events was improperly set to a button count instead of an integer bitmap.

Testing: The issue is caused by the embedder not sending a corresponding mouse up event with a mouse down one, so I'm not sure if WPT can enable us to test this.
Fixes: Partially fixes #45491, prevents `pointerup`/`pointerdown` events from breaking entirely. 
Fixes #47300.