### PR TITLE
layout: Make the implementation of used `TransformStyle` more complete

### DIFF
--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -408,7 +408,7 @@ impl DisplayListBuilder<'_> {
         // actually need to create a stacking context, just avoid creating one.
         let style = fragment.style();
         let effects = style.get_effects();
-        let transform_style = style.get_used_transform_style();
+        let transform_style = style.used_transform_style(fragment.base.flags);
         if effects.filter.0.is_empty() &&
             effects.opacity == 1.0 &&
             effects.mix_blend_mode == ComputedMixBlendMode::Normal &&

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -617,7 +617,7 @@ impl BoxFragment {
             reference_frame_data.origin.to_webrender(),
             frame_origin_for_query,
             containing_block.scroll_node_id,
-            style.get_box().transform_style.to_webrender(),
+            style.used_transform_style(self.base.flags).to_webrender(),
             reference_frame_data.transform,
             reference_frame_data.kind,
         );

--- a/components/layout/style_ext.rs
+++ b/components/layout/style_ext.rs
@@ -333,6 +333,7 @@ pub(crate) trait ComputedValuesExt {
     fn z_index_applies(&self, fragment_flags: FragmentFlags) -> bool;
     fn effective_z_index(&self, fragment_flags: FragmentFlags) -> i32;
     fn effective_overflow(&self, fragment_flags: FragmentFlags) -> AxesOverflow;
+    fn used_transform_style(&self, fragment_flags: FragmentFlags) -> ComputedTransformStyle;
     fn establishes_block_formatting_context(&self, fragment_flags: FragmentFlags) -> bool;
     fn establishes_stacking_context(&self, fragment_flags: FragmentFlags) -> bool;
     fn establishes_scroll_container(&self, fragment_flags: FragmentFlags) -> bool;
@@ -657,6 +658,50 @@ impl ComputedValuesExt for ComputedValues {
         overflow
     }
 
+    /// Get the used `transform-style` value according to the the rules in
+    /// <https://drafts.csswg.org/css-transforms/#grouping-property-values>.
+    fn used_transform_style(&self, fragment_flags: FragmentFlags) -> ComputedTransformStyle {
+        // The check for flat here is to avoid having to check all of the properties below when
+        // possible.
+        let box_style = self.get_box();
+        if box_style.transform_style == ComputedTransformStyle::Flat {
+            return ComputedTransformStyle::Flat;
+        }
+
+        // https://drafts.csswg.org/css-transforms-2/#grouping-property-values
+        //  * overflow: any value other than visible or clip.
+        //  * opacity: any value less than 1.
+        //  * filter: any value other than none.
+        //  * clip: any value other than auto.
+        //  * clip-path: any value other than none.
+        //  * isolation: used value of isolate.
+        //  * mask-image: any value other than none.
+        //  * mask-border-source: any value other than none.
+        //  * mix-blend-mode: any value other than normal.
+        //  * contain: paint and any other property/value combination that causes
+        //    paint containment. Note: this includes any property that affect the
+        //    used value of the contain property, such as content-visibility:
+        //    hidden.
+        //
+        // TODO: Support `mask-image`, `mask-border-source`, and `contain`.
+        let effects = self.get_effects();
+        let overflow = self.effective_overflow(fragment_flags);
+        if !matches!(overflow.x, Overflow::Visible | Overflow::Clip) ||
+            !matches!(overflow.y, Overflow::Visible | Overflow::Clip) ||
+            effects.opacity < 1.0 ||
+            !effects.filter.0.is_empty() ||
+            !effects.clip.is_auto() ||
+            self.get_svg().clip_path != ClipPath::None ||
+            self.get_box().isolation == ComputedIsolation::Isolate ||
+            effects.mix_blend_mode != ComputedMixBlendMode::Normal
+        {
+            return ComputedTransformStyle::Flat;
+        }
+
+        // Return the computed value if not overridden by the above exceptions
+        box_style.transform_style
+    }
+
     /// Return true if this style is a normal block and establishes
     /// a new block formatting context.
     ///
@@ -741,7 +786,8 @@ impl ComputedValuesExt for ComputedValues {
         // > establishes both a stacking context and a containing block for all descendants.
         if self.is_transformable(fragment_flags) &&
             (self.has_transform_or_perspective_style() ||
-                self.get_box().transform_style == ComputedTransformStyle::Preserve3d ||
+                self.used_transform_style(fragment_flags) ==
+                    ComputedTransformStyle::Preserve3d ||
                 will_change_bits
                     .intersects(WillChangeBits::TRANSFORM | WillChangeBits::PERSPECTIVE))
         {
@@ -854,7 +900,8 @@ impl ComputedValuesExt for ComputedValues {
         // > establishes both a stacking context and a containing block for all descendants.
         if self.is_transformable(fragment_flags) &&
             (self.has_transform_or_perspective_style() ||
-                self.get_box().transform_style == ComputedTransformStyle::Preserve3d ||
+                self.used_transform_style(fragment_flags) ==
+                    ComputedTransformStyle::Preserve3d ||
                 will_change_bits
                     .intersects(WillChangeBits::TRANSFORM | WillChangeBits::PERSPECTIVE))
         {

--- a/tests/wpt/meta/css/css-transforms/transform3d-preserve3d-008.html.ini
+++ b/tests/wpt/meta/css/css-transforms/transform3d-preserve3d-008.html.ini
@@ -1,2 +1,0 @@
-[transform3d-preserve3d-008.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/transform3d-preserve3d-009.html.ini
+++ b/tests/wpt/meta/css/css-transforms/transform3d-preserve3d-009.html.ini
@@ -1,2 +1,0 @@
-[transform3d-preserve3d-009.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/transform3d-preserve3d-013.html.ini
+++ b/tests/wpt/meta/css/css-transforms/transform3d-preserve3d-013.html.ini
@@ -1,2 +1,0 @@
-[transform3d-preserve3d-013.html]
-  expected: FAIL

--- a/tests/wpt/tests/css/css-transforms/transform-preserve3d-grouping-property-root-crash.html
+++ b/tests/wpt/tests/css/css-transforms/transform-preserve3d-grouping-property-root-crash.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/42476">
+<style>
+  :root {
+      transform: translate(8%);
+      transform-style: preserve-3d;
+      clip-path: circle(90%);
+      border-right-style: double;
+  }
+</style>


### PR DESCRIPTION
Stylo was using a very incomplete method for calculating the used
`TransformStyle` for boxes, which didn't incorporate all of the grouping
properties from the specification. This change moves the functionality
into Servo (as cannot properly compute this value without
`FragmentFlags`) and makes it more complete. We still do not process the
value of `contain`, `mask-image`, and `mask-border-source` as we do not
support those values yet.

Incidentally, this also fixes a panic that we were causing in WebRender,
probably by going down a path that Gecko does not exercise.

Stylo PR: servo/stylo#388

Testing: This adds a new crashtest. Three other WPT tests start to pass.
Fixes: #42476.
