### PR TITLE
Bump `rsa` to 0.10.0-rc.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,6 +780,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1585,6 +1591,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1699,6 +1711,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42a0d26b245348befa0c121944541476763dcc46ede886c88f9d12e1697d27c3"
+dependencies = [
+ "cpubits",
+ "ctutils",
+ "num-traits",
+ "rand_core 0.10.1",
+ "serdect",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1717,6 +1743,16 @@ checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "getrandom 0.4.1",
  "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "crypto-primes"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3633a51a39c69ebbaa4feaa694bd83d241e4093901c84a0963b19d9bb3f0cf8f"
+dependencies = [
+ "crypto-bigint 0.7.3",
  "rand_core 0.10.1",
 ]
 
@@ -1903,7 +1939,7 @@ checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
  "der_derive",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
  "zeroize",
 ]
 
@@ -1914,6 +1950,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
 dependencies = [
  "const-oid 0.10.2",
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
@@ -2244,14 +2281,14 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
- "crypto-bigint",
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
  "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
  "hkdf 0.12.4",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1",
@@ -4739,9 +4776,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "leb128fmt"
@@ -5372,23 +5406,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.6",
- "serde",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5420,17 +5437,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
  "num-traits",
 ]
 
@@ -6122,7 +6128,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "ecdsa",
  "elliptic-curve",
  "primeorder",
@@ -6225,6 +6231,15 @@ name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
  "base64ct",
 ]
@@ -6358,13 +6373,12 @@ dependencies = [
 
 [[package]]
 name = "pkcs1"
-version = "0.7.5"
+version = "0.8.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+checksum = "986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e"
 dependencies = [
- "der 0.7.10",
- "pkcs8 0.10.2",
- "spki 0.7.3",
+ "der 0.8.0",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -7060,23 +7074,19 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.10"
+version = "0.10.0-rc.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+checksum = "30b2aa4ba0d89f73d1e332df05be0eeab8840351c36ca5654341dfdb57bb3caf"
 dependencies = [
- "const-oid 0.9.6",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
+ "const-oid 0.10.2",
+ "crypto-bigint 0.7.3",
+ "crypto-primes",
+ "digest 0.11.3",
  "pkcs1",
- "pkcs8 0.10.2",
- "rand_core 0.6.4",
- "sha1 0.10.6",
- "sha2 0.10.9",
- "signature 2.2.0",
- "spki 0.7.3",
- "subtle",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "signature 3.0.0",
+ "spki 0.8.0",
  "zeroize",
 ]
 
@@ -7348,7 +7358,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "der 0.7.10",
  "generic-array",
  "pkcs8 0.10.2",
@@ -7521,6 +7531,16 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct 1.0.0",
  "serde",
 ]
 
@@ -8713,6 +8733,7 @@ dependencies = [
  "content-security-policy",
  "cookie 0.18.1",
  "crossbeam-channel",
+ "crypto-bigint 0.7.3",
  "cshake",
  "cssparser",
  "ctr",
@@ -8746,7 +8767,6 @@ dependencies = [
  "mozangle",
  "mozjs",
  "nom-rfc8288",
- "num-bigint-dig",
  "num-traits",
  "num_cpus",
  "ocb3",
@@ -8801,9 +8821,7 @@ dependencies = [
  "servo-webxr-api",
  "servo-xpath",
  "servo_arc",
- "sha1 0.10.6",
  "sha1 0.11.0",
- "sha2 0.10.9",
  "sha2 0.11.0",
  "sha3 0.12.0",
  "smallvec",
@@ -9475,12 +9493,6 @@ name = "speexdsp-resampler"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b72d540d5c565dbe1f891d7e21ceb21d2649508306782f1066989fccb0b363d3"
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spirv"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ crossbeam-channel = "0.5"
 cshake = "0.2"
 cssparser = { version = "0.37", features = ["serde"] }
 ctr = "0.9.2"
+crypto-bigint = "0.7"
 data-url = "0.3"
 der = { version = "0.7", features = ["alloc", "derive"] }
 digest = "0.11"
@@ -158,7 +159,6 @@ napi-ohos = "1.2.0"
 nix = "0.30"
 nom = "8.0.0"
 nom-rfc8288 = "0.4.0"
-num-bigint-dig = "0.8"
 num-complex = "0.4.6"
 num-derive = "0.4.2"
 num-traits = "0.2"
@@ -207,7 +207,7 @@ rayon = "1"
 read-fonts = "0.39.2"
 regex = "1.12"
 resvg = "0.47.0"
-rsa = { version = "0.9.10", features = ["sha1", "sha2"] }
+rsa = "=0.10.0-rc.18"
 rusqlite = "0.37"
 rustc-demangle = "0.1"
 rustc-hash = "2.1.2"
@@ -226,9 +226,7 @@ serde_json = "1.0"
 serde_test = "1.0"
 servo_arc = { git = "https://github.com/servo/stylo", rev = "813923186eff5bcb957fe6da8538038acd918e98" }
 sha1 = "0.11"
-sha1_0_10 = { package = "sha1", version = "0.10" }
 sha2 = "0.11"
-sha2_0_10 = { package = "sha2", version = "0.10" }
 sha3 = "0.12"
 signal-hook-registry = "1.4.8"
 skrifa = "0.42.1"
@@ -374,8 +372,8 @@ xpath = { package = "servo-xpath", version = "=0.3.0", path = "components/xpath"
 # consider RSA key generation tests fail due to timeout.
 # Building with higher optimization levels can speed up the key
 # generation process to avoid false negative result in those tests.
-# More details: <https://docs.rs/rsa/0.9.8/rsa/index.html#example>
-[profile.dev.package.num-bigint-dig]
+# More details: <https://docs.rs/rsa/0.10.0-rc.18/rsa/index.html>
+[profile.dev.package.crypto-bigint]
 opt-level = 3
 
 # Force tikv-jemalloc-sys to build with at least -O1.

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -64,6 +64,7 @@ crossbeam-channel = { workspace = true }
 cshake = { workspace = true }
 cssparser = { workspace = true }
 ctr = { workspace = true }
+crypto-bigint = { workspace = true }
 data-url = { workspace = true }
 deny_public_fields = { workspace = true }
 der = { workspace = true }
@@ -106,7 +107,6 @@ ml-dsa = { workspace = true }
 ml-kem = { workspace = true }
 net_traits = { workspace = true }
 nom-rfc8288 = { workspace = true }
-num-bigint-dig = { workspace = true }
 num-traits = { workspace = true }
 num_cpus = { workspace = true }
 ocb3 = { workspace = true }
@@ -144,9 +144,7 @@ servo-tracing = { workspace = true }
 servo-url = { workspace = true }
 servo_arc = { workspace = true }
 sha1 = { workspace = true }
-sha1_0_10 = { workspace = true }
 sha2 = { workspace = true }
-sha2_0_10 = { workspace = true }
 sha3 = { workspace = true }
 smallvec = { workspace = true }
 storage_traits = { workspace = true }

--- a/components/script/dom/webcrypto/cryptokey.rs
+++ b/components/script/dom/webcrypto/cryptokey.rs
@@ -356,10 +356,11 @@ impl TryFrom<SerializableCryptoKeyHandle> for Handle {
     fn try_from(value: SerializableCryptoKeyHandle) -> Result<Self, Self::Error> {
         match &value {
             SerializableCryptoKeyHandle::RsaPrivateKey(private_key) => Ok(Handle::RsaPrivateKey(
-                pkcs8::DecodePrivateKey::from_pkcs8_der(private_key).map_err(|_| ())?,
+                rsa::pkcs8::DecodePrivateKey::from_pkcs8_der(private_key).map_err(|_| ())?,
             )),
             SerializableCryptoKeyHandle::RsaPublicKey(public_key) => Ok(Handle::RsaPublicKey(
-                pkcs8::spki::DecodePublicKey::from_public_key_der(public_key).map_err(|_| ())?,
+                rsa::pkcs8::spki::DecodePublicKey::from_public_key_der(public_key)
+                    .map_err(|_| ())?,
             )),
             SerializableCryptoKeyHandle::P256PrivateKey(private_key) => Ok(Handle::P256PrivateKey(
                 p256::SecretKey::from_sec1_der(private_key).map_err(|_| ())?,
@@ -492,16 +493,15 @@ impl TryFrom<&Handle> for SerializableCryptoKeyHandle {
     fn try_from(value: &Handle) -> Result<Self, Self::Error> {
         match value {
             Handle::RsaPrivateKey(private_key) => Ok(SerializableCryptoKeyHandle::RsaPrivateKey(
-                pkcs8::EncodePrivateKey::to_pkcs8_der(private_key)
+                rsa::pkcs8::EncodePrivateKey::to_pkcs8_der(private_key)
                     .map_err(|_| ())?
-                    .to_bytes()
+                    .as_bytes()
                     .to_vec(),
             )),
             Handle::RsaPublicKey(public_key) => Ok(SerializableCryptoKeyHandle::RsaPublicKey(
-                pkcs8::spki::EncodePublicKey::to_public_key_der(public_key)
+                rsa::pkcs8::spki::EncodePublicKey::to_public_key_der(public_key)
                     .map_err(|_| ())?
-                    .into_vec()
-                    .to_vec(),
+                    .into_vec(),
             )),
             Handle::P256PrivateKey(private_key) => Ok(SerializableCryptoKeyHandle::P256PrivateKey(
                 private_key.to_sec1_der().map_err(|_| ())?.to_vec(),

--- a/components/script/dom/webcrypto/subtlecrypto/rsa_common.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/rsa_common.rs
@@ -2,21 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::ops::{Mul, Sub};
-
 use base64ct::{Base64UrlUnpadded, Encoding};
+use crypto_bigint::NonZero;
 use js::context::JSContext;
-use num_bigint_dig::{BigInt, ModInverse, Sign};
-use num_traits::One;
-use pkcs8::der::asn1::BitString;
-use pkcs8::der::{AnyRef, Decode};
-use pkcs8::rand_core::OsRng;
-use pkcs8::spki::EncodePublicKey;
-use pkcs8::{EncodePrivateKey, PrivateKeyInfo, SubjectPublicKeyInfo};
-use rsa::pkcs1::{self, DecodeRsaPrivateKey};
+use rsa::pkcs8::spki::{DecodePublicKey, EncodePublicKey};
+use rsa::pkcs8::{DecodePrivateKey, EncodePrivateKey};
 use rsa::traits::{PrivateKeyParts, PublicKeyParts};
-use rsa::{BigUint, RsaPrivateKey, RsaPublicKey};
-use sec1::der::Encode;
+use rsa::{BoxedUint, RsaPrivateKey, RsaPublicKey};
 
 use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::{
     CryptoKeyMethods, CryptoKeyPair, KeyType, KeyUsage,
@@ -100,11 +92,11 @@ pub(crate) fn generate_key(
             "The public expoenent is an even number".to_string(),
         )));
     }
-    let mut rng = OsRng;
+    let mut rng = rand::rng();
     let modulus_length = normalized_algorithm.modulus_length as usize;
-    let public_exponent = BigUint::from_bytes_be(&normalized_algorithm.public_exponent);
-    let private_key = RsaPrivateKey::new_with_exp(&mut rng, modulus_length, &public_exponent)
-        .map_err(|_| Error::Operation(Some("RSA failed to generate private key".to_string())))?;
+    let public_exponent = BoxedUint::from_be_slice_vartime(&normalized_algorithm.public_exponent);
+    let private_key = RsaPrivateKey::new_with_exp(&mut rng, modulus_length, public_exponent)
+        .map_err(|_| Error::Operation(Some("Failed to generate RSA private key".into())))?;
     let public_key = private_key.to_public_key();
 
     // Step 4. Let algorithm be a new RsaHashedKeyAlgorithm dictionary.
@@ -261,43 +253,18 @@ pub(crate) fn import_key(
             // Step 2.2. Let spki be the result of running the parse a subjectPublicKeyInfo
             // algorithm over keyData.
             // Step 2.3. If an error occurred while parsing, then throw a DataError.
-            let spki =
-                SubjectPublicKeyInfo::<AnyRef, BitString>::from_der(key_data).map_err(|_| {
-                    Error::Data(Some(
-                        "Fail to parse SubjectPublicKeyInfo over keyData".to_string(),
-                    ))
-                })?;
-
             // Step 2.4. If the algorithm object identifier field of the algorithm
             // AlgorithmIdentifier field of spki is not equal to the rsaEncryption object
             // identifier defined in [RFC3447], then throw a DataError.
-            if spki.algorithm.oid != pkcs1::ALGORITHM_OID {
-                return Err(Error::Data(Some(
-                    "Algorithm object identifier of spki is not an rsaEncryption".to_string(),
-                )));
-            }
-
             // Step 2.5. Let publicKey be the result of performing the parse an ASN.1 structure
             // algorithm, with data as the subjectPublicKeyInfo field of spki, structure as the
             // RSAPublicKey structure specified in Section A.1.1 of [RFC3447], and exactData set to
             // true.
             // Step 2.6. If an error occurred while parsing, or it can be determined that publicKey
             // is not a valid public key according to [RFC3447], then throw a DataError.
-            let pkcs1_bytes = spki.subject_public_key.as_bytes().ok_or(Error::Data(Some(
-                "Fail to parse byte sequence over SubjectPublicKey field of spki".to_string(),
-            )))?;
-            let rsa_public_key_structure =
-                pkcs1::RsaPublicKey::try_from(pkcs1_bytes).map_err(|_| {
-                    Error::Data(Some(
-                        "SubjectPublicKey field of spki is not an RSAPublicKey structure"
-                            .to_string(),
-                    ))
-                })?;
-            let n = BigUint::from_bytes_be(rsa_public_key_structure.modulus.as_bytes());
-            let e = BigUint::from_bytes_be(rsa_public_key_structure.public_exponent.as_bytes());
-            let public_key = RsaPublicKey::new(n, e).map_err(|_| {
+            let public_key = RsaPublicKey::from_public_key_der(key_data).map_err(|_| {
                 Error::Data(Some(
-                    "Fail to construct RSA public key from modulus and public exponent".to_string(),
+                    "Failed to import RSA public key in SPKI format".into(),
                 ))
             })?;
 
@@ -339,35 +306,20 @@ pub(crate) fn import_key(
             // Step 2.2. Let privateKeyInfo be the result of running the parse a privateKeyInfo
             // algorithm over keyData.
             // Step 2.3. If an error occurred while parsing, then throw a DataError.
-            let private_key_info = PrivateKeyInfo::from_der(key_data).map_err(|_| {
-                Error::Data(Some(
-                    "Fail to parse PrivateKeyInfo over keyData".to_string(),
-                ))
-            })?;
-
             // Step 2.4. If the algorithm object identifier field of the privateKeyAlgorithm
             // PrivateKeyAlgorithm field of privateKeyInfo is not equal to the rsaEncryption object
             // identifier defined in [RFC3447], then throw a DataError.
-            if private_key_info.algorithm.oid != pkcs1::ALGORITHM_OID {
-                return Err(Error::Data(Some(
-                    "Algorithm object identifier of PrivateKeyInfo is not an rsaEncryption"
-                        .to_string(),
-                )));
-            }
-
             // Step 2.5. Let rsaPrivateKey be the result of performing the parse an ASN.1 structure
             // algorithm, with data as the privateKey field of privateKeyInfo, structure as the
             // RSAPrivateKey structure specified in Section A.1.2 of [RFC3447], and exactData set
             // to true.
             // Step 2.6. If an error occurred while parsing, or if rsaPrivateKey is not a valid RSA
             // private key according to [RFC3447], then throw a DataError.
-            let rsa_private_key = RsaPrivateKey::from_pkcs1_der(private_key_info.private_key)
-                .map_err(|_| {
-                    Error::Data(Some(
-                        "PrivateKey field of PrivateKeyInfo is not an RSAPrivateKey structure"
-                            .to_string(),
-                    ))
-                })?;
+            let rsa_private_key = RsaPrivateKey::from_pkcs8_der(key_data).map_err(|_| {
+                Error::Data(Some(
+                    "Failed to import RSA private key in PKCS#8 format".into(),
+                ))
+            })?;
 
             // Step 2.7. Let key be a new CryptoKey that represents the RSA private key identified
             // by rsaPrivateKey.
@@ -610,7 +562,7 @@ pub(crate) fn import_key(
                     (None, None, None, None, None) => Vec::new(),
                     _ => return Err(Error::Data(Some(
                         "The p, q, dp, dq, qi fields of jwk must be either all-present or all-absent"
-                            .to_string()
+                            .to_string(),
                     ))),
                 };
                 jwk.decode_primes_from_oth_field(&mut primes)?;
@@ -620,12 +572,12 @@ pub(crate) fn import_key(
                 // Step 2.9.3. If privateKey is not a valid RSA private key according to [RFC3447],
                 // then throw a DataError.
                 let private_key = RsaPrivateKey::from_components(
-                    BigUint::from_bytes_be(&n),
-                    BigUint::from_bytes_be(&e),
-                    BigUint::from_bytes_be(&d),
+                    BoxedUint::from_be_slice_vartime(&n),
+                    BoxedUint::from_be_slice_vartime(&e),
+                    BoxedUint::from_be_slice_vartime(&d),
                     primes
                         .into_iter()
-                        .map(|prime| BigUint::from_bytes_be(&prime))
+                        .map(|prime| BoxedUint::from_be_slice_vartime(&prime))
                         .collect(),
                 )
                 .map_err(|_| {
@@ -652,13 +604,15 @@ pub(crate) fn import_key(
                 // interpreting jwk according to Section 6.3.1 of JSON Web Algorithms [JWA].
                 // Step 2.9.3. If publicKey can be determined to not be a valid RSA public key
                 // according to [RFC3447], then throw a DataError.
-                let public_key =
-                    RsaPublicKey::new(BigUint::from_bytes_be(&n), BigUint::from_bytes_be(&e))
-                        .map_err(|_| {
-                            Error::Data(Some(
-                                "Failed to construct RSA public key from values in jwk".to_string(),
-                            ))
-                        })?;
+                let public_key = RsaPublicKey::new(
+                    BoxedUint::from_be_slice_vartime(&n),
+                    BoxedUint::from_be_slice_vartime(&e),
+                )
+                .map_err(|_| {
+                    Error::Data(Some(
+                        "Failed to construct RSA public key from values in jwk".into(),
+                    ))
+                })?;
 
                 // Step 2.9.4. Let key be a new CryptoKey representing publicKey.
                 // Step 2.9.5. Set the [[type]] internal slot of key to "public"
@@ -685,12 +639,14 @@ pub(crate) fn import_key(
     // Step 7. Set the hash attribute of algorithm to the hash member of normalizedAlgorithm.
     // Step 8. Set the [[algorithm]] internal slot of key to algorithm
     let (modulus_length, public_exponent) = match &key_handle {
-        Handle::RsaPrivateKey(private_key) => {
-            (private_key.size() as u32 * 8, private_key.e().to_bytes_be())
-        },
-        Handle::RsaPublicKey(public_key) => {
-            (public_key.size() as u32 * 8, public_key.e().to_bytes_be())
-        },
+        Handle::RsaPrivateKey(private_key) => (
+            private_key.size() as u32 * 8,
+            private_key.e().to_be_bytes_trimmed_vartime().to_vec(),
+        ),
+        Handle::RsaPublicKey(public_key) => (
+            public_key.size() as u32 * 8,
+            public_key.e().to_be_bytes_trimmed_vartime().to_vec(),
+        ),
         _ => unreachable!(),
     };
     let algorithm = SubtleRsaHashedKeyAlgorithm {
@@ -778,11 +734,7 @@ pub(crate) fn export_key(
             })?;
 
             // Step 3.3. Let result be the result of DER-encoding data.
-            ExportedKey::new_bytes(data.to_der().map_err(|_| {
-                Error::Operation(Some(
-                    "Failed to convert SubjectPublicKeyInfo to DER-encodeing data".to_string(),
-                ))
-            })?)
+            ExportedKey::new_bytes(data.into_vec())
         },
         // If format is "pkcs8":
         KeyFormat::Pkcs8 => {
@@ -822,7 +774,7 @@ pub(crate) fn export_key(
             })?;
 
             // Step 3.3. Let result be the result of DER-encoding data.
-            ExportedKey::new_bytes(data.to_bytes().to_vec())
+            ExportedKey::new_bytes(data.as_bytes().to_vec())
         },
         // If format is "jwk":
         KeyFormat::Jwk => {
@@ -945,8 +897,8 @@ pub(crate) fn export_key(
                     )));
                 },
             };
-            jwk.n = Some(Base64UrlUnpadded::encode_string(&n.to_bytes_be()).into());
-            jwk.e = Some(Base64UrlUnpadded::encode_string(&e.to_bytes_be()).into());
+            jwk.encode_string_field(JwkStringField::N, &n.to_be_bytes_trimmed_vartime());
+            jwk.encode_string_field(JwkStringField::E, &e.to_be_bytes_trimmed_vartime());
 
             // Step 3.6. If the [[type]] internal slot of key is "private":
             if key.Type() == KeyType::Private {
@@ -977,23 +929,15 @@ pub(crate) fn export_key(
                     "Failed to extract second factor CRT exponent dq from RSA private key"
                         .to_string(),
                 )))?;
-                let qi = private_key
-                    .qinv()
-                    .ok_or(Error::Operation(Some(
-                        "Failed to extract first CRT coefficient qi from RSA private key"
-                            .to_string(),
-                    )))?
-                    .modpow(&BigInt::one(), &BigInt::from_biguint(Sign::Plus, p.clone()))
-                    .to_biguint()
-                    .ok_or(Error::Operation(Some(
-                        "Failed to convert first CRT coefficient qi to BigUint".to_string(),
-                    )))?;
-                jwk.encode_string_field(JwkStringField::D, &d.to_bytes_be());
-                jwk.encode_string_field(JwkStringField::P, &p.to_bytes_be());
-                jwk.encode_string_field(JwkStringField::Q, &q.to_bytes_be());
-                jwk.encode_string_field(JwkStringField::DP, &dp.to_bytes_be());
-                jwk.encode_string_field(JwkStringField::DQ, &dq.to_bytes_be());
-                jwk.encode_string_field(JwkStringField::QI, &qi.to_bytes_be());
+                let qi = private_key.crt_coefficient().ok_or(Error::Operation(Some(
+                    "Failed to extract first CRT coefficient qi from RSA private key".into(),
+                )))?;
+                jwk.encode_string_field(JwkStringField::D, &d.to_be_bytes_trimmed_vartime());
+                jwk.encode_string_field(JwkStringField::P, &p.to_be_bytes_trimmed_vartime());
+                jwk.encode_string_field(JwkStringField::Q, &q.to_be_bytes_trimmed_vartime());
+                jwk.encode_string_field(JwkStringField::DP, &dp.to_be_bytes_trimmed_vartime());
+                jwk.encode_string_field(JwkStringField::DQ, &dq.to_be_bytes_trimmed_vartime());
+                jwk.encode_string_field(JwkStringField::QI, &qi.to_be_bytes_trimmed_vartime());
 
                 // Step 3.6.2. If the underlying RSA private key represented by the [[handle]]
                 // internal slot of key is represented by more than two primes, set the attribute
@@ -1003,31 +947,35 @@ pub(crate) fn export_key(
                 for (i, p_i) in primes.iter().enumerate().skip(2) {
                     // d_i = d mod (p_i - 1)
                     // t_i = (p_1 * p_2 * ... * p_(i-1)) ^ (-1) mod p_i
-                    let d_i = private_key
-                        .d()
-                        .modpow(&BigUint::one(), &p_i.sub(&BigUint::one()));
+                    let d_i = private_key.d().rem(
+                        &NonZero::new(p_i.wrapping_sub(BoxedUint::one()))
+                            .expect("Prime numbers must be greater than one"),
+                    );
+                    let non_zero_pi =
+                        NonZero::new(p_i.clone()).expect("Prime numbers must be non-zero");
                     let t_i = primes
                         .iter()
                         .take(i - 1)
-                        .fold(BigUint::one(), |product, p_j| product.mul(p_j))
-                        .mod_inverse(p_i)
+                        .fold(BoxedUint::one(), |product, p_j| {
+                            product.mul_mod(p_j, &non_zero_pi)
+                        })
+                        .invert_mod(&non_zero_pi)
                         .ok_or(Error::Operation(Some(
-                            "Failed to compute factor CRT coefficient of other RSA primes"
-                                .to_string(),
-                        )))?
-                        .modpow(
-                            &BigInt::one(),
-                            &BigInt::from_biguint(Sign::Plus, p_i.clone()),
-                        )
-                        .to_biguint()
-                        .ok_or(Error::Operation(Some(
-                            "Failed to convert factor CRT coefficient of other RSA primes to BigUint"
-                                .to_string(),
+                            "Failed to compute factor CRT coefficient of other RSA primes".into(),
                         )))?;
                     oth.push(RsaOtherPrimesInfo {
-                        r: Some(Base64UrlUnpadded::encode_string(&p_i.to_bytes_be()).into()),
-                        d: Some(Base64UrlUnpadded::encode_string(&d_i.to_bytes_be()).into()),
-                        t: Some(Base64UrlUnpadded::encode_string(&t_i.to_bytes_be()).into()),
+                        r: Some(
+                            Base64UrlUnpadded::encode_string(&p_i.to_be_bytes_trimmed_vartime())
+                                .into(),
+                        ),
+                        d: Some(
+                            Base64UrlUnpadded::encode_string(&d_i.to_be_bytes_trimmed_vartime())
+                                .into(),
+                        ),
+                        t: Some(
+                            Base64UrlUnpadded::encode_string(&t_i.to_be_bytes_trimmed_vartime())
+                                .into(),
+                        ),
                     });
                 }
                 if !oth.is_empty() {

--- a/components/script/dom/webcrypto/subtlecrypto/rsa_oaep_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/rsa_oaep_operation.rs
@@ -3,10 +3,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use js::context::JSContext;
-use pkcs8::rand_core::OsRng;
-use rsa::Oaep;
-use sha1_0_10::Sha1;
-use sha2_0_10::{Sha256, Sha384, Sha512};
+use rsa::oaep::{DecryptingKey, EncryptingKey};
+use rsa::traits::{Decryptor, RandomizedEncryptor};
+use sha1::Sha1;
+use sha2::{Sha256, Sha384, Sha512};
 
 use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::{
     CryptoKeyMethods, CryptoKeyPair, KeyType, KeyUsage,
@@ -38,11 +38,7 @@ pub(crate) fn encrypt(
 
     // Step 2. Let label be the label member of normalizedAlgorithm or the empty byte sequence if
     // the label member of normalizedAlgorithm is not present.
-    let label = normalized_algorithm
-        .label
-        .as_ref()
-        .map(|label| String::from_utf8_lossy(label))
-        .unwrap_or_default();
+    let label = normalized_algorithm.label.as_deref().unwrap_or_default();
 
     // Step 3. Perform the encryption operation defined in Section 7.1 of [RFC3447] with the key
     // represented by key as the recipient's RSA public key, plaintext as the message to be
@@ -61,21 +57,32 @@ pub(crate) fn encrypt(
             "[[algorithm]] internal slot of key is not an RsaHashedKeyAlgorithm".to_string(),
         )));
     };
-    let padding = match algorithm.hash.name() {
-        CryptoAlgorithm::Sha1 => Oaep::new_with_label::<Sha1, _>(label),
-        CryptoAlgorithm::Sha256 => Oaep::new_with_label::<Sha256, _>(label),
-        CryptoAlgorithm::Sha384 => Oaep::new_with_label::<Sha384, _>(label),
-        CryptoAlgorithm::Sha512 => Oaep::new_with_label::<Sha512, _>(label),
-        _ => {
+    let mut rng = rand::rng();
+    let ciphertext = match algorithm.hash.name() {
+        CryptoAlgorithm::Sha1 => {
+            let encryption_key = EncryptingKey::<Sha1>::new_with_label(public_key.clone(), label);
+            encryption_key.encrypt_with_rng(&mut rng, plaintext)
+        },
+        CryptoAlgorithm::Sha256 => {
+            let encryption_key = EncryptingKey::<Sha256>::new_with_label(public_key.clone(), label);
+            encryption_key.encrypt_with_rng(&mut rng, plaintext)
+        },
+        CryptoAlgorithm::Sha384 => {
+            let encryption_key = EncryptingKey::<Sha384>::new_with_label(public_key.clone(), label);
+            encryption_key.encrypt_with_rng(&mut rng, plaintext)
+        },
+        CryptoAlgorithm::Sha512 => {
+            let encryption_key = EncryptingKey::<Sha512>::new_with_label(public_key.clone(), label);
+            encryption_key.encrypt_with_rng(&mut rng, plaintext)
+        },
+        algorithm_hash_name => {
             return Err(Error::Operation(Some(format!(
-                "Unsupported \"{}\" hash for RSASSA-PKCS1-v1_5",
-                algorithm.hash.name().as_str()
+                "Unsupported hash for RSASSA-PKCS1-v1_5: {}",
+                algorithm_hash_name.as_str()
             ))));
         },
-    };
-    let ciphertext = public_key
-        .encrypt(&mut OsRng, padding, plaintext)
-        .map_err(|_| Error::Operation(Some("RSA-OAEP failed to encrypt plaintext".to_string())))?;
+    }
+    .map_err(|_| Error::Operation(Some("RSA-OAEP failed to encrypt plaintext".into())))?;
 
     // Step 6. Return ciphertext.
     Ok(ciphertext)
@@ -97,11 +104,7 @@ pub(crate) fn decrypt(
 
     // Step 2. Let label be the label member of normalizedAlgorithm or the empty byte sequence if
     // the label member of normalizedAlgorithm is not present.
-    let label = normalized_algorithm
-        .label
-        .as_ref()
-        .map(|label| String::from_utf8_lossy(label))
-        .unwrap_or_default();
+    let label = normalized_algorithm.label.as_deref().unwrap_or_default();
 
     // Step 3. Perform the decryption operation defined in Section 7.1 of [RFC3447] with the key
     // represented by key as the recipient's RSA private key, ciphertext as the ciphertext to be
@@ -120,21 +123,34 @@ pub(crate) fn decrypt(
             "[[algorithm]] internal slot of key is not an RsaHashedKeyAlgorithm".to_string(),
         )));
     };
-    let padding = match algorithm.hash.name() {
-        CryptoAlgorithm::Sha1 => Oaep::new_with_label::<Sha1, _>(label),
-        CryptoAlgorithm::Sha256 => Oaep::new_with_label::<Sha256, _>(label),
-        CryptoAlgorithm::Sha384 => Oaep::new_with_label::<Sha384, _>(label),
-        CryptoAlgorithm::Sha512 => Oaep::new_with_label::<Sha512, _>(label),
-        _ => {
+    let plaintext = match algorithm.hash.name() {
+        CryptoAlgorithm::Sha1 => {
+            let decrypting_key = DecryptingKey::<Sha1>::new_with_label(private_key.clone(), label);
+            decrypting_key.decrypt(ciphertext)
+        },
+        CryptoAlgorithm::Sha256 => {
+            let decrypting_key =
+                DecryptingKey::<Sha256>::new_with_label(private_key.clone(), label);
+            decrypting_key.decrypt(ciphertext)
+        },
+        CryptoAlgorithm::Sha384 => {
+            let decrypting_key =
+                DecryptingKey::<Sha384>::new_with_label(private_key.clone(), label);
+            decrypting_key.decrypt(ciphertext)
+        },
+        CryptoAlgorithm::Sha512 => {
+            let decrypting_key =
+                DecryptingKey::<Sha512>::new_with_label(private_key.clone(), label);
+            decrypting_key.decrypt(ciphertext)
+        },
+        algorithm_hash_name => {
             return Err(Error::Operation(Some(format!(
-                "Unsupported \"{}\" hash for RSASSA-PKCS1-v1_5",
-                algorithm.hash.name().as_str()
+                "Unsupported hash for RSASSA-PKCS1-v1_5: {}",
+                algorithm_hash_name.as_str()
             ))));
         },
-    };
-    let plaintext = private_key
-        .decrypt(padding, ciphertext)
-        .map_err(|_| Error::Operation(Some("RSA-OAEP failed to decrypt ciphertext".to_string())))?;
+    }
+    .map_err(|_| Error::Operation(Some("RSA-OAEP failed to decrypt ciphertext".into())))?;
 
     // Step 6. Return plaintext.
     Ok(plaintext)

--- a/components/script/dom/webcrypto/subtlecrypto/rsa_pss_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/rsa_pss_operation.rs
@@ -3,11 +3,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use js::context::JSContext;
-use pkcs8::rand_core::OsRng;
 use rsa::pss::{Signature, SigningKey, VerifyingKey};
 use rsa::signature::{RandomizedSigner, SignatureEncoding, Verifier};
-use sha1_0_10::Sha1;
-use sha2_0_10::{Sha256, Sha384, Sha512};
+use sha1::Sha1;
+use sha2::{Sha256, Sha384, Sha512};
 
 use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::{
     CryptoKeyMethods, CryptoKeyPair, KeyType, KeyUsage,
@@ -55,7 +54,7 @@ pub(crate) fn sign(
             "[[algorithm]] internal slot of key is not an RsaHashedKeyAlgorithm".to_string(),
         )));
     };
-    let mut rng = OsRng;
+    let mut rng = rand::rng();
     let signature = match algorithm.hash.name() {
         CryptoAlgorithm::Sha1 => {
             let signing_key = SigningKey::<Sha1>::new_with_salt_len(

--- a/components/script/dom/webcrypto/subtlecrypto/rsassa_pkcs1_v1_5_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/rsassa_pkcs1_v1_5_operation.rs
@@ -5,8 +5,8 @@
 use js::context::JSContext;
 use rsa::pkcs1v15::{Signature, SigningKey, VerifyingKey};
 use rsa::signature::{SignatureEncoding, Signer, Verifier};
-use sha1_0_10::Sha1;
-use sha2_0_10::{Sha256, Sha384, Sha512};
+use sha1::Sha1;
+use sha2::{Sha256, Sha384, Sha512};
 
 use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::{
     CryptoKeyMethods, CryptoKeyPair, KeyType, KeyUsage,

--- a/deny.toml
+++ b/deny.toml
@@ -205,6 +205,8 @@ skip = [
     "sha1",
     "sha2",
     "chacha20",
+    "crypto-bigint",
+    "pem-rfc7468",
 ]
 
 # github.com organizations to allow git sources for


### PR DESCRIPTION
Bump `rsa` to 0.9.10 to 0.10.0-rc.18. We pin the version with `=0.10.0-rc.18` at `Cargo.toml` bacause it is not a stable release. We can later switch back to normal approach with `0.10` once the new stable release is out.

The notable change is that the `num_bigint_dig::BigInt` is replaced by `crypto_bigint::BoxedUInt`. So, we remove `num_bigint_dig` and add `crypto-bigint` at `Cargo.toml`.

Meanwhile, we no longer directly call the old `sha1` 0.10 and `sha2` 0.10, so the entries `sha1_0_10` and `sha2_0_10` are also removed from `Cargo.toml`.

Testing: Covered by existing WPT tests in `WebCryptoAPI` subdirectory
Fixes: Part of #42206
