### PR TITLE
webgpu: Implement proper support for `QuerySet`

### DIFF
--- a/components/script/dom/webgpu/gpucommandencoder.rs
+++ b/components/script/dom/webgpu/gpucommandencoder.rs
@@ -152,7 +152,7 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
     ) -> DomRoot<GPUComputePassEncoder> {
         let compute_pass_id = self.global().wgpu_id_hub().create_compute_pass_id();
 
-        if let Err(e) = self
+        if let Err(error) = self
             .droppable
             .channel
             .0
@@ -160,11 +160,11 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
                 command_encoder_id: self.id().0,
                 compute_pass_id,
                 label: (&descriptor.parent).convert(),
-                timestamp_writes: descriptor.timestampWrites.as_ref().map(|tw| tw.convert()),
+                timestamp_writes: descriptor.timestampWrites.as_ref().map(Convert::convert),
                 device_id: self.device.id().0,
             })
         {
-            warn!("Failed to send WebGPURequest::BeginComputePass {e:?}");
+            warn!("Failed to send WebGPURequest::BeginComputePass {error:?}");
         }
 
         GPUComputePassEncoder::new(
@@ -231,7 +231,7 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
             .collect::<Fallible<Vec<_>>>()?;
         let render_pass_id = self.global().wgpu_id_hub().create_render_pass_id();
 
-        if let Err(e) = self
+        if let Err(error) = self
             .droppable
             .channel
             .0
@@ -241,11 +241,11 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
                 label: (&descriptor.parent).convert(),
                 depth_stencil_attachment,
                 color_attachments,
-                timestamp_writes: descriptor.timestampWrites.as_ref().map(|tw| tw.convert()),
+                timestamp_writes: descriptor.timestampWrites.as_ref().map(Convert::convert),
                 device_id: self.device.id().0,
             })
         {
-            warn!("Failed to send WebGPURequest::BeginRenderPass {e:?}");
+            warn!("Failed to send WebGPURequest::BeginRenderPass {error:?}");
         }
 
         Ok(GPURenderPassEncoder::new(
@@ -433,7 +433,7 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
         destination: &GPUBuffer,
         destination_offset: u64,
     ) {
-        if let Err(e) = self
+        if let Err(error) = self
             .droppable
             .channel
             .0
@@ -447,7 +447,7 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
                 device_id: self.device.id().0,
             })
         {
-            warn!("Error sending WebGPURequest::ResolveQuerySet: {e:?}")
+            warn!("Error sending WebGPURequest::ResolveQuerySet: {error:?}")
         }
     }
 }

--- a/components/script/dom/webgpu/gpucommandencoder.rs
+++ b/components/script/dom/webgpu/gpucommandencoder.rs
@@ -24,6 +24,7 @@ use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::gpuconvert::{convert_load_op, convert_texture_for_wgpu_with_cx};
+use crate::dom::types::GPUQuerySet;
 use crate::dom::webgpu::gpubuffer::GPUBuffer;
 use crate::dom::webgpu::gpucommandbuffer::GPUCommandBuffer;
 use crate::dom::webgpu::gpucomputepassencoder::GPUComputePassEncoder;
@@ -159,6 +160,7 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
                 command_encoder_id: self.id().0,
                 compute_pass_id,
                 label: (&descriptor.parent).convert(),
+                timestamp_writes: descriptor.timestampWrites.as_ref().map(|tw| tw.convert()),
                 device_id: self.device.id().0,
             })
         {
@@ -239,6 +241,7 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
                 label: (&descriptor.parent).convert(),
                 depth_stencil_attachment,
                 color_attachments,
+                timestamp_writes: descriptor.timestampWrites.as_ref().map(|tw| tw.convert()),
                 device_id: self.device.id().0,
             })
         {
@@ -419,6 +422,32 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
                 })
         {
             warn!("Error sending WebGPURequest::CommandEncoderInsertDebugMarker: {e:?}")
+        }
+    }
+
+    fn ResolveQuerySet(
+        &self,
+        query_set: &GPUQuerySet,
+        first_query: u32,
+        query_count: u32,
+        destination: &GPUBuffer,
+        destination_offset: u64,
+    ) {
+        if let Err(e) = self
+            .droppable
+            .channel
+            .0
+            .send(WebGPURequest::ResolveQuerySet {
+                command_encoder_id: self.droppable.encoder.0,
+                query_set_id: query_set.id().0,
+                start_query: first_query,
+                query_count,
+                destination: destination.id().0,
+                destination_offset,
+                device_id: self.device.id().0,
+            })
+        {
+            warn!("Error sending WebGPURequest::ResolveQuerySet: {e:?}")
         }
     }
 }

--- a/components/script/dom/webgpu/gpuconvert.rs
+++ b/components/script/dom/webgpu/gpuconvert.rs
@@ -822,7 +822,7 @@ impl Convert<ComputePassDescriptor<'static>> for &GPUComputePassDescriptor {
     fn convert(self) -> ComputePassDescriptor<'static> {
         ComputePassDescriptor {
             label: (&self.parent).convert(),
-            timestamp_writes: self.timestampWrites.as_ref().map(|tw| tw.convert()),
+            timestamp_writes: self.timestampWrites.as_ref().map(Convert::convert),
         }
     }
 }

--- a/components/script/dom/webgpu/gpuconvert.rs
+++ b/components/script/dom/webgpu/gpuconvert.rs
@@ -6,11 +6,12 @@ use std::borrow::Cow;
 use std::num::NonZeroU64;
 
 use js::context::JSContext;
+use script_bindings::codegen::GenericBindings::WebGPUBinding::GPUQueryType;
 use webgpu_traits::WebGPUTextureView;
 use wgpu_core::binding_model::{BindGroupEntry, BindingResource, BufferBinding};
-use wgpu_core::command as wgpu_com;
+use wgpu_core::command::{self as wgpu_com, ComputePassDescriptor, PassTimestampWrites};
 use wgpu_core::pipeline::ProgrammableStageDescriptor;
-use wgpu_core::resource::TextureDescriptor;
+use wgpu_core::resource::{QuerySetDescriptor, TextureDescriptor};
 use wgpu_types::{self, AstcBlock, AstcChannel};
 
 use crate::conversions::{Convert, TryConvert};
@@ -18,13 +19,14 @@ use crate::dom::bindings::codegen::Bindings::CanvasRenderingContext2DBinding::Pr
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUAddressMode, GPUBindGroupEntry, GPUBindGroupLayoutEntry, GPUBindingResource,
     GPUBlendComponent, GPUBlendFactor, GPUBlendOperation, GPUBufferBindingType, GPUColor,
-    GPUCompareFunction, GPUCullMode, GPUExtent3D, GPUFilterMode, GPUFrontFace, GPUIndexFormat,
-    GPULoadOp, GPUMipmapFilterMode, GPUObjectDescriptorBase, GPUOrigin2D, GPUOrigin3D,
-    GPUPrimitiveState, GPUPrimitiveTopology, GPUProgrammableStage, GPUSamplerBindingType,
-    GPUStencilOperation, GPUStorageTextureAccess, GPUStoreOp, GPUTexelCopyBufferInfo,
-    GPUTexelCopyBufferLayout, GPUTexelCopyTextureInfo, GPUTextureAspect, GPUTextureDescriptor,
-    GPUTextureDimension, GPUTextureFormat, GPUTextureSampleType, GPUTextureViewDimension,
-    GPUVertexFormat,
+    GPUCompareFunction, GPUComputePassDescriptor, GPUComputePassTimestampWrites, GPUCullMode,
+    GPUExtent3D, GPUFilterMode, GPUFrontFace, GPUIndexFormat, GPULoadOp, GPUMipmapFilterMode,
+    GPUObjectDescriptorBase, GPUOrigin2D, GPUOrigin3D, GPUPrimitiveState, GPUPrimitiveTopology,
+    GPUProgrammableStage, GPUQuerySetDescriptor, GPURenderPassTimestampWrites,
+    GPUSamplerBindingType, GPUStencilOperation, GPUStorageTextureAccess, GPUStoreOp,
+    GPUTexelCopyBufferInfo, GPUTexelCopyBufferLayout, GPUTexelCopyTextureInfo, GPUTextureAspect,
+    GPUTextureDescriptor, GPUTextureDimension, GPUTextureFormat, GPUTextureSampleType,
+    GPUTextureViewDimension, GPUVertexFormat,
 };
 use crate::dom::bindings::codegen::UnionTypes::GPUTextureOrGPUTextureView;
 use crate::dom::bindings::error::{Error, Fallible};
@@ -779,6 +781,48 @@ impl Convert<wgpu_types::PredefinedColorSpace> for PredefinedColorSpace {
     fn convert(self) -> wgpu_types::PredefinedColorSpace {
         match self {
             PredefinedColorSpace::Srgb => wgpu_types::PredefinedColorSpace::Srgb,
+        }
+    }
+}
+
+impl Convert<QuerySetDescriptor<'static>> for &GPUQuerySetDescriptor {
+    fn convert(self) -> QuerySetDescriptor<'static> {
+        QuerySetDescriptor {
+            label: (&self.parent).convert(),
+            count: self.count,
+            ty: match self.type_ {
+                GPUQueryType::Occlusion => wgpu_types::QueryType::Occlusion,
+                GPUQueryType::Timestamp => wgpu_types::QueryType::Timestamp,
+            },
+        }
+    }
+}
+
+impl Convert<PassTimestampWrites> for &GPUComputePassTimestampWrites {
+    fn convert(self) -> PassTimestampWrites {
+        PassTimestampWrites {
+            query_set: self.querySet.id().0,
+            beginning_of_pass_write_index: self.beginningOfPassWriteIndex,
+            end_of_pass_write_index: self.endOfPassWriteIndex,
+        }
+    }
+}
+
+impl Convert<PassTimestampWrites> for &GPURenderPassTimestampWrites {
+    fn convert(self) -> PassTimestampWrites {
+        PassTimestampWrites {
+            query_set: self.querySet.id().0,
+            beginning_of_pass_write_index: self.beginningOfPassWriteIndex,
+            end_of_pass_write_index: self.endOfPassWriteIndex,
+        }
+    }
+}
+
+impl Convert<ComputePassDescriptor<'static>> for &GPUComputePassDescriptor {
+    fn convert(self) -> ComputePassDescriptor<'static> {
+        ComputePassDescriptor {
+            label: (&self.parent).convert(),
+            timestamp_writes: self.timestampWrites.as_ref().map(|tw| tw.convert()),
         }
     }
 }

--- a/components/script/dom/webgpu/gpudevice.rs
+++ b/components/script/dom/webgpu/gpudevice.rs
@@ -34,9 +34,9 @@ use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUAdapterMethods, GPUBindGroupDescriptor, GPUBindGroupLayoutDescriptor, GPUBufferDescriptor,
     GPUCommandEncoderDescriptor, GPUComputePipelineDescriptor, GPUDeviceLostReason,
     GPUDeviceMethods, GPUErrorFilter, GPUPipelineErrorReason, GPUPipelineLayoutDescriptor,
-    GPURenderBundleEncoderDescriptor, GPURenderPipelineDescriptor, GPUSamplerDescriptor,
-    GPUShaderModuleDescriptor, GPUTextureDescriptor, GPUTextureFormat, GPUUncapturedErrorEventInit,
-    GPUVertexStepMode,
+    GPUQuerySetDescriptor, GPURenderBundleEncoderDescriptor, GPURenderPipelineDescriptor,
+    GPUSamplerDescriptor, GPUShaderModuleDescriptor, GPUTextureDescriptor, GPUTextureFormat,
+    GPUUncapturedErrorEventInit, GPUVertexStepMode,
 };
 use crate::dom::bindings::codegen::UnionTypes::GPUPipelineLayoutOrGPUAutoLayoutMode;
 use crate::dom::bindings::error::{Error, Fallible};
@@ -50,7 +50,7 @@ use crate::dom::event::Event;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
-use crate::dom::types::GPUError;
+use crate::dom::types::{GPUError, GPUQuerySet};
 use crate::dom::webgpu::gpuadapter::GPUAdapter;
 use crate::dom::webgpu::gpuadapterinfo::GPUAdapterInfo;
 use crate::dom::webgpu::gpubindgroup::GPUBindGroup;
@@ -586,6 +586,15 @@ impl GPUDeviceMethods<crate::DomTypeHolder> for GPUDevice {
         descriptor: &GPURenderBundleEncoderDescriptor,
     ) -> Fallible<DomRoot<GPURenderBundleEncoder>> {
         GPURenderBundleEncoder::create(cx, self, descriptor)
+    }
+
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createqueryset>
+    fn CreateQuerySet(
+        &self,
+        cx: &mut JSContext,
+        descriptor: &GPUQuerySetDescriptor,
+    ) -> Fallible<DomRoot<GPUQuerySet>> {
+        GPUQuerySet::create(cx, self, descriptor)
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-pusherrorscope>

--- a/components/script/dom/webgpu/gpuqueryset.rs
+++ b/components/script/dom/webgpu/gpuqueryset.rs
@@ -29,14 +29,14 @@ struct DroppableGPUQuerySet {
 
 impl Drop for DroppableGPUQuerySet {
     fn drop(&mut self) {
-        if let Err(e) = self
+        if let Err(error) = self
             .channel
             .0
             .send(WebGPURequest::DropQuerySet(self.query_set.0))
         {
             warn!(
-                "Failed to send WebGPURequest::DropQuerySet({:?}) ({})",
-                self.query_set.0, e
+                "Failed to send WebGPURequest::DropQuerySet({:?}) ({error})",
+                self.query_set.0
             );
         }
     }
@@ -108,12 +108,12 @@ impl GPUQuerySet {
         let query_set_id = device.global().wgpu_id_hub().create_query_set_id();
         // 5. Issue the initialization steps on the Device timeline of this.
         let channel = device.channel();
-        if let Err(e) = channel.0.send(WebGPURequest::CreateQuerySet {
+        if let Err(error) = channel.0.send(WebGPURequest::CreateQuerySet {
             device_id: device.id().0,
             query_set_id,
             descriptor: descriptor.convert(),
         }) {
-            warn!("Failed to send WebGPURequest::CreateQuerySet: {e}");
+            warn!("Failed to send WebGPURequest::CreateQuerySet: {error}");
         }
         // 6. Return q
         Ok(Self::new(
@@ -137,7 +137,8 @@ impl GPUQuerySet {
 impl GPUQuerySetMethods<crate::DomTypeHolder> for GPUQuerySet {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuqueryset-destroy>
     fn Destroy(&self) {
-        // wgpu does not implement proper destroy for query sets
+        // TODO: wgpu does not implement proper destroy for query sets.
+        // Waiting for https://github.com/gfx-rs/wgpu/pull/9671 to be released.
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>

--- a/components/script/dom/webgpu/gpuqueryset.rs
+++ b/components/script/dom/webgpu/gpuqueryset.rs
@@ -3,30 +3,160 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use script_bindings::reflector::Reflector;
+use js::context::JSContext;
+use script_bindings::cell::DomRefCell;
+use script_bindings::codegen::GenericBindings::WebGPUBinding::{GPUDeviceMethods, GPUQueryType};
+use script_bindings::error::{Error, Fallible};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::root::DomRoot;
+use webgpu_traits::{WebGPU, WebGPUQuerySet, WebGPURequest};
 
-use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPUQuerySetMethods;
+use crate::conversions::Convert;
+use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
+    GPUQuerySetDescriptor, GPUQuerySetMethods,
+};
+use crate::dom::bindings::reflector::DomGlobal as _;
 use crate::dom::bindings::str::USVString;
+use crate::dom::types::{GPUDevice, GlobalScope};
+
+#[derive(JSTraceable, MallocSizeOf)]
+struct DroppableGPUQuerySet {
+    #[no_trace]
+    channel: WebGPU,
+    #[no_trace]
+    query_set: WebGPUQuerySet,
+}
+
+impl Drop for DroppableGPUQuerySet {
+    fn drop(&mut self) {
+        if let Err(e) = self
+            .channel
+            .0
+            .send(WebGPURequest::DropQuerySet(self.query_set.0))
+        {
+            warn!(
+                "Failed to send WebGPURequest::DropQuerySet({:?}) ({})",
+                self.query_set.0, e
+            );
+        }
+    }
+}
 
 #[dom_struct]
 pub(crate) struct GPUQuerySet {
     reflector_: Reflector,
+    droppable: DroppableGPUQuerySet,
+    label: DomRefCell<USVString>,
+    r#type: GPUQueryType,
+    count: u32,
 }
 
-// TODO: wgpu does not expose right fields right now
+impl GPUQuerySet {
+    pub(crate) fn new_inherited(
+        label: USVString,
+        channel: WebGPU,
+        query_set: WebGPUQuerySet,
+        r#type: GPUQueryType,
+        count: u32,
+    ) -> Self {
+        GPUQuerySet {
+            reflector_: Reflector::new(),
+            label: DomRefCell::new(label),
+            droppable: DroppableGPUQuerySet { channel, query_set },
+            r#type,
+            count,
+        }
+    }
+
+    pub(crate) fn new(
+        cx: &mut JSContext,
+        global: &GlobalScope,
+        label: USVString,
+        channel: WebGPU,
+        query_set: WebGPUQuerySet,
+        r#type: GPUQueryType,
+        count: u32,
+    ) -> DomRoot<Self> {
+        reflect_dom_object_with_cx(
+            Box::new(GPUQuerySet::new_inherited(
+                label, channel, query_set, r#type, count,
+            )),
+            global,
+            cx,
+        )
+    }
+
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createqueryset>
+    pub(crate) fn create(
+        cx: &mut JSContext,
+        device: &GPUDevice,
+        descriptor: &GPUQuerySetDescriptor,
+    ) -> Fallible<DomRoot<Self>> {
+        // 1. If descriptor.type is "timestamp", but "timestamp-query" is not enabled for this:
+        if descriptor.type_ == GPUQueryType::Timestamp &&
+            !device
+                .Features()
+                .wgpu_features()
+                .contains(wgpu_types::Features::TIMESTAMP_QUERY)
+        {
+            // Throw a TypeError.
+            return Err(Error::Type(
+                c"The device does not support timestamp queries".to_owned(),
+            ));
+        }
+        // 2. Let q be ! create a new WebGPU object(this, GPUQuerySet, descriptor).
+        let query_set_id = device.global().wgpu_id_hub().create_query_set_id();
+        // 5. Issue the initialization steps on the Device timeline of this.
+        let channel = device.channel();
+        if let Err(e) = channel.0.send(WebGPURequest::CreateQuerySet {
+            device_id: device.id().0,
+            query_set_id,
+            descriptor: descriptor.convert(),
+        }) {
+            warn!("Failed to send WebGPURequest::CreateQuerySet: {e}");
+        }
+        // 6. Return q
+        Ok(Self::new(
+            cx,
+            &device.global(),
+            descriptor.parent.label.clone(),
+            channel,
+            WebGPUQuerySet(query_set_id),
+            // 3. Set q.type to descriptor.type.
+            descriptor.type_,
+            // 4. Set q.count to descriptor.count.
+            descriptor.count,
+        ))
+    }
+
+    pub(crate) fn id(&self) -> WebGPUQuerySet {
+        self.droppable.query_set
+    }
+}
+
 impl GPUQuerySetMethods<crate::DomTypeHolder> for GPUQuerySet {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuqueryset-destroy>
     fn Destroy(&self) {
-        todo!()
+        // wgpu does not implement proper destroy for query sets
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn Label(&self) -> USVString {
-        todo!()
+        self.label.borrow().clone()
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, _value: USVString) {
-        todo!()
+    fn SetLabel(&self, value: USVString) {
+        *self.label.borrow_mut() = value;
+    }
+
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuqueryset-type>
+    fn Type(&self) -> GPUQueryType {
+        self.r#type
+    }
+
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuqueryset-count>
+    fn Count(&self) -> u32 {
+        self.count
     }
 }

--- a/components/script/dom/webgpu/identityhub.rs
+++ b/components/script/dom/webgpu/identityhub.rs
@@ -5,13 +5,13 @@
 use webgpu_traits::{ComputePass, ComputePassId, RenderPass, RenderPassId};
 use wgpu_core::id::markers::{
     Adapter, BindGroup, BindGroupLayout, Buffer, CommandBuffer, CommandEncoder, ComputePipeline,
-    Device, PipelineLayout, Queue, RenderBundle, RenderPipeline, Sampler, ShaderModule, Texture,
-    TextureView,
+    Device, PipelineLayout, QuerySet, Queue, RenderBundle, RenderPipeline, Sampler, ShaderModule,
+    Texture, TextureView,
 };
 use wgpu_core::id::{
     AdapterId, BindGroupId, BindGroupLayoutId, BufferId, CommandBufferId, CommandEncoderId,
-    ComputePipelineId, DeviceId, PipelineLayoutId, QueueId, RenderBundleId, RenderPipelineId,
-    SamplerId, ShaderModuleId, TextureId, TextureViewId,
+    ComputePipelineId, DeviceId, PipelineLayoutId, QuerySetId, QueueId, RenderBundleId,
+    RenderPipelineId, SamplerId, ShaderModuleId, TextureId, TextureViewId,
 };
 use wgpu_core::identity::IdentityManager;
 
@@ -35,6 +35,7 @@ pub(crate) struct IdentityHub {
     render_bundles: IdentityManager<RenderBundle>,
     compute_passes: IdentityManager<ComputePass>,
     render_passes: IdentityManager<RenderPass>,
+    query_sets: IdentityManager<QuerySet>,
 }
 
 impl Default for IdentityHub {
@@ -58,6 +59,7 @@ impl Default for IdentityHub {
             render_bundles: IdentityManager::new(),
             compute_passes: IdentityManager::new(),
             render_passes: IdentityManager::new(),
+            query_sets: IdentityManager::new(),
         }
     }
 }
@@ -205,5 +207,13 @@ impl IdentityHub {
 
     pub(crate) fn free_render_pass_id(&self, id: RenderPassId) {
         self.render_passes.free(id);
+    }
+
+    pub(crate) fn create_query_set_id(&self) -> QuerySetId {
+        self.query_sets.process()
+    }
+
+    pub(crate) fn free_query_set_id(&self, id: QuerySetId) {
+        self.query_sets.free(id);
     }
 }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -604,6 +604,7 @@ DOMInterfaces = {
         'CreatePipelineLayout',
         'CreateComputePipeline', 'CreateCommandEncoder',
         'CreateTexture', 'CreateSampler', 'CreateRenderPipeline',  'CreateRenderBundleEncoder',
+        'CreateQuerySet',
     ],
     'weakReferenceable': True, # for usage in GlobalScope https://github.com/servo/servo/issues/32519
 },

--- a/components/script_bindings/webidls/WebGPU.webidl
+++ b/components/script_bindings/webidls/WebGPU.webidl
@@ -169,7 +169,9 @@ interface GPUDevice : EventTarget {
     GPUCommandEncoder createCommandEncoder(optional GPUCommandEncoderDescriptor descriptor = {});
     [Throws]
     GPURenderBundleEncoder createRenderBundleEncoder(GPURenderBundleEncoderDescriptor descriptor);
-    //GPUQuerySet createQuerySet(GPUQuerySetDescriptor descriptor);
+
+    [Throws]
+    GPUQuerySet createQuerySet(GPUQuerySetDescriptor descriptor);
 };
 GPUDevice includes GPUObjectBase;
 
@@ -965,6 +967,13 @@ interface GPUCommandEncoder {
         GPUExtent3D copySize);
     */
 
+    undefined resolveQuerySet(
+        GPUQuerySet querySet,
+        GPUSize32 firstQuery,
+        GPUSize32 queryCount,
+        GPUBuffer destination,
+        GPUSize64 destinationOffset);
+
     GPUCommandBuffer finish(optional GPUCommandBufferDescriptor descriptor = {});
 };
 GPUCommandEncoder includes GPUObjectBase;
@@ -1006,7 +1015,14 @@ GPUComputePassEncoder includes GPUCommandsMixin;
 GPUComputePassEncoder includes GPUDebugCommandsMixin;
 GPUComputePassEncoder includes GPUBindingCommandsMixin;
 
+dictionary GPUComputePassTimestampWrites {
+    required GPUQuerySet querySet;
+    GPUSize32 beginningOfPassWriteIndex;
+    GPUSize32 endOfPassWriteIndex;
+};
+
 dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
+    GPUComputePassTimestampWrites timestampWrites;
 };
 
 [Exposed=(Window, Worker), SecureContext, Pref="dom_webgpu_enabled"]
@@ -1034,11 +1050,17 @@ GPURenderPassEncoder includes GPUDebugCommandsMixin;
 GPURenderPassEncoder includes GPUBindingCommandsMixin;
 GPURenderPassEncoder includes GPURenderCommandsMixin;
 
+dictionary GPURenderPassTimestampWrites {
+    required GPUQuerySet querySet;
+    GPUSize32 beginningOfPassWriteIndex;
+    GPUSize32 endOfPassWriteIndex;
+};
+
 dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
     required sequence<GPURenderPassColorAttachment> colorAttachments;
     GPURenderPassDepthStencilAttachment depthStencilAttachment;
     GPUQuerySet occlusionQuerySet;
-    //GPURenderPassTimestampWrites timestampWrites;
+    GPURenderPassTimestampWrites timestampWrites;
     //GPUSize64 maxDrawCount = 50000000;
 };
 
@@ -1167,6 +1189,9 @@ GPUQueue includes GPUObjectBase;
 [Exposed=(Window, Worker), SecureContext, Pref="dom_webgpu_enabled"]
 interface GPUQuerySet {
     undefined destroy();
+
+    readonly attribute GPUQueryType type;
+    readonly attribute GPUSize32Out count;
 };
 GPUQuerySet includes GPUObjectBase;
 

--- a/components/shared/webgpu/ids.rs
+++ b/components/shared/webgpu/ids.rs
@@ -9,8 +9,8 @@ pub use wgpu_core::id::markers::{
 };
 use wgpu_core::id::{
     AdapterId, BindGroupId, BindGroupLayoutId, BufferId, CommandBufferId, CommandEncoderId,
-    ComputePipelineId, DeviceId, PipelineLayoutId, QueueId, RenderBundleId, RenderPipelineId,
-    SamplerId, ShaderModuleId, SurfaceId, TextureId, TextureViewId,
+    ComputePipelineId, DeviceId, PipelineLayoutId, QuerySetId, QueueId, RenderBundleId,
+    RenderPipelineId, SamplerId, ShaderModuleId, SurfaceId, TextureId, TextureViewId,
 };
 pub use wgpu_core::id::{
     ComputePassEncoderId as ComputePassId, RenderPassEncoderId as RenderPassId,
@@ -51,3 +51,4 @@ webgpu_resource!(WebGPUTextureView, TextureViewId);
 webgpu_resource!(WebGPUComputePass, ComputePassId);
 webgpu_resource!(WebGPURenderPass, RenderPassId);
 webgpu_resource!(WebGPUContextId, u64);
+webgpu_resource!(WebGPUQuerySet, QuerySetId);

--- a/components/shared/webgpu/messages/recv.rs
+++ b/components/shared/webgpu/messages/recv.rs
@@ -21,7 +21,7 @@ use wgpu_core::binding_model::{
     BindGroupDescriptor, BindGroupLayoutDescriptor, PipelineLayoutDescriptor,
 };
 use wgpu_core::command::{
-    RenderBundleDescriptor, RenderBundleEncoder, RenderPassColorAttachment,
+    PassTimestampWrites, RenderBundleDescriptor, RenderBundleEncoder, RenderPassColorAttachment,
     RenderPassDepthStencilAttachment, TexelCopyBufferInfo, TexelCopyTextureInfo,
 };
 use wgpu_core::device::HostMap;
@@ -40,7 +40,7 @@ pub use wgpu_core::id::{
 use wgpu_core::instance::RequestAdapterOptions;
 use wgpu_core::pipeline::{ComputePipelineDescriptor, RenderPipelineDescriptor};
 use wgpu_core::resource::{
-    BufferAccessError, BufferDescriptor, SamplerDescriptor, TextureDescriptor,
+    BufferAccessError, BufferDescriptor, QuerySetDescriptor, SamplerDescriptor, TextureDescriptor,
     TextureViewDescriptor,
 };
 use wgpu_types::{
@@ -271,6 +271,7 @@ pub enum WebGPURequest {
         command_encoder_id: CommandEncoderId,
         compute_pass_id: ComputePassId,
         label: Label<'static>,
+        timestamp_writes: Option<PassTimestampWrites>,
         device_id: DeviceId,
     },
     ComputePassSetPipeline {
@@ -323,6 +324,7 @@ pub enum WebGPURequest {
         label: Label<'static>,
         color_attachments: Vec<Option<RenderPassColorAttachment>>,
         depth_stencil_attachment: Option<RenderPassDepthStencilAttachment<TextureViewId>>,
+        timestamp_writes: Option<PassTimestampWrites>,
         device_id: DeviceId,
     },
     RenderPassCommand {
@@ -386,5 +388,19 @@ pub enum WebGPURequest {
         pipeline_id: RenderPipelineId,
         index: u32,
         id: BindGroupLayoutId,
+    },
+    CreateQuerySet {
+        device_id: DeviceId,
+        query_set_id: QuerySetId,
+        descriptor: QuerySetDescriptor<'static>,
+    },
+    ResolveQuerySet {
+        device_id: DeviceId,
+        command_encoder_id: CommandEncoderId,
+        query_set_id: QuerySetId,
+        start_query: u32,
+        query_count: u32,
+        destination: BufferId,
+        destination_offset: u64,
     },
 }

--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -722,6 +722,7 @@ impl WGPU {
                         command_encoder_id,
                         compute_pass_id,
                         label,
+                        timestamp_writes,
                         device_id,
                     } => {
                         let global = &self.global;
@@ -729,7 +730,7 @@ impl WGPU {
                             command_encoder_id,
                             &ComputePassDescriptor {
                                 label,
-                                timestamp_writes: None,
+                                timestamp_writes,
                             },
                         );
                         assert!(
@@ -853,6 +854,7 @@ impl WGPU {
                         label,
                         color_attachments,
                         depth_stencil_attachment,
+                        timestamp_writes,
                         device_id,
                     } => {
                         let global = &self.global;
@@ -860,7 +862,7 @@ impl WGPU {
                             label,
                             color_attachments: color_attachments.into(),
                             depth_stencil_attachment: depth_stencil_attachment.as_ref(),
-                            timestamp_writes: None,
+                            timestamp_writes: timestamp_writes.as_ref(),
                             occlusion_query_set: None,
                             multiview_mask: None,
                         };
@@ -1215,6 +1217,39 @@ impl WGPU {
                             Some(id),
                         );
                         self.maybe_dispatch_wgpu_error(device_id, error);
+                    },
+                    WebGPURequest::CreateQuerySet {
+                        device_id,
+                        query_set_id,
+                        descriptor,
+                    } => {
+                        let global = &self.global;
+                        let (_, error) = global.device_create_query_set(
+                            device_id,
+                            &descriptor,
+                            Some(query_set_id),
+                        );
+                        self.maybe_dispatch_wgpu_error(device_id, error);
+                    },
+                    WebGPURequest::ResolveQuerySet {
+                        device_id,
+                        command_encoder_id,
+                        query_set_id,
+                        start_query,
+                        query_count,
+                        destination,
+                        destination_offset,
+                    } => {
+                        let global = &self.global;
+                        let result = global.command_encoder_resolve_query_set(
+                            command_encoder_id,
+                            query_set_id,
+                            start_query,
+                            query_count,
+                            destination,
+                            destination_offset,
+                        );
+                        self.maybe_dispatch_wgpu_error(device_id, result.err());
                     },
                 }
             }

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_opaque_copy.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_opaque_copy.https.html.ini
@@ -1,3 +1,3 @@
 [canvas_composite_alpha_bgra8unorm_opaque_copy.https.html]
   expected:
-    if os == "linux" and not debug: PASS
+    if os == "linux" and not debug: FAIL

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_opaque_draw.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_opaque_draw.https.html.ini
@@ -1,3 +1,3 @@
 [canvas_composite_alpha_bgra8unorm_opaque_draw.https.html]
   expected:
-    if os == "linux" and not debug: PASS
+    if os == "linux" and not debug: FAIL

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_opaque_copy.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_opaque_copy.https.html.ini
@@ -1,3 +1,3 @@
 [canvas_composite_alpha_rgba8unorm_opaque_copy.https.html]
   expected:
-    if os == "linux" and not debug: PASS
+    if os == "linux" and not debug: FAIL

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_opaque_draw.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_opaque_draw.https.html.ini
@@ -1,3 +1,3 @@
 [canvas_composite_alpha_rgba8unorm_opaque_draw.https.html]
   expected:
-    if os == "linux" and not debug: PASS
+    if os == "linux" and not debug: FAIL


### PR DESCRIPTION
We already had skeleton impl, but it was not used anywhere. There are still some problems in wgpu, mainly {Compute,Render}PassDescriptors are not ser/de so we cannot use them for IPC (fix awaiting upstream: https://github.com/gfx-rs/wgpu/pull/9666) and there is no destroy impl in wgpu as of right now (I whipped https://github.com/gfx-rs/wgpu/pull/9671), both deno and firefox just do nothing in that case.

Testing: Covered by WebGPU CTS.
