### PR TITLE
webgpu: Implement basic form of `copyExternalImageToTexture`

### DIFF
--- a/components/script/dom/canvas/imagedata.rs
+++ b/components/script/dom/canvas/imagedata.rs
@@ -206,6 +206,18 @@ impl ImageData {
     }
 
     #[expect(unsafe_code)]
+    pub(crate) fn get_snapshot(&self) -> Snapshot {
+        Snapshot::from_vec(
+            self.get_size(),
+            SnapshotPixelFormat::RGBA,
+            SnapshotAlphaMode::Transparent {
+                premultiplied: false,
+            },
+            unsafe { self.as_slice().to_vec() },
+        )
+    }
+
+    #[expect(unsafe_code)]
     pub(crate) fn to_shared_memory(&self) -> GenericSharedMemory {
         // This is safe because we copy the slice content
         GenericSharedMemory::from_bytes(unsafe { self.as_slice() })

--- a/components/script/dom/webgpu/gpuconvert.rs
+++ b/components/script/dom/webgpu/gpuconvert.rs
@@ -14,15 +14,17 @@ use wgpu_core::resource::TextureDescriptor;
 use wgpu_types::{self, AstcBlock, AstcChannel};
 
 use crate::conversions::{Convert, TryConvert};
+use crate::dom::bindings::codegen::Bindings::CanvasRenderingContext2DBinding::PredefinedColorSpace;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUAddressMode, GPUBindGroupEntry, GPUBindGroupLayoutEntry, GPUBindingResource,
     GPUBlendComponent, GPUBlendFactor, GPUBlendOperation, GPUBufferBindingType, GPUColor,
     GPUCompareFunction, GPUCullMode, GPUExtent3D, GPUFilterMode, GPUFrontFace, GPUIndexFormat,
-    GPULoadOp, GPUMipmapFilterMode, GPUObjectDescriptorBase, GPUOrigin3D, GPUPrimitiveState,
-    GPUPrimitiveTopology, GPUProgrammableStage, GPUSamplerBindingType, GPUStencilOperation,
-    GPUStorageTextureAccess, GPUStoreOp, GPUTexelCopyBufferInfo, GPUTexelCopyBufferLayout,
-    GPUTexelCopyTextureInfo, GPUTextureAspect, GPUTextureDescriptor, GPUTextureDimension,
-    GPUTextureFormat, GPUTextureSampleType, GPUTextureViewDimension, GPUVertexFormat,
+    GPULoadOp, GPUMipmapFilterMode, GPUObjectDescriptorBase, GPUOrigin2D, GPUOrigin3D,
+    GPUPrimitiveState, GPUPrimitiveTopology, GPUProgrammableStage, GPUSamplerBindingType,
+    GPUStencilOperation, GPUStorageTextureAccess, GPUStoreOp, GPUTexelCopyBufferInfo,
+    GPUTexelCopyBufferLayout, GPUTexelCopyTextureInfo, GPUTextureAspect, GPUTextureDescriptor,
+    GPUTextureDimension, GPUTextureFormat, GPUTextureSampleType, GPUTextureViewDimension,
+    GPUVertexFormat,
 };
 use crate::dom::bindings::codegen::UnionTypes::GPUTextureOrGPUTextureView;
 use crate::dom::bindings::error::{Error, Fallible};
@@ -527,6 +529,29 @@ impl TryConvert<wgpu_types::Origin3d> for &GPUOrigin3D {
     }
 }
 
+impl TryConvert<wgpu_types::Origin2d> for &GPUOrigin2D {
+    type Error = Error;
+
+    /// <https://gpuweb.github.io/gpuweb/#abstract-opdef-validate-gpuorigin2d-shape>
+    fn try_convert(self) -> Result<wgpu_types::Origin2d, Self::Error> {
+        match self {
+            GPUOrigin2D::RangeEnforcedUnsignedLongSequence(v) => {
+                if v.len() > 2 {
+                    Err(Error::Type(
+                        c"sequence is too long for GPUOrigin2D".to_owned(),
+                    ))
+                } else {
+                    Ok(wgpu_types::Origin2d {
+                        x: v.first().copied().unwrap_or(0),
+                        y: v.get(1).copied().unwrap_or(0),
+                    })
+                }
+            },
+            GPUOrigin2D::GPUOrigin2DDict(d) => Ok(wgpu_types::Origin2d { x: d.x, y: d.y }),
+        }
+    }
+}
+
 impl TryConvert<wgpu_com::TexelCopyTextureInfo> for &GPUTexelCopyTextureInfo {
     type Error = Error;
 
@@ -746,6 +771,14 @@ impl Convert<wgpu_types::TextureDimension> for GPUTextureDimension {
             GPUTextureDimension::_1d => wgpu_types::TextureDimension::D1,
             GPUTextureDimension::_2d => wgpu_types::TextureDimension::D2,
             GPUTextureDimension::_3d => wgpu_types::TextureDimension::D3,
+        }
+    }
+}
+
+impl Convert<wgpu_types::PredefinedColorSpace> for PredefinedColorSpace {
+    fn convert(self) -> wgpu_types::PredefinedColorSpace {
+        match self {
+            PredefinedColorSpace::Srgb => wgpu_types::PredefinedColorSpace::Srgb,
         }
     }
 }

--- a/components/script/dom/webgpu/gpuqueue.rs
+++ b/components/script/dom/webgpu/gpuqueue.rs
@@ -6,16 +6,27 @@ use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
+use pixels::{SnapshotAlphaMode, SnapshotPixelFormat};
 use script_bindings::cell::DomRefCell;
+use script_bindings::codegen::GenericBindings::CanvasRenderingContext2DBinding::ImageDataMethods;
+use script_bindings::codegen::GenericBindings::HTMLCanvasElementBinding::HTMLCanvasElementMethods;
+use script_bindings::codegen::GenericBindings::HTMLImageElementBinding::HTMLImageElementMethods;
+use script_bindings::codegen::GenericBindings::HTMLVideoElementBinding::HTMLVideoElementMethods;
+use script_bindings::codegen::GenericBindings::ImageBitmapBinding::ImageBitmapMethods;
+use script_bindings::codegen::GenericBindings::OffscreenCanvasBinding::OffscreenCanvasMethods;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use servo_base::generic_channel::GenericSharedMemory;
 use webgpu_traits::{WebGPU, WebGPUQueue, WebGPURequest};
 
 use crate::conversions::{Convert, TryConvert};
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
-    GPUExtent3D, GPUQueueMethods, GPUSize64, GPUTexelCopyBufferLayout, GPUTexelCopyTextureInfo,
+    GPUCopyExternalImageDestInfo, GPUCopyExternalImageSourceInfo, GPUExtent3D, GPUQueueMethods,
+    GPUSize64, GPUTexelCopyBufferLayout, GPUTexelCopyTextureInfo,
 };
-use crate::dom::bindings::codegen::UnionTypes::ArrayBufferViewOrArrayBuffer as BufferSource;
+use crate::dom::bindings::codegen::UnionTypes::{
+    ArrayBufferViewOrArrayBuffer as BufferSource,
+    ImageBitmapOrImageDataOrHTMLImageElementOrHTMLVideoElementOrHTMLCanvasElementOrOffscreenCanvas as GPUCopyExternalImageSource,
+};
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot};
@@ -203,6 +214,171 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
             return Err(Error::Operation(None));
         }
 
+        Ok(())
+    }
+
+    #[expect(
+        clippy::nonminimal_bool,
+        reason = "Following the spec steps more closely"
+    )]
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuqueue-copyexternalimagetotexture>
+    fn CopyExternalImageToTexture(
+        &self,
+        source: &GPUCopyExternalImageSourceInfo,
+        destination: &GPUCopyExternalImageDestInfo,
+        copy_size: GPUExtent3D,
+    ) -> Fallible<()> {
+        // 1. ? validate GPUOrigin2D shape(source.origin).
+        let source_origin = source.origin.try_convert()?;
+        // 2. ? validate GPUOrigin3D shape(destination.origin).
+        let destination_tex_info = destination.parent.try_convert()?;
+        // 3. ? validate GPUExtent3D shape(copySize).
+        let copy_size = copy_size.try_convert()?;
+        // 4. Let sourceImage be source.source.
+        let source_image = &source.source;
+        // 5. If sourceImage is not origin-clean, throw a SecurityError and return.
+        let is_origin_clean = match source_image {
+            GPUCopyExternalImageSource::ImageBitmap(inner) => inner.origin_is_clean(),
+            GPUCopyExternalImageSource::ImageData(_) => true,
+            GPUCopyExternalImageSource::HTMLImageElement(inner) => {
+                inner.same_origin(GlobalScope::entry().origin())
+            },
+            GPUCopyExternalImageSource::HTMLVideoElement(inner) => inner.origin_is_clean(),
+            GPUCopyExternalImageSource::HTMLCanvasElement(inner) => inner.origin_is_clean(),
+            GPUCopyExternalImageSource::OffscreenCanvas(inner) => inner.origin_is_clean(),
+        };
+        if !is_origin_clean {
+            return Err(Error::Security(Some(
+                "Image source is not origin clean!".to_string(),
+            )));
+        }
+        // 6. If any of the following requirements are unmet, throw an OperationError and return.
+        let (source_image_width, source_image_height) = match source_image {
+            GPUCopyExternalImageSource::ImageBitmap(inner) => (inner.Width(), inner.Height()),
+            GPUCopyExternalImageSource::ImageData(inner) => (inner.Width(), inner.Height()),
+            GPUCopyExternalImageSource::HTMLImageElement(inner) => (inner.Width(), inner.Height()),
+            GPUCopyExternalImageSource::HTMLVideoElement(inner) => (inner.Width(), inner.Height()),
+            GPUCopyExternalImageSource::HTMLCanvasElement(inner) => (inner.Width(), inner.Height()),
+            GPUCopyExternalImageSource::OffscreenCanvas(inner) => {
+                (inner.Width() as u32, inner.Height() as u32)
+            },
+        };
+        // source.origin.x + copySize.width must be ≤ the width of sourceImage.
+        if !(source_origin.x + copy_size.width <= source_image_width) {
+            return Err(Error::Operation(Some(
+                "Source origin x + copy width exceeds source image width".to_string(),
+            )));
+        }
+        // source.origin.y + copySize.height must be ≤ the height of sourceImage.
+        if !(source_origin.y + copy_size.height <= source_image_height) {
+            return Err(Error::Operation(Some(
+                "Source origin y + copy height exceeds source image height".to_string(),
+            )));
+        }
+        // copySize.depthOrArrayLayers must be ≤ 1.
+        if !(copy_size.depth_or_array_layers <= 1) {
+            return Err(Error::Operation(Some(
+                "Copy depth or array layers must be less than or equal to 1".to_string(),
+            )));
+        }
+        // 7. Let usability be ? check the usability of the image argument(source).
+        // with usable variant we also send the snapshot
+        let usable_snapshot = match source_image {
+            GPUCopyExternalImageSource::ImageBitmap(bitmap) => {
+                // If image's [[Detached]] internal slot value is set to true, then throw an "InvalidStateError" DOMException.
+                Some(bitmap.bitmap_data().clone().ok_or_else(|| {
+                    Error::InvalidState(Some("ImageBitmap is detached".to_string()))
+                })?)
+            },
+            GPUCopyExternalImageSource::ImageData(data) => {
+                // If image's [[Detached]] internal slot value is set to true, then throw an "InvalidStateError" DOMException.
+                if data.is_detached() {
+                    return Err(Error::InvalidState(Some(
+                        "ImageData is detached".to_string(),
+                    )));
+                }
+                Some(data.get_snapshot())
+            },
+            GPUCopyExternalImageSource::HTMLImageElement(inner) => {
+                if inner.is_usable()? {
+                    inner.get_raster_image_data()
+                } else {
+                    None
+                }
+            },
+            GPUCopyExternalImageSource::HTMLVideoElement(inner) => {
+                if inner.is_usable() {
+                    inner.get_current_frame_data()
+                } else {
+                    None
+                }
+            },
+            GPUCopyExternalImageSource::HTMLCanvasElement(inner) => {
+                // If image has either a horizontal dimension or a vertical dimension equal to zero, then throw an "InvalidStateError" DOMException.
+                if inner.is_valid() {
+                    inner.get_image_data()
+                } else {
+                    return Err(Error::InvalidState(Some(
+                        "Canvas has zero area".to_string(),
+                    )));
+                }
+            },
+            GPUCopyExternalImageSource::OffscreenCanvas(inner) => {
+                // If image has either a horizontal dimension or a vertical dimension equal to zero, then throw an "InvalidStateError" DOMException.
+                if inner.Width() == 0 || inner.Height() == 0 {
+                    return Err(Error::InvalidState(Some(
+                        "Canvas has zero area".to_string(),
+                    )));
+                } else {
+                    inner.get_image_data()
+                }
+            },
+        };
+        // this is out ouf spec, but we currently do not support more
+        let texture_descriptor = destination.parent.texture.wgpu_texture_descriptor();
+        let target_snapshot_format =
+            match texture_descriptor.format {
+                wgpu_types::TextureFormat::Bgra8Unorm |
+                wgpu_types::TextureFormat::Bgra8UnormSrgb => SnapshotPixelFormat::BGRA,
+                wgpu_types::TextureFormat::Rgba8Unorm |
+                wgpu_types::TextureFormat::Rgba8UnormSrgb => SnapshotPixelFormat::RGBA,
+                _ => {
+                    return Err(Error::Operation(Some(
+                        "Unsupported texture format for copy".to_string(),
+                    )));
+                },
+            };
+        let usable_snapshot = usable_snapshot.map(|mut snapshot| {
+            if source.flipY {
+                pixels::flip_y_rgba8_image_inplace(snapshot.size(), snapshot.as_raw_bytes_mut());
+            }
+            snapshot.transform(
+                SnapshotAlphaMode::Transparent {
+                    premultiplied: destination.premultipliedAlpha,
+                },
+                target_snapshot_format,
+            );
+            snapshot.to_shared()
+        });
+        // 8. Issue the subsequent steps on the Device timeline of this.
+        if let Err(e) = self
+            .channel
+            .0
+            .send(WebGPURequest::CopyExternalImageToTexture {
+                device_id: self.device.borrow().as_ref().unwrap().id().0,
+                queue_id: self.queue.0,
+                usable_source: usable_snapshot,
+                destination: destination_tex_info,
+                dest_tex_descriptor: texture_descriptor,
+                copy_size,
+            })
+        {
+            warn!(
+                "Failed to send CopyExternalImageToTexture({:?}) ({e})",
+                destination.parent.texture.id().0
+            );
+            return Err(Error::Operation(None));
+        }
         Ok(())
     }
 

--- a/components/script/dom/webgpu/gputexture.rs
+++ b/components/script/dom/webgpu/gputexture.rs
@@ -9,7 +9,7 @@ use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{WebGPU, WebGPURequest, WebGPUTexture, WebGPUTextureView};
-use wgpu_core::resource;
+use wgpu_core::resource::{self, TextureDescriptor};
 
 use super::gpuconvert::convert_texture_descriptor;
 use crate::conversions::Convert;
@@ -131,6 +131,19 @@ impl GPUTexture {
 impl GPUTexture {
     pub(crate) fn id(&self) -> WebGPUTexture {
         self.droppable.texture
+    }
+
+    pub(crate) fn wgpu_texture_descriptor(&self) -> TextureDescriptor<'static> {
+        TextureDescriptor {
+            label: Some(self.label.borrow().to_string().into()),
+            size: self.texture_size,
+            mip_level_count: self.mip_level_count,
+            sample_count: self.sample_count,
+            dimension: self.dimension.convert(),
+            format: self.format.convert(),
+            usage: wgpu_types::TextureUsages::from_bits_retain(self.texture_usage),
+            view_formats: vec![],
+        }
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createtexture>

--- a/components/script_bindings/webidls/WebGPU.webidl
+++ b/components/script_bindings/webidls/WebGPU.webidl
@@ -898,12 +898,20 @@ dictionary GPUTexelCopyTextureInfo {
 };
 
 dictionary GPUCopyExternalImageDestInfo : GPUTexelCopyTextureInfo {
-    //GPUPredefinedColorSpace colorSpace = "srgb"; //TODO
+    PredefinedColorSpace colorSpace = "srgb";
     boolean premultipliedAlpha = false;
 };
 
-dictionary GPUImageCopyExternalImage {
-    required (ImageBitmap or HTMLCanvasElement or OffscreenCanvas) source;
+typedef (ImageBitmap or
+         ImageData or
+         HTMLImageElement or
+         HTMLVideoElement or
+         //VideoFrame or
+         HTMLCanvasElement or
+         OffscreenCanvas) GPUCopyExternalImageSource;
+
+dictionary GPUCopyExternalImageSourceInfo {
+    required GPUCopyExternalImageSource source;
     GPUOrigin2D origin = {};
     boolean flipY = false;
 };
@@ -1148,11 +1156,11 @@ interface GPUQueue {
       GPUTexelCopyBufferLayout dataLayout,
       GPUExtent3D size);
 
-    //[Throws]
-    //undefined copyExternalImageToTexture(
-    //  GPUImageCopyExternalImage source,
-    //  GPUCopyExternalImageDestInfo destination,
-    //  GPUExtent3D copySize);
+    [Throws]
+    undefined copyExternalImageToTexture(
+        GPUCopyExternalImageSourceInfo source,
+        GPUCopyExternalImageDestInfo destination,
+        GPUExtent3D copySize);
 };
 GPUQueue includes GPUObjectBase;
 

--- a/components/shared/webgpu/messages/recv.rs
+++ b/components/shared/webgpu/messages/recv.rs
@@ -113,6 +113,14 @@ pub enum WebGPURequest {
         destination: TexelCopyTextureInfo,
         copy_size: Extent3d,
     },
+    CopyExternalImageToTexture {
+        device_id: DeviceId,
+        queue_id: QueueId,
+        usable_source: Option<SharedSnapshot>,
+        destination: TexelCopyTextureInfo,
+        dest_tex_descriptor: TextureDescriptor<'static>,
+        copy_size: Extent3d,
+    },
     CommandEncoderPushDebugGroup {
         device_id: DeviceId,
         command_encoder_id: CommandEncoderId,

--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -31,7 +31,9 @@ use wgpu_core::command::RenderPassDescriptor;
 use wgpu_core::resource::BufferAccessResult;
 pub use wgpu_types as wgt;
 use wgpu_types::error::WebGpuError;
-use wgpu_types::{ExperimentalFeatures, MemoryHints};
+use wgpu_types::{
+    ExperimentalFeatures, MemoryHints, TexelCopyBufferLayout, TextureDimension, TextureUsages,
+};
 use wgt::InstanceDescriptor;
 
 use crate::canvas_context::WebGpuExternalImageMap;
@@ -959,6 +961,66 @@ impl WGPU {
                             &data,
                             &data_layout,
                             &size,
+                        );
+                        drop(_guard);
+                        self.maybe_dispatch_wgpu_error(device_id, result.err());
+                    },
+                    WebGPURequest::CopyExternalImageToTexture {
+                        device_id,
+                        queue_id,
+                        usable_source,
+                        destination,
+                        dest_tex_descriptor,
+                        copy_size,
+                    } => {
+                        // device and queue timeline of https://www.w3.org/TR/webgpu/#dom-gpuqueue-copyexternalimagetotexture
+                        let global = &self.global;
+                        // If any of the following requirements are unmet, generate a validation error and return.
+                        // usability must be good.
+                        let Some(source) = usable_source else {
+                            self.maybe_dispatch_error(
+                                device_id,
+                                Some(Error::Validation("Source is not usable".to_string())),
+                            );
+                            continue;
+                        };
+                        // texture.usage must include both RENDER_ATTACHMENT
+                        if !dest_tex_descriptor
+                            .usage
+                            .contains(TextureUsages::RENDER_ATTACHMENT)
+                        {
+                            self.maybe_dispatch_error(
+                                device_id,
+                                Some(Error::Validation(
+                                    "Texture usage must include RENDER_ATTACHMENT".to_string(),
+                                )),
+                            );
+                            continue;
+                        }
+                        // texture.dimension must be "2d".
+                        if dest_tex_descriptor.dimension != TextureDimension::D2 {
+                            self.maybe_dispatch_error(
+                                device_id,
+                                Some(Error::Validation(
+                                    "Texture dimension must be 2d".to_string(),
+                                )),
+                            );
+                            continue;
+                        }
+                        // texture.format must be a plain color format supporting RENDER_ATTACHMENT and be a unorm/unorm-srgb or float/ufloat format (not snorm, uint, or sint).
+                        // currently to to hard to check
+                        // the rest will be checked as part of write texture
+                        let _guard = self.poller.lock();
+                        let result = global.queue_write_texture(
+                            queue_id,
+                            &destination,
+                            source.data(),
+                            &TexelCopyBufferLayout {
+                                offset: 0,
+                                bytes_per_row: Some(source.size().width * 4),
+                                rows_per_image: None,
+                            },
+                            &copy_size,
                         );
                         drop(_guard);
                         self.maybe_dispatch_wgpu_error(device_id, result.err());

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_complex_bgra8unorm_copy.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_complex_bgra8unorm_copy.https.html.ini
@@ -1,3 +1,3 @@
 [canvas_complex_bgra8unorm_copy.https.html]
   expected:
-    if os == "linux" and not debug: FAIL
+    if os == "linux" and not debug: PASS

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_complex_bgra8unorm_draw.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_complex_bgra8unorm_draw.https.html.ini
@@ -1,3 +1,3 @@
 [canvas_complex_bgra8unorm_draw.https.html]
   expected:
-    if os == "linux" and not debug: FAIL
+    if os == "linux" and not debug: PASS

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_complex_rgba8unorm_copy.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_complex_rgba8unorm_copy.https.html.ini
@@ -1,3 +1,3 @@
 [canvas_complex_rgba8unorm_copy.https.html]
   expected:
-    if os == "linux" and not debug: FAIL
+    if os == "linux" and not debug: PASS

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_complex_rgba8unorm_draw.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_complex_rgba8unorm_draw.https.html.ini
@@ -1,3 +1,3 @@
 [canvas_complex_rgba8unorm_draw.https.html]
   expected:
-    if os == "linux" and not debug: FAIL
+    if os == "linux" and not debug: PASS


### PR DESCRIPTION
For first implementation we only support rgba/bgra (which covers the most practical usecases anyway). Firefox also (ab)uses writeTexture to implement this, but they do proper full conversion.

Testing: Covered by WebGPU CTS.
