### PR TITLE
script: Use out-parameters for IDL methods returning JS objects

### DIFF
--- a/components/script/dom/debugger/debuggeradddebuggeeevent.rs
+++ b/components/script/dom/debugger/debuggeradddebuggeeevent.rs
@@ -2,10 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::ptr::NonNull;
-
 use dom_struct::dom_struct;
 use js::jsapi::{Heap, JSObject, Value};
+use js::rust::MutableHandleObject;
 use script_bindings::conversions::SafeToJSValConvertible;
 use script_bindings::reflector::{DomObject, reflect_dom_object};
 use script_bindings::str::DOMString;
@@ -59,8 +58,12 @@ impl DebuggerAddDebuggeeEvent {
 
 impl DebuggerAddDebuggeeEventMethods<crate::DomTypeHolder> for DebuggerAddDebuggeeEvent {
     // check-tidy: no specs after this line
-    fn Global(&self, _cx: script_bindings::script_runtime::JSContext) -> NonNull<JSObject> {
-        NonNull::new(self.global.get()).unwrap()
+    fn Global(
+        &self,
+        _cx: script_bindings::script_runtime::JSContext,
+        mut return_value: MutableHandleObject,
+    ) {
+        return_value.set(self.global.get());
     }
 
     fn PipelineId(

--- a/components/script/dom/event/promiserejectionevent.rs
+++ b/components/script/dom/event/promiserejectionevent.rs
@@ -2,13 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::ptr::NonNull;
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::jsapi::{Heap, JSObject};
 use js::jsval::JSVal;
-use js::rust::{HandleObject, HandleValue, MutableHandleValue};
+use js::rust::{HandleObject, HandleValue, MutableHandleObject, MutableHandleValue};
 use script_bindings::reflector::reflect_dom_object_with_proto;
 use stylo_atoms::Atom;
 
@@ -120,8 +119,8 @@ impl PromiseRejectionEventMethods<crate::DomTypeHolder> for PromiseRejectionEven
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-promiserejectionevent-promise>
-    fn Promise(&self, _cx: JSContext) -> NonNull<JSObject> {
-        NonNull::new(self.promise.get()).unwrap()
+    fn Promise(&self, _cx: JSContext, mut return_value: MutableHandleObject) {
+        return_value.set(self.promise.get());
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-promiserejectionevent-reason>

--- a/components/script/dom/html/input_element/mod.rs
+++ b/components/script/dom/html/input_element/mod.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cell::{Cell, RefCell, RefMut};
-use std::ptr::NonNull;
 use std::{f64, ptr};
 
 use dom_struct::dom_struct;
@@ -1268,16 +1267,17 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
 
     // https://html.spec.whatwg.org/multipage/#dom-input-valueasdate
     #[expect(unsafe_code)]
-    fn GetValueAsDate(&self, cx: SafeJSContext) -> Option<NonNull<JSObject>> {
-        self.input_type()
+    fn GetValueAsDate(&self, cx: SafeJSContext, mut return_value: MutableHandleObject) {
+        if let Some(date_time) = self
+            .input_type()
             .as_specific()
             .convert_string_to_naive_datetime(self.Value())
-            .map(|date_time| unsafe {
-                let time = ClippedTime {
-                    t: (date_time - OffsetDateTime::UNIX_EPOCH).whole_milliseconds() as f64,
-                };
-                NonNull::new_unchecked(NewDateObject(*cx, time))
-            })
+        {
+            let time = ClippedTime {
+                t: (date_time - OffsetDateTime::UNIX_EPOCH).whole_milliseconds() as f64,
+            };
+            return_value.set(unsafe { NewDateObject(*cx, time) });
+        }
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-input-valueasdate

--- a/components/script/dom/testing/testbinding.rs
+++ b/components/script/dom/testing/testbinding.rs
@@ -5,7 +5,7 @@
 // check-tidy: no specs after this line
 
 use std::borrow::ToOwned;
-use std::ptr::{self, NonNull};
+use std::ptr;
 use std::rc::Rc;
 use std::time::Duration;
 
@@ -14,7 +14,9 @@ use js::context::JSContext;
 use js::jsapi::{Heap, JS_NewPlainObject, JSObject};
 use js::jsval::JSVal;
 use js::realm::CurrentRealm;
-use js::rust::{CustomAutoRooterGuard, HandleObject, HandleValue, MutableHandleValue};
+use js::rust::{
+    CustomAutoRooterGuard, HandleObject, HandleValue, MutableHandleObject, MutableHandleValue,
+};
 use js::typedarray::{self, HeapUint8ClampedArray};
 use script_bindings::cformat;
 use script_bindings::interfaces::TestBindingHelpers;
@@ -237,11 +239,8 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
     fn AnyAttribute(&self, _: SafeJSContext, _: MutableHandleValue) {}
     fn SetAnyAttribute(&self, _: SafeJSContext, _: HandleValue) {}
     #[expect(unsafe_code)]
-    fn ObjectAttribute(&self, cx: SafeJSContext) -> NonNull<JSObject> {
-        unsafe {
-            rooted!(in(*cx) let obj = JS_NewPlainObject(*cx));
-            NonNull::new(obj.get()).expect("got a null pointer")
-        }
+    fn ObjectAttribute(&self, cx: SafeJSContext, mut return_value: MutableHandleObject) {
+        return_value.set(unsafe { JS_NewPlainObject(*cx) });
     }
     fn SetObjectAttribute(&self, _: SafeJSContext, _: *mut JSObject) {}
 
@@ -341,8 +340,8 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
     fn SetInterfaceAttributeWeak(&self, url: Option<&URL>) {
         self.url.set(url);
     }
-    fn GetObjectAttributeNullable(&self, _: SafeJSContext) -> Option<NonNull<JSObject>> {
-        None
+    fn GetObjectAttributeNullable(&self, _: SafeJSContext, mut return_value: MutableHandleObject) {
+        return_value.set(ptr::null_mut());
     }
     fn SetObjectAttributeNullable(&self, _: SafeJSContext, _: *mut JSObject) {}
     fn GetUnionAttributeNullable(&self) -> Option<HTMLElementOrLong> {
@@ -430,8 +429,8 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
         )
     }
     fn ReceiveAny(&self, _: SafeJSContext, _: MutableHandleValue) {}
-    fn ReceiveObject(&self, cx: SafeJSContext) -> NonNull<JSObject> {
-        self.ObjectAttribute(cx)
+    fn ReceiveObject(&self, cx: SafeJSContext, return_value: MutableHandleObject) {
+        self.ObjectAttribute(cx, return_value);
     }
     fn ReceiveUnion(&self) -> HTMLElementOrLong {
         HTMLElementOrLong::Long(0)
@@ -542,8 +541,8 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
             BlobImpl::new_from_bytes(vec![], "".to_owned()),
         ))
     }
-    fn ReceiveNullableObject(&self, cx: SafeJSContext) -> Option<NonNull<JSObject>> {
-        self.GetObjectAttributeNullable(cx)
+    fn ReceiveNullableObject(&self, cx: SafeJSContext, return_value: MutableHandleObject) {
+        self.GetObjectAttributeNullable(cx, return_value)
     }
     fn ReceiveNullableUnion(&self) -> Option<HTMLElementOrLong> {
         Some(HTMLElementOrLong::Long(0))

--- a/components/script/dom/webcrypto/cryptokey.rs
+++ b/components/script/dom/webcrypto/cryptokey.rs
@@ -3,11 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cell::Cell;
-use std::ptr::NonNull;
 use std::str::FromStr;
 
 use dom_struct::dom_struct;
 use js::jsapi::{Heap, JSObject, Value};
+use js::rust::MutableHandleObject;
 use malloc_size_of::MallocSizeOf;
 use rustc_hash::FxHashMap;
 use script_bindings::cell::DomRefCell;
@@ -219,16 +219,16 @@ impl CryptoKeyMethods<crate::DomTypeHolder> for CryptoKey {
     }
 
     /// <https://w3c.github.io/webcrypto/#dom-cryptokey-algorithm>
-    fn Algorithm(&self, _cx: JSContext) -> NonNull<JSObject> {
+    fn Algorithm(&self, _cx: JSContext, mut return_value: MutableHandleObject) {
         // Returns the cached ECMAScript object associated with the [[algorithm]] internal slot.
-        NonNull::new(self.algorithm_cached.get()).unwrap()
+        return_value.set(self.algorithm_cached.get())
     }
 
     /// <https://w3c.github.io/webcrypto/#dom-cryptokey-usages>
-    fn Usages(&self, _cx: JSContext) -> NonNull<JSObject> {
+    fn Usages(&self, _cx: JSContext, mut return_value: MutableHandleObject) {
         // Returns the cached ECMAScript object associated with the [[usages]] internal slot, which
         // indicates which cryptographic operations are permissible to be used with this key.
-        NonNull::new(self.usages_cached.get()).unwrap()
+        return_value.set(self.usages_cached.get())
     }
 }
 

--- a/components/script/dom/webgl/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl/webgl2renderingcontext.rs
@@ -3,17 +3,16 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cell::Cell;
-use std::cmp;
-use std::ptr::{self, NonNull};
 #[cfg(feature = "webxr")]
 use std::rc::Rc;
+use std::{cmp, ptr};
 
 use bitflags::bitflags;
 use dom_struct::dom_struct;
 use euclid::default::{Point2D, Rect, Size2D};
 use js::jsapi::{JSObject, Type};
 use js::jsval::{BooleanValue, DoubleValue, Int32Value, NullValue, ObjectValue, UInt32Value};
-use js::rust::{CustomAutoRooterGuard, HandleObject, MutableHandleValue};
+use js::rust::{CustomAutoRooterGuard, HandleObject, MutableHandleObject, MutableHandleValue};
 use js::typedarray::{ArrayBufferView, CreateWith, Float32, Int32Array, Uint32, Uint32Array};
 use pixels::{Alpha, Snapshot};
 use script_bindings::conversions::SafeToJSValConvertible;
@@ -1276,8 +1275,8 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.14>
-    fn GetExtension(&self, cx: JSContext, name: DOMString) -> Option<NonNull<JSObject>> {
-        self.base.GetExtension(cx, name)
+    fn GetExtension(&self, cx: JSContext, name: DOMString, return_value: MutableHandleObject) {
+        self.base.GetExtension(cx, name, return_value)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.4>

--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -3,10 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cell::Cell;
-use std::cmp;
-use std::ptr::{self, NonNull};
 #[cfg(feature = "webxr")]
 use std::rc::Rc;
+use std::{cmp, ptr};
 
 #[cfg(feature = "webgl_backtrace")]
 use backtrace::Backtrace;
@@ -15,7 +14,7 @@ use dom_struct::dom_struct;
 use euclid::default::{Point2D, Rect, Size2D};
 use js::jsapi::{JSContext, JSObject, Type};
 use js::jsval::{BooleanValue, DoubleValue, Int32Value, NullValue, ObjectValue, UInt32Value};
-use js::rust::{CustomAutoRooterGuard, MutableHandleValue};
+use js::rust::{CustomAutoRooterGuard, MutableHandleObject, MutableHandleValue};
 use js::typedarray::{
     ArrayBufferView, CreateWith, Float32, Float32Array, Int32, Int32Array, TypedArray,
     TypedArrayElementCreator, Uint32Array,
@@ -2566,10 +2565,20 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.14>
-    fn GetExtension(&self, _cx: SafeJSContext, name: DOMString) -> Option<NonNull<JSObject>> {
+    fn GetExtension(
+        &self,
+        _cx: SafeJSContext,
+        name: DOMString,
+        mut return_value: MutableHandleObject,
+    ) {
         self.extension_manager
             .init_once(|| self.get_gl_extensions());
-        self.extension_manager.get_or_init_extension(&name, self)
+        return_value.set(
+            self.extension_manager
+                .get_or_init_extension(&name, self)
+                .map(|nonnull| nonnull.as_ptr())
+                .unwrap_or(ptr::null_mut()),
+        );
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -1552,12 +1552,16 @@ def returnTypeNeedsOutparam(type: IDLType | None) -> bool:
     if type.nullable():
         assert isinstance(type, IDLNullableType)
         type = type.inner
+    if type.isObject():
+        return True
     return type.isAny()
 
 
 def outparamTypeFromReturnType(type: IDLType) -> str:
     if type.isAny():
         return "MutableHandleValue"
+    if type.isObject():
+        return "MutableHandleObject"
     raise TypeError(f"Don't know how to handle {type} as an outparam")
 
 
@@ -1658,10 +1662,7 @@ def getRetvalDeclarationForType(returnType: IDLType | None, descriptorProvider: 
     if returnType.isAny():
         return CGGeneric("JSVal")
     if returnType.isObject() or returnType.isSpiderMonkeyInterface():
-        result = CGGeneric("NonNull<JSObject>")
-        if returnType.nullable():
-            result = CGWrapper(result, pre="Option<", post=">")
-        return result
+        return CGGeneric("*mut JSObject")
     if returnType.isSequence() or returnType.isRecord():
         result = getRetvalDeclarationForType(innerContainerType(returnType), descriptorProvider)
         result = wrapInNativeContainerType(returnType, result)

--- a/components/script_bindings/iterable.rs
+++ b/components/script_bindings/iterable.rs
@@ -7,11 +7,10 @@
 use std::cell::Cell;
 use std::marker::PhantomData;
 use std::ptr;
-use std::ptr::NonNull;
 
 use dom_struct::dom_struct;
 use js::conversions::ToJSValConvertible;
-use js::jsapi::{Heap, JSObject};
+use js::jsapi::{Heap, JS_NewObject};
 use js::jsval::UndefinedValue;
 use js::rust::{HandleObject, HandleValue, MutableHandleObject};
 
@@ -117,12 +116,11 @@ impl<D: DomTypes, T: DomObjectIteratorWrap<D> + JSTraceable + Iterable + DomGlob
 
     /// Return the next value from the iterable object.
     #[expect(non_snake_case)]
-    pub fn Next(&self, cx: JSContext) -> Fallible<NonNull<JSObject>> {
+    pub fn Next(&self, cx: JSContext, return_value: MutableHandleObject) -> Fallible<()> {
         let index = self.index.get();
         rooted!(in(*cx) let mut value = UndefinedValue());
-        rooted!(in(*cx) let mut rval = ptr::null_mut::<JSObject>());
         let result = if index >= self.iterable.get_iterable_length() {
-            dict_return(cx, rval.handle_mut(), true, value.handle())
+            dict_return(cx, return_value, true, value.handle())
         } else {
             match self.type_ {
                 IteratorType::Keys => {
@@ -131,7 +129,7 @@ impl<D: DomTypes, T: DomObjectIteratorWrap<D> + JSTraceable + Iterable + DomGlob
                             .get_key_at_index(index)
                             .to_jsval(*cx, value.handle_mut());
                     }
-                    dict_return(cx, rval.handle_mut(), false, value.handle())
+                    dict_return(cx, return_value, false, value.handle())
                 },
                 IteratorType::Values => {
                     unsafe {
@@ -139,7 +137,7 @@ impl<D: DomTypes, T: DomObjectIteratorWrap<D> + JSTraceable + Iterable + DomGlob
                             .get_value_at_index(index)
                             .to_jsval(*cx, value.handle_mut());
                     }
-                    dict_return(cx, rval.handle_mut(), false, value.handle())
+                    dict_return(cx, return_value, false, value.handle())
                 },
                 IteratorType::Entries => {
                     rooted!(in(*cx) let mut key = UndefinedValue());
@@ -151,12 +149,12 @@ impl<D: DomTypes, T: DomObjectIteratorWrap<D> + JSTraceable + Iterable + DomGlob
                             .get_value_at_index(index)
                             .to_jsval(*cx, value.handle_mut());
                     }
-                    key_and_value_return(cx, rval.handle_mut(), key.handle(), value.handle())
+                    key_and_value_return(cx, return_value, key.handle(), value.handle())
                 },
             }
         };
         self.index.set(index + 1);
-        result.map(|_| NonNull::new(rval.get()).expect("got a null pointer"))
+        result
     }
 }
 
@@ -180,11 +178,11 @@ fn dict_return(
     let mut dict = IterableKeyOrValueResult::empty();
     dict.done = done;
     dict.value.set(value.get());
-    rooted!(in(*cx) let mut dict_value = UndefinedValue());
+
     unsafe {
-        dict.to_jsval(*cx, dict_value.handle_mut());
+        result.set(JS_NewObject(*cx, ptr::null()));
+        dict.to_jsobject(*cx, result);
     }
-    result.set(dict_value.to_object());
     Ok(())
 }
 
@@ -202,10 +200,9 @@ fn key_and_value_return(
             .map(|handle| RootedTraceableBox::from_box(Heap::boxed(handle.get())))
             .collect(),
     );
-    rooted!(in(*cx) let mut dict_value = UndefinedValue());
     unsafe {
-        dict.to_jsval(*cx, dict_value.handle_mut());
+        result.set(JS_NewObject(*cx, ptr::null()));
+        dict.to_jsobject(*cx, result);
     }
-    result.set(dict_value.to_object());
     Ok(())
 }


### PR DESCRIPTION
Currently we pass `NonNull<JSObject>` around, which is scary because that object is not necessarily rooted anywhere.
Instead, we can use a `MutableHandleObject` as an out-parameter.

Testing: This should not change existing behaviour, which I verified with a try run: https://github.com/simonwuelker/servo/actions/runs/27479947033