### PR TITLE
tests: Unskip `entries-api`

### DIFF
--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -152,6 +152,8 @@ skip: true
   skip: false
 [encoding-detection]
   skip: false
+[entries-api]
+  skip: false
 [eventsource]
   skip: false
 [fetch]

--- a/tests/wpt/meta/entries-api/idlharness.window.js.ini
+++ b/tests/wpt/meta/entries-api/idlharness.window.js.ini
@@ -1,0 +1,150 @@
+[idlharness.window.html]
+  [FileSystemEntry interface: existence and properties of interface object]
+    expected: FAIL
+
+  [FileSystemEntry interface object length]
+    expected: FAIL
+
+  [FileSystemEntry interface object name]
+    expected: FAIL
+
+  [FileSystemEntry interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [FileSystemEntry interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [FileSystemEntry interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [FileSystemEntry interface: attribute isFile]
+    expected: FAIL
+
+  [FileSystemEntry interface: attribute isDirectory]
+    expected: FAIL
+
+  [FileSystemEntry interface: attribute name]
+    expected: FAIL
+
+  [FileSystemEntry interface: attribute fullPath]
+    expected: FAIL
+
+  [FileSystemEntry interface: attribute filesystem]
+    expected: FAIL
+
+  [FileSystemEntry interface: operation getParent(optional FileSystemEntryCallback, optional ErrorCallback)]
+    expected: FAIL
+
+  [FileSystemDirectoryEntry interface: existence and properties of interface object]
+    expected: FAIL
+
+  [FileSystemDirectoryEntry interface object length]
+    expected: FAIL
+
+  [FileSystemDirectoryEntry interface object name]
+    expected: FAIL
+
+  [FileSystemDirectoryEntry interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [FileSystemDirectoryEntry interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [FileSystemDirectoryEntry interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [FileSystemDirectoryEntry interface: operation createReader()]
+    expected: FAIL
+
+  [FileSystemDirectoryEntry interface: operation getFile(optional USVString?, optional FileSystemFlags, optional FileSystemEntryCallback, optional ErrorCallback)]
+    expected: FAIL
+
+  [FileSystemDirectoryEntry interface: operation getDirectory(optional USVString?, optional FileSystemFlags, optional FileSystemEntryCallback, optional ErrorCallback)]
+    expected: FAIL
+
+  [FileSystemDirectoryReader interface: existence and properties of interface object]
+    expected: FAIL
+
+  [FileSystemDirectoryReader interface object length]
+    expected: FAIL
+
+  [FileSystemDirectoryReader interface object name]
+    expected: FAIL
+
+  [FileSystemDirectoryReader interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [FileSystemDirectoryReader interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [FileSystemDirectoryReader interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [FileSystemDirectoryReader interface: operation readEntries(FileSystemEntriesCallback, optional ErrorCallback)]
+    expected: FAIL
+
+  [FileSystemFileEntry interface: existence and properties of interface object]
+    expected: FAIL
+
+  [FileSystemFileEntry interface object length]
+    expected: FAIL
+
+  [FileSystemFileEntry interface object name]
+    expected: FAIL
+
+  [FileSystemFileEntry interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [FileSystemFileEntry interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [FileSystemFileEntry interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [FileSystemFileEntry interface: operation file(FileCallback, optional ErrorCallback)]
+    expected: FAIL
+
+  [FileSystem interface: existence and properties of interface object]
+    expected: FAIL
+
+  [FileSystem interface object length]
+    expected: FAIL
+
+  [FileSystem interface object name]
+    expected: FAIL
+
+  [FileSystem interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [FileSystem interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [FileSystem interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [FileSystem interface: attribute name]
+    expected: FAIL
+
+  [FileSystem interface: attribute root]
+    expected: FAIL
+
+  [File interface: attribute webkitRelativePath]
+    expected: FAIL
+
+  [File interface: new File([\], "example.txt") must inherit property "webkitRelativePath" with the proper type]
+    expected: FAIL
+
+  [HTMLInputElement interface: attribute webkitdirectory]
+    expected: FAIL
+
+  [HTMLInputElement interface: attribute webkitEntries]
+    expected: FAIL
+
+  [HTMLInputElement interface: document.createElement("input") must inherit property "webkitdirectory" with the proper type]
+    expected: FAIL
+
+  [HTMLInputElement interface: document.createElement("input") must inherit property "webkitEntries" with the proper type]
+    expected: FAIL
+
+  [DataTransferItem interface: operation webkitGetAsEntry()]
+    expected: FAIL


### PR DESCRIPTION
The very first step of #45653.

Testing: Existing tests. We pass 18/68.
Part of #45653
