### PR TITLE
script: Flush layout changes before running intersection observer updates.

### DIFF
--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -1802,7 +1802,8 @@ impl ReflowPhases {
     /// so [`ReflowPhases::empty()`] implies that.
     fn necessary(reflow_goal: &ReflowGoal) -> Self {
         match reflow_goal {
-            ReflowGoal::LayoutQuery(query) => match query {
+            ReflowGoal::LayoutQuery(None) => Self::empty(),
+            ReflowGoal::LayoutQuery(Some(query)) => match query {
                 QueryMsg::NodesFromPointQuery => {
                     Self::StackingContextTreeConstruction | Self::DisplayListConstruction
                 },

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -1802,14 +1802,14 @@ impl ReflowPhases {
     /// so [`ReflowPhases::empty()`] implies that.
     fn necessary(reflow_goal: &ReflowGoal) -> Self {
         match reflow_goal {
-            ReflowGoal::LayoutQuery(None) => Self::empty(),
-            ReflowGoal::LayoutQuery(Some(query)) => match query {
+            ReflowGoal::LayoutQuery(query) => match query {
                 QueryMsg::NodesFromPointQuery => {
                     Self::StackingContextTreeConstruction | Self::DisplayListConstruction
                 },
                 QueryMsg::BoxArea |
                 QueryMsg::BoxAreas |
                 QueryMsg::ElementsFromPoint |
+                QueryMsg::FlushForUpdateTheRenderingQuery |
                 QueryMsg::OffsetParentQuery |
                 QueryMsg::ResolvedStyleQuery |
                 QueryMsg::ScrollingAreaOrOffsetQuery |

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -3211,6 +3211,12 @@ impl Document {
         cx: &mut js::context::JSContext,
         time: CrossProcessInstant,
     ) {
+        if self.intersection_observers.borrow().is_empty() {
+            return;
+        }
+        // Ensure that any layout changes are flushed for subsequent queries.
+        self.window().layout_reflow_pre_query(cx);
+
         // Step 1-2
         for intersection_observer in &*self.intersection_observers.borrow() {
             self.update_single_intersection_observer_steps(cx, intersection_observer, time);

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -3215,7 +3215,8 @@ impl Document {
             return;
         }
         // Ensure that any layout changes are flushed for subsequent queries.
-        self.window().layout_reflow_pre_query(cx);
+        self.window()
+            .reflow_for_non_flushing_update_the_rendering_queries(cx);
 
         // Step 1-2
         for intersection_observer in &*self.intersection_observers.borrow() {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2860,7 +2860,12 @@ impl Window {
         // TODO https://github.com/servo/servo/issues/44499
         let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
 
-        self.reflow(&mut cx, ReflowGoal::LayoutQuery(query_msg));
+        self.reflow(&mut cx, ReflowGoal::LayoutQuery(Some(query_msg)));
+    }
+
+    /// Trigger a reflow in preparation for subsequent queries.
+    pub(crate) fn layout_reflow_pre_query(&self, cx: &mut JSContext) {
+        self.reflow(cx, ReflowGoal::LayoutQuery(None));
     }
 
     pub(crate) fn resolved_font_style_query(

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2860,12 +2860,15 @@ impl Window {
         // TODO https://github.com/servo/servo/issues/44499
         let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
 
-        self.reflow(&mut cx, ReflowGoal::LayoutQuery(Some(query_msg)));
+        self.reflow(&mut cx, ReflowGoal::LayoutQuery(query_msg));
     }
 
-    /// Trigger a reflow in preparation for subsequent queries.
-    pub(crate) fn layout_reflow_pre_query(&self, cx: &mut JSContext) {
-        self.reflow(cx, ReflowGoal::LayoutQuery(None));
+    /// Trigger a reflow in preparation for subsequent queries that don't perform a reflow.
+    pub(crate) fn reflow_for_non_flushing_update_the_rendering_queries(&self, cx: &mut JSContext) {
+        self.reflow(
+            cx,
+            ReflowGoal::LayoutQuery(QueryMsg::FlushForUpdateTheRenderingQuery),
+        );
     }
 
     pub(crate) fn resolved_font_style_query(

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -551,6 +551,7 @@ pub enum QueryMsg {
     StyleQuery,
     TextIndexQuery,
     PaddingQuery,
+    FlushForUpdateTheRenderingQuery,
 }
 
 /// The goal of a reflow request.
@@ -566,7 +567,7 @@ pub enum ReflowGoal {
 
     /// Script has done a layout query and this reflow ensurs that layout is up-to-date
     /// with the latest changes to the DOM.
-    LayoutQuery(Option<QueryMsg>),
+    LayoutQuery(QueryMsg),
 
     /// Tells layout about a single new scrolling offset from the script. The rest will
     /// remain untouched. Layout will forward whether the element is scrolled through

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -566,7 +566,7 @@ pub enum ReflowGoal {
 
     /// Script has done a layout query and this reflow ensurs that layout is up-to-date
     /// with the latest changes to the DOM.
-    LayoutQuery(QueryMsg),
+    LayoutQuery(Option<QueryMsg>),
 
     /// Tells layout about a single new scrolling offset from the script. The rest will
     /// remain untouched. Layout will forward whether the element is scrolled through

--- a/tests/wpt/meta/intersection-observer/containing-block.html.ini
+++ b/tests/wpt/meta/intersection-observer/containing-block.html.ini
@@ -2,8 +2,5 @@
   [Not in containing block and not intersecting.]
     expected: FAIL
 
-  [In containing block and intersecting.]
-    expected: FAIL
-
-  [In containing block and not intersecting.]
+  [Not in containing block and intersecting.]
     expected: FAIL

--- a/tests/wpt/meta/intersection-observer/isIntersecting-change-events.html.ini
+++ b/tests/wpt/meta/intersection-observer/isIntersecting-change-events.html.ini
@@ -1,3 +1,0 @@
-[isIntersecting-change-events.html]
-  [Add 4th target.]
-    expected: FAIL

--- a/tests/wpt/meta/intersection-observer/reinsert-element.html.ini
+++ b/tests/wpt/meta/intersection-observer/reinsert-element.html.ini
@@ -1,3 +1,0 @@
-[reinsert-element.html]
-  [An element that is removed and reinserted without an intervening rendering update doesn't generate a 'not-intersecting' notification.]
-    expected: FAIL

--- a/tests/wpt/meta/intersection-observer/shadow-content.html.ini
+++ b/tests/wpt/meta/intersection-observer/shadow-content.html.ini
@@ -1,3 +1,0 @@
-[shadow-content.html]
-  [First rAF after creating shadow DOM.]
-    expected: FAIL


### PR DESCRIPTION
Since we have layout query APIs that can skip performing any layout, we need a way to ensure that any pending layout changes have actually been processed before those queries are used. If a page contains any intersection observers, we force a reflow; if no more layout changes occur within this task then the final reflow operation that updates the rendering should just skip all of the work that was already done.

Testing: New passing tests.
Fixes: #45632
