### PR TITLE
deps: Bump `pkcs8` to 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1938,7 +1938,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
- "der_derive",
  "pem-rfc7468 0.7.0",
  "zeroize",
 ]
@@ -1952,17 +1951,6 @@ dependencies = [
  "const-oid 0.10.2",
  "pem-rfc7468 1.0.0",
  "zeroize",
-]
-
-[[package]]
-name = "der_derive"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -6388,7 +6376,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der 0.7.10",
- "rand_core 0.6.4",
  "spki 0.7.3",
 ]
 
@@ -8738,7 +8725,6 @@ dependencies = [
  "cssparser",
  "ctr",
  "data-url",
- "der 0.7.10",
  "digest 0.11.3",
  "ecdsa",
  "elliptic-curve",
@@ -8776,7 +8762,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "phf",
- "pkcs8 0.10.2",
+ "pkcs8 0.11.0",
  "postcard",
  "rand 0.10.1",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ cfg-if = "1.0.4"
 chacha20poly1305 = "0.10"
 chardetng = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
-cipher = { version = "0.4.4", features = ["alloc"] }
+cipher = { version = "0.4.4", features = ["alloc", "rand_core"] }
 content-security-policy = { version = "0.8.0", features = ["serde"] }
 cookie = { package = "cookie", version = "0.18" }
 criterion = "0.8"
@@ -73,7 +73,6 @@ cssparser = { version = "0.37", features = ["serde"] }
 ctr = "0.9.2"
 crypto-bigint = "0.7"
 data-url = "0.3"
-der = { version = "0.7", features = ["alloc", "derive"] }
 digest = "0.11"
 dirs = "6.0"
 dpi = "0.1"
@@ -83,7 +82,7 @@ egui = "0.34.3"
 egui-file-dialog = "0.13.0"
 egui-winit = { version = "0.34.3", default-features = false }
 egui_glow = "0.34.3"
-elliptic-curve = "0.13"
+elliptic-curve = { version = "0.13", features = ["pkcs8"] }
 encoding_rs = { version = "0.8", features = ["serde"] }
 env_filter = "0.1.4"
 env_logger = "0.11"
@@ -193,7 +192,7 @@ petgraph = "0.8.3"
 phf = "0.13"
 phf_codegen = "0.13"
 phf_shared = "0.13"
-pkcs8 = { version = "0.10", features = ["rand_core"] }
+pkcs8 = "0.11"
 pollster = "0.4"
 postcard = { version = "1.1.3", default-features = false, features = ["use-std"] }
 prettyplease = "0.2.32"

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -67,7 +67,6 @@ ctr = { workspace = true }
 crypto-bigint = { workspace = true }
 data-url = { workspace = true }
 deny_public_fields = { workspace = true }
-der = { workspace = true }
 devtools_traits = { workspace = true }
 digest = { workspace = true }
 dom_struct = { workspace = true }

--- a/components/script/dom/webcrypto/subtlecrypto/aes_common.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/aes_common.rs
@@ -4,8 +4,8 @@
 
 use aes::cipher::crypto_common::Key;
 use aes::{Aes128, Aes192, Aes256};
+use cipher::rand_core::{OsRng, RngCore};
 use js::context::JSContext;
-use pkcs8::rand_core::{OsRng, RngCore};
 use zeroize::Zeroizing;
 
 use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::{

--- a/components/script/dom/webcrypto/subtlecrypto/ec_common.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ec_common.rs
@@ -3,16 +3,16 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use elliptic_curve::SecretKey;
+use elliptic_curve::pkcs8::der::Decode;
+use elliptic_curve::pkcs8::{
+    AssociatedOid, EncodePrivateKey, EncodePublicKey, PrivateKeyInfo, SubjectPublicKeyInfo,
+};
 use elliptic_curve::rand_core::OsRng;
 use elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint, ValidatePublicKey};
 use js::context::JSContext;
 use p256::NistP256;
 use p384::NistP384;
 use p521::NistP521;
-use pkcs8::der::Decode;
-use pkcs8::{
-    AssociatedOid, EncodePrivateKey, EncodePublicKey, PrivateKeyInfo, SubjectPublicKeyInfo,
-};
 use sec1::der::asn1::BitString;
 use sec1::{EcParameters, EcPrivateKey, EncodedPoint};
 

--- a/components/script/dom/webcrypto/subtlecrypto/x25519_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/x25519_operation.rs
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use elliptic_curve::rand_core::OsRng;
 use js::context::JSContext;
-use pkcs8::PrivateKeyInfo;
-use pkcs8::der::asn1::{BitStringRef, OctetString, OctetStringRef};
-use pkcs8::der::{AnyRef, Decode, Encode};
-use pkcs8::rand_core::OsRng;
-use pkcs8::spki::{AlgorithmIdentifier, ObjectIdentifier, SubjectPublicKeyInfo};
+use pkcs8::der::asn1::{OctetString, OctetStringRef};
+use pkcs8::der::{Decode, Encode};
+use pkcs8::{AlgorithmIdentifierRef, ObjectIdentifier, PrivateKeyInfoRef, SubjectPublicKeyInfoRef};
 use x25519_dalek::{PublicKey, StaticSecret};
+use zeroize::Zeroizing;
 
 use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::{
     CryptoKeyMethods, CryptoKeyPair, KeyType, KeyUsage,
@@ -204,8 +204,11 @@ pub(crate) fn import_key(
             // Step 2.2. Let spki be the result of running the parse a subjectPublicKeyInfo
             // algorithm over keyData.
             // Step 2.3. If an error occurred while parsing, then throw a DataError.
-            let spki = SubjectPublicKeyInfo::<AnyRef, BitStringRef>::from_der(key_data)
-                .map_err(|_| Error::Data(None))?;
+            let spki = SubjectPublicKeyInfoRef::from_der(key_data).map_err(|_| {
+                Error::Data(Some(
+                    "Failed to parse the X25519 public key in SPKI format".into(),
+                ))
+            })?;
 
             // Step 2.4. If the algorithm object identifier field of the algorithm
             // AlgorithmIdentifier field of spki is not equal to the id-X25519 object identifier
@@ -262,8 +265,11 @@ pub(crate) fn import_key(
             // Step 2.2. Let privateKeyInfo be the result of running the parse a privateKeyInfo
             // algorithm over keyData.
             // Step 2.3. If an error occurs while parsing, then throw a DataError.
-            let private_key_info =
-                PrivateKeyInfo::from_der(key_data).map_err(|_| Error::Data(None))?;
+            let private_key_info = PrivateKeyInfoRef::from_der(key_data).map_err(|_| {
+                Error::Data(Some(
+                    "Failed to parse the X25519 private key in PKCS#8 format".into(),
+                ))
+            })?;
 
             // Step 2.4. If the algorithm object identifier field of the privateKeyAlgorithm
             // PrivateKeyAlgorithm field of privateKeyInfo is not equal to the id-X25519 object
@@ -284,13 +290,23 @@ pub(crate) fn import_key(
             // as the ASN.1 CurvePrivateKey structure specified in Section 7 of [RFC8410], and
             // exactData set to true.
             // Step 2.7. If an error occurred while parsing, then throw a DataError.
-            let curve_private_key = OctetStringRef::from_der(private_key_info.private_key)
-                .map_err(|_| Error::Data(None))?;
-            let key_bytes: [u8; PRIVATE_KEY_LENGTH] = curve_private_key
-                .as_bytes()
-                .try_into()
-                .map_err(|_| Error::Data(None))?;
-            let private_key = StaticSecret::from(key_bytes);
+            let curve_private_key = private_key_info
+                .private_key
+                .decode_into::<OctetString>()
+                .map_err(|_| {
+                    Error::Data(Some(
+                        "Failed to decode the privateKey field of PrivateKeyInfo ASN.1 structure"
+                            .into(),
+                    ))
+                })?;
+            let key_bytes: [u8; PRIVATE_KEY_LENGTH] =
+                curve_private_key.as_bytes().try_into().map_err(|_| {
+                    Error::Data(Some(
+                        "Failed to extract the raw bytes from the CurvePrivateKey ASN.1 structure"
+                            .into(),
+                    ))
+                })?;
+            let curve_private_key = StaticSecret::from(key_bytes);
 
             // Step 2.8. Let key be a new CryptoKey that represents the X25519 private key
             // identified by curvePrivateKey.
@@ -308,7 +324,7 @@ pub(crate) fn import_key(
                 extractable,
                 KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
                 usages,
-                Handle::X25519PrivateKey(private_key),
+                Handle::X25519PrivateKey(curve_private_key),
             )
         },
         // If format is "jwk":
@@ -499,13 +515,18 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             let Handle::X25519PublicKey(public_key) = key.handle() else {
                 return Err(Error::Operation(None));
             };
-            let data = SubjectPublicKeyInfo::<BitStringRef, _> {
-                algorithm: AlgorithmIdentifier {
+            let data = SubjectPublicKeyInfoRef {
+                algorithm: AlgorithmIdentifierRef {
                     oid: ObjectIdentifier::new_unwrap(X25519_OID_STRING),
                     parameters: None,
                 },
-                subject_public_key: BitStringRef::from_bytes(public_key.as_bytes())
-                    .map_err(|_| Error::Data(None))?,
+                subject_public_key: public_key.as_bytes().try_into().map_err(|_| {
+                    Error::Data(Some(
+                        "Failed to construct the subjectPublicKey field of SubjectPublicKeyInfo \
+                            ASN.1 structure"
+                            .into(),
+                    ))
+                })?,
             };
 
             // Step 3.3. Let result be the result of DER-encoding data.
@@ -533,14 +554,33 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             let Handle::X25519PrivateKey(private_key) = key.handle() else {
                 return Err(Error::Operation(None));
             };
-            let curve_private_key =
-                OctetString::new(private_key.as_bytes()).map_err(|_| Error::Data(None))?;
-            let data = PrivateKeyInfo {
-                algorithm: AlgorithmIdentifier {
+            let curve_private_key = OctetStringRef::new(private_key.as_bytes().as_slice())
+                .map_err(|_| {
+                    Error::Operation(Some(
+                        "Failed to construct CurvePrivateKey ASN.1 structure".into(),
+                    ))
+                })?;
+            let encoded_curve_private_key: Zeroizing<Vec<u8>> = curve_private_key
+                .to_der()
+                .map_err(|_| {
+                    Error::Operation(Some(
+                        "Failed to encode CurvePrivateKey ASN.1 structure in DER format".into(),
+                    ))
+                })?
+                .into();
+            let private_key_field =
+                OctetStringRef::new(&encoded_curve_private_key).map_err(|_| {
+                    Error::Operation(Some(
+                        "Failed to construct privateKey field of PrivateKeyInfo ASN.1 structure"
+                            .into(),
+                    ))
+                })?;
+            let data = PrivateKeyInfoRef {
+                algorithm: AlgorithmIdentifierRef {
                     oid: ObjectIdentifier::new_unwrap(X25519_OID_STRING),
                     parameters: None,
                 },
-                private_key: &curve_private_key.to_der().map_err(|_| Error::Data(None))?,
+                private_key: private_key_field,
                 public_key: None,
             };
 


### PR DESCRIPTION
Bump `pkcs8` from 0.10.2 to 0.11.0. We use `spki` and `der` as re-exported modules of `pkcs8`, thus they are also bumped from 0.7.3 and 0.7.10 to 0.8.0 and 0.8.0, respectively.

Since we no longer directly call `der`, we remove it from `Cargo.toml`.

Note that, since we have not yet bumped the crates for elliptic curve algorithms and AES algorithms, `ec_common.rs` and `aes_common.rs` still relied on the old version of `pkcs8` and `pkcs8::rand_core`. Therefore, we use `elliptic_curve::pkcs8` and `cipher::rand_core` instead to refer the old version re-exported by `elliptic_curve` and `cipher`.

Testing: Covered by existing WPT tests in `WebCryptoAPI` subdirectory
Fixes: Part of #42206