### PR TITLE
script: Check if intersection observer target is in containing block chain of root.

### DIFF
--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -370,7 +370,7 @@ impl Layout for LayoutThread {
 
     /// Return the node corresponding to the containing block of the provided node.
     #[servo_tracing::instrument(skip_all)]
-    fn query_containing_block_descendant(
+    fn query_containing_block_is_descendant(
         &self,
         root: TrustedNodeAddress,
         possible_descendant: TrustedNodeAddress,

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -88,7 +88,8 @@ use crate::display_list::{DisplayListBuilder, HitTest, PaintTimingHandler, Stack
 use crate::dom::NodeExt;
 use crate::query::{
     find_character_offset_in_fragment_descendants, get_the_text_steps, process_box_area_request,
-    process_box_areas_request, process_client_rect_request, process_containing_block_query,
+    process_box_areas_request, process_client_rect_request,
+    process_containing_block_descendant_query, process_containing_block_query,
     process_current_css_zoom_query, process_effective_overflow_query,
     process_node_scroll_area_request, process_offset_parent_query, process_padding_request,
     process_resolved_font_style_query, process_resolved_style_request,
@@ -364,6 +365,24 @@ impl Layout for LayoutThread {
         with_layout_state(|| {
             let node = unsafe { ServoLayoutNode::new(&node) };
             process_containing_block_query(node)
+        })
+    }
+
+    /// Return the node corresponding to the containing block of the provided node.
+    #[servo_tracing::instrument(skip_all)]
+    fn query_containing_block_descendant(
+        &self,
+        root: TrustedNodeAddress,
+        possible_descendant: TrustedNodeAddress,
+    ) -> bool {
+        with_layout_state(|| {
+            let (root, possible_descendant) = unsafe {
+                (
+                    ServoLayoutNode::new(&root),
+                    ServoLayoutNode::new(&possible_descendant),
+                )
+            };
+            process_containing_block_descendant_query(root, possible_descendant)
         })
     }
 

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -1463,14 +1463,14 @@ pub fn process_containing_block_query(node: ServoLayoutNode) -> Option<Untrusted
 }
 
 pub fn process_containing_block_descendant_query(
-    root: ServoLayoutNode,
+    possible_ancestor: ServoLayoutNode,
     mut possible_descendant: ServoLayoutNode,
 ) -> bool {
-    while let Some(containing_block) = containing_block_for_node(possible_descendant) {
-        if containing_block == root {
+    while let Some(establishing_node) = containing_block_for_node(possible_descendant) {
+        if establishing_node == possible_ancestor {
             return true;
         }
-        possible_descendant = containing_block;
+        possible_descendant = establishing_node;
     }
     false
 }

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -1462,6 +1462,19 @@ pub fn process_containing_block_query(node: ServoLayoutNode) -> Option<Untrusted
     containing_block.map(|node| node.opaque().into())
 }
 
+pub fn process_containing_block_descendant_query(
+    root: ServoLayoutNode,
+    mut possible_descendant: ServoLayoutNode,
+) -> bool {
+    while let Some(containing_block) = containing_block_for_node(possible_descendant) {
+        if containing_block == root {
+            return true;
+        }
+        possible_descendant = containing_block;
+    }
+    false
+}
+
 pub fn process_resolved_font_style_query<'dom, E>(
     context: &SharedStyleContext,
     node: E,

--- a/components/script/dom/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver.rs
@@ -507,7 +507,7 @@ impl IntersectionObserver {
                 }
                 if !element
                     .owner_window()
-                    .containing_block_descendant_query_without_reflow(
+                    .is_containing_block_descendant_query_without_reflow(
                         element.upcast(),
                         target.upcast(),
                     )

--- a/components/script/dom/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver.rs
@@ -505,8 +505,15 @@ impl IntersectionObserver {
                 if element.owner_document() != target.owner_document() {
                     return IntersectionObservationOutput::default_skipped();
                 }
-                // TODO(stevennovaryo): implement LayoutThread query for descendant of containing block chain.
-                debug!("descendant of containing block chain is not implemented");
+                if !element
+                    .owner_window()
+                    .containing_block_descendant_query_without_reflow(
+                        element.upcast(),
+                        target.upcast(),
+                    )
+                {
+                    return IntersectionObservationOutput::default_skipped();
+                }
             },
             _ => {},
         }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2847,13 +2847,13 @@ impl Window {
 
     /// Query whether a node is part of another node's containing block chain.
     /// <https://drafts.csswg.org/css-display/#containing-block-chain>
-    pub(crate) fn containing_block_descendant_query_without_reflow(
+    pub(crate) fn is_containing_block_descendant_query_without_reflow(
         &self,
-        root: &Node,
+        possible_ancestor: &Node,
         possible_descendant: &Node,
     ) -> bool {
-        self.layout.borrow().query_containing_block_descendant(
-            root.to_trusted_node_address(),
+        self.layout.borrow().query_containing_block_is_descendant(
+            possible_ancestor.to_trusted_node_address(),
             possible_descendant.to_trusted_node_address(),
         )
     }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2845,6 +2845,19 @@ impl Window {
             .map(|address| unsafe { from_untrusted_node_address(address) })
     }
 
+    /// Query whether a node is part of another node's containing block chain.
+    /// <https://drafts.csswg.org/css-display/#containing-block-chain>
+    pub(crate) fn containing_block_descendant_query_without_reflow(
+        &self,
+        root: &Node,
+        possible_descendant: &Node,
+    ) -> bool {
+        self.layout.borrow().query_containing_block_descendant(
+            root.to_trusted_node_address(),
+            possible_descendant.to_trusted_node_address(),
+        )
+    }
+
     /// Query the used padding values for the given node, but do not force a reflow.
     /// This is used for things like `ResizeObserver` which should observe the value
     /// from the most recent reflow, but do not need it to reflect the current state of

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -356,6 +356,11 @@ pub trait Layout {
     ) -> NodeRenderingType;
 
     fn query_containing_block(&self, node: TrustedNodeAddress) -> Option<UntrustedNodeAddress>;
+    fn query_containing_block_descendant(
+        &self,
+        root: TrustedNodeAddress,
+        possible_descendant: TrustedNodeAddress,
+    ) -> bool;
     fn query_padding(&self, node: TrustedNodeAddress) -> Option<PhysicalSides>;
     fn query_box_area(
         &self,

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -356,7 +356,7 @@ pub trait Layout {
     ) -> NodeRenderingType;
 
     fn query_containing_block(&self, node: TrustedNodeAddress) -> Option<UntrustedNodeAddress>;
-    fn query_containing_block_descendant(
+    fn query_containing_block_is_descendant(
         &self,
         root: TrustedNodeAddress,
         possible_descendant: TrustedNodeAddress,

--- a/tests/wpt/meta/intersection-observer/scroll-margin-not-contained.html.ini
+++ b/tests/wpt/meta/intersection-observer/scroll-margin-not-contained.html.ini
@@ -1,3 +1,0 @@
-[scroll-margin-not-contained.html]
-  [Test scroll margin intersection]
-    expected: FAIL

--- a/tests/wpt/meta/intersection-observer/target-is-root.html.ini
+++ b/tests/wpt/meta/intersection-observer/target-is-root.html.ini
@@ -1,3 +1,0 @@
-[target-is-root.html]
-  [IntersectionObserver when root == target doesn't compute an intersection]
-    expected: FAIL


### PR DESCRIPTION
Implements a layout query to determine if one node is in the containing block chain of another node.

Testing: New passing tests.
Fixes: part of #35767
