### PR TITLE
script: Pass `&mut JSContext` to `Promise::reject_error`

### DIFF
--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -270,15 +270,7 @@ impl Promise {
         self.reject_with_cx(cx, v.handle());
     }
 
-    pub(crate) fn reject_error(&self, error: Error, can_gc: CanGc) {
-        let cx = GlobalScope::get_cx();
-        let _ac = enter_realm(self);
-        rooted!(in(*cx) let mut v = UndefinedValue());
-        error.to_jsval(cx, &self.global(), v.handle_mut(), can_gc);
-        self.reject(cx, v.handle(), can_gc);
-    }
-
-    pub(crate) fn reject_error_with_cx(&self, cx: &mut JSContext, error: Error) {
+    pub(crate) fn reject_error(&self, cx: &mut JSContext, error: Error) {
         let mut realm = enter_auto_realm(cx, self);
         let cx = &mut realm.current_realm();
         rooted!(&in(cx) let mut v = UndefinedValue());
@@ -289,6 +281,11 @@ impl Promise {
             CanGc::from_cx(cx),
         );
         self.reject_with_cx(cx, v.handle());
+    }
+
+    /// Deprecate: use [`Self::reject_error`] instead
+    pub(crate) fn reject_error_with_cx(&self, cx: &mut JSContext, error: Error) {
+        self.reject_error(cx, error);
     }
 
     #[expect(unsafe_code)]

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -283,7 +283,7 @@ impl Promise {
         self.reject_with_cx(cx, v.handle());
     }
 
-    /// Deprecate: use [`Self::reject_error`] instead
+    /// Deprecated: use [`Self::reject_error`] instead
     pub(crate) fn reject_error_with_cx(&self, cx: &mut JSContext, error: Error) {
         self.reject_error(cx, error);
     }

--- a/components/script/dom/servointernals.rs
+++ b/components/script/dom/servointernals.rs
@@ -26,7 +26,6 @@ use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
-use crate::realms::InRealm;
 use crate::routed_promise::{RoutedPromiseListener, callback_promise};
 use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
@@ -69,9 +68,9 @@ impl ServoInternals {
 
 impl ServoInternalsMethods<crate::DomTypeHolder> for ServoInternals {
     /// <https://servo.org/internal-no-spec>
-    fn ReportMemory(&self, comp: InRealm, can_gc: CanGc) -> Rc<Promise> {
-        let global = &self.global();
-        let promise = Promise::new_in_current_realm(comp, can_gc);
+    fn ReportMemory(&self, cx: &mut CurrentRealm) -> Rc<Promise> {
+        let promise = Promise::new_in_realm(cx);
+        let global = self.global();
         let task_source = global.task_manager().dom_manipulation_task_source();
         let callback = callback_promise(&promise, self, task_source);
 
@@ -80,7 +79,7 @@ impl ServoInternalsMethods<crate::DomTypeHolder> for ServoInternals {
             .send(ScriptToConstellationMessage::ReportMemory(callback))
             .is_err()
         {
-            promise.reject_error(Error::Operation(None), can_gc);
+            promise.reject_error(cx, Error::Operation(None));
         }
         promise
     }

--- a/components/script/dom/storagemanager.rs
+++ b/components/script/dom/storagemanager.rs
@@ -5,6 +5,7 @@
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::realm::CurrentRealm;
 use script_bindings::reflector::{Reflector, reflect_dom_object};
 use servo_base::generic_channel::GenericCallback;
 
@@ -21,7 +22,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::permissions::request_permission_to_use;
 use crate::dom::promise::Promise;
-use crate::realms::InRealm;
 use crate::script_runtime::CanGc;
 use crate::task_source::SendableTaskSource;
 
@@ -121,9 +121,9 @@ impl StorageManagerEstimateResponseHandler {
 
 impl StorageManagerMethods<crate::DomTypeHolder> for StorageManager {
     /// <https://storage.spec.whatwg.org/#dom-storagemanager-persisted>
-    fn Persisted(&self, comp: InRealm, can_gc: CanGc) -> Rc<Promise> {
+    fn Persisted(&self, cx: &mut CurrentRealm) -> Rc<Promise> {
         // Step 1. Let promise be a new promise.
-        let promise = Promise::new_in_current_realm(comp, can_gc);
+        let promise = Promise::new_in_realm(cx);
         // Step 2. Let global be this’s relevant global object.
         let global = self.global();
 
@@ -132,8 +132,8 @@ impl StorageManagerMethods<crate::DomTypeHolder> for StorageManager {
         // Step 4. If shelf is failure, then reject promise with a TypeError.
         if self.origin_cannot_obtain_local_storage_shelf() {
             promise.reject_error(
+                cx,
                 Error::Type(c"Storage is unavailable for opaque origins".to_owned()),
-                can_gc,
             );
             return promise;
         }
@@ -166,9 +166,9 @@ impl StorageManagerMethods<crate::DomTypeHolder> for StorageManager {
     }
 
     /// <https://storage.spec.whatwg.org/#dom-storagemanager-persist>
-    fn Persist(&self, comp: InRealm, can_gc: CanGc) -> Rc<Promise> {
+    fn Persist(&self, cx: &mut CurrentRealm) -> Rc<Promise> {
         // Step 1. Let promise be a new promise.
-        let promise = Promise::new_in_current_realm(comp, can_gc);
+        let promise = Promise::new_in_realm(cx);
         // Step 2. Let global be this’s relevant global object.
         let global = self.global();
 
@@ -177,8 +177,8 @@ impl StorageManagerMethods<crate::DomTypeHolder> for StorageManager {
         // Step 4. If shelf is failure, then reject promise with a TypeError.
         if self.origin_cannot_obtain_local_storage_shelf() {
             promise.reject_error(
+                cx,
                 Error::Type(c"Storage is unavailable for opaque origins".to_owned()),
-                can_gc,
             );
             return promise;
         }
@@ -222,9 +222,9 @@ impl StorageManagerMethods<crate::DomTypeHolder> for StorageManager {
     }
 
     /// <https://storage.spec.whatwg.org/#dom-storagemanager-estimate>
-    fn Estimate(&self, comp: InRealm, can_gc: CanGc) -> Rc<Promise> {
+    fn Estimate(&self, cx: &mut CurrentRealm) -> Rc<Promise> {
         // Step 1. Let promise be a new promise.
-        let promise = Promise::new_in_current_realm(comp, can_gc);
+        let promise = Promise::new_in_realm(cx);
         // Step 2. Let global be this’s relevant global object.
         let global = self.global();
 
@@ -233,8 +233,8 @@ impl StorageManagerMethods<crate::DomTypeHolder> for StorageManager {
         // Step 4. If shelf is failure, then reject promise with a TypeError.
         if self.origin_cannot_obtain_local_storage_shelf() {
             promise.reject_error(
+                cx,
                 Error::Type(c"Storage is unavailable for opaque origins".to_owned()),
-                can_gc,
             );
             return promise;
         }

--- a/components/script/dom/testing/testbinding.rs
+++ b/components/script/dom/testing/testbinding.rs
@@ -1042,8 +1042,8 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
         p.reject(cx, v, can_gc);
     }
 
-    fn PromiseRejectWithTypeError(&self, p: &Promise, s: USVString, can_gc: CanGc) {
-        p.reject_error(Error::Type(cformat!("{}", s.0)), can_gc);
+    fn PromiseRejectWithTypeError(&self, cx: &mut JSContext, p: &Promise, s: USVString) {
+        p.reject_error(cx, Error::Type(cformat!("{}", s.0)));
     }
 
     fn ResolvePromiseDelayed(&self, p: &Promise, value: DOMString, delay: u64) {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1136,8 +1136,7 @@ DOMInterfaces = {
 },
 
 'ServoInternals': {
-    'inRealms': ['ReportMemory'],
-    'canGc': ['ReportMemory'],
+    'realm': ['ReportMemory'],
     'additionalTraits': ['crate::interfaces::ServoInternalsHelpers'],
 },
 
@@ -1166,8 +1165,7 @@ DOMInterfaces = {
 },
 
 'StorageManager': {
-    'inRealms': ['Persisted', 'Persist', 'Estimate'],
-    'canGc': ['Persisted', 'Persist', 'Estimate'],
+    'realm': ['Persisted', 'Persist', 'Estimate'],
 },
 
 'StyleSheet': {
@@ -1186,7 +1184,7 @@ DOMInterfaces = {
 #FIXME(jdm): This should be 'register': False, but then we don't generate enum types
 'TestBinding': {
     'inRealms': ['PromiseAttribute'],
-    'canGc': ['PromiseAttribute', 'PromiseResolveNative', 'PromiseRejectNative', 'PromiseRejectWithTypeError'],
+    'canGc': ['PromiseAttribute', 'PromiseResolveNative', 'PromiseRejectNative'],
     'additionalTraits': ['crate::interfaces::TestBindingHelpers'],
     'cx': [
         'Constructor',
@@ -1195,6 +1193,7 @@ DOMInterfaces = {
         'GetDictionaryWithTypedArray',
         'GetInterfaceAttributeNullable',
         'InterfaceAttribute',
+        'PromiseRejectWithTypeError',
         'ReceiveInterface',
         'ReceiveInterfaceSequence',
         'ReceiveNullableInterface',


### PR DESCRIPTION
These were the last few usages. The `reject_error_with_cx` is marked as deprecated so in a follow-up we can replace all of its usages with `reject_error` again.

Fixes #45453

Testing: it compiles