### PR TITLE
script: Introduce `dom_entries_api_enabled` & dummy `File.webkitRelativePath` impl 

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -152,6 +152,8 @@ pub struct Preferences {
     pub dom_crypto_subtle_enabled: bool,
     pub dom_document_dblclick_timeout: i64,
     pub dom_document_dblclick_dist: i64,
+    // feature: File and Directory Entries API | #45653 | Web/API/File_and_Directory_Entries_API
+    pub dom_entries_api_enabled: bool,
     // feature: Document.execCommand | #25005 | Web/API/Document/execCommand
     pub dom_exec_command_enabled: bool,
     // feature: CSS Font Loading API | #29376 | Web/API/CSS_Font_Loading_API
@@ -393,6 +395,7 @@ impl Preferences {
             dom_crypto_subtle_enabled: true,
             dom_document_dblclick_dist: 1,
             dom_document_dblclick_timeout: 300,
+            dom_entries_api_enabled: false,
             dom_exec_command_enabled: false,
             dom_fontface_enabled: false,
             dom_fullscreen_test: false,

--- a/components/script/dom/file/file.rs
+++ b/components/script/dom/file/file.rs
@@ -226,7 +226,7 @@ impl FileMethods<crate::DomTypeHolder> for File {
         self.name.clone()
     }
 
-    /// <https://wicg.github.io/entries-api/#dom-filesystementry-webkitrelativepath>
+    /// <https://wicg.github.io/entries-api/#dom-file-webkitrelativepath>
     fn WebkitRelativePath(&self) -> USVString {
         USVString(self.webkitrelativepath.to_string())
     }

--- a/components/script/dom/file/file.rs
+++ b/components/script/dom/file/file.rs
@@ -35,7 +35,7 @@ pub(crate) struct File {
     // TODO: This depends on the `webkitdirectory` from `HTMLInputElement`.
     // Then need to change `SelectedFile` in embedder,
     // and filemanager_thread to recursively walk.
-    webkitrelativepath: DOMString,
+    webkit_relative_path: USVString,
 }
 
 impl File {
@@ -43,14 +43,14 @@ impl File {
         blob_impl: &BlobImpl,
         name: DOMString,
         modified: Option<SystemTime>,
-        webkit_relative_path: DOMString,
+        webkit_relative_path: USVString,
     ) -> File {
         File {
             blob: Blob::new_inherited(blob_impl),
             name,
             // https://w3c.github.io/FileAPI/#dfn-lastModified
             modified: modified.unwrap_or_else(SystemTime::now),
-            webkitrelativepath: webkit_relative_path,
+            webkit_relative_path,
         }
     }
 
@@ -67,7 +67,7 @@ impl File {
             blob_impl,
             name,
             modified,
-            DOMString::new(),
+            USVString::default(),
             can_gc,
         )
     }
@@ -78,7 +78,7 @@ impl File {
         blob_impl: BlobImpl,
         name: DOMString,
         modified: Option<SystemTime>,
-        webkit_relative_path: DOMString,
+        webkit_relative_path: USVString,
         can_gc: CanGc,
     ) -> DomRoot<File> {
         let file = reflect_dom_object_with_proto(
@@ -145,7 +145,7 @@ impl File {
             blob_impl,
             name: self.name.to_string(),
             modified: self.LastModified(),
-            webkit_relative_path: self.webkitrelativepath.to_string(),
+            webkit_relative_path: self.webkit_relative_path.to_string(),
         })
     }
 }
@@ -172,7 +172,7 @@ impl Serializable for File {
             serialized.blob_impl,
             serialized.name.into(),
             Some(modified.into()),
-            DOMString::from(serialized.webkit_relative_path),
+            USVString::from(serialized.webkit_relative_path),
             CanGc::from_cx(cx),
         ))
     }
@@ -216,7 +216,7 @@ impl FileMethods<crate::DomTypeHolder> for File {
             BlobImpl::new_from_bytes(bytes, type_string),
             filename,
             modified,
-            DOMString::new(),
+            USVString::default(),
             can_gc,
         ))
     }
@@ -228,7 +228,7 @@ impl FileMethods<crate::DomTypeHolder> for File {
 
     /// <https://wicg.github.io/entries-api/#dom-file-webkitrelativepath>
     fn WebkitRelativePath(&self) -> USVString {
-        USVString(self.webkitrelativepath.to_string())
+        self.webkit_relative_path.clone()
     }
 
     /// <https://w3c.github.io/FileAPI/#dfn-lastModified>

--- a/components/script/dom/file/file.rs
+++ b/components/script/dom/file/file.rs
@@ -20,7 +20,7 @@ use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::serializable::Serializable;
-use crate::dom::bindings::str::DOMString;
+use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::bindings::structuredclone::StructuredData;
 use crate::dom::blob::{Blob, normalize_type_string, process_blob_parts};
 use crate::dom::globalscope::GlobalScope;
@@ -32,15 +32,25 @@ pub(crate) struct File {
     blob: Blob,
     name: DOMString,
     modified: SystemTime,
+    // TODO: This depends on the `webkitdirectory` from `HTMLInputElement`.
+    // Then need to change `SelectedFile` in embedder,
+    // and filemanager_thread to recursively walk.
+    webkitrelativepath: DOMString,
 }
 
 impl File {
-    fn new_inherited(blob_impl: &BlobImpl, name: DOMString, modified: Option<SystemTime>) -> File {
+    fn new_inherited(
+        blob_impl: &BlobImpl,
+        name: DOMString,
+        modified: Option<SystemTime>,
+        webkit_relative_path: DOMString,
+    ) -> File {
         File {
             blob: Blob::new_inherited(blob_impl),
             name,
             // https://w3c.github.io/FileAPI/#dfn-lastModified
             modified: modified.unwrap_or_else(SystemTime::now),
+            webkitrelativepath: webkit_relative_path,
         }
     }
 
@@ -51,7 +61,15 @@ impl File {
         modified: Option<SystemTime>,
         can_gc: CanGc,
     ) -> DomRoot<File> {
-        Self::new_with_proto(global, None, blob_impl, name, modified, can_gc)
+        Self::new_with_proto(
+            global,
+            None,
+            blob_impl,
+            name,
+            modified,
+            DOMString::new(),
+            can_gc,
+        )
     }
 
     fn new_with_proto(
@@ -60,10 +78,16 @@ impl File {
         blob_impl: BlobImpl,
         name: DOMString,
         modified: Option<SystemTime>,
+        webkit_relative_path: DOMString,
         can_gc: CanGc,
     ) -> DomRoot<File> {
         let file = reflect_dom_object_with_proto(
-            Box::new(File::new_inherited(&blob_impl, name, modified)),
+            Box::new(File::new_inherited(
+                &blob_impl,
+                name,
+                modified,
+                webkit_relative_path,
+            )),
             global,
             proto,
             can_gc,
@@ -121,6 +145,7 @@ impl File {
             blob_impl,
             name: self.name.to_string(),
             modified: self.LastModified(),
+            webkit_relative_path: self.webkitrelativepath.to_string(),
         })
     }
 }
@@ -141,11 +166,13 @@ impl Serializable for File {
         serialized: SerializableFile,
     ) -> Result<DomRoot<Self>, ()> {
         let modified = OffsetDateTime::UNIX_EPOCH + Duration::milliseconds(serialized.modified);
-        Ok(File::new(
+        Ok(File::new_with_proto(
             owner,
+            None,
             serialized.blob_impl,
             serialized.name.into(),
             Some(modified.into()),
+            DOMString::from(serialized.webkit_relative_path),
             CanGc::from_cx(cx),
         ))
     }
@@ -189,6 +216,7 @@ impl FileMethods<crate::DomTypeHolder> for File {
             BlobImpl::new_from_bytes(bytes, type_string),
             filename,
             modified,
+            DOMString::new(),
             can_gc,
         ))
     }
@@ -196,6 +224,11 @@ impl FileMethods<crate::DomTypeHolder> for File {
     /// <https://w3c.github.io/FileAPI/#dfn-name>
     fn Name(&self) -> DOMString {
         self.name.clone()
+    }
+
+    /// <https://wicg.github.io/entries-api/#dom-filesystementry-webkitrelativepath>
+    fn WebkitRelativePath(&self) -> USVString {
+        USVString(self.webkitrelativepath.to_string())
     }
 
     /// <https://w3c.github.io/FileAPI/#dfn-lastModified>

--- a/components/script_bindings/webidls/File.webidl
+++ b/components/script_bindings/webidls/File.webidl
@@ -16,3 +16,8 @@ interface File : Blob {
 dictionary FilePropertyBag : BlobPropertyBag {
   long long lastModified;
 };
+
+// https://wicg.github.io/entries-api/#file-interface
+partial interface File {
+    [Pref="dom_entries_api_enabled"] readonly attribute USVString webkitRelativePath;
+};

--- a/components/shared/constellation/structured_data/serializable.rs
+++ b/components/shared/constellation/structured_data/serializable.rs
@@ -146,6 +146,7 @@ pub struct SerializableFile {
     pub blob_impl: BlobImpl,
     pub name: String,
     pub modified: i64,
+    pub webkit_relative_path: String,
 }
 
 impl BroadcastClone for SerializableFile {
@@ -165,6 +166,7 @@ impl BroadcastClone for SerializableFile {
             blob_impl,
             name: self.name.clone(),
             modified: self.modified,
+            webkit_relative_path: self.webkit_relative_path.clone(),
         })
     }
 }

--- a/tests/wpt/meta/entries-api/__dir__.ini
+++ b/tests/wpt/meta/entries-api/__dir__.ini
@@ -1,0 +1,1 @@
+prefs: [dom_entries_api_enabled: true]

--- a/tests/wpt/meta/entries-api/idlharness.window.js.ini
+++ b/tests/wpt/meta/entries-api/idlharness.window.js.ini
@@ -128,12 +128,6 @@
   [FileSystem interface: attribute root]
     expected: FAIL
 
-  [File interface: attribute webkitRelativePath]
-    expected: FAIL
-
-  [File interface: new File([\], "example.txt") must inherit property "webkitRelativePath" with the proper type]
-    expected: FAIL
-
   [HTMLInputElement interface: attribute webkitdirectory]
     expected: FAIL
 


### PR DESCRIPTION
There are many interfaces needed to be introduced, so I will just introduce the pref
and a minimal dummy interface shipped with it.

To actually implement `File.webkitRelativePath`, we need to
1. Implement the `HTMLInputElement.webkitdirectory`,
2. Change `SelectedFile` in embedder.
3. Walk recursively in filemanager_thread to compute relative path.
4. Add servoshell implementation

Testing: New passing in wpt. However, the tests are just about interfaces.
Part of #45653
