### PR TITLE
Fix: Clear cached spatial node ids before scroll tree rebuild to prev…

### DIFF
--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -268,11 +268,15 @@ impl DisplayListBuilder<'_> {
     }
 
     pub(crate) fn add_all_spatial_nodes(&mut self) {
-        // A count of the number of SpatialTree nodes pushed to the WebRender display
-        // list. This is merely to ensure that the currently-unused SpatialTreeItemKey
-        // produced for every SpatialTree node is unique.
-        let mut scroll_tree = std::mem::take(&mut self.paint_info.scroll_tree);
-        let mut mapping = Vec::with_capacity(scroll_tree.nodes.len());
+    // Clear cached spatial node ids from all fragments before rebuilding the scroll tree.
+    // Fragments may have cached ids that are no longer valid after scroll tree reconstruction.
+         self.fragment_tree.clear_all_spatial_tree_node_ids();
+
+    // A count of the number of SpatialTree nodes pushed to the WebRender display
+    // list. This is merely to ensure that the currently-unused SpatialTreeItemKey
+    // produced for every SpatialTree node is unique.
+           let mut scroll_tree = std::mem::take(&mut self.paint_info.scroll_tree);
+           let mut mapping = Vec::with_capacity(scroll_tree.nodes.len());
 
         mapping.push(SpatialId::root_reference_frame(self.pipeline_id()));
         mapping.push(SpatialId::root_scroll_node(self.pipeline_id()));

--- a/components/layout/fragment_tree/fragment_tree.rs
+++ b/components/layout/fragment_tree/fragment_tree.rs
@@ -183,4 +183,33 @@ impl FragmentTree {
 
         find_body(&self.root_fragments)
     }
+
+    /// Clear cached spatial tree node ids from all fragments.
+    /// This must be called before rebuilding the scroll tree to prevent stale ids.
+    pub(crate) fn clear_all_spatial_tree_node_ids(&self) {
+        self.clear_spatial_nodes_in_fragments(&self.root_fragments);
+    }
+
+    fn clear_spatial_nodes_in_fragments(&self, fragments: &[Fragment]) {
+        for fragment in fragments {
+            match fragment {
+                Fragment::Box(box_fragment) => {
+                    box_fragment.spatial_tree_node.set(None);
+                    self.clear_spatial_nodes_in_fragments(&box_fragment.children);
+                }
+                Fragment::Float(box_fragment) => {
+                    box_fragment.spatial_tree_node.set(None);
+                    self.clear_spatial_nodes_in_fragments(&box_fragment.children);
+                }
+                Fragment::Positioning(positioning) => {
+                    self.clear_spatial_nodes_in_fragments(&positioning.children);
+                }
+                Fragment::LayoutRoot(layout_root) => {
+                    let inner = layout_root.inner();
+                    self.clear_spatial_nodes_in_fragments(&[inner.clone()]);
+                }
+                _ => {} // Text, Image, IFrame don't have spatial_tree_node
+            }
+        }
+    }
 }

--- a/components/shared/paint/display_list.rs
+++ b/components/shared/paint/display_list.rs
@@ -649,6 +649,11 @@ impl ScrollTree {
         &self,
         node_id: ScrollTreeNodeId,
     ) -> ScrollTreeNodeTransformationCache {
+        // Safety: fragments may cache stale spatial node ids if the scroll tree was rebuilt.
+        // Return identity transform instead of panicking on out-of-bounds access.
+        if node_id.index >= self.nodes.len() {
+            return ScrollTreeNodeTransformationCache::default();
+        }
         let node = self.get_node(node_id);
         if let Some(cached_transforms) = node.transformation_cache.get() {
             return cached_transforms;


### PR DESCRIPTION
…ent getBoundingClientRect panic

Fragments cache spatial node ids that become invalid when the scroll tree is
rebuilt with a different structure. Calling `getBoundingClientRect()` on these
elements causes a panic with index out of bounds.

### Example:
```
./servoshell 'https://www.youtube.com/results?search_query=test'
 Panics with: index out of bounds: the len is 43 but the index is 45
```
Root cause:<br>
When `DisplayListBuilder::add_all_spatial_nodes()` rebuilds the scroll tree,
the cached node ids in fragments are not invalidated, leading to out-of-bounds
access when layout queries try to use stale ids.

---

### Fixes

Files Changed:
1. `components/layout/fragment_tree/fragment_tree.rs` Add clear methods
2. `components/layout/display_list/mod.rs` Call clear before rebuild
3. `components/shared/paint/display_list.rs` Add bounds check

---

>  1 and 2 fixes the root cause (proper engineering).
> 3 prevents crashes if 1 or 2 is incomplete (defensive programming).

Before: 
```
index out of bounds: the len is 43 but the index is 45
[ERROR servoshell::panic_hook] panic
```
After:
```
Page loads successfully
JavaScript promise rejections (expected, unrelated to this fix)
```