### PR TITLE
script: Configure `cx` context for all `HTMLElement` interface bindings

### DIFF
--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -226,8 +226,9 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     global_event_handlers!(NoOnload);
 
     /// <https://html.spec.whatwg.org/multipage/#dom-dataset>
-    fn Dataset(&self, can_gc: CanGc) -> DomRoot<DOMStringMap> {
-        self.dataset.or_init(|| DOMStringMap::new(self, can_gc))
+    fn Dataset(&self, cx: &mut JSContext) -> DomRoot<DOMStringMap> {
+        self.dataset
+            .or_init(|| DOMStringMap::new(self, CanGc::from_cx(cx)))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#handler-onerror>
@@ -697,7 +698,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage#dom-attachinternals>
-    fn AttachInternals(&self, can_gc: CanGc) -> Fallible<DomRoot<ElementInternals>> {
+    fn AttachInternals(&self, cx: &mut JSContext) -> Fallible<DomRoot<ElementInternals>> {
         // Step 1: If this's is value is not null, then throw a "NotSupportedError" DOMException
         if self.element.get_is().is_some() {
             return Err(Error::NotSupported(None));
@@ -722,7 +723,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
         }
 
         // Step 5: If this's attached internals is non-null, then throw an "NotSupportedError" DOMException
-        let internals = self.element.ensure_element_internals(can_gc);
+        let internals = self.element.ensure_element_internals(CanGc::from_cx(cx));
         if internals.attached() {
             return Err(Error::NotSupported(None));
         }

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -1241,8 +1241,9 @@ impl HTMLLinkElementMethods<crate::DomTypeHolder> for HTMLLinkElement {
     make_setter!(SetReferrerPolicy, "referrerpolicy");
 
     /// <https://drafts.csswg.org/cssom/#dom-linkstyle-sheet>
-    fn GetSheet(&self, can_gc: CanGc) -> Option<DomRoot<DOMStyleSheet>> {
-        self.get_cssom_stylesheet(can_gc).map(DomRoot::upcast)
+    fn GetSheet(&self, cx: &mut JSContext) -> Option<DomRoot<DOMStyleSheet>> {
+        self.get_cssom_stylesheet(CanGc::from_cx(cx))
+            .map(DomRoot::upcast)
     }
 }
 

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -1320,7 +1320,7 @@ impl HTMLMediaElement {
     fn select_next_source_child(&self, cx: &mut JSContext) {
         // Step 9.children.12. Forget the media element's media-resource-specific tracks.
         self.AudioTracks(cx).clear();
-        self.VideoTracks(CanGc::from_cx(cx)).clear();
+        self.VideoTracks(cx).clear();
 
         // Step 9.children.13. Find next candidate: Let candidate be null.
         let mut source_candidate = None;
@@ -1639,7 +1639,7 @@ impl HTMLMediaElement {
 
                     // Step 2. Forget the media element's media-resource-specific tracks.
                     this.AudioTracks(cx).clear();
-                    this.VideoTracks(CanGc::from_cx(cx)).clear();
+                    this.VideoTracks(cx).clear();
 
                     // Step 3. Set the element's networkState attribute to the NETWORK_NO_SOURCE
                     // value.
@@ -1759,7 +1759,7 @@ impl HTMLMediaElement {
 
             // Step 7.4. Forget the media element's media-resource-specific tracks.
             self.AudioTracks(cx).clear();
-            self.VideoTracks(CanGc::from_cx(cx)).clear();
+            self.VideoTracks(cx).clear();
 
             // Step 7.5. If readyState is not set to HAVE_NOTHING, then set it to that state.
             if self.ready_state.get() != ReadyState::HaveNothing {
@@ -2467,7 +2467,7 @@ impl HTMLMediaElement {
 
         // => "If the media resource is found to have a video track"
         for (i, _track) in metadata.video_tracks.iter().enumerate() {
-            let video_track_list = self.VideoTracks(CanGc::from_cx(cx));
+            let video_track_list = self.VideoTracks(cx);
 
             // Step 1. Create a VideoTrack object to represent the video track.
             let kind = match i {
@@ -3268,21 +3268,25 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-media-played>
-    fn Played(&self, can_gc: CanGc) -> DomRoot<TimeRanges> {
+    fn Played(&self, cx: &mut JSContext) -> DomRoot<TimeRanges> {
         TimeRanges::new(
             self.global().as_window(),
             self.played.borrow().clone(),
-            can_gc,
+            CanGc::from_cx(cx),
         )
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-media-seekable>
-    fn Seekable(&self, can_gc: CanGc) -> DomRoot<TimeRanges> {
-        TimeRanges::new(self.global().as_window(), self.seekable(), can_gc)
+    fn Seekable(&self, cx: &mut JSContext) -> DomRoot<TimeRanges> {
+        TimeRanges::new(
+            self.global().as_window(),
+            self.seekable(),
+            CanGc::from_cx(cx),
+        )
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-media-buffered>
-    fn Buffered(&self, can_gc: CanGc) -> DomRoot<TimeRanges> {
+    fn Buffered(&self, cx: &mut JSContext) -> DomRoot<TimeRanges> {
         let mut buffered = TimeRangesContainer::default();
         if let Some(ref player) = *self.player.borrow() {
             let ranges = player.lock().unwrap().buffered();
@@ -3290,7 +3294,7 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
                 let _ = buffered.add(range.start, range.end);
             }
         }
-        TimeRanges::new(self.global().as_window(), buffered, can_gc)
+        TimeRanges::new(self.global().as_window(), buffered, CanGc::from_cx(cx))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-media-audiotracks>
@@ -3301,26 +3305,26 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-media-videotracks>
-    fn VideoTracks(&self, can_gc: CanGc) -> DomRoot<VideoTrackList> {
+    fn VideoTracks(&self, cx: &mut JSContext) -> DomRoot<VideoTrackList> {
         let window = self.owner_window();
         self.video_tracks_list
-            .or_init(|| VideoTrackList::new(&window, &[], Some(self), can_gc))
+            .or_init(|| VideoTrackList::new(&window, &[], Some(self), CanGc::from_cx(cx)))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-media-texttracks>
-    fn TextTracks(&self, can_gc: CanGc) -> DomRoot<TextTrackList> {
+    fn TextTracks(&self, cx: &mut JSContext) -> DomRoot<TextTrackList> {
         let window = self.owner_window();
         self.text_tracks_list
-            .or_init(|| TextTrackList::new(&window, &[], can_gc))
+            .or_init(|| TextTrackList::new(&window, &[], CanGc::from_cx(cx)))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-media-addtexttrack>
     fn AddTextTrack(
         &self,
+        cx: &mut JSContext,
         kind: TextTrackKind,
         label: DOMString,
         language: DOMString,
-        can_gc: CanGc,
     ) -> DomRoot<TextTrack> {
         let window = self.owner_window();
         // Step 1 & 2
@@ -3333,10 +3337,10 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
             language,
             TextTrackMode::Hidden,
             None,
-            can_gc,
+            CanGc::from_cx(cx),
         );
         // Step 3 & 4
-        self.TextTracks(can_gc).add(&track);
+        self.TextTracks(cx).add(&track);
         // Step 5
         DomRoot::from_ref(&track)
     }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -750,8 +750,7 @@ DOMInterfaces = {
 },
 
 'HTMLLinkElement': {
-    'canGc': ['GetSheet'],
-    'cx': ['Blocking', 'RelList', 'SetCrossOrigin', 'SetRel'],
+    'cx': ['Blocking', 'GetSheet', 'RelList', 'SetCrossOrigin', 'SetRel'],
 },
 
 'HTMLMapElement': {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -759,10 +759,9 @@ DOMInterfaces = {
 },
 
 'HTMLMediaElement': {
-    'canGc': ['AddTextTrack', 'Buffered', 'Played', 'Seekable',  'TextTracks', 'VideoTracks'],
     'realm': ['Play'],
     'weakReferenceable': True,
-    'cx': ['AudioTracks', 'SetCrossOrigin', 'SetSrcObject', 'Load', 'Pause'],
+    'cx': [ 'AddTextTrack', 'AudioTracks', 'Buffered', 'Played', 'Seekable', 'SetCrossOrigin', 'SetSrcObject', 'TextTracks', 'Load', 'Pause', 'VideoTracks'],
 },
 
 'HTMLMeterElement': {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -691,20 +691,18 @@ DOMInterfaces = {
 },
 
 'HTMLElement': {
-    'canGc': [
+    'cx': [
         'AttachInternals',
+        'Blur',
+        'Click',
         'Dataset',
+        'Focus',
         'GetOnblur',
         'GetOnerror',
         'GetOnfocus',
         'GetOnload',
         'GetOnresize',
         'GetOnscroll',
-    ],
-    'cx': [
-        'Blur',
-        'Click',
-        'Focus',
         'Style',
     ],
     'implicitCxSetters': True,

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -773,8 +773,7 @@ DOMInterfaces = {
 },
 
 'HTMLOptionElement': {
-    'canGc': ['SetSelected'],
-    'cx': ['Option', 'SetText'],
+    'cx': ['Option', 'SetSelected', 'SetText'],
 },
 
 'HTMLOptionsCollection': {


### PR DESCRIPTION
Move all the bindings for `HTMLElement` and its child interfaces to use `&mut JSContext`, including setters that were previously implicitly using the `cx` setting.

Testing: it compiles
Part of https://github.com/servo/servo/issues/42638
