### PR TITLE
script: Be more conservative about reporting isIntersecting below the initial threshold.

### DIFF
--- a/components/script/dom/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver.rs
@@ -581,12 +581,31 @@ impl IntersectionObserver {
             .borrow()
             .iter()
             .position(|threshold| **threshold > intersection_ratio)
-            .unwrap_or(self.thresholds.borrow().len()) as i32;
+            .unwrap_or(self.thresholds.borrow().len());
+
+        let threshold_index = if is_intersecting {
+            // If the index is 0, the first threshold value is greater
+            // than the observed ratio, so we're not actually matching yet.
+            // The spec differentiates between this case and the case where
+            // there is no intersection, but other browser engines do not.
+            if threshold_index == 0 {
+                ThresholdIndex::NotMatching
+            } else {
+                ThresholdIndex::Matching(threshold_index)
+            }
+        } else {
+            ThresholdIndex::NotMatching
+        };
 
         // Step 14
         // > Let isVisible be the result of running the visibility algorithm on target.
         // TODO: Implement visibility algorithm
         let is_visible = false;
+
+        // We never report isIntersecting as true unless we have exceeded a threshold,
+        // which matches other browser eengines.
+        // See https://github.com/w3c/IntersectionObserver/issues/432 for background.
+        let is_intersecting = matches!(threshold_index, ThresholdIndex::Matching(..));
 
         IntersectionObservationOutput::new_computed(
             threshold_index,
@@ -642,7 +661,7 @@ impl IntersectionObserver {
             // > if isVisible does not equal previousIsVisible,
             // > queue an IntersectionObserverEntry, passing in observer, time, rootBounds,
             // > targetRect, intersectionRect, isIntersecting, isVisible, and target.
-            if intersection_output.threshold_index != previous_threshold_index ||
+            if Some(intersection_output.threshold_index) != previous_threshold_index ||
                 intersection_output.is_intersecting != previous_is_intersecting ||
                 intersection_output.is_visible != previous_is_visible
             {
@@ -668,7 +687,7 @@ impl IntersectionObserver {
             // > 21. Assign isVisible to registration’s previousIsVisible property.
             registration
                 .previous_threshold_index
-                .set(intersection_output.threshold_index);
+                .set(Some(intersection_output.threshold_index));
             registration
                 .previous_is_intersecting
                 .set(intersection_output.is_intersecting);
@@ -795,16 +814,22 @@ impl IntersectionObserverMethods<crate::DomTypeHolder> for IntersectionObserver 
     }
 }
 
+#[derive(Clone, Copy, Debug, JSTraceable, MallocSizeOf, PartialEq)]
+enum ThresholdIndex {
+    NotMatching,
+    Matching(usize),
+}
+
 /// <https://w3c.github.io/IntersectionObserver/#intersectionobserverregistration>
 #[derive(Clone, JSTraceable, MallocSizeOf)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct IntersectionObserverRegistration {
     pub(crate) observer: Dom<IntersectionObserver>,
-    pub(crate) previous_threshold_index: Cell<i32>,
-    pub(crate) previous_is_intersecting: Cell<bool>,
+    previous_threshold_index: Cell<Option<ThresholdIndex>>,
+    previous_is_intersecting: Cell<bool>,
     #[no_trace]
-    pub(crate) last_update_time: Cell<CrossProcessInstant>,
-    pub(crate) previous_is_visible: Cell<bool>,
+    last_update_time: Cell<CrossProcessInstant>,
+    previous_is_visible: Cell<bool>,
 }
 
 impl IntersectionObserverRegistration {
@@ -816,7 +841,7 @@ impl IntersectionObserverRegistration {
     pub(crate) fn new_initial(observer: &IntersectionObserver) -> Self {
         IntersectionObserverRegistration {
             observer: Dom::from_ref(observer),
-            previous_threshold_index: Cell::new(-1),
+            previous_threshold_index: Cell::new(None),
             previous_is_intersecting: Cell::new(false),
             last_update_time: Cell::new(CrossProcessInstant::epoch()),
             previous_is_visible: Cell::new(false),
@@ -998,7 +1023,7 @@ fn compute_the_intersection(
 /// <https://w3c.github.io/IntersectionObserver/#update-intersection-observations-algo>.
 /// See [`IntersectionObserver::maybe_compute_intersection_output`].
 struct IntersectionObservationOutput {
-    pub(crate) threshold_index: i32,
+    pub(crate) threshold_index: ThresholdIndex,
     pub(crate) is_intersecting: bool,
     pub(crate) target_rect: Rect<Au, CSSPixel>,
     pub(crate) intersection_rect: Rect<Au, CSSPixel>,
@@ -1024,7 +1049,7 @@ impl IntersectionObservationOutput {
     /// to current browser implementation or WPT test is used instead.
     fn default_skipped() -> Self {
         Self {
-            threshold_index: 0,
+            threshold_index: ThresholdIndex::NotMatching,
             is_intersecting: false,
             target_rect: Rect::zero(),
             intersection_rect: Rect::zero(),
@@ -1035,7 +1060,7 @@ impl IntersectionObservationOutput {
     }
 
     fn new_computed(
-        threshold_index: i32,
+        threshold_index: ThresholdIndex,
         is_intersecting: bool,
         target_rect: Rect<Au, CSSPixel>,
         intersection_rect: Rect<Au, CSSPixel>,

--- a/components/script/dom/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver.rs
@@ -557,8 +557,6 @@ impl IntersectionObserver {
         // > even if the intersection has zero area (because rootBounds or targetRect have zero area).
         // Because we are considering edge-adjacent, instead of checking whether the rectangle is empty,
         // we are checking whether the rectangle is negative or not.
-        // TODO(stevennovaryo): there is a dicussion regarding isIntersecting definition, we should update
-        //                      it accordingly. https://github.com/w3c/IntersectionObserver/issues/432
         let is_intersecting = maybe_intersection_rect.is_some();
 
         // Step 12
@@ -583,16 +581,12 @@ impl IntersectionObserver {
             .position(|threshold| **threshold > intersection_ratio)
             .unwrap_or(self.thresholds.borrow().len());
 
-        let threshold_index = if is_intersecting {
-            // If the index is 0, the first threshold value is greater
-            // than the observed ratio, so we're not actually matching yet.
-            // The spec differentiates between this case and the case where
-            // there is no intersection, but other browser engines do not.
-            if threshold_index == 0 {
-                ThresholdIndex::NotMatching
-            } else {
-                ThresholdIndex::Matching(threshold_index)
-            }
+        // If the index is 0, the first threshold value is greater
+        // than the observed ratio, so we're not actually matching yet.
+        // The spec differentiates between this case and the case where
+        // there is no intersection, but other browser engines do not.
+        let threshold_index = if is_intersecting && threshold_index > 0 {
+            ThresholdIndex::Matching(threshold_index)
         } else {
             ThresholdIndex::NotMatching
         };

--- a/tests/wpt/meta/intersection-observer/containing-block.html.ini
+++ b/tests/wpt/meta/intersection-observer/containing-block.html.ini
@@ -1,6 +1,0 @@
-[containing-block.html]
-  [Not in containing block and not intersecting.]
-    expected: FAIL
-
-  [Not in containing block and intersecting.]
-    expected: FAIL

--- a/tests/wpt/meta/intersection-observer/initial-observation-with-threshold.html.ini
+++ b/tests/wpt/meta/intersection-observer/initial-observation-with-threshold.html.ini
@@ -1,3 +1,0 @@
-[initial-observation-with-threshold.html]
-  [First rAF]
-    expected: FAIL

--- a/tests/wpt/meta/intersection-observer/isIntersecting-threshold.html.ini
+++ b/tests/wpt/meta/intersection-observer/isIntersecting-threshold.html.ini
@@ -1,3 +1,0 @@
-[isIntersecting-threshold.html]
-  [Scrolled to half way through target element]
-    expected: FAIL

--- a/tests/wpt/meta/intersection-observer/remove-element.html.ini
+++ b/tests/wpt/meta/intersection-observer/remove-element.html.ini
@@ -1,6 +1,0 @@
-[remove-element.html]
-  [root.scrollTop = 150 after reinserting target.]
-    expected: FAIL
-
-  [root.insertBefore(target, trailingSpace).]
-    expected: FAIL


### PR DESCRIPTION
These changes both make our threshold indexing code easier to follow and also align us better with how other browser engines have implemented IntersectionObserver. There are spec issues that have been open for six years without resolution, sadly, but the relevant WPT tests help us ensure that we're matching other engines.

Testing: Newly passing tests.
Fixes: part of #35767
