### PR TITLE
stylo: Use f64 everywhere in animation logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7409,7 +7409,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.38.0"
-source = "git+https://github.com/servo/stylo?rev=813923186eff5bcb957fe6da8538038acd918e98#813923186eff5bcb957fe6da8538038acd918e98"
+source = "git+https://github.com/servo/stylo?rev=3a386f0028c693df4574092def105081294bf8bb#3a386f0028c693df4574092def105081294bf8bb"
 dependencies = [
  "bitflags 2.11.1",
  "cssparser",
@@ -9159,7 +9159,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=813923186eff5bcb957fe6da8538038acd918e98#813923186eff5bcb957fe6da8538038acd918e98"
+source = "git+https://github.com/servo/stylo?rev=3a386f0028c693df4574092def105081294bf8bb#3a386f0028c693df4574092def105081294bf8bb"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -9650,7 +9650,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=813923186eff5bcb957fe6da8538038acd918e98#813923186eff5bcb957fe6da8538038acd918e98"
+source = "git+https://github.com/servo/stylo?rev=3a386f0028c693df4574092def105081294bf8bb#3a386f0028c693df4574092def105081294bf8bb"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -9706,7 +9706,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=813923186eff5bcb957fe6da8538038acd918e98#813923186eff5bcb957fe6da8538038acd918e98"
+source = "git+https://github.com/servo/stylo?rev=3a386f0028c693df4574092def105081294bf8bb#3a386f0028c693df4574092def105081294bf8bb"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -9715,7 +9715,7 @@ dependencies = [
 [[package]]
 name = "stylo_derive"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=813923186eff5bcb957fe6da8538038acd918e98#813923186eff5bcb957fe6da8538038acd918e98"
+source = "git+https://github.com/servo/stylo?rev=3a386f0028c693df4574092def105081294bf8bb#3a386f0028c693df4574092def105081294bf8bb"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -9727,7 +9727,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=813923186eff5bcb957fe6da8538038acd918e98#813923186eff5bcb957fe6da8538038acd918e98"
+source = "git+https://github.com/servo/stylo?rev=3a386f0028c693df4574092def105081294bf8bb#3a386f0028c693df4574092def105081294bf8bb"
 dependencies = [
  "bitflags 2.11.1",
  "stylo_malloc_size_of",
@@ -9736,7 +9736,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=813923186eff5bcb957fe6da8538038acd918e98#813923186eff5bcb957fe6da8538038acd918e98"
+source = "git+https://github.com/servo/stylo?rev=3a386f0028c693df4574092def105081294bf8bb#3a386f0028c693df4574092def105081294bf8bb"
 dependencies = [
  "app_units",
  "cssparser",
@@ -9753,7 +9753,7 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=813923186eff5bcb957fe6da8538038acd918e98#813923186eff5bcb957fe6da8538038acd918e98"
+source = "git+https://github.com/servo/stylo?rev=3a386f0028c693df4574092def105081294bf8bb#3a386f0028c693df4574092def105081294bf8bb"
 dependencies = [
  "toml",
 ]
@@ -9761,7 +9761,7 @@ dependencies = [
 [[package]]
 name = "stylo_traits"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=813923186eff5bcb957fe6da8538038acd918e98#813923186eff5bcb957fe6da8538038acd918e98"
+source = "git+https://github.com/servo/stylo?rev=3a386f0028c693df4574092def105081294bf8bb#3a386f0028c693df4574092def105081294bf8bb"
 dependencies = [
  "app_units",
  "bitflags 2.11.1",
@@ -10181,7 +10181,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.4.0"
-source = "git+https://github.com/servo/stylo?rev=813923186eff5bcb957fe6da8538038acd918e98#813923186eff5bcb957fe6da8538038acd918e98"
+source = "git+https://github.com/servo/stylo?rev=3a386f0028c693df4574092def105081294bf8bb#3a386f0028c693df4574092def105081294bf8bb"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -10194,7 +10194,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=813923186eff5bcb957fe6da8538038acd918e98#813923186eff5bcb957fe6da8538038acd918e98"
+source = "git+https://github.com/servo/stylo?rev=3a386f0028c693df4574092def105081294bf8bb#3a386f0028c693df4574092def105081294bf8bb"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -217,14 +217,14 @@ rustls-platform-verifier = "0.7.0"
 sea-query = { version = "=1.0.0-rc.31", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = "=0.8.0-rc.15"
 sec1 = "0.7"
-selectors = { git = "https://github.com/servo/stylo", rev = "813923186eff5bcb957fe6da8538038acd918e98" }
+selectors = { git = "https://github.com/servo/stylo", rev = "3a386f0028c693df4574092def105081294bf8bb" }
 seq-macro = "0.3.6"
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
 serde_json = "1.0"
 serde_test = "1.0"
-servo_arc = { git = "https://github.com/servo/stylo", rev = "813923186eff5bcb957fe6da8538038acd918e98" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "3a386f0028c693df4574092def105081294bf8bb" }
 sha1 = "0.11"
 sha2 = "0.11"
 sha3 = "0.12"
@@ -234,12 +234,12 @@ smallvec = { version = "1.15", features = ["serde", "union"] }
 speexdsp-resampler = "0.1.0"
 string_cache = "0.9"
 strum = { version = "0.28", features = ["derive"] }
-stylo = { git = "https://github.com/servo/stylo", rev = "813923186eff5bcb957fe6da8538038acd918e98" }
-stylo_atoms = { git = "https://github.com/servo/stylo", rev = "813923186eff5bcb957fe6da8538038acd918e98" }
-stylo_dom = { git = "https://github.com/servo/stylo", rev = "813923186eff5bcb957fe6da8538038acd918e98" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "813923186eff5bcb957fe6da8538038acd918e98" }
-stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "813923186eff5bcb957fe6da8538038acd918e98" }
-stylo_traits = { git = "https://github.com/servo/stylo", rev = "813923186eff5bcb957fe6da8538038acd918e98" }
+stylo = { git = "https://github.com/servo/stylo", rev = "3a386f0028c693df4574092def105081294bf8bb" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "3a386f0028c693df4574092def105081294bf8bb" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "3a386f0028c693df4574092def105081294bf8bb" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "3a386f0028c693df4574092def105081294bf8bb" }
+stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "3a386f0028c693df4574092def105081294bf8bb" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "3a386f0028c693df4574092def105081294bf8bb" }
 surfman = { version = "0.13.0", features = ["chains"] }
 swapper = "0.1"
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }

--- a/tests/wpt/tests/css/css-animations/crashtests/servo-bug-45008.html
+++ b/tests/wpt/tests/css/css-animations/crashtests/servo-bug-45008.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/45008">
+<style>
+  div {
+      animation: 1s -2s infinite keyframes;
+  }
+  @keyframes keyframes {
+      0% { border-left-color: red; }
+  }
+</style>
+<div></div>


### PR DESCRIPTION
Bumps Stylo to https://github.com/servo/stylo/pull/392/

This avoids potential assert failures due to the precision loss of converting f64 into f32.

Testing: Adds a crashtest. Since the problem was dependent on timing, it would only fail intermittently. With the fix it should never fail.
Fixes: #45008
