### PR TITLE
android: Stop passing `Activity` instance to `MediaSession`

### DIFF
--- a/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.java
+++ b/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.java
@@ -416,7 +416,7 @@ public class MainActivity extends Activity implements Servo.Client {
     @Override
     public void onMediaSessionMetadata(String title, String artist, String album) {
         if (mMediaSession == null) {
-            mMediaSession = new MediaSession(mServoView, this, getApplicationContext());
+            mMediaSession = new MediaSession(mServoView, getApplicationContext());
         }
         Log.d("onMediaSessionMetadata", title + " " + artist + " " + album);
         mMediaSession.updateMetadata(title, artist, album);
@@ -426,7 +426,7 @@ public class MainActivity extends Activity implements Servo.Client {
     public void onMediaSessionPlaybackStateChange(int state) {
         Log.d("onMediaSessionPlaybackStateChange", String.valueOf(state));
         if (mMediaSession == null) {
-            mMediaSession = new MediaSession(mServoView, this, getApplicationContext());
+            mMediaSession = new MediaSession(mServoView, getApplicationContext());
         }
 
         mMediaSession.setPlaybackState(state);
@@ -445,7 +445,7 @@ public class MainActivity extends Activity implements Servo.Client {
     public void onMediaSessionSetPositionState(float duration, float position, float playbackRate) {
         Log.d("onMediaSessionSetPositionState", duration + " " + position + " " + playbackRate);
         if (mMediaSession == null) {
-            mMediaSession = new MediaSession(mServoView, this, getApplicationContext());
+            mMediaSession = new MediaSession(mServoView, getApplicationContext());
         }
 
         mMediaSession.setPositionState(duration, position, playbackRate);

--- a/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MediaSession.java
+++ b/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MediaSession.java
@@ -57,7 +57,6 @@ public class MediaSession {
     private static final String KEY_MEDIA_STOP = "org.servo.servoview.MainActivity.stop";
 
     ServoView mView;
-    MainActivity mActivity;
     Context mContext;
 
     NotificationID mNotificationID;
@@ -69,9 +68,8 @@ public class MediaSession {
     String mArtist;
     String mAlbum;
 
-    public MediaSession(ServoView view, MainActivity activity, Context context) {
+    public MediaSession(ServoView view, Context context) {
       mView = view;
-      mActivity = activity;
       mContext = context;
       mNotificationID = new NotificationID();
       createMediaNotificationChannel();


### PR DESCRIPTION
The `MainActivity` instance passed to `MediaSession` is completely unused, so this dependency can be removed.

Testing: There are no automated tests for Android.