### PR TITLE
script: Bring back offthread compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,7 +822,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -5129,8 +5129,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs"
-version = "0.16.3"
-source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#5e8570af5d50bc9744d0cef5c71c5c292f0816a6"
+version = "0.16.5"
+source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#0fdaa65e4c102a970c70a1df2fa5a1d8b5a941e8"
 dependencies = [
  "bindgen",
  "cc",
@@ -5143,8 +5143,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "140.11.0-2"
-source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#5e8570af5d50bc9744d0cef5c71c5c292f0816a6"
+version = "140.12.0-1"
+source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#0fdaa65e4c102a970c70a1df2fa5a1d8b5a941e8"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,7 +822,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -5130,7 +5130,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.16.3"
-source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#e44b7da7d7bb43dc93e308a6c9ad957fcfc599af"
+source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#5e8570af5d50bc9744d0cef5c71c5c292f0816a6"
 dependencies = [
  "bindgen",
  "cc",
@@ -5144,7 +5144,7 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "140.11.0-2"
-source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#e44b7da7d7bb43dc93e308a6c9ad957fcfc599af"
+source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#5e8570af5d50bc9744d0cef5c71c5c292f0816a6"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4503,9 +4503,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -5129,9 +5129,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs"
-version = "0.16.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8d7e5cba578bc71ec962623e1bfffa5aaaa7665c54fa236d6f930c492807f7d"
+version = "0.16.3"
+source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#e44b7da7d7bb43dc93e308a6c9ad957fcfc599af"
 dependencies = [
  "bindgen",
  "cc",
@@ -5144,9 +5143,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "140.12.0-0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f78cdbe11d0dba944f54f21f0f2b8c3ffb24b94170c0c075fadc24cc3e947dc4"
+version = "140.11.0-2"
+source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#e44b7da7d7bb43dc93e308a6c9ad957fcfc599af"
 dependencies = [
  "bindgen",
  "cc",
@@ -6633,7 +6631,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,7 +854,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,7 +854,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -2586,7 +2586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3154,7 +3154,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5440,7 +5440,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.25.1"
-source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#2bcf845c6564fb8a6adf341f613013d9890ffd33"
+source = "git+https://github.com/servo/mozjs.git?rev=refs%2Fpull%2F500%2Fhead#2bcf845c6564fb8a6adf341f613013d9890ffd33"
 dependencies = [
  "bindgen",
  "cc",
@@ -5454,7 +5454,7 @@ dependencies = [
 [[package]]
 name = "mozjs_collator_glue"
 version = "153.0.0"
-source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#2bcf845c6564fb8a6adf341f613013d9890ffd33"
+source = "git+https://github.com/servo/mozjs.git?rev=refs%2Fpull%2F500%2Fhead#2bcf845c6564fb8a6adf341f613013d9890ffd33"
 dependencies = [
  "arraystring",
  "arrayvec",
@@ -5468,7 +5468,7 @@ dependencies = [
 [[package]]
 name = "mozjs_icu_collator"
 version = "153.0.0"
-source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#2bcf845c6564fb8a6adf341f613013d9890ffd33"
+source = "git+https://github.com/servo/mozjs.git?rev=refs%2Fpull%2F500%2Fhead#2bcf845c6564fb8a6adf341f613013d9890ffd33"
 dependencies = [
  "displaydoc",
  "icu_locale",
@@ -5488,12 +5488,12 @@ dependencies = [
 [[package]]
 name = "mozjs_icu_collator_data"
 version = "153.0.0"
-source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#2bcf845c6564fb8a6adf341f613013d9890ffd33"
+source = "git+https://github.com/servo/mozjs.git?rev=refs%2Fpull%2F500%2Fhead#2bcf845c6564fb8a6adf341f613013d9890ffd33"
 
 [[package]]
 name = "mozjs_icu_collections"
 version = "153.0.0"
-source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#2bcf845c6564fb8a6adf341f613013d9890ffd33"
+source = "git+https://github.com/servo/mozjs.git?rev=refs%2Fpull%2F500%2Fhead#2bcf845c6564fb8a6adf341f613013d9890ffd33"
 dependencies = [
  "displaydoc",
  "icu_casemap",
@@ -5507,7 +5507,7 @@ dependencies = [
 [[package]]
 name = "mozjs_icu_normalizer"
 version = "153.0.0"
-source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#2bcf845c6564fb8a6adf341f613013d9890ffd33"
+source = "git+https://github.com/servo/mozjs.git?rev=refs%2Fpull%2F500%2Fhead#2bcf845c6564fb8a6adf341f613013d9890ffd33"
 dependencies = [
  "displaydoc",
  "icu_properties 2.1.2",
@@ -5524,12 +5524,12 @@ dependencies = [
 [[package]]
 name = "mozjs_icu_normalizer_data"
 version = "153.0.0"
-source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#2bcf845c6564fb8a6adf341f613013d9890ffd33"
+source = "git+https://github.com/servo/mozjs.git?rev=refs%2Fpull%2F500%2Fhead#2bcf845c6564fb8a6adf341f613013d9890ffd33"
 
 [[package]]
 name = "mozjs_locale_glue"
 version = "153.0.0"
-source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#2bcf845c6564fb8a6adf341f613013d9890ffd33"
+source = "git+https://github.com/servo/mozjs.git?rev=refs%2Fpull%2F500%2Fhead#2bcf845c6564fb8a6adf341f613013d9890ffd33"
 dependencies = [
  "cbindgen",
  "icu_locale",
@@ -5538,7 +5538,7 @@ dependencies = [
 [[package]]
 name = "mozjs_normalizer_glue"
 version = "153.0.0"
-source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#2bcf845c6564fb8a6adf341f613013d9890ffd33"
+source = "git+https://github.com/servo/mozjs.git?rev=refs%2Fpull%2F500%2Fhead#2bcf845c6564fb8a6adf341f613013d9890ffd33"
 dependencies = [
  "cbindgen",
  "encoding_rs",
@@ -5550,7 +5550,7 @@ dependencies = [
 [[package]]
 name = "mozjs_properties_glue"
 version = "153.0.0"
-source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#2bcf845c6564fb8a6adf341f613013d9890ffd33"
+source = "git+https://github.com/servo/mozjs.git?rev=refs%2Fpull%2F500%2Fhead#2bcf845c6564fb8a6adf341f613013d9890ffd33"
 dependencies = [
  "cbindgen",
  "icu_casemap",
@@ -5561,7 +5561,7 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "153.0.0-1"
-source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#2bcf845c6564fb8a6adf341f613013d9890ffd33"
+source = "git+https://github.com/servo/mozjs.git?rev=refs%2Fpull%2F500%2Fhead#2bcf845c6564fb8a6adf341f613013d9890ffd33"
 dependencies = [
  "bindgen",
  "cc",
@@ -5583,7 +5583,7 @@ dependencies = [
 [[package]]
 name = "mozjs_unicode_bidi_ffi"
 version = "153.0.0"
-source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#2bcf845c6564fb8a6adf341f613013d9890ffd33"
+source = "git+https://github.com/servo/mozjs.git?rev=refs%2Fpull%2F500%2Fhead#2bcf845c6564fb8a6adf341f613013d9890ffd33"
 dependencies = [
  "cbindgen",
  "icu_properties 2.1.2",
@@ -5593,7 +5593,7 @@ dependencies = [
 [[package]]
 name = "mozjs_utf16_iter"
 version = "153.0.0"
-source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#2bcf845c6564fb8a6adf341f613013d9890ffd33"
+source = "git+https://github.com/servo/mozjs.git?rev=refs%2Fpull%2F500%2Fhead#2bcf845c6564fb8a6adf341f613013d9890ffd33"
 dependencies = [
  "mozjs_icu_collections",
 ]
@@ -5601,7 +5601,7 @@ dependencies = [
 [[package]]
 name = "mozjs_utf8_iter"
 version = "153.0.0"
-source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#2bcf845c6564fb8a6adf341f613013d9890ffd33"
+source = "git+https://github.com/servo/mozjs.git?rev=refs%2Fpull%2F500%2Fhead#2bcf845c6564fb8a6adf341f613013d9890ffd33"
 dependencies = [
  "mozjs_icu_collections",
 ]
@@ -6577,7 +6577,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7726,7 +7726,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7783,7 +7783,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10266,7 +10266,7 @@ dependencies = [
  "derive_more",
  "encoding_rs",
  "euclid",
- "icu_segmenter 2.1.2",
+ "icu_segmenter 1.5.0",
  "indexmap",
  "itertools 0.14.0",
  "itoa",
@@ -10554,7 +10554,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12278,7 +12278,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,7 +854,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3135,7 +3135,7 @@ dependencies = [
  "vec_map",
  "wasm-bindgen",
  "web-sys",
- "windows 0.61.3",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -4051,7 +4051,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4789,9 +4789,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -5439,9 +5439,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c666e4b78b1ab5cbfa68cca37fe4de68a12cb40fb48b2807a0d14fe84890ca81"
+version = "0.25.1"
+source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#2bcf845c6564fb8a6adf341f613013d9890ffd33"
 dependencies = [
  "bindgen",
  "cc",
@@ -5455,8 +5454,7 @@ dependencies = [
 [[package]]
 name = "mozjs_collator_glue"
 version = "153.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d330b59a436d446124fae0115c677f786b182b3cfbbb9e1460dfd789b6220e"
+source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#2bcf845c6564fb8a6adf341f613013d9890ffd33"
 dependencies = [
  "arraystring",
  "arrayvec",
@@ -5470,8 +5468,7 @@ dependencies = [
 [[package]]
 name = "mozjs_icu_collator"
 version = "153.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e20d3cd19d06337756e27bbe58e8f6136fd9371af02351854c74ff3b0cd6354"
+source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#2bcf845c6564fb8a6adf341f613013d9890ffd33"
 dependencies = [
  "displaydoc",
  "icu_locale",
@@ -5491,14 +5488,12 @@ dependencies = [
 [[package]]
 name = "mozjs_icu_collator_data"
 version = "153.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e869ba6b2f8960fb52ef18ae81b0160d7e72c461ced73681dfad916ac94e5fba"
+source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#2bcf845c6564fb8a6adf341f613013d9890ffd33"
 
 [[package]]
 name = "mozjs_icu_collections"
 version = "153.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f85e375edb763fd03de1dcc357b6d7b325afee7895764415a1e73bc8371ffe"
+source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#2bcf845c6564fb8a6adf341f613013d9890ffd33"
 dependencies = [
  "displaydoc",
  "icu_casemap",
@@ -5512,8 +5507,7 @@ dependencies = [
 [[package]]
 name = "mozjs_icu_normalizer"
 version = "153.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae4065b463408fadb3548e58594b85b10031ccb863252ad39da0343e587e09e"
+source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#2bcf845c6564fb8a6adf341f613013d9890ffd33"
 dependencies = [
  "displaydoc",
  "icu_properties 2.1.2",
@@ -5530,14 +5524,12 @@ dependencies = [
 [[package]]
 name = "mozjs_icu_normalizer_data"
 version = "153.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba0b6737962931cc55247972cc17d84132faf2aaa9a9c0d5eb3f6d892e5593e4"
+source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#2bcf845c6564fb8a6adf341f613013d9890ffd33"
 
 [[package]]
 name = "mozjs_locale_glue"
 version = "153.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e7677a58f7cbca8d77fb3833fac679d3c7ceaffd06f54a52e6508fd16263f30"
+source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#2bcf845c6564fb8a6adf341f613013d9890ffd33"
 dependencies = [
  "cbindgen",
  "icu_locale",
@@ -5546,8 +5538,7 @@ dependencies = [
 [[package]]
 name = "mozjs_normalizer_glue"
 version = "153.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb267434ba58d999f3749e9a156d5fcdfd3633a45e1bd4ba92b802cb07358727"
+source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#2bcf845c6564fb8a6adf341f613013d9890ffd33"
 dependencies = [
  "cbindgen",
  "encoding_rs",
@@ -5559,8 +5550,7 @@ dependencies = [
 [[package]]
 name = "mozjs_properties_glue"
 version = "153.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc5a22e3a1daf87de3f3e625d7652d102124850cf7e18828f4615fb9ddafed14"
+source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#2bcf845c6564fb8a6adf341f613013d9890ffd33"
 dependencies = [
  "cbindgen",
  "icu_casemap",
@@ -5570,9 +5560,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "153.0.0-0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c6ba1cfb2d9fa0cb144d9cbd721664e73518df054c79404be44c9d25bc31ab"
+version = "153.0.0-1"
+source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#2bcf845c6564fb8a6adf341f613013d9890ffd33"
 dependencies = [
  "bindgen",
  "cc",
@@ -5594,8 +5583,7 @@ dependencies = [
 [[package]]
 name = "mozjs_unicode_bidi_ffi"
 version = "153.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b863d108fb1ac889545ba03e4fcea54cbe94c120d9b40080a3309b7ecd3fede"
+source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#2bcf845c6564fb8a6adf341f613013d9890ffd33"
 dependencies = [
  "cbindgen",
  "icu_properties 2.1.2",
@@ -5605,8 +5593,7 @@ dependencies = [
 [[package]]
 name = "mozjs_utf16_iter"
 version = "153.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea6d470af028bd441a9cfd0a604b9a7c7ca64a606c584698a279a34f5ec3c90"
+source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#2bcf845c6564fb8a6adf341f613013d9890ffd33"
 dependencies = [
  "mozjs_icu_collections",
 ]
@@ -5614,8 +5601,7 @@ dependencies = [
 [[package]]
 name = "mozjs_utf8_iter"
 version = "153.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be78a1690af5a65b4f0df6e3f6d52dbcdfec1fbc546634bea9678b64c1d9125d"
+source = "git+https://github.com/Gae24/mozjs.git?branch=offthread#2bcf845c6564fb8a6adf341f613013d9890ffd33"
 dependencies = [
  "mozjs_icu_collections",
 ]
@@ -7192,7 +7178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ inventory = "0.3.24"
 ipc-channel = "0.22"
 itertools = "0.15"
 jni = "0.22"
-js = { package = "mozjs", version = "=0.16.4", default-features = false, features = ["intl", "libz-sys"] }
+js = { package = "mozjs", version = "=0.16.5", default-features = false, features = ["intl", "libz-sys"] }
 k12 = "0.5"
 keyboard-types = { version = "0.8.3", features = ["serde", "webdriver"] }
 kurbo = { version = "0.13.1", features = ["euclid"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -440,8 +440,8 @@ codegen-units = 1
 #
 # Or for mozjs:
 #
-# mozjs = { path = "../mozjs/mozjs" }
-# mozjs_sys = { path = "../mozjs/mozjs-sys" }
+mozjs = { git = "https://github.com/Gae24/mozjs.git", branch = "offthread" }
+mozjs_sys = { git = "https://github.com/Gae24/mozjs.git", branch = "offthread" }
 #
 # Or for CSP crate:
 # content-security-policy = { path = "../rust-content-security-policy" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -460,8 +460,8 @@ codegen-units = 1
 #
 # Or for mozjs:
 #
-mozjs = { git = "https://github.com/Gae24/mozjs.git", branch = "offthread" }
-mozjs_sys = { git = "https://github.com/Gae24/mozjs.git", branch = "offthread" }
+mozjs = { git = "https://github.com/servo/mozjs.git", rev = "refs/pull/500/head" }
+mozjs_sys = { git = "https://github.com/servo/mozjs.git", rev = "refs/pull/500/head" }
 #
 # Or for CSP crate:
 # content-security-policy = { path = "../rust-content-security-policy" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,7 @@ inventory = "0.3.24"
 ipc-channel = "0.22"
 itertools = "0.15"
 jni = "0.22"
-js = { package = "mozjs", version = "=0.25.0", default-features = false, features = ["intl", "libz-sys"] }
+js = { package = "mozjs", version = "=0.25.1", default-features = false, features = ["intl", "libz-sys"] }
 k12 = "0.5"
 keccak = "0.2"
 keyboard-types = { version = "0.8.3", features = ["serde", "webdriver"] }
@@ -460,8 +460,8 @@ codegen-units = 1
 #
 # Or for mozjs:
 #
-# mozjs = { path = "../mozjs/mozjs" }
-# mozjs_sys = { path = "../mozjs/mozjs-sys" }
+mozjs = { git = "https://github.com/Gae24/mozjs.git", branch = "offthread" }
+mozjs_sys = { git = "https://github.com/Gae24/mozjs.git", branch = "offthread" }
 #
 # Or for CSP crate:
 # content-security-policy = { path = "../rust-content-security-policy" }

--- a/components/script/dom/globalscope/script_execution.rs
+++ b/components/script/dom/globalscope/script_execution.rs
@@ -9,15 +9,17 @@ use std::rc::Rc;
 
 use content_security_policy::sandboxing_directive::SandboxingFlagSet;
 use js::context::JSContext;
-use js::jsapi::{ExceptionStackBehavior, Heap, JSScript, SetScriptPrivate};
+use js::jsapi::{ExceptionStackBehavior, Heap, InstantiateOptions, JSScript, SetScriptPrivate};
 use js::jsval::{PrivateValue, UndefinedValue};
+use js::offthread::InstantiationStorage;
 use js::panic::maybe_resume_unwind;
 use js::rust::wrappers2::{
-    Compile1, JS_ClearPendingException, JS_ExecuteScript, JS_GetScriptPrivate,
-    JS_IsExceptionPending, JS_SetPendingException,
+    Compile1, InstantiateGlobalStencil, JS_ClearPendingException, JS_ExecuteScript,
+    JS_GetScriptPrivate, JS_IsExceptionPending, JS_SetPendingException,
 };
 use js::rust::{
-    CompileOptionsWrapper, HandleValue, MutableHandleValue, transform_str_to_source_text,
+    CompileOptionsWrapper, HandleValue, MutableHandleValue, OwningCompileOptionsWrapper, Stencil,
+    transform_str_to_source_text,
 };
 use script_bindings::cformat;
 use script_bindings::settings_stack::run_a_script;
@@ -33,7 +35,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
 use crate::realms::enter_auto_realm;
 use crate::script_module::{
-    ModuleScript, ModuleSource, ModuleTree, RethrowError, ScriptFetchOptions,
+    ModuleScript, ModuleSource, ModuleTree, RethrowError, ScriptFetchOptions, gen_type_error,
 };
 use crate::unminify::unminify_js;
 
@@ -51,6 +53,54 @@ pub(crate) struct ClassicScript {
     url: ServoUrl,
     /// <https://html.spec.whatwg.org/multipage/#muted-errors>
     muted_errors: ErrorReporting,
+}
+
+impl ClassicScript {
+    #[expect(clippy::too_many_arguments)]
+    #[expect(unsafe_code)]
+    pub(crate) fn from_stencil(
+        cx: &mut JSContext,
+        global: &GlobalScope,
+        stencil: Stencil,
+        mut storage: InstantiationStorage,
+        owning_options: OwningCompileOptionsWrapper,
+        url: ServoUrl,
+        fetch_options: ScriptFetchOptions,
+        muted_errors: ErrorReporting,
+    ) -> ClassicScript {
+        // TODO needs FrontendContext
+        // check JS_HadFrontendErrors and call JS_ConvertFrontendErrorsToRuntimeErrors
+        let record = if stencil.is_null() {
+            Err(gen_type_error(
+                cx,
+                global,
+                Error::Type(c"Off-thread compilation failed".to_owned()),
+            ))
+        } else {
+            let options = owning_options.read_only();
+            let instantiate_options = InstantiateOptions {
+                skipFilenameValidation: options._base.skipFilenameValidation_,
+                hideScriptFromDebugger: options._base.hideScriptFromDebugger_,
+                deferDebugMetadata: options._base.deferDebugMetadata_,
+                eagerDelazificationStrategy_: options._base.eagerDelazificationStrategy_,
+            };
+
+            rooted!(&in(cx) let script = unsafe { InstantiateGlobalStencil(
+                cx,
+                &instantiate_options,
+                *stencil,
+                storage.as_mut_ptr(),
+            )});
+            Ok(RootedTraceableBox::from_box(Heap::boxed(script.get())))
+        };
+
+        ClassicScript {
+            record,
+            url,
+            fetch_options,
+            muted_errors,
+        }
+    }
 }
 
 #[derive(Clone, Copy, JSTraceable, MallocSizeOf)]

--- a/components/script/dom/globalscope/script_execution.rs
+++ b/components/script/dom/globalscope/script_execution.rs
@@ -9,16 +9,19 @@ use std::rc::Rc;
 
 use content_security_policy::sandboxing_directive::SandboxingFlagSet;
 use js::context::JSContext;
-use js::jsapi::{ExceptionStackBehavior, Heap, InstantiateOptions, JSScript, SetScriptPrivate};
+use js::jsapi::{
+    ExceptionStackBehavior, HadFrontendErrors, Heap, InstantiateOptions, JSScript, SetScriptPrivate,
+};
 use js::jsval::{PrivateValue, UndefinedValue};
-use js::offthread::InstantiationStorage;
+use js::offthread::CompilationResult;
 use js::panic::maybe_resume_unwind;
 use js::rust::wrappers2::{
-    Compile1, InstantiateGlobalStencil, JS_ClearPendingException, JS_ExecuteScript,
-    JS_GetScriptPrivate, JS_IsExceptionPending, JS_SetPendingException,
+    Compile1, ConvertFrontendErrorsToRuntimeErrors, InstantiateGlobalStencil,
+    JS_ClearPendingException, JS_ExecuteScript, JS_GetScriptPrivate, JS_IsExceptionPending,
+    JS_SetPendingException,
 };
 use js::rust::{
-    CompileOptionsWrapper, HandleValue, MutableHandleValue, OwningCompileOptionsWrapper, Stencil,
+    CompileOptionsWrapper, HandleValue, MutableHandleValue, OwningCompileOptionsWrapper,
     transform_str_to_source_text,
 };
 use script_bindings::cformat;
@@ -56,28 +59,37 @@ pub(crate) struct ClassicScript {
 }
 
 impl ClassicScript {
-    #[expect(clippy::too_many_arguments)]
     #[expect(unsafe_code)]
     pub(crate) fn from_stencil(
         cx: &mut JSContext,
         global: &GlobalScope,
-        stencil: Stencil,
-        mut storage: InstantiationStorage,
+        compilation_result: CompilationResult,
         owning_options: OwningCompileOptionsWrapper,
         url: ServoUrl,
         fetch_options: ScriptFetchOptions,
         muted_errors: ErrorReporting,
     ) -> ClassicScript {
-        // TODO needs FrontendContext
-        // check JS_HadFrontendErrors and call JS_ConvertFrontendErrorsToRuntimeErrors
-        let record = if stencil.is_null() {
-            Err(gen_type_error(
-                cx,
-                global,
-                Error::Type(c"Off-thread compilation failed".to_owned()),
-            ))
+        let options = owning_options.read_only();
+        let CompilationResult {
+            stencil,
+            mut storage,
+            fc,
+        } = compilation_result;
+
+        let record = if unsafe { HadFrontendErrors(*fc) } {
+            unsafe { ConvertFrontendErrorsToRuntimeErrors(cx, *fc, options) };
+
+            if unsafe { JS_IsExceptionPending(cx) } {
+                Err(RethrowError::from_pending_exception(cx))
+            } else {
+                Err(gen_type_error(
+                    cx,
+                    global,
+                    Error::Type(c"Off-thread compilation failed".to_owned()),
+                ))
+            }
         } else {
-            let options = owning_options.read_only();
+            debug_assert!(!stencil.is_null());
             let instantiate_options = InstantiateOptions {
                 skipFilenameValidation: options._base.skipFilenameValidation_,
                 hideScriptFromDebugger: options._base.hideScriptFromDebugger_,

--- a/components/script/dom/globalscope/script_execution.rs
+++ b/components/script/dom/globalscope/script_execution.rs
@@ -21,8 +21,7 @@ use js::rust::wrappers2::{
     JS_SetPendingException,
 };
 use js::rust::{
-    CompileOptionsWrapper, HandleValue, MutableHandleValue, OwningCompileOptionsWrapper,
-    transform_str_to_source_text,
+    CompileOptionsWrapper, HandleValue, MutableHandleValue, transform_str_to_source_text,
 };
 use script_bindings::cformat;
 use script_bindings::settings_stack::run_a_script;
@@ -38,7 +37,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
 use crate::realms::enter_auto_realm;
 use crate::script_module::{
-    ModuleScript, ModuleSource, ModuleTree, RethrowError, ScriptFetchOptions, gen_type_error,
+    ModuleScript, ModuleSource, ModuleTree, RethrowError, ScriptFetchOptions,
 };
 use crate::unminify::unminify_js;
 
@@ -62,32 +61,23 @@ impl ClassicScript {
     #[expect(unsafe_code)]
     pub(crate) fn from_stencil(
         cx: &mut JSContext,
-        global: &GlobalScope,
         compilation_result: CompilationResult,
-        owning_options: OwningCompileOptionsWrapper,
         url: ServoUrl,
         fetch_options: ScriptFetchOptions,
         muted_errors: ErrorReporting,
     ) -> ClassicScript {
-        let options = owning_options.read_only();
         let CompilationResult {
             stencil,
             mut storage,
             fc,
+            compile_options,
         } = compilation_result;
+
+        let options = compile_options.read_only();
 
         let record = if unsafe { HadFrontendErrors(*fc) } {
             unsafe { ConvertFrontendErrorsToRuntimeErrors(cx, *fc, options) };
-
-            if unsafe { JS_IsExceptionPending(cx) } {
-                Err(RethrowError::from_pending_exception(cx))
-            } else {
-                Err(gen_type_error(
-                    cx,
-                    global,
-                    Error::Type(c"Off-thread compilation failed".to_owned()),
-                ))
-            }
+            Err(RethrowError::from_pending_exception(cx))
         } else {
             debug_assert!(!stencil.is_null());
             let instantiate_options = InstantiateOptions {

--- a/components/script/dom/globalscope/script_execution.rs
+++ b/components/script/dom/globalscope/script_execution.rs
@@ -10,15 +10,17 @@ use std::rc::Rc;
 use bitflags::bitflags;
 use content_security_policy::sandboxing_directive::SandboxingFlagSet;
 use js::context::JSContext;
-use js::jsapi::{ExceptionStackBehavior, Heap, JSScript, SetScriptPrivate};
+use js::jsapi::{ExceptionStackBehavior, Heap, InstantiateOptions, JSScript, SetScriptPrivate};
 use js::jsval::{PrivateValue, UndefinedValue};
+use js::offthread::InstantiationStorage;
 use js::panic::maybe_resume_unwind;
 use js::rust::wrappers2::{
-    Compile1, JS_ClearPendingException, JS_ExecuteScript, JS_GetScriptPrivate,
-    JS_IsExceptionPending, JS_SetPendingException,
+    Compile1, InstantiateGlobalStencil, JS_ClearPendingException, JS_ExecuteScript,
+    JS_GetScriptPrivate, JS_IsExceptionPending, JS_SetPendingException,
 };
 use js::rust::{
-    CompileOptionsWrapper, HandleValue, MutableHandleValue, transform_str_to_source_text,
+    CompileOptionsWrapper, HandleValue, MutableHandleValue, OwningCompileOptionsWrapper, Stencil,
+    transform_str_to_source_text,
 };
 use script_bindings::cformat;
 use script_bindings::settings_stack::run_a_script;
@@ -31,7 +33,9 @@ use crate::dom::bindings::error::{Error, ErrorInfo, ErrorResult, report_pending_
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
-use crate::modules::script_module::{ModuleScript, ModuleTree, RethrowError, ScriptFetchOptions};
+use crate::modules::script_module::{
+    ModuleScript, ModuleTree, RethrowError, ScriptFetchOptions, gen_type_error,
+};
 use crate::realms::enter_auto_realm;
 use crate::unminify::{ScriptSource, unminify_js};
 
@@ -64,6 +68,55 @@ pub(crate) struct ClassicScript {
     url: ServoUrl,
     /// The options that were used when compiling this script.
     options: ScriptOptions,
+}
+
+impl ClassicScript {
+    #[expect(clippy::too_many_arguments)]
+    #[expect(unsafe_code)]
+    pub(crate) fn from_stencil(
+        cx: &mut JSContext,
+        global: &GlobalScope,
+        stencil: Stencil,
+        mut storage: InstantiationStorage,
+        owning_options: OwningCompileOptionsWrapper,
+        url: ServoUrl,
+        script_options: ScriptOptions,
+        fetch_options: ScriptFetchOptions,
+    ) -> ClassicScript {
+        // TODO needs FrontendContext
+        // check JS_HadFrontendErrors and call JS_ConvertFrontendErrorsToRuntimeErrors
+        let record = if stencil.is_null() {
+            Err(gen_type_error(
+                cx,
+                global,
+                Error::Type(c"Off-thread compilation failed".to_owned()),
+            ))
+        } else {
+            let options = owning_options.read_only();
+            let instantiate_options = InstantiateOptions {
+                skipFilenameValidation: options._base.skipFilenameValidation_,
+                hideScriptFromDebugger: options._base.hideScriptFromDebugger_,
+                deferDebugMetadata: options._base.deferDebugMetadata_,
+                eagerDelazificationStrategy_: options._base.eagerDelazificationStrategy_,
+                eagerBaselineStrategy_: options._base.eagerBaselineStrategy_,
+            };
+
+            rooted!(&in(cx) let script = unsafe { InstantiateGlobalStencil(
+                cx,
+                &instantiate_options,
+                *stencil,
+                storage.as_mut_ptr(),
+            )});
+            Ok(RootedTraceableBox::from_box(Heap::boxed(script.get())))
+        };
+
+        ClassicScript {
+            record,
+            url,
+            fetch_options,
+            options: script_options,
+        }
+    }
 }
 
 pub(crate) enum RethrowErrors {

--- a/components/script/dom/globalscope/script_execution.rs
+++ b/components/script/dom/globalscope/script_execution.rs
@@ -22,8 +22,7 @@ use js::rust::wrappers2::{
     JS_SetPendingException,
 };
 use js::rust::{
-    CompileOptionsWrapper, HandleValue, MutableHandleValue, OwningCompileOptionsWrapper,
-    transform_str_to_source_text,
+    CompileOptionsWrapper, HandleValue, MutableHandleValue, transform_str_to_source_text,
 };
 use script_bindings::cformat;
 use script_bindings::settings_stack::run_a_script;
@@ -36,9 +35,7 @@ use crate::dom::bindings::error::{Error, ErrorInfo, ErrorResult, report_pending_
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
-use crate::modules::script_module::{
-    ModuleScript, ModuleTree, RethrowError, ScriptFetchOptions, gen_type_error,
-};
+use crate::modules::script_module::{ModuleScript, ModuleTree, RethrowError, ScriptFetchOptions};
 use crate::realms::enter_auto_realm;
 use crate::unminify::{ScriptSource, unminify_js};
 
@@ -77,32 +74,23 @@ impl ClassicScript {
     #[expect(unsafe_code)]
     pub(crate) fn from_stencil(
         cx: &mut JSContext,
-        global: &GlobalScope,
         compilation_result: CompilationResult,
-        owning_options: OwningCompileOptionsWrapper,
         url: ServoUrl,
         script_options: ScriptOptions,
         fetch_options: ScriptFetchOptions,
     ) -> ClassicScript {
-        let options = owning_options.read_only();
         let CompilationResult {
             stencil,
             mut storage,
             fc,
+            compile_options,
         } = compilation_result;
+
+        let options = compile_options.read_only();
 
         let record = if unsafe { HadFrontendErrors(*fc) } {
             unsafe { ConvertFrontendErrorsToRuntimeErrors(cx, *fc, options) };
-
-            if unsafe { JS_IsExceptionPending(cx) } {
-                Err(RethrowError::from_pending_exception(cx))
-            } else {
-                Err(gen_type_error(
-                    cx,
-                    global,
-                    Error::Type(c"Off-thread compilation failed".to_owned()),
-                ))
-            }
+            Err(RethrowError::from_pending_exception(cx))
         } else {
             debug_assert!(!stencil.is_null());
             let instantiate_options = InstantiateOptions {

--- a/components/script/dom/globalscope/script_execution.rs
+++ b/components/script/dom/globalscope/script_execution.rs
@@ -10,16 +10,19 @@ use std::rc::Rc;
 use bitflags::bitflags;
 use content_security_policy::sandboxing_directive::SandboxingFlagSet;
 use js::context::JSContext;
-use js::jsapi::{ExceptionStackBehavior, Heap, InstantiateOptions, JSScript, SetScriptPrivate};
+use js::jsapi::{
+    ExceptionStackBehavior, HadFrontendErrors, Heap, InstantiateOptions, JSScript, SetScriptPrivate,
+};
 use js::jsval::{PrivateValue, UndefinedValue};
-use js::offthread::InstantiationStorage;
+use js::offthread::CompilationResult;
 use js::panic::maybe_resume_unwind;
 use js::rust::wrappers2::{
-    Compile1, InstantiateGlobalStencil, JS_ClearPendingException, JS_ExecuteScript,
-    JS_GetScriptPrivate, JS_IsExceptionPending, JS_SetPendingException,
+    Compile1, ConvertFrontendErrorsToRuntimeErrors, InstantiateGlobalStencil,
+    JS_ClearPendingException, JS_ExecuteScript, JS_GetScriptPrivate, JS_IsExceptionPending,
+    JS_SetPendingException,
 };
 use js::rust::{
-    CompileOptionsWrapper, HandleValue, MutableHandleValue, OwningCompileOptionsWrapper, Stencil,
+    CompileOptionsWrapper, HandleValue, MutableHandleValue, OwningCompileOptionsWrapper,
     transform_str_to_source_text,
 };
 use script_bindings::cformat;
@@ -71,28 +74,37 @@ pub(crate) struct ClassicScript {
 }
 
 impl ClassicScript {
-    #[expect(clippy::too_many_arguments)]
     #[expect(unsafe_code)]
     pub(crate) fn from_stencil(
         cx: &mut JSContext,
         global: &GlobalScope,
-        stencil: Stencil,
-        mut storage: InstantiationStorage,
+        compilation_result: CompilationResult,
         owning_options: OwningCompileOptionsWrapper,
         url: ServoUrl,
         script_options: ScriptOptions,
         fetch_options: ScriptFetchOptions,
     ) -> ClassicScript {
-        // TODO needs FrontendContext
-        // check JS_HadFrontendErrors and call JS_ConvertFrontendErrorsToRuntimeErrors
-        let record = if stencil.is_null() {
-            Err(gen_type_error(
-                cx,
-                global,
-                Error::Type(c"Off-thread compilation failed".to_owned()),
-            ))
+        let options = owning_options.read_only();
+        let CompilationResult {
+            stencil,
+            mut storage,
+            fc,
+        } = compilation_result;
+
+        let record = if unsafe { HadFrontendErrors(*fc) } {
+            unsafe { ConvertFrontendErrorsToRuntimeErrors(cx, *fc, options) };
+
+            if unsafe { JS_IsExceptionPending(cx) } {
+                Err(RethrowError::from_pending_exception(cx))
+            } else {
+                Err(gen_type_error(
+                    cx,
+                    global,
+                    Error::Type(c"Off-thread compilation failed".to_owned()),
+                ))
+            }
         } else {
-            let options = owning_options.read_only();
+            debug_assert!(!stencil.is_null());
             let instantiate_options = InstantiateOptions {
                 skipFilenameValidation: options._base.skipFilenameValidation_,
                 hideScriptFromDebugger: options._base.hideScriptFromDebugger_,

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -15,7 +15,7 @@ use encoding_rs::Encoding;
 use html5ever::{LocalName, Prefix, local_name};
 use js::context::JSContext;
 use js::offthread::compile_to_stencil_offthread;
-use js::rust::{HandleObject, OwningCompileOptionsWrapper};
+use js::rust::HandleObject;
 use net_traits::http_status::HttpStatus;
 use net_traits::request::{
     CorsSettings, Destination, ParserMetadata, Referrer, RequestBuilder, RequestId,
@@ -54,7 +54,9 @@ use crate::dom::element::{
 };
 use crate::dom::event::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::globalscope::script_execution::{ClassicScript, ErrorReporting, RethrowErrors, fill_compile_options};
+use crate::dom::globalscope::script_execution::{
+    ClassicScript, ErrorReporting, RethrowErrors, fill_compile_options,
+};
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::virtualmethods::VirtualMethods;
 use crate::dom::node::{ChildrenMutation, CloneChildrenFlag, Node, NodeTraits, UnbindContext};
@@ -405,7 +407,6 @@ impl FetchResponseListener for ClassicContext {
                 true,
                 1,
             );
-            let owning_options = OwningCompileOptionsWrapper::new_copied(cx, options.ptr);
 
             let src = Arc::new(source_text.to_string());
 
@@ -419,13 +420,10 @@ impl FetchResponseListener for ClassicContext {
             let _offthread_token = compile_to_stencil_offthread(options.ptr, src, move |result| {
                 task_source.queue(task!(instantiate_stencil: move |cx| {
                     let script_element = trusted.root();
-                    let global = script_element.global();
 
                     let script = ClassicScript::from_stencil(
                         cx,
-                        &global,
                         result,
-                        owning_options,
                         final_url,
                         fetch_options,
                         muted_errors,

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -15,14 +15,13 @@ use encoding_rs::Encoding;
 use html5ever::{LocalName, Prefix, local_name};
 use js::context::JSContext;
 use js::offthread::compile_to_stencil_offthread;
-use js::rust::{CompileOptionsWrapper, HandleObject, OwningCompileOptionsWrapper};
+use js::rust::{HandleObject, OwningCompileOptionsWrapper};
 use net_traits::http_status::HttpStatus;
 use net_traits::request::{
     CorsSettings, Destination, ParserMetadata, Referrer, RequestBuilder, RequestId,
 };
 use net_traits::{FetchMetadata, Metadata, NetworkError, ResourceFetchTiming};
 use script_bindings::cell::DomRefCell;
-use script_bindings::cformat;
 use servo_base::id::WebViewId;
 use servo_config::pref;
 use servo_url::ServoUrl;
@@ -55,7 +54,7 @@ use crate::dom::element::{
 };
 use crate::dom::event::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::globalscope::script_execution::{ClassicScript, ErrorReporting, RethrowErrors};
+use crate::dom::globalscope::script_execution::{ClassicScript, ErrorReporting, RethrowErrors, fill_compile_options};
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::virtualmethods::VirtualMethods;
 use crate::dom::node::{ChildrenMutation, CloneChildrenFlag, Node, NodeTraits, UnbindContext};
@@ -398,8 +397,14 @@ impl FetchResponseListener for ClassicContext {
         let fetch_options = self.fetch_options.clone();
 
         if pref!(dom_script_asynch) {
-            let url = cformat!("{}", final_url.as_str());
-            let options = CompileOptionsWrapper::new(cx, url, 1);
+            let options = fill_compile_options(
+                cx,
+                final_url.as_str(),
+                Some(IntroductionType::SRC_SCRIPT),
+                muted_errors,
+                true,
+                1,
+            );
             let owning_options = OwningCompileOptionsWrapper::new_copied(cx, options.ptr);
 
             let src = Arc::new(source_text.to_string());
@@ -411,29 +416,27 @@ impl FetchResponseListener for ClassicContext {
 
             let trusted = self.elem.clone();
 
-            let _offthread_token =
-                compile_to_stencil_offthread(options.ptr, src, move |stencil, storage| {
-                    task_source.queue(task!(instantiate_stencil: move |cx| {
-                        let script_element = trusted.root();
-                        let global = script_element.global();
+            let _offthread_token = compile_to_stencil_offthread(options.ptr, src, move |result| {
+                task_source.queue(task!(instantiate_stencil: move |cx| {
+                    let script_element = trusted.root();
+                    let global = script_element.global();
 
-                        let script = ClassicScript::from_stencil(
-                            cx,
-                            &global,
-                            stencil,
-                            storage,
-                            owning_options,
-                            final_url,
-                            fetch_options,
-                            muted_errors,
-                        );
+                    let script = ClassicScript::from_stencil(
+                        cx,
+                        &global,
+                        result,
+                        owning_options,
+                        final_url,
+                        fetch_options,
+                        muted_errors,
+                    );
 
-                        *script_element.result.borrow_mut() = Some(Ok(Script::Classic(script)));
-                        finish_fetching_a_script(&script_element, self.kind, cx);
-                    }));
+                    *script_element.result.borrow_mut() = Some(Ok(Script::Classic(script)));
+                    finish_fetching_a_script(&script_element, self.kind, cx);
+                }));
 
-                    None
-                });
+                None
+            });
 
             return;
         }

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -8,19 +8,23 @@ use std::ffi::CStr;
 use std::fs::read_to_string;
 use std::path::PathBuf;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use dom_struct::dom_struct;
 use encoding_rs::Encoding;
 use html5ever::{LocalName, Prefix, local_name};
 use js::context::JSContext;
-use js::rust::HandleObject;
+use js::offthread::compile_to_stencil_offthread;
+use js::rust::{CompileOptionsWrapper, HandleObject, OwningCompileOptionsWrapper};
 use net_traits::http_status::HttpStatus;
 use net_traits::request::{
     CorsSettings, Destination, ParserMetadata, Referrer, RequestBuilder, RequestId,
 };
 use net_traits::{FetchMetadata, Metadata, NetworkError, ResourceFetchTiming};
 use script_bindings::cell::DomRefCell;
+use script_bindings::cformat;
 use servo_base::id::WebViewId;
+use servo_config::pref;
 use servo_url::ServoUrl;
 use style::attr::AttrValue;
 use style::str::{HTML_SPACE_CHARACTERS, StaticStringVec};
@@ -389,7 +393,50 @@ impl FetchResponseListener for ClassicContext {
         }
 
         // Step 5.6. Let mutedErrors be true if response was CORS-cross-origin, and false otherwise.
-        let muted_errors = self.response_was_cors_cross_origin;
+        let muted_errors = ErrorReporting::from(self.response_was_cors_cross_origin);
+
+        let fetch_options = self.fetch_options.clone();
+
+        if pref!(dom_script_asynch) {
+            let url = cformat!("{}", final_url.as_str());
+            let options = CompileOptionsWrapper::new(cx, url, 1);
+            let owning_options = OwningCompileOptionsWrapper::new_copied(cx, options.ptr);
+
+            let src = Arc::new(source_text.to_string());
+
+            let task_source = global
+                .task_manager()
+                .dom_manipulation_task_source()
+                .to_sendable();
+
+            let trusted = self.elem.clone();
+
+            let _offthread_token =
+                compile_to_stencil_offthread(options.ptr, src, move |stencil, storage| {
+                    task_source.queue(task!(instantiate_stencil: move |cx| {
+                        let script_element = trusted.root();
+                        let global = script_element.global();
+
+                        let script = ClassicScript::from_stencil(
+                            cx,
+                            &global,
+                            stencil,
+                            storage,
+                            owning_options,
+                            final_url,
+                            fetch_options,
+                            muted_errors,
+                        );
+
+                        *script_element.result.borrow_mut() = Some(Ok(Script::Classic(script)));
+                        finish_fetching_a_script(&script_element, self.kind, cx);
+                    }));
+
+                    None
+                });
+
+            return;
+        }
 
         // Step 5.7. Let script be the result of creating a classic script given
         // sourceText, settingsObject, response's URL, options, mutedErrors, and url.
@@ -397,46 +444,15 @@ impl FetchResponseListener for ClassicContext {
             cx,
             source_text,
             final_url,
-            self.fetch_options.clone(),
-            ErrorReporting::from(muted_errors),
+            fetch_options,
+            muted_errors,
             Some(IntroductionType::SRC_SCRIPT),
             1,
             true,
         );
 
-        /*
-        let options = unsafe { CompileOptionsWrapper::new(*cx, final_url.as_str(), 1) };
-
-        let can_compile_off_thread = pref!(dom_script_asynch) &&
-            unsafe { CanCompileOffThread(*cx, options.ptr as *const _, source_text.len()) };
-
-        if can_compile_off_thread {
-            let source_string = source_text.to_string();
-
-            let context = Box::new(OffThreadCompilationContext {
-                script_element: self.elem.clone(),
-                script_kind: self.kind,
-                final_url,
-                url: self.url.clone(),
-                task_source: elem.owner_global().task_manager().dom_manipulation_task_source(),
-                script_text: source_string,
-                fetch_options: self.fetch_options.clone(),
-            });
-
-            unsafe {
-                assert!(!CompileToStencilOffThread1(
-                    *cx,
-                    options.ptr as *const _,
-                    &mut transform_str_to_source_text(&context.script_text) as *mut _,
-                    Some(off_thread_compilation_callback),
-                    Box::into_raw(context) as *mut c_void,
-                )
-                .is_null());
-            }
-        } else {*/
         *elem.result.borrow_mut() = Some(Ok(Script::Classic(script)));
         finish_fetching_a_script(&elem, self.kind, cx);
-        // }
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {

--- a/components/script/dom/html/scripting/htmlscriptelement.rs
+++ b/components/script/dom/html/scripting/htmlscriptelement.rs
@@ -8,13 +8,15 @@ use std::ffi::CStr;
 use std::fs::read_to_string;
 use std::path::PathBuf;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use bytes::{Bytes, BytesMut};
 use dom_struct::dom_struct;
 use encoding_rs::Encoding;
 use html5ever::{LocalName, Prefix, local_name};
 use js::context::JSContext;
-use js::rust::HandleObject;
+use js::offthread::compile_to_stencil_offthread;
+use js::rust::{CompileOptionsWrapper, HandleObject, OwningCompileOptionsWrapper};
 use net_traits::blob_url_store::UrlWithBlobClaim;
 use net_traits::http_status::HttpStatus;
 use net_traits::request::{
@@ -22,7 +24,9 @@ use net_traits::request::{
 };
 use net_traits::{FetchMetadata, Metadata, NetworkError, ResourceFetchTiming};
 use script_bindings::cell::DomRefCell;
+use script_bindings::cformat;
 use servo_base::id::WebViewId;
+use servo_config::pref;
 use servo_url::ServoUrl;
 use style::attr::AttrValue;
 use style::str::{HTML_SPACE_CHARACTERS, StaticStringVec};
@@ -402,6 +406,49 @@ impl FetchResponseListener for ClassicContext {
             self.response_was_cors_cross_origin,
         );
 
+        let fetch_options = self.fetch_options.clone();
+
+        if pref!(dom_script_asynch) {
+            let url = cformat!("{}", final_url.as_str());
+            let options = CompileOptionsWrapper::new(cx, url, 1);
+            let owning_options = OwningCompileOptionsWrapper::new_copied(cx, options.ptr);
+
+            let src = Arc::new(source_text.to_string());
+
+            let task_source = global
+                .task_manager()
+                .dom_manipulation_task_source()
+                .to_sendable();
+
+            let trusted = self.elem.clone();
+
+            let _offthread_token =
+                compile_to_stencil_offthread(options.ptr, src, move |stencil, storage| {
+                    task_source.queue(task!(instantiate_stencil: move |cx| {
+                        let script_element = trusted.root();
+                        let global = script_element.global();
+
+                        let script = ClassicScript::from_stencil(
+                            cx,
+                            &global,
+                            stencil,
+                            storage,
+                            owning_options,
+                            final_url,
+                            script_options,
+                            fetch_options,
+                        );
+
+                        *script_element.result.borrow_mut() = Some(Ok(Script::Classic(script)));
+                        finish_fetching_a_script(&script_element, self.kind, cx);
+                    }));
+
+                    None
+                });
+
+            return;
+        }
+
         // Step 5.7. Let script be the result of creating a classic script given
         // sourceText, settingsObject, response's URL, options, mutedErrors, and url.
         let script = global.create_a_classic_script(
@@ -409,44 +456,13 @@ impl FetchResponseListener for ClassicContext {
             source_text,
             final_url,
             script_options,
-            self.fetch_options.clone(),
+            fetch_options,
             Some(IntroductionType::SRC_SCRIPT),
             1,
         );
 
-        /*
-        let options = unsafe { CompileOptionsWrapper::new(*cx, final_url.as_str(), 1) };
-
-        let can_compile_off_thread = pref!(dom_script_asynch) &&
-            unsafe { CanCompileOffThread(*cx, options.ptr as *const _, source_text.len()) };
-
-        if can_compile_off_thread {
-            let source_string = source_text.to_string();
-
-            let context = Box::new(OffThreadCompilationContext {
-                script_element: self.elem.clone(),
-                script_kind: self.kind,
-                final_url,
-                url: self.url.clone(),
-                task_source: elem.owner_global().task_manager().dom_manipulation_task_source(),
-                script_text: source_string,
-                fetch_options: self.fetch_options.clone(),
-            });
-
-            unsafe {
-                assert!(!CompileToStencilOffThread1(
-                    *cx,
-                    options.ptr as *const _,
-                    &mut transform_str_to_source_text(&context.script_text) as *mut _,
-                    Some(off_thread_compilation_callback),
-                    Box::into_raw(context) as *mut c_void,
-                )
-                .is_null());
-            }
-        } else {*/
         *elem.result.borrow_mut() = Some(Ok(Script::Classic(script)));
         finish_fetching_a_script(&elem, self.kind, cx);
-        // }
     }
 
     fn process_csp_violations(

--- a/components/script/dom/html/scripting/htmlscriptelement.rs
+++ b/components/script/dom/html/scripting/htmlscriptelement.rs
@@ -16,7 +16,7 @@ use encoding_rs::Encoding;
 use html5ever::{LocalName, Prefix, local_name};
 use js::context::JSContext;
 use js::offthread::compile_to_stencil_offthread;
-use js::rust::{HandleObject, OwningCompileOptionsWrapper};
+use js::rust::HandleObject;
 use net_traits::blob_url_store::UrlWithBlobClaim;
 use net_traits::http_status::HttpStatus;
 use net_traits::request::{
@@ -417,7 +417,6 @@ impl FetchResponseListener for ClassicContext {
                 Some(IntroductionType::SRC_SCRIPT),
                 1,
             );
-            let owning_options = OwningCompileOptionsWrapper::new_copied(cx, options.ptr);
 
             let src = Arc::new(source_text.to_string());
 
@@ -431,13 +430,10 @@ impl FetchResponseListener for ClassicContext {
             let _offthread_token = compile_to_stencil_offthread(options.ptr, src, move |result| {
                 task_source.queue(task!(instantiate_stencil: move |cx| {
                     let script_element = trusted.root();
-                    let global = script_element.global();
 
                     let script = ClassicScript::from_stencil(
                         cx,
-                        &global,
                         result,
-                        owning_options,
                         final_url,
                         script_options,
                         fetch_options,

--- a/components/script/dom/html/scripting/htmlscriptelement.rs
+++ b/components/script/dom/html/scripting/htmlscriptelement.rs
@@ -16,7 +16,7 @@ use encoding_rs::Encoding;
 use html5ever::{LocalName, Prefix, local_name};
 use js::context::JSContext;
 use js::offthread::compile_to_stencil_offthread;
-use js::rust::{CompileOptionsWrapper, HandleObject, OwningCompileOptionsWrapper};
+use js::rust::{HandleObject, OwningCompileOptionsWrapper};
 use net_traits::blob_url_store::UrlWithBlobClaim;
 use net_traits::http_status::HttpStatus;
 use net_traits::request::{
@@ -24,7 +24,6 @@ use net_traits::request::{
 };
 use net_traits::{FetchMetadata, Metadata, NetworkError, ResourceFetchTiming};
 use script_bindings::cell::DomRefCell;
-use script_bindings::cformat;
 use servo_base::id::WebViewId;
 use servo_config::pref;
 use servo_url::ServoUrl;
@@ -56,7 +55,9 @@ use crate::dom::element::{
 };
 use crate::dom::event::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::globalscope::script_execution::{ClassicScript, RethrowErrors};
+use crate::dom::globalscope::script_execution::{
+    ClassicScript, RethrowErrors, fill_compile_options,
+};
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::virtualmethods::VirtualMethods;
 use crate::dom::node::{ChildrenMutation, CloneChildrenFlag, Node, NodeTraits, UnbindContext};
@@ -409,8 +410,13 @@ impl FetchResponseListener for ClassicContext {
         let fetch_options = self.fetch_options.clone();
 
         if pref!(dom_script_asynch) {
-            let url = cformat!("{}", final_url.as_str());
-            let options = CompileOptionsWrapper::new(cx, url, 1);
+            let options = fill_compile_options(
+                cx,
+                final_url.as_str(),
+                script_options,
+                Some(IntroductionType::SRC_SCRIPT),
+                1,
+            );
             let owning_options = OwningCompileOptionsWrapper::new_copied(cx, options.ptr);
 
             let src = Arc::new(source_text.to_string());
@@ -422,29 +428,27 @@ impl FetchResponseListener for ClassicContext {
 
             let trusted = self.elem.clone();
 
-            let _offthread_token =
-                compile_to_stencil_offthread(options.ptr, src, move |stencil, storage| {
-                    task_source.queue(task!(instantiate_stencil: move |cx| {
-                        let script_element = trusted.root();
-                        let global = script_element.global();
+            let _offthread_token = compile_to_stencil_offthread(options.ptr, src, move |result| {
+                task_source.queue(task!(instantiate_stencil: move |cx| {
+                    let script_element = trusted.root();
+                    let global = script_element.global();
 
-                        let script = ClassicScript::from_stencil(
-                            cx,
-                            &global,
-                            stencil,
-                            storage,
-                            owning_options,
-                            final_url,
-                            script_options,
-                            fetch_options,
-                        );
+                    let script = ClassicScript::from_stencil(
+                        cx,
+                        &global,
+                        result,
+                        owning_options,
+                        final_url,
+                        script_options,
+                        fetch_options,
+                    );
 
-                        *script_element.result.borrow_mut() = Some(Ok(Script::Classic(script)));
-                        finish_fetching_a_script(&script_element, self.kind, cx);
-                    }));
+                    *script_element.result.borrow_mut() = Some(Ok(Script::Classic(script)));
+                    finish_fetching_a_script(&script_element, self.kind, cx);
+                }));
 
-                    None
-                });
+                None
+            });
 
             return;
         }


### PR DESCRIPTION
Restore offthread compilation.
Currently it's limited to classic scripts, matching the exact state prior to its removal.
Companion PR to https://github.com/servo/mozjs/pull/500

Testing: Preference is already enabled, should be covered by existing tests
Fixes: #32870 
