### PR TITLE
android: Remove duplicate toolbar

### DIFF
--- a/support/android/apk/servoapp/src/main/res/values/styles.xml
+++ b/support/android/apk/servoapp/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.Material3.Light">
+    <style name="AppTheme" parent="Theme.Material3.Light.NoActionBar">
         <item name="android:statusBarColor">#212121</item>
     </style>
 


### PR DESCRIPTION
The history and settings screen have two toolbars instead of one (as one would expect). Technically, they currently have an action bar and a toolbar, with the latter being a modern replacement for the former.

|Before|After|
|---|---|
|<img width="1080" height="2400" src="https://github.com/user-attachments/assets/d6503f6e-5ad9-457a-8fff-eb492607bdbd" />|<img width="1080" height="2400" src="https://github.com/user-attachments/assets/81cb0b79-c685-4032-bca4-9f0dad3094eb" />|


Testing: There are no automated tests for Android.