### PR TITLE
deps: Bump chach20poly1305 to 0.11.0-rc.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,13 +139,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef60ac202874e574ce7a7158cc8bca7313dd344322482e4fadee288bf4a306b8"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
 ]
 
@@ -155,9 +165,9 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
- "aead",
+ "aead 0.5.2",
  "aes",
- "cipher",
+ "cipher 0.4.4",
  "ctr",
  "ghash",
  "subtle",
@@ -1163,7 +1173,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1226,35 +1236,26 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
+ "cipher 0.5.2",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
+ "zeroize",
 ]
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.10.1"
+version = "0.11.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+checksum = "1c9ed179664f12fd6f155f6dd632edf5f3806d48c228c67ff78366f2a0eb6b5e"
 dependencies = [
- "aead",
- "chacha20 0.9.1",
- "cipher",
+ "aead 0.6.0",
+ "chacha20",
+ "cipher 0.5.2",
  "poly1305",
  "zeroize",
 ]
@@ -1318,8 +1319,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
- "inout",
- "zeroize",
+ "inout 0.1.4",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -1803,7 +1814,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -4488,6 +4499,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "interpolate_name"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5876,8 +5896,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c196e0276c471c843dd5777e7543a36a298a4be942a2a688d8111cd43390dedb"
 dependencies = [
- "aead",
- "cipher",
+ "aead 0.5.2",
+ "cipher 0.4.4",
  "ctr",
  "subtle",
 ]
@@ -6475,13 +6495,12 @@ checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
 name = "poly1305"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+checksum = "a00baa632505d05512f48a963e16051c54fda9a95cc9acea1a4e3c90991c4a2e"
 dependencies = [
- "cpufeatures 0.2.17",
- "opaque-debug",
- "universal-hash",
+ "cpufeatures 0.3.0",
+ "universal-hash 0.6.1",
 ]
 
 [[package]]
@@ -6502,7 +6521,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
 ]
 
 [[package]]
@@ -6735,7 +6754,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "chacha20 0.10.0",
+ "chacha20",
  "getrandom 0.4.1",
  "rand_core 0.10.1",
 ]
@@ -8716,7 +8735,7 @@ dependencies = [
  "chacha20poly1305",
  "chardetng",
  "chrono",
- "cipher",
+ "cipher 0.4.4",
  "content-security-policy",
  "cookie 0.18.1",
  "crossbeam-channel",
@@ -10598,6 +10617,16 @@ checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
  "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ bytes = "1.0"
 cbc = "0.1.2"
 cc = "1.2"
 cfg-if = "1.0.4"
-chacha20poly1305 = "0.10"
+chacha20poly1305 = { version = "=0.11.0-rc.3", features = ["rand_core", "zeroize"] }
 chardetng = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 cipher = { version = "0.4.4", features = ["alloc", "rand_core"] }

--- a/components/script/dom/webcrypto/cryptokey.rs
+++ b/components/script/dom/webcrypto/cryptokey.rs
@@ -473,7 +473,7 @@ impl TryFrom<SerializableCryptoKeyHandle> for Handle {
                 ))
             },
             SerializableCryptoKeyHandle::ChaCha20Poly1305Key(key) => Ok(
-                Handle::ChaCha20Poly1305Key(chacha20poly1305::Key::clone_from_slice(key)),
+                Handle::ChaCha20Poly1305Key(chacha20poly1305::Key::try_from(key).map_err(|_| ())?),
             ),
             SerializableCryptoKeyHandle::Argon2Password(password) => {
                 Ok(Handle::Argon2Password(password.clone().into()))

--- a/components/script/dom/webcrypto/subtlecrypto/chacha20_poly1305_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/chacha20_poly1305_operation.rs
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use chacha20poly1305::aead::{AeadMutInPlace, KeyInit, OsRng};
-use chacha20poly1305::{ChaCha20Poly1305, Key};
+use chacha20poly1305::aead::Generate;
+use chacha20poly1305::{AeadInOut, ChaCha20Poly1305, Key, KeyInit};
 use js::context::JSContext;
 use zeroize::Zeroizing;
 
@@ -58,16 +58,20 @@ pub(crate) fn encrypt(
     // [[handle]] internal slot of key as the key input parameter, the iv member of
     // normalizedAlgorithm as the nonce input parameter, plaintext as the plaintext input
     // parameter, and additionalData as the additional authenticated data (AAD) input parameter.
-    let Handle::ChaCha20Poly1305Key(handle) = key.handle() else {
+    let Handle::ChaCha20Poly1305Key(chacha20poly1305_key) = key.handle() else {
         return Err(Error::Operation(Some(
             "Unable to access key represented by [[handle]] internal slot".to_string(),
         )));
     };
-    let mut cipher = ChaCha20Poly1305::new(handle);
-    let nonce = normalized_algorithm.iv.as_slice();
+    let cipher = ChaCha20Poly1305::new(chacha20poly1305_key);
+    let nonce = normalized_algorithm
+        .iv
+        .as_slice()
+        .try_into()
+        .map_err(|_| Error::Operation(Some("Invalid nonce for ChaCha20Poly1305".into())))?;
     let mut ciphertext = plaintext.to_vec();
     cipher
-        .encrypt_in_place(nonce.into(), additional_data, &mut ciphertext)
+        .encrypt_in_place(&nonce, additional_data, &mut ciphertext)
         .map_err(|_| {
             Error::Operation(Some(
                 "ChaCha20-Poly1305 fails to encrypt plaintext".to_string(),
@@ -127,16 +131,20 @@ pub(crate) fn decrypt(
     //     throw an OperationError
     // Otherwise:
     //     Let plaintext be the resulting plaintext.
-    let Handle::ChaCha20Poly1305Key(handle) = key.handle() else {
+    let Handle::ChaCha20Poly1305Key(chacha20poly1305_key) = key.handle() else {
         return Err(Error::Operation(Some(
             "Unable to access key represented by [[handle]] internal slot".to_string(),
         )));
     };
-    let mut cipher = ChaCha20Poly1305::new(handle);
-    let nonce = normalized_algorithm.iv.as_slice();
+    let cipher = ChaCha20Poly1305::new(chacha20poly1305_key);
+    let nonce = normalized_algorithm
+        .iv
+        .as_slice()
+        .try_into()
+        .map_err(|_| Error::Operation(Some("Invalid nonce for ChaCha20Poly1305".into())))?;
     let mut plaintext = ciphertext.to_vec();
     cipher
-        .decrypt_in_place(nonce.into(), additional_data, &mut plaintext)
+        .decrypt_in_place(&nonce, additional_data, &mut plaintext)
         .map_err(|_| {
             Error::Operation(Some(
                 "ChaCha20-Poly1305 fails to decrypt ciphertext".to_string(),
@@ -171,7 +179,8 @@ pub(crate) fn generate_key(
 
     // Step 2. Generate a 256-bit key.
     // Step 3. If the key generation step fails, then throw an OperationError.
-    let generated_key = ChaCha20Poly1305::generate_key(&mut OsRng);
+    let chacha20poly1305_key = Key::try_generate()
+        .map_err(|_| Error::Operation(Some("Failed to generate ChaCha20Poly1305 key".into())))?;
 
     // Step 4. Let key be a new CryptoKey object representing the generated key.
     // Step 5. Set the [[type]] internal slot of key to "secret".
@@ -190,7 +199,7 @@ pub(crate) fn generate_key(
         extractable,
         KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
         usages,
-        Handle::ChaCha20Poly1305Key(generated_key),
+        Handle::ChaCha20Poly1305Key(chacha20poly1305_key),
     );
 
     // Step 11. Return key.
@@ -305,10 +314,11 @@ pub(crate) fn import_key(
     // Step 6. Let algorithm be a new KeyAlgorithm.
     // Step 7. Set the name attribute of algorithm to "ChaCha20-Poly1305".
     // Step 8. Set the [[algorithm]] internal slot of key to algorithm.
-    let handle =
-        Handle::ChaCha20Poly1305Key(Key::from_exact_iter(data.to_vec()).ok_or(Error::Data(
-            Some("ChaCha20-Poly1305 fails to create key from data".to_string()),
-        ))?);
+    let handle = Handle::ChaCha20Poly1305Key(Key::try_from(data.as_slice()).map_err(|_| {
+        Error::Data(Some(
+            "ChaCha20-Poly1305 fails to create key from data".into(),
+        ))
+    })?);
     let algorithm = SubtleKeyAlgorithm {
         name: CryptoAlgorithm::ChaCha20Poly1305,
     };
@@ -330,7 +340,7 @@ pub(crate) fn import_key(
 pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedKey, Error> {
     // Step 1. If the underlying cryptographic key material represented by the [[handle]] internal
     // slot of key cannot be accessed, then throw an OperationError.
-    let Handle::ChaCha20Poly1305Key(key_handle) = key.handle() else {
+    let Handle::ChaCha20Poly1305Key(chacha20poly1305_key) = key.handle() else {
         return Err(Error::Operation(Some(
             "The underlying cryptographic key material represented by the [[handle]] internal \
             slot of key cannot be accessed"
@@ -344,7 +354,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
         KeyFormat::Raw_secret => {
             // Step 2.1. Let data be a byte sequence containing the raw octets of the key
             // represented by [[handle]] internal slot of key.
-            let data = key_handle.to_vec();
+            let data = chacha20poly1305_key.to_vec();
 
             // Step 2.2 Let result be data.
             ExportedKey::new_bytes(data)
@@ -360,7 +370,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             // Step 2.3. Set the k attribute of jwk to be a string containing the raw octets of the
             // key represented by [[handle]] internal slot of key, encoded according to Section 6.4
             // of JSON Web Algorithms [JWA].
-            jwk.encode_string_field(JwkStringField::K, key_handle.as_slice());
+            jwk.encode_string_field(JwkStringField::K, chacha20poly1305_key.as_slice());
 
             // Step 2.4. Set the alg attribute of jwk to the string "C20P".
             jwk.alg = Some(DOMString::from("C20P"));

--- a/deny.toml
+++ b/deny.toml
@@ -204,9 +204,12 @@ skip = [
     "hmac",
     "sha1",
     "sha2",
-    "chacha20",
     "crypto-bigint",
     "pem-rfc7468",
+    "aead",
+    "cipher",
+    "inout",
+    "universal-hash",
 ]
 
 # github.com organizations to allow git sources for


### PR DESCRIPTION
Bump chach20poly1305 from 0.10.1 to 0.11.0-rc.3. We pin the version with `=0.11.0-rc.3` at `Cargo.toml` bacause it is not yet a stable release. We can later switch back to normal approach with `0.11` once the new stable release is out.

Testing: Covered by existing WPT tests in `WebCryptoAPI` subdirectory
Fixes: Part of #42206