### PR TITLE
servoshell: Avoid panic in Bluetoth device picker with no devices.

### DIFF
--- a/ports/servoshell/desktop/dialog.rs
+++ b/ports/servoshell/desktop/dialog.rs
@@ -410,17 +410,19 @@ impl Dialog {
                         frame.content_ui.add_space(10.0);
 
                         let devices = request.devices();
-                        egui::ComboBox::from_label("")
-                            .selected_text(devices[*selected_device_index].name.clone())
-                            .show_ui(&mut frame.content_ui, |ui| {
-                                for (i, device) in devices.iter().enumerate() {
-                                    ui.selectable_value(
-                                        selected_device_index,
-                                        i,
-                                        device.name.clone(),
-                                    );
-                                }
-                            });
+                        let combo_box =
+                            if let Some(selected_device) = devices.get(*selected_device_index) {
+                                egui::ComboBox::from_label("")
+                                    .selected_text(selected_device.name.clone())
+                            } else {
+                                egui::ComboBox::from_label("")
+                            };
+
+                        combo_box.show_ui(&mut frame.content_ui, |ui| {
+                            for (i, device) in devices.iter().enumerate() {
+                                ui.selectable_value(selected_device_index, i, device.name.clone());
+                            }
+                        });
 
                         frame.end(ui);
                     } else {
@@ -431,8 +433,13 @@ impl Dialog {
                         ui,
                         |_ui| {},
                         |ui| {
-                            if ui.button("Ok").clicked() ||
-                                ui.input(|i| i.key_pressed(egui::Key::Enter))
+                            let ok_button = egui::Button::new("Ok");
+                            let has_selected_device = request.as_ref().is_some_and(|request| {
+                                request.devices().get(*selected_device_index).is_some()
+                            });
+                            if ui.add_enabled(has_selected_device, ok_button).clicked() ||
+                                (has_selected_device &&
+                                    ui.input(|i| i.key_pressed(egui::Key::Enter)))
                             {
                                 let request =
                                     request.take().expect("non-None until dialog is closed");


### PR DESCRIPTION
The spec for [requestDevice] states that the picker must be shown even when the scan finds no matching devices. The current logic assumes that there is at least one device to pick from and panics when the list of devices is empty.

Fix this by explictly handling the case with empty device list. The new logic displays an empty drop-down and also disables the 'Ok' button when there are no devices to choose from. This also matches the behaviour of Chrome's picker.

There were other issues found during testing - the `Escape` and `Enter` keys don't work. These are pre-existing issues and not addressed in this patch.

Testing: Manually tested as there are no tests for servoshell.
Fixes: #45313

[requestDevice]: https://webbluetoothcg.github.io/web-bluetooth/#request-bluetooth-devices