### PR TITLE
ci: Disable macOS's C API job on push to 'main'.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           {
             echo 'result<<EOF'
-            python ./python/servo/try_parser.py ${{ github.event_name == 'pull_request' && 'linux-unit-tests lint' || github.event_name == 'push' && 'full macos bencher production-bencher coverage' || 'fail-fast full macos-arm-capi' }}
+            python ./python/servo/try_parser.py ${{ github.event_name == 'pull_request' && 'linux-unit-tests lint' || github.event_name == 'push' && 'full macos macos-arm-capi bencher production-bencher coverage' || 'fail-fast full' }}
             echo EOF
            } >> $GITHUB_OUTPUT
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           {
             echo 'result<<EOF'
-            python ./python/servo/try_parser.py ${{ github.event_name == 'pull_request' && 'linux-unit-tests lint' || github.event_name == 'push' && 'full macos bencher production-bencher coverage' || 'fail-fast full' }}
+            python ./python/servo/try_parser.py ${{ github.event_name == 'pull_request' && 'linux-unit-tests lint' || github.event_name == 'push' && 'full macos bencher production-bencher coverage' || 'fail-fast full macos-arm-capi' }}
             echo EOF
            } >> $GITHUB_OUTPUT
 

--- a/python/servo/try_parser.py
+++ b/python/servo/try_parser.py
@@ -220,7 +220,7 @@ class Config(object):
                 words.extend(["linux-wpt", "linux-bencher"])
                 words.extend(["android", "ohos", "lint"])
                 words.extend(["linux-build-libservo", "windows-build-libservo"])
-                words.extend(["linux-capi", "windows-capi", "macos-arm-capi"])
+                words.extend(["linux-capi", "windows-capi"])
                 continue  # skip over keyword
             if word == "bencher":
                 words.extend(
@@ -341,7 +341,7 @@ class TestParser(unittest.TestCase):
                         "number_of_wpt_chunks": 20,
                     },
                     {
-                        "name": "MacOS Arm64 (Unit Tests, C API)",
+                        "name": "MacOS Arm64 (Unit Tests)",
                         "workflow": "macos-arm64",
                         "wpt": False,
                         "profile": "checked-release",
@@ -350,7 +350,7 @@ class TestParser(unittest.TestCase):
                         "build_libservo": False,
                         "bencher": False,
                         "build_args": "",
-                        "capi": True,
+                        "capi": False,
                         "coverage": False,
                         "wpt_args": "",
                         "number_of_wpt_chunks": 20,


### PR DESCRIPTION
It seems this could be a bottleneck due to the limited availabily of github runners for macOS. If this doesn't help, we can disable it for macOS on `merge_group` as well.

Testing: The `try_parser`'s test for the 'full' keyword has been updated. Manually tested in fork that push to main doesn't run the C API job.
