### PR TITLE
script: Only restrict input length when minlength and maxlength apply

### DIFF
--- a/components/script/dom/html/input_element/mod.rs
+++ b/components/script/dom/html/input_element/mod.rs
@@ -20,6 +20,7 @@ use js::rust::wrappers::{CheckRegExpSyntax, ExecuteRegExpNoStatics, ObjectIsRegE
 use js::rust::wrappers2::{DateGetMsecSinceEpoch, ObjectIsDate};
 use js::rust::{HandleObject, MutableHandleObject};
 use layout_api::{ScriptSelection, SharedSelection};
+use num_traits::ToPrimitive;
 use script_bindings::cell::{DomRefCell, Ref};
 use script_bindings::domstring::parse_floating_point_number;
 use servo_base::generic_channel::GenericSender;
@@ -2153,6 +2154,19 @@ impl VirtualMethods for HTMLInputElement {
                         textinput.set_content(value);
                         self.upcast::<Node>().dirty(NodeDamage::Other);
 
+                        // Set or remove the length restrictions depending on whether they apply
+                        if self.does_minmaxlength_apply() {
+                            textinput.set_min_length(
+                                self.MinLength().to_usize().map(Utf16CodeUnitLength),
+                            );
+                            textinput.set_max_length(
+                                self.MaxLength().to_usize().map(Utf16CodeUnitLength),
+                            );
+                        } else {
+                            textinput.set_min_length(None);
+                            textinput.set_max_length(None);
+                        }
+
                         // Steps 7-9
                         if !previously_selectable && self.selection_api_applies() {
                             textinput.clear_selection_to_start();
@@ -2190,7 +2204,7 @@ impl VirtualMethods for HTMLInputElement {
                 AttrValue::Int(_, value) => {
                     let mut textinput = self.textinput.borrow_mut();
 
-                    if value < 0 {
+                    if value < 0 || !self.does_minmaxlength_apply() {
                         textinput.set_max_length(None);
                     } else {
                         textinput.set_max_length(Some(Utf16CodeUnitLength(value as usize)))
@@ -2202,7 +2216,7 @@ impl VirtualMethods for HTMLInputElement {
                 AttrValue::Int(_, value) => {
                     let mut textinput = self.textinput.borrow_mut();
 
-                    if value < 0 {
+                    if value < 0 || !self.does_minmaxlength_apply() {
                         textinput.set_min_length(None);
                     } else {
                         textinput.set_min_length(Some(Utf16CodeUnitLength(value as usize)))

--- a/components/script/dom/html/input_element/mod.rs
+++ b/components/script/dom/html/input_element/mod.rs
@@ -2200,11 +2200,11 @@ impl VirtualMethods for HTMLInputElement {
                 self.textinput.borrow_mut().set_content(value);
                 self.update_placeholder_shown_state();
             },
-            local_name!("maxlength") => match *attr.value() {
+            local_name!("maxlength") if self.does_minmaxlength_apply() => match *attr.value() {
                 AttrValue::Int(_, value) => {
                     let mut textinput = self.textinput.borrow_mut();
 
-                    if value < 0 || !self.does_minmaxlength_apply() {
+                    if value < 0 {
                         textinput.set_max_length(None);
                     } else {
                         textinput.set_max_length(Some(Utf16CodeUnitLength(value as usize)))
@@ -2212,11 +2212,11 @@ impl VirtualMethods for HTMLInputElement {
                 },
                 _ => panic!("Expected an AttrValue::Int"),
             },
-            local_name!("minlength") => match *attr.value() {
+            local_name!("minlength") if self.does_minmaxlength_apply() => match *attr.value() {
                 AttrValue::Int(_, value) => {
                     let mut textinput = self.textinput.borrow_mut();
 
-                    if value < 0 || !self.does_minmaxlength_apply() {
+                    if value < 0 {
                         textinput.set_min_length(None);
                     } else {
                         textinput.set_min_length(Some(Utf16CodeUnitLength(value as usize)))

--- a/tests/wpt/meta/html/semantics/forms/the-input-element/maxlength-number.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-input-element/maxlength-number.html.ini
@@ -1,3 +1,0 @@
-[maxlength-number.html]
-  [maxlength doesn't apply to input type=number]
-    expected: FAIL


### PR DESCRIPTION
Previously, the number of characters the user was able to enter in an input was restricted, even when the length restriction attributes did not apply to the input type.

With this PR, the length restrictions are only enforced when the `minlength` and `maxlength` attributes apply, by adding and removing them from the underlying `TextInput` depending on the input type.

Testing: Passes an additional web platform test.
