### PR TITLE
Implement `height` and `orientation` media features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7451,7 +7451,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.38.0"
-source = "git+https://github.com/servo/stylo?rev=6b4eb30c6a312babd3bf12f5a75a3479c6b840ec#6b4eb30c6a312babd3bf12f5a75a3479c6b840ec"
+source = "git+https://github.com/servo/stylo?rev=1a8f15315fdd7959f7beae05517c0ae262bbe6a3#1a8f15315fdd7959f7beae05517c0ae262bbe6a3"
 dependencies = [
  "bitflags 2.13.0",
  "cssparser",
@@ -9202,7 +9202,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=6b4eb30c6a312babd3bf12f5a75a3479c6b840ec#6b4eb30c6a312babd3bf12f5a75a3479c6b840ec"
+source = "git+https://github.com/servo/stylo?rev=1a8f15315fdd7959f7beae05517c0ae262bbe6a3#1a8f15315fdd7959f7beae05517c0ae262bbe6a3"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -9673,7 +9673,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=6b4eb30c6a312babd3bf12f5a75a3479c6b840ec#6b4eb30c6a312babd3bf12f5a75a3479c6b840ec"
+source = "git+https://github.com/servo/stylo?rev=1a8f15315fdd7959f7beae05517c0ae262bbe6a3#1a8f15315fdd7959f7beae05517c0ae262bbe6a3"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -9729,7 +9729,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=6b4eb30c6a312babd3bf12f5a75a3479c6b840ec#6b4eb30c6a312babd3bf12f5a75a3479c6b840ec"
+source = "git+https://github.com/servo/stylo?rev=1a8f15315fdd7959f7beae05517c0ae262bbe6a3#1a8f15315fdd7959f7beae05517c0ae262bbe6a3"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -9738,7 +9738,7 @@ dependencies = [
 [[package]]
 name = "stylo_derive"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=6b4eb30c6a312babd3bf12f5a75a3479c6b840ec#6b4eb30c6a312babd3bf12f5a75a3479c6b840ec"
+source = "git+https://github.com/servo/stylo?rev=1a8f15315fdd7959f7beae05517c0ae262bbe6a3#1a8f15315fdd7959f7beae05517c0ae262bbe6a3"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -9750,7 +9750,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=6b4eb30c6a312babd3bf12f5a75a3479c6b840ec#6b4eb30c6a312babd3bf12f5a75a3479c6b840ec"
+source = "git+https://github.com/servo/stylo?rev=1a8f15315fdd7959f7beae05517c0ae262bbe6a3#1a8f15315fdd7959f7beae05517c0ae262bbe6a3"
 dependencies = [
  "bitflags 2.13.0",
  "stylo_malloc_size_of",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=6b4eb30c6a312babd3bf12f5a75a3479c6b840ec#6b4eb30c6a312babd3bf12f5a75a3479c6b840ec"
+source = "git+https://github.com/servo/stylo?rev=1a8f15315fdd7959f7beae05517c0ae262bbe6a3#1a8f15315fdd7959f7beae05517c0ae262bbe6a3"
 dependencies = [
  "app_units",
  "cssparser",
@@ -9776,7 +9776,7 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=6b4eb30c6a312babd3bf12f5a75a3479c6b840ec#6b4eb30c6a312babd3bf12f5a75a3479c6b840ec"
+source = "git+https://github.com/servo/stylo?rev=1a8f15315fdd7959f7beae05517c0ae262bbe6a3#1a8f15315fdd7959f7beae05517c0ae262bbe6a3"
 dependencies = [
  "toml",
 ]
@@ -9784,7 +9784,7 @@ dependencies = [
 [[package]]
 name = "stylo_traits"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=6b4eb30c6a312babd3bf12f5a75a3479c6b840ec#6b4eb30c6a312babd3bf12f5a75a3479c6b840ec"
+source = "git+https://github.com/servo/stylo?rev=1a8f15315fdd7959f7beae05517c0ae262bbe6a3#1a8f15315fdd7959f7beae05517c0ae262bbe6a3"
 dependencies = [
  "app_units",
  "bitflags 2.13.0",
@@ -10204,7 +10204,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.4.0"
-source = "git+https://github.com/servo/stylo?rev=6b4eb30c6a312babd3bf12f5a75a3479c6b840ec#6b4eb30c6a312babd3bf12f5a75a3479c6b840ec"
+source = "git+https://github.com/servo/stylo?rev=1a8f15315fdd7959f7beae05517c0ae262bbe6a3#1a8f15315fdd7959f7beae05517c0ae262bbe6a3"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -10217,7 +10217,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=6b4eb30c6a312babd3bf12f5a75a3479c6b840ec#6b4eb30c6a312babd3bf12f5a75a3479c6b840ec"
+source = "git+https://github.com/servo/stylo?rev=1a8f15315fdd7959f7beae05517c0ae262bbe6a3#1a8f15315fdd7959f7beae05517c0ae262bbe6a3"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7451,7 +7451,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.38.0"
-source = "git+https://github.com/servo/stylo?rev=1a8f15315fdd7959f7beae05517c0ae262bbe6a3#1a8f15315fdd7959f7beae05517c0ae262bbe6a3"
+source = "git+https://github.com/servo/stylo?rev=9d12364ecccb69cd26622391180f130c5346e393#9d12364ecccb69cd26622391180f130c5346e393"
 dependencies = [
  "bitflags 2.13.0",
  "cssparser",
@@ -9202,7 +9202,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=1a8f15315fdd7959f7beae05517c0ae262bbe6a3#1a8f15315fdd7959f7beae05517c0ae262bbe6a3"
+source = "git+https://github.com/servo/stylo?rev=9d12364ecccb69cd26622391180f130c5346e393#9d12364ecccb69cd26622391180f130c5346e393"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -9673,7 +9673,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=1a8f15315fdd7959f7beae05517c0ae262bbe6a3#1a8f15315fdd7959f7beae05517c0ae262bbe6a3"
+source = "git+https://github.com/servo/stylo?rev=9d12364ecccb69cd26622391180f130c5346e393#9d12364ecccb69cd26622391180f130c5346e393"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -9729,7 +9729,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=1a8f15315fdd7959f7beae05517c0ae262bbe6a3#1a8f15315fdd7959f7beae05517c0ae262bbe6a3"
+source = "git+https://github.com/servo/stylo?rev=9d12364ecccb69cd26622391180f130c5346e393#9d12364ecccb69cd26622391180f130c5346e393"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -9738,7 +9738,7 @@ dependencies = [
 [[package]]
 name = "stylo_derive"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=1a8f15315fdd7959f7beae05517c0ae262bbe6a3#1a8f15315fdd7959f7beae05517c0ae262bbe6a3"
+source = "git+https://github.com/servo/stylo?rev=9d12364ecccb69cd26622391180f130c5346e393#9d12364ecccb69cd26622391180f130c5346e393"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -9750,7 +9750,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=1a8f15315fdd7959f7beae05517c0ae262bbe6a3#1a8f15315fdd7959f7beae05517c0ae262bbe6a3"
+source = "git+https://github.com/servo/stylo?rev=9d12364ecccb69cd26622391180f130c5346e393#9d12364ecccb69cd26622391180f130c5346e393"
 dependencies = [
  "bitflags 2.13.0",
  "stylo_malloc_size_of",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=1a8f15315fdd7959f7beae05517c0ae262bbe6a3#1a8f15315fdd7959f7beae05517c0ae262bbe6a3"
+source = "git+https://github.com/servo/stylo?rev=9d12364ecccb69cd26622391180f130c5346e393#9d12364ecccb69cd26622391180f130c5346e393"
 dependencies = [
  "app_units",
  "cssparser",
@@ -9776,7 +9776,7 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=1a8f15315fdd7959f7beae05517c0ae262bbe6a3#1a8f15315fdd7959f7beae05517c0ae262bbe6a3"
+source = "git+https://github.com/servo/stylo?rev=9d12364ecccb69cd26622391180f130c5346e393#9d12364ecccb69cd26622391180f130c5346e393"
 dependencies = [
  "toml",
 ]
@@ -9784,7 +9784,7 @@ dependencies = [
 [[package]]
 name = "stylo_traits"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=1a8f15315fdd7959f7beae05517c0ae262bbe6a3#1a8f15315fdd7959f7beae05517c0ae262bbe6a3"
+source = "git+https://github.com/servo/stylo?rev=9d12364ecccb69cd26622391180f130c5346e393#9d12364ecccb69cd26622391180f130c5346e393"
 dependencies = [
  "app_units",
  "bitflags 2.13.0",
@@ -10204,7 +10204,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.4.0"
-source = "git+https://github.com/servo/stylo?rev=1a8f15315fdd7959f7beae05517c0ae262bbe6a3#1a8f15315fdd7959f7beae05517c0ae262bbe6a3"
+source = "git+https://github.com/servo/stylo?rev=9d12364ecccb69cd26622391180f130c5346e393#9d12364ecccb69cd26622391180f130c5346e393"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -10217,7 +10217,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=1a8f15315fdd7959f7beae05517c0ae262bbe6a3#1a8f15315fdd7959f7beae05517c0ae262bbe6a3"
+source = "git+https://github.com/servo/stylo?rev=9d12364ecccb69cd26622391180f130c5346e393#9d12364ecccb69cd26622391180f130c5346e393"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,14 +215,14 @@ rustls-pki-types = "1.14"
 rustls-platform-verifier = "0.7.0"
 sea-query = { version = "=1.0.0-rc.31", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = "=0.8.0-rc.15"
-selectors = { git = "https://github.com/servo/stylo", rev = "1a8f15315fdd7959f7beae05517c0ae262bbe6a3" }
+selectors = { git = "https://github.com/servo/stylo", rev = "9d12364ecccb69cd26622391180f130c5346e393" }
 seq-macro = "0.3.6"
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
 serde_json = "1.0"
 serde_test = "1.0"
-servo_arc = { git = "https://github.com/servo/stylo", rev = "1a8f15315fdd7959f7beae05517c0ae262bbe6a3" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "9d12364ecccb69cd26622391180f130c5346e393" }
 sha1 = "0.11"
 sha2 = "0.11"
 sha3 = "0.12"
@@ -232,12 +232,12 @@ smallvec = { version = "1.15", features = ["serde", "union"] }
 speexdsp-resampler = "0.1.0"
 string_cache = "0.9"
 strum = { version = "0.28", features = ["derive"] }
-stylo = { git = "https://github.com/servo/stylo", rev = "1a8f15315fdd7959f7beae05517c0ae262bbe6a3" }
-stylo_atoms = { git = "https://github.com/servo/stylo", rev = "1a8f15315fdd7959f7beae05517c0ae262bbe6a3" }
-stylo_dom = { git = "https://github.com/servo/stylo", rev = "1a8f15315fdd7959f7beae05517c0ae262bbe6a3" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "1a8f15315fdd7959f7beae05517c0ae262bbe6a3" }
-stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "1a8f15315fdd7959f7beae05517c0ae262bbe6a3" }
-stylo_traits = { git = "https://github.com/servo/stylo", rev = "1a8f15315fdd7959f7beae05517c0ae262bbe6a3" }
+stylo = { git = "https://github.com/servo/stylo", rev = "9d12364ecccb69cd26622391180f130c5346e393" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "9d12364ecccb69cd26622391180f130c5346e393" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "9d12364ecccb69cd26622391180f130c5346e393" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "9d12364ecccb69cd26622391180f130c5346e393" }
+stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "9d12364ecccb69cd26622391180f130c5346e393" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "9d12364ecccb69cd26622391180f130c5346e393" }
 surfman = { version = "0.13.0", features = ["chains"] }
 swapper = "0.1"
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,14 +215,14 @@ rustls-pki-types = "1.14"
 rustls-platform-verifier = "0.7.0"
 sea-query = { version = "=1.0.0-rc.31", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = "=0.8.0-rc.15"
-selectors = { git = "https://github.com/servo/stylo", rev = "6b4eb30c6a312babd3bf12f5a75a3479c6b840ec" }
+selectors = { git = "https://github.com/servo/stylo", rev = "1a8f15315fdd7959f7beae05517c0ae262bbe6a3" }
 seq-macro = "0.3.6"
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
 serde_json = "1.0"
 serde_test = "1.0"
-servo_arc = { git = "https://github.com/servo/stylo", rev = "6b4eb30c6a312babd3bf12f5a75a3479c6b840ec" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "1a8f15315fdd7959f7beae05517c0ae262bbe6a3" }
 sha1 = "0.11"
 sha2 = "0.11"
 sha3 = "0.12"
@@ -232,12 +232,12 @@ smallvec = { version = "1.15", features = ["serde", "union"] }
 speexdsp-resampler = "0.1.0"
 string_cache = "0.9"
 strum = { version = "0.28", features = ["derive"] }
-stylo = { git = "https://github.com/servo/stylo", rev = "6b4eb30c6a312babd3bf12f5a75a3479c6b840ec" }
-stylo_atoms = { git = "https://github.com/servo/stylo", rev = "6b4eb30c6a312babd3bf12f5a75a3479c6b840ec" }
-stylo_dom = { git = "https://github.com/servo/stylo", rev = "6b4eb30c6a312babd3bf12f5a75a3479c6b840ec" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "6b4eb30c6a312babd3bf12f5a75a3479c6b840ec" }
-stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "6b4eb30c6a312babd3bf12f5a75a3479c6b840ec" }
-stylo_traits = { git = "https://github.com/servo/stylo", rev = "6b4eb30c6a312babd3bf12f5a75a3479c6b840ec" }
+stylo = { git = "https://github.com/servo/stylo", rev = "1a8f15315fdd7959f7beae05517c0ae262bbe6a3" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "1a8f15315fdd7959f7beae05517c0ae262bbe6a3" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "1a8f15315fdd7959f7beae05517c0ae262bbe6a3" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "1a8f15315fdd7959f7beae05517c0ae262bbe6a3" }
+stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "1a8f15315fdd7959f7beae05517c0ae262bbe6a3" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "1a8f15315fdd7959f7beae05517c0ae262bbe6a3" }
 surfman = { version = "0.13.0", features = ["chains"] }
 swapper = "0.1"
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }

--- a/tests/wpt/meta/css/css-values/calc-in-media-queries-with-mixed-units.html.ini
+++ b/tests/wpt/meta/css/css-values/calc-in-media-queries-with-mixed-units.html.ini
@@ -1,7 +1,4 @@
 [calc-in-media-queries-with-mixed-units.html]
-  [box should be orange if the calc between vw-em in @media was correct]
-    expected: FAIL
-
   [box should be orange if the calc between px/em*em in @media was correct]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-values/viewport-units-media-queries.html.ini
+++ b/tests/wpt/meta/css/css-values/viewport-units-media-queries.html.ini
@@ -1,39 +1,6 @@
 [viewport-units-media-queries.html]
-  [@media(height:100vh) applies]
-    expected: FAIL
-
-  [@media(height:100vb) applies]
-    expected: FAIL
-
-  [@media(height:100vmin) applies]
-    expected: FAIL
-
-  [@media(height:100svh) applies]
-    expected: FAIL
-
-  [@media(height:100svb) applies]
-    expected: FAIL
-
-  [@media(height:100svmin) applies]
-    expected: FAIL
-
-  [@media(height:100lvh) applies]
-    expected: FAIL
-
-  [@media(height:100lvb) applies]
-    expected: FAIL
-
-  [@media(height:100lvmin) applies]
-    expected: FAIL
-
-  [@media(height:100dvh) applies]
-    expected: FAIL
-
-  [@media(height:100dvb) applies]
-    expected: FAIL
-
-  [@media(height:100dvmin) applies]
-    expected: FAIL
-
   [@media(width:90vw) does not apply]
+    expected: FAIL
+
+  [@media(height:90vh) does not apply]
     expected: FAIL

--- a/tests/wpt/meta/css/cssom-view/MediaQueryList-addListener-removeListener.html.ini
+++ b/tests/wpt/meta/css/cssom-view/MediaQueryList-addListener-removeListener.html.ini
@@ -1,3 +1,0 @@
-[MediaQueryList-addListener-removeListener.html]
-  [listeners are called when <iframe> is resized]
-    expected: FAIL

--- a/tests/wpt/meta/css/mediaqueries/mq-case-insensitive-001.html.ini
+++ b/tests/wpt/meta/css/mediaqueries/mq-case-insensitive-001.html.ini
@@ -1,2 +1,0 @@
-[mq-case-insensitive-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/mediaqueries/test_media_queries.html.ini
+++ b/tests/wpt/meta/css/mediaqueries/test_media_queries.html.ini
@@ -32,270 +32,6 @@
   [Sanity check for update]
     expected: FAIL
 
-  [expression_should_be_known: (orientation)]
-    expected: FAIL
-
-  [expression_should_be_known: not (orientation)]
-    expected: FAIL
-
-  [expression_should_be_known: (orientation) and (orientation)]
-    expected: FAIL
-
-  [expression_should_be_known: (orientation) or (orientation)]
-    expected: FAIL
-
-  [expression_should_be_known: (orientation) or ((orientation) and ((orientation) or (orientation) or (not (orientation))))]
-    expected: FAIL
-
-  [expression_should_be_known: height]
-    expected: FAIL
-
-  [expression_should_be_known: height : 0]
-    expected: FAIL
-
-  [expression_should_be_known: height : 0px]
-    expected: FAIL
-
-  [expression_should_be_known: height : 0em]
-    expected: FAIL
-
-  [expression_should_be_known: height : -0]
-    expected: FAIL
-
-  [expression_should_be_known: height : -0cm]
-    expected: FAIL
-
-  [expression_should_be_known: height : 1px]
-    expected: FAIL
-
-  [expression_should_be_known: height : 0.001mm]
-    expected: FAIL
-
-  [expression_should_be_known: height : 100000px]
-    expected: FAIL
-
-  [expression_should_be_known: min-height : -0]
-    expected: FAIL
-
-  [expression_should_be_known: max-height : -0]
-    expected: FAIL
-
-  [expression_should_be_known: height : -1px]
-    expected: FAIL
-
-  [expression_should_be_known: min-height : -1px]
-    expected: FAIL
-
-  [expression_should_be_known: max-height : -1px]
-    expected: FAIL
-
-  [expression_should_be_known: height : -0.00001mm]
-    expected: FAIL
-
-  [expression_should_be_known: height : -100000em]
-    expected: FAIL
-
-  [expression_should_be_known: height > 0]
-    expected: FAIL
-
-  [expression_should_be_known: height > 0px]
-    expected: FAIL
-
-  [expression_should_be_known: height > 0em]
-    expected: FAIL
-
-  [expression_should_be_known: height > -0]
-    expected: FAIL
-
-  [expression_should_be_known: height > -0cm]
-    expected: FAIL
-
-  [expression_should_be_known: height > 1px]
-    expected: FAIL
-
-  [expression_should_be_known: height > 0.001mm]
-    expected: FAIL
-
-  [expression_should_be_known: height > 100000px]
-    expected: FAIL
-
-  [expression_should_be_known: 0px > height > 100000px]
-    expected: FAIL
-
-  [expression_should_be_known: height > -1px]
-    expected: FAIL
-
-  [expression_should_be_known: height > -0.00001mm]
-    expected: FAIL
-
-  [expression_should_be_known: height > -100000em]
-    expected: FAIL
-
-  [expression_should_be_known: 0px > height > 0px]
-    expected: FAIL
-
-  [expression_should_be_known: 0px > height >= 0px]
-    expected: FAIL
-
-  [expression_should_be_known: height >= 0]
-    expected: FAIL
-
-  [expression_should_be_known: height >= 0px]
-    expected: FAIL
-
-  [expression_should_be_known: height >= 0em]
-    expected: FAIL
-
-  [expression_should_be_known: height >= -0]
-    expected: FAIL
-
-  [expression_should_be_known: height >= -0cm]
-    expected: FAIL
-
-  [expression_should_be_known: height >= 1px]
-    expected: FAIL
-
-  [expression_should_be_known: height >= 0.001mm]
-    expected: FAIL
-
-  [expression_should_be_known: height >= 100000px]
-    expected: FAIL
-
-  [expression_should_be_known: 0px >= height >= 100000px]
-    expected: FAIL
-
-  [expression_should_be_known: height >= -1px]
-    expected: FAIL
-
-  [expression_should_be_known: height >= -0.00001mm]
-    expected: FAIL
-
-  [expression_should_be_known: height >= -100000em]
-    expected: FAIL
-
-  [expression_should_be_known: 0px >= height > 0px]
-    expected: FAIL
-
-  [expression_should_be_known: 0px >= height >= 0px]
-    expected: FAIL
-
-  [expression_should_be_known: height = 0]
-    expected: FAIL
-
-  [expression_should_be_known: height = 0px]
-    expected: FAIL
-
-  [expression_should_be_known: height = 0em]
-    expected: FAIL
-
-  [expression_should_be_known: height = -0]
-    expected: FAIL
-
-  [expression_should_be_known: height = -0cm]
-    expected: FAIL
-
-  [expression_should_be_known: height = 1px]
-    expected: FAIL
-
-  [expression_should_be_known: height = 0.001mm]
-    expected: FAIL
-
-  [expression_should_be_known: height = 100000px]
-    expected: FAIL
-
-  [expression_should_be_known: height = -1px]
-    expected: FAIL
-
-  [expression_should_be_known: height = -0.00001mm]
-    expected: FAIL
-
-  [expression_should_be_known: height = -100000em]
-    expected: FAIL
-
-  [expression_should_be_known: height <= 0]
-    expected: FAIL
-
-  [expression_should_be_known: height <= 0px]
-    expected: FAIL
-
-  [expression_should_be_known: height <= 0em]
-    expected: FAIL
-
-  [expression_should_be_known: height <= -0]
-    expected: FAIL
-
-  [expression_should_be_known: height <= -0cm]
-    expected: FAIL
-
-  [expression_should_be_known: height <= 1px]
-    expected: FAIL
-
-  [expression_should_be_known: height <= 0.001mm]
-    expected: FAIL
-
-  [expression_should_be_known: height <= 100000px]
-    expected: FAIL
-
-  [expression_should_be_known: 0px <= height <= 100000px]
-    expected: FAIL
-
-  [expression_should_be_known: height <= -1px]
-    expected: FAIL
-
-  [expression_should_be_known: height <= -0.00001mm]
-    expected: FAIL
-
-  [expression_should_be_known: height <= -100000em]
-    expected: FAIL
-
-  [expression_should_be_known: 0px <= height <= 0px]
-    expected: FAIL
-
-  [expression_should_be_known: 0px <= height < 0px]
-    expected: FAIL
-
-  [expression_should_be_known: height < 0]
-    expected: FAIL
-
-  [expression_should_be_known: height < 0px]
-    expected: FAIL
-
-  [expression_should_be_known: height < 0em]
-    expected: FAIL
-
-  [expression_should_be_known: height < -0]
-    expected: FAIL
-
-  [expression_should_be_known: height < -0cm]
-    expected: FAIL
-
-  [expression_should_be_known: height < 1px]
-    expected: FAIL
-
-  [expression_should_be_known: height < 0.001mm]
-    expected: FAIL
-
-  [expression_should_be_known: height < 100000px]
-    expected: FAIL
-
-  [expression_should_be_known: 0px < height < 100000px]
-    expected: FAIL
-
-  [expression_should_be_known: height < -1px]
-    expected: FAIL
-
-  [expression_should_be_known: height < -0.00001mm]
-    expected: FAIL
-
-  [expression_should_be_known: height < -100000em]
-    expected: FAIL
-
-  [expression_should_be_known: 0px < height <= 0px]
-    expected: FAIL
-
-  [expression_should_be_known: 0px < height < 0px]
-    expected: FAIL
-
   [should_apply: all and (width: ${value}px)]
     expected: FAIL
 
@@ -350,28 +86,16 @@
   [should_apply: all and (height = ${value}px)]
     expected: FAIL
 
-  [should_apply: all and (min-height: ${value}px)]
-    expected: FAIL
-
-  [should_apply: all and (min-height: ${value - 1}px)]
-    expected: FAIL
-
   [should_apply: all and (max-height: ${value}px)]
     expected: FAIL
 
   [should_apply: all and (max-height: ${value + 1}px)]
     expected: FAIL
 
-  [should_apply: all and (min-height: ${Math.floor(value/em_size) - 1}em)]
-    expected: FAIL
-
   [should_apply: all and (max-height: ${Math.ceil(value/em_size) + 1}em)]
     expected: FAIL
 
   [should_apply: (height <= ${value}px)]
-    expected: FAIL
-
-  [should_apply: (height >= ${value}px)]
     expected: FAIL
 
   [should_apply: (0px < height <= ${value}px)]
@@ -384,18 +108,6 @@
     expected: FAIL
 
   [should_apply: (height <= ${value + 1}px)]
-    expected: FAIL
-
-  [should_apply: (height > ${value - 1}px)]
-    expected: FAIL
-
-  [should_apply: (height >= ${value - 1}px)]
-    expected: FAIL
-
-  [should_apply: (${value - 1}px < height)]
-    expected: FAIL
-
-  [should_apply: (${value - 1}px <= height)]
     expected: FAIL
 
   [should_apply: (${value - 1}px < height < ${value + 1}px)]
@@ -414,33 +126,6 @@
     expected: FAIL
 
   [should_apply: (${value}px >= height > ${value - 1}px)]
-    expected: FAIL
-
-  [width = 0, height != 0: should_apply: all and (height)]
-    expected: FAIL
-
-  [width != 0, height != 0: should_apply: all and (height)]
-    expected: FAIL
-
-  [ratio that reduces to 59/40: expression_should_be_known: orientation]
-    expected: FAIL
-
-  [ratio that reduces to 59/40: expression_should_be_known: orientation: portrait]
-    expected: FAIL
-
-  [ratio that reduces to 59/40: expression_should_be_known: orientation: landscape]
-    expected: FAIL
-
-  [ratio that reduces to 59/40: should_apply: (orientation)]
-    expected: FAIL
-
-  [ratio that reduces to 59/40: should_apply: (orientation: landscape)]
-    expected: FAIL
-
-  [ratio that reduces to 59/40: should_apply: not all and (orientation: portrait)]
-    expected: FAIL
-
-  [ratio that reduces to 59/80: should_apply: (orientation)]
     expected: FAIL
 
   [ratio that reduces to 59/80: should_apply: not all and (orientation: landscape)]
@@ -620,9 +305,6 @@
   [should_apply: (grid: 0)]
     expected: FAIL
 
-  [should_apply: (orientation]
-    expected: FAIL
-
   [should_apply: not all and (grid]
     expected: FAIL
 
@@ -678,4 +360,40 @@
     expected: FAIL
 
   [should_not_apply: (min-aspect-ratio: 59/79)]
+    expected: FAIL
+
+  [should_not_apply: all and (min-height: ${value + 1}px)]
+    expected: FAIL
+
+  [should_not_apply: all and (min-height: ${Math.ceil(value/em_size) + 1}em)]
+    expected: FAIL
+
+  [should_not_apply: (height > ${value}px)]
+    expected: FAIL
+
+  [should_not_apply: (height > ${value + 1}px)]
+    expected: FAIL
+
+  [should_not_apply: (height >= ${value + 1}px)]
+    expected: FAIL
+
+  [width = 0, height = 0: should_not_apply: all and (height)]
+    expected: FAIL
+
+  [width != 0, height = 0: should_not_apply: all and (height)]
+    expected: FAIL
+
+  [ratio that reduces to 59/80: should_not_apply: (orientation: landscape)]
+    expected: FAIL
+
+  ['or' keyword: should_not_apply: (height) or (height)]
+    expected: FAIL
+
+  [nesting: should_not_apply: ((height))]
+    expected: FAIL
+
+  ['not' keyword: should_not_apply: not ((width) and (not (height)))]
+    expected: FAIL
+
+  [three-valued logic: should_not_apply: ((unknown) or (height))]
     expected: FAIL

--- a/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/multiple-centered-dialogs.html.ini
+++ b/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/multiple-centered-dialogs.html.ini
@@ -1,3 +1,0 @@
-[multiple-centered-dialogs.html]
-  [Test that multiple dialogs are centered properly.]
-    expected: FAIL


### PR DESCRIPTION
Upgrade to a Stylo version that implements the `height` and `orientation` media features.

Stylo PR: https://github.com/servo/stylo/pull/395

Not sure why this is causing some new test failures, but that is not uncommon when enabling a feature that was previous entirely unimplemented. This looks like an overall win to me.

Testing: WPT tests
Part of #39068 
