### PR TITLE
script: Ensure DocumentTimeline value is rooted while Document is constructed

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -3521,7 +3521,7 @@ impl Document {
         has_trustworthy_ancestor_origin: bool,
         custom_element_reaction_stack: Rc<CustomElementReactionStack>,
         creation_sandboxing_flag_set: SandboxingFlagSet,
-        can_gc: CanGc,
+        timeline: &DocumentTimeline,
     ) -> Document {
         let url = url.unwrap_or_else(|| ServoUrl::parse("about:blank").unwrap());
 
@@ -3646,7 +3646,7 @@ impl Document {
             dirty_canvases: DomRefCell::new(Default::default()),
             has_pending_animated_image_update: Cell::new(false),
             selection: MutNullableDom::new(None),
-            timeline: DocumentTimeline::new(window, can_gc).as_traced(),
+            timeline: Dom::from_ref(timeline),
             animations: Animations::new(),
             image_animation_manager: DomRefCell::new(ImageAnimationManager::default()),
             dirty_root: Default::default(),
@@ -3851,6 +3851,7 @@ impl Document {
         creation_sandboxing_flag_set: SandboxingFlagSet,
         can_gc: CanGc,
     ) -> DomRoot<Document> {
+        let timeline = DocumentTimeline::new(window, can_gc);
         let document = reflect_dom_object_with_proto(
             Box::new(Document::new_inherited(
                 window,
@@ -3873,7 +3874,7 @@ impl Document {
                 has_trustworthy_ancestor_origin,
                 custom_element_reaction_stack,
                 creation_sandboxing_flag_set,
-                can_gc,
+                &timeline,
             )),
             window,
             proto,

--- a/components/script/dom/xmldocument.rs
+++ b/components/script/dom/xmldocument.rs
@@ -14,6 +14,7 @@ use script_traits::DocumentActivity;
 use servo_url::{MutableOrigin, ServoUrl};
 
 use crate::document_loader::DocumentLoader;
+use crate::dom::animations::documenttimeline::DocumentTimeline;
 use crate::dom::bindings::codegen::Bindings::DocumentBinding::{
     DocumentMethods, NamedPropertyValue,
 };
@@ -50,7 +51,7 @@ impl XMLDocument {
         inherited_insecure_requests_policy: Option<InsecureRequestsPolicy>,
         has_trustworthy_ancestor_origin: bool,
         custom_element_reaction_stack: Rc<CustomElementReactionStack>,
-        can_gc: CanGc,
+        timeline: &DocumentTimeline,
     ) -> XMLDocument {
         XMLDocument {
             document: Document::new_inherited(
@@ -74,7 +75,7 @@ impl XMLDocument {
                 has_trustworthy_ancestor_origin,
                 custom_element_reaction_stack,
                 window.Document().creation_sandboxing_flag_set(),
-                can_gc,
+                timeline,
             ),
         }
     }
@@ -96,6 +97,7 @@ impl XMLDocument {
         custom_element_reaction_stack: Rc<CustomElementReactionStack>,
         can_gc: CanGc,
     ) -> DomRoot<XMLDocument> {
+        let timeline = DocumentTimeline::new(window, can_gc);
         let doc = reflect_dom_object(
             Box::new(XMLDocument::new_inherited(
                 window,
@@ -111,7 +113,7 @@ impl XMLDocument {
                 inherited_insecure_requests_policy,
                 has_trustworthy_ancestor_origin,
                 custom_element_reaction_stack,
-                can_gc,
+                &timeline,
             )),
             window,
             can_gc,


### PR DESCRIPTION
The pattern `Something::new(...).as_traced()` inside of `new_inherited` is unsafe, since it can be garbage collected if any further allocations trigger a GC before the object that contains it is finished having its reflector allocated and initialized.

Testing: Can't construct a test for this due to GC timing; this fixes a crash that is exposed by running with GC zeal enabled.