### PR TITLE
net: Correctly emit `filename*=UTF-8''` in blob response `Content-Disposition` header

### DIFF
--- a/components/net/filemanager_thread.rs
+++ b/components/net/filemanager_thread.rs
@@ -17,7 +17,7 @@ use headers::{ContentLength, ContentRange, ContentType, HeaderMap, HeaderMapExt,
 use http::header::{self, HeaderValue};
 use ipc_channel::ipc::IpcSender;
 use log::warn;
-use mime::{self, Mime};
+use mime::Mime;
 use net_traits::blob_url_store::{BlobBuf, BlobTokenCommunicator, BlobURLStoreError};
 use net_traits::filemanager_thread::{
     FileManagerResult, FileManagerThreadError, FileManagerThreadMsg, FileTokenCheck,
@@ -938,29 +938,14 @@ fn set_headers(
         Some(name) => name,
         None => return,
     };
-    let charset = mime.get_param(mime::CHARSET);
-    let charset = charset
-        .map(|c| c.as_ref().into())
-        .unwrap_or("us-ascii".to_owned());
     // TODO(eijebong): Replace this once the typed header is there
     //                 https://github.com/hyperium/headers/issues/8
     headers.insert(
         header::CONTENT_DISPOSITION,
         HeaderValue::from_bytes(
             format!(
-                "inline; {}",
-                if charset.to_lowercase() == "utf-8" {
-                    format!(
-                        "filename=\"{}\"",
-                        String::from_utf8(name.as_bytes().into()).unwrap()
-                    )
-                } else {
-                    format!(
-                        "filename*=\"{}\"''{}",
-                        charset,
-                        http_percent_encode(name.as_bytes())
-                    )
-                }
+                "inline; filename*=UTF-8''{}",
+                http_percent_encode(name.as_bytes())
             )
             .as_bytes(),
         )

--- a/components/net/filemanager_thread.rs
+++ b/components/net/filemanager_thread.rs
@@ -313,7 +313,7 @@ impl FileManager {
                     &mut response.headers,
                     len,
                     buf.type_string.parse().unwrap_or(mime::TEXT_PLAIN),
-                    /* filename */ None,
+                    buf.filename.clone(),
                     content_range,
                 );
 
@@ -933,7 +933,7 @@ fn set_headers(
     if let Some(content_range) = content_range {
         headers.typed_insert(content_range);
     }
-    headers.typed_insert(ContentType::from(mime.clone()));
+    headers.typed_insert(ContentType::from(mime));
     let name = match filename {
         Some(name) => name,
         None => return,

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -180,7 +180,7 @@ fn test_fetch_blob() {
 
     let bytes = b"content";
     let blob_buf = BlobBuf {
-        filename: Some("test.txt".into()),
+        filename: Some("test .txt".into()),
         type_string: "text/plain".into(),
         size: bytes.len() as u64,
         bytes: bytes.to_vec(),
@@ -216,7 +216,7 @@ fn test_fetch_blob() {
     let fetch_response = receiver.recv().unwrap();
     assert!(!fetch_response.is_network_error());
 
-    assert_eq!(fetch_response.headers.len(), 2);
+    assert_eq!(fetch_response.headers.len(), 3);
 
     let content_type: Mime = fetch_response
         .headers
@@ -227,6 +227,15 @@ fn test_fetch_blob() {
 
     let content_length: ContentLength = fetch_response.headers.typed_get().unwrap();
     assert_eq!(content_length.0, bytes.len() as u64);
+
+    let content_disposition = fetch_response
+        .headers
+        .get(header::CONTENT_DISPOSITION)
+        .unwrap();
+    assert_eq!(
+        content_disposition.to_str().unwrap(),
+        "inline; filename*=UTF-8''test%20.txt"
+    );
 
     assert_eq!(*fetch_response.body.lock(), ResponseBody::Receiving(vec![]));
 }


### PR DESCRIPTION
We use the correct format specified in [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Disposition#as_a_response_header_for_the_main_body) for response header. It was wrong.

1. Actually set the header for blob fetch response. Previously it is skipped as we never set the name.
2. Stop computing `charset` from MIME.
3. Emit only modern filename*=UTF-8'' with `http_percent_encode`. According to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Disposition#as_a_response_header_for_the_main_body:~:text=It%27s%20recommended%20to%20include%20both%20for%20maximum%20compatibility), a response header can include both. But this is only consumed by Servo itself.

This part of code looks very similar to `<form>` data but the handling is different.

Testing: We update the existing unit test to cover this. We also improved the test, to cover the percent escape sequence.
