### PR TITLE
script: more `&mut JSContext` in `script_runtime.rs`

### DIFF
--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -88,7 +88,7 @@ use crate::microtask::{Microtask, MicrotaskQueue, UserMicrotask};
 use crate::network_listener::{FetchResponseListener, ResourceTimingListener, submit_timing};
 use crate::realms::{AlreadyInRealm, InRealm, enter_auto_realm};
 use crate::script_module::ScriptFetchOptions;
-use crate::script_runtime::{CanGc, IntroductionType, JSContext, JSContextHelper, Runtime};
+use crate::script_runtime::{CanGc, IntroductionType, JSContext, Runtime, get_reports};
 use crate::task::TaskCanceller;
 use crate::timers::{IsInterval, TimerCallback};
 
@@ -1044,9 +1044,8 @@ impl WorkerGlobalScope {
         match msg {
             CommonScriptMsg::Task(_, task, _, _) => task.run_box(cx),
             CommonScriptMsg::CollectReports(reports_chan) => {
-                let cx: JSContext = cx.into();
                 perform_memory_report(|ops| {
-                    let reports = cx.get_reports(format!("url({})", self.get_url()), ops);
+                    let reports = get_reports(cx, format!("url({})", self.get_url()), ops);
                     reports_chan.send(ProcessReports::new(reports));
                 });
             },

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -23,8 +23,8 @@ use background_hang_monitor_api::ScriptHangAnnotation;
 use js::conversions::jsstr_to_string;
 use js::gc::StackGCVector;
 use js::glue::{
-    CreateJobQueue, DeleteJobQueue, DispatchablePointer, DispatchableRun, JS_GetReservedSlot,
-    JobQueueTraps, RUST_js_GetErrorMessage, RegisterScriptEnvironmentPreparer,
+    CreateJobQueue, DeleteJobQueue, DispatchablePointer, JS_GetReservedSlot, JobQueueTraps,
+    RUST_js_GetErrorMessage, RegisterScriptEnvironmentPreparer,
     RunScriptEnvironmentPreparerClosure, SetBuildId, StreamConsumerConsumeChunk,
     StreamConsumerNoteResponseURLs, StreamConsumerStreamEnd, StreamConsumerStreamError,
 };
@@ -45,11 +45,12 @@ use js::realm::CurrentRealm;
 pub(crate) use js::rust::ThreadSafeJSContext;
 use js::rust::wrappers::{GetPromiseIsHandled, JS_GetPromiseResult};
 use js::rust::wrappers2::{
-    CollectServoSizes, ContextOptionsRef, InitConsumeStreamCallback, JS_AddExtraGCRootsTracer,
-    JS_InitDestroyPrincipalsCallback, JS_InitReadPrincipalsCallback, JS_SetGCCallback,
-    JS_SetGCParameter, JS_SetGlobalJitCompilerOption, JS_SetOffthreadIonCompilationEnabled,
-    JS_SetSecurityCallbacks, SetDOMCallbacks, SetGCSliceCallback, SetJobQueue,
-    SetPreserveWrapperCallbacks, SetPromiseRejectionTrackerCallback, SetUpEventLoopDispatch,
+    CollectServoSizes, ContextOptionsRef, DispatchableRun, InitConsumeStreamCallback,
+    JS_AddExtraGCRootsTracer, JS_InitDestroyPrincipalsCallback, JS_InitReadPrincipalsCallback,
+    JS_SetGCCallback, JS_SetGCParameter, JS_SetGlobalJitCompilerOption,
+    JS_SetOffthreadIonCompilationEnabled, JS_SetSecurityCallbacks, SetDOMCallbacks,
+    SetGCSliceCallback, SetJobQueue, SetPreserveWrapperCallbacks,
+    SetPromiseRejectionTrackerCallback, SetUpEventLoopDispatch,
 };
 use js::rust::{
     Handle, HandleObject as RustHandleObject, HandleValue, IntoHandle, JSEngine, JSEngineHandle,
@@ -831,10 +832,8 @@ impl Runtime {
             };
 
             let runnable = Runnable(dispatchable);
-            let task = task!(dispatch_to_event_loop_message: move || {
-                if let Some(cx) = RustRuntime::get() {
-                    runnable.run(cx.as_ptr(), Dispatchable_MaybeShuttingDown::NotShuttingDown);
-                }
+            let task = task!(dispatch_to_event_loop_message: move |cx| {
+                runnable.run(cx, Dispatchable_MaybeShuttingDown::NotShuttingDown);
             });
 
             script_event_loop_sender
@@ -1461,7 +1460,11 @@ unsafe impl Send for Runnable {}
 
 #[expect(unsafe_code)]
 impl Runnable {
-    fn run(&self, cx: *mut RawJSContext, maybe_shutting_down: Dispatchable_MaybeShuttingDown) {
+    fn run(
+        &self,
+        cx: &mut js::context::JSContext,
+        maybe_shutting_down: Dispatchable_MaybeShuttingDown,
+    ) {
         unsafe {
             DispatchableRun(cx, self.0, maybe_shutting_down);
         }

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -23,8 +23,8 @@ use background_hang_monitor_api::ScriptHangAnnotation;
 use js::conversions::jsstr_to_string;
 use js::gc::StackGCVector;
 use js::glue::{
-    CollectServoSizes, CreateJobQueue, DeleteJobQueue, DispatchablePointer, DispatchableRun,
-    JS_GetReservedSlot, JobQueueTraps, RUST_js_GetErrorMessage, RegisterScriptEnvironmentPreparer,
+    CreateJobQueue, DeleteJobQueue, DispatchablePointer, DispatchableRun, JS_GetReservedSlot,
+    JobQueueTraps, RUST_js_GetErrorMessage, RegisterScriptEnvironmentPreparer,
     RunScriptEnvironmentPreparerClosure, SetBuildId, StreamConsumerConsumeChunk,
     StreamConsumerNoteResponseURLs, StreamConsumerStreamEnd, StreamConsumerStreamError,
 };
@@ -45,7 +45,7 @@ use js::realm::CurrentRealm;
 pub(crate) use js::rust::ThreadSafeJSContext;
 use js::rust::wrappers::{GetPromiseIsHandled, JS_GetPromiseResult};
 use js::rust::wrappers2::{
-    ContextOptionsRef, InitConsumeStreamCallback, JS_AddExtraGCRootsTracer,
+    CollectServoSizes, ContextOptionsRef, InitConsumeStreamCallback, JS_AddExtraGCRootsTracer,
     JS_InitDestroyPrincipalsCallback, JS_InitReadPrincipalsCallback, JS_SetGCCallback,
     JS_SetGCParameter, JS_SetGlobalJitCompilerOption, JS_SetOffthreadIonCompilationEnabled,
     JS_SetSecurityCallbacks, SetDOMCallbacks, SetGCSliceCallback, SetJobQueue,
@@ -1226,73 +1226,69 @@ unsafe fn set_gc_zeal_options(_: *mut RawJSContext) {}
 
 pub(crate) use script_bindings::script_runtime::JSContext;
 
-/// Extra methods for the JSContext type defined in script_bindings, when
-/// the methods are only called by code in the script crate.
-pub(crate) trait JSContextHelper {
-    fn get_reports(&self, path_seg: String, ops: &mut MallocSizeOfOps) -> Vec<Report>;
-}
+#[expect(unsafe_code)]
+pub(crate) fn get_reports(
+    cx: &mut js::context::JSContext,
+    path_seg: String,
+    ops: &mut MallocSizeOfOps,
+) -> Vec<Report> {
+    MALLOC_SIZE_OF_OPS.with(|ops_tls| ops_tls.set(ops));
+    let stats = unsafe {
+        let mut stats = ::std::mem::zeroed();
+        if !CollectServoSizes(cx, &mut stats, Some(get_size)) {
+            return vec![];
+        }
+        stats
+    };
+    MALLOC_SIZE_OF_OPS.with(|ops| ops.set(ptr::null_mut()));
 
-impl JSContextHelper for JSContext {
-    #[expect(unsafe_code)]
-    fn get_reports(&self, path_seg: String, ops: &mut MallocSizeOfOps) -> Vec<Report> {
-        MALLOC_SIZE_OF_OPS.with(|ops_tls| ops_tls.set(ops));
-        let stats = unsafe {
-            let mut stats = ::std::mem::zeroed();
-            if !CollectServoSizes(**self, &mut stats, Some(get_size)) {
-                return vec![];
-            }
-            stats
-        };
-        MALLOC_SIZE_OF_OPS.with(|ops| ops.set(ptr::null_mut()));
+    let mut reports = vec![];
+    let mut report = |mut path_suffix, kind, size| {
+        let mut path = path![path_seg, "js"];
+        path.append(&mut path_suffix);
+        reports.push(Report { path, kind, size })
+    };
 
-        let mut reports = vec![];
-        let mut report = |mut path_suffix, kind, size| {
-            let mut path = path![path_seg, "js"];
-            path.append(&mut path_suffix);
-            reports.push(Report { path, kind, size })
-        };
+    // A note about possibly confusing terminology: the JS GC "heap" is allocated via
+    // mmap/VirtualAlloc, which means it's not on the malloc "heap", so we use
+    // `ExplicitNonHeapSize` as its kind.
+    report(
+        path!["gc-heap", "used"],
+        ReportKind::ExplicitNonHeapSize,
+        stats.gcHeapUsed,
+    );
 
-        // A note about possibly confusing terminology: the JS GC "heap" is allocated via
-        // mmap/VirtualAlloc, which means it's not on the malloc "heap", so we use
-        // `ExplicitNonHeapSize` as its kind.
-        report(
-            path!["gc-heap", "used"],
-            ReportKind::ExplicitNonHeapSize,
-            stats.gcHeapUsed,
-        );
+    report(
+        path!["gc-heap", "unused"],
+        ReportKind::ExplicitNonHeapSize,
+        stats.gcHeapUnused,
+    );
 
-        report(
-            path!["gc-heap", "unused"],
-            ReportKind::ExplicitNonHeapSize,
-            stats.gcHeapUnused,
-        );
+    report(
+        path!["gc-heap", "admin"],
+        ReportKind::ExplicitNonHeapSize,
+        stats.gcHeapAdmin,
+    );
 
-        report(
-            path!["gc-heap", "admin"],
-            ReportKind::ExplicitNonHeapSize,
-            stats.gcHeapAdmin,
-        );
+    report(
+        path!["gc-heap", "decommitted"],
+        ReportKind::ExplicitNonHeapSize,
+        stats.gcHeapDecommitted,
+    );
 
-        report(
-            path!["gc-heap", "decommitted"],
-            ReportKind::ExplicitNonHeapSize,
-            stats.gcHeapDecommitted,
-        );
+    // SpiderMonkey uses the system heap, not jemalloc.
+    report(
+        path!["malloc-heap"],
+        ReportKind::ExplicitSystemHeapSize,
+        stats.mallocHeap,
+    );
 
-        // SpiderMonkey uses the system heap, not jemalloc.
-        report(
-            path!["malloc-heap"],
-            ReportKind::ExplicitSystemHeapSize,
-            stats.mallocHeap,
-        );
-
-        report(
-            path!["non-heap"],
-            ReportKind::ExplicitNonHeapSize,
-            stats.nonHeap,
-        );
-        reports
-    }
+    report(
+        path!["non-heap"],
+        ReportKind::ExplicitNonHeapSize,
+        stats.nonHeap,
+    );
+    reports
 }
 
 pub(crate) struct StreamConsumer(*mut JSStreamConsumer);

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -158,8 +158,7 @@ use crate::network_listener::{FetchResponseListener, submit_timing};
 use crate::realms::{enter_auto_realm, enter_realm};
 use crate::script_mutation_observers::ScriptMutationObservers;
 use crate::script_runtime::{
-    CanGc, IntroductionType, JSContextHelper, Runtime, ScriptThreadEventCategory,
-    ThreadSafeJSContext,
+    CanGc, IntroductionType, Runtime, ScriptThreadEventCategory, ThreadSafeJSContext, get_reports,
 };
 use crate::script_window_proxies::ScriptWindowProxies;
 use crate::task_queue::TaskQueue;
@@ -2111,7 +2110,7 @@ impl ScriptThread {
                 task.run_box(cx)
             },
             MainThreadScriptMsg::Common(CommonScriptMsg::CollectReports(chan)) => {
-                self.collect_reports(chan)
+                self.collect_reports(cx, chan)
             },
             MainThreadScriptMsg::Common(CommonScriptMsg::ReportCspViolations(
                 pipeline_id,
@@ -2781,7 +2780,7 @@ impl ScriptThread {
         );
     }
 
-    fn collect_reports(&self, reports_chan: ReportsChan) {
+    fn collect_reports(&self, cx: &mut js::context::JSContext, reports_chan: ReportsChan) {
         let documents = self.documents.borrow();
         let urls = itertools::join(documents.iter().map(|(_, d)| d.url().to_string()), ", ");
 
@@ -2795,7 +2794,7 @@ impl ScriptThread {
             }
 
             let prefix = format!("url({urls})");
-            reports.extend(self.get_cx().get_reports(prefix, ops));
+            reports.extend(get_reports(cx, prefix, ops));
         });
 
         reports_chan.send(ProcessReports::new(reports));


### PR DESCRIPTION
Drop `JSContextHelper` trait and pass `&mut JSContext` to `get_reports` and `Runnable::run`.

Testing: It compiles
Part of #40600 
