### PR TITLE
android: Restrict visibility of Java symbols

### DIFF
--- a/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.java
+++ b/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.java
@@ -36,21 +36,21 @@ public class MainActivity extends Activity implements Servo.Client {
     // than one
     private static final int HISTORY_REQUEST_CODE = 1;
 
-    ServoView mServoView;
-    BottomNavigationView mBottomNav;
+    private ServoView mServoView;
+    private BottomNavigationView mBottomNav;
 
-    EditText mUrlField;
-    boolean mUrlFieldIsFocused;
+    private EditText mUrlField;
+    private boolean mUrlFieldIsFocused;
 
-    CircularProgressIndicator mProgressBar;
-    TextView mIdleText;
-    boolean mCanGoBack;
-    MediaSession mMediaSession;
-    HistoryManager mHistoryManager;
-    String mCurrentUrl;
-    String mCurrentTitle;
+    private CircularProgressIndicator mProgressBar;
+    private TextView mIdleText;
+    private boolean mCanGoBack;
+    private MediaSession mMediaSession;
+    private HistoryManager mHistoryManager;
+    private String mCurrentUrl;
+    private String mCurrentTitle;
     
-    class Settings {
+    private static class Settings {
         Settings(SharedPreferences preferences) {
             showAnimatingIndicator = preferences.getBoolean("animating_indicator", false);
             experimental = preferences.getBoolean("experimental", false);
@@ -59,7 +59,7 @@ public class MainActivity extends Activity implements Servo.Client {
         boolean showAnimatingIndicator;
         boolean experimental;
     }
-    Settings mSettings;
+    private Settings mSettings;
 
     private final View.OnClickListener actionClickListener = v -> dispatchAction(v.getId());
 
@@ -201,7 +201,7 @@ public class MainActivity extends Activity implements Servo.Client {
         });
     }
 
-    public void loadUrlFromField() {
+    private void loadUrlFromField() {
         String text = mUrlField.getText().toString();
         text = text.trim();
 
@@ -384,7 +384,7 @@ public class MainActivity extends Activity implements Servo.Client {
         Log.d("onMediaSessionSetPositionState", duration + " " + position + " " + playbackRate);
     }
 
-    public void onAnimatingIndicatorPrefChanged(boolean value) {
+    private void onAnimatingIndicatorPrefChanged(boolean value) {
         if (value) {
             mIdleText.setVisibility(View.VISIBLE);
         } else {
@@ -392,11 +392,11 @@ public class MainActivity extends Activity implements Servo.Client {
         }
     }
 
-    public void onExperimentalPrefChanged(boolean value) {
+    private void onExperimentalPrefChanged(boolean value) {
         mServoView.setExperimentalMode(value);
     }
 
-    public void updateSettingsIfNecessary(boolean force) {
+    private void updateSettingsIfNecessary(boolean force) {
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
         Settings updated = new Settings(preferences);
 

--- a/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MediaSession.java
+++ b/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MediaSession.java
@@ -21,7 +21,7 @@ import androidx.core.content.ContextCompat;
 import org.servo.servoview.ServoView;
 
 public class MediaSession {
-    private class NotificationID {
+    private static class NotificationID {
         private int lastID = 0;
         public int getNext() {
           lastID++;
@@ -56,17 +56,17 @@ public class MediaSession {
     private static final String KEY_MEDIA_NEXT = "org.servo.servoview.MainActivity.next";
     private static final String KEY_MEDIA_STOP = "org.servo.servoview.MainActivity.stop";
 
-    ServoView mView;
-    Context mContext;
+    private final ServoView mView;
+    private final Context mContext;
 
-    NotificationID mNotificationID;
-    BroadcastReceiver mMediaSessionActionReceiver;
+    private final NotificationID mNotificationID;
+    private BroadcastReceiver mMediaSessionActionReceiver;
 
-    int mPlaybackState = PLAYBACK_STATE_PAUSED;
+    private int mPlaybackState = PLAYBACK_STATE_PAUSED;
 
-    String mTitle;
-    String mArtist;
-    String mAlbum;
+    private String mTitle;
+    private String mArtist;
+    private String mAlbum;
 
     public MediaSession(ServoView view, Context context) {
       mView = view;


### PR DESCRIPTION
To aid with the migration of these classes to Kotlin (see https://github.com/servo/servo/issues/45640), restricting the visibility of these symbols means that the Kotlin translation can be more faithful without looking odd (e.g., converting modifier-less fields to `internal` when they don't need to be `internal` would look odd in Kotlin).

Testing: There are no automated tests for Android.