### PR TITLE
fonts: Don't store font face rule source location in FontTemplate

### DIFF
--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -38,6 +38,7 @@ use style::device::Device;
 use style::font_face::{
     FontFaceSourceFormat, FontFaceSourceFormatKeyword, Source, SourceList, UrlSource,
 };
+use style::properties::generated::font_face::Descriptors as FontFaceRuleDescriptors;
 use style::properties::style_structs::Font as FontStyleStruct;
 use style::shared_lock::SharedRwLockReadGuard;
 use style::stylesheets::{
@@ -663,7 +664,7 @@ impl FontContextWebFontMethods for Arc<FontContext> {
 
             let initiator = FontFaceRuleInitiator {
                 stylesheet: stylesheet.clone(),
-                font_face_rule: rule.clone(),
+                font_face_rule: rule.descriptors.clone(),
                 callback: finished_callback.clone(),
             };
 
@@ -931,7 +932,7 @@ pub(crate) type ScriptWebFontLoadFinishedCallback =
 
 pub(crate) struct FontFaceRuleInitiator {
     stylesheet: DocumentStyleSheet,
-    font_face_rule: FontFaceRule,
+    font_face_rule: FontFaceRuleDescriptors,
     callback: StylesheetWebFontLoadFinishedCallback,
 }
 
@@ -948,7 +949,7 @@ impl WebFontLoadInitiator {
         }
     }
 
-    pub(crate) fn font_face_rule(&self) -> Option<&FontFaceRule> {
+    pub(crate) fn font_face_rule(&self) -> Option<&FontFaceRuleDescriptors> {
         match self {
             Self::Stylesheet(initiator) => Some(&initiator.font_face_rule),
             Self::Script(_) => None,

--- a/components/fonts/shapers/mod.rs
+++ b/components/fonts/shapers/mod.rs
@@ -10,7 +10,7 @@ pub(crate) use harfbuzz::Shaper;
 use read_fonts::types::Tag;
 use rustc_hash::FxHashMap;
 use style::computed_values::font_variant_position::T as FontVariantPosition;
-use style::font_face::FontFaceRule;
+use style::properties::generated::font_face::Descriptors as FontFaceRuleDescriptors;
 use style::values::computed::{FontVariantEastAsian, FontVariantLigatures, FontVariantNumeric};
 
 use crate::{
@@ -63,7 +63,7 @@ pub(crate) trait GlyphShapingResult {
 /// <https://drafts.csswg.org/css-fonts-4/#apply-font-matching-variations>.
 pub(crate) fn compute_used_font_features(
     options: &ShapingOptions,
-    font_face_rule: Option<&FontFaceRule>,
+    font_face_rule: Option<&FontFaceRuleDescriptors>,
 ) -> impl Iterator<Item = (Tag, u32)> {
     let mut features = FxHashMap::default();
 
@@ -79,7 +79,7 @@ pub(crate) fn compute_used_font_features(
     // Step 7. If the font is defined via an @font-face rule, the font features implied
     // by the font-feature-settings descriptor in the @font-face rule are applied.
     if let Some(font_feature_settings) =
-        font_face_rule.and_then(|rule| rule.descriptors.font_feature_settings.as_ref())
+        font_face_rule.and_then(|rule| rule.font_feature_settings.as_ref())
     {
         for feature_setting in font_feature_settings.0.iter() {
             add_feature(

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -1312,6 +1312,7 @@ malloc_size_of_is_stylo_malloc_size_of!(style::dom::OpaqueNode);
 malloc_size_of_is_stylo_malloc_size_of!(style::invalidation::element::restyle_hints::RestyleHint);
 malloc_size_of_is_stylo_malloc_size_of!(style::logical_geometry::WritingMode);
 malloc_size_of_is_stylo_malloc_size_of!(style::media_queries::MediaList);
+malloc_size_of_is_stylo_malloc_size_of!(style::properties::generated::font_face::Descriptors);
 malloc_size_of_is_stylo_malloc_size_of!(
     style::properties::longhands::align_items::computed_value::T
 );

--- a/components/shared/fonts/font_template.rs
+++ b/components/shared/fonts/font_template.rs
@@ -14,7 +14,8 @@ use serde::{Deserialize, Serialize};
 use style::computed_values::font_optical_sizing::T as FontOpticalSizing;
 use style::computed_values::font_stretch::T as FontStretch;
 use style::computed_values::font_style::T as FontStyle;
-use style::stylesheets::{DocumentStyleSheet, FontFaceRule};
+use style::properties::generated::font_face::Descriptors as FontFaceRuleDescriptors;
+use style::stylesheets::DocumentStyleSheet;
 use style::values::computed::font::FontWeight;
 use webrender_api::FontVariation;
 
@@ -164,7 +165,7 @@ pub struct FontTemplate {
     /// If this font is a web font, this is a reference to the `@font-face` rule that
     /// created it.
     #[serde(skip)]
-    pub font_face_rule: Option<FontFaceRule>,
+    pub font_face_rule: Option<FontFaceRuleDescriptors>,
 }
 
 impl Debug for FontTemplate {
@@ -182,7 +183,7 @@ impl FontTemplate {
         identifier: FontIdentifier,
         descriptor: FontTemplateDescriptor,
         stylesheet: Option<DocumentStyleSheet>,
-        font_face_rule: Option<FontFaceRule>,
+        font_face_rule: Option<FontFaceRuleDescriptors>,
     ) -> FontTemplate {
         assert!(
             (stylesheet.is_some() && font_face_rule.is_some()) ||
@@ -203,7 +204,7 @@ impl FontTemplate {
         local_template: FontTemplateRef,
         css_font_template_descriptors: &CSSFontFaceDescriptors,
         stylesheet: Option<DocumentStyleSheet>,
-        font_face_rule: Option<FontFaceRule>,
+        font_face_rule: Option<FontFaceRuleDescriptors>,
     ) -> Result<FontTemplate, &'static str> {
         let mut alias_template = local_template.borrow().clone();
         alias_template
@@ -249,9 +250,7 @@ impl FontTemplate {
         if let Some(font_face_rule) = &self.font_face_rule {
             // Step 6. If the font is defined via an @font-face rule, the font variations implied by the font-variation-settings
             // descriptor in the @font-face rule are applied.
-            if let Some(variation_settings) =
-                font_face_rule.descriptors.font_variation_settings.as_ref()
-            {
+            if let Some(variation_settings) = font_face_rule.font_variation_settings.as_ref() {
                 variation_settings
                     .0
                     .iter()
@@ -310,7 +309,7 @@ pub trait FontTemplateRefMethods {
     fn char_in_unicode_range(&self, character: char) -> bool;
 
     /// Return the `@font-face` rule that defined this template, if any.
-    fn font_face_rule(&self) -> Option<AtomicRef<'_, FontFaceRule>>;
+    fn font_face_rule(&self) -> Option<AtomicRef<'_, FontFaceRuleDescriptors>>;
 }
 
 impl FontTemplateRefMethods for FontTemplateRef {
@@ -339,7 +338,7 @@ impl FontTemplateRefMethods for FontTemplateRef {
             .is_none_or(|ranges| ranges.iter().any(|range| range.contains(&character)))
     }
 
-    fn font_face_rule(&self) -> Option<AtomicRef<'_, FontFaceRule>> {
+    fn font_face_rule(&self) -> Option<AtomicRef<'_, FontFaceRuleDescriptors>> {
         AtomicRef::filter_map(self.borrow(), |template| template.font_face_rule.as_ref())
     }
 }


### PR DESCRIPTION
We we're storing a full `FontFaceRule` on `FontTemplate`s that are web fonts. A `FontFaceRule` consists of various descriptors (`family-name`, `src`, `display`, ...)  and a source location. We're only interested in the descriptors, so we can throw away the source location.

In theory this can reduce the size of a `FontTemplate` by 8 bytes, but I haven't verified that this is actually the case. This work is part of a larger refactor I'm doing, and I've split it off because its easy to review on its own.

Testing: This should not change behaviour, which is covered by existing tests