### PR TITLE
layout: Give standard phasing to text decorations

### DIFF
--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -1109,17 +1109,34 @@ impl Fragment {
         }
 
         let mut rect = rect.to_webrender();
-        let line_thickness = rect.height().ceil();
-
+        let wavy_line_thickness = rect.height().ceil();
         if text_decoration.style == ComputedTextDecorationStyle::Wavy {
-            rect = rect.inflate(0.0, line_thickness * 1.0);
+            rect = rect.inflate(0.0, wavy_line_thickness);
         }
+
+        // In Servo, text decorations can span multiple text fragments. In order to have dots,
+        // dashes, and wavy line segments match up between multiple fragments, this code extends
+        // the painting rect for the decoration types for which this matters to the origin. As
+        // the rectangle starts at the origin, all painted decorations will be in phase. As the
+        // clipping rectangle is left unchanged, the actual painted region remains the size of
+        // the original rectangle.
+        let expand_rect_for_text_decoration = |mut rect: Box2D<f32, LayoutPixel>| {
+            if matches!(
+                text_decoration.style,
+                ComputedTextDecorationStyle::Dotted |
+                    ComputedTextDecorationStyle::Dashed |
+                    ComputedTextDecorationStyle::Wavy,
+            ) {
+                rect.min.x = rect.min.x.min(0.0);
+            }
+            rect
+        };
 
         let common_properties = builder.common_properties(state, rect, parent_style);
         builder.wr().push_line(
             &common_properties,
-            &rect,
-            line_thickness,
+            &expand_rect_for_text_decoration(rect),
+            wavy_line_thickness,
             wr::LineOrientation::Horizontal,
             &rgba(text_decoration.color),
             text_decoration.style.to_webrender(),
@@ -1136,7 +1153,7 @@ impl Fragment {
             builder.wr().push_line(
                 &common_properties,
                 &rect,
-                line_thickness,
+                wavy_line_thickness,
                 wr::LineOrientation::Horizontal,
                 &rgba(text_decoration.color),
                 text_decoration.style.to_webrender(),

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -377,6 +377,19 @@
       {}
      ]
     ],
+    "text-decoration-continuity.html": [
+     "6178982a1b35c2d6e745ca02dcf73d58fd862a5c",
+     [
+      null,
+      [
+       [
+        "/_mozilla/appearance/text-decoration-continuity-ref.html",
+        "=="
+       ]
+      ],
+      {}
+     ]
+    ],
     "textarea-caret-following-linebreak-blank-line.html": [
      "c6cfb2563e8fa736bf85dcadb7d20e862a4b5d52",
      [
@@ -8445,6 +8458,10 @@
     },
     "text-advance-less-than-ink-clipping-ref.html": [
      "af9ec609b175040a66756fb6ce00d81a2e5707ec",
+     []
+    ],
+    "text-decoration-continuity-ref.html": [
+     "4aa04e8e28e7170955ac5b2844db3e5f73d865d2",
      []
     ],
     "textarea-caret-following-linebreak-blank-line-ref.html": [

--- a/tests/wpt/mozilla/tests/appearance/text-decoration-continuity-ref.html
+++ b/tests/wpt/mozilla/tests/appearance/text-decoration-continuity-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Text-decorations should be contiguous across inline box boundaries</title>
+    <link rel="author" title="Martin Robinson" href="mrobinson@igalia.com" />
+    <link rel="help" href="https://www.w3.org/TR/css-text-decor-4/#text-decoration-property" />
+    <style>
+      div {
+        font-size: 100px;
+      }
+      .test1 {
+        text-decoration: wavy red underline;
+      }
+      .test2 {
+        text-decoration: dotted red underline;
+      }
+      .test3 {
+        text-decoration: dashed red underline;
+      }
+    </style>
+  </head>
+  <body>
+    <div class=test1>foobarbaz</div>
+    <div class=test2>foobarbaz</div>
+    <div class=test3>foobarbaz</div>
+  </body>
+</html>

--- a/tests/wpt/mozilla/tests/appearance/text-decoration-continuity.html
+++ b/tests/wpt/mozilla/tests/appearance/text-decoration-continuity.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Text-decorations should be contiguous across inline box boundaries</title>
+    <link rel="author" title="Martin Robinson" href="mrobinson@igalia.com" />
+    <link rel="help" href="https://www.w3.org/TR/css-text-decor-4/#text-decoration-property" />
+    <link rel="match" href="text-decoration-continuity-ref.html"/>
+    <style>
+      div {
+        font-size: 100px;
+      }
+      .test1 {
+        text-decoration: wavy red underline;
+      }
+      .test2 {
+        text-decoration: dotted red underline;
+      }
+      .test3 {
+        text-decoration: dashed red underline;
+      }
+    </style>
+  </head>
+  <body>
+    <div class=test1>foo<span>bar</span>baz</div>
+    <div class=test2>foo<span>bar</span>baz</div>
+    <div class=test3>foo<span>bar</span>baz</div>
+  </body>
+</html>


### PR DESCRIPTION
When painting text decorations, the exact position of dots, dashes, and
waves depends on where their painting rectangles begin. For text runs
that are next to each other, this can mean that the individual pieces
of those decorations do not line up properly.

This change makes it so that the left edge of all decorations like this
starts at the origin. Even though the box itself is clipped to the
actual deocration painting area, the phase of all decorations on a line
is now the same.

Testing: This change adds a Servo-specific appearance test. WPT tests do
not really cover the exact appearance of text decorations.
