### PR TITLE
servoshell: Defaulting to a scheme with urls which specify a port

### DIFF
--- a/ports/servoshell/parser.rs
+++ b/ports/servoshell/parser.rs
@@ -42,6 +42,9 @@ pub fn get_default_url(
             ("file", None, Ok(ref path)) if exists(path) => {
                 new_url = cmdline_url;
             },
+            (domain, None, Err(_)) if is_not_normal_scheme(domain) => {
+                new_url = ServoUrl::parse(&format!("http://{}:{}", domain, &url.path())).ok();
+            },
             _ => {},
         }
     }
@@ -99,4 +102,14 @@ fn try_as_search_page(request: &str, searchpage: &str) -> Option<ServoUrl> {
         return None;
     }
     ServoUrl::parse(&searchpage.replace("%s", request)).ok()
+}
+
+fn is_not_normal_scheme(s: &str) -> bool {
+    s != "file" &&
+        s != "http" &&
+        s != "https" &&
+        s != "ws" &&
+        s != "wss" &&
+        s != "ftp" &&
+        s != "data"
 }

--- a/ports/servoshell/parser.rs
+++ b/ports/servoshell/parser.rs
@@ -42,8 +42,8 @@ pub fn get_default_url(
             ("file", None, Ok(ref path)) if exists(path) => {
                 new_url = cmdline_url;
             },
-            (domain, None, Err(_)) if is_not_normal_scheme(domain) => {
-                new_url = ServoUrl::parse(&format!("http://{}:{}", domain, &url.path())).ok();
+            (scheme, None, Err(_)) if !is_normal_scheme(scheme) => {
+                new_url = ServoUrl::parse(&format!("http://{}:{}", scheme, &url.path())).ok();
             },
             _ => {},
         }
@@ -71,11 +71,19 @@ pub fn get_default_url(
 /// interpret the string as a search term.
 pub(crate) fn location_bar_input_to_url(request: &str, searchpage: &str) -> Option<ServoUrl> {
     let request = request.trim();
-    ServoUrl::parse(request)
-        .ok()
-        .or_else(|| try_as_file(request))
-        .or_else(|| try_as_domain(request))
-        .or_else(|| try_as_search_page(request, searchpage))
+    let input_url = ServoUrl::parse(request).ok();
+    if let Some(url) = input_url {
+        match (url.scheme(), url.host(), url.to_file_path()) {
+            (scheme, None, Err(_)) if !is_normal_scheme(scheme) => {
+                ServoUrl::parse(&format!("http://{}:{}", scheme, &url.path())).ok()
+            },
+            _ => Some(url),
+        }
+    } else {
+        try_as_file(request)
+            .or_else(|| try_as_domain(request))
+            .or_else(|| try_as_search_page(request, searchpage))
+    }
 }
 
 fn try_as_file(request: &str) -> Option<ServoUrl> {
@@ -104,12 +112,12 @@ fn try_as_search_page(request: &str, searchpage: &str) -> Option<ServoUrl> {
     ServoUrl::parse(&searchpage.replace("%s", request)).ok()
 }
 
-fn is_not_normal_scheme(s: &str) -> bool {
-    s != "file" &&
-        s != "http" &&
-        s != "https" &&
-        s != "ws" &&
-        s != "wss" &&
-        s != "ftp" &&
-        s != "data"
+fn is_normal_scheme(s: &str) -> bool {
+    s == "file" ||
+        s == "http" ||
+        s == "https" ||
+        s == "ws" ||
+        s == "wss" ||
+        s == "ftp" ||
+        s == "data"
 }

--- a/ports/servoshell/test.rs
+++ b/ports/servoshell/test.rs
@@ -155,6 +155,12 @@ fn test_cmdline_and_location_bar_url() {
         "file:///fake/cwd/dragonfruit",
         "https://duckduckgo.com/html/?q=dragonfruit",
     );
+    test_url(
+        "localhost:80",
+        "http://localhost:80",
+        "file:///fake/cwd/localhost",
+        "http://localhost:80",
+    )
 }
 
 #[test]
@@ -208,6 +214,12 @@ fn test_cmdline_and_location_bar_url() {
         "file:///C:/fake/cwd/dragonfruit",
         "https://duckduckgo.com/html/?q=dragonfruit",
     );
+    test_url(
+        "localhost:80",
+        "http://localhost:80",
+        "file:///C:/fake/cwd/localhost",
+        "http://localhost:80",
+    )
 }
 
 #[cfg(target_os = "linux")]

--- a/ports/servoshell/test.rs
+++ b/ports/servoshell/test.rs
@@ -156,10 +156,10 @@ fn test_cmdline_and_location_bar_url() {
         "https://duckduckgo.com/html/?q=dragonfruit",
     );
     test_url(
-        "localhost:80",
-        "http://localhost:80",
-        "file:///fake/cwd/localhost",
-        "http://localhost:80",
+        "localhost:8000",
+        "http://localhost:8000/",
+        "http://localhost:8000/",
+        "http://localhost:8000/",
     )
 }
 
@@ -215,10 +215,10 @@ fn test_cmdline_and_location_bar_url() {
         "https://duckduckgo.com/html/?q=dragonfruit",
     );
     test_url(
-        "localhost:80",
-        "http://localhost:80",
-        "file:///C:/fake/cwd/localhost",
-        "http://localhost:80",
+        "localhost:8000",
+        "http://localhost:8000/",
+        "http://localhost:8000/",
+        "http://localhost:8000/",
     )
 }
 


### PR DESCRIPTION
When providing a url which has a port specified, the domain is considered as the scheme. The url is updated to have a `http` scheme.

Testing: New tests with port have been added.
Fixes: #45572
