### PR TITLE
mach: Fix ARM64 windows build using `mach.bat`

### DIFF
--- a/mach.bat
+++ b/mach.bat
@@ -2,7 +2,7 @@
 
 REM UV defaults to x86_64 Python on Arm64, so we need to override that.
 REM https://github.com/astral-sh/uv/issues/12906
-if "%PROCESSOR_ARCHITECTURE%"=="ARM64" ( set UV_PYTHON=arm64 )
+if "%PROCESSOR_ARCHITECTURE%"=="ARM64" ( set "UV_PYTHON=arm64" )
 
 set workdir=%~dp0
 uv run --frozen python %workdir%mach %*


### PR DESCRIPTION
Right now `./mach` on nushell on Windows immediately fails:

```
D:\servo> ./mach
warning: The `native-tls` setting is deprecated and will be removed in a future release. Use `system-certs` instead.
error: No interpreter found for executable name `arm64 ` in managed installations, search path, or registry
```

Apparently without the string syntax the command argument includes the following space too.

(Not sure we want to cover this in CI?)