### PR TITLE
android: Bump compile SDK to 37

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ For more detailed build instructions, see the Servo Book under [Getting the Code
    "emulator" \
    "ndk;28.2.13676358" \
    "platform-tools" \
-   "platforms;android-34" \
-   "system-images;android-34;google_apis;x86_64"
+   "platforms;android-37" \
+   "system-images;android-37;google_apis;x86_64"
   ```
 - Follow the instructions above for the platform you are building on
 

--- a/support/android/apk/servoapp/build.gradle.kts
+++ b/support/android/apk/servoapp/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 android {
-    compileSdk = 34
+    compileSdk = 37
     buildToolsVersion = "36.0.0"
 
     namespace = "org.servo.servoshell"

--- a/support/android/apk/servoview/build.gradle.kts
+++ b/support/android/apk/servoview/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 android {
-    compileSdk = 34
+    compileSdk = 37
     buildToolsVersion = "36.0.0"
 
     namespace = "org.servo.servoview"


### PR DESCRIPTION
This unblocks dependency upgrades, as some require compile SDKs later than 34. Since the compile SDK is only used for compilation, a successful compilation is enough to demonstrate that bumping the compile SDK is fine.

Testing: There are no automated tests for Android.