### PR TITLE
Fix SharedWorker partitioned reuse

### DIFF
--- a/components/script/dom/workers/sharedworker.rs
+++ b/components/script/dom/workers/sharedworker.rs
@@ -10,11 +10,13 @@ use devtools_traits::{DevtoolsPageInfo, ScriptToDevtoolsControlMsg, WorkerId};
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
+use malloc_size_of_derive::MallocSizeOf;
+use net_traits::pub_domains::reg_suffix;
 use net_traits::request::{CredentialsMode, Referrer};
 use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use servo_base::generic_channel;
 use servo_constellation_traits::{MessagePortImpl, WorkerScriptLoadOrigin};
-use servo_url::{ImmutableOrigin, ServoUrl};
+use servo_url::{Host, ImmutableOrigin, ServoUrl};
 use uuid::Uuid;
 
 use crate::conversions::Convert;
@@ -59,7 +61,7 @@ pub(crate) type TrustedSharedWorkerAddress = Trusted<SharedWorker>;
 /// Key used by the script-side SharedWorker registry.
 #[derive(Clone)]
 struct SharedWorkerKey {
-    storage_key: ImmutableOrigin,
+    storage_key: SharedWorkerStorageKey,
     constructor_origin: ImmutableOrigin,
     constructor_url: ServoUrl,
     name: String,
@@ -68,7 +70,7 @@ struct SharedWorkerKey {
 impl SharedWorkerKey {
     fn matches(
         &self,
-        storage_key: &ImmutableOrigin,
+        storage_key: &SharedWorkerStorageKey,
         constructor_origin: &ImmutableOrigin,
         constructor_url: &ServoUrl,
         name: &str,
@@ -77,6 +79,54 @@ impl SharedWorkerKey {
             self.constructor_origin == *constructor_origin &&
             self.constructor_url == *constructor_url &&
             self.name == name
+    }
+}
+
+#[derive(Clone, Eq, MallocSizeOf, PartialEq)]
+enum SharedWorkerSite {
+    Opaque(ImmutableOrigin),
+    Tuple { scheme: String, host: Host },
+}
+
+impl SharedWorkerSite {
+    /// <https://html.spec.whatwg.org/multipage/#obtain-a-site>
+    fn from_origin(origin: ImmutableOrigin) -> Self {
+        match origin {
+            // 1. If origin is an opaque origin, then return origin.
+            ImmutableOrigin::Opaque(_) => SharedWorkerSite::Opaque(origin),
+            // 3. Return (origin's scheme, origin's host's registrable domain).
+            ImmutableOrigin::Tuple(scheme, Host::Domain(domain), _) => SharedWorkerSite::Tuple {
+                scheme,
+                host: Host::Domain(reg_suffix(&domain).to_owned()),
+            },
+            // 2. If origin's host's registrable domain is null, then return
+            // (origin's scheme, origin's host).
+            ImmutableOrigin::Tuple(scheme, host, _) => SharedWorkerSite::Tuple { scheme, host },
+        }
+    }
+}
+
+#[derive(Clone, Eq, MallocSizeOf, PartialEq)]
+pub(crate) struct SharedWorkerStorageKey {
+    origin: ImmutableOrigin,
+    top_level_site: Option<SharedWorkerSite>,
+}
+
+impl SharedWorkerStorageKey {
+    /// <https://storage.spec.whatwg.org/#storage-key>
+    fn for_window(global: &GlobalScope, window: &Window) -> Self {
+        // A storage key is a tuple consisting of an origin (an origin).
+        // This is expected to change; see Client-Side Storage Partitioning.
+        let origin = global.obtain_storage_key_for_non_storage_purposes();
+
+        let top_level_site = window
+            .top_level_document_if_local()
+            .map(|document| SharedWorkerSite::from_origin(document.origin().immutable().clone()));
+
+        SharedWorkerStorageKey {
+            origin,
+            top_level_site,
+        }
     }
 }
 
@@ -404,7 +454,7 @@ impl SharedWorkerMethods<crate::DomTypeHolder> for SharedWorker {
         let caller_is_secure_context = global.is_secure_context();
         // Step 9. Let outsideStorageKey be the result of running obtain a storage
         // key for non-storage purposes given outsideSettings.
-        let outside_storage_key = global.obtain_storage_key_for_non_storage_purposes();
+        let outside_storage_key = SharedWorkerStorageKey::for_window(global, window);
 
         let worker_name_string = worker_name.to_string();
         let (control_sender, control_receiver) = unbounded();

--- a/components/script/dom/workers/sharedworkerglobalscope.rs
+++ b/components/script/dom/workers/sharedworkerglobalscope.rs
@@ -48,7 +48,7 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::html::htmlscriptelement::Script;
 use crate::dom::messageport::MessagePort;
-use crate::dom::sharedworker::{SharedWorker, TrustedSharedWorkerAddress};
+use crate::dom::sharedworker::{SharedWorker, SharedWorkerStorageKey, TrustedSharedWorkerAddress};
 use crate::dom::types::DebuggerGlobalScope;
 #[cfg(feature = "webgpu")]
 use crate::dom::webgpu::identityhub::IdentityHub;
@@ -62,7 +62,6 @@ use crate::task_source::TaskSourceName;
 
 pub(crate) enum SharedWorkerScriptMsg {
     CommonWorker(WorkerScriptMsg),
-    #[allow(dead_code)]
     Connect(MessagePortImpl),
     WakeUp,
 }
@@ -168,7 +167,7 @@ pub(crate) struct SharedWorkerGlobalScope {
     debugger_global: Dom<DebuggerGlobalScope>,
     // A `SharedWorkerGlobalScope` object has associated constructor origin (an origin), constructor URL (a URL record), and credentials (a credentials mode), and extended lifetime (a boolean).
     #[no_trace]
-    storage_key: ImmutableOrigin,
+    storage_key: SharedWorkerStorageKey,
     #[no_trace]
     constructor_origin: ImmutableOrigin,
     #[no_trace]
@@ -223,7 +222,6 @@ impl WorkerEventLoopMethods for SharedWorkerGlobalScope {
 
 impl SharedWorkerGlobalScope {
     #[allow(clippy::too_many_arguments)]
-    #[allow(dead_code)]
     fn new_inherited(
         init: WorkerGlobalScopeInit,
         worker_name: DOMString,
@@ -241,7 +239,7 @@ impl SharedWorkerGlobalScope {
         insecure_requests_policy: InsecureRequestsPolicy,
         font_context: Option<Arc<FontContext>>,
         debugger_global: &DebuggerGlobalScope,
-        storage_key: ImmutableOrigin,
+        storage_key: SharedWorkerStorageKey,
         constructor_origin: ImmutableOrigin,
         constructor_url: ServoUrl,
         credentials: CredentialsMode,
@@ -279,7 +277,6 @@ impl SharedWorkerGlobalScope {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[allow(dead_code)]
     pub(crate) fn new(
         init: WorkerGlobalScopeInit,
         worker_name: DOMString,
@@ -297,7 +294,7 @@ impl SharedWorkerGlobalScope {
         insecure_requests_policy: InsecureRequestsPolicy,
         font_context: Option<Arc<FontContext>>,
         debugger_global: &DebuggerGlobalScope,
-        storage_key: ImmutableOrigin,
+        storage_key: SharedWorkerStorageKey,
         constructor_origin: ImmutableOrigin,
         constructor_url: ServoUrl,
         credentials: CredentialsMode,
@@ -335,7 +332,6 @@ impl SharedWorkerGlobalScope {
 
     /// <https://html.spec.whatwg.org/multipage/#run-a-worker>
     #[expect(unsafe_code)]
-    #[allow(dead_code)]
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn run_shared_worker_scope(
         mut init: WorkerGlobalScopeInit,
@@ -358,7 +354,7 @@ impl SharedWorkerGlobalScope {
         extended_lifetime: bool,
         constructor_origin: ImmutableOrigin,
         constructor_url: ServoUrl,
-        storage_key: ImmutableOrigin,
+        storage_key: SharedWorkerStorageKey,
         insecure_requests_policy: InsecureRequestsPolicy,
         policy_container: PolicyContainer,
         font_context: Option<Arc<FontContext>>,

--- a/tests/wpt/meta/workers/SharedWorker-constructor.html.ini
+++ b/tests/wpt/meta/workers/SharedWorker-constructor.html.ini
@@ -1,1 +1,5 @@
 prefs: [dom_sharedworker_enabled: true]
+
+[SharedWorker-constructor.html]
+  [Test recursive worker creation results in exception.]
+    expected: FAIL

--- a/tests/wpt/meta/workers/SharedWorker-constructor.html.ini
+++ b/tests/wpt/meta/workers/SharedWorker-constructor.html.ini
@@ -1,5 +1,1 @@
 prefs: [dom_sharedworker_enabled: true]
-
-[SharedWorker-constructor.html]
-  [Test recursive worker creation results in exception.]
-    expected: FAIL

--- a/tests/wpt/meta/workers/shared-worker-partitioned.tentative.html.ini
+++ b/tests/wpt/meta/workers/shared-worker-partitioned.tentative.html.ini
@@ -1,3 +1,1 @@
-[shared-worker-partitioned.tentative.html]
-  [Test partitioning of shared workers]
-    expected: FAIL
+prefs: [dom_sharedworker_enabled: true]


### PR DESCRIPTION
SharedWorkers from different top-level sites should not share the same worker,
even when they use the same URL and name.

Testing: shared-worker-partitioned.tentative.html pass..

part of https://github.com/servo/servo/issues/7458
