### PR TITLE
script: Do not skip unfocusable elements when targeting `click` events

### DIFF
--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -1110,15 +1110,8 @@ impl DocumentEventHandler {
         // From <https://w3c.github.io/pointerevents/#click>
         // > The click event type MUST be dispatched on the topmost event target indicated by the
         // > pointer, when the user presses down and releases the primary pointer button.
-        //
-        // For nodes inside a text input UA shadow DOM, dispatch dblclick at the shadow host.
-        // TODO: This should likely be handled via event retargeting.
-        let element = match hit_test_result.node.find_click_focusable_area() {
-            FocusableArea::Node { node, .. } => DomRoot::downcast::<Element>(node),
-            _ => None,
-        }
-        .unwrap_or_else(|| DomRoot::from_ref(element));
-        self.most_recently_clicked_element.set(Some(&*element));
+        let element = &element.inclusive_ancestor_element_in_non_ua_shadow_root();
+        self.most_recently_clicked_element.set(Some(element));
 
         let click_count = self.click_counting_info.borrow().count;
         element.set_click_in_progress(true);
@@ -3016,4 +3009,19 @@ pub(crate) fn character_to_code(character: char) -> Option<Code> {
         ' ' => Code::Space,
         _ => return None,
     })
+}
+
+impl Element {
+    /// Find the first inclusive ancestor of this [`Element`] that is not in a UA shadow root.
+    fn inclusive_ancestor_element_in_non_ua_shadow_root(&self) -> DomRoot<Element> {
+        if !self.upcast::<Node>().is_in_ua_widget() {
+            return DomRoot::from_ref(self);
+        }
+        let Some(shadow_root) = self.containing_shadow_root() else {
+            return DomRoot::from_ref(self);
+        };
+        shadow_root
+            .Host()
+            .inclusive_ancestor_element_in_non_ua_shadow_root()
+    }
 }

--- a/tests/wpt/meta/html/semantics/interactive-elements/the-summary-element/interactive-content.html.ini
+++ b/tests/wpt/meta/html/semantics/interactive-elements/the-summary-element/interactive-content.html.ini
@@ -61,6 +61,3 @@
 
   [Clicking a <video> doesn't open <details>]
     expected: FAIL
-
-  [Clicking a <label> doesn't open <details>]
-    expected: FAIL


### PR DESCRIPTION
Instead of using a focusable element as the target of a `click` event,
simply retarget outside of UA widget shadow trees. This prevents `click`
events from wrongly skipping non-focusable elements when they have a
focusable ancestor.

Testing: This causes a WPT subtest to pass.
Fixes: #45067.
