### PR TITLE
script: Trigger restyle when attribute referenced by `attr()` changes

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -4112,7 +4112,14 @@ impl Document {
             entry.hint.insert(RestyleHint::RESTYLE_STYLE_ATTRIBUTE);
         }
 
-        if vtable_for(el.upcast()).attribute_affects_presentational_hints(attr) {
+        if vtable_for(el.upcast()).attribute_affects_presentational_hints(attr) ||
+            el.check_style_on_self_or_eager_pseudos(|style| {
+                if let Some(ref attribute_references) = style.attribute_references {
+                    return attribute_references.contains_key(attr.local_name());
+                }
+                false
+            })
+        {
             entry.hint.insert(RestyleHint::RESTYLE_SELF);
         }
 

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -1019,6 +1019,23 @@ impl Element {
                 .is_none()
         })
     }
+
+    pub(crate) fn check_style_on_self_or_eager_pseudos(
+        &self,
+        check_styles_fn: impl Fn(&ComputedValues) -> bool,
+    ) -> bool {
+        let style_data = self.style_data.borrow();
+        let Some(data) = style_data.as_ref().map(|data| data.element_data.borrow()) else {
+            return false;
+        };
+
+        if check_styles_fn(data.styles.primary()) {
+            return true;
+        }
+
+        let mut pseudo_styles = data.styles.pseudos.as_array().iter();
+        pseudo_styles.any(|style| style.as_deref().is_some_and(&check_styles_fn))
+    }
 }
 
 /// <https://dom.spec.whatwg.org/#valid-shadow-host-name>

--- a/tests/wpt/meta/css/css-values/attr-invalidation.html.ini
+++ b/tests/wpt/meta/css/css-values/attr-invalidation.html.ini
@@ -1,3 +1,0 @@
-[attr-invalidation.html]
-  [CSS Values and Units Test: attr() invalidation]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-values/attr-null-namespace.xhtml.ini
+++ b/tests/wpt/meta/css/css-values/attr-null-namespace.xhtml.ini
@@ -4,6 +4,3 @@
 
   [Attribute in null-namespace is substituted]
     expected: FAIL
-
-  [Attribute in null-namespace is substituted (JS)]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-values/attr-pseudo-elem-invalidation-2.html.ini
+++ b/tests/wpt/meta/css/css-values/attr-pseudo-elem-invalidation-2.html.ini
@@ -1,10 +1,4 @@
 [attr-pseudo-elem-invalidation-2.html]
-  [CSS Values and Units Test: attr() invalidation of pseudo elements]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr() invalidation of pseudo elements 1]
-    expected: FAIL
-
   [CSS Values and Units Test: attr() invalidation of pseudo elements 2]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-values/attr-pseudo-element-originating.html.ini
+++ b/tests/wpt/meta/css/css-values/attr-pseudo-element-originating.html.ini
@@ -13,6 +13,3 @@
 
   [::part() attr() invalidation across exportparts]
     expected: FAIL
-
-  [::slotted() attr() invalidation on the slotted element]
-    expected: FAIL


### PR DESCRIPTION
When `layout_css_attr_enabled` is enabled, arbitrary CSS properties can use `attr()` to refer to the value of an attribute. Therefore, when the attribute that has such a reference changes its value, a restyle is needed.

Testing: 4 tests improve