### PR TITLE
devtools: Fix console exception test being flaky

### DIFF
--- a/python/servo/devtools_tests/test_console_tab.py
+++ b/python/servo/devtools_tests/test_console_tab.py
@@ -17,24 +17,6 @@ from geckordp.actors.web_console import WebConsoleActor
 from .utils import Devtools
 
 
-def evaluate(js: str, timeout: float = 1) -> dict:
-    with Devtools.connect() as devtools:
-        console = WebConsoleActor(devtools.client, devtools.targets[0]["consoleActor"])
-        evaluation_result = Future()
-        result_id = ""
-
-        def on_evaluation(data):
-            assert result_id == data["resultID"]
-            evaluation_result.set_result(data)
-
-        devtools.client.add_event_listener(console.actor_id, Events.WebConsole.EVALUATION_RESULT, on_evaluation)
-
-        evaluation_result = Future()
-        result = console.evaluate_js_async(js)
-        result_id = result["resultID"]
-        return evaluation_result.result(timeout)
-
-
 def evaluate_and_capture_console_log_output(js: str, timeout: float = 1) -> dict:
     with Devtools.connect() as devtools:
         devtools.watcher.watch_resources([Resources.CONSOLE_MESSAGE])
@@ -181,7 +163,18 @@ class TestConsoleTab:
     def test_console_throw_exception(self, run_servoshell):
         run_servoshell(url="data:text/html,")
 
-        result = evaluate("document.head.insertBefore(document.documentElement);")
-        assert not result["result"]
-        assert result["exception"]
-        assert "Not enough arguments" in result["exceptionMessage"]
+        with Devtools.connect() as devtools:
+            console = WebConsoleActor(devtools.client, devtools.targets[0]["consoleActor"])
+            evaluation_result = Future()
+
+            def on_evaluation(data):
+                evaluation_result.set_result(data)
+
+            devtools.client.add_event_listener(console.actor_id, Events.WebConsole.EVALUATION_RESULT, on_evaluation)
+
+            console.evaluate_js_async("document.head.insertBefore(document.documentElement);")
+            result = evaluation_result.result(1)
+
+            assert not result["result"]
+            assert result["exception"]
+            assert "Not enough arguments" in result["exceptionMessage"]


### PR DESCRIPTION
Before we were overwriting the `evaluation_result` future. Additionally, when checking that the `result_id` matched the evaluation result, there was a race condition where the event could fire before we set `result_id`.

Now we removed the check from `on_evaluation`, as there should only be one result anyways in this test. Also, since this test is the only one that used the `evaluate` function, it is now inlined in the test. If we have this pattern more times we can split it again.

Testing: Changes to existing test, `test_console_throw_exception`.
