### PR TITLE
servoshell: Make tabs not scrollable on OpenHarmony

### DIFF
--- a/support/openharmony/entry/src/main/ets/pages/Index.ets
+++ b/support/openharmony/entry/src/main/ets/pages/Index.ets
@@ -125,6 +125,7 @@ struct Index {
           }.tabBar(this.tabBuilder(String(item), index))
         })
       }.barHeight(40)
+      .scrollable(false)
       .onChange((index: number) => {
         this.currentIndex = index;
         servoshell.focusWebview(index, this.tablist);


### PR DESCRIPTION
Disable being able to scroll between tabs on ohos, since that causes problems when web-content also reacts to touch events, e.g. when playing a game. You can still switch between tabs via the tab bar at the top, so this change should lead to more expected behavior.

Testing: ohos servoshell UI is not tested in CI. 

