### PR TITLE
script: Use children_unrooted in node insert

### DIFF
--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -2499,7 +2499,10 @@ impl Node {
         // Step 1. Let nodes be node’s children, if node is a DocumentFragment node; otherwise « node ».
         rooted_vec!(let mut new_nodes);
         let new_nodes = if let NodeTypeId::DocumentFragment(_) = node.type_id() {
-            new_nodes.extend(node.children().map(|node| Dom::from_ref(&*node)));
+            new_nodes.extend(
+                node.children_unrooted(cx.no_gc())
+                    .map(|node| Dom::from_ref(&**node)),
+            );
             new_nodes.r()
         } else {
             from_ref(&node)


### PR DESCRIPTION
This uses the children_unrooted function in Node::insert instead of the rooted version, saving us roughly 0.6% (in ScriptThread) on a a sample run of github. As these elements are anyway "not rooted" via the rooted vector, this does not change functionality.

Testing: Does not change functionality.
