### PR TITLE
script: Implement some of the dialog focusing steps

### DIFF
--- a/components/script/dom/element/focus.rs
+++ b/components/script/dom/element/focus.rs
@@ -80,7 +80,8 @@ impl Element {
         // > ...
         // > Modulo platform conventions, it is suggested that the following elements should be
         // > considered as focusable areas and be sequentially focusable:
-        let is_focusable_area_due_to_type = match node.type_id() {
+        let type_id = node.type_id();
+        let is_focusable_area_due_to_type = match type_id {
             // >  - a elements that have an href attribute
             NodeTypeId::Element(ElementTypeId::HTMLElement(
                 HTMLElementTypeId::HTMLAnchorElement,
@@ -93,14 +94,12 @@ impl Element {
             // >  - Navigable containers
             //
             // Note: the `hidden` attribute is checked above for all elements.
-            // Note: Other browsers allow dialog elements to be focused.
             NodeTypeId::Element(ElementTypeId::HTMLElement(
                 HTMLElementTypeId::HTMLInputElement |
                 HTMLElementTypeId::HTMLButtonElement |
                 HTMLElementTypeId::HTMLSelectElement |
                 HTMLElementTypeId::HTMLTextAreaElement |
-                HTMLElementTypeId::HTMLIFrameElement |
-                HTMLElementTypeId::HTMLDialogElement,
+                HTMLElementTypeId::HTMLIFrameElement,
             )) => true,
             _ => {
                 // >  - summary elements that are the first summary element child of a details element
@@ -138,7 +137,14 @@ impl Element {
             return FocusableAreaKind::Sequential;
         }
 
-        Default::default()
+        // > Any other element or part of an element determined by the user agent to be a focusable
+        // > area, especially to aid with accessibility or to better match platform conventions.
+        match type_id {
+            NodeTypeId::Element(ElementTypeId::HTMLElement(
+                HTMLElementTypeId::HTMLDialogElement,
+            )) => FocusableAreaKind::Click,
+            _ => Default::default(),
+        }
     }
 
     /// <https://html.spec.whatwg.org/multipage/#sequentially-focusable>.

--- a/components/script/dom/element/focus.rs
+++ b/components/script/dom/element/focus.rs
@@ -93,12 +93,14 @@ impl Element {
             // >  - Navigable containers
             //
             // Note: the `hidden` attribute is checked above for all elements.
+            // Note: Other browsers allow dialog elements to be focused.
             NodeTypeId::Element(ElementTypeId::HTMLElement(
                 HTMLElementTypeId::HTMLInputElement |
                 HTMLElementTypeId::HTMLButtonElement |
                 HTMLElementTypeId::HTMLSelectElement |
                 HTMLElementTypeId::HTMLTextAreaElement |
-                HTMLElementTypeId::HTMLIFrameElement,
+                HTMLElementTypeId::HTMLIFrameElement |
+                HTMLElementTypeId::HTMLDialogElement,
             )) => true,
             _ => {
                 // >  - summary elements that are the first summary element child of a details element

--- a/components/script/dom/html/htmldialogelement.rs
+++ b/components/script/dom/html/htmldialogelement.rs
@@ -8,6 +8,7 @@ use html5ever::{LocalName, Prefix, local_name, ns};
 use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
+use script_bindings::codegen::GenericBindings::HTMLElementBinding::HTMLElementMethods;
 use script_bindings::error::{Error, ErrorResult};
 use stylo_dom::ElementState;
 
@@ -17,6 +18,7 @@ use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
+use crate::dom::document::focus::FocusableArea;
 use crate::dom::element::Element;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
@@ -155,7 +157,8 @@ impl HTMLDialogElement {
 
         // TODO: Step 21. Run hide all popovers until given hideUntil, false, and true.
 
-        // TODO(Issue #32702): Step 22. Run the dialog focusing steps given subject.
+        // Step 22. Run the dialog focusing steps given subject.
+        self.run_dialog_focusing_steps(cx);
         Ok(())
     }
 
@@ -275,6 +278,41 @@ impl HTMLDialogElement {
             }));
         // TODO: Step 3. Set element's dialog toggle task tracker to a struct with task set to the just-queued task and old state set to oldState.
     }
+
+    /// <https://html.spec.whatwg.org/multipage/#dialog-focusing-steps>
+    fn run_dialog_focusing_steps(&self, cx: &mut JSContext) {
+        // TODO: Step 1. If the allow focus steps given subject's node document return false, then return.
+
+        // Step 2. Let control be null.
+        let mut control: Option<FocusableArea> = None;
+
+        // Step 3. If subject has the autofocus attribute, then set control to subject.
+        if self.upcast::<HTMLElement>().Autofocus() {
+            control = self.upcast::<Node>().get_the_focusable_area();
+        }
+
+        // Step 4. If control is null, then set control to the focus delegate of subject.
+        if control.is_none() {
+            control = self.upcast::<Node>().focus_delegate();
+        }
+
+        // Step 5. If control is null, then set control to subject.
+        if control.is_none() {
+            control = self.upcast::<Node>().get_the_focusable_area();
+        }
+
+        // Step 6. Run the focusing steps for control.
+        // FIXME: Use the focusing step once they support a focusable area as an argument
+        if let Some(control) = control {
+            let document = self.owner_document();
+            document.focus_handler().focus(cx, control);
+        }
+
+        // TODO: Step 7. Let topDocument be control's node navigable's top-level traversable's active document.
+        // TODO: Step 8. If control's node document's origin is not the same as the origin of topDocument, then return.
+        // TODO: Step 9. Empty topDocument's autofocus candidates.
+        // TODO: Step 10. Set topDocument's autofocus processed flag to true.
+    }
 }
 
 impl HTMLDialogElementMethods<crate::DomTypeHolder> for HTMLDialogElement {
@@ -352,8 +390,8 @@ impl HTMLDialogElementMethods<crate::DomTypeHolder> for HTMLDialogElement {
 
         // TODO: Step 12. Run hide all popovers until given hideUntil, false, and true.
 
-        // TODO(Issue #32702): Step 13. Run the dialog focusing steps given this.
-
+        // Step 13. Run the dialog focusing steps given this.
+        self.run_dialog_focusing_steps(cx);
         Ok(())
     }
 

--- a/components/script/dom/html/htmldialogelement.rs
+++ b/components/script/dom/html/htmldialogelement.rs
@@ -18,7 +18,6 @@ use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
-use crate::dom::document::focus::FocusableArea;
 use crate::dom::element::Element;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;

--- a/components/script/dom/html/htmldialogelement.rs
+++ b/components/script/dom/html/htmldialogelement.rs
@@ -284,7 +284,7 @@ impl HTMLDialogElement {
         // TODO: Step 1. If the allow focus steps given subject's node document return false, then return.
 
         // Step 2. Let control be null.
-        let mut control: Option<FocusableArea> = None;
+        let mut control = None;
 
         // Step 3. If subject has the autofocus attribute, then set control to subject.
         if self.upcast::<HTMLElement>().Autofocus() {

--- a/components/script/dom/node/focus.rs
+++ b/components/script/dom/node/focus.rs
@@ -213,7 +213,7 @@ impl Node {
     ///
     /// In addition to returning the focus delegate for this [`Node`], this method also returns
     /// the [`FocusableAreaKind`] for efficiency reasons.
-    fn focus_delegate(&self) -> Option<FocusableArea> {
+    pub(crate) fn focus_delegate(&self) -> Option<FocusableArea> {
         // > 1. If focusTarget is a shadow host and its shadow root's delegates focus is false, then
         // >    return null.
         let shadow_root = self.downcast::<Element>().and_then(Element::shadow_root);

--- a/tests/wpt/meta/focus/nested-focus-within-iframe-focus-event.html.ini
+++ b/tests/wpt/meta/focus/nested-focus-within-iframe-focus-event.html.ini
@@ -1,4 +1,0 @@
-[nested-focus-within-iframe-focus-event.html]
-  expected: ERROR
-  [dialog.focus() in navigable's focus handler]
-    expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/child-sequential-focus.html.ini
+++ b/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/child-sequential-focus.html.ini
@@ -1,7 +1,4 @@
 [child-sequential-focus.html]
-  [dialog element with autofocus should get initial focus.]
-    expected: FAIL
-
   [Only keyboard-focusable elements should get dialog initial focus.]
     expected: FAIL
 

--- a/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/dialog-cancel-with-select.html.ini
+++ b/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/dialog-cancel-with-select.html.ini
@@ -1,3 +1,4 @@
 [dialog-cancel-with-select.html]
+  expected: TIMEOUT
   [Test dialog modal is closed by escape key with select focused]
-    expected: FAIL
+    expected: NOTRUN

--- a/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/dialog-focus-shadow.html.ini
+++ b/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/dialog-focus-shadow.html.ini
@@ -8,49 +8,25 @@
   [show: No autofocus, no delegatesFocus, sibling before]
     expected: FAIL
 
-  [showModal: No autofocus, no delegatesFocus, sibling before]
-    expected: FAIL
-
   [show: No autofocus, no delegatesFocus, sibling after]
-    expected: FAIL
-
-  [showModal: No autofocus, no delegatesFocus, sibling after]
     expected: FAIL
 
   [show: No autofocus, yes delegatesFocus, no siblings]
     expected: FAIL
 
-  [showModal: No autofocus, yes delegatesFocus, no siblings]
-    expected: FAIL
-
   [show: No autofocus, yes delegatesFocus, sibling before]
-    expected: FAIL
-
-  [showModal: No autofocus, yes delegatesFocus, sibling before]
     expected: FAIL
 
   [show: No autofocus, yes delegatesFocus, sibling after]
     expected: FAIL
 
-  [showModal: No autofocus, yes delegatesFocus, sibling after]
-    expected: FAIL
-
   [show: Autofocus before, no delegatesFocus]
-    expected: FAIL
-
-  [showModal: Autofocus before, no delegatesFocus]
     expected: FAIL
 
   [show: Autofocus before, yes delegatesFocus]
     expected: FAIL
 
-  [showModal: Autofocus before, yes delegatesFocus]
-    expected: FAIL
-
   [show: Autofocus after, no delegatesFocus]
-    expected: FAIL
-
-  [showModal: Autofocus after, no delegatesFocus]
     expected: FAIL
 
   [show: Autofocus after, yes delegatesFocus]
@@ -62,9 +38,6 @@
   [show: Autofocus on shadow host, yes delegatesFocus, no siblings]
     expected: FAIL
 
-  [showModal: Autofocus on shadow host, yes delegatesFocus, no siblings]
-    expected: FAIL
-
   [show: Autofocus on shadow host, yes delegatesFocus, sibling before]
     expected: FAIL
 
@@ -72,9 +45,6 @@
     expected: FAIL
 
   [show: Autofocus on shadow host, yes delegatesFocus, sibling after]
-    expected: FAIL
-
-  [showModal: Autofocus on shadow host, yes delegatesFocus, sibling after]
     expected: FAIL
 
   [show: Autofocus on shadow host, no delegatesFocus, no siblings]
@@ -86,13 +56,7 @@
   [show: Autofocus on shadow host, no delegatesFocus, sibling before]
     expected: FAIL
 
-  [showModal: Autofocus on shadow host, no delegatesFocus, sibling before]
-    expected: FAIL
-
   [show: Autofocus on shadow host, no delegatesFocus, sibling after]
-    expected: FAIL
-
-  [showModal: Autofocus on shadow host, no delegatesFocus, sibling after]
     expected: FAIL
 
   [show: Autofocus inside shadow tree, yes delegatesFocus, no siblings]
@@ -102,9 +66,6 @@
     expected: FAIL
 
   [show: Autofocus inside shadow tree, yes delegatesFocus, sibling before]
-    expected: FAIL
-
-  [showModal: Autofocus inside shadow tree, yes delegatesFocus, sibling before]
     expected: FAIL
 
   [show: Autofocus inside shadow tree, yes delegatesFocus, sibling after]
@@ -122,29 +83,14 @@
   [show: Autofocus inside shadow tree, no delegatesFocus, sibling before]
     expected: FAIL
 
-  [showModal: Autofocus inside shadow tree, no delegatesFocus, sibling before]
-    expected: FAIL
-
   [show: Autofocus inside shadow tree, no delegatesFocus, sibling after]
-    expected: FAIL
-
-  [showModal: Autofocus inside shadow tree, no delegatesFocus, sibling after]
     expected: FAIL
 
   [show: Two shadow trees, both delegatesFocus, first tree doesn't have autofocus element, second does]
     expected: FAIL
 
-  [showModal: Two shadow trees, both delegatesFocus, first tree doesn't have autofocus element, second does]
-    expected: FAIL
-
   [show: No autofocus, no delegatesFocus, slotted target]
     expected: FAIL
 
-  [showModal: No autofocus, no delegatesFocus, slotted target]
-    expected: FAIL
-
   [show: Shadowroot on child, no autofocus, no delegatesFocus]
-    expected: FAIL
-
-  [showModal: Shadowroot on child, no autofocus, no delegatesFocus]
     expected: FAIL

--- a/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/dialog-focus-shadow.html.ini
+++ b/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/dialog-focus-shadow.html.ini
@@ -1,10 +1,4 @@
 [dialog-focus-shadow.html]
-  [show: No autofocus, no delegatesFocus, no siblings]
-    expected: FAIL
-
-  [showModal: No autofocus, no delegatesFocus, no siblings]
-    expected: FAIL
-
   [show: Autofocus after, yes delegatesFocus]
     expected: FAIL
 
@@ -17,12 +11,6 @@
   [showModal: Autofocus on shadow host, yes delegatesFocus, sibling before]
     expected: FAIL
 
-  [show: Autofocus on shadow host, no delegatesFocus, no siblings]
-    expected: FAIL
-
-  [showModal: Autofocus on shadow host, no delegatesFocus, no siblings]
-    expected: FAIL
-
   [show: Autofocus inside shadow tree, yes delegatesFocus, no siblings]
     expected: FAIL
 
@@ -33,10 +21,4 @@
     expected: FAIL
 
   [showModal: Autofocus inside shadow tree, yes delegatesFocus, sibling after]
-    expected: FAIL
-
-  [show: Autofocus inside shadow tree, no delegatesFocus, no siblings]
-    expected: FAIL
-
-  [showModal: Autofocus inside shadow tree, no delegatesFocus, no siblings]
     expected: FAIL

--- a/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/dialog-focus-shadow.html.ini
+++ b/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/dialog-focus-shadow.html.ini
@@ -5,37 +5,10 @@
   [showModal: No autofocus, no delegatesFocus, no siblings]
     expected: FAIL
 
-  [show: No autofocus, no delegatesFocus, sibling before]
-    expected: FAIL
-
-  [show: No autofocus, no delegatesFocus, sibling after]
-    expected: FAIL
-
-  [show: No autofocus, yes delegatesFocus, no siblings]
-    expected: FAIL
-
-  [show: No autofocus, yes delegatesFocus, sibling before]
-    expected: FAIL
-
-  [show: No autofocus, yes delegatesFocus, sibling after]
-    expected: FAIL
-
-  [show: Autofocus before, no delegatesFocus]
-    expected: FAIL
-
-  [show: Autofocus before, yes delegatesFocus]
-    expected: FAIL
-
-  [show: Autofocus after, no delegatesFocus]
-    expected: FAIL
-
   [show: Autofocus after, yes delegatesFocus]
     expected: FAIL
 
   [showModal: Autofocus after, yes delegatesFocus]
-    expected: FAIL
-
-  [show: Autofocus on shadow host, yes delegatesFocus, no siblings]
     expected: FAIL
 
   [show: Autofocus on shadow host, yes delegatesFocus, sibling before]
@@ -44,28 +17,16 @@
   [showModal: Autofocus on shadow host, yes delegatesFocus, sibling before]
     expected: FAIL
 
-  [show: Autofocus on shadow host, yes delegatesFocus, sibling after]
-    expected: FAIL
-
   [show: Autofocus on shadow host, no delegatesFocus, no siblings]
     expected: FAIL
 
   [showModal: Autofocus on shadow host, no delegatesFocus, no siblings]
     expected: FAIL
 
-  [show: Autofocus on shadow host, no delegatesFocus, sibling before]
-    expected: FAIL
-
-  [show: Autofocus on shadow host, no delegatesFocus, sibling after]
-    expected: FAIL
-
   [show: Autofocus inside shadow tree, yes delegatesFocus, no siblings]
     expected: FAIL
 
   [showModal: Autofocus inside shadow tree, yes delegatesFocus, no siblings]
-    expected: FAIL
-
-  [show: Autofocus inside shadow tree, yes delegatesFocus, sibling before]
     expected: FAIL
 
   [show: Autofocus inside shadow tree, yes delegatesFocus, sibling after]
@@ -78,19 +39,4 @@
     expected: FAIL
 
   [showModal: Autofocus inside shadow tree, no delegatesFocus, no siblings]
-    expected: FAIL
-
-  [show: Autofocus inside shadow tree, no delegatesFocus, sibling before]
-    expected: FAIL
-
-  [show: Autofocus inside shadow tree, no delegatesFocus, sibling after]
-    expected: FAIL
-
-  [show: Two shadow trees, both delegatesFocus, first tree doesn't have autofocus element, second does]
-    expected: FAIL
-
-  [show: No autofocus, no delegatesFocus, slotted target]
-    expected: FAIL
-
-  [show: Shadowroot on child, no autofocus, no delegatesFocus]
     expected: FAIL

--- a/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/dialog-focusability.html.ini
+++ b/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/dialog-focusability.html.ini
@@ -1,0 +1,3 @@
+[dialog-focusability.html]
+  [The dialog element itself should not be keyboard focusable.]
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/dialog-focusability.html.ini
+++ b/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/dialog-focusability.html.ini
@@ -1,3 +1,0 @@
-[dialog-focusability.html]
-  [The dialog element itself should not be keyboard focusable.]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/dialog-focusing-steps-inert.html.ini
+++ b/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/dialog-focusing-steps-inert.html.ini
@@ -1,3 +1,6 @@
 [dialog-focusing-steps-inert.html]
   [dialog.showModal(): focusing steps should apply focus fixup rule when dialog is inert]
     expected: FAIL
+
+  [dialog.show(): focusing steps should not change focus when dialog is inert]
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/dialog-showModal.html.ini
+++ b/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/dialog-showModal.html.ini
@@ -1,7 +1,4 @@
 [dialog-showModal.html]
-  [opening dialog without focusable children]
-    expected: FAIL
-
   [opening dialog with multiple focusable children, one having the autofocus attribute]
     expected: FAIL
 

--- a/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/dialog-showModal.html.ini
+++ b/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/dialog-showModal.html.ini
@@ -1,11 +1,5 @@
 [dialog-showModal.html]
-  [dialog element: showModal()]
-    expected: FAIL
-
   [opening dialog without focusable children]
-    expected: FAIL
-
-  [opening dialog with multiple focusable children]
     expected: FAIL
 
   [opening dialog with multiple focusable children, one having the autofocus attribute]

--- a/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/focus-after-close.html.ini
+++ b/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/focus-after-close.html.ini
@@ -7,3 +7,15 @@
 
   [Focus should be moved to the previously focused element even if it has moved to shadow DOM root in between show/close]
     expected: FAIL
+
+  [Focus should be moved to the previously focused element (Simple dialog usage)]
+    expected: FAIL
+
+  [Focus should be moved to the body if the previously focused element is removed]
+    expected: FAIL
+
+  [Focus should be moved to the shadow DOM host if the previouly focused element is a shadow DOM node]
+    expected: FAIL
+
+  [Focus should not scroll if the previously focused element is outside the viewport]
+    expected: FAIL


### PR DESCRIPTION
This implements the most important dialog focusing steps in order to focus the correct element when a dialog is opened. It also makes the `dialog` element click focusable, so that it can be properly focused.

The remaining steps require [autofocus candidates](https://html.spec.whatwg.org/multipage/interaction.html#autofocus-candidates) to be implemented.

Testing: Passes additional web platform tests, but causes some failures for tests requiring the focus to be returned to the original element after the dialog is closed.
Fixes: #32702
