### PR TITLE
script: Run insert validations steps separately when inserting from the parser

### DIFF
--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -240,7 +240,7 @@ bitflags! {
 /// <https://dom.spec.whatwg.org/#concept-node-insert>
 /// <https://dom.spec.whatwg.org/#concept-node-remove>
 #[derive(Clone, Copy, MallocSizeOf)]
-pub(super) enum SuppressObserver {
+pub(crate) enum SuppressObserver {
     Suppressed,
     Unsuppressed,
 }
@@ -2487,7 +2487,7 @@ impl Node {
     }
 
     /// <https://dom.spec.whatwg.org/#concept-node-insert>
-    pub(super) fn insert(
+    pub(crate) fn insert(
         cx: &mut JSContext,
         node: &Node,
         parent: &Node,

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -45,6 +45,7 @@ use tendril::stream::LossyDecoder;
 use tendril::{ByteTendril, TendrilSink};
 
 use crate::document_loader::{DocumentLoader, LoadType};
+use crate::dom::SuppressObserver;
 use crate::dom::bindings::codegen::Bindings::DocumentBinding::{
     DocumentMethods, DocumentReadyState,
 };
@@ -1580,6 +1581,61 @@ pub(crate) struct FragmentContext<'a> {
     pub(crate) context_element_allows_scripting: bool,
 }
 
+/// <https://html.spec.whatwg.org/multipage/#insert-an-element-at-the-adjusted-insertion-location>
+#[cfg_attr(crown, expect(crown::unrooted_must_root))]
+fn insert_an_element_at_the_adjusted_insertion_location(
+    cx: &mut JSContext,
+    node_to_insert: Dom<Node>,
+    adjusted_insertion_location_parent: &Node,
+    adjusted_insertion_location_child: Option<&Node>,
+    parsing_algorithm: ParsingAlgorithm,
+    custom_element_reaction_stack: &CustomElementReactionStack,
+) {
+    // Step 1: Let the adjusted insertion location be the appropriate place for inserting a node.
+    //
+    // Note: This is handled as part of the input.
+
+    // Step 2: If it is not possible to insert element at the adjusted insertion location,
+    // abort these steps.
+    if Node::ensure_pre_insertion_validity(
+        cx.no_gc(),
+        &node_to_insert,
+        adjusted_insertion_location_parent,
+        adjusted_insertion_location_child,
+    )
+    .is_err()
+    {
+        return;
+    }
+
+    // Step 3. If the parser was not created as part of the HTML fragment parsing algorithm,
+    // then push a new element queue onto element's relevant agent's custom element reactions
+    // stack.
+    let element_in_non_fragment =
+        parsing_algorithm != ParsingAlgorithm::Fragment && node_to_insert.is::<Element>();
+    if element_in_non_fragment {
+        custom_element_reaction_stack.push_new_element_queue();
+    }
+
+    // Step 4: Insert element at the adjusted insertion location.
+    Node::insert(
+        cx,
+        &node_to_insert,
+        adjusted_insertion_location_parent,
+        adjusted_insertion_location_child,
+        SuppressObserver::Unsuppressed,
+    );
+
+    // Step 5: If the parser was not created as part of the HTML fragment parsing algorithm,
+    // then pop the element queue from element's relevant agent's custom element reactions
+    // stack, and invoke custom element reactions in that queue.
+    //
+    // Note: Handled as part of `pop_current_element_queue()`.
+    if element_in_non_fragment {
+        custom_element_reaction_stack.pop_current_element_queue(cx);
+    }
+}
+
 #[cfg_attr(crown, expect(crown::unrooted_must_root))]
 fn insert(
     cx: &mut JSContext,
@@ -1590,19 +1646,20 @@ fn insert(
     custom_element_reaction_stack: &CustomElementReactionStack,
 ) {
     match child {
-        NodeOrText::AppendNode(n) => {
-            // https://html.spec.whatwg.org/multipage/#insert-a-foreign-element
-            // applies if this is an element; if not, it may be
-            // https://html.spec.whatwg.org/multipage/#insert-a-comment
-            let element_in_non_fragment =
-                parsing_algorithm != ParsingAlgorithm::Fragment && n.is::<Element>();
-            if element_in_non_fragment {
-                custom_element_reaction_stack.push_new_element_queue();
-            }
-            parent.InsertBefore(cx, &n, reference_child).unwrap();
-            if element_in_non_fragment {
-                custom_element_reaction_stack.pop_current_element_queue(cx);
-            }
+        NodeOrText::AppendNode(node) => {
+            // This encompasses two parts of the specification:
+            //  - https://html.spec.whatwg.org/multipage/#insert-a-foreign-element
+            //  - https://html.spec.whatwg.org/multipage/#insert-a-comment
+            //
+            // TODO: This part of the code should match the specification more closely.
+            insert_an_element_at_the_adjusted_insertion_location(
+                cx,
+                node,
+                parent,
+                reference_child,
+                parsing_algorithm,
+                custom_element_reaction_stack,
+            );
         },
         NodeOrText::AppendText(t) => {
             // https://html.spec.whatwg.org/multipage/#insert-a-character

--- a/tests/wpt/meta/css/css-transitions/dynamic-root-element.html.ini
+++ b/tests/wpt/meta/css/css-transitions/dynamic-root-element.html.ini
@@ -1,2 +1,0 @@
-[dynamic-root-element.html]
-  expected: CRASH

--- a/tests/wpt/meta/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/quirks.window.js.ini
+++ b/tests/wpt/meta/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/quirks.window.js.ini
@@ -1,2 +1,0 @@
-[quirks.window.html]
-  expected: CRASH

--- a/tests/wpt/tests/dom/ranges/Range-insertNode-multiple-document-children-crash.html
+++ b/tests/wpt/tests/dom/ranges/Range-insertNode-multiple-document-children-crash.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+
+<head>
+    <link rel="help" href="https://github.com/servo/servo/issues/20218">
+</head>
+
+<script>
+    onload = () => {
+      document.open();
+      try {
+          document.createRange().insertNode(document.createElement("a"));
+          document.createRange().insertNode(document.createElement("a"));
+      } finally {
+          document.close();
+      }
+    };
+</script>


### PR DESCRIPTION
When inserting from the parser, the specification doesn't say to call
`insertBefore()` (as we were doing) which combines the validation and
insertion steps. Instead it requires that we run validation as a
separate, earlier, step and abort the insertion when it isn't possible. This
change makes the parser more closely follow the specification in this way.

Testing: This change adds a new WPT crash test and fixes two other crashing WPT tests.
Fixes: #20218.
