### PR TITLE
Bump mozjs ESR to 140.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5169,9 +5169,9 @@ dependencies = [
 
 [[package]]
 name = "mozjs"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3f2158af50bac3443634558badc018860a59f7c70b7706117845da1022d60d0"
+checksum = "d8d7e5cba578bc71ec962623e1bfffa5aaaa7665c54fa236d6f930c492807f7d"
 dependencies = [
  "bindgen",
  "cc",
@@ -5184,9 +5184,9 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "140.11.0-1"
+version = "140.12.0-0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1f9f0e5d9957edaf0f833a97edd41680c9231026dcf3fc617847e1571f377c"
+checksum = "f78cdbe11d0dba944f54f21f0f2b8c3ffb24b94170c0c075fadc24cc3e947dc4"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,7 +138,7 @@ inventory = "0.3.24"
 ipc-channel = "0.22"
 itertools = "0.14"
 jni = "0.22"
-js = { package = "mozjs", version = "=0.16.3", default-features = false, features = ["intl", "libz-sys"] }
+js = { package = "mozjs", version = "=0.16.4", default-features = false, features = ["intl", "libz-sys"] }
 k12 = "0.5"
 keyboard-types = { version = "0.8.3", features = ["serde", "webdriver"] }
 kurbo = { version = "0.13.1", features = ["euclid"] }


### PR DESCRIPTION
This pulls in the ESR 140.12 security updates for spidermonkey.
[mozjs security bump PR](https://github.com/servo/mozjs/pull/759)

Testing: dependency update is covered by existing tests
