### PR TITLE
net: Improve Fetch compliance with blob scheme

### DIFF
--- a/components/net/filemanager_thread.rs
+++ b/components/net/filemanager_thread.rs
@@ -14,7 +14,6 @@ use embedder_traits::{
     SelectedFile,
 };
 use headers::{ContentLength, ContentRange, ContentType, HeaderMap, HeaderMapExt, Range};
-use http::header::{self, HeaderValue};
 use ipc_channel::ipc::IpcSender;
 use log::warn;
 use mime::Mime;
@@ -23,7 +22,6 @@ use net_traits::filemanager_thread::{
     FileManagerResult, FileManagerThreadError, FileManagerThreadMsg, FileTokenCheck,
     GetTokenForFileReply, ReadFileProgress, RelativePos,
 };
-use net_traits::http_percent_encode;
 use net_traits::response::{Response, ResponseBody};
 use parking_lot::{Mutex, RwLock};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -309,11 +307,10 @@ impl FileManager {
                     None
                 };
 
-                set_headers(
+                set_blob_response_headers(
                     &mut response.headers,
                     len,
                     buf.type_string.parse().unwrap_or(mime::TEXT_PLAIN),
-                    buf.filename.clone(),
                     content_range,
                 );
 
@@ -355,12 +352,6 @@ impl FileManager {
                     ));
                 }
 
-                let filename = metadata
-                    .path
-                    .file_name()
-                    .and_then(|osstr| osstr.to_str())
-                    .map(|s| s.to_string());
-
                 let content_range = if is_range_requested {
                     let abs_range = range.to_abs_blob_range(metadata.size as usize);
                     ContentRange::bytes(abs_range.start as u64..abs_range.end as u64, metadata.size)
@@ -368,13 +359,12 @@ impl FileManager {
                 } else {
                     None
                 };
-                set_headers(
+                set_blob_response_headers(
                     &mut response.headers,
                     metadata.size,
                     mime_guess::from_path(metadata.path)
                         .first()
                         .unwrap_or(mime::TEXT_PLAIN),
-                    filename,
                     content_range,
                 );
 
@@ -922,11 +912,10 @@ async fn read_file_in_chunks(
     }
 }
 
-fn set_headers(
+fn set_blob_response_headers(
     headers: &mut HeaderMap,
     content_length: u64,
     mime: Mime,
-    filename: Option<String>,
     content_range: Option<ContentRange>,
 ) {
     headers.typed_insert(ContentLength(content_length));
@@ -934,21 +923,4 @@ fn set_headers(
         headers.typed_insert(content_range);
     }
     headers.typed_insert(ContentType::from(mime));
-    let name = match filename {
-        Some(name) => name,
-        None => return,
-    };
-    // TODO(eijebong): Replace this once the typed header is there
-    //                 https://github.com/hyperium/headers/issues/8
-    headers.insert(
-        header::CONTENT_DISPOSITION,
-        HeaderValue::from_bytes(
-            format!(
-                "inline; filename*=UTF-8''{}",
-                http_percent_encode(name.as_bytes())
-            )
-            .as_bytes(),
-        )
-        .unwrap(),
-    );
 }

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -216,7 +216,7 @@ fn test_fetch_blob() {
     let fetch_response = receiver.recv().unwrap();
     assert!(!fetch_response.is_network_error());
 
-    assert_eq!(fetch_response.headers.len(), 3);
+    assert_eq!(fetch_response.headers.len(), 2);
 
     let content_type: Mime = fetch_response
         .headers
@@ -227,15 +227,6 @@ fn test_fetch_blob() {
 
     let content_length: ContentLength = fetch_response.headers.typed_get().unwrap();
     assert_eq!(content_length.0, bytes.len() as u64);
-
-    let content_disposition = fetch_response
-        .headers
-        .get(header::CONTENT_DISPOSITION)
-        .unwrap();
-    assert_eq!(
-        content_disposition.to_str().unwrap(),
-        "inline; filename*=UTF-8''test%20.txt"
-    );
 
     assert_eq!(*fetch_response.body.lock(), ResponseBody::Receiving(vec![]));
 }

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -1273,34 +1273,6 @@ pub fn trim_http_whitespace(mut slice: &[u8]) -> &[u8] {
     slice
 }
 
-pub fn http_percent_encode(bytes: &[u8]) -> String {
-    // This encode set is used for HTTP header values and is defined at
-    // https://tools.ietf.org/html/rfc5987#section-3.2
-    const HTTP_VALUE: &percent_encoding::AsciiSet = &percent_encoding::CONTROLS
-        .add(b' ')
-        .add(b'"')
-        .add(b'%')
-        .add(b'\'')
-        .add(b'(')
-        .add(b')')
-        .add(b'*')
-        .add(b',')
-        .add(b'/')
-        .add(b':')
-        .add(b';')
-        .add(b'<')
-        .add(b'-')
-        .add(b'>')
-        .add(b'?')
-        .add(b'[')
-        .add(b'\\')
-        .add(b']')
-        .add(b'{')
-        .add(b'}');
-
-    percent_encoding::percent_encode(bytes, HTTP_VALUE).to_string()
-}
-
 /// Returns the cached current system locale, or en-US by default.
 pub fn get_current_locale() -> &'static (String, HeaderValue) {
     static CURRENT_LOCALE: OnceLock<(String, HeaderValue)> = OnceLock::new();


### PR DESCRIPTION
I tried to improve response header `Content-Disposition` for blob in #45709. 
Turns out to be futile as the original code was wrong by [Fetch Standard](https://fetch.spec.whatwg.org/#concept-scheme-fetch:~:text=%22blob%22,-Let):
we may only have `Content-Length`, `Content-Type` and `Content-Range` header.

1. We remove `Content-Disposition` completely.
2. Rename `set_headers` to `set_blob_response_headers`. Original name is confusing.
3. Can finally remove `http_percent_encode`, which was also used when `<form>` encoding was in wrong shape.

Testing: Updated UT. This is not testable by WPT, as the original header `Content-Disposition` is only inserted
for those chosen from embedder file picker (`<input type="file">`), but not those in memory.