### PR TITLE
media/script: Use GenericChannels for media crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8258,6 +8258,7 @@ dependencies = [
 name = "servo-media"
 version = "0.3.0"
 dependencies = [
+ "servo-base",
  "servo-media-audio",
  "servo-media-player",
  "servo-media-streams",
@@ -8307,7 +8308,7 @@ dependencies = [
 name = "servo-media-dummy"
 version = "0.3.0"
 dependencies = [
- "ipc-channel",
+ "servo-base",
  "servo-media",
  "servo-media-audio",
  "servo-media-player",
@@ -8344,9 +8345,9 @@ dependencies = [
  "gstreamer-sys",
  "gstreamer-video",
  "gstreamer-webrtc",
- "ipc-channel",
  "log",
  "mime",
+ "servo-base",
  "servo-media",
  "servo-media-audio",
  "servo-media-gstreamer-render",
@@ -8421,9 +8422,9 @@ dependencies = [
 name = "servo-media-player"
 version = "0.3.0"
 dependencies = [
- "ipc-channel",
  "malloc_size_of_derive",
  "serde",
+ "servo-base",
  "servo-malloc-size-of",
  "servo-media-streams",
  "servo-media-traits",
@@ -8448,6 +8449,7 @@ dependencies = [
  "malloc_size_of_derive",
  "rustc-hash 2.1.2",
  "serde",
+ "servo-base",
  "servo-config",
  "servo-malloc-size-of",
  "servo-media",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8401,7 +8401,6 @@ name = "servo-media-ohos"
 version = "0.3.0"
 dependencies = [
  "crossbeam-channel",
- "ipc-channel",
  "libc",
  "log",
  "mime",
@@ -8409,6 +8408,7 @@ dependencies = [
  "ohos-sys-opaque-types",
  "ohos-window-sys",
  "serde_json",
+ "servo-base",
  "servo-media",
  "servo-media-audio",
  "servo-media-player",

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -735,6 +735,12 @@ impl<T: MallocSizeOf> MallocSizeOf for std::sync::Mutex<T> {
     }
 }
 
+impl<T: MallocSizeOf> MallocSizeOf for std::sync::RwLock<T> {
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        (*self.read().unwrap()).size_of(ops)
+    }
+}
+
 impl<T: MallocSizeOf> MallocSizeOf for parking_lot::Mutex<T> {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
         (*self.lock()).size_of(ops)

--- a/components/media/backends/dummy/Cargo.toml
+++ b/components/media/backends/dummy/Cargo.toml
@@ -14,7 +14,7 @@ name = "servo_media_dummy"
 path = "lib.rs"
 
 [dependencies]
-ipc-channel = { workspace = true }
+servo-base = { workspace = true }
 servo-media = { workspace = true }
 servo-media-audio = { workspace = true }
 servo-media-player = { workspace = true }

--- a/components/media/backends/dummy/lib.rs
+++ b/components/media/backends/dummy/lib.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-extern crate ipc_channel;
 extern crate servo_media;
 extern crate servo_media_audio;
 extern crate servo_media_player;
@@ -15,7 +14,7 @@ use std::ops::Range;
 use std::sync::mpsc::{self, Sender};
 use std::sync::{Arc, Mutex};
 
-use ipc_channel::ipc::IpcSender;
+use servo_base::generic_channel::GenericCallback;
 use servo_media::{Backend, BackendInit, MediaInstanceError, SupportsMediaType};
 use servo_media_audio::block::{Block, Chunk};
 use servo_media_audio::context::{AudioContext, AudioContextOptions};
@@ -87,7 +86,7 @@ impl Backend for DummyBackend {
         &self,
         _id: &ClientContextId,
         _: StreamType,
-        _: IpcSender<PlayerEvent>,
+        _: GenericCallback<PlayerEvent>,
         _: Option<Arc<Mutex<dyn video::VideoFrameRenderer>>>,
         _: Option<Arc<Mutex<dyn audio::AudioRenderer>>>,
         _: Box<dyn PlayerGLContext>,

--- a/components/media/backends/gstreamer/Cargo.toml
+++ b/components/media/backends/gstreamer/Cargo.toml
@@ -31,9 +31,9 @@ gstreamer-sdp = { workspace = true }
 gstreamer-sys = { workspace = true }
 gstreamer-video = { workspace = true }
 gstreamer-webrtc = { workspace = true }
-ipc-channel = { workspace = true }
 log = { workspace = true }
 mime = { workspace = true }
+servo-base = { workspace = true }
 servo-media = { workspace = true }
 servo-media-audio = { workspace = true }
 servo-media-gstreamer-render = { workspace = true }

--- a/components/media/backends/gstreamer/lib.rs
+++ b/components/media/backends/gstreamer/lib.rs
@@ -26,11 +26,11 @@ use std::vec::Vec;
 
 use device_monitor::GStreamerDeviceMonitor;
 use gstreamer::prelude::*;
-use ipc_channel::ipc::IpcSender;
 use log::warn;
 use media_stream::GStreamerMediaStream;
 use mime::Mime;
 use registry_scanner::GSTREAMER_REGISTRY_SCANNER;
+use servo_base::generic_channel::GenericCallback;
 use servo_media::{Backend, BackendDeInit, BackendInit, MediaInstanceError, SupportsMediaType};
 use servo_media_audio::context::{AudioContext, AudioContextOptions};
 use servo_media_audio::decoder::AudioDecoder;
@@ -173,7 +173,7 @@ impl Backend for GStreamerBackend {
         &self,
         context_id: &ClientContextId,
         stream_type: StreamType,
-        sender: IpcSender<PlayerEvent>,
+        sender: GenericCallback<PlayerEvent>,
         renderer: Option<Arc<Mutex<dyn VideoFrameRenderer>>>,
         audio_renderer: Option<Arc<Mutex<dyn AudioRenderer>>>,
         gl_context: Box<dyn PlayerGLContext>,

--- a/components/media/backends/gstreamer/player.rs
+++ b/components/media/backends/gstreamer/player.rs
@@ -16,7 +16,7 @@ use gstreamer;
 use gstreamer_app;
 use gstreamer_play;
 use gstreamer_play::prelude::*;
-use ipc_channel::ipc::{IpcReceiver, IpcSender, channel};
+use servo_base::generic_channel::{self, GenericCallback, GenericReceiver};
 use servo_media::MediaInstanceError;
 use servo_media_player::audio::AudioRenderer;
 use servo_media_player::context::PlayerGLContext;
@@ -409,12 +409,13 @@ macro_rules! notify(
 
 struct SeekChannel {
     sender: SeekLock,
-    recv: IpcReceiver<SeekLockMsg>,
+    recv: GenericReceiver<SeekLockMsg>,
 }
 
 impl SeekChannel {
     fn new() -> Self {
-        let (sender, recv) = channel::<SeekLockMsg>().expect("Couldn't create IPC channel");
+        let (sender, recv) =
+            generic_channel::channel::<SeekLockMsg>().expect("Couldn't create IPC channel");
         Self {
             sender: SeekLock {
                 lock_channel: sender,
@@ -440,7 +441,7 @@ pub struct GStreamerPlayer {
     /// Channel to communicate with the owner GStreamerBackend instance.
     backend_chan: Arc<Mutex<Sender<BackendMsg>>>,
     inner: RefCell<Option<Arc<Mutex<PlayerInner>>>>,
-    observer: Arc<Mutex<IpcSender<PlayerEvent>>>,
+    observer: Arc<Mutex<GenericCallback<PlayerEvent>>>,
     audio_renderer: Option<Arc<Mutex<dyn AudioRenderer>>>,
     video_renderer: Option<Arc<Mutex<dyn VideoFrameRenderer>>>,
     /// Indicates whether the setup was succesfully performed and
@@ -459,7 +460,7 @@ impl GStreamerPlayer {
         context_id: &ClientContextId,
         backend_chan: Arc<Mutex<Sender<BackendMsg>>>,
         stream_type: StreamType,
-        observer: IpcSender<PlayerEvent>,
+        observer: GenericCallback<PlayerEvent>,
         video_renderer: Option<Arc<Mutex<dyn VideoFrameRenderer>>>,
         audio_renderer: Option<Arc<Mutex<dyn AudioRenderer>>>,
         gl_context: Box<dyn PlayerGLContext>,

--- a/components/media/backends/ohos/Cargo.toml
+++ b/components/media/backends/ohos/Cargo.toml
@@ -15,13 +15,13 @@ path = "lib.rs"
 
 [dependencies]
 crossbeam-channel = { workspace = true }
-ipc-channel = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
 mime = { workspace = true }
 ohos-media-sys = { workspace = true, features = ["api-21"] }
 ohos-sys-opaque-types = { workspace = true }
 ohos-window-sys = { workspace = true, features = ["api-13"] }
+servo-base = { workspace = true }
 servo-media = { workspace = true }
 servo-media-audio = { workspace = true }
 servo-media-player = { workspace = true }

--- a/components/media/backends/ohos/lib.rs
+++ b/components/media/backends/ohos/lib.rs
@@ -10,6 +10,7 @@ use std::thread;
 
 use log::{debug, warn};
 use mime::Mime;
+use servo_base::generic_channel::GenericCallback;
 use servo_media::player::StreamType;
 use servo_media::{
     Backend, BackendInit, BackendMsg, ClientContextId, MediaInstance, MediaInstanceError,
@@ -98,7 +99,7 @@ impl Backend for OhosBackend {
         &self,
         context_id: &servo_media::ClientContextId,
         stream_type: servo_media_player::StreamType,
-        sender: servo_media_player::ipc_channel::ipc::IpcSender<servo_media_player::PlayerEvent>,
+        sender: GenericCallback<servo_media_player::PlayerEvent>,
         video_renderer: Option<
             std::sync::Arc<std::sync::Mutex<dyn servo_media_player::video::VideoFrameRenderer>>,
         >,

--- a/components/media/backends/ohos/player.rs
+++ b/components/media/backends/ohos/player.rs
@@ -8,7 +8,6 @@ use std::sync::{Arc, Mutex, mpsc};
 use std::time;
 
 use crossbeam_channel::Sender;
-use ipc_channel::ipc::{IpcReceiver, channel};
 use log::{debug, error, warn};
 use ohos_media_sys::avformat::{
     OH_AVFormat, OH_AVFormat_GetFloatValue, OH_AVFormat_GetIntValue, OH_AVFormat_GetLongValue,
@@ -19,6 +18,7 @@ use ohos_media_sys::avplayer_base::{
     OH_PLAYER_SEEK_POSITION, OH_PLAYER_STATE, OH_PLAYER_STATE_CHANGE_REASON,
     OH_PLAYER_VIDEO_HEIGHT, OH_PLAYER_VIDEO_WIDTH, OH_PLAYER_VOLUME,
 };
+use servo_base::generic_channel::{GenericCallback, GenericReceiver, channel};
 use servo_media::{BackendMsg, ClientContextId, MediaInstance, MediaInstanceError};
 use servo_media_player::metadata::Metadata;
 use servo_media_player::video::{self, Buffer, VideoFrame, VideoFrameData};
@@ -64,7 +64,7 @@ pub struct OhosAvPlayer {
     id: usize,
     context_id: ClientContextId,
     player_inner: Arc<Mutex<OhosPlayerInner>>,
-    event_sender: Arc<Mutex<ipc_channel::ipc::IpcSender<servo_media::player::PlayerEvent>>>,
+    event_sender: Arc<Mutex<GenericCallback<servo_media::player::PlayerEvent>>>,
     video_sink: Option<Arc<Mutex<VideoSink>>>,
     backend_chan: Arc<Mutex<mpsc::Sender<BackendMsg>>>,
     last_metadata: Arc<Mutex<Cell<Metadata>>>,
@@ -84,7 +84,7 @@ impl OhosAvPlayer {
     pub fn new(
         id: usize,
         context_id: ClientContextId,
-        sender: ipc_channel::ipc::IpcSender<servo_media::player::PlayerEvent>,
+        sender: GenericCallback<servo_media::player::PlayerEvent>,
         video_renderer: Option<
             std::sync::Arc<std::sync::Mutex<dyn servo_media::player::video::VideoFrameRenderer>>,
         >,
@@ -348,7 +348,7 @@ impl OhosAvPlayer {
 
 struct SeekChannel {
     sender: SeekLock,
-    recv: IpcReceiver<SeekLockMsg>,
+    recv: GenericReceiver<SeekLockMsg>,
 }
 
 impl SeekChannel {
@@ -550,7 +550,7 @@ struct VideoSink {
     video_render:
         std::sync::Arc<std::sync::Mutex<dyn servo_media::player::video::VideoFrameRenderer>>,
     player_inner: Arc<Mutex<OhosPlayerInner>>,
-    event_sender: Arc<Mutex<ipc_channel::ipc::IpcSender<servo_media::player::PlayerEvent>>>,
+    event_sender: Arc<Mutex<GenericCallback<servo_media::player::PlayerEvent>>>,
     thread_send_chan: Cell<Option<Sender<RenderMsg>>>,
 }
 
@@ -565,7 +565,7 @@ impl VideoSink {
             std::sync::Mutex<dyn servo_media::player::video::VideoFrameRenderer>,
         >,
         player_inner: Arc<Mutex<OhosPlayerInner>>,
-        event_sender: Arc<Mutex<ipc_channel::ipc::IpcSender<servo_media::player::PlayerEvent>>>,
+        event_sender: Arc<Mutex<GenericCallback<servo_media::player::PlayerEvent>>>,
     ) -> Self {
         VideoSink {
             video_render,

--- a/components/media/media-thread/Cargo.toml
+++ b/components/media/media-thread/Cargo.toml
@@ -22,6 +22,7 @@ malloc_size_of_derive = { workspace = true }
 paint_api = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
+servo-base = { workspace = true }
 servo-config = { workspace = true }
 servo-media = { workspace = true }
 webrender_api = { workspace = true }

--- a/components/media/media-thread/lib.rs
+++ b/components/media/media-thread/lib.rs
@@ -10,7 +10,6 @@ mod media_thread;
 use std::sync::Mutex;
 
 use euclid::default::Size2D;
-use ipc_channel::ipc::{IpcReceiver, IpcSender, channel};
 use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
 use paint_api::{
@@ -18,6 +17,7 @@ use paint_api::{
     WebRenderImageHandlerType,
 };
 use serde::{Deserialize, Serialize};
+use servo_base::generic_channel::{self, GenericCallback, GenericReceiver, GenericSender};
 use servo_config::pref;
 pub use servo_media::player::context::{GlApi, GlContext, NativeDisplay, PlayerGLContext};
 
@@ -35,7 +35,7 @@ static WINDOW_GL_CONTEXT: Mutex<WindowGLContext> = Mutex::new(WindowGLContext::i
 #[derive(Debug, Deserialize, Serialize)]
 pub enum GLPlayerMsgForward {
     PlayerId(u64),
-    Lock(IpcSender<(u32, Size2D<i32>, usize)>),
+    Lock(GenericSender<(u32, Size2D<i32>, usize)>),
     Unlock(),
 }
 
@@ -47,7 +47,7 @@ pub enum GLPlayerMsgForward {
 #[derive(Debug, Deserialize, Serialize)]
 pub enum GLPlayerMsg {
     /// Registers an instantiated player in DOM
-    RegisterPlayer(IpcSender<GLPlayerMsgForward>),
+    RegisterPlayer(GenericCallback<GLPlayerMsgForward>),
     /// Unregisters a player's ID
     UnregisterPlayer(u64),
     /// Locks a specific texture from a player. Lock messages are used
@@ -62,7 +62,7 @@ pub enum GLPlayerMsg {
     ///
     /// Currently OpenGL Sync Objects are used to implement the
     /// synchronization mechanism.
-    Lock(u64, IpcSender<(u32, Size2D<i32>, usize)>),
+    Lock(u64, GenericSender<(u32, Size2D<i32>, usize)>),
     /// Unlocks a specific texture from a player. Unlock messages are
     /// used for a correct synchronization with WebRender external
     /// image API.
@@ -88,7 +88,7 @@ pub struct WindowGLContext {
     /// Application's native display
     pub display: NativeDisplay,
     /// A channel to the GLPlayer thread.
-    pub glplayer_thread_sender: Option<IpcSender<GLPlayerMsg>>,
+    pub glplayer_thread_sender: Option<GenericSender<GLPlayerMsg>>,
 }
 
 impl WindowGLContext {
@@ -193,20 +193,20 @@ struct GLPlayerExternalImages {
     // @FIXME(victor): this should be added when GstGLSyncMeta is
     // added
     // webrender_gl: Rc<dyn gl::Gl>,
-    glplayer_channel: IpcSender<GLPlayerMsg>,
+    glplayer_channel: GenericSender<GLPlayerMsg>,
     // Used to avoid creating a new channel on each received WebRender
     // request.
     lock_channel: (
-        IpcSender<(u32, Size2D<i32>, usize)>,
-        IpcReceiver<(u32, Size2D<i32>, usize)>,
+        GenericSender<(u32, Size2D<i32>, usize)>,
+        GenericReceiver<(u32, Size2D<i32>, usize)>,
     ),
 }
 
 impl GLPlayerExternalImages {
-    fn new(sender: IpcSender<GLPlayerMsg>) -> Self {
+    fn new(sender: GenericSender<GLPlayerMsg>) -> Self {
         Self {
             glplayer_channel: sender,
-            lock_channel: channel().unwrap(),
+            lock_channel: generic_channel::channel().unwrap(),
         }
     }
 }

--- a/components/media/media-thread/media_thread.rs
+++ b/components/media/media-thread/media_thread.rs
@@ -4,10 +4,10 @@
 
 use std::thread;
 
-use ipc_channel::ipc::{IpcSender, channel};
 use log::{trace, warn};
 use paint_api::{WebRenderExternalImageIdManager, WebRenderImageHandlerType};
 use rustc_hash::FxHashMap;
+use servo_base::generic_channel::{self, GenericCallback, GenericSender};
 use webrender_api::ExternalImageId;
 
 /// GL player threading API entry point that lives in the
@@ -18,7 +18,7 @@ use crate::{GLPlayerMsg, GLPlayerMsgForward};
 /// a set of video players with GL render.
 pub struct GLPlayerThread {
     /// Map of live players.
-    players: FxHashMap<u64, IpcSender<GLPlayerMsgForward>>,
+    players: FxHashMap<u64, GenericCallback<GLPlayerMsgForward>>,
     /// List of registered webrender external images.
     /// We use it to get an unique ID for new players.
     external_image_id_manager: WebRenderExternalImageIdManager,
@@ -34,8 +34,8 @@ impl GLPlayerThread {
 
     pub fn start(
         external_image_id_manager: WebRenderExternalImageIdManager,
-    ) -> IpcSender<GLPlayerMsg> {
-        let (sender, receiver) = channel().unwrap();
+    ) -> GenericSender<GLPlayerMsg> {
+        let (sender, receiver) = generic_channel::channel().unwrap();
         thread::Builder::new()
             .name("GLPlayer".to_owned())
             .spawn(move || {

--- a/components/media/player/Cargo.toml
+++ b/components/media/player/Cargo.toml
@@ -14,9 +14,9 @@ name = "servo_media_player"
 path = "lib.rs"
 
 [dependencies]
-ipc-channel = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+servo-base = { workspace = true }
 servo-media-streams = { workspace = true }
 servo-media-traits = { workspace = true }

--- a/components/media/player/lib.rs
+++ b/components/media/player/lib.rs
@@ -5,7 +5,6 @@
 use std::ops::Range;
 use std::time::Duration;
 
-pub extern crate ipc_channel;
 extern crate servo_media_streams as streams;
 extern crate servo_media_traits;
 
@@ -14,8 +13,8 @@ pub mod context;
 pub mod metadata;
 pub mod video;
 
-use ipc_channel::ipc::{self, IpcSender};
 use serde::{Deserialize, Serialize};
+use servo_base::generic_channel::{self, GenericSender};
 use servo_media_traits::MediaInstance;
 use streams::registry::MediaStreamId;
 
@@ -48,16 +47,17 @@ pub enum PlayerError {
     SetTrackFailed,
 }
 
-pub type SeekLockMsg = (bool, IpcSender<()>);
+pub type SeekLockMsg = (bool, GenericSender<()>);
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SeekLock {
-    pub lock_channel: IpcSender<SeekLockMsg>,
+    pub lock_channel: GenericSender<SeekLockMsg>,
 }
 
 impl SeekLock {
     pub fn unlock(&self, result: bool) {
-        let (ack_sender, ack_recv) = ipc::channel::<()>().expect("Could not create IPC channel");
+        let (ack_sender, ack_recv) =
+            generic_channel::channel::<()>().expect("Could not create IPC channel");
         self.lock_channel.send((result, ack_sender)).unwrap();
         ack_recv.recv().unwrap()
     }

--- a/components/media/servo-media/Cargo.toml
+++ b/components/media/servo-media/Cargo.toml
@@ -14,6 +14,7 @@ name = "servo_media"
 path = "lib.rs"
 
 [dependencies]
+servo-base = { workspace = true }
 servo-media-audio = { workspace = true }
 servo-media-player = { workspace = true }
 servo-media-streams = { workspace = true }

--- a/components/media/servo-media/lib.rs
+++ b/components/media/servo-media/lib.rs
@@ -16,9 +16,9 @@ use audio::context::{AudioContext, AudioContextOptions};
 use audio::sink::AudioSinkError;
 use player::audio::AudioRenderer;
 use player::context::PlayerGLContext;
-use player::ipc_channel::ipc::IpcSender;
 use player::video::VideoFrameRenderer;
 use player::{Player, PlayerEvent, StreamType};
+use servo_base::generic_channel::GenericCallback;
 use streams::capture::MediaTrackConstraintSet;
 use streams::device_monitor::MediaDeviceMonitor;
 use streams::registry::MediaStreamId;
@@ -43,7 +43,7 @@ pub trait Backend: Send + Sync {
         &self,
         id: &ClientContextId,
         stream_type: StreamType,
-        sender: IpcSender<PlayerEvent>,
+        sender: GenericCallback<PlayerEvent>,
         video_renderer: Option<Arc<Mutex<dyn VideoFrameRenderer>>>,
         audio_renderer: Option<Arc<Mutex<dyn AudioRenderer>>>,
         gl_context: Box<dyn PlayerGLContext>,

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -5,7 +5,7 @@
 use std::cell::{Cell, RefCell};
 use std::collections::VecDeque;
 use std::rc::Rc;
-use std::sync::{Arc, Mutex, Weak};
+use std::sync::{Arc, Mutex, OnceLock, RwLock, Weak};
 use std::time::{Duration, Instant};
 use std::{f64, mem};
 
@@ -17,8 +17,6 @@ use headers::{ContentLength, ContentRange, HeaderMapExt};
 use html5ever::{LocalName, Prefix, QualName, local_name, ns};
 use http::StatusCode;
 use http::header::{self, HeaderMap, HeaderValue};
-use ipc_channel::ipc::{self};
-use ipc_channel::router::ROUTER;
 use js::context::JSContext;
 use js::realm::{AutoRealm, CurrentRealm};
 use layout_api::MediaFrame;
@@ -35,7 +33,7 @@ use script_bindings::codegen::InheritTypes::{
     ElementTypeId, HTMLElementTypeId, HTMLMediaElementTypeId, NodeTypeId,
 };
 use script_bindings::weakref::WeakRef;
-use servo_base::generic_channel::GenericSharedMemory;
+use servo_base::generic_channel::{self, GenericCallback, GenericSharedMemory};
 use servo_base::id::WebViewId;
 use servo_config::pref;
 use servo_media::player::audio::AudioRenderer;
@@ -177,7 +175,8 @@ impl FrameHolder {
 pub(crate) struct MediaFrameRenderer {
     webview_id: WebViewId,
     player_id: Option<usize>,
-    glplayer_id: Option<u64>,
+    #[conditional_malloc_size_of]
+    glplayer_id: Arc<RwLock<Option<u64>>>,
     paint_api: CrossProcessPaintApi,
     #[ignore_malloc_size_of = "Defined in other crates"]
     player_context: WindowGLContext,
@@ -198,7 +197,7 @@ impl MediaFrameRenderer {
         Self {
             webview_id,
             player_id: None,
-            glplayer_id: None,
+            glplayer_id: Arc::new(RwLock::new(None)),
             paint_api,
             player_context,
             current_frame: None,
@@ -216,71 +215,60 @@ impl MediaFrameRenderer {
         weak_video_renderer: Weak<Mutex<MediaFrameRenderer>>,
     ) {
         self.player_id = Some(player_id);
+        let glplayer_id = self.glplayer_id.clone();
+        let callback = GenericCallback::new(move |message| {
+            let message = message.unwrap();
+            let weak_video_renderer = weak_video_renderer.clone();
 
-        let (glplayer_id, image_receiver) = self
-            .player_context
-            .glplayer_thread_sender
-            .as_ref()
-            .map(|sender| {
-                let (image_sender, image_receiver) = ipc::channel::<GLPlayerMsgForward>().unwrap();
-                sender
-                    .send(GLPlayerMsg::RegisterPlayer(image_sender))
-                    .unwrap();
-                match image_receiver.recv().unwrap() {
-                    GLPlayerMsgForward::PlayerId(id) => (Some(id), Some(image_receiver)),
-                    _ => unreachable!(),
+            let glplayer_id = glplayer_id.clone();
+            task_source.queue(task!(handle_glplayer_message: move || {
+                trace!("GLPlayer message {:?}", message);
+
+                let Some(video_renderer) = weak_video_renderer.upgrade() else {
+                    return;
+                };
+
+                match message {
+                    GLPlayerMsgForward::Lock(sender) => {
+                        if let Some(holder) = video_renderer
+                            .lock()
+                            .unwrap()
+                            .current_frame_holder
+                            .as_mut() {
+                                holder.lock();
+                                sender.send(holder.get()).unwrap();
+                            };
+                    },
+                    GLPlayerMsgForward::Unlock() => {
+                        if let Some(holder) = video_renderer
+                            .lock()
+                            .unwrap()
+                            .current_frame_holder
+                            .as_mut() { holder.unlock() }
+                    },
+                    GLPlayerMsgForward::PlayerId(id) => {
+                        let mut glplayer_id = glplayer_id.write().unwrap();
+                        if let Some(already_set_id) = *glplayer_id {
+                            error!("Player id already set to {already_set_id} will be replaced with {id}");
+                        }
+                        *glplayer_id = Some(id);
+                    },
                 }
-            })
-            .unwrap_or((None, None));
+            }));
+        })
+        .expect("Could not create callback");
 
-        self.glplayer_id = glplayer_id;
-
-        let Some(image_receiver) = image_receiver else {
-            return;
-        };
-
-        ROUTER.add_typed_route(
-            image_receiver,
-            Box::new(move |message| {
-                let message = message.unwrap();
-                let weak_video_renderer = weak_video_renderer.clone();
-
-                task_source.queue(task!(handle_glplayer_message: move || {
-                    trace!("GLPlayer message {:?}", message);
-
-                    let Some(video_renderer) = weak_video_renderer.upgrade() else {
-                        return;
-                    };
-
-                    match message {
-                        GLPlayerMsgForward::Lock(sender) => {
-                            if let Some(holder) = video_renderer
-                                .lock()
-                                .unwrap()
-                                .current_frame_holder
-                                .as_mut() {
-                                    holder.lock();
-                                    sender.send(holder.get()).unwrap();
-                                };
-                        },
-                        GLPlayerMsgForward::Unlock() => {
-                            if let Some(holder) = video_renderer
-                                .lock()
-                                .unwrap()
-                                .current_frame_holder
-                                .as_mut() { holder.unlock() }
-                        },
-                        _ => (),
-                    }
-                }));
-            }),
-        );
+        if let Some(glplayer_thread_sender) = &self.player_context.glplayer_thread_sender {
+            glplayer_thread_sender
+                .send(GLPlayerMsg::RegisterPlayer(callback))
+                .unwrap();
+        }
     }
 
     fn reset(&mut self) {
         self.player_id = None;
 
-        if let Some(glplayer_id) = self.glplayer_id.take() {
+        if let Some(glplayer_id) = self.glplayer_id.write().unwrap().take() {
             self.player_context
                 .send(GLPlayerMsg::UnregisterPlayer(glplayer_id));
         }
@@ -326,7 +314,9 @@ impl Drop for MediaFrameRenderer {
 
 impl VideoFrameRenderer for MediaFrameRenderer {
     fn render(&mut self, frame: VideoFrame) {
-        if self.player_id.is_none() || (frame.is_gl_texture() && self.glplayer_id.is_none()) {
+        if self.player_id.is_none() ||
+            (frame.is_gl_texture() && self.glplayer_id.read().unwrap().is_none())
+        {
             return;
         }
 
@@ -384,6 +374,8 @@ impl VideoFrameRenderer for MediaFrameRenderer {
                 // FIXME: This code is duplicated below this branch
                 let image_data = self
                     .glplayer_id
+                    .read()
+                    .unwrap()
                     .filter(|_| frame.is_gl_texture())
                     .map(|glplayer_id| {
                         let texture_target = if frame.is_external_oes() {
@@ -430,6 +422,8 @@ impl VideoFrameRenderer for MediaFrameRenderer {
 
                 let image_data = self
                     .glplayer_id
+                    .read()
+                    .unwrap()
                     .filter(|_| frame.is_gl_texture())
                     .map(|glplayer_id| {
                         let texture_target = if frame.is_external_oes() {
@@ -2137,7 +2131,7 @@ impl HTMLMediaElement {
         };
 
         let window = self.owner_window();
-        let (action_sender, action_receiver) = ipc::channel::<PlayerEvent>().unwrap();
+
         let video_renderer: Option<Arc<Mutex<dyn VideoFrameRenderer>>> = match self.media_type_id()
         {
             HTMLMediaElementTypeId::HTMLAudioElement => None,
@@ -2149,25 +2143,10 @@ impl HTMLMediaElement {
         let pipeline_id = window.pipeline_id();
         let client_context_id =
             ClientContextId::build(pipeline_id.namespace_id.0, pipeline_id.index.0.get());
-        let player = ServoMedia::get().create_player(
-            &client_context_id,
-            stream_type,
-            action_sender,
-            video_renderer,
-            audio_renderer,
-            Box::new(window.get_player_context()),
-        );
-        let player_id = {
-            let player_guard = player.lock().unwrap();
 
-            if let Err(error) = player_guard.set_mute(self.muted.get()) {
-                warn!("Could not set mute state: {error:?}");
-            }
-
-            player_guard.get_id()
-        };
-
-        *self.player.borrow_mut() = Some(player);
+        // This player id will be set later when we have a player.
+        // The callback will be the only valid user after this function.
+        let shared_player_id = Arc::new(OnceLock::new());
 
         let event_handler = Arc::new(Mutex::new(HTMLMediaElementEventHandler::new(self)));
         let weak_event_handler = Arc::downgrade(&event_handler);
@@ -2178,23 +2157,52 @@ impl HTMLMediaElement {
             .task_manager()
             .media_element_task_source()
             .to_sendable();
-        ROUTER.add_typed_route(
-            action_receiver,
-            Box::new(move |message| {
-                let event = message.unwrap();
-                let weak_event_handler = weak_event_handler.clone();
 
-                task_source.queue(task!(handle_player_event: move |cx| {
-                    trace!("HTMLMediaElement event: {event:?}");
+        let shared_player_id_clone = shared_player_id.clone();
+        let action_callback = generic_channel::GenericCallback::new(move |message| {
+            let event = message.unwrap();
+            let weak_event_handler = weak_event_handler.clone();
 
-                    let Some(event_handler) = weak_event_handler.upgrade() else {
-                        return;
-                    };
+            let shared_player_id_clone = shared_player_id_clone.clone();
+            task_source.queue(task!(handle_player_event: move |cx| {
+                trace!("HTMLMediaElement event: {event:?}");
 
-                    event_handler.lock().unwrap().handle_player_event(player_id, event, cx);
-                }));
-            }),
+                let Some(event_handler) = weak_event_handler.upgrade() else {
+                    return;
+                };
+
+                if let Some(shared_player_id) = shared_player_id_clone.get() {
+                    event_handler.lock().unwrap().handle_player_event(*shared_player_id, event, cx);
+                } else {
+                    error!("Player Action without ID being assigned yet.");
+                }
+            }));
+        })
+        .unwrap();
+        let player = ServoMedia::get().create_player(
+            &client_context_id,
+            stream_type,
+            action_callback,
+            video_renderer,
+            audio_renderer,
+            Box::new(window.get_player_context()),
         );
+
+        let player_id = {
+            let player_guard = player.lock().unwrap();
+
+            if let Err(error) = player_guard.set_mute(self.muted.get()) {
+                warn!("Could not set mute state: {error:?}");
+            }
+
+            let id = player_guard.get_id();
+            if shared_player_id.set(id).is_err() {
+                error!("Error setting player id. Already set?");
+            }
+            id
+        };
+
+        *self.player.borrow_mut() = Some(player);
 
         let task_source = self
             .owner_global()


### PR DESCRIPTION
This moves the media crates to use  GenericChannel and GenericCallback, as well as HTMLMediaElement.
This is mostly a replacement with equal functionality except for two cases in HTMLMediaElement.
- HTMLMediaElement::setup has a slightly different flow where previously we waited for the channel to send the PlayerId back via a message and then setup the callback. Now we setup the callback directly and handling the setting the PlayerId in the callback.
- HTMLMediaElement::create_media_player where previously the callback needed the player to be created for the callback to use the player_id which we solve with an `Arc<OnceLock<_>>`.

I think the tradeoff is worth it to keep the code cleaner and not introduce any cycles.

Testing: I am not sure if the media crate has tests or if they are tested by WPT tests but the changes are minimally and have log messages if something out of the ordinary happens.
