### PR TITLE
media: use GenericCallback for audio/analysermode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8321,6 +8321,7 @@ dependencies = [
  "num-traits",
  "petgraph",
  "serde",
+ "servo-base",
  "servo-malloc-size-of",
  "servo-media-derive",
  "servo-media-player",

--- a/components/media/audio/Cargo.toml
+++ b/components/media/audio/Cargo.toml
@@ -23,6 +23,7 @@ num-complex = { workspace = true }
 num-traits = { workspace = true }
 petgraph = { workspace = true, features = ["stable_graph"] }
 serde = { workspace = true, features = ["derive"] }
+servo-base = { workspace = true }
 servo-media-derive = { workspace = true }
 servo-media-player = { workspace = true }
 servo-media-streams = { workspace = true }

--- a/components/media/audio/analyser_node.rs
+++ b/components/media/audio/analyser_node.rs
@@ -4,8 +4,10 @@
 
 use std::cmp;
 use std::f32::consts::PI;
+use std::sync::{Arc, OnceLock};
 
 use malloc_size_of_derive::MallocSizeOf;
+use servo_base::generic_channel::GenericCallback;
 
 use crate::block::{Block, Chunk, FRAMES_PER_BLOCK_USIZE};
 use crate::node::{AudioNodeEngine, AudioNodeType, BlockInfo, ChannelInfo, ChannelInterpretation};
@@ -13,11 +15,11 @@ use crate::node::{AudioNodeEngine, AudioNodeType, BlockInfo, ChannelInfo, Channe
 #[derive(AudioNodeCommon)]
 pub(crate) struct AnalyserNode {
     channel_info: ChannelInfo,
-    callback: Box<dyn FnMut(Block) + Send>,
+    callback: Arc<OnceLock<GenericCallback<Block>>>,
 }
 
 impl AnalyserNode {
-    pub fn new(callback: Box<dyn FnMut(Block) + Send>, channel_info: ChannelInfo) -> Self {
+    pub fn new(callback: Arc<OnceLock<GenericCallback<Block>>>, channel_info: ChannelInfo) -> Self {
         Self {
             callback,
             channel_info,
@@ -36,7 +38,9 @@ impl AudioNodeEngine for AnalyserNode {
         let mut push = inputs.blocks[0].clone();
         push.mix(1, ChannelInterpretation::Speakers);
 
-        (self.callback)(push);
+        if let Some(callback) = self.callback.get() {
+            let _ = callback.send(push);
+        }
 
         // analyser node doesn't modify the inputs
         inputs

--- a/components/media/audio/node.rs
+++ b/components/media/audio/node.rs
@@ -4,8 +4,10 @@
 
 use std::cmp::min;
 use std::sync::mpsc::Sender;
+use std::sync::{Arc, OnceLock};
 
 use malloc_size_of_derive::MallocSizeOf;
+use servo_base::generic_channel::GenericCallback;
 use servo_media_streams::{MediaSocket, MediaStreamId};
 
 use crate::biquad_filter_node::{BiquadFilterNodeMessage, BiquadFilterNodeOptions};
@@ -25,7 +27,7 @@ use crate::wave_shaper_node::{WaveShaperNodeMessage, WaveShaperNodeOptions};
 /// Information required to construct an audio node
 #[derive(MallocSizeOf)]
 pub enum AudioNodeInit {
-    AnalyserNode(#[ignore_malloc_size_of = "Fn"] Box<dyn FnMut(Block) + Send>),
+    AnalyserNode(#[conditional_malloc_size_of] Arc<OnceLock<GenericCallback<Block>>>),
     BiquadFilterNode(BiquadFilterNodeOptions),
     AudioBuffer,
     AudioBufferSourceNode(AudioBufferSourceNodeOptions),

--- a/components/script/dom/audio/analysernode.rs
+++ b/components/script/dom/audio/analysernode.rs
@@ -2,14 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::sync::{Arc, OnceLock};
+
 use dom_struct::dom_struct;
-use ipc_channel::ipc::{self, IpcReceiver};
-use ipc_channel::router::ROUTER;
 use js::context::JSContext;
 use js::rust::{CustomAutoRooterGuard, HandleObject};
 use js::typedarray::{Float32Array, Uint8Array};
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use servo_base::generic_channel::GenericCallback;
 use servo_media::audio::analyser_node::AnalysisEngine;
 use servo_media::audio::block::Block;
 use servo_media::audio::node::AudioNodeInit;
@@ -43,7 +44,8 @@ impl AnalyserNode {
         _: &Window,
         context: &BaseAudioContext,
         options: &AnalyserOptions,
-    ) -> Fallible<(AnalyserNode, IpcReceiver<Block>)> {
+        callback: Arc<OnceLock<GenericCallback<Block>>>,
+    ) -> Fallible<AnalyserNode> {
         let node_options =
             options
                 .parent
@@ -64,14 +66,9 @@ impl AnalyserNode {
             return Err(Error::IndexSize(None));
         }
 
-        let (send, rcv) = ipc::channel().unwrap();
-        let callback = move |block| {
-            send.send(block).unwrap();
-        };
-
         let node = AudioNode::new_inherited(
             cx,
-            AudioNodeInit::AnalyserNode(Box::new(callback)),
+            AudioNodeInit::AnalyserNode(callback),
             context,
             node_options,
             1, // inputs
@@ -84,13 +81,10 @@ impl AnalyserNode {
             *options.minDecibels,
             *options.maxDecibels,
         );
-        Ok((
-            AnalyserNode {
-                node,
-                engine: DomRefCell::new(engine),
-            },
-            rcv,
-        ))
+        Ok(AnalyserNode {
+            node,
+            engine: DomRefCell::new(engine),
+        })
     }
 
     pub(crate) fn new(
@@ -110,7 +104,9 @@ impl AnalyserNode {
         context: &BaseAudioContext,
         options: &AnalyserOptions,
     ) -> Fallible<DomRoot<AnalyserNode>> {
-        let (node, recv) = AnalyserNode::new_inherited(cx, window, context, options)?;
+        let callback_oncelock = Arc::new(OnceLock::new());
+        let node =
+            AnalyserNode::new_inherited(cx, window, context, options, callback_oncelock.clone())?;
         let object = reflect_dom_object_with_proto_and_cx(Box::new(node), window, proto, cx);
         let task_source = window
             .as_global_scope()
@@ -119,16 +115,18 @@ impl AnalyserNode {
             .to_sendable();
         let this = Trusted::new(&*object);
 
-        ROUTER.add_typed_route(
-            recv,
-            Box::new(move |block| {
-                let this = this.clone();
-                task_source.queue(task!(append_analysis_block: move || {
-                    let this = this.root();
-                    this.push_block(block.unwrap())
-                }));
-            }),
-        );
+        let callback = GenericCallback::new(move |block| {
+            let this = this.clone();
+            task_source.queue(task!(append_analysis_block: move || {
+                let this = this.root();
+                this.push_block(block.unwrap())
+            }));
+        })
+        .unwrap();
+        if callback_oncelock.set(callback).is_err() {
+            log::error!("AnalyzerNode callback is already set. Not setting it again");
+        }
+
         Ok(object)
     }
 


### PR DESCRIPTION
We switch audio/analyser_mode from ipc to GenericCallback. We use a similar setup as in https://github.com/servo/servo/pull/45779 to avoid constructing a lazycallback. Instead we use Arc<OnceLock<GenericCallback>>.
While this changes the execution slightly it should be more robust and less prone to cycles than an equivalent LazyCallback situation.


Testing: The change in execution is very slight. I don't know if this is tested by WPT.
