### PR TITLE
constellation/script: Use GenericCallback instead of ipc for broadcasts

### DIFF
--- a/components/constellation/broadcastchannel.rs
+++ b/components/constellation/broadcastchannel.rs
@@ -4,9 +4,9 @@
 
 use std::collections::HashMap;
 
-use ipc_channel::ipc::IpcSender;
 use log::warn;
 use rustc_hash::FxHashMap;
+use servo_base::generic_channel::GenericCallback;
 use servo_base::id::BroadcastChannelRouterId;
 use servo_constellation_traits::BroadcastChannelMsg;
 use servo_url::ImmutableOrigin;
@@ -14,7 +14,7 @@ use servo_url::ImmutableOrigin;
 #[derive(Default)]
 pub(crate) struct BroadcastChannels {
     /// A map of broadcast routers to their Generic sender.
-    routers: FxHashMap<BroadcastChannelRouterId, IpcSender<BroadcastChannelMsg>>,
+    routers: FxHashMap<BroadcastChannelRouterId, GenericCallback<BroadcastChannelMsg>>,
 
     /// A map of origin to a map of channel name to a list of relevant routers.
     channels: HashMap<ImmutableOrigin, HashMap<String, Vec<BroadcastChannelRouterId>>>,
@@ -26,13 +26,9 @@ impl BroadcastChannels {
     pub fn new_broadcast_channel_router(
         &mut self,
         router_id: BroadcastChannelRouterId,
-        broadcast_ipc_sender: IpcSender<BroadcastChannelMsg>,
+        broadcast_callback: GenericCallback<BroadcastChannelMsg>,
     ) {
-        if self
-            .routers
-            .insert(router_id, broadcast_ipc_sender)
-            .is_some()
-        {
+        if self.routers.insert(router_id, broadcast_callback).is_some() {
             warn!("Multiple attempts to add BroadcastChannel router.");
         }
     }

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -25,7 +25,6 @@ use embedder_traits::{
 };
 use fonts::FontContext;
 use indexmap::IndexSet;
-use ipc_channel::ipc::{self};
 use ipc_channel::router::ROUTER;
 use js::jsapi::{
     CurrentGlobalOrNull, GetNonCCWObjectGlobal, HandleObject, Heap, JSContext, JSObject, JSScript,
@@ -1712,27 +1711,22 @@ impl GlobalScope {
         let mut current_state = self.broadcast_channel_state.borrow_mut();
 
         if let BroadcastChannelState::UnManaged = &*current_state {
-            // Setup a route for IPC, for broadcasts from the constellation to our channels.
-            let (broadcast_control_sender, broadcast_control_receiver) =
-                ipc::channel().expect("ipc channel failure");
             let context = Trusted::new(self);
             let listener = BroadcastListener {
                 task_source: self.task_manager().dom_manipulation_task_source().into(),
                 context,
             };
-            ROUTER.add_typed_route(
-                broadcast_control_receiver,
-                Box::new(move |message| match message {
-                    Ok(msg) => listener.handle(msg),
-                    Err(err) => warn!("Error receiving a BroadcastChannelMsg: {:?}", err),
-                }),
-            );
+            let broadcast_control_callback = GenericCallback::new(move |message| match message {
+                Ok(msg) => listener.handle(msg),
+                Err(err) => warn!("Error receiving a BroadcastChannelMsg: {:?}", err),
+            })
+            .expect("Could not generate callback");
             let router_id = BroadcastChannelRouterId::new();
             *current_state = BroadcastChannelState::Managed(router_id, HashMap::new());
             let _ = self.script_to_constellation_chan().send(
                 ScriptToConstellationMessage::NewBroadcastChannelRouter(
                     router_id,
-                    broadcast_control_sender,
+                    broadcast_control_callback,
                     self.origin().immutable().clone(),
                 ),
             );

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -634,7 +634,7 @@ pub enum ScriptToConstellationMessage {
     /// A global has started managing broadcast-channels.
     NewBroadcastChannelRouter(
         BroadcastChannelRouterId,
-        IpcSender<BroadcastChannelMsg>,
+        GenericCallback<BroadcastChannelMsg>,
         ImmutableOrigin,
     ),
     /// A global has stopped managing broadcast-channels.


### PR DESCRIPTION
This switches BroadcastChannels from IPC to GenericCallback.

Testing: This should not change functionality as GenericCallback is now reasonably well tested.
