### PR TITLE
script: Make `CryptoKey::usages` return reference of internal value

### DIFF
--- a/components/script/dom/webcrypto/cryptokey.rs
+++ b/components/script/dom/webcrypto/cryptokey.rs
@@ -10,7 +10,7 @@ use js::jsapi::{Heap, JSObject, Value};
 use js::rust::MutableHandleObject;
 use malloc_size_of::MallocSizeOf;
 use rustc_hash::FxHashMap;
-use script_bindings::cell::DomRefCell;
+use script_bindings::cell::{DomRefCell, Ref};
 use script_bindings::conversions::SafeToJSValConvertible;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use servo_base::id::{CryptoKeyId, CryptoKeyIndex};
@@ -178,8 +178,8 @@ impl CryptoKey {
         &self.algorithm
     }
 
-    pub(crate) fn usages(&self) -> Vec<KeyUsage> {
-        self.usages.borrow().clone()
+    pub(crate) fn usages(&self) -> Ref<'_, Vec<KeyUsage>> {
+        self.usages.borrow()
     }
 
     pub(crate) fn handle(&self) -> &Handle {

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -4218,7 +4218,7 @@ trait JsonWebKeyExt {
     fn stringify(&self, cx: &mut js::context::JSContext) -> Result<Zeroizing<DOMString>, Error>;
     fn get_usages_from_key_ops(&self) -> Result<Vec<KeyUsage>, Error>;
     fn check_key_ops(&self, specified_usages: &[KeyUsage]) -> Result<(), Error>;
-    fn set_key_ops(&mut self, usages: Vec<KeyUsage>);
+    fn set_key_ops(&mut self, usages: &[KeyUsage]);
     fn encode_string_field(&mut self, field: JwkStringField, data: &[u8]);
     fn decode_optional_string_field(
         &self,
@@ -4334,10 +4334,10 @@ impl JsonWebKeyExt for JsonWebKey {
     }
 
     // Set the key_ops attribute of jwk to equal the given usages.
-    fn set_key_ops(&mut self, usages: Vec<KeyUsage>) {
+    fn set_key_ops(&mut self, usages: &[KeyUsage]) {
         self.key_ops = Some(
             usages
-                .into_iter()
+                .iter()
                 .map(|usage| DOMString::from(usage.as_str()))
                 .collect(),
         );

--- a/components/script/dom/webcrypto/subtlecrypto/aes_common.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/aes_common.rs
@@ -730,7 +730,7 @@ pub(crate) fn export_key(
             }
 
             // Step 2.5. Set the key_ops attribute of jwk to equal the usages attribute of key.
-            jwk.set_key_ops(key.usages());
+            jwk.set_key_ops(&key.usages());
 
             // Step 2.6. Set the ext attribute of jwk to equal the [[extractable]] internal slot of
             // key.

--- a/components/script/dom/webcrypto/subtlecrypto/chacha20_poly1305_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/chacha20_poly1305_operation.rs
@@ -376,7 +376,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             jwk.alg = Some(DOMString::from("C20P"));
 
             // Step 2.5. Set the key_ops attribute of jwk to equal the usages attribute of key.
-            jwk.set_key_ops(key.usages());
+            jwk.set_key_ops(&key.usages());
 
             // Step 2.6. Set the ext attribute of jwk to equal the [[extractable]] internal slot of
             // key.

--- a/components/script/dom/webcrypto/subtlecrypto/ec_common.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ec_common.rs
@@ -1276,7 +1276,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             }
 
             // Step 3.4. Set the key_ops attribute of jwk to the usages attribute of key.
-            jwk.set_key_ops(key.usages());
+            jwk.set_key_ops(&key.usages());
 
             // Step 3.4. Set the ext attribute of jwk to the [[extractable]] internal slot of key.
             jwk.ext = Some(key.Extractable());

--- a/components/script/dom/webcrypto/subtlecrypto/ed25519_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ed25519_operation.rs
@@ -625,7 +625,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             }
 
             // Step 3.7. Set the key_ops attribute of jwk to the usages attribute of key.
-            jwk.set_key_ops(key.usages());
+            jwk.set_key_ops(&key.usages());
 
             // Step 3.8. Set the ext attribute of jwk to the [[extractable]] internal slot of key.
             jwk.ext = Some(key.Extractable());

--- a/components/script/dom/webcrypto/subtlecrypto/hmac_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/hmac_operation.rs
@@ -424,7 +424,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             jwk.alg = Some(DOMString::from(hash_algorithm));
 
             // Step 4.7. Set the key_ops attribute of jwk to the usages attribute of key.
-            jwk.set_key_ops(key.usages());
+            jwk.set_key_ops(&key.usages());
 
             // Step 4.8. Set the ext attribute of jwk to the [[extractable]] internal slot of key.
             jwk.ext = Some(key.Extractable());

--- a/components/script/dom/webcrypto/subtlecrypto/ml_dsa_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ml_dsa_operation.rs
@@ -1161,7 +1161,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             }
 
             // Step 3.7. Set the key_ops attribute of jwk to the usages attribute of key.
-            jwk.set_key_ops(key.usages());
+            jwk.set_key_ops(&key.usages());
 
             // Step 3.8. Set the ext attribute of jwk to the [[extractable]] internal slot of key.
             jwk.ext = Some(key.Extractable());

--- a/components/script/dom/webcrypto/subtlecrypto/ml_kem_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ml_kem_operation.rs
@@ -1297,7 +1297,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             }
 
             // Step 2.7. Set the key_ops attribute of jwk to the usages attribute of key.
-            jwk.set_key_ops(key.usages());
+            jwk.set_key_ops(&key.usages());
 
             // Step 2.8. Set the ext attribute of jwk to the [[extractable]] internal slot of key.
             jwk.ext = Some(key.Extractable());

--- a/components/script/dom/webcrypto/subtlecrypto/rsa_common.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/rsa_common.rs
@@ -984,7 +984,7 @@ pub(crate) fn export_key(
             }
 
             // Step 3.7. Set the key_ops attribute of jwk to the usages attribute of key.
-            jwk.set_key_ops(key.usages());
+            jwk.set_key_ops(&key.usages());
 
             // Step 3.8. Set the ext attribute of jwk to the [[extractable]] internal slot of key.
             jwk.ext = Some(key.Extractable());

--- a/components/script/dom/webcrypto/subtlecrypto/x25519_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/x25519_operation.rs
@@ -624,7 +624,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             }
 
             // Step 3.6. Set the key_ops attribute of jwk to the usages attribute of key.
-            jwk.set_key_ops(key.usages());
+            jwk.set_key_ops(&key.usages());
 
             // Step 3.7. Set the ext attribute of jwk to the [[extractable]] internal slot of key.
             jwk.ext = Some(key.Extractable());


### PR DESCRIPTION
Currently, `CryptoKey::usages` returns an owned `Vec<KeyUsage>` cloned from its internal list of usages. However, all its callers only read the list of key usages, and they don't actually need an owned list.

This patch changes the returned value of `CryptoKey::usages` from an owned `Vec<KeyUsage>` to a reference of the internal list of key usages so that we can skip cloning the list.

`JsonWebKeyExt::set_key_ops` is also changed to take `&[KeyUsage]` returned from `CryptoKey::usages` accordingly.

Testing: Refactoring. Covered by existing WPT tests for WebCryptoAPI.