### PR TITLE
devtools: Remove `completionType` from `EvalResult`

### DIFF
--- a/components/default-resources/resources/debugger.js
+++ b/components/default-resources/resources/debugger.js
@@ -396,7 +396,6 @@ addEventListener("eval", event => {
     let resultValue;
     if (completionValue === null) {
         resultValue = {
-            completionType: "terminated",
             value: createValueGrip(undefined, 0),
             hasException: false,
         };
@@ -407,21 +406,18 @@ addEventListener("eval", event => {
         // let value = dbg.adoptDebuggeeValue(completionValue.throw);
         let realError = completionValue.throw.unsafeDereference();
         resultValue = {
-            completionType: "throw",
             value: createValueGrip(completionValue.throw, 0),
             exceptionMessage: realError.message,
             hasException: true,
         };
     } else if ("return" in completionValue) {
         resultValue = {
-            completionType: "return",
             value: createValueGrip(completionValue.return, 0),
             hasException: false,
         };
     }
 
     evalResult(event, {
-        completionType: resultValue.completionType,
         serializedValue: JSON.stringify(resultValue.value),
         exceptionMessage: resultValue.hasException ? resultValue.exceptionMessage : null,
         hasException: resultValue.hasException,

--- a/components/script_bindings/webidls/DebuggerEvalEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerEvalEvent.webidl
@@ -18,7 +18,6 @@ partial interface DebuggerGlobalScope {
 
 dictionary EvalResult {
     required DOMString serializedValue;
-    required DOMString completionType;
     required DOMString? exceptionMessage;
     boolean hasException;
 };


### PR DESCRIPTION
Remove `completionType` from `EvalResult`, we don't use it.

Testing: We don't use this type, so this should not impact tests. Existing tests are passing
Fixes: part of #36027 
