### PR TITLE
script: Do not clear the `WindowProxy` when exiting a pipeline

### DIFF
--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -2422,17 +2422,6 @@ impl Window {
         self.current_state.set(WindowState::Zombie);
         *self.js_runtime.borrow_mut() = None;
 
-        // If this is the currently active pipeline,
-        // nullify the window_proxy.
-        if let Some(proxy) = self.window_proxy.get() {
-            let pipeline_id = self.pipeline_id();
-            if let Some(currently_active) = proxy.currently_active() &&
-                currently_active == pipeline_id
-            {
-                self.window_proxy.set(None);
-            }
-        }
-
         if let Some(performance) = self.performance.get() {
             performance.clear_and_disable_performance_entry_buffer();
         }

--- a/tests/wpt/meta/html/browsers/the-window-object/self-et-al.window.js.ini
+++ b/tests/wpt/meta/html/browsers/the-window-object/self-et-al.window.js.ini
@@ -1,2 +1,13 @@
 [self-et-al.window.html]
-  expected: CRASH
+  expected: TIMEOUT
+  [popupWindow.frames before, after closing, and after discarding]
+    expected: TIMEOUT
+
+  [popupWindow.globalThis before, after closing, and after discarding]
+    expected: TIMEOUT
+
+  [popupWindow.self before, after closing, and after discarding]
+    expected: TIMEOUT
+
+  [popupWindow.window before, after closing, and after discarding]
+    expected: TIMEOUT


### PR DESCRIPTION
Instead of clearing the `WindowProxy` on a `Window` when exiting a
pipeline, leave it in place (marked as discarded). This solves some
issues where code can attempt to access the proxy while it is being torn
down. Garbage collection leaks shouldn't be an issue in this case
because:

1. The proxy is stored as a `Dom` traced value so cycles should be
   collected.
2. Navigations (maybe sometimes?) do not clear these values anyway,
   so they are long-lived.

I validated that the `Window` object for the removed frames was dropped
and also that they don't show up in `about: memory`.

Testing: This fixes a panic in a WPT test.
Fixes: #24459.
Fixes: #28298.
Fixes: #44868.

