### PR TITLE
layout: Make accessibility tree an actual tree.

### DIFF
--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -258,10 +258,10 @@ impl AccessibilityTree {
                 _ => None,
             })
         {
-            let node = self.nodes.remove(&id);
+            let _node = self.nodes.remove(&id);
             {
                 #[cfg(debug_assertions)]
-                assert!(node.is_some(), "Node for id {:?} was already removed", id);
+                assert!(_node.is_some(), "Node for id {id:?} was already removed");
             }
             if let Some(opaque_node) = self.id_to_opaque_node.remove(&id) {
                 self.opaque_node_to_id.remove(&opaque_node);
@@ -334,10 +334,8 @@ impl AccessibilityTree {
         };
 
         // Traverse the tree from the given root.
-        let mut nodes: Vec<(
-            ArcRefCell<AccessibilityNode>,
-            Option<WeakRefCell<AccessibilityNode>>,
-        )> = vec![(root_node, None)];
+        // `nodes` is a Vec of pairs of nodes and their expected parents.
+        let mut nodes = vec![(root_node, None)];
         let mut seen_node_ids = FxHashSet::default();
         while let Some((node, expected_parent)) = nodes.pop() {
             let node = node.borrow();
@@ -351,11 +349,14 @@ impl AccessibilityTree {
 
             node.assert_integrity(expected_parent);
 
+            // assert_node_for_id() here double-checks that the node hasn't been incorrectly evicted
+            // from the map while it's still retained as a child node.
             let weak_node = Some(self.assert_node_for_id(&node.id).downgrade());
             nodes.extend(node.children().iter().cloned().zip(repeat(weak_node)));
         }
 
         // If this fails, then the tree has orphaned nodes (a leak).
+        // If a node has been incorrectly removed from the map, that will be caught above.
         assert_eq!(seen_node_ids, self.nodes.keys().copied().collect());
     }
 
@@ -413,21 +414,21 @@ impl AccessibilityNode {
         let dom_children: Vec<ServoLayoutNode> = dom_node.flat_tree_children().collect();
 
         let mut damage_from_children = LocalAccessibilityDamage::empty();
-        let new_children = dom_children
-            .iter()
-            .map(|dom_child| {
-                let (child_id, child_node) = tree.get_or_create_node(dom_child, update);
-                let child_damage =
-                    tree.update_node_and_descendants_from_dom_node(&child_node, dom_child, update);
-                damage_from_children.insert(child_damage);
-                (child_id, child_node)
-            })
-            .collect();
+        let mut new_child_ids = vec![];
+        let mut new_child_nodes = vec![];
+        for dom_child in dom_children {
+            let (child_id, child_node) = tree.get_or_create_node(&dom_child, update);
+            let child_damage =
+                tree.update_node_and_descendants_from_dom_node(&child_node, &dom_child, update);
+            damage_from_children.insert(child_damage);
+            new_child_ids.push(child_id);
+            new_child_nodes.push(child_node);
+        }
         if !damage_from_children.is_empty() {
             damage.insert(LocalAccessibilityDamage::SUBTREE_CHANGED);
         }
 
-        damage.insert(self.set_children(weak_self, new_children, update));
+        damage.insert(self.set_children(weak_self, new_child_ids, new_child_nodes, update));
         damage
     }
 
@@ -545,11 +546,10 @@ impl AccessibilityNode {
     fn set_children(
         &mut self,
         weak_self: WeakRefCell<Self>,
-        new_children: Vec<(NodeId, ArcRefCell<AccessibilityNode>)>,
+        new_child_ids: Vec<NodeId>,
+        new_child_nodes: Vec<ArcRefCell<AccessibilityNode>>,
         update: &mut AccessibilityUpdate,
     ) -> LocalAccessibilityDamage {
-        let (new_child_ids, new_child_nodes): (Vec<NodeId>, Vec<ArcRefCell<AccessibilityNode>>) =
-            new_children.into_iter().unzip();
         if new_child_ids == self.child_ids() {
             return LocalAccessibilityDamage::empty();
         }
@@ -660,7 +660,7 @@ impl AccessibilityNode {
             );
         }
 
-        let children_ids: Vec<NodeId> = self
+        let children_ids: Vec<_> = self
             .children()
             .iter()
             .map(|child| child.borrow().id)
@@ -777,7 +777,7 @@ fn test_accessibility_update_add_some_nodes_twice() {
     let root_node = tree.get_or_create_node_with_id(NodeId(2), &mut root_update);
     tree.root_node = Some(root_node.clone());
 
-    let nodes = [
+    let nodes: Vec<_> = [
         (3, Role::GenericContainer),
         (4, Role::Heading),
         (5, Role::Paragraph),
@@ -790,9 +790,13 @@ fn test_accessibility_update_add_some_nodes_twice() {
         (id, node)
     })
     .collect();
-    root_node
-        .borrow_mut()
-        .set_children(root_node.downgrade(), nodes, &mut root_update);
+    let (child_node_ids, child_nodes) = nodes.iter().cloned().unzip();
+    root_node.borrow_mut().set_children(
+        root_node.downgrade(),
+        child_node_ids,
+        child_nodes,
+        &mut root_update,
+    );
 
     let mut update = AccessibilityUpdate::new(None);
 

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -48,8 +48,6 @@ struct AccessibilityUpdate {
     /// `AccessibilityData`. Only set if `pref::expensive_accessibility_test_assertions_enabled`
     /// is set.
     rooted_nodes: Option<FxHashSet<OpaqueNode>>,
-    /// Nodes which were removed from their parents but may still be reparented later in the update.
-    removed_nodes: FxHashMap<NodeId, ArcRefCell<AccessibilityNode>>,
 }
 
 struct AccessibilityNode {
@@ -57,11 +55,6 @@ struct AccessibilityNode {
     /// nodes, and as an identifier in [`accesskit`] datastructures: [`accesskit::Node`]s,
     /// [`accesskit::TreeUpdate`]s and [`accesskit::ActionRequest`]s.
     id: NodeId,
-    /// A `WeakRefCell` wrapping this node.
-    ///
-    /// Note: this only needs to be `Option` because there is no equivalent to `Arc::new_cyclic()`
-    /// for `ArcRefCell`.
-    weak_self: Option<WeakRefCell<AccessibilityNode>>,
     /// The computed [`accesskit::Node`] data. This will be copied and serialized into a
     /// [`accesskit::TreeUpdate`] whenever it is changed during an update.
     accesskit_node: accesskit::Node,
@@ -86,7 +79,7 @@ struct AccessibilityNode {
 pub struct AccessibilityTree {
     /// All nodes currently in the tree as of the most recent update. New nodes are added and stale
     /// nodes are pruned during [`AccessibilityTree::update_tree()`].
-    nodes: FxHashMap<NodeId, WeakRefCell<AccessibilityNode>>,
+    nodes: FxHashMap<NodeId, ArcRefCell<AccessibilityNode>>,
     /// A map to allow retrieving the [`AccessibilityNode`] which corresponds to a particular DOM
     /// node, if any.
     ///
@@ -185,12 +178,13 @@ impl AccessibilityTree {
         dom_node: &ServoLayoutNode<'_>,
         update: &mut AccessibilityUpdate,
     ) -> LocalAccessibilityDamage {
+        let weak_node = node.downgrade();
         let mut node = node.borrow_mut();
         let mut damage = LocalAccessibilityDamage::empty();
 
         // TODO: read accessibility damage from DOM (right now, assume damage is complete)
         damage.insert(node.update_node_from_dom_node(dom_node));
-        damage.insert(node.update_descendants_from_dom_node(dom_node, self, update));
+        damage.insert(node.update_descendants_from_dom_node(weak_node, dom_node, self, update));
 
         damage.insert(node.update_node_local(damage));
 
@@ -226,18 +220,13 @@ impl AccessibilityTree {
         id: NodeId,
         update: &mut AccessibilityUpdate,
     ) -> ArcRefCell<AccessibilityNode> {
-        if let Some(node) = self.nodes.get(&id) &&
-            let Some(node) = node.upgrade()
-        {
-            return node;
+        if let Some(node) = self.nodes.get(&id) {
+            return node.clone();
         }
 
         let node = ArcRefCell::new(AccessibilityNode::new(id));
-        update.set_tree_state_change(id, node.clone(), TreeChange::New);
-        let weak_node = node.downgrade();
-        self.nodes.insert(id, weak_node.clone());
-
-        node.borrow_mut().weak_self = Some(weak_node);
+        update.set_tree_state_change(id, TreeChange::New);
+        self.nodes.insert(id, node.clone());
 
         node
     }
@@ -246,7 +235,7 @@ impl AccessibilityTree {
         let Some(node) = self.nodes.get(id) else {
             panic!("{id:?} does not exist in tree");
         };
-        node.upgrade().expect("Node should not be dropped")
+        node.clone()
     }
 
     /// Consume the [`AccessibilityUpdate`] by deleting all nodes it detected as being removed from
@@ -272,13 +261,7 @@ impl AccessibilityTree {
             let node = self.nodes.remove(&id);
             {
                 #[cfg(debug_assertions)]
-                let Some(node) = node else {
-                    panic!("Node for id {id:?} was already removed");
-                };
-                debug_assert!(
-                    node.upgrade().is_some(),
-                    "Node {id:?} was dropped before removal"
-                );
+                assert!(node.is_some(), "Node for id {:?} was already removed", id);
             }
             if let Some(opaque_node) = self.id_to_opaque_node.remove(&id) {
                 self.opaque_node_to_id.remove(&opaque_node);
@@ -350,13 +333,6 @@ impl AccessibilityTree {
             return;
         };
 
-        for (id, node) in self.nodes.iter() {
-            assert!(
-                node.upgrade().is_some(),
-                "Node with id {id:?} retained in `nodes` but was already dropped"
-            );
-        }
-
         // Traverse the tree from the given root.
         let mut nodes: Vec<(
             ArcRefCell<AccessibilityNode>,
@@ -375,7 +351,7 @@ impl AccessibilityTree {
 
             node.assert_integrity(expected_parent);
 
-            let weak_node = node.weak_self.clone();
+            let weak_node = Some(self.assert_node_for_id(&node.id).downgrade());
             nodes.extend(node.children().iter().cloned().zip(repeat(weak_node)));
         }
 
@@ -415,7 +391,6 @@ impl AccessibilityNode {
     fn new_with_role(id: NodeId, role: Role) -> Self {
         Self {
             id,
-            weak_self: None,
             accesskit_node: accesskit::Node::new(role),
             parent_node: None,
             child_nodes: vec![],
@@ -424,22 +399,11 @@ impl AccessibilityNode {
         }
     }
 
-    fn expect_weak_self(&self) -> WeakRefCell<AccessibilityNode> {
-        self.weak_self
-            .clone()
-            .expect("weak_self should be set at creation time")
-    }
-
-    fn expect_strong_self(&self) -> ArcRefCell<AccessibilityNode> {
-        self.expect_weak_self()
-            .upgrade()
-            .expect("weak_self can't be dropped while self is still alive")
-    }
-
     /// Update this node's [`Self::children`] from its corresponding DOM node. If any children are
     /// newly added to the tree, populate them and recursively populate their children.
     fn update_descendants_from_dom_node<'dom>(
         &mut self,
+        weak_self: WeakRefCell<Self>,
         dom_node: &ServoLayoutNode<'dom>,
         tree: &mut AccessibilityTree,
         update: &mut AccessibilityUpdate,
@@ -463,7 +427,7 @@ impl AccessibilityNode {
             damage.insert(LocalAccessibilityDamage::SUBTREE_CHANGED);
         }
 
-        damage.insert(self.set_children(new_children, update));
+        damage.insert(self.set_children(weak_self, new_children, update));
         damage
     }
 
@@ -484,7 +448,7 @@ impl AccessibilityNode {
             "New shouldn't be set recursively"
         );
 
-        update.set_tree_state_change(self.id, self.expect_strong_self(), change);
+        update.set_tree_state_change(self.id, change);
 
         for child in self.children().iter() {
             // `new_change` might be different per node, if only some nodes were moved elsewhere.
@@ -580,6 +544,7 @@ impl AccessibilityNode {
     /// children.
     fn set_children(
         &mut self,
+        weak_self: WeakRefCell<Self>,
         new_children: Vec<(NodeId, ArcRefCell<AccessibilityNode>)>,
         update: &mut AccessibilityUpdate,
     ) -> LocalAccessibilityDamage {
@@ -590,7 +555,6 @@ impl AccessibilityNode {
         }
 
         let old_child_ids = self.child_ids();
-        let weak_self = self.expect_weak_self();
 
         for (old_id, old_child) in old_child_ids.iter().zip(self.children().iter()) {
             if !new_child_ids.contains(old_id) {
@@ -731,7 +695,6 @@ impl AccessibilityUpdate {
             changed_nodes: FxHashSet::default(),
             tree_changes: FxHashMap::default(),
             rooted_nodes,
-            removed_nodes: FxHashMap::default(),
         }
     }
 
@@ -741,12 +704,7 @@ impl AccessibilityUpdate {
         node.updated = false;
     }
 
-    fn set_tree_state_change(
-        &mut self,
-        node_id: NodeId,
-        node: ArcRefCell<AccessibilityNode>,
-        change: TreeChange,
-    ) {
+    fn set_tree_state_change(&mut self, node_id: NodeId, change: TreeChange) {
         let old_change = self.tree_changes.get(&node_id);
 
         assert!(
@@ -765,12 +723,6 @@ impl AccessibilityUpdate {
             .unwrap_or(change);
 
         self.tree_changes.insert(node_id, resolved_change);
-
-        if resolved_change == TreeChange::Removed {
-            self.removed_nodes.insert(node_id, node);
-        } else {
-            self.removed_nodes.remove(&node_id);
-        }
     }
 
     fn is_new(&mut self, node_id: &NodeId) -> bool {
@@ -838,7 +790,9 @@ fn test_accessibility_update_add_some_nodes_twice() {
         (id, node)
     })
     .collect();
-    root_node.borrow_mut().set_children(nodes, &mut root_update);
+    root_node
+        .borrow_mut()
+        .set_children(root_node.downgrade(), nodes, &mut root_update);
 
     let mut update = AccessibilityUpdate::new(None);
 

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 use std::collections::VecDeque;
 use std::fmt::Debug;
+use std::iter::repeat;
 use std::sync::atomic::AtomicU64;
 use std::sync::{LazyLock, atomic};
 
@@ -20,6 +21,7 @@ use style::dom::OpaqueNode;
 use web_atoms::{LocalName, local_name};
 
 use crate::ArcRefCell;
+use crate::cell::WeakRefCell;
 
 bitflags! {
     /// Damage which was caused by changes to the accessibility tree. These changes can cause other
@@ -46,6 +48,8 @@ struct AccessibilityUpdate {
     /// `AccessibilityData`. Only set if `pref::expensive_accessibility_test_assertions_enabled`
     /// is set.
     rooted_nodes: Option<FxHashSet<OpaqueNode>>,
+    /// Nodes which were removed from their parents but may still be reparented later in the update.
+    removed_nodes: FxHashMap<NodeId, ArcRefCell<AccessibilityNode>>,
 }
 
 struct AccessibilityNode {
@@ -53,9 +57,18 @@ struct AccessibilityNode {
     /// nodes, and as an identifier in [`accesskit`] datastructures: [`accesskit::Node`]s,
     /// [`accesskit::TreeUpdate`]s and [`accesskit::ActionRequest`]s.
     id: NodeId,
+    /// A `WeakRefCell` wrapping this node.
+    ///
+    /// Note: this only needs to be `Option` because there is no equivalent to `Arc::new_cyclic()`
+    /// for `ArcRefCell`.
+    weak_self: Option<WeakRefCell<AccessibilityNode>>,
     /// The computed [`accesskit::Node`] data. This will be copied and serialized into a
     /// [`accesskit::TreeUpdate`] whenever it is changed during an update.
     accesskit_node: accesskit::Node,
+    /// This node's parent, if any.
+    parent_node: Option<WeakRefCell<AccessibilityNode>>,
+    /// All this node's children.
+    child_nodes: Vec<ArcRefCell<AccessibilityNode>>,
     /// The [`OpaqueNode`] for the DOM node which corresponds to this accessibility node, if any.
     /// An accessibility node may not correspond to a DOM node if it corresponds to a
     /// pseudo-element, or in a test.
@@ -73,7 +86,7 @@ struct AccessibilityNode {
 pub struct AccessibilityTree {
     /// All nodes currently in the tree as of the most recent update. New nodes are added and stale
     /// nodes are pruned during [`AccessibilityTree::update_tree()`].
-    nodes: FxHashMap<NodeId, ArcRefCell<AccessibilityNode>>,
+    nodes: FxHashMap<NodeId, WeakRefCell<AccessibilityNode>>,
     /// A map to allow retrieving the [`AccessibilityNode`] which corresponds to a particular DOM
     /// node, if any.
     ///
@@ -88,9 +101,10 @@ pub struct AccessibilityTree {
     /// [grafted](https://docs.rs/accesskit/latest/accesskit/struct.Node.html#method.tree_id) into
     /// an application's tree.
     tree_id: accesskit::TreeId,
-    /// Sent with each [`accesskit::TreeUpdate`] to identify the root node, and also used in
-    /// [`Self::assert_integrity()`].
-    root_node_id: Option<NodeId>,
+    /// This node's ID is sent with each [`accesskit::TreeUpdate`] to identify the root node.
+    /// Also used for any complete tree walk, such as in [`Self::assert_integrity()`] and
+    /// [`Self::print()`].
+    root_node: Option<ArcRefCell<AccessibilityNode>>,
     /// Sent to the embedder alongside each [`accesskit::TreeUpdate`], so that the embedder can
     /// drop updates from documents which have been navigated away from.
     embedder_epoch: Epoch,
@@ -140,7 +154,7 @@ impl AccessibilityTree {
             opaque_node_to_id: FxHashMap::default(),
             id_to_opaque_node: FxHashMap::default(),
             tree_id,
-            root_node_id: None,
+            root_node: None,
             embedder_epoch,
             debug: opts::get().debug.clone(),
         }
@@ -154,8 +168,8 @@ impl AccessibilityTree {
         rooted_nodes: Option<FxHashSet<OpaqueNode>>,
     ) -> Option<accesskit::TreeUpdate> {
         let mut update = AccessibilityUpdate::new(rooted_nodes);
-        let (root_node_id, root_node) = self.get_or_create_node(root_dom_node, &mut update);
-        self.root_node_id = Some(root_node_id);
+        let (_, root_node) = self.get_or_create_node(root_dom_node, &mut update);
+        self.root_node = Some(root_node.clone());
 
         self.update_node_and_descendants_from_dom_node(&root_node, root_dom_node, &mut update);
 
@@ -178,7 +192,7 @@ impl AccessibilityTree {
         damage.insert(node.update_node_from_dom_node(dom_node));
         damage.insert(node.update_descendants_from_dom_node(dom_node, self, update));
 
-        damage.insert(node.update_node_local(damage, self));
+        damage.insert(node.update_node_local(damage));
 
         if node.updated {
             update.add(&mut node);
@@ -212,13 +226,18 @@ impl AccessibilityTree {
         id: NodeId,
         update: &mut AccessibilityUpdate,
     ) -> ArcRefCell<AccessibilityNode> {
-        if let Some(node) = self.nodes.get(&id) {
-            return node.clone();
+        if let Some(node) = self.nodes.get(&id) &&
+            let Some(node) = node.upgrade()
+        {
+            return node;
         }
 
-        update.set_tree_state_change(id, TreeChange::New);
         let node = ArcRefCell::new(AccessibilityNode::new(id));
-        self.nodes.insert(id, node.clone());
+        update.set_tree_state_change(id, node.clone(), TreeChange::New);
+        let weak_node = node.downgrade();
+        self.nodes.insert(id, weak_node.clone());
+
+        node.borrow_mut().weak_self = Some(weak_node);
 
         node
     }
@@ -227,7 +246,7 @@ impl AccessibilityTree {
         let Some(node) = self.nodes.get(id) else {
             panic!("{id:?} does not exist in tree");
         };
-        node.clone()
+        node.upgrade().expect("Node should not be dropped")
     }
 
     /// Consume the [`AccessibilityUpdate`] by deleting all nodes it detected as being removed from
@@ -251,7 +270,16 @@ impl AccessibilityTree {
             })
         {
             let node = self.nodes.remove(&id);
-            debug_assert!(node.is_some(), "Node for id {id:?} was already removed");
+            {
+                #[cfg(debug_assertions)]
+                let Some(node) = node else {
+                    panic!("Node for id {id:?} was already removed");
+                };
+                debug_assert!(
+                    node.upgrade().is_some(),
+                    "Node {id:?} was dropped before removal"
+                );
+            }
             if let Some(opaque_node) = self.id_to_opaque_node.remove(&id) {
                 self.opaque_node_to_id.remove(&opaque_node);
             }
@@ -318,36 +346,50 @@ impl AccessibilityTree {
     /// For accessibility tests only, because it’s expensive.
     fn assert_integrity(&self) {
         debug_assert!(pref!(expensive_accessibility_test_assertions_enabled));
-        let Some(root_node_id) = self.root_node_id else {
+        let Some(root_node) = self.root_node.clone() else {
             return;
         };
+
+        for (id, node) in self.nodes.iter() {
+            assert!(
+                node.upgrade().is_some(),
+                "Node with id {id:?} retained in `nodes` but was already dropped"
+            );
+        }
+
         // Traverse the tree from the given root.
-        let mut node_ids = vec![root_node_id];
+        let mut nodes: Vec<(
+            ArcRefCell<AccessibilityNode>,
+            Option<WeakRefCell<AccessibilityNode>>,
+        )> = vec![(root_node, None)];
         let mut seen_node_ids = FxHashSet::default();
-        while let Some(node_id) = node_ids.pop() {
+        while let Some((node, expected_parent)) = nodes.pop() {
+            let node = node.borrow();
+
             // If this fails, then the tree is not a tree at all.
             assert!(
-                seen_node_ids.insert(node_id),
-                "Tree contains {node_id:?} in multiple places"
+                seen_node_ids.insert(node.id),
+                "Tree contains {:?} in multiple places",
+                node.id
             );
-            // If this fails, then the tree has dangling references.
-            let node = self.assert_node_for_id(&node_id);
-            let node = node.borrow();
-            node_ids.extend(node.child_ids().iter().rev());
+
+            node.assert_integrity(expected_parent);
+
+            let weak_node = node.weak_self.clone();
+            nodes.extend(node.children().iter().cloned().zip(repeat(weak_node)));
         }
+
         // If this fails, then the tree has orphaned nodes (a leak).
-        // Dangling references are already caught in the loop above.
         assert_eq!(seen_node_ids, self.nodes.keys().copied().collect());
     }
 
     fn print(&self) {
-        let Some(root_node_id) = self.root_node_id else {
+        let Some(root_node) = self.root_node.clone() else {
             return;
         };
 
         let mut print_tree = PrintTree::new("Accessibility Tree");
-        let node = self.assert_node_for_id(&root_node_id);
-        node.borrow().print(self, &mut print_tree);
+        root_node.borrow().print(&mut print_tree);
         print_tree.end_level();
     }
 }
@@ -373,10 +415,25 @@ impl AccessibilityNode {
     fn new_with_role(id: NodeId, role: Role) -> Self {
         Self {
             id,
+            weak_self: None,
             accesskit_node: accesskit::Node::new(role),
+            parent_node: None,
+            child_nodes: vec![],
             opaque_node: None,
             updated: true,
         }
+    }
+
+    fn expect_weak_self(&self) -> WeakRefCell<AccessibilityNode> {
+        self.weak_self
+            .clone()
+            .expect("weak_self should be set at creation time")
+    }
+
+    fn expect_strong_self(&self) -> ArcRefCell<AccessibilityNode> {
+        self.expect_weak_self()
+            .upgrade()
+            .expect("weak_self can't be dropped while self is still alive")
     }
 
     /// Update this node's [`Self::children`] from its corresponding DOM node. If any children are
@@ -392,21 +449,21 @@ impl AccessibilityNode {
         let dom_children: Vec<ServoLayoutNode> = dom_node.flat_tree_children().collect();
 
         let mut damage_from_children = LocalAccessibilityDamage::empty();
-        let new_child_ids = dom_children
+        let new_children = dom_children
             .iter()
             .map(|dom_child| {
                 let (child_id, child_node) = tree.get_or_create_node(dom_child, update);
                 let child_damage =
                     tree.update_node_and_descendants_from_dom_node(&child_node, dom_child, update);
                 damage_from_children.insert(child_damage);
-                child_id
+                (child_id, child_node)
             })
             .collect();
         if !damage_from_children.is_empty() {
             damage.insert(LocalAccessibilityDamage::SUBTREE_CHANGED);
         }
 
-        damage.insert(self.set_children(new_child_ids, tree, update));
+        damage.insert(self.set_children(new_children, update));
         damage
     }
 
@@ -421,25 +478,17 @@ impl AccessibilityNode {
     /// Note: if a node is moved, the requested `change` must always be `Moved(Pending)`: the logic
     /// in this method will determine whether the move is `Complete` and set the stored value
     /// accordingly.
-    fn set_subtree_state_change(
-        &self,
-        change: TreeChange,
-        tree: &mut AccessibilityTree,
-        update: &mut AccessibilityUpdate,
-    ) {
+    fn set_subtree_state_change(&self, change: TreeChange, update: &mut AccessibilityUpdate) {
         assert!(
             change != TreeChange::New,
             "New shouldn't be set recursively"
         );
 
-        update.set_tree_state_change(self.id, change);
+        update.set_tree_state_change(self.id, self.expect_strong_self(), change);
 
-        for child_id in self.child_ids().iter() {
-            let child = tree.assert_node_for_id(child_id);
+        for child in self.children().iter() {
             // `new_change` might be different per node, if only some nodes were moved elsewhere.
-            child
-                .borrow()
-                .set_subtree_state_change(change, tree, update);
+            child.borrow().set_subtree_state_change(change, update);
         }
     }
 
@@ -464,16 +513,12 @@ impl AccessibilityNode {
     /// For example, if there were nodes added or removed in its subtree, its computed text may have
     /// changed, so that will be recomputed here.
     /// If any changes are made, add this node to the given [`AccessibilityUpdate`].
-    fn update_node_local(
-        &mut self,
-        damage: LocalAccessibilityDamage,
-        tree: &mut AccessibilityTree,
-    ) -> LocalAccessibilityDamage {
+    fn update_node_local(&mut self, damage: LocalAccessibilityDamage) -> LocalAccessibilityDamage {
         let mut new_damage = LocalAccessibilityDamage::empty();
         if damage.contains(LocalAccessibilityDamage::SUBTREE_CHANGED) ||
             damage.contains(LocalAccessibilityDamage::ROLE_CHANGED)
         {
-            if let Some(text) = self.label_from_descendants(tree) {
+            if let Some(text) = self.label_from_descendants() {
                 new_damage.insert(self.set_label(text.as_str()));
             } else {
                 new_damage.insert(self.clear_label());
@@ -483,14 +528,13 @@ impl AccessibilityNode {
         new_damage
     }
 
-    fn label_from_descendants(&self, tree: &AccessibilityTree) -> Option<String> {
+    fn label_from_descendants(&self) -> Option<String> {
         if !NAME_FROM_CONTENTS_ROLES.contains(&self.role()) {
             return None;
         }
-        let mut children = VecDeque::from_iter(self.child_ids().iter().copied());
+        let mut children = VecDeque::from_iter(self.children().iter().cloned());
         let mut text = String::new();
-        while let Some(child_id) = children.pop_front() {
-            let child = tree.assert_node_for_id(&child_id);
+        while let Some(child) = children.pop_front() {
             let child = child.borrow();
             match child.role() {
                 Role::TextRun => {
@@ -499,8 +543,8 @@ impl AccessibilityNode {
                     }
                 },
                 _ => {
-                    for id in child.child_ids().iter().rev() {
-                        children.push_front(*id);
+                    for node in child.children().iter().rev() {
+                        children.push_front(node.clone());
                     }
                 },
             }
@@ -508,22 +552,25 @@ impl AccessibilityNode {
         Some(text.trim().to_owned())
     }
 
-    fn print(&self, tree: &AccessibilityTree, print_tree: &mut PrintTree) {
-        if self.child_ids().is_empty() {
+    fn print(&self, print_tree: &mut PrintTree) {
+        if self.children().is_empty() {
             print_tree.add_item(format!("{self:?}"));
             return;
         }
 
         print_tree.new_level(format!("{self:?}"));
 
-        for child_id in self.child_ids() {
-            let child = tree.assert_node_for_id(child_id);
-            child.borrow().print(tree, print_tree);
+        for child in self.children() {
+            child.borrow().print(print_tree);
         }
         print_tree.end_level();
     }
 
     // TODO: use macros to generate getter/setter methods.
+
+    fn children(&self) -> &Vec<ArcRefCell<AccessibilityNode>> {
+        &self.child_nodes
+    }
 
     fn child_ids(&self) -> &[NodeId] {
         self.accesskit_node.children()
@@ -533,33 +580,41 @@ impl AccessibilityNode {
     /// children.
     fn set_children(
         &mut self,
-        new_child_ids: Vec<NodeId>,
-        tree: &mut AccessibilityTree,
+        new_children: Vec<(NodeId, ArcRefCell<AccessibilityNode>)>,
         update: &mut AccessibilityUpdate,
     ) -> LocalAccessibilityDamage {
+        let (new_child_ids, new_child_nodes): (Vec<NodeId>, Vec<ArcRefCell<AccessibilityNode>>) =
+            new_children.into_iter().unzip();
         if new_child_ids == self.child_ids() {
             return LocalAccessibilityDamage::empty();
         }
 
         let old_child_ids = self.child_ids();
-        for old_id in old_child_ids.iter() {
-            if !new_child_ids.contains(old_id) {
-                let removed_child = tree.assert_node_for_id(old_id);
-                let removed_child = removed_child.borrow();
-                removed_child.set_subtree_state_change(TreeChange::Removed, tree, update);
-            }
-        }
+        let weak_self = self.expect_weak_self();
 
-        for new_id in new_child_ids.iter() {
-            if !old_child_ids.contains(new_id) {
-                let new_child = tree.assert_node_for_id(new_id);
-                let new_child = new_child.borrow();
-                if !update.is_new(new_id) {
-                    new_child.set_subtree_state_change(TreeChange::PendingMove, tree, update);
+        for (old_id, old_child) in old_child_ids.iter().zip(self.children().iter()) {
+            if !new_child_ids.contains(old_id) {
+                let mut removed_child = old_child.borrow_mut();
+                removed_child.set_subtree_state_change(TreeChange::Removed, update);
+                if let Some(parent_node) = removed_child.parent_node.clone() &&
+                    parent_node.ptr_eq(&weak_self)
+                {
+                    removed_child.parent_node = None;
                 }
             }
         }
 
+        for (new_id, new_child) in new_child_ids.iter().zip(new_child_nodes.iter()) {
+            if !old_child_ids.contains(new_id) {
+                let mut new_child = new_child.borrow_mut();
+                new_child.parent_node = Some(weak_self.clone());
+                if !update.is_new(new_id) {
+                    new_child.set_subtree_state_change(TreeChange::PendingMove, update);
+                }
+            }
+        }
+
+        self.child_nodes = new_child_nodes;
         self.accesskit_node.set_children(new_child_ids);
         self.updated = true;
 
@@ -625,6 +680,33 @@ impl AccessibilityNode {
         self.updated = true;
         LocalAccessibilityDamage::TEXT_CHANGED
     }
+
+    fn assert_integrity(&self, expected_parent: Option<WeakRefCell<AccessibilityNode>>) {
+        debug_assert!(pref!(expensive_accessibility_test_assertions_enabled));
+
+        if let Some(actual_parent) = &self.parent_node {
+            let expected = expected_parent.expect("Actual parent but no expected parent");
+            let expected = expected.upgrade().expect("Expected parent was dropped");
+            let actual = actual_parent.upgrade().expect("Actual parent was dropped");
+            assert!(actual.ptr_eq(&expected));
+        } else {
+            assert!(
+                expected_parent.is_none(),
+                "Expected parent but no actual parent"
+            );
+        }
+
+        let children_ids: Vec<NodeId> = self
+            .children()
+            .iter()
+            .map(|child| child.borrow().id)
+            .collect();
+        assert_eq!(
+            children_ids,
+            self.child_ids(),
+            "children() IDs didn't match child_ids() for {self:?}"
+        );
+    }
 }
 
 impl Debug for AccessibilityNode {
@@ -649,6 +731,7 @@ impl AccessibilityUpdate {
             changed_nodes: FxHashSet::default(),
             tree_changes: FxHashMap::default(),
             rooted_nodes,
+            removed_nodes: FxHashMap::default(),
         }
     }
 
@@ -658,7 +741,12 @@ impl AccessibilityUpdate {
         node.updated = false;
     }
 
-    fn set_tree_state_change(&mut self, node_id: NodeId, change: TreeChange) {
+    fn set_tree_state_change(
+        &mut self,
+        node_id: NodeId,
+        node: ArcRefCell<AccessibilityNode>,
+        change: TreeChange,
+    ) {
         let old_change = self.tree_changes.get(&node_id);
 
         assert!(
@@ -666,7 +754,7 @@ impl AccessibilityUpdate {
             "Incoming change must never be Moved"
         );
 
-        let new_change = old_change
+        let resolved_change = old_change
             .map(|old_change| match (old_change, change) {
                 (TreeChange::PendingMove, TreeChange::Removed) => TreeChange::Moved,
                 (TreeChange::Removed, TreeChange::PendingMove) => TreeChange::Moved,
@@ -676,7 +764,13 @@ impl AccessibilityUpdate {
             })
             .unwrap_or(change);
 
-        self.tree_changes.insert(node_id, new_change);
+        self.tree_changes.insert(node_id, resolved_change);
+
+        if resolved_change == TreeChange::Removed {
+            self.removed_nodes.insert(node_id, node);
+        } else {
+            self.removed_nodes.remove(&node_id);
+        }
     }
 
     fn is_new(&mut self, node_id: &NodeId) -> bool {
@@ -689,8 +783,11 @@ impl AccessibilityUpdate {
     /// [`Self::tree_changes`].
     fn finalize(mut self, tree: &mut AccessibilityTree) -> Option<accesskit::TreeUpdate> {
         let root_node_id = tree
-            .root_node_id
-            .expect("AccessibilityUpdate::finalize() called but no root_node_id set in tree");
+            .root_node
+            .clone()
+            .expect("AccessibilityUpdate::finalize() called but no root_node set in tree")
+            .borrow()
+            .id;
 
         if self.changed_nodes.is_empty() {
             assert!(self.tree_changes.is_empty());
@@ -726,7 +823,7 @@ fn test_accessibility_update_add_some_nodes_twice() {
     let mut root_update = AccessibilityUpdate::new(None);
 
     let root_node = tree.get_or_create_node_with_id(NodeId(2), &mut root_update);
-    tree.root_node_id = Some(root_node.borrow().id);
+    tree.root_node = Some(root_node.clone());
 
     let nodes = [
         (3, Role::GenericContainer),
@@ -738,12 +835,10 @@ fn test_accessibility_update_add_some_nodes_twice() {
         let id = NodeId(id);
         let node = tree.get_or_create_node_with_id(id, &mut root_update);
         node.borrow_mut().set_role(role);
-        id
+        (id, node)
     })
     .collect();
-    root_node
-        .borrow_mut()
-        .set_children(nodes, &mut tree, &mut root_update);
+    root_node.borrow_mut().set_children(nodes, &mut root_update);
 
     let mut update = AccessibilityUpdate::new(None);
 

--- a/components/layout/cell.rs
+++ b/components/layout/cell.rs
@@ -92,6 +92,10 @@ impl<T> WeakRefCell<T> {
     pub(crate) fn upgrade(&self) -> Option<ArcRefCell<T>> {
         self.value.upgrade().map(|value| ArcRefCell { value })
     }
+
+    pub(crate) fn ptr_eq(&self, other: &Self) -> bool {
+        self.value.ptr_eq(&other.value)
+    }
 }
 
 pub(crate) enum RefOrAtomicRef<'a, T> {


### PR DESCRIPTION
Modify `AccessibilityNode` to have strong references to its children, and a weak reference to its parent.
Modify `AccessibilityTree` to have a reference to the root node itself, rather than the root node ID.

This means we don't need to pass `AccessibilityTree` into methods which walk the tree structure, nor do we need to do map lookups to walk the tree.

Testing: Updates the integrity check to account for the changes.
Fixes: Part of #45967