### PR TITLE
script: More resiliently handle out of order removal / access of `TreeOrderedIndexMap`

### DIFF
--- a/components/script/dom/tree_ordered_index_map.rs
+++ b/components/script/dom/tree_ordered_index_map.rs
@@ -209,12 +209,8 @@ impl TreeOrderedIndexMap {
         }
 
         Self::resolve_one(no_gc, scope, key, occupied_entry.get_mut(), self.index_type);
-        if let Some(element) = occupied_entry.get().element.get() {
-            return Some(element);
-        }
 
-        occupied_entry.remove();
-        None
+        occupied_entry.get().element.get()
     }
 
     /// Get all of the entries in the map, in DOM order that share a particular `key`. If the
@@ -231,13 +227,10 @@ impl TreeOrderedIndexMap {
 
         {
             let mut map = self.map.borrow_mut();
-            if let Entry::Occupied(mut occupied_entry) = map.entry(key.clone()) {
-                if occupied_entry.get().needs_resolution() {
-                    Self::resolve_one(no_gc, scope, key, occupied_entry.get_mut(), self.index_type);
-                }
-                if occupied_entry.get().elements.is_empty() {
-                    occupied_entry.remove();
-                }
+            if let Entry::Occupied(mut occupied_entry) = map.entry(key.clone()) &&
+                occupied_entry.get().needs_resolution()
+            {
+                Self::resolve_one(no_gc, scope, key, occupied_entry.get_mut(), self.index_type);
             }
         }
         Ref::map(self.map.borrow(), |map| {
@@ -303,8 +296,6 @@ impl TreeOrderedIndexMap {
                 _ => {},
             }
         }
-
-        entry.count = entry.elements.len();
     }
 
     /// Resolve all entries in the map, meaning the next access will not need any resolution.
@@ -345,22 +336,6 @@ impl TreeOrderedIndexMap {
                     return;
                 }
             }
-        }
-
-        // If no elements were found for any of the entries needing resolution,
-        // remove them from the map mirroring what `resolve_one` does. For all
-        // other entries, update their final `count`.
-        let mut keys_needing_removal = Vec::new();
-        for (key, entry) in entries_needing_rebuild {
-            if entry.elements.is_empty() {
-                keys_needing_removal.push(key.clone());
-            } else {
-                entry.count = entry.elements.len();
-            }
-        }
-
-        for key in keys_needing_removal {
-            map.remove(&key);
         }
     }
 }

--- a/tests/wpt/tests/html/semantics/forms/the-button-element/button-form-refers-to-elements-with-duplicate-ids-crash.html
+++ b/tests/wpt/tests/html/semantics/forms/the-button-element/button-form-refers-to-elements-with-duplicate-ids-crash.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/45792">
+
+<button form="duplicate"></button>
+<div id="container">
+  <span id="duplicate"></span>
+  <span id="duplicate"></span>
+</div>
+<script>
+  container.remove();
+</script>


### PR DESCRIPTION
Sometimes script will multiple items from the tree, call JavaScript
code, and finally remove some of those removed-from-tree item's `id`s
from the `TreeOrderedIndexMap`. When this happens and a map entry is in
unresolved state, it will try to re-resolve entries accessed during
script execution. During re-resolution we were trying to remove newly
empty entries from the map (regardless of their count), meaning that
when removed-from-tree but not removed-from-map entries have their ids
removed, the map would be in an unexpected state.

This change removes the cleanup code, relying on script to always call
one remove for any addition in order to clean up old entries. This
prevents going into an unreachable code section because a map entry is
always expected when a remove happens.

In short, the previous implementation had a self-healing approach that
could put the `TreeOrderedIndexMap` in an unexpected state, so this
change removes that self-healing code. This shouldn't be an issue as
long as every addition comes with a removal. The failure mode is that
the map has too many entries, which isn't an error, just a little messy.
Some kinds of misuse are already guarded with assertions (the code that
was tripped by this bug).

Testing: This change adds a new WPT crash test.
Fixes: #45792.
