### PR TITLE
deps: Bump x25519-dalek to 3.0.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1828,12 +1828,12 @@ checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.3"
+version = "5.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+checksum = "c906a87e53a36ff795d72e06e8162a83c5436e3ea89e942a9cb9fc083f0a384f"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
  "fiat-crypto",
  "rustc_version",
@@ -2468,7 +2468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2594,9 +2594,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "filetime"
@@ -3038,7 +3038,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7170,7 +7170,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7227,7 +7227,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9936,7 +9936,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11478,7 +11478,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12021,13 +12021,13 @@ checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "x25519-dalek"
-version = "2.0.1"
+version = "3.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+checksum = "eee64e8620caa64914d669b1f68f858aaff54e2d0f9ad3b30a613b58a1baa83e"
 dependencies = [
  "curve25519-dalek",
- "rand_core 0.6.4",
- "serde",
+ "getrandom 0.4.1",
+ "rand_core 0.10.1",
  "zeroize",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -284,7 +284,7 @@ winit = "0.30.13"
 winresource = "0.1"
 wio = "0.2"
 wr_malloc_size_of = "0.2.2"
-x25519-dalek = { version = "2.0.1", features = ["static_secrets"] }
+x25519-dalek = { version = "=3.0.0-rc.1", features = ["getrandom", "static_secrets", "zeroize"] }
 xcomponent-sys = "0.3.6"
 xml = "1.1"
 xml5ever = "0.39"

--- a/components/script/dom/webcrypto/subtlecrypto/x25519_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/x25519_operation.rs
@@ -2,9 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use elliptic_curve::rand_core::OsRng;
 use js::context::JSContext;
-use pkcs8::der::asn1::{OctetString, OctetStringRef};
+use pkcs8::der::asn1::OctetStringRef;
 use pkcs8::der::{Decode, Encode};
 use pkcs8::{AlgorithmIdentifierRef, ObjectIdentifier, PrivateKeyInfoRef, SubjectPublicKeyInfoRef};
 use x25519_dalek::{PublicKey, StaticSecret};
@@ -125,7 +124,7 @@ pub(crate) fn generate_key(
 
     // Step 2. Generate an X25519 key pair, with the private key being 32 random bytes, and the
     // public key being X25519(a, 9), as defined in [RFC7748], section 6.1.
-    let private_key = StaticSecret::random_from_rng(OsRng);
+    let private_key = StaticSecret::random();
     let public_key = PublicKey::from(&private_key);
 
     // Step 3. Let algorithm be a new KeyAlgorithm object.
@@ -292,7 +291,7 @@ pub(crate) fn import_key(
             // Step 2.7. If an error occurred while parsing, then throw a DataError.
             let curve_private_key = private_key_info
                 .private_key
-                .decode_into::<OctetString>()
+                .decode_into::<&OctetStringRef>()
                 .map_err(|_| {
                     Error::Data(Some(
                         "Failed to decode the privateKey field of PrivateKeyInfo ASN.1 structure"


### PR DESCRIPTION
Bump x25519-dalek from 2.0.1 to 3.0.0-rc.1.

Since the new version of x25519-dalek is still in release candidate phase, we pin them with `=3.0.0-rc.1`. We can later switch back to normal version number, i.e. `3.0`, once the new stable releases are out.

The `zeroize` feature is also enabled to ensure that the secret key is zeroized after use.

The importKey operation is also changed from using `OctetString` to using `OctetStringRef` to save us one memory allocation.

Testing: Covered by existing WPT tests in `WebCryptoAPI` subdirectory
Part of: #42206