### PR TITLE
script: Remove final usages of `CanGc` in `document_event_handler`

### DIFF
--- a/components/script/dom/clipboard/clipboardevent.rs
+++ b/components/script/dom/clipboard/clipboardevent.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use script_bindings::str::DOMString;
 use style::Atom;
 
@@ -17,7 +18,6 @@ use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::datatransfer::DataTransfer;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 /// The types of clipboard events in the Clipboard APIs specification:
 /// <https://www.w3.org/TR/clipboard-apis/#clipboard-actions>.
@@ -56,19 +56,19 @@ impl ClipboardEvent {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         event_type: Atom,
         can_bubble: EventBubbles,
         cancelable: EventCancelable,
         clipboard_data: Option<&DataTransfer>,
-        can_gc: CanGc,
     ) -> DomRoot<ClipboardEvent> {
-        let ev = reflect_dom_object_with_proto(
+        let ev = reflect_dom_object_with_proto_and_cx(
             Box::new(ClipboardEvent::new_inherited()),
             window,
             proto,
-            can_gc,
+            cx,
         );
         ev.upcast::<Event>()
             .init_event(event_type, bool::from(can_bubble), bool::from(cancelable));
@@ -88,22 +88,22 @@ impl ClipboardEvent {
 impl ClipboardEventMethods<crate::DomTypeHolder> for ClipboardEvent {
     /// <https://www.w3.org/TR/clipboard-apis/#dom-clipboardevent-clipboardevent>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         event_type: DOMString,
         init: &ClipboardEventInit,
     ) -> DomRoot<ClipboardEvent> {
         let bubbles = EventBubbles::from(init.parent.bubbles);
         let cancelable = EventCancelable::from(init.parent.cancelable);
         let event = ClipboardEvent::new(
+            cx,
             window,
             proto,
             event_type.into(),
             bubbles,
             cancelable,
             init.clipboardData.as_deref(),
-            can_gc,
         );
         event.upcast::<Event>().set_composed(init.parent.composed);
         event

--- a/components/script/dom/datatransfer/datatransfer.rs
+++ b/components/script/dom/datatransfer/datatransfer.rs
@@ -6,11 +6,12 @@ use std::cell::{Ref, RefCell};
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::{HandleObject, MutableHandleValue};
 use net_traits::image_cache::Image;
 use script_bindings::cell::DomRefCell;
 use script_bindings::match_domstring_ascii;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
 
 use crate::dom::bindings::codegen::Bindings::DataTransferBinding::DataTransferMethods;
 use crate::dom::bindings::inheritance::Castable;
@@ -64,27 +65,27 @@ impl DataTransfer {
     }
 
     pub(crate) fn new_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         data_store: Rc<RefCell<Option<DragDataStore>>>,
     ) -> DomRoot<DataTransfer> {
-        let item_list = DataTransferItemList::new(window, Rc::clone(&data_store), can_gc);
+        let item_list = DataTransferItemList::new(cx, window, Rc::clone(&data_store));
 
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(DataTransfer::new_inherited(data_store, &item_list)),
             window,
             proto,
-            can_gc,
+            cx,
         )
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         data_store: Rc<RefCell<Option<DragDataStore>>>,
-        can_gc: CanGc,
     ) -> DomRoot<DataTransfer> {
-        Self::new_with_proto(window, None, can_gc, data_store)
+        Self::new_with_proto(cx, window, None, data_store)
     }
 
     pub(crate) fn data_store(&self) -> Option<Ref<'_, DragDataStore>> {
@@ -95,16 +96,16 @@ impl DataTransfer {
 impl DataTransferMethods<crate::DomTypeHolder> for DataTransfer {
     /// <https://html.spec.whatwg.org/multipage/#dom-datatransfer>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<DataTransfer> {
         let mut drag_data_store = DragDataStore::new();
         drag_data_store.set_mode(Mode::ReadWrite);
 
         let data_store = Rc::new(RefCell::new(Some(drag_data_store)));
 
-        DataTransfer::new_with_proto(window, proto, can_gc, data_store)
+        DataTransfer::new_with_proto(cx, window, proto, data_store)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-datatransfer-dropeffect>

--- a/components/script/dom/datatransfer/datatransferitemlist.rs
+++ b/components/script/dom/datatransfer/datatransferitemlist.rs
@@ -6,8 +6,9 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::MutableHandleValue;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 
 use crate::dom::bindings::codegen::Bindings::DataTransferItemListBinding::DataTransferItemListMethods;
 use crate::dom::bindings::error::{Error, Fallible};
@@ -19,7 +20,6 @@ use crate::dom::datatransferitem::DataTransferItem;
 use crate::dom::file::File;
 use crate::dom::window::Window;
 use crate::drag_data_store::{DragDataStore, Kind, Mode};
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct DataTransferItemList {
@@ -41,14 +41,14 @@ impl DataTransferItemList {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         data_store: Rc<RefCell<Option<DragDataStore>>>,
-        can_gc: CanGc,
     ) -> DomRoot<DataTransferItemList> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(DataTransferItemList::new_inherited(data_store)),
             window,
-            can_gc,
+            cx,
         )
     }
 

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -5445,7 +5445,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
                 CanGc::from_cx(cx),
             ))),
             "compositionevent" | "textevent" => Ok(DomRoot::upcast(
-                CompositionEvent::new_uninitialized(&self.window, CanGc::from_cx(cx)),
+                CompositionEvent::new_uninitialized(cx, &self.window),
             )),
             "customevent" => Ok(DomRoot::upcast(CustomEvent::new_uninitialized(
                 self.window.upcast(),
@@ -5482,13 +5482,19 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
                 "".into(),
                 CanGc::from_cx(cx),
             ))),
-            "touchevent" => Ok(DomRoot::upcast(DomTouchEvent::new_uninitialized(
-                &self.window,
-                &TouchList::new(&self.window, &[], CanGc::from_cx(cx)),
-                &TouchList::new(&self.window, &[], CanGc::from_cx(cx)),
-                &TouchList::new(&self.window, &[], CanGc::from_cx(cx)),
-                CanGc::from_cx(cx),
-            ))),
+            "touchevent" => {
+                let touches = TouchList::new(cx, &self.window, &[]);
+                let changed_touches = TouchList::new(cx, &self.window, &[]);
+                let target_touches = TouchList::new(cx, &self.window, &[]);
+
+                Ok(DomRoot::upcast(DomTouchEvent::new_uninitialized(
+                    cx,
+                    &self.window,
+                    &touches,
+                    &changed_touches,
+                    &target_touches,
+                )))
+            },
             "uievent" | "uievents" => Ok(DomRoot::upcast(UIEvent::new_uninitialized(
                 &self.window,
                 CanGc::from_cx(cx),

--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -39,7 +39,6 @@ use script_bindings::inheritance::Castable;
 use script_bindings::match_domstring_ascii;
 use script_bindings::num::Finite;
 use script_bindings::root::{Dom, DomRoot, DomSlice};
-use script_bindings::script_runtime::CanGc;
 use script_bindings::str::DOMString;
 use script_traits::ConstellationInputEvent;
 use servo_base::generic_channel::GenericCallback;
@@ -1456,7 +1455,12 @@ impl DocumentEventHandler {
             TouchEventType::Cancel => "touchcancel",
         };
 
+        let touches = TouchList::new(cx, window, self.active_touch_points.borrow().r());
+        let changed_touches = TouchList::new(cx, window, from_ref(&&*changed_touch));
+        let target_touches = TouchList::new(cx, window, target_touches.r());
+
         let touch_event = TouchEvent::new(
+            cx,
             window,
             event_name.into(),
             EventBubbles::Bubbles,
@@ -1464,19 +1468,14 @@ impl DocumentEventHandler {
             EventComposed::Composed,
             Some(window),
             0i32,
-            &TouchList::new(
-                window,
-                self.active_touch_points.borrow().r(),
-                CanGc::from_cx(cx),
-            ),
-            &TouchList::new(window, from_ref(&&*changed_touch), CanGc::from_cx(cx)),
-            &TouchList::new(window, target_touches.r(), CanGc::from_cx(cx)),
+            &touches,
+            &changed_touches,
+            &target_touches,
             // FIXME: modifier keys
             false,
             false,
             false,
             false,
-            CanGc::from_cx(cx),
         );
         let event = touch_event.upcast::<Event>();
         event.fire(cx, &touch_dispatch_target);
@@ -1588,6 +1587,7 @@ impl DocumentEventHandler {
 
         let cancelable = composition_event.state == keyboard_types::CompositionState::Start;
         let event = CompositionEvent::new(
+            cx,
             &self.window,
             composition_event.state.event_type().into(),
             true,
@@ -1595,7 +1595,6 @@ impl DocumentEventHandler {
             Some(&self.window),
             0,
             DOMString::from(composition_event.data),
-            CanGc::from_cx(cx),
         );
 
         let event = event.upcast::<Event>();
@@ -1644,6 +1643,7 @@ impl DocumentEventHandler {
         );
         // https://w3c.github.io/uievents/#event-wheelevents
         let dom_event = WheelEvent::new(
+            cx,
             &self.window,
             event_type,
             EventBubbles::Bubbles,
@@ -1668,7 +1668,6 @@ impl DocumentEventHandler {
             Finite::wrap(-event.delta.y),
             Finite::wrap(-event.delta.z),
             event.delta.mode as u32,
-            CanGc::from_cx(cx),
         );
 
         let dom_event = dom_event.upcast::<Event>();
@@ -1973,13 +1972,13 @@ impl DocumentEventHandler {
         clipboard_event_type: ClipboardEventType,
     ) -> DomRoot<ClipboardEvent> {
         let clipboard_event = ClipboardEvent::new(
+            cx,
             &self.window,
             None,
             clipboard_event_type.as_str().into(),
             EventBubbles::Bubbles,
             EventCancelable::Cancelable,
             None,
-            CanGc::from_cx(cx),
         );
 
         // Step 1 Let clear_was_called be false
@@ -2038,9 +2037,9 @@ impl DocumentEventHandler {
 
         // Step 3
         let clipboard_event_data = DataTransfer::new(
+            cx,
             &self.window,
             Rc::new(RefCell::new(Some(drag_data_store))),
-            CanGc::from_cx(cx),
         );
 
         // Step 8

--- a/components/script/dom/event/compositionevent.rs
+++ b/components/script/dom/event/compositionevent.rs
@@ -3,8 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::{reflect_dom_object, reflect_dom_object_with_proto};
+use script_bindings::reflector::{
+    reflect_dom_object_with_cx, reflect_dom_object_with_proto_and_cx,
+};
 use style::Atom;
 
 use crate::dom::bindings::codegen::Bindings::CompositionEventBinding::{
@@ -16,7 +19,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::uievent::UIEvent;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct CompositionEvent {
@@ -32,12 +34,16 @@ impl CompositionEvent {
         }
     }
 
-    pub(crate) fn new_uninitialized(window: &Window, can_gc: CanGc) -> DomRoot<CompositionEvent> {
-        reflect_dom_object(Box::new(CompositionEvent::new_inherited()), window, can_gc)
+    pub(crate) fn new_uninitialized(
+        cx: &mut JSContext,
+        window: &Window,
+    ) -> DomRoot<CompositionEvent> {
+        reflect_dom_object_with_cx(Box::new(CompositionEvent::new_inherited()), window, cx)
     }
 
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         event_type: Atom,
         can_bubble: bool,
@@ -45,15 +51,15 @@ impl CompositionEvent {
         view: Option<&Window>,
         detail: i32,
         data: DOMString,
-        can_gc: CanGc,
     ) -> DomRoot<CompositionEvent> {
         Self::new_with_proto(
-            window, None, event_type, can_bubble, cancelable, view, detail, data, can_gc,
+            cx, window, None, event_type, can_bubble, cancelable, view, detail, data,
         )
     }
 
     #[expect(clippy::too_many_arguments)]
     fn new_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         event_type: Atom,
@@ -62,16 +68,15 @@ impl CompositionEvent {
         view: Option<&Window>,
         detail: i32,
         data: DOMString,
-        can_gc: CanGc,
     ) -> DomRoot<CompositionEvent> {
-        let ev = reflect_dom_object_with_proto(
+        let ev = reflect_dom_object_with_proto_and_cx(
             Box::new(CompositionEvent {
                 uievent: UIEvent::new_inherited(),
                 data,
             }),
             window,
             proto,
-            can_gc,
+            cx,
         );
         ev.uievent
             .init_event(event_type, can_bubble, cancelable, view, detail);
@@ -86,13 +91,14 @@ impl CompositionEvent {
 impl CompositionEventMethods<crate::DomTypeHolder> for CompositionEvent {
     /// <https://w3c.github.io/uievents/#dom-compositionevent-compositionevent>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         event_type: DOMString,
         init: &CompositionEventBinding::CompositionEventInit,
     ) -> Fallible<DomRoot<CompositionEvent>> {
         let event = CompositionEvent::new_with_proto(
+            cx,
             window,
             proto,
             event_type.into(),
@@ -101,7 +107,6 @@ impl CompositionEventMethods<crate::DomTypeHolder> for CompositionEvent {
             init.parent.view.as_deref(),
             init.parent.detail,
             init.data.clone(),
-            can_gc,
         );
         Ok(event)
     }

--- a/components/script/dom/event/touchevent.rs
+++ b/components/script/dom/event/touchevent.rs
@@ -5,7 +5,8 @@
 use std::cell::Cell;
 
 use dom_struct::dom_struct;
-use script_bindings::reflector::reflect_dom_object;
+use js::context::JSContext;
+use script_bindings::reflector::reflect_dom_object_with_cx;
 use style::Atom;
 
 use crate::dom::bindings::codegen::Bindings::TouchEventBinding::TouchEventMethods;
@@ -16,7 +17,6 @@ use crate::dom::event::{Event, EventBubbles, EventCancelable, EventComposed};
 use crate::dom::touchlist::TouchList;
 use crate::dom::uievent::UIEvent;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 /// <https://w3c.github.io/touch-events/#dom-touchevent>
 #[dom_struct]
@@ -64,25 +64,26 @@ impl TouchEvent {
     }
 
     pub(crate) fn new_uninitialized(
+        cx: &mut JSContext,
         window: &Window,
         touches: &TouchList,
         changed_touches: &TouchList,
         target_touches: &TouchList,
-        can_gc: CanGc,
     ) -> DomRoot<TouchEvent> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(TouchEvent::new_inherited(
                 touches,
                 changed_touches,
                 target_touches,
             )),
             window,
-            can_gc,
+            cx,
         )
     }
 
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         event_type: Atom,
         can_bubble: EventBubbles,
@@ -97,10 +98,9 @@ impl TouchEvent {
         alt_key: bool,
         shift_key: bool,
         meta_key: bool,
-        can_gc: CanGc,
     ) -> DomRoot<TouchEvent> {
         let ev =
-            TouchEvent::new_uninitialized(window, touches, changed_touches, target_touches, can_gc);
+            TouchEvent::new_uninitialized(cx, window, touches, changed_touches, target_touches);
         ev.upcast::<UIEvent>().init_event(
             event_type,
             bool::from(can_bubble),

--- a/components/script/dom/event/wheelevent.rs
+++ b/components/script/dom/event/wheelevent.rs
@@ -6,9 +6,10 @@ use std::cell::Cell;
 
 use dom_struct::dom_struct;
 use euclid::Point2D;
+use js::context::JSContext;
 use js::rust::HandleObject;
 use keyboard_types::Modifiers;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use style::Atom;
 use style_traits::CSSPixel;
 
@@ -24,7 +25,6 @@ use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::mouseevent::MouseEvent;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct WheelEvent {
@@ -47,15 +47,21 @@ impl WheelEvent {
     }
 
     fn new_unintialized(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<WheelEvent> {
-        reflect_dom_object_with_proto(Box::new(WheelEvent::new_inherited()), window, proto, can_gc)
+        reflect_dom_object_with_proto_and_cx(
+            Box::new(WheelEvent::new_inherited()),
+            window,
+            proto,
+            cx,
+        )
     }
 
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         event_type: Atom,
         can_bubble: EventBubbles,
@@ -74,9 +80,9 @@ impl WheelEvent {
         delta_y: Finite<f64>,
         delta_z: Finite<f64>,
         delta_mode: u32,
-        can_gc: CanGc,
     ) -> DomRoot<WheelEvent> {
         Self::new_with_proto(
+            cx,
             window,
             None,
             event_type,
@@ -96,12 +102,12 @@ impl WheelEvent {
             delta_y,
             delta_z,
             delta_mode,
-            can_gc,
         )
     }
 
     #[allow(clippy::too_many_arguments)]
     fn new_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         event_type: Atom,
@@ -121,9 +127,8 @@ impl WheelEvent {
         delta_y: Finite<f64>,
         delta_z: Finite<f64>,
         delta_mode: u32,
-        can_gc: CanGc,
     ) -> DomRoot<WheelEvent> {
-        let ev = WheelEvent::new_unintialized(window, proto, can_gc);
+        let ev = WheelEvent::new_unintialized(cx, window, proto);
         ev.intitialize_wheel_event(
             event_type,
             can_bubble,
@@ -197,9 +202,9 @@ impl WheelEvent {
 impl WheelEventMethods<crate::DomTypeHolder> for WheelEvent {
     /// <https://w3c.github.io/uievents/#dom-wheelevent-wheelevent>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         event_type: DOMString,
         init: &WheelEventBinding::WheelEventInit,
     ) -> Fallible<DomRoot<WheelEvent>> {
@@ -213,6 +218,7 @@ impl WheelEventMethods<crate::DomTypeHolder> for WheelEvent {
         );
 
         let event = WheelEvent::new_with_proto(
+            cx,
             window,
             proto,
             event_type.into(),
@@ -232,7 +238,6 @@ impl WheelEventMethods<crate::DomTypeHolder> for WheelEvent {
             init.deltaY,
             init.deltaZ,
             init.deltaMode,
-            can_gc,
         );
 
         Ok(event)

--- a/components/script/dom/touchlist.rs
+++ b/components/script/dom/touchlist.rs
@@ -3,13 +3,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use js::context::JSContext;
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 
 use crate::dom::bindings::codegen::Bindings::TouchListBinding::TouchListMethods;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::touch::Touch;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct TouchList {
@@ -25,8 +25,12 @@ impl TouchList {
         }
     }
 
-    pub(crate) fn new(window: &Window, touches: &[&Touch], can_gc: CanGc) -> DomRoot<TouchList> {
-        reflect_dom_object(Box::new(TouchList::new_inherited(touches)), window, can_gc)
+    pub(crate) fn new(
+        cx: &mut JSContext,
+        window: &Window,
+        touches: &[&Touch],
+    ) -> DomRoot<TouchList> {
+        reflect_dom_object_with_cx(Box::new(TouchList::new_inherited(touches)), window, cx)
     }
 }
 

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -136,12 +136,20 @@ DOMInterfaces = {
     'realm': ['ReadText', 'WriteText']
 },
 
+'ClipboardEvent': {
+    'cx': ['Constructor']
+},
+
 'ClipboardItem': {
     'cx': ['Constructor', 'Types'],
     'realm': ['GetType']
 },
 
 'Comment': {
+    'cx': ['Constructor']
+},
+
+'CompositionEvent': {
     'cx': ['Constructor']
 },
 
@@ -233,7 +241,7 @@ DOMInterfaces = {
 },
 
 'DataTransfer': {
-    'cx': ['Files', 'Types']
+    'cx': ['Constructor', 'Files', 'Types']
 },
 
 'DataTransferItem': {
@@ -1278,6 +1286,10 @@ DOMInterfaces = {
 
 'WebGLShader': {
     'weakReferenceable': True,
+},
+
+'WheelEvent': {
+    'cx': ['Constructor']
 },
 
 'WindowClient': {


### PR DESCRIPTION
Part of #40600

Testing: it compiles