### PR TITLE
script: introduce `fill_compile_options`

### DIFF
--- a/components/script/dom/global_scope_script_execution.rs
+++ b/components/script/dom/global_scope_script_execution.rs
@@ -69,6 +69,15 @@ impl From<bool> for ErrorReporting {
     }
 }
 
+impl From<ErrorReporting> for bool {
+    fn from(error_reporting: ErrorReporting) -> Self {
+        match error_reporting {
+            ErrorReporting::Muted => true,
+            ErrorReporting::Unmuted => false,
+        }
+    }
+}
+
 pub(crate) enum RethrowErrors {
     Yes,
     No,
@@ -77,6 +86,7 @@ pub(crate) enum RethrowErrors {
 impl GlobalScope {
     /// <https://html.spec.whatwg.org/multipage/#creating-a-classic-script>
     #[expect(clippy::too_many_arguments)]
+    #[expect(unsafe_code)]
     pub(crate) fn create_a_classic_script(
         &self,
         cx: &mut JSContext,
@@ -96,8 +106,6 @@ impl GlobalScope {
         };
         unminify_js(&mut script_source);
 
-        rooted!(&in(cx) let mut compiled_script = std::ptr::null_mut::<JSScript>());
-
         // TODO Step 1. If mutedErrors is true, then set baseURL to about:blank.
 
         // TODO Step 2. If scripting is disabled for settings, then set source to the empty string.
@@ -106,16 +114,18 @@ impl GlobalScope {
 
         // TODO Step 9. Record classic script creation time given script and sourceURLForWindowScripts.
 
-        // Step 10. Let result be ParseScript(source, settings's realm, script).
-        compiled_script.set(compile_script(
+        let options = fill_compile_options(
             cx,
-            &script_source.source.str(),
             url.as_str(),
-            line_number,
             introduction_type,
-            muted_errors,
-            true,
-        ));
+            muted_errors.into(),
+            true, // noScriptRval
+            line_number,
+        );
+        let mut source = transform_str_to_source_text(&script_source.source.str());
+
+        // Step 10. Let result be ParseScript(source, settings's realm, script).
+        rooted!(&in(cx) let compiled_script = unsafe { Compile1(cx, options.ptr, &mut source) });
 
         // Step 11. If result is a list of errors, then:
         let record = if compiled_script.get().is_null() {
@@ -325,25 +335,17 @@ impl GlobalScope {
     }
 }
 
-#[expect(unsafe_code)]
-pub(crate) fn compile_script(
+pub(crate) fn fill_compile_options(
     cx: &mut JSContext,
-    text: &str,
     filename: &str,
-    line_number: u32,
     introduction_type: Option<&'static CStr>,
-    muted_errors: ErrorReporting,
+    muted_errors: bool,
     no_script_rval: bool,
-) -> *mut JSScript {
-    let muted_errors = match muted_errors {
-        ErrorReporting::Muted => true,
-        ErrorReporting::Unmuted => false,
-    };
-
+    line_number: u32,
+) -> CompileOptionsWrapper {
     // TODO: pass filename as CString to avoid allocation
     // See https://github.com/servo/servo/issues/42126
-    let filename = cformat!("{filename}");
-    let mut options = CompileOptionsWrapper::new(cx, filename, line_number);
+    let mut options = CompileOptionsWrapper::new(cx, cformat!("{filename}"), line_number);
     if let Some(introduction_type) = introduction_type {
         options.set_introduction_type(introduction_type);
     }
@@ -355,8 +357,7 @@ pub(crate) fn compile_script(
     options.set_is_run_once(true);
     options.set_no_script_rval(no_script_rval);
 
-    debug!("Compiling script");
-    unsafe { Compile1(cx, options.ptr, &mut transform_str_to_source_text(text)) }
+    options
 }
 
 /// <https://tc39.es/ecma262/#sec-runtime-semantics-scriptevaluation>

--- a/components/script/dom/global_scope_script_execution.rs
+++ b/components/script/dom/global_scope_script_execution.rs
@@ -69,15 +69,6 @@ impl From<bool> for ErrorReporting {
     }
 }
 
-impl From<ErrorReporting> for bool {
-    fn from(error_reporting: ErrorReporting) -> Self {
-        match error_reporting {
-            ErrorReporting::Muted => true,
-            ErrorReporting::Unmuted => false,
-        }
-    }
-}
-
 pub(crate) enum RethrowErrors {
     Yes,
     No,
@@ -118,7 +109,7 @@ impl GlobalScope {
             cx,
             url.as_str(),
             introduction_type,
-            muted_errors.into(),
+            muted_errors,
             true, // noScriptRval
             line_number,
         );
@@ -339,10 +330,15 @@ pub(crate) fn fill_compile_options(
     cx: &mut JSContext,
     filename: &str,
     introduction_type: Option<&'static CStr>,
-    muted_errors: bool,
+    muted_errors: ErrorReporting,
     no_script_rval: bool,
     line_number: u32,
 ) -> CompileOptionsWrapper {
+    let muted_errors = match muted_errors {
+        ErrorReporting::Muted => true,
+        ErrorReporting::Unmuted => false,
+    };
+
     // TODO: pass filename as CString to avoid allocation
     // See https://github.com/servo/servo/issues/42126
     let mut options = CompileOptionsWrapper::new(cx, cformat!("{filename}"), line_number);

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -120,7 +120,9 @@ use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventsource::EventSource;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::file::File;
-use crate::dom::global_scope_script_execution::{evaluate_script, fill_compile_options};
+use crate::dom::global_scope_script_execution::{
+    ErrorReporting, evaluate_script, fill_compile_options,
+};
 use crate::dom::idbfactory::IDBFactory;
 use crate::dom::messageport::MessagePort;
 use crate::dom::paintworkletglobalscope::PaintWorkletGlobalScope;
@@ -2952,7 +2954,7 @@ impl GlobalScope {
                 cx,
                 filename,
                 introduction_type,
-                false,          // mutedErrors_
+                ErrorReporting::Unmuted,
                 rval.is_none(), // noScriptRval
                 1,              // lineno
             );

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -27,14 +27,15 @@ use fonts::FontContext;
 use indexmap::IndexSet;
 use ipc_channel::router::ROUTER;
 use js::jsapi::{
-    CurrentGlobalOrNull, GetNonCCWObjectGlobal, HandleObject, Heap, JSContext, JSObject, JSScript,
+    CurrentGlobalOrNull, GetNonCCWObjectGlobal, HandleObject, Heap, JSContext, JSObject,
 };
 use js::jsval::UndefinedValue;
 use js::panic::maybe_resume_unwind;
 use js::realm::CurrentRealm;
+use js::rust::wrappers2::Compile1;
 use js::rust::{
     CustomAutoRooter, CustomAutoRooterGuard, HandleValue, MutableHandleValue, ParentRuntime,
-    Runtime, get_object_class,
+    Runtime, get_object_class, transform_str_to_source_text,
 };
 use js::{JSCLASS_IS_DOMJSCLASS, JSCLASS_IS_GLOBAL};
 use net_traits::blob_url_store::BlobBuf;
@@ -119,7 +120,7 @@ use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventsource::EventSource;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::file::File;
-use crate::dom::global_scope_script_execution::{ErrorReporting, compile_script, evaluate_script};
+use crate::dom::global_scope_script_execution::{evaluate_script, fill_compile_options};
 use crate::dom::idbfactory::IDBFactory;
 use crate::dom::messageport::MessagePort;
 use crate::dom::paintworkletglobalscope::PaintWorkletGlobalScope;
@@ -2934,6 +2935,7 @@ impl GlobalScope {
     }
 
     /// Evaluate JS code on this global scope.
+    #[expect(unsafe_code)]
     pub(crate) fn evaluate_js_on_global(
         &self,
         cx: &mut CurrentRealm,
@@ -2946,18 +2948,17 @@ impl GlobalScope {
             let url = self.api_base_url();
             let fetch_options = ScriptFetchOptions::default_classic_script();
 
-            let no_script_rval = rval.is_none();
-
-            rooted!(&in(cx) let mut compiled_script = std::ptr::null_mut::<JSScript>());
-            compiled_script.set(compile_script(
+            let options = fill_compile_options(
                 cx,
-                &code,
                 filename,
-                1,
                 introduction_type,
-                ErrorReporting::Unmuted,
-                no_script_rval,
-            ));
+                false,          // mutedErrors_
+                rval.is_none(), // noScriptRval
+                1,              // lineno
+            );
+
+            let mut source = transform_str_to_source_text(&code);
+            rooted!(&in(cx) let compiled_script = unsafe { Compile1(cx, options.ptr, &mut source) });
 
             let Some(script) = NonNull::new(*compiled_script) else {
                 debug!("error compiling Dom string");

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -68,7 +68,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::csp::{GlobalCspReporting, Violation};
-use crate::dom::global_scope_script_execution::fill_compile_options;
+use crate::dom::global_scope_script_execution::{ErrorReporting, fill_compile_options};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::html::htmlscriptelement::{SCRIPT_JS_MIMES, substitute_with_local_script};
 use crate::dom::performance::performanceresourcetiming::InitiatorType;
@@ -314,8 +314,8 @@ impl ModuleTree {
             cx,
             url.as_str(),
             introduction_type,
-            false, // mutedErrors_
-            true,  // noScriptRval
+            ErrorReporting::Unmuted,
+            true, // noScriptRval
             line_number,
         );
 
@@ -400,9 +400,9 @@ impl ModuleTree {
             cx,
             url.as_str(),
             introduction_type,
-            false, // mutedErrors_
-            true,  // noScriptRval
-            1,     // lineno
+            ErrorReporting::Unmuted,
+            true, // noScriptRval
+            1,    // lineno
         );
 
         rooted!(&in(cx) let mut module_script: *mut JSObject = std::ptr::null_mut());

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -35,9 +35,7 @@ use js::rust::wrappers2::{
     JS_NewStringCopyN, JS_SetPendingException, ModuleEvaluate, ModuleLink,
     ThrowOnModuleEvaluationFailure,
 };
-use js::rust::{
-    CompileOptionsWrapper, Handle, HandleValue, ToString, transform_str_to_source_text,
-};
+use js::rust::{Handle, HandleValue, ToString, transform_str_to_source_text};
 use mime::Mime;
 use net_traits::blob_url_store::UrlWithBlobClaim;
 use net_traits::http_status::HttpStatus;
@@ -49,7 +47,6 @@ use net_traits::request::{
 };
 use net_traits::{FetchMetadata, Metadata, NetworkError, ReferrerPolicy, ResourceFetchTiming};
 use script_bindings::cell::DomRefCell;
-use script_bindings::cformat;
 use script_bindings::domstring::BytesView;
 use script_bindings::error::Fallible;
 use script_bindings::reflector::DomObject;
@@ -71,6 +68,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::csp::{GlobalCspReporting, Violation};
+use crate::dom::global_scope_script_execution::fill_compile_options;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::html::htmlscriptelement::{SCRIPT_JS_MIMES, substitute_with_local_script};
 use crate::dom::performance::performanceresourcetiming::InitiatorType;
@@ -312,7 +310,14 @@ impl ModuleTree {
             loaded_modules: DomRefCell::new(IndexMap::new()),
         };
 
-        let compile_options = fill_module_compile_options(cx, url, introduction_type, line_number);
+        let compile_options = fill_compile_options(
+            cx,
+            url.as_str(),
+            introduction_type,
+            false, // mutedErrors_
+            true,  // noScriptRval
+            line_number,
+        );
 
         let mut module_source = ModuleSource {
             source,
@@ -391,7 +396,14 @@ impl ModuleTree {
         // Step 3. Set script's base URL and fetch options to null.
         // Note: We don't need to call `SetModulePrivate` for json scripts
 
-        let compile_options = fill_module_compile_options(cx, url, introduction_type, 1);
+        let compile_options = fill_compile_options(
+            cx,
+            url.as_str(),
+            introduction_type,
+            false, // mutedErrors_
+            true,  // noScriptRval
+            1,     // lineno
+        );
 
         rooted!(&in(cx) let mut module_script: *mut JSObject = std::ptr::null_mut());
 
@@ -1610,27 +1622,6 @@ pub(crate) fn fetch_a_single_module_script(
         let task_source = global.task_manager().networking_task_source().to_sendable();
         global.fetch(request, context, task_source);
     })
-}
-
-fn fill_module_compile_options(
-    cx: &mut JSContext,
-    url: &ServoUrl,
-    introduction_type: Option<&'static CStr>,
-    line_number: u32,
-) -> CompileOptionsWrapper {
-    let mut options = CompileOptionsWrapper::new(cx, cformat!("{url}"), line_number);
-    if let Some(introduction_type) = introduction_type {
-        options.set_introduction_type(introduction_type);
-    }
-
-    // https://searchfox.org/firefox-main/rev/46fa95cd7f10222996ec267947ab94c5107b1475/js/public/CompileOptions.h#284
-    options.set_muted_errors(false);
-
-    // https://searchfox.org/firefox-main/rev/46fa95cd7f10222996ec267947ab94c5107b1475/js/public/CompileOptions.h#518
-    options.set_is_run_once(true);
-    options.set_no_script_rval(true);
-
-    options
 }
 
 pub(crate) type ModuleSpecifierMap = IndexMap<String, Option<ServoUrl>>;


### PR DESCRIPTION
This PR extracts `CompileOptions` initialization from `compile_script`, centralizing it in a single function `fill_compile_options`.
Extracted from #45687

Testing: It compiles