### PR TITLE
script: Pass `&mut JSContext` to specific event classes used in document

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -930,13 +930,12 @@ impl Document {
                 document.update_visibility_state(cx, DocumentVisibilityState::Visible);
                 // Step 4.6.4 Fire a page transition event named pageshow at document's relevant
                 // global object with true.
-                let event = PageTransitionEvent::new(
+                let event = PageTransitionEvent::new(cx,
                     window,
                     atom!("pageshow"),
                     false, // bubbles
                     false, // cancelable
                     true, // persisted
-                    CanGc::from_cx(cx),
                 );
                 let event = event.upcast::<Event>();
                 event.set_trusted(true);
@@ -1928,14 +1927,13 @@ impl Document {
                 .dom_manipulation_task_source()
                 .queue(task!(hashchange_event: move |cx| {
                         let window = window.root();
-                        HashChangeEvent::new(
+                        HashChangeEvent::new(cx,
                             &window,
                             atom!("hashchange"),
                             false,
                             false,
                             old_url,
                             new_url,
-                            CanGc::from_cx(cx),
                         )
                         .upcast::<Event>()
                         .fire(cx, window.upcast());
@@ -2023,11 +2021,11 @@ impl Document {
         self.incr_ignore_opens_during_unload_counter();
         // Step 3-5.
         let beforeunload_event = BeforeUnloadEvent::new(
+            cx,
             &self.window,
             atom!("beforeunload"),
             EventBubbles::Bubbles,
             EventCancelable::Cancelable,
-            CanGc::from_cx(cx),
         );
         let event = beforeunload_event.upcast::<Event>();
         event.set_trusted(true);
@@ -2087,12 +2085,12 @@ impl Document {
             // Fire a page transition event named pagehide at oldDocument's relevant global object with oldDocument's
             // salvageable state.
             let event = PageTransitionEvent::new(
+                cx,
                 &self.window,
                 atom!("pagehide"),
                 false,                  // bubbles
                 false,                  // cancelable
                 self.salvageable.get(), // persisted
-                CanGc::from_cx(cx),
             );
             let event = event.upcast::<Event>();
             event.set_trusted(true);
@@ -2275,13 +2273,12 @@ impl Document {
                 document.page_showing.set(true);
 
                 // Step 9.11. Fire a page transition event named pageshow at window with false.
-                let page_show_event = PageTransitionEvent::new(
+                let page_show_event = PageTransitionEvent::new(cx,
                     window,
                     atom!("pageshow"),
                     false, // bubbles
                     false, // cancelable
                     false, // persisted
-                    CanGc::from_cx(cx),
                 );
                 let page_show_event = page_show_event.upcast::<Event>();
                 page_show_event.set_trusted(true);
@@ -5441,8 +5438,8 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         interface.make_ascii_lowercase();
         match &*interface.str() {
             "beforeunloadevent" => Ok(DomRoot::upcast(BeforeUnloadEvent::new_uninitialized(
+                cx,
                 &self.window,
-                CanGc::from_cx(cx),
             ))),
             "compositionevent" | "textevent" => Ok(DomRoot::upcast(
                 CompositionEvent::new_uninitialized(cx, &self.window),
@@ -5458,12 +5455,12 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
                 CanGc::from_cx(cx),
             )),
             "focusevent" => Ok(DomRoot::upcast(FocusEvent::new_uninitialized(
+                cx,
                 &self.window,
-                CanGc::from_cx(cx),
             ))),
             "hashchangeevent" => Ok(DomRoot::upcast(HashChangeEvent::new_uninitialized(
+                cx,
                 &self.window,
-                CanGc::from_cx(cx),
             ))),
             "keyboardevent" => Ok(DomRoot::upcast(KeyboardEvent::new_uninitialized(
                 cx,
@@ -5478,9 +5475,9 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
                 &self.window,
             ))),
             "storageevent" => Ok(DomRoot::upcast(StorageEvent::new_uninitialized(
+                cx,
                 &self.window,
                 "".into(),
-                CanGc::from_cx(cx),
             ))),
             "touchevent" => {
                 let touches = TouchList::new(cx, &self.window, &[]);

--- a/components/script/dom/document/document_embedder_controls.rs
+++ b/components/script/dom/document/document_embedder_controls.rs
@@ -453,10 +453,10 @@ impl ContextMenuNodes {
 
         match action {
             ContextMenuAction::GoBack => {
-                let _ = window.History().Back();
+                let _ = window.History(cx).Back();
             },
             ContextMenuAction::GoForward => {
-                let _ = window.History().Forward();
+                let _ = window.History(cx).Forward();
             },
             ContextMenuAction::Reload => {
                 window.Location(cx).reload_without_origin_check(cx);

--- a/components/script/dom/document/focus.rs
+++ b/components/script/dom/document/focus.rs
@@ -15,7 +15,6 @@ use script_bindings::codegen::GenericBindings::ShadowRootBinding::ShadowRootMeth
 use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
 use script_bindings::inheritance::Castable;
 use script_bindings::root::{Dom, DomRoot};
-use script_bindings::script_runtime::CanGc;
 use servo_base::id::BrowsingContextId;
 use servo_constellation_traits::{
     RemoteFocusOperation, ScriptToConstellationMessage, SequentialFocusDirection,
@@ -494,6 +493,7 @@ impl DocumentFocusHandler {
         };
 
         let event = FocusEvent::new(
+            cx,
             &self.window,
             event_name,
             EventBubbles::DoesNotBubble,
@@ -501,7 +501,6 @@ impl DocumentFocusHandler {
             Some(&self.window),
             0i32,
             related_target,
-            CanGc::from_cx(cx),
         );
         let event = event.upcast::<Event>();
         event.set_trusted(true);

--- a/components/script/dom/event/beforeunloadevent.rs
+++ b/components/script/dom/event/beforeunloadevent.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object;
+use script_bindings::reflector::reflect_dom_object_with_cx;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::BeforeUnloadEventBinding::BeforeUnloadEventMethods;
@@ -14,7 +15,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 // https://html.spec.whatwg.org/multipage/#beforeunloadevent
 #[dom_struct]
@@ -31,18 +31,21 @@ impl BeforeUnloadEvent {
         }
     }
 
-    pub(crate) fn new_uninitialized(window: &Window, can_gc: CanGc) -> DomRoot<BeforeUnloadEvent> {
-        reflect_dom_object(Box::new(BeforeUnloadEvent::new_inherited()), window, can_gc)
+    pub(crate) fn new_uninitialized(
+        cx: &mut JSContext,
+        window: &Window,
+    ) -> DomRoot<BeforeUnloadEvent> {
+        reflect_dom_object_with_cx(Box::new(BeforeUnloadEvent::new_inherited()), window, cx)
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         type_: Atom,
         bubbles: EventBubbles,
         cancelable: EventCancelable,
-        can_gc: CanGc,
     ) -> DomRoot<BeforeUnloadEvent> {
-        let ev = BeforeUnloadEvent::new_uninitialized(window, can_gc);
+        let ev = BeforeUnloadEvent::new_uninitialized(cx, window);
         {
             let event = ev.upcast::<Event>();
             event.init_event(type_, bool::from(bubbles), bool::from(cancelable));

--- a/components/script/dom/event/focusevent.rs
+++ b/components/script/dom/event/focusevent.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use style::Atom;
 
 use crate::dom::bindings::codegen::Bindings::FocusEventBinding;
@@ -18,7 +19,6 @@ use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::uievent::UIEvent;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 /// The type of a [`FocusEvent`].
 pub(crate) enum FocusEventType {
@@ -40,20 +40,26 @@ impl FocusEvent {
         }
     }
 
-    pub(crate) fn new_uninitialized(window: &Window, can_gc: CanGc) -> DomRoot<FocusEvent> {
-        Self::new_uninitialized_with_proto(window, None, can_gc)
+    pub(crate) fn new_uninitialized(cx: &mut JSContext, window: &Window) -> DomRoot<FocusEvent> {
+        Self::new_uninitialized_with_proto(cx, window, None)
     }
 
     pub(crate) fn new_uninitialized_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<FocusEvent> {
-        reflect_dom_object_with_proto(Box::new(FocusEvent::new_inherited()), window, proto, can_gc)
+        reflect_dom_object_with_proto_and_cx(
+            Box::new(FocusEvent::new_inherited()),
+            window,
+            proto,
+            cx,
+        )
     }
 
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         event_type: Atom,
         can_bubble: EventBubbles,
@@ -61,9 +67,9 @@ impl FocusEvent {
         view: Option<&Window>,
         detail: i32,
         related_target: Option<&EventTarget>,
-        can_gc: CanGc,
     ) -> DomRoot<FocusEvent> {
         Self::new_with_proto(
+            cx,
             window,
             None,
             event_type,
@@ -72,12 +78,12 @@ impl FocusEvent {
             view,
             detail,
             related_target,
-            can_gc,
         )
     }
 
     #[expect(clippy::too_many_arguments)]
     fn new_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         event_type: Atom,
@@ -86,9 +92,8 @@ impl FocusEvent {
         view: Option<&Window>,
         detail: i32,
         related_target: Option<&EventTarget>,
-        can_gc: CanGc,
     ) -> DomRoot<FocusEvent> {
-        let ev = FocusEvent::new_uninitialized_with_proto(window, proto, can_gc);
+        let ev = FocusEvent::new_uninitialized_with_proto(cx, window, proto);
         ev.upcast::<UIEvent>().init_event(
             event_type,
             bool::from(can_bubble),
@@ -104,15 +109,16 @@ impl FocusEvent {
 impl FocusEventMethods<crate::DomTypeHolder> for FocusEvent {
     /// <https://w3c.github.io/uievents/#dom-focusevent-focusevent>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         event_type: DOMString,
         init: &FocusEventBinding::FocusEventInit,
     ) -> Fallible<DomRoot<FocusEvent>> {
         let bubbles = EventBubbles::from(init.parent.parent.bubbles);
         let cancelable = EventCancelable::from(init.parent.parent.cancelable);
         let event = FocusEvent::new_with_proto(
+            cx,
             window,
             proto,
             event_type.into(),
@@ -121,7 +127,6 @@ impl FocusEventMethods<crate::DomTypeHolder> for FocusEvent {
             init.parent.view.as_deref(),
             init.parent.detail,
             init.relatedTarget.as_deref(),
-            can_gc,
         );
         event
             .upcast::<Event>()

--- a/components/script/dom/event/hashchangeevent.rs
+++ b/components/script/dom/event/hashchangeevent.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -16,7 +17,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::event::Event;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 // https://html.spec.whatwg.org/multipage/#hashchangeevent
 #[dom_struct]
@@ -35,39 +35,43 @@ impl HashChangeEvent {
         }
     }
 
-    pub(crate) fn new_uninitialized(window: &Window, can_gc: CanGc) -> DomRoot<HashChangeEvent> {
-        Self::new_uninitialized_with_proto(window, None, can_gc)
+    pub(crate) fn new_uninitialized(
+        cx: &mut JSContext,
+        window: &Window,
+    ) -> DomRoot<HashChangeEvent> {
+        Self::new_uninitialized_with_proto(cx, window, None)
     }
 
     fn new_uninitialized_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HashChangeEvent> {
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(HashChangeEvent::new_inherited(String::new(), String::new())),
             window,
             proto,
-            can_gc,
+            cx,
         )
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         type_: Atom,
         bubbles: bool,
         cancelable: bool,
         old_url: String,
         new_url: String,
-        can_gc: CanGc,
     ) -> DomRoot<HashChangeEvent> {
         Self::new_with_proto(
-            window, None, type_, bubbles, cancelable, old_url, new_url, can_gc,
+            cx, window, None, type_, bubbles, cancelable, old_url, new_url,
         )
     }
 
     #[expect(clippy::too_many_arguments)]
     fn new_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         type_: Atom,
@@ -75,13 +79,12 @@ impl HashChangeEvent {
         cancelable: bool,
         old_url: String,
         new_url: String,
-        can_gc: CanGc,
     ) -> DomRoot<HashChangeEvent> {
-        let ev = reflect_dom_object_with_proto(
+        let ev = reflect_dom_object_with_proto_and_cx(
             Box::new(HashChangeEvent::new_inherited(old_url, new_url)),
             window,
             proto,
-            can_gc,
+            cx,
         );
         {
             let event = ev.upcast::<Event>();
@@ -94,13 +97,14 @@ impl HashChangeEvent {
 impl HashChangeEventMethods<crate::DomTypeHolder> for HashChangeEvent {
     /// <https://html.spec.whatwg.org/multipage/#hashchangeevent>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         type_: DOMString,
         init: &HashChangeEventBinding::HashChangeEventInit,
     ) -> Fallible<DomRoot<HashChangeEvent>> {
         Ok(HashChangeEvent::new_with_proto(
+            cx,
             window,
             proto,
             Atom::from(type_),
@@ -108,7 +112,6 @@ impl HashChangeEventMethods<crate::DomTypeHolder> for HashChangeEvent {
             init.parent.cancelable,
             init.oldURL.0.clone(),
             init.newURL.0.clone(),
-            can_gc,
         ))
     }
 

--- a/components/script/dom/event/pagetransitionevent.rs
+++ b/components/script/dom/event/pagetransitionevent.rs
@@ -5,8 +5,9 @@
 use std::cell::Cell;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -18,7 +19,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::event::Event;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 // https://html.spec.whatwg.org/multipage/#pagetransitionevent
 #[dom_struct]
@@ -36,39 +36,39 @@ impl PageTransitionEvent {
     }
 
     fn new_uninitialized(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<PageTransitionEvent> {
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(PageTransitionEvent::new_inherited()),
             window,
             proto,
-            can_gc,
+            cx,
         )
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         type_: Atom,
         bubbles: bool,
         cancelable: bool,
         persisted: bool,
-        can_gc: CanGc,
     ) -> DomRoot<PageTransitionEvent> {
-        Self::new_with_proto(window, None, type_, bubbles, cancelable, persisted, can_gc)
+        Self::new_with_proto(cx, window, None, type_, bubbles, cancelable, persisted)
     }
 
     fn new_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         type_: Atom,
         bubbles: bool,
         cancelable: bool,
         persisted: bool,
-        can_gc: CanGc,
     ) -> DomRoot<PageTransitionEvent> {
-        let ev = PageTransitionEvent::new_uninitialized(window, proto, can_gc);
+        let ev = PageTransitionEvent::new_uninitialized(cx, window, proto);
         ev.persisted.set(persisted);
         {
             let event = ev.upcast::<Event>();
@@ -81,20 +81,20 @@ impl PageTransitionEvent {
 impl PageTransitionEventMethods<crate::DomTypeHolder> for PageTransitionEvent {
     /// <https://html.spec.whatwg.org/multipage/#pagetransitionevent>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         type_: DOMString,
         init: &PageTransitionEventBinding::PageTransitionEventInit,
     ) -> Fallible<DomRoot<PageTransitionEvent>> {
         Ok(PageTransitionEvent::new_with_proto(
+            cx,
             window,
             proto,
             Atom::from(type_),
             init.parent.bubbles,
             init.parent.cancelable,
             init.persisted,
-            can_gc,
         ))
     }
 

--- a/components/script/dom/event/storageevent.rs
+++ b/components/script/dom/event/storageevent.rs
@@ -3,9 +3,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -18,7 +19,6 @@ use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::storage::Storage;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct StorageEvent {
@@ -50,29 +50,30 @@ impl StorageEvent {
     }
 
     pub(crate) fn new_uninitialized(
+        cx: &mut JSContext,
         window: &Window,
         url: DOMString,
-        can_gc: CanGc,
     ) -> DomRoot<StorageEvent> {
-        Self::new_uninitialized_with_proto(window, None, url, can_gc)
+        Self::new_uninitialized_with_proto(cx, window, None, url)
     }
 
     fn new_uninitialized_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         url: DOMString,
-        can_gc: CanGc,
     ) -> DomRoot<StorageEvent> {
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(StorageEvent::new_inherited(None, None, None, url, None)),
             window,
             proto,
-            can_gc,
+            cx,
         )
     }
 
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &Window,
         type_: Atom,
         bubbles: EventBubbles,
@@ -82,9 +83,9 @@ impl StorageEvent {
         newValue: Option<DOMString>,
         url: DOMString,
         storageArea: Option<&Storage>,
-        can_gc: CanGc,
     ) -> DomRoot<StorageEvent> {
         Self::new_with_proto(
+            cx,
             global,
             None,
             type_,
@@ -95,12 +96,12 @@ impl StorageEvent {
             newValue,
             url,
             storageArea,
-            can_gc,
         )
     }
 
     #[allow(clippy::too_many_arguments)]
     fn new_with_proto(
+        cx: &mut JSContext,
         global: &Window,
         proto: Option<HandleObject>,
         type_: Atom,
@@ -111,9 +112,8 @@ impl StorageEvent {
         newValue: Option<DOMString>,
         url: DOMString,
         storageArea: Option<&Storage>,
-        can_gc: CanGc,
     ) -> DomRoot<StorageEvent> {
-        let ev = reflect_dom_object_with_proto(
+        let ev = reflect_dom_object_with_proto_and_cx(
             Box::new(StorageEvent::new_inherited(
                 key,
                 oldValue,
@@ -123,7 +123,7 @@ impl StorageEvent {
             )),
             global,
             proto,
-            can_gc,
+            cx,
         );
         {
             let event = ev.upcast::<Event>();
@@ -137,9 +137,9 @@ impl StorageEvent {
 impl StorageEventMethods<crate::DomTypeHolder> for StorageEvent {
     /// <https://html.spec.whatwg.org/multipage/#storageevent>
     fn Constructor(
+        cx: &mut JSContext,
         global: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         type_: DOMString,
         init: &StorageEventBinding::StorageEventInit,
     ) -> Fallible<DomRoot<StorageEvent>> {
@@ -151,6 +151,7 @@ impl StorageEventMethods<crate::DomTypeHolder> for StorageEvent {
         let bubbles = EventBubbles::from(init.parent.bubbles);
         let cancelable = EventCancelable::from(init.parent.cancelable);
         let event = StorageEvent::new_with_proto(
+            cx,
             global,
             proto,
             Atom::from(type_),
@@ -161,7 +162,6 @@ impl StorageEventMethods<crate::DomTypeHolder> for StorageEvent {
             newValue,
             url,
             storageArea,
-            can_gc,
         );
         Ok(event)
     }

--- a/components/script/dom/history.rs
+++ b/components/script/dom/history.rs
@@ -12,7 +12,7 @@ use js::jsval::{JSVal, NullValue, UndefinedValue};
 use js::rust::{HandleValue, MutableHandleValue};
 use net_traits::CoreResourceMsg;
 use profile_traits::generic_channel;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use servo_base::generic_channel::GenericSend;
 use servo_base::id::HistoryStateId;
 use servo_constellation_traits::{
@@ -34,7 +34,6 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::hashchangeevent::HashChangeEvent;
 use crate::dom::popstateevent::PopStateEvent;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 enum PushOrReplace {
     Push,
@@ -62,8 +61,9 @@ impl History {
         }
     }
 
-    pub(crate) fn new(window: &Window, can_gc: CanGc) -> DomRoot<History> {
-        let dom_root = reflect_dom_object(Box::new(History::new_inherited(window)), window, can_gc);
+    pub(crate) fn new(cx: &mut JSContext, window: &Window) -> DomRoot<History> {
+        let dom_root =
+            reflect_dom_object_with_cx(Box::new(History::new_inherited(window)), window, cx);
         dom_root.state.set(NullValue());
         dom_root
     }
@@ -159,13 +159,13 @@ impl History {
         // Step 16.3
         if hash_changed {
             let event = HashChangeEvent::new(
+                cx,
                 &self.window,
                 atom!("hashchange"),
                 false,
                 false,
                 old_url.into_string(),
                 url.into_string(),
-                CanGc::from_cx(cx),
             );
             event
                 .upcast::<Event>()

--- a/components/script/dom/storage.rs
+++ b/components/script/dom/storage.rs
@@ -3,9 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use js::context::NoGC;
+use js::context::{JSContext, NoGC};
 use profile_traits::generic_channel;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use servo_base::generic_channel::{GenericSend, SendResult};
 use servo_base::id::WebViewId;
 use servo_constellation_traits::ScriptToConstellationMessage;
@@ -22,7 +22,6 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::storageevent::StorageEvent;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct Storage {
@@ -40,15 +39,11 @@ impl Storage {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &Window,
         storage_type: WebStorageType,
-        can_gc: CanGc,
     ) -> DomRoot<Storage> {
-        reflect_dom_object(
-            Box::new(Storage::new_inherited(storage_type)),
-            global,
-            can_gc,
-        )
+        reflect_dom_object_with_cx(Box::new(Storage::new_inherited(storage_type)), global, cx)
     }
 
     fn webview_id(&self) -> WebViewId {
@@ -250,7 +245,7 @@ impl Storage {
             task!(send_storage_notification: move |cx| {
                 let this = this.root();
                 let global = this.global();
-                let event = StorageEvent::new(
+                let event = StorageEvent::new(cx,
                     global.as_window(),
                     atom!("storage"),
                     EventBubbles::DoesNotBubble,
@@ -260,7 +255,6 @@ impl Storage {
                     new_value.map(DOMString::from),
                     DOMString::from(url.into_string()),
                     Some(&this),
-                    CanGc::from_cx(cx)
                 );
                 event.upcast::<Event>().fire(cx, global.upcast());
             }),

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1371,7 +1371,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-window-close>
-    fn Close(&self) {
+    fn Close(&self, cx: &mut JSContext) {
         // Step 1. Let thisTraversable be this's navigable.
         let window_proxy = match self.window_proxy.get() {
             Some(proxy) => proxy,
@@ -1384,7 +1384,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
         }
         // Note: check the length of the "session history", as opposed to the joint session history?
         // see https://github.com/whatwg/html/issues/3734
-        if let Ok(history_length) = self.History().GetLength() {
+        if let Ok(history_length) = self.History(cx).GetLength() {
             let is_auxiliary = window_proxy.is_auxiliary();
 
             // https://html.spec.whatwg.org/multipage/#script-closable
@@ -1421,9 +1421,8 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-history>
-    fn History(&self) -> DomRoot<History> {
-        self.history
-            .or_init(|| History::new(self, CanGc::deprecated_note()))
+    fn History(&self, cx: &mut JSContext) -> DomRoot<History> {
+        self.history.or_init(|| History::new(cx, self))
     }
 
     /// <https://w3c.github.io/IndexedDB/#factory-interface>
@@ -1460,7 +1459,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
         }
 
         // Step 4. Let storage be a new Storage object whose map is map.
-        let storage = Storage::new(self, WebStorageType::Session, CanGc::from_cx(cx));
+        let storage = Storage::new(cx, self, WebStorageType::Session);
 
         // Step 5. Set this's associated Document's session storage holder to storage.
         self.session_storage.set(Some(&storage));
@@ -1487,7 +1486,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
         }
 
         // Step 4. Let storage be a new Storage object whose map is map.
-        let storage = Storage::new(self, WebStorageType::Local, CanGc::from_cx(cx));
+        let storage = Storage::new(cx, self, WebStorageType::Local);
 
         // Step 5. Set this's associated Document's local storage holder to storage.
         self.local_storage.set(Some(&storage));

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1871,7 +1871,7 @@ impl ScriptThread {
                 self.handle_update_history_state_msg(cx, pipeline_id, history_state_id, url)
             },
             ScriptThreadMessage::RemoveHistoryStates(pipeline_id, history_states) => {
-                self.handle_remove_history_states(pipeline_id, history_states)
+                self.handle_remove_history_states(cx, pipeline_id, history_states)
             },
             ScriptThreadMessage::FocusDocumentAsPartOfFocusingSteps(
                 pipeline_id,
@@ -3101,18 +3101,19 @@ impl ScriptThread {
         let Some(window) = self.documents.borrow().find_window(pipeline_id) else {
             return warn!("update history state after pipeline {pipeline_id} closed.",);
         };
-        window.History().activate_state(cx, history_state_id, url);
+        window.History(cx).activate_state(cx, history_state_id, url);
     }
 
     fn handle_remove_history_states(
         &self,
+        cx: &mut js::context::JSContext,
         pipeline_id: PipelineId,
         history_states: Vec<HistoryStateId>,
     ) {
         let Some(window) = self.documents.borrow().find_window(pipeline_id) else {
             return warn!("update history state after pipeline {pipeline_id} closed.",);
         };
-        window.History().remove_states(history_states);
+        window.History(cx).remove_states(history_states);
     }
 
     /// Window was resized, but this script was not active, so don't reflow yet

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -534,6 +534,10 @@ DOMInterfaces = {
     'canGc': ['ReadAsArrayBuffer'],
 },
 
+'FocusEvent': {
+    'cx': ['Constructor'],
+},
+
 'FontFace': {
     'cx': ['Constructor', 'Load'],
 },
@@ -650,6 +654,10 @@ DOMInterfaces = {
 },
 
 'GPUValidationError': {
+    'cx': ['Constructor'],
+},
+
+'HashChangeEvent': {
     'cx': ['Constructor'],
 },
 
@@ -1062,6 +1070,10 @@ DOMInterfaces = {
     'cx': ['Constructor'],
 },
 
+'PageTransitionEvent': {
+    'cx': ['Constructor'],
+},
+
 'PaintRenderingContext2D': {
     'cx': ['CreateLinearGradient', 'CreatePattern', 'CreateRadialGradient', 'GetTransform'],
 },
@@ -1179,6 +1191,10 @@ DOMInterfaces = {
 },
 
 'StereoPannerNode': {
+    'cx': ['Constructor'],
+},
+
+'StorageEvent': {
     'cx': ['Constructor'],
 },
 
@@ -1302,6 +1318,7 @@ DOMInterfaces = {
     'additionalTraits': ['crate::interfaces::WindowHelpers'],
     'realm': ['CreateImageBitmap', 'CreateImageBitmap_', 'WebdriverCallback', 'GetOpener', 'Fetch'],
     'cx': [
+        'Close',
         'CustomElements',
         'Focus',
         'FetchLater',
@@ -1309,6 +1326,7 @@ DOMInterfaces = {
         'GetLocalStorage',
         'GetSelection',
         'GetSessionStorage',
+        'History',
         'Location',
         'NamedGetter',
         'Open',


### PR DESCRIPTION
To remove the final usages of `CanGc` in `document.rs`, this cleans up the relevant event classes.

Part of #40600

Testing: it compiles