### PR TITLE
script: Remove `CanGC` from DOM Events

### DIFF
--- a/components/script/animations.rs
+++ b/components/script/animations.rs
@@ -34,7 +34,6 @@ use crate::dom::event::Event;
 use crate::dom::node::{Node, NodeDamage, NodeTraits, from_untrusted_node_address};
 use crate::dom::transitionevent::TransitionEvent;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 /// The set of animations for a document.
 #[derive(Default, JSTraceable, MallocSizeOf)]
@@ -542,7 +541,7 @@ impl Animations {
                     elapsedTime: elapsed_time,
                     pseudoElement: pseudo_element,
                 };
-                TransitionEvent::new(&window, event_atom, &event_init, CanGc::from_cx(cx))
+                TransitionEvent::new(cx, &window, event_atom, &event_init)
                     .upcast::<Event>()
                     .fire(cx, node.upcast());
             } else {
@@ -552,7 +551,7 @@ impl Animations {
                     elapsedTime: elapsed_time,
                     pseudoElement: pseudo_element,
                 };
-                AnimationEvent::new(&window, event_atom, &event_init, CanGc::from_cx(cx))
+                AnimationEvent::new(cx, &window, event_atom, &event_init)
                     .upcast::<Event>()
                     .fire(cx, node.upcast());
             }

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -930,7 +930,8 @@ impl Document {
                 document.update_visibility_state(cx, DocumentVisibilityState::Visible);
                 // Step 4.6.4 Fire a page transition event named pageshow at document's relevant
                 // global object with true.
-                let event = PageTransitionEvent::new(cx,
+                let event = PageTransitionEvent::new(
+                    cx,
                     window,
                     atom!("pageshow"),
                     false, // bubbles
@@ -1927,7 +1928,8 @@ impl Document {
                 .dom_manipulation_task_source()
                 .queue(task!(hashchange_event: move |cx| {
                         let window = window.root();
-                        HashChangeEvent::new(cx,
+                        HashChangeEvent::new(
+                            cx,
                             &window,
                             atom!("hashchange"),
                             false,
@@ -2101,11 +2103,11 @@ impl Document {
         // Step 7
         if !self.fired_unload.get() {
             let event = Event::new(
+                cx,
                 self.window.upcast(),
                 atom!("unload"),
                 EventBubbles::Bubbles,
                 EventCancelable::Cancelable,
-                CanGc::from_cx(cx),
             );
             event.set_trusted(true);
             let event_target = self.window.upcast::<EventTarget>();
@@ -2245,11 +2247,11 @@ impl Document {
 
                 // Step 9.5. Fire an event named load at window, with legacy target override flag set.
                 let load_event = Event::new(
+                    cx,
                     window.upcast(),
                     atom!("load"),
                     EventBubbles::DoesNotBubble,
                     EventCancelable::NotCancelable,
-                    CanGc::from_cx(cx),
                 );
                 load_event.set_trusted(true);
                 debug!("About to dispatch load for {:?}", document.url());
@@ -2273,7 +2275,8 @@ impl Document {
                 document.page_showing.set(true);
 
                 // Step 9.11. Fire a page transition event named pageshow at window with false.
-                let page_show_event = PageTransitionEvent::new(cx,
+                let page_show_event = PageTransitionEvent::new(
+                    cx,
                     window,
                     atom!("pageshow"),
                     false, // bubbles
@@ -5445,15 +5448,14 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
                 CompositionEvent::new_uninitialized(cx, &self.window),
             )),
             "customevent" => Ok(DomRoot::upcast(CustomEvent::new_uninitialized(
+                cx,
                 self.window.upcast(),
-                CanGc::from_cx(cx),
             ))),
             // FIXME(#25136): devicemotionevent, deviceorientationevent
             // FIXME(#7529): dragevent
-            "events" | "event" | "htmlevents" | "svgevents" => Ok(Event::new_uninitialized(
-                self.window.upcast(),
-                CanGc::from_cx(cx),
-            )),
+            "events" | "event" | "htmlevents" | "svgevents" => {
+                Ok(Event::new_uninitialized(cx, self.window.upcast()))
+            },
             "focusevent" => Ok(DomRoot::upcast(FocusEvent::new_uninitialized(
                 cx,
                 &self.window,
@@ -5467,8 +5469,8 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
                 &self.window,
             ))),
             "messageevent" => Ok(DomRoot::upcast(MessageEvent::new_uninitialized(
+                cx,
                 self.window.upcast(),
-                CanGc::from_cx(cx),
             ))),
             "mouseevent" | "mouseevents" => Ok(DomRoot::upcast(MouseEvent::new_uninitialized(
                 cx,
@@ -5483,7 +5485,6 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
                 let touches = TouchList::new(cx, &self.window, &[]);
                 let changed_touches = TouchList::new(cx, &self.window, &[]);
                 let target_touches = TouchList::new(cx, &self.window, &[]);
-
                 Ok(DomRoot::upcast(DomTouchEvent::new_uninitialized(
                     cx,
                     &self.window,
@@ -5493,8 +5494,8 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
                 )))
             },
             "uievent" | "uievents" => Ok(DomRoot::upcast(UIEvent::new_uninitialized(
+                cx,
                 &self.window,
-                CanGc::from_cx(cx),
             ))),
             _ => Err(Error::NotSupported(None)),
         }

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -5485,6 +5485,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
                 let touches = TouchList::new(cx, &self.window, &[]);
                 let changed_touches = TouchList::new(cx, &self.window, &[]);
                 let target_touches = TouchList::new(cx, &self.window, &[]);
+
                 Ok(DomRoot::upcast(DomTouchEvent::new_uninitialized(
                     cx,
                     &self.window,

--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -1458,6 +1458,7 @@ impl DocumentEventHandler {
         let touches = TouchList::new(cx, window, self.active_touch_points.borrow().r());
         let changed_touches = TouchList::new(cx, window, from_ref(&&*changed_touch));
         let target_touches = TouchList::new(cx, window, target_touches.r());
+
         let touch_event = TouchEvent::new(
             cx,
             window,

--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -1458,7 +1458,6 @@ impl DocumentEventHandler {
         let touches = TouchList::new(cx, window, self.active_touch_points.borrow().r());
         let changed_touches = TouchList::new(cx, window, from_ref(&&*changed_touch));
         let target_touches = TouchList::new(cx, window, target_touches.r());
-
         let touch_event = TouchEvent::new(
             cx,
             window,

--- a/components/script/dom/event/animationevent.rs
+++ b/components/script/dom/event/animationevent.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::AnimationEventBinding::{
@@ -17,7 +18,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::event::Event;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct AnimationEvent {
@@ -39,26 +39,26 @@ impl AnimationEvent {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         type_: Atom,
         init: &AnimationEventInit,
-        can_gc: CanGc,
     ) -> DomRoot<AnimationEvent> {
-        Self::new_with_proto(window, None, type_, init, can_gc)
+        Self::new_with_proto(cx, window, None, type_, init)
     }
 
     fn new_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         type_: Atom,
         init: &AnimationEventInit,
-        can_gc: CanGc,
     ) -> DomRoot<AnimationEvent> {
-        let ev = reflect_dom_object_with_proto(
+        let ev = reflect_dom_object_with_proto_and_cx(
             Box::new(AnimationEvent::new_inherited(init)),
             window,
             proto,
-            can_gc,
+            cx,
         );
         {
             let event = ev.upcast::<Event>();
@@ -71,13 +71,13 @@ impl AnimationEvent {
 impl AnimationEventMethods<crate::DomTypeHolder> for AnimationEvent {
     /// <https://drafts.csswg.org/css-animations/#dom-animationevent-animationevent>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         type_: DOMString,
         init: &AnimationEventInit,
     ) -> DomRoot<AnimationEvent> {
-        AnimationEvent::new_with_proto(window, proto, Atom::from(type_), init, can_gc)
+        AnimationEvent::new_with_proto(cx, window, proto, Atom::from(type_), init)
     }
 
     /// <https://drafts.csswg.org/css-animations/#interface-animationevent-attributes>

--- a/components/script/dom/event/closeevent.rs
+++ b/components/script/dom/event/closeevent.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::CloseEventBinding;
@@ -16,7 +17,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct CloseEvent {
@@ -39,6 +39,7 @@ impl CloseEvent {
 
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         type_: Atom,
         bubbles: EventBubbles,
@@ -46,15 +47,15 @@ impl CloseEvent {
         wasClean: bool,
         code: u16,
         reason: DOMString,
-        can_gc: CanGc,
     ) -> DomRoot<CloseEvent> {
         Self::new_with_proto(
-            global, None, type_, bubbles, cancelable, wasClean, code, reason, can_gc,
+            cx, global, None, type_, bubbles, cancelable, wasClean, code, reason,
         )
     }
 
     #[expect(clippy::too_many_arguments)]
     fn new_with_proto(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
         type_: Atom,
@@ -63,10 +64,9 @@ impl CloseEvent {
         wasClean: bool,
         code: u16,
         reason: DOMString,
-        can_gc: CanGc,
     ) -> DomRoot<CloseEvent> {
         let event = Box::new(CloseEvent::new_inherited(wasClean, code, reason));
-        let ev = reflect_dom_object_with_proto(event, global, proto, can_gc);
+        let ev = reflect_dom_object_with_proto_and_cx(event, global, proto, cx);
         {
             let event = ev.upcast::<Event>();
             event.init_event(type_, bool::from(bubbles), bool::from(cancelable));
@@ -78,15 +78,16 @@ impl CloseEvent {
 impl CloseEventMethods<crate::DomTypeHolder> for CloseEvent {
     /// <https://websockets.spec.whatwg.org/#the-closeevent-interface>
     fn Constructor(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         type_: DOMString,
         init: &CloseEventBinding::CloseEventInit,
     ) -> Fallible<DomRoot<CloseEvent>> {
         let bubbles = EventBubbles::from(init.parent.bubbles);
         let cancelable = EventCancelable::from(init.parent.cancelable);
         Ok(CloseEvent::new_with_proto(
+            cx,
             global,
             proto,
             Atom::from(type_),
@@ -95,7 +96,6 @@ impl CloseEventMethods<crate::DomTypeHolder> for CloseEvent {
             init.wasClean,
             init.code,
             init.reason.clone(),
-            can_gc,
         ))
     }
 

--- a/components/script/dom/event/commandevent.rs
+++ b/components/script/dom/event/commandevent.rs
@@ -3,10 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::codegen::GenericBindings::NodeBinding::NodeMethods;
 use script_bindings::inheritance::Castable;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::CommandEventBinding;
@@ -20,7 +21,6 @@ use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::node::Node;
 use crate::dom::types::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct CommandEvent {
@@ -45,6 +45,7 @@ impl CommandEvent {
 
     #[allow(clippy::too_many_arguments)]
     fn new_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         type_: Atom,
@@ -52,10 +53,9 @@ impl CommandEvent {
         cancelable: EventCancelable,
         source: Option<DomRoot<Element>>,
         command: DOMString,
-        can_gc: CanGc,
     ) -> DomRoot<CommandEvent> {
         let event = Box::new(CommandEvent::new_inherited(source, command));
-        let event = reflect_dom_object_with_proto(event, window, proto, can_gc);
+        let event = reflect_dom_object_with_proto_and_cx(event, window, proto, cx);
         {
             let event = event.upcast::<Event>();
             event.init_event(type_, bool::from(bubbles), bool::from(cancelable));
@@ -65,16 +65,16 @@ impl CommandEvent {
 
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         type_: Atom,
         bubbles: EventBubbles,
         cancelable: EventCancelable,
         source: Option<DomRoot<Element>>,
         command: DOMString,
-        can_gc: CanGc,
     ) -> DomRoot<CommandEvent> {
         Self::new_with_proto(
-            window, None, type_, bubbles, cancelable, source, command, can_gc,
+            cx, window, None, type_, bubbles, cancelable, source, command,
         )
     }
 }
@@ -82,15 +82,16 @@ impl CommandEvent {
 impl CommandEventMethods<crate::DomTypeHolder> for CommandEvent {
     /// <https://html.spec.whatwg.org/multipage/#commandevent>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         type_: DOMString,
         init: &CommandEventBinding::CommandEventInit,
     ) -> Fallible<DomRoot<CommandEvent>> {
         let bubbles = EventBubbles::from(init.parent.bubbles);
         let cancelable = EventCancelable::from(init.parent.cancelable);
         Ok(CommandEvent::new_with_proto(
+            cx,
             window,
             proto,
             Atom::from(type_),
@@ -98,7 +99,6 @@ impl CommandEventMethods<crate::DomTypeHolder> for CommandEvent {
             cancelable,
             init.source.as_ref().map(|s| DomRoot::from_ref(&**s)),
             init.command.clone(),
-            can_gc,
         ))
     }
 

--- a/components/script/dom/event/customevent.rs
+++ b/components/script/dom/event/customevent.rs
@@ -3,10 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::jsapi::Heap;
 use js::jsval::JSVal;
 use js::rust::{HandleObject, HandleValue, MutableHandleValue};
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::CustomEventBinding;
@@ -18,7 +19,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::event::Event;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::{CanGc, JSContext};
+use crate::script_runtime::JSContext as SafeJSContext;
 
 // https://dom.spec.whatwg.org/#interface-customevent
 #[dom_struct]
@@ -36,33 +37,36 @@ impl CustomEvent {
         }
     }
 
-    pub(crate) fn new_uninitialized(global: &GlobalScope, can_gc: CanGc) -> DomRoot<CustomEvent> {
-        Self::new_uninitialized_with_proto(global, None, can_gc)
+    pub(crate) fn new_uninitialized(
+        cx: &mut JSContext,
+        global: &GlobalScope,
+    ) -> DomRoot<CustomEvent> {
+        Self::new_uninitialized_with_proto(cx, global, None)
     }
 
     fn new_uninitialized_with_proto(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<CustomEvent> {
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(CustomEvent::new_inherited()),
             global,
             proto,
-            can_gc,
+            cx,
         )
     }
 
     fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
         type_: Atom,
         bubbles: bool,
         cancelable: bool,
         detail: HandleValue,
-        can_gc: CanGc,
     ) -> DomRoot<CustomEvent> {
-        let ev = CustomEvent::new_uninitialized_with_proto(global, proto, can_gc);
+        let ev = CustomEvent::new_uninitialized_with_proto(cx, global, proto);
         ev.init_custom_event(type_, bubbles, cancelable, detail);
         ev
     }
@@ -87,34 +91,34 @@ impl CustomEvent {
 impl CustomEventMethods<crate::DomTypeHolder> for CustomEvent {
     /// <https://dom.spec.whatwg.org/#dom-customevent-customevent>
     fn Constructor(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         type_: DOMString,
         init: RootedTraceableBox<CustomEventBinding::CustomEventInit>,
     ) -> DomRoot<CustomEvent> {
         let event = CustomEvent::new(
+            cx,
             global,
             proto,
             Atom::from(type_),
             init.parent.bubbles,
             init.parent.cancelable,
             init.detail.handle(),
-            can_gc,
         );
         event.upcast::<Event>().set_composed(init.parent.composed);
         event
     }
 
     /// <https://dom.spec.whatwg.org/#dom-customevent-detail>
-    fn Detail(&self, _cx: JSContext, mut retval: MutableHandleValue) {
+    fn Detail(&self, _cx: SafeJSContext, mut retval: MutableHandleValue) {
         retval.set(self.detail.get())
     }
 
     /// <https://dom.spec.whatwg.org/#dom-customevent-initcustomevent>
     fn InitCustomEvent(
         &self,
-        _cx: JSContext,
+        _cx: SafeJSContext,
         type_: DOMString,
         can_bubble: bool,
         cancelable: bool,

--- a/components/script/dom/event/errorevent.rs
+++ b/components/script/dom/event/errorevent.rs
@@ -5,11 +5,12 @@
 use std::cell::Cell;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::jsapi::Heap;
 use js::jsval::JSVal;
 use js::rust::{HandleObject, HandleValue, MutableHandleValue};
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::ErrorEventBinding;
@@ -22,7 +23,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::{CanGc, JSContext};
+use crate::script_runtime::JSContext as SafeJSContext;
 
 #[dom_struct]
 pub(crate) struct ErrorEvent {
@@ -48,15 +49,21 @@ impl ErrorEvent {
     }
 
     fn new_uninitialized(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<ErrorEvent> {
-        reflect_dom_object_with_proto(Box::new(ErrorEvent::new_inherited()), global, proto, can_gc)
+        reflect_dom_object_with_proto_and_cx(
+            Box::new(ErrorEvent::new_inherited()),
+            global,
+            proto,
+            cx,
+        )
     }
 
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         type_: Atom,
         bubbles: EventBubbles,
@@ -66,16 +73,15 @@ impl ErrorEvent {
         lineno: u32,
         colno: u32,
         error: HandleValue,
-        can_gc: CanGc,
     ) -> DomRoot<ErrorEvent> {
         Self::new_with_proto(
-            global, None, type_, bubbles, cancelable, message, filename, lineno, colno, error,
-            can_gc,
+            cx, global, None, type_, bubbles, cancelable, message, filename, lineno, colno, error,
         )
     }
 
     #[allow(clippy::too_many_arguments)]
     fn new_with_proto(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
         type_: Atom,
@@ -86,9 +92,8 @@ impl ErrorEvent {
         lineno: u32,
         colno: u32,
         error: HandleValue,
-        can_gc: CanGc,
     ) -> DomRoot<ErrorEvent> {
-        let ev = ErrorEvent::new_uninitialized(global, proto, can_gc);
+        let ev = ErrorEvent::new_uninitialized(cx, global, proto);
         {
             let event = ev.upcast::<Event>();
             event.init_event(type_, bool::from(bubbles), bool::from(cancelable));
@@ -105,9 +110,9 @@ impl ErrorEvent {
 impl ErrorEventMethods<crate::DomTypeHolder> for ErrorEvent {
     /// <https://html.spec.whatwg.org/multipage/#errorevent>
     fn Constructor(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         type_: DOMString,
         init: RootedTraceableBox<ErrorEventBinding::ErrorEventInit>,
     ) -> Fallible<DomRoot<ErrorEvent>> {
@@ -130,6 +135,7 @@ impl ErrorEventMethods<crate::DomTypeHolder> for ErrorEvent {
         let cancelable = EventCancelable::from(init.parent.cancelable);
 
         let event = ErrorEvent::new_with_proto(
+            cx,
             global,
             proto,
             Atom::from(type_),
@@ -140,7 +146,6 @@ impl ErrorEventMethods<crate::DomTypeHolder> for ErrorEvent {
             line_num,
             col_num,
             init.error.handle(),
-            can_gc,
         );
         event.upcast::<Event>().set_composed(init.parent.composed);
         Ok(event)
@@ -167,7 +172,7 @@ impl ErrorEventMethods<crate::DomTypeHolder> for ErrorEvent {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-errorevent-error>
-    fn Error(&self, _cx: JSContext, mut retval: MutableHandleValue) {
+    fn Error(&self, _cx: SafeJSContext, mut retval: MutableHandleValue) {
         retval.set(self.error.get());
     }
 

--- a/components/script/dom/event/event.rs
+++ b/components/script/dom/event/event.rs
@@ -15,7 +15,7 @@ use keyboard_types::{Key, NamedKey};
 use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::PointerEventBinding::PointerEventMethods;
 use script_bindings::match_domstring_ascii;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
 use servo_base::cross_process_instant::CrossProcessInstant;
 use stylo_atoms::Atom;
 
@@ -46,7 +46,6 @@ use crate::dom::node::{Node, NodeTraits};
 use crate::dom::shadowroot::ShadowRoot;
 use crate::dom::types::{KeyboardEvent, PointerEvent, UserActivation};
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 use crate::task::TaskOnce;
 
 /// <https://dom.spec.whatwg.org/#concept-event>
@@ -131,37 +130,37 @@ impl Event {
         }
     }
 
-    pub(crate) fn new_uninitialized(global: &GlobalScope, can_gc: CanGc) -> DomRoot<Event> {
-        Self::new_uninitialized_with_proto(global, None, can_gc)
+    pub(crate) fn new_uninitialized(cx: &mut JSContext, global: &GlobalScope) -> DomRoot<Event> {
+        Self::new_uninitialized_with_proto(cx, global, None)
     }
 
     pub(crate) fn new_uninitialized_with_proto(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<Event> {
-        reflect_dom_object_with_proto(Box::new(Event::new_inherited()), global, proto, can_gc)
+        reflect_dom_object_with_proto_and_cx(Box::new(Event::new_inherited()), global, proto, cx)
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         type_: Atom,
         bubbles: EventBubbles,
         cancelable: EventCancelable,
-        can_gc: CanGc,
     ) -> DomRoot<Event> {
-        Self::new_with_proto(global, None, type_, bubbles, cancelable, can_gc)
+        Self::new_with_proto(cx, global, None, type_, bubbles, cancelable)
     }
 
     fn new_with_proto(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
         type_: Atom,
         bubbles: EventBubbles,
         cancelable: EventCancelable,
-        can_gc: CanGc,
     ) -> DomRoot<Event> {
-        let event = Event::new_uninitialized_with_proto(global, proto, can_gc);
+        let event = Event::new_uninitialized_with_proto(cx, global, proto);
 
         // NOTE: The spec doesn't tell us to call init event here, it just happens to do what we need.
         event.init_event(type_, bool::from(bubbles), bool::from(cancelable));
@@ -768,14 +767,14 @@ impl Event {
 
     /// <https://dom.spec.whatwg.org/#inner-event-creation-steps>
     fn inner_creation_steps(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
         init: &EventBinding::EventInit,
-        can_gc: CanGc,
     ) -> DomRoot<Event> {
         // Step 1. Let event be the result of creating a new object using eventInterface.
         // If realm is non-null, then use that realm; otherwise, use the default behavior defined in Web IDL.
-        let event = Event::new_uninitialized_with_proto(global, proto, can_gc);
+        let event = Event::new_uninitialized_with_proto(cx, global, proto);
 
         // Step 2. Set event’s initialized flag.
         event.set_flags(EventFlags::Initialized);
@@ -835,15 +834,15 @@ impl Event {
 impl EventMethods<crate::DomTypeHolder> for Event {
     /// <https://dom.spec.whatwg.org/#concept-event-constructor>
     fn Constructor(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         type_: DOMString,
         init: &EventBinding::EventInit,
     ) -> Fallible<DomRoot<Event>> {
         // Step 1. Let event be the result of running the inner event creation steps with
         // this interface, null, now, and eventInitDict.
-        let event = Event::inner_creation_steps(global, proto, init, can_gc);
+        let event = Event::inner_creation_steps(cx, global, proto, init);
 
         // Step 2. Initialize event’s type attribute to type.
         *event.type_.borrow_mut() = Atom::from(type_);

--- a/components/script/dom/event/eventtarget.rs
+++ b/components/script/dom/event/eventtarget.rs
@@ -23,7 +23,7 @@ use libc::c_char;
 use rustc_hash::{FxBuildHasher, FxHashSet};
 use script_bindings::cell::DomRefCell;
 use script_bindings::cformat;
-use script_bindings::reflector::{DomObject, Reflector, reflect_dom_object_with_proto};
+use script_bindings::reflector::{DomObject, Reflector, reflect_dom_object_with_proto_and_cx};
 use servo_constellation_traits::ConstellationInterest;
 use servo_url::ServoUrl;
 use style::str::HTML_SPACE_CHARACTERS;
@@ -73,7 +73,7 @@ use crate::dom::shadowroot::ShadowRoot;
 use crate::dom::window::Window;
 use crate::dom::workerglobalscope::WorkerGlobalScope;
 use crate::realms::{enter_auto_realm, enter_realm};
-use crate::script_runtime::{CanGc, IntroductionType};
+use crate::script_runtime::IntroductionType;
 
 /// <https://html.spec.whatwg.org/multipage/#event-handler-content-attributes>
 /// Generated from WebIDL definitions of EventHandler attributes on interfaces
@@ -421,15 +421,15 @@ impl EventTarget {
     }
 
     fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<EventTarget> {
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(EventTarget::new_inherited()),
             global,
             proto,
-            can_gc,
+            cx,
         )
     }
 
@@ -869,13 +869,7 @@ impl EventTarget {
         cancelable: EventCancelable,
         composed: EventComposed,
     ) -> bool {
-        let event = Event::new(
-            &self.global(),
-            name,
-            bubbles,
-            cancelable,
-            CanGc::from_cx(cx),
-        );
+        let event = Event::new(cx, &self.global(), name, bubbles, cancelable);
         event.set_composed(composed.into());
         event.fire(cx, self)
     }
@@ -1081,11 +1075,11 @@ impl EventTarget {
 impl EventTargetMethods<crate::DomTypeHolder> for EventTarget {
     /// <https://dom.spec.whatwg.org/#dom-eventtarget-eventtarget>
     fn Constructor(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<EventTarget>> {
-        Ok(EventTarget::new(global, proto, can_gc))
+        Ok(EventTarget::new(cx, global, proto))
     }
 
     /// <https://dom.spec.whatwg.org/#dom-eventtarget-addeventlistener>

--- a/components/script/dom/event/extendableevent.rs
+++ b/components/script/dom/event/extendableevent.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::{HandleObject, HandleValue};
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -17,7 +18,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::event::Event;
 use crate::dom::serviceworkerglobalscope::ServiceWorkerGlobalScope;
-use crate::script_runtime::{CanGc, JSContext};
+use crate::script_runtime::JSContext as SafeJSContext;
 
 // https://w3c.github.io/ServiceWorker/#extendable-event
 #[dom_struct]
@@ -35,28 +36,28 @@ impl ExtendableEvent {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         worker: &ServiceWorkerGlobalScope,
         type_: Atom,
         bubbles: bool,
         cancelable: bool,
-        can_gc: CanGc,
     ) -> DomRoot<ExtendableEvent> {
-        Self::new_with_proto(worker, None, type_, bubbles, cancelable, can_gc)
+        Self::new_with_proto(cx, worker, None, type_, bubbles, cancelable)
     }
 
     fn new_with_proto(
+        cx: &mut JSContext,
         worker: &ServiceWorkerGlobalScope,
         proto: Option<HandleObject>,
         type_: Atom,
         bubbles: bool,
         cancelable: bool,
-        can_gc: CanGc,
     ) -> DomRoot<ExtendableEvent> {
-        let ev = reflect_dom_object_with_proto(
+        let ev = reflect_dom_object_with_proto_and_cx(
             Box::new(ExtendableEvent::new_inherited()),
             worker,
             proto,
-            can_gc,
+            cx,
         );
         {
             let event = ev.upcast::<Event>();
@@ -69,24 +70,24 @@ impl ExtendableEvent {
 impl ExtendableEventMethods<crate::DomTypeHolder> for ExtendableEvent {
     /// <https://w3c.github.io/ServiceWorker/#dom-extendableevent-extendableevent>
     fn Constructor(
+        cx: &mut JSContext,
         worker: &ServiceWorkerGlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         type_: DOMString,
         init: &ExtendableEventInit,
     ) -> Fallible<DomRoot<ExtendableEvent>> {
         Ok(ExtendableEvent::new_with_proto(
+            cx,
             worker,
             proto,
             Atom::from(type_),
             init.parent.bubbles,
             init.parent.cancelable,
-            can_gc,
         ))
     }
 
     /// <https://w3c.github.io/ServiceWorker/#wait-until-method>
-    fn WaitUntil(&self, _cx: JSContext, _val: HandleValue) -> ErrorResult {
+    fn WaitUntil(&self, _cx: SafeJSContext, _val: HandleValue) -> ErrorResult {
         // Step 1
         if !self.extensions_allowed {
             return Err(Error::InvalidState(None));

--- a/components/script/dom/event/extendablemessageevent.rs
+++ b/components/script/dom/event/extendablemessageevent.rs
@@ -7,7 +7,7 @@ use js::context::JSContext;
 use js::jsapi::Heap;
 use js::jsval::JSVal;
 use js::rust::{HandleObject, HandleValue, MutableHandleValue};
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::ExtendableEventBinding::ExtendableEvent_Binding::ExtendableEventMethods;
@@ -28,7 +28,6 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::messageport::MessagePort;
 use crate::dom::serviceworker::ServiceWorker;
 use crate::dom::serviceworkerglobalscope::ServiceWorkerGlobalScope;
-use crate::script_runtime::CanGc;
 
 /// <https://w3c.github.io/ServiceWorker/#dom-extendablemessageevent-source>
 #[derive(Clone, JSTraceable, MallocSizeOf)]
@@ -126,6 +125,7 @@ impl ExtendableMessageEvent {
 
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         type_: Atom,
         bubbles: bool,
@@ -135,9 +135,9 @@ impl ExtendableMessageEvent {
         lastEventId: DOMString,
         source: Option<MessageSource>,
         ports: Vec<DomRoot<MessagePort>>,
-        can_gc: CanGc,
     ) -> DomRoot<ExtendableMessageEvent> {
         Self::new_with_proto(
+            cx,
             global,
             None,
             type_,
@@ -148,12 +148,12 @@ impl ExtendableMessageEvent {
             lastEventId,
             source,
             ports,
-            can_gc,
         )
     }
 
     #[allow(clippy::too_many_arguments)]
     fn new_with_proto(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
         type_: Atom,
@@ -164,7 +164,6 @@ impl ExtendableMessageEvent {
         lastEventId: DOMString,
         source: Option<MessageSource>,
         ports: Vec<DomRoot<MessagePort>>,
-        can_gc: CanGc,
     ) -> DomRoot<ExtendableMessageEvent> {
         let ev = Box::new(ExtendableMessageEvent::new_inherited(
             origin,
@@ -172,7 +171,7 @@ impl ExtendableMessageEvent {
             source,
             ports,
         ));
-        let ev = reflect_dom_object_with_proto(ev, global, proto, can_gc);
+        let ev = reflect_dom_object_with_proto_and_cx(ev, global, proto, cx);
         {
             let event = ev.upcast::<Event>();
             event.init_event(type_, bubbles, cancelable);
@@ -194,6 +193,7 @@ impl ExtendableMessageEvent {
         ports: Vec<DomRoot<MessagePort>>,
     ) {
         let Extendablemessageevent = ExtendableMessageEvent::new(
+            cx,
             scope,
             atom!("message"),
             false,
@@ -203,7 +203,6 @@ impl ExtendableMessageEvent {
             DOMString::new(),
             source,
             ports,
-            CanGc::from_cx(cx),
         );
         Extendablemessageevent.upcast::<Event>().fire(cx, target);
     }
@@ -211,6 +210,7 @@ impl ExtendableMessageEvent {
     pub(crate) fn dispatch_error(cx: &mut JSContext, target: &EventTarget, scope: &GlobalScope) {
         let init = ExtendableMessageEventBinding::ExtendableMessageEventInit::empty();
         let ExtendableMsgEvent = ExtendableMessageEvent::new(
+            cx,
             scope,
             atom!("messageerror"),
             init.parent.parent.bubbles,
@@ -222,7 +222,6 @@ impl ExtendableMessageEvent {
                 .as_ref()
                 .and_then(|s| s.as_ref().map(|s| s.into())),
             init.ports.clone(),
-            CanGc::from_cx(cx),
         );
         ExtendableMsgEvent.upcast::<Event>().fire(cx, target);
     }
@@ -231,14 +230,15 @@ impl ExtendableMessageEvent {
 impl ExtendableMessageEventMethods<crate::DomTypeHolder> for ExtendableMessageEvent {
     /// <https://w3c.github.io/ServiceWorker/#dom-extendablemessageevent-extendablemessageevent>
     fn Constructor(
+        cx: &mut JSContext,
         worker: &ServiceWorkerGlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         type_: DOMString,
         init: RootedTraceableBox<ExtendableMessageEventBinding::ExtendableMessageEventInit>,
     ) -> Fallible<DomRoot<ExtendableMessageEvent>> {
         let global = worker.upcast::<GlobalScope>();
         let ev = ExtendableMessageEvent::new_with_proto(
+            cx,
             global,
             proto,
             Atom::from(type_),
@@ -251,7 +251,6 @@ impl ExtendableMessageEventMethods<crate::DomTypeHolder> for ExtendableMessageEv
                 .as_ref()
                 .and_then(|s| s.as_ref().map(|s| s.into())),
             vec![],
-            can_gc,
         );
         Ok(ev)
     }

--- a/components/script/dom/event/formdataevent.rs
+++ b/components/script/dom/event/formdataevent.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -17,7 +18,6 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::formdata::FormData;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct FormDataEvent {
@@ -27,35 +27,33 @@ pub(crate) struct FormDataEvent {
 
 impl FormDataEvent {
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         type_: Atom,
         can_bubble: EventBubbles,
         cancelable: EventCancelable,
         form_data: &FormData,
-        can_gc: CanGc,
     ) -> DomRoot<FormDataEvent> {
-        Self::new_with_proto(
-            window, None, type_, can_bubble, cancelable, form_data, can_gc,
-        )
+        Self::new_with_proto(cx, window, None, type_, can_bubble, cancelable, form_data)
     }
 
     fn new_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         type_: Atom,
         can_bubble: EventBubbles,
         cancelable: EventCancelable,
         form_data: &FormData,
-        can_gc: CanGc,
     ) -> DomRoot<FormDataEvent> {
-        let ev = reflect_dom_object_with_proto(
+        let ev = reflect_dom_object_with_proto_and_cx(
             Box::new(FormDataEvent {
                 event: Event::new_inherited(),
                 form_data: Dom::from_ref(form_data),
             }),
             window,
             proto,
-            can_gc,
+            cx,
         );
 
         {
@@ -69,9 +67,9 @@ impl FormDataEvent {
 impl FormDataEventMethods<crate::DomTypeHolder> for FormDataEvent {
     /// <https://html.spec.whatwg.org/multipage/#formdataevent>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         type_: DOMString,
         init: &FormDataEventBinding::FormDataEventInit,
     ) -> Fallible<DomRoot<FormDataEvent>> {
@@ -79,13 +77,13 @@ impl FormDataEventMethods<crate::DomTypeHolder> for FormDataEvent {
         let cancelable = EventCancelable::from(init.parent.cancelable);
 
         let event = FormDataEvent::new_with_proto(
+            cx,
             window,
             proto,
             Atom::from(type_),
             bubbles,
             cancelable,
             &init.formData.clone(),
-            can_gc,
         );
 
         Ok(event)

--- a/components/script/dom/event/messageevent.rs
+++ b/components/script/dom/event/messageevent.rs
@@ -248,7 +248,6 @@ impl MessageEventMethods<crate::DomTypeHolder> for MessageEvent {
         cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-
         type_: DOMString,
         init: RootedTraceableBox<MessageEventBinding::MessageEventInit>,
     ) -> Fallible<DomRoot<MessageEvent>> {

--- a/components/script/dom/event/messageevent.rs
+++ b/components/script/dom/event/messageevent.rs
@@ -8,7 +8,7 @@ use js::jsapi::Heap;
 use js::jsval::JSVal;
 use js::rust::{HandleObject, HandleValue, MutableHandleValue};
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -27,7 +27,6 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::messageport::MessagePort;
 use crate::dom::serviceworker::ServiceWorker;
 use crate::dom::windowproxy::WindowProxy;
-use crate::script_runtime::CanGc;
 
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 #[derive(JSTraceable, MallocSizeOf)]
@@ -91,16 +90,20 @@ impl MessageEvent {
         }
     }
 
-    pub(crate) fn new_uninitialized(global: &GlobalScope, can_gc: CanGc) -> DomRoot<MessageEvent> {
-        Self::new_uninitialized_with_proto(global, None, can_gc)
+    pub(crate) fn new_uninitialized(
+        cx: &mut JSContext,
+        global: &GlobalScope,
+    ) -> DomRoot<MessageEvent> {
+        Self::new_uninitialized_with_proto(cx, global, None)
     }
 
     fn new_uninitialized_with_proto(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<MessageEvent> {
         MessageEvent::new_initialized(
+            cx,
             global,
             proto,
             HandleValue::undefined(),
@@ -108,12 +111,12 @@ impl MessageEvent {
             None,
             DOMString::new(),
             vec![],
-            can_gc,
         )
     }
 
     #[allow(clippy::too_many_arguments)]
     fn new_initialized(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
         data: HandleValue,
@@ -121,7 +124,6 @@ impl MessageEvent {
         source: Option<&WindowProxyOrMessagePortOrServiceWorker>,
         lastEventId: DOMString,
         ports: Vec<DomRoot<MessagePort>>,
-        can_gc: CanGc,
     ) -> DomRoot<MessageEvent> {
         let ev = Box::new(MessageEvent::new_inherited(
             origin,
@@ -129,7 +131,7 @@ impl MessageEvent {
             lastEventId,
             ports,
         ));
-        let ev = reflect_dom_object_with_proto(ev, global, proto, can_gc);
+        let ev = reflect_dom_object_with_proto_and_cx(ev, global, proto, cx);
         ev.data.set(data.get());
 
         ev
@@ -137,6 +139,7 @@ impl MessageEvent {
 
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         type_: Atom,
         bubbles: bool,
@@ -146,9 +149,9 @@ impl MessageEvent {
         source: Option<&WindowProxyOrMessagePortOrServiceWorker>,
         lastEventId: DOMString,
         ports: Vec<DomRoot<MessagePort>>,
-        can_gc: CanGc,
     ) -> DomRoot<MessageEvent> {
         Self::new_with_proto(
+            cx,
             global,
             None,
             type_,
@@ -159,12 +162,12 @@ impl MessageEvent {
             source,
             lastEventId,
             ports,
-            can_gc,
         )
     }
 
     #[allow(clippy::too_many_arguments)]
     fn new_with_proto(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
         type_: Atom,
@@ -175,9 +178,9 @@ impl MessageEvent {
         source: Option<&WindowProxyOrMessagePortOrServiceWorker>,
         lastEventId: DOMString,
         ports: Vec<DomRoot<MessagePort>>,
-        can_gc: CanGc,
     ) -> DomRoot<MessageEvent> {
         let ev = MessageEvent::new_initialized(
+            cx,
             global,
             proto,
             data,
@@ -185,7 +188,6 @@ impl MessageEvent {
             source,
             lastEventId,
             ports,
-            can_gc,
         );
         {
             let event = ev.upcast::<Event>();
@@ -204,6 +206,7 @@ impl MessageEvent {
         ports: Vec<DomRoot<MessagePort>>,
     ) {
         let messageevent = MessageEvent::new(
+            cx,
             scope,
             atom!("message"),
             false,
@@ -217,7 +220,6 @@ impl MessageEvent {
                 .as_ref(),
             DOMString::new(),
             ports,
-            CanGc::from_cx(cx),
         );
         messageevent.upcast::<Event>().fire(cx, target);
     }
@@ -225,6 +227,7 @@ impl MessageEvent {
     pub(crate) fn dispatch_error(cx: &mut JSContext, target: &EventTarget, scope: &GlobalScope) {
         let init = MessageEventBinding::MessageEventInit::empty();
         let messageevent = MessageEvent::new(
+            cx,
             scope,
             atom!("messageerror"),
             init.parent.bubbles,
@@ -234,7 +237,6 @@ impl MessageEvent {
             init.source.as_ref(),
             init.lastEventId.clone(),
             init.ports.clone(),
-            CanGc::from_cx(cx),
         );
         messageevent.upcast::<Event>().fire(cx, target);
     }
@@ -243,13 +245,15 @@ impl MessageEvent {
 impl MessageEventMethods<crate::DomTypeHolder> for MessageEvent {
     /// <https://html.spec.whatwg.org/multipage/#messageevent>
     fn Constructor(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
+
         type_: DOMString,
         init: RootedTraceableBox<MessageEventBinding::MessageEventInit>,
     ) -> Fallible<DomRoot<MessageEvent>> {
         let ev = MessageEvent::new_with_proto(
+            cx,
             global,
             proto,
             Atom::from(type_),
@@ -260,7 +264,6 @@ impl MessageEventMethods<crate::DomTypeHolder> for MessageEvent {
             init.source.as_ref(),
             init.lastEventId.clone(),
             init.ports.clone(),
-            can_gc,
         );
         Ok(ev)
     }

--- a/components/script/dom/event/popstateevent.rs
+++ b/components/script/dom/event/popstateevent.rs
@@ -3,10 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::jsapi::Heap;
 use js::jsval::JSVal;
 use js::rust::{HandleObject, HandleValue, MutableHandleValue};
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -20,7 +21,7 @@ use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::event::Event;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::window::Window;
-use crate::script_runtime::{CanGc, JSContext};
+use crate::script_runtime::JSContext as SafeJSContext;
 
 // https://html.spec.whatwg.org/multipage/#the-popstateevent-interface
 #[dom_struct]
@@ -39,28 +40,28 @@ impl PopStateEvent {
     }
 
     fn new_uninitialized(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<PopStateEvent> {
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(PopStateEvent::new_inherited()),
             window,
             proto,
-            can_gc,
+            cx,
         )
     }
 
     fn new(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         type_: Atom,
         bubbles: bool,
         cancelable: bool,
         state: HandleValue,
-        can_gc: CanGc,
     ) -> DomRoot<PopStateEvent> {
-        let ev = PopStateEvent::new_uninitialized(window, proto, can_gc);
+        let ev = PopStateEvent::new_uninitialized(cx, window, proto);
         ev.state.set(state.get());
         {
             let event = ev.upcast::<Event>();
@@ -75,15 +76,7 @@ impl PopStateEvent {
         window: &Window,
         state: HandleValue,
     ) {
-        let event = PopStateEvent::new(
-            window,
-            None,
-            atom!("popstate"),
-            false,
-            false,
-            state,
-            CanGc::from_cx(cx),
-        );
+        let event = PopStateEvent::new(cx, window, None, atom!("popstate"), false, false, state);
         event.upcast::<Event>().fire(cx, target);
     }
 }
@@ -91,25 +84,25 @@ impl PopStateEvent {
 impl PopStateEventMethods<crate::DomTypeHolder> for PopStateEvent {
     /// <https://html.spec.whatwg.org/multipage/#popstateevent>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         type_: DOMString,
         init: RootedTraceableBox<PopStateEventBinding::PopStateEventInit>,
     ) -> Fallible<DomRoot<PopStateEvent>> {
         Ok(PopStateEvent::new(
+            cx,
             window,
             proto,
             Atom::from(type_),
             init.parent.bubbles,
             init.parent.cancelable,
             init.state.handle(),
-            can_gc,
         ))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-popstateevent-state>
-    fn State(&self, _cx: JSContext, mut retval: MutableHandleValue) {
+    fn State(&self, _cx: SafeJSContext, mut retval: MutableHandleValue) {
         retval.set(self.state.get())
     }
 

--- a/components/script/dom/event/progressevent.rs
+++ b/components/script/dom/event/progressevent.rs
@@ -3,9 +3,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::num::Finite;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -17,7 +18,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct ProgressEvent {
@@ -43,6 +43,7 @@ impl ProgressEvent {
 
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         type_: Atom,
         can_bubble: EventBubbles,
@@ -50,9 +51,9 @@ impl ProgressEvent {
         length_computable: bool,
         loaded: Finite<f64>,
         total: Finite<f64>,
-        can_gc: CanGc,
     ) -> DomRoot<ProgressEvent> {
         Self::new_with_proto(
+            cx,
             global,
             None,
             type_,
@@ -61,12 +62,12 @@ impl ProgressEvent {
             length_computable,
             loaded,
             total,
-            can_gc,
         )
     }
 
     #[expect(clippy::too_many_arguments)]
     fn new_with_proto(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
         type_: Atom,
@@ -75,9 +76,8 @@ impl ProgressEvent {
         length_computable: bool,
         loaded: Finite<f64>,
         total: Finite<f64>,
-        can_gc: CanGc,
     ) -> DomRoot<ProgressEvent> {
-        let ev = reflect_dom_object_with_proto(
+        let ev = reflect_dom_object_with_proto_and_cx(
             Box::new(ProgressEvent::new_inherited(
                 length_computable,
                 loaded,
@@ -85,7 +85,7 @@ impl ProgressEvent {
             )),
             global,
             proto,
-            can_gc,
+            cx,
         );
         {
             let event = ev.upcast::<Event>();
@@ -98,15 +98,17 @@ impl ProgressEvent {
 impl ProgressEventMethods<crate::DomTypeHolder> for ProgressEvent {
     /// <https://xhr.spec.whatwg.org/#dom-progressevent-progressevent>
     fn Constructor(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
+
         type_: DOMString,
         init: &ProgressEventBinding::ProgressEventInit,
     ) -> Fallible<DomRoot<ProgressEvent>> {
         let bubbles = EventBubbles::from(init.parent.bubbles);
         let cancelable = EventCancelable::from(init.parent.cancelable);
         let ev = ProgressEvent::new_with_proto(
+            cx,
             global,
             proto,
             Atom::from(type_),
@@ -115,7 +117,6 @@ impl ProgressEventMethods<crate::DomTypeHolder> for ProgressEvent {
             init.lengthComputable,
             init.loaded,
             init.total,
-            can_gc,
         );
         Ok(ev)
     }

--- a/components/script/dom/event/progressevent.rs
+++ b/components/script/dom/event/progressevent.rs
@@ -101,7 +101,6 @@ impl ProgressEventMethods<crate::DomTypeHolder> for ProgressEvent {
         cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-
         type_: DOMString,
         init: &ProgressEventBinding::ProgressEventInit,
     ) -> Fallible<DomRoot<ProgressEvent>> {

--- a/components/script/dom/event/promiserejectionevent.rs
+++ b/components/script/dom/event/promiserejectionevent.rs
@@ -5,10 +5,11 @@
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::jsapi::{Heap, JSObject};
 use js::jsval::JSVal;
 use js::rust::{HandleObject, HandleValue, MutableHandleObject, MutableHandleValue};
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -22,7 +23,7 @@ use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
-use crate::script_runtime::{CanGc, JSContext};
+use crate::script_runtime::JSContext as SafeJSContext;
 
 #[dom_struct]
 pub(crate) struct PromiseRejectionEvent {
@@ -43,15 +44,16 @@ impl PromiseRejectionEvent {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         type_: Atom,
         bubbles: EventBubbles,
         cancelable: EventCancelable,
         promise: Rc<Promise>,
         reason: HandleValue,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
         Self::new_with_proto(
+            cx,
             global,
             None,
             type_,
@@ -59,12 +61,12 @@ impl PromiseRejectionEvent {
             cancelable,
             promise.promise_obj(),
             reason,
-            can_gc,
         )
     }
 
     #[allow(clippy::too_many_arguments)]
     fn new_with_proto(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
         type_: Atom,
@@ -72,13 +74,12 @@ impl PromiseRejectionEvent {
         cancelable: EventCancelable,
         promise: HandleObject,
         reason: HandleValue,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        let ev = reflect_dom_object_with_proto(
+        let ev = reflect_dom_object_with_proto_and_cx(
             Box::new(PromiseRejectionEvent::new_inherited()),
             global,
             proto,
-            can_gc,
+            cx,
         );
         ev.promise.set(promise.get());
 
@@ -95,9 +96,9 @@ impl PromiseRejectionEvent {
 impl PromiseRejectionEventMethods<crate::DomTypeHolder> for PromiseRejectionEvent {
     /// <https://html.spec.whatwg.org/multipage/#promiserejectionevent>
     fn Constructor(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         type_: DOMString,
         init: RootedTraceableBox<PromiseRejectionEventBinding::PromiseRejectionEventInit>,
     ) -> Fallible<DomRoot<Self>> {
@@ -106,6 +107,7 @@ impl PromiseRejectionEventMethods<crate::DomTypeHolder> for PromiseRejectionEven
         let cancelable = EventCancelable::from(init.parent.cancelable);
 
         let event = PromiseRejectionEvent::new_with_proto(
+            cx,
             global,
             proto,
             Atom::from(type_),
@@ -113,18 +115,17 @@ impl PromiseRejectionEventMethods<crate::DomTypeHolder> for PromiseRejectionEven
             cancelable,
             init.promise.handle(),
             reason,
-            can_gc,
         );
         Ok(event)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-promiserejectionevent-promise>
-    fn Promise(&self, _cx: JSContext, mut return_value: MutableHandleObject) {
+    fn Promise(&self, _cx: SafeJSContext, mut return_value: MutableHandleObject) {
         return_value.set(self.promise.get());
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-promiserejectionevent-reason>
-    fn Reason(&self, _cx: JSContext, mut retval: MutableHandleValue) {
+    fn Reason(&self, _cx: SafeJSContext, mut retval: MutableHandleValue) {
         retval.set(self.reason.get())
     }
 

--- a/components/script/dom/event/submitevent.rs
+++ b/components/script/dom/event/submitevent.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -16,7 +17,6 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::event::Event;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct SubmitEvent {
@@ -33,30 +33,30 @@ impl SubmitEvent {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         type_: Atom,
         bubbles: bool,
         cancelable: bool,
         submitter: Option<DomRoot<HTMLElement>>,
-        can_gc: CanGc,
     ) -> DomRoot<SubmitEvent> {
-        Self::new_with_proto(window, None, type_, bubbles, cancelable, submitter, can_gc)
+        Self::new_with_proto(cx, window, None, type_, bubbles, cancelable, submitter)
     }
 
     fn new_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         type_: Atom,
         bubbles: bool,
         cancelable: bool,
         submitter: Option<DomRoot<HTMLElement>>,
-        can_gc: CanGc,
     ) -> DomRoot<SubmitEvent> {
-        let ev = reflect_dom_object_with_proto(
+        let ev = reflect_dom_object_with_proto_and_cx(
             Box::new(SubmitEvent::new_inherited(submitter)),
             window,
             proto,
-            can_gc,
+            cx,
         );
         {
             let event = ev.upcast::<Event>();
@@ -69,20 +69,20 @@ impl SubmitEvent {
 impl SubmitEventMethods<crate::DomTypeHolder> for SubmitEvent {
     /// <https://html.spec.whatwg.org/multipage/#submitevent>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         type_: DOMString,
         init: &SubmitEventBinding::SubmitEventInit,
     ) -> DomRoot<SubmitEvent> {
         SubmitEvent::new_with_proto(
+            cx,
             window,
             proto,
             Atom::from(type_),
             init.parent.bubbles,
             init.parent.cancelable,
             init.submitter.as_ref().map(|s| DomRoot::from_ref(&**s)),
-            can_gc,
         )
     }
 

--- a/components/script/dom/event/toggleevent.rs
+++ b/components/script/dom/event/toggleevent.rs
@@ -3,10 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::codegen::GenericBindings::NodeBinding::NodeMethods;
 use script_bindings::inheritance::Castable;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -20,7 +21,6 @@ use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::node::Node;
 use crate::dom::types::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct ToggleEvent {
@@ -49,6 +49,7 @@ impl ToggleEvent {
 
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         type_: Atom,
         bubbles: EventBubbles,
@@ -56,15 +57,15 @@ impl ToggleEvent {
         old_state: DOMString,
         new_state: DOMString,
         source: Option<DomRoot<Element>>,
-        can_gc: CanGc,
     ) -> DomRoot<ToggleEvent> {
         Self::new_with_proto(
-            window, None, type_, bubbles, cancelable, old_state, new_state, source, can_gc,
+            cx, window, None, type_, bubbles, cancelable, old_state, new_state, source,
         )
     }
 
     #[allow(clippy::too_many_arguments)]
     fn new_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         type_: Atom,
@@ -73,10 +74,9 @@ impl ToggleEvent {
         old_state: DOMString,
         new_state: DOMString,
         source: Option<DomRoot<Element>>,
-        can_gc: CanGc,
     ) -> DomRoot<ToggleEvent> {
         let event = Box::new(ToggleEvent::new_inherited(old_state, new_state, source));
-        let event = reflect_dom_object_with_proto(event, window, proto, can_gc);
+        let event = reflect_dom_object_with_proto_and_cx(event, window, proto, cx);
         {
             let event = event.upcast::<Event>();
             event.init_event(type_, bool::from(bubbles), bool::from(cancelable));
@@ -88,15 +88,17 @@ impl ToggleEvent {
 impl ToggleEventMethods<crate::DomTypeHolder> for ToggleEvent {
     /// <https://html.spec.whatwg.org/multipage/#toggleevent>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
+
         type_: DOMString,
         init: &ToggleEventBinding::ToggleEventInit,
     ) -> Fallible<DomRoot<ToggleEvent>> {
         let bubbles = EventBubbles::from(init.parent.bubbles);
         let cancelable = EventCancelable::from(init.parent.cancelable);
         Ok(ToggleEvent::new_with_proto(
+            cx,
             window,
             proto,
             Atom::from(type_),
@@ -105,7 +107,6 @@ impl ToggleEventMethods<crate::DomTypeHolder> for ToggleEvent {
             init.oldState.clone(),
             init.newState.clone(),
             init.source.as_ref().map(|s| DomRoot::from_ref(&**s)),
-            can_gc,
         ))
     }
 

--- a/components/script/dom/event/transitionevent.rs
+++ b/components/script/dom/event/transitionevent.rs
@@ -75,7 +75,6 @@ impl TransitionEventMethods<crate::DomTypeHolder> for TransitionEvent {
         cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-
         type_: DOMString,
         init: &TransitionEventInit,
     ) -> Fallible<DomRoot<TransitionEvent>> {

--- a/components/script/dom/event/transitionevent.rs
+++ b/components/script/dom/event/transitionevent.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -18,7 +19,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::event::Event;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct TransitionEvent {
@@ -40,26 +40,26 @@ impl TransitionEvent {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         type_: Atom,
         init: &TransitionEventInit,
-        can_gc: CanGc,
     ) -> DomRoot<TransitionEvent> {
-        Self::new_with_proto(window, None, type_, init, can_gc)
+        Self::new_with_proto(cx, window, None, type_, init)
     }
 
     fn new_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         type_: Atom,
         init: &TransitionEventInit,
-        can_gc: CanGc,
     ) -> DomRoot<TransitionEvent> {
-        let ev = reflect_dom_object_with_proto(
+        let ev = reflect_dom_object_with_proto_and_cx(
             Box::new(TransitionEvent::new_inherited(init)),
             window,
             proto,
-            can_gc,
+            cx,
         );
         {
             let event = ev.upcast::<Event>();
@@ -72,18 +72,19 @@ impl TransitionEvent {
 impl TransitionEventMethods<crate::DomTypeHolder> for TransitionEvent {
     /// <https://drafts.csswg.org/css-transitions/#dom-transitionevent-transitionevent>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
+
         type_: DOMString,
         init: &TransitionEventInit,
     ) -> Fallible<DomRoot<TransitionEvent>> {
         Ok(TransitionEvent::new_with_proto(
+            cx,
             window,
             proto,
             Atom::from(type_),
             init,
-            can_gc,
         ))
     }
 

--- a/components/script/dom/event/uievent.rs
+++ b/components/script/dom/event/uievent.rs
@@ -6,8 +6,9 @@ use std::cell::Cell;
 use std::default::Default;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use servo_config::pref;
 use stylo_atoms::Atom;
 
@@ -24,7 +25,6 @@ use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::node::NodeTraits;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 // https://w3c.github.io/uievents/#interface-uievent
 #[dom_struct]
@@ -49,20 +49,21 @@ impl UIEvent {
         self.which.set(v);
     }
 
-    pub(crate) fn new_uninitialized(window: &Window, can_gc: CanGc) -> DomRoot<UIEvent> {
-        Self::new_uninitialized_with_proto(window, None, can_gc)
+    pub(crate) fn new_uninitialized(cx: &mut JSContext, window: &Window) -> DomRoot<UIEvent> {
+        Self::new_uninitialized_with_proto(cx, window, None)
     }
 
     fn new_uninitialized_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<UIEvent> {
-        reflect_dom_object_with_proto(Box::new(UIEvent::new_inherited()), window, proto, can_gc)
+        reflect_dom_object_with_proto_and_cx(Box::new(UIEvent::new_inherited()), window, proto, cx)
     }
 
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         event_type: Atom,
         can_bubble: EventBubbles,
@@ -70,15 +71,15 @@ impl UIEvent {
         view: Option<&Window>,
         detail: i32,
         which: u32,
-        can_gc: CanGc,
     ) -> DomRoot<UIEvent> {
         Self::new_with_proto(
-            window, None, event_type, can_bubble, cancelable, view, detail, which, can_gc,
+            cx, window, None, event_type, can_bubble, cancelable, view, detail, which,
         )
     }
 
     #[allow(clippy::too_many_arguments)]
     fn new_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         event_type: Atom,
@@ -87,9 +88,8 @@ impl UIEvent {
         view: Option<&Window>,
         detail: i32,
         which: u32,
-        can_gc: CanGc,
     ) -> DomRoot<UIEvent> {
-        let ev = UIEvent::new_uninitialized_with_proto(window, proto, can_gc);
+        let ev = UIEvent::new_uninitialized_with_proto(cx, window, proto);
         ev.initialize_ui_event(
             event_type,
             view.map(|window| window.upcast::<EventTarget>()),
@@ -152,15 +152,16 @@ impl UIEvent {
 impl UIEventMethods<crate::DomTypeHolder> for UIEvent {
     /// <https://w3c.github.io/uievents/#dom-uievent-uievent>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         event_type: DOMString,
         init: &UIEventBinding::UIEventInit,
     ) -> Fallible<DomRoot<UIEvent>> {
         let bubbles = EventBubbles::from(init.parent.bubbles);
         let cancelable = EventCancelable::from(init.parent.cancelable);
         let event = UIEvent::new_with_proto(
+            cx,
             window,
             proto,
             event_type.into(),
@@ -169,7 +170,6 @@ impl UIEventMethods<crate::DomTypeHolder> for UIEvent {
             init.view.as_deref(),
             init.detail,
             init.which,
-            can_gc,
         );
         Ok(event)
     }

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -280,6 +280,7 @@ impl EventSourceContext {
             self.data
                 .safe_to_jsval(cx.into(), data.handle_mut(), CanGc::from_cx(cx));
             MessageEvent::new(
+                cx,
                 &event_source.global(),
                 type_,
                 false,
@@ -289,7 +290,6 @@ impl EventSourceContext {
                 None,
                 event_source.last_event_id.borrow().clone(),
                 Vec::with_capacity(0),
-                CanGc::from_cx(cx),
             )
         };
         // Step 7

--- a/components/script/dom/file/filereader.rs
+++ b/components/script/dom/file/filereader.rs
@@ -517,6 +517,7 @@ impl FileReader {
         total: Option<u64>,
     ) {
         let progressevent = ProgressEvent::new(
+            cx,
             &self.global(),
             type_,
             EventBubbles::DoesNotBubble,
@@ -524,7 +525,6 @@ impl FileReader {
             total.is_some(),
             Finite::wrap(loaded as f64),
             Finite::wrap(total.unwrap_or(0) as f64),
-            CanGc::from_cx(cx),
         );
         progressevent.upcast::<Event>().fire(cx, self.upcast());
     }

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2824,6 +2824,7 @@ impl GlobalScope {
         // and additional attributes initialized according to errorInfo.
 
         let event = ErrorEvent::new(
+            cx,
             self,
             atom!("error"),
             EventBubbles::DoesNotBubble,
@@ -2833,7 +2834,6 @@ impl GlobalScope {
             error_info.lineno,
             error_info.column,
             value,
-            CanGc::from_cx(cx),
         );
 
         let not_handled = event

--- a/components/script/dom/html/htmlbuttonelement.rs
+++ b/components/script/dom/html/htmlbuttonelement.rs
@@ -553,6 +553,7 @@ impl Activatable for HTMLButtonElement {
             // TODO source attribute
             // Step 5.4 If continue is false, then return.
             let event = CommandEvent::new(
+                cx,
                 &self.owner_window(),
                 atom!("command"),
                 EventBubbles::DoesNotBubble,
@@ -560,7 +561,6 @@ impl Activatable for HTMLButtonElement {
                 Some(DomRoot::from_ref(self.upcast())),
                 self.upcast::<Element>()
                     .get_string_attribute(&local_name!("command")),
-                CanGc::from_cx(cx),
             );
             let event = event.upcast::<Event>();
             if !event.fire(cx, target.upcast::<EventTarget>()) {

--- a/components/script/dom/html/htmldetailselement.rs
+++ b/components/script/dom/html/htmldetailselement.rs
@@ -37,7 +37,6 @@ use crate::dom::node::{
 };
 use crate::dom::text::Text;
 use crate::dom::toggleevent::ToggleEvent;
-use crate::script_runtime::CanGc;
 
 /// The summary that should be presented if no `<summary>` element is present
 const DEFAULT_SUMMARY: &str = "Details";
@@ -466,6 +465,7 @@ impl VirtualMethods for HTMLDetailsElement {
                     let this = this.root();
                     if counter == this.toggle_counter.get() {
                         let event = ToggleEvent::new(
+                            cx,
                             this.global().as_window(),
                             atom!("toggle"),
                             EventBubbles::DoesNotBubble,
@@ -473,7 +473,6 @@ impl VirtualMethods for HTMLDetailsElement {
                             DOMString::from(old_state),
                             DOMString::from(new_state),
                             None,
-                            CanGc::from_cx(cx),
                         );
                         let event = event.upcast::<Event>();
                         event.fire(cx, this.upcast::<EventTarget>());

--- a/components/script/dom/html/htmldialogelement.rs
+++ b/components/script/dom/html/htmldialogelement.rs
@@ -26,7 +26,6 @@ use crate::dom::htmlbuttonelement::{CommandState, HTMLButtonElement};
 use crate::dom::node::virtualmethods::VirtualMethods;
 use crate::dom::node::{Node, NodeTraits};
 use crate::dom::toggleevent::ToggleEvent;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLDialogElement {
@@ -102,6 +101,7 @@ impl HTMLDialogElement {
 
         // Step 6. If the result of firing an event named beforetoggle, using ToggleEvent, with the cancelable attribute initialized to true, the oldState attribute initialized to "closed", the newState attribute initialized to "open", and the source attribute initialized to source at subject is false, then return.
         let event = ToggleEvent::new(
+            cx,
             &self.owner_window(),
             atom!("beforetoggle"),
             EventBubbles::DoesNotBubble,
@@ -109,7 +109,6 @@ impl HTMLDialogElement {
             DOMString::from("closed"),
             DOMString::from("open"),
             source.borrow().clone(),
-            CanGc::from_cx(cx),
         );
         let event = event.upcast::<Event>();
         if !event.fire(cx, self.upcast::<EventTarget>()) {
@@ -176,6 +175,7 @@ impl HTMLDialogElement {
 
         // Step 2. Fire an event named beforetoggle, using ToggleEvent, with the oldState attribute initialized to "open", the newState attribute initialized to "closed", and the source attribute initialized to source at subject.
         let event = ToggleEvent::new(
+            cx,
             &self.owner_window(),
             atom!("beforetoggle"),
             EventBubbles::DoesNotBubble,
@@ -183,7 +183,6 @@ impl HTMLDialogElement {
             DOMString::from("open"),
             DOMString::from("closed"),
             source.borrow().clone(),
-            CanGc::from_cx(cx),
         );
         let event = event.upcast::<Event>();
         event.fire(cx, self.upcast::<EventTarget>());
@@ -261,6 +260,7 @@ impl HTMLDialogElement {
 
                 // Step 2.1. Fire an event named toggle at element, using ToggleEvent, with the oldState attribute initialized to oldState, the newState attribute initialized to newState, and the source attribute initialized to source.
                 let event = ToggleEvent::new(
+                    cx,
                     &this.owner_window(),
                     atom!("toggle"),
                     EventBubbles::DoesNotBubble,
@@ -268,7 +268,6 @@ impl HTMLDialogElement {
                     DOMString::from(old_state),
                     DOMString::from(new_state),
                     source,
-                    CanGc::from_cx(cx),
                 );
                 let event = event.upcast::<Event>();
                 event.fire(cx, this.upcast::<EventTarget>());
@@ -351,6 +350,7 @@ impl HTMLDialogElementMethods<crate::DomTypeHolder> for HTMLDialogElement {
 
         // Step 3. If the result of firing an event named beforetoggle, using ToggleEvent, with the cancelable attribute initialized to true, the oldState attribute initialized to "closed", and the newState attribute initialized to "open" at this is false, then return.
         let event = ToggleEvent::new(
+            cx,
             &self.owner_window(),
             atom!("beforetoggle"),
             EventBubbles::DoesNotBubble,
@@ -358,7 +358,6 @@ impl HTMLDialogElementMethods<crate::DomTypeHolder> for HTMLDialogElement {
             DOMString::from("closed"),
             DOMString::from("open"),
             None,
-            CanGc::from_cx(cx),
         );
         let event = event.upcast::<Event>();
         if !event.fire(cx, self.upcast::<EventTarget>()) {

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -771,12 +771,12 @@ impl HTMLFormElement {
 
             // Step 6.5
             let event = SubmitEvent::new(
+                cx,
                 self.global().as_window(),
                 atom!("submit"),
                 true,
                 true,
                 submitter_button.map(DomRoot::from_ref),
-                CanGc::from_cx(cx),
             );
             let event = event.upcast::<Event>();
             event.fire(cx, self.upcast::<EventTarget>());
@@ -1350,12 +1350,12 @@ impl HTMLFormElement {
 
         // Step 7
         let event = FormDataEvent::new(
+            cx,
             &window,
             atom!("formdata"),
             EventBubbles::Bubbles,
             EventCancelable::NotCancelable,
             &form_data,
-            CanGc::from_cx(cx),
         );
 
         event

--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -547,7 +547,8 @@ impl HTMLSelectElement {
                 // Step 2. Fire an event named input at the select element, with the bubbles and composed
                 // attributes initialized to true.
                 this.upcast::<EventTarget>()
-                    .fire_event_with_params(cx,
+                    .fire_event_with_params(
+                        cx,
                         atom!("input"),
                         EventBubbles::Bubbles,
                         EventCancelable::NotCancelable,

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -253,7 +253,8 @@ impl HTMLTextAreaElement {
                     // Step 1. Set target's has scheduled selectionchange event to false.
                     this.has_scheduled_selectionchange_event.set(false);
                     // Step 2. If target is an element, fire an event named selectionchange, which bubbles and not cancelable, at target.
-                    this.upcast::<EventTarget>().fire_event_with_params(cx,
+                    this.upcast::<EventTarget>().fire_event_with_params(
+                        cx,
                         atom!("selectionchange"),
                         EventBubbles::Bubbles,
                         EventCancelable::NotCancelable,

--- a/components/script/dom/html/input_element/mod.rs
+++ b/components/script/dom/html/input_element/mod.rs
@@ -945,7 +945,8 @@ impl HTMLInputElement {
                     // Step 1. Set target's has scheduled selectionchange event to false.
                     this.has_scheduled_selectionchange_event.set(false);
                     // Step 2. If target is an element, fire an event named selectionchange, which bubbles and not cancelable, at target.
-                    this.upcast::<EventTarget>().fire_event_with_params(cx,
+                    this.upcast::<EventTarget>().fire_event_with_params(
+                        cx,
                         atom!("selectionchange"),
                         EventBubbles::Bubbles,
                         EventCancelable::NotCancelable,

--- a/components/script/dom/indexeddb/idbfactory.rs
+++ b/components/script/dom/indexeddb/idbfactory.rs
@@ -440,11 +440,11 @@ impl IDBFactory {
         // with its bubbles
         // and cancelable attributes initialized to true.
         let event = Event::new(
+            cx,
             &global,
             Atom::from("error"),
             EventBubbles::Bubbles,
             EventCancelable::Cancelable,
-            CanGc::from_cx(cx),
         );
         event.fire(cx, request.upcast());
     }

--- a/components/script/dom/indexeddb/idbopendbrequest.rs
+++ b/components/script/dom/indexeddb/idbopendbrequest.rs
@@ -89,11 +89,11 @@ impl OpenRequestListener {
                 let error = map_backend_error_to_dom_error(err);
                 open_request.set_error(Some(error), CanGc::from_cx(cx));
                 let event = Event::new(
+                    cx,
                     &global,
                     Atom::from("error"),
                     EventBubbles::Bubbles,
                     EventCancelable::Cancelable,
-                    CanGc::from_cx(cx),
                 );
                 event.fire(cx, open_request.upcast());
             },
@@ -300,11 +300,11 @@ impl IDBOpenDBRequest {
         self.set_result(result_val.handle());
 
         let event = Event::new(
+            cx,
             &global,
             Atom::from("success"),
             EventBubbles::DoesNotBubble,
             EventCancelable::NotCancelable,
-            CanGc::from_cx(cx),
         );
         event.fire(cx, self.upcast());
     }

--- a/components/script/dom/indexeddb/idbrequest.rs
+++ b/components/script/dom/indexeddb/idbrequest.rs
@@ -266,11 +266,11 @@ impl RequestListener {
             // Step 2: Set event’s type attribute to "success".
             // Step 3: Set event’s bubbles and cancelable attributes to false.
             let event = Event::new(
+                cx,
                 &global,
                 Atom::from("success"),
                 EventBubbles::DoesNotBubble,
                 EventCancelable::NotCancelable,
-                CanGc::from_cx(cx),
             );
 
             // Step 5: Let legacyOutputDidListenersThrowFlag be initially false.
@@ -339,11 +339,11 @@ impl RequestListener {
         // Step 2: Set event’s type attribute to "error".
         // Step 3: Set event’s bubbles and cancelable attributes to true.
         let event = Event::new(
+            cx,
             global,
             Atom::from("error"),
             EventBubbles::Bubbles,
             EventCancelable::Cancelable,
-            CanGc::from_cx(cx),
         );
 
         // If result is an error and transaction’s state is committing, then run abort a

--- a/components/script/dom/indexeddb/idbtransaction.rs
+++ b/components/script/dom/indexeddb/idbtransaction.rs
@@ -578,11 +578,11 @@ impl IDBTransaction {
                 }
                 let global = this.global();
                 let event = Event::new(
+                    cx,
                     &global,
                     Atom::from("abort"),
                     EventBubbles::DoesNotBubble,
                     EventCancelable::NotCancelable,
-                    CanGc::from_cx(cx),
                 );
                 event.fire(cx, this.upcast());
                 if this.mode == IDBTransactionMode::Versionchange {
@@ -643,11 +643,11 @@ impl IDBTransaction {
                 this.finished.set(true);
                 let global = this.global();
                 let event = Event::new(
+                    cx,
                     &global,
                     Atom::from("complete"),
                     EventBubbles::DoesNotBubble,
                     EventCancelable::NotCancelable,
-                    CanGc::from_cx(cx)
                 );
                 // https://w3c.github.io/IndexedDB/#commit-transaction
                 // Step 5.3: Fire an event named complete at transaction.

--- a/components/script/dom/storage.rs
+++ b/components/script/dom/storage.rs
@@ -245,7 +245,8 @@ impl Storage {
             task!(send_storage_notification: move |cx| {
                 let this = this.root();
                 let global = this.global();
-                let event = StorageEvent::new(cx,
+                let event = StorageEvent::new(
+                    cx,
                     global.as_window(),
                     atom!("storage"),
                     EventBubbles::DoesNotBubble,

--- a/components/script/dom/webgpu/gpudevice.rs
+++ b/components/script/dom/webgpu/gpudevice.rs
@@ -221,7 +221,8 @@ impl GPUDevice {
                 let this = this.root();
                 let error = GPUError::from_error(cx, &this.global(), error);
 
-                let event = GPUUncapturedErrorEvent::new(cx,
+                let event = GPUUncapturedErrorEvent::new(
+                    cx,
                     &this.global(),
                     atom!("uncapturederror"),
                     &GPUUncapturedErrorEventInit {

--- a/components/script/dom/webrtc/rtcdatachannel.rs
+++ b/components/script/dom/webrtc/rtcdatachannel.rs
@@ -152,22 +152,22 @@ impl RTCDataChannel {
 
     pub(crate) fn on_open(&self, cx: &mut JSContext) {
         let event = Event::new(
+            cx,
             &self.global(),
             atom!("open"),
             EventBubbles::DoesNotBubble,
             EventCancelable::NotCancelable,
-            CanGc::from_cx(cx),
         );
         event.upcast::<Event>().fire(cx, self.upcast());
     }
 
     pub(crate) fn on_close(&self, cx: &mut JSContext) {
         let event = Event::new(
+            cx,
             &self.global(),
             atom!("close"),
             EventBubbles::DoesNotBubble,
             EventCancelable::NotCancelable,
-            CanGc::from_cx(cx),
         );
         event.upcast::<Event>().fire(cx, self.upcast());
 
@@ -254,11 +254,11 @@ impl RTCDataChannel {
     pub(crate) fn on_state_change(&self, cx: &mut JSContext, state: DataChannelState) {
         if let DataChannelState::Closing = state {
             let event = Event::new(
+                cx,
                 &self.global(),
                 atom!("closing"),
                 EventBubbles::DoesNotBubble,
                 EventCancelable::NotCancelable,
-                CanGc::from_cx(cx),
             );
             event.upcast::<Event>().fire(cx, self.upcast());
         };

--- a/components/script/dom/webrtc/rtcpeerconnection.rs
+++ b/components/script/dom/webrtc/rtcpeerconnection.rs
@@ -255,11 +255,11 @@ impl RTCPeerConnection {
             return;
         }
         let event = Event::new(
+            cx,
             &self.global(),
             atom!("negotiationneeded"),
             EventBubbles::DoesNotBubble,
             EventCancelable::NotCancelable,
-            CanGc::from_cx(cx),
         );
         event.upcast::<Event>().fire(cx, self.upcast());
     }
@@ -370,11 +370,11 @@ impl RTCPeerConnection {
 
         // step 5
         let event = Event::new(
+            cx,
             &self.global(),
             atom!("icegatheringstatechange"),
             EventBubbles::DoesNotBubble,
             EventCancelable::NotCancelable,
-            CanGc::from_cx(cx),
         );
         event.upcast::<Event>().fire(cx, self.upcast());
 
@@ -412,11 +412,11 @@ impl RTCPeerConnection {
 
         // step 5
         let event = Event::new(
+            cx,
             &self.global(),
             atom!("iceconnectionstatechange"),
             EventBubbles::DoesNotBubble,
             EventCancelable::NotCancelable,
-            CanGc::from_cx(cx),
         );
         event.upcast::<Event>().fire(cx, self.upcast());
     }
@@ -435,11 +435,11 @@ impl RTCPeerConnection {
         self.signaling_state.set(state);
 
         let event = Event::new(
+            cx,
             &self.global(),
             atom!("signalingstatechange"),
             EventBubbles::DoesNotBubble,
             EventCancelable::NotCancelable,
-            CanGc::from_cx(cx),
         );
         event.upcast::<Event>().fire(cx, self.upcast());
     }

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -576,6 +576,7 @@ impl TaskOnce for CloseTask {
         let code = self.code.unwrap_or(close_code::NO_STATUS);
         let reason = DOMString::from(self.reason.unwrap_or("".to_owned()));
         let close_event = CloseEvent::new(
+            cx,
             &ws.global(),
             atom!("close"),
             EventBubbles::DoesNotBubble,
@@ -583,7 +584,6 @@ impl TaskOnce for CloseTask {
             clean_close,
             code,
             reason,
-            CanGc::from_cx(cx),
         );
         close_event.upcast::<Event>().fire(cx, ws.upcast());
     }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -3386,6 +3386,7 @@ impl Window {
         // http://dev.w3.org/csswg/cssom-view/#resizing-viewports
         if size_type == WindowSizeType::Resize {
             let uievent = UIEvent::new(
+                cx,
                 self,
                 atom!("resize"),
                 EventBubbles::DoesNotBubble,
@@ -3393,7 +3394,6 @@ impl Window {
                 Some(self),
                 0i32,
                 0u32,
-                CanGc::from_cx(cx),
             );
             uievent.upcast::<Event>().fire(cx, self.upcast());
         }
@@ -3412,6 +3412,7 @@ impl Window {
             let visual_viewport = self.get_or_init_visual_viewport(CanGc::from_cx(cx));
 
             let uievent = UIEvent::new(
+                cx,
                 self,
                 atom!("resize"),
                 EventBubbles::DoesNotBubble,
@@ -3419,7 +3420,6 @@ impl Window {
                 Some(self),
                 0i32,
                 0u32,
-                CanGc::from_cx(cx),
             );
             uievent.upcast::<Event>().fire(cx, visual_viewport.upcast());
 

--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -59,7 +59,7 @@ use crate::messaging::{CommonScriptMsg, ScriptEventLoopReceiver, ScriptEventLoop
 use crate::realms::enter_auto_realm;
 use crate::script_module::{ModuleFetchClient, fetch_a_module_worker_script_graph};
 use crate::script_runtime::ScriptThreadEventCategory::WorkerEvent;
-use crate::script_runtime::{CanGc, Runtime, ThreadSafeJSContext};
+use crate::script_runtime::{Runtime, ThreadSafeJSContext};
 use crate::task_queue::{QueuedTask, QueuedTaskConversion, TaskQueue};
 use crate::task_source::TaskSourceName;
 
@@ -702,6 +702,7 @@ impl DedicatedWorkerGlobalScope {
             // Step 7.2.2. Set notHandled to the result of firing an event named error at workerObject, using ErrorEvent,
             // with the cancelable attribute initialized to true, and additional attributes initialized according to errorInfo.
             let event = ErrorEvent::new(
+                cx,
                 &global,
                 atom!("error"),
                 EventBubbles::DoesNotBubble,
@@ -711,7 +712,6 @@ impl DedicatedWorkerGlobalScope {
                 error_info.lineno,
                 error_info.column,
                 HandleValue::null(),
-                CanGc::from_cx(cx),
             );
 
             // Step 7.2.3. If notHandled is true, then report exception for workerObject's relevant global object with omitError set to true.

--- a/components/script/dom/workers/serviceworkerglobalscope.rs
+++ b/components/script/dom/workers/serviceworkerglobalscope.rs
@@ -572,7 +572,7 @@ impl ServiceWorkerGlobalScope {
     }
 
     fn dispatch_activate(&self, cx: &mut CurrentRealm) {
-        let event = ExtendableEvent::new(self, atom!("activate"), false, false, CanGc::from_cx(cx));
+        let event = ExtendableEvent::new(cx, self, atom!("activate"), false, false);
         let event = (*event).upcast::<Event>();
         event.dispatch(cx, self.upcast(), false);
     }

--- a/components/script/dom/workers/sharedworkerglobalscope.rs
+++ b/components/script/dom/workers/sharedworkerglobalscope.rs
@@ -640,6 +640,7 @@ impl SharedWorkerGlobalScope {
                     inside_port.clone(),
                 );
                 let event = MessageEvent::new(
+                    cx,
                     worker_global.upcast::<GlobalScope>(),
                     Atom::from("connect"),
                     false,
@@ -649,7 +650,6 @@ impl SharedWorkerGlobalScope {
                     Some(&source),
                     DOMString::new(),
                     vec![inside_port],
-                    CanGc::from_cx(cx),
                 );
 
                 event

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -1034,11 +1034,11 @@ impl XMLHttpRequest {
         self.ready_state.set(rs);
         if rs != XMLHttpRequestState::Unsent {
             let event = Event::new(
+                cx,
                 &self.global(),
                 atom!("readystatechange"),
                 EventBubbles::DoesNotBubble,
                 EventCancelable::Cancelable,
-                CanGc::from_cx(cx),
             );
             event.fire(cx, self.upcast());
         }
@@ -1194,11 +1194,11 @@ impl XMLHttpRequest {
                         self.ready_state.set(XMLHttpRequestState::Loading);
                     }
                     let event = Event::new(
+                        cx,
                         &self.global(),
                         atom!("readystatechange"),
                         EventBubbles::DoesNotBubble,
                         EventCancelable::Cancelable,
-                        CanGc::from_cx(cx),
                     );
                     event.fire(cx, self.upcast());
                     return_if_fetch_was_terminated!();
@@ -1288,6 +1288,7 @@ impl XMLHttpRequest {
             (total.unwrap_or(0), total.is_some())
         };
         let progressevent = ProgressEvent::new(
+            cx,
             &self.global(),
             type_,
             EventBubbles::DoesNotBubble,
@@ -1295,7 +1296,6 @@ impl XMLHttpRequest {
             length_computable,
             Finite::wrap(loaded as f64),
             Finite::wrap(total_length as f64),
-            CanGc::from_cx(cx),
         );
         let target = if upload {
             self.upload.upcast()

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -494,13 +494,13 @@ unsafe extern "C" fn promise_rejection_tracker(
                     unsafe{JS_GetPromiseResult(root_promise.reflector().get_jsobject(), reason.handle_mut())};
 
                     let event = PromiseRejectionEvent::new(
+                        cx,
                         &target.global(),
                         atom!("rejectionhandled"),
                         EventBubbles::DoesNotBubble,
                         EventCancelable::Cancelable,
                         root_promise,
                         reason.handle(),
-                        CanGc::from_cx(cx),
                     );
 
                     event.upcast::<Event>().fire(cx, &target);
@@ -681,13 +681,13 @@ pub(crate) fn notify_about_rejected_promises(global: &GlobalScope) {
                 );
 
                 let event = PromiseRejectionEvent::new(
+                    cx,
                     &target.global(),
                     atom!("unhandledrejection"),
                     EventBubbles::DoesNotBubble,
                     EventCancelable::Cancelable,
                     promise.clone(),
                     reason.handle(),
-                    CanGc::from_cx(cx)
                 );
                 event.upcast::<Event>().fire(cx, &target);
 

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -40,6 +40,10 @@ DOMInterfaces = {
     'cx': ['Constructor']
 },
 
+'AnimationEvent': {
+    'cx': ['Constructor']
+},
+
 'Attr': {
     'implicitCxSetters': True,
 },
@@ -61,6 +65,10 @@ DOMInterfaces = {
     'inRealms': ['ParseFromString', 'GetBounds', 'GetClientRects'],
     'cx': ['CreateBuffer', 'CreateGain', 'CreateOscillator', 'CreatePanner', 'CreateStereoPanner', 'CreateBiquadFilter', 'CreateIIRFilter', 'CreateAnalyser', 'CreateConstantSource', 'CreateChannelMerger', 'CreateChannelSplitter', 'CreateBufferSource', 'Destination', 'Listener'],
     'realm': ['DecodeAudioData', 'Resume'],
+},
+
+'BeforeUnloadEvent': {
+    'cx': ['Constructor']
 },
 
 'BiquadFilterNode': {
@@ -143,6 +151,14 @@ DOMInterfaces = {
 'ClipboardItem': {
     'cx': ['Constructor', 'Types'],
     'realm': ['GetType']
+},
+
+'CloseEvent': {
+    'cx': ['Constructor']
+},
+
+'CommandEvent': {
+    'cx': ['Constructor']
 },
 
 'Comment': {
@@ -238,6 +254,10 @@ DOMInterfaces = {
 'CustomElementRegistry': {
     'cx': ['Constructor', 'Define', 'Get', 'Upgrade'],
     'realm': ['WhenDefined']
+},
+
+'CustomEvent': {
+    'cx': ['Constructor']
 },
 
 'DataTransfer': {
@@ -505,16 +525,28 @@ DOMInterfaces = {
     'cx': ['CheckValidity', 'GetValidity', 'ReportValidity', 'SetValidity'],
 },
 
+'ErrorEvent': {
+    'cx': ['Constructor']
+},
+
+'Event': {
+    'cx': ['Constructor']
+},
+
 'EventSource': {
     'weakReferenceable': True,
 },
 
 'EventTarget': {
-    'cx': ['DispatchEvent'],
+    'cx': ['Constructor', 'DispatchEvent'],
+},
+
+'ExtendableEvent': {
+    'cx': ['Constructor']
 },
 
 'ExtendableMessageEvent': {
-    'cx': ['Data', 'Ports'],
+    'cx': ['Constructor', 'Data', 'Ports'],
 },
 
 'FakeXRDevice': {
@@ -548,6 +580,10 @@ DOMInterfaces = {
 
 'FormData': {
     'cx': ['Constructor'],
+},
+
+'FormDataEvent': {
+    'cx': ['Constructor']
 },
 
 'GainNode': {
@@ -997,7 +1033,7 @@ DOMInterfaces = {
 },
 
 'MessageEvent': {
-    'cx': ['Data', 'InitMessageEvent', 'Ports'],
+    'cx': ['Constructor', 'Data', 'InitMessageEvent', 'Ports'],
 },
 
 'MouseEvent': {
@@ -1106,10 +1142,22 @@ DOMInterfaces = {
     'cx': ['Constructor'],
 },
 
+'PopStateEvent': {
+    'cx': ['Constructor'],
+},
+
+'ProgressEvent': {
+    'cx': ['Constructor'],
+},
+
 'Promise': {
     'spiderMonkeyInterface': True,
     'additionalTraits': ["js::conversions::FromJSValConvertibleRc"],
     'allowDropImpl': True,
+},
+
+'PromiseRejectionEvent': {
+    'cx': ['Constructor'],
 },
 
 'RadioNodeList': {
@@ -1206,6 +1254,10 @@ DOMInterfaces = {
     'cx': ['Media'],
 },
 
+'SubmitEvent': {
+    'cx': ['Constructor'],
+},
+
 'SubtleCrypto': {
     'realm': ['Encrypt', 'Decrypt', 'Sign', 'Verify', 'GenerateKey', 'DeriveKey', 'DeriveBits', 'Digest', 'ImportKey', 'ExportKey', 'WrapKey', 'UnwrapKey', 'EncapsulateKey', 'EncapsulateBits', 'DecapsulateKey', 'DecapsulateBits', 'GetPublicKey'],
     'cx': ['Supports', 'Supports_'],
@@ -1262,7 +1314,19 @@ DOMInterfaces = {
     'cx': ['Constructor'],
 },
 
+'ToggleEvent': {
+    'cx': ['Constructor'],
+},
+
+'TouchEvent': {
+    'cx': ['Constructor'],
+},
+
 'TransformStream': {
+    'cx': ['Constructor'],
+},
+
+'TransitionEvent': {
     'cx': ['Constructor'],
 },
 
@@ -1276,6 +1340,10 @@ DOMInterfaces = {
 
 'TrustedTypePolicyFactory': {
     'cx': ['CreatePolicy', 'EmptyHTML', 'EmptyScript']
+},
+
+'UIEvent': {
+    'cx': ['Constructor'],
 },
 
 'URL': {
@@ -1306,7 +1374,7 @@ DOMInterfaces = {
 },
 
 'WheelEvent': {
-    'cx': ['Constructor']
+    'cx': ['Constructor'],
 },
 
 'WindowClient': {


### PR DESCRIPTION
This removes all usages of `CanGC` from DOM Events. This is part of #40600.

Testing: It compiles.