### PR TITLE
script: Pass `&mut JSContext` to `reject_native`

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -821,9 +821,7 @@ fn resolve_result_promise(
                 FetchedData::FormData(f) => promise.resolve_native_with_cx(cx, &f),
                 FetchedData::Bytes(b) => promise.resolve_native_with_cx(cx, &b),
                 FetchedData::ArrayBuffer(a) => promise.resolve_native_with_cx(cx, &a),
-                FetchedData::JSException(e) => {
-                    promise.reject_native(&e.handle(), CanGc::from_cx(cx))
-                },
+                FetchedData::JSException(e) => promise.reject_native(cx, &e.handle()),
             };
         },
         Err(err) => promise.reject_error_with_cx(cx, err),

--- a/components/script/dom/navigationpreloadmanager.rs
+++ b/components/script/dom/navigationpreloadmanager.rs
@@ -6,6 +6,7 @@ use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::jsval::UndefinedValue;
+use js::realm::CurrentRealm;
 use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use crate::dom::bindings::codegen::Bindings::NavigationPreloadManagerBinding::{
@@ -18,7 +19,6 @@ use crate::dom::domexception::{DOMErrorName, DOMException};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 use crate::dom::serviceworkerregistration::ServiceWorkerRegistration;
-use crate::realms::InRealm;
 use crate::script_runtime::CanGc;
 
 #[dom_struct]
@@ -48,74 +48,80 @@ impl NavigationPreloadManager {
 
 impl NavigationPreloadManagerMethods<crate::DomTypeHolder> for NavigationPreloadManager {
     /// <https://w3c.github.io/ServiceWorker/#navigation-preload-manager-enable>
-    fn Enable(&self, comp: InRealm, can_gc: CanGc) -> Rc<Promise> {
-        let promise = Promise::new_in_current_realm(comp, can_gc);
+    fn Enable(&self, cx: &mut CurrentRealm) -> Rc<Promise> {
+        let promise = Promise::new_in_realm(cx);
 
         // 2.
         if self.serviceworker_registration.is_active() {
-            promise.reject_native(
-                &DOMException::new(&self.global(), DOMErrorName::InvalidStateError, can_gc),
-                can_gc,
+            let exception = DOMException::new(
+                &self.global(),
+                DOMErrorName::InvalidStateError,
+                CanGc::from_cx(cx),
             );
+            promise.reject_native(cx, &exception);
         } else {
             // 3.
             self.serviceworker_registration
                 .set_navigation_preload_enabled(true);
 
             // 4.
-            promise.resolve_native(&UndefinedValue(), can_gc);
+            promise.resolve_native_with_cx(cx, &UndefinedValue());
         }
 
         promise
     }
 
     /// <https://w3c.github.io/ServiceWorker/#navigation-preload-manager-disable>
-    fn Disable(&self, comp: InRealm, can_gc: CanGc) -> Rc<Promise> {
-        let promise = Promise::new_in_current_realm(comp, can_gc);
+    fn Disable(&self, cx: &mut CurrentRealm) -> Rc<Promise> {
+        let promise = Promise::new_in_realm(cx);
 
         // 2.
         if self.serviceworker_registration.is_active() {
-            promise.reject_native(
-                &DOMException::new(&self.global(), DOMErrorName::InvalidStateError, can_gc),
-                can_gc,
+            let exception = DOMException::new(
+                &self.global(),
+                DOMErrorName::InvalidStateError,
+                CanGc::from_cx(cx),
             );
+            promise.reject_native(cx, &exception);
         } else {
             // 3.
             self.serviceworker_registration
                 .set_navigation_preload_enabled(false);
 
             // 4.
-            promise.resolve_native(&UndefinedValue(), can_gc);
+            promise.resolve_native_with_cx(cx, &UndefinedValue());
         }
 
         promise
     }
 
     /// <https://w3c.github.io/ServiceWorker/#navigation-preload-manager-setheadervalue>
-    fn SetHeaderValue(&self, value: ByteString, comp: InRealm, can_gc: CanGc) -> Rc<Promise> {
-        let promise = Promise::new_in_current_realm(comp, can_gc);
+    fn SetHeaderValue(&self, cx: &mut CurrentRealm, value: ByteString) -> Rc<Promise> {
+        let promise = Promise::new_in_realm(cx);
 
         // 2.
         if self.serviceworker_registration.is_active() {
-            promise.reject_native(
-                &DOMException::new(&self.global(), DOMErrorName::InvalidStateError, can_gc),
-                can_gc,
+            let exception = DOMException::new(
+                &self.global(),
+                DOMErrorName::InvalidStateError,
+                CanGc::from_cx(cx),
             );
+            promise.reject_native(cx, &exception);
         } else {
             // 3.
             self.serviceworker_registration
                 .set_navigation_preload_header_value(value);
 
             // 4.
-            promise.resolve_native(&UndefinedValue(), can_gc);
+            promise.resolve_native_with_cx(cx, &UndefinedValue());
         }
 
         promise
     }
 
     /// <https://w3c.github.io/ServiceWorker/#navigation-preload-manager-getstate>
-    fn GetState(&self, comp: InRealm, can_gc: CanGc) -> Rc<Promise> {
-        let promise = Promise::new_in_current_realm(comp, can_gc);
+    fn GetState(&self, cx: &mut CurrentRealm) -> Rc<Promise> {
+        let promise = Promise::new_in_realm(cx);
         // 2.
         let mut state = NavigationPreloadState::empty();
 
@@ -133,7 +139,7 @@ impl NavigationPreloadManagerMethods<crate::DomTypeHolder> for NavigationPreload
             .get_navigation_preload_header_value();
 
         // 5.
-        promise.resolve_native(&state, can_gc);
+        promise.resolve_native_with_cx(cx, &state);
 
         promise
     }

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -248,18 +248,7 @@ impl Promise {
         }
     }
 
-    pub(crate) fn reject_native<T>(&self, val: &T, can_gc: CanGc)
-    where
-        T: SafeToJSValConvertible,
-    {
-        let cx = GlobalScope::get_cx();
-        let _ac = enter_realm(self);
-        rooted!(in(*cx) let mut v = UndefinedValue());
-        val.safe_to_jsval(cx, v.handle_mut(), can_gc);
-        self.reject(cx, v.handle(), can_gc);
-    }
-
-    pub(crate) fn reject_native_with_cx<T>(&self, cx: &mut JSContext, val: &T)
+    pub(crate) fn reject_native<T>(&self, cx: &mut JSContext, val: &T)
     where
         T: SafeToJSValConvertible,
     {
@@ -268,6 +257,14 @@ impl Promise {
         rooted!(&in(cx) let mut v = UndefinedValue());
         val.safe_to_jsval(cx.into(), v.handle_mut(), CanGc::from_cx(cx));
         self.reject_with_cx(cx, v.handle());
+    }
+
+    /// Deprecated: use [`Self::reject_native`] instead
+    pub(crate) fn reject_native_with_cx<T>(&self, cx: &mut JSContext, val: &T)
+    where
+        T: SafeToJSValConvertible,
+    {
+        self.reject_native(cx, val);
     }
 
     pub(crate) fn reject_error(&self, cx: &mut JSContext, error: Error) {

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -1918,7 +1918,7 @@ impl ReadableStream {
 
         // Let writer be ! AcquireWritableStreamDefaultWriter(dest).
         let writer = dest
-            .aquire_default_writer(cx.into(), global, CanGc::from_cx(cx))
+            .aquire_default_writer(cx, global)
             .expect("Acquiring a default writer for pipe_to cannot fail");
 
         // Set source.[[disturbed]] to true.

--- a/components/script/dom/stream/readablestreamdefaultreader.rs
+++ b/components/script/dom/stream/readablestreamdefaultreader.rs
@@ -35,7 +35,6 @@ use crate::dom::stream::defaultteereadrequest::DefaultTeeReadRequest;
 use crate::dom::stream::readablestreamgenericreader::ReadableStreamGenericReader;
 use crate::dom::types::ReadableStreamDefaultController;
 use crate::realms::enter_auto_realm;
-use crate::script_runtime::CanGc;
 
 type ReadAllBytesSuccessSteps = dyn Fn(&mut js::context::JSContext, &[u8]);
 type ReadAllBytesFailureSteps = dyn Fn(&mut js::context::JSContext, SafeHandleValue);
@@ -122,12 +121,12 @@ impl ReadRequest {
             ReadRequest::Read(promise) => {
                 // chunk steps, given chunk
                 // Resolve promise with «[ "value" → chunk, "done" → false ]».
-                promise.resolve_native(
+                promise.resolve_native_with_cx(
+                    cx,
                     &ReadableStreamReadResult {
                         done: Some(false),
                         value: chunk,
                     },
-                    CanGc::from_cx(cx),
                 );
             },
             ReadRequest::DefaultTee { tee_read_request } => {
@@ -191,12 +190,12 @@ impl ReadRequest {
                 // Resolve promise with «[ "value" → undefined, "done" → true ]».
                 let result = RootedTraceableBox::new(Heap::default());
                 result.set(UndefinedValue());
-                promise.resolve_native(
+                promise.resolve_native_with_cx(
+                    cx,
                     &ReadableStreamReadResult {
                         done: Some(true),
                         value: result,
                     },
-                    CanGc::from_cx(cx),
                 );
             },
             ReadRequest::DefaultTee { tee_read_request } => {
@@ -231,7 +230,7 @@ impl ReadRequest {
             ReadRequest::Read(promise) => {
                 // error steps, given e
                 // Reject promise with e.
-                promise.reject_native(&e, CanGc::from_cx(cx))
+                promise.reject_native(cx, &e)
             },
             ReadRequest::DefaultTee { tee_read_request } => {
                 tee_read_request.error_steps();

--- a/components/script/dom/stream/writablestream.rs
+++ b/components/script/dom/stream/writablestream.rs
@@ -355,7 +355,7 @@ impl WritableStream {
             assert!(self.in_flight_close_request.borrow().is_none());
 
             // Reject stream.[[closeRequest]] with stream.[[storedError]].
-            close_request.reject_native(&stored_error.handle(), CanGc::from_cx(cx))
+            close_request.reject_native(cx, &stored_error.handle())
 
             // Set stream.[[closeRequest]] to undefined.
             // Done with `take` above.
@@ -806,15 +806,14 @@ impl WritableStream {
     /// <https://streams.spec.whatwg.org/#acquire-writable-stream-default-writer>
     pub(crate) fn aquire_default_writer(
         &self,
-        cx: SafeJSContext,
+        cx: &mut CurrentRealm,
         global: &GlobalScope,
-        can_gc: CanGc,
     ) -> Result<DomRoot<WritableStreamDefaultWriter>, Error> {
         // Let writer be a new WritableStreamDefaultWriter object.
-        let writer = WritableStreamDefaultWriter::new(global, None, can_gc);
+        let writer = WritableStreamDefaultWriter::new(cx, global, None);
 
         // Perform ? SetUpWritableStreamDefaultWriter(writer, stream).
-        writer.setup(cx, self, can_gc)?;
+        writer.setup(cx, self)?;
 
         // Return writer.
         Ok(writer)
@@ -1115,7 +1114,7 @@ impl WritableStreamMethods<crate::DomTypeHolder> for WritableStream {
         let global = GlobalScope::from_current_realm(realm);
 
         // Return ? AcquireWritableStreamDefaultWriter(this).
-        self.aquire_default_writer(realm.into(), &global, CanGc::from_cx(realm))
+        self.aquire_default_writer(realm, &global)
     }
 }
 

--- a/components/script/dom/stream/writablestreamdefaultwriter.rs
+++ b/components/script/dom/stream/writablestreamdefaultwriter.rs
@@ -10,7 +10,7 @@ use js::context::JSContext;
 use js::jsval::UndefinedValue;
 use js::realm::CurrentRealm;
 use js::rust::{HandleObject as SafeHandleObject, HandleValue as SafeHandleValue};
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
 
 use crate::dom::bindings::codegen::Bindings::WritableStreamDefaultWriterBinding::WritableStreamDefaultWriterMethods;
 use crate::dom::bindings::error::{Error, ErrorToJsval};
@@ -19,7 +19,7 @@ use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 use crate::dom::stream::writablestream::WritableStream;
-use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
+use crate::script_runtime::CanGc;
 
 /// <https://streams.spec.whatwg.org/#writablestreamdefaultwriter>
 #[dom_struct]
@@ -40,36 +40,31 @@ pub struct WritableStreamDefaultWriter {
 impl WritableStreamDefaultWriter {
     /// <https://streams.spec.whatwg.org/#set-up-writable-stream-default-writer>
     /// The parts that create a new promise.
-    fn new_inherited(global: &GlobalScope, can_gc: CanGc) -> WritableStreamDefaultWriter {
+    fn new_inherited(cx: &mut CurrentRealm) -> WritableStreamDefaultWriter {
         WritableStreamDefaultWriter {
             reflector_: Reflector::new(),
             stream: Default::default(),
-            closed_promise: RefCell::new(Promise::new(global, can_gc)),
-            ready_promise: RefCell::new(Promise::new(global, can_gc)),
+            closed_promise: RefCell::new(Promise::new_in_realm(cx)),
+            ready_promise: RefCell::new(Promise::new_in_realm(cx)),
         }
     }
 
     pub(crate) fn new(
+        cx: &mut CurrentRealm,
         global: &GlobalScope,
         proto: Option<SafeHandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<WritableStreamDefaultWriter> {
-        reflect_dom_object_with_proto(
-            Box::new(WritableStreamDefaultWriter::new_inherited(global, can_gc)),
+        reflect_dom_object_with_proto_and_cx(
+            Box::new(WritableStreamDefaultWriter::new_inherited(cx)),
             global,
             proto,
-            can_gc,
+            cx,
         )
     }
 
     /// <https://streams.spec.whatwg.org/#set-up-writable-stream-default-writer>
     /// Continuing from `new_inherited`, the rest.
-    pub(crate) fn setup(
-        &self,
-        cx: SafeJSContext,
-        stream: &WritableStream,
-        can_gc: CanGc,
-    ) -> Result<(), Error> {
+    pub(crate) fn setup(&self, cx: &mut JSContext, stream: &WritableStream) -> Result<(), Error> {
         // If ! IsWritableStreamLocked(stream) is true, throw a TypeError exception.
         if stream.is_locked() {
             return Err(Error::Type(c"Stream is locked".to_owned()));
@@ -93,7 +88,7 @@ impl WritableStreamDefaultWriter {
             } else {
                 // Otherwise, set writer.[[readyPromise]] to a promise resolved with undefined.
                 // Note: new promise created in `new_inherited`.
-                self.ready_promise.borrow().resolve_native(&(), can_gc);
+                self.ready_promise.borrow().resolve_native_with_cx(cx, &());
             }
 
             // Set writer.[[closedPromise]] to a new promise.
@@ -103,14 +98,14 @@ impl WritableStreamDefaultWriter {
 
         // Otherwise, if state is "erroring",
         if stream.is_erroring() {
-            rooted!(in(*cx) let mut error = UndefinedValue());
+            rooted!(&in(cx) let mut error = UndefinedValue());
             stream.get_stored_error(error.handle_mut());
 
             // Set writer.[[readyPromise]] to a promise rejected with stream.[[storedError]].
             // Set writer.[[readyPromise]].[[PromiseIsHandled]] to true.
             // Note: new promise created in `new_inherited`.
             let ready_promise = self.ready_promise.borrow();
-            ready_promise.reject_native(&error.handle(), can_gc);
+            ready_promise.reject_native(cx, &error.handle());
             ready_promise.set_promise_is_handled();
 
             // Set writer.[[closedPromise]] to a new promise.
@@ -122,11 +117,11 @@ impl WritableStreamDefaultWriter {
         if stream.is_closed() {
             // Set writer.[[readyPromise]] to a promise resolved with undefined.
             // Note: new promise created in `new_inherited`.
-            self.ready_promise.borrow().resolve_native(&(), can_gc);
+            self.ready_promise.borrow().resolve_native_with_cx(cx, &());
 
             // Set writer.[[closedPromise]] to a promise resolved with undefined.
             // Note: new promise created in `new_inherited`.
-            self.closed_promise.borrow().resolve_native(&(), can_gc);
+            self.closed_promise.borrow().resolve_native_with_cx(cx, &());
             return Ok(());
         }
 
@@ -135,21 +130,21 @@ impl WritableStreamDefaultWriter {
         assert!(stream.is_errored());
 
         // Let storedError be stream.[[storedError]].
-        rooted!(in(*cx) let mut error = UndefinedValue());
+        rooted!(&in(cx) let mut error = UndefinedValue());
         stream.get_stored_error(error.handle_mut());
 
         // Set writer.[[readyPromise]] to a promise rejected with stream.[[storedError]].
         // Set writer.[[readyPromise]].[[PromiseIsHandled]] to true.
         // Note: new promise created in `new_inherited`.
         let ready_promise = self.ready_promise.borrow();
-        ready_promise.reject_native(&error.handle(), can_gc);
+        ready_promise.reject_native(cx, &error.handle());
         ready_promise.set_promise_is_handled();
 
         // Set writer.[[closedPromise]] to a promise rejected with storedError.
         // Set writer.[[closedPromise]].[[PromiseIsHandled]] to true.
         // Note: new promise created in `new_inherited`.
         let ready_promise = self.closed_promise.borrow();
-        ready_promise.reject_native(&error.handle(), can_gc);
+        ready_promise.reject_native(cx, &error.handle());
         ready_promise.set_promise_is_handled();
 
         Ok(())
@@ -524,17 +519,15 @@ impl WritableStreamDefaultWriterMethods<crate::DomTypeHolder> for WritableStream
 
     /// <https://streams.spec.whatwg.org/#default-writer-constructor>
     fn Constructor(
+        cx: &mut CurrentRealm,
         global: &GlobalScope,
         proto: Option<SafeHandleObject>,
-        can_gc: CanGc,
         stream: &WritableStream,
     ) -> Result<DomRoot<WritableStreamDefaultWriter>, Error> {
-        let writer = WritableStreamDefaultWriter::new(global, proto, can_gc);
-
-        let cx = GlobalScope::get_cx();
+        let writer = WritableStreamDefaultWriter::new(cx, global, proto);
 
         // Perform ? SetUpWritableStreamDefaultWriter(this, stream).
-        writer.setup(cx, stream, can_gc)?;
+        writer.setup(cx, stream)?;
 
         Ok(writer)
     }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1012,8 +1012,7 @@ DOMInterfaces = {
 },
 
 'NavigationPreloadManager': {
-    'inRealms': ['Disable', 'Enable', 'GetState', 'SetHeaderValue'],
-    'canGc': ['Disable', 'Enable', 'GetState', 'SetHeaderValue'],
+    'realm': ['Disable', 'Enable', 'GetState', 'SetHeaderValue'],
 },
 
 'Navigator': {
@@ -1512,7 +1511,7 @@ DOMInterfaces = {
 
 'WritableStreamDefaultWriter': {
     'cx': ['ReleaseLock'],
-    'realm': ['Abort', 'Close', 'Write'],
+    'realm': ['Abort', 'Close', 'Constructor', 'Write'],
 },
 
 'TransformStreamDefaultController': {

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -6913,7 +6913,7 @@ let global = D::GlobalScope::from_object(JS_CALLEE(cx.raw_cx(), vp).to_object())
                     "Some(desired_proto)",
                 ]
 
-            if nativeName not in self.descriptor.cxMethods:
+            if nativeName not in self.descriptor.cxMethods and nativeName not in self.descriptor.realmMethods:
                 args += ['CanGc::from_cx(cx)']
 
             constructor = CGMethodCall(args, nativeName, True, self.descriptor, self.constructor)
@@ -7141,14 +7141,15 @@ class CGInterfaceTrait(CGThing):
             for (i, (rettype, arguments)) in enumerate(ctor.signatures()):
                 name = (baseName or ctor.identifier.name) + ('_' * i)
                 cx = name in descriptor.cxMethods
-                args = list(method_arguments(descriptor, rettype, arguments, cx=cx))
+                realm = name in descriptor.realmMethods
+                args = list(method_arguments(descriptor, rettype, arguments, cx=cx, realm=realm))
                 extra = [
                     ("global", f"&D::{exposedGlobal}"),
                     ("proto", "Option<HandleObject>"),
                 ]
-                if not cx:
+                if not cx and not realm:
                     extra += [("can_gc", "CanGc")]
-                if args and args[0][0] == "cx":
+                if args and (args[0][0] == "cx" or args[0][0] == "realm"):
                     args = [args[0]] + extra + args[1:]
                 else:
                     args = extra + args


### PR DESCRIPTION
Also requires us to update the bindings to support passing a `CurrentRealm` to a `Constructor`.

Part of #40600

Testing: it compiles