### PR TITLE
deps: Bump elliptic-curve dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41ac571010bd60765c56085a4f1d412012a9be2663b1a2f2b19b49318653fd0d"
 dependencies = [
  "aes",
- "const-oid 0.10.2",
+ "const-oid",
  "zeroize",
 ]
 
@@ -785,12 +785,6 @@ dependencies = [
  "rustc-demangle",
  "windows-link 0.2.1",
 ]
-
-[[package]]
-name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base16ct"
@@ -1470,12 +1464,6 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
@@ -1706,27 +1694,18 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.5"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "crypto-bigint"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a0d26b245348befa0c121944541476763dcc46ede886c88f9d12e1697d27c3"
+checksum = "97bb4a855e3b10f84c4e7e895a7de01db7f9a7b7eb7f73ed9773fd52ac686451"
 dependencies = [
  "cpubits",
  "ctutils",
+ "getrandom 0.4.1",
+ "hybrid-array",
  "num-traits",
  "rand_core 0.10.1",
  "serdect",
+ "subtle",
  "zeroize",
 ]
 
@@ -1757,7 +1736,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3633a51a39c69ebbaa4feaa694bd83d241e4093901c84a0963b19d9bb3f0cf8f"
 dependencies = [
- "crypto-bigint 0.7.3",
+ "crypto-bigint",
  "rand_core 0.10.1",
 ]
 
@@ -1818,6 +1797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
+ "subtle",
 ]
 
 [[package]]
@@ -1947,23 +1927,12 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid 0.9.6",
- "pem-rfc7468 0.7.0",
- "zeroize",
-]
-
-[[package]]
-name = "der"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
 dependencies = [
- "const-oid 0.10.2",
- "pem-rfc7468 1.0.0",
+ "const-oid",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -2004,9 +1973,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid 0.9.6",
  "crypto-common 0.1.7",
- "subtle",
 ]
 
 [[package]]
@@ -2016,7 +1983,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
- "const-oid 0.10.2",
+ "const-oid",
  "crypto-common 0.2.2",
  "ctutils",
 ]
@@ -2178,16 +2145,17 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.16.9"
+version = "0.17.0-rc.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+checksum = "0f7195c1205cec99025b3004e8034e1ddc12746333aa0a3945df7f9b80882ca2"
 dependencies = [
- "der 0.7.10",
- "digest 0.10.7",
+ "der",
+ "digest 0.11.3",
  "elliptic-curve",
  "rfc6979",
- "signature 2.2.0",
- "spki 0.7.3",
+ "signature",
+ "spki",
+ "zeroize",
 ]
 
 [[package]]
@@ -2278,20 +2246,21 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.8"
+version = "0.14.0-rc.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+checksum = "51c58d86e2f3cebbf2dfd94c4bf049585c7def71058ba506bfdafcb57652a34b"
 dependencies = [
- "base16ct 0.2.0",
- "crypto-bigint 0.5.5",
- "digest 0.10.7",
+ "base16ct",
+ "crypto-bigint",
+ "crypto-common 0.2.2",
+ "digest 0.11.3",
  "ff",
- "generic-array",
  "group",
- "hkdf 0.12.4",
- "pem-rfc7468 0.7.0",
- "pkcs8 0.10.2",
- "rand_core 0.6.4",
+ "hkdf",
+ "hybrid-array",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.10.1",
  "sec1",
  "subtle",
  "zeroize",
@@ -2584,11 +2553,11 @@ checksum = "b97b65636e5b9ef369943878ac74335ba1c55c1cb6adbf1e2c293c624248d693"
 
 [[package]]
 name = "ff"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -2919,7 +2888,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -3210,12 +3178,12 @@ checksum = "b40ca9252762c466af32d0b1002e91e4e1bc5398f77455e55474deb466355ff5"
 
 [[package]]
 name = "group"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -3752,29 +3720,11 @@ checksum = "1955ab89524976e5949c171fe571bf1821bb28574b71b262f8787e34e32b7f10"
 
 [[package]]
 name = "hkdf"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
-dependencies = [
- "hmac 0.12.1",
-]
-
-[[package]]
-name = "hkdf"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
 dependencies = [
- "hmac 0.13.0",
-]
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.7",
+ "hmac",
 ]
 
 [[package]]
@@ -3859,6 +3809,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "ctutils",
+ "subtle",
  "typenum",
  "zeroize",
 ]
@@ -5114,14 +5065,14 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "add6b9d92e496f16f4526d68ff29da1483aba4b119baeab8bed3b9e3544a6f3d"
 dependencies = [
- "const-oid 0.10.2",
+ "const-oid",
  "crypto-common 0.2.2",
  "ctutils",
  "hybrid-array",
  "module-lattice",
- "pkcs8 0.11.0",
+ "pkcs8",
  "shake",
- "signature 3.0.0",
+ "signature",
  "zeroize",
 ]
 
@@ -5131,11 +5082,11 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e15f3e5b957493873e396a66914e83e616b6afe335cdef7efe5c6e1216aba66"
 dependencies = [
- "const-oid 0.10.2",
+ "const-oid",
  "hybrid-array",
  "kem",
  "module-lattice",
- "pkcs8 0.11.0",
+ "pkcs8",
  "rand_core 0.10.1",
  "sha3 0.11.0",
  "zeroize",
@@ -6118,40 +6069,43 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.13.2"
+version = "0.14.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+checksum = "fc7d8ed70255af8fecea30f284e523066cb19918cb2b4c17f41f78cda3291d64"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "primefield",
  "primeorder",
- "sha2 0.10.9",
+ "sha2 0.11.0",
 ]
 
 [[package]]
 name = "p384"
-version = "0.13.1"
+version = "0.14.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+checksum = "563b53b275b129c6f070e538bf0845f8e6abd0b5ffeb3f53f1d6ea5f8dbb3b2c"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "fiat-crypto",
+ "primefield",
  "primeorder",
- "sha2 0.10.9",
+ "sha2 0.11.0",
 ]
 
 [[package]]
 name = "p521"
-version = "0.13.3"
+version = "0.14.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+checksum = "71bed4316a8e79ff1f728527a4334da0c57256ed7ca8b34c2297d9cc34e70511"
 dependencies = [
- "base16ct 0.2.0",
+ "base16ct",
  "ecdsa",
  "elliptic-curve",
+ "primefield",
  "primeorder",
- "rand_core 0.6.4",
- "sha2 0.10.9",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -6241,15 +6195,6 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
 ]
 
 [[package]]
@@ -6405,18 +6350,8 @@ version = "0.8.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e"
 dependencies = [
- "der 0.8.0",
- "spki 0.8.0",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der 0.7.10",
- "spki 0.7.3",
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -6425,8 +6360,8 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
- "der 0.8.0",
- "spki 0.8.0",
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -6608,12 +6543,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "primeorder"
-version = "0.13.6"
+name = "primefield"
+version = "0.14.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+checksum = "8675564771a62f69a0af716b03e89b917b963c7b173b5855575e84fd4f605ca0"
+dependencies = [
+ "crypto-bigint",
+ "crypto-common 0.2.2",
+ "ff",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44545bd63647ac77eaed1589000a031632b0f7175e2c1cc48778787e9783baaf"
 dependencies = [
  "elliptic-curve",
+ "once_cell",
+ "primefield",
+ "serdect",
 ]
 
 [[package]]
@@ -7037,12 +6989,12 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.4.0"
+version = "0.6.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+checksum = "9935425142ac6e252364413291d96c8bc9898d0876a801824c7af4eae397b689"
 dependencies = [
- "hmac 0.12.1",
- "subtle",
+ "ctutils",
+ "hmac",
 ]
 
 [[package]]
@@ -7103,15 +7055,15 @@ version = "0.10.0-rc.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30b2aa4ba0d89f73d1e332df05be0eeab8840351c36ca5654341dfdb57bb3caf"
 dependencies = [
- "const-oid 0.10.2",
- "crypto-bigint 0.7.3",
+ "const-oid",
+ "crypto-bigint",
  "crypto-primes",
  "digest 0.11.3",
  "pkcs1",
- "pkcs8 0.11.0",
+ "pkcs8",
  "rand_core 0.10.1",
- "signature 3.0.0",
- "spki 0.8.0",
+ "signature",
+ "spki",
  "zeroize",
 ]
 
@@ -7379,14 +7331,14 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
 dependencies = [
- "base16ct 0.2.0",
- "der 0.7.10",
- "generic-array",
- "pkcs8 0.10.2",
+ "base16ct",
+ "ctutils",
+ "der",
+ "hybrid-array",
  "subtle",
  "zeroize",
 ]
@@ -7565,7 +7517,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
 dependencies = [
- "base16ct 1.0.0",
+ "base16ct",
  "serde",
 ]
 
@@ -8757,7 +8709,7 @@ dependencies = [
  "content-security-policy",
  "cookie 0.18.1",
  "crossbeam-channel",
- "crypto-bigint 0.7.3",
+ "crypto-bigint",
  "cshake",
  "cssparser",
  "ctr",
@@ -8770,7 +8722,7 @@ dependencies = [
  "flate2",
  "glow",
  "headers",
- "hkdf 0.13.0",
+ "hkdf",
  "html5ever",
  "http 1.4.2",
  "httparse",
@@ -8800,13 +8752,12 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "phf",
- "pkcs8 0.11.0",
+ "pkcs8",
  "postcard",
  "rand 0.10.1",
  "regex",
  "rsa",
  "rustc-hash 2.1.2",
- "sec1",
  "selectors",
  "seq-macro",
  "serde",
@@ -9343,16 +9294,6 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "signature"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
@@ -9529,22 +9470,12 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der 0.7.10",
-]
-
-[[package]]
-name = "spki"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
 dependencies = [
  "base64ct",
- "der 0.8.0",
+ "der",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,12 +76,12 @@ digest = "0.11"
 dirs = "6.0"
 dpi = "0.1"
 dwrote = "0.11.5"
-ecdsa = "0.16"
+ecdsa = "=0.17.0-rc.20"
 egui = "0.34.3"
 egui-file-dialog = "0.13.0"
 egui-winit = { version = "0.34.3", default-features = false }
 egui_glow = "0.34.3"
-elliptic-curve = { version = "0.13", features = ["pkcs8"] }
+elliptic-curve = { version = "=0.14.0-rc.35", features = ["pkcs8"] }
 encoding_rs = { version = "0.8", features = ["serde"] }
 env_filter = "0.1.4"
 env_logger = "0.11"
@@ -182,9 +182,9 @@ ohos-window-manager-sys = "0.1"
 ohos-window-sys = "0.1.7"
 once_cell = "1.21.4"
 openxr = "0.21"
-p256 = { version = "0.13", features = ["ecdh"] }
-p384 = { version = "0.13", features = ["ecdh"] }
-p521 = { version = "0.13", features = ["ecdh"] }
+p256 = { version = "=0.14.0-rc.12", features = ["ecdh"] }
+p384 = { version = "=0.14.0-rc.12", features = ["ecdh"] }
+p521 = { version = "=0.14.0-rc.12", features = ["ecdh"] }
 parking_lot = { version = "0.12", features = ["serde"] }
 peniko = "0.6"
 percent-encoding = "2.3"
@@ -215,7 +215,6 @@ rustls-pki-types = "1.14"
 rustls-platform-verifier = "0.7.0"
 sea-query = { version = "=1.0.0-rc.31", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = "=0.8.0-rc.15"
-sec1 = "0.7"
 selectors = { git = "https://github.com/servo/stylo", rev = "49e912cf401a7f867d33d61baa2389bb3d6f73e0" }
 seq-macro = "0.3.6"
 serde = "1.0.228"

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -126,7 +126,6 @@ rsa = { workspace = true }
 rustc-hash = { workspace = true }
 script_bindings = { workspace = true }
 script_traits = { workspace = true }
-sec1 = { workspace = true }
 selectors = { workspace = true }
 seq-macro = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/components/script/dom/webcrypto/cryptokey.rs
+++ b/components/script/dom/webcrypto/cryptokey.rs
@@ -363,13 +363,13 @@ impl TryFrom<SerializableCryptoKeyHandle> for Handle {
                     .map_err(|_| ())?,
             )),
             SerializableCryptoKeyHandle::P256PrivateKey(private_key) => Ok(Handle::P256PrivateKey(
-                p256::SecretKey::from_sec1_der(private_key).map_err(|_| ())?,
+                p256::SecretKey::from_slice(private_key).map_err(|_| ())?,
             )),
             SerializableCryptoKeyHandle::P384PrivateKey(private_key) => Ok(Handle::P384PrivateKey(
-                p384::SecretKey::from_sec1_der(private_key).map_err(|_| ())?,
+                p384::SecretKey::from_slice(private_key).map_err(|_| ())?,
             )),
             SerializableCryptoKeyHandle::P521PrivateKey(private_key) => Ok(Handle::P521PrivateKey(
-                p521::SecretKey::from_sec1_der(private_key).map_err(|_| ())?,
+                p521::SecretKey::from_slice(private_key).map_err(|_| ())?,
             )),
             SerializableCryptoKeyHandle::P256PublicKey(public_key) => Ok(Handle::P256PublicKey(
                 p256::PublicKey::from_sec1_bytes(public_key).map_err(|_| ())?,
@@ -498,13 +498,13 @@ impl TryFrom<&Handle> for SerializableCryptoKeyHandle {
                     .into_vec(),
             )),
             Handle::P256PrivateKey(private_key) => Ok(SerializableCryptoKeyHandle::P256PrivateKey(
-                private_key.to_sec1_der().map_err(|_| ())?.to_vec(),
+                private_key.to_bytes().as_slice().to_vec(),
             )),
             Handle::P384PrivateKey(private_key) => Ok(SerializableCryptoKeyHandle::P384PrivateKey(
-                private_key.to_sec1_der().map_err(|_| ())?.to_vec(),
+                private_key.to_bytes().as_slice().to_vec(),
             )),
             Handle::P521PrivateKey(private_key) => Ok(SerializableCryptoKeyHandle::P521PrivateKey(
-                private_key.to_sec1_der().map_err(|_| ())?.to_vec(),
+                private_key.to_bytes().as_slice().to_vec(),
             )),
             Handle::P256PublicKey(public_key) => Ok(SerializableCryptoKeyHandle::P256PublicKey(
                 public_key.to_sec1_bytes().to_vec(),

--- a/components/script/dom/webcrypto/subtlecrypto/ec_common.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ec_common.rs
@@ -2,25 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use elliptic_curve::SecretKey;
-use elliptic_curve::pkcs8::der::Decode;
-use elliptic_curve::pkcs8::{
-    AssociatedOid, EncodePrivateKey, EncodePublicKey, PrivateKeyInfo, SubjectPublicKeyInfo,
-};
-use elliptic_curve::rand_core::OsRng;
-use elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint, ValidatePublicKey};
+use elliptic_curve::pkcs8::{DecodePrivateKey, DecodePublicKey, EncodePrivateKey, EncodePublicKey};
+use elliptic_curve::sec1::{ModulusSize, Sec1Point, ToSec1Point, ValidatePublicKey};
+use elliptic_curve::{Curve, FieldBytesSize, Generate, PublicKey, SecretKey};
 use js::context::JSContext;
 use p256::NistP256;
 use p384::NistP384;
 use p521::NistP521;
-use sec1::der::asn1::BitString;
-use sec1::{EcParameters, EcPrivateKey, EncodedPoint};
 
 use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::{
     CryptoKeyMethods, CryptoKeyPair, KeyType, KeyUsage,
 };
 use crate::dom::bindings::codegen::Bindings::SubtleCryptoBinding::{JsonWebKey, KeyFormat};
-use crate::dom::bindings::error::Error;
+use crate::dom::bindings::error::{Error, ErrorResult};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::cryptokey::{CryptoKey, Handle};
@@ -90,7 +84,9 @@ pub(crate) fn generate_key(
     // NOTE: We currently do not support other applicable specifications.
     let (private_key_handle, public_key_handle) = match normalized_algorithm.named_curve.as_str() {
         NAMED_CURVE_P256 => {
-            let private_key = SecretKey::<NistP256>::random(&mut OsRng);
+            let private_key = SecretKey::<NistP256>::try_generate().map_err(|_| {
+                Error::Operation(Some("Failed to generate P-256 private key".into()))
+            })?;
             let public_key = private_key.public_key();
             (
                 Handle::P256PrivateKey(private_key),
@@ -98,7 +94,9 @@ pub(crate) fn generate_key(
             )
         },
         NAMED_CURVE_P384 => {
-            let private_key = SecretKey::<NistP384>::random(&mut OsRng);
+            let private_key = SecretKey::<NistP384>::try_generate().map_err(|_| {
+                Error::Operation(Some("Failed to generate P-384 private key".into()))
+            })?;
             let public_key = private_key.public_key();
             (
                 Handle::P384PrivateKey(private_key),
@@ -106,7 +104,9 @@ pub(crate) fn generate_key(
             )
         },
         NAMED_CURVE_P521 => {
-            let private_key = SecretKey::<NistP521>::random(&mut OsRng);
+            let private_key = SecretKey::<NistP521>::try_generate().map_err(|_| {
+                Error::Operation(Some("Failed to generate P-521 private key".into()))
+            })?;
             let public_key = private_key.public_key();
             (
                 Handle::P521PrivateKey(private_key),
@@ -256,108 +256,70 @@ pub(crate) fn import_key(
             // Step 2.2. Let spki be the result of running the parse a subjectPublicKeyInfo
             // algorithm over keyData
             // Step 2.3. If an error occurred while parsing, then throw a DataError.
-            let spki = SubjectPublicKeyInfo::<_, BitString>::from_der(key_data)
-                .map_err(|_| Error::Data(Some("Failed to parse SPKI".into())))?;
-
             // Step 2.4. If the algorithm object identifier field of the algorithm
             // AlgorithmIdentifier field of spki is not equal to the id-ecPublicKey object
             // identifier defined in [RFC5480], then throw a DataError.
-            if spki.algorithm.oid != elliptic_curve::ALGORITHM_OID {
-                return Err(Error::Data(Some(
-                    "algorithm OID does not match id-ecPublicKey OID".into(),
-                )));
-            }
-
             // Step 2.5. If the parameters field of the algorithm AlgorithmIdentifier field of spki
             // is absent, then throw a DataError.
             // Step 2.6. Let params be the parameters field of the algorithm AlgorithmIdentifier
             // field of spki.
             // Step 2.7. If params is not an instance of the ECParameters ASN.1 type defined in
             // [RFC5480] that specifies a namedCurve, then throw a DataError.
-            let Some(params): Option<EcParameters> = spki.algorithm.parameters else {
-                return Err(Error::Data(Some(
-                    "SPKI parameters field is not present".into(),
-                )));
-            };
-
             // Step 2.8. Let namedCurve be a string whose initial value is undefined.
             // Step 2.9.
-            // If params is equivalent to the secp256r1 object identifier defined in [RFC5480]:
-            //     Set namedCurve "P-256".
-            // If params is equivalent to the secp384r1 object identifier defined in [RFC5480]:
-            //     Set namedCurve "P-384".
-            // If params is equivalent to the secp521r1 object identifier defined in [RFC5480]:
-            //     Set namedCurve "P-521".
-            let named_curve = match params {
-                EcParameters::NamedCurve(NistP256::OID) => Some(NAMED_CURVE_P256),
-                EcParameters::NamedCurve(NistP384::OID) => Some(NAMED_CURVE_P384),
-                EcParameters::NamedCurve(NistP521::OID) => Some(NAMED_CURVE_P521),
-                _ => None,
-            };
-
+            //     If params is equivalent to the secp256r1 object identifier defined in [RFC5480]:
+            //         Set namedCurve "P-256".
+            //     If params is equivalent to the secp384r1 object identifier defined in [RFC5480]:
+            //         Set namedCurve "P-384".
+            //     If params is equivalent to the secp521r1 object identifier defined in [RFC5480]:
+            //         Set namedCurve "P-521".
             // Step 2.10.
-            let handle = match named_curve {
-                // If namedCurve is not undefined:
-                Some(curve) => {
-                    // Step 2.10.1. Let publicKey be the Elliptic Curve public key identified by
-                    // performing the conversion steps defined in Section 2.3.4 of [SEC1] to the
-                    // subjectPublicKey field of spki.
-                    // Step 2.10.2. The uncompressed point format MUST be supported.
-                    // Step 2.10.3. If the implementation does not support the compressed point
-                    // format and a compressed point is provided, throw a DataError.
-                    // Step 2.10.4. If a decode error occurs or an identity point is found, throw a
-                    // DataError.
-                    let sec1_bytes = spki.subject_public_key.as_bytes().ok_or(Error::Data(
-                        Some("SPKI public key bitlength is not a multiple of 8".into()),
-                    ))?;
-                    match curve {
-                        NAMED_CURVE_P256 => {
-                            let public_key =
-                                p256::PublicKey::from_sec1_bytes(sec1_bytes).map_err(|_| {
-                                    Error::Data(Some("Failed to parse P-256 public key".into()))
-                                })?;
-                            Handle::P256PublicKey(public_key)
-                        },
-                        NAMED_CURVE_P384 => {
-                            let public_key =
-                                p384::PublicKey::from_sec1_bytes(sec1_bytes).map_err(|_| {
-                                    Error::Data(Some("Failed to parse P-384 public key".into()))
-                                })?;
-                            Handle::P384PublicKey(public_key)
-                        },
-                        NAMED_CURVE_P521 => {
-                            let public_key =
-                                p521::PublicKey::from_sec1_bytes(sec1_bytes).map_err(|_| {
-                                    Error::Data(Some("Failed to parse P-521 public key".into()))
-                                })?;
-                            Handle::P521PublicKey(public_key)
-                        },
-                        _ => unreachable!(),
-                    }
-
-                    // Step 2.10.5. Let key be a new CryptoKey that represents publicKey.
-                    // NOTE: CryptoKey is created in Step 2.13 - 2.17.
-                },
-                // Otherwise:
-                None => {
-                    // Step 2.10.1. Perform any key import steps defined by other applicable
-                    // specifications, passing format, spki and obtaining namedCurve and key.
-                    // Step 2.10.2. If an error occurred or there are no applicable specifications,
-                    // throw a DataError.
-                    // NOTE: We currently do not support applicable specifications.
-                    return Err(Error::NotSupported(Some("Unsupported namedCurve".into())));
-                },
-            };
-
+            //     If namedCurve is not undefined:
+            //         Step 2.10.1. Let publicKey be the Elliptic Curve public key identified by
+            //         performing the conversion steps defined in Section 2.3.4 of [SEC1] using the
+            //         subjectPublicKey field of spki.
+            //         Step 2.10.2. The uncompressed point format MUST be supported.
+            //         Step 2.10.3. If the implementation does not support the compressed point
+            //         format and a compressed point is provided, throw a DataError.
+            //         Step 2.10.4. If a decode error occurs or an identity point is found, throw a
+            //         DataError.
+            //         Step 2.10.5. Let key be a new CryptoKey that represents publicKey.
+            //     Otherwise:
+            //         Step 2.10.1. Perform any key import steps defined by other applicable
+            //         specifications, passing format, spki and obtaining namedCurve and key.
+            //         Step 2.10.2. If an error occurred or there are no applicable specifications,
+            //         throw a DataError.
             // Step 2.11. If namedCurve is defined, and not equal to the namedCurve member of
             // normalizedAlgorithm, throw a DataError.
-            if named_curve.is_some_and(|curve| curve != normalized_algorithm.named_curve) {
-                return Err(Error::Data(Some("namedCurve mismatch".into())));
-            }
-
-            // Step 2.12. If the key value is not a valid point on the Elliptic Curve identified by
-            // the namedCurve member of normalizedAlgorithm throw a DataError.
-            // NOTE: Done in Step 2.10.
+            // Step 2.12. If the public key value is not a valid point on the Elliptic Curve
+            // identified by the namedCurve member of normalizedAlgorithm throw a DataError.
+            let handle = match normalized_algorithm.named_curve.as_str() {
+                NAMED_CURVE_P256 => Handle::P256PublicKey(
+                    PublicKey::<NistP256>::from_public_key_der(key_data).map_err(|_| {
+                        Error::Data(Some(
+                            "Failed to parse the P-256 elliptic-curve public key in SPKI format"
+                                .into(),
+                        ))
+                    })?,
+                ),
+                NAMED_CURVE_P384 => Handle::P384PublicKey(
+                    PublicKey::<NistP384>::from_public_key_der(key_data).map_err(|_| {
+                        Error::Data(Some(
+                            "Failed to parse the P-384 elliptic-curve public key in SPKI format"
+                                .into(),
+                        ))
+                    })?,
+                ),
+                NAMED_CURVE_P521 => Handle::P521PublicKey(
+                    PublicKey::<NistP521>::from_public_key_der(key_data).map_err(|_| {
+                        Error::Data(Some(
+                            "Failed to parse the P-521 elliptic-curve public key in SPKI format"
+                                .into(),
+                        ))
+                    })?,
+                ),
+                _ => return Err(Error::Data(Some("Unsupported namedCurve".into()))),
+            };
 
             // Step 2.13. Set the [[type]] internal slot of key to "public"
             // Step 2.14. Let algorithm be a new EcKeyAlgorithm.
@@ -374,9 +336,7 @@ pub(crate) fn import_key(
                         CryptoAlgorithm::Ecdh
                     },
                 },
-                named_curve: named_curve
-                    .expect("named_curve must exist here")
-                    .to_string(),
+                named_curve: normalized_algorithm.named_curve.clone(),
             };
             CryptoKey::new(
                 cx,
@@ -417,18 +377,9 @@ pub(crate) fn import_key(
             // Step 2.2. Let privateKeyInfo be the result of running the parse a privateKeyInfo
             // algorithm over keyData.
             // Step 2.3. If an error occurs while parsing, throw a DataError.
-            let private_key_info = PrivateKeyInfo::from_der(key_data)
-                .map_err(|_| Error::Data(Some("Failed to parse PrivateKeyInfo".into())))?;
-
             // Step 2.4. If the algorithm object identifier field of the privateKeyAlgorithm
             // PrivateKeyAlgorithm field of privateKeyInfo is not equal to the id-ecPublicKey
             // object identifier defined in [RFC5480], throw a DataError.
-            if private_key_info.algorithm.oid != elliptic_curve::ALGORITHM_OID {
-                return Err(Error::Data(Some(
-                    "algorithm OID does not match id-ecPublicKey OID".into(),
-                )));
-            }
-
             // Step 2.5. If the parameters field of the privateKeyAlgorithm
             // PrivateKeyAlgorithmIdentifier field of privateKeyInfo is not present, throw a
             // DataError.
@@ -436,107 +387,66 @@ pub(crate) fn import_key(
             // PrivateKeyAlgorithmIdentifier field of privateKeyInfo.
             // Step 2.7. If params is not an instance of the ECParameters ASN.1 type defined in
             // [RFC5480] that specifies a namedCurve, then throw a DataError.
-            let params: EcParameters = if let Some(params) = private_key_info.algorithm.parameters {
-                params
-                    .decode_as()
-                    .map_err(|_| Error::Data(Some("Failed to decode EC parameters".into())))?
-            } else {
-                return Err(Error::Data(Some(
-                    "privateKeyInfo parameters field is not present".into(),
-                )));
-            };
-
             // Step 2.8. Let namedCurve be a string whose initial value is undefined.
             // Step 2.9.
-            // If params is equivalent to the secp256r1 object identifier defined in [RFC5480]:
-            //     Set namedCurve to "P-256".
-            // If params is equivalent to the secp384r1 object identifier defined in [RFC5480]:
-            //     Set namedCurve to "P-384".
-            // If params is equivalent to the secp521r1 object identifier defined in [RFC5480]:
-            //     Set namedCurve to "P-521".
-            let named_curve = match params {
-                EcParameters::NamedCurve(NistP256::OID) => Some(NAMED_CURVE_P256),
-                EcParameters::NamedCurve(NistP384::OID) => Some(NAMED_CURVE_P384),
-                EcParameters::NamedCurve(NistP521::OID) => Some(NAMED_CURVE_P521),
-                _ => None,
-            };
-
+            //     If params is equivalent to the secp256r1 object identifier defined in [RFC5480]:
+            //         Set namedCurve to "P-256".
+            //     If params is equivalent to the secp384r1 object identifier defined in [RFC5480]:
+            //         Set namedCurve to "P-384".
+            //     If params is equivalent to the secp521r1 object identifier defined in [RFC5480]:
+            //         Set namedCurve to "P-521".
             // Step 2.10.
-            let handle = match named_curve {
-                // If namedCurve is not undefined:
-                Some(curve) => {
-                    // Step 2.10.1. Let ecPrivateKey be the result of performing the parse an ASN.1
-                    // structure algorithm, with data as the privateKey field of privateKeyInfo,
-                    // structure as the ASN.1 ECPrivateKey structure specified in Section 3 of
-                    // [RFC5915], and exactData set to true.
-                    // Step 2.10.2. If an error occurred while parsing, then throw a DataError.
-                    let ec_private_key = EcPrivateKey::try_from(private_key_info.private_key)
-                        .map_err(|_| Error::Data(Some("Failed to parse EC private key".into())))?;
-
-                    // Step 2.10.3. If the parameters field of ecPrivateKey is present, and is not
-                    // an instance of the namedCurve ASN.1 type defined in [RFC5480], or does not
-                    // contain the same object identifier as the parameters field of the
-                    // privateKeyAlgorithm PrivateKeyAlgorithmIdentifier field of privateKeyInfo,
-                    // throw a DataError.
-                    if ec_private_key
-                        .parameters
-                        .is_some_and(|parameters| parameters != params)
-                    {
-                        return Err(Error::Data(Some(
-                            "EC private key parameters do not match privateKeyInfo algorithm parameters".into(),
-                        )));
-                    }
-
-                    // Step 2.10.4. Let key be a new CryptoKey that represents the Elliptic Curve
-                    // private key identified by performing the conversion steps defined in Section
-                    // 3 of [RFC5915] using ecPrivateKey.
-                    // NOTE: CryptoKey is created in Step 2.13 - 2.17.
-                    match curve {
-                        NAMED_CURVE_P256 => {
-                            let private_key =
-                                p256::SecretKey::try_from(ec_private_key).map_err(|_| {
-                                    Error::Data(Some("Failed to parse P-256 private key".into()))
-                                })?;
-                            Handle::P256PrivateKey(private_key)
-                        },
-                        NAMED_CURVE_P384 => {
-                            let private_key =
-                                p384::SecretKey::try_from(ec_private_key).map_err(|_| {
-                                    Error::Data(Some("Failed to parse P-384 private key".into()))
-                                })?;
-                            Handle::P384PrivateKey(private_key)
-                        },
-                        NAMED_CURVE_P521 => {
-                            let private_key =
-                                p521::SecretKey::try_from(ec_private_key).map_err(|_| {
-                                    Error::Data(Some("Failed to parse P-521 private key".into()))
-                                })?;
-                            Handle::P521PrivateKey(private_key)
-                        },
-                        _ => unreachable!(),
-                    }
-                },
-                // Otherwise:
-                None => {
-                    // Step 2.10.1. Perform any key import steps defined by other applicable
-                    // specifications, passing format, privateKeyInfo and obtaining namedCurve and
-                    // key.
-                    // Step 2.10.2. If an error occurred or there are no applicable specifications,
-                    // throw a DataError.
-                    // NOTE: We currently do not support applicable specifications.
-                    return Err(Error::NotSupported(Some("Unsupported namedCurve".into())));
-                },
-            };
-
+            //     If namedCurve is not undefined:
+            //         Step 2.10.1. Let ecPrivateKey be the result of performing the parse an ASN.1
+            //         structure algorithm, with data as the privateKey field of privateKeyInfo,
+            //         structure as the ASN.1 ECPrivateKey structure specified in Section 3 of
+            //         [RFC5915], and exactData set to true.
+            //         Step 2.10.2. If an error occurred while parsing, then throw a DataError.
+            //         Step 2.10.3. If the parameters field of ecPrivateKey is present, and is not
+            //         an instance of the namedCurve ASN.1 type defined in [RFC5480], or does not
+            //         contain the same object identifier as the parameters field of the
+            //         privateKeyAlgorithm PrivateKeyAlgorithmIdentifier field of privateKeyInfo,
+            //         then throw a DataError.
+            //         Step 2.10.4. Let key be a new CryptoKey that represents the Elliptic Curve
+            //         private key identified by performing the conversion steps defined in Section
+            //         3 of [RFC5915] using ecPrivateKey.
+            //     Otherwise:
+            //         Step 2.10.1. Perform any key import steps defined by other applicable
+            //         specifications, passing format, privateKeyInfo and obtaining namedCurve and
+            //         key.
+            //         Step 2.10.2. If an error occurred or there are no applicable specifications,
+            //         throw a DataError.
             // Step 2.11. If namedCurve is defined, and not equal to the namedCurve member of
             // normalizedAlgorithm, throw a DataError.
-            if named_curve.is_some_and(|curve| curve != normalized_algorithm.named_curve) {
-                return Err(Error::Data(Some("namedCurve mismatch".into())));
-            }
-
-            // Step 2.12. If the key value is not a valid point on the Elliptic Curve identified by
-            // the namedCurve member of normalizedAlgorithm throw a DataError.
-            // NOTE: Done in Step 2.10.
+            // Step 2.12. If the private key value is not a valid point on the Elliptic Curve
+            // identified by the namedCurve member of normalizedAlgorithm throw a DataError.
+            let handle = match normalized_algorithm.named_curve.as_str() {
+                NAMED_CURVE_P256 => Handle::P256PrivateKey(
+                    SecretKey::<NistP256>::from_pkcs8_der(key_data).map_err(|_| {
+                        Error::Data(Some(
+                            "Failed to parse the P-256 elliptic-curve private key in PKCS#8 format"
+                                .into(),
+                        ))
+                    })?,
+                ),
+                NAMED_CURVE_P384 => Handle::P384PrivateKey(
+                    SecretKey::<NistP384>::from_pkcs8_der(key_data).map_err(|_| {
+                        Error::Data(Some(
+                            "Failed to parse the P-384 elliptic-curve private key in PKCS#8 format"
+                                .into(),
+                        ))
+                    })?,
+                ),
+                NAMED_CURVE_P521 => Handle::P521PrivateKey(
+                    SecretKey::<NistP521>::from_pkcs8_der(key_data).map_err(|_| {
+                        Error::Data(Some(
+                            "Failed to parse the P-521 elliptic-curve private key in PKCS#8 format"
+                                .into(),
+                        ))
+                    })?,
+                ),
+                _ => return Err(Error::Data(Some("Unsupported namedCurve".into()))),
+            };
 
             // Step 2.13. Set the [[type]] internal slot of key to "private".
             // Step 2.14. Let algorithm be a new EcKeyAlgorithm.
@@ -553,9 +463,7 @@ pub(crate) fn import_key(
                         CryptoAlgorithm::Ecdh
                     },
                 },
-                named_curve: named_curve
-                    .expect("named_curve must exist here")
-                    .to_string(),
+                named_curve: normalized_algorithm.named_curve.clone(),
             };
             CryptoKey::new(
                 cx,
@@ -625,8 +533,8 @@ pub(crate) fn import_key(
 
             match ec_algorithm {
                 EcAlgorithm::Ecdsa => {
-                    // Step 2.4. If usages is non-empty and the use field of jwk is present and is not
-                    // "sig", then throw a DataError.
+                    // Step 2.4. If usages is non-empty and the use field of jwk is present and is
+                    // not "sig", then throw a DataError.
                     if !usages.is_empty() && jwk.use_.as_ref().is_some_and(|use_| use_ != "sig") {
                         return Err(Error::Data(Some(
                             "Usages is not empty, JWK `use` field is present, \
@@ -636,8 +544,8 @@ pub(crate) fn import_key(
                     }
                 },
                 EcAlgorithm::Ecdh => {
-                    // Step 2.4. If usages is non-empty and the use field of jwk is present and is not
-                    // equal to "enc" then throw a DataError.
+                    // Step 2.4. If usages is non-empty and the use field of jwk is present and is
+                    // not equal to "enc" then throw a DataError.
                     if !usages.is_empty() && jwk.use_.as_ref().is_some_and(|use_| use_ != "enc") {
                         return Err(Error::Data(Some(
                             "Usages is not empty, JWK `use` field is present, \
@@ -729,50 +637,35 @@ pub(crate) fn import_key(
                     // NOTE: CryptoKey is created in Step 2.12 - 2.15.
                     let handle = match named_curve.as_str() {
                         NAMED_CURVE_P256 => {
-                            let private_key = p256::SecretKey::from_slice(&d).map_err(|_| {
-                                Error::Data(Some("Failed to parse P-256 private key".into()))
-                            })?;
-                            let mut sec1_bytes = vec![4u8];
-                            sec1_bytes.extend_from_slice(&x);
-                            sec1_bytes.extend_from_slice(&y);
-                            let encoded_point =
-                                EncodedPoint::from_bytes(&sec1_bytes).map_err(|_| {
-                                    Error::Data(Some("Failed to encode curve point".into()))
+                            let private_key =
+                                SecretKey::<NistP256>::from_slice(&d).map_err(|_| {
+                                    Error::Data(Some("Failed to parse P-256 private key".into()))
                                 })?;
-                            NistP256::validate_public_key(&private_key, &encoded_point).map_err(
-                                |_| Error::Data(Some("Failed to validate P-256 public key".into())),
+                            validate_public_key::<NistP256>(
+                                &private_key,
+                                &x_y_to_sec1_bytes(&x, &y),
                             )?;
                             Handle::P256PrivateKey(private_key)
                         },
                         NAMED_CURVE_P384 => {
-                            let private_key = p384::SecretKey::from_slice(&d).map_err(|_| {
-                                Error::Data(Some("Failed to parse P-384 private key".into()))
-                            })?;
-                            let mut sec1_bytes = vec![4u8];
-                            sec1_bytes.extend_from_slice(&x);
-                            sec1_bytes.extend_from_slice(&y);
-                            let encoded_point =
-                                EncodedPoint::from_bytes(&sec1_bytes).map_err(|_| {
-                                    Error::Data(Some("Failed to encode curve point".into()))
+                            let private_key =
+                                SecretKey::<NistP384>::from_slice(&d).map_err(|_| {
+                                    Error::Data(Some("Failed to parse P-384 private key".into()))
                                 })?;
-                            NistP384::validate_public_key(&private_key, &encoded_point).map_err(
-                                |_| Error::Data(Some("Failed to validate P-384 public key".into())),
+                            validate_public_key::<NistP384>(
+                                &private_key,
+                                &x_y_to_sec1_bytes(&x, &y),
                             )?;
                             Handle::P384PrivateKey(private_key)
                         },
                         NAMED_CURVE_P521 => {
-                            let private_key = p521::SecretKey::from_slice(&d).map_err(|_| {
-                                Error::Data(Some("Failed to parse P-521 private key".into()))
-                            })?;
-                            let mut sec1_bytes = vec![4u8];
-                            sec1_bytes.extend_from_slice(&x);
-                            sec1_bytes.extend_from_slice(&y);
-                            let encoded_point =
-                                EncodedPoint::from_bytes(&sec1_bytes).map_err(|_| {
-                                    Error::Data(Some("Failed to encode curve point".into()))
+                            let private_key =
+                                SecretKey::<NistP521>::from_slice(&d).map_err(|_| {
+                                    Error::Data(Some("Failed to parse P-521 private key".into()))
                                 })?;
-                            NistP521::validate_public_key(&private_key, &encoded_point).map_err(
-                                |_| Error::Data(Some("Failed to validate P-521 public key".into())),
+                            validate_public_key::<NistP521>(
+                                &private_key,
+                                &x_y_to_sec1_bytes(&x, &y),
                             )?;
                             Handle::P521PrivateKey(private_key)
                         },
@@ -798,48 +691,27 @@ pub(crate) fn import_key(
                     // NOTE: CryptoKey is created in Step 2.12 - 2.15.
                     let handle = match named_curve.as_str() {
                         NAMED_CURVE_P256 => {
-                            let mut sec1_bytes = vec![4u8];
-                            sec1_bytes.extend_from_slice(&x);
-                            sec1_bytes.extend_from_slice(&y);
-                            let encoded_point =
-                                EncodedPoint::from_bytes(&sec1_bytes).map_err(|_| {
-                                    Error::Data(Some("Failed to encode curve point".into()))
+                            let sec1_bytes = x_y_to_sec1_bytes(&x, &y);
+                            let public_key = PublicKey::<NistP256>::from_sec1_bytes(&sec1_bytes)
+                                .map_err(|_| {
+                                    Error::Data(Some("Failed to decode P-256 public key".into()))
                                 })?;
-                            let public_key = p256::PublicKey::from_encoded_point(&encoded_point)
-                                .into_option()
-                                .ok_or(Error::Data(Some(
-                                    "Failed to decode P-256 public key".into(),
-                                )))?;
                             Handle::P256PublicKey(public_key)
                         },
                         NAMED_CURVE_P384 => {
-                            let mut sec1_bytes = vec![4u8];
-                            sec1_bytes.extend_from_slice(&x);
-                            sec1_bytes.extend_from_slice(&y);
-                            let encoded_point =
-                                EncodedPoint::from_bytes(&sec1_bytes).map_err(|_| {
-                                    Error::Data(Some("Failed to encode curve point".into()))
+                            let sec1_bytes = x_y_to_sec1_bytes(&x, &y);
+                            let public_key = PublicKey::<NistP384>::from_sec1_bytes(&sec1_bytes)
+                                .map_err(|_| {
+                                    Error::Data(Some("Failed to decode P-384 public key".into()))
                                 })?;
-                            let public_key = p384::PublicKey::from_encoded_point(&encoded_point)
-                                .into_option()
-                                .ok_or(Error::Data(Some(
-                                    "Failed to decode P-384 public key".into(),
-                                )))?;
                             Handle::P384PublicKey(public_key)
                         },
                         NAMED_CURVE_P521 => {
-                            let mut sec1_bytes = vec![4u8];
-                            sec1_bytes.extend_from_slice(&x);
-                            sec1_bytes.extend_from_slice(&y);
-                            let encoded_point =
-                                EncodedPoint::from_bytes(&sec1_bytes).map_err(|_| {
-                                    Error::Data(Some("Failed to encode curve point".into()))
+                            let sec1_bytes = x_y_to_sec1_bytes(&x, &y);
+                            let public_key = PublicKey::<NistP521>::from_sec1_bytes(&sec1_bytes)
+                                .map_err(|_| {
+                                    Error::Data(Some("Failed to decode P-521 public key".into()))
                                 })?;
-                            let public_key = p521::PublicKey::from_encoded_point(&encoded_point)
-                                .into_option()
-                                .ok_or(Error::Data(Some(
-                                    "Failed to decode P-521 public key".into(),
-                                )))?;
                             Handle::P521PublicKey(public_key)
                         },
                         _ => unreachable!(),
@@ -936,19 +808,19 @@ pub(crate) fn import_key(
                 // DataError.
                 match normalized_algorithm.named_curve.as_str() {
                     NAMED_CURVE_P256 => {
-                        let q = p256::PublicKey::from_sec1_bytes(key_data).map_err(|_| {
+                        let q = PublicKey::<NistP256>::from_sec1_bytes(key_data).map_err(|_| {
                             Error::Data(Some("Failed to decode P-256 public key".into()))
                         })?;
                         Handle::P256PublicKey(q)
                     },
                     NAMED_CURVE_P384 => {
-                        let q = p384::PublicKey::from_sec1_bytes(key_data).map_err(|_| {
+                        let q = PublicKey::<NistP384>::from_sec1_bytes(key_data).map_err(|_| {
                             Error::Data(Some("Failed to decode P-384 public key".into()))
                         })?;
                         Handle::P384PublicKey(q)
                     },
                     NAMED_CURVE_P521 => {
-                        let q = p521::PublicKey::from_sec1_bytes(key_data).map_err(|_| {
+                        let q = PublicKey::<NistP521>::from_sec1_bytes(key_data).map_err(|_| {
                             Error::Data(Some("Failed to decode P-521 public key".into()))
                         })?;
                         Handle::P521PublicKey(q)
@@ -1194,21 +1066,21 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
                 };
                 let (x, y) = match key.handle() {
                     Handle::P256PublicKey(public_key) => {
-                        let encoded_point = public_key.to_encoded_point(false);
+                        let encoded_point = public_key.to_sec1_point(false);
                         (
                             encoded_point.x().ok_or(extraction_error())?.to_vec(),
                             encoded_point.y().ok_or(extraction_error())?.to_vec(),
                         )
                     },
                     Handle::P384PublicKey(public_key) => {
-                        let encoded_point = public_key.to_encoded_point(false);
+                        let encoded_point = public_key.to_sec1_point(false);
                         (
                             encoded_point.x().ok_or(extraction_error())?.to_vec(),
                             encoded_point.y().ok_or(extraction_error())?.to_vec(),
                         )
                     },
                     Handle::P521PublicKey(public_key) => {
-                        let encoded_point = public_key.to_encoded_point(false);
+                        let encoded_point = public_key.to_sec1_point(false);
                         (
                             encoded_point.x().ok_or(extraction_error())?.to_vec(),
                             encoded_point.y().ok_or(extraction_error())?.to_vec(),
@@ -1216,7 +1088,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
                     },
                     Handle::P256PrivateKey(private_key) => {
                         let public_key = private_key.public_key();
-                        let encoded_point = public_key.to_encoded_point(false);
+                        let encoded_point = public_key.to_sec1_point(false);
                         (
                             encoded_point.x().ok_or(extraction_error())?.to_vec(),
                             encoded_point.y().ok_or(extraction_error())?.to_vec(),
@@ -1224,7 +1096,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
                     },
                     Handle::P384PrivateKey(private_key) => {
                         let public_key = private_key.public_key();
-                        let encoded_point = public_key.to_encoded_point(false);
+                        let encoded_point = public_key.to_sec1_point(false);
                         (
                             encoded_point.x().ok_or(extraction_error())?.to_vec(),
                             encoded_point.y().ok_or(extraction_error())?.to_vec(),
@@ -1232,7 +1104,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
                     },
                     Handle::P521PrivateKey(private_key) => {
                         let public_key = private_key.public_key();
-                        let encoded_point = public_key.to_encoded_point(false);
+                        let encoded_point = public_key.to_sec1_point(false);
                         (
                             encoded_point.x().ok_or(extraction_error())?.to_vec(),
                             encoded_point.y().ok_or(extraction_error())?.to_vec(),
@@ -1253,9 +1125,15 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
                 //     JSON Web Algorithms [JWA].
                 if key.Type() == KeyType::Private {
                     let d = match key.handle() {
-                        Handle::P256PrivateKey(private_key) => private_key.to_bytes().to_vec(),
-                        Handle::P384PrivateKey(private_key) => private_key.to_bytes().to_vec(),
-                        Handle::P521PrivateKey(private_key) => private_key.to_bytes().to_vec(),
+                        Handle::P256PrivateKey(private_key) => {
+                            private_key.to_bytes().as_slice().to_vec()
+                        },
+                        Handle::P384PrivateKey(private_key) => {
+                            private_key.to_bytes().as_slice().to_vec()
+                        },
+                        Handle::P521PrivateKey(private_key) => {
+                            private_key.to_bytes().as_slice().to_vec()
+                        },
                         _ => {
                             return Err(Error::Operation(Some(
                                 "The key is not an elliptic curve private key".into(),
@@ -1389,4 +1267,27 @@ pub(crate) fn get_public_key(
     );
 
     Ok(public_key)
+}
+
+/// Concatenate big endian serialized coordinates of an elliptic curve point, to form an
+/// uncompressed SEC1 encoded curve point, with prefix `0x04` indicating it is an uncompressed
+/// point.
+fn x_y_to_sec1_bytes(x: &[u8], y: &[u8]) -> Vec<u8> {
+    let mut sec1_bytes = Vec::with_capacity(1 + x.len() + y.len());
+    sec1_bytes.push(4u8);
+    sec1_bytes.extend_from_slice(x);
+    sec1_bytes.extend_from_slice(y);
+    sec1_bytes
+}
+
+/// Validate the public key in form of uncompressed SEC1 encoded curve point, against a private key.
+fn validate_public_key<C>(private_key: &SecretKey<C>, sec1_bytes: &[u8]) -> ErrorResult
+where
+    C: Curve + ValidatePublicKey,
+    FieldBytesSize<C>: ModulusSize,
+{
+    let sec1_point = Sec1Point::<C>::from_bytes(sec1_bytes)
+        .map_err(|_| Error::Data(Some("Failed to encode curve point".into())))?;
+    C::validate_public_key(private_key, &sec1_point)
+        .map_err(|_| Error::Data(Some("The public key does not match the private key".into())))
 }

--- a/components/script/dom/webcrypto/subtlecrypto/ecdh_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ecdh_operation.rs
@@ -3,11 +3,14 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use elliptic_curve::Curve;
-use elliptic_curve::generic_array::typenum::Unsigned;
+use elliptic_curve::array::typenum::Unsigned;
 use js::context::JSContext;
 use p256::NistP256;
+use p256::ecdh::diffie_hellman as p256_diffie_hellman;
 use p384::NistP384;
+use p384::ecdh::diffie_hellman as p384_diffie_hellman;
 use p521::NistP521;
+use p521::ecdh::diffie_hellman as p521_diffie_hellman;
 
 use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::{
     CryptoKeyMethods, CryptoKeyPair, KeyType, KeyUsage,
@@ -124,7 +127,7 @@ pub(crate) fn derive_bits(
                     "Public key is not a P-256 public key".to_string(),
                 )));
             };
-            p256::ecdh::diffie_hellman(private_key.to_nonzero_scalar(), public_key.as_affine())
+            p256_diffie_hellman(private_key.to_nonzero_scalar(), public_key.as_affine())
                 .raw_secret_bytes()
                 .to_vec()
         },
@@ -139,7 +142,7 @@ pub(crate) fn derive_bits(
                     "Public key is not a P384 public key".to_string(),
                 )));
             };
-            p384::ecdh::diffie_hellman(private_key.to_nonzero_scalar(), public_key.as_affine())
+            p384_diffie_hellman(private_key.to_nonzero_scalar(), public_key.as_affine())
                 .raw_secret_bytes()
                 .to_vec()
         },
@@ -154,7 +157,7 @@ pub(crate) fn derive_bits(
                     "Public key is not a P-521 public key".to_string(),
                 )));
             };
-            p521::ecdh::diffie_hellman(private_key.to_nonzero_scalar(), public_key.as_affine())
+            p521_diffie_hellman(private_key.to_nonzero_scalar(), public_key.as_affine())
                 .raw_secret_bytes()
                 .to_vec()
         },

--- a/components/script/dom/webcrypto/subtlecrypto/ecdsa_operation.rs
+++ b/components/script/dom/webcrypto/subtlecrypto/ecdsa_operation.rs
@@ -5,7 +5,6 @@
 use digest::Digest;
 use ecdsa::signature::hazmat::{PrehashVerifier, RandomizedPrehashSigner};
 use ecdsa::{Signature, SigningKey, VerifyingKey};
-use elliptic_curve::rand_core::OsRng;
 use js::context::JSContext;
 use p256::NistP256;
 use p384::NistP384;
@@ -27,10 +26,6 @@ use crate::dom::subtlecrypto::{
     NAMED_CURVE_P521, NormalizedAlgorithm, SubtleEcKeyGenParams, SubtleEcKeyImportParams,
     SubtleEcdsaParams, ec_common,
 };
-
-const P256_PREHASH_LENGTH: usize = 32;
-const P384_PREHASH_LENGTH: usize = 48;
-const P521_PREHASH_LENGTH: usize = 66;
 
 /// <https://w3c.github.io/webcrypto/#ecdsa-operations-sign>
 pub(crate) fn sign(
@@ -85,47 +80,35 @@ pub(crate) fn sign(
     let KeyAlgorithmAndDerivatives::EcKeyAlgorithm(algorithm) = key.algorithm() else {
         return Err(Error::Operation(None));
     };
+    let mut rng = rand::rng();
     let result = match algorithm.named_curve.as_str() {
         NAMED_CURVE_P256 => {
-            // P-256 expects prehash with length at least 32 bytes. If M is shorter than 32 bytes,
-            // expand it by left padding with zeros.
-            let m = expand_prehash(m, P256_PREHASH_LENGTH);
-
             let Handle::P256PrivateKey(d) = key.handle() else {
                 return Err(Error::Operation(None));
             };
             let signing_key = SigningKey::<NistP256>::from(d);
             let signature: Signature<NistP256> = signing_key
-                .sign_prehash_with_rng(&mut OsRng, m.as_slice())
+                .sign_prehash_with_rng(&mut rng, &m)
                 .map_err(|_| Error::Operation(None))?;
             signature.to_vec()
         },
         NAMED_CURVE_P384 => {
-            // P-384 expects prehash with length at least 48 bytes. If M is shorter than 48 bytes,
-            // expand it by left padding with zeros.
-            let m = expand_prehash(m, P384_PREHASH_LENGTH);
-
             let Handle::P384PrivateKey(d) = key.handle() else {
                 return Err(Error::Operation(None));
             };
             let signing_key = SigningKey::<NistP384>::from(d);
             let signature: Signature<NistP384> = signing_key
-                .sign_prehash_with_rng(&mut OsRng, m.as_slice())
+                .sign_prehash_with_rng(&mut rng, &m)
                 .map_err(|_| Error::Abort(None))?;
             signature.to_vec()
         },
         NAMED_CURVE_P521 => {
-            // P-521 expects prehash with length at least 66 bytes. If M is shorter than 66 bytes,
-            // expand it by left padding with zeros.
-            let m = expand_prehash(m, P521_PREHASH_LENGTH);
-
             let Handle::P521PrivateKey(d) = key.handle() else {
                 return Err(Error::Operation(None));
             };
-            let signing_key = p521::ecdsa::SigningKey::from_slice(d.to_bytes().as_slice())
-                .map_err(|_| Error::Operation(None))?;
+            let signing_key = SigningKey::<NistP521>::from(d);
             let signature: Signature<NistP521> = signing_key
-                .sign_prehash_with_rng(&mut OsRng, m.as_slice())
+                .sign_prehash_with_rng(&mut rng, &m)
                 .map_err(|_| Error::Operation(None))?;
             signature.to_vec()
         },
@@ -188,10 +171,6 @@ pub(crate) fn verify(
     };
     let result = match algorithm.named_curve.as_str() {
         NAMED_CURVE_P256 => {
-            // P-256 expects prehash with length at least 32 bytes. If M is shorter than 32 bytes,
-            // expand it by left padding with zeros.
-            let m = expand_prehash(m, P256_PREHASH_LENGTH);
-
             let Handle::P256PublicKey(q) = key.handle() else {
                 return Err(Error::Operation(None));
             };
@@ -204,10 +183,6 @@ pub(crate) fn verify(
             }
         },
         NAMED_CURVE_P384 => {
-            // P-384 expects prehash with length at least 48 bytes. If M is shorter than 48 bytes,
-            // expand it by left padding with zeros.
-            let m = expand_prehash(m, P384_PREHASH_LENGTH);
-
             let Handle::P384PublicKey(q) = key.handle() else {
                 return Err(Error::Operation(None));
             };
@@ -220,21 +195,15 @@ pub(crate) fn verify(
             }
         },
         NAMED_CURVE_P521 => {
-            // P-521 expects prehash with length at least 66 bytes. If M is shorter than 66 bytes,
-            // expand it by left padding with zeros.
-            let m = expand_prehash(m, P521_PREHASH_LENGTH);
-
             let Handle::P521PublicKey(q) = key.handle() else {
                 return Err(Error::Operation(None));
             };
-            match (
-                Signature::<NistP521>::from_slice(signature),
-                p521::ecdsa::VerifyingKey::from_sec1_bytes(q.to_sec1_bytes().to_vec().as_slice()),
-            ) {
-                (Ok(signature), Ok(verifying_key)) => {
+            match Signature::<NistP521>::from_slice(signature) {
+                Ok(signature) => {
+                    let verifying_key = VerifyingKey::<NistP521>::from(q);
                     verifying_key.verify_prehash(&m, &signature).is_ok()
                 },
-                _ => false,
+                Err(_) => false,
             }
         },
         _ => return Err(Error::NotSupported(None)),
@@ -299,19 +268,4 @@ pub(crate) fn get_public_key(
     usages: Vec<KeyUsage>,
 ) -> Result<DomRoot<CryptoKey>, Error> {
     ec_common::get_public_key(cx, global, key, algorithm, usages)
-}
-
-/// A helper function that expand a prehash to a specified length if the prehash is shorter than
-/// the specified length.
-///
-/// If the length of `prehash` is less than `length`, return a prehash with length `length`
-/// constructed by left-padding `prehash` with zeros. Otherwire, return the unmodified `prehash`.
-fn expand_prehash(prehash: Vec<u8>, length: usize) -> Vec<u8> {
-    if prehash.len() < length {
-        let mut left_padded_prehash = vec![0u8; length];
-        left_padded_prehash[length - prehash.len()..].copy_from_slice(&prehash);
-        left_padded_prehash
-    } else {
-        prehash
-    }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -144,6 +144,7 @@ skip = [
     "rand",
     "rand_chacha",
     "rand_core",
+    "sha1",
 
     # duplicated by blurz/blurmock
     "hex",
@@ -186,26 +187,19 @@ skip = [
     "tiny-skia",
     "tiny-skia-path",
 
-    # Duplicated by RustCrypto crates. We are upgrading RustCrypto
-    # dependencies in multiple rounds (issue #42206). During the
-    # upgrading process, we might have some duplicated dependencies due
-    # to partial upgrade, temporarily.
-    "const-oid",
+    # Duplicated by content-security-policy
+    "sha2",
+
+    # Duplicated by sha1 and sha2, which are duplicated by tungstenite
+    # and content-security-policy.
     "cpufeatures",
     "crypto-common",
     "digest",
-    "sha3",
-    "der",
-    "pkcs8",
-    "spki",
-    "signature",
     "block-buffer",
-    "hkdf",
-    "hmac",
-    "sha1",
-    "sha2",
-    "crypto-bigint",
-    "pem-rfc7468",
+
+    # Duplicated by ml-kem. This should be gone in next version (>0.3.2)
+    # of ml-kem.
+    "sha3",
 ]
 
 # github.com organizations to allow git sources for


### PR DESCRIPTION
Bump ecdsa from 0.16.9 to 0.17.0-rc.20.
Bump elliptic-curve from 0.13.8 to 0.14.0-rc.35.
Bump p256 from 0.13.2 to 0.14.0-rc.12.
Bump p384 from 0.13.1 to 0.14.0-rc.12.
Bump p521 from 0.13.3 to 0.14.0-rc.12.

Since the new versions of these crates are still in release candidate phase, we pin them with `=` prefix. We can later switch back to normal version number once the new stable releases are out.

Here are some notable changes of this upgrade.

The sec1 crate is removed since it is no longer in use.

Elliptic-curve private keys are now directly serialized into raw bytes, instead of uncompressed SEC1 encoded curve point.

In `ec_common.rs`, we now use `PublicKey::from_public_key_der` provided by the `elliptic-curve` crate to parse public keys in SPKI format, instead of unpacking the SPKI ASN.1 structures manually. Similarly, we now use `SecretKey::from_pkcs8_der` provided by the `elliptic-curve` crate to parse private keys in PKCS#8 format, instead of unpacking the PKCS#8 ASN.1 structures manually. These changes help reduce our code complexity.

The helper function `expand_prehash` in `ecdsa_operation.rs` is removed since it is no longer in use.

This is the last part of issue #42206, which bumps our RustCrypto dependencies. Most of the duplicated dependencies introduced during the transition period have gone. Unfortunately, a few of them remain since some other dependencies are still using the old version of the digest crates `sha1`, `sha2` and `sha3`.

Testing: Covered by existing WPT tests in `WebCryptoAPI` subdirectory
Part of: #42206