### PR TITLE
fonts: Simplify logic around `@font-face` descriptors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7451,7 +7451,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.38.0"
-source = "git+https://github.com/servo/stylo?rev=49e912cf401a7f867d33d61baa2389bb3d6f73e0#49e912cf401a7f867d33d61baa2389bb3d6f73e0"
+source = "git+https://github.com/servo/stylo?rev=71bbb705678fbcdbab105f0ffc5a339b6600186f#71bbb705678fbcdbab105f0ffc5a339b6600186f"
 dependencies = [
  "bitflags 2.13.0",
  "cssparser",
@@ -9202,7 +9202,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=49e912cf401a7f867d33d61baa2389bb3d6f73e0#49e912cf401a7f867d33d61baa2389bb3d6f73e0"
+source = "git+https://github.com/servo/stylo?rev=71bbb705678fbcdbab105f0ffc5a339b6600186f#71bbb705678fbcdbab105f0ffc5a339b6600186f"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -9673,7 +9673,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=49e912cf401a7f867d33d61baa2389bb3d6f73e0#49e912cf401a7f867d33d61baa2389bb3d6f73e0"
+source = "git+https://github.com/servo/stylo?rev=71bbb705678fbcdbab105f0ffc5a339b6600186f#71bbb705678fbcdbab105f0ffc5a339b6600186f"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -9729,7 +9729,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=49e912cf401a7f867d33d61baa2389bb3d6f73e0#49e912cf401a7f867d33d61baa2389bb3d6f73e0"
+source = "git+https://github.com/servo/stylo?rev=71bbb705678fbcdbab105f0ffc5a339b6600186f#71bbb705678fbcdbab105f0ffc5a339b6600186f"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -9738,7 +9738,7 @@ dependencies = [
 [[package]]
 name = "stylo_derive"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=49e912cf401a7f867d33d61baa2389bb3d6f73e0#49e912cf401a7f867d33d61baa2389bb3d6f73e0"
+source = "git+https://github.com/servo/stylo?rev=71bbb705678fbcdbab105f0ffc5a339b6600186f#71bbb705678fbcdbab105f0ffc5a339b6600186f"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -9750,7 +9750,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=49e912cf401a7f867d33d61baa2389bb3d6f73e0#49e912cf401a7f867d33d61baa2389bb3d6f73e0"
+source = "git+https://github.com/servo/stylo?rev=71bbb705678fbcdbab105f0ffc5a339b6600186f#71bbb705678fbcdbab105f0ffc5a339b6600186f"
 dependencies = [
  "bitflags 2.13.0",
  "stylo_malloc_size_of",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=49e912cf401a7f867d33d61baa2389bb3d6f73e0#49e912cf401a7f867d33d61baa2389bb3d6f73e0"
+source = "git+https://github.com/servo/stylo?rev=71bbb705678fbcdbab105f0ffc5a339b6600186f#71bbb705678fbcdbab105f0ffc5a339b6600186f"
 dependencies = [
  "app_units",
  "cssparser",
@@ -9776,7 +9776,7 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=49e912cf401a7f867d33d61baa2389bb3d6f73e0#49e912cf401a7f867d33d61baa2389bb3d6f73e0"
+source = "git+https://github.com/servo/stylo?rev=71bbb705678fbcdbab105f0ffc5a339b6600186f#71bbb705678fbcdbab105f0ffc5a339b6600186f"
 dependencies = [
  "toml",
 ]
@@ -9784,7 +9784,7 @@ dependencies = [
 [[package]]
 name = "stylo_traits"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=49e912cf401a7f867d33d61baa2389bb3d6f73e0#49e912cf401a7f867d33d61baa2389bb3d6f73e0"
+source = "git+https://github.com/servo/stylo?rev=71bbb705678fbcdbab105f0ffc5a339b6600186f#71bbb705678fbcdbab105f0ffc5a339b6600186f"
 dependencies = [
  "app_units",
  "bitflags 2.13.0",
@@ -10204,7 +10204,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.4.0"
-source = "git+https://github.com/servo/stylo?rev=49e912cf401a7f867d33d61baa2389bb3d6f73e0#49e912cf401a7f867d33d61baa2389bb3d6f73e0"
+source = "git+https://github.com/servo/stylo?rev=71bbb705678fbcdbab105f0ffc5a339b6600186f#71bbb705678fbcdbab105f0ffc5a339b6600186f"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -10217,7 +10217,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=49e912cf401a7f867d33d61baa2389bb3d6f73e0#49e912cf401a7f867d33d61baa2389bb3d6f73e0"
+source = "git+https://github.com/servo/stylo?rev=71bbb705678fbcdbab105f0ffc5a339b6600186f#71bbb705678fbcdbab105f0ffc5a339b6600186f"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,14 +215,14 @@ rustls-pki-types = "1.14"
 rustls-platform-verifier = "0.7.0"
 sea-query = { version = "=1.0.0-rc.31", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = "=0.8.0-rc.15"
-selectors = { git = "https://github.com/servo/stylo", rev = "49e912cf401a7f867d33d61baa2389bb3d6f73e0" }
+selectors = { git = "https://github.com/servo/stylo", rev = "71bbb705678fbcdbab105f0ffc5a339b6600186f" }
 seq-macro = "0.3.6"
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
 serde_json = "1.0"
 serde_test = "1.0"
-servo_arc = { git = "https://github.com/servo/stylo", rev = "49e912cf401a7f867d33d61baa2389bb3d6f73e0" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "71bbb705678fbcdbab105f0ffc5a339b6600186f" }
 sha1 = "0.11"
 sha2 = "0.11"
 sha3 = "0.12"
@@ -232,12 +232,12 @@ smallvec = { version = "1.15", features = ["serde", "union"] }
 speexdsp-resampler = "0.1.0"
 string_cache = "0.9"
 strum = { version = "0.28", features = ["derive"] }
-stylo = { git = "https://github.com/servo/stylo", rev = "49e912cf401a7f867d33d61baa2389bb3d6f73e0" }
-stylo_atoms = { git = "https://github.com/servo/stylo", rev = "49e912cf401a7f867d33d61baa2389bb3d6f73e0" }
-stylo_dom = { git = "https://github.com/servo/stylo", rev = "49e912cf401a7f867d33d61baa2389bb3d6f73e0" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "49e912cf401a7f867d33d61baa2389bb3d6f73e0" }
-stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "49e912cf401a7f867d33d61baa2389bb3d6f73e0" }
-stylo_traits = { git = "https://github.com/servo/stylo", rev = "49e912cf401a7f867d33d61baa2389bb3d6f73e0" }
+stylo = { git = "https://github.com/servo/stylo", rev = "71bbb705678fbcdbab105f0ffc5a339b6600186f" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "71bbb705678fbcdbab105f0ffc5a339b6600186f" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "71bbb705678fbcdbab105f0ffc5a339b6600186f" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "71bbb705678fbcdbab105f0ffc5a339b6600186f" }
+stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "71bbb705678fbcdbab105f0ffc5a339b6600186f" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "71bbb705678fbcdbab105f0ffc5a339b6600186f" }
 surfman = { version = "0.13.0", features = ["chains"] }
 swapper = "0.1"
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -1315,6 +1315,8 @@ malloc_size_of_is_stylo_malloc_size_of!(style::computed_values::font_variant_pos
 malloc_size_of_is_stylo_malloc_size_of!(style::computed_values::text_decoration_style::T);
 malloc_size_of_is_stylo_malloc_size_of!(style::computed_values::text_rendering::T);
 malloc_size_of_is_stylo_malloc_size_of!(style::dom::OpaqueNode);
+malloc_size_of_is_stylo_malloc_size_of!(style::font_face::ComputedFontStretchRange);
+malloc_size_of_is_stylo_malloc_size_of!(style::font_face::ComputedFontWeightRange);
 malloc_size_of_is_stylo_malloc_size_of!(style::invalidation::element::restyle_hints::RestyleHint);
 malloc_size_of_is_stylo_malloc_size_of!(style::logical_geometry::WritingMode);
 malloc_size_of_is_stylo_malloc_size_of!(style::media_queries::MediaList);

--- a/components/shared/fonts/font_descriptor.rs
+++ b/components/shared/fonts/font_descriptor.rs
@@ -8,12 +8,13 @@ use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
 use style::computed_values::font_optical_sizing::T as FontOpticalSizing;
 use style::computed_values::font_variant_caps;
-use style::font_face::{Descriptors, FontStyle as FontFaceStyle};
+use style::font_face::{
+    ComputedFontStretchRange, ComputedFontStyleDescriptor, ComputedFontWeightRange, Descriptors,
+    FontStretchRange, FontStyle as FontFaceStyle, FontWeightRange,
+};
 use style::properties::style_structs::Font as FontStyleStruct;
 use style::stylesheets::FontFaceRule;
-use style::values::computed::font::{FixedPoint, FontStyleFixedPoint};
 use style::values::computed::{Au, FontStretch, FontStyle, FontSynthesis, FontWeight};
-use style::values::specified::FontStretch as SpecifiedFontStretch;
 use webrender_api::FontVariation;
 
 /// `FontDescriptor` describes the parameters of a `Font`. It represents rendering a given font
@@ -67,14 +68,6 @@ impl FontDescriptor {
     }
 }
 
-/// A version of `FontStyle` from Stylo that is serializable. Normally this is not
-/// because the specified version of `FontStyle` contains floats.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub enum ComputedFontStyleDescriptor {
-    Italic,
-    Oblique(FontStyleFixedPoint, FontStyleFixedPoint),
-}
-
 /// This data structure represents the various optional descriptors that can be
 /// applied to a `@font-face` rule in CSS. These are used to create a [`FontTemplate`]
 /// from the given font data used as the source of the `@font-face` rule. If values
@@ -83,8 +76,8 @@ pub enum ComputedFontStyleDescriptor {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct CSSFontFaceDescriptors {
     pub family_name: LowercaseFontFamilyName,
-    pub weight: Option<(FontWeight, FontWeight)>,
-    pub stretch: Option<(FontStretch, FontStretch)>,
+    pub weight: Option<ComputedFontWeightRange>,
+    pub stretch: Option<ComputedFontStretchRange>,
     pub style: Option<ComputedFontStyleDescriptor>,
     pub unicode_range: Option<Vec<RangeInclusive<u32>>>,
 }
@@ -109,31 +102,15 @@ impl From<&Descriptors> for CSSFontFaceDescriptors {
         let weight = descriptors
             .font_weight
             .as_ref()
-            .and_then(|weight_range| weight_range.0.compute().zip(weight_range.1.compute()));
-
-        let stretch_to_computed = |specified: &SpecifiedFontStretch| {
-            Some(match specified {
-                SpecifiedFontStretch::Stretch(percentage) => {
-                    FontStretch::from_percentage(percentage.compute()?.0)
-                },
-                SpecifiedFontStretch::Keyword(keyword) => keyword.compute(),
-                SpecifiedFontStretch::System(_) => FontStretch::NORMAL,
-            })
-        };
-        let stretch = descriptors.font_stretch.as_ref().and_then(|stretch_range| {
-            stretch_to_computed(&stretch_range.0).zip(stretch_to_computed(&stretch_range.1))
-        });
-
-        fn style_to_computed(specified: &FontFaceStyle) -> Option<ComputedFontStyleDescriptor> {
-            Some(match specified {
-                FontFaceStyle::Italic => ComputedFontStyleDescriptor::Italic,
-                FontFaceStyle::Oblique(angle_a, angle_b) => ComputedFontStyleDescriptor::Oblique(
-                    FixedPoint::from_float(angle_a.degrees()?),
-                    FixedPoint::from_float(angle_b.degrees()?),
-                ),
-            })
-        }
-        let style = descriptors.font_style.as_ref().and_then(style_to_computed);
+            .and_then(FontWeightRange::compute);
+        let stretch = descriptors
+            .font_stretch
+            .as_ref()
+            .and_then(FontStretchRange::compute);
+        let style = descriptors
+            .font_style
+            .as_ref()
+            .and_then(FontFaceStyle::compute);
         let unicode_range = descriptors
             .unicode_range
             .as_ref()

--- a/components/shared/fonts/font_template.rs
+++ b/components/shared/fonts/font_template.rs
@@ -14,12 +14,15 @@ use serde::{Deserialize, Serialize};
 use style::computed_values::font_optical_sizing::T as FontOpticalSizing;
 use style::computed_values::font_stretch::T as FontStretch;
 use style::computed_values::font_style::T as FontStyle;
+use style::font_face::{
+    ComputedFontStretchRange, ComputedFontStyleDescriptor, ComputedFontWeightRange,
+};
 use style::properties::generated::font_face::Descriptors as FontFaceRuleDescriptors;
 use style::stylesheets::DocumentStyleSheet;
 use style::values::computed::font::FontWeight;
 use webrender_api::FontVariation;
 
-use crate::{CSSFontFaceDescriptors, ComputedFontStyleDescriptor, FontDescriptor, FontIdentifier};
+use crate::{CSSFontFaceDescriptors, FontDescriptor, FontIdentifier};
 
 /// A reference to a [`FontTemplate`] with shared ownership and mutability.
 #[derive(Clone, Debug, MallocSizeOf)]
@@ -44,8 +47,8 @@ impl Deref for FontTemplateRef {
 /// NB: If you change this, you will need to update `style::properties::compute_font_hash()`.
 #[derive(Clone, Debug, Deserialize, Hash, MallocSizeOf, PartialEq, Serialize)]
 pub struct FontTemplateDescriptor {
-    pub weight: (FontWeight, FontWeight),
-    pub stretch: (FontStretch, FontStretch),
+    pub weight: ComputedFontWeightRange,
+    pub stretch: ComputedFontStretchRange,
     pub style: (FontStyle, FontStyle),
     #[ignore_malloc_size_of = "MallocSizeOf does not yet support RangeInclusive"]
     pub unicode_range: Option<Vec<RangeInclusive<u32>>>,
@@ -65,8 +68,8 @@ impl FontTemplateDescriptor {
     #[inline]
     pub fn new(weight: FontWeight, stretch: FontStretch, style: FontStyle) -> Self {
         Self {
-            weight: (weight, weight),
-            stretch: (stretch, stretch),
+            weight: ComputedFontWeightRange(weight, weight),
+            stretch: ComputedFontStretchRange(stretch, stretch),
             style: (style, style),
             unicode_range: None,
         }
@@ -126,8 +129,8 @@ impl FontTemplateDescriptor {
         &mut self,
         css_font_template_descriptors: &CSSFontFaceDescriptors,
     ) {
-        if let Some(weight) = css_font_template_descriptors.weight {
-            self.weight = weight;
+        if let Some(ref weight) = css_font_template_descriptors.weight {
+            self.weight = weight.clone();
         }
         self.style = match css_font_template_descriptors.style {
             Some(ComputedFontStyleDescriptor::Italic) => (FontStyle::ITALIC, FontStyle::ITALIC),
@@ -137,8 +140,8 @@ impl FontTemplateDescriptor {
             ),
             None => self.style,
         };
-        if let Some(stretch) = css_font_template_descriptors.stretch {
-            self.stretch = stretch;
+        if let Some(ref stretch) = css_font_template_descriptors.stretch {
+            self.stretch = stretch.clone();
         }
         if let Some(ref unicode_range) = css_font_template_descriptors.unicode_range {
             self.unicode_range = Some(unicode_range.clone());
@@ -344,13 +347,13 @@ impl FontTemplateRefMethods for FontTemplateRef {
 ///
 /// This implementation is ported from Gecko at:
 /// <https://searchfox.org/mozilla-central/rev/0529464f0d2981347ef581f7521ace8b7af7f7ac/gfx/thebes/gfxFontUtils.h#1217>.
-trait FontMatchDistanceMethod: Sized {
-    fn match_distance(&self, range: &(Self, Self)) -> f32;
+trait FontMatchDistanceMethod<T>: Sized {
+    fn match_distance(&self, range: &T) -> f32;
     fn to_float(&self) -> f32;
 }
 
-impl FontMatchDistanceMethod for FontStretch {
-    fn match_distance(&self, range: &(Self, Self)) -> f32 {
+impl FontMatchDistanceMethod<ComputedFontStretchRange> for FontStretch {
+    fn match_distance(&self, range: &ComputedFontStretchRange) -> f32 {
         // stretch distance ==> [0,2000]
         const REVERSE_DISTANCE: f32 = 1000.0;
 
@@ -383,7 +386,7 @@ impl FontMatchDistanceMethod for FontStretch {
     }
 }
 
-impl FontMatchDistanceMethod for FontWeight {
+impl FontMatchDistanceMethod<ComputedFontWeightRange> for FontWeight {
     // Calculate weight distance with values in the range (0..1000). In general,
     // heavier weights match towards even heavier weights while lighter weights
     // match towards even lighter weights. Target weight values in the range
@@ -395,7 +398,7 @@ impl FontMatchDistanceMethod for FontWeight {
     // weights are farther away than lighter weights. If the target is 5 and the
     // font weight 995, the distance would be 1590 for the same reason.
 
-    fn match_distance(&self, range: &(Self, Self)) -> f32 {
+    fn match_distance(&self, range: &ComputedFontWeightRange) -> f32 {
         // weight distance ==> [0,1600]
         const NOT_WITHIN_CENTRAL_RANGE: f32 = 100.0;
         const REVERSE_DISTANCE: f32 = 600.0;
@@ -445,7 +448,7 @@ impl FontMatchDistanceMethod for FontWeight {
     }
 }
 
-impl FontMatchDistanceMethod for FontStyle {
+impl FontMatchDistanceMethod<(Self, Self)> for FontStyle {
     fn match_distance(&self, range: &(Self, Self)) -> f32 {
         // style distance ==> [0,500]
         let min_style = range.0;

--- a/tests/wpt/tests/css/css-fonts/variations/font-descriptor-range-reversed-002-ref.html
+++ b/tests/wpt/tests/css/css-fonts/variations/font-descriptor-range-reversed-002-ref.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>CSS Reference</title>
+
+<style>
+@font-face {
+  font-family: TestWeight;
+  src: url(resources/csstest-weights-100-kerned.ttf);
+  font-weight: 400 300;
+}
+@font-face {
+  font-family: TestStyle;
+  src: url(resources/csstest-weights-100-kerned.ttf);
+  font-style: oblique 40deg 30deg;
+}
+@font-face {
+  font-family: TestStretch;
+  src: url(resources/csstest-weights-100-kerned.ttf);
+  font-stretch: 130% 120%;
+}
+</style>
+
+<p style="font-family: TestWeight; font-weight: 250;">A</p>
+<p style="font-family: TestStyle; font-style: oblique 25deg;">A</p>
+<p style="font-family: TestStretch; font-stretch: 115%;">A</p>
+
+<script>
+document.fonts.ready.then(function() {
+  document.documentElement.className = "";
+});
+</script>

--- a/tests/wpt/tests/css/css-fonts/variations/font-descriptor-range-reversed-002.html
+++ b/tests/wpt/tests/css/css-fonts/variations/font-descriptor-range-reversed-002.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>CSS Test: Matching @font-face font-weight, font-style, and font-stretch descriptors with reversed ranges</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts-4/#font-prop-desc">
+<link rel="match" href="font-descriptor-range-reversed-002-ref.html">
+
+<!-- Using csstest-weights-{100,900}-kerned.ttf just as two convenient
+     different fonts here with different "A" glyphs -->
+
+<style>
+@font-face {
+  font-family: TestWeight;
+  src: url(resources/csstest-weights-900-kerned.ttf);
+  font-weight: 310 400;
+}
+@font-face {
+  font-family: TestWeight;
+  src: url(resources/csstest-weights-100-kerned.ttf);
+  font-weight: 400 300;
+}
+@font-face {
+  font-family: TestStyle;
+  src: url(resources/csstest-weights-100-kerned.ttf);
+  font-style: oblique 40deg 30deg;
+}
+@font-face {
+  font-family: TestStyle;
+  src: url(resources/csstest-weights-900-kerned.ttf);
+  font-style: oblique 31deg 40deg;
+}
+@font-face {
+  font-family: TestStretch;
+  src: url(resources/csstest-weights-100-kerned.ttf);
+  font-stretch: 130% 120%;
+}
+@font-face {
+  font-family: TestStretch;
+  src: url(resources/csstest-weights-900-kerned.ttf);
+  font-stretch: 121% 130%;
+}
+</style>
+
+<!-- Matches `font-weight: 300 200;` -->
+<p style="font-family: TestWeight; font-weight: 250;">A</p>
+
+<!-- Matches `font-style: oblique 30deg 20deg;` -->
+<p style="font-family: TestStyle; font-style: oblique 25deg;">A</p>
+
+<!-- Matches `font-style: oblique 120% 110%;` -->
+<p style="font-family: TestStretch; font-stretch: 115%;">A</p>
+
+<script>
+document.fonts.ready.then(function() {
+  document.documentElement.className = "";
+});
+</script>


### PR DESCRIPTION
This changes `CSSFontFaceDescriptors` to use:
- `ComputedFontWeightRange` instead of a pair of `FontWeight`
- `ComputedFontStretchRange` instead of a pair of `FontStretch`
- Stylo's `ComputedFontStyleDescriptor` instead of a similar copy of that

This way we can simply use the `compute()` method of `FontWeightRange`, `FontStretchRange` and `FontFaceStyle` to compute the above. The behavior should be mostly the same, but:
 - Now the ranges will be sorted, if they were in the wrong order
 - Degrees in `font-style` will be clamped within the [-90deg, 90deg] range

Bumps Stylo to https://github.com/servo/stylo/pull/399

Testing: Adding a test for ranges in the wrong order