### PR TITLE
script: Remove `CanGc` from IndexedDB

### DIFF
--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -70,7 +70,7 @@ pub(crate) fn throw_dom_exception(cx: &mut JSContext, global: &GlobalScope, resu
         });
     }
 
-    match create_dom_exception(global, result, CanGc::from_cx(cx)) {
+    match create_dom_exception(cx, global, result) {
         Ok(exception) => unsafe {
             assert!(!JS_IsExceptionPending(cx));
             rooted!(&in(cx) let mut thrown = UndefinedValue());
@@ -98,13 +98,16 @@ pub(crate) fn throw_dom_exception(cx: &mut JSContext, global: &GlobalScope, resu
 /// If no such DOMException exists, return a subset of the original error values
 /// that may need additional handling.
 pub(crate) fn create_dom_exception(
+    cx: &mut JSContext,
     global: &GlobalScope,
     result: Error,
-    can_gc: CanGc,
 ) -> Result<DomRoot<DOMException>, JsEngineError> {
-    let new_custom_exception = |error_name, message| {
+    let mut new_custom_exception = |error_name, message| {
         Ok(DOMException::new_with_custom_message(
-            global, error_name, message, can_gc,
+            global,
+            error_name,
+            message,
+            CanGc::from_cx(cx),
         ))
     };
 
@@ -203,7 +206,7 @@ pub(crate) fn create_dom_exception(
                 DOMString::new(),
                 quota,
                 requested,
-                can_gc,
+                CanGc::from_cx(cx),
             )));
         },
         Error::TypeMismatch(Some(custom_message)) => {
@@ -238,7 +241,7 @@ pub(crate) fn create_dom_exception(
         Error::Range(message) => return Err(JsEngineError::Range(message)),
         Error::JSFailed => return Err(JsEngineError::JSFailed),
     };
-    Ok(DOMException::new(global, code, can_gc))
+    Ok(DOMException::new(global, code, CanGc::from_cx(cx)))
 }
 
 /// A struct encapsulating information about a runtime script error.

--- a/components/script/dom/domstringlist.rs
+++ b/components/script/dom/domstringlist.rs
@@ -4,13 +4,13 @@
 
 use dom_struct::dom_struct;
 use itertools::Itertools;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use js::context::JSContext;
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 
 use crate::dom::bindings::codegen::Bindings::DOMStringListBinding::DOMStringListMethods;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct DOMStringList {
@@ -27,22 +27,18 @@ impl DOMStringList {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         strings: Vec<DOMString>,
-        can_gc: CanGc,
     ) -> DomRoot<DOMStringList> {
-        reflect_dom_object(
-            Box::new(DOMStringList::new_inherited(strings)),
-            global,
-            can_gc,
-        )
+        reflect_dom_object_with_cx(Box::new(DOMStringList::new_inherited(strings)), global, cx)
     }
 
     /// <https://www.w3.org/TR/IndexedDB-3/#sorted-name-list>
     pub(crate) fn new_sorted<'a>(
+        cx: &mut JSContext,
         global: &GlobalScope,
         strings: impl IntoIterator<Item = &'a DOMString>,
-        can_gc: CanGc,
     ) -> DomRoot<DOMStringList> {
         let sorted = strings
             .into_iter()
@@ -54,7 +50,7 @@ impl DOMStringList {
                     .into()
             })
             .collect();
-        Self::new(global, sorted, can_gc)
+        Self::new(cx, global, sorted)
     }
 }
 

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -3050,9 +3050,8 @@ impl GlobalScope {
     }
 
     /// Returns the idb factory for this global.
-    pub(crate) fn get_indexeddb(&self) -> DomRoot<IDBFactory> {
-        self.indexeddb
-            .or_init(|| IDBFactory::new(self, CanGc::deprecated_note()))
+    pub(crate) fn get_indexeddb(&self, cx: &mut js::context::JSContext) -> DomRoot<IDBFactory> {
+        self.indexeddb.or_init(|| IDBFactory::new(cx, self))
     }
 
     pub(crate) fn get_existing_indexeddb(&self) -> Option<DomRoot<IDBFactory>> {

--- a/components/script/dom/indexeddb/idbcursor.rs
+++ b/components/script/dom/indexeddb/idbcursor.rs
@@ -10,8 +10,7 @@ use js::jsapi::Heap;
 use js::jsval::{JSVal, UndefinedValue};
 use js::rust::MutableHandleValue;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
-use script_bindings::script_runtime::CanGc;
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use storage_traits::indexeddb::{IndexedDBKeyRange, IndexedDBKeyType, IndexedDBRecord};
 
 use crate::dom::bindings::codegen::Bindings::IDBCursorBinding::{
@@ -106,6 +105,7 @@ impl IDBCursor {
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         transaction: &IDBTransaction,
         direction: IDBCursorDirection,
@@ -113,9 +113,8 @@ impl IDBCursor {
         source: ObjectStoreOrIndex,
         range: IndexedDBKeyRange,
         key_only: bool,
-        can_gc: CanGc,
     ) -> DomRoot<IDBCursor> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(IDBCursor::new_inherited(
                 transaction,
                 direction,
@@ -125,7 +124,7 @@ impl IDBCursor {
                 key_only,
             )),
             global,
-            can_gc,
+            cx,
         )
     }
 

--- a/components/script/dom/indexeddb/idbcursorwithvalue.rs
+++ b/components/script/dom/indexeddb/idbcursorwithvalue.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::MutableHandleValue;
-use script_bindings::reflector::reflect_dom_object;
+use script_bindings::reflector::reflect_dom_object_with_cx;
 use storage_traits::indexeddb::IndexedDBKeyRange;
 
 use crate::dom::bindings::codegen::Bindings::IDBCursorBinding::IDBCursorDirection;
@@ -13,7 +14,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::indexeddb::idbcursor::{IDBCursor, ObjectStoreOrIndex};
 use crate::dom::indexeddb::idbtransaction::IDBTransaction;
-use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 
 #[dom_struct]
 pub(crate) struct IDBCursorWithValue {
@@ -45,6 +45,7 @@ impl IDBCursorWithValue {
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         transaction: &IDBTransaction,
         direction: IDBCursorDirection,
@@ -52,9 +53,8 @@ impl IDBCursorWithValue {
         source: ObjectStoreOrIndex,
         range: IndexedDBKeyRange,
         key_only: bool,
-        can_gc: CanGc,
     ) -> DomRoot<IDBCursorWithValue> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(IDBCursorWithValue::new_inherited(
                 transaction,
                 direction,
@@ -64,14 +64,14 @@ impl IDBCursorWithValue {
                 key_only,
             )),
             global,
-            can_gc,
+            cx,
         )
     }
 }
 
 impl IDBCursorWithValueMethods<crate::DomTypeHolder> for IDBCursorWithValue {
     /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbcursorwithvalue-value>
-    fn Value(&self, _cx: SafeJSContext, value: MutableHandleValue) {
+    fn Value(&self, _cx: &mut JSContext, value: MutableHandleValue) {
         self.cursor.value(value);
     }
 }

--- a/components/script/dom/indexeddb/idbdatabase.rs
+++ b/components/script/dom/indexeddb/idbdatabase.rs
@@ -8,7 +8,7 @@ use dom_struct::dom_struct;
 use js::context::JSContext;
 use profile_traits::generic_channel::channel;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object;
+use script_bindings::reflector::reflect_dom_object_with_cx;
 use servo_base::generic_channel::{GenericSend, GenericSender};
 use storage_traits::indexeddb::{IndexedDBThreadMsg, KeyPath, SyncOperation};
 use stylo_atoms::Atom;
@@ -31,7 +31,6 @@ use crate::dom::indexeddb::idbobjectstore::{IDBObjectStore, IDBObjectStoreAbortS
 use crate::dom::indexeddb::idbtransaction::IDBTransaction;
 use crate::dom::indexeddb::idbversionchangeevent::IDBVersionChangeEvent;
 use crate::indexeddb::is_valid_key_path;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct IDBDatabase {
@@ -75,14 +74,14 @@ impl IDBDatabase {
     }
 
     pub fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         name: DOMString,
         id: Uuid,
         version: u64,
         object_store_names: Vec<String>,
-        can_gc: CanGc,
     ) -> DomRoot<IDBDatabase> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(IDBDatabase::new_inherited(
                 name,
                 id,
@@ -90,7 +89,7 @@ impl IDBDatabase {
                 object_store_names,
             )),
             global,
-            can_gc,
+            cx,
         )
     }
 
@@ -102,12 +101,8 @@ impl IDBDatabase {
         self.name.clone()
     }
 
-    pub fn object_stores(&self) -> DomRoot<DOMStringList> {
-        DOMStringList::new(
-            &self.global(),
-            self.object_store_names.borrow().clone(),
-            CanGc::deprecated_note(),
-        )
+    pub fn object_stores(&self, cx: &mut JSContext) -> DomRoot<DOMStringList> {
+        DOMStringList::new(cx, &self.global(), self.object_store_names.borrow().clone())
     }
 
     pub(crate) fn object_store_names_snapshot(&self) -> Vec<DOMString> {
@@ -188,6 +183,7 @@ impl IDBDatabaseMethods<crate::DomTypeHolder> for IDBDatabase {
     /// <https://w3c.github.io/IndexedDB/#dom-idbdatabase-transaction>
     fn Transaction(
         &self,
+        cx: &mut JSContext,
         store_names: StringOrStringSequence,
         mode: IDBTransactionMode,
         options: &IDBTransactionOptions,
@@ -235,15 +231,8 @@ impl IDBDatabaseMethods<crate::DomTypeHolder> for IDBDatabase {
         // connection, mode, options’ durability member, and the set of object
         // stores named in scope.
         let durability = options.durability;
-        let scope = DOMStringList::new(&self.global(), scope, CanGc::deprecated_note());
-        let transaction = IDBTransaction::new(
-            &self.global(),
-            self,
-            mode,
-            durability,
-            &scope,
-            CanGc::deprecated_note(),
-        );
+        let scope = DOMStringList::new(cx, &self.global(), scope);
+        let transaction = IDBTransaction::new(cx, &self.global(), self, mode, durability, &scope);
 
         // Step 8. Set transaction’s cleanup event loop to the current event loop.
         transaction.set_cleanup_event_loop();
@@ -254,7 +243,7 @@ impl IDBDatabaseMethods<crate::DomTypeHolder> for IDBDatabase {
         // https://w3c.github.io/IndexedDB/#transaction-concept
         // A transaction optionally has a cleanup event loop which is an event loop.
         self.global()
-            .get_indexeddb()
+            .get_indexeddb(cx)
             .register_indexeddb_transaction(&transaction);
 
         // Step 9. Return an IDBTransaction object representing transaction.
@@ -323,6 +312,7 @@ impl IDBDatabaseMethods<crate::DomTypeHolder> for IDBDatabase {
         // created object store uses a key generator. If keyPath is not null,
         // set the created object store’s key path to keyPath.
         let object_store = IDBObjectStore::new(
+            cx,
             &self.global(),
             self.name.clone(),
             name.clone(),
@@ -332,7 +322,6 @@ impl IDBDatabaseMethods<crate::DomTypeHolder> for IDBDatabase {
                 rollback_indexes_on_abort: vec![],
                 key_generator_current_number: if auto_increment { Some(1_i64) } else { None },
             },
-            CanGc::from_cx(cx),
             &transaction,
         );
 
@@ -436,8 +425,8 @@ impl IDBDatabaseMethods<crate::DomTypeHolder> for IDBDatabase {
     }
 
     /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbdatabase-objectstorenames>
-    fn ObjectStoreNames(&self, can_gc: CanGc) -> DomRoot<DOMStringList> {
-        DOMStringList::new_sorted(&self.global(), &*self.object_store_names.borrow(), can_gc)
+    fn ObjectStoreNames(&self, cx: &mut JSContext) -> DomRoot<DOMStringList> {
+        DOMStringList::new_sorted(cx, &self.global(), &*self.object_store_names.borrow())
     }
 
     /// <https://w3c.github.io/IndexedDB/#dom-idbdatabase-close>

--- a/components/script/dom/indexeddb/idbfactory.rs
+++ b/components/script/dom/indexeddb/idbfactory.rs
@@ -11,7 +11,7 @@ use js::rust::HandleValue;
 use profile_traits::generic_callback::GenericCallback;
 use script_bindings::cell::DomRefCell;
 use script_bindings::inheritance::Castable;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use servo_base::generic_channel::GenericSend;
 use servo_url::origin::ImmutableOrigin;
 use storage_traits::client_storage::{StorageIdentifier, StorageProxyMap, StorageType};
@@ -36,7 +36,6 @@ use crate::dom::indexeddb::idbopendbrequest::IDBOpenDBRequest;
 use crate::dom::promise::Promise;
 use crate::dom::types::IDBTransaction;
 use crate::indexeddb::{convert_value_to_key, map_backend_error_to_dom_error};
-use crate::script_runtime::CanGc;
 
 /// A non-jstraceable string wrapper for use in `HashMapTracedValues`.
 #[derive(Clone, Debug, Eq, Hash, MallocSizeOf, PartialEq)]
@@ -92,7 +91,7 @@ impl IDBFactory {
         txn.clear_registered_in_global();
     }
 
-    pub(crate) fn cleanup_indexeddb_transactions(&self) -> bool {
+    pub(crate) fn cleanup_indexeddb_transactions(&self, cx: &mut JSContext) -> bool {
         // We implement the HTML-triggered deactivation effect by tracking script-created
         // transactions on the global and deactivating them at the microtask checkpoint.
         let snapshot: Vec<DomRoot<IDBTransaction>> = {
@@ -138,7 +137,7 @@ impl IDBFactory {
                 txn.set_active_flag(false);
                 txn.clear_cleanup_event_loop();
                 if txn.is_usable() {
-                    txn.maybe_commit();
+                    txn.maybe_commit(cx);
                 }
             }
         }
@@ -158,7 +157,7 @@ impl IDBFactory {
         true
     }
 
-    pub(crate) fn maybe_commit_txn(&self, db_name: &str, txn_serial: u64) {
+    pub(crate) fn maybe_commit_txn(&self, cx: &mut JSContext, db_name: &str, txn_serial: u64) {
         let key = DBName(db_name.to_string());
         let snapshot: Vec<DomRoot<IDBTransaction>> = {
             let map = self.indexeddb_transactions.borrow();
@@ -170,7 +169,7 @@ impl IDBFactory {
 
         for txn in snapshot {
             if txn.get_serial_number() == txn_serial {
-                txn.maybe_commit();
+                txn.maybe_commit(cx);
                 break;
             }
         }
@@ -198,8 +197,8 @@ impl IDBFactory {
         );
     }
 
-    pub fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<IDBFactory> {
-        reflect_dom_object(Box::new(IDBFactory::new_inherited()), global, can_gc)
+    pub fn new(cx: &mut JSContext, global: &GlobalScope) -> DomRoot<IDBFactory> {
+        reflect_dom_object_with_cx(Box::new(IDBFactory::new_inherited()), global, cx)
     }
 
     /// Setup the callback to the backend service, if this hasn't been done already.
@@ -385,9 +384,9 @@ impl IDBFactory {
                 self.global()
                     .task_manager()
                     .dom_manipulation_task_source()
-                    .queue(task!(indexeddb_maybe_commit_txn: move || {
+                    .queue(task!(indexeddb_maybe_commit_txn: move |cx| {
                         let factory = factory.root();
-                        factory.maybe_commit_txn(&db_name, txn);
+                        factory.maybe_commit_txn(cx, &db_name, txn);
                     }));
             },
         }
@@ -425,7 +424,7 @@ impl IDBFactory {
         request.set_result(HandleValue::undefined());
 
         // Step 5.3.1.2: Set request’s error to result.
-        request.set_error(Some(dom_exception), CanGc::from_cx(cx));
+        request.set_error(cx, Some(dom_exception));
         // Open requests expose a transaction only while `upgradeneeded` is being dispatched;
         // otherwise `IDBOpenDBRequest.transaction` must be null.
         // https://w3c.github.io/IndexedDB/#dom-idbrequest-transaction
@@ -550,7 +549,12 @@ impl IDBFactory {
 
 impl IDBFactoryMethods<crate::DomTypeHolder> for IDBFactory {
     /// <https://w3c.github.io/IndexedDB/#dom-idbfactory-open>
-    fn Open(&self, name: DOMString, version: Option<u64>) -> Fallible<DomRoot<IDBOpenDBRequest>> {
+    fn Open(
+        &self,
+        cx: &mut JSContext,
+        name: DOMString,
+        version: Option<u64>,
+    ) -> Fallible<DomRoot<IDBOpenDBRequest>> {
         // Step 1: If version is 0 (zero), throw a TypeError.
         if version == Some(0) {
             return Err(Error::Type(
@@ -573,7 +577,7 @@ impl IDBFactoryMethods<crate::DomTypeHolder> for IDBFactory {
             self.obtain_a_local_storage_bottle_map(&global, global.origin().immutable().clone())?;
 
         // Step 4: Let request be a new open request.
-        let request = IDBOpenDBRequest::new(&self.global(), CanGc::deprecated_note());
+        let request = IDBOpenDBRequest::new(cx, &self.global());
 
         // Step 5: Runs in parallel
         if self
@@ -588,7 +592,11 @@ impl IDBFactoryMethods<crate::DomTypeHolder> for IDBFactory {
     }
 
     /// <https://www.w3.org/TR/IndexedDB/#dom-idbfactory-deletedatabase>
-    fn DeleteDatabase(&self, name: DOMString) -> Fallible<DomRoot<IDBOpenDBRequest>> {
+    fn DeleteDatabase(
+        &self,
+        cx: &mut JSContext,
+        name: DOMString,
+    ) -> Fallible<DomRoot<IDBOpenDBRequest>> {
         // Step 1: Let environment be this’s relevant settings object.
         let global = self.global();
 
@@ -604,7 +612,7 @@ impl IDBFactoryMethods<crate::DomTypeHolder> for IDBFactory {
             self.obtain_a_local_storage_bottle_map(&global, global.origin().immutable().clone())?;
 
         // Step 3: Let request be a new open request
-        let request = IDBOpenDBRequest::new(&self.global(), CanGc::deprecated_note());
+        let request = IDBOpenDBRequest::new(cx, &self.global());
 
         // Step 4: Runs in parallel
         if request

--- a/components/script/dom/indexeddb/idbindex.rs
+++ b/components/script/dom/indexeddb/idbindex.rs
@@ -2,18 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::gc::MutableHandleValue;
 use script_bindings::codegen::GenericBindings::IDBIndexBinding::IDBIndexMethods;
 use script_bindings::conversions::SafeToJSValConvertible;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::script_runtime::CanGc;
 use script_bindings::str::DOMString;
 
-use crate::dom::bindings::import::base::SafeJSContext;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::idbobjectstore::KeyPath;
 use crate::dom::indexeddb::idbobjectstore::IDBObjectStore;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct IDBIndex {
@@ -44,15 +44,15 @@ impl IDBIndex {
     }
 
     pub fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         object_store: DomRoot<IDBObjectStore>,
         name: DOMString,
         multi_entry: bool,
         unique: bool,
         key_path: KeyPath,
-        can_gc: CanGc,
     ) -> DomRoot<IDBIndex> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(IDBIndex::new_inherited(
                 object_store,
                 name,
@@ -61,7 +61,7 @@ impl IDBIndex {
                 key_path,
             )),
             global,
-            can_gc,
+            cx,
         )
     }
 }
@@ -83,13 +83,13 @@ impl IDBIndexMethods<crate::DomTypeHolder> for IDBIndex {
     }
 
     /// <https://www.w3.org/TR/IndexedDB/#dom-idbindex-keypath>
-    fn KeyPath(&self, cx: SafeJSContext, can_gc: CanGc, retval: MutableHandleValue) {
+    fn KeyPath(&self, cx: &mut JSContext, retval: MutableHandleValue) {
         match &self.key_path {
             KeyPath::String(string) => {
-                string.safe_to_jsval(cx, retval, can_gc);
+                string.safe_to_jsval(cx.into(), retval, CanGc::from_cx(cx));
             },
             KeyPath::StringSequence(sequence) => {
-                sequence.safe_to_jsval(cx, retval, can_gc);
+                sequence.safe_to_jsval(cx.into(), retval, CanGc::from_cx(cx));
             },
         }
     }

--- a/components/script/dom/indexeddb/idbkeyrange.rs
+++ b/components/script/dom/indexeddb/idbkeyrange.rs
@@ -7,9 +7,8 @@ use js::context::JSContext;
 use js::gc::MutableHandleValue;
 use js::rust::HandleValue;
 use script_bindings::codegen::GenericBindings::IDBKeyRangeBinding::IDBKeyRangeMethods;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use script_bindings::root::DomRoot;
-use script_bindings::script_runtime::CanGc;
 use storage_traits::indexeddb::IndexedDBKeyRange;
 
 use crate::dom::bindings::error::{Error, Fallible};
@@ -31,8 +30,12 @@ impl IDBKeyRange {
         }
     }
 
-    pub fn new(global: &GlobalScope, inner: IndexedDBKeyRange, can_gc: CanGc) -> DomRoot<Self> {
-        reflect_dom_object(Box::new(IDBKeyRange::new_inherited(inner)), global, can_gc)
+    pub fn new(
+        cx: &mut JSContext,
+        global: &GlobalScope,
+        inner: IndexedDBKeyRange,
+    ) -> DomRoot<Self> {
+        reflect_dom_object_with_cx(Box::new(IDBKeyRange::new_inherited(inner)), global, cx)
     }
 
     pub fn inner(&self) -> &IndexedDBKeyRange {
@@ -79,7 +82,7 @@ impl IDBKeyRangeMethods<crate::DomTypeHolder> for IDBKeyRange {
 
         // Step 3. Create and return a new key range containing only key.
         let inner = IndexedDBKeyRange::only(key);
-        Ok(IDBKeyRange::new(global, inner, CanGc::from_cx(cx)))
+        Ok(IDBKeyRange::new(cx, global, inner))
     }
 
     /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbkeyrange-lowerbound>
@@ -97,7 +100,7 @@ impl IDBKeyRangeMethods<crate::DomTypeHolder> for IDBKeyRange {
         // Step 3. Create and return a new key range with lower bound set to lowerKey, lower open
         // flag set to open, upper bound set to null, and upper open flag set to true.
         let inner = IndexedDBKeyRange::lower_bound(lower_key, open);
-        Ok(IDBKeyRange::new(global, inner, CanGc::from_cx(cx)))
+        Ok(IDBKeyRange::new(cx, global, inner))
     }
 
     /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbkeyrange-upperbound>
@@ -116,7 +119,7 @@ impl IDBKeyRangeMethods<crate::DomTypeHolder> for IDBKeyRange {
         // Step 3. Create and return a new key range with lower bound set to null, lower open flag
         // set to true, upper bound set to upperKey, and upper open flag set to open.
         let inner = IndexedDBKeyRange::upper_bound(upper_key, open);
-        Ok(IDBKeyRange::new(global, inner, CanGc::from_cx(cx)))
+        Ok(IDBKeyRange::new(cx, global, inner))
     }
 
     /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbkeyrange-bound>
@@ -149,7 +152,7 @@ impl IDBKeyRangeMethods<crate::DomTypeHolder> for IDBKeyRange {
         // flag set to lowerOpen, upper bound set to upperKey and upper open flag set to upperOpen.
         let inner =
             IndexedDBKeyRange::new(Some(lower_key), Some(upper_key), lower_open, upper_open);
-        Ok(IDBKeyRange::new(global, inner, CanGc::from_cx(cx)))
+        Ok(IDBKeyRange::new(cx, global, inner))
     }
 
     /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbkeyrange-_includes>

--- a/components/script/dom/indexeddb/idbobjectstore.rs
+++ b/components/script/dom/indexeddb/idbobjectstore.rs
@@ -14,7 +14,7 @@ use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::IDBObjectStoreBinding::IDBIndexParameters;
 use script_bindings::codegen::GenericUnionTypes::StringOrStringSequence;
 use script_bindings::error::ErrorResult;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use servo_base::generic_channel::{GenericSend, GenericSender};
 use storage_traits::indexeddb::{
     self, AsyncOperation, AsyncReadOnlyOperation, AsyncReadWriteOperation, IndexedDBKeyType,
@@ -46,7 +46,6 @@ use crate::indexeddb::{
     ExtractionResult, can_inject_key_into_value, convert_value_to_key, convert_value_to_key_range,
     extract_key, inject_key_into_value, is_valid_key_path,
 };
-use crate::script_runtime::CanGc;
 
 #[derive(Clone, JSTraceable, MallocSizeOf)]
 pub enum KeyPath {
@@ -164,15 +163,15 @@ impl IDBObjectStore {
     }
 
     pub fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         db_name: DOMString,
         name: DOMString,
         options: Option<&IDBObjectStoreParameters>,
         abort_state: IDBObjectStoreAbortState,
-        can_gc: CanGc,
         transaction: &IDBTransaction,
     ) -> DomRoot<IDBObjectStore> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(IDBObjectStore::new_inherited(
                 db_name,
                 name,
@@ -181,7 +180,7 @@ impl IDBObjectStore {
                 transaction,
             )),
             global,
-            can_gc,
+            cx,
         )
     }
 
@@ -190,7 +189,7 @@ impl IDBObjectStore {
     }
 
     /// <https://w3c.github.io/IndexedDB/#abort-an-upgrade-transaction>
-    pub(crate) fn restore_metadata_after_abort(&self, can_gc: CanGc) {
+    pub(crate) fn restore_metadata_after_abort(&self, cx: &mut JSContext) {
         let Some(abort_state) = self.abort_state_on_abort.borrow().as_ref().cloned() else {
             return;
         };
@@ -208,13 +207,13 @@ impl IDBObjectStore {
         self.index_set.borrow_mut().clear();
         for index in abort_state.rollback_indexes {
             self.add_index(
+                cx,
                 index.name.clone().into(),
                 &IDBIndexParameters {
                     multiEntry: index.multi_entry,
                     unique: index.unique,
                 },
                 index.key_path.clone().into(),
-                can_gc,
             );
         }
 
@@ -470,6 +469,7 @@ impl IDBObjectStore {
         // Step 12. Let operation be an algorithm to run store a record into an object store with
         // store, clone, key, and no-overwrite flag.
         let request = IDBRequest::execute_async(
+            cx,
             self,
             |callback| {
                 AsyncOperation::ReadWrite(AsyncReadWriteOperation::PutItem {
@@ -482,7 +482,6 @@ impl IDBObjectStore {
             },
             None,
             None,
-            CanGc::from_cx(cx),
         )?;
         // Keep the in-memory key generator in sync with the queued put request.
         if let Some(next_key_generator_current_number) = key_generator_current_number_for_put {
@@ -527,6 +526,7 @@ impl IDBObjectStore {
         // interface as well.
         let cursor = if key_only {
             IDBCursor::new(
+                cx,
                 &self.global(),
                 &self.transaction,
                 direction,
@@ -534,10 +534,10 @@ impl IDBObjectStore {
                 ObjectStoreOrIndex::ObjectStore(Dom::from_ref(self)),
                 range.clone(),
                 key_only,
-                CanGc::from_cx(cx),
             )
         } else {
             DomRoot::upcast(IDBCursorWithValue::new(
+                cx,
                 &self.global(),
                 &self.transaction,
                 direction,
@@ -545,7 +545,6 @@ impl IDBObjectStore {
                 ObjectStoreOrIndex::ObjectStore(Dom::from_ref(self)),
                 range.clone(),
                 key_only,
-                CanGc::from_cx(cx),
             ))
         };
 
@@ -561,6 +560,7 @@ impl IDBObjectStore {
         };
 
         IDBRequest::execute_async(
+            cx,
             self,
             |callback| {
                 AsyncOperation::ReadOnly(AsyncReadOnlyOperation::Iterate {
@@ -570,26 +570,25 @@ impl IDBObjectStore {
             },
             None,
             Some(iteration_param),
-            CanGc::from_cx(cx),
         )
         .inspect(|request| cursor.set_request(request))
     }
 
     pub(crate) fn add_index(
         &self,
+        cx: &mut JSContext,
         name: DOMString,
         options: &IDBIndexParameters,
         key_path: KeyPath,
-        can_gc: CanGc,
     ) -> DomRoot<IDBIndex> {
         let index = IDBIndex::new(
+            cx,
             &self.global(),
             DomRoot::from_ref(self),
             name.clone(),
             options.multiEntry,
             options.unique,
             key_path,
-            can_gc,
         );
         self.index_set
             .borrow_mut()
@@ -640,6 +639,7 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
         // Step 8. Return the result (an IDBRequest) of running asynchronously execute a request with this and operation.
         serialized_query.and_then(|key_range| {
             IDBRequest::execute_async(
+                cx,
                 self,
                 |callback| {
                     AsyncOperation::ReadWrite(AsyncReadWriteOperation::RemoveItem {
@@ -649,7 +649,6 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
                 },
                 None,
                 None,
-                CanGc::from_cx(cx),
             )
         })
     }
@@ -668,11 +667,11 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
         // Step 6. Let operation be an algorithm to run clear an object store with store.
         // Step 7. Return the result (an IDBRequest) of running asynchronously execute a request with this and operation.
         IDBRequest::execute_async(
+            cx,
             self,
             |callback| AsyncOperation::ReadWrite(AsyncReadWriteOperation::Clear(callback)),
             None,
             None,
-            CanGc::from_cx(cx),
         )
     }
 
@@ -693,6 +692,7 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
         // Step 7. Return the result (an IDBRequest) of running asynchronously execute a request with this and operation.
         serialized_query.and_then(|q| {
             IDBRequest::execute_async(
+                cx,
                 self,
                 |callback| {
                     AsyncOperation::ReadOnly(AsyncReadOnlyOperation::GetItem {
@@ -702,7 +702,6 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
                 },
                 None,
                 None,
-                CanGc::from_cx(cx),
             )
         })
     }
@@ -725,6 +724,7 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
         // store as operation, using store and range.
         serialized_query.and_then(|q| {
             IDBRequest::execute_async(
+                cx,
                 self,
                 |callback| {
                     AsyncOperation::ReadOnly(AsyncReadOnlyOperation::GetKey {
@@ -734,7 +734,6 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
                 },
                 None,
                 None,
-                CanGc::from_cx(cx),
             )
         })
     }
@@ -762,6 +761,7 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
         // store as operation, using store and range.
         serialized_query.and_then(|q| {
             IDBRequest::execute_async(
+                cx,
                 self,
                 |callback| {
                     AsyncOperation::ReadOnly(AsyncReadOnlyOperation::GetAllItems {
@@ -772,7 +772,6 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
                 },
                 None,
                 None,
-                CanGc::from_cx(cx),
             )
         })
     }
@@ -800,6 +799,7 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
         // store as operation, using store and range.
         serialized_query.and_then(|q| {
             IDBRequest::execute_async(
+                cx,
                 self,
                 |callback| {
                     AsyncOperation::ReadOnly(AsyncReadOnlyOperation::GetAllKeys {
@@ -810,7 +810,6 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
                 },
                 None,
                 None,
-                CanGc::from_cx(cx),
             )
         })
     }
@@ -832,6 +831,7 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
         // Step 7. Return the result (an IDBRequest) of running asynchronously execute a request with this and operation.
         serialized_query.and_then(|q| {
             IDBRequest::execute_async(
+                cx,
                 self,
                 |callback| {
                     AsyncOperation::ReadOnly(AsyncReadOnlyOperation::Count {
@@ -841,7 +841,6 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
                 },
                 None,
                 None,
-                CanGc::from_cx(cx),
             )
         })
     }
@@ -928,8 +927,8 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
     }
 
     /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbobjectstore-indexnames>
-    fn IndexNames(&self, can_gc: CanGc) -> DomRoot<DOMStringList> {
-        DOMStringList::new_sorted(&self.global(), self.index_set.borrow().keys(), can_gc)
+    fn IndexNames(&self, cx: &mut JSContext) -> DomRoot<DOMStringList> {
+        DOMStringList::new_sorted(cx, &self.global(), self.index_set.borrow().keys())
     }
 
     /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbobjectstore-transaction>
@@ -1003,7 +1002,7 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
         }
 
         // Step 12. Add index to this object store handle's index set.
-        let index = self.add_index(name, options, key_path, CanGc::from_cx(cx));
+        let index = self.add_index(cx, name, options, key_path);
 
         // Step 13. Return a new index handle associated with index and this object store handle.
         Ok(index)

--- a/components/script/dom/indexeddb/idbopendbrequest.rs
+++ b/components/script/dom/indexeddb/idbopendbrequest.rs
@@ -8,7 +8,7 @@ use js::jsval::UndefinedValue;
 use js::rust::HandleValue;
 use profile_traits::generic_callback::GenericCallback;
 use script_bindings::conversions::SafeToJSValConvertible;
-use script_bindings::reflector::reflect_dom_object;
+use script_bindings::reflector::reflect_dom_object_with_cx;
 use servo_base::generic_channel::GenericSend;
 use servo_url::origin::ImmutableOrigin;
 use storage_traits::client_storage::StorageProxyMap;
@@ -87,7 +87,7 @@ impl OpenRequestListener {
                 // and fire an event named error at request
                 // with its bubbles and cancelable attributes initialized to true.
                 let error = map_backend_error_to_dom_error(err);
-                open_request.set_error(Some(error), CanGc::from_cx(cx));
+                open_request.set_error(cx, Some(error));
                 let event = Event::new(
                     cx,
                     &global,
@@ -120,8 +120,8 @@ impl IDBOpenDBRequest {
         }
     }
 
-    pub fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<IDBOpenDBRequest> {
-        reflect_dom_object(Box::new(IDBOpenDBRequest::new_inherited()), global, can_gc)
+    pub fn new(cx: &mut JSContext, global: &GlobalScope) -> DomRoot<IDBOpenDBRequest> {
+        reflect_dom_object_with_cx(Box::new(IDBOpenDBRequest::new_inherited()), global, cx)
     }
 
     pub(crate) fn get_id(&self) -> Uuid {
@@ -146,12 +146,12 @@ impl IDBOpenDBRequest {
         self.pending_connection.or_init(|| {
             debug_assert!(!upgraded, "A connection should exist for the upgraded db.");
             IDBDatabase::new(
+                cx,
                 global,
                 name.into(),
                 self.get_id(),
                 version,
                 object_store_names,
-                CanGc::from_cx(cx),
             )
         })
     }
@@ -169,14 +169,16 @@ impl IDBOpenDBRequest {
     ) {
         let global = self.global();
 
+        let scope = connection.object_stores(cx);
+
         let transaction = IDBTransaction::new_with_serial(
+            cx,
             &global,
             connection,
             IDBTransactionMode::Versionchange,
             IDBTransactionDurability::Default,
-            &connection.object_stores(),
+            &scope,
             transaction,
-            CanGc::from_cx(cx),
         );
         transaction.set_versionchange_old_version(old_version);
         connection.set_transaction(&transaction);
@@ -217,11 +219,11 @@ impl IDBOpenDBRequest {
             // Step 10.6.2: If didThrow is true, run abort a transaction with
             // transaction and a newly created "AbortError" DOMException.
             if did_throw {
-                transaction.initiate_abort(Error::Abort(None), CanGc::from_cx(cx));
+                transaction.initiate_abort(cx, Error::Abort(None));
                 transaction.request_backend_abort();
             } else {
                 // The upgrade transaction auto-commits once inactive and quiescent.
-                transaction.maybe_commit();
+                transaction.maybe_commit(cx);
             }
         }
     }
@@ -270,8 +272,8 @@ impl IDBOpenDBRequest {
         self.idbrequest.set_ready_state_done();
     }
 
-    pub fn set_error(&self, error: Option<Error>, can_gc: CanGc) {
-        self.idbrequest.set_error(error, can_gc);
+    pub fn set_error(&self, cx: &mut JSContext, error: Option<Error>) {
+        self.idbrequest.set_error(cx, error);
     }
 
     pub fn clear_transaction(&self) {

--- a/components/script/dom/indexeddb/idbrequest.rs
+++ b/components/script/dom/indexeddb/idbrequest.rs
@@ -11,7 +11,7 @@ use js::jsapi::Heap;
 use js::jsval::{DoubleValue, JSVal, ObjectValue, UndefinedValue};
 use js::rust::HandleValue;
 use profile_traits::generic_callback::GenericCallback;
-use script_bindings::reflector::{DomObject, reflect_dom_object};
+use script_bindings::reflector::{DomObject, reflect_dom_object_with_cx};
 use serde::{Deserialize, Serialize};
 use servo_base::generic_channel::GenericSend;
 use storage_traits::indexeddb::{
@@ -40,7 +40,6 @@ use crate::dom::indexeddb::idbobjectstore::IDBObjectStore;
 use crate::dom::indexeddb::idbtransaction::IDBTransaction;
 use crate::indexeddb::key_type_to_jsval;
 use crate::realms::enter_auto_realm;
-use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 
 #[derive(Clone)]
 struct RequestListener {
@@ -124,7 +123,7 @@ impl From<u64> for IdbResult {
 }
 
 impl RequestListener {
-    fn send_request_handled(transaction: &IDBTransaction, request_id: u64) {
+    fn send_request_handled(cx: &mut JSContext, transaction: &IDBTransaction, request_id: u64) {
         let global = transaction.global();
         // https://w3c.github.io/IndexedDB/#transaction-lifecycle
         // A transaction is inactive after control returns to the event loop and
@@ -145,7 +144,7 @@ impl RequestListener {
 
         // This request's result has been handled by script, the
         // transaction might finally be ready to auto-commit.
-        transaction.maybe_commit();
+        transaction.maybe_commit(cx);
     }
 
     // https://www.w3.org/TR/IndexedDB-3/#async-execute-request
@@ -259,7 +258,7 @@ impl RequestListener {
             request.set_result(answer.handle());
 
             // Substep 3.2: Set the error of request to undefined
-            request.set_error(None, CanGc::from_cx(cx));
+            request.set_error(cx, None);
 
             // https://w3c.github.io/IndexedDB/#fire-success-event
             // Step 1: Let event be the result of creating an event using Event.
@@ -294,13 +293,13 @@ impl RequestListener {
                 // Step 8.2: If legacyOutputDidListenersThrowFlag is true, then run abort a
                 // transaction with transaction and a newly created "AbortError" DOMException.
                 if did_listeners_throw.get() {
-                    transaction.initiate_abort(Error::Abort(None), CanGc::from_cx(cx));
+                    transaction.initiate_abort(cx, Error::Abort(None));
                     transaction.request_backend_abort();
                 }
             }
             transaction.request_finished();
 
-            Self::send_request_handled(&transaction, self.request_id);
+            Self::send_request_handled(cx, &transaction, self.request_id);
         } else {
             // FIXME:(arihant2math) dispatch correct error
             // Substep 2
@@ -332,7 +331,7 @@ impl RequestListener {
         request.set_result(undefined.handle());
 
         // Substep 2: Set the error of request to result.
-        request.set_error(Some(error.clone()), CanGc::from_cx(cx));
+        request.set_error(cx, Some(error.clone()));
 
         // https://w3c.github.io/IndexedDB/#fire-error-event
         // Step 1: Let event be the result of creating an event using Event.
@@ -349,7 +348,7 @@ impl RequestListener {
         // If result is an error and transaction’s state is committing, then run abort a
         // transaction with transaction and result, and terminate these steps.
         if transaction.is_committing() {
-            transaction.initiate_abort(error.clone(), CanGc::from_cx(cx));
+            transaction.initiate_abort(cx, error.clone());
             transaction.request_backend_abort();
         }
         // Step 5: Let legacyOutputDidListenersThrowFlag be initially false.
@@ -377,17 +376,17 @@ impl RequestListener {
             // exception, transaction’s error property is set to an AbortError rather than request’s
             // error, even if preventDefault() is never called.
             if did_listeners_throw.get() {
-                transaction.initiate_abort(Error::Abort(None), CanGc::from_cx(cx));
+                transaction.initiate_abort(cx, Error::Abort(None));
                 transaction.request_backend_abort();
             } else if default_not_prevented {
                 // Step 8.3: If event’s canceled flag is false, then run abort a transaction
                 // using transaction and request’s error, and terminate these steps.
-                transaction.initiate_abort(error, CanGc::from_cx(cx));
+                transaction.initiate_abort(cx, error);
                 transaction.request_backend_abort();
             }
         }
         transaction.request_finished();
-        Self::send_request_handled(&transaction, request_id);
+        Self::send_request_handled(cx, &transaction, request_id);
     }
 }
 
@@ -415,8 +414,8 @@ impl IDBRequest {
         }
     }
 
-    pub fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<IDBRequest> {
-        reflect_dom_object(Box::new(IDBRequest::new_inherited()), global, can_gc)
+    pub fn new(cx: &mut JSContext, global: &GlobalScope) -> DomRoot<IDBRequest> {
+        reflect_dom_object_with_cx(Box::new(IDBRequest::new_inherited()), global, cx)
     }
 
     pub fn set_source(&self, source: Option<&IDBObjectStore>) {
@@ -431,9 +430,9 @@ impl IDBRequest {
         self.result.set(result.get());
     }
 
-    pub fn set_error(&self, error: Option<Error>, can_gc: CanGc) {
+    pub fn set_error(&self, cx: &mut JSContext, error: Option<Error>) {
         if let Some(error) = error {
-            if let Ok(exception) = create_dom_exception(&self.global(), error, can_gc) {
+            if let Ok(exception) = create_dom_exception(cx, &self.global(), error) {
                 self.error.set(Some(&exception));
             }
         } else {
@@ -459,11 +458,11 @@ impl IDBRequest {
 
     // https://www.w3.org/TR/IndexedDB-3/#asynchronously-execute-a-request
     pub fn execute_async<T, F>(
+        cx: &mut JSContext,
         source: &IDBObjectStore,
         operation_fn: F,
         request: Option<DomRoot<IDBRequest>>,
         iteration_param: Option<IterationParam>,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<IDBRequest>>
     where
         T: Into<IdbResult> + for<'a> Deserialize<'a> + Serialize + Send + Sync + 'static,
@@ -481,7 +480,7 @@ impl IDBRequest {
 
         // Step 3: If request was not given, let request be a new request with source as source.
         let request = request.unwrap_or_else(|| {
-            let new_request = IDBRequest::new(&global, can_gc);
+            let new_request = IDBRequest::new(cx, &global);
             new_request.set_source(Some(source));
             new_request.set_transaction(&transaction);
             new_request
@@ -566,7 +565,7 @@ impl IDBRequestMethods<crate::DomTypeHolder> for IDBRequest {
     /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbrequest-result>
     fn GetResult(
         &self,
-        _cx: SafeJSContext,
+        _cx: &mut JSContext,
         mut val: js::rust::MutableHandle<'_, js::jsapi::Value>,
     ) -> Fallible<()> {
         // Step 1. If this's done flag is false, then throw an "InvalidStateError" DOMException.

--- a/components/script/dom/indexeddb/idbtransaction.rs
+++ b/components/script/dom/indexeddb/idbtransaction.rs
@@ -6,11 +6,12 @@ use std::cell::Cell;
 use std::collections::{HashMap, HashSet};
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use profile_traits::generic_callback::GenericCallback;
 use profile_traits::generic_channel::channel;
 use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericUnionTypes::StringOrStringSequence;
-use script_bindings::reflector::reflect_dom_object;
+use script_bindings::reflector::reflect_dom_object_with_cx;
 use servo_base::generic_channel::{GenericSend, GenericSender};
 use servo_base::id::ScriptEventLoopId;
 use storage_traits::indexeddb::{
@@ -40,7 +41,6 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::indexeddb::idbdatabase::IDBDatabase;
 use crate::dom::indexeddb::idbobjectstore::{IDBObjectStore, IDBObjectStoreAbortState};
 use crate::dom::indexeddb::idbrequest::IDBRequest;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct IDBTransaction {
@@ -127,36 +127,36 @@ impl IDBTransaction {
 
     /// Does a blocking call to create a backend transaction and get its id.
     pub fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         connection: &IDBDatabase,
         mode: IDBTransactionMode,
         durability: IDBTransactionDurability,
         scope: &DOMStringList,
-        can_gc: CanGc,
     ) -> DomRoot<IDBTransaction> {
         let serial_number =
             IDBTransaction::create_transaction(global, connection.get_name(), mode, scope);
         IDBTransaction::new_with_serial(
+            cx,
             global,
             connection,
             mode,
             durability,
             scope,
             serial_number,
-            can_gc,
         )
     }
 
     pub(crate) fn new_with_serial(
+        cx: &mut JSContext,
         global: &GlobalScope,
         connection: &IDBDatabase,
         mode: IDBTransactionMode,
         durability: IDBTransactionDurability,
         scope: &DOMStringList,
         serial_number: u64,
-        can_gc: CanGc,
     ) -> DomRoot<IDBTransaction> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(IDBTransaction::new_inherited(
                 connection,
                 mode,
@@ -165,7 +165,7 @@ impl IDBTransaction {
                 serial_number,
             )),
             global,
-            can_gc,
+            cx,
         )
     }
 
@@ -286,7 +286,7 @@ impl IDBTransaction {
     }
 
     /// <https://w3c.github.io/IndexedDB/#abort-an-upgrade-transaction>
-    fn restore_associated_object_store_handles_after_abort(&self, can_gc: CanGc) {
+    fn restore_associated_object_store_handles_after_abort(&self, cx: &mut JSContext) {
         // Step 5. For each object store handle handle associated with transaction,
         // including those for object stores that were created or deleted during
         // transaction:
@@ -297,7 +297,7 @@ impl IDBTransaction {
             .map(|store| DomRoot::from_ref(&**store))
             .collect::<Vec<_>>();
         for store in stores {
-            store.restore_metadata_after_abort(can_gc);
+            store.restore_metadata_after_abort(cx);
         }
     }
 
@@ -319,7 +319,7 @@ impl IDBTransaction {
             move |message: Result<TxnCompleteMsg, ipc_channel::IpcError>| {
                 let this = this.clone();
                 let task_source = task_source.clone();
-                task_source.queue(task!(handle_commit_result: move || {
+                task_source.queue(task!(handle_commit_result: move |cx| {
                     let this = this.root();
                     let message = message.expect("Could not unwrap message");
                     match message.result {
@@ -328,7 +328,7 @@ impl IDBTransaction {
                         }
                         Err(_err) => {
                              // TODO: Map backend commit/rollback failure to an appropriate DOMException
-                            this.initiate_abort(Error::Operation(None), CanGc::deprecated_note());
+                            this.initiate_abort(cx, Error::Operation(None));
 
                             this.finalize_abort();
                         }
@@ -361,7 +361,7 @@ impl IDBTransaction {
         true
     }
 
-    pub(crate) fn maybe_commit(&self) {
+    pub(crate) fn maybe_commit(&self, cx: &mut JSContext) {
         // https://w3c.github.io/IndexedDB/#transaction-lifetime
         // Step 5: transaction when all requests
         //  placed against the transaction have completed and their returned results handled,
@@ -387,7 +387,7 @@ impl IDBTransaction {
             // We failed to initiate the commit algorithm (backend task could not be queued),
             // so the transaction cannot progress to a successful "complete".
             // Choose the most appropriate DOMException mapping for Servo here.
-            self.initiate_abort(Error::InvalidState(None), CanGc::deprecated_note());
+            self.initiate_abort(cx, Error::InvalidState(None));
             self.finalize_abort();
         }
     }
@@ -474,7 +474,7 @@ impl IDBTransaction {
         self.pending_request_count.set(remaining);
     }
 
-    pub(crate) fn initiate_abort(&self, error: Error, can_gc: CanGc) {
+    pub(crate) fn initiate_abort(&self, cx: &mut JSContext, error: Error) {
         // https://w3c.github.io/IndexedDB/#transaction-lifetime
         // Step 4: An abort will also be initiated following a failed request that is not handled by script.
         // A transaction can be aborted at any time before it is finished,
@@ -494,14 +494,14 @@ impl IDBTransaction {
             {
                 self.db.restore_object_store_names(names);
             }
-            self.restore_associated_object_store_handles_after_abort(can_gc);
+            self.restore_associated_object_store_handles_after_abort(cx);
         }
         self.abort_initiated.set(true);
         // https://w3c.github.io/IndexedDB/#transaction-concept
         // A transaction has a error which is set if the transaction is aborted.
         // NOTE: Implementors need to keep in mind that the value "null" is considered an error, as it is set from abort()
         if self.error.get().is_none() &&
-            let Ok(exception) = create_dom_exception(&self.global(), error, can_gc)
+            let Ok(exception) = create_dom_exception(cx, &self.global(), error)
         {
             self.error.set(Some(&exception));
         }
@@ -587,7 +587,7 @@ impl IDBTransaction {
                 event.fire(cx, this.upcast());
                 if this.mode == IDBTransactionMode::Versionchange {
                     this.global()
-                        .get_indexeddb()
+                        .get_indexeddb(cx)
                         .clear_open_request_transaction_for_txn(&this);
                     let origin = this.global().origin().immutable().clone();
                     let db_name = String::from(this.db.get_name());
@@ -608,7 +608,7 @@ impl IDBTransaction {
                 this.version_change_old_object_store_names.borrow_mut().take();
                 this.notify_backend_transaction_finished();
                 if this.registered_in_global.get() {
-                    this.global().get_indexeddb().unregister_indexeddb_transaction(&this);
+                    this.global().get_indexeddb(cx).unregister_indexeddb_transaction(&this);
                 }
             }));
     }
@@ -657,7 +657,7 @@ impl IDBTransaction {
                     //  Step 5.1: If transaction is an upgrade transaction, then let request be the request
                     // associated with transaction and set request’s transaction to null.
                     this.global()
-                        .get_indexeddb()
+                        .get_indexeddb(cx)
                         .clear_open_request_transaction_for_txn(&this);
                     let origin = this.global().origin().immutable().clone();
                     let db_name = String::from(this.db.get_name());
@@ -673,7 +673,7 @@ impl IDBTransaction {
                 }
                 this.notify_backend_transaction_finished();
                 if this.registered_in_global.get() {
-                    this.global().get_indexeddb().unregister_indexeddb_transaction(&this);
+                    this.global().get_indexeddb(cx).unregister_indexeddb_transaction(&this);
                 }
             }),
         );
@@ -730,7 +730,11 @@ impl IDBTransactionMethods<crate::DomTypeHolder> for IDBTransaction {
     }
 
     /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbtransaction-objectstore>
-    fn ObjectStore(&self, name: DOMString, can_gc: CanGc) -> Fallible<DomRoot<IDBObjectStore>> {
+    fn ObjectStore(
+        &self,
+        cx: &mut JSContext,
+        name: DOMString,
+    ) -> Fallible<DomRoot<IDBObjectStore>> {
         // Step 1: If transaction has finished, throw an "InvalidStateError" DOMException.
         if self.finished.get() || self.abort_initiated.get() {
             return Err(Error::InvalidState(None));
@@ -757,6 +761,7 @@ impl IDBTransactionMethods<crate::DomTypeHolder> for IDBTransaction {
 
         let parameters = self.object_store_parameters(&name);
         let store = IDBObjectStore::new(
+            cx,
             &self.global(),
             self.db.get_name(),
             name.clone(),
@@ -775,19 +780,18 @@ impl IDBTransactionMethods<crate::DomTypeHolder> for IDBTransaction {
                     .as_ref()
                     .and_then(|(_, _, key_generator_current_number)| *key_generator_current_number),
             },
-            can_gc,
             self,
         );
         if let Some(indexes) = parameters.map(|(_, indexes, _)| indexes) {
             for index in indexes {
                 store.add_index(
+                    cx,
                     index.name.into(),
                     &IDBIndexParameters {
                         multiEntry: index.multi_entry,
                         unique: index.unique,
                     },
                     index.key_path.into(),
-                    can_gc,
                 );
             }
         }
@@ -811,21 +815,21 @@ impl IDBTransactionMethods<crate::DomTypeHolder> for IDBTransaction {
     }
 
     /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbtransaction-abort>
-    fn Abort(&self) -> Fallible<()> {
+    fn Abort(&self, cx: &mut JSContext) -> Fallible<()> {
         if self.finished.get() || self.committing.get() {
             return Err(Error::InvalidState(None));
         }
         self.active.set(false);
-        self.initiate_abort(Error::Abort(None), CanGc::deprecated_note());
+        self.initiate_abort(cx, Error::Abort(None));
         self.request_backend_abort();
 
         Ok(())
     }
 
     /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbtransaction-objectstorenames>
-    fn ObjectStoreNames(&self) -> DomRoot<DOMStringList> {
+    fn ObjectStoreNames(&self, cx: &mut JSContext) -> DomRoot<DOMStringList> {
         if self.mode == IDBTransactionMode::Versionchange {
-            self.db.object_stores()
+            self.db.object_stores(cx)
         } else {
             self.object_store_names.as_rooted()
         }

--- a/components/script/dom/indexeddb/idbversionchangeevent.rs
+++ b/components/script/dom/indexeddb/idbversionchangeevent.rs
@@ -6,7 +6,7 @@ use std::cell::Cell;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -20,7 +20,6 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct IDBVersionChangeEvent {
@@ -39,15 +38,16 @@ impl IDBVersionChangeEvent {
     }
 
     pub fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         type_: Atom,
         bubbles: EventBubbles,
         cancelable: EventCancelable,
         old_version: u64,
         new_version: Option<u64>,
-        can_gc: CanGc,
     ) -> DomRoot<IDBVersionChangeEvent> {
         Self::new_with_proto(
+            cx,
             global,
             None,
             type_,
@@ -55,12 +55,12 @@ impl IDBVersionChangeEvent {
             bool::from(cancelable),
             old_version,
             new_version,
-            can_gc,
         )
     }
 
     #[expect(clippy::too_many_arguments)]
     fn new_with_proto(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
         type_: Atom,
@@ -68,16 +68,15 @@ impl IDBVersionChangeEvent {
         cancelable: bool,
         old_version: u64,
         new_version: Option<u64>,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        let ev = reflect_dom_object_with_proto(
+        let ev = reflect_dom_object_with_proto_and_cx(
             Box::new(IDBVersionChangeEvent::new_inherited(
                 old_version,
                 new_version,
             )),
             global,
             proto,
-            can_gc,
+            cx,
         );
         {
             let event = ev.upcast::<Event>();
@@ -101,13 +100,13 @@ impl IDBVersionChangeEvent {
         // Step 4: Set event’s oldVersion attribute to oldVersion.
         // Step 5: Set event’s newVersion attribute to newVersion.
         let event = IDBVersionChangeEvent::new(
+            cx,
             global,
             event_type,
             EventBubbles::DoesNotBubble,
             EventCancelable::NotCancelable,
             old_version,
             new_version,
-            CanGc::from_cx(cx),
         );
 
         // Step 6: Let legacyOutputDidListenersThrowFlag be false.
@@ -128,13 +127,14 @@ impl IDBVersionChangeEvent {
 impl IDBVersionChangeEventMethods<crate::DomTypeHolder> for IDBVersionChangeEvent {
     /// <https://w3c.github.io/IndexedDB/#dom-idbversionchangeevent-idbversionchangeevent>
     fn Constructor(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         type_: DOMString,
         init: &IDBVersionChangeEventInit,
     ) -> DomRoot<Self> {
         Self::new_with_proto(
+            cx,
             global,
             proto,
             Atom::from(type_),
@@ -142,7 +142,6 @@ impl IDBVersionChangeEventMethods<crate::DomTypeHolder> for IDBVersionChangeEven
             init.parent.cancelable,
             init.oldVersion,
             init.newVersion,
-            can_gc,
         )
     }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1426,8 +1426,8 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     }
 
     /// <https://w3c.github.io/IndexedDB/#factory-interface>
-    fn IndexedDB(&self) -> DomRoot<IDBFactory> {
-        self.upcast::<GlobalScope>().get_indexeddb()
+    fn IndexedDB(&self, cx: &mut JSContext) -> DomRoot<IDBFactory> {
+        self.upcast::<GlobalScope>().get_indexeddb(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-window-customelements>

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -667,8 +667,8 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
     }
 
     /// <https://w3c.github.io/IndexedDB/#factory-interface>
-    fn IndexedDB(&self) -> DomRoot<IDBFactory> {
-        self.upcast::<GlobalScope>().get_indexeddb()
+    fn IndexedDB(&self, cx: &mut JSContext) -> DomRoot<IDBFactory> {
+        self.upcast::<GlobalScope>().get_indexeddb(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-workerglobalscope-location>

--- a/components/script/microtask.rs
+++ b/components/script/microtask.rs
@@ -183,7 +183,7 @@ impl MicrotaskQueue {
         // “These steps are invoked by [HTML]. They ensure that transactions created by a script call
         // to transaction() are deactivated once the task that invoked the script has completed.”
         for global in globalscopes.iter() {
-            let _ = global.get_indexeddb().cleanup_indexeddb_transactions();
+            let _ = global.get_indexeddb(cx).cleanup_indexeddb_transactions(cx);
         }
 
         // TODO: Step 6. Perform ClearKeptObjects().

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -922,17 +922,20 @@ DOMInterfaces = {
     'cx': ['Key', 'PrimaryKey']
 },
 
+'IDBCursorWithValue': {
+    'cx': ['Value']
+},
+
 'IDBDatabase': {
-    'canGc': ['ObjectStoreNames'],
-    'cx': ['CreateObjectStore'],
+    'cx': ['CreateObjectStore', 'ObjectStoreNames', 'Transaction'],
 },
 
 'IDBFactory': {
-    'cx': ['Cmp', 'Databases'],
+    'cx': ['Cmp', 'Databases', 'DeleteDatabase', 'Open'],
 },
 
 'IDBIndex': {
-    'canGc': ['KeyPath'],
+    'cx': ['KeyPath'],
 },
 
 'IDBKeyRange': {
@@ -940,12 +943,19 @@ DOMInterfaces = {
 },
 
 'IDBObjectStore': {
-    'canGc': ['IndexNames'],
-    'cx': ['CreateIndex', 'Put', 'Add', 'Delete', 'Clear', 'Get', 'GetKey', 'GetAll', 'GetAllKeys', 'Count', 'OpenCursor', 'OpenKeyCursor', 'KeyPath'],
+    'cx': ['CreateIndex', 'IndexNames', 'Put', 'Add', 'Delete', 'Clear', 'Get', 'GetKey', 'GetAll', 'GetAllKeys', 'Count', 'OpenCursor', 'OpenKeyCursor', 'KeyPath'],
+},
+
+'IDBRequest': {
+    'cx': ['GetResult'],
 },
 
 'IDBTransaction': {
-    'canGc': ['ObjectStore']
+    'cx': ['Abort', 'ObjectStore', 'ObjectStoreNames'],
+},
+
+'IDBVersionChangeEvent': {
+    'cx': ['Constructor'],
 },
 
 'IIRFilterNode': {
@@ -1413,6 +1423,7 @@ DOMInterfaces = {
         'TestRunner',
         'TrustedTypes',
         'WebdriverException',
+        'IndexedDB',
     ]
 },
 
@@ -1433,7 +1444,7 @@ DOMInterfaces = {
 },
 
 'WorkerGlobalScope': {
-    'cx': ['ImportScripts', 'ReportError', 'SetInterval', 'SetTimeout', 'TrustedTypes', 'StructuredClone'],
+    'cx': ['ImportScripts', 'ReportError', 'SetInterval', 'SetTimeout', 'TrustedTypes', 'StructuredClone', 'IndexedDB'],
     'realm': ['CreateImageBitmap', 'CreateImageBitmap_', 'Fetch'],
 },
 


### PR DESCRIPTION
This removes almost all usages of CanGC from IndexedDB. This is part of #40600.

Testing: It compiles.