### PR TITLE
script: Restore focus when closing dialogs

### DIFF
--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -364,7 +364,7 @@ impl Element {
         self.rare_data.borrow_mut()
     }
 
-    fn ensure_rare_data(&self) -> RefMut<'_, Box<ElementRareData>> {
+    pub(crate) fn ensure_rare_data(&self) -> RefMut<'_, Box<ElementRareData>> {
         let mut rare_data = self.rare_data.borrow_mut();
         if rare_data.is_none() {
             *rare_data = Some(Default::default());

--- a/components/script/dom/html/htmldialogelement.rs
+++ b/components/script/dom/html/htmldialogelement.rs
@@ -234,7 +234,6 @@ impl HTMLDialogElement {
             // Step 12.3. If subject's node document's focused area of the document's DOM anchor is
             // a shadow-including inclusive descendant of subject, or wasModal is true, then run the
             // focusing steps for element; the viewport should not be scrolled by doing this step.
-            // TODO: Do not scroll the viewport
             let subject_node = subject.upcast::<Node>();
             let document = subject.owner_document();
             if document

--- a/components/script/dom/html/htmldialogelement.rs
+++ b/components/script/dom/html/htmldialogelement.rs
@@ -23,6 +23,7 @@ use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::htmlbuttonelement::{CommandState, HTMLButtonElement};
+use crate::dom::iterators::ShadowIncluding;
 use crate::dom::node::virtualmethods::VirtualMethods;
 use crate::dom::node::{Node, NodeTraits};
 use crate::dom::toggleevent::ToggleEvent;
@@ -144,7 +145,13 @@ impl HTMLDialogElement {
 
         // TODO: Step 15. If subject's node document's top layer does not already contain subject, then add an element to the top layer given subject.
 
-        // TODO: Step 16. Set subject's previously focused element to the focused element.
+        // Step 16. Set subject's previously focused element to the focused element.
+        self.upcast::<HTMLElement>().set_previously_focused_element(
+            self.owner_document()
+                .focus_handler()
+                .focused_area()
+                .element(),
+        );
 
         // TODO: Step 17. Let document be subject's node document.
 
@@ -202,7 +209,8 @@ impl HTMLDialogElement {
 
         // TODO: Step 6. If is modal of subject is true, then request an element to be removed from the top layer given subject.
 
-        // TODO: Step 7. Let wasModal be the value of subject's is modal flag.
+        // Step 7. Let wasModal be the value of subject's is modal flag.
+        let was_modal = subject.state().contains(ElementState::MODAL);
 
         // Step 8. Set is modal of subject to false.
         self.upcast::<Element>().set_modal_state(false);
@@ -216,10 +224,30 @@ impl HTMLDialogElement {
 
         // TODO: Step 11. Set subject's request close source element to null.
 
-        // TODO: Step 12. If subject's previously focused element is not null, then:
-        // TODO: Step 12.1. Let element be subject's previously focused element.
-        // TODO: Step 12.2. Set subject's previously focused element to null.
-        // TODO: Step 12.3. If subject's node document's focused area of the document's DOM anchor is a shadow-including inclusive descendant of subject, or wasModal is true, then run the focusing steps for element; the viewport should not be scrolled by doing this step.
+        // Step 12. If subject's previously focused element is not null, then:
+        if let Some(element) = self.upcast::<HTMLElement>().previously_focused_element() {
+            // Step 12.1. Let element be subject's previously focused element.
+            // Step 12.2. Set subject's previously focused element to null.
+            self.upcast::<HTMLElement>()
+                .set_previously_focused_element(None);
+
+            // Step 12.3. If subject's node document's focused area of the document's DOM anchor is
+            // a shadow-including inclusive descendant of subject, or wasModal is true, then run the
+            // focusing steps for element; the viewport should not be scrolled by doing this step.
+            // TODO: Do not scroll the viewport
+            let subject_node = subject.upcast::<Node>();
+            let document = subject.owner_document();
+            if document
+                .focus_handler()
+                .focused_area()
+                .dom_anchor(&document)
+                .traverse_preorder(ShadowIncluding::Yes)
+                .any(|node| &*node == subject_node) ||
+                was_modal
+            {
+                element.upcast::<Node>().run_the_focusing_steps(cx, None);
+            }
+        }
 
         // Step 13. Queue an element task on the user interaction task source given the subject element to fire an event named close at subject.
         let target = self.upcast::<EventTarget>();
@@ -377,7 +405,13 @@ impl HTMLDialogElementMethods<crate::DomTypeHolder> for HTMLDialogElement {
         element.set_bool_attribute(cx, &local_name!("open"), true);
         element.set_open_state(true);
 
-        // TODO: Step 7. Set this's previously focused element to the focused element.
+        // Step 7. Set this's previously focused element to the focused element.
+        self.upcast::<HTMLElement>().set_previously_focused_element(
+            self.owner_document()
+                .focus_handler()
+                .focused_area()
+                .element(),
+        );
 
         // TODO: Step 8. Let document be this's node document.
 

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -77,8 +77,6 @@ pub(crate) struct HTMLElement {
     element: Element,
     style_decl: MutNullableDom<CSSStyleDeclaration>,
     dataset: MutNullableDom<DOMStringMap>,
-    /// <https://html.spec.whatwg.org/multipage/#previously-focused-element>
-    previously_focused_element: MutNullableDom<Element>,
 }
 
 impl HTMLElement {
@@ -106,7 +104,6 @@ impl HTMLElement {
             ),
             style_decl: Default::default(),
             dataset: Default::default(),
-            previously_focused_element: Default::default(),
         }
     }
 
@@ -183,11 +180,17 @@ impl HTMLElement {
     }
 
     pub(crate) fn previously_focused_element(&self) -> Option<DomRoot<Element>> {
-        self.previously_focused_element.get()
+        self.upcast::<Element>()
+            .ensure_rare_data()
+            .previously_focused_element
+            .get()
     }
 
     pub(crate) fn set_previously_focused_element(&self, element: Option<&Element>) {
-        self.previously_focused_element.set(element);
+        self.upcast::<Element>()
+            .ensure_rare_data()
+            .previously_focused_element
+            .set(element);
     }
 }
 

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -77,6 +77,8 @@ pub(crate) struct HTMLElement {
     element: Element,
     style_decl: MutNullableDom<CSSStyleDeclaration>,
     dataset: MutNullableDom<DOMStringMap>,
+    /// <https://html.spec.whatwg.org/multipage/#previously-focused-element>
+    previously_focused_element: MutNullableDom<Element>,
 }
 
 impl HTMLElement {
@@ -104,6 +106,7 @@ impl HTMLElement {
             ),
             style_decl: Default::default(),
             dataset: Default::default(),
+            previously_focused_element: Default::default(),
         }
     }
 
@@ -177,6 +180,14 @@ impl HTMLElement {
         matches!(&*self.ContentEditable().str(), "true" | "plaintext-only")
         // > or a child HTML element of a Document whose design mode enabled is true.
         // TODO
+    }
+
+    pub(crate) fn previously_focused_element(&self) -> Option<DomRoot<Element>> {
+        self.previously_focused_element.get()
+    }
+
+    pub(crate) fn set_previously_focused_element(&self, element: Option<&Element>) {
+        self.previously_focused_element.set(element);
     }
 }
 

--- a/components/script/dom/raredata.rs
+++ b/components/script/dom/raredata.rs
@@ -22,6 +22,7 @@ use crate::dom::mutationobserver::RegisteredObserver;
 use crate::dom::nodelist::NodeList;
 use crate::dom::range::{Range, WeakRangeVec};
 use crate::dom::shadowroot::ShadowRoot;
+use crate::dom::types::Element;
 use crate::dom::window::LayoutValue;
 
 // XXX(ferjm) Ideally merge NodeRareData and ElementRareData so they share
@@ -103,4 +104,7 @@ pub(crate) struct ElementRareData {
     /// Whether this element had duplicate attributes during tokenization.
     /// Used for CSP nonce validation (step 3 of "is element nonceable").
     pub(crate) had_duplicate_attributes: bool,
+
+    /// <https://html.spec.whatwg.org/multipage/#previously-focused-element>
+    pub(crate) previously_focused_element: MutNullableDom<Element>,
 }

--- a/tests/unit/script/size_of.rs
+++ b/tests/unit/script/size_of.rs
@@ -32,8 +32,8 @@ macro_rules! sizeof_checker (
 sizeof_checker!(size_event_target, EventTarget, 56);
 sizeof_checker!(size_node, Node, 160);
 sizeof_checker!(size_element, Element, 352);
-sizeof_checker!(size_htmlelement, HTMLElement, 376);
-sizeof_checker!(size_div, HTMLDivElement, 376);
-sizeof_checker!(size_span, HTMLSpanElement, 376);
+sizeof_checker!(size_htmlelement, HTMLElement, 368);
+sizeof_checker!(size_div, HTMLDivElement, 368);
+sizeof_checker!(size_span, HTMLSpanElement, 368);
 sizeof_checker!(size_text, Text, 192);
 sizeof_checker!(size_characterdata, CharacterData, 192);

--- a/tests/unit/script/size_of.rs
+++ b/tests/unit/script/size_of.rs
@@ -32,8 +32,8 @@ macro_rules! sizeof_checker (
 sizeof_checker!(size_event_target, EventTarget, 56);
 sizeof_checker!(size_node, Node, 160);
 sizeof_checker!(size_element, Element, 352);
-sizeof_checker!(size_htmlelement, HTMLElement, 368);
-sizeof_checker!(size_div, HTMLDivElement, 368);
-sizeof_checker!(size_span, HTMLSpanElement, 368);
+sizeof_checker!(size_htmlelement, HTMLElement, 376);
+sizeof_checker!(size_div, HTMLDivElement, 376);
+sizeof_checker!(size_span, HTMLSpanElement, 376);
 sizeof_checker!(size_text, Text, 192);
 sizeof_checker!(size_characterdata, CharacterData, 192);

--- a/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/dialog-focus-previous-outside.html.ini
+++ b/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/dialog-focus-previous-outside.html.ini
@@ -4,9 +4,3 @@
 
   [Focus restore should occur when the focused element is slotted into a dialog.]
     expected: FAIL
-
-  [Focus restore should always occur for modal dialogs.]
-    expected: FAIL
-
-  [Focus restore should work when the dialog itself is focused.]
-    expected: FAIL


### PR DESCRIPTION
Previously the focus was not returned to the original focused element after a dialog has been closed. This change implements the step for storing the previously focused elements and focusing it when dialogs are closed.

Testing: Passes additional web platform tests.
