### PR TITLE
script: Remove `reject_{native,error}_with_cx`

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -717,7 +717,7 @@ pub(crate) fn consume_body<T: BodyMixin + DomObject>(
 
     // If object is unusable, then return a promise rejected with a TypeError.
     if object.is_unusable() {
-        promise.reject_error_with_cx(
+        promise.reject_error(
             cx,
             Error::Type(c"The body's stream is disturbed or locked".to_owned()),
         );
@@ -764,7 +764,7 @@ pub(crate) fn consume_body<T: BodyMixin + DomObject>(
     let reader = match stream.acquire_default_reader(cx) {
         Ok(r) => r,
         Err(e) => {
-            promise.reject_error_with_cx(cx, e);
+            promise.reject_error(cx, e);
             return promise;
         },
     };
@@ -824,7 +824,7 @@ fn resolve_result_promise(
                 FetchedData::JSException(e) => promise.reject_native(cx, &e.handle()),
             };
         },
-        Err(err) => promise.reject_error_with_cx(cx, err),
+        Err(err) => promise.reject_error(cx, err),
     }
 }
 

--- a/components/script/dom/audio/audiocontext.rs
+++ b/components/script/dom/audio/audiocontext.rs
@@ -147,7 +147,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
 
         // Step 2.
         if self.context.control_thread_state() == ProcessingState::Closed {
-            promise.reject_error_with_cx(cx, Error::InvalidState(None));
+            promise.reject_error(cx, Error::InvalidState(None));
             return promise;
         }
 
@@ -187,7 +187,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
                     .dom_manipulation_task_source()
                     .queue(task!(suspend_error: move |cx| {
                         let promise = trusted_promise.root();
-                        promise.reject_error_with_cx(cx, Error::Type(c"Something went wrong".to_owned()));
+                        promise.reject_error(cx, Error::Type(c"Something went wrong".to_owned()));
                     }));
             },
         };
@@ -203,7 +203,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
 
         // Step 2.
         if self.context.control_thread_state() == ProcessingState::Closed {
-            promise.reject_error_with_cx(cx, Error::InvalidState(None));
+            promise.reject_error(cx, Error::InvalidState(None));
             return promise;
         }
 
@@ -243,7 +243,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
                     .dom_manipulation_task_source()
                     .queue(task!(suspend_error: move |cx| {
                         let promise = trusted_promise.root();
-                        promise.reject_error_with_cx(cx, Error::Type(c"Something went wrong".to_owned()));
+                        promise.reject_error(cx, Error::Type(c"Something went wrong".to_owned()));
                     }));
             },
         };

--- a/components/script/dom/audio/baseaudiocontext.rs
+++ b/components/script/dom/audio/baseaudiocontext.rs
@@ -213,7 +213,7 @@ impl BaseAudioContext {
         for promise in &*promises {
             match result {
                 Ok(ref value) => promise.resolve_native_with_cx(cx, value),
-                Err(ref error) => promise.reject_error_with_cx(cx, error.clone()),
+                Err(ref error) => promise.reject_error(cx, error.clone()),
             }
         }
     }
@@ -293,7 +293,7 @@ impl BaseAudioContextMethods<crate::DomTypeHolder> for BaseAudioContext {
 
         // Step 2.
         if self.audio_context_impl.lock().unwrap().state() == ProcessingState::Closed {
-            promise.reject_error_with_cx(cx, Error::InvalidState(None));
+            promise.reject_error(cx, Error::InvalidState(None));
             return promise;
         }
 
@@ -558,7 +558,7 @@ impl BaseAudioContextMethods<crate::DomTypeHolder> for BaseAudioContext {
                             let _ = callback.Call__(cx, &exception, ExceptionHandling::Report);
                         }
                         let error = cformat!("Audio decode error {:?}", error);
-                        resolver.promise.reject_error_with_cx(cx, Error::Type(error));
+                        resolver.promise.reject_error(cx, Error::Type(error));
                     }));
                 })
                 .build();
@@ -568,7 +568,7 @@ impl BaseAudioContextMethods<crate::DomTypeHolder> for BaseAudioContext {
                 .decode_audio_data(audio_data, callbacks);
         } else {
             // Step 3.
-            promise.reject_error_with_cx(cx, Error::DataClone(None));
+            promise.reject_error(cx, Error::DataClone(None));
             return promise;
         }
 

--- a/components/script/dom/audio/offlineaudiocontext.rs
+++ b/components/script/dom/audio/offlineaudiocontext.rs
@@ -140,7 +140,7 @@ impl OfflineAudioContextMethods<crate::DomTypeHolder> for OfflineAudioContext {
     fn StartRendering(&self, cx: &mut CurrentRealm) -> Rc<Promise> {
         let promise = Promise::new_in_realm(cx);
         if self.rendering_started.get() {
-            promise.reject_error_with_cx(cx, Error::InvalidState(None));
+            promise.reject_error(cx, Error::InvalidState(None));
             return promise;
         }
         self.rendering_started.set(true);
@@ -216,7 +216,7 @@ impl OfflineAudioContextMethods<crate::DomTypeHolder> for OfflineAudioContext {
             .resume()
             .is_none()
         {
-            promise.reject_error_with_cx(
+            promise.reject_error(
                 cx,
                 Error::Type(c"Could not start offline rendering".to_owned()),
             );

--- a/components/script/dom/bindings/refcounted.rs
+++ b/components/script/dom/bindings/refcounted.rs
@@ -138,7 +138,7 @@ impl TrustedPromise {
         let this = self;
         task!(reject_promise: move |cx| {
             debug!("Rejecting promise.");
-            this.root().reject_error_with_cx(cx, error);
+            this.root().reject_error(cx, error);
         })
     }
 

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -327,7 +327,7 @@ impl BlobMethods<crate::DomTypeHolder> for Blob {
                     promise.resolve_native_with_cx(cx, &text);
                 },
                 Err(e) => {
-                    promise.reject_error_with_cx(cx, e);
+                    promise.reject_error(cx, e);
                 },
             }),
         );
@@ -346,7 +346,7 @@ impl BlobMethods<crate::DomTypeHolder> for Blob {
         let reader = match stream.and_then(|s| s.acquire_default_reader(cx)) {
             Ok(reader) => reader,
             Err(error) => {
-                promise.reject_error_with_cx(cx, error);
+                promise.reject_error(cx, error);
                 return promise;
             },
         };
@@ -389,7 +389,7 @@ impl BlobMethods<crate::DomTypeHolder> for Blob {
         let reader = match stream.and_then(|s| s.acquire_default_reader(cx)) {
             Ok(r) => r,
             Err(e) => {
-                p.reject_error_with_cx(cx, e);
+                p.reject_error(cx, e);
                 return p;
             },
         };

--- a/components/script/dom/bluetooth/bluetooth.rs
+++ b/components/script/dom/bluetooth/bluetooth.rs
@@ -129,7 +129,7 @@ where
             Ok(response) => self.receiver.root().handle_response(cx, response, &promise),
             // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetooth-requestdevice
             // Step 3 - 4.
-            Err(error) => promise.reject_error_with_cx(cx, error.convert()),
+            Err(error) => promise.reject_error(cx, error.convert()),
         }
     }
 }
@@ -178,7 +178,7 @@ impl Bluetooth {
         if let Some(filters) = filters {
             // Step 2.1.
             if filters.is_empty() {
-                p.reject_error_with_cx(cx, Type(FILTER_EMPTY_ERROR.to_owned()));
+                p.reject_error(cx, Type(FILTER_EMPTY_ERROR.to_owned()));
                 return;
             }
 
@@ -191,7 +191,7 @@ impl Bluetooth {
                     // Step 2.4.2.
                     Ok(f) => uuid_filters.push(f),
                     Err(e) => {
-                        p.reject_error_with_cx(cx, e);
+                        p.reject_error(cx, e);
                         return;
                     },
                 }
@@ -205,7 +205,7 @@ impl Bluetooth {
             let uuid = match BluetoothUUID::service(opt_service.clone()) {
                 Ok(u) => String::from(u),
                 Err(e) => {
-                    p.reject_error_with_cx(cx, e);
+                    p.reject_error(cx, e);
                     return;
                 },
             };
@@ -228,7 +228,7 @@ impl Bluetooth {
         if let PermissionState::Denied =
             descriptor_permission_state(PermissionName::Bluetooth, None)
         {
-            return p.reject_error_with_cx(cx, Error::NotFound(None));
+            return p.reject_error(cx, Error::NotFound(None));
         }
 
         // Note: Step 3, 6 - 8 are implemented in
@@ -301,13 +301,13 @@ where
         let canonicalized = match uuid_canonicalizer(u) {
             Ok(canonicalized_uuid) => String::from(canonicalized_uuid),
             Err(e) => {
-                p.reject_error_with_cx(cx, e);
+                p.reject_error(cx, e);
                 return p;
             },
         };
         // Step 2.
         if uuid_is_blocklisted(canonicalized.as_ref(), Blocklist::All) {
-            p.reject_error_with_cx(cx, Security(None));
+            p.reject_error(cx, Security(None));
             return p;
         }
         Some(canonicalized)
@@ -317,7 +317,7 @@ where
 
     // Step 3 - 4.
     if !connected {
-        p.reject_error_with_cx(cx, Network(None));
+        p.reject_error(cx, Network(None));
         return p;
     }
 
@@ -539,7 +539,7 @@ impl BluetoothMethods<crate::DomTypeHolder> for Bluetooth {
         if (option.filters.is_some() && option.acceptAllDevices) ||
             (option.filters.is_none() && !option.acceptAllDevices)
         {
-            p.reject_error_with_cx(cx, Error::Type(OPTIONS_ERROR.to_owned()));
+            p.reject_error(cx, Error::Type(OPTIONS_ERROR.to_owned()));
             return p;
         }
 
@@ -610,9 +610,7 @@ impl AsyncBluetoothListener for Bluetooth {
             BluetoothResponse::GetAvailability(is_available) => {
                 promise.resolve_native_with_cx(cx, &is_available);
             },
-            _ => {
-                promise.reject_error_with_cx(cx, Error::Type(c"Something went wrong...".to_owned()))
-            },
+            _ => promise.reject_error(cx, Error::Type(c"Something went wrong...".to_owned())),
         }
     }
 }
@@ -685,7 +683,7 @@ impl PermissionAlgorithm for Bluetooth {
                 for filter in filters {
                     match canonicalize_filter(filter) {
                         Ok(f) => scan_filters.push(f),
-                        Err(error) => return promise.reject_error_with_cx(cx, error),
+                        Err(error) => return promise.reject_error(cx, error),
                     }
                 }
 
@@ -706,7 +704,7 @@ impl PermissionAlgorithm for Bluetooth {
                 match receiver.recv().unwrap() {
                     Ok(true) => (),
                     Ok(false) => continue,
-                    Err(error) => return promise.reject_error_with_cx(cx, error.convert()),
+                    Err(error) => return promise.reject_error(cx, error.convert()),
                 };
             }
 
@@ -735,7 +733,7 @@ impl PermissionAlgorithm for Bluetooth {
     ) {
         // Step 1.
         if descriptor.filters.is_some() == descriptor.acceptAllDevices {
-            return promise.reject_error_with_cx(cx, Error::Type(OPTIONS_ERROR.to_owned()));
+            return promise.reject_error(cx, Error::Type(OPTIONS_ERROR.to_owned()));
         }
 
         // Step 2.

--- a/components/script/dom/bluetooth/bluetoothdevice.rs
+++ b/components/script/dom/bluetooth/bluetoothdevice.rs
@@ -342,9 +342,7 @@ impl AsyncBluetoothListener for BluetoothDevice {
                 // Step 3.2.
                 promise.resolve_native_with_cx(cx, &());
             },
-            _ => {
-                promise.reject_error_with_cx(cx, Error::Type(c"Something went wrong...".to_owned()))
-            },
+            _ => promise.reject_error(cx, Error::Type(c"Something went wrong...".to_owned())),
         }
     }
 }

--- a/components/script/dom/bluetooth/bluetoothpermissionresult.rs
+++ b/components/script/dom/bluetooth/bluetoothpermissionresult.rs
@@ -143,9 +143,7 @@ impl AsyncBluetoothListener for BluetoothPermissionResult {
                 // Step 8.
                 promise.resolve_native_with_cx(cx, self);
             },
-            _ => {
-                promise.reject_error_with_cx(cx, Error::Type(c"Something went wrong...".to_owned()))
-            },
+            _ => promise.reject_error(cx, Error::Type(c"Something went wrong...".to_owned())),
         }
     }
 }

--- a/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
@@ -161,13 +161,13 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
 
         // Step 1.
         if uuid_is_blocklisted(&self.uuid.str(), Blocklist::Reads) {
-            p.reject_error_with_cx(cx, Security(None));
+            p.reject_error(cx, Security(None));
             return p;
         }
 
         // Step 2.
         if !self.Service().Device().get_gatt(cx).Connected() {
-            p.reject_error_with_cx(cx, Network(None));
+            p.reject_error(cx, Network(None));
             return p;
         }
 
@@ -175,7 +175,7 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
 
         // Step 5.1.
         if !self.Properties().Read() {
-            p.reject_error_with_cx(cx, NotSupported(None));
+            p.reject_error(cx, NotSupported(None));
             return p;
         }
 
@@ -198,7 +198,7 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
 
         // Step 1.
         if uuid_is_blocklisted(&self.uuid.str(), Blocklist::Writes) {
-            p.reject_error_with_cx(cx, Security(None));
+            p.reject_error(cx, Security(None));
             return p;
         }
 
@@ -209,13 +209,13 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
         };
 
         if vec.len() > MAXIMUM_ATTRIBUTE_LENGTH {
-            p.reject_error_with_cx(cx, InvalidModification(None));
+            p.reject_error(cx, InvalidModification(None));
             return p;
         }
 
         // Step 4.
         if !self.Service().Device().get_gatt(cx).Connected() {
-            p.reject_error_with_cx(cx, Network(None));
+            p.reject_error(cx, Network(None));
             return p;
         }
 
@@ -226,7 +226,7 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
             self.Properties().WriteWithoutResponse() ||
             self.Properties().AuthenticatedSignedWrites())
         {
-            p.reject_error_with_cx(cx, NotSupported(None));
+            p.reject_error(cx, NotSupported(None));
             return p;
         }
 
@@ -249,19 +249,19 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
 
         // Step 1.
         if uuid_is_blocklisted(&self.uuid.str(), Blocklist::Reads) {
-            p.reject_error_with_cx(cx, Security(None));
+            p.reject_error(cx, Security(None));
             return p;
         }
 
         // Step 2.
         if !self.Service().Device().get_gatt(cx).Connected() {
-            p.reject_error_with_cx(cx, Network(None));
+            p.reject_error(cx, Network(None));
             return p;
         }
 
         // Step 5.
         if !(self.Properties().Notify() || self.Properties().Indicate()) {
-            p.reject_error_with_cx(cx, NotSupported(None));
+            p.reject_error(cx, NotSupported(None));
             return p;
         }
 
@@ -368,9 +368,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTCharacteristic {
                 // (StopNotification)  Step 5.
                 promise.resolve_native_with_cx(cx, self);
             },
-            _ => {
-                promise.reject_error_with_cx(cx, Error::Type(c"Something went wrong...".to_owned()))
-            },
+            _ => promise.reject_error(cx, Error::Type(c"Something went wrong...".to_owned())),
         }
     }
 }

--- a/components/script/dom/bluetooth/bluetoothremotegattdescriptor.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattdescriptor.rs
@@ -103,7 +103,7 @@ impl BluetoothRemoteGATTDescriptorMethods<crate::DomTypeHolder> for BluetoothRem
 
         // Step 1.
         if uuid_is_blocklisted(&self.uuid.str(), Blocklist::Reads) {
-            p.reject_error_with_cx(cx, Security(None));
+            p.reject_error(cx, Security(None));
             return p;
         }
 
@@ -115,7 +115,7 @@ impl BluetoothRemoteGATTDescriptorMethods<crate::DomTypeHolder> for BluetoothRem
             .get_gatt(cx)
             .Connected()
         {
-            p.reject_error_with_cx(cx, Network(None));
+            p.reject_error(cx, Network(None));
             return p;
         }
 
@@ -139,7 +139,7 @@ impl BluetoothRemoteGATTDescriptorMethods<crate::DomTypeHolder> for BluetoothRem
 
         // Step 1.
         if uuid_is_blocklisted(&self.uuid.str(), Blocklist::Writes) {
-            p.reject_error_with_cx(cx, Security(None));
+            p.reject_error(cx, Security(None));
             return p;
         }
 
@@ -149,7 +149,7 @@ impl BluetoothRemoteGATTDescriptorMethods<crate::DomTypeHolder> for BluetoothRem
             ArrayBufferViewOrArrayBuffer::ArrayBuffer(ab) => ab.to_vec(),
         };
         if vec.len() > MAXIMUM_ATTRIBUTE_LENGTH {
-            p.reject_error_with_cx(cx, InvalidModification(None));
+            p.reject_error(cx, InvalidModification(None));
             return p;
         }
 
@@ -161,7 +161,7 @@ impl BluetoothRemoteGATTDescriptorMethods<crate::DomTypeHolder> for BluetoothRem
             .get_gatt(cx)
             .Connected()
         {
-            p.reject_error_with_cx(cx, Network(None));
+            p.reject_error(cx, Network(None));
             return p;
         }
 
@@ -212,9 +212,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTDescriptor {
                 // TODO: Resolve promise with undefined instead of a value.
                 promise.resolve_native_with_cx(cx, &());
             },
-            _ => {
-                promise.reject_error_with_cx(cx, Error::Type(c"Something went wrong...".to_owned()))
-            },
+            _ => promise.reject_error(cx, Error::Type(c"Something went wrong...".to_owned())),
         }
     }
 }

--- a/components/script/dom/bluetooth/bluetoothremotegattserver.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattserver.rs
@@ -165,9 +165,9 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTServer {
                 // Step 5.2.3
                 if self.Device().is_represented_device_null() {
                     if let Err(e) = self.Device().garbage_collect_the_connection(cx) {
-                        return promise.reject_error_with_cx(cx, e);
+                        return promise.reject_error(cx, e);
                     }
-                    return promise.reject_error_with_cx(cx, Error::Network(None));
+                    return promise.reject_error(cx, Error::Network(None));
                 }
 
                 // Step 5.2.4.
@@ -192,9 +192,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTServer {
                 }
                 promise.resolve_native_with_cx(cx, &services);
             },
-            _ => {
-                promise.reject_error_with_cx(cx, Error::Type(c"Something went wrong...".to_owned()))
-            },
+            _ => promise.reject_error(cx, Error::Type(c"Something went wrong...".to_owned())),
         }
     }
 }

--- a/components/script/dom/bluetooth/bluetoothremotegattservice.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattservice.rs
@@ -215,9 +215,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTService {
                 }
                 promise.resolve_native_with_cx(cx, &services);
             },
-            _ => {
-                promise.reject_error_with_cx(cx, Error::Type(c"Something went wrong...".to_owned()))
-            },
+            _ => promise.reject_error(cx, Error::Type(c"Something went wrong...".to_owned())),
         }
     }
 }

--- a/components/script/dom/canvas/imagebitmap.rs
+++ b/components/script/dom/canvas/imagebitmap.rs
@@ -290,7 +290,7 @@ impl ImageBitmap {
 
         // Step 1. If either sw or sh is given and is 0, then return a promise rejected with a RangeError.
         if sw.is_some_and(|w| w == 0) {
-            p.reject_error_with_cx(
+            p.reject_error(
                 realm,
                 Error::Range(c"'sw' must be a non-zero value".to_owned()),
             );
@@ -298,7 +298,7 @@ impl ImageBitmap {
         }
 
         if sh.is_some_and(|h| h == 0) {
-            p.reject_error_with_cx(
+            p.reject_error(
                 realm,
                 Error::Range(c"'sh' must be a non-zero value".to_owned()),
             );
@@ -308,12 +308,12 @@ impl ImageBitmap {
         // Step 2. If either options's resizeWidth or options's resizeHeight is present and is 0,
         // then return a promise rejected with an "InvalidStateError" DOMException.
         if options.resizeWidth.is_some_and(|w| w == 0) {
-            p.reject_error_with_cx(realm, Error::InvalidState(None));
+            p.reject_error(realm, Error::InvalidState(None));
             return p;
         }
 
         if options.resizeHeight.is_some_and(|h| h == 0) {
-            p.reject_error_with_cx(realm, Error::InvalidState(None));
+            p.reject_error(realm, Error::InvalidState(None));
             return p;
         }
 
@@ -342,7 +342,7 @@ impl ImageBitmap {
                 task!(reject_promise: move |cx| {
                     let promise = trusted_promise.root();
 
-                    promise.reject_error_with_cx(cx, Error::InvalidState(None));
+                    promise.reject_error(cx, Error::InvalidState(None));
                 }),
             );
         };
@@ -354,14 +354,14 @@ impl ImageBitmap {
             ImageBitmapSource::HTMLImageElement(ref image) => {
                 // <https://html.spec.whatwg.org/multipage/#check-the-usability-of-the-image-argument>
                 if !image.is_usable().is_ok_and(|u| u) {
-                    p.reject_error_with_cx(realm, Error::InvalidState(None));
+                    p.reject_error(realm, Error::InvalidState(None));
                     return p;
                 }
 
                 // If no ImageBitmap object can be constructed, then the promise
                 // is rejected instead.
                 let Some(snapshot) = image.get_raster_image_data() else {
-                    p.reject_error_with_cx(realm, Error::InvalidState(None));
+                    p.reject_error(realm, Error::InvalidState(None));
                     return p;
                 };
 
@@ -370,7 +370,7 @@ impl ImageBitmap {
                 let Some(bitmap_data) =
                     ImageBitmap::crop_and_transform_bitmap_data(snapshot, sx, sy, sw, sh, options)
                 else {
-                    p.reject_error_with_cx(realm, Error::InvalidState(None));
+                    p.reject_error(realm, Error::InvalidState(None));
                     return p;
                 };
 
@@ -386,20 +386,20 @@ impl ImageBitmap {
             ImageBitmapSource::HTMLVideoElement(ref video) => {
                 // <https://html.spec.whatwg.org/multipage/#check-the-usability-of-the-image-argument>
                 if !video.is_usable() {
-                    p.reject_error_with_cx(realm, Error::InvalidState(None));
+                    p.reject_error(realm, Error::InvalidState(None));
                     return p;
                 }
 
                 // Step 6.1. If image's networkState attribute is NETWORK_EMPTY, then return
                 // a promise rejected with an "InvalidStateError" DOMException.
                 if video.is_network_state_empty() {
-                    p.reject_error_with_cx(realm, Error::InvalidState(None));
+                    p.reject_error(realm, Error::InvalidState(None));
                     return p;
                 }
 
                 // If no ImageBitmap object can be constructed, then the promise is rejected instead.
                 let Some(snapshot) = video.get_current_frame_data() else {
-                    p.reject_error_with_cx(realm, Error::InvalidState(None));
+                    p.reject_error(realm, Error::InvalidState(None));
                     return p;
                 };
 
@@ -410,7 +410,7 @@ impl ImageBitmap {
                 let Some(bitmap_data) =
                     ImageBitmap::crop_and_transform_bitmap_data(snapshot, sx, sy, sw, sh, options)
                 else {
-                    p.reject_error_with_cx(realm, Error::InvalidState(None));
+                    p.reject_error(realm, Error::InvalidState(None));
                     return p;
                 };
 
@@ -426,13 +426,13 @@ impl ImageBitmap {
             ImageBitmapSource::HTMLCanvasElement(ref canvas) => {
                 // <https://html.spec.whatwg.org/multipage/#check-the-usability-of-the-image-argument>
                 if canvas.get_size().is_empty() {
-                    p.reject_error_with_cx(realm, Error::InvalidState(None));
+                    p.reject_error(realm, Error::InvalidState(None));
                     return p;
                 }
 
                 // If no ImageBitmap object can be constructed, then the promise is rejected instead.
                 let Some(snapshot) = canvas.get_image_data() else {
-                    p.reject_error_with_cx(realm, Error::InvalidState(None));
+                    p.reject_error(realm, Error::InvalidState(None));
                     return p;
                 };
 
@@ -441,7 +441,7 @@ impl ImageBitmap {
                 let Some(bitmap_data) =
                     ImageBitmap::crop_and_transform_bitmap_data(snapshot, sx, sy, sw, sh, options)
                 else {
-                    p.reject_error_with_cx(realm, Error::InvalidState(None));
+                    p.reject_error(realm, Error::InvalidState(None));
                     return p;
                 };
 
@@ -457,13 +457,13 @@ impl ImageBitmap {
             ImageBitmapSource::ImageBitmap(ref bitmap) => {
                 // <https://html.spec.whatwg.org/multipage/#check-the-usability-of-the-image-argument>
                 if bitmap.is_detached() {
-                    p.reject_error_with_cx(realm, Error::InvalidState(None));
+                    p.reject_error(realm, Error::InvalidState(None));
                     return p;
                 }
 
                 // If no ImageBitmap object can be constructed, then the promise is rejected instead.
                 let Some(snapshot) = bitmap.bitmap_data().clone() else {
-                    p.reject_error_with_cx(realm, Error::InvalidState(None));
+                    p.reject_error(realm, Error::InvalidState(None));
                     return p;
                 };
 
@@ -472,7 +472,7 @@ impl ImageBitmap {
                 let Some(bitmap_data) =
                     ImageBitmap::crop_and_transform_bitmap_data(snapshot, sx, sy, sw, sh, options)
                 else {
-                    p.reject_error_with_cx(realm, Error::InvalidState(None));
+                    p.reject_error(realm, Error::InvalidState(None));
                     return p;
                 };
 
@@ -488,13 +488,13 @@ impl ImageBitmap {
             ImageBitmapSource::OffscreenCanvas(ref canvas) => {
                 // <https://html.spec.whatwg.org/multipage/#check-the-usability-of-the-image-argument>
                 if canvas.get_size().is_empty() {
-                    p.reject_error_with_cx(realm, Error::InvalidState(None));
+                    p.reject_error(realm, Error::InvalidState(None));
                     return p;
                 }
 
                 // If no ImageBitmap object can be constructed, then the promise is rejected instead.
                 let Some(snapshot) = canvas.get_image_data() else {
-                    p.reject_error_with_cx(realm, Error::InvalidState(None));
+                    p.reject_error(realm, Error::InvalidState(None));
                     return p;
                 };
 
@@ -503,7 +503,7 @@ impl ImageBitmap {
                 let Some(bitmap_data) =
                     ImageBitmap::crop_and_transform_bitmap_data(snapshot, sx, sy, sw, sh, options)
                 else {
-                    p.reject_error_with_cx(realm, Error::InvalidState(None));
+                    p.reject_error(realm, Error::InvalidState(None));
                     return p;
                 };
 
@@ -561,7 +561,7 @@ impl ImageBitmap {
                 // Step 6.2. If IsDetachedBuffer(buffer) is true, then return a promise rejected
                 // with an "InvalidStateError" DOMException.
                 if image_data.is_detached() {
-                    p.reject_error_with_cx(realm, Error::InvalidState(None));
+                    p.reject_error(realm, Error::InvalidState(None));
                     return p;
                 }
 
@@ -581,7 +581,7 @@ impl ImageBitmap {
                 let Some(bitmap_data) =
                     ImageBitmap::crop_and_transform_bitmap_data(snapshot, sx, sy, sw, sh, options)
                 else {
-                    p.reject_error_with_cx(realm, Error::InvalidState(None));
+                    p.reject_error(realm, Error::InvalidState(None));
                     return p;
                 };
 
@@ -594,7 +594,7 @@ impl ImageBitmap {
             ImageBitmapSource::CSSStyleValue(_) => {
                 // TODO: CSSStyleValue is not part of ImageBitmapSource
                 // <https://html.spec.whatwg.org/multipage/#imagebitmapsource>
-                p.reject_error_with_cx(realm, Error::NotSupported(None));
+                p.reject_error(realm, Error::NotSupported(None));
             },
         }
 

--- a/components/script/dom/canvas/offscreencanvas.rs
+++ b/components/script/dom/canvas/offscreencanvas.rs
@@ -514,7 +514,7 @@ impl OffscreenCanvasMethods<crate::DomTypeHolder> for OffscreenCanvas {
         // then return a promise rejected with an "InvalidStateError"
         // DOMException.
         if let Some(OffscreenRenderingContext::Detached) = *self.context.borrow() {
-            promise.reject_error_with_cx(cx, Error::InvalidState(None));
+            promise.reject_error(cx, Error::InvalidState(None));
             return promise;
         }
 
@@ -522,7 +522,7 @@ impl OffscreenCanvasMethods<crate::DomTypeHolder> for OffscreenCanvas {
         // output bitmap's origin-clean flag is set to false, then return a
         // promise rejected with a "SecurityError" DOMException.
         if !self.origin_is_clean() {
-            promise.reject_error_with_cx(cx, Error::Security(None));
+            promise.reject_error(cx, Error::Security(None));
             return promise;
         }
 
@@ -530,13 +530,13 @@ impl OffscreenCanvasMethods<crate::DomTypeHolder> for OffscreenCanvas {
         // dimension or its vertical dimension is zero), then return a promise
         // rejected with an "IndexSizeError" DOMException.
         if self.Width() == 0 || self.Height() == 0 {
-            promise.reject_error_with_cx(cx, Error::IndexSize(None));
+            promise.reject_error(cx, Error::IndexSize(None));
             return promise;
         }
 
         // Step 4. Let bitmap be a copy of this's bitmap.
         let Some(mut snapshot) = self.get_image_data() else {
-            promise.reject_error_with_cx(cx, Error::InvalidState(None));
+            promise.reject_error(cx, Error::InvalidState(None));
             return promise;
         };
 
@@ -563,7 +563,7 @@ impl OffscreenCanvasMethods<crate::DomTypeHolder> for OffscreenCanvas {
                 if snapshot.encode_for_mime_type(&image_type, quality, &mut encoded).is_err() {
                     // Step 7.2.1. If file is null, then reject result with an
                     // "EncodingError" DOMException.
-                    promise.reject_error_with_cx(cx, Error::Encoding(None));
+                    promise.reject_error(cx, Error::Encoding(None));
                     return;
                 };
 

--- a/components/script/dom/clipboard/clipboard.rs
+++ b/components/script/dom/clipboard/clipboard.rs
@@ -72,7 +72,7 @@ impl Callback for RepresentationDataPromiseRejectionHandler {
     fn callback(&self, cx: &mut CurrentRealm, _v: SafeHandleValue) {
         // Reject p with "NotFoundError" DOMException in realm.
         // Return p.
-        self.promise.reject_error_with_cx(cx, Error::NotFound(None));
+        self.promise.reject_error(cx, Error::NotFound(None));
     }
 }
 

--- a/components/script/dom/clipboard/clipboarditem.rs
+++ b/components/script/dom/clipboard/clipboarditem.rs
@@ -85,7 +85,7 @@ impl Callback for RepresentationDataPromiseRejectionHandler {
     /// Substeps of 8.1.2.2 If representationDataPromise was rejected, then:
     fn callback(&self, cx: &mut CurrentRealm, _v: SafeHandleValue) {
         // 1. Reject p with "NotFoundError" DOMException in realm.
-        self.promise.reject_error_with_cx(cx, Error::NotFound(None));
+        self.promise.reject_error(cx, Error::NotFound(None));
     }
 }
 
@@ -304,7 +304,7 @@ impl ClipboardItemMethods<crate::DomTypeHolder> for ClipboardItem {
         }
 
         // Step 9 Reject p with "NotFoundError" DOMException in realm.
-        p.reject_error_with_cx(realm, Error::NotFound(None));
+        p.reject_error(realm, Error::NotFound(None));
 
         // Step 10 Return p.
         Ok(p)

--- a/components/script/dom/cookiestore.rs
+++ b/components/script/dom/cookiestore.rs
@@ -195,7 +195,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
-            p.reject_error_with_cx(cx, Error::Security(None));
+            p.reject_error(cx, Error::Security(None));
             return p;
         }
 
@@ -236,7 +236,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
-            p.reject_error_with_cx(cx, Error::Security(None));
+            p.reject_error(cx, Error::Security(None));
             return p;
         }
 
@@ -246,7 +246,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         // 5. If options is empty, then return a promise rejected with a TypeError.
         // "is empty" is not strictly defined anywhere in the spec but the only value we require here is "url"
         if options.url.is_none() && options.name.is_none() {
-            p.reject_error_with_cx(cx, Error::Type(c"Options cannot be empty".to_owned()));
+            p.reject_error(cx, Error::Type(c"Options cannot be empty".to_owned()));
             return p;
         }
 
@@ -264,7 +264,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
                     .as_ref()
                     .is_ok_and(|parsed| !parsed.is_equal_excluding_fragments(&creation_url))
             {
-                p.reject_error_with_cx(cx, Error::Type(c"URL does not match context".to_owned()));
+                p.reject_error(cx, Error::Type(c"URL does not match context".to_owned()));
                 return p;
             }
 
@@ -274,7 +274,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
                 .as_ref()
                 .is_ok_and(|parsed| creation_url.origin() != parsed.origin())
             {
-                p.reject_error_with_cx(cx, Error::Type(c"Not same origin".to_owned()));
+                p.reject_error(cx, Error::Type(c"Not same origin".to_owned()));
                 return p;
             }
 
@@ -315,7 +315,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
-            p.reject_error_with_cx(cx, Error::Security(None));
+            p.reject_error(cx, Error::Security(None));
             return p;
         }
         // 4. Let url be settings’s creation URL.
@@ -356,7 +356,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
-            p.reject_error_with_cx(cx, Error::Security(None));
+            p.reject_error(cx, Error::Security(None));
             return p;
         }
 
@@ -377,7 +377,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
                     .as_ref()
                     .is_ok_and(|parsed| !parsed.is_equal_excluding_fragments(&creation_url))
             {
-                p.reject_error_with_cx(cx, Error::Type(c"URL does not match context".to_owned()));
+                p.reject_error(cx, Error::Type(c"URL does not match context".to_owned()));
                 return p;
             }
 
@@ -387,7 +387,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
                 .as_ref()
                 .is_ok_and(|parsed| creation_url.origin() != parsed.origin())
             {
-                p.reject_error_with_cx(cx, Error::Type(c"Not same origin".to_owned()));
+                p.reject_error(cx, Error::Type(c"Not same origin".to_owned()));
                 return p;
             }
 
@@ -429,7 +429,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
-            p.reject_error_with_cx(cx, Error::Security(None));
+            p.reject_error(cx, Error::Security(None));
             return p;
         }
 
@@ -446,7 +446,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         let creation_url = global.creation_url();
         let Some(cookie) = CookieStore::set_a_cookie(&creation_url, &properties) else {
             // If r is failure, then reject p with a TypeError and abort these steps.
-            p.reject_error_with_cx(cx, Error::Type(c"Invalid cookie".to_owned()));
+            p.reject_error(cx, Error::Type(c"Invalid cookie".to_owned()));
             return p;
         };
 
@@ -483,7 +483,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
-            p.reject_error_with_cx(cx, Error::Security(None));
+            p.reject_error(cx, Error::Security(None));
             return p;
         }
 
@@ -493,7 +493,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         // 6.1. Let r be the result of running set a cookie with url, options["name"], options["value"],
         // options["expires"], options["domain"], options["path"], options["sameSite"], and options["partitioned"].
         let Some(cookie) = CookieStore::set_a_cookie(&creation_url, options) else {
-            p.reject_error_with_cx(cx, Error::Type(c"Invalid cookie".to_owned()));
+            p.reject_error(cx, Error::Type(c"Invalid cookie".to_owned()));
             return p;
         };
 
@@ -530,7 +530,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
-            p.reject_error_with_cx(cx, Error::Security(None));
+            p.reject_error(cx, Error::Security(None));
             return p;
         }
 
@@ -566,7 +566,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
-            p.reject_error_with_cx(cx, Error::Security(None));
+            p.reject_error(cx, Error::Security(None));
             return p;
         }
 

--- a/components/script/dom/credentialmanagement/credentialscontainer.rs
+++ b/components/script/dom/credentialmanagement/credentialscontainer.rs
@@ -56,15 +56,15 @@ impl CredentialsContainer {
         let promise = Promise::new_in_realm(cx);
         // Step 4. If document is not fully active, then return a promise rejected with an "InvalidStateError" DOMException.
         if !document.is_fully_active() {
-            promise.reject_error_with_cx(cx, Error::InvalidState(None));
+            promise.reject_error(cx, Error::InvalidState(None));
             return Ok(promise);
         }
         // Step 5. If options.signal is aborted, then return a promise rejected with options.signal’s abort reason.
         if options.signal.as_ref().is_some_and(|s| s.aborted()) {
-            promise.reject_error_with_cx(cx, Error::Abort(None));
+            promise.reject_error(cx, Error::Abort(None));
             return Ok(promise);
         }
-        promise.reject_error_with_cx(cx, Error::NotSupported(None));
+        promise.reject_error(cx, Error::NotSupported(None));
         Ok(promise)
     }
 
@@ -82,10 +82,10 @@ impl CredentialsContainer {
         let promise = Promise::new_in_realm(cx);
         // Step 3. If settings’s relevant global object's associated Document is not fully active, then return a promise rejected with an "InvalidStateError" DOMException.
         if !global.as_window().Document().is_fully_active() {
-            promise.reject_error_with_cx(cx, Error::InvalidState(None));
+            promise.reject_error(cx, Error::InvalidState(None));
             return Ok(promise);
         }
-        promise.reject_error_with_cx(cx, Error::NotSupported(None));
+        promise.reject_error(cx, Error::NotSupported(None));
         Ok(promise)
     }
 
@@ -106,10 +106,10 @@ impl CredentialsContainer {
         let promise = Promise::new_in_realm(cx);
         // Step 5. If document is not fully active, then return a promise rejected with an "InvalidStateError" DOMException.
         if !document.is_fully_active() {
-            promise.reject_error_with_cx(cx, Error::InvalidState(None));
+            promise.reject_error(cx, Error::InvalidState(None));
             return Ok(promise);
         }
-        promise.reject_error_with_cx(cx, Error::NotSupported(None));
+        promise.reject_error(cx, Error::NotSupported(None));
         Ok(promise)
     }
 }
@@ -141,7 +141,7 @@ impl CredentialsContainerMethods<DomTypeHolder> for CredentialsContainer {
     /// <https://www.w3.org/TR/credential-management-1/#dom-credentialscontainer-preventsilentaccess>
     fn PreventSilentAccess(&self, cx: &mut CurrentRealm) -> Fallible<Rc<Promise>> {
         let promise = Promise::new_in_realm(cx);
-        promise.reject_error_with_cx(cx, Error::NotSupported(None));
+        promise.reject_error(cx, Error::NotSupported(None));
         Ok(promise)
     }
 }

--- a/components/script/dom/css/fontface.rs
+++ b/components/script/dom/css/fontface.rs
@@ -190,7 +190,7 @@ impl FontFace {
         let font_status_promise = Promise::new2(cx, global);
         // If any of them fail to parse correctly, reject font face’s [[FontStatusPromise]] with a
         // DOMException named "SyntaxError"
-        font_status_promise.reject_error_with_cx(cx, Error::Syntax(None));
+        font_status_promise.reject_error(cx, Error::Syntax(None));
 
         // set font face’s corresponding attributes to the empty string, and set font face’s status
         // attribute to "error"
@@ -364,7 +364,7 @@ impl FontFace {
             // Step 2. Otherwise, reject font face’s [[FontStatusPromise]] with a DOMException named "SyntaxError"
             // and set font face’s status attribute to "error".
             self.font_status_promise
-                .reject_error_with_cx(cx, Error::Syntax(None));
+                .reject_error(cx, Error::Syntax(None));
             self.status.set(FontFaceLoadStatus::Error);
 
             // For each FontFaceSet font face is in:
@@ -598,7 +598,7 @@ impl FontFaceMethods<crate::DomTypeHolder> for FontFace {
                             // [[FontStatusPromise]] with a DOMException whose name is "NetworkError"
                             // and set font face’s status attribute to "error".
                             font_face.status.set(FontFaceLoadStatus::Error);
-                            font_face.font_status_promise.reject_error_with_cx(cx, Error::Network(None));
+                            font_face.font_status_promise.reject_error(cx, Error::Network(None));
                         }
                         Some(template) => {
                             // Step 5.2. Otherwise, font face now represents the loaded font;

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -603,7 +603,7 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
                 DOMErrorName::SyntaxError,
                 CanGc::from_cx(realm),
             );
-            promise.reject_native_with_cx(realm, &error);
+            promise.reject_native(realm, &error);
             return promise;
         }
 

--- a/components/script/dom/fullscreen/lib.rs
+++ b/components/script/dom/fullscreen/lib.rs
@@ -48,8 +48,7 @@ impl Document {
         // Step 3
         // > If pendingDoc is not fully active, then reject promise with a TypeError exception and return promise.
         if !self.is_fully_active() {
-            promise
-                .reject_error_with_cx(cx, Error::Type(c"Document is not fully active".to_owned()));
+            promise.reject_error(cx, Error::Type(c"Document is not fully active".to_owned()));
             return promise;
         }
 
@@ -161,7 +160,7 @@ impl Document {
         // Step 2
         // > If doc is not fully active or doc’s fullscreen element is null, then reject promise with a TypeError exception and return promise.
         if !self.is_fully_active() || self.fullscreen_element().is_none() {
-            promise.reject_error_with_cx(
+            promise.reject_error(
                 cx,
                 Error::Type(
                     c"No fullscreen element to exit or document is not fully active".to_owned(),
@@ -310,8 +309,7 @@ impl TaskOnce for ElementPerformFullscreenEnter {
             document
                 .upcast::<EventTarget>()
                 .fire_event(cx, atom!("fullscreenerror"));
-            promise
-                .reject_error_with_cx(cx, Error::Type(c"fullscreen is not connected".to_owned()));
+            promise.reject_error(cx, Error::Type(c"fullscreen is not connected".to_owned()));
             return;
         }
 

--- a/components/script/dom/gamepad/gamepadhapticactuator.rs
+++ b/components/script/dom/gamepad/gamepadhapticactuator.rs
@@ -134,7 +134,7 @@ impl GamepadHapticActuatorMethods<crate::DomTypeHolder> for GamepadHapticActuato
             // <https://www.w3.org/TR/gamepad/#dfn-valid-dual-rumble-effect>
             GamepadHapticEffectType::Dual_rumble => {
                 if *params.strongMagnitude < 0.0 || *params.strongMagnitude > 1.0 {
-                    playing_effect_promise.reject_error_with_cx(
+                    playing_effect_promise.reject_error(
                         cx,
                         Error::Type(
                             c"Strong magnitude value is not within range of 0.0 to 1.0.".to_owned(),
@@ -142,7 +142,7 @@ impl GamepadHapticActuatorMethods<crate::DomTypeHolder> for GamepadHapticActuato
                     );
                     return playing_effect_promise;
                 } else if *params.weakMagnitude < 0.0 || *params.weakMagnitude > 1.0 {
-                    playing_effect_promise.reject_error_with_cx(
+                    playing_effect_promise.reject_error(
                         cx,
                         Error::Type(
                             c"Weak magnitude value is not within range of 0.0 to 1.0.".to_owned(),
@@ -154,7 +154,7 @@ impl GamepadHapticActuatorMethods<crate::DomTypeHolder> for GamepadHapticActuato
             // <https://www.w3.org/TR/gamepad/#dfn-valid-trigger-rumble-effect>
             GamepadHapticEffectType::Trigger_rumble => {
                 if *params.strongMagnitude < 0.0 || *params.strongMagnitude > 1.0 {
-                    playing_effect_promise.reject_error_with_cx(
+                    playing_effect_promise.reject_error(
                         cx,
                         Error::Type(
                             c"Strong magnitude value is not within range of 0.0 to 1.0.".to_owned(),
@@ -162,7 +162,7 @@ impl GamepadHapticActuatorMethods<crate::DomTypeHolder> for GamepadHapticActuato
                     );
                     return playing_effect_promise;
                 } else if *params.weakMagnitude < 0.0 || *params.weakMagnitude > 1.0 {
-                    playing_effect_promise.reject_error_with_cx(
+                    playing_effect_promise.reject_error(
                         cx,
                         Error::Type(
                             c"Weak magnitude value is not within range of 0.0 to 1.0.".to_owned(),
@@ -170,7 +170,7 @@ impl GamepadHapticActuatorMethods<crate::DomTypeHolder> for GamepadHapticActuato
                     );
                     return playing_effect_promise;
                 } else if *params.leftTrigger < 0.0 || *params.leftTrigger > 1.0 {
-                    playing_effect_promise.reject_error_with_cx(
+                    playing_effect_promise.reject_error(
                         cx,
                         Error::Type(
                             c"Left trigger value is not within range of 0.0 to 1.0.".to_owned(),
@@ -178,7 +178,7 @@ impl GamepadHapticActuatorMethods<crate::DomTypeHolder> for GamepadHapticActuato
                     );
                     return playing_effect_promise;
                 } else if *params.rightTrigger < 0.0 || *params.rightTrigger > 1.0 {
-                    playing_effect_promise.reject_error_with_cx(
+                    playing_effect_promise.reject_error(
                         cx,
                         Error::Type(
                             c"Right trigger value is not within range of 0.0 to 1.0.".to_owned(),
@@ -191,7 +191,7 @@ impl GamepadHapticActuatorMethods<crate::DomTypeHolder> for GamepadHapticActuato
 
         let document = self.global().as_window().Document();
         if !document.is_fully_active() {
-            playing_effect_promise.reject_error_with_cx(cx, Error::InvalidState(None));
+            playing_effect_promise.reject_error(cx, Error::InvalidState(None));
         }
 
         self.sequence_id.set(self.sequence_id.get().wrapping_add(1));
@@ -208,7 +208,7 @@ impl GamepadHapticActuatorMethods<crate::DomTypeHolder> for GamepadHapticActuato
         }
 
         if !self.effects.contains(&type_) {
-            playing_effect_promise.reject_error_with_cx(cx, Error::NotSupported(None));
+            playing_effect_promise.reject_error(cx, Error::NotSupported(None));
             return playing_effect_promise;
         }
 
@@ -254,7 +254,7 @@ impl GamepadHapticActuatorMethods<crate::DomTypeHolder> for GamepadHapticActuato
 
         let document = self.global().as_window().Document();
         if !document.is_fully_active() {
-            promise.reject_error_with_cx(cx, Error::InvalidState(None));
+            promise.reject_error(cx, Error::InvalidState(None));
             return promise;
         }
 

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -1347,7 +1347,7 @@ impl HTMLImageElement {
         if !self.owner_document().is_fully_active() ||
             matches!(self.current_request.borrow().state, State::Broken)
         {
-            promise.reject_error_with_cx(cx, Error::Encoding(None));
+            promise.reject_error(cx, Error::Encoding(None));
         } else if matches!(
             self.current_request.borrow().state,
             State::CompletelyAvailable
@@ -1361,7 +1361,7 @@ impl HTMLImageElement {
             // request's state is unavailable and current URL is empty string (<img> without "src"
             // and "srcset" attributes) then reject promise with an "EncodingError" DOMException.
             // <https://github.com/whatwg/html/issues/11769>
-            promise.reject_error_with_cx(cx, Error::Encoding(None));
+            promise.reject_error(cx, Error::Encoding(None));
         } else {
             self.image_decode_promises.borrow_mut().push(promise);
         }
@@ -1416,7 +1416,7 @@ impl HTMLImageElement {
             .dom_manipulation_task_source()
             .queue(task!(reject_image_decode_promises: move |cx| {
                 for trusted_promise in trusted_image_decode_promises {
-                    trusted_promise.root().reject_error_with_cx(cx, Error::Encoding(None));
+                    trusted_promise.root().reject_error(cx, Error::Encoding(None));
                 }
             }));
     }

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -1875,7 +1875,7 @@ impl HTMLMediaElement {
         for promise in &*promises {
             match result {
                 Ok(ref value) => promise.resolve_native_with_cx(cx, value),
-                Err(ref error) => promise.reject_error_with_cx(cx, error.clone()),
+                Err(ref error) => promise.reject_error(cx, error.clone()),
             }
         }
     }
@@ -3122,7 +3122,7 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
             .get()
             .is_some_and(|e| e.Code() == MEDIA_ERR_SRC_NOT_SUPPORTED)
         {
-            promise.reject_error_with_cx(cx, Error::NotSupported(None));
+            promise.reject_error(cx, Error::NotSupported(None));
             return promise;
         }
 

--- a/components/script/dom/indexeddb/idbfactory.rs
+++ b/components/script/dom/indexeddb/idbfactory.rs
@@ -629,7 +629,7 @@ impl IDBFactoryMethods<crate::DomTypeHolder> for IDBFactory {
             Some(storage_key) => storage_key,
             None => {
                 let p = Promise::new2(cx, &global);
-                p.reject_error_with_cx(cx, Error::Security(None));
+                p.reject_error(cx, Error::Security(None));
                 return p;
             },
         };
@@ -662,7 +662,7 @@ impl IDBFactoryMethods<crate::DomTypeHolder> for IDBFactory {
                         rooted!(&in(cx) let mut rval = UndefinedValue());
                         error
                             .to_jsval(cx, &promise.global(), rval.handle_mut());
-                        promise.reject_native_with_cx(cx, &rval.handle());
+                        promise.reject_native(cx, &rval.handle());
                     },
                     Ok(info_list) => {
                         let info_list: Vec<IDBDatabaseInfo> = info_list

--- a/components/script/dom/permissions.rs
+++ b/components/script/dom/permissions.rs
@@ -108,7 +108,7 @@ impl Permissions {
         let root_desc = match Permissions::create_descriptor(cx, permissionDesc) {
             Ok(descriptor) => descriptor,
             Err(error) => {
-                p.reject_error_with_cx(cx, error);
+                p.reject_error(cx, error);
                 return p;
             },
         };
@@ -123,7 +123,7 @@ impl Permissions {
                 let bluetooth_desc = match Bluetooth::create_descriptor(cx, permissionDesc) {
                     Ok(descriptor) => descriptor,
                     Err(error) => {
-                        p.reject_error_with_cx(cx, error);
+                        p.reject_error(cx, error);
                         return p;
                     },
                 };

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -259,25 +259,12 @@ impl Promise {
         self.reject_with_cx(cx, v.handle());
     }
 
-    /// Deprecated: use [`Self::reject_native`] instead
-    pub(crate) fn reject_native_with_cx<T>(&self, cx: &mut JSContext, val: &T)
-    where
-        T: SafeToJSValConvertible,
-    {
-        self.reject_native(cx, val);
-    }
-
     pub(crate) fn reject_error(&self, cx: &mut JSContext, error: Error) {
         let mut realm = enter_auto_realm(cx, self);
         let cx = &mut realm.current_realm();
         rooted!(&in(cx) let mut v = UndefinedValue());
         error.to_jsval(cx, &self.global(), v.handle_mut());
         self.reject_with_cx(cx, v.handle());
-    }
-
-    /// Deprecated: use [`Self::reject_error`] instead
-    pub(crate) fn reject_error_with_cx(&self, cx: &mut JSContext, error: Error) {
-        self.reject_error(cx, error);
     }
 
     #[expect(unsafe_code)]
@@ -688,7 +675,7 @@ pub(crate) fn wait_for_all_promise(
     // Let failureSteps be the following steps, given reason:
     let failure_steps = Rc::new(move |cx: &mut JSContext, reason: HandleValue| {
         // Reject promise with reason.
-        failure_promise.reject_native_with_cx(cx, &reason);
+        failure_promise.reject_native(cx, &reason);
     });
 
     // Wait for all with promises, given successSteps and failureSteps.

--- a/components/script/dom/storagemanager.rs
+++ b/components/script/dom/storagemanager.rs
@@ -76,7 +76,7 @@ impl StorageManagerBooleanResponseHandler {
                 let promise = trusted_promise.root();
                 match result {
                     Ok(value) => promise.resolve_native_with_cx(cx, &value),
-                    Err(message) => promise.reject_error_with_cx(cx, StorageManager::type_error_from_string(message)),
+                    Err(message) => promise.reject_error(cx, StorageManager::type_error_from_string(message)),
                 }
             }));
     }
@@ -112,7 +112,7 @@ impl StorageManagerEstimateResponseHandler {
                         promise.resolve_native_with_cx(cx, &estimate);
                     },
                     Err(message) => {
-                        promise.reject_error_with_cx(cx, StorageManager::type_error_from_string(message));
+                        promise.reject_error(cx, StorageManager::type_error_from_string(message));
                     },
                 }
             }));

--- a/components/script/dom/stream/readablebytestreamcontroller.rs
+++ b/components/script/dom/stream/readablebytestreamcontroller.rs
@@ -1835,7 +1835,7 @@ impl ReadableByteStreamController {
             rooted!(&in(cx) let mut rval = UndefinedValue());
             error.to_jsval(cx, global, rval.handle_mut());
             let promise = Promise::new2(cx, global);
-            promise.reject_native_with_cx(cx, &rval.handle());
+            promise.reject_native(cx, &rval.handle());
             promise
         });
 

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -736,8 +736,7 @@ impl PipeTo {
             rooted!(&in(cx) let mut error = UndefinedValue());
             error.set(shutdown_error.get());
             // If error was given, reject promise with error.
-            self.result_promise
-                .reject_native_with_cx(cx, &error.handle());
+            self.result_promise.reject_native(cx, &error.handle());
         } else {
             // Otherwise, resolve promise with undefined.
             self.result_promise.resolve_native_with_cx(cx, &());
@@ -775,7 +774,7 @@ impl Callback for SourceCancelPromiseRejectionHandler {
     /// <https://streams.spec.whatwg.org/#readable-stream-cancel>.
     /// An implementation of <https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled>
     fn callback(&self, cx: &mut CurrentRealm, v: SafeHandleValue) {
-        self.result.reject_native_with_cx(cx, &v);
+        self.result.reject_native(cx, &v);
     }
 }
 
@@ -1614,7 +1613,7 @@ impl ReadableStream {
             let promise = Promise::new2(cx, global);
             rooted!(&in(cx) let mut rval = UndefinedValue());
             self.stored_error.safe_to_jsval(cx, rval.handle_mut());
-            promise.reject_native_with_cx(cx, &rval.handle());
+            promise.reject_native(cx, &rval.handle());
             return promise;
         }
         // Perform ! ReadableStreamClose(stream).
@@ -2183,7 +2182,7 @@ impl ReadableStreamMethods<crate::DomTypeHolder> for ReadableStream {
             // If ! IsReadableStreamLocked(this) is true,
             // return a promise rejected with a TypeError exception.
             let promise = Promise::new2(cx, &global);
-            promise.reject_error_with_cx(cx, Error::Type(c"stream is locked".to_owned()));
+            promise.reject_error(cx, Error::Type(c"stream is locked".to_owned()));
             promise
         } else {
             // Return ! ReadableStreamCancel(this, reason).
@@ -2231,7 +2230,7 @@ impl ReadableStreamMethods<crate::DomTypeHolder> for ReadableStream {
         if self.is_locked() {
             // return a promise rejected with a TypeError exception.
             let promise = Promise::new2(cx, &global);
-            promise.reject_error_with_cx(cx, Error::Type(c"Source stream is locked".to_owned()));
+            promise.reject_error(cx, Error::Type(c"Source stream is locked".to_owned()));
             return promise;
         }
 
@@ -2239,8 +2238,7 @@ impl ReadableStreamMethods<crate::DomTypeHolder> for ReadableStream {
         if destination.is_locked() {
             // return a promise rejected with a TypeError exception.
             let promise = Promise::new2(cx, &global);
-            promise
-                .reject_error_with_cx(cx, Error::Type(c"Destination stream is locked".to_owned()));
+            promise.reject_error(cx, Error::Type(c"Destination stream is locked".to_owned()));
             return promise;
         }
 

--- a/components/script/dom/stream/readablestreambyobreader.rs
+++ b/components/script/dom/stream/readablestreambyobreader.rs
@@ -126,7 +126,7 @@ impl ReadIntoRequest {
             ReadIntoRequest::Read(promise) => {
                 // error steps, given e
                 // Reject promise with e.
-                promise.reject_native_with_cx(cx, &e)
+                promise.reject_native(cx, &e)
             },
             ReadIntoRequest::ByteTee {
                 byte_tee_read_into_request,
@@ -270,7 +270,7 @@ impl ReadableStreamBYOBReader {
     /// <https://streams.spec.whatwg.org/#abstract-opdef-readablestreambyobreadererrorreadintorequests>
     pub(crate) fn error_read_into_requests(&self, cx: &mut JSContext, e: SafeHandleValue) {
         // Reject reader.[[closedPromise]] with e.
-        self.closed_promise.borrow().reject_native_with_cx(cx, &e);
+        self.closed_promise.borrow().reject_native(cx, &e);
 
         // Set reader.[[closedPromise]].[[PromiseIsHandled]] to true.
         self.closed_promise.borrow().set_promise_is_handled();
@@ -426,13 +426,13 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
 
         // If view.[[ByteLength]] is 0, return a promise rejected with a TypeError exception.
         if view.byte_length() == 0 {
-            promise.reject_error_with_cx(cx, Error::Type(c"view byte length is 0".to_owned()));
+            promise.reject_error(cx, Error::Type(c"view byte length is 0".to_owned()));
             return promise;
         }
         // If view.[[ViewedArrayBuffer]].[[ArrayBufferByteLength]] is 0,
         // return a promise rejected with a TypeError exception.
         if view.viewed_buffer_array_byte_length(cx.into()) == 0 {
-            promise.reject_error_with_cx(
+            promise.reject_error(
                 cx,
                 Error::Type(c"viewed buffer byte length is 0".to_owned()),
             );
@@ -442,13 +442,13 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
         // If ! IsDetachedBuffer(view.[[ViewedArrayBuffer]]) is true,
         // return a promise rejected with a TypeError exception.
         if view.is_detached_buffer(cx.into()) {
-            promise.reject_error_with_cx(cx, Error::Type(c"view is detached".to_owned()));
+            promise.reject_error(cx, Error::Type(c"view is detached".to_owned()));
             return promise;
         }
 
         // If options["min"] is 0, return a promise rejected with a TypeError exception.
         if min == 0 {
-            promise.reject_error_with_cx(cx, Error::Type(c"min is 0".to_owned()));
+            promise.reject_error(cx, Error::Type(c"min is 0".to_owned()));
             return promise;
         }
 
@@ -456,7 +456,7 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
         if view.has_typed_array_name() {
             // If options["min"] > view.[[ArrayLength]], return a promise rejected with a RangeError exception.
             if min > (view.get_typed_array_length() as u64) {
-                promise.reject_error_with_cx(
+                promise.reject_error(
                     cx,
                     Error::Range(c"min is greater than array length".to_owned()),
                 );
@@ -466,7 +466,7 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
             // Otherwise (i.e., it is a DataView),
             // If options["min"] > view.[[ByteLength]], return a promise rejected with a RangeError exception.
             if min > (view.byte_length() as u64) {
-                promise.reject_error_with_cx(
+                promise.reject_error(
                     cx,
                     Error::Range(c"min is greater than byte length".to_owned()),
                 );
@@ -476,7 +476,7 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
 
         // If this.[[stream]] is undefined, return a promise rejected with a TypeError exception.
         if self.stream.get().is_none() {
-            promise.reject_error_with_cx(
+            promise.reject_error(
                 cx,
                 Error::Type(c"min is greater than byte length".to_owned()),
             );

--- a/components/script/dom/stream/readablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/readablestreamdefaultcontroller.rs
@@ -585,7 +585,7 @@ impl ReadableStreamDefaultController {
 
             error.to_jsval(cx, global, rval.handle_mut());
             let promise = Promise::new2(cx, global);
-            promise.reject_native_with_cx(cx, &rval.handle());
+            promise.reject_native(cx, &rval.handle());
             promise
         });
 

--- a/components/script/dom/stream/readablestreamdefaultreader.rs
+++ b/components/script/dom/stream/readablestreamdefaultreader.rs
@@ -423,7 +423,7 @@ impl ReadableStreamDefaultReader {
     /// <https://streams.spec.whatwg.org/#readable-stream-error>
     pub(crate) fn error(&self, cx: &mut js::context::JSContext, e: SafeHandleValue) {
         // Reject reader.[[closedPromise]] with e.
-        self.closed_promise.borrow().reject_native_with_cx(cx, &e);
+        self.closed_promise.borrow().reject_native(cx, &e);
 
         // Set reader.[[closedPromise]].[[PromiseIsHandled]] to true.
         self.closed_promise.borrow().set_promise_is_handled();

--- a/components/script/dom/stream/readablestreamgenericreader.rs
+++ b/components/script/dom/stream/readablestreamgenericreader.rs
@@ -104,10 +104,8 @@ pub(crate) trait ReadableStreamGenericReader {
 
             if stream.is_readable() {
                 // If stream.[[state]] is "readable", reject reader.[[closedPromise]] with a TypeError exception.
-                self.get_closed_promise().reject_error_with_cx(
-                    cx,
-                    Error::Type(c"stream state is not readable".to_owned()),
-                );
+                self.get_closed_promise()
+                    .reject_error(cx, Error::Type(c"stream state is not readable".to_owned()));
             } else {
                 // Otherwise, set reader.[[closedPromise]] to a promise rejected with a TypeError exception.
                 rooted!(&in(cx) let mut error = UndefinedValue());
@@ -155,7 +153,7 @@ pub(crate) trait ReadableStreamGenericReader {
             // If this.[[stream]] is undefined,
             // return a promise rejected with a TypeError exception.
             let promise = Promise::new2(cx, global);
-            promise.reject_error_with_cx(cx, Error::Type(c"stream is undefined".to_owned()));
+            promise.reject_error(cx, Error::Type(c"stream is undefined".to_owned()));
             promise
         } else {
             // Return ! ReadableStreamReaderGenericCancel(this, reason).

--- a/components/script/dom/stream/transformstream.rs
+++ b/components/script/dom/stream/transformstream.rs
@@ -186,7 +186,7 @@ impl Callback for CancelPromiseFulfillment {
             self.controller
                 .get_finish_promise()
                 .expect("finish promise is not set")
-                .reject_native_with_cx(cx, &error.handle());
+                .reject_native(cx, &error.handle());
         } else {
             // Otherwise:
             // Perform ! ReadableStreamDefaultControllerError(readable.[[controller]], reason).

--- a/components/script/dom/stream/transformstreamdefaultcontroller.rs
+++ b/components/script/dom/stream/transformstreamdefaultcontroller.rs
@@ -233,7 +233,7 @@ impl TransformStreamDefaultController {
                         )
                         .unwrap_or_else(|e| {
                             let p = Promise::new2(cx, global);
-                            p.reject_error_with_cx(cx, e);
+                            p.reject_error(cx, e);
                             p
                         })
                 } else {
@@ -270,7 +270,7 @@ impl TransformStreamDefaultController {
                         let realm = &mut realm.current_realm();
                         let p = Promise::new_in_realm(realm);
                         // return a promise rejected with e.
-                        p.reject_error_with_cx(realm, e);
+                        p.reject_error(realm, e);
                         p
                     })
             },
@@ -293,7 +293,7 @@ impl TransformStreamDefaultController {
                         let realm = &mut realm.current_realm();
                         let p = Promise::new_in_realm(realm);
                         // return a promise rejected with e.
-                        p.reject_error_with_cx(realm, e);
+                        p.reject_error(realm, e);
                         p
                     })
             },
@@ -317,7 +317,7 @@ impl TransformStreamDefaultController {
                         let realm = &mut realm.current_realm();
                         let p = Promise::new_in_realm(realm);
                         // return a promise rejected with e.
-                        p.reject_error_with_cx(realm, e);
+                        p.reject_error(realm, e);
                         p
                     })
             },
@@ -341,7 +341,7 @@ impl TransformStreamDefaultController {
                         let realm = &mut realm.current_realm();
                         let p = Promise::new_in_realm(realm);
                         // return a promise rejected with e.
-                        p.reject_error_with_cx(realm, e);
+                        p.reject_error(realm, e);
                         p
                     })
             },
@@ -375,7 +375,7 @@ impl TransformStreamDefaultController {
                         .Call_(cx, &this_object.handle(), chunk, ExceptionHandling::Rethrow)
                         .unwrap_or_else(|e| {
                             let p = Promise::new2(cx, global);
-                            p.reject_error_with_cx(cx, e);
+                            p.reject_error(cx, e);
                             p
                         })
                 } else {
@@ -455,7 +455,7 @@ impl TransformStreamDefaultController {
                         .Call_(cx, &this_object.handle(), self, ExceptionHandling::Rethrow)
                         .unwrap_or_else(|e| {
                             let p = Promise::new2(cx, global);
-                            p.reject_error_with_cx(cx, e);
+                            p.reject_error(cx, e);
                             p
                         })
                 } else {
@@ -483,7 +483,7 @@ impl TransformStreamDefaultController {
                         let realm = &mut realm.current_realm();
                         let p = Promise::new_in_realm(realm);
                         // return a promise rejected with e.
-                        p.reject_error_with_cx(realm, e);
+                        p.reject_error(realm, e);
                         p
                     })
             },
@@ -506,7 +506,7 @@ impl TransformStreamDefaultController {
                         let realm = &mut realm.current_realm();
                         let p = Promise::new_in_realm(realm);
                         // return a promise rejected with e.
-                        p.reject_error_with_cx(realm, e);
+                        p.reject_error(realm, e);
                         p
                     })
             },
@@ -531,7 +531,7 @@ impl TransformStreamDefaultController {
                         let realm = &mut realm.current_realm();
                         let p = Promise::new_in_realm(realm);
                         // return a promise rejected with e.
-                        p.reject_error_with_cx(realm, e);
+                        p.reject_error(realm, e);
                         p
                     })
             },
@@ -556,7 +556,7 @@ impl TransformStreamDefaultController {
                         let realm = &mut realm.current_realm();
                         let p = Promise::new_in_realm(realm);
                         // return a promise rejected with e.
-                        p.reject_error_with_cx(realm, e);
+                        p.reject_error(realm, e);
                         p
                     })
             },

--- a/components/script/dom/stream/underlyingsourcecontainer.rs
+++ b/components/script/dom/stream/underlyingsourcecontainer.rs
@@ -194,7 +194,7 @@ impl UnderlyingSourceContainer {
                 // If result is an abrupt completion,
                 if let Err(error) = result {
                     // Return a promise rejected with result.[[Value]].
-                    promise.reject_error_with_cx(cx, error);
+                    promise.reject_error(cx, error);
                 } else {
                     // Otherwise, return a promise resolved with undefined.
                     promise.resolve_native_with_cx(cx, &());

--- a/components/script/dom/stream/writablestream.rs
+++ b/components/script/dom/stream/writablestream.rs
@@ -89,8 +89,7 @@ struct AbortAlgorithmRejectionHandler {
 impl Callback for AbortAlgorithmRejectionHandler {
     fn callback(&self, cx: &mut CurrentRealm, reason: SafeHandleValue) {
         // Reject abortRequest’s promise with reason.
-        self.abort_request_promise
-            .reject_native_with_cx(cx, &reason);
+        self.abort_request_promise.reject_native(cx, &reason);
 
         // Perform ! WritableStreamRejectCloseAndClosedPromiseIfNeeded(stream).
         self.stream
@@ -557,7 +556,7 @@ impl WritableStream {
         };
 
         // Reject stream.[[inFlightCloseRequest]] with error.
-        in_flight_close_request.reject_native_with_cx(cx, &error);
+        in_flight_close_request.reject_native(cx, &error);
 
         // Set stream.[[inFlightCloseRequest]] to undefined.
         // Done above with `take`.
@@ -569,9 +568,7 @@ impl WritableStream {
         rooted!(&in(cx) let pending_abort_request = self.pending_abort_request.borrow_mut().take());
         if let Some(pending_abort_request) = &*pending_abort_request {
             // Reject stream.[[pendingAbortRequest]]'s promise with error.
-            pending_abort_request
-                .promise
-                .reject_native_with_cx(cx, &error);
+            pending_abort_request.promise.reject_native(cx, &error);
 
             // Set stream.[[pendingAbortRequest]] to undefined.
             // Done above with `take`.
@@ -594,7 +591,7 @@ impl WritableStream {
         };
 
         // Reject stream.[[inFlightWriteRequest]] with error.
-        in_flight_write_request.reject_native_with_cx(cx, &error);
+        in_flight_write_request.reject_native(cx, &error);
 
         // Set stream.[[inFlightWriteRequest]] to undefined.
         // Done above with `take`.
@@ -742,8 +739,7 @@ impl WritableStream {
         if self.is_closed() || self.is_errored() {
             // return a promise rejected with a TypeError exception.
             let promise = Promise::new2(cx, global);
-            promise
-                .reject_error_with_cx(cx, Error::Type(c"Stream is closed or errored.".to_owned()));
+            promise.reject_error(cx, Error::Type(c"Stream is closed or errored.".to_owned()));
             return promise;
         }
 
@@ -1071,7 +1067,7 @@ impl WritableStreamMethods<crate::DomTypeHolder> for WritableStream {
         if self.is_locked() {
             // return a promise rejected with a TypeError exception.
             let promise = Promise::new2(cx, &global);
-            promise.reject_error_with_cx(cx, Error::Type(c"Stream is locked.".to_owned()));
+            promise.reject_error(cx, Error::Type(c"Stream is locked.".to_owned()));
             return promise;
         }
 
@@ -1087,7 +1083,7 @@ impl WritableStreamMethods<crate::DomTypeHolder> for WritableStream {
         if self.is_locked() {
             // return a promise rejected with a TypeError exception.
             let promise = Promise::new2(cx, &global);
-            promise.reject_error_with_cx(cx, Error::Type(c"Stream is locked.".to_owned()));
+            promise.reject_error(cx, Error::Type(c"Stream is locked.".to_owned()));
             return promise;
         }
 
@@ -1095,7 +1091,7 @@ impl WritableStreamMethods<crate::DomTypeHolder> for WritableStream {
         if self.close_queued_or_in_flight() {
             // return a promise rejected with a TypeError exception.
             let promise = Promise::new2(cx, &global);
-            promise.reject_error_with_cx(
+            promise.reject_error(
                 cx,
                 Error::Type(c"Stream has closed queued or in-flight".to_owned()),
             );

--- a/components/script/dom/stream/writablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/writablestreamdefaultcontroller.rs
@@ -186,7 +186,7 @@ impl Callback for TransferBackPressurePromiseReaction {
             global.disentangle_port(cx, &self.port);
 
             // Return a promise rejected with result.[[Value]].
-            self.result_promise.reject_error_with_cx(cx, error);
+            self.result_promise.reject_error(cx, error);
         } else {
             // Otherwise, return a promise resolved with undefined.
             self.result_promise.resolve_native(&(), can_gc);
@@ -614,7 +614,7 @@ impl WritableStreamDefaultController {
                 };
                 result.unwrap_or_else(|e| {
                     let promise = Promise::new2(cx, global);
-                    promise.reject_error_with_cx(cx, e);
+                    promise.reject_error(cx, e);
                     promise
                 })
             },
@@ -632,7 +632,7 @@ impl WritableStreamDefaultController {
 
                 // If result is an abrupt completion, return a promise rejected with result.[[Value]]
                 if let Err(error) = result {
-                    promise.reject_error_with_cx(cx, error);
+                    promise.reject_error(cx, error);
                 } else {
                     // Otherwise, return a promise resolved with undefined.
                     promise.resolve_native_with_cx(cx, &());
@@ -687,7 +687,7 @@ impl WritableStreamDefaultController {
                 };
                 result.unwrap_or_else(|e| {
                     let promise = Promise::new2(cx, global);
-                    promise.reject_error_with_cx(cx, e);
+                    promise.reject_error(cx, e);
                     promise
                 })
             },
@@ -761,7 +761,7 @@ impl WritableStreamDefaultController {
                 };
                 result.unwrap_or_else(|e| {
                     let promise = Promise::new2(cx, global);
-                    promise.reject_error_with_cx(cx, e);
+                    promise.reject_error(cx, e);
                     promise
                 })
             },

--- a/components/script/dom/stream/writablestreamdefaultwriter.rs
+++ b/components/script/dom/stream/writablestreamdefaultwriter.rs
@@ -155,9 +155,7 @@ impl WritableStreamDefaultWriter {
         cx: &mut JSContext,
         error: &SafeHandleValue,
     ) {
-        self.closed_promise
-            .borrow()
-            .reject_native_with_cx(cx, error);
+        self.closed_promise.borrow().reject_native(cx, error);
     }
 
     pub(crate) fn set_close_promise_is_handled(&self) {
@@ -188,7 +186,7 @@ impl WritableStreamDefaultWriter {
         // If writer.[[readyPromise]].[[PromiseState]] is "pending",
         if ready_promise.is_pending() {
             // reject writer.[[readyPromise]] with error.
-            ready_promise.reject_native_with_cx(cx, &error);
+            ready_promise.reject_native(cx, &error);
 
             // Set writer.[[readyPromise]].[[PromiseIsHandled]] to true.
             ready_promise.set_promise_is_handled();
@@ -214,7 +212,7 @@ impl WritableStreamDefaultWriter {
         // If writer.[[closedPromise]].[[PromiseState]] is "pending",
         if closed_promise.is_pending() {
             // reject writer.[[closedPromise]] with error.
-            closed_promise.reject_native_with_cx(cx, &error);
+            closed_promise.reject_native(cx, &error);
 
             // Set writer.[[closedPromise]].[[PromiseIsHandled]] to true.
             closed_promise.set_promise_is_handled();
@@ -287,7 +285,7 @@ impl WritableStreamDefaultWriter {
             .is_some_and(|current_stream| current_stream == stream)
         {
             let promise = Promise::new2(cx, global);
-            promise.reject_error_with_cx(
+            promise.reject_error(
                 cx,
                 Error::Type(c"Stream is not equal to writer stream".to_owned()),
             );
@@ -301,7 +299,7 @@ impl WritableStreamDefaultWriter {
             rooted!(&in(cx) let mut error = UndefinedValue());
             stream.get_stored_error(error.handle_mut());
             let promise = Promise::new2(cx, global);
-            promise.reject_native_with_cx(cx, &error.handle());
+            promise.reject_native(cx, &error.handle());
             return promise;
         }
 
@@ -311,7 +309,7 @@ impl WritableStreamDefaultWriter {
             // return a promise rejected with a TypeError exception
             // indicating that the stream is closing or closed
             let promise = Promise::new2(cx, global);
-            promise.reject_error_with_cx(
+            promise.reject_error(
                 cx,
                 Error::Type(c"Stream has been closed, or has close queued or in-flight".to_owned()),
             );
@@ -324,7 +322,7 @@ impl WritableStreamDefaultWriter {
             rooted!(&in(cx) let mut error = UndefinedValue());
             stream.get_stored_error(error.handle_mut());
             let promise = Promise::new2(cx, global);
-            promise.reject_native_with_cx(cx, &error.handle());
+            promise.reject_native(cx, &error.handle());
             return promise;
         }
 
@@ -402,7 +400,7 @@ impl WritableStreamDefaultWriter {
             rooted!(&in(cx) let mut error = UndefinedValue());
             stream.get_stored_error(error.handle_mut());
             let promise = Promise::new2(cx, global);
-            promise.reject_native_with_cx(cx, &error.handle());
+            promise.reject_native(cx, &error.handle());
             return promise;
         }
 
@@ -450,7 +448,7 @@ impl WritableStreamDefaultWriterMethods<crate::DomTypeHolder> for WritableStream
         if self.stream.get().is_none() {
             // return a promise rejected with a TypeError exception.
             let promise = Promise::new2(cx, &global);
-            promise.reject_error_with_cx(cx, Error::Type(c"Stream is undefined".to_owned()));
+            promise.reject_error(cx, Error::Type(c"Stream is undefined".to_owned()));
             return promise;
         }
 
@@ -467,14 +465,14 @@ impl WritableStreamDefaultWriterMethods<crate::DomTypeHolder> for WritableStream
         let Some(stream) = self.stream.get() else {
             // If stream is undefined,
             // return a promise rejected with a TypeError exception.
-            promise.reject_error_with_cx(cx, Error::Type(c"Stream is undefined".to_owned()));
+            promise.reject_error(cx, Error::Type(c"Stream is undefined".to_owned()));
             return promise;
         };
 
         // If ! WritableStreamCloseQueuedOrInFlight(stream) is true
         if stream.close_queued_or_in_flight() {
             // return a promise rejected with a TypeError exception.
-            promise.reject_error_with_cx(
+            promise.reject_error(
                 cx,
                 Error::Type(c"Stream has closed queued or in-flight".to_owned()),
             );
@@ -509,7 +507,7 @@ impl WritableStreamDefaultWriterMethods<crate::DomTypeHolder> for WritableStream
         if self.stream.get().is_none() {
             // return a promise rejected with a TypeError exception.
             let promise = Promise::new2(cx, &global);
-            promise.reject_error_with_cx(cx, Error::Type(c"Stream is undefined".to_owned()));
+            promise.reject_error(cx, Error::Type(c"Stream is undefined".to_owned()));
             return promise;
         }
 

--- a/components/script/dom/wakelock/wakelock.rs
+++ b/components/script/dom/wakelock/wakelock.rs
@@ -58,7 +58,7 @@ impl WakeLockMethods<crate::DomTypeHolder> for WakeLock {
 
         // Step 2. If document is not fully active, reject with NotAllowedError.
         if !document.is_fully_active() {
-            promise.reject_error_with_cx(cx, Error::NotAllowed(Some(
+            promise.reject_error(cx, Error::NotAllowed(Some(
                         "Failed to execute 'request' on 'WakeLock': The requesting page is not fully active."
                         .to_string())));
             return promise;
@@ -66,7 +66,7 @@ impl WakeLockMethods<crate::DomTypeHolder> for WakeLock {
 
         // Step 3. If document's visibility state is "hidden", reject with NotAllowedError.
         if document.VisibilityState() == DocumentVisibilityState::Hidden {
-            promise.reject_error_with_cx(cx, Error::NotAllowed(Some(
+            promise.reject_error(cx, Error::NotAllowed(Some(
                         "Failed to execute 'request' on 'WakeLock': The requesting page is not visible."
                         .to_string()
                         )));
@@ -76,7 +76,7 @@ impl WakeLockMethods<crate::DomTypeHolder> for WakeLock {
         // Step 4. Obtain permission for "screen-wake-lock".
         // <https://w3c.github.io/screen-wake-lock/#dfn-obtain-permission>
         let Some(webview_id) = global.webview_id() else {
-            promise.reject_error_with_cx(
+            promise.reject_error(
                 cx,
                 Error::NotAllowed(Some("Unable to obtain WakeLock permission.".to_string())),
             );
@@ -104,7 +104,7 @@ impl RoutedPromiseListener<AllowOrDeny> for WakeLock {
         match response {
             // Step 7a. If permission is denied, reject with NotAllowedError.
             AllowOrDeny::Deny => {
-                promise.reject_error_with_cx(
+                promise.reject_error(
                     cx,
                     Error::NotAllowed(Some(
                         "Failed to execute 'request' on 'WakeLock': Permission denied.".to_string(),

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -223,7 +223,7 @@ impl SubtleCrypto {
                     CanGc::from_cx(cx),
                 ) {
                     Ok(_) => promise.resolve_native_with_cx(cx, &*array_buffer_ptr),
-                    Err(_) => promise.reject_error_with_cx(cx, Error::JSFailed),
+                    Err(_) => promise.reject_error(cx, Error::JSFailed),
                 }
             }));
     }
@@ -327,7 +327,7 @@ impl SubtleCrypto {
             .crypto_task_source()
             .queue(task!(reject_error: move |cx| {
                 let promise = trusted_promise.root();
-                promise.reject_error_with_cx(cx, error);
+                promise.reject_error(cx, error);
             }));
     }
 
@@ -386,7 +386,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             Ok(normalized_algorithm) => normalized_algorithm,
             Err(error) => {
                 let promise = Promise::new_in_realm(cx);
-                promise.reject_error_with_cx(cx, error);
+                promise.reject_error(cx, error);
                 return promise;
             },
         };
@@ -473,7 +473,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             Ok(normalized_algorithm) => normalized_algorithm,
             Err(error) => {
                 let promise = Promise::new_in_realm(cx);
-                promise.reject_error_with_cx(cx, error);
+                promise.reject_error(cx, error);
                 return promise;
             },
         };
@@ -560,7 +560,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             Ok(normalized_algorithm) => normalized_algorithm,
             Err(error) => {
                 let promise = Promise::new_in_realm(cx);
-                promise.reject_error_with_cx(cx, error);
+                promise.reject_error(cx, error);
                 return promise;
             },
         };
@@ -647,7 +647,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             Ok(algorithm) => algorithm,
             Err(error) => {
                 let promise = Promise::new_in_realm(cx);
-                promise.reject_error_with_cx(cx, error);
+                promise.reject_error(cx, error);
                 return promise;
             },
         };
@@ -737,7 +737,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             Ok(normalized_algorithm) => normalized_algorithm,
             Err(error) => {
                 let promise = Promise::new_in_realm(cx);
-                promise.reject_error_with_cx(cx, error);
+                promise.reject_error(cx, error);
                 return promise;
             },
         };
@@ -806,7 +806,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
         {
             Ok(normalized_algorithm) => normalized_algorithm,
             Err(error) => {
-                promise.reject_error_with_cx(cx, error);
+                promise.reject_error(cx, error);
                 return promise;
             },
         };
@@ -913,7 +913,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
         {
             Ok(normalized_algorithm) => normalized_algorithm,
             Err(error) => {
-                promise.reject_error_with_cx(cx, error);
+                promise.reject_error(cx, error);
                 return promise;
             },
         };
@@ -926,7 +926,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             match normalize_algorithm::<ImportKeyOperation>(cx, &derived_key_type) {
                 Ok(normalized_algorithm) => normalized_algorithm,
                 Err(error) => {
-                    promise.reject_error_with_cx(cx, error);
+                    promise.reject_error(cx, error);
                     return promise;
                 },
             };
@@ -939,7 +939,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             match normalize_algorithm::<GetKeyLengthOperation>(cx, &derived_key_type) {
                 Ok(normalized_algorithm) => normalized_algorithm,
                 Err(error) => {
-                    promise.reject_error_with_cx(cx, error);
+                    promise.reject_error(cx, error);
                     return promise;
                 },
             };
@@ -1060,7 +1060,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
         {
             Ok(normalized_algorithm) => normalized_algorithm,
             Err(error) => {
-                promise.reject_error_with_cx(cx, error);
+                promise.reject_error(cx, error);
                 return promise;
             },
         };
@@ -1140,7 +1140,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             Ok(algorithm) => algorithm,
             Err(error) => {
                 let promise = Promise::new_in_realm(cx);
-                promise.reject_error_with_cx(cx, error);
+                promise.reject_error(cx, error);
                 return promise;
             },
         };
@@ -1155,7 +1155,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                         // Step 4.1. If the keyData parameter passed to the importKey() method is
                         // not a JsonWebKey dictionary, throw a TypeError.
                         let promise = Promise::new_in_realm(cx);
-                        promise.reject_error_with_cx(
+                        promise.reject_error(
                             cx,
                             Error::Type(c"The keyData type does not match the format".to_owned()),
                         );
@@ -1174,7 +1174,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                             Ok(stringified) => Zeroizing::new(stringified.as_bytes().to_vec()),
                             Err(error) => {
                                 let promise = Promise::new_in_realm(cx);
-                                promise.reject_error_with_cx(cx, error);
+                                promise.reject_error(cx, error);
                                 return promise;
                             },
                         }
@@ -1188,7 +1188,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                     // JsonWebKey dictionary, throw a TypeError.
                     ArrayBufferViewOrArrayBufferOrJsonWebKey::JsonWebKey(_) => {
                         let promise = Promise::new_in_realm(cx);
-                        promise.reject_error_with_cx(
+                        promise.reject_error(
                             cx,
                             Error::Type(c"The keyData type does not match the format".to_owned()),
                         );
@@ -1382,7 +1382,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 Ok(algorithm) => WrapKeyAlgorithmOrEncryptAlgorithm::EncryptAlgorithm(algorithm),
                 Err(error) => {
                     let promise = Promise::new_in_realm(cx);
-                    promise.reject_error_with_cx(cx, error);
+                    promise.reject_error(cx, error);
                     return promise;
                 },
             }
@@ -1560,7 +1560,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 Ok(algorithm) => UnwrapKeyAlgorithmOrDecryptAlgorithm::DecryptAlgorithm(algorithm),
                 Err(error) => {
                     let promise = Promise::new_in_realm(cx);
-                    promise.reject_error_with_cx(cx, error);
+                    promise.reject_error(cx, error);
                     return promise;
                 },
             }
@@ -1574,7 +1574,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 Ok(algorithm) => algorithm,
                 Err(error) => {
                     let promise = Promise::new_in_realm(cx);
-                    promise.reject_error_with_cx(cx, error);
+                    promise.reject_error(cx, error);
                     return promise;
                 },
             };
@@ -1736,7 +1736,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             match normalize_algorithm::<EncapsulateOperation>(cx, &encapsulation_algorithm) {
                 Ok(algorithm) => algorithm,
                 Err(error) => {
-                    promise.reject_error_with_cx(cx, error);
+                    promise.reject_error(cx, error);
                     return promise;
                 },
             };
@@ -1749,7 +1749,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             match normalize_algorithm::<ImportKeyOperation>(cx, &shared_key_algorithm) {
                 Ok(algorithm) => algorithm,
                 Err(error) => {
-                    promise.reject_error_with_cx(cx, error);
+                    promise.reject_error(cx, error);
                     return promise;
                 },
             };
@@ -1877,7 +1877,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             match normalize_algorithm::<EncapsulateOperation>(cx, &encapsulation_algorithm) {
                 Ok(algorithm) => algorithm,
                 Err(error) => {
-                    promise.reject_error_with_cx(cx, error);
+                    promise.reject_error(cx, error);
                     return promise;
                 },
             };
@@ -1971,7 +1971,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 Ok(normalized_algorithm) => normalized_algorithm,
                 Err(error) => {
                     let promise = Promise::new_in_realm(cx);
-                    promise.reject_error_with_cx(cx, error);
+                    promise.reject_error(cx, error);
                     return promise;
                 },
             };
@@ -1985,7 +1985,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 Ok(normalized_algorithm) => normalized_algorithm,
                 Err(error) => {
                     let promise = Promise::new_in_realm(cx);
-                    promise.reject_error_with_cx(cx, error);
+                    promise.reject_error(cx, error);
                     return promise;
                 },
             };
@@ -2108,7 +2108,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 Ok(normalized_algorithm) => normalized_algorithm,
                 Err(error) => {
                     let promise = Promise::new_in_realm(cx);
-                    promise.reject_error_with_cx(cx, error);
+                    promise.reject_error(cx, error);
                     return promise;
                 },
             };
@@ -2212,7 +2212,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
             Ok(normalized_algorithm) => normalized_algorithm,
             Err(error) => {
                 let promise = Promise::new_in_realm(cx);
-                promise.reject_error_with_cx(cx, error);
+                promise.reject_error(cx, error);
                 return promise;
             },
         };

--- a/components/script/dom/webgpu/gpu.rs
+++ b/components/script/dom/webgpu/gpu.rs
@@ -101,7 +101,7 @@ impl GPUMethods<crate::DomTypeHolder> for GPU {
             ))
             .is_err()
         {
-            promise.reject_error_with_cx(cx, Error::Operation(None));
+            promise.reject_error(cx, Error::Operation(None));
         }
         // 4. Return promise
         promise

--- a/components/script/dom/webgpu/gpuadapter.rs
+++ b/components/script/dom/webgpu/gpuadapter.rs
@@ -201,7 +201,7 @@ impl GPUAdapterMethods<crate::DomTypeHolder> for GPUAdapter {
             if let Some(feature) = gpu_to_wgt_feature(ext) {
                 required_features.insert(feature);
             } else {
-                promise.reject_error_with_cx(
+                promise.reject_error(
                     cx,
                     Error::Type(cformat!("{} is not supported feature", ext.as_str())),
                 );
@@ -214,7 +214,7 @@ impl GPUAdapterMethods<crate::DomTypeHolder> for GPUAdapter {
             for (limit, value) in (*limits).iter() {
                 if !set_limit(&mut required_limits, &limit.str(), *value) {
                     warn!("Unknown GPUDevice limit: {limit}");
-                    promise.reject_error_with_cx(cx, Error::Operation(None));
+                    promise.reject_error(cx, Error::Operation(None));
                     return promise;
                 }
             }
@@ -245,7 +245,7 @@ impl GPUAdapterMethods<crate::DomTypeHolder> for GPUAdapter {
             })
             .is_err()
         {
-            promise.reject_error_with_cx(cx, Error::Operation(None));
+            promise.reject_error(cx, Error::Operation(None));
         }
         // Step 5
         promise
@@ -294,7 +294,7 @@ impl RoutedPromiseListener<WebGPUDeviceResponse> for GPUAdapter {
                 promise.resolve_native_with_cx(cx, &device);
             },
             // 1. If features are not supported reject promise with a TypeError.
-            (_, _, Err(RequestDeviceError::UnsupportedFeature(f))) => promise.reject_error_with_cx(
+            (_, _, Err(RequestDeviceError::UnsupportedFeature(f))) => promise.reject_error(
                 cx,
                 Error::Type(cformat!(
                     "{}",
@@ -307,7 +307,7 @@ impl RoutedPromiseListener<WebGPUDeviceResponse> for GPUAdapter {
                     "{}",
                     wgpu_core::instance::RequestDeviceError::LimitsExceeded(l)
                 );
-                promise.reject_error_with_cx(cx, Error::Operation(None))
+                promise.reject_error(cx, Error::Operation(None))
             },
             // 3. user agent otherwise cannot fulfill the request
             (device_id, queue_id, Err(RequestDeviceError::Other(e))) => {

--- a/components/script/dom/webgpu/gpubuffer.rs
+++ b/components/script/dom/webgpu/gpubuffer.rs
@@ -208,7 +208,7 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
         // Step 1
         let promise = self.pending_map.borrow_mut().take();
         if let Some(promise) = promise {
-            promise.reject_error_with_cx(cx, Error::Abort(None));
+            promise.reject_error(cx, Error::Abort(None));
         }
         // Step 2
         let mut mapping = RootedTraceableBox::new(self.mapping.borrow_mut().take());
@@ -265,7 +265,7 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
         let promise = Promise::new_in_realm(cx);
         // Step 2
         if self.pending_map.borrow().is_some() {
-            promise.reject_error_with_cx(cx, Error::Operation(None));
+            promise.reject_error(cx, Error::Operation(None));
             return promise;
         }
         // Step 4
@@ -398,9 +398,9 @@ impl GPUBuffer {
         // Step 4
         let is_lost = self.device.is_lost();
         if is_lost {
-            p.reject_error_with_cx(cx, Error::Abort(None));
+            p.reject_error(cx, Error::Abort(None));
         } else {
-            p.reject_error_with_cx(cx, Error::Operation(None));
+            p.reject_error(cx, Error::Operation(None));
         }
     }
 
@@ -426,7 +426,7 @@ impl GPUBuffer {
         match mapping {
             Err(error) => {
                 *self.pending_map.borrow_mut() = None;
-                p.reject_error_with_cx(cx, error);
+                p.reject_error(cx, error);
             },
             Ok(mut mapping) => {
                 // Step 5

--- a/components/script/dom/webgpu/gpudevice.rs
+++ b/components/script/dom/webgpu/gpudevice.rs
@@ -668,7 +668,7 @@ impl RoutedPromiseListener<WebGPUPoppedErrorScopeResponse> for GPUDevice {
             Ok(None) | Err(PopError::Lost) => {
                 promise.resolve_native_with_cx(cx, &None::<Option<GPUError>>)
             },
-            Err(PopError::Empty) => promise.reject_error_with_cx(cx, Error::Operation(None)),
+            Err(PopError::Empty) => promise.reject_error(cx, Error::Operation(None)),
             Ok(Some(error)) => {
                 let error = GPUError::from_error(cx, &self.global(), error);
                 promise.resolve_native_with_cx(cx, &error);
@@ -702,7 +702,7 @@ impl RoutedPromiseListener<WebGPUComputePipelineResponse> for GPUDevice {
                     msg.into(),
                     GPUPipelineErrorReason::Validation,
                 );
-                promise.reject_native_with_cx(cx, &gpu_pipeline_error)
+                promise.reject_native(cx, &gpu_pipeline_error)
             },
             Err(webgpu_traits::Error::OutOfMemory(msg) | webgpu_traits::Error::Internal(msg)) => {
                 let gpu_pipeline_error = GPUPipelineError::new(
@@ -711,7 +711,7 @@ impl RoutedPromiseListener<WebGPUComputePipelineResponse> for GPUDevice {
                     msg.into(),
                     GPUPipelineErrorReason::Internal,
                 );
-                promise.reject_native_with_cx(cx, &gpu_pipeline_error)
+                promise.reject_native(cx, &gpu_pipeline_error)
             },
         }
     }
@@ -743,7 +743,7 @@ impl RoutedPromiseListener<WebGPURenderPipelineResponse> for GPUDevice {
                     GPUPipelineErrorReason::Validation,
                 );
 
-                promise.reject_native_with_cx(cx, &pipeline_error)
+                promise.reject_native(cx, &pipeline_error)
             },
             Err(webgpu_traits::Error::OutOfMemory(msg) | webgpu_traits::Error::Internal(msg)) => {
                 let pipeline_error = GPUPipelineError::new(
@@ -752,7 +752,7 @@ impl RoutedPromiseListener<WebGPURenderPipelineResponse> for GPUDevice {
                     msg.into(),
                     GPUPipelineErrorReason::Internal,
                 );
-                promise.reject_native_with_cx(cx, &pipeline_error)
+                promise.reject_native(cx, &pipeline_error)
             },
         }
     }

--- a/components/script/dom/webrtc/rtcpeerconnection.rs
+++ b/components/script/dom/webrtc/rtcpeerconnection.rs
@@ -559,7 +559,7 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
     ) -> Rc<Promise> {
         let p = Promise::new_in_realm(current_realm);
         if candidate.sdpMid.is_none() && candidate.sdpMLineIndex.is_none() {
-            p.reject_error_with_cx(
+            p.reject_error(
                 current_realm,
                 Error::Type(c"one of sdpMid and sdpMLineIndex must be set".to_owned()),
             );
@@ -568,7 +568,7 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
 
         // XXXManishearth add support for sdpMid
         if candidate.sdpMLineIndex.is_none() {
-            p.reject_error_with_cx(
+            p.reject_error(
                 current_realm,
                 Error::Type(c"servo only supports sdpMLineIndex right now".to_owned()),
             );
@@ -600,7 +600,7 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
     ) -> Rc<Promise> {
         let p = Promise::new_in_realm(current_realm);
         if self.closed.get() {
-            p.reject_error_with_cx(current_realm, Error::InvalidState(None));
+            p.reject_error(current_realm, Error::InvalidState(None));
             return p;
         }
         self.offer_promises.borrow_mut().push(p.clone());
@@ -616,7 +616,7 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
     ) -> Rc<Promise> {
         let p = Promise::new_in_realm(current_realm);
         if self.closed.get() {
-            p.reject_error_with_cx(current_realm, Error::InvalidState(None));
+            p.reject_error(current_realm, Error::InvalidState(None));
             return p;
         }
         self.answer_promises.borrow_mut().push(p.clone());

--- a/components/script/dom/webxr/xrsession.rs
+++ b/components/script/dom/webxr/xrsession.rs
@@ -843,14 +843,14 @@ impl XRSessionMethods<crate::DomTypeHolder> for XRSession {
         if !self.is_immersive() &&
             (ty == XRReferenceSpaceType::Bounded_floor || ty == XRReferenceSpaceType::Unbounded)
         {
-            p.reject_error_with_cx(cx, Error::NotSupported(None));
+            p.reject_error(cx, Error::NotSupported(None));
             return p;
         }
 
         match ty {
             XRReferenceSpaceType::Unbounded => {
                 // XXXmsub2 figure out how to support this
-                p.reject_error_with_cx(cx, Error::NotSupported(None))
+                p.reject_error(cx, Error::NotSupported(None))
             },
             ty => {
                 if ty != XRReferenceSpaceType::Viewer &&
@@ -864,7 +864,7 @@ impl XRSessionMethods<crate::DomTypeHolder> for XRSession {
                         .iter()
                         .any(|f| *f == s)
                     {
-                        p.reject_error_with_cx(cx, Error::NotSupported(None));
+                        p.reject_error(cx, Error::NotSupported(None));
                         return p;
                     }
                 }
@@ -941,7 +941,7 @@ impl XRSessionMethods<crate::DomTypeHolder> for XRSession {
             .iter()
             .any(|f| f == "hit-test")
         {
-            p.reject_error_with_cx(cx, Error::NotSupported(None));
+            p.reject_error(cx, Error::NotSupported(None));
             return p;
         }
 
@@ -1052,15 +1052,12 @@ impl XRSessionMethods<crate::DomTypeHolder> for XRSession {
                 supported_frame_rates.is_empty() ||
                 self.ended.get()
             {
-                promise.reject_error_with_cx(cx, Error::InvalidState(None));
+                promise.reject_error(cx, Error::InvalidState(None));
                 return promise;
             }
 
             if !supported_frame_rates.contains(&*rate) {
-                promise.reject_error_with_cx(
-                    cx,
-                    Error::Type(c"Provided framerate not supported".into()),
-                );
+                promise.reject_error(cx, Error::Type(c"Provided framerate not supported".into()));
                 return promise;
             }
         }

--- a/components/script/dom/webxr/xrsystem.rs
+++ b/components/script/dom/webxr/xrsystem.rs
@@ -172,13 +172,13 @@ impl XRSystemMethods<crate::DomTypeHolder> for XRSystem {
                         "The dom.webxr.unsafe-assume-user-intent preference assumes user intent to enter WebXR."
                     );
                 } else {
-                    promise.reject_error_with_cx(realm, Error::Security(None));
+                    promise.reject_error(realm, Error::Security(None));
                     return promise;
                 }
             }
 
             if self.pending_or_active_session() {
-                promise.reject_error_with_cx(realm, Error::InvalidState(None));
+                promise.reject_error(realm, Error::InvalidState(None));
                 return promise;
             }
 
@@ -199,7 +199,7 @@ impl XRSystemMethods<crate::DomTypeHolder> for XRSystem {
                     if mode != XRSessionMode::Inline {
                         self.pending_immersive_session.set(false);
                     }
-                    promise.reject_error_with_cx(realm, Error::NotSupported(None));
+                    promise.reject_error(realm, Error::NotSupported(None));
                     return promise;
                 }
             }
@@ -286,7 +286,7 @@ impl XRSystem {
                 if mode != XRSessionMode::Inline {
                     self.pending_immersive_session.set(false);
                 }
-                promise.reject_error_with_cx(cx, Error::NotSupported(None));
+                promise.reject_error(cx, Error::NotSupported(None));
                 return;
             },
         };

--- a/components/script/dom/webxr/xrtest.rs
+++ b/components/script/dom/webxr/xrtest.rs
@@ -62,7 +62,7 @@ impl XRTest {
                 .push(Dom::from_ref(&device));
             promise.resolve_native_with_cx(cx, &device);
         } else {
-            promise.reject_native_with_cx(cx, &());
+            promise.reject_native(cx, &());
         }
     }
 }
@@ -80,7 +80,7 @@ impl XRTestMethods<crate::DomTypeHolder> for XRTest {
             match get_origin(o) {
                 Ok(origin) => Some(origin),
                 Err(e) => {
-                    p.reject_error_with_cx(cx, e);
+                    p.reject_error(cx, e);
                     return p;
                 },
             }
@@ -92,7 +92,7 @@ impl XRTestMethods<crate::DomTypeHolder> for XRTest {
             match get_origin(o) {
                 Ok(origin) => Some(origin),
                 Err(e) => {
-                    p.reject_error_with_cx(cx, e);
+                    p.reject_error(cx, e);
                     return p;
                 },
             }
@@ -103,7 +103,7 @@ impl XRTestMethods<crate::DomTypeHolder> for XRTest {
         let views = match get_views(&init.views) {
             Ok(views) => views,
             Err(e) => {
-                p.reject_error_with_cx(cx, e);
+                p.reject_error(cx, e);
                 return p;
             },
         };
@@ -118,7 +118,7 @@ impl XRTestMethods<crate::DomTypeHolder> for XRTest {
             let w = match get_world(w) {
                 Ok(w) => w,
                 Err(e) => {
-                    p.reject_error_with_cx(cx, e);
+                    p.reject_error(cx, e);
                     return p;
                 },
             };

--- a/components/script/dom/workers/serviceworkercontainer.rs
+++ b/components/script/dom/workers/serviceworkercontainer.rs
@@ -83,13 +83,13 @@ impl ServiceWorkerContainer {
             // Note: we are in the task already.
             JobResult::RejectPromise(error) => match error {
                 JobError::TypeError => {
-                    promise.reject_error_with_cx(
+                    promise.reject_error(
                         cx,
                         Error::Type(c"Failed to register a ServiceWorker".to_owned()),
                     );
                 },
                 JobError::SecurityError => {
-                    promise.reject_error_with_cx(cx, Error::Security(None));
+                    promise.reject_error(cx, Error::Security(None));
                 },
             },
             // <https://w3c.github.io/ServiceWorker/#resolve-job-promise>
@@ -342,7 +342,7 @@ impl ServiceWorkerContainerMethods<crate::DomTypeHolder> for ServiceWorkerContai
             Ok(url) => url,
             Err(_) => {
                 // B: Step 1
-                promise.reject_error_with_cx(realm, Error::Type(c"Invalid script URL".to_owned()));
+                promise.reject_error(realm, Error::Type(c"Invalid script URL".to_owned()));
                 return promise;
             },
         };
@@ -354,10 +354,7 @@ impl ServiceWorkerContainerMethods<crate::DomTypeHolder> for ServiceWorkerContai
                 match api_base_url.join(inner_scope) {
                     Ok(url) => url,
                     Err(_) => {
-                        promise.reject_error_with_cx(
-                            realm,
-                            Error::Type(c"Invalid scope URL".to_owned()),
-                        );
+                        promise.reject_error(realm, Error::Type(c"Invalid scope URL".to_owned()));
                         return promise;
                     },
                 }
@@ -371,7 +368,7 @@ impl ServiceWorkerContainerMethods<crate::DomTypeHolder> for ServiceWorkerContai
         match script_url.scheme() {
             "https" | "http" => {},
             _ => {
-                promise.reject_error_with_cx(
+                promise.reject_error(
                     realm,
                     Error::Type(c"Only secure origins are allowed".to_owned()),
                 );
@@ -382,7 +379,7 @@ impl ServiceWorkerContainerMethods<crate::DomTypeHolder> for ServiceWorkerContai
         if script_url.path().to_ascii_lowercase().contains("%2f") ||
             script_url.path().to_ascii_lowercase().contains("%5c")
         {
-            promise.reject_error_with_cx(
+            promise.reject_error(
                 realm,
                 Error::Type(c"Script URL contains forbidden characters".to_owned()),
             );
@@ -393,7 +390,7 @@ impl ServiceWorkerContainerMethods<crate::DomTypeHolder> for ServiceWorkerContai
         match scope.scheme() {
             "https" | "http" => {},
             _ => {
-                promise.reject_error_with_cx(
+                promise.reject_error(
                     realm,
                     Error::Type(c"Only secure origins are allowed".to_owned()),
                 );
@@ -404,7 +401,7 @@ impl ServiceWorkerContainerMethods<crate::DomTypeHolder> for ServiceWorkerContai
         if scope.path().to_ascii_lowercase().contains("%2f") ||
             scope.path().to_ascii_lowercase().contains("%5c")
         {
-            promise.reject_error_with_cx(
+            promise.reject_error(
                 realm,
                 Error::Type(c"Scope URL contains forbidden characters".to_owned()),
             );
@@ -420,7 +417,7 @@ impl ServiceWorkerContainerMethods<crate::DomTypeHolder> for ServiceWorkerContai
 
         // Step 10: Let storage key be the result of running obtain a storage key given client.
         let Some(storage_key) = global.obtain_storage_key() else {
-            promise.reject_error_with_cx(
+            promise.reject_error(
                 realm,
                 Error::Type(c"Failed to obtain a storage key".to_owned()),
             );
@@ -453,7 +450,7 @@ impl ServiceWorkerContainerMethods<crate::DomTypeHolder> for ServiceWorkerContai
                 false,
                 "Failed to send StartRegister algorithm message to the constellation."
             );
-            promise.reject_error_with_cx(
+            promise.reject_error(
                 realm,
                 Error::Type(c"Failed to register a ServiceWorker".to_owned()),
             );
@@ -474,7 +471,7 @@ impl ServiceWorkerContainerMethods<crate::DomTypeHolder> for ServiceWorkerContai
 
         // Step 2: Let client storage key be the result of running obtain a storage key given client.
         let Some(storage_key) = global.obtain_storage_key() else {
-            promise.reject_error_with_cx(
+            promise.reject_error(
                 realm,
                 Error::Type(c"Failed to obtain a storage key".to_owned()),
             );
@@ -486,10 +483,7 @@ impl ServiceWorkerContainerMethods<crate::DomTypeHolder> for ServiceWorkerContai
             Ok(url) => url,
             Err(_) => {
                 // Step 4: If clientURL is failure, return a promise rejected with a TypeError.
-                promise.reject_error_with_cx(
-                    realm,
-                    Error::Type(c"Failed to parse clientURL".to_owned()),
-                );
+                promise.reject_error(realm, Error::Type(c"Failed to parse clientURL".to_owned()));
                 return promise;
             },
         };
@@ -499,7 +493,7 @@ impl ServiceWorkerContainerMethods<crate::DomTypeHolder> for ServiceWorkerContai
 
         // Step 6: If the origin of clientURL is not client’s origin, return a promise rejected with a "SecurityError" DOMException.
         if &client_url.origin() != global.origin().immutable() {
-            promise.reject_error_with_cx(realm, Error::Security(None));
+            promise.reject_error(realm, Error::Security(None));
             return promise;
         }
 
@@ -521,7 +515,7 @@ impl ServiceWorkerContainerMethods<crate::DomTypeHolder> for ServiceWorkerContai
         {
             // Note: pop the promise we just pushed, since we will not get a result back to handle it.
             self.pending_algorithm_results.borrow_mut().pop_back();
-            promise.reject_error_with_cx(
+            promise.reject_error(
                 realm,
                 Error::Type(c"Failed to send MatchServiceWorkerRegistration algorithm".to_owned()),
             );

--- a/components/script/dom/workers/serviceworkerregistration.rs
+++ b/components/script/dom/workers/serviceworkerregistration.rs
@@ -223,7 +223,7 @@ impl ServiceWorkerRegistrationMethods<crate::DomTypeHolder> for ServiceWorkerReg
         // Step 4: Invoke Schedule Job with job.
         // Note: done in the container.
         let Some(storage_key) = global.obtain_storage_key() else {
-            promise.reject_error_with_cx(
+            promise.reject_error(
                 cx,
                 Error::Type(c"Failed to obtain a storage key".to_owned()),
             );

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -149,7 +149,7 @@ impl WorkletMethods<crate::DomTypeHolder> for Worklet {
             Err(err) => {
                 // Step 4.
                 debug!("URL {:?} parse error {:?}.", module_url.0, err);
-                promise.reject_error_with_cx(realm, Error::Syntax(None));
+                promise.reject_error(realm, Error::Syntax(None));
                 return promise;
             },
         };

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -226,7 +226,7 @@ pub(crate) fn Fetch(
     let request_object = match Request::Constructor(cx, global, None, input, init) {
         Err(e) => {
             response.error_stream(cx, e.clone());
-            promise.reject_error_with_cx(cx, e);
+            promise.reject_error(cx, e);
             return promise;
         },
         Ok(r) => r,
@@ -563,8 +563,7 @@ impl FetchResponseListener for FetchContext {
             // Step 12.3. If response is a network error, then reject
             // p with a TypeError and abort these steps.
             Err(error) => {
-                promise
-                    .reject_error_with_cx(cx, Error::Type(cformat!("Network error: {:?}", error)));
+                promise.reject_error(cx, Error::Type(cformat!("Network error: {:?}", error)));
                 self.fetch_promise = Some(TrustedPromise::new(promise));
                 let response = self.response_object.root();
                 response.set_type(cx, DOMResponseType::Error);


### PR DESCRIPTION
These are now all migrated to their non-`with_cx` variant.

Part of #40600

Testing: it compiles