### PR TITLE
script: Ensure newly slotted/unslotted nodes have a full restyle / relayout

### DIFF
--- a/components/script/dom/html/htmlslotelement.rs
+++ b/components/script/dom/html/htmlslotelement.rs
@@ -325,13 +325,31 @@ impl HTMLSlotElement {
         if self.assigned_nodes.borrow().iter().eq(slottables.iter()) {
             return;
         }
+
+        // Clear the style and layout data for all previously assigned slottables as well as
+        // marking them as dirty, as they need a full restyle and layout.
+        for slottable in self.assigned_nodes().iter() {
+            slottable
+                .node()
+                .remove_style_and_layout_data_from_subtree(no_gc);
+            slottable.node().dirty(NodeDamage::Other);
+        }
+
         self.signal_a_slot_change();
 
-        // NOTE: This is not written in the spec, which is likely a bug (https://github.com/whatwg/dom/issues/1352)
-        // If we don't disconnect the old slottables from this slot then they'll stay implictly
-        // connected, which causes problems later on
+        // If we don't disconnect the old slottables from this slot then they'll stay implicitily
+        // connected, which causes problems later on. Only do this for slottables that have not
+        // already been reassigned to a different slot.
+        //
+        // NOTE: This is not written in the spec, which is likely a bug. See:
+        // <https://github.com/whatwg/dom/issues/1352>.
         for slottable in self.assigned_nodes().iter() {
-            slottable.set_assigned_slot(None);
+            if slottable
+                .assigned_slot()
+                .is_some_and(|assigned_slot| &*assigned_slot == self)
+            {
+                slottable.set_assigned_slot(None);
+            }
         }
 
         // Step 3. Set slot’s assigned nodes to slottables.
@@ -340,6 +358,15 @@ impl HTMLSlotElement {
         // Step 4. For each slottable in slottables, set slottable’s assigned slot to slot.
         for slottable in slottables.iter() {
             slottable.set_assigned_slot(Some(self));
+        }
+
+        // Also clear the style and layout data for all currently assigned slottables
+        // as well as marking them as dirty, as they need a full restyle and layout.
+        for slottable in slottables.iter() {
+            slottable
+                .node()
+                .remove_style_and_layout_data_from_subtree(no_gc);
+            slottable.node().dirty(NodeDamage::Other);
         }
     }
 

--- a/tests/wpt/meta/css/css-shadow/shadow-fallback-dynamic-004.html.ini
+++ b/tests/wpt/meta/css/css-shadow/shadow-fallback-dynamic-004.html.ini
@@ -1,2 +1,0 @@
-[shadow-fallback-dynamic-004.html]
-  expected: CRASH

--- a/tests/wpt/meta/css/css-shadow/shadow-reassign-dynamic-003.html.ini
+++ b/tests/wpt/meta/css/css-shadow/shadow-reassign-dynamic-003.html.ini
@@ -1,3 +1,0 @@
-[shadow-reassign-dynamic-003.html]
-  [Computed color after re-slotting.]
-    expected: FAIL

--- a/tests/wpt/meta/shadow-dom/crashtests/slot-dir-auto-unbound.html.ini
+++ b/tests/wpt/meta/shadow-dom/crashtests/slot-dir-auto-unbound.html.ini
@@ -1,2 +1,0 @@
-[slot-dir-auto-unbound.html]
-  expected: CRASH

--- a/tests/wpt/tests/shadow-dom/slot-with-slottable-slot-in-display-none-subtree-crash.html
+++ b/tests/wpt/tests/shadow-dom/slot-with-slottable-slot-in-display-none-subtree-crash.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/45794">
+<script>
+    onload = () => {
+        var shadowRoot = shadowHost.attachShadow({mode: "open"});
+        iframe.srcdoc = "A";
+        slot.style.color = "pink";
+        document.body.clientHeight;
+        shadowRoot.appendChild(noneDiv);
+    };
+</script>
+
+<div id="noneDiv" style="display: none;">
+    <slot style="display: none;" name="innerSlot">
+</div>
+
+<h3 id="shadowHost">
+    <slot id="slot" slot="innerSlot">
+        <iframe id="iframe">
+    </slot>
+</h3>


### PR DESCRIPTION
When slotting and unslotting slottables in a slot, ensure that they get
a full restyle and layout during the next layout. This fixes an issue
where the tree can have unstyled parents with styled children, which
violates Stylo invariants -- leading to a panic.

In addition, this exposes *another* issue where we were clearing the
*assinged slot* of slottables that had already been re-assigned. Slots
are processed in order during slot re-assignment. If the new slot for a
slottable that moves from one slot to another is is handled first during
this process, by the time we reach the second slot (the one the
slottable moved from), we shouldn't clear the slottable's *assigned slot*.
The new guard here ensures that this doesn't happen, preventing panics
exposed by the first fix in this PR.

Special thanks to Frédéric Wang Nélar and Oriol Brufau for help
minimizing this test case.

Testing: A new WPT test is added. Unfortunately this test cannot reproduce
the crash consistently. In addition a few other WPT tests start to pass.
Fixes: #45794.
