### PR TITLE
script: Remove `Promise::reject_with_cx`

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -753,7 +753,7 @@ pub(crate) fn consume_body<T: BodyMixin + DomObject>(
     if stream.is_errored() {
         rooted!(&in(cx) let mut stored_error = UndefinedValue());
         stream.get_stored_error(stored_error.handle_mut());
-        promise.reject_with_cx(cx, stored_error.handle());
+        promise.reject(cx, stored_error.handle());
         return promise;
     }
 
@@ -794,7 +794,7 @@ pub(crate) fn consume_body<T: BodyMixin + DomObject>(
             );
         }),
         Rc::new(move |cx, v| {
-            error_promise.reject_with_cx(cx, v);
+            error_promise.reject(cx, v);
         }),
     );
 

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -370,7 +370,7 @@ impl BlobMethods<crate::DomTypeHolder> for Blob {
                 success_promise.resolve_native_with_cx(cx, &array_buffer);
             }),
             Rc::new(move |cx, value| {
-                failure_promise.reject_with_cx(cx, value);
+                failure_promise.reject(cx, value);
             }),
         );
 
@@ -411,7 +411,7 @@ impl BlobMethods<crate::DomTypeHolder> for Blob {
                 p_success.resolve_native_with_cx(cx, &arr);
             }),
             Rc::new(move |cx, v| {
-                p_failure.reject_with_cx(cx, v);
+                p_failure.reject(cx, v);
             }),
         );
         p

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -256,7 +256,7 @@ impl Promise {
         let cx = &mut realm.current_realm();
         rooted!(&in(cx) let mut v = UndefinedValue());
         val.safe_to_jsval(cx.into(), v.handle_mut(), CanGc::from_cx(cx));
-        self.reject_with_cx(cx, v.handle());
+        self.reject(cx, v.handle());
     }
 
     pub(crate) fn reject_error(&self, cx: &mut JSContext, error: Error) {
@@ -264,20 +264,11 @@ impl Promise {
         let cx = &mut realm.current_realm();
         rooted!(&in(cx) let mut v = UndefinedValue());
         error.to_jsval(cx, &self.global(), v.handle_mut());
-        self.reject_with_cx(cx, v.handle());
+        self.reject(cx, v.handle());
     }
 
     #[expect(unsafe_code)]
-    pub(crate) fn reject(&self, cx: SafeJSContext, value: HandleValue, _can_gc: CanGc) {
-        unsafe {
-            if !js::rust::wrappers::RejectPromise(*cx, self.promise_obj(), value) {
-                js::jsapi::JS_ClearPendingException(*cx);
-            }
-        }
-    }
-
-    #[expect(unsafe_code)]
-    pub(crate) fn reject_with_cx(&self, cx: &mut JSContext, value: HandleValue) {
+    pub(crate) fn reject(&self, cx: &mut JSContext, value: HandleValue) {
         unsafe {
             if !RejectPromise(cx, self.promise_obj(), value) {
                 JS_ClearPendingException(cx);

--- a/components/script/dom/stream/transformstream.rs
+++ b/components/script/dom/stream/transformstream.rs
@@ -75,7 +75,7 @@ impl Callback for TransformBackPressureChangePromiseFulfillment {
         if self.writable.is_erroring() {
             rooted!(&in(cx) let mut error = UndefinedValue());
             self.writable.get_stored_error(error.handle_mut());
-            self.result_promise.reject_with_cx(cx, error.handle());
+            self.result_promise.reject(cx, error.handle());
             return;
         }
 
@@ -141,9 +141,8 @@ struct PerformTransformRejection {
 
 impl Callback for PerformTransformRejection {
     fn callback(&self, cx: &mut CurrentRealm, v: SafeHandleValue) {
-        let can_gc = CanGc::from_cx(cx);
         // Stream already errored in perform_transform, just reject result_promise
-        self.result_promise.reject(cx.into(), v, can_gc);
+        self.result_promise.reject(cx, v);
     }
 }
 
@@ -158,8 +157,7 @@ struct BackpressureChangeRejection {
 
 impl Callback for BackpressureChangeRejection {
     fn callback(&self, cx: &mut CurrentRealm, reason: SafeHandleValue) {
-        let can_gc = CanGc::from_cx(cx);
-        self.result_promise.reject(cx.into(), reason, can_gc);
+        self.result_promise.reject(cx, reason);
     }
 }
 
@@ -226,7 +224,7 @@ impl Callback for CancelPromiseRejection {
         self.controller
             .get_finish_promise()
             .expect("finish promise is not set")
-            .reject_with_cx(cx, v);
+            .reject(cx, v);
     }
 }
 
@@ -258,7 +256,7 @@ impl Callback for SourceCancelPromiseFulfillment {
         if self.writeable.is_errored() {
             rooted!(&in(cx) let mut error = UndefinedValue());
             self.writeable.get_stored_error(error.handle_mut());
-            finish_promise.reject_with_cx(cx, error.handle());
+            finish_promise.reject(cx, error.handle());
         } else {
             // Otherwise:
             // Perform ! WritableStreamDefaultControllerErrorIfNeeded(writable.[[controller]], reason).
@@ -306,7 +304,7 @@ impl Callback for SourceCancelPromiseRejection {
         self.controller
             .get_finish_promise()
             .expect("finish promise is not set")
-            .reject_with_cx(cx, v);
+            .reject(cx, v);
     }
 }
 
@@ -334,7 +332,7 @@ impl Callback for FlushPromiseFulfillment {
         if self.readable.is_errored() {
             rooted!(&in(cx) let mut error = UndefinedValue());
             self.readable.get_stored_error(error.handle_mut());
-            finish_promise.reject_with_cx(cx, error.handle());
+            finish_promise.reject(cx, error.handle());
         } else {
             // Otherwise:
             // Perform ! ReadableStreamDefaultControllerClose(readable.[[controller]]).
@@ -368,7 +366,7 @@ impl Callback for FlushPromiseRejection {
         self.controller
             .get_finish_promise()
             .expect("finish promise is not set")
-            .reject_with_cx(cx, v);
+            .reject(cx, v);
     }
 }
 

--- a/components/script/dom/stream/writablestream.rs
+++ b/components/script/dom/stream/writablestream.rs
@@ -276,7 +276,7 @@ impl WritableStream {
         let write_requests = mem::take(&mut *self.write_requests.borrow_mut());
         for request in write_requests {
             // Reject writeRequest with storedError.
-            request.reject_with_cx(cx, stored_error.handle());
+            request.reject(cx, stored_error.handle());
         }
 
         // Set stream.[[writeRequests]] to an empty list.
@@ -300,7 +300,7 @@ impl WritableStream {
                 // Reject abortRequest’s promise with storedError.
                 pending_abort_request
                     .promise
-                    .reject_with_cx(cx, stored_error.handle());
+                    .reject(cx, stored_error.handle());
 
                 // Perform ! WritableStreamRejectCloseAndClosedPromiseIfNeeded(stream).
                 self.reject_close_and_closed_promise_if_needed(cx);

--- a/components/script/dom/testing/testbinding.rs
+++ b/components/script/dom/testing/testbinding.rs
@@ -1038,8 +1038,8 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
         p.resolve(cx, v, can_gc);
     }
 
-    fn PromiseRejectNative(&self, cx: SafeJSContext, p: &Promise, v: HandleValue, can_gc: CanGc) {
-        p.reject(cx, v, can_gc);
+    fn PromiseRejectNative(&self, cx: &mut JSContext, p: &Promise, v: HandleValue) {
+        p.reject(cx, v);
     }
 
     fn PromiseRejectWithTypeError(&self, cx: &mut JSContext, p: &Promise, s: USVString) {

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -185,7 +185,7 @@ fn abort_fetch_call(
     cx: &mut js::context::JSContext,
 ) {
     // Step 1. Reject promise with error.
-    promise.reject_with_cx(cx, abort_reason);
+    promise.reject(cx, abort_reason);
     // Step 2. If request’s body is non-null and is readable, then cancel request’s body with error.
     if let Some(body) = request.body() &&
         body.is_readable()

--- a/components/script/module_loading.rs
+++ b/components/script/module_loading.rs
@@ -49,7 +49,7 @@ struct OnRejectedHandler {
 impl Callback for OnRejectedHandler {
     fn callback(&self, cx: &mut CurrentRealm, v: HandleValue) {
         // a. Perform ! Call(promiseCapability.[[Reject]], undefined, « reason »).
-        self.promise.reject_with_cx(cx, v);
+        self.promise.reject(cx, v);
     }
 }
 
@@ -250,7 +250,7 @@ fn continue_module_loading(
             state.is_loading.set(false);
 
             // b. Perform ! Call(state.[[PromiseCapability]].[[Reject]], undefined, « moduleCompletion.[[Value]] »).
-            state.promise.reject_with_cx(cx, exception.handle());
+            state.promise.reject(cx, exception.handle());
         },
     }
 
@@ -297,7 +297,7 @@ fn continue_dynamic_import(
     // Step 1. If moduleCompletion is an abrupt completion, then
     if let Err(exception) = module_completion {
         // a. Perform ! Call(promiseCapability.[[Reject]], undefined, « moduleCompletion.[[Value]] »).
-        promise.reject_with_cx(cx, exception.handle());
+        promise.reject(cx, exception.handle());
 
         // b. Return unused.
         return;
@@ -339,7 +339,7 @@ fn continue_dynamic_import(
             if !link {
                 // i. Perform ! Call(promiseCapability.[[Reject]], undefined, « link.[[Value]] »).
                 let exception = RethrowError::from_pending_exception(cx);
-                inner_promise.reject_with_cx(cx, exception.handle());
+                inner_promise.reject(cx, exception.handle());
 
                 // ii. Return NormalCompletion(undefined).
                 return;
@@ -352,7 +352,7 @@ fn continue_dynamic_import(
 
             if !rval.is_object() {
                 let error = RethrowError::from_pending_exception(cx);
-                return inner_promise.reject_with_cx(cx, error.handle());
+                return inner_promise.reject(cx, error.handle());
             }
 
             rooted!(&in(cx) let evaluate_promise = rval.to_object());

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1279,7 +1279,7 @@ DOMInterfaces = {
 #FIXME(jdm): This should be 'register': False, but then we don't generate enum types
 'TestBinding': {
     'inRealms': ['PromiseAttribute'],
-    'canGc': ['PromiseAttribute', 'PromiseResolveNative', 'PromiseRejectNative'],
+    'canGc': ['PromiseAttribute', 'PromiseResolveNative'],
     'additionalTraits': ['crate::interfaces::TestBindingHelpers'],
     'cx': [
         'Constructor',
@@ -1288,6 +1288,7 @@ DOMInterfaces = {
         'GetDictionaryWithTypedArray',
         'GetInterfaceAttributeNullable',
         'InterfaceAttribute',
+        'PromiseRejectNative',
         'PromiseRejectWithTypeError',
         'ReceiveInterface',
         'ReceiveInterfaceSequence',


### PR DESCRIPTION
It can now be named `reject` again.

Part of #40600

Testing: it compiles
