### PR TITLE
script: Remove `Promise::new2`

### DIFF
--- a/components/script/dom/cookiestore.rs
+++ b/components/script/dom/cookiestore.rs
@@ -191,7 +191,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         let origin = global.origin();
 
         // 5. Let p be a new promise.
-        let p = Promise::new2(cx, &global);
+        let p = Promise::new(cx, &global);
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
@@ -232,7 +232,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         let origin = global.origin();
 
         // 7. Let p be a new promise.
-        let p = Promise::new2(cx, &global);
+        let p = Promise::new(cx, &global);
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
@@ -311,7 +311,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         let origin = global.origin();
 
         // 5. Let p be a new promise.
-        let p = Promise::new2(cx, &global);
+        let p = Promise::new(cx, &global);
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
@@ -352,7 +352,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         let origin = global.origin();
 
         // 6. Let p be a new promise.
-        let p = Promise::new2(cx, &global);
+        let p = Promise::new(cx, &global);
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
@@ -425,7 +425,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         let origin = global.origin();
 
         // 9. Let p be a new promise.
-        let p = Promise::new2(cx, &global);
+        let p = Promise::new(cx, &global);
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
@@ -479,7 +479,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         let origin = global.origin();
 
         // 5. Let p be a new promise.
-        let p = Promise::new2(cx, &global);
+        let p = Promise::new(cx, &global);
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
@@ -526,7 +526,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         let origin = global.origin();
 
         // 5. Let p be a new promise.
-        let p = Promise::new2(cx, &global);
+        let p = Promise::new(cx, &global);
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
@@ -562,7 +562,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         let origin = global.origin();
 
         // 5. Let p be a new promise.
-        let p = Promise::new2(cx, &global);
+        let p = Promise::new(cx, &global);
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {

--- a/components/script/dom/css/fontface.rs
+++ b/components/script/dom/css/fontface.rs
@@ -187,7 +187,7 @@ impl FontFace {
     /// Construct a [`FontFace`] to be used in the case of failure in parsing the
     /// font face descriptors.
     fn new_failed_font_face(cx: &mut JSContext, global: &GlobalScope) -> Self {
-        let font_status_promise = Promise::new2(cx, global);
+        let font_status_promise = Promise::new(cx, global);
         // If any of them fail to parse correctly, reject font face’s [[FontStatusPromise]] with a
         // DOMException named "SyntaxError"
         font_status_promise.reject_error(cx, Error::Syntax(None));
@@ -243,7 +243,7 @@ impl FontFace {
         };
 
         // Set its internal [[FontStatusPromise]] slot to a fresh pending Promise object.
-        let font_status_promise = Promise::new2(cx, global);
+        let font_status_promise = Promise::new(cx, global);
 
         let sources = parsed_font_face_rule.descriptors.src.clone();
 

--- a/components/script/dom/css/fontfaceset.rs
+++ b/components/script/dom/css/fontfaceset.rs
@@ -49,7 +49,7 @@ impl FontFaceSet {
     fn new_inherited(cx: &mut JSContext, global: &GlobalScope) -> Self {
         FontFaceSet {
             target: EventTarget::new_inherited(),
-            promise: Promise::new2(cx, global).into(),
+            promise: Promise::new(cx, global).into(),
             set_entries: Default::default(),
         }
     }
@@ -131,7 +131,7 @@ impl FontFaceSet {
         // Step 3. If font face set’s [[ReadyPromise]] slot currently holds a fulfilled
         // promise, replace it with a fresh pending promise.
         if self.promise.borrow().is_fulfilled() {
-            *self.promise.borrow_mut() = Promise::new2(cx, &self.global());
+            *self.promise.borrow_mut() = Promise::new(cx, &self.global());
         }
 
         // Step 4. Queue a task to fire a font load event named loading at font face set.
@@ -195,7 +195,7 @@ impl FontFaceSetMethods<crate::DomTypeHolder> for FontFaceSet {
     fn Load(&self, cx: &mut JSContext, _font: DOMString, _text: DOMString) -> Rc<Promise> {
         // Step 1. Let font face set be the FontFaceSet object this method was called on. Let
         // promise be a newly-created promise object.
-        let load_promise = Promise::new2(cx, &self.global());
+        let load_promise = Promise::new(cx, &self.global());
 
         // Step 3. Find the matching font faces from font face set using the font and text
         // arguments passed to the function, and let font face list be the return value (ignoring

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -1925,7 +1925,7 @@ impl HTMLImageElementMethods<crate::DomTypeHolder> for HTMLImageElement {
     /// <https://html.spec.whatwg.org/multipage/#dom-img-decode>
     fn Decode(&self, cx: &mut JSContext) -> Rc<Promise> {
         // Step 1. Let promise be a new promise.
-        let promise = Promise::new2(cx, &self.global());
+        let promise = Promise::new(cx, &self.global());
 
         // Step 2. Queue a microtask to perform the following steps:
         let task = ImageElementMicrotask::Decode {

--- a/components/script/dom/indexeddb/idbfactory.rs
+++ b/components/script/dom/indexeddb/idbfactory.rs
@@ -636,14 +636,14 @@ impl IDBFactoryMethods<crate::DomTypeHolder> for IDBFactory {
         let storage_key = match global.obtain_storage_key() {
             Some(storage_key) => storage_key,
             None => {
-                let p = Promise::new2(cx, &global);
+                let p = Promise::new(cx, &global);
                 p.reject_error(cx, Error::Security(None));
                 return p;
             },
         };
 
         // Step 3: Let p be a new promise.
-        let p = Promise::new2(cx, &global);
+        let p = Promise::new(cx, &global);
 
         // Note: the option is required to pass the promise to a task from within the generic callback,
         // see #41356

--- a/components/script/dom/notification.rs
+++ b/components/script/dom/notification.rs
@@ -404,7 +404,7 @@ impl NotificationMethods<crate::DomTypeHolder> for Notification {
         permission_callback: Option<Rc<NotificationPermissionCallback>>,
     ) -> Rc<Promise> {
         // Step 2: Let promise be a new promise in this’s relevant Realm.
-        let promise = Promise::new2(cx, global);
+        let promise = Promise::new(cx, global);
 
         // TODO: Step 3: Run these steps in parallel:
         // Step 3.1: Let permissionState be the result of requesting permission to use "notifications".
@@ -704,7 +704,7 @@ fn request_notification_permission(
     cx: &mut JSContext,
     global: &GlobalScope,
 ) -> NotificationPermission {
-    let promise = &Promise::new2(cx, global);
+    let promise = &Promise::new(cx, global);
     let descriptor = PermissionDescriptor {
         name: PermissionName::Notifications,
     };

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -100,10 +100,10 @@ impl Drop for Promise {
 }
 
 impl Promise {
-    pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> Rc<Promise> {
-        let realm = enter_realm(global);
-        let comp = InRealm::Entered(&realm);
-        Promise::new_in_current_realm(comp, can_gc)
+    pub(crate) fn new(cx: &mut js::context::JSContext, global: &GlobalScope) -> Rc<Promise> {
+        let mut realm = enter_auto_realm(cx, global);
+        let cx = &mut realm.current_realm();
+        Promise::new_in_realm(cx)
     }
 
     pub(crate) fn new_in_current_realm(_comp: InRealm, can_gc: CanGc) -> Rc<Promise> {
@@ -111,15 +111,6 @@ impl Promise {
         rooted!(in(*cx) let mut obj = ptr::null_mut::<JSObject>());
         Promise::create_js_promise(cx, obj.handle_mut(), can_gc);
         Promise::new_with_js_promise(obj.handle(), cx)
-    }
-
-    pub(crate) fn new2(cx: &mut js::context::JSContext, global: &GlobalScope) -> Rc<Promise> {
-        let mut realm = AutoRealm::new(
-            cx,
-            std::ptr::NonNull::new(global.reflector().get_jsobject().get()).unwrap(),
-        );
-        let mut current_realm = realm.current_realm();
-        Promise::new_in_realm(&mut current_realm)
     }
 
     pub(crate) fn new_in_realm(current_realm: &mut CurrentRealm) -> Rc<Promise> {
@@ -651,7 +642,7 @@ pub(crate) fn wait_for_all_promise(
     promises: Vec<Rc<Promise>>,
 ) -> Rc<Promise> {
     // Let promise be a new promise of type Promise<sequence<T>> in realm.
-    let promise = Promise::new2(cx, global);
+    let promise = Promise::new(cx, global);
     let success_promise = promise.clone();
     let failure_promise = promise.clone();
 

--- a/components/script/dom/serviceworker/serviceworkerregistration.rs
+++ b/components/script/dom/serviceworker/serviceworkerregistration.rs
@@ -194,7 +194,7 @@ impl ServiceWorkerRegistrationMethods<crate::DomTypeHolder> for ServiceWorkerReg
         // Note: `self` is the registration.
 
         // Step 2: Let promise be a new promise.
-        let promise = Promise::new2(cx, &self.global());
+        let promise = Promise::new(cx, &self.global());
 
         let Some(worker) = self.get_newest_worker() else {
             promise.resolve_native_with_cx(cx, &true);

--- a/components/script/dom/serviceworker/windowclient.rs
+++ b/components/script/dom/serviceworker/windowclient.rs
@@ -22,12 +22,12 @@ impl WindowClientMethods<crate::DomTypeHolder> for WindowClient {
     /// <https://w3c.github.io/ServiceWorker/#dom-windowclient-focus>
     fn Focus(&self, cx: &mut JSContext) -> Rc<Promise> {
         // TODO: Implement
-        Promise::new2(cx, &self.global())
+        Promise::new(cx, &self.global())
     }
 
     /// <https://w3c.github.io/ServiceWorker/#dom-windowclient-navigate>
     fn Navigate(&self, cx: &mut JSContext, _url: USVString) -> Rc<Promise> {
         // TODO: Implement
-        Promise::new2(cx, &self.global())
+        Promise::new(cx, &self.global())
     }
 }

--- a/components/script/dom/stream/readablebytestreamcontroller.rs
+++ b/components/script/dom/stream/readablebytestreamcontroller.rs
@@ -1819,7 +1819,7 @@ impl ReadableByteStreamController {
         let result = underlying_source
             .call_cancel_algorithm(cx, global, reason)
             .unwrap_or_else(|| {
-                let promise = Promise::new2(cx, global);
+                let promise = Promise::new(cx, global);
                 promise.resolve_native_with_cx(cx, &());
                 Ok(promise)
             });
@@ -1827,7 +1827,7 @@ impl ReadableByteStreamController {
         let promise = result.unwrap_or_else(|error| {
             rooted!(&in(cx) let mut rval = UndefinedValue());
             error.to_jsval(cx, global, rval.handle_mut());
-            let promise = Promise::new2(cx, global);
+            let promise = Promise::new(cx, global);
             promise.reject_native(cx, &rval.handle());
             promise
         });

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -1610,7 +1610,7 @@ impl ReadableStream {
         }
         // If stream.[[state]] is "errored", return a promise rejected with stream.[[storedError]].
         if self.is_errored() {
-            let promise = Promise::new2(cx, global);
+            let promise = Promise::new(cx, global);
             rooted!(&in(cx) let mut rval = UndefinedValue());
             self.stored_error.safe_to_jsval(cx, rval.handle_mut());
             promise.reject_native(cx, &rval.handle());
@@ -1652,7 +1652,7 @@ impl ReadableStream {
         // Create a new promise,
         // and setup a handler in order to react to the fulfillment of sourceCancelPromise.
         let global = self.global();
-        let result_promise = Promise::new2(cx, &global);
+        let result_promise = Promise::new(cx, &global);
         let fulfillment_handler = Box::new(SourceCancelPromiseFulfillmentHandler {
             result: result_promise.clone(),
         });
@@ -1713,7 +1713,7 @@ impl ReadableStream {
         let reason_2 = Rc::new(Heap::default());
 
         // Let cancelPromise be a new promise.
-        let cancel_promise = Promise::new2(cx, &self.global());
+        let cancel_promise = Promise::new(cx, &self.global());
         let reader_version = Rc::new(Cell::new(0));
 
         let byte_tee_source_1 = ByteTeeUnderlyingSource::new(
@@ -1805,7 +1805,7 @@ impl ReadableStream {
         // Let reason2 be undefined.
         let reason_2 = Rc::new(Heap::default());
         // Let cancelPromise be a new promise.
-        let cancel_promise = Promise::new2(cx, &self.global());
+        let cancel_promise = Promise::new(cx, &self.global());
 
         let tee_source_1 = DefaultTeeUnderlyingSource::new(
             &reader,
@@ -1927,7 +1927,7 @@ impl ReadableStream {
         // Done below with default.
 
         // Let promise be a new promise.
-        let promise = Promise::new2(cx, global);
+        let promise = Promise::new(cx, global);
 
         // In parallel, but not really, using reader and writer, read all chunks from source and write them to dest.
         rooted!(&in(cx) let pipe_to = PipeTo {
@@ -2181,7 +2181,7 @@ impl ReadableStreamMethods<crate::DomTypeHolder> for ReadableStream {
         if self.is_locked() {
             // If ! IsReadableStreamLocked(this) is true,
             // return a promise rejected with a TypeError exception.
-            let promise = Promise::new2(cx, &global);
+            let promise = Promise::new(cx, &global);
             promise.reject_error(cx, Error::Type(c"stream is locked".to_owned()));
             promise
         } else {
@@ -2229,7 +2229,7 @@ impl ReadableStreamMethods<crate::DomTypeHolder> for ReadableStream {
         // If ! IsReadableStreamLocked(this) is true,
         if self.is_locked() {
             // return a promise rejected with a TypeError exception.
-            let promise = Promise::new2(cx, &global);
+            let promise = Promise::new(cx, &global);
             promise.reject_error(cx, Error::Type(c"Source stream is locked".to_owned()));
             return promise;
         }
@@ -2237,7 +2237,7 @@ impl ReadableStreamMethods<crate::DomTypeHolder> for ReadableStream {
         // If ! IsWritableStreamLocked(destination) is true,
         if destination.is_locked() {
             // return a promise rejected with a TypeError exception.
-            let promise = Promise::new2(cx, &global);
+            let promise = Promise::new(cx, &global);
             promise.reject_error(cx, Error::Type(c"Destination stream is locked".to_owned()));
             return promise;
         }

--- a/components/script/dom/stream/readablestreambyobreader.rs
+++ b/components/script/dom/stream/readablestreambyobreader.rs
@@ -211,7 +211,7 @@ impl ReadableStreamBYOBReader {
             reflector_: Reflector::new(),
             stream: MutNullableDom::new(None),
             read_into_requests: DomRefCell::new(Default::default()),
-            closed_promise: DomRefCell::new(Promise::new2(cx, global)),
+            closed_promise: DomRefCell::new(Promise::new(cx, global)),
         }
     }
 
@@ -422,7 +422,7 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
         let view = HeapBufferSource::<ArrayBufferViewU8>::from_view(view);
         let min = options.min;
         // Let promise be a new promise.
-        let promise = Promise::new2(cx, &self.global());
+        let promise = Promise::new(cx, &self.global());
 
         // If view.[[ByteLength]] is 0, return a promise rejected with a TypeError exception.
         if view.byte_length() == 0 {

--- a/components/script/dom/stream/readablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/readablestreamdefaultcontroller.rs
@@ -576,7 +576,7 @@ impl ReadableStreamDefaultController {
         let result = underlying_source
             .call_cancel_algorithm(cx, global, reason)
             .unwrap_or_else(|| {
-                let promise = Promise::new2(cx, global);
+                let promise = Promise::new(cx, global);
                 promise.resolve_native_with_cx(cx, &());
                 Ok(promise)
             });
@@ -584,7 +584,7 @@ impl ReadableStreamDefaultController {
             rooted!(&in(cx) let mut rval = UndefinedValue());
 
             error.to_jsval(cx, global, rval.handle_mut());
-            let promise = Promise::new2(cx, global);
+            let promise = Promise::new(cx, global);
             promise.reject_native(cx, &rval.handle());
             promise
         });

--- a/components/script/dom/stream/readablestreamdefaultreader.rs
+++ b/components/script/dom/stream/readablestreamdefaultreader.rs
@@ -154,7 +154,7 @@ impl ReadRequest {
                         // Step 3. Read-loop given reader, bytes, successSteps, and failureSteps.
                         // Spec note: Avoid direct recursion; queue into a microtask.
                         // Resolving the promise will queue a microtask to call into the native handler.
-                        let tick = Promise::new2(cx, &global);
+                        let tick = Promise::new(cx, &global);
                         tick.resolve_native_with_cx(cx, &());
 
                         let handler = PromiseNativeHandler::new(
@@ -361,7 +361,7 @@ impl ReadableStreamDefaultReader {
             reflector_: Reflector::new(),
             stream: MutNullableDom::new(None),
             read_requests: DomRefCell::new(Default::default()),
-            closed_promise: DomRefCell::new(Promise::new2(cx, global)),
+            closed_promise: DomRefCell::new(Promise::new(cx, global)),
         }
     }
 
@@ -648,7 +648,7 @@ impl ReadableStreamDefaultReaderMethods<crate::DomTypeHolder> for ReadableStream
             return Promise::new_rejected(cx, &self.global(), error.handle());
         }
         // Let promise be a new promise.
-        let promise = Promise::new2(cx, &self.global());
+        let promise = Promise::new(cx, &self.global());
 
         // Let readRequest be a new read request with the following items:
         // chunk steps, given chunk

--- a/components/script/dom/stream/readablestreamgenericreader.rs
+++ b/components/script/dom/stream/readablestreamgenericreader.rs
@@ -44,7 +44,7 @@ pub(crate) trait ReadableStreamGenericReader {
         if stream.is_readable() {
             // If stream.[[state]] is "readable
             // Set reader.[[closedPromise]] to a new promise.
-            self.set_closed_promise(Promise::new2(cx, global));
+            self.set_closed_promise(Promise::new(cx, global));
         } else if stream.is_closed() {
             // Otherwise, if stream.[[state]] is "closed",
             // Set reader.[[closedPromise]] to a promise resolved with undefined.
@@ -146,7 +146,7 @@ pub(crate) trait ReadableStreamGenericReader {
         if self.get_stream().is_none() {
             // If this.[[stream]] is undefined,
             // return a promise rejected with a TypeError exception.
-            let promise = Promise::new2(cx, global);
+            let promise = Promise::new(cx, global);
             promise.reject_error(cx, Error::Type(c"stream is undefined".to_owned()));
             promise
         } else {

--- a/components/script/dom/stream/transformstream.rs
+++ b/components/script/dom/stream/transformstream.rs
@@ -267,7 +267,7 @@ impl Callback for SourceCancelPromiseFulfillment {
                 .error_if_needed(cx, reason.handle(), global);
 
             // Perform ! TransformStreamUnblockWrite(stream).
-            self.stream.unblock_write(global, CanGc::from_cx(cx));
+            self.stream.unblock_write(cx, global);
 
             // Resolve controller.[[finishPromise]] with undefined.
             finish_promise.resolve_native_with_cx(cx, &());
@@ -298,7 +298,7 @@ impl Callback for SourceCancelPromiseRejection {
             .error_if_needed(cx, v, global);
 
         // Perform ! TransformStreamUnblockWrite(stream).
-        self.stream.unblock_write(global, CanGc::from_cx(cx));
+        self.stream.unblock_write(cx, global);
 
         // Reject controller.[[finishPromise]] with r.
         self.controller
@@ -562,7 +562,7 @@ impl TransformStream {
         // Note: This is done in the constructor.
 
         // Perform ! TransformStreamSetBackpressure(stream, true).
-        self.set_backpressure(global, true, CanGc::from_cx(cx));
+        self.set_backpressure(cx, global, true);
 
         // Set stream.[[controller]] to undefined.
         self.controller.set(None);
@@ -571,18 +571,23 @@ impl TransformStream {
     }
 
     /// <https://streams.spec.whatwg.org/#transform-stream-set-backpressure>
-    pub(crate) fn set_backpressure(&self, global: &GlobalScope, backpressure: bool, can_gc: CanGc) {
+    pub(crate) fn set_backpressure(
+        &self,
+        cx: &mut JSContext,
+        global: &GlobalScope,
+        backpressure: bool,
+    ) {
         // Assert: stream.[[backpressure]] is not backpressure.
         assert!(self.backpressure.get() != backpressure);
 
         // If stream.[[backpressureChangePromise]] is not undefined, resolve
         // stream.[[backpressureChangePromise]] with undefined.
         if let Some(promise) = self.backpressure_change_promise.borrow_mut().take() {
-            promise.resolve_native(&(), can_gc);
+            promise.resolve_native_with_cx(cx, &());
         }
 
         // Set stream.[[backpressureChangePromise]] to a new promise.;
-        *self.backpressure_change_promise.borrow_mut() = Some(Promise::new(global, can_gc));
+        *self.backpressure_change_promise.borrow_mut() = Some(Promise::new(cx, global));
 
         // Set stream.[[backpressure]] to backpressure.
         self.backpressure.set(backpressure);
@@ -674,7 +679,7 @@ impl TransformStream {
             assert!(backpressure_change_promise.is_some());
 
             // Return the result of reacting to backpressureChangePromise with the following fulfillment steps:
-            let result_promise = Promise::new2(cx, global);
+            let result_promise = Promise::new(cx, global);
             rooted!(&in(cx) let mut fulfillment_handler = Some(TransformBackPressureChangePromiseFulfillment {
                 controller: Dom::from_ref(&controller),
                 writable: Dom::from_ref(&self.writable.get().expect("writable stream")),
@@ -723,7 +728,7 @@ impl TransformStream {
         let readable = self.readable.get().expect("readable stream is not set");
 
         // Let controller.[[finishPromise]] be a new promise.
-        controller.set_finish_promise(Promise::new2(cx, global));
+        controller.set_finish_promise(Promise::new(cx, global));
 
         // Let cancelPromise be the result of performing controller.[[cancelAlgorithm]], passing reason.
         let cancel_promise = controller.perform_cancel(cx, global, reason)?;
@@ -780,7 +785,7 @@ impl TransformStream {
             .ok_or(Error::Type(c"readable stream is not set".to_owned()))?;
 
         // Let controller.[[finishPromise]] be a new promise.
-        controller.set_finish_promise(Promise::new2(cx, global));
+        controller.set_finish_promise(Promise::new(cx, global));
 
         // Let flushPromise be the result of performing controller.[[flushAlgorithm]].
         let flush_promise = controller.perform_flush(cx, global)?;
@@ -837,7 +842,7 @@ impl TransformStream {
             .ok_or(Error::Type(c"writable stream is not set".to_owned()))?;
 
         // Let controller.[[finishPromise]] be a new promise.
-        controller.set_finish_promise(Promise::new2(cx, global));
+        controller.set_finish_promise(Promise::new(cx, global));
 
         // Let cancelPromise be the result of performing controller.[[cancelAlgorithm]], passing reason.
         let cancel_promise = controller.perform_cancel(cx, global, reason)?;
@@ -875,8 +880,8 @@ impl TransformStream {
     /// <https://streams.spec.whatwg.org/#transform-stream-default-source-pull>
     pub(crate) fn transform_stream_default_source_pull(
         &self,
+        cx: &mut JSContext,
         global: &GlobalScope,
-        can_gc: CanGc,
     ) -> Fallible<Rc<Promise>> {
         // Assert: stream.[[backpressure]] is true.
         assert!(self.backpressure.get());
@@ -885,7 +890,7 @@ impl TransformStream {
         assert!(self.backpressure_change_promise.borrow().is_some());
 
         // Perform ! TransformStreamSetBackpressure(stream, false).
-        self.set_backpressure(global, false, can_gc);
+        self.set_backpressure(cx, global, false);
 
         // Return stream.[[backpressureChangePromise]].
         Ok(self
@@ -911,14 +916,14 @@ impl TransformStream {
             .error_if_needed(cx, error, global);
 
         // Perform ! TransformStreamUnblockWrite(stream).
-        self.unblock_write(global, CanGc::from_cx(cx))
+        self.unblock_write(cx, global)
     }
 
     /// <https://streams.spec.whatwg.org/#transform-stream-unblock-write>
-    pub(crate) fn unblock_write(&self, global: &GlobalScope, can_gc: CanGc) {
+    pub(crate) fn unblock_write(&self, cx: &mut JSContext, global: &GlobalScope) {
         // If stream.[[backpressure]] is true, perform ! TransformStreamSetBackpressure(stream, false).
         if self.backpressure.get() {
-            self.set_backpressure(global, false, can_gc);
+            self.set_backpressure(cx, global, false);
         }
     }
 
@@ -988,7 +993,7 @@ impl TransformStreamMethods<crate::DomTypeHolder> for TransformStream {
         let writable_size_algorithm = extract_size_algorithm(writable_strategy, CanGc::from_cx(cx));
 
         // Let startPromise be a new promise.
-        let start_promise = Promise::new2(cx, global);
+        let start_promise = Promise::new(cx, global);
 
         // Perform ! InitializeTransformStream(this, startPromise, writableHighWaterMark,
         // writableSizeAlgorithm, readableHighWaterMark, readableSizeAlgorithm).

--- a/components/script/dom/stream/transformstreamdefaultcontroller.rs
+++ b/components/script/dom/stream/transformstreamdefaultcontroller.rs
@@ -232,7 +232,7 @@ impl TransformStreamDefaultController {
                             ExceptionHandling::Rethrow,
                         )
                         .unwrap_or_else(|e| {
-                            let p = Promise::new2(cx, global);
+                            let p = Promise::new(cx, global);
                             p.reject_error(cx, e);
                             p
                         })
@@ -374,7 +374,7 @@ impl TransformStreamDefaultController {
                     cancel
                         .Call_(cx, &this_object.handle(), chunk, ExceptionHandling::Rethrow)
                         .unwrap_or_else(|e| {
-                            let p = Promise::new2(cx, global);
+                            let p = Promise::new(cx, global);
                             p.reject_error(cx, e);
                             p
                         })
@@ -454,7 +454,7 @@ impl TransformStreamDefaultController {
                     flush
                         .Call_(cx, &this_object.handle(), self, ExceptionHandling::Rethrow)
                         .unwrap_or_else(|e| {
-                            let p = Promise::new2(cx, global);
+                            let p = Promise::new(cx, global);
                             p.reject_error(cx, e);
                             p
                         })
@@ -623,7 +623,7 @@ impl TransformStreamDefaultController {
             assert!(backpressure);
 
             // Perform ! TransformStreamSetBackpressure(stream, true).
-            stream.set_backpressure(global, true, CanGc::from_cx(cx));
+            stream.set_backpressure(cx, global, true);
         }
         Ok(())
     }

--- a/components/script/dom/stream/underlyingsourcecontainer.rs
+++ b/components/script/dom/stream/underlyingsourcecontainer.rs
@@ -189,7 +189,7 @@ impl UnderlyingSourceContainer {
                 // Disentangle port.
                 self.global().disentangle_port(cx, port);
 
-                let promise = Promise::new2(cx, &self.global());
+                let promise = Promise::new(cx, &self.global());
 
                 // If result is an abrupt completion,
                 if let Err(error) = result {
@@ -255,9 +255,7 @@ impl UnderlyingSourceContainer {
             // Note: other source type have no pull steps for now.
             UnderlyingSource::Transform(stream, _) => {
                 // Return ! TransformStreamDefaultSourcePullAlgorithm(stream).
-                Some(
-                    stream.transform_stream_default_source_pull(&self.global(), CanGc::from_cx(cx)),
-                )
+                Some(stream.transform_stream_default_source_pull(cx, &self.global()))
             },
             _ => None,
         }

--- a/components/script/dom/stream/writablestream.rs
+++ b/components/script/dom/stream/writablestream.rs
@@ -627,7 +627,11 @@ impl WritableStream {
     }
 
     /// <https://streams.spec.whatwg.org/#writable-stream-add-write-request>
-    pub(crate) fn add_write_request(&self, global: &GlobalScope, can_gc: CanGc) -> Rc<Promise> {
+    pub(crate) fn add_write_request(
+        &self,
+        cx: &mut JSContext,
+        global: &GlobalScope,
+    ) -> Rc<Promise> {
         // Assert: ! IsWritableStreamLocked(stream) is true.
         assert!(self.is_locked());
 
@@ -635,7 +639,7 @@ impl WritableStream {
         assert!(self.is_writable());
 
         // Let promise be a new promise.
-        let promise = Promise::new(global, can_gc);
+        let promise = Promise::new(cx, global);
 
         // Append promise to stream.[[writeRequests]].
         self.write_requests.borrow_mut().push_back(promise.clone());
@@ -710,7 +714,7 @@ impl WritableStream {
         };
 
         // Let promise be a new promise.
-        let promise = Promise::new2(cx, global);
+        let promise = Promise::new(cx, global);
 
         // Set stream.[[pendingAbortRequest]] to a new pending abort request
         // whose promise is promise,
@@ -738,7 +742,7 @@ impl WritableStream {
         // If state is "closed" or "errored",
         if self.is_closed() || self.is_errored() {
             // return a promise rejected with a TypeError exception.
-            let promise = Promise::new2(cx, global);
+            let promise = Promise::new(cx, global);
             promise.reject_error(cx, Error::Type(c"Stream is closed or errored.".to_owned()));
             return promise;
         }
@@ -750,7 +754,7 @@ impl WritableStream {
         assert!(!self.close_queued_or_in_flight());
 
         // Let promise be a new promise.
-        let promise = Promise::new2(cx, global);
+        let promise = Promise::new(cx, global);
 
         // Set stream.[[closeRequest]] to promise.
         *self.close_request.borrow_mut() = Some(promise.clone());
@@ -762,7 +766,7 @@ impl WritableStream {
             // and state is "writable",
             if self.get_backpressure() && self.is_writable() {
                 // resolve writer.[[readyPromise]] with undefined.
-                writer.resolve_ready_promise_with_undefined(CanGc::from_cx(cx));
+                writer.resolve_ready_promise_with_undefined(cx);
             }
         }
 
@@ -818,9 +822,9 @@ impl WritableStream {
     /// <https://streams.spec.whatwg.org/#writable-stream-update-backpressure>
     pub(crate) fn update_backpressure(
         &self,
+        cx: &mut JSContext,
         backpressure: bool,
         global: &GlobalScope,
-        can_gc: CanGc,
     ) {
         // Assert: stream.[[state]] is "writable".
         self.is_writable();
@@ -837,14 +841,14 @@ impl WritableStream {
                 // and backpressure is not stream.[[backpressure]],
                 if backpressure {
                     // If backpressure is true, set writer.[[readyPromise]] to a new promise.
-                    let promise = Promise::new(global, can_gc);
+                    let promise = Promise::new(cx, global);
                     writer.set_ready_promise(promise);
                 } else {
                     // Otherwise,
                     // Assert: backpressure is false.
                     assert!(!backpressure);
                     // Resolve writer.[[readyPromise]] with undefined.
-                    writer.resolve_ready_promise_with_undefined(can_gc);
+                    writer.resolve_ready_promise_with_undefined(cx);
                 }
             }
         }
@@ -873,7 +877,7 @@ impl WritableStream {
         // Note: other algorithms defined in the controller at call site.
 
         // Let backpressurePromise be a new promise.
-        let backpressure_promise = Rc::new(RefCell::new(Some(Promise::new2(cx, &global))));
+        let backpressure_promise = Rc::new(RefCell::new(Some(Promise::new(cx, &global))));
 
         // Let controller be a new WritableStreamDefaultController.
         let controller = WritableStreamDefaultController::new(
@@ -1066,7 +1070,7 @@ impl WritableStreamMethods<crate::DomTypeHolder> for WritableStream {
         // If ! IsWritableStreamLocked(this) is true,
         if self.is_locked() {
             // return a promise rejected with a TypeError exception.
-            let promise = Promise::new2(cx, &global);
+            let promise = Promise::new(cx, &global);
             promise.reject_error(cx, Error::Type(c"Stream is locked.".to_owned()));
             return promise;
         }
@@ -1082,7 +1086,7 @@ impl WritableStreamMethods<crate::DomTypeHolder> for WritableStream {
         // If ! IsWritableStreamLocked(this) is true,
         if self.is_locked() {
             // return a promise rejected with a TypeError exception.
-            let promise = Promise::new2(cx, &global);
+            let promise = Promise::new(cx, &global);
             promise.reject_error(cx, Error::Type(c"Stream is locked.".to_owned()));
             return promise;
         }
@@ -1090,7 +1094,7 @@ impl WritableStreamMethods<crate::DomTypeHolder> for WritableStream {
         // If ! WritableStreamCloseQueuedOrInFlight(this) is true
         if self.close_queued_or_in_flight() {
             // return a promise rejected with a TypeError exception.
-            let promise = Promise::new2(cx, &global);
+            let promise = Promise::new(cx, &global);
             promise.reject_error(
                 cx,
                 Error::Type(c"Stream has closed queued or in-flight".to_owned()),

--- a/components/script/dom/stream/writablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/writablestreamdefaultcontroller.rs
@@ -170,7 +170,7 @@ impl Callback for TransferBackPressurePromiseReaction {
         let can_gc = CanGc::from_cx(cx);
         let global = self.result_promise.global();
         // Set backpressurePromise to a new promise.
-        let promise = Promise::new2(cx, &global);
+        let promise = Promise::new(cx, &global);
         *self.backpressure_promise.borrow_mut() = Some(promise);
 
         // Let result be PackAndPostMessageHandlingError(port, "chunk", chunk).
@@ -234,7 +234,7 @@ impl Callback for WriteAlgorithmFulfillmentHandler {
             let backpressure = controller.get_backpressure();
 
             // Perform ! WritableStreamUpdateBackpressure(stream, backpressure).
-            stream.update_backpressure(backpressure, &global, can_gc);
+            stream.update_backpressure(cx, backpressure, &global);
         }
 
         // Perform ! WritableStreamDefaultControllerAdvanceQueueIfNeeded(controller).
@@ -482,7 +482,7 @@ impl WritableStreamDefaultController {
         let backpressure = self.get_backpressure();
 
         // Perform ! WritableStreamUpdateBackpressure(stream, backpressure).
-        stream.update_backpressure(backpressure, global, CanGc::from_cx(cx));
+        stream.update_backpressure(cx, backpressure, global);
 
         // Let startResult be the result of performing startAlgorithm. (This may throw an exception.)
         // Let startPromise be a promise resolved with startResult.
@@ -603,7 +603,7 @@ impl WritableStreamDefaultController {
                     Ok(Promise::new_resolved(cx, global, ()))
                 };
                 result.unwrap_or_else(|e| {
-                    let promise = Promise::new2(cx, global);
+                    let promise = Promise::new(cx, global);
                     promise.reject_error(cx, e);
                     promise
                 })
@@ -618,7 +618,7 @@ impl WritableStreamDefaultController {
                 // Disentangle port.
                 global.disentangle_port(cx, port);
 
-                let promise = Promise::new2(cx, global);
+                let promise = Promise::new(cx, global);
 
                 // If result is an abrupt completion, return a promise rejected with result.[[Value]]
                 if let Err(error) = result {
@@ -671,7 +671,7 @@ impl WritableStreamDefaultController {
                     Ok(Promise::new_resolved(cx, global, ()))
                 };
                 result.unwrap_or_else(|e| {
-                    let promise = Promise::new2(cx, global);
+                    let promise = Promise::new(cx, global);
                     promise.reject_error(cx, e);
                     promise
                 })
@@ -691,7 +691,7 @@ impl WritableStreamDefaultController {
                 }
 
                 // Return the result of reacting to backpressurePromise with the following fulfillment steps:
-                let result_promise = Promise::new2(cx, global);
+                let result_promise = Promise::new(cx, global);
                 rooted!(&in(cx) let mut fulfillment_handler = Some(TransferBackPressurePromiseReaction {
                     port: port.clone(),
                     backpressure_promise: backpressure_promise.clone(),
@@ -740,7 +740,7 @@ impl WritableStreamDefaultController {
                     Ok(Promise::new_resolved(cx, global, ()))
                 };
                 result.unwrap_or_else(|e| {
-                    let promise = Promise::new2(cx, global);
+                    let promise = Promise::new(cx, global);
                     promise.reject_error(cx, e);
                     promise
                 })
@@ -1002,7 +1002,7 @@ impl WritableStreamDefaultController {
             let backpressure = self.get_backpressure();
 
             // Perform ! WritableStreamUpdateBackpressure(stream, backpressure).
-            stream.update_backpressure(backpressure, global, CanGc::from_cx(cx));
+            stream.update_backpressure(cx, backpressure, global);
         }
 
         // Perform ! WritableStreamDefaultControllerAdvanceQueueIfNeeded(controller).

--- a/components/script/dom/stream/writablestreamdefaultwriter.rs
+++ b/components/script/dom/stream/writablestreamdefaultwriter.rs
@@ -166,8 +166,8 @@ impl WritableStreamDefaultWriter {
         *self.ready_promise.borrow_mut() = promise;
     }
 
-    pub(crate) fn resolve_ready_promise_with_undefined(&self, can_gc: CanGc) {
-        self.ready_promise.borrow().resolve_native(&(), can_gc);
+    pub(crate) fn resolve_ready_promise_with_undefined(&self, cx: &mut JSContext) {
+        self.ready_promise.borrow().resolve_native_with_cx(cx, &());
     }
 
     pub(crate) fn resolve_closed_promise_with_undefined(&self, can_gc: CanGc) {
@@ -284,7 +284,7 @@ impl WritableStreamDefaultWriter {
             .get()
             .is_some_and(|current_stream| current_stream == stream)
         {
-            let promise = Promise::new2(cx, global);
+            let promise = Promise::new(cx, global);
             promise.reject_error(
                 cx,
                 Error::Type(c"Stream is not equal to writer stream".to_owned()),
@@ -298,7 +298,7 @@ impl WritableStreamDefaultWriter {
             // return a promise rejected with stream.[[storedError]].
             rooted!(&in(cx) let mut error = UndefinedValue());
             stream.get_stored_error(error.handle_mut());
-            let promise = Promise::new2(cx, global);
+            let promise = Promise::new(cx, global);
             promise.reject_native(cx, &error.handle());
             return promise;
         }
@@ -308,7 +308,7 @@ impl WritableStreamDefaultWriter {
         if stream.close_queued_or_in_flight() || stream.is_closed() {
             // return a promise rejected with a TypeError exception
             // indicating that the stream is closing or closed
-            let promise = Promise::new2(cx, global);
+            let promise = Promise::new(cx, global);
             promise.reject_error(
                 cx,
                 Error::Type(c"Stream has been closed, or has close queued or in-flight".to_owned()),
@@ -321,7 +321,7 @@ impl WritableStreamDefaultWriter {
             // return a promise rejected with stream.[[storedError]].
             rooted!(&in(cx) let mut error = UndefinedValue());
             stream.get_stored_error(error.handle_mut());
-            let promise = Promise::new2(cx, global);
+            let promise = Promise::new(cx, global);
             promise.reject_native(cx, &error.handle());
             return promise;
         }
@@ -330,7 +330,7 @@ impl WritableStreamDefaultWriter {
         assert!(stream.is_writable());
 
         // Let promise be ! WritableStreamAddWriteRequest(stream).
-        let promise = stream.add_write_request(global, CanGc::from_cx(cx));
+        let promise = stream.add_write_request(cx, global);
 
         // Perform ! WritableStreamDefaultControllerWrite(controller, chunk, chunkSize).
         controller.write(cx, global, chunk, chunk_size);
@@ -389,7 +389,7 @@ impl WritableStreamDefaultWriter {
         // or state is "closed",
         if stream.close_queued_or_in_flight() || stream.is_closed() {
             // return a promise resolved with undefined.
-            let promise = Promise::new2(cx, global);
+            let promise = Promise::new(cx, global);
             promise.resolve_native_with_cx(cx, &());
             return promise;
         }
@@ -399,7 +399,7 @@ impl WritableStreamDefaultWriter {
             // return a promise rejected with stream.[[storedError]].
             rooted!(&in(cx) let mut error = UndefinedValue());
             stream.get_stored_error(error.handle_mut());
-            let promise = Promise::new2(cx, global);
+            let promise = Promise::new(cx, global);
             promise.reject_native(cx, &error.handle());
             return promise;
         }
@@ -447,7 +447,7 @@ impl WritableStreamDefaultWriterMethods<crate::DomTypeHolder> for WritableStream
         // If this.[[stream]] is undefined,
         if self.stream.get().is_none() {
             // return a promise rejected with a TypeError exception.
-            let promise = Promise::new2(cx, &global);
+            let promise = Promise::new(cx, &global);
             promise.reject_error(cx, Error::Type(c"Stream is undefined".to_owned()));
             return promise;
         }
@@ -459,7 +459,7 @@ impl WritableStreamDefaultWriterMethods<crate::DomTypeHolder> for WritableStream
     /// <https://streams.spec.whatwg.org/#default-writer-close>
     fn Close(&self, cx: &mut CurrentRealm) -> Rc<Promise> {
         let global = GlobalScope::from_current_realm(cx);
-        let promise = Promise::new2(cx, &global);
+        let promise = Promise::new(cx, &global);
 
         // Let stream be this.[[stream]].
         let Some(stream) = self.stream.get() else {
@@ -506,7 +506,7 @@ impl WritableStreamDefaultWriterMethods<crate::DomTypeHolder> for WritableStream
         // If this.[[stream]] is undefined,
         if self.stream.get().is_none() {
             // return a promise rejected with a TypeError exception.
-            let promise = Promise::new2(cx, &global);
+            let promise = Promise::new(cx, &global);
             promise.reject_error(cx, Error::Type(c"Stream is undefined".to_owned()));
             return promise;
         }

--- a/components/script/dom/testing/testutils.rs
+++ b/components/script/dom/testing/testutils.rs
@@ -5,9 +5,9 @@
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::jsapi::{GCReason, JS_GC};
 use script_bindings::reflector::Reflector;
-use script_bindings::script_runtime::CanGc;
 
 use crate::dom::bindings::codegen::Bindings::TestUtilsBinding::TestUtilsMethods;
 use crate::dom::globalscope::GlobalScope;
@@ -22,21 +22,21 @@ pub(crate) struct TestUtils {
 impl TestUtilsMethods<crate::DomTypeHolder> for TestUtils {
     /// <https://testutils.spec.whatwg.org/#dom-testutils-gc>
     #[expect(unsafe_code)]
-    fn Gc(global: &GlobalScope) -> Rc<Promise> {
+    fn Gc(cx: &mut JSContext, global: &GlobalScope) -> Rc<Promise> {
         // 1. Let p be a new promise.
-        let promise = Promise::new(global, CanGc::deprecated_note());
+        let promise = Promise::new(cx, global);
         let trusted = TrustedPromise::new(promise.clone());
         // 2. Run the following in parallel:
         // 2.1 Run implementation-defined steps to perform a garbage collection covering at least the entry Realm.
         // 2.2 Resolve p.
         // We need to spin the event-loop in order get the GC to actually run.
         // We do this by queuing a task that calls the GC and then resolves the promise.
-        let task = task!(testutils_gc: move || {
+        let task = task!(testutils_gc: move |cx| {
             unsafe {
-                JS_GC(*GlobalScope::get_cx(), GCReason::DOM_TESTUTILS);
+                JS_GC(cx.raw_cx(), GCReason::DOM_TESTUTILS);
             }
             let promise = trusted.root();
-            promise.resolve_native(&(), CanGc::deprecated_note());
+            promise.resolve_native_with_cx(cx, &());
         });
 
         global

--- a/components/script/dom/webgl/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl/webgl2renderingcontext.rs
@@ -4969,11 +4969,9 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
 
     /// <https://immersive-web.github.io/webxr/#dom-webglrenderingcontextbase-makexrcompatible>
     #[cfg(feature = "webxr")]
-    fn MakeXRCompatible(&self, can_gc: CanGc) -> Rc<Promise> {
+    fn MakeXRCompatible(&self, cx: &mut js::context::JSContext) -> Rc<Promise> {
         // XXXManishearth Fill in with compatibility checks when rust-webxr supports this
-        let p = Promise::new(&self.global(), can_gc);
-        p.resolve_native(&(), can_gc);
-        p
+        Promise::new_resolved(cx, &self.global(), ())
     }
 }
 

--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -4991,11 +4991,9 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
 
     /// <https://immersive-web.github.io/webxr/#dom-webglrenderingcontextbase-makexrcompatible>
     #[cfg(feature = "webxr")]
-    fn MakeXRCompatible(&self, can_gc: CanGc) -> Rc<Promise> {
+    fn MakeXRCompatible(&self, cx: &mut js::context::JSContext) -> Rc<Promise> {
         // XXXManishearth Fill in with compatibility checks when rust-webxr supports this
-        let p = Promise::new(&self.global(), can_gc);
-        p.resolve_native(&(), can_gc);
-        p
+        Promise::new_resolved(cx, &self.global(), ())
     }
 }
 

--- a/components/script/dom/webgpu/gpudevice.rs
+++ b/components/script/dom/webgpu/gpudevice.rs
@@ -166,7 +166,7 @@ impl GPUDevice {
         let limits = GPUSupportedLimits::new(cx, global, limits);
         let features = GPUSupportedFeatures::Constructor(cx, global, None, features).unwrap();
         let adapter_info = GPUAdapterInfo::clone_from(cx, global, &adapter.Info());
-        let lost_promise = Promise::new2(cx, global);
+        let lost_promise = Promise::new(cx, global);
         let device = reflect_dom_object_with_cx(
             Box::new(GPUDevice::new_inherited(
                 channel,

--- a/components/script/dom/webgpu/gpuqueue.rs
+++ b/components/script/dom/webgpu/gpuqueue.rs
@@ -385,7 +385,7 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuqueue-onsubmittedworkdone>
     fn OnSubmittedWorkDone(&self, cx: &mut JSContext) -> Rc<Promise> {
         let global = self.global();
-        let promise = Promise::new2(cx, &global);
+        let promise = Promise::new(cx, &global);
         let task_source = global.task_manager().dom_manipulation_task_source();
         let callback = callback_promise(&promise, self, task_source);
 

--- a/components/script/dom/webrtc/rtcrtpsender.rs
+++ b/components/script/dom/webrtc/rtcrtpsender.rs
@@ -5,6 +5,7 @@
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use script_bindings::reflector::{Reflector, reflect_dom_object};
 
 use crate::dom::bindings::codegen::Bindings::RTCRtpSenderBinding::{
@@ -52,9 +53,7 @@ impl RTCRtpSenderMethods<crate::DomTypeHolder> for RTCRtpSender {
     }
 
     /// <https://w3c.github.io/webrtc-pc/#dom-rtcrtpsender-setparameters>
-    fn SetParameters(&self, _parameters: &RTCRtpSendParameters, can_gc: CanGc) -> Rc<Promise> {
-        let promise = Promise::new(&self.global(), can_gc);
-        promise.resolve_native(&(), can_gc);
-        promise
+    fn SetParameters(&self, cx: &mut JSContext, _parameters: &RTCRtpSendParameters) -> Rc<Promise> {
+        Promise::new_resolved(cx, &self.global(), ())
     }
 }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1198,7 +1198,7 @@ DOMInterfaces = {
 },
 
 'RTCRtpSender': {
-    'canGc': ['SetParameters'],
+    'cx': ['SetParameters'],
 },
 
 'RTCTrackEvent': {
@@ -1307,6 +1307,10 @@ DOMInterfaces = {
     'cx': ['TestAttribute'],
 },
 
+'TestUtils': {
+    'cx': ['Gc'],
+},
+
 'TestWorklet': {
     'cx': ['Constructor'],
     'realm': ['AddModule'],
@@ -1375,14 +1379,12 @@ DOMInterfaces = {
 },
 
 'WebGLRenderingContext': {
-    'canGc': ['MakeXRCompatible'],
-    'cx': ['GetExtension'],
+    'cx': ['GetExtension', 'MakeXRCompatible'],
     'weakReferenceable': True,
 },
 
 'WebGL2RenderingContext': {
-    'canGc': ['MakeXRCompatible'],
-    'cx': ['GetExtension'],
+    'cx': ['GetExtension', 'MakeXRCompatible'],
     'additionalTraits': ['crate::interfaces::WebGL2RenderingContextHelpers'],
 },
 


### PR DESCRIPTION
All callers are now migrated to `Promise::new` which takes a `&mut JSContext`.

Part of #40600

Testing: it compiles