### PR TITLE
script: Move CanGc to &mut JSContext for DOMMatrix and DOMMatrixReadOnly

### DIFF
--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -2203,7 +2203,7 @@ impl CanvasState {
         cx: &mut JSContext,
     ) -> DomRoot<DOMMatrix> {
         let transform = self.state.borrow_mut().transform;
-        DOMMatrix::new(global, true, transform.to_3d(), CanGc::from_cx(cx))
+        DOMMatrix::new(global, true, transform.to_3d(), cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-settransform>

--- a/components/script/dom/geometry/dommatrix.rs
+++ b/components/script/dom/geometry/dommatrix.rs
@@ -40,9 +40,9 @@ impl DOMMatrix {
         global: &GlobalScope,
         is2D: bool,
         matrix: Transform3D<f64>,
-        can_gc: CanGc,
+        cx: &mut JSContext,
     ) -> DomRoot<Self> {
-        Self::new_with_proto(global, None, is2D, matrix, can_gc)
+        Self::new_with_proto(global, None, is2D, matrix, cx)
     }
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
@@ -51,10 +51,10 @@ impl DOMMatrix {
         proto: Option<HandleObject>,
         is2D: bool,
         matrix: Transform3D<f64>,
-        can_gc: CanGc,
+        cx: &mut JSContext,
     ) -> DomRoot<Self> {
         let dommatrix = Self::new_inherited(is2D, matrix);
-        reflect_dom_object_with_proto(Box::new(dommatrix), global, proto, can_gc)
+        reflect_dom_object_with_proto(Box::new(dommatrix), global, proto, CanGc::from_cx(cx))
     }
 
     pub(crate) fn new_inherited(is2D: bool, matrix: Transform3D<f64>) -> Self {
@@ -66,9 +66,9 @@ impl DOMMatrix {
     pub(crate) fn from_readonly(
         global: &GlobalScope,
         ro: &DOMMatrixReadOnly,
-        can_gc: CanGc,
+        cx: &mut JSContext,
     ) -> DomRoot<Self> {
-        Self::new(global, ro.is2D(), *ro.matrix(), can_gc)
+        Self::new(global, ro.is2D(), *ro.matrix(), cx)
     }
 }
 
@@ -76,9 +76,9 @@ impl DOMMatrix {
 impl DOMMatrixMethods<crate::DomTypeHolder> for DOMMatrix {
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-dommatrixreadonly>
     fn Constructor(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         init: Option<StringOrUnrestrictedDoubleSequence>,
     ) -> Fallible<DomRoot<Self>> {
         if init.is_none() {
@@ -87,7 +87,7 @@ impl DOMMatrixMethods<crate::DomTypeHolder> for DOMMatrix {
                 proto,
                 true,
                 Transform3D::identity(),
-                can_gc,
+                cx,
             ));
         }
         match init.unwrap() {
@@ -98,14 +98,14 @@ impl DOMMatrixMethods<crate::DomTypeHolder> for DOMMatrix {
                     ));
                 }
                 if s.is_empty() {
-                    return Ok(Self::new(global, true, Transform3D::identity(), can_gc));
+                    return Ok(Self::new(global, true, Transform3D::identity(), cx));
                 }
                 transform_to_matrix(&s.str())
-                    .map(|(is2D, matrix)| Self::new_with_proto(global, proto, is2D, matrix, can_gc))
+                    .map(|(is2D, matrix)| Self::new_with_proto(global, proto, is2D, matrix, cx))
             },
             StringOrUnrestrictedDoubleSequence::UnrestrictedDoubleSequence(ref entries) => {
                 entries_to_matrix(&entries[..])
-                    .map(|(is2D, matrix)| Self::new_with_proto(global, proto, is2D, matrix, can_gc))
+                    .map(|(is2D, matrix)| Self::new_with_proto(global, proto, is2D, matrix, cx))
             },
         }
     }
@@ -117,7 +117,7 @@ impl DOMMatrixMethods<crate::DomTypeHolder> for DOMMatrix {
         other: &DOMMatrixInit,
     ) -> Fallible<DomRoot<Self>> {
         dommatrixinit_to_matrix(other)
-            .map(|(is2D, matrix)| Self::new(global, is2D, matrix, CanGc::from_cx(cx)))
+            .map(|(is2D, matrix)| Self::new(global, is2D, matrix, cx))
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrix-fromfloat32array>
@@ -128,9 +128,7 @@ impl DOMMatrixMethods<crate::DomTypeHolder> for DOMMatrix {
     ) -> Fallible<DomRoot<DOMMatrix>> {
         let vec: Vec<f64> = array.to_vec().iter().map(|&x| x as f64).collect();
         DOMMatrix::Constructor(
-            global,
-            None,
-            CanGc::from_cx(cx),
+            cx, global, None,
             Some(StringOrUnrestrictedDoubleSequence::UnrestrictedDoubleSequence(vec)),
         )
     }
@@ -143,9 +141,7 @@ impl DOMMatrixMethods<crate::DomTypeHolder> for DOMMatrix {
     ) -> Fallible<DomRoot<DOMMatrix>> {
         let vec: Vec<f64> = array.to_vec();
         DOMMatrix::Constructor(
-            global,
-            None,
-            CanGc::from_cx(cx),
+            cx, global, None,
             Some(StringOrUnrestrictedDoubleSequence::UnrestrictedDoubleSequence(vec)),
         )
     }

--- a/components/script/dom/geometry/dommatrix.rs
+++ b/components/script/dom/geometry/dommatrix.rs
@@ -116,8 +116,7 @@ impl DOMMatrixMethods<crate::DomTypeHolder> for DOMMatrix {
         global: &GlobalScope,
         other: &DOMMatrixInit,
     ) -> Fallible<DomRoot<Self>> {
-        dommatrixinit_to_matrix(other)
-            .map(|(is2D, matrix)| Self::new(global, is2D, matrix, cx))
+        dommatrixinit_to_matrix(other).map(|(is2D, matrix)| Self::new(global, is2D, matrix, cx))
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrix-fromfloat32array>
@@ -128,7 +127,9 @@ impl DOMMatrixMethods<crate::DomTypeHolder> for DOMMatrix {
     ) -> Fallible<DomRoot<DOMMatrix>> {
         let vec: Vec<f64> = array.to_vec().iter().map(|&x| x as f64).collect();
         DOMMatrix::Constructor(
-            cx, global, None,
+            cx,
+            global,
+            None,
             Some(StringOrUnrestrictedDoubleSequence::UnrestrictedDoubleSequence(vec)),
         )
     }
@@ -141,7 +142,9 @@ impl DOMMatrixMethods<crate::DomTypeHolder> for DOMMatrix {
     ) -> Fallible<DomRoot<DOMMatrix>> {
         let vec: Vec<f64> = array.to_vec();
         DOMMatrix::Constructor(
-            cx, global, None,
+            cx,
+            global,
+            None,
             Some(StringOrUnrestrictedDoubleSequence::UnrestrictedDoubleSequence(vec)),
         )
     }
@@ -562,15 +565,10 @@ impl Serializable for DOMMatrix {
                     0.0,
                     1.0,
                 ),
-                CanGc::from_cx(cx),
+                cx,
             ))
         } else {
-            Ok(Self::new(
-                owner,
-                false,
-                serialized.matrix,
-                CanGc::from_cx(cx),
-            ))
+            Ok(Self::new(owner, false, serialized.matrix, cx))
         }
     }
 

--- a/components/script/dom/geometry/dommatrix.rs
+++ b/components/script/dom/geometry/dommatrix.rs
@@ -112,39 +112,40 @@ impl DOMMatrixMethods<crate::DomTypeHolder> for DOMMatrix {
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrix-frommatrix>
     fn FromMatrix(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         other: &DOMMatrixInit,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<Self>> {
-        dommatrixinit_to_matrix(other).map(|(is2D, matrix)| Self::new(global, is2D, matrix, can_gc))
+        dommatrixinit_to_matrix(other)
+            .map(|(is2D, matrix)| Self::new(global, is2D, matrix, CanGc::from_cx(cx)))
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrix-fromfloat32array>
     fn FromFloat32Array(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         array: CustomAutoRooterGuard<Float32Array>,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<DOMMatrix>> {
         let vec: Vec<f64> = array.to_vec().iter().map(|&x| x as f64).collect();
         DOMMatrix::Constructor(
             global,
             None,
-            can_gc,
+            CanGc::from_cx(cx),
             Some(StringOrUnrestrictedDoubleSequence::UnrestrictedDoubleSequence(vec)),
         )
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrix-fromfloat64array>
     fn FromFloat64Array(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         array: CustomAutoRooterGuard<Float64Array>,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<DOMMatrix>> {
         let vec: Vec<f64> = array.to_vec();
         DOMMatrix::Constructor(
             global,
             None,
-            can_gc,
+            CanGc::from_cx(cx),
             Some(StringOrUnrestrictedDoubleSequence::UnrestrictedDoubleSequence(vec)),
         )
     }

--- a/components/script/dom/geometry/dommatrixreadonly.rs
+++ b/components/script/dom/geometry/dommatrixreadonly.rs
@@ -45,7 +45,7 @@ use crate::dom::dommatrix::DOMMatrix;
 use crate::dom::dompoint::DOMPoint;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
-use crate::script_runtime::{CanGc};
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 #[expect(non_snake_case)]

--- a/components/script/dom/geometry/dommatrixreadonly.rs
+++ b/components/script/dom/geometry/dommatrixreadonly.rs
@@ -45,7 +45,7 @@ use crate::dom::dommatrix::DOMMatrix;
 use crate::dom::dompoint::DOMPoint;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
-use crate::script_runtime::{CanGc, JSContext};
+use crate::script_runtime::{CanGc};
 
 #[dom_struct]
 #[expect(non_snake_case)]

--- a/components/script/dom/geometry/dommatrixreadonly.rs
+++ b/components/script/dom/geometry/dommatrixreadonly.rs
@@ -513,39 +513,40 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-frommatrix>
     fn FromMatrix(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         other: &DOMMatrixInit,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<Self>> {
-        dommatrixinit_to_matrix(other).map(|(is2D, matrix)| Self::new(global, is2D, matrix, can_gc))
+        dommatrixinit_to_matrix(other)
+            .map(|(is2D, matrix)| Self::new(global, is2D, matrix, CanGc::from_cx(cx)))
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-fromfloat32array>
     fn FromFloat32Array(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         array: CustomAutoRooterGuard<Float32Array>,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<DOMMatrixReadOnly>> {
         let vec: Vec<f64> = array.to_vec().iter().map(|&x| x as f64).collect();
         DOMMatrixReadOnly::Constructor(
             global,
             None,
-            can_gc,
+            CanGc::from_cx(cx),
             Some(StringOrUnrestrictedDoubleSequence::UnrestrictedDoubleSequence(vec)),
         )
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-fromfloat64array>
     fn FromFloat64Array(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         array: CustomAutoRooterGuard<Float64Array>,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<DOMMatrixReadOnly>> {
         let vec: Vec<f64> = array.to_vec();
         DOMMatrixReadOnly::Constructor(
             global,
             None,
-            can_gc,
+            CanGc::from_cx(cx),
             Some(StringOrUnrestrictedDoubleSequence::UnrestrictedDoubleSequence(vec)),
         )
     }
@@ -687,28 +688,28 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-translate>
-    fn Translate(&self, tx: f64, ty: f64, tz: f64, can_gc: CanGc) -> DomRoot<DOMMatrix> {
-        DOMMatrix::from_readonly(&self.global(), self, can_gc).TranslateSelf(tx, ty, tz)
+    fn Translate(&self, cx: &mut js::context::JSContext, tx: f64, ty: f64, tz: f64) -> DomRoot<DOMMatrix> {
+        DOMMatrix::from_readonly(&self.global(), self, CanGc::from_cx(cx)).TranslateSelf(tx, ty, tz)
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-scale>
     fn Scale(
         &self,
+        cx: &mut js::context::JSContext,
         scaleX: f64,
         scaleY: Option<f64>,
         scaleZ: f64,
         originX: f64,
         originY: f64,
         originZ: f64,
-        can_gc: CanGc,
     ) -> DomRoot<DOMMatrix> {
-        DOMMatrix::from_readonly(&self.global(), self, can_gc)
+        DOMMatrix::from_readonly(&self.global(), self, CanGc::from_cx(cx))
             .ScaleSelf(scaleX, scaleY, scaleZ, originX, originY, originZ)
     }
 
     /// <https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-scalenonuniform>
-    fn ScaleNonUniform(&self, scaleX: f64, scaleY: f64, can_gc: CanGc) -> DomRoot<DOMMatrix> {
-        DOMMatrix::from_readonly(&self.global(), self, can_gc).ScaleSelf(
+    fn ScaleNonUniform(&self, cx: &mut js::context::JSContext, scaleX: f64, scaleY: f64) -> DomRoot<DOMMatrix> {
+        DOMMatrix::from_readonly(&self.global(), self, CanGc::from_cx(cx)).ScaleSelf(
             scaleX,
             Some(scaleY),
             1.0,
@@ -721,82 +722,83 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-scale3d>
     fn Scale3d(
         &self,
+        cx: &mut js::context::JSContext,
         scale: f64,
         originX: f64,
         originY: f64,
         originZ: f64,
-        can_gc: CanGc,
     ) -> DomRoot<DOMMatrix> {
-        DOMMatrix::from_readonly(&self.global(), self, can_gc)
+        DOMMatrix::from_readonly(&self.global(), self, CanGc::from_cx(cx))
             .Scale3dSelf(scale, originX, originY, originZ)
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-rotate>
     fn Rotate(
         &self,
+        cx: &mut js::context::JSContext,
         rotX: f64,
         rotY: Option<f64>,
         rotZ: Option<f64>,
-        can_gc: CanGc,
     ) -> DomRoot<DOMMatrix> {
-        DOMMatrix::from_readonly(&self.global(), self, can_gc).RotateSelf(rotX, rotY, rotZ)
+        DOMMatrix::from_readonly(&self.global(), self, CanGc::from_cx(cx)).RotateSelf(rotX, rotY, rotZ)
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-rotatefromvector>
-    fn RotateFromVector(&self, x: f64, y: f64, can_gc: CanGc) -> DomRoot<DOMMatrix> {
-        DOMMatrix::from_readonly(&self.global(), self, can_gc).RotateFromVectorSelf(x, y)
+    fn RotateFromVector(&self, cx: &mut js::context::JSContext, x: f64, y: f64) -> DomRoot<DOMMatrix> {
+        DOMMatrix::from_readonly(&self.global(), self, CanGc::from_cx(cx)).RotateFromVectorSelf(x, y)
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-rotateaxisangle>
     fn RotateAxisAngle(
         &self,
+        cx: &mut js::context::JSContext,
         x: f64,
         y: f64,
         z: f64,
         angle: f64,
-        can_gc: CanGc,
     ) -> DomRoot<DOMMatrix> {
-        DOMMatrix::from_readonly(&self.global(), self, can_gc).RotateAxisAngleSelf(x, y, z, angle)
+        DOMMatrix::from_readonly(&self.global(), self, CanGc::from_cx(cx))
+            .RotateAxisAngleSelf(x, y, z, angle)
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-skewx>
-    fn SkewX(&self, sx: f64, can_gc: CanGc) -> DomRoot<DOMMatrix> {
-        DOMMatrix::from_readonly(&self.global(), self, can_gc).SkewXSelf(sx)
+    fn SkewX(&self, cx: &mut js::context::JSContext, sx: f64) -> DomRoot<DOMMatrix> {
+        DOMMatrix::from_readonly(&self.global(), self, CanGc::from_cx(cx)).SkewXSelf(sx)
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-skewy>
-    fn SkewY(&self, sy: f64, can_gc: CanGc) -> DomRoot<DOMMatrix> {
-        DOMMatrix::from_readonly(&self.global(), self, can_gc).SkewYSelf(sy)
+    fn SkewY(&self, cx: &mut js::context::JSContext, sy: f64) -> DomRoot<DOMMatrix> {
+        DOMMatrix::from_readonly(&self.global(), self, CanGc::from_cx(cx)).SkewYSelf(sy)
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-multiply>
-    fn Multiply(&self, other: &DOMMatrixInit, can_gc: CanGc) -> Fallible<DomRoot<DOMMatrix>> {
-        DOMMatrix::from_readonly(&self.global(), self, can_gc).MultiplySelf(other)
+    fn Multiply(&self, cx: &mut js::context::JSContext, other: &DOMMatrixInit) -> Fallible<DomRoot<DOMMatrix>> {
+        DOMMatrix::from_readonly(&self.global(), self, CanGc::from_cx(cx)).MultiplySelf(other)
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-flipx>
-    fn FlipX(&self, can_gc: CanGc) -> DomRoot<DOMMatrix> {
+    fn FlipX(&self, cx: &mut js::context::JSContext) -> DomRoot<DOMMatrix> {
         let is2D = self.is2D.get();
         let flip = Transform3D::new(
             -1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0,
         );
         let matrix = flip.then(&self.matrix.borrow());
-        DOMMatrix::new(&self.global(), is2D, matrix, can_gc)
+        DOMMatrix::new(&self.global(), is2D, matrix, CanGc::from_cx(cx))
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-flipy>
-    fn FlipY(&self, can_gc: CanGc) -> DomRoot<DOMMatrix> {
+    fn FlipY(&self, cx: &mut js::context::JSContext) -> DomRoot<DOMMatrix> {
         let is2D = self.is2D.get();
         let flip = Transform3D::new(
             1.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0,
         );
         let matrix = flip.then(&self.matrix.borrow());
-        DOMMatrix::new(&self.global(), is2D, matrix, can_gc)
+        DOMMatrix::new(&self.global(), is2D, matrix, CanGc::from_cx(cx))
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-inverse>
-    fn Inverse(&self, can_gc: CanGc) -> DomRoot<DOMMatrix> {
-        DOMMatrix::from_readonly(&self.global(), self, can_gc).InvertSelf()
+    fn Inverse(&self, cx: &mut js::context::JSContext) -> DomRoot<DOMMatrix> {
+        DOMMatrix::from_readonly(&self.global(), self, CanGc::from_cx(cx)).InvertSelf()
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-transformpoint>
@@ -821,7 +823,7 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-tofloat32array>
-    fn ToFloat32Array(&self, cx: JSContext, can_gc: CanGc) -> RootedTraceableBox<HeapFloat32Array> {
+    fn ToFloat32Array(&self, cx: &mut js::context::JSContext) -> RootedTraceableBox<HeapFloat32Array> {
         let vec: Vec<f32> = self
             .matrix
             .borrow()
@@ -829,19 +831,19 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
             .iter()
             .map(|&x| x as f32)
             .collect();
-        rooted!(in (*cx) let mut array = ptr::null_mut::<JSObject>());
-        create_buffer_source(cx, &vec, array.handle_mut(), can_gc)
+        rooted!(&in(cx) let mut array = ptr::null_mut::<JSObject>());
+        create_buffer_source(cx.into(), &vec, array.handle_mut(), CanGc::from_cx(cx))
             .expect("Converting matrix to float32 array should never fail")
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-tofloat64array>
-    fn ToFloat64Array(&self, cx: JSContext, can_gc: CanGc) -> RootedTraceableBox<HeapFloat64Array> {
-        rooted!(in (*cx) let mut array = ptr::null_mut::<JSObject>());
+    fn ToFloat64Array(&self, cx: &mut js::context::JSContext) -> RootedTraceableBox<HeapFloat64Array> {
+        rooted!(&in(cx) let mut array = ptr::null_mut::<JSObject>());
         create_buffer_source(
-            cx,
+            cx.into(),
             &self.matrix.borrow().to_array(),
             array.handle_mut(),
-            can_gc,
+            CanGc::from_cx(cx),
         )
         .expect("Converting matrix to float64 array should never fail")
     }

--- a/components/script/dom/geometry/dommatrixreadonly.rs
+++ b/components/script/dom/geometry/dommatrixreadonly.rs
@@ -62,9 +62,9 @@ impl DOMMatrixReadOnly {
         global: &GlobalScope,
         is2D: bool,
         matrix: Transform3D<f64>,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) -> DomRoot<Self> {
-        Self::new_with_proto(global, None, is2D, matrix, can_gc)
+        Self::new_with_proto(global, None, is2D, matrix, cx)
     }
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
@@ -73,10 +73,10 @@ impl DOMMatrixReadOnly {
         proto: Option<HandleObject>,
         is2D: bool,
         matrix: Transform3D<f64>,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) -> DomRoot<Self> {
         let dommatrix = Self::new_inherited(is2D, matrix);
-        reflect_dom_object_with_proto(Box::new(dommatrix), global, proto, can_gc)
+        reflect_dom_object_with_proto(Box::new(dommatrix), global, proto, CanGc::from_cx(cx))
     }
 
     pub(crate) fn new_inherited(is2D: bool, matrix: Transform3D<f64>) -> Self {
@@ -477,9 +477,9 @@ impl DOMMatrixReadOnly {
 impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-dommatrixreadonly>
     fn Constructor(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         init: Option<StringOrUnrestrictedDoubleSequence>,
     ) -> Fallible<DomRoot<Self>> {
         if init.is_none() {
@@ -488,7 +488,7 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
                 proto,
                 true,
                 Transform3D::identity(),
-                can_gc,
+                cx,
             ));
         }
         match init.unwrap() {
@@ -499,14 +499,14 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
                     ));
                 }
                 if s.is_empty() {
-                    return Ok(Self::new(global, true, Transform3D::identity(), can_gc));
+                    return Ok(Self::new(global, true, Transform3D::identity(), cx));
                 }
                 transform_to_matrix(&s.str())
-                    .map(|(is2D, matrix)| Self::new_with_proto(global, proto, is2D, matrix, can_gc))
+                    .map(|(is2D, matrix)| Self::new_with_proto(global, proto, is2D, matrix, cx))
             },
             StringOrUnrestrictedDoubleSequence::UnrestrictedDoubleSequence(ref entries) => {
                 entries_to_matrix(&entries[..])
-                    .map(|(is2D, matrix)| Self::new_with_proto(global, proto, is2D, matrix, can_gc))
+                    .map(|(is2D, matrix)| Self::new_with_proto(global, proto, is2D, matrix, cx))
             },
         }
     }
@@ -518,7 +518,7 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
         other: &DOMMatrixInit,
     ) -> Fallible<DomRoot<Self>> {
         dommatrixinit_to_matrix(other)
-            .map(|(is2D, matrix)| Self::new(global, is2D, matrix, CanGc::from_cx(cx)))
+            .map(|(is2D, matrix)| Self::new(global, is2D, matrix, cx))
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-fromfloat32array>
@@ -529,9 +529,7 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
     ) -> Fallible<DomRoot<DOMMatrixReadOnly>> {
         let vec: Vec<f64> = array.to_vec().iter().map(|&x| x as f64).collect();
         DOMMatrixReadOnly::Constructor(
-            global,
-            None,
-            CanGc::from_cx(cx),
+            cx, global, None,
             Some(StringOrUnrestrictedDoubleSequence::UnrestrictedDoubleSequence(vec)),
         )
     }
@@ -544,9 +542,7 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
     ) -> Fallible<DomRoot<DOMMatrixReadOnly>> {
         let vec: Vec<f64> = array.to_vec();
         DOMMatrixReadOnly::Constructor(
-            global,
-            None,
-            CanGc::from_cx(cx),
+            cx, global, None,
             Some(StringOrUnrestrictedDoubleSequence::UnrestrictedDoubleSequence(vec)),
         )
     }
@@ -689,7 +685,7 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-translate>
     fn Translate(&self, cx: &mut js::context::JSContext, tx: f64, ty: f64, tz: f64) -> DomRoot<DOMMatrix> {
-        DOMMatrix::from_readonly(&self.global(), self, CanGc::from_cx(cx)).TranslateSelf(tx, ty, tz)
+        DOMMatrix::from_readonly(&self.global(), self, cx).TranslateSelf(tx, ty, tz)
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-scale>
@@ -703,13 +699,13 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
         originY: f64,
         originZ: f64,
     ) -> DomRoot<DOMMatrix> {
-        DOMMatrix::from_readonly(&self.global(), self, CanGc::from_cx(cx))
+        DOMMatrix::from_readonly(&self.global(), self, cx)
             .ScaleSelf(scaleX, scaleY, scaleZ, originX, originY, originZ)
     }
 
     /// <https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-scalenonuniform>
     fn ScaleNonUniform(&self, cx: &mut js::context::JSContext, scaleX: f64, scaleY: f64) -> DomRoot<DOMMatrix> {
-        DOMMatrix::from_readonly(&self.global(), self, CanGc::from_cx(cx)).ScaleSelf(
+        DOMMatrix::from_readonly(&self.global(), self, cx).ScaleSelf(
             scaleX,
             Some(scaleY),
             1.0,
@@ -728,7 +724,7 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
         originY: f64,
         originZ: f64,
     ) -> DomRoot<DOMMatrix> {
-        DOMMatrix::from_readonly(&self.global(), self, CanGc::from_cx(cx))
+        DOMMatrix::from_readonly(&self.global(), self, cx)
             .Scale3dSelf(scale, originX, originY, originZ)
     }
 
@@ -740,12 +736,12 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
         rotY: Option<f64>,
         rotZ: Option<f64>,
     ) -> DomRoot<DOMMatrix> {
-        DOMMatrix::from_readonly(&self.global(), self, CanGc::from_cx(cx)).RotateSelf(rotX, rotY, rotZ)
+        DOMMatrix::from_readonly(&self.global(), self, cx).RotateSelf(rotX, rotY, rotZ)
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-rotatefromvector>
     fn RotateFromVector(&self, cx: &mut js::context::JSContext, x: f64, y: f64) -> DomRoot<DOMMatrix> {
-        DOMMatrix::from_readonly(&self.global(), self, CanGc::from_cx(cx)).RotateFromVectorSelf(x, y)
+        DOMMatrix::from_readonly(&self.global(), self, cx).RotateFromVectorSelf(x, y)
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-rotateaxisangle>
@@ -757,23 +753,23 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
         z: f64,
         angle: f64,
     ) -> DomRoot<DOMMatrix> {
-        DOMMatrix::from_readonly(&self.global(), self, CanGc::from_cx(cx))
+        DOMMatrix::from_readonly(&self.global(), self, cx)
             .RotateAxisAngleSelf(x, y, z, angle)
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-skewx>
     fn SkewX(&self, cx: &mut js::context::JSContext, sx: f64) -> DomRoot<DOMMatrix> {
-        DOMMatrix::from_readonly(&self.global(), self, CanGc::from_cx(cx)).SkewXSelf(sx)
+        DOMMatrix::from_readonly(&self.global(), self, cx).SkewXSelf(sx)
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-skewy>
     fn SkewY(&self, cx: &mut js::context::JSContext, sy: f64) -> DomRoot<DOMMatrix> {
-        DOMMatrix::from_readonly(&self.global(), self, CanGc::from_cx(cx)).SkewYSelf(sy)
+        DOMMatrix::from_readonly(&self.global(), self, cx).SkewYSelf(sy)
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-multiply>
     fn Multiply(&self, cx: &mut js::context::JSContext, other: &DOMMatrixInit) -> Fallible<DomRoot<DOMMatrix>> {
-        DOMMatrix::from_readonly(&self.global(), self, CanGc::from_cx(cx)).MultiplySelf(other)
+        DOMMatrix::from_readonly(&self.global(), self, cx).MultiplySelf(other)
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-flipx>
@@ -783,7 +779,7 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
             -1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0,
         );
         let matrix = flip.then(&self.matrix.borrow());
-        DOMMatrix::new(&self.global(), is2D, matrix, CanGc::from_cx(cx))
+        DOMMatrix::new(&self.global(), is2D, matrix, cx)
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-flipy>
@@ -793,12 +789,12 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
             1.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0,
         );
         let matrix = flip.then(&self.matrix.borrow());
-        DOMMatrix::new(&self.global(), is2D, matrix, CanGc::from_cx(cx))
+        DOMMatrix::new(&self.global(), is2D, matrix, cx)
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-inverse>
     fn Inverse(&self, cx: &mut js::context::JSContext) -> DomRoot<DOMMatrix> {
-        DOMMatrix::from_readonly(&self.global(), self, CanGc::from_cx(cx)).InvertSelf()
+        DOMMatrix::from_readonly(&self.global(), self, cx).InvertSelf()
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-transformpoint>

--- a/components/script/dom/geometry/dommatrixreadonly.rs
+++ b/components/script/dom/geometry/dommatrixreadonly.rs
@@ -517,8 +517,7 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
         global: &GlobalScope,
         other: &DOMMatrixInit,
     ) -> Fallible<DomRoot<Self>> {
-        dommatrixinit_to_matrix(other)
-            .map(|(is2D, matrix)| Self::new(global, is2D, matrix, cx))
+        dommatrixinit_to_matrix(other).map(|(is2D, matrix)| Self::new(global, is2D, matrix, cx))
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-fromfloat32array>
@@ -529,7 +528,9 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
     ) -> Fallible<DomRoot<DOMMatrixReadOnly>> {
         let vec: Vec<f64> = array.to_vec().iter().map(|&x| x as f64).collect();
         DOMMatrixReadOnly::Constructor(
-            cx, global, None,
+            cx,
+            global,
+            None,
             Some(StringOrUnrestrictedDoubleSequence::UnrestrictedDoubleSequence(vec)),
         )
     }
@@ -542,7 +543,9 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
     ) -> Fallible<DomRoot<DOMMatrixReadOnly>> {
         let vec: Vec<f64> = array.to_vec();
         DOMMatrixReadOnly::Constructor(
-            cx, global, None,
+            cx,
+            global,
+            None,
             Some(StringOrUnrestrictedDoubleSequence::UnrestrictedDoubleSequence(vec)),
         )
     }
@@ -684,7 +687,13 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-translate>
-    fn Translate(&self, cx: &mut js::context::JSContext, tx: f64, ty: f64, tz: f64) -> DomRoot<DOMMatrix> {
+    fn Translate(
+        &self,
+        cx: &mut js::context::JSContext,
+        tx: f64,
+        ty: f64,
+        tz: f64,
+    ) -> DomRoot<DOMMatrix> {
         DOMMatrix::from_readonly(&self.global(), self, cx).TranslateSelf(tx, ty, tz)
     }
 
@@ -704,7 +713,12 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
     }
 
     /// <https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-scalenonuniform>
-    fn ScaleNonUniform(&self, cx: &mut js::context::JSContext, scaleX: f64, scaleY: f64) -> DomRoot<DOMMatrix> {
+    fn ScaleNonUniform(
+        &self,
+        cx: &mut js::context::JSContext,
+        scaleX: f64,
+        scaleY: f64,
+    ) -> DomRoot<DOMMatrix> {
         DOMMatrix::from_readonly(&self.global(), self, cx).ScaleSelf(
             scaleX,
             Some(scaleY),
@@ -740,7 +754,12 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-rotatefromvector>
-    fn RotateFromVector(&self, cx: &mut js::context::JSContext, x: f64, y: f64) -> DomRoot<DOMMatrix> {
+    fn RotateFromVector(
+        &self,
+        cx: &mut js::context::JSContext,
+        x: f64,
+        y: f64,
+    ) -> DomRoot<DOMMatrix> {
         DOMMatrix::from_readonly(&self.global(), self, cx).RotateFromVectorSelf(x, y)
     }
 
@@ -753,8 +772,7 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
         z: f64,
         angle: f64,
     ) -> DomRoot<DOMMatrix> {
-        DOMMatrix::from_readonly(&self.global(), self, cx)
-            .RotateAxisAngleSelf(x, y, z, angle)
+        DOMMatrix::from_readonly(&self.global(), self, cx).RotateAxisAngleSelf(x, y, z, angle)
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-skewx>
@@ -768,7 +786,11 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-multiply>
-    fn Multiply(&self, cx: &mut js::context::JSContext, other: &DOMMatrixInit) -> Fallible<DomRoot<DOMMatrix>> {
+    fn Multiply(
+        &self,
+        cx: &mut js::context::JSContext,
+        other: &DOMMatrixInit,
+    ) -> Fallible<DomRoot<DOMMatrix>> {
         DOMMatrix::from_readonly(&self.global(), self, cx).MultiplySelf(other)
     }
 
@@ -819,7 +841,10 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-tofloat32array>
-    fn ToFloat32Array(&self, cx: &mut js::context::JSContext) -> RootedTraceableBox<HeapFloat32Array> {
+    fn ToFloat32Array(
+        &self,
+        cx: &mut js::context::JSContext,
+    ) -> RootedTraceableBox<HeapFloat32Array> {
         let vec: Vec<f32> = self
             .matrix
             .borrow()
@@ -833,7 +858,10 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-tofloat64array>
-    fn ToFloat64Array(&self, cx: &mut js::context::JSContext) -> RootedTraceableBox<HeapFloat64Array> {
+    fn ToFloat64Array(
+        &self,
+        cx: &mut js::context::JSContext,
+    ) -> RootedTraceableBox<HeapFloat64Array> {
         rooted!(&in(cx) let mut array = ptr::null_mut::<JSObject>());
         create_buffer_source(
             cx.into(),
@@ -1027,15 +1055,10 @@ impl Serializable for DOMMatrixReadOnly {
                     0.0,
                     1.0,
                 ),
-                CanGc::from_cx(cx),
+                cx,
             ))
         } else {
-            Ok(Self::new(
-                owner,
-                false,
-                serialized.matrix,
-                CanGc::from_cx(cx),
-            ))
+            Ok(Self::new(owner, false, serialized.matrix, cx))
         }
     }
 

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -381,12 +381,11 @@ DOMInterfaces = {
 },
 
 'DOMMatrix': {
-    'canGc': ['FromMatrix', 'FromFloat32Array', 'FromFloat64Array'],
+    'cx': ['FromMatrix', 'FromFloat32Array', 'FromFloat64Array'],
 },
 
 'DOMMatrixReadOnly': {
-    'cx': ['Stringifier', 'TransformPoint'],
-    'canGc': ['Multiply', 'Inverse', 'Scale', 'Translate', 'Rotate', 'RotateFromVector','FlipY', 'ScaleNonUniform', 'Scale3d', 'RotateAxisAngle', 'SkewX', 'SkewY', 'FlipX', 'FromFloat32Array', 'FromFloat64Array', 'FromMatrix', 'ToFloat32Array', 'ToFloat64Array'],
+    'cx': ['Stringifier', 'TransformPoint', 'Multiply', 'Inverse', 'Scale', 'Translate', 'Rotate', 'RotateFromVector', 'FlipY', 'ScaleNonUniform', 'Scale3d', 'RotateAxisAngle', 'SkewX', 'SkewY', 'FlipX', 'FromFloat32Array', 'FromFloat64Array', 'FromMatrix', 'ToFloat32Array', 'ToFloat64Array'],
 },
 
 'DOMParser': {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -381,11 +381,11 @@ DOMInterfaces = {
 },
 
 'DOMMatrix': {
-    'cx': ['FromMatrix', 'FromFloat32Array', 'FromFloat64Array'],
+    'cx': ['Constructor', 'FromMatrix', 'FromFloat32Array', 'FromFloat64Array'],
 },
 
 'DOMMatrixReadOnly': {
-    'cx': ['Stringifier', 'TransformPoint', 'Multiply', 'Inverse', 'Scale', 'Translate', 'Rotate', 'RotateFromVector', 'FlipY', 'ScaleNonUniform', 'Scale3d', 'RotateAxisAngle', 'SkewX', 'SkewY', 'FlipX', 'FromFloat32Array', 'FromFloat64Array', 'FromMatrix', 'ToFloat32Array', 'ToFloat64Array'],
+    'cx': ['Constructor', 'Stringifier', 'TransformPoint', 'Multiply', 'Inverse', 'Scale', 'Translate', 'Rotate', 'RotateFromVector', 'FlipY', 'ScaleNonUniform', 'Scale3d', 'RotateAxisAngle', 'SkewX', 'SkewY', 'FlipX', 'FromFloat32Array', 'FromFloat64Array', 'FromMatrix', 'ToFloat32Array', 'ToFloat64Array'],
 },
 
 'DOMParser': {


### PR DESCRIPTION

Ports all `canGc` methods in `DOMMatrix` and `DOMMatrixReadOnly` to use `&mut JSContext`, replacing `can_gc: CanGc` with `cx: &mut js::context::JSContext` and using `CanGc::from_cx(cx)` internally.

Testing: Compilation Successful

Fixes : Part of #42638 
