### PR TITLE
constellation: Update pipeline correctly when traversing session history

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -4312,6 +4312,9 @@ where
         history_state_id: Option<HistoryStateId>,
         url: ServoUrl,
     ) {
+        if let Some(pipeline) = self.pipelines.get_mut(&pipeline_id) {
+            pipeline.url = url.clone();
+        }
         let msg = ScriptThreadMessage::UpdateHistoryState(pipeline_id, history_state_id, url);
         self.send_message_to_pipeline(pipeline_id, msg, "History state updated after closure");
     }

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -4889,6 +4889,10 @@ where
                         Some(previous_url.clone())
                     }
                 },
+                SessionHistoryDiff::Hash { ref new_url, .. } => {
+                    *previous_url = new_url.clone();
+                    Some(new_url.clone())
+                },
                 _ => Some(previous_url.clone()),
             };
 
@@ -4912,6 +4916,10 @@ where
                 } else {
                     Some(previous_url.clone())
                 }
+            },
+            SessionHistoryDiff::Hash { ref old_url, .. } => {
+                *previous_url = old_url.clone();
+                Some(old_url.clone())
             },
             _ => Some(previous_url.clone()),
         };

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -4313,6 +4313,7 @@ where
         url: ServoUrl,
     ) {
         if let Some(pipeline) = self.pipelines.get_mut(&pipeline_id) {
+            pipeline.history_state_id = history_state_id;
             pipeline.url = url.clone();
         }
         let msg = ScriptThreadMessage::UpdateHistoryState(pipeline_id, history_state_id, url);

--- a/tests/wpt/meta/css/cssom-view/scroll-behavior-smooth-navigation.html.ini
+++ b/tests/wpt/meta/css/cssom-view/scroll-behavior-smooth-navigation.html.ini
@@ -4,6 +4,3 @@
 
   [Make sure the page is ready for animation.]
     expected: FAIL
-
-  [Smooth scrolling while doing history navigation.]
-    expected: FAIL

--- a/tests/wpt/tests/css/cssom-view/scroll-behavior-smooth-navigation.html
+++ b/tests/wpt/tests/css/cssom-view/scroll-behavior-smooth-navigation.html
@@ -50,7 +50,7 @@
       window.onhashchange = function() {
         instantHistoryNavigationTest.step(function() {
           assert_equals(location.hash, "", "Shouldn't be scrolled to a fragment.");
-          assert_equals(window.scrollY, 0, "Shouldn't be scrolled back to top yet.");
+          assert_equals(window.scrollY, 0, "Should be scrolled to top.");
         });
         p.remove();
         instantHistoryNavigationTest.done();

--- a/tests/wpt/tests/html/browsers/history/the-history-interface/back-pushstate-back-history-state.html
+++ b/tests/wpt/tests/html/browsers/history/the-history-interface/back-pushstate-back-history-state.html
@@ -1,0 +1,34 @@
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <title>history.state is null after pushState+back+pushState+back</title>
+    <link rel="author" title="Euclid Ye" href="mailto:yezhizhenjiakang@gmail.com">
+    <link rel=help href="https://github.com/servo/servo/issues/45905">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <script>
+    promise_test(async t => {
+      history.pushState({x: 1}, "");
+
+      await new Promise(resolve => {
+        addEventListener("popstate", resolve, {once: true});
+        history.back();
+      });
+      assert_equals(history.state?.x, undefined,
+        "state is null after back from first pushState");
+
+      history.pushState({x: 2}, "");
+
+      await new Promise(resolve => {
+        addEventListener("popstate", resolve, {once: true});
+        history.back();
+      });
+      assert_equals(history.state?.x, undefined,
+        "state is null after back from second pushState");
+    }, "history.state is null after pushState+back+pushState+back");
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
As titled. This fixes a bug where traverse session history does not update url correctly.
For cross-origin navigation, we don't have this problem as we end up with new pipeline.

Testing: New passing in `/css/cssom-view/scroll-behavior-smooth-navigation.html`. 
We also fix the assertion message in the test.
We add a new test `html\browsers\history\the-history-interface\back-pushstate-back-history-state.html`
to cover `history_state_id` change.

Fixes: https://github.com/servo/servo/issues/45835
Fixes: https://github.com/servo/servo/issues/45905
