### PR TITLE
script: Pass rooted UnderlyingSourceContainer to ReadableStreamDefaultController constructor.

### DIFF
--- a/components/script/dom/stream/readablebytestreamcontroller.rs
+++ b/components/script/dom/stream/readablebytestreamcontroller.rs
@@ -223,19 +223,15 @@ pub(crate) struct ReadableByteStreamController {
 
 impl ReadableByteStreamController {
     fn new_inherited(
-        cx: &mut JSContext,
-        underlying_source_type: UnderlyingSourceType,
+        underlying_source_container: &UnderlyingSourceContainer,
         strategy_hwm: f64,
-        global: &GlobalScope,
     ) -> ReadableByteStreamController {
-        let underlying_source_container =
-            UnderlyingSourceContainer::new(cx, global, underlying_source_type);
         let auto_allocate_chunk_size = underlying_source_container.auto_allocate_chunk_size();
         ReadableByteStreamController {
             reflector_: Reflector::new(),
             byob_request: MutNullableDom::new(None),
             stream: MutNullableDom::new(None),
-            underlying_source: MutNullableDom::new(Some(&*underlying_source_container)),
+            underlying_source: MutNullableDom::new(Some(underlying_source_container)),
             auto_allocate_chunk_size,
             pending_pull_intos: DomRefCell::new(Vec::new()),
             strategy_hwm,
@@ -254,12 +250,12 @@ impl ReadableByteStreamController {
         strategy_hwm: f64,
         global: &GlobalScope,
     ) -> DomRoot<ReadableByteStreamController> {
+        let underlying_source_container =
+            UnderlyingSourceContainer::new(cx, global, underlying_source_type);
         reflect_dom_object_with_cx(
             Box::new(ReadableByteStreamController::new_inherited(
-                cx,
-                underlying_source_type,
+                &underlying_source_container,
                 strategy_hwm,
-                global,
             )),
             global,
             cx,

--- a/components/script/dom/stream/readablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/readablestreamdefaultcontroller.rs
@@ -359,14 +359,9 @@ impl ReadableStreamDefaultController {
         strategy_hwm: f64,
         strategy_size: Rc<QueuingStrategySize>,
     ) -> DomRoot<ReadableStreamDefaultController> {
-        let underlying_source = UnderlyingSourceContainer::new(
-            cx,
-            global,
-            underlying_source,
-        );
+        let underlying_source = UnderlyingSourceContainer::new(cx, global, underlying_source);
         reflect_dom_object_with_cx(
             Box::new(ReadableStreamDefaultController::new_inherited(
-                cx,
                 strategy_hwm,
                 strategy_size,
                 &underlying_source,

--- a/components/script/dom/stream/readablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/readablestreamdefaultcontroller.rs
@@ -334,21 +334,15 @@ pub(crate) struct ReadableStreamDefaultController {
 
 impl ReadableStreamDefaultController {
     fn new_inherited(
-        cx: &mut JSContext,
-        global: &GlobalScope,
-        underlying_source_type: UnderlyingSourceType,
         strategy_hwm: f64,
         strategy_size: Rc<QueuingStrategySize>,
+        underlying_source: &UnderlyingSourceContainer,
     ) -> ReadableStreamDefaultController {
         ReadableStreamDefaultController {
             reflector_: Reflector::new(),
             queue: Default::default(),
             stream: MutNullableDom::new(None),
-            underlying_source: MutNullableDom::new(Some(&*UnderlyingSourceContainer::new(
-                cx,
-                global,
-                underlying_source_type,
-            ))),
+            underlying_source: MutNullableDom::new(Some(underlying_source)),
             strategy_hwm,
             strategy_size: RefCell::new(Some(strategy_size)),
             close_requested: Default::default(),
@@ -365,13 +359,17 @@ impl ReadableStreamDefaultController {
         strategy_hwm: f64,
         strategy_size: Rc<QueuingStrategySize>,
     ) -> DomRoot<ReadableStreamDefaultController> {
+        let underlying_source = UnderlyingSourceContainer::new(
+            cx,
+            global,
+            underlying_source,
+        );
         reflect_dom_object_with_cx(
             Box::new(ReadableStreamDefaultController::new_inherited(
                 cx,
-                global,
-                underlying_source,
                 strategy_hwm,
                 strategy_size,
+                &underlying_source,
             )),
             global,
             cx,


### PR DESCRIPTION
This change fixes an unsafe pattern, where we allocate a new object and store it inside an unrooted object. When the reflector for the unrooted object is allocated, a GC can occur which can cause the first object to be collected since it's not yet reachable from a rooted location, leaving a dangling pointer.

Testing: Requires zealous GC to be enabled to write a deterministic test.