### PR TITLE
Remove impl_performance_entry_struct macro

### DIFF
--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -817,63 +817,6 @@ macro_rules! window_event_handlers(
     );
 );
 
-/// DOM struct implementation for simple interfaces inheriting from PerformanceEntry.
-macro_rules! impl_performance_entry_struct(
-    ($binding:ident, $struct:ident, $type:path,
-        { $( $(#[$attr:meta])* $field_name:ident : $field_type:ty, ),* } // Arguments
-    ) => (
-        use servo_base::cross_process_instant::CrossProcessInstant;
-        use time::Duration;
-
-        use script_bindings::reflector::reflect_dom_object;
-        use crate::dom::bindings::root::DomRoot;
-        use crate::dom::bindings::str::DOMString;
-        use crate::dom::globalscope::GlobalScope;
-        use crate::dom::performance::performanceentry::{EntryType, PerformanceEntry};
-        use crate::script_runtime::CanGc;
-        use dom_struct::dom_struct;
-
-        #[dom_struct]
-        pub(crate) struct $struct {
-            entry: PerformanceEntry,
-            $( $(#[$attr])* $field_name: $field_type, )*
-        }
-
-        impl $struct {
-            #[cfg_attr(crown, expect(crown::unrooted_must_root))]
-            fn new_inherited(
-                name: DOMString,
-                start_time: CrossProcessInstant,
-                duration: Duration,
-                $( $field_name: $field_type, )* ) -> $struct {
-                $struct {
-                    entry: PerformanceEntry::new_inherited(name,
-                                                           $type,
-                                                           Some(start_time),
-                                                           duration),
-                    $( $field_name: $field_name, )*
-                }
-            }
-
-            #[cfg_attr(crown, expect(crown::unrooted_must_root))]
-            pub(crate) fn new(global: &GlobalScope,
-                       name: DOMString,
-                       start_time: CrossProcessInstant,
-                       duration: Duration,
-                       $( $field_name: $field_type ),*
-                    ) -> DomRoot<$struct> {
-                let entry = $struct::new_inherited(
-                    name,
-                    start_time,
-                    duration,
-                    $( $field_name, )*
-                );
-                reflect_dom_object(Box::new(entry), global, CanGc::deprecated_note())
-            }
-        }
-    );
-);
-
 macro_rules! handle_potential_webgl_error {
     ($context:expr, $call:expr, $return_on_error:expr) => {
         match $call {

--- a/components/script/dom/performance/performance.rs
+++ b/components/script/dom/performance/performance.rs
@@ -12,6 +12,7 @@ use js::jsval::NullValue;
 use script_bindings::cell::DomRefCell;
 use script_bindings::cformat;
 use script_bindings::codegen::GenericBindings::PerformanceBinding::PerformanceMarkOptions;
+use script_bindings::codegen::GenericBindings::PerformanceMarkBinding::PerformanceMarkMethods;
 use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
 use script_bindings::codegen::GenericUnionTypes::StringOrPerformanceMeasureOptions;
 use script_bindings::reflector::reflect_dom_object;
@@ -609,7 +610,7 @@ impl PerformanceMethods<crate::DomTypeHolder> for Performance {
     ) -> Fallible<DomRoot<PerformanceMark>> {
         // Step 1. Run the PerformanceMark constructor and let entry be the newly created object.
         let entry =
-            PerformanceMark::new_with_proto(cx, &self.global(), None, mark_name, mark_options)?;
+            PerformanceMark::Constructor(cx, &self.global(), None, mark_name, mark_options)?;
 
         // Step 2. Queue a PerformanceEntry entry.
         // Step 3. Add entry to the performance entry buffer. (This is done in queue_entry itself)
@@ -759,7 +760,6 @@ impl PerformanceMethods<crate::DomTypeHolder> for Performance {
             measure_name,
             start_time,
             end_time - start_time,
-            Default::default(),
         );
 
         // Step 9. Set entry’s detail attribute as follows:

--- a/components/script/dom/performance/performancemark.rs
+++ b/components/script/dom/performance/performancemark.rs
@@ -2,31 +2,53 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use dom_struct::dom_struct;
 use js::gc::HandleValue;
 use js::jsapi::Heap;
 use js::jsval::{JSVal, NullValue};
 use js::rust::{HandleObject, MutableHandleValue};
 use script_bindings::codegen::GenericBindings::PerformanceBinding::PerformanceMarkOptions;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use servo_base::cross_process_instant::CrossProcessInstant;
+use time::Duration;
 
 use crate::dom::PERFORMANCE_TIMING_ATTRIBUTES;
 use crate::dom::bindings::codegen::Bindings::PerformanceMarkBinding::PerformanceMarkMethods;
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::inheritance::Castable;
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::structuredclone;
 use crate::dom::bindings::trace::RootedTraceableBox;
+use crate::dom::globalscope::GlobalScope;
+use crate::dom::performance::performanceentry::{EntryType, PerformanceEntry};
 use crate::dom::window::Window;
 use crate::script_runtime::JSContext;
 
-impl_performance_entry_struct!(
-    PerformanceMarkBinding,
-    PerformanceMark, EntryType::Mark,
-    {
-        #[ignore_malloc_size_of = "Defined in rust-mozjs"]
-        detail: Heap<JSVal>,
-    }
-);
+#[dom_struct]
+pub(crate) struct PerformanceMark {
+    entry: PerformanceEntry,
+    #[ignore_malloc_size_of = "Defined in rust-mozjs"]
+    detail: Heap<JSVal>,
+}
 
 impl PerformanceMark {
+    fn new_inherited(
+        name: DOMString,
+        start_time: CrossProcessInstant,
+        duration: Duration,
+    ) -> PerformanceMark {
+        PerformanceMark {
+            entry: PerformanceEntry::new_inherited(
+                name,
+                EntryType::Mark,
+                Some(start_time),
+                duration,
+            ),
+            detail: Default::default(),
+        }
+    }
+
     fn set_detail(&self, handle: HandleValue<'_>) {
         self.detail.set(handle.get());
     }
@@ -34,7 +56,30 @@ impl PerformanceMark {
     pub(crate) fn new_with_proto(
         cx: &mut js::context::JSContext,
         global: &GlobalScope,
-        _proto: Option<HandleObject>,
+        proto: Option<HandleObject>,
+        name: DOMString,
+        start_time: CrossProcessInstant,
+        duration: Duration,
+    ) -> DomRoot<PerformanceMark> {
+        reflect_dom_object_with_proto_and_cx(
+            Box::new(PerformanceMark::new_inherited(name, start_time, duration)),
+            global,
+            proto,
+            cx,
+        )
+    }
+}
+
+impl PerformanceMarkMethods<crate::DomTypeHolder> for PerformanceMark {
+    fn Detail(&self, _cx: JSContext, mut retval: MutableHandleValue) {
+        retval.set(self.detail.get())
+    }
+
+    /// <https://w3c.github.io/user-timing/#the-performancemark-constructor>
+    fn Constructor(
+        cx: &mut js::context::JSContext,
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
         mark_name: DOMString,
         mark_options: RootedTraceableBox<PerformanceMarkOptions>,
     ) -> Fallible<DomRoot<PerformanceMark>> {
@@ -66,12 +111,13 @@ impl PerformanceMark {
         };
 
         // Step 6. Set entry’s duration attribute to 0.
-        let entry = PerformanceMark::new(
+        let entry = PerformanceMark::new_with_proto(
+            cx,
             global,
+            proto,
             mark_name,
             start_time,
             Duration::ZERO,
-            Default::default(),
         );
 
         // Step 7. If markOptions’s detail is null, set entry’s detail to null.
@@ -88,22 +134,5 @@ impl PerformanceMark {
         entry.set_detail(detail.handle());
 
         Ok(entry)
-    }
-}
-
-impl PerformanceMarkMethods<crate::DomTypeHolder> for PerformanceMark {
-    fn Detail(&self, _cx: JSContext, mut retval: MutableHandleValue) {
-        retval.set(self.detail.get())
-    }
-
-    /// <https://w3c.github.io/user-timing/#the-performancemark-constructor>
-    fn Constructor(
-        cx: &mut js::context::JSContext,
-        global: &GlobalScope,
-        proto: Option<HandleObject>,
-        mark_name: DOMString,
-        mark_options: RootedTraceableBox<PerformanceMarkOptions>,
-    ) -> Fallible<DomRoot<PerformanceMark>> {
-        PerformanceMark::new_with_proto(cx, global, proto, mark_name, mark_options)
     }
 }

--- a/components/script/dom/performance/performancemark.rs
+++ b/components/script/dom/performance/performancemark.rs
@@ -71,6 +71,7 @@ impl PerformanceMark {
 }
 
 impl PerformanceMarkMethods<crate::DomTypeHolder> for PerformanceMark {
+    /// <https://w3c.github.io/user-timing/#dom-performancemark-detail>
     fn Detail(&self, _cx: JSContext, mut retval: MutableHandleValue) {
         retval.set(self.detail.get())
     }

--- a/components/script/dom/performance/performancemeasure.rs
+++ b/components/script/dom/performance/performancemeasure.rs
@@ -2,25 +2,62 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use dom_struct::dom_struct;
 use js::gc::HandleValue;
 use js::jsapi::Heap;
 use js::jsval::JSVal;
 use js::rust::MutableHandleValue;
+use script_bindings::reflector::reflect_dom_object;
+use servo_base::cross_process_instant::CrossProcessInstant;
+use time::Duration;
 
 use crate::dom::bindings::codegen::Bindings::PerformanceMeasureBinding::PerformanceMeasureMethods;
-use crate::script_runtime::JSContext;
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::str::DOMString;
+use crate::dom::globalscope::GlobalScope;
+use crate::dom::performance::performanceentry::{EntryType, PerformanceEntry};
+use crate::script_runtime::{CanGc, JSContext};
 
-impl_performance_entry_struct!(
-    PerformanceMeasureBinding,
-    PerformanceMeasure,
-    EntryType::Measure,
-    {
-        #[ignore_malloc_size_of = "Defined in rust-mozjs"]
-        detail: Heap<JSVal>,
-    }
-);
+#[dom_struct]
+pub(crate) struct PerformanceMeasure {
+    entry: PerformanceEntry,
+    #[ignore_malloc_size_of = "Defined in rust-mozjs"]
+    detail: Heap<JSVal>,
+}
 
 impl PerformanceMeasure {
+    fn new_inherited(
+        name: DOMString,
+        start_time: CrossProcessInstant,
+        duration: Duration,
+    ) -> PerformanceMeasure {
+        PerformanceMeasure {
+            entry: PerformanceEntry::new_inherited(
+                name,
+                EntryType::Measure,
+                Some(start_time),
+                duration,
+            ),
+            detail: Default::default(),
+        }
+    }
+
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
+    pub(crate) fn new(
+        global: &GlobalScope,
+        name: DOMString,
+        start_time: CrossProcessInstant,
+        duration: Duration,
+    ) -> DomRoot<PerformanceMeasure> {
+        reflect_dom_object(
+            Box::new(PerformanceMeasure::new_inherited(
+                name, start_time, duration,
+            )),
+            global,
+            CanGc::deprecated_note(),
+        )
+    }
+
     pub(crate) fn set_detail(&self, handle: HandleValue<'_>) {
         self.detail.set(handle.get());
     }

--- a/components/script/dom/performance/performancemeasure.rs
+++ b/components/script/dom/performance/performancemeasure.rs
@@ -42,7 +42,6 @@ impl PerformanceMeasure {
         }
     }
 
-    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn new(
         global: &GlobalScope,
         name: DOMString,
@@ -64,6 +63,7 @@ impl PerformanceMeasure {
 }
 
 impl PerformanceMeasureMethods<crate::DomTypeHolder> for PerformanceMeasure {
+    /// <https://w3c.github.io/user-timing/#dom-performancemeasure-detail>
     fn Detail(&self, _cx: JSContext, mut retval: MutableHandleValue) {
         retval.set(self.detail.get())
     }


### PR DESCRIPTION
Removed the `impl_performance_entry_struct` macro and replaced it with  explicit handwritten implementation for `PerformanceMark` and `PerformanceMeasure`

Testing: All exisiting cases pass
Fixes: #45778 
