### PR TITLE
webgpu: Support `GPUExternalTexture`

### DIFF
--- a/components/script/dom/html/htmlvideoelement.rs
+++ b/components/script/dom/html/htmlvideoelement.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cell::Cell;
+use std::rc::Rc;
 use std::sync::Arc;
 
 use dom_struct::dom_struct;
@@ -22,6 +23,7 @@ use net_traits::{
 };
 use pixels::{Snapshot, SnapshotAlphaMode, SnapshotPixelFormat};
 use script_bindings::cell::DomRefCell;
+use script_bindings::error::Fallible;
 use servo_media::player::video::VideoFrame;
 use servo_url::ServoUrl;
 use style::attr::{AttrValue, LengthOrPercentageOrAuto};
@@ -62,6 +64,10 @@ pub(crate) struct HTMLVideoElement {
     #[ignore_malloc_size_of = "VideoFrame"]
     #[no_trace]
     last_frame: DomRefCell<Option<VideoFrame>>,
+    #[cfg(feature = "webgpu")]
+    #[ignore_malloc_size_of = "rc"]
+    /// Planar texture for WebGPU
+    planar_texture: DomRefCell<Option<Rc<crate::dom::gpuexternaltexture::PlanarTexture>>>,
 }
 
 impl HTMLVideoElement {
@@ -77,6 +83,8 @@ impl HTMLVideoElement {
             generation_id: Cell::new(0),
             load_blocker: Default::default(),
             last_frame: Default::default(),
+            #[cfg(feature = "webgpu")]
+            planar_texture: DomRefCell::new(None),
         }
     }
 
@@ -146,6 +154,54 @@ impl HTMLVideoElement {
                 }
             },
             None => None,
+        }
+    }
+
+    #[cfg(feature = "webgpu")]
+    pub(crate) fn planar_video_for_webgpu(
+        &self,
+        device: &crate::dom::types::GPUDevice,
+    ) -> Fallible<(
+        Size2D<u32>,
+        Option<Rc<crate::dom::gpuexternaltexture::PlanarTexture>>,
+    )> {
+        use crate::dom::gpuexternaltexture::PlanarTexture;
+        // 1. If source is not origin-clean, throw a SecurityError and return.
+        if !self.origin_is_clean() {
+            return Err(script_bindings::error::Error::Security(Some(
+                "Source is not origin-clean".to_string(),
+            )));
+        }
+        // 2. Let usability be ? check the usability of the image argument(source).
+        if !self.is_usable() {
+            // 3. If usability is not good:
+            // Generate a validation error.
+            // Return an invalidated GPUExternalTexture.
+            Ok((Size2D::zero(), None))
+        } else {
+            // 4. Let data be the result of converting the current image contents of source into the color space descriptor.colorSpace with unpremultiplied alpha.
+            let mut planar_texture = self.planar_texture.borrow_mut();
+            match planar_texture.as_ref() {
+                Some(planar_texture) => {
+                    if planar_texture.is_expired() &&
+                        let Some(snapshot) = self.get_current_frame_data()
+                    {
+                        planar_texture.update(snapshot);
+                    }
+                },
+                None => {
+                    *planar_texture = self.get_current_frame_data().map(|snapshot| {
+                        Rc::new(PlanarTexture::new(device.channel(), device, snapshot))
+                    });
+                },
+            };
+            Ok((
+                planar_texture
+                    .as_ref()
+                    .map(|pt| pt.size())
+                    .unwrap_or_default(),
+                planar_texture.as_ref().cloned(),
+            ))
         }
     }
 

--- a/components/script/dom/html/htmlvideoelement.rs
+++ b/components/script/dom/html/htmlvideoelement.rs
@@ -65,7 +65,7 @@ pub(crate) struct HTMLVideoElement {
     #[no_trace]
     last_frame: DomRefCell<Option<VideoFrame>>,
     #[cfg(feature = "webgpu")]
-    #[ignore_malloc_size_of = "rc"]
+    #[conditional_malloc_size_of]
     /// Planar texture for WebGPU
     planar_texture: DomRefCell<Option<Rc<crate::dom::gpuexternaltexture::PlanarTexture>>>,
 }

--- a/components/script/dom/webgpu/gpuconvert.rs
+++ b/components/script/dom/webgpu/gpuconvert.rs
@@ -763,6 +763,9 @@ pub(crate) fn convert_bind_group_entry<'a>(
                 offset: 0,
                 size: None,
             }),
+            GPUBindingResource::GPUExternalTexture(ref t) => {
+                BindingResource::ExternalTexture(t.id().0)
+            },
         },
     }
 }

--- a/components/script/dom/webgpu/gpudevice.rs
+++ b/components/script/dom/webgpu/gpudevice.rs
@@ -33,10 +33,10 @@ use crate::dom::bindings::codegen::Bindings::EventBinding::EventInit;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUAdapterMethods, GPUBindGroupDescriptor, GPUBindGroupLayoutDescriptor, GPUBufferDescriptor,
     GPUCommandEncoderDescriptor, GPUComputePipelineDescriptor, GPUDeviceLostReason,
-    GPUDeviceMethods, GPUErrorFilter, GPUPipelineErrorReason, GPUPipelineLayoutDescriptor,
-    GPUQuerySetDescriptor, GPURenderBundleEncoderDescriptor, GPURenderPipelineDescriptor,
-    GPUSamplerDescriptor, GPUShaderModuleDescriptor, GPUTextureDescriptor, GPUTextureFormat,
-    GPUUncapturedErrorEventInit, GPUVertexStepMode,
+    GPUDeviceMethods, GPUErrorFilter, GPUExternalTextureDescriptor, GPUPipelineErrorReason,
+    GPUPipelineLayoutDescriptor, GPUQuerySetDescriptor, GPURenderBundleEncoderDescriptor,
+    GPURenderPipelineDescriptor, GPUSamplerDescriptor, GPUShaderModuleDescriptor,
+    GPUTextureDescriptor, GPUTextureFormat, GPUUncapturedErrorEventInit, GPUVertexStepMode,
 };
 use crate::dom::bindings::codegen::UnionTypes::GPUPipelineLayoutOrGPUAutoLayoutMode;
 use crate::dom::bindings::error::{Error, Fallible};
@@ -58,6 +58,7 @@ use crate::dom::webgpu::gpubindgrouplayout::GPUBindGroupLayout;
 use crate::dom::webgpu::gpubuffer::GPUBuffer;
 use crate::dom::webgpu::gpucommandencoder::GPUCommandEncoder;
 use crate::dom::webgpu::gpucomputepipeline::GPUComputePipeline;
+use crate::dom::webgpu::gpuexternaltexture::GPUExternalTexture;
 use crate::dom::webgpu::gpupipelinelayout::GPUPipelineLayout;
 use crate::dom::webgpu::gpuqueue::GPUQueue;
 use crate::dom::webgpu::gpurenderbundleencoder::GPURenderBundleEncoder;
@@ -596,6 +597,15 @@ impl GPUDeviceMethods<crate::DomTypeHolder> for GPUDevice {
         descriptor: &GPUQuerySetDescriptor,
     ) -> Fallible<DomRoot<GPUQuerySet>> {
         GPUQuerySet::create(cx, self, descriptor)
+    }
+
+    /// <https://www.w3.org/TR/webgpu/#dom-gpudevice-importexternaltexture>
+    fn ImportExternalTexture(
+        &self,
+        cx: &mut JSContext,
+        descriptor: &GPUExternalTextureDescriptor,
+    ) -> Fallible<DomRoot<GPUExternalTexture>> {
+        GPUExternalTexture::create(cx, self, descriptor)
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-pusherrorscope>

--- a/components/script/dom/webgpu/gpuexternaltexture.rs
+++ b/components/script/dom/webgpu/gpuexternaltexture.rs
@@ -146,7 +146,7 @@ impl Drop for DroppableGPUExternalTexture {
 pub(crate) struct GPUExternalTexture {
     reflector_: Reflector,
     label: DomRefCell<USVString>,
-    #[ignore_malloc_size_of = "rc"]
+    #[conditional_malloc_size_of]
     planar_texture: Option<Rc<PlanarTexture>>,
     droppable: DroppableGPUExternalTexture,
 }
@@ -219,6 +219,7 @@ impl GPUExternalTexture {
             .wgpu_features()
             .contains(Features::EXTERNAL_TEXTURE)
         {
+            // 2.1 - 2.4 inside the method
             descriptor.source.planar_video_for_webgpu(device)?
         } else {
             // spec assumes that this is always supported, but that is not the case in wgpu
@@ -226,7 +227,7 @@ impl GPUExternalTexture {
                 "ExternalTexture is not supported on this device".to_string(),
             )));
         };
-        // 5. Let result be a new GPUExternalTexture object wrapping data.
+        // 2.5. Let result be a new GPUExternalTexture object wrapping data.
         let device_id = device.id().0;
         let channel = device.channel();
         let external_texture_id = device.global().wgpu_id_hub().create_external_texture_id();
@@ -247,11 +248,11 @@ impl GPUExternalTexture {
             &device.global(),
             channel,
             WebGPUExternalTexture(external_texture_id),
-            // Set result.label to descriptor.label.
+            // 5. Set result.label to descriptor.label.
             descriptor.parent.label.clone(),
             planar_texture,
         );
-        // If source is an HTMLVideoElement, queue an automatic expiry task with device this and the following steps
+        // 3. If source is an HTMLVideoElement, queue an automatic expiry task with device this and the following steps
         let this = Trusted::new(&*result);
         device
             .global()
@@ -261,7 +262,7 @@ impl GPUExternalTexture {
                 this.root().expire();
             }));
 
-        // Return result.
+        // 6. Return result.
         Ok(result)
     }
 }

--- a/components/script/dom/webgpu/gpuexternaltexture.rs
+++ b/components/script/dom/webgpu/gpuexternaltexture.rs
@@ -1,0 +1,285 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::cell::Cell;
+use std::rc::Rc;
+
+use dom_struct::dom_struct;
+use euclid::default::Size2D;
+use js::context::JSContext;
+use pixels::Snapshot;
+use script_bindings::cell::DomRefCell;
+use script_bindings::codegen::GenericBindings::WebGPUBinding::GPUDeviceMethods as _;
+use script_bindings::error::Fallible;
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use webgpu_traits::{
+    WebGPU, WebGPUDevice, WebGPUExternalTexture, WebGPUQueue, WebGPURequest, WebGPUTexture,
+    WebGPUTextureView,
+};
+use wgpu_types::Features;
+
+use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
+    GPUExternalTextureDescriptor, GPUExternalTextureMethods,
+};
+use crate::dom::bindings::error::Error;
+use crate::dom::bindings::refcounted::Trusted;
+use crate::dom::bindings::reflector::DomGlobal as _;
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::str::USVString;
+use crate::dom::globalscope::GlobalScope;
+use crate::dom::gpudevice::GPUDevice;
+
+/// Backing of GPUExternalTexture
+#[derive(JSTraceable, MallocSizeOf)]
+pub(crate) struct PlanarTexture {
+    #[ignore_malloc_size_of = "defined in webgpu"]
+    #[no_trace]
+    channel: WebGPU,
+    #[no_trace]
+    device_id: WebGPUDevice,
+    #[no_trace]
+    queue_id: WebGPUQueue,
+    #[no_trace]
+    texture_id: WebGPUTexture,
+    #[no_trace]
+    texture_view_id: WebGPUTextureView,
+    expired: Cell<bool>,
+    #[no_trace]
+    size: Size2D<u32>,
+}
+
+impl PlanarTexture {
+    pub(crate) fn new(channel: WebGPU, device: &GPUDevice, snapshot: Snapshot) -> Self {
+        let device_id = device.id();
+        let queue_id = device.queue_id();
+        let texture_id = WebGPUTexture(device.global().wgpu_id_hub().create_texture_id());
+        let texture_view_id =
+            WebGPUTextureView(device.global().wgpu_id_hub().create_texture_view_id());
+        let size = snapshot.size();
+        if let Err(error) = channel.0.send(WebGPURequest::CreatePlanarTexture {
+            device_id: device_id.0,
+            texture_id: texture_id.0,
+            texture_view_id: texture_view_id.0,
+            size,
+            format: snapshot.format(),
+        }) {
+            warn!("Failed to send CreatePlanarTexture ({error})");
+        }
+        let self_ = Self {
+            channel,
+            device_id,
+            queue_id,
+            texture_id,
+            texture_view_id,
+            size,
+            expired: Cell::new(true),
+        };
+        self_.update(snapshot);
+        self_
+    }
+
+    pub(crate) fn size(&self) -> Size2D<u32> {
+        self.size
+    }
+
+    pub(crate) fn update(&self, snapshot: Snapshot) {
+        if !self.expired.get() {
+            return;
+        }
+        if let Err(error) = self.channel.0.send(WebGPURequest::UpdatePlanarTexture {
+            device_id: self.device_id.0,
+            queue_id: self.queue_id.0,
+            texture_id: self.texture_id.0,
+            snapshot: snapshot.to_shared(),
+        }) {
+            warn!("Failed to send UpdatePlanarTexture ({error})");
+        }
+        self.expired.set(false);
+    }
+
+    pub(crate) fn expire(&self) {
+        self.expired.set(true);
+    }
+
+    pub(crate) fn is_expired(&self) -> bool {
+        self.expired.get()
+    }
+}
+
+impl Drop for PlanarTexture {
+    fn drop(&mut self) {
+        if let Err(error) = self.channel.0.send(WebGPURequest::DropPlanarTexture(
+            self.texture_id.0,
+            self.texture_view_id.0,
+        )) {
+            warn!("Failed to send DropPlanarTexture ({error})");
+        }
+    }
+}
+
+#[derive(JSTraceable, MallocSizeOf)]
+struct DroppableGPUExternalTexture {
+    #[ignore_malloc_size_of = "defined in webgpu"]
+    #[no_trace]
+    channel: WebGPU,
+    #[no_trace]
+    external_texture: WebGPUExternalTexture,
+}
+
+impl Drop for DroppableGPUExternalTexture {
+    fn drop(&mut self) {
+        if let Err(error) = self
+            .channel
+            .0
+            .send(WebGPURequest::DropExternalTexture(self.external_texture.0))
+        {
+            warn!(
+                "Failed to send DropExternalTexture ({:?}) ({error})",
+                self.external_texture.0
+            );
+        }
+    }
+}
+
+#[dom_struct]
+pub(crate) struct GPUExternalTexture {
+    reflector_: Reflector,
+    label: DomRefCell<USVString>,
+    #[ignore_malloc_size_of = "rc"]
+    planar_texture: Option<Rc<PlanarTexture>>,
+    droppable: DroppableGPUExternalTexture,
+}
+
+impl GPUExternalTexture {
+    fn new_inherited(
+        channel: WebGPU,
+        external_texture: WebGPUExternalTexture,
+        label: USVString,
+        planar_texture: Option<Rc<PlanarTexture>>,
+    ) -> GPUExternalTexture {
+        Self {
+            reflector_: Reflector::new(),
+            label: DomRefCell::new(label),
+            droppable: DroppableGPUExternalTexture {
+                channel,
+                external_texture,
+            },
+            planar_texture,
+        }
+    }
+
+    pub(crate) fn new(
+        cx: &mut JSContext,
+        global: &GlobalScope,
+        channel: WebGPU,
+        external_texture: WebGPUExternalTexture,
+        label: USVString,
+        planar_texture: Option<Rc<PlanarTexture>>,
+    ) -> DomRoot<GPUExternalTexture> {
+        reflect_dom_object_with_cx(
+            Box::new(GPUExternalTexture::new_inherited(
+                channel,
+                external_texture,
+                label,
+                planar_texture,
+            )),
+            global,
+            cx,
+        )
+    }
+
+    pub(crate) fn expire(&self) {
+        if let Some(planar_texture) = &self.planar_texture {
+            planar_texture.expire();
+        }
+        if let Err(error) = self
+            .droppable
+            .channel
+            .0
+            .send(WebGPURequest::DestroyExternalTexture(
+                self.droppable.external_texture.0,
+            ))
+        {
+            warn!(
+                "Failed to send DestroyExternalTexture ({:?}) ({error})",
+                self.droppable.external_texture.0
+            );
+        }
+    }
+
+    /// <https://www.w3.org/TR/webgpu/#dom-gpudevice-importexternaltexture>
+    pub(crate) fn create(
+        cx: &mut JSContext,
+        device: &super::gpudevice::GPUDevice,
+        descriptor: &GPUExternalTextureDescriptor,
+    ) -> Fallible<DomRoot<GPUExternalTexture>> {
+        let (size, planar_texture) = if device
+            .Features()
+            .wgpu_features()
+            .contains(Features::EXTERNAL_TEXTURE)
+        {
+            descriptor.source.planar_video_for_webgpu(device)?
+        } else {
+            // spec assumes that this is always supported, but that is not the case in wgpu
+            return Err(Error::NotSupported(Some(
+                "ExternalTexture is not supported on this device".to_string(),
+            )));
+        };
+        // 5. Let result be a new GPUExternalTexture object wrapping data.
+        let device_id = device.id().0;
+        let channel = device.channel();
+        let external_texture_id = device.global().wgpu_id_hub().create_external_texture_id();
+
+        if let Err(error) = channel.0.send(WebGPURequest::ImportExternalTexture {
+            device_id,
+            external_texture_id,
+            size,
+            label: descriptor.parent.label.to_string(),
+            plane0: planar_texture
+                .as_ref()
+                .map(|planar_texture| planar_texture.texture_view_id.0),
+        }) {
+            warn!("Failed to send ImportExternalTexture ({error})");
+        };
+        let result = Self::new(
+            cx,
+            &device.global(),
+            channel,
+            WebGPUExternalTexture(external_texture_id),
+            // Set result.label to descriptor.label.
+            descriptor.parent.label.clone(),
+            planar_texture,
+        );
+        // If source is an HTMLVideoElement, queue an automatic expiry task with device this and the following steps
+        let this = Trusted::new(&*result);
+        device
+            .global()
+            .task_manager()
+            .webgpu_task_source()
+            .queue(task!(expire: move || {
+                this.root().expire();
+            }));
+
+        // Return result.
+        Ok(result)
+    }
+}
+
+impl GPUExternalTexture {
+    pub(crate) fn id(&self) -> WebGPUExternalTexture {
+        self.droppable.external_texture
+    }
+}
+
+impl GPUExternalTextureMethods<crate::DomTypeHolder> for GPUExternalTexture {
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
+    fn Label(&self) -> USVString {
+        self.label.borrow().clone()
+    }
+
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
+    fn SetLabel(&self, value: USVString) {
+        *self.label.borrow_mut() = value;
+    }
+}

--- a/components/script/dom/webgpu/identityhub.rs
+++ b/components/script/dom/webgpu/identityhub.rs
@@ -5,13 +5,13 @@
 use webgpu_traits::{ComputePass, ComputePassId, RenderPass, RenderPassId};
 use wgpu_core::id::markers::{
     Adapter, BindGroup, BindGroupLayout, Buffer, CommandBuffer, CommandEncoder, ComputePipeline,
-    Device, PipelineLayout, QuerySet, Queue, RenderBundle, RenderPipeline, Sampler, ShaderModule,
-    Texture, TextureView,
+    Device, ExternalTexture, PipelineLayout, QuerySet, Queue, RenderBundle, RenderPipeline,
+    Sampler, ShaderModule, Texture, TextureView,
 };
 use wgpu_core::id::{
     AdapterId, BindGroupId, BindGroupLayoutId, BufferId, CommandBufferId, CommandEncoderId,
-    ComputePipelineId, DeviceId, PipelineLayoutId, QuerySetId, QueueId, RenderBundleId,
-    RenderPipelineId, SamplerId, ShaderModuleId, TextureId, TextureViewId,
+    ComputePipelineId, DeviceId, ExternalTextureId, PipelineLayoutId, QuerySetId, QueueId,
+    RenderBundleId, RenderPipelineId, SamplerId, ShaderModuleId, TextureId, TextureViewId,
 };
 use wgpu_core::identity::IdentityManager;
 
@@ -36,6 +36,7 @@ pub(crate) struct IdentityHub {
     compute_passes: IdentityManager<ComputePass>,
     render_passes: IdentityManager<RenderPass>,
     query_sets: IdentityManager<QuerySet>,
+    external_textures: IdentityManager<ExternalTexture>,
 }
 
 impl Default for IdentityHub {
@@ -60,6 +61,7 @@ impl Default for IdentityHub {
             compute_passes: IdentityManager::new(),
             render_passes: IdentityManager::new(),
             query_sets: IdentityManager::new(),
+            external_textures: IdentityManager::new(),
         }
     }
 }
@@ -215,5 +217,13 @@ impl IdentityHub {
 
     pub(crate) fn free_query_set_id(&self, id: QuerySetId) {
         self.query_sets.free(id);
+    }
+
+    pub(crate) fn create_external_texture_id(&self) -> ExternalTextureId {
+        self.external_textures.process()
+    }
+
+    pub(crate) fn free_external_texture_id(&self, id: ExternalTextureId) {
+        self.external_textures.free(id);
     }
 }

--- a/components/script/dom/webgpu/mod.rs
+++ b/components/script/dom/webgpu/mod.rs
@@ -21,6 +21,7 @@ pub(crate) mod gpuconvert;
 pub(crate) mod gpudevice;
 pub(crate) mod gpudevicelostinfo;
 pub(crate) mod gpuerror;
+pub(crate) mod gpuexternaltexture;
 pub(crate) mod gpuinternalerror;
 pub(crate) mod gpumapmode;
 pub(crate) mod gpuoutofmemoryerror;

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -578,6 +578,7 @@ DOMInterfaces = {
         'CreateComputePipeline', 'CreateCommandEncoder',
         'CreateTexture', 'CreateSampler', 'CreateRenderPipeline',  'CreateRenderBundleEncoder',
         'CreateQuerySet',
+        'ImportExternalTexture',
     ],
     'weakReferenceable': True, # for usage in GlobalScope https://github.com/servo/servo/issues/32519
     'no_gc': ['SetLabel'],

--- a/components/script_bindings/webidls/WebGPU.webidl
+++ b/components/script_bindings/webidls/WebGPU.webidl
@@ -151,6 +151,8 @@ interface GPUDevice : EventTarget {
     [Throws]
     GPUTexture createTexture(GPUTextureDescriptor descriptor);
     GPUSampler createSampler(optional GPUSamplerDescriptor descriptor = {});
+    [Throws]
+    GPUExternalTexture importExternalTexture(GPUExternalTextureDescriptor descriptor);
 
     [Throws]
     GPUBindGroupLayout createBindGroupLayout(GPUBindGroupLayoutDescriptor descriptor);
@@ -429,6 +431,17 @@ enum GPUTextureFormat {
 };
 
 [Exposed=(Window, Worker), SecureContext, Pref="dom_webgpu_enabled"]
+interface GPUExternalTexture {
+};
+GPUExternalTexture includes GPUObjectBase;
+
+dictionary GPUExternalTextureDescriptor : GPUObjectDescriptorBase {
+    // TODO: VideoFrame
+    required HTMLVideoElement source;
+    PredefinedColorSpace colorSpace = "srgb";
+};
+
+[Exposed=(Window, Worker), SecureContext, Pref="dom_webgpu_enabled"]
 interface GPUSampler {
 };
 GPUSampler includes GPUObjectBase;
@@ -567,7 +580,8 @@ typedef (GPUSampler or
          GPUTexture or
          GPUTextureView or
          GPUBuffer or
-         GPUBufferBinding) GPUBindingResource;
+         GPUBufferBinding or
+         GPUExternalTexture) GPUBindingResource;
 
 dictionary GPUBindGroupEntry {
     required GPUIndex32 binding;

--- a/components/shared/webgpu/ids.rs
+++ b/components/shared/webgpu/ids.rs
@@ -9,8 +9,9 @@ pub use wgpu_core::id::markers::{
 };
 use wgpu_core::id::{
     AdapterId, BindGroupId, BindGroupLayoutId, BufferId, CommandBufferId, CommandEncoderId,
-    ComputePipelineId, DeviceId, PipelineLayoutId, QuerySetId, QueueId, RenderBundleId,
-    RenderPipelineId, SamplerId, ShaderModuleId, SurfaceId, TextureId, TextureViewId,
+    ComputePipelineId, DeviceId, ExternalTextureId, PipelineLayoutId, QuerySetId, QueueId,
+    RenderBundleId, RenderPipelineId, SamplerId, ShaderModuleId, SurfaceId, TextureId,
+    TextureViewId,
 };
 pub use wgpu_core::id::{
     ComputePassEncoderId as ComputePassId, RenderPassEncoderId as RenderPassId,
@@ -52,3 +53,4 @@ webgpu_resource!(WebGPUComputePass, ComputePassId);
 webgpu_resource!(WebGPURenderPass, RenderPassId);
 webgpu_resource!(WebGPUContextId, u64);
 webgpu_resource!(WebGPUQuerySet, QuerySetId);
+webgpu_resource!(WebGPUExternalTexture, ExternalTextureId);

--- a/components/shared/webgpu/messages/recv.rs
+++ b/components/shared/webgpu/messages/recv.rs
@@ -6,7 +6,7 @@
 //! (usually from the ScriptThread, and more specifically from DOM objects)
 
 use arrayvec::ArrayVec;
-use pixels::SharedSnapshot;
+use pixels::{SharedSnapshot, SnapshotPixelFormat};
 use serde::{Deserialize, Serialize};
 use servo_base::Epoch;
 use servo_base::generic_channel::{
@@ -30,9 +30,9 @@ pub use wgpu_core::id::markers::{
 };
 use wgpu_core::id::{
     AdapterId, BindGroupId, BindGroupLayoutId, BufferId, CommandBufferId, CommandEncoderId,
-    ComputePassEncoderId, ComputePipelineId, DeviceId, PipelineLayoutId, QuerySetId, QueueId,
-    RenderBundleId, RenderPassEncoderId, RenderPipelineId, SamplerId, ShaderModuleId, TextureId,
-    TextureViewId,
+    ComputePassEncoderId, ComputePipelineId, DeviceId, ExternalTextureId, PipelineLayoutId,
+    QuerySetId, QueueId, RenderBundleId, RenderPassEncoderId, RenderPipelineId, SamplerId,
+    ShaderModuleId, TextureId, TextureViewId,
 };
 pub use wgpu_core::id::{
     ComputePassEncoderId as ComputePassId, RenderPassEncoderId as RenderPassId,
@@ -403,4 +403,30 @@ pub enum WebGPURequest {
         destination: BufferId,
         destination_offset: u64,
     },
+    /// Create planar texture and view to be imported as external texture
+    CreatePlanarTexture {
+        device_id: DeviceId,
+        size: Size2D<u32>,
+        format: SnapshotPixelFormat,
+        texture_id: TextureId,
+        /// aka plane
+        texture_view_id: TextureViewId,
+    },
+    UpdatePlanarTexture {
+        device_id: DeviceId,
+        queue_id: QueueId,
+        texture_id: TextureId,
+        snapshot: SharedSnapshot,
+    },
+    DropPlanarTexture(TextureId, TextureViewId),
+    /// Import plane as external texture, if plane not provided it creates invalid external texture
+    ImportExternalTexture {
+        device_id: DeviceId,
+        external_texture_id: ExternalTextureId,
+        label: String,
+        size: Size2D<u32>,
+        plane0: Option<TextureViewId>,
+    },
+    DestroyExternalTexture(ExternalTextureId),
+    DropExternalTexture(ExternalTextureId),
 }

--- a/components/shared/webgpu/messages/to_script.rs
+++ b/components/shared/webgpu/messages/to_script.rs
@@ -8,8 +8,8 @@ use serde::{Deserialize, Serialize};
 use servo_base::id::PipelineId;
 use wgpu_core::id::{
     AdapterId, BindGroupId, BindGroupLayoutId, BufferId, CommandBufferId, CommandEncoderId,
-    ComputePassEncoderId, ComputePipelineId, DeviceId, PipelineLayoutId, QuerySetId,
-    RenderBundleId, RenderPassEncoderId, RenderPipelineId, SamplerId, ShaderModuleId,
+    ComputePassEncoderId, ComputePipelineId, DeviceId, ExternalTextureId, PipelineLayoutId,
+    QuerySetId, RenderBundleId, RenderPassEncoderId, RenderPipelineId, SamplerId, ShaderModuleId,
     StagingBufferId, SurfaceId, TextureId, TextureViewId,
 };
 
@@ -40,6 +40,7 @@ pub enum WebGPUMsg {
     FreeQuerySet(QuerySetId),
     FreeComputePass(ComputePassEncoderId),
     FreeRenderPass(RenderPassEncoderId),
+    FreeExternalTexture(ExternalTextureId),
     UncapturedError {
         device: WebGPUDevice,
         pipeline_id: PipelineId,

--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -27,12 +27,14 @@ use wgc::id::DeviceId;
 use wgc::pipeline::ShaderModuleDescriptor;
 use wgc::resource::BufferMapOperation;
 pub use wgpu_core as wgc;
-use wgpu_core::command::RenderPassDescriptor;
-use wgpu_core::resource::BufferAccessResult;
+use wgpu_core::command::{RenderPassDescriptor, TexelCopyTextureInfo};
+use wgpu_core::resource::{BufferAccessResult, TextureViewDescriptor};
 pub use wgpu_types as wgt;
 use wgpu_types::error::WebGpuError;
 use wgpu_types::{
-    ExperimentalFeatures, MemoryHints, TexelCopyBufferLayout, TextureDimension, TextureUsages,
+    ExperimentalFeatures, Extent3d, ExternalTextureDescriptor, ExternalTextureFormat,
+    ExternalTextureTransferFunction, MemoryHints, Origin3d, TexelCopyBufferLayout, TextureAspect,
+    TextureDescriptor, TextureDimension, TextureFormat, TextureUsages,
 };
 use wgt::InstanceDescriptor;
 
@@ -656,7 +658,7 @@ impl WGPU {
                         queue_id,
                         pipeline_id,
                     } => {
-                        let desc = DeviceDescriptor {
+                        let mut desc = DeviceDescriptor {
                             label: descriptor.label.as_ref().map(crate::Cow::from),
                             required_features: descriptor.required_features,
                             required_limits: descriptor.required_limits.clone(),
@@ -665,6 +667,11 @@ impl WGPU {
                             experimental_features: ExperimentalFeatures::disabled(),
                         };
                         let global = &self.global;
+                        // enable external texture support if available
+                        let features = global.adapter_features(adapter_id.0);
+                        if features.contains(wgpu_types::Features::EXTERNAL_TEXTURE) {
+                            desc.required_features |= wgpu_types::Features::EXTERNAL_TEXTURE;
+                        }
                         let device = WebGPUDevice(device_id);
                         let queue = WebGPUQueue(queue_id);
                         let result = global
@@ -1255,6 +1262,170 @@ impl WGPU {
                         );
                         self.maybe_dispatch_wgpu_error(device_id, result.err());
                     },
+                    WebGPURequest::CreatePlanarTexture {
+                        device_id,
+                        size,
+                        format,
+                        texture_id,
+                        texture_view_id,
+                    } => {
+                        let (_, maybe_error) = self.global.device_create_texture(
+                            device_id,
+                            &TextureDescriptor {
+                                label: None,
+                                size: Extent3d {
+                                    width: size.width,
+                                    height: size.height,
+                                    depth_or_array_layers: 1,
+                                },
+                                mip_level_count: 1,
+                                sample_count: 1,
+                                dimension: TextureDimension::D2,
+                                format: match format {
+                                    pixels::SnapshotPixelFormat::RGBA => TextureFormat::Rgba8Unorm,
+                                    pixels::SnapshotPixelFormat::BGRA => TextureFormat::Bgra8Unorm,
+                                },
+                                usage: TextureUsages::COPY_DST | TextureUsages::TEXTURE_BINDING,
+                                view_formats: Vec::new(),
+                            },
+                            Some(texture_id),
+                        );
+                        self.maybe_dispatch_error(
+                            device_id,
+                            maybe_error.map(|error| {
+                                Error::Internal(format!(
+                                    "Failed to create planar texture: {error:?}"
+                                ))
+                            }),
+                        );
+                        let (_, maybe_error) = self.global.texture_create_view(
+                            texture_id,
+                            &TextureViewDescriptor {
+                                ..Default::default()
+                            },
+                            Some(texture_view_id),
+                        );
+                        self.maybe_dispatch_error(
+                            device_id,
+                            maybe_error.map(|error| {
+                                Error::Internal(format!(
+                                    "Failed to create planar texture view: {error:?}"
+                                ))
+                            }),
+                        );
+                    },
+                    WebGPURequest::UpdatePlanarTexture {
+                        device_id,
+                        queue_id,
+                        texture_id,
+                        snapshot,
+                    } => {
+                        let result = self.global.queue_write_texture(
+                            queue_id,
+                            &TexelCopyTextureInfo {
+                                texture: texture_id,
+                                mip_level: 0,
+                                origin: Origin3d::ZERO,
+                                aspect: TextureAspect::All,
+                            },
+                            snapshot.data(),
+                            &TexelCopyBufferLayout {
+                                offset: 0,
+                                bytes_per_row: Some(snapshot.size().width * 4),
+                                rows_per_image: None,
+                            },
+                            &Extent3d {
+                                width: snapshot.size().width,
+                                height: snapshot.size().height,
+                                depth_or_array_layers: 1,
+                            },
+                        );
+                        self.maybe_dispatch_error(
+                            device_id,
+                            result.err().map(|error| {
+                                Error::Internal(format!(
+                                    "Failed to write planar texture: {error:?}"
+                                ))
+                            }),
+                        );
+                    },
+                    WebGPURequest::DropPlanarTexture(id, view_id) => {
+                        self.global.texture_view_drop(view_id);
+                        self.global.texture_drop(id);
+                        self.poller.wake();
+                        if let Err(e) = self.script_sender.send(WebGPUMsg::FreeTextureView(view_id))
+                        {
+                            warn!("Unable to send FreeTextureView({:?}) ({:?})", view_id, e);
+                        };
+                        if let Err(e) = self.script_sender.send(WebGPUMsg::FreeTexture(id)) {
+                            warn!("Unable to send FreeTexture({:?}) ({:?})", id, e);
+                        };
+                    },
+                    WebGPURequest::ImportExternalTexture {
+                        device_id,
+                        external_texture_id,
+                        size,
+                        label,
+                        plane0,
+                    } => {
+                        let desc = ExternalTextureDescriptor {
+                            label: Some(label.into()),
+                            width: size.width,
+                            height: size.height,
+                            format: ExternalTextureFormat::Rgba,
+                            yuv_conversion_matrix: [0.; 16],
+                            gamut_conversion_matrix: [
+                                1., 0., 0., //
+                                0., 1., 0., //
+                                0., 0., 1., //
+                            ],
+                            src_transfer_function: ExternalTextureTransferFunction::default(),
+                            dst_transfer_function: ExternalTextureTransferFunction::default(),
+                            sample_transform: [
+                                1., 0., //
+                                0., 1., //
+                                0., 0., //
+                            ],
+                            load_transform: [
+                                1., 0., //
+                                0., 1., //
+                                0., 0., //
+                            ],
+                        };
+                        if let Some(plane0) = plane0 {
+                            let (_, maybe_error) = self.global.device_create_external_texture(
+                                device_id,
+                                &desc,
+                                &[plane0],
+                                Some(external_texture_id),
+                            );
+                            self.maybe_dispatch_error(
+                                device_id,
+                                maybe_error.map(|error| {
+                                    Error::Internal(format!(
+                                        "Failed to import external texture: {error:?}"
+                                    ))
+                                }),
+                            );
+                        } else {
+                            self.global
+                                .create_external_texture_error(Some(external_texture_id), &desc);
+                            self.maybe_dispatch_error(
+                                device_id,
+                                Some(Error::Validation("Usability is not good".to_string())),
+                            );
+                        }
+                    },
+                    WebGPURequest::DestroyExternalTexture(id) => {
+                        self.global.external_texture_destroy(id);
+                    },
+                    WebGPURequest::DropExternalTexture(id) => {
+                        self.global.external_texture_drop(id);
+                        if let Err(e) = self.script_sender.send(WebGPUMsg::FreeExternalTexture(id))
+                        {
+                            warn!("Unable to send FreeExternalTexture({:?}) ({:?})", id, e);
+                        };
+                    },
                 }
             }
         }
@@ -1281,6 +1452,7 @@ impl WGPU {
 
     /// <https://www.w3.org/TR/webgpu/#abstract-opdef-dispatch-error>
     fn dispatch_error(&mut self, device_id: id::DeviceId, error: Error) {
+        log::trace!("Dispatching error for device {:?}: {:?}", device_id, error);
         let mut devices = self.devices.lock().unwrap();
         let device_scope = devices
             .get_mut(&device_id)

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -14452,7 +14452,7 @@
      ]
     ],
     "interfaces.https.html": [
-     "d162d1ce0cf0a893f9ba6fd230ee7b518dfcf6f8",
+     "f91a491abdf5414d1116ebc8b63c0010f7493a37",
      [
       null,
       {}

--- a/tests/wpt/mozilla/tests/mozilla/interfaces.https.html
+++ b/tests/wpt/mozilla/tests/mozilla/interfaces.https.html
@@ -133,6 +133,7 @@ test_interfaces([
   "GPUDevice",
   "GPUDeviceLostInfo",
   "GPUError",
+  "GPUExternalTexture",
   "GPUInternalError",
   "GPUMapMode",
   "GPUOutOfMemoryError",

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/idl/exposed.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/idl/exposed.https.html.ini
@@ -1,3 +1,3 @@
 [exposed.https.html]
   expected:
-    if os == "linux" and not debug: ERROR
+    if os == "linux" and not debug: TIMEOUT


### PR DESCRIPTION
The idea behind `GPUExternalTexture` is that one could use texture from decoder in webgpu (and make it zerocopy). We do not have any texture sharing mechanism in servo yet and so this PR does this using CPU copies. We use `get_current_frame_data` to obtain Snapshot which we then upload to wgpu as normal texture (`PlanarTexture` in the code and that is per HTMLVideoElement so we can just update instead of creating new whole texture - something similar is done in FF) which is then imported as external texture in wgpu. Unfortunately external textures only work on DirectX12 (Windows) and Metal (Mac) so on vulkan (Linux) we throw `Unsupported` dom exception. Nevertheless many tests now pass because they do not fail at missing `GPUExternalTexture` or `importExternalTexture`.

`./servoshell.exe --pref dom_webgpu_enabled --pref dom_webgpu_wgpu_backend=dx12 https://webgpufundamentals.org/webgpu/webgpu-simple-textured-quad-external-video.html`:
<img width="1026" height="772" alt="Servo on windows running https://webgpufundamentals.org/webgpu/webgpu-simple-textured-quad-external-video.html" src="https://github.com/user-attachments/assets/ce83db19-6ff2-47cb-818d-3483268ac144" />


Testing: Covered by WebGPU CTS (partially) and tested manually using example.