### PR TITLE
script: Move iframe sandbox attribute parsing before context creation 

### DIFF
--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -1208,12 +1208,12 @@ impl VirtualMethods for HTMLIFrameElement {
 
         debug!("<iframe> running post connection steps");
 
-        // Step 1. Create a new child navigable for insertedNode.
-        self.create_nested_browsing_context(cx);
-
-        // Step 2: If insertedNode has a sandbox attribute, then parse the sandboxing directive
+        // Step 1: If insertedNode has a sandbox attribute, then parse the sandboxing directive
         // given the attribute's value and insertedNode's iframe sandboxing flag set.
         self.parse_sandbox_attribute();
+
+        // Step 2. Create a new child navigable for insertedNode.
+        self.create_nested_browsing_context(cx);
 
         // Step 3. Process the iframe attributes for insertedNode, with initialInsertion set to true.
         self.process_the_iframe_attributes(ProcessingMode::FirstTime, cx);

--- a/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/same-origin-contextual-fragment.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/same-origin-contextual-fragment.html.ini
@@ -1,3 +1,0 @@
-[same-origin-contextual-fragment.html]
-  [\n      HTML5 Sandbox: an iframe with same-origin and no allow-scripts does not\n      run scripts from a contextual fragment.\n    ]
-    expected: FAIL


### PR DESCRIPTION
The latest WHATWG HTML spec was updated which changed the order of execution Browsing context creation -> Sandbox attribute parsing to its reverse

Testing: The existing tests covers this change. (same-origin-contextual-fragment.html still passes as expected). But there was a problem that I felt worth mentioning in the issues page though it didn't seem to be related to this code change. 

Fixes: #45846
