### PR TITLE
script: Mute iframe load events if iframe load event is ongoing.

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -664,6 +664,11 @@ pub(crate) struct Document {
 
     /// Data necessary for maintaining the accessibility tree.
     accessibility_data: DomRefCell<AccessibilityData>,
+
+    /// <https://html.spec.whatwg.org/multipage/#iframe-load-in-progress>
+    iframe_load_in_progress: Cell<bool>,
+    /// <https://html.spec.whatwg.org/multipage/#mute-iframe-load>
+    mute_iframe_load: Cell<bool>,
 }
 
 impl Document {
@@ -3672,6 +3677,8 @@ impl Document {
             default_single_line_container_name: Default::default(),
             css_styling_flag: Default::default(),
             accessibility_data: Default::default(),
+            iframe_load_in_progress: Default::default(),
+            mute_iframe_load: Default::default(),
         }
     }
 
@@ -4772,6 +4779,14 @@ impl Document {
     /// <https://w3c.github.io/editing/docs/execCommand/#css-styling-flag>
     pub(crate) fn set_css_styling_flag(&self, value: bool) {
         self.css_styling_flag.set(value)
+    }
+
+    pub(crate) fn mute_iframe_load_flag(&self) -> bool {
+        self.mute_iframe_load.get()
+    }
+
+    pub(crate) fn set_iframe_load_in_progress(&self, value: bool) {
+        self.iframe_load_in_progress.set(value)
     }
 }
 
@@ -6194,7 +6209,9 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
 
         // Step 14. If document's iframe load in progress flag is set, then set document's mute
         // iframe load flag.
-        // TODO: https://github.com/servo/servo/issues/21938
+        if self.iframe_load_in_progress.get() {
+            self.mute_iframe_load.set(true);
+        }
 
         // Step 15: Set document to no-quirks mode.
         self.set_quirks_mode(QuirksMode::NoQuirks);

--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -805,9 +805,22 @@ impl HTMLIFrameElement {
     pub(crate) fn run_iframe_load_event_steps(&self, cx: &mut JSContext) {
         // TODO 1. Assert: element's content navigable is not null.
 
-        // TODO 2-4 Mark resource timing.
+        // Step 2. Let childDocument be element's content navigable's active document.
+        let child_document = self.GetContentDocument();
 
-        // TODO 5 Set childDocument's iframe load in progress flag.
+        // Step 3. If childDocument has its mute iframe load flag set, then return.
+        // Step 5. Set childDocument's iframe load in progress flag.
+        if let Some(document) = child_document {
+            if document.mute_iframe_load_flag() {
+                let blocker = &self.load_blocker;
+                LoadBlocker::terminate(blocker, cx);
+                return;
+            }
+            document.set_iframe_load_in_progress(true);
+        }
+
+        // Step 4. If element's pending resource-timing start time is not null, then:
+        // TODO
 
         // Step 6. Fire an event named load at element.
         self.upcast::<EventTarget>().fire_event(cx, atom!("load"));
@@ -815,7 +828,10 @@ impl HTMLIFrameElement {
         let blocker = &self.load_blocker;
         LoadBlocker::terminate(blocker, cx);
 
-        // TODO Step 7 - unset child document `mute iframe load` flag
+        // Step 7. Unset childDocument's iframe load in progress flag
+        if let Some(child_document) = self.GetContentDocument() {
+            child_document.set_iframe_load_in_progress(false);
+        }
     }
 
     /// Parse the `sandbox` attribute value given the [`Attr`]. This sets the `sandboxing_flag_set`

--- a/tests/wpt/meta/content-security-policy/generic/policy-inherited-correctly-by-plznavigate.html.ini
+++ b/tests/wpt/meta/content-security-policy/generic/policy-inherited-correctly-by-plznavigate.html.ini
@@ -1,2 +1,0 @@
-[policy-inherited-correctly-by-plznavigate.html]
-  expected: ERROR


### PR DESCRIPTION
This prevents unexpected load events if particular navigations are triggered during an iframe's existing load event.

Testing: New passing test.
Part of #43149