### PR TITLE
script: Implement non-fallible pipe `ReadableStream` through `TransformStream`

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -30,9 +30,6 @@ use url::form_urlencoded;
 use crate::dom::bindings::buffer_source::create_buffer_source;
 use crate::dom::bindings::codegen::Bindings::BlobBinding::Blob_Binding::BlobMethods;
 use crate::dom::bindings::codegen::Bindings::FormDataBinding::FormDataMethods;
-use crate::dom::bindings::codegen::Bindings::ReadableStreamBinding::{
-    ReadableStreamMethods, ReadableWritablePair, StreamPipeOptions,
-};
 use crate::dom::bindings::codegen::Bindings::XMLHttpRequestBinding::BodyInit;
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::inheritance::Castable;
@@ -49,7 +46,9 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::html::htmlformelement::{encode_multipart_form_data, generate_boundary};
 use crate::dom::promise::Promise;
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
-use crate::dom::readablestream::{ReadableStream, get_read_promise_bytes, get_read_promise_done};
+use crate::dom::readablestream::{
+    ReadableStream, get_read_promise_bytes, get_read_promise_done, pipe_through,
+};
 use crate::dom::urlsearchparams::URLSearchParams;
 use crate::mime_multipart::{Node, read_multipart_body};
 use crate::realms::enter_auto_realm;
@@ -1189,17 +1188,12 @@ pub(crate) fn body_text_stream<T: BodyMixin + DomObject>(
     let decoder =
         TextDecoderStream::new_with_proto(cx, &object.global(), None, UTF_8, false, false)?;
 
-    let pair = ReadableWritablePair {
-        readable: decoder.Readable(),
-        writable: decoder.Writable(),
-    };
-    let options = StreamPipeOptions {
-        preventClose: false,
-        preventAbort: false,
-        preventCancel: false,
-        signal: None,
-    };
-    let mut realm = CurrentRealm::assert(cx);
-    // Stel 6. Return the result of stream, piped through decoder.
-    stream.PipeThrough(&mut realm, &pair, &options)
+    // Step 6. Return the result of stream, piped through decoder.
+    Ok(pipe_through(
+        &stream,
+        cx,
+        &object.global(),
+        &decoder.Writable(),
+        decoder.Readable(),
+    ))
 }

--- a/components/script/dom/file/blob.rs
+++ b/components/script/dom/file/blob.rs
@@ -23,9 +23,6 @@ use uuid::Uuid;
 use crate::dom::bindings::buffer_source::create_buffer_source;
 use crate::dom::bindings::codegen::Bindings::BlobBinding;
 use crate::dom::bindings::codegen::Bindings::BlobBinding::BlobMethods;
-use crate::dom::bindings::codegen::Bindings::ReadableStreamBinding::{
-    ReadableStreamMethods, ReadableWritablePair, StreamPipeOptions,
-};
 use crate::dom::bindings::codegen::UnionTypes::ArrayBufferOrArrayBufferViewOrBlobOrString;
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::reflector::DomGlobal;
@@ -36,7 +33,7 @@ use crate::dom::bindings::structuredclone::StructuredData;
 use crate::dom::encoding::textdecoderstream::TextDecoderStream;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
-use crate::dom::stream::readablestream::ReadableStream;
+use crate::dom::stream::readablestream::{ReadableStream, pipe_through};
 use crate::script_runtime::CanGc;
 
 /// <https://w3c.github.io/FileAPI/#dfn-Blob>
@@ -304,18 +301,13 @@ impl BlobMethods<crate::DomTypeHolder> for Blob {
             false, // ignoreBOM
         )?;
         // Step 4: Return the result of calling stream, piped through decoder.
-        let pair = ReadableWritablePair {
-            readable: decoder.Readable(),
-            writable: decoder.Writable(),
-        };
-        let options = StreamPipeOptions {
-            preventClose: false,
-            preventAbort: false,
-            preventCancel: false,
-            signal: None,
-        };
-        let mut realm = CurrentRealm::assert(cx);
-        stream.PipeThrough(&mut realm, &pair, &options)
+        Ok(pipe_through(
+            &stream,
+            cx,
+            &self.global(),
+            &decoder.Writable(),
+            decoder.Readable(),
+        ))
     }
 
     /// <https://w3c.github.io/FileAPI/#slice-method-algo>

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -2552,6 +2552,7 @@ pub(crate) fn pipe_through(
     readable: DomRoot<ReadableStream>,
 ) -> DomRoot<ReadableStream> {
     // Assert: `! IsReadableStreamLocked(readable)` is false.
+
     // Assert: `! IsWritableStreamLocked(transform.[[writable]])` is false.
 
     // Above is done in `pipe_to` below.
@@ -2560,7 +2561,7 @@ pub(crate) fn pipe_through(
         &mut realm, global, dest, false, // preventClose
         false, // preventAbort
         false, // preventCancel
-        None,  //signal
+        None,  // signal
     );
 
     promise.set_promise_is_handled(cx);

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -2540,9 +2540,9 @@ impl Transferable for ReadableStream {
 
 /// <https://streams.spec.whatwg.org/#readablestream-pipe-through>
 /// Pipe a ReadableStream through a transform and return the readable side.
-/// Unlike [`ReadableStream::PipeThrough`], this is not failliable.
+/// Note: Unlike [`ReadableStream::PipeThrough`], this is not failliable.
 ///
-/// Spec says it takes same options as [`ReadableStream::PipeThrough`],
+/// Note: Spec says it takes same options as [`ReadableStream::PipeThrough`],
 /// however all usages use default `false`.
 pub(crate) fn pipe_through(
     source: &ReadableStream,
@@ -2551,12 +2551,14 @@ pub(crate) fn pipe_through(
     dest: &WritableStream,
     readable: DomRoot<ReadableStream>,
 ) -> DomRoot<ReadableStream> {
-    // Assert: `! IsReadableStreamLocked(readable)` is false.
+    // Step 1. Assert: `! IsReadableStreamLocked(readable)` is false.
 
-    // Assert: `! IsWritableStreamLocked(transform.[[writable]])` is false.
+    // Step 2. Assert: `! IsWritableStreamLocked(transform.[[writable]])` is false.
 
     // Above is done in `pipe_to` below.
     let mut realm = CurrentRealm::assert(cx);
+    // Step 4. Let promise be ! ReadableStreamPipeTo(readable,
+    // transform.[[writable]], preventClose, preventAbort, preventCancel, signalArg).
     let promise = source.pipe_to(
         &mut realm, global, dest, false, // preventClose
         false, // preventAbort
@@ -2564,6 +2566,8 @@ pub(crate) fn pipe_through(
         None,  // signal
     );
 
+    // Step 5. Set promise.[[PromiseIsHandled]] to true.
     promise.set_promise_is_handled(cx);
+    // Step 6. Return transform.[[readable]].
     readable
 }

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -2537,3 +2537,32 @@ impl Transferable for ReadableStream {
         }
     }
 }
+
+/// <https://streams.spec.whatwg.org/#readablestream-pipe-through>
+/// Pipe a ReadableStream through a transform and return the readable side.
+/// Unlike [`ReadableStream::PipeThrough`], this is not failliable.
+///
+/// Spec says it takes same options as [`ReadableStream::PipeThrough`],
+/// however all usages use default `false`.
+pub(crate) fn pipe_through(
+    source: &ReadableStream,
+    cx: &mut JSContext,
+    global: &GlobalScope,
+    dest: &WritableStream,
+    readable: DomRoot<ReadableStream>,
+) -> DomRoot<ReadableStream> {
+    // Assert: ! IsReadableStreamLocked(readable) is false.
+    // Assert: ! IsWritableStreamLocked(transform.[[writable]]) is false.
+
+    // Above is done in `pipe_to` below.
+    let mut realm = CurrentRealm::assert(cx);
+    let promise = source.pipe_to(
+        &mut realm, global, dest, false, // preventClose
+        false, // preventAbort
+        false, // preventCancel
+        None,  //signal
+    );
+
+    promise.set_promise_is_handled(cx);
+    readable
+}

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -2551,8 +2551,8 @@ pub(crate) fn pipe_through(
     dest: &WritableStream,
     readable: DomRoot<ReadableStream>,
 ) -> DomRoot<ReadableStream> {
-    // Assert: ! IsReadableStreamLocked(readable) is false.
-    // Assert: ! IsWritableStreamLocked(transform.[[writable]]) is false.
+    // Assert: `! IsReadableStreamLocked(readable)` is false.
+    // Assert: `! IsWritableStreamLocked(transform.[[writable]])` is false.
 
     // Above is done in `pipe_to` below.
     let mut realm = CurrentRealm::assert(cx);


### PR DESCRIPTION
This implements https://streams.spec.whatwg.org/#readablestream-pipe-through
Opened spec issue: https://github.com/whatwg/streams/pull/1375

Testing: Covered by existing tests.
Fixes: https://github.com/servo/servo/pull/45864#discussion_r3452245526
Part of #45860