### PR TITLE
script: Use `CurrentRealm` instead of `InRealm` for promise creation

### DIFF
--- a/components/script/dom/bindings/reflector.rs
+++ b/components/script/dom/bindings/reflector.rs
@@ -11,11 +11,6 @@ use crate::dom::types::GlobalScope;
 use crate::realms::enter_realm;
 
 pub(crate) trait DomGlobal {
-    /// Returns the [relevant global] in whatever realm is currently active.
-    ///
-    /// [relevant global]: https://html.spec.whatwg.org/multipage/#concept-relevant-global
-    fn global_(&self, realm: InRealm) -> DomRoot<GlobalScope>;
-
     /// Returns the [relevant global] in the same realm as the callee object.
     /// If you know the callee's realm is already the current realm, it is
     /// more efficient to call [DomGlobal::global_] instead.
@@ -25,12 +20,11 @@ pub(crate) trait DomGlobal {
 }
 
 impl<T: DomGlobalGeneric<DomTypeHolder>> DomGlobal for T {
-    fn global_(&self, realm: InRealm) -> DomRoot<GlobalScope> {
-        <Self as DomGlobalGeneric<DomTypeHolder>>::global_(self, realm)
-    }
-
     fn global(&self) -> DomRoot<GlobalScope> {
         let realm = enter_realm(self);
-        <Self as DomGlobalGeneric<DomTypeHolder>>::global_(self, InRealm::entered(&realm))
+        <Self as DomGlobalGeneric<DomTypeHolder>>::global_from_reflector(
+            self,
+            InRealm::entered(&realm),
+        )
     }
 }

--- a/components/script/dom/promise/promise.rs
+++ b/components/script/dom/promise/promise.rs
@@ -45,7 +45,7 @@ use crate::dom::bindings::root::{AsHandleValue, DomRoot};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::microtask::{Microtask, MicrotaskRunnable};
-use crate::realms::{InRealm, enter_auto_realm};
+use crate::realms::enter_auto_realm;
 use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 
@@ -270,10 +270,7 @@ impl Promise {
         cx: &mut CurrentRealm,
         handler: &PromiseNativeHandler,
     ) {
-        let in_realm_proof = cx.into();
-        let realm = InRealm::Already(&in_realm_proof);
-
-        run_a_script::<DomTypeHolder, _, _>(cx, &handler.global_(realm), |cx| {
+        run_a_script::<DomTypeHolder, _, _>(cx, &GlobalScope::from_current_realm(cx), |cx| {
             rooted!(&in(cx) let resolve_func =
                 create_native_handler_function(cx,
                                                handler.reflector().get_jsobject(),

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -4259,7 +4259,7 @@ class CGCallGenerator(CGThing):
             if static:
                 glob = "global.upcast::<D::GlobalScope>()"
             else:
-                glob = "&this.global_(InRealm::already(&AlreadyInRealm::assert_for_cx(SafeJSContext::from_ptr(cx.raw_cx()))))"
+                glob = "&D::GlobalScope::from_current_realm(&CurrentRealm::assert(cx))"
 
             self.cgRoot.append(CGGeneric(
                 "let result = match result {\n"

--- a/components/script_bindings/import.rs
+++ b/components/script_bindings/import.rs
@@ -40,7 +40,7 @@ pub(crate) mod base {
     pub(crate) use crate::lock::ThreadUnsafeOnceLock;
     pub(crate) use crate::num::Finite;
     pub(crate) use crate::proxyhandler::CrossOriginProperties;
-    pub(crate) use crate::reflector::{DomGlobalGeneric, DomObject};
+    pub(crate) use crate::reflector::DomObject;
     pub(crate) use crate::root::DomRoot;
     pub(crate) use crate::script_runtime::JSContext as SafeJSContext;
     pub(crate) use crate::str::{ByteString, DOMString, USVString};

--- a/components/script_bindings/iterable.rs
+++ b/components/script_bindings/iterable.rs
@@ -74,12 +74,6 @@ pub struct IterableIterator<
     _marker: NoTrace<PhantomData<D>>,
 }
 
-impl<D: DomTypes, T: DomObjectIteratorWrap<D> + JSTraceable + Iterable> IterableIterator<D, T> {
-    pub fn global_(&self, realm: InRealm) -> DomRoot<D::GlobalScope> {
-        <Self as DomGlobalGeneric<D>>::global_(self, realm)
-    }
-}
-
 impl<
     D: DomTypes,
     T: DomObjectIteratorWrap<D>
@@ -109,7 +103,7 @@ impl<D: DomTypes, T: DomObjectIteratorWrap<D> + JSTraceable + Iterable + DomGlob
         });
         <D as DomHelpers<D>>::reflect_dom_object(
             iterator,
-            &*iterable.global_(realm),
+            &*iterable.global_from_reflector(realm),
             CanGc::deprecated_note(),
         )
     }

--- a/components/script_bindings/reflector.rs
+++ b/components/script_bindings/reflector.rs
@@ -4,6 +4,7 @@
 
 use std::cell::Cell;
 
+use js::context::JSContext;
 use js::jsapi::{AddAssociatedMemory, Heap, JSObject, MemoryUse, RemoveAssociatedMemory};
 use js::rust::HandleObject;
 use malloc_size_of_derive::MallocSizeOf;
@@ -218,7 +219,7 @@ pub trait DomGlobalGeneric<D: DomTypes>: DomObject {
     /// Returns the [`GlobalScope`] of the realm that the [`DomObject`] was created in.  If this
     /// object is a `Node`, this will be different from it's owning `Document` if adopted by. For
     /// `Node`s it's almost always better to use `NodeTraits::owning_global`.
-    fn global_(&self, realm: InRealm) -> DomRoot<D::GlobalScope>
+    fn global_from_reflector(&self, realm: InRealm) -> DomRoot<D::GlobalScope>
     where
         Self: Sized,
     {
@@ -233,7 +234,7 @@ pub trait DomObjectWrap<D: DomTypes>: Sized + DomObject + DomGlobalGeneric<D> {
     /// Function pointer to the general wrap function type
     #[expect(clippy::type_complexity)]
     const WRAP: unsafe fn(
-        &mut js::context::JSContext,
+        &mut JSContext,
         &D::GlobalScope,
         Option<HandleObject>,
         Box<Self>,
@@ -246,7 +247,7 @@ pub trait DomObjectIteratorWrap<D: DomTypes>: DomObjectWrap<D> + JSTraceable + I
     /// Function pointer to the wrap function for `IterableIterator<T>`
     #[expect(clippy::type_complexity)]
     const ITER_WRAP: unsafe fn(
-        &mut js::context::JSContext,
+        &mut JSContext,
         &D::GlobalScope,
         Option<HandleObject>,
         Box<IterableIterator<D, Self>>,
@@ -287,7 +288,7 @@ where
 pub fn reflect_dom_object_with_cx<D, T, U>(
     obj: Box<T>,
     global: &U,
-    cx: &mut js::context::JSContext,
+    cx: &mut JSContext,
 ) -> DomRoot<T>
 where
     D: DomTypes,
@@ -304,7 +305,7 @@ pub fn reflect_dom_object_with_proto_and_cx<D, T, U>(
     obj: Box<T>,
     global: &U,
     proto: Option<HandleObject>,
-    cx: &mut js::context::JSContext,
+    cx: &mut JSContext,
 ) -> DomRoot<T>
 where
     D: DomTypes,

--- a/tests/wpt/meta/domxpath/resolver-callback-interface-cross-realm.tentative.html.ini
+++ b/tests/wpt/meta/domxpath/resolver-callback-interface-cross-realm.tentative.html.ini
@@ -4,12 +4,3 @@
 
   [XPathNSResolver is cross-realm plain object with non-callable 'lookupNamespaceURI' property]
     expected: FAIL
-
-  [XPathNSResolver is cross-realm non-callable revoked Proxy]
-    expected: FAIL
-
-  [XPathNSResolver is cross-realm callable revoked Proxy]
-    expected: FAIL
-
-  [XPathNSResolver is cross-realm plain object with revoked Proxy as 'lookupNamespaceURI' property]
-    expected: FAIL


### PR DESCRIPTION
To avoid jumping through hoops, instead use the `CurrentRealm` we already have for obtaining the relevant `GlobalScope`.

Part of #40600

Testing: fixes a WPT test