### PR TITLE
script_bindings: more `&mut JSContext` and safe handles in `proxyhandler.rs`

### DIFF
--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -6216,8 +6216,8 @@ class CGProxyNamedOperation(CGProxySpecialOperation):
     def define(self) -> str:
         # Our first argument is the id we're getting.
         argName = self.arguments[0].identifier.name
-        return (f'let {argName} = jsid_to_string(cx, Handle::from_raw(id)).expect("Not a string-convertible JSID?");\n'
-                "let this = UnwrapProxy::<D>(proxy);\n"
+        return (f'let {argName} = jsid_to_string(cx, id).expect("Not a string-convertible JSID?");\n'
+                "let this = UnwrapProxy::<D>(proxy.into());\n"
                 "let this = &*this;\n"
                 f"{CGProxySpecialOperation.define(self)}")
 
@@ -6260,14 +6260,14 @@ class CGProxyNamedDeleter(CGProxyNamedOperation):
         # Our first argument is the id we're getting.
         argName = self.arguments[0].identifier.name
         return ("if !id.is_symbol() {\n"
-                f'    let {argName} = match jsid_to_string(cx, Handle::from_raw(id)) {{\n'
+                f'    let {argName} = match jsid_to_string(cx, id) {{\n'
                 "        Some(val) => val,\n"
                 "        None => {\n"
                 "            throw_type_error(cx.raw_cx(), c\"Not a string-convertible JSID\");\n"
                 "            return false;\n"
                 "        }\n"
                 "    };\n"
-                "    let this = UnwrapProxy::<D>(proxy);\n"
+                "    let this = UnwrapProxy::<D>(proxy.into());\n"
                 "    let this = &*this;\n"
                 f"    {CGProxySpecialOperation.define(self)}"
                 "}\n")
@@ -6305,36 +6305,39 @@ class CGDOMJSProxyHandler_getOwnPropertyDescriptor(CGAbstractExternMethod):
 
         get = "let mut cx = JSContext::from_ptr(ptr::NonNull::new(cx).unwrap());\n"
         get += "let mut cx = CurrentRealm::assert(&mut cx);\n"
-        get += "let cx = &mut cx;\n"
+        get += "let cx = &mut cx;\n\n"
+        get += "let proxy = Handle::from_raw(proxy);\n"
+        get += "let id = Handle::from_raw(id);\n"
+        get += "let mut desc = MutableHandle::from_raw(desc);\n\n"
 
         if self.descriptor.isMaybeCrossOriginObject():
             get += dedent(
                 """
-                if !<D as DomHelpers<D>>::is_platform_object_same_origin(cx, proxy) {
+                if !<D as DomHelpers<D>>::is_platform_object_same_origin(cx, proxy.into()) {
                     if !proxyhandler::cross_origin_get_own_property_helper(
-                        cx, proxy, CROSS_ORIGIN_PROPERTIES.get(), id, desc, &mut *is_none
+                        cx, proxy, CROSS_ORIGIN_PROPERTIES.get(), id, desc.reborrow(), &mut *is_none
                     ) {
                         return false;
                     }
                     if *is_none {
-                        return proxyhandler::cross_origin_property_fallback::<D>(cx, proxy, id, desc, &mut *is_none);
+                        return proxyhandler::cross_origin_property_fallback::<D>(cx, proxy, id, desc.reborrow(), &mut *is_none);
                     }
                     return true;
                 }
 
                 // Safe to enter the Realm of proxy now.
-                let mut cx = AutoRealm::new_from_handle(cx, Handle::from_raw(proxy));
+                let mut cx = AutoRealm::new_from_handle(cx, proxy);
                 let cx = &mut cx;
                 """)
 
         if indexedGetter:
-            get += "let index = get_array_index_from_id(Handle::from_raw(id));\n"
+            get += "let index = get_array_index_from_id(id);\n"
 
             attrs = "JSPROP_ENUMERATE"
             if self.descriptor.operations['IndexedSetter'] is None:
                 attrs += " | JSPROP_READONLY"
             fillDescriptor = ("set_property_descriptor(\n"
-                              "    MutableHandle::from_raw(desc),\n"
+                              "    desc.reborrow(),\n"
                               "    rval.handle(),\n"
                               f"    ({attrs}) as u32,\n"
                               "    &mut *is_none\n"
@@ -6346,7 +6349,7 @@ class CGDOMJSProxyHandler_getOwnPropertyDescriptor(CGAbstractExternMethod):
                 'pre': 'rooted!(&in(cx) let mut rval = UndefinedValue());'
             }
             get += ("if let Some(index) = index {\n"
-                    "    let this = UnwrapProxy::<D>(proxy);\n"
+                    "    let this = UnwrapProxy::<D>(proxy.into());\n"
                     "    let this = &*this;\n"
                     f"{CGIndenter(CGProxyIndexedGetter(self.descriptor, templateValues)).define()}\n"
                     "}\n")
@@ -6362,7 +6365,7 @@ class CGDOMJSProxyHandler_getOwnPropertyDescriptor(CGAbstractExternMethod):
             else:
                 attrs = "0"
             fillDescriptor = ("set_property_descriptor(\n"
-                              "    MutableHandle::from_raw(desc),\n"
+                              "    desc,\n"
                               "    rval.handle(),\n"
                               f"    ({attrs}) as u32,\n"
                               "    &mut *is_none\n"
@@ -6384,7 +6387,7 @@ class CGDOMJSProxyHandler_getOwnPropertyDescriptor(CGAbstractExternMethod):
             namedGet = f"""
 if {condition} {{
     let mut has_on_proto = false;
-    if !has_property_on_prototype(cx.raw_cx(), proxy_lt, id_lt, &mut has_on_proto) {{
+    if !has_property_on_prototype(cx.raw_cx(), proxy, id, &mut has_on_proto) {{
         return false;
     }}
     if !has_on_proto {{
@@ -6397,13 +6400,11 @@ if {condition} {{
 
         return f"""{get}\
 rooted!(&in(cx) let mut expando = ptr::null_mut::<JSObject>());
-get_expando_object(proxy, expando.handle_mut());
+get_expando_object(proxy.into(), expando.handle_mut());
 //if (!xpc::WrapperFactory::IsXrayWrapper(proxy) && (expando = GetExpandoObject(proxy))) {{
-let proxy_lt = Handle::from_raw(proxy);
-let id_lt = Handle::from_raw(id);
 if !expando.is_null() {{
     rooted!(&in(cx) let mut ignored = ptr::null_mut::<JSObject>());
-    if !JS_GetPropertyDescriptorById(cx.raw_cx(), expando.handle().into(), id, desc, ignored.handle_mut().into(), is_none) {{
+    if !JS_GetPropertyDescriptorById(cx, expando.handle(), id, desc.reborrow(), ignored.handle_mut(), is_none) {{
         return false;
     }}
     if !*is_none {{
@@ -6430,32 +6431,33 @@ class CGDOMJSProxyHandler_defineProperty(CGAbstractExternMethod):
     def getBody(self) -> str:
         set = "let mut cx = JSContext::from_ptr(ptr::NonNull::new(cx).unwrap());\n"
         set += "let mut cx = CurrentRealm::assert(&mut cx);\n"
-        set += "let cx = &mut cx;\n"
-
+        set += "let cx = &mut cx;\n\n"
+        set += "let proxy = Handle::from_raw(proxy);\n"
+        set += "let id = Handle::from_raw(id);\n"
 
         if self.descriptor.isMaybeCrossOriginObject():
             set += dedent(
                 """
-                if !<D as DomHelpers<D>>::is_platform_object_same_origin(cx, proxy) {
-                    return proxyhandler::report_cross_origin_denial::<D>(cx, Handle::from_raw(id), "define");
+                if !<D as DomHelpers<D>>::is_platform_object_same_origin(cx, proxy.into()) {
+                    return proxyhandler::report_cross_origin_denial::<D>(cx, id, "define");
                 }
 
                 // Safe to enter the Realm of proxy now.
-                let mut cx = AutoRealm::new_from_handle(cx, Handle::from_raw(proxy));
+                let mut cx = AutoRealm::new_from_handle(cx, proxy);
                 let cx = &mut cx;
                 """)
 
         indexedSetter = self.descriptor.operations['IndexedSetter']
         if indexedSetter:
-            set += ("let index = get_array_index_from_id(Handle::from_raw(id));\n"
+            set += ("let index = get_array_index_from_id(id);\n"
                     "if let Some(index) = index {\n"
-                    "    let this = UnwrapProxy::<D>(proxy);\n"
+                    "    let this = UnwrapProxy::<D>(proxy.into());\n"
                     "    let this = &*this;\n"
                     f"{CGIndenter(CGProxyIndexedSetter(self.descriptor)).define()}"
                     "    return (*opresult).succeed();\n"
                     "}\n")
         elif self.descriptor.operations['IndexedGetter']:
-            set += ("if get_array_index_from_id(Handle::from_raw(id)).is_some() {\n"
+            set += ("if get_array_index_from_id(id).is_some() {\n"
                     "    return (*opresult).failNoIndexedSetter();\n"
                     "}\n")
 
@@ -6475,7 +6477,7 @@ class CGDOMJSProxyHandler_defineProperty(CGAbstractExternMethod):
                     "        return (*opresult).fail_no_named_setter();\n"
                     "    }\n"
                     "}\n")
-        set += f"return proxyhandler::define_property(cx.raw_cx(), {', '.join(a.name for a in self.args[1:])});"
+        set += f"return proxyhandler::define_property(cx.raw_cx(), proxy.into(), id.into(), desc, opresult);"
         return set
 
     def definition_body(self) -> CGThing:
@@ -6493,17 +6495,19 @@ class CGDOMJSProxyHandler_delete(CGAbstractExternMethod):
     def getBody(self) -> str:
         set = "let mut cx = JSContext::from_ptr(ptr::NonNull::new(cx).unwrap());\n"
         set += "let mut cx = CurrentRealm::assert(&mut cx);\n"
-        set += "let cx = &mut cx;\n"
+        set += "let cx = &mut cx;\n\n"
+        set += "let proxy = Handle::from_raw(proxy);\n"
+        set += "let id = Handle::from_raw(id);\n"
 
         if self.descriptor.isMaybeCrossOriginObject():
             set += dedent(
                 """
-                if !<D as DomHelpers<D>>::is_platform_object_same_origin(cx, proxy) {
-                    return proxyhandler::report_cross_origin_denial::<D>(cx, Handle::from_raw(id), "delete");
+                if !<D as DomHelpers<D>>::is_platform_object_same_origin(cx, proxy.into()) {
+                    return proxyhandler::report_cross_origin_denial::<D>(cx, id, "delete");
                 }
 
                 // Safe to enter the Realm of proxy now.
-                let mut cx = AutoRealm::new_from_handle(cx, Handle::from_raw(proxy));
+                let mut cx = AutoRealm::new_from_handle(cx, proxy);
                 let cx = &mut cx;
                 """)
 
@@ -6512,7 +6516,7 @@ class CGDOMJSProxyHandler_delete(CGAbstractExternMethod):
                 raise TypeError("Can't handle a deleter on an interface that has "
                                 "unforgeables. Figure out how that should work!")
             set += CGProxyNamedDeleter(self.descriptor).define()
-        set += f"return proxyhandler::delete(cx.raw_cx(), {', '.join(a.name for a in self.args[1:])});"
+        set += f"return proxyhandler::delete(cx.raw_cx(), proxy.into(), id.into(), res);"
         return set
 
     def definition_body(self) -> CGThing:
@@ -6608,26 +6612,30 @@ class CGDOMJSProxyHandler_hasOwn(CGAbstractExternMethod):
                          let mut cx = JSContext::from_ptr(ptr::NonNull::new(cx).unwrap());
                          let mut cx = CurrentRealm::assert(&mut cx);
                          let cx = &mut cx;
+
+                         let proxy = Handle::from_raw(proxy);
+                         let id = Handle::from_raw(id);
+
                          """)
 
         if self.descriptor.isMaybeCrossOriginObject():
             indexed += dedent(
                 """
-                if !<D as DomHelpers<D>>::is_platform_object_same_origin(cx, proxy) {
+                if !<D as DomHelpers<D>>::is_platform_object_same_origin(cx, proxy.into()) {
                     return proxyhandler::cross_origin_has_own(
-                        cx, proxy, CROSS_ORIGIN_PROPERTIES.get(), id, bp
+                        cx, proxy.into(), CROSS_ORIGIN_PROPERTIES.get(), id.into(), bp
                     );
                 }
 
                 // Safe to enter the Realm of proxy now.
-                let mut cx = AutoRealm::new_from_handle(cx, Handle::from_raw(proxy));
+                let mut cx = AutoRealm::new_from_handle(cx, proxy);
                 let cx = &mut cx;
                 """)
 
         if indexedGetter:
-            indexed += ("let index = get_array_index_from_id(Handle::from_raw(id));\n"
+            indexed += ("let index = get_array_index_from_id(id);\n"
                         "if let Some(index) = index {\n"
-                        "    let this = UnwrapProxy::<D>(proxy);\n"
+                        "    let this = UnwrapProxy::<D>(proxy.into());\n"
                         "    let this = &*this;\n"
                         f"{CGIndenter(CGProxyIndexedGetter(self.descriptor)).define()}\n"
                         "    *bp = result.is_some();\n"
@@ -6641,7 +6649,7 @@ class CGDOMJSProxyHandler_hasOwn(CGAbstractExternMethod):
             named = f"""
 if {condition} {{
     let mut has_on_proto = false;
-    if !has_property_on_prototype(cx.raw_cx(), proxy_lt, id_lt, &mut has_on_proto) {{
+    if !has_property_on_prototype(cx.raw_cx(), proxy, id, &mut has_on_proto) {{
         return false;
     }}
     if !has_on_proto {{
@@ -6657,11 +6665,9 @@ if {condition} {{
 
         return f"""{indexed}\
 rooted!(&in(cx) let mut expando = ptr::null_mut::<JSObject>());
-let proxy_lt = Handle::from_raw(proxy);
-let id_lt = Handle::from_raw(id);
-get_expando_object(proxy, expando.handle_mut());
+get_expando_object(proxy.into(), expando.handle_mut());
 if !expando.is_null() {{
-    let ok = JS_HasPropertyById(cx.raw_cx(), expando.handle().into(), id, bp);
+    let ok = JS_HasPropertyById(cx.raw_cx(), expando.handle().into(), id.into(), bp);
     if !ok || *bp {{
         return ok;
     }}
@@ -6687,27 +6693,27 @@ class CGDOMJSProxyHandler_get(CGAbstractExternMethod):
         if self.descriptor.isMaybeCrossOriginObject():
             maybeCrossOriginGet = dedent(
                 """
-                if !<D as DomHelpers<D>>::is_platform_object_same_origin(cx, proxy) {
-                    return proxyhandler::cross_origin_get::<D>(cx, proxy, receiver, id, vp);
+                if !<D as DomHelpers<D>>::is_platform_object_same_origin(cx, proxy.into()) {
+                    return proxyhandler::cross_origin_get::<D>(cx, proxy.into(), receiver, id.into(), vp);
                 }
 
                 // Safe to enter the Realm of proxy now.
-                let mut cx = AutoRealm::new_from_handle(cx, Handle::from_raw(proxy));
+                let mut cx = AutoRealm::new_from_handle(cx, proxy);
                 let cx = &mut cx;
                 """)
         else:
             maybeCrossOriginGet = ""
         getFromExpando = """\
 rooted!(&in(cx) let mut expando = ptr::null_mut::<JSObject>());
-get_expando_object(proxy, expando.handle_mut());
+get_expando_object(proxy.into(), expando.handle_mut());
 if !expando.is_null() {
     let mut hasProp = false;
-    if !JS_HasPropertyById(cx.raw_cx(), expando.handle().into(), id, &mut hasProp) {
+    if !JS_HasPropertyById(cx.raw_cx(), expando.handle().into(), id.into(), &mut hasProp) {
         return false;
     }
 
     if hasProp {
-        return JS_ForwardGetPropertyTo(cx.raw_cx(), expando.handle().into(), id, receiver, vp);
+        return JS_ForwardGetPropertyTo(cx.raw_cx(), expando.handle().into(), id.into(), receiver, vp);
     }
 }"""
 
@@ -6718,9 +6724,9 @@ if !expando.is_null() {
 
         indexedGetter = self.descriptor.operations['IndexedGetter']
         if indexedGetter:
-            getIndexedOrExpando = ("let index = get_array_index_from_id(id_lt);\n"
+            getIndexedOrExpando = ("let index = get_array_index_from_id(id);\n"
                                    "if let Some(index) = index {\n"
-                                   "    let this = UnwrapProxy::<D>(proxy);\n"
+                                   "    let this = UnwrapProxy::<D>(proxy.into());\n"
                                    "    let this = &*this;\n"
                                    f"{CGIndenter(CGProxyIndexedGetter(self.descriptor, templateValues)).define()}")
             trimmedGetFromExpando = stripTrailingWhitespace(getFromExpando.replace('\n', '\n    '))
@@ -6754,16 +6760,17 @@ let mut cx = JSContext::from_ptr(ptr::NonNull::new(cx).unwrap());
 let mut cx = CurrentRealm::assert(&mut cx);
 let cx = &mut cx;
 
+let proxy = Handle::from_raw(proxy);
+let id = Handle::from_raw(id);
+
 {maybeCrossOriginGet}
 
-let proxy_lt = Handle::from_raw(proxy);
 let mut vp_lt = MutableHandle::from_raw(vp);
-let id_lt = Handle::from_raw(id);
 let receiver_lt = Handle::from_raw(receiver);
 
 {getIndexedOrExpando}
 let mut found = false;
-if !get_property_on_prototype(cx.raw_cx(), proxy_lt, receiver_lt, id_lt, &mut found, vp_lt.reborrow()) {{
+if !get_property_on_prototype(cx.raw_cx(), proxy, receiver_lt, id, &mut found, vp_lt.reborrow()) {{
     return false;
 }}
 
@@ -6791,7 +6798,10 @@ class CGDOMJSProxyHandler_getPrototype(CGAbstractExternMethod):
             """
             let mut cx = JSContext::from_ptr(ptr::NonNull::new(cx).unwrap());
             let mut realm = CurrentRealm::assert(&mut cx);
-            proxyhandler::maybe_cross_origin_get_prototype::<D>(&mut realm, proxy, GetProtoObject::<D>, proto)
+
+            let proxy = Handle::from_raw(proxy);
+            let proto = MutableHandleObject::from_raw(proto);
+            proxyhandler::maybe_cross_origin_get_prototype::<D>(&mut realm, proxy.into(), GetProtoObject::<D>, proto.into())
             """)
 
     def definition_body(self) -> CGThing:

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -6477,7 +6477,7 @@ class CGDOMJSProxyHandler_defineProperty(CGAbstractExternMethod):
                     "        return (*opresult).fail_no_named_setter();\n"
                     "    }\n"
                     "}\n")
-        set += f"return proxyhandler::define_property(cx, proxy, id, desc, opresult);"
+        set += "return proxyhandler::define_property(cx, proxy, id, desc, opresult);"
         return set
 
     def definition_body(self) -> CGThing:
@@ -6516,7 +6516,7 @@ class CGDOMJSProxyHandler_delete(CGAbstractExternMethod):
                 raise TypeError("Can't handle a deleter on an interface that has "
                                 "unforgeables. Figure out how that should work!")
             set += CGProxyNamedDeleter(self.descriptor).define()
-        set += f"return proxyhandler::delete(cx, proxy, id, res);"
+        set += "return proxyhandler::delete(cx, proxy, id, res);"
         return set
 
     def definition_body(self) -> CGThing:

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -4034,12 +4034,12 @@ class CGDefineProxyHandler(CGAbstractMethod):
         return CGAbstractMethod.define(self)
 
     def definition_body(self) -> CGThing:
-        customDefineProperty = 'proxyhandler::define_property'
+        customDefineProperty = 'proxyhandler::define_property_raw'
         if self.descriptor.isMaybeCrossOriginObject() or self.descriptor.operations['IndexedSetter'] or \
            self.descriptor.operations['NamedSetter']:
             customDefineProperty = 'defineProperty::<D>'
 
-        customDelete = 'proxyhandler::delete'
+        customDelete = 'proxyhandler::delete_raw'
         if self.descriptor.isMaybeCrossOriginObject() or self.descriptor.operations['NamedDeleter']:
             customDelete = 'delete::<D>'
 
@@ -6400,7 +6400,7 @@ if {condition} {{
 
         return f"""{get}\
 rooted!(&in(cx) let mut expando = ptr::null_mut::<JSObject>());
-get_expando_object(proxy.into(), expando.handle_mut());
+get_expando_object(proxy, expando.handle_mut());
 //if (!xpc::WrapperFactory::IsXrayWrapper(proxy) && (expando = GetExpandoObject(proxy))) {{
 if !expando.is_null() {{
     rooted!(&in(cx) let mut ignored = ptr::null_mut::<JSObject>());
@@ -6477,7 +6477,7 @@ class CGDOMJSProxyHandler_defineProperty(CGAbstractExternMethod):
                     "        return (*opresult).fail_no_named_setter();\n"
                     "    }\n"
                     "}\n")
-        set += f"return proxyhandler::define_property(cx.raw_cx(), proxy.into(), id.into(), desc, opresult);"
+        set += f"return proxyhandler::define_property(cx, proxy, id, desc, opresult);"
         return set
 
     def definition_body(self) -> CGThing:
@@ -6516,7 +6516,7 @@ class CGDOMJSProxyHandler_delete(CGAbstractExternMethod):
                 raise TypeError("Can't handle a deleter on an interface that has "
                                 "unforgeables. Figure out how that should work!")
             set += CGProxyNamedDeleter(self.descriptor).define()
-        set += f"return proxyhandler::delete(cx.raw_cx(), proxy.into(), id.into(), res);"
+        set += f"return proxyhandler::delete(cx, proxy, id, res);"
         return set
 
     def definition_body(self) -> CGThing:
@@ -6623,7 +6623,7 @@ class CGDOMJSProxyHandler_hasOwn(CGAbstractExternMethod):
                 """
                 if !<D as DomHelpers<D>>::is_platform_object_same_origin(cx, proxy.into()) {
                     return proxyhandler::cross_origin_has_own(
-                        cx, proxy.into(), CROSS_ORIGIN_PROPERTIES.get(), id.into(), bp
+                        cx, proxy, CROSS_ORIGIN_PROPERTIES.get(), id, bp
                     );
                 }
 
@@ -6665,7 +6665,7 @@ if {condition} {{
 
         return f"""{indexed}\
 rooted!(&in(cx) let mut expando = ptr::null_mut::<JSObject>());
-get_expando_object(proxy.into(), expando.handle_mut());
+get_expando_object(proxy, expando.handle_mut());
 if !expando.is_null() {{
     let ok = JS_HasPropertyById(cx.raw_cx(), expando.handle().into(), id.into(), bp);
     if !ok || *bp {{
@@ -6694,7 +6694,7 @@ class CGDOMJSProxyHandler_get(CGAbstractExternMethod):
             maybeCrossOriginGet = dedent(
                 """
                 if !<D as DomHelpers<D>>::is_platform_object_same_origin(cx, proxy.into()) {
-                    return proxyhandler::cross_origin_get::<D>(cx, proxy.into(), receiver, id.into(), vp);
+                    return proxyhandler::cross_origin_get::<D>(cx, proxy, receiver, id, vp);
                 }
 
                 // Safe to enter the Realm of proxy now.
@@ -6705,7 +6705,7 @@ class CGDOMJSProxyHandler_get(CGAbstractExternMethod):
             maybeCrossOriginGet = ""
         getFromExpando = """\
 rooted!(&in(cx) let mut expando = ptr::null_mut::<JSObject>());
-get_expando_object(proxy.into(), expando.handle_mut());
+get_expando_object(proxy, expando.handle_mut());
 if !expando.is_null() {
     let mut hasProp = false;
     if !JS_HasPropertyById(cx.raw_cx(), expando.handle().into(), id.into(), &mut hasProp) {
@@ -6801,7 +6801,7 @@ class CGDOMJSProxyHandler_getPrototype(CGAbstractExternMethod):
 
             let proxy = Handle::from_raw(proxy);
             let proto = MutableHandleObject::from_raw(proto);
-            proxyhandler::maybe_cross_origin_get_prototype::<D>(&mut realm, proxy.into(), GetProtoObject::<D>, proto.into())
+            proxyhandler::maybe_cross_origin_get_prototype::<D>(&mut realm, proxy, GetProtoObject::<D>, proto)
             """)
 
     def definition_body(self) -> CGThing:

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -3311,7 +3311,7 @@ def CopyLegacyUnforgeablePropertiesToInstance(descriptor: Descriptor) -> str:
     if descriptor.proxy:
         copyCode += """\
 rooted!(&in(cx) let mut expando = ptr::null_mut::<JSObject>());
-ensure_expando_object(cx.raw_cx(), obj.handle().into(), expando.handle_mut());
+ensure_expando_object(cx, obj.handle(), expando.handle_mut());
 """
         obj = "expando"
     else:

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -4034,12 +4034,12 @@ class CGDefineProxyHandler(CGAbstractMethod):
         return CGAbstractMethod.define(self)
 
     def definition_body(self) -> CGThing:
-        customDefineProperty = 'proxyhandler::define_property_raw'
+        customDefineProperty = 'proxyhandler::define_property'
         if self.descriptor.isMaybeCrossOriginObject() or self.descriptor.operations['IndexedSetter'] or \
            self.descriptor.operations['NamedSetter']:
             customDefineProperty = 'defineProperty::<D>'
 
-        customDelete = 'proxyhandler::delete_raw'
+        customDelete = 'proxyhandler::delete'
         if self.descriptor.isMaybeCrossOriginObject() or self.descriptor.operations['NamedDeleter']:
             customDelete = 'delete::<D>'
 
@@ -6477,7 +6477,7 @@ class CGDOMJSProxyHandler_defineProperty(CGAbstractExternMethod):
                     "        return (*opresult).fail_no_named_setter();\n"
                     "    }\n"
                     "}\n")
-        set += "return proxyhandler::define_property(cx, proxy, id, desc, opresult);"
+        set += "return proxyhandler::define_property(cx.raw_cx(), proxy.into(), id.into(), desc, opresult);"
         return set
 
     def definition_body(self) -> CGThing:
@@ -6516,7 +6516,7 @@ class CGDOMJSProxyHandler_delete(CGAbstractExternMethod):
                 raise TypeError("Can't handle a deleter on an interface that has "
                                 "unforgeables. Figure out how that should work!")
             set += CGProxyNamedDeleter(self.descriptor).define()
-        set += "return proxyhandler::delete(cx, proxy, id, res);"
+        set += "return proxyhandler::delete(cx.raw_cx(), proxy.into(), id.into(), res);"
         return set
 
     def definition_body(self) -> CGThing:

--- a/components/script_bindings/import.rs
+++ b/components/script_bindings/import.rs
@@ -59,13 +59,13 @@ pub(crate) mod module {
     pub(crate) use js::jsapi::{
         __BindgenBitfieldUnit, CallArgs, GCContext, GetRealmFunctionPrototype, GetWellKnownSymbol,
         Handle as RawHandle, HandleId as RawHandleId, HandleObject as RawHandleObject,
-        JS_ForwardGetPropertyTo, JS_GetPropertyDescriptorById, JS_HasPropertyById,
-        JS_NewPlainObject, JS_SetReservedSlot, JSAutoRealm, JSCLASS_FOREGROUND_FINALIZE,
-        JSCLASS_RESERVED_SLOTS_SHIFT, JSClass, JSClassOps, JSFunctionSpec, JSJitGetterCallArgs,
-        JSJitInfo, JSJitInfo__bindgen_ty_1, JSJitInfo__bindgen_ty_2, JSJitInfo__bindgen_ty_3,
-        JSJitInfo_AliasSet, JSJitInfo_ArgType, JSJitInfo_OpType, JSJitMethodCallArgs,
-        JSJitSetterCallArgs, JSNativeWrapper, JSPROP_ENUMERATE, JSPROP_PERMANENT, JSPROP_READONLY,
-        JSPropertySpec, JSPropertySpec_Accessor, JSPropertySpec_AccessorsOrValue,
+        JS_ForwardGetPropertyTo, JS_HasPropertyById, JS_NewPlainObject, JS_SetReservedSlot,
+        JSAutoRealm, JSCLASS_FOREGROUND_FINALIZE, JSCLASS_RESERVED_SLOTS_SHIFT, JSClass,
+        JSClassOps, JSFunctionSpec, JSJitGetterCallArgs, JSJitInfo, JSJitInfo__bindgen_ty_1,
+        JSJitInfo__bindgen_ty_2, JSJitInfo__bindgen_ty_3, JSJitInfo_AliasSet, JSJitInfo_ArgType,
+        JSJitInfo_OpType, JSJitMethodCallArgs, JSJitSetterCallArgs, JSNativeWrapper,
+        JSPROP_ENUMERATE, JSPROP_PERMANENT, JSPROP_READONLY, JSPropertySpec,
+        JSPropertySpec_Accessor, JSPropertySpec_AccessorsOrValue,
         JSPropertySpec_AccessorsOrValue_Accessors, JSPropertySpec_Kind, JSPropertySpec_Name,
         JSPropertySpec_ValueWrapper, JSPropertySpec_ValueWrapper__bindgen_ty_1,
         JSPropertySpec_ValueWrapper_Type, JSTracer, JSTypedMethodJitInfo, JSValueType,
@@ -79,6 +79,7 @@ pub(crate) mod module {
         JS_GetProperty, JS_NewObjectWithoutMetadata, JS_SetImmutablePrototype, JS_SetProperty,
         JS_SetPrototype, RUST_SYMBOL_TO_JSID,
     };
+    pub(crate) use js::rust::wrappers2::JS_GetPropertyDescriptorById;
     pub(crate) use js::rust::{CustomAutoRooterGuard, GCMethods, Handle, MutableHandle};
     pub(crate) use js::{
         JS_CALLEE, JSCLASS_GLOBAL_SLOT_COUNT, JSCLASS_IS_DOMJSCLASS, JSCLASS_IS_GLOBAL,

--- a/components/script_bindings/proxyhandler.rs
+++ b/components/script_bindings/proxyhandler.rs
@@ -54,6 +54,8 @@ pub(crate) unsafe extern "C" fn shadow_check_callback(
     id: RawHandleId,
 ) -> DOMProxyShadowsResult {
     // TODO: support OverrideBuiltins when #12978 is fixed.
+
+    // SAFETY: it is safe to construct a JSContext from engine hook.
     let mut cx = JSContext::from_ptr(NonNull::new(cx).unwrap());
     let cx = &mut cx;
 

--- a/components/script_bindings/proxyhandler.rs
+++ b/components/script_bindings/proxyhandler.rs
@@ -10,13 +10,14 @@ use std::os::raw::c_char;
 use std::ptr;
 use std::ptr::NonNull;
 
+use js::context::{JSContext, RawJSContext};
 use js::conversions::{ToJSValConvertible, jsstr_to_string};
 use js::glue::{GetProxyHandler, GetProxyHandlerFamily, GetProxyPrivate, SetProxyPrivate};
 use js::jsapi::{
     DOMProxyShadowsResult, GetStaticPrototype, Handle as RawHandle, HandleId as RawHandleId,
     HandleObject as RawHandleObject, HandleValue as RawHandleValue, HandleValueArray,
-    IsWindowProxy, JSContext, JSErrNum, JSFunctionSpec, JSITER_HIDDEN, JSITER_OWNONLY,
-    JSITER_SYMBOLS, JSObject, JSPROP_READONLY, JSPropertySpec, JSString,
+    IsWindowProxy, JSErrNum, JSFunctionSpec, JSITER_HIDDEN, JSITER_OWNONLY, JSITER_SYMBOLS,
+    JSObject, JSPROP_READONLY, JSPropertySpec, JSString,
     MutableHandleIdVector as RawMutableHandleIdVector,
     MutableHandleObject as RawMutableHandleObject, MutableHandleValue as RawMutableHandleValue,
     ObjectOpResult, PropertyDescriptor, SetDOMProxyInformation, SymbolCode, jsid,
@@ -41,7 +42,6 @@ use crate::conversions::{is_dom_proxy, jsid_to_string, native_from_object};
 use crate::error::Error;
 use crate::interfaces::{DomHelpers, GlobalScopeHelpers};
 use crate::reflector::DomObject;
-use crate::script_runtime::JSContext as SafeJSContext;
 use crate::str::DOMString;
 
 /// Determine if this id shadows any existing properties for this proxy.
@@ -49,12 +49,12 @@ use crate::str::DOMString;
 /// # Safety
 /// `cx` must point to a valid, non-null JSContext.
 pub(crate) unsafe extern "C" fn shadow_check_callback(
-    cx: *mut JSContext,
+    cx: *mut RawJSContext,
     object: RawHandleObject,
     id: RawHandleId,
 ) -> DOMProxyShadowsResult {
     // TODO: support OverrideBuiltins when #12978 is fixed.
-    let mut cx = js::context::JSContext::from_ptr(NonNull::new(cx).unwrap());
+    let mut cx = JSContext::from_ptr(NonNull::new(cx).unwrap());
     let cx = &mut cx;
 
     let object = HandleObject::from_raw(object);
@@ -94,13 +94,14 @@ pub fn init() {
 /// `cx` must point to a valid, non-null JSContext.
 /// `result` must point to a valid, non-null ObjectOpResult.
 pub(crate) unsafe extern "C" fn define_property_raw(
-    cx: *mut JSContext,
+    cx: *mut RawJSContext,
     proxy: RawHandleObject,
     id: RawHandleId,
     desc: RawHandle<PropertyDescriptor>,
     result: *mut ObjectOpResult,
 ) -> bool {
-    let mut cx = js::context::JSContext::from_ptr(NonNull::new(cx).unwrap());
+    // SAFETY: it is safe to construct a JSContext from engine hook.
+    let mut cx = JSContext::from_ptr(NonNull::new(cx).unwrap());
     let cx = &mut cx;
     define_property(
         cx,
@@ -114,7 +115,7 @@ pub(crate) unsafe extern "C" fn define_property_raw(
 /// # Safety
 /// `result` must point to a valid, non-null ObjectOpResult.
 pub(crate) unsafe fn define_property(
-    cx: &mut js::context::JSContext,
+    cx: &mut JSContext,
     proxy: HandleObject,
     id: HandleId,
     desc: RawHandle<PropertyDescriptor>,
@@ -131,12 +132,13 @@ pub(crate) unsafe fn define_property(
 /// `cx` must point to a valid, non-null JSContext.
 /// `bp` must point to a valid, non-null ObjectOpResult.
 pub(crate) unsafe extern "C" fn delete_raw(
-    cx: *mut JSContext,
+    cx: *mut RawJSContext,
     proxy: RawHandleObject,
     id: RawHandleId,
     bp: *mut ObjectOpResult,
 ) -> bool {
-    let mut cx = js::context::JSContext::from_ptr(NonNull::new(cx).unwrap());
+    // SAFETY: it is safe to construct a JSContext from engine hook.
+    let mut cx = JSContext::from_ptr(NonNull::new(cx).unwrap());
     let cx = &mut cx;
     delete(cx, Handle::from_raw(proxy), Handle::from_raw(id), bp)
 }
@@ -144,7 +146,7 @@ pub(crate) unsafe extern "C" fn delete_raw(
 /// # Safety
 /// `result` must point to a valid, non-null ObjectOpResult.
 pub(crate) unsafe fn delete(
-    cx: &mut js::context::JSContext,
+    cx: &mut JSContext,
     proxy: HandleObject,
     id: HandleId,
     bp: *mut ObjectOpResult,
@@ -164,7 +166,7 @@ pub(crate) unsafe fn delete(
 /// # Safety
 /// `result` must point to a valid, non-null ObjectOpResult.
 pub(crate) unsafe extern "C" fn prevent_extensions(
-    _cx: *mut JSContext,
+    _cx: *mut RawJSContext,
     _proxy: RawHandleObject,
     result: *mut ObjectOpResult,
 ) -> bool {
@@ -177,7 +179,7 @@ pub(crate) unsafe extern "C" fn prevent_extensions(
 /// # Safety
 /// `succeeded` must point to a valid, non-null bool.
 pub(crate) unsafe extern "C" fn is_extensible(
-    _cx: *mut JSContext,
+    _cx: *mut RawJSContext,
     _proxy: RawHandleObject,
     succeeded: *mut bool,
 ) -> bool {
@@ -198,7 +200,7 @@ pub(crate) unsafe extern "C" fn is_extensible(
 /// # Safety
 /// `is_ordinary` must point to a valid, non-null bool.
 pub(crate) unsafe extern "C" fn get_prototype_if_ordinary(
-    _: *mut JSContext,
+    _: *mut RawJSContext,
     proxy: RawHandleObject,
     is_ordinary: *mut bool,
     proto: RawMutableHandleObject,
@@ -225,7 +227,7 @@ pub(crate) fn get_expando_object(obj: HandleObject, mut expando: MutableHandleOb
 /// Get the expando object, or create it if it doesn't exist yet.
 /// Fails on JSAPI failure.
 pub(crate) fn ensure_expando_object(
-    cx: &mut js::context::JSContext,
+    cx: &mut JSContext,
     obj: HandleObject,
     mut expando: MutableHandleObject,
 ) {
@@ -259,7 +261,7 @@ pub fn set_property_descriptor(
     *is_none = false;
 }
 
-fn id_to_source(cx: &mut js::context::JSContext, id: HandleId) -> Option<DOMString> {
+fn id_to_source(cx: &mut JSContext, id: HandleId) -> Option<DOMString> {
     unsafe {
         if RUST_JSID_IS_VOID(id) {
             return None;
@@ -301,7 +303,7 @@ impl CrossOriginProperties {
 ///
 /// [`CrossOriginOwnPropertyKeys`]: https://html.spec.whatwg.org/multipage/#crossoriginownpropertykeys-(-o-)
 fn cross_origin_own_property_keys(
-    cx: &mut js::context::JSContext,
+    cx: &mut JSContext,
     _proxy: HandleObject,
     cross_origin_properties: &'static CrossOriginProperties,
     props: RawMutableHandleIdVector,
@@ -327,7 +329,7 @@ fn cross_origin_own_property_keys(
 /// # Safety
 /// `is_ordinary` must point to a valid, non-null bool.
 pub(crate) unsafe extern "C" fn maybe_cross_origin_get_prototype_if_ordinary_rawcx(
-    _: *mut JSContext,
+    _: *mut RawJSContext,
     _proxy: RawHandleObject,
     is_ordinary: *mut bool,
     _proto: RawMutableHandleObject,
@@ -345,12 +347,13 @@ pub(crate) unsafe extern "C" fn maybe_cross_origin_get_prototype_if_ordinary_raw
 /// # Safety
 /// `result` must point to a valid, non-null ObjectOpResult.
 pub(crate) unsafe extern "C" fn maybe_cross_origin_set_prototype_rawcx(
-    cx: *mut JSContext,
+    cx: *mut RawJSContext,
     proxy: RawHandleObject,
     proto: RawHandleObject,
     result: *mut ObjectOpResult,
 ) -> bool {
-    let mut cx = js::context::JSContext::from_ptr(NonNull::new(cx).unwrap());
+    // SAFETY: it is safe to construct a JSContext from engine hook.
+    let mut cx = JSContext::from_ptr(NonNull::new(cx).unwrap());
     let cx = &mut cx;
     // > 1. Return `! SetImmutablePrototype(this, V)`.
     //
@@ -406,7 +409,7 @@ fn is_data_descriptor(d: &PropertyDescriptor) -> bool {
 /// # Safety
 /// `bp` must point to a valid, non-null bool.
 pub(crate) unsafe fn cross_origin_has_own(
-    cx: &mut js::realm::CurrentRealm,
+    cx: &mut CurrentRealm,
     _proxy: HandleObject,
     cross_origin_properties: &'static CrossOriginProperties,
     id: HandleId,
@@ -451,7 +454,7 @@ const ALLOWLISTED_SYMBOL_CODES: &[SymbolCode] = &[
     SymbolCode::isConcatSpreadable,
 ];
 
-fn is_cross_origin_allowlisted_prop(cx: &mut js::context::JSContext, id: HandleId) -> bool {
+fn is_cross_origin_allowlisted_prop(cx: &mut JSContext, id: HandleId) -> bool {
     unsafe {
         if jsid_to_string(cx, id).is_some_and(|st| st == "then") {
             return true;
@@ -471,10 +474,7 @@ fn is_cross_origin_allowlisted_prop(cx: &mut js::context::JSContext, id: HandleI
 /// `props`. This is used to implement [`CrossOriginOwnPropertyKeys`].
 ///
 /// [`CrossOriginOwnPropertyKeys`]: https://html.spec.whatwg.org/multipage/#crossoriginownpropertykeys-(-o-)
-fn append_cross_origin_allowlisted_prop_keys(
-    cx: &mut js::context::JSContext,
-    props: RawMutableHandleIdVector,
-) {
+fn append_cross_origin_allowlisted_prop_keys(cx: &mut JSContext, props: RawMutableHandleIdVector) {
     unsafe {
         rooted!(&in(cx) let mut id: jsid);
 
@@ -547,11 +547,11 @@ fn ensure_cross_origin_property_holder(
 /// IDL operations on a cross-origin object involve [a security check][1].
 ///
 /// [1]: https://html.spec.whatwg.org/multipage/#integration-with-idl
-pub(crate) fn is_cross_origin_object<D: DomTypes>(cx: SafeJSContext, obj: RawHandleObject) -> bool {
+pub(crate) fn is_cross_origin_object<D: DomTypes>(cx: &mut JSContext, obj: HandleObject) -> bool {
     unsafe {
         IsWindowProxy(*obj) ||
-            native_from_object::<D::Location>(*obj, *cx).is_ok() ||
-            native_from_object::<D::DissimilarOriginLocation>(*obj, *cx).is_ok()
+            native_from_object::<D::Location>(*obj, cx.raw_cx()).is_ok() ||
+            native_from_object::<D::DissimilarOriginLocation>(*obj, cx.raw_cx()).is_ok()
     }
 }
 
@@ -589,7 +589,7 @@ pub(crate) fn report_cross_origin_denial<D: DomTypes>(
 ///
 /// [`Location`]: https://html.spec.whatwg.org/multipage/#location-set
 pub(crate) unsafe extern "C" fn maybe_cross_origin_set_rawcx<D: DomTypes>(
-    cx: *mut JSContext,
+    cx: *mut RawJSContext,
     proxy: RawHandleObject,
     id: RawHandleId,
     v: RawHandleValue,
@@ -597,8 +597,9 @@ pub(crate) unsafe extern "C" fn maybe_cross_origin_set_rawcx<D: DomTypes>(
     result: *mut ObjectOpResult,
 ) -> bool {
     unsafe {
-        let mut cx = js::context::JSContext::from_ptr(NonNull::new(cx).unwrap());
-        let mut realm = js::realm::CurrentRealm::assert(&mut cx);
+        // SAFETY: it is safe to construct a JSContext from engine hook.
+        let mut cx = JSContext::from_ptr(NonNull::new(cx).unwrap());
+        let mut realm = CurrentRealm::assert(&mut cx);
         let proxy = HandleObject::from_raw(proxy);
         let id = Handle::from_raw(id);
         let v = Handle::from_raw(v);
@@ -609,7 +610,7 @@ pub(crate) unsafe extern "C" fn maybe_cross_origin_set_rawcx<D: DomTypes>(
         }
 
         // Safe to enter the Realm of proxy now.
-        let mut realm = js::realm::AutoRealm::new_from_handle(&mut realm, proxy);
+        let mut realm = AutoRealm::new_from_handle(&mut realm, proxy);
 
         // OrdinarySet
         // <https://tc39.es/ecma262/#sec-ordinaryset>
@@ -648,11 +649,7 @@ pub(crate) unsafe extern "C" fn maybe_cross_origin_set_rawcx<D: DomTypes>(
 pub(crate) fn maybe_cross_origin_get_prototype<D: DomTypes>(
     cx: &mut CurrentRealm,
     proxy: HandleObject,
-    get_proto_object: fn(
-        cx: &mut js::context::JSContext,
-        global: HandleObject,
-        rval: MutableHandleObject,
-    ),
+    get_proto_object: fn(cx: &mut JSContext, global: HandleObject, rval: MutableHandleObject),
     mut proto: MutableHandleObject,
 ) -> bool {
     // > 1. If ! IsPlatformObjectSameOrigin(this) is true, then return ! OrdinaryGetPrototypeOf(this).
@@ -860,11 +857,10 @@ pub(crate) struct JSProxyHandlerOwnPropertyKeysConfig<T>
 where
     T: DomObject,
 {
-    pub(crate) indexed_getter_and_length: Option<fn(&T, &mut js::context::JSContext) -> u32>,
+    pub(crate) indexed_getter_and_length: Option<fn(&T, &mut JSContext) -> u32>,
     pub(crate) cross_origin: Option<&'static CrossOriginProperties>,
     pub(crate) unwrapped_proxy: unsafe fn(RawHandleObject) -> *const T,
-    pub(crate) supported_named_properties:
-        Option<fn(*const T, &mut js::context::JSContext) -> Vec<DOMString>>,
+    pub(crate) supported_named_properties: Option<fn(*const T, &mut JSContext) -> Vec<DOMString>>,
 }
 
 /// Helper type to keep AutoRealm and &mut CurrentRealm alive with Deref to JSContext
@@ -874,7 +870,7 @@ enum Realm<'a> {
 }
 
 impl<'cx> Deref for Realm<'cx> {
-    type Target = js::context::JSContext;
+    type Target = JSContext;
 
     fn deref(&'_ self) -> &'_ Self::Target {
         match self {
@@ -897,7 +893,7 @@ impl<'cx> DerefMut for Realm<'cx> {
 /// SAFETY: cx must point to a valid, non-null JS context.
 pub(crate) unsafe fn JSProxyHandlerOwnPropertyKeys<D, T>(
     config: JSProxyHandlerOwnPropertyKeysConfig<T>,
-    cx: *mut js::jsapi::JSContext,
+    cx: *mut RawJSContext,
     proxy: RawHandleObject,
     props: RawMutableHandleIdVector,
 ) -> bool
@@ -906,7 +902,8 @@ where
     T: DomObject,
 {
     unsafe {
-        let mut cx = js::context::JSContext::from_ptr(ptr::NonNull::new(cx).unwrap());
+        // SAFETY: it is safe to construct a JSContext from engine hook.
+        let mut cx = JSContext::from_ptr(ptr::NonNull::new(cx).unwrap());
         let mut cx = CurrentRealm::assert(&mut cx);
         let current_realm = &mut cx;
         let unwrapped_proxy = (config.unwrapped_proxy)(proxy);
@@ -976,15 +973,14 @@ where
 pub(crate) struct JSProxyHandlerOwnEnumerablePropertyKeysConfig<T: DomObject> {
     pub(crate) unwrapped_proxy: unsafe fn(RawHandleObject) -> *const T,
     #[expect(clippy::type_complexity)]
-    pub(crate) indexed_getter_and_length:
-        Option<Box<dyn Fn(&T, &mut js::context::JSContext) -> u32>>,
+    pub(crate) indexed_getter_and_length: Option<Box<dyn Fn(&T, &mut JSContext) -> u32>>,
     pub(crate) cross_origin: bool,
 }
 
 #[expect(non_snake_case)]
 pub(crate) fn JSProxyHandlerGetOwnEnumerablePropertyKeys<T, D>(
     config: JSProxyHandlerOwnEnumerablePropertyKeysConfig<T>,
-    cx: *mut js::jsapi::JSContext,
+    cx: *mut RawJSContext,
     proxy: RawHandleObject,
     props: RawMutableHandleIdVector,
 ) -> bool
@@ -993,7 +989,8 @@ where
     T: DomObject,
 {
     unsafe {
-        let mut cx = js::context::JSContext::from_ptr(ptr::NonNull::new(cx).unwrap());
+        // SAFETY: it is safe to construct a JSContext from engine hook.
+        let mut cx = JSContext::from_ptr(ptr::NonNull::new(cx).unwrap());
         let unwrapped_proxy = (config.unwrapped_proxy)(proxy);
         let mut cx = CurrentRealm::assert(&mut cx);
         let current_realm = &mut cx;

--- a/components/script_bindings/proxyhandler.rs
+++ b/components/script_bindings/proxyhandler.rs
@@ -14,8 +14,9 @@ use js::conversions::{ToJSValConvertible, jsstr_to_string};
 use js::glue::{GetProxyHandler, GetProxyHandlerFamily, GetProxyPrivate, SetProxyPrivate};
 use js::jsapi::{
     DOMProxyShadowsResult, GetStaticPrototype, Handle as RawHandle, HandleId as RawHandleId,
-    HandleObject as RawHandleObject, HandleValue as RawHandleValue, JSContext, JSErrNum,
-    JSFunctionSpec, JSITER_HIDDEN, JSITER_OWNONLY, JSITER_SYMBOLS, JSObject, JSPropertySpec,
+    HandleObject as RawHandleObject, HandleValue as RawHandleValue, HandleValueArray,
+    IsWindowProxy, JSContext, JSErrNum, JSFunctionSpec, JSITER_HIDDEN, JSITER_OWNONLY,
+    JSITER_SYMBOLS, JSObject, JSPROP_READONLY, JSPropertySpec, JSString,
     MutableHandleIdVector as RawMutableHandleIdVector,
     MutableHandleObject as RawMutableHandleObject, MutableHandleValue as RawMutableHandleValue,
     ObjectOpResult, PropertyDescriptor, SetDOMProxyInformation, SymbolCode, jsid,
@@ -24,16 +25,16 @@ use js::jsid::SymbolId;
 use js::jsval::{ObjectValue, UndefinedValue};
 use js::realm::{AutoRealm, CurrentRealm};
 use js::rust::wrappers2::{
-    AppendToIdVector, GetObjectProto, GetPropertyKeys, GetWellKnownSymbol,
-    JS_AlreadyHasOwnPropertyById, JS_AtomizeAndPinString, JS_DefineFunctions, JS_DefineProperties,
-    JS_DefinePropertyById, JS_DeletePropertyById, JS_IdToValue, JS_IsExceptionPending,
+    AppendToIdVector, Call, GetObjectProto, GetPropertyKeys, GetWellKnownSymbol,
+    InvokeGetOwnPropertyDescriptor, JS_AlreadyHasOwnPropertyById, JS_AtomizeAndPinString,
+    JS_DefineFunctions, JS_DefineProperties, JS_DefinePropertyById, JS_DeletePropertyById,
+    JS_GetOwnPropertyDescriptorById, JS_IdToValue, JS_IsExceptionPending,
     JS_NewObjectWithGivenProto, JS_ValueToSource, RUST_INTERNED_STRING_TO_JSID, RUST_JSID_IS_VOID,
-    SetDataPropertyDescriptor, int_to_jsid,
+    SetDataPropertyDescriptor, SetPropertyIgnoringNamedGetter, int_to_jsid,
 };
 use js::rust::{
     Handle, HandleId, HandleObject, HandleValue, IntoHandle, MutableHandle, MutableHandleObject,
 };
-use js::{jsapi, rooted};
 
 use crate::DomTypes;
 use crate::conversions::{is_dom_proxy, jsid_to_string, native_from_object};
@@ -264,13 +265,13 @@ fn id_to_source(cx: &mut js::context::JSContext, id: HandleId) -> Option<DOMStri
             return None;
         }
         rooted!(&in(cx) let mut value = UndefinedValue());
-        rooted!(&in(cx) let mut jsstr = ptr::null_mut::<jsapi::JSString>());
+        rooted!(&in(cx) let mut jsstr = ptr::null_mut::<JSString>());
         JS_IdToValue(cx, id.get(), value.handle_mut())
             .then(|| {
                 jsstr.set(JS_ValueToSource(cx, value.handle()));
                 jsstr.get()
             })
-            .and_then(ptr::NonNull::new)
+            .and_then(NonNull::new)
             .map(|jsstr| jsstr_to_string(cx, jsstr).into())
     }
 }
@@ -441,9 +442,7 @@ pub(crate) fn cross_origin_get_own_property_helper(
     rooted!(&in(cx) let mut holder = ptr::null_mut::<JSObject>());
     ensure_cross_origin_property_holder(cx, proxy, cross_origin_properties, holder.handle_mut());
 
-    unsafe {
-        js::rust::wrappers2::JS_GetOwnPropertyDescriptorById(cx, holder.handle(), id, desc, is_none)
-    }
+    unsafe { JS_GetOwnPropertyDescriptorById(cx, holder.handle(), id, desc, is_none) }
 }
 
 const ALLOWLISTED_SYMBOL_CODES: &[SymbolCode] = &[
@@ -550,7 +549,7 @@ fn ensure_cross_origin_property_holder(
 /// [1]: https://html.spec.whatwg.org/multipage/#integration-with-idl
 pub(crate) fn is_cross_origin_object<D: DomTypes>(cx: SafeJSContext, obj: RawHandleObject) -> bool {
     unsafe {
-        jsapi::IsWindowProxy(*obj) ||
+        IsWindowProxy(*obj) ||
             native_from_object::<D::Location>(*obj, *cx).is_ok() ||
             native_from_object::<D::DissimilarOriginLocation>(*obj, *cx).is_ok()
     }
@@ -616,7 +615,7 @@ pub(crate) unsafe extern "C" fn maybe_cross_origin_set_rawcx<D: DomTypes>(
         // <https://tc39.es/ecma262/#sec-ordinaryset>
         rooted!(&in(&mut realm) let mut own_desc = PropertyDescriptor::default());
         let mut is_none = false;
-        if !js::rust::wrappers2::InvokeGetOwnPropertyDescriptor(
+        if !InvokeGetOwnPropertyDescriptor(
             GetProxyHandler(*proxy),
             &mut realm,
             proxy,
@@ -627,7 +626,7 @@ pub(crate) unsafe extern "C" fn maybe_cross_origin_set_rawcx<D: DomTypes>(
             return false;
         }
 
-        js::rust::wrappers2::SetPropertyIgnoringNamedGetter(
+        SetPropertyIgnoringNamedGetter(
             &mut realm,
             proxy,
             id,
@@ -661,7 +660,11 @@ pub(crate) fn maybe_cross_origin_get_prototype<D: DomTypes>(
         let mut realm = AutoRealm::new_from_handle(cx, proxy);
         let mut realm = realm.current_realm();
         let global = D::GlobalScope::from_current_realm(&realm);
-        get_proto_object(&mut realm, global.reflector().get_jsobject(), proto.reborrow());
+        get_proto_object(
+            &mut realm,
+            global.reflector().get_jsobject(),
+            proto.reborrow(),
+        );
         return !proto.is_null();
     }
 
@@ -689,7 +692,7 @@ pub(crate) fn cross_origin_get<D: DomTypes>(
     let mut vp = unsafe { MutableHandle::from_raw(vp) };
     let mut is_none = false;
     if !unsafe {
-        js::rust::wrappers2::InvokeGetOwnPropertyDescriptor(
+        InvokeGetOwnPropertyDescriptor(
             GetProxyHandler(*proxy),
             cx,
             proxy,
@@ -736,11 +739,11 @@ pub(crate) fn cross_origin_get<D: DomTypes>(
 
     // > 7. Return `? Call(getter, Receiver)`.
     unsafe {
-        js::rust::wrappers2::Call(
+        Call(
             cx,
             receiver,
             getter_jsval.handle(),
-            &jsapi::HandleValueArray::empty(),
+            &HandleValueArray::empty(),
             vp,
         )
     }
@@ -763,7 +766,7 @@ unsafe fn cross_origin_set<D: DomTypes>(
     // > 1. Let desc be ? O.[[GetOwnProperty]](P).
     rooted!(&in(cx) let mut descriptor = PropertyDescriptor::default());
     let mut is_none = false;
-    if !js::rust::wrappers2::InvokeGetOwnPropertyDescriptor(
+    if !InvokeGetOwnPropertyDescriptor(
         GetProxyHandler(*proxy),
         cx,
         proxy,
@@ -799,13 +802,13 @@ unsafe fn cross_origin_set<D: DomTypes>(
     // >
     // > 3.2. Return true.
     rooted!(&in(cx) let mut ignored = UndefinedValue());
-    if !js::rust::wrappers2::Call(
+    if !Call(
         cx,
         receiver,
         setter_jsval.handle(),
         // FIXME: Our binding lacks `HandleValueArray(Handle<Value>)`
         // <https://searchfox.org/mozilla-central/rev/072710086ddfe25aa2962c8399fefb2304e8193b/js/public/ValueArray.h#54-55>
-        &jsapi::HandleValueArray {
+        &HandleValueArray {
             length_: 1,
             elements_: v.ptr,
         },
@@ -841,7 +844,7 @@ pub(crate) fn cross_origin_property_fallback<D: DomTypes>(
         set_property_descriptor(
             desc,
             HandleValue::undefined(),
-            jsapi::JSPROP_READONLY as u32,
+            JSPROP_READONLY as u32,
             is_none,
         );
         return true;

--- a/components/script_bindings/proxyhandler.rs
+++ b/components/script_bindings/proxyhandler.rs
@@ -14,27 +14,24 @@ use js::conversions::{ToJSValConvertible, jsstr_to_string};
 use js::glue::{GetProxyHandler, GetProxyHandlerFamily, GetProxyPrivate, SetProxyPrivate};
 use js::jsapi::{
     DOMProxyShadowsResult, GetStaticPrototype, Handle as RawHandle, HandleId as RawHandleId,
-    HandleObject as RawHandleObject, HandleValue as RawHandleValue, JS_DefinePropertyById,
-    JSContext, JSErrNum, JSFunctionSpec, JSITER_HIDDEN, JSITER_OWNONLY, JSITER_SYMBOLS, JSObject,
-    JSPropertySpec, MutableHandle as RawMutableHandle,
-    MutableHandleIdVector as RawMutableHandleIdVector,
+    HandleObject as RawHandleObject, HandleValue as RawHandleValue, JSContext, JSErrNum,
+    JSFunctionSpec, JSITER_HIDDEN, JSITER_OWNONLY, JSITER_SYMBOLS, JSObject, JSPropertySpec,
+    MutableHandle as RawMutableHandle, MutableHandleIdVector as RawMutableHandleIdVector,
     MutableHandleObject as RawMutableHandleObject, MutableHandleValue as RawMutableHandleValue,
     ObjectOpResult, PropertyDescriptor, SetDOMProxyInformation, SymbolCode, jsid,
 };
 use js::jsid::SymbolId;
 use js::jsval::{ObjectValue, UndefinedValue};
 use js::realm::{AutoRealm, CurrentRealm};
-use js::rust::wrappers::{
-    JS_AlreadyHasOwnPropertyById, JS_NewObjectWithGivenProto, SetDataPropertyDescriptor,
-};
+use js::rust::wrappers::{JS_AlreadyHasOwnPropertyById, SetDataPropertyDescriptor};
 use js::rust::wrappers2::{
-    AppendToIdVector, GetPropertyKeys, GetWellKnownSymbol, JS_AtomizeAndPinString, JS_IdToValue,
-    JS_IsExceptionPending, JS_ValueToSource, RUST_INTERNED_STRING_TO_JSID, RUST_JSID_IS_VOID,
-    int_to_jsid,
+    AppendToIdVector, GetPropertyKeys, GetWellKnownSymbol, JS_AtomizeAndPinString,
+    JS_DefineFunctions, JS_DefineProperties, JS_DefinePropertyById, JS_IdToValue,
+    JS_IsExceptionPending, JS_NewObjectWithGivenProto, JS_ValueToSource,
+    RUST_INTERNED_STRING_TO_JSID, RUST_JSID_IS_VOID, int_to_jsid,
 };
 use js::rust::{
-    Handle, HandleId, HandleObject, HandleValue, IntoHandle, MutableHandle,
-    MutableHandleObject,
+    Handle, HandleId, HandleObject, HandleValue, IntoHandle, MutableHandle, MutableHandleObject,
 };
 use js::{jsapi, rooted};
 
@@ -100,9 +97,18 @@ pub(crate) unsafe extern "C" fn define_property(
     desc: RawHandle<PropertyDescriptor>,
     result: *mut ObjectOpResult,
 ) -> bool {
-    rooted!(in(cx) let mut expando = ptr::null_mut::<JSObject>());
-    ensure_expando_object(cx, proxy, expando.handle_mut());
-    JS_DefinePropertyById(cx, expando.handle().into(), id, desc, result)
+    let mut cx = js::context::JSContext::from_ptr(NonNull::new(cx).unwrap());
+    let cx = &mut cx;
+
+    rooted!(&in(cx) let mut expando = ptr::null_mut::<JSObject>());
+    ensure_expando_object(cx, Handle::from_raw(proxy), expando.handle_mut());
+    JS_DefinePropertyById(
+        cx,
+        expando.handle(),
+        Handle::from_raw(id),
+        Handle::from_raw(desc),
+        result,
+    )
 }
 
 /// Deletes an expando off the given `proxy`.
@@ -191,25 +197,24 @@ pub(crate) fn get_expando_object(obj: RawHandleObject, mut expando: MutableHandl
 
 /// Get the expando object, or create it if it doesn't exist yet.
 /// Fails on JSAPI failure.
-///
-/// # Safety
-/// `cx` must point to a valid, non-null JSContext.
-pub(crate) unsafe fn ensure_expando_object(
-    cx: *mut JSContext,
-    obj: RawHandleObject,
+pub(crate) fn ensure_expando_object(
+    cx: &mut js::context::JSContext,
+    obj: HandleObject,
     mut expando: MutableHandleObject,
 ) {
-    assert!(is_dom_proxy(obj.get()));
-    get_expando_object(obj, expando.reborrow());
-    if expando.is_null() {
-        expando.set(JS_NewObjectWithGivenProto(
-            cx,
-            ptr::null_mut(),
-            HandleObject::null(),
-        ));
-        assert!(!expando.is_null());
+    unsafe {
+        assert!(is_dom_proxy(obj.get()));
+        get_expando_object(obj.into(), expando.reborrow());
+        if expando.is_null() {
+            expando.set(JS_NewObjectWithGivenProto(
+                cx,
+                ptr::null_mut(),
+                HandleObject::null(),
+            ));
+            assert!(!expando.is_null());
 
-        SetProxyPrivate(obj.get(), &ObjectValue(expando.get()));
+            SetProxyPrivate(obj.get(), &ObjectValue(expando.get()));
+        }
     }
 }
 
@@ -490,19 +495,19 @@ fn ensure_cross_origin_property_holder(
 
     // Create a holder for the current Realm
     unsafe {
-        out_holder.set(js::rust::wrappers2::JS_NewObjectWithGivenProto(
+        out_holder.set(JS_NewObjectWithGivenProto(
             cx,
             ptr::null_mut(),
             HandleObject::null(),
         ));
 
         if out_holder.get().is_null() ||
-            !js::rust::wrappers2::JS_DefineProperties(
+            !JS_DefineProperties(
                 cx,
                 out_holder.handle(),
                 cross_origin_properties.attributes.as_ptr(),
             ) ||
-            !js::rust::wrappers2::JS_DefineFunctions(
+            !JS_DefineFunctions(
                 cx,
                 out_holder.handle(),
                 cross_origin_properties.methods.as_ptr(),

--- a/components/script_bindings/proxyhandler.rs
+++ b/components/script_bindings/proxyhandler.rs
@@ -16,7 +16,7 @@ use js::jsapi::{
     DOMProxyShadowsResult, GetStaticPrototype, Handle as RawHandle, HandleId as RawHandleId,
     HandleObject as RawHandleObject, HandleValue as RawHandleValue, JSContext, JSErrNum,
     JSFunctionSpec, JSITER_HIDDEN, JSITER_OWNONLY, JSITER_SYMBOLS, JSObject, JSPropertySpec,
-    MutableHandle as RawMutableHandle, MutableHandleIdVector as RawMutableHandleIdVector,
+    MutableHandleIdVector as RawMutableHandleIdVector,
     MutableHandleObject as RawMutableHandleObject, MutableHandleValue as RawMutableHandleValue,
     ObjectOpResult, PropertyDescriptor, SetDOMProxyInformation, SymbolCode, jsid,
 };
@@ -25,7 +25,7 @@ use js::jsval::{ObjectValue, UndefinedValue};
 use js::realm::{AutoRealm, CurrentRealm};
 use js::rust::wrappers::{JS_AlreadyHasOwnPropertyById, SetDataPropertyDescriptor};
 use js::rust::wrappers2::{
-    AppendToIdVector, GetPropertyKeys, GetWellKnownSymbol, JS_AtomizeAndPinString,
+    AppendToIdVector, GetObjectProto, GetPropertyKeys, GetWellKnownSymbol, JS_AtomizeAndPinString,
     JS_DefineFunctions, JS_DefineProperties, JS_DefinePropertyById, JS_IdToValue,
     JS_IsExceptionPending, JS_NewObjectWithGivenProto, JS_ValueToSource,
     RUST_INTERNED_STRING_TO_JSID, RUST_JSID_IS_VOID, int_to_jsid,
@@ -323,6 +323,8 @@ pub(crate) unsafe extern "C" fn maybe_cross_origin_set_prototype_rawcx(
     proto: RawHandleObject,
     result: *mut ObjectOpResult,
 ) -> bool {
+    let mut cx = js::context::JSContext::from_ptr(NonNull::new(cx).unwrap());
+    let cx = &mut cx;
     // > 1. Return `! SetImmutablePrototype(this, V)`.
     //
     // <https://tc39.es/ecma262/#sec-set-immutable-prototype>:
@@ -330,8 +332,8 @@ pub(crate) unsafe extern "C" fn maybe_cross_origin_set_prototype_rawcx(
     // > 1. Assert: Either `Type(V)` is Object or `Type(V)` is Null.
     //
     // > 2. Let current be `? O.[[GetPrototypeOf]]()`.
-    rooted!(in(cx) let mut current = ptr::null_mut::<JSObject>());
-    if !jsapi::GetObjectProto(cx, proxy, current.handle_mut().into()) {
+    rooted!(&in(cx) let mut current = ptr::null_mut::<JSObject>());
+    if !GetObjectProto(cx, Handle::from_raw(proxy), current.handle_mut()) {
         return false;
     }
 
@@ -404,17 +406,13 @@ pub(crate) unsafe fn cross_origin_has_own(
 /// [`CrossOriginGetOwnPropertyHelper`]: https://html.spec.whatwg.org/multipage/#crossorigingetownpropertyhelper-(-o,-p-)
 pub(crate) fn cross_origin_get_own_property_helper(
     cx: &mut CurrentRealm,
-    proxy: RawHandleObject,
+    proxy: HandleObject,
     cross_origin_properties: &'static CrossOriginProperties,
-    id: RawHandleId,
-    desc: RawMutableHandle<PropertyDescriptor>,
+    id: HandleId,
+    desc: MutableHandle<PropertyDescriptor>,
     is_none: &mut bool,
 ) -> bool {
     rooted!(&in(cx) let mut holder = ptr::null_mut::<JSObject>());
-    let id = unsafe { Handle::from_raw(id) };
-    let proxy = unsafe { Handle::from_raw(proxy) };
-    let desc = unsafe { MutableHandle::from_raw(desc) };
-
     ensure_cross_origin_property_holder(cx, proxy, cross_origin_properties, holder.handle_mut());
 
     unsafe {
@@ -428,12 +426,9 @@ const ALLOWLISTED_SYMBOL_CODES: &[SymbolCode] = &[
     SymbolCode::isConcatSpreadable,
 ];
 
-pub(crate) fn is_cross_origin_allowlisted_prop(
-    cx: &mut js::context::JSContext,
-    id: RawHandleId,
-) -> bool {
+fn is_cross_origin_allowlisted_prop(cx: &mut js::context::JSContext, id: HandleId) -> bool {
     unsafe {
-        if jsid_to_string(cx, Handle::from_raw(id)).is_some_and(|st| st == "then") {
+        if jsid_to_string(cx, id).is_some_and(|st| st == "then") {
             return true;
         }
 
@@ -736,7 +731,7 @@ pub(crate) fn cross_origin_get<D: DomTypes>(
 /// for a maybe-cross-origin object.
 ///
 /// [`CrossOriginSet`]: https://html.spec.whatwg.org/multipage/#crossoriginset-(-o,-p,-v,-receiver-)
-pub(crate) unsafe fn cross_origin_set<D: DomTypes>(
+unsafe fn cross_origin_set<D: DomTypes>(
     cx: &mut CurrentRealm,
     proxy: HandleObject,
     id: HandleId,
@@ -810,9 +805,9 @@ pub(crate) unsafe fn cross_origin_set<D: DomTypes>(
 /// [`CrossOriginPropertyFallback`]: https://html.spec.whatwg.org/multipage/#crossoriginpropertyfallback-(-p-)
 pub(crate) fn cross_origin_property_fallback<D: DomTypes>(
     cx: &mut CurrentRealm,
-    _proxy: RawHandleObject,
-    id: RawHandleId,
-    desc: RawMutableHandle<PropertyDescriptor>,
+    _proxy: HandleObject,
+    id: HandleId,
+    desc: MutableHandle<PropertyDescriptor>,
     is_none: &mut bool,
 ) -> bool {
     assert!(*is_none, "why are we being called?");
@@ -823,15 +818,13 @@ pub(crate) fn cross_origin_property_fallback<D: DomTypes>(
     // >    [[Configurable]]: true }`.
     if is_cross_origin_allowlisted_prop(cx, id) {
         set_property_descriptor(
-            unsafe { MutableHandle::from_raw(desc) },
+            desc,
             HandleValue::undefined(),
             jsapi::JSPROP_READONLY as u32,
             is_none,
         );
         return true;
     }
-
-    let id = unsafe { Handle::from_raw(id) };
 
     // > 2. Throw a `SecurityError` `DOMException`.
     report_cross_origin_denial::<D>(cx, id, "access")

--- a/components/script_bindings/proxyhandler.rs
+++ b/components/script_bindings/proxyhandler.rs
@@ -13,10 +13,10 @@ use std::ptr::NonNull;
 use js::conversions::{ToJSValConvertible, jsstr_to_string};
 use js::glue::{GetProxyHandler, GetProxyHandlerFamily, GetProxyPrivate, SetProxyPrivate};
 use js::jsapi::{
-    DOMProxyShadowsResult, GetStaticPrototype, GetWellKnownSymbol, Handle as RawHandle,
-    HandleId as RawHandleId, HandleObject as RawHandleObject, HandleValue as RawHandleValue,
-    JS_DefinePropertyById, JSContext, JSErrNum, JSFunctionSpec, JSITER_HIDDEN, JSITER_OWNONLY,
-    JSITER_SYMBOLS, JSObject, JSPropertySpec, MutableHandle as RawMutableHandle,
+    DOMProxyShadowsResult, GetStaticPrototype, Handle as RawHandle, HandleId as RawHandleId,
+    HandleObject as RawHandleObject, HandleValue as RawHandleValue, JS_DefinePropertyById,
+    JSContext, JSErrNum, JSFunctionSpec, JSITER_HIDDEN, JSITER_OWNONLY, JSITER_SYMBOLS, JSObject,
+    JSPropertySpec, MutableHandle as RawMutableHandle,
     MutableHandleIdVector as RawMutableHandleIdVector,
     MutableHandleObject as RawMutableHandleObject, MutableHandleValue as RawMutableHandleValue,
     ObjectOpResult, PropertyDescriptor, SetDOMProxyInformation, SymbolCode, jsid,
@@ -25,15 +25,16 @@ use js::jsid::SymbolId;
 use js::jsval::{ObjectValue, UndefinedValue};
 use js::realm::{AutoRealm, CurrentRealm};
 use js::rust::wrappers::{
-    AppendToIdVector, JS_AlreadyHasOwnPropertyById, JS_NewObjectWithGivenProto,
-    SetDataPropertyDescriptor,
+    JS_AlreadyHasOwnPropertyById, JS_NewObjectWithGivenProto, SetDataPropertyDescriptor,
 };
 use js::rust::wrappers2::{
-    GetPropertyKeys, JS_AtomizeAndPinString, JS_IdToValue, JS_IsExceptionPending, JS_ValueToSource,
-    RUST_INTERNED_STRING_TO_JSID, RUST_JSID_IS_VOID, int_to_jsid,
+    AppendToIdVector, GetPropertyKeys, GetWellKnownSymbol, JS_AtomizeAndPinString, JS_IdToValue,
+    JS_IsExceptionPending, JS_ValueToSource, RUST_INTERNED_STRING_TO_JSID, RUST_JSID_IS_VOID,
+    int_to_jsid,
 };
 use js::rust::{
-    Handle, HandleId, HandleObject, HandleValue, IntoHandle, MutableHandle, MutableHandleObject,
+    Handle, HandleId, HandleObject, HandleValue, IntoHandle, MutableHandle,
+    MutableHandleObject,
 };
 use js::{jsapi, rooted};
 
@@ -267,7 +268,7 @@ impl CrossOriginProperties {
 /// Implementation of [`CrossOriginOwnPropertyKeys`].
 ///
 /// [`CrossOriginOwnPropertyKeys`]: https://html.spec.whatwg.org/multipage/#crossoriginownpropertykeys-(-o-)
-pub(crate) fn cross_origin_own_property_keys(
+fn cross_origin_own_property_keys(
     cx: &mut js::context::JSContext,
     _proxy: RawHandleObject,
     cross_origin_properties: &'static CrossOriginProperties,
@@ -277,13 +278,9 @@ pub(crate) fn cross_origin_own_property_keys(
     // >    `e.[[Property]]` to `keys`.
     for key in cross_origin_properties.keys() {
         unsafe {
-            rooted!(&in(cx) let rooted = js::rust::wrappers2::JS_AtomizeAndPinString(cx, key));
+            rooted!(&in(cx) let rooted = JS_AtomizeAndPinString(cx, key));
             rooted!(&in(cx) let mut rooted_jsid: jsid);
-            js::rust::wrappers2::RUST_INTERNED_STRING_TO_JSID(
-                cx,
-                rooted.handle().get(),
-                rooted_jsid.handle_mut(),
-            );
+            RUST_INTERNED_STRING_TO_JSID(cx, rooted.handle().get(), rooted_jsid.handle_mut());
             AppendToIdVector(props, rooted_jsid.handle());
         }
     }
@@ -437,7 +434,7 @@ pub(crate) fn is_cross_origin_allowlisted_prop(
 
         rooted!(&in(cx) let mut allowed_id: jsid);
         ALLOWLISTED_SYMBOL_CODES.iter().any(|&allowed_code| {
-            allowed_id.set(SymbolId(GetWellKnownSymbol(cx.raw_cx(), allowed_code)));
+            allowed_id.set(SymbolId(GetWellKnownSymbol(cx, allowed_code)));
             // `jsid`s containing `JS::Symbol *` can be compared by
             // referential equality
             allowed_id.get().asBits_ == id.asBits_
@@ -456,20 +453,13 @@ fn append_cross_origin_allowlisted_prop_keys(
     unsafe {
         rooted!(&in(cx) let mut id: jsid);
 
-        let jsstring = js::rust::wrappers2::JS_AtomizeAndPinString(cx, c"then".as_ptr());
+        let jsstring = JS_AtomizeAndPinString(cx, c"then".as_ptr());
         rooted!(&in(cx) let rooted = jsstring);
-        js::rust::wrappers2::RUST_INTERNED_STRING_TO_JSID(
-            cx,
-            rooted.handle().get(),
-            id.handle_mut(),
-        );
+        RUST_INTERNED_STRING_TO_JSID(cx, rooted.handle().get(), id.handle_mut());
         AppendToIdVector(props, id.handle());
 
         for &allowed_code in ALLOWLISTED_SYMBOL_CODES.iter() {
-            id.set(SymbolId(js::rust::wrappers2::GetWellKnownSymbol(
-                cx,
-                allowed_code,
-            )));
+            id.set(SymbolId(GetWellKnownSymbol(cx, allowed_code)));
             AppendToIdVector(props, id.handle());
         }
     }

--- a/components/script_bindings/proxyhandler.rs
+++ b/components/script_bindings/proxyhandler.rs
@@ -23,12 +23,12 @@ use js::jsapi::{
 use js::jsid::SymbolId;
 use js::jsval::{ObjectValue, UndefinedValue};
 use js::realm::{AutoRealm, CurrentRealm};
-use js::rust::wrappers::{JS_AlreadyHasOwnPropertyById, SetDataPropertyDescriptor};
 use js::rust::wrappers2::{
-    AppendToIdVector, GetObjectProto, GetPropertyKeys, GetWellKnownSymbol, JS_AtomizeAndPinString,
-    JS_DefineFunctions, JS_DefineProperties, JS_DefinePropertyById, JS_IdToValue,
-    JS_IsExceptionPending, JS_NewObjectWithGivenProto, JS_ValueToSource,
-    RUST_INTERNED_STRING_TO_JSID, RUST_JSID_IS_VOID, int_to_jsid,
+    AppendToIdVector, GetObjectProto, GetPropertyKeys, GetWellKnownSymbol,
+    JS_AlreadyHasOwnPropertyById, JS_AtomizeAndPinString, JS_DefineFunctions, JS_DefineProperties,
+    JS_DefinePropertyById, JS_DeletePropertyById, JS_IdToValue, JS_IsExceptionPending,
+    JS_NewObjectWithGivenProto, JS_ValueToSource, RUST_INTERNED_STRING_TO_JSID, RUST_JSID_IS_VOID,
+    SetDataPropertyDescriptor, int_to_jsid,
 };
 use js::rust::{
     Handle, HandleId, HandleObject, HandleValue, IntoHandle, MutableHandle, MutableHandleObject,
@@ -42,7 +42,6 @@ use crate::interfaces::{DomHelpers, GlobalScopeHelpers};
 use crate::reflector::DomObject;
 use crate::script_runtime::JSContext as SafeJSContext;
 use crate::str::DOMString;
-use crate::utils::delete_property_by_id;
 
 /// Determine if this id shadows any existing properties for this proxy.
 ///
@@ -54,8 +53,11 @@ pub(crate) unsafe extern "C" fn shadow_check_callback(
     id: RawHandleId,
 ) -> DOMProxyShadowsResult {
     // TODO: support OverrideBuiltins when #12978 is fixed.
+    let mut cx = js::context::JSContext::from_ptr(NonNull::new(cx).unwrap());
+    let cx = &mut cx;
 
-    rooted!(in(cx) let mut expando = ptr::null_mut::<JSObject>());
+    let object = HandleObject::from_raw(object);
+    rooted!(&in(cx) let mut expando = ptr::null_mut::<JSObject>());
     get_expando_object(object, expando.handle_mut());
     if !expando.get().is_null() {
         let mut has_own = false;
@@ -90,7 +92,7 @@ pub fn init() {
 /// # Safety
 /// `cx` must point to a valid, non-null JSContext.
 /// `result` must point to a valid, non-null ObjectOpResult.
-pub(crate) unsafe extern "C" fn define_property(
+pub(crate) unsafe extern "C" fn define_property_raw(
     cx: *mut JSContext,
     proxy: RawHandleObject,
     id: RawHandleId,
@@ -99,16 +101,27 @@ pub(crate) unsafe extern "C" fn define_property(
 ) -> bool {
     let mut cx = js::context::JSContext::from_ptr(NonNull::new(cx).unwrap());
     let cx = &mut cx;
-
-    rooted!(&in(cx) let mut expando = ptr::null_mut::<JSObject>());
-    ensure_expando_object(cx, Handle::from_raw(proxy), expando.handle_mut());
-    JS_DefinePropertyById(
+    define_property(
         cx,
-        expando.handle(),
+        Handle::from_raw(proxy),
         Handle::from_raw(id),
-        Handle::from_raw(desc),
+        desc,
         result,
     )
+}
+
+/// # Safety
+/// `result` must point to a valid, non-null ObjectOpResult.
+pub(crate) unsafe fn define_property(
+    cx: &mut js::context::JSContext,
+    proxy: HandleObject,
+    id: HandleId,
+    desc: RawHandle<PropertyDescriptor>,
+    result: *mut ObjectOpResult,
+) -> bool {
+    rooted!(&in(cx) let mut expando = ptr::null_mut::<JSObject>());
+    ensure_expando_object(cx, proxy, expando.handle_mut());
+    JS_DefinePropertyById(cx, expando.handle(), id, Handle::from_raw(desc), result)
 }
 
 /// Deletes an expando off the given `proxy`.
@@ -116,20 +129,33 @@ pub(crate) unsafe extern "C" fn define_property(
 /// # Safety
 /// `cx` must point to a valid, non-null JSContext.
 /// `bp` must point to a valid, non-null ObjectOpResult.
-pub(crate) unsafe extern "C" fn delete(
+pub(crate) unsafe extern "C" fn delete_raw(
     cx: *mut JSContext,
     proxy: RawHandleObject,
     id: RawHandleId,
     bp: *mut ObjectOpResult,
 ) -> bool {
-    rooted!(in(cx) let mut expando = ptr::null_mut::<JSObject>());
+    let mut cx = js::context::JSContext::from_ptr(NonNull::new(cx).unwrap());
+    let cx = &mut cx;
+    delete(cx, Handle::from_raw(proxy), Handle::from_raw(id), bp)
+}
+
+/// # Safety
+/// `result` must point to a valid, non-null ObjectOpResult.
+pub(crate) unsafe fn delete(
+    cx: &mut js::context::JSContext,
+    proxy: HandleObject,
+    id: HandleId,
+    bp: *mut ObjectOpResult,
+) -> bool {
+    rooted!(&in(cx) let mut expando = ptr::null_mut::<JSObject>());
     get_expando_object(proxy, expando.handle_mut());
     if expando.is_null() {
         (*bp).code_ = 0 /* OkCode */;
         return true;
     }
 
-    delete_property_by_id(cx, expando.handle(), Handle::from_raw(id), bp)
+    JS_DeletePropertyById(cx, expando.handle(), id, bp)
 }
 
 /// Controls whether the Extensible bit can be changed
@@ -182,7 +208,7 @@ pub(crate) unsafe extern "C" fn get_prototype_if_ordinary(
 }
 
 /// Get the expando object, or null if there is none.
-pub(crate) fn get_expando_object(obj: RawHandleObject, mut expando: MutableHandleObject) {
+pub(crate) fn get_expando_object(obj: HandleObject, mut expando: MutableHandleObject) {
     unsafe {
         assert!(is_dom_proxy(obj.get()));
         let val = &mut UndefinedValue();
@@ -204,7 +230,7 @@ pub(crate) fn ensure_expando_object(
 ) {
     unsafe {
         assert!(is_dom_proxy(obj.get()));
-        get_expando_object(obj.into(), expando.reborrow());
+        get_expando_object(obj, expando.reborrow());
         if expando.is_null() {
             expando.set(JS_NewObjectWithGivenProto(
                 cx,
@@ -275,7 +301,7 @@ impl CrossOriginProperties {
 /// [`CrossOriginOwnPropertyKeys`]: https://html.spec.whatwg.org/multipage/#crossoriginownpropertykeys-(-o-)
 fn cross_origin_own_property_keys(
     cx: &mut js::context::JSContext,
-    _proxy: RawHandleObject,
+    _proxy: HandleObject,
     cross_origin_properties: &'static CrossOriginProperties,
     props: RawMutableHandleIdVector,
 ) -> bool {
@@ -348,25 +374,25 @@ pub(crate) unsafe extern "C" fn maybe_cross_origin_set_prototype_rawcx(
     true
 }
 
-pub(crate) fn get_getter_object(d: &PropertyDescriptor, out: RawMutableHandleObject) {
+fn get_getter_object(d: &PropertyDescriptor, out: RawMutableHandleObject) {
     if d.hasGetter_() {
         out.set(d.getter_);
     }
 }
 
-pub(crate) fn get_setter_object(d: &PropertyDescriptor, out: RawMutableHandleObject) {
+fn get_setter_object(d: &PropertyDescriptor, out: RawMutableHandleObject) {
     if d.hasSetter_() {
         out.set(d.setter_);
     }
 }
 
 /// <https://tc39.es/ecma262/#sec-isaccessordescriptor>
-pub(crate) fn is_accessor_descriptor(d: &PropertyDescriptor) -> bool {
+fn is_accessor_descriptor(d: &PropertyDescriptor) -> bool {
     d.hasSetter_() || d.hasGetter_()
 }
 
 /// <https://tc39.es/ecma262/#sec-isdatadescriptor>
-pub(crate) fn is_data_descriptor(d: &PropertyDescriptor) -> bool {
+fn is_data_descriptor(d: &PropertyDescriptor) -> bool {
     d.hasWritable_() || d.hasValue_()
 }
 
@@ -380,15 +406,15 @@ pub(crate) fn is_data_descriptor(d: &PropertyDescriptor) -> bool {
 /// `bp` must point to a valid, non-null bool.
 pub(crate) unsafe fn cross_origin_has_own(
     cx: &mut js::realm::CurrentRealm,
-    _proxy: RawHandleObject,
+    _proxy: HandleObject,
     cross_origin_properties: &'static CrossOriginProperties,
-    id: RawHandleId,
+    id: HandleId,
     bp: *mut bool,
 ) -> bool {
     // TODO: Once we have the slot for the holder, it'd be more efficient to
     //       use `ensure_cross_origin_property_holder`. We'll need `_proxy` to
     //       do that.
-    *bp = jsid_to_string(cx, Handle::from_raw(id)).is_some_and(|key| {
+    *bp = jsid_to_string(cx, id).is_some_and(|key| {
         cross_origin_properties.keys().any(|defined_key| {
             let defined_key = CStr::from_ptr(defined_key);
             defined_key.to_bytes() == key.str().as_bytes()
@@ -622,23 +648,20 @@ pub(crate) unsafe extern "C" fn maybe_cross_origin_set_rawcx<D: DomTypes>(
 /// [`Location`]: https://html.spec.whatwg.org/multipage/#location-getprototypeof
 pub(crate) fn maybe_cross_origin_get_prototype<D: DomTypes>(
     cx: &mut CurrentRealm,
-    proxy: RawHandleObject,
+    proxy: HandleObject,
     get_proto_object: fn(
         cx: &mut js::context::JSContext,
         global: HandleObject,
         rval: MutableHandleObject,
     ),
-    proto: RawMutableHandleObject,
+    mut proto: MutableHandleObject,
 ) -> bool {
-    let proxy = unsafe { Handle::from_raw(proxy) };
     // > 1. If ! IsPlatformObjectSameOrigin(this) is true, then return ! OrdinaryGetPrototypeOf(this).
     if <D as DomHelpers<D>>::is_platform_object_same_origin(cx, proxy.into_handle()) {
         let mut realm = AutoRealm::new_from_handle(cx, proxy);
         let mut realm = realm.current_realm();
         let global = D::GlobalScope::from_current_realm(&realm);
-        get_proto_object(&mut realm, global.reflector().get_jsobject(), unsafe {
-            MutableHandleObject::from_raw(proto)
-        });
+        get_proto_object(&mut realm, global.reflector().get_jsobject(), proto.reborrow());
         return !proto.is_null();
     }
 
@@ -655,16 +678,14 @@ pub(crate) fn maybe_cross_origin_get_prototype<D: DomTypes>(
 /// [`CrossOriginGet`]: https://html.spec.whatwg.org/multipage/#crossoriginget-(-o,-p,-receiver-)
 pub(crate) fn cross_origin_get<D: DomTypes>(
     cx: &mut CurrentRealm,
-    proxy: RawHandleObject,
+    proxy: HandleObject,
     receiver: RawHandleValue,
-    id: RawHandleId,
+    id: HandleId,
     vp: RawMutableHandleValue,
 ) -> bool {
     // > 1. Let `desc` be `? O.[[GetOwnProperty]](P)`.
     rooted!(&in(cx) let mut descriptor = PropertyDescriptor::default());
-    let proxy = unsafe { Handle::from_raw(proxy) };
     let receiver = unsafe { Handle::from_raw(receiver) };
-    let id = unsafe { Handle::from_raw(id) };
     let mut vp = unsafe { MutableHandle::from_raw(vp) };
     let mut is_none = false;
     if !unsafe {
@@ -887,8 +908,10 @@ where
         let current_realm = &mut cx;
         let unwrapped_proxy = (config.unwrapped_proxy)(proxy);
 
+        let proxy = Handle::from_raw(proxy);
+
         let mut cx = if let Some(cross_origin_properties) = config.cross_origin {
-            if !<D as DomHelpers<D>>::is_platform_object_same_origin(current_realm, proxy) {
+            if !<D as DomHelpers<D>>::is_platform_object_same_origin(current_realm, proxy.into()) {
                 return cross_origin_own_property_keys(
                     current_realm,
                     proxy,
@@ -898,7 +921,7 @@ where
             }
 
             // Safe to enter the Realm of proxy now.
-            let cx = AutoRealm::new_from_handle(current_realm, Handle::from_raw(proxy));
+            let cx = AutoRealm::new_from_handle(current_realm, proxy);
             Realm::AutoRealm(cx)
         } else {
             Realm::CurrentRealm(current_realm)
@@ -972,14 +995,16 @@ where
         let mut cx = CurrentRealm::assert(&mut cx);
         let current_realm = &mut cx;
 
+        let proxy = Handle::from_raw(proxy);
+
         let mut cx = if config.cross_origin {
-            if !<D as DomHelpers<D>>::is_platform_object_same_origin(current_realm, proxy) {
+            if !<D as DomHelpers<D>>::is_platform_object_same_origin(current_realm, proxy.into()) {
                 // There are no enumerable cross-origin props, so we're done.
                 return true;
             }
 
             // Safe to enter the Realm of proxy now.
-            let cx = AutoRealm::new_from_handle(current_realm, Handle::from_raw(proxy));
+            let cx = AutoRealm::new_from_handle(current_realm, proxy);
             Realm::AutoRealm(cx)
         } else {
             Realm::CurrentRealm(current_realm)

--- a/components/script_bindings/proxyhandler.rs
+++ b/components/script_bindings/proxyhandler.rs
@@ -93,7 +93,7 @@ pub fn init() {
 /// # Safety
 /// `cx` must point to a valid, non-null JSContext.
 /// `result` must point to a valid, non-null ObjectOpResult.
-pub(crate) unsafe extern "C" fn define_property_raw(
+pub(crate) unsafe extern "C" fn define_property(
     cx: *mut RawJSContext,
     proxy: RawHandleObject,
     id: RawHandleId,
@@ -103,27 +103,15 @@ pub(crate) unsafe extern "C" fn define_property_raw(
     // SAFETY: it is safe to construct a JSContext from engine hook.
     let mut cx = JSContext::from_ptr(NonNull::new(cx).unwrap());
     let cx = &mut cx;
-    define_property(
-        cx,
-        Handle::from_raw(proxy),
-        Handle::from_raw(id),
-        desc,
-        result,
-    )
-}
 
-/// # Safety
-/// `result` must point to a valid, non-null ObjectOpResult.
-pub(crate) unsafe fn define_property(
-    cx: &mut JSContext,
-    proxy: HandleObject,
-    id: HandleId,
-    desc: RawHandle<PropertyDescriptor>,
-    result: *mut ObjectOpResult,
-) -> bool {
+    let proxy = Handle::from_raw(proxy);
+    let id = Handle::from_raw(id);
+    let desc = Handle::from_raw(desc);
+
     rooted!(&in(cx) let mut expando = ptr::null_mut::<JSObject>());
     ensure_expando_object(cx, proxy, expando.handle_mut());
-    JS_DefinePropertyById(cx, expando.handle(), id, Handle::from_raw(desc), result)
+
+    JS_DefinePropertyById(cx, expando.handle(), id, desc, result)
 }
 
 /// Deletes an expando off the given `proxy`.
@@ -131,7 +119,7 @@ pub(crate) unsafe fn define_property(
 /// # Safety
 /// `cx` must point to a valid, non-null JSContext.
 /// `bp` must point to a valid, non-null ObjectOpResult.
-pub(crate) unsafe extern "C" fn delete_raw(
+pub(crate) unsafe extern "C" fn delete(
     cx: *mut RawJSContext,
     proxy: RawHandleObject,
     id: RawHandleId,
@@ -140,19 +128,13 @@ pub(crate) unsafe extern "C" fn delete_raw(
     // SAFETY: it is safe to construct a JSContext from engine hook.
     let mut cx = JSContext::from_ptr(NonNull::new(cx).unwrap());
     let cx = &mut cx;
-    delete(cx, Handle::from_raw(proxy), Handle::from_raw(id), bp)
-}
 
-/// # Safety
-/// `result` must point to a valid, non-null ObjectOpResult.
-pub(crate) unsafe fn delete(
-    cx: &mut JSContext,
-    proxy: HandleObject,
-    id: HandleId,
-    bp: *mut ObjectOpResult,
-) -> bool {
+    let proxy = Handle::from_raw(proxy);
+    let id = Handle::from_raw(id);
+
     rooted!(&in(cx) let mut expando = ptr::null_mut::<JSObject>());
     get_expando_object(proxy, expando.handle_mut());
+
     if expando.is_null() {
         (*bp).code_ = 0 /* OkCode */;
         return true;
@@ -255,9 +237,7 @@ pub fn set_property_descriptor(
     attrs: u32,
     is_none: &mut bool,
 ) {
-    unsafe {
-        SetDataPropertyDescriptor(desc, value, attrs);
-    }
+    unsafe { SetDataPropertyDescriptor(desc, value, attrs) };
     *is_none = false;
 }
 

--- a/components/script_bindings/utils.rs
+++ b/components/script_bindings/utils.rs
@@ -21,15 +21,13 @@ use js::jsapi::{
     JS_IsGlobalObject, JS_MayResolveStandardClass, JS_NewEnumerateStandardClasses,
     JS_ResolveStandardClass, JSAtom, JSAtomState, JSContext, JSJitInfo, JSObject, JSPROP_ENUMERATE,
     JSTracer, MutableHandleIdVector as RawMutableHandleIdVector,
-    MutableHandleValue as RawMutableHandleValue, ObjectOpResult, PropertyKey, StringIsArrayIndex,
-    jsid,
+    MutableHandleValue as RawMutableHandleValue, PropertyKey, StringIsArrayIndex, jsid,
 };
 use js::jsid::StringId;
 use js::jsval::{JSVal, UndefinedValue};
 use js::rust::wrappers::{
-    CallOriginalPromiseReject, JS_DefineProperty, JS_DeletePropertyById, JS_ForwardGetPropertyTo,
-    JS_GetPendingException, JS_GetPrototype, JS_HasOwnProperty, JS_HasPropertyById,
-    JS_SetPendingException, JS_SetProperty,
+    CallOriginalPromiseReject, JS_DefineProperty, JS_ForwardGetPropertyTo, JS_GetPendingException,
+    JS_GetPrototype, JS_HasOwnProperty, JS_HasPropertyById, JS_SetPendingException, JS_SetProperty,
 };
 use js::rust::wrappers2::{JS_GetProperty, JS_HasProperty};
 use js::rust::{
@@ -362,19 +360,6 @@ pub unsafe fn has_property_on_prototype(
     }
     assert!(!proto.is_null());
     JS_HasPropertyById(cx, proto.handle(), id, found)
-}
-
-/// Deletes the property `id` from `object`.
-///
-/// # Safety
-/// `cx` must point to a valid, non-null JSContext.
-pub(crate) unsafe fn delete_property_by_id(
-    cx: *mut JSContext,
-    object: HandleObject,
-    id: HandleId,
-    bp: *mut ObjectOpResult,
-) -> bool {
-    JS_DeletePropertyById(cx, object, id, bp)
 }
 
 pub trait CallPolicy {

--- a/components/script_bindings/utils.rs
+++ b/components/script_bindings/utils.rs
@@ -587,7 +587,7 @@ unsafe fn generic_call<D: DomTypes, const EXCEPTION_TO_REJECTION: bool>(
     if needs_security_check_on_interface_match {
         let mut realm = js::realm::CurrentRealm::assert(&mut cx);
         // [cross_origin_operation == false]
-        if is_cross_origin_object::<D>((&mut realm).into(), obj.handle().into()) &&
+        if is_cross_origin_object::<D>(&mut realm, obj.handle()) &&
             !<D as DomHelpers<D>>::is_platform_object_same_origin(&realm, obj.handle().into())
         {
             // [this_class_cross_origin == true && this_same_origin == false]

--- a/components/script_bindings/wrap.rs
+++ b/components/script_bindings/wrap.rs
@@ -126,7 +126,7 @@ pub(crate) unsafe fn wrap<T: MutDomObject, D: DomTypes>(
         if config.has_legacy_unforgeable_members {
             rooted!(&in(cx) let mut expando = ptr::null_mut::<JSObject>());
             if config.is_proxy {
-                ensure_expando_object(cx.raw_cx(), obj.handle().into(), expando.handle_mut());
+                ensure_expando_object(cx, obj.handle(), expando.handle_mut());
             }
 
             let copy_fn = if config.is_global {


### PR DESCRIPTION
In addition to `JSContext` work, bindings arguments are converted to safe handles from the start avoiding multiple conversions.

Testing: It compiles
Part of #40600
