### PR TITLE
script: Expose `initialize` method of `CustomElementRegistry`; Reduce unnecessary rooting in all variants of `fn set_custom_element_registry`

### DIFF
--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -633,6 +633,71 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
             }
         });
     }
+
+    /// <https://html.spec.whatwg.org/multipage/#dom-customelementregistry-initialize>
+    fn Initialize(&self, root: &Node) -> ErrorResult {
+        // Step 1. If this's is scoped is false and either root is a Document node
+        // or root's node document's custom element registry is not this, then
+        // throw a "NotSupportedError" DOMException.
+        if !self.is_scoped.get() {
+            let is_document = root.is::<Document>();
+            let registry_mismatch = root
+                .owner_doc()
+                .custom_element_registry()
+                .is_some_and(|registry| *registry != *self);
+            if is_document || registry_mismatch {
+                return Err(Error::NotSupported(Some(
+                    "Initialize is not allowed on a non-scoped registry for this root".to_owned(),
+                )));
+            }
+        }
+
+        // Step 2. If root is a Document node whose custom element registry is null,
+        // then set root's custom element registry to this.
+        if let Some(document) = root.downcast::<Document>() {
+            if document.custom_element_registry().is_none() {
+                document.set_custom_element_registry(DomRoot::from_ref(self));
+            }
+        }
+        // Step 3. Otherwise, if root is a ShadowRoot node whose custom element registry
+        // is null, then set root's custom element registry to this.
+        else if let Some(shadow_root) = root.downcast::<ShadowRoot>() &&
+            shadow_root.custom_element_registry().is_none()
+        {
+            shadow_root.set_custom_element_registry(DomRoot::from_ref(self));
+        }
+
+        // Step 4. For each inclusive descendant inclusiveDescendant of root, in tree order:
+        for node in root.traverse_preorder(ShadowIncluding::No) {
+            // Step 4.1. If inclusiveDescendant is not an Element node, then continue.
+            let Some(element) = node.downcast::<Element>() else {
+                continue;
+            };
+
+            // Step 4.2. If inclusiveDescendant's custom element registry is null:
+            if element.custom_element_registry().is_none() {
+                // Step 4.2.1. Set inclusiveDescendant's custom element registry to this.
+                element.set_custom_element_registry(Some(DomRoot::from_ref(self)));
+
+                // Step 4.2.2. If this's is scoped is true, then append
+                // inclusiveDescendant's node document to this's scoped document set.
+                // TODO: scoped_document_set needs to be added to CustomElementRegistry.
+                if self.is_scoped.get() {
+                    // TODO: self.scoped_document_set.borrow_mut().push(...)
+                }
+            // Step 4.3. If inclusiveDescendant's custom element registry is not this, then continue.
+            } else if element
+                .custom_element_registry()
+                .is_none_or(|registry| *registry != *self)
+            {
+                continue;
+            }
+
+            // Step 4.4. Try to upgrade inclusiveDescendant.
+            try_upgrade_element(element);
+        }
+        Ok(())
+    }
 }
 
 #[derive(Clone, JSTraceable, MallocSizeOf)]

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -656,7 +656,7 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
         // then set root's custom element registry to this.
         if let Some(document) = root.downcast::<Document>() {
             if document.custom_element_registry().is_none() {
-                document.set_custom_element_registry(DomRoot::from_ref(self));
+                document.set_custom_element_registry(self);
             }
         }
         // Step 3. Otherwise, if root is a ShadowRoot node whose custom element registry
@@ -664,7 +664,7 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
         else if let Some(shadow_root) = root.downcast::<ShadowRoot>() &&
             shadow_root.custom_element_registry().is_none()
         {
-            shadow_root.set_custom_element_registry(DomRoot::from_ref(self));
+            shadow_root.set_custom_element_registry(self);
         }
 
         // Step 4. For each inclusive descendant inclusiveDescendant of root, in tree order:
@@ -677,7 +677,7 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
             // Step 4.2. If inclusiveDescendant's custom element registry is null:
             if element.custom_element_registry().is_none() {
                 // Step 4.2.1. Set inclusiveDescendant's custom element registry to this.
-                element.set_custom_element_registry(Some(DomRoot::from_ref(self)));
+                element.set_custom_element_registry(Some(self));
 
                 // Step 4.2.2. If this's is scoped is true, then append
                 // inclusiveDescendant's node document to this's scoped document set.
@@ -807,7 +807,7 @@ impl CustomElementDefinition {
         cx: &mut JSContext,
         document: &Document,
         prefix: Option<Prefix>,
-        registry: Option<DomRoot<CustomElementRegistry>>,
+        registry: Option<&CustomElementRegistry>,
     ) -> Fallible<DomRoot<Element>> {
         let window = document.window();
 

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -2837,7 +2837,7 @@ impl Document {
         self.document_or_shadow_root.custom_element_registry()
     }
 
-    pub(crate) fn set_custom_element_registry(&self, registry: DomRoot<CustomElementRegistry>) {
+    pub(crate) fn set_custom_element_registry(&self, registry: &CustomElementRegistry) {
         self.document_or_shadow_root
             .set_custom_element_registry(Some(registry));
     }

--- a/components/script/dom/document/documentorshadowroot.rs
+++ b/components/script/dom/document/documentorshadowroot.rs
@@ -137,11 +137,8 @@ impl DocumentOrShadowRoot {
         self.custom_element_registry.get()
     }
 
-    pub(crate) fn set_custom_element_registry(
-        &self,
-        registry: Option<DomRoot<CustomElementRegistry>>,
-    ) {
-        self.custom_element_registry.set(registry.as_deref());
+    pub(crate) fn set_custom_element_registry(&self, registry: Option<&CustomElementRegistry>) {
+        self.custom_element_registry.set(registry);
     }
 
     /// Retarget the result of `elementsFromPoint` or `elementFromPoint` according to the

--- a/components/script/dom/element/create.rs
+++ b/components/script/dom/element/create.rs
@@ -149,7 +149,7 @@ fn create_html_element(
             let element = create_native_html_element(cx, name, prefix, document, creator, proto);
             element.set_is(definition.name.clone());
             element.set_custom_element_state(CustomElementState::Undefined);
-            element.set_custom_element_registry(registry);
+            element.set_custom_element_registry(registry.as_deref());
 
             match mode {
                 // Step 4.3. If synchronousCustomElements is true, then run this step while catching any exceptions:
@@ -177,7 +177,7 @@ fn create_html_element(
                         cx,
                         document,
                         prefix.clone(),
-                        registry.clone(),
+                        registry.as_deref(),
                     ) {
                         Ok(element) => {
                             element.set_custom_element_definition(definition.clone());
@@ -202,7 +202,7 @@ fn create_html_element(
                                 cx, local_name, prefix, document, proto,
                             ));
                             element.set_custom_element_state(CustomElementState::Failed);
-                            element.set_custom_element_registry(registry);
+                            element.set_custom_element_registry(registry.as_deref());
                             element
                         },
                     };
@@ -218,7 +218,7 @@ fn create_html_element(
                         cx, name.local, prefix, document, proto,
                     ));
                     result.set_custom_element_state(CustomElementState::Undefined);
-                    result.set_custom_element_registry(registry);
+                    result.set_custom_element_registry(registry.as_deref());
                     // Step 4.2.2. Enqueue a custom element upgrade reaction given result and definition.
                     ScriptThread::enqueue_upgrade_reaction(&result, definition);
                     return result;
@@ -240,12 +240,12 @@ fn create_html_element(
         Some(is) => {
             result.set_is(is);
             result.set_custom_element_state(CustomElementState::Undefined);
-            result.set_custom_element_registry(registry);
+            result.set_custom_element_registry(registry.as_deref());
         },
         None => {
             if is_valid_custom_element_name(&name.local) {
                 result.set_custom_element_state(CustomElementState::Undefined);
-                result.set_custom_element_registry(registry);
+                result.set_custom_element_registry(registry.as_deref());
             } else {
                 // Note: This is a performance optimization. See the doc comment of the method for
                 // more information.

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -1694,11 +1694,8 @@ impl Element {
         *self.prefix.borrow_mut() = prefix;
     }
 
-    pub(crate) fn set_custom_element_registry(
-        &self,
-        registry: Option<DomRoot<CustomElementRegistry>>,
-    ) {
-        self.ensure_rare_data().custom_element_registry = registry.as_deref().map(Dom::from_ref);
+    pub(crate) fn set_custom_element_registry(&self, registry: Option<&CustomElementRegistry>) {
+        self.ensure_rare_data().custom_element_registry = registry.map(Dom::from_ref);
     }
 
     pub(crate) fn custom_element_registry(&self) -> Option<DomRoot<CustomElementRegistry>> {

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -3000,7 +3000,7 @@ impl Node {
                     None,
                 );
                 // TODO: Move this into `Element::create`
-                element.set_custom_element_registry(registry);
+                element.set_custom_element_registry(registry.as_deref());
                 DomRoot::upcast::<Node>(element)
             },
         };

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -378,7 +378,7 @@ impl ShadowRoot {
         self.document_or_shadow_root.custom_element_registry()
     }
 
-    pub(crate) fn set_custom_element_registry(&self, registry: DomRoot<CustomElementRegistry>) {
+    pub(crate) fn set_custom_element_registry(&self, registry: &CustomElementRegistry) {
         self.document_or_shadow_root
             .set_custom_element_registry(Some(registry));
     }

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -377,6 +377,11 @@ impl ShadowRoot {
     pub(crate) fn custom_element_registry(&self) -> Option<DomRoot<CustomElementRegistry>> {
         self.document_or_shadow_root.custom_element_registry()
     }
+
+    pub(crate) fn set_custom_element_registry(&self, registry: DomRoot<CustomElementRegistry>) {
+        self.document_or_shadow_root
+            .set_custom_element_registry(Some(registry));
+    }
 }
 
 impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -1442,7 +1442,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
         // A Window's associated Document is always created with
         // a new CustomElementRegistry object.
         let registry = CustomElementRegistry::new(cx, self);
-        document.set_custom_element_registry(DomRoot::from_ref(&*registry));
+        document.set_custom_element_registry(&registry);
         // Step 2: Return this's associated Document's custom element registry.
         registry
     }

--- a/components/script_bindings/webidls/CustomElementRegistry.webidl
+++ b/components/script_bindings/webidls/CustomElementRegistry.webidl
@@ -18,6 +18,7 @@ interface CustomElementRegistry {
   DOMString? getName(CustomElementConstructor constructor);
   Promise<CustomElementConstructor> whenDefined(DOMString name);
   [CEReactions] undefined upgrade(Node root);
+  [CEReactions, Throws] undefined initialize(Node root);
 };
 
 callback CustomElementConstructor = HTMLElement();

--- a/tests/wpt/meta/custom-elements/registries/CustomElementRegistry-initialize.html.ini
+++ b/tests/wpt/meta/custom-elements/registries/CustomElementRegistry-initialize.html.ini
@@ -1,39 +1,3 @@
 [CustomElementRegistry-initialize.html]
-  [initialize is a function on both global and scoped CustomElementRegistry]
-    expected: FAIL
-
-  [initialize sets element.customElementRegistry to the global registry]
-    expected: FAIL
-
-  [initialize does not set the registry of nested shadow tree to the global registry]
-    expected: FAIL
-
-  [initialize sets element.customElementRegistry to a scoped registry]
-    expected: FAIL
-
-  [initialize does not set the registry of nested shadow tree to a scoped registry]
-    expected: FAIL
-
-  [initialize sets element.customElementRegistry permantently]
-    expected: FAIL
-
   [initialize is no-op on a subtree with a non-null registry]
-    expected: FAIL
-
-  [initialize works on Document]
-    expected: FAIL
-
-  [initialize works on DocumentFragment]
-    expected: FAIL
-
-  [initialize throws when the registry scoped is false and the root is the document.]
-    expected: FAIL
-
-  [initialize throws when the registry scoped is false and the root document already has another registry]
-    expected: FAIL
-
-  [initialize does not set descendants whose customElementRegistry already uses a different registry]
-    expected: FAIL
-
-  [initialize sets registry on shadow root descendants with no registry]
     expected: FAIL

--- a/tests/wpt/meta/custom-elements/registries/Element-customElementRegistry.html.ini
+++ b/tests/wpt/meta/custom-elements/registries/Element-customElementRegistry.html.ini
@@ -8,9 +8,6 @@
   [customElementRegistry on a clone of a declarative shadow tree with shadowrootcustomelementregistry should return the global registry after getting inserted into a document]
     expected: FAIL
 
-  [customElementRegistry on an element inside a declarative shadow DOM with shadowrootcustomelementregistry should return the scoped registry after calling initialize]
-    expected: FAIL
-
   [customElementRegistry on a builtin element created by calling createElement on CustomElementRegistry should return the registry]
     expected: FAIL
 

--- a/tests/wpt/meta/custom-elements/registries/element-mutation.html.ini
+++ b/tests/wpt/meta/custom-elements/registries/element-mutation.html.ini
@@ -2,24 +2,6 @@
   [Declarative shadow DOM with shadowrootcustomelementregistry attribute without registry initialized should remain null registry after adoption.]
     expected: FAIL
 
-  [An element with scoped registry should not change its registry when run append out of the shadow tree.]
-    expected: FAIL
-
-  [An element with scoped registry should not change its registry when run append into another shadow tree with different scoped registry.]
-    expected: FAIL
-
-  [An element with scoped registry should not change its registry when run appendChild out of the shadow tree.]
-    expected: FAIL
-
-  [An element with scoped registry should not change its registry when run appendChild into another shadow tree with different scoped registry.]
-    expected: FAIL
-
-  [An element with scoped registry should not change its registry when run prepend out of the shadow tree.]
-    expected: FAIL
-
-  [An element with scoped registry should not change its registry when run prepend into another shadow tree with different scoped registry.]
-    expected: FAIL
-
   [A freshly created element should preserve global registry when run prepend between scoped shadow roots.]
     expected: FAIL
 

--- a/tests/wpt/meta/custom-elements/registries/scoped-registry-append-does-not-upgrade.html.ini
+++ b/tests/wpt/meta/custom-elements/registries/scoped-registry-append-does-not-upgrade.html.ini
@@ -2,9 +2,6 @@
   [Connecting a custom element candiate with a scoped custom element registry does not change the registry]
     expected: FAIL
 
-  [Inserting a custom element candiate with null registry does not change the registry]
-    expected: FAIL
-
   [Inserting the shadow host of a shadow root with a scoped custom element registry does not change the registry]
     expected: FAIL
 

--- a/tests/wpt/meta/custom-elements/registries/scoped-registry-initialize-upgrades.html.ini
+++ b/tests/wpt/meta/custom-elements/registries/scoped-registry-initialize-upgrades.html.ini
@@ -1,23 +1,14 @@
 [scoped-registry-initialize-upgrades.html]
-  [Document: CustomElementRegistry.prototype.initialize should upgrade the element given to the first argument]
-    expected: FAIL
-
   [Document: CustomElementRegistry.prototype.initialize should upgrade elements in tree order]
     expected: FAIL
 
   [Document: CustomElementRegistry.prototype.initialize only upgrades elements beloning to the registry]
     expected: FAIL
 
-  [HTMLDocument: CustomElementRegistry.prototype.initialize should upgrade the element given to the first argument]
-    expected: FAIL
-
   [HTMLDocument: CustomElementRegistry.prototype.initialize should upgrade elements in tree order]
     expected: FAIL
 
   [HTMLDocument: CustomElementRegistry.prototype.initialize only upgrades elements beloning to the registry]
-    expected: FAIL
-
-  [XHTMLDocument: CustomElementRegistry.prototype.initialize should upgrade the element given to the first argument]
     expected: FAIL
 
   [XHTMLDocument: CustomElementRegistry.prototype.initialize should upgrade elements in tree order]

--- a/tests/wpt/meta/custom-elements/registries/scoped-registry-initialize.html.ini
+++ b/tests/wpt/meta/custom-elements/registries/scoped-registry-initialize.html.ini
@@ -1,53 +1,17 @@
 [scoped-registry-initialize.html]
-  [Document: customElementRegistry of an upgrade candidate after calling CustomElementRegistry.prototype.initialize should return the registry]
-    expected: FAIL
-
-  [Document: customElementRegistry of an upgrade candidate created with an explicit customElementRegistry argument should return the registry]
-    expected: FAIL
-
-  [Document: customElementRegistry of an unknown element after calling CustomElementRegistry.prototype.initialize should return the registry]
-    expected: FAIL
-
   [Document: customElementRegistry of an unknown element created with an explicit customElementRegistry argument should return the registry]
-    expected: FAIL
-
-  [Document: customElementRegistry of document and an upgrade candidate after calling CustomElementRegistry.prototype.initialize should return the registry]
     expected: FAIL
 
   [Document: customElementRegistry of an element created after calling CustomElementRegistry.prototype.initialize should return the registry]
     expected: FAIL
 
-  [HTMLDocument: customElementRegistry of an upgrade candidate after calling CustomElementRegistry.prototype.initialize should return the registry]
-    expected: FAIL
-
-  [HTMLDocument: customElementRegistry of an upgrade candidate created with an explicit customElementRegistry argument should return the registry]
-    expected: FAIL
-
-  [HTMLDocument: customElementRegistry of an unknown element after calling CustomElementRegistry.prototype.initialize should return the registry]
-    expected: FAIL
-
   [HTMLDocument: customElementRegistry of an unknown element created with an explicit customElementRegistry argument should return the registry]
-    expected: FAIL
-
-  [HTMLDocument: customElementRegistry of document and an upgrade candidate after calling CustomElementRegistry.prototype.initialize should return the registry]
     expected: FAIL
 
   [HTMLDocument: customElementRegistry of an element created after calling CustomElementRegistry.prototype.initialize should return the registry]
     expected: FAIL
 
-  [XHTMLDocument: customElementRegistry of an upgrade candidate after calling CustomElementRegistry.prototype.initialize should return the registry]
-    expected: FAIL
-
-  [XHTMLDocument: customElementRegistry of an upgrade candidate created with an explicit customElementRegistry argument should return the registry]
-    expected: FAIL
-
-  [XHTMLDocument: customElementRegistry of an unknown element after calling CustomElementRegistry.prototype.initialize should return the registry]
-    expected: FAIL
-
   [XHTMLDocument: customElementRegistry of an unknown element created with an explicit customElementRegistry argument should return the registry]
-    expected: FAIL
-
-  [XHTMLDocument: customElementRegistry of document and an upgrade candidate after calling CustomElementRegistry.prototype.initialize should return the registry]
     expected: FAIL
 
   [XHTMLDocument: customElementRegistry of an element created after calling CustomElementRegistry.prototype.initialize should return the registry]

--- a/tests/wpt/meta/html/dom/idlharness.https.html.ini
+++ b/tests/wpt/meta/html/dom/idlharness.https.html.ini
@@ -4655,9 +4655,6 @@
   [OffscreenCanvasRenderingContext2D interface: attribute lang]
     expected: FAIL
 
-  [CustomElementRegistry interface: operation initialize(Node)]
-    expected: FAIL
-
   [NavigationTransition interface: attribute committed]
     expected: FAIL
 


### PR DESCRIPTION
Wire `initialize` to `CustomElementRegistry` interface
Reduce unnecessary rooting in all variants of `fn set_custom_element_registry`.

Testing: More WPT Passed
Fixes: Part of https://github.com/servo/servo/issues/45603