### PR TITLE
release: Fix partial nightly releases on failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,6 +110,14 @@ jobs:
       - upload-vendored-source
       - upload-artifacts-nightly
       - upload-artifacts-release
+      # Add all build-* jobs here, so that the we take the `Publish release (failure)` branch, if
+      # any of the build jobs failed.
+      - build-android
+      - build-linux
+      - build-mac
+      - build-mac-arm64
+      - build-ohos
+      - build-win
 
   publish-crates-io:
     name: 'Publish to crates.io'
@@ -196,8 +204,11 @@ jobs:
 
   upload-artifacts-nightly:
     # Only run scheduled nightly builds on upstream servo.
+    # Partial failures of the build jobs are accepted for nightly.
     if: |
-      (github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch')
+      !cancelled() 
+        && needs.create-draft-release.result == 'success'
+        && (github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch')
         && (inputs.regular_release || false) == false
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
When one of the build jobs spuriously fails, we still want to upload the nightly artifacts.
The release should take the failed path, and be marked as a prerelease, so that it doesn't appear on the servo.org download page. We add the build jobs as direct dependencies on the nightly publish job, so that the `if` condition can detect that via `needs`.
This fixes publishing (success branch) of an empty nightly release, if one of the build jobs failed, breaking download links on servo.org. 
Reported on zulip.

For the regular release failing is fine, human intervention is expected and there is no automatic publish.

Testing: Not tested

