### PR TITLE
script: Harden javascript: URL evaluation.

### DIFF
--- a/components/script/dom/globalscope/globalscope.rs
+++ b/components/script/dom/globalscope/globalscope.rs
@@ -2933,6 +2933,8 @@ impl GlobalScope {
         introduction_type: Option<&'static CStr>,
         rval: Option<MutableHandleValue>,
     ) -> Result<(), JavaScriptEvaluationError> {
+        assert!(self.can_run_script());
+
         run_a_script::<DomTypeHolder, _, _>(cx, self, |cx| {
             let url = self.api_base_url();
             let fetch_options = ScriptFetchOptions::default_classic_script();

--- a/components/script/dom/globalscope/script_execution.rs
+++ b/components/script/dom/globalscope/script_execution.rs
@@ -303,7 +303,7 @@ impl GlobalScope {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#check-if-we-can-run-script>
-    fn can_run_script(&self) -> bool {
+    pub(crate) fn can_run_script(&self) -> bool {
         // Step 1 If the global object specified by settings is a Window object
         // whose Document object is not fully active, then return "do not run".
         //

--- a/components/script/dom/globalscope/script_execution.rs
+++ b/components/script/dom/globalscope/script_execution.rs
@@ -316,7 +316,7 @@ impl GlobalScope {
         // does not have its sandboxed scripts browsing context flag set.
         if let Some(window) = self.downcast::<Window>() {
             let doc = window.Document();
-            doc.is_fully_active() ||
+            doc.is_fully_active() &&
                 !doc.has_active_sandboxing_flag(
                     SandboxingFlagSet::SANDBOXED_SCRIPTS_BROWSING_CONTEXT_FLAG,
                 )

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -617,18 +617,12 @@ impl ScriptThread {
     ///
     /// <https://github.com/whatwg/html/issues/2591>
     fn check_load_origin(source: &LoadOrigin, target: &OriginSnapshot) -> bool {
-        match (source, target.immutable()) {
-            (LoadOrigin::Constellation, _) | (LoadOrigin::WebDriver, _) => {
+        match source {
+            LoadOrigin::Constellation | LoadOrigin::WebDriver => {
                 // Always allow loads initiated by the constellation or webdriver.
                 true
             },
-            (_, ImmutableOrigin::Opaque(_)) => {
-                // If the target is opaque, allow.
-                // This covers newly created about:blank auxiliaries, and iframe with no src.
-                // TODO: https://github.com/servo/servo/issues/22879
-                true
-            },
-            (LoadOrigin::Script(source_origin), _) => source_origin.same_origin_domain(target),
+            LoadOrigin::Script(source_origin) => source_origin.same_origin_domain(target),
         }
     }
 


### PR DESCRIPTION
Although we're not supposed to end up in code that evaluates javascript: URLs in contexts in which that's not allowed, vulnerabilties can happen. This change should turn that into an assertion failure instead of allowing it to happen.

This also fixes a condition for determining if a window can execute JS, where we previously would return true for a non-sandboxed document that was not active. I have not been able to figure out a way to test this condition.

Testing: There are already tests for the logic that prevents us from attempting to evaluate JS in these cases.
