### PR TITLE
script: JSContextify most of webgl

### DIFF
--- a/components/script/dom/webgl/extensions/ext/angleinstancedarrays.rs
+++ b/components/script/dom/webgl/extensions/ext/angleinstancedarrays.rs
@@ -5,6 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::script_runtime::temp_cx;
 use servo_canvas_traits::webgl::WebGLVersion;
 
 use super::{WebGLExtension, WebGLExtensionSpec, WebGLExtensions};
@@ -67,15 +68,19 @@ impl WebGLExtension for ANGLEInstancedArrays {
 
 impl ANGLEInstancedArraysMethods<crate::DomTypeHolder> for ANGLEInstancedArrays {
     /// <https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/>
+    #[expect(unsafe_code, reason = "transfer to jscontext")]
     fn DrawArraysInstancedANGLE(&self, mode: u32, first: i32, count: i32, primcount: i32) {
+        let mut cx = unsafe { temp_cx() };
+        let cx = &mut cx;
         handle_potential_webgl_error!(
             self.ctx,
             self.ctx
-                .draw_arrays_instanced(mode, first, count, primcount)
+                .draw_arrays_instanced(cx, mode, first, count, primcount)
         )
     }
 
     /// <https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/>
+    #[expect(unsafe_code, reason = "transfer to jscontext")]
     fn DrawElementsInstancedANGLE(
         &self,
         mode: u32,
@@ -84,14 +89,19 @@ impl ANGLEInstancedArraysMethods<crate::DomTypeHolder> for ANGLEInstancedArrays 
         offset: i64,
         primcount: i32,
     ) {
+        let mut cx = unsafe { temp_cx() };
+        let cx = &mut cx;
         handle_potential_webgl_error!(
             self.ctx,
             self.ctx
-                .draw_elements_instanced(mode, count, type_, offset, primcount)
+                .draw_elements_instanced(cx, mode, count, type_, offset, primcount)
         )
     }
 
+    #[expect(unsafe_code, reason = "transfer to jscontext")]
     fn VertexAttribDivisorANGLE(&self, index: u32, divisor: u32) {
-        self.ctx.vertex_attrib_divisor(index, divisor);
+        let mut cx = unsafe { temp_cx() };
+        let cx = &mut cx;
+        self.ctx.vertex_attrib_divisor(cx, index, divisor);
     }
 }

--- a/components/script/dom/webgl/extensions/ext/oesvertexarrayobject.rs
+++ b/components/script/dom/webgl/extensions/ext/oesvertexarrayobject.rs
@@ -5,6 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::script_runtime::temp_cx;
 use servo_canvas_traits::webgl::WebGLVersion;
 
 use super::{WebGLExtension, WebGLExtensionSpec, WebGLExtensions};
@@ -33,13 +34,19 @@ impl OESVertexArrayObject {
 
 impl OESVertexArrayObjectMethods<crate::DomTypeHolder> for OESVertexArrayObject {
     /// <https://www.khronos.org/registry/webgl/extensions/OES_vertex_array_object/>
+    #[expect(unsafe_code, reason = "transfer to jscontext")]
     fn CreateVertexArrayOES(&self) -> Option<DomRoot<WebGLVertexArrayObjectOES>> {
-        self.ctx.create_vertex_array()
+        let mut cx = unsafe { temp_cx() };
+        let cx = &mut cx;
+        self.ctx.create_vertex_array(cx)
     }
 
     /// <https://www.khronos.org/registry/webgl/extensions/OES_vertex_array_object/>
+    #[expect(unsafe_code, reason = "transfer to jscontext")]
     fn DeleteVertexArrayOES(&self, vao: Option<&WebGLVertexArrayObjectOES>) {
-        self.ctx.delete_vertex_array(vao);
+        let mut cx = unsafe { temp_cx() };
+        let cx = &mut cx;
+        self.ctx.delete_vertex_array(cx, vao);
     }
 
     /// <https://www.khronos.org/registry/webgl/extensions/OES_vertex_array_object/>

--- a/components/script/dom/webgl/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl/webgl2renderingcontext.rs
@@ -18,6 +18,7 @@ use pixels::{Alpha, Snapshot};
 use script_bindings::conversions::SafeToJSValConvertible;
 use script_bindings::interfaces::WebGL2RenderingContextHelpers;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::script_runtime::CanGc;
 use servo_base::generic_channel::{self, GenericSharedMemory};
 use servo_canvas_traits::webgl::WebGLError::*;
 use servo_canvas_traits::webgl::{
@@ -74,7 +75,7 @@ use crate::dom::webgl::webgltransformfeedback::WebGLTransformFeedback;
 use crate::dom::webgl::webgluniformlocation::WebGLUniformLocation;
 use crate::dom::webgl::webglvertexarrayobject::WebGLVertexArrayObject;
 use crate::dom::window::Window;
-use crate::script_runtime::{CanGc, JSContext};
+use crate::script_runtime::JSContext;
 
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 #[derive(JSTraceable, MallocSizeOf)]
@@ -216,8 +217,11 @@ impl WebGL2RenderingContext {
 static WEBGL2_ORIGINS: &[&str] = &["www.servoexperiments.com"];
 
 impl WebGL2RenderingContext {
-    pub(crate) fn current_vao(&self) -> DomRoot<WebGLVertexArrayObject> {
-        self.base.current_vao_webgl2()
+    pub(crate) fn current_vao(
+        &self,
+        cx: &mut js::context::JSContext,
+    ) -> DomRoot<WebGLVertexArrayObject> {
+        self.base.current_vao_webgl2(cx)
     }
 
     pub(crate) fn validate_uniform_block_for_draw(&self) {
@@ -262,7 +266,7 @@ impl WebGL2RenderingContext {
         }
     }
 
-    fn validate_vertex_attribs_for_draw(&self) {
+    fn validate_vertex_attribs_for_draw(&self, cx: &mut js::context::JSContext) {
         let program = match self.base.current_program() {
             Some(program) => program,
             None => return,
@@ -287,7 +291,7 @@ impl WebGL2RenderingContext {
                 constants::FLOAT_VEC4,
             ],
         ];
-        let vao = self.current_vao();
+        let vao = self.current_vao(cx);
         for prog_attrib in program.active_attribs().iter() {
             let attrib = handle_potential_webgl_error!(
                 self.base,
@@ -326,7 +330,11 @@ impl WebGL2RenderingContext {
         DomRoot::from_ref(&*self.base)
     }
 
-    fn bound_buffer(&self, target: u32) -> WebGLResult<Option<DomRoot<WebGLBuffer>>> {
+    fn bound_buffer(
+        &self,
+        cx: &mut js::context::JSContext,
+        target: u32,
+    ) -> WebGLResult<Option<DomRoot<WebGLBuffer>>> {
         match target {
             constants::COPY_READ_BUFFER => Ok(self.bound_copy_read_buffer.get()),
             constants::COPY_WRITE_BUFFER => Ok(self.bound_copy_write_buffer.get()),
@@ -334,8 +342,10 @@ impl WebGL2RenderingContext {
             constants::PIXEL_UNPACK_BUFFER => Ok(self.bound_pixel_unpack_buffer.get()),
             constants::TRANSFORM_FEEDBACK_BUFFER => Ok(self.bound_transform_feedback_buffer.get()),
             constants::UNIFORM_BUFFER => Ok(self.bound_uniform_buffer.get()),
-            constants::ELEMENT_ARRAY_BUFFER => Ok(self.current_vao().element_array_buffer().get()),
-            _ => self.base.bound_buffer(target),
+            constants::ELEMENT_ARRAY_BUFFER => {
+                Ok(self.current_vao(cx).element_array_buffer().get())
+            },
+            _ => self.base.bound_buffer(cx, target),
         }
     }
 
@@ -839,23 +849,39 @@ impl WebGL2RenderingContext {
         true
     }
 
-    fn vertex_attrib_i(&self, index: u32, x: i32, y: i32, z: i32, w: i32) {
+    fn vertex_attrib_i(
+        &self,
+        cx: &mut js::context::JSContext,
+        index: u32,
+        x: i32,
+        y: i32,
+        z: i32,
+        w: i32,
+    ) {
         if index >= self.base.limits().max_vertex_attribs {
             return self.base.webgl_error(InvalidValue);
         }
         self.base.current_vertex_attribs()[index as usize] = VertexAttrib::Int(x, y, z, w);
-        self.current_vao()
+        self.current_vao(cx)
             .set_vertex_attrib_type(index, constants::INT);
         self.base
             .send_command(WebGLCommand::VertexAttribI(index, x, y, z, w));
     }
 
-    fn vertex_attrib_u(&self, index: u32, x: u32, y: u32, z: u32, w: u32) {
+    fn vertex_attrib_u(
+        &self,
+        cx: &mut js::context::JSContext,
+        index: u32,
+        x: u32,
+        y: u32,
+        z: u32,
+        w: u32,
+    ) {
         if index >= self.base.limits().max_vertex_attribs {
             return self.base.webgl_error(InvalidValue);
         }
         self.base.current_vertex_attribs()[index as usize] = VertexAttrib::Uint(x, y, z, w);
-        self.current_vao()
+        self.current_vao(cx)
             .set_vertex_attrib_type(index, constants::UNSIGNED_INT);
         self.base
             .send_command(WebGLCommand::VertexAttribU(index, x, y, z, w));
@@ -1028,6 +1054,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5>
     fn GetBufferParameter(
         &self,
+        cx: &mut js::context::JSContext,
         _cx: JSContext,
         target: u32,
         parameter: u32,
@@ -1035,7 +1062,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     ) {
         let buffer = handle_potential_webgl_error!(
             self.base,
-            self.bound_buffer(target),
+            self.bound_buffer(cx, target),
             return retval.set(NullValue())
         );
         self.base.get_buffer_param(buffer, parameter, retval)
@@ -1124,12 +1151,18 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
                 return;
             },
             constants::ELEMENT_ARRAY_BUFFER_BINDING => {
-                let buffer = self.current_vao().element_array_buffer().get();
+                let buffer = {
+                    let cx = unsafe { temp_cx() };
+                    self.current_vao().element_array_buffer().get()
+                };
                 buffer.safe_to_jsval(cx, rval, CanGc::deprecated_note());
                 return;
             },
             constants::VERTEX_ARRAY_BINDING => {
-                let vao = self.current_vao();
+                let vao = {
+                    let cx = unsafe { temp_cx() };
+                    self.current_vao()
+                };
                 let vao = vao.id().map(|_| &*vao);
                 vao.safe_to_jsval(cx, rval, CanGc::deprecated_note());
                 return;
@@ -1393,7 +1426,12 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.2>
-    fn BindBuffer(&self, target: u32, buffer: Option<&WebGLBuffer>) {
+    fn BindBuffer(
+        &self,
+        cx: &mut js::context::JSContext,
+        target: u32,
+        buffer: Option<&WebGLBuffer>,
+    ) {
         let current_vao;
         let slot = match target {
             constants::COPY_READ_BUFFER => &self.bound_copy_read_buffer,
@@ -1403,10 +1441,10 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
             constants::TRANSFORM_FEEDBACK_BUFFER => &self.bound_transform_feedback_buffer,
             constants::UNIFORM_BUFFER => &self.bound_uniform_buffer,
             constants::ELEMENT_ARRAY_BUFFER => {
-                current_vao = self.current_vao();
+                current_vao = self.current_vao(cx);
                 current_vao.element_array_buffer()
             },
-            _ => return self.base.BindBuffer(target, buffer),
+            _ => return self.base.BindBuffer(cx, target, buffer),
         };
         self.base.bind_buffer_maybe(slot, target, buffer);
     }
@@ -1457,18 +1495,24 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5>
-    fn BufferData_(&self, target: u32, data: Option<ArrayBufferViewOrArrayBuffer>, usage: u32) {
+    fn BufferData_(
+        &self,
+        cx: &mut js::context::JSContext,
+        target: u32,
+        data: Option<ArrayBufferViewOrArrayBuffer>,
+        usage: u32,
+    ) {
         let usage = handle_potential_webgl_error!(self.base, self.buffer_usage(usage), return);
         let bound_buffer =
-            handle_potential_webgl_error!(self.base, self.bound_buffer(target), return);
+            handle_potential_webgl_error!(self.base, self.bound_buffer(cx, target), return);
         self.base.buffer_data(target, data, usage, bound_buffer)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5>
-    fn BufferData(&self, target: u32, size: i64, usage: u32) {
+    fn BufferData(&self, cx: &mut js::context::JSContext, target: u32, size: i64, usage: u32) {
         let usage = handle_potential_webgl_error!(self.base, self.buffer_usage(usage), return);
         let bound_buffer =
-            handle_potential_webgl_error!(self.base, self.bound_buffer(target), return);
+            handle_potential_webgl_error!(self.base, self.bound_buffer(cx, target), return);
         self.base.buffer_data_(target, size, usage, bound_buffer)
     }
 
@@ -1476,6 +1520,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     #[expect(unsafe_code)]
     fn BufferData__(
         &self,
+        cx: &mut js::context::JSContext,
         target: u32,
         data: CustomAutoRooterGuard<ArrayBufferView>,
         usage: u32,
@@ -1484,7 +1529,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     ) {
         let usage = handle_potential_webgl_error!(self.base, self.buffer_usage(usage), return);
         let bound_buffer =
-            handle_potential_webgl_error!(self.base, self.bound_buffer(target), return);
+            handle_potential_webgl_error!(self.base, self.bound_buffer(cx, target), return);
         let bound_buffer =
             handle_potential_webgl_error!(self.base, bound_buffer.ok_or(InvalidOperation), return);
 
@@ -1517,9 +1562,15 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5>
-    fn BufferSubData(&self, target: u32, offset: i64, data: ArrayBufferViewOrArrayBuffer) {
+    fn BufferSubData(
+        &self,
+        cx: &mut js::context::JSContext,
+        target: u32,
+        offset: i64,
+        data: ArrayBufferViewOrArrayBuffer,
+    ) {
         let bound_buffer =
-            handle_potential_webgl_error!(self.base, self.bound_buffer(target), return);
+            handle_potential_webgl_error!(self.base, self.bound_buffer(cx, target), return);
         self.base
             .buffer_sub_data(target, offset, data, bound_buffer)
     }
@@ -1528,6 +1579,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     #[expect(unsafe_code)]
     fn BufferSubData_(
         &self,
+        cx: &mut js::context::JSContext,
         target: u32,
         dst_byte_offset: i64,
         src_data: CustomAutoRooterGuard<ArrayBufferView>,
@@ -1535,7 +1587,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
         length: u32,
     ) {
         let bound_buffer =
-            handle_potential_webgl_error!(self.base, self.bound_buffer(target), return);
+            handle_potential_webgl_error!(self.base, self.bound_buffer(cx, target), return);
         let bound_buffer =
             handle_potential_webgl_error!(self.base, bound_buffer.ok_or(InvalidOperation), return);
 
@@ -1580,6 +1632,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.3>
     fn CopyBufferSubData(
         &self,
+        cx: &mut js::context::JSContext,
         read_target: u32,
         write_target: u32,
         read_offset: i64,
@@ -1591,12 +1644,12 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
         }
 
         let read_buffer =
-            handle_potential_webgl_error!(self.base, self.bound_buffer(read_target), return);
+            handle_potential_webgl_error!(self.base, self.bound_buffer(cx, read_target), return);
         let read_buffer =
             handle_potential_webgl_error!(self.base, read_buffer.ok_or(InvalidOperation), return);
 
         let write_buffer =
-            handle_potential_webgl_error!(self.base, self.bound_buffer(write_target), return);
+            handle_potential_webgl_error!(self.base, self.bound_buffer(cx, write_target), return);
         let write_buffer =
             handle_potential_webgl_error!(self.base, write_buffer.ok_or(InvalidOperation), return);
 
@@ -1637,6 +1690,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     #[expect(unsafe_code)]
     fn GetBufferSubData(
         &self,
+        cx: &mut js::context::JSContext,
         target: u32,
         src_byte_offset: i64,
         mut dst_buffer: CustomAutoRooterGuard<ArrayBufferView>,
@@ -1644,7 +1698,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
         length: u32,
     ) {
         let bound_buffer =
-            handle_potential_webgl_error!(self.base, self.bound_buffer(target), return);
+            handle_potential_webgl_error!(self.base, self.bound_buffer(cx, target), return);
         let bound_buffer =
             handle_potential_webgl_error!(self.base, bound_buffer.ok_or(InvalidOperation), return);
 
@@ -1864,23 +1918,29 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5>
-    fn CreateBuffer(&self) -> Option<DomRoot<WebGLBuffer>> {
-        self.base.CreateBuffer()
+    fn CreateBuffer(&self, cx: &mut js::context::JSContext) -> Option<DomRoot<WebGLBuffer>> {
+        self.base.CreateBuffer(cx)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6>
-    fn CreateFramebuffer(&self) -> Option<DomRoot<WebGLFramebuffer>> {
-        self.base.CreateFramebuffer()
+    fn CreateFramebuffer(
+        &self,
+        cx: &mut js::context::JSContext,
+    ) -> Option<DomRoot<WebGLFramebuffer>> {
+        self.base.CreateFramebuffer(cx)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.7>
-    fn CreateRenderbuffer(&self) -> Option<DomRoot<WebGLRenderbuffer>> {
-        self.base.CreateRenderbuffer()
+    fn CreateRenderbuffer(
+        &self,
+        cx: &mut js::context::JSContext,
+    ) -> Option<DomRoot<WebGLRenderbuffer>> {
+        self.base.CreateRenderbuffer(cx)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8>
-    fn CreateTexture(&self) -> Option<DomRoot<WebGLTexture>> {
-        self.base.CreateTexture()
+    fn CreateTexture(&self, cx: &mut js::context::JSContext) -> Option<DomRoot<WebGLTexture>> {
+        self.base.CreateTexture(cx)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
@@ -1889,17 +1949,24 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
-    fn CreateShader(&self, shader_type: u32) -> Option<DomRoot<WebGLShader>> {
-        self.base.CreateShader(shader_type)
+    fn CreateShader(
+        &self,
+        cx: &mut js::context::JSContext,
+        shader_type: u32,
+    ) -> Option<DomRoot<WebGLShader>> {
+        self.base.CreateShader(cx, shader_type)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.17>
-    fn CreateVertexArray(&self) -> Option<DomRoot<WebGLVertexArrayObject>> {
-        self.base.create_vertex_array_webgl2()
+    fn CreateVertexArray(
+        &self,
+        cx: &mut js::context::JSContext,
+    ) -> Option<DomRoot<WebGLVertexArrayObject>> {
+        self.base.create_vertex_array_webgl2(cx)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5>
-    fn DeleteBuffer(&self, buffer: Option<&WebGLBuffer>) {
+    fn DeleteBuffer(&self, cx: &mut js::context::JSContext, buffer: Option<&WebGLBuffer>) {
         let buffer = match buffer {
             Some(buffer) => buffer,
             None => return,
@@ -1908,7 +1975,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
         if buffer.is_marked_for_deletion() {
             return;
         }
-        self.current_vao().unbind_buffer(buffer);
+        self.current_vao(cx).unbind_buffer(cx, buffer);
         self.unbind_from(self.base.array_buffer_slot(), buffer);
         self.unbind_from(&self.bound_copy_read_buffer, buffer);
         self.unbind_from(&self.bound_copy_write_buffer, buffer);
@@ -1953,21 +2020,32 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.17>
-    fn DeleteVertexArray(&self, vertex_array: Option<&WebGLVertexArrayObject>) {
-        self.base.delete_vertex_array_webgl2(vertex_array);
+    fn DeleteVertexArray(
+        &self,
+        cx: &mut js::context::JSContext,
+        vertex_array: Option<&WebGLVertexArrayObject>,
+    ) {
+        self.base.delete_vertex_array_webgl2(cx, vertex_array);
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11>
-    fn DrawArrays(&self, mode: u32, first: i32, count: i32) {
+    fn DrawArrays(&self, cx: &mut js::context::JSContext, mode: u32, first: i32, count: i32) {
         self.validate_uniform_block_for_draw();
-        self.validate_vertex_attribs_for_draw();
+        self.validate_vertex_attribs_for_draw(cx);
         self.base.DrawArrays(mode, first, count)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11>
-    fn DrawElements(&self, mode: u32, count: i32, type_: u32, offset: i64) {
+    fn DrawElements(
+        &self,
+        cx: &mut js::context::JSContext,
+        mode: u32,
+        count: i32,
+        type_: u32,
+        offset: i64,
+    ) {
         self.validate_uniform_block_for_draw();
-        self.validate_vertex_attribs_for_draw();
+        self.validate_vertex_attribs_for_draw(cx);
         self.base.DrawElements(mode, count, type_, offset)
     }
 
@@ -1984,19 +2062,21 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn GetActiveUniform(
         &self,
+        cx: &mut js::context::JSContext,
         program: &WebGLProgram,
         index: u32,
     ) -> Option<DomRoot<WebGLActiveInfo>> {
-        self.base.GetActiveUniform(program, index)
+        self.base.GetActiveUniform(cx, program, index)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn GetActiveAttrib(
         &self,
+        cx: &mut js::context::JSContext,
         program: &WebGLProgram,
         index: u32,
     ) -> Option<DomRoot<WebGLActiveInfo>> {
-        self.base.GetActiveAttrib(program, index)
+        self.base.GetActiveAttrib(cx, program, index)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
@@ -2062,11 +2142,12 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
     fn GetShaderPrecisionFormat(
         &self,
+        cx: &mut js::context::JSContext,
         shader_type: u32,
         precision_type: u32,
     ) -> Option<DomRoot<WebGLShaderPrecisionFormat>> {
         self.base
-            .GetShaderPrecisionFormat(shader_type, precision_type)
+            .GetShaderPrecisionFormat(cx, shader_type, precision_type)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.2>
@@ -2120,10 +2201,11 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn GetUniformLocation(
         &self,
+        cx: &mut js::context::JSContext,
         program: &WebGLProgram,
         name: DOMString,
     ) -> Option<DomRoot<WebGLUniformLocation>> {
-        self.base.GetUniformLocation(program, name)
+        self.base.GetUniformLocation(cx, program, name)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
@@ -2986,52 +3068,93 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
-    fn VertexAttrib1f(&self, indx: u32, x: f32) {
-        self.base.VertexAttrib1f(indx, x)
+    fn VertexAttrib1f(&self, cx: &mut js::context::JSContext, indx: u32, x: f32) {
+        self.base.VertexAttrib1f(cx, indx, x)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
-    fn VertexAttrib1fv(&self, indx: u32, v: Float32ArrayOrUnrestrictedFloatSequence) {
-        self.base.VertexAttrib1fv(indx, v)
+    fn VertexAttrib1fv(
+        &self,
+        cx: &mut js::context::JSContext,
+        indx: u32,
+        v: Float32ArrayOrUnrestrictedFloatSequence,
+    ) {
+        self.base.VertexAttrib1fv(cx, indx, v)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
-    fn VertexAttrib2f(&self, indx: u32, x: f32, y: f32) {
-        self.base.VertexAttrib2f(indx, x, y)
+    fn VertexAttrib2f(&self, cx: &mut js::context::JSContext, indx: u32, x: f32, y: f32) {
+        self.base.VertexAttrib2f(cx, indx, x, y)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
-    fn VertexAttrib2fv(&self, indx: u32, v: Float32ArrayOrUnrestrictedFloatSequence) {
-        self.base.VertexAttrib2fv(indx, v)
+    fn VertexAttrib2fv(
+        &self,
+        cx: &mut js::context::JSContext,
+        indx: u32,
+        v: Float32ArrayOrUnrestrictedFloatSequence,
+    ) {
+        self.base.VertexAttrib2fv(cx, indx, v)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
-    fn VertexAttrib3f(&self, indx: u32, x: f32, y: f32, z: f32) {
-        self.base.VertexAttrib3f(indx, x, y, z)
+    fn VertexAttrib3f(&self, cx: &mut js::context::JSContext, indx: u32, x: f32, y: f32, z: f32) {
+        self.base.VertexAttrib3f(cx, indx, x, y, z)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
-    fn VertexAttrib3fv(&self, indx: u32, v: Float32ArrayOrUnrestrictedFloatSequence) {
-        self.base.VertexAttrib3fv(indx, v)
+    fn VertexAttrib3fv(
+        &self,
+        cx: &mut js::context::JSContext,
+        indx: u32,
+        v: Float32ArrayOrUnrestrictedFloatSequence,
+    ) {
+        self.base.VertexAttrib3fv(cx, indx, v)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
-    fn VertexAttrib4f(&self, indx: u32, x: f32, y: f32, z: f32, w: f32) {
-        self.base.VertexAttrib4f(indx, x, y, z, w)
+    fn VertexAttrib4f(
+        &self,
+        cx: &mut js::context::JSContext,
+        indx: u32,
+        x: f32,
+        y: f32,
+        z: f32,
+        w: f32,
+    ) {
+        self.base.VertexAttrib4f(cx, indx, x, y, z, w)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
-    fn VertexAttrib4fv(&self, indx: u32, v: Float32ArrayOrUnrestrictedFloatSequence) {
-        self.base.VertexAttrib4fv(indx, v)
+    fn VertexAttrib4fv(
+        &self,
+        cx: &mut js::context::JSContext,
+        indx: u32,
+        v: Float32ArrayOrUnrestrictedFloatSequence,
+    ) {
+        self.base.VertexAttrib4fv(cx, indx, v)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.8>
-    fn VertexAttribI4i(&self, index: u32, x: i32, y: i32, z: i32, w: i32) {
-        self.vertex_attrib_i(index, x, y, z, w)
+    fn VertexAttribI4i(
+        &self,
+        cx: &mut js::context::JSContext,
+        index: u32,
+        x: i32,
+        y: i32,
+        z: i32,
+        w: i32,
+    ) {
+        self.vertex_attrib_i(cx, index, x, y, z, w)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.8>
-    fn VertexAttribI4iv(&self, index: u32, v: Int32ArrayOrLongSequence) {
+    fn VertexAttribI4iv(
+        &self,
+        cx: &mut js::context::JSContext,
+        index: u32,
+        v: Int32ArrayOrLongSequence,
+    ) {
         let values = match v {
             Int32ArrayOrLongSequence::Int32Array(v) => v.to_vec(),
             Int32ArrayOrLongSequence::LongSequence(v) => v,
@@ -3039,16 +3162,29 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
         if values.len() < 4 {
             return self.base.webgl_error(InvalidValue);
         }
-        self.vertex_attrib_i(index, values[0], values[1], values[2], values[3]);
+        self.vertex_attrib_i(cx, index, values[0], values[1], values[2], values[3]);
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.8>
-    fn VertexAttribI4ui(&self, index: u32, x: u32, y: u32, z: u32, w: u32) {
-        self.vertex_attrib_u(index, x, y, z, w)
+    fn VertexAttribI4ui(
+        &self,
+        cx: &mut js::context::JSContext,
+        index: u32,
+        x: u32,
+        y: u32,
+        z: u32,
+        w: u32,
+    ) {
+        self.vertex_attrib_u(cx, index, x, y, z, w)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.8>
-    fn VertexAttribI4uiv(&self, index: u32, v: Uint32ArrayOrUnsignedLongSequence) {
+    fn VertexAttribI4uiv(
+        &self,
+        cx: &mut js::context::JSContext,
+        index: u32,
+        v: Uint32ArrayOrUnsignedLongSequence,
+    ) {
         let values = match v {
             Uint32ArrayOrUnsignedLongSequence::Uint32Array(v) => v.to_vec(),
             Uint32ArrayOrUnsignedLongSequence::UnsignedLongSequence(v) => v,
@@ -3056,7 +3192,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
         if values.len() < 4 {
             return self.base.webgl_error(InvalidValue);
         }
-        self.vertex_attrib_u(index, values[0], values[1], values[2], values[3]);
+        self.vertex_attrib_u(cx, index, values[0], values[1], values[2], values[3]);
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
@@ -3771,19 +3907,27 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.9>
-    fn DrawArraysInstanced(&self, mode: u32, first: i32, count: i32, primcount: i32) {
+    fn DrawArraysInstanced(
+        &self,
+        cx: &mut js::contextJSContext,
+        mode: u32,
+        first: i32,
+        count: i32,
+        primcount: i32,
+    ) {
         self.validate_uniform_block_for_draw();
-        self.validate_vertex_attribs_for_draw();
+        self.validate_vertex_attribs_for_draw(cx);
         handle_potential_webgl_error!(
             self.base,
             self.base
-                .draw_arrays_instanced(mode, first, count, primcount)
+                .draw_arrays_instanced(cx, mode, first, count, primcount)
         )
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.9>
     fn DrawElementsInstanced(
         &self,
+        cx: &mut js::context::JSContext,
         mode: u32,
         count: i32,
         type_: u32,
@@ -3791,11 +3935,11 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
         primcount: i32,
     ) {
         self.validate_uniform_block_for_draw();
-        self.validate_vertex_attribs_for_draw();
+        self.validate_vertex_attribs_for_draw(cx);
         handle_potential_webgl_error!(
             self.base,
             self.base
-                .draw_elements_instanced(mode, count, type_, offset, primcount)
+                .draw_elements_instanced(cx, mode, count, type_, offset, primcount)
         )
     }
 
@@ -3828,8 +3972,8 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.12>
-    fn CreateQuery(&self) -> Option<DomRoot<WebGLQuery>> {
-        Some(WebGLQuery::new(&self.base, CanGc::deprecated_note()))
+    fn CreateQuery(&self, cx: &mut js::context::JSContext) -> Option<DomRoot<WebGLQuery>> {
+        Some(WebGLQuery::new(cx, &self.base))
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.12>
@@ -4418,11 +4562,11 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
             ));
         let (size, ty, name) = receiver.recv().unwrap();
         Some(WebGLActiveInfo::new(
+            cx,
             self.base.global().as_window(),
             size,
             ty,
             DOMString::from(name),
-            CanGc::deprecated_note(),
         ))
     }
 

--- a/components/script/dom/webgl/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl/webgl2renderingcontext.rs
@@ -18,7 +18,7 @@ use pixels::{Alpha, Snapshot};
 use script_bindings::conversions::SafeToJSValConvertible;
 use script_bindings::interfaces::WebGL2RenderingContextHelpers;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
-use script_bindings::script_runtime::CanGc;
+use script_bindings::script_runtime::{CanGc, temp_cx};
 use servo_base::generic_channel::{self, GenericSharedMemory};
 use servo_canvas_traits::webgl::WebGLError::*;
 use servo_canvas_traits::webgl::{
@@ -1052,14 +1052,16 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5>
+    #[expect(unsafe_code, reason = "transfer to jscontext")]
     fn GetBufferParameter(
         &self,
-        cx: &mut js::context::JSContext,
         _cx: JSContext,
         target: u32,
         parameter: u32,
         mut retval: MutableHandleValue,
     ) {
+        let mut cx = unsafe { temp_cx() };
+        let cx = &mut cx;
         let buffer = handle_potential_webgl_error!(
             self.base,
             self.bound_buffer(cx, target),
@@ -1069,6 +1071,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
+    #[expect(unsafe_code, reason = "transfer to jscontext")]
     fn GetParameter(&self, cx: JSContext, parameter: u32, mut rval: MutableHandleValue) {
         match parameter {
             constants::VERSION => {
@@ -1152,16 +1155,18 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
             },
             constants::ELEMENT_ARRAY_BUFFER_BINDING => {
                 let buffer = {
-                    let cx = unsafe { temp_cx() };
-                    self.current_vao().element_array_buffer().get()
+                    let mut cx = unsafe { temp_cx() };
+                    let cx = &mut cx;
+                    self.current_vao(cx).element_array_buffer().get()
                 };
                 buffer.safe_to_jsval(cx, rval, CanGc::deprecated_note());
                 return;
             },
             constants::VERTEX_ARRAY_BINDING => {
                 let vao = {
-                    let cx = unsafe { temp_cx() };
-                    self.current_vao()
+                    let mut cx = unsafe { temp_cx() };
+                    let cx = &mut cx;
+                    self.current_vao(cx)
                 };
                 let vao = vao.id().map(|_| &*vao);
                 vao.safe_to_jsval(cx, rval, CanGc::deprecated_note());
@@ -1944,8 +1949,8 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
-    fn CreateProgram(&self) -> Option<DomRoot<WebGLProgram>> {
-        self.base.CreateProgram()
+    fn CreateProgram(&self, cx: &mut js::context::JSContext) -> Option<DomRoot<WebGLProgram>> {
+        self.base.CreateProgram(cx)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
@@ -1975,7 +1980,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
         if buffer.is_marked_for_deletion() {
             return;
         }
-        self.current_vao(cx).unbind_buffer(cx, buffer);
+        self.current_vao(cx).unbind_buffer(buffer);
         self.unbind_from(self.base.array_buffer_slot(), buffer);
         self.unbind_from(&self.bound_copy_read_buffer, buffer);
         self.unbind_from(&self.bound_copy_write_buffer, buffer);
@@ -2032,7 +2037,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     fn DrawArrays(&self, cx: &mut js::context::JSContext, mode: u32, first: i32, count: i32) {
         self.validate_uniform_block_for_draw();
         self.validate_vertex_attribs_for_draw(cx);
-        self.base.DrawArrays(mode, first, count)
+        self.base.DrawArrays(cx, mode, first, count)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11>
@@ -2046,17 +2051,17 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     ) {
         self.validate_uniform_block_for_draw();
         self.validate_vertex_attribs_for_draw(cx);
-        self.base.DrawElements(mode, count, type_, offset)
+        self.base.DrawElements(cx, mode, count, type_, offset)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
-    fn EnableVertexAttribArray(&self, attrib_id: u32) {
-        self.base.EnableVertexAttribArray(attrib_id)
+    fn EnableVertexAttribArray(&self, cx: &mut js::context::JSContext, attrib_id: u32) {
+        self.base.EnableVertexAttribArray(cx, attrib_id)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
-    fn DisableVertexAttribArray(&self, attrib_id: u32) {
-        self.base.DisableVertexAttribArray(attrib_id)
+    fn DisableVertexAttribArray(&self, cx: &mut js::context::JSContext, attrib_id: u32) {
+        self.base.DisableVertexAttribArray(cx, attrib_id)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
@@ -2214,8 +2219,13 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
-    fn GetVertexAttribOffset(&self, index: u32, pname: u32) -> i64 {
-        self.base.GetVertexAttribOffset(index, pname)
+    fn GetVertexAttribOffset(
+        &self,
+        cx: &mut js::context::JSContext,
+        index: u32,
+        pname: u32,
+    ) -> i64 {
+        self.base.GetVertexAttribOffset(cx, index, pname)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
@@ -3198,6 +3208,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn VertexAttribPointer(
         &self,
+        cx: &mut js::context::JSContext,
         attrib_id: u32,
         size: i32,
         data_type: u32,
@@ -3206,11 +3217,19 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
         offset: i64,
     ) {
         self.base
-            .VertexAttribPointer(attrib_id, size, data_type, normalized, stride, offset)
+            .VertexAttribPointer(cx, attrib_id, size, data_type, normalized, stride, offset)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.8>
-    fn VertexAttribIPointer(&self, index: u32, size: i32, type_: u32, stride: i32, offset: i64) {
+    fn VertexAttribIPointer(
+        &self,
+        cx: &mut js::context::JSContext,
+        index: u32,
+        size: i32,
+        type_: u32,
+        stride: i32,
+        offset: i64,
+    ) {
         match type_ {
             constants::BYTE |
             constants::UNSIGNED_BYTE |
@@ -3221,7 +3240,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
             _ => return self.base.webgl_error(InvalidEnum),
         };
         self.base
-            .VertexAttribPointer(index, size, type_, false, stride, offset)
+            .VertexAttribPointer(cx, index, size, type_, false, stride, offset)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.4>
@@ -3909,7 +3928,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.9>
     fn DrawArraysInstanced(
         &self,
-        cx: &mut js::contextJSContext,
+        cx: &mut js::context::JSContext,
         mode: u32,
         first: i32,
         count: i32,
@@ -3946,6 +3965,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.9>
     fn DrawRangeElements(
         &self,
+        cx: &mut js::context::JSContext,
         mode: u32,
         start: u32,
         end: u32,
@@ -3958,17 +3978,17 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
             return;
         }
         self.validate_uniform_block_for_draw();
-        self.validate_vertex_attribs_for_draw();
+        self.validate_vertex_attribs_for_draw(cx);
         handle_potential_webgl_error!(
             self.base,
             self.base
-                .draw_elements_instanced(mode, count, type_, offset, 1)
+                .draw_elements_instanced(cx, mode, count, type_, offset, 1)
         )
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.9>
-    fn VertexAttribDivisor(&self, index: u32, divisor: u32) {
-        self.base.vertex_attrib_divisor(index, divisor);
+    fn VertexAttribDivisor(&self, cx: &mut js::context::JSContext, index: u32, divisor: u32) {
+        self.base.vertex_attrib_divisor(cx, index, divisor);
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.12>
@@ -4009,8 +4029,8 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.13>
-    fn CreateSampler(&self) -> Option<DomRoot<WebGLSampler>> {
-        Some(WebGLSampler::new(&self.base, CanGc::deprecated_note()))
+    fn CreateSampler(&self, cx: &mut js::context::JSContext) -> Option<DomRoot<WebGLSampler>> {
+        Some(WebGLSampler::new(cx, &self.base))
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.13>
@@ -4133,7 +4153,12 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.14>
-    fn FenceSync(&self, condition: u32, flags: u32) -> Option<DomRoot<WebGLSync>> {
+    fn FenceSync(
+        &self,
+        cx: &mut js::context::JSContext,
+        condition: u32,
+        flags: u32,
+    ) -> Option<DomRoot<WebGLSync>> {
         if flags != 0 {
             self.base.webgl_error(InvalidValue);
             return None;
@@ -4143,7 +4168,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
             return None;
         }
 
-        Some(WebGLSync::new(&self.base, CanGc::deprecated_note()))
+        Some(WebGLSync::new(cx, &self.base))
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.14>
@@ -4334,11 +4359,11 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.15>
-    fn CreateTransformFeedback(&self) -> Option<DomRoot<WebGLTransformFeedback>> {
-        Some(WebGLTransformFeedback::new(
-            &self.base,
-            CanGc::deprecated_note(),
-        ))
+    fn CreateTransformFeedback(
+        &self,
+        cx: &mut js::context::JSContext,
+    ) -> Option<DomRoot<WebGLTransformFeedback>> {
+        Some(WebGLTransformFeedback::new(cx, &self.base))
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.15>
@@ -4536,6 +4561,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.7.15>
     fn GetTransformFeedbackVarying(
         &self,
+        cx: &mut js::context::JSContext,
         program: &WebGLProgram,
         index: u32,
     ) -> Option<DomRoot<WebGLActiveInfo>> {

--- a/components/script/dom/webgl/webglactiveinfo.rs
+++ b/components/script/dom/webgl/webglactiveinfo.rs
@@ -4,13 +4,13 @@
 
 // https://www.khronos.org/registry/webgl/specs/latest/1.0/webgl.idl
 use dom_struct::dom_struct;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use js::context::JSContext;
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 
 use crate::dom::bindings::codegen::Bindings::WebGLActiveInfoBinding::WebGLActiveInfoMethods;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct WebGLActiveInfo {
@@ -32,16 +32,16 @@ impl WebGLActiveInfo {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         size: i32,
         ty: u32,
         name: DOMString,
-        can_gc: CanGc,
     ) -> DomRoot<WebGLActiveInfo> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(WebGLActiveInfo::new_inherited(size, ty, name)),
             window,
-            can_gc,
+            cx,
         )
     }
 }

--- a/components/script/dom/webgl/webglbuffer.rs
+++ b/components/script/dom/webgl/webglbuffer.rs
@@ -6,7 +6,8 @@
 use std::cell::Cell;
 
 use dom_struct::dom_struct;
-use script_bindings::reflector::{DomObject, reflect_dom_object};
+use js::context::JSContext;
+use script_bindings::reflector::{DomObject, reflect_dom_object, reflect_dom_object_with_cx};
 use script_bindings::weakref::WeakRef;
 use servo_base::generic_channel;
 use servo_canvas_traits::webgl::{
@@ -20,7 +21,6 @@ use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::webgl::webglobject::WebGLObject;
 use crate::dom::webgl::webglrenderingcontext::{Operation, WebGLRenderingContext};
-use crate::script_runtime::CanGc;
 
 fn target_is_copy_buffer(target: u32) -> bool {
     target == WebGL2RenderingContextConstants::COPY_READ_BUFFER ||
@@ -137,26 +137,26 @@ impl WebGLBuffer {
     }
 
     pub(crate) fn maybe_new(
+        cx: &mut JSContext,
         context: &WebGLRenderingContext,
-        can_gc: CanGc,
     ) -> Option<DomRoot<Self>> {
         let (sender, receiver) = webgl_channel().unwrap();
         context.send_command(WebGLCommand::CreateBuffer(sender));
         receiver
             .recv()
             .unwrap()
-            .map(|id| WebGLBuffer::new(context, id, can_gc))
+            .map(|id| WebGLBuffer::new(cx, context, id))
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         context: &WebGLRenderingContext,
         id: WebGLBufferId,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(WebGLBuffer::new_inherited(context, id)),
             &*context.global(),
-            can_gc,
+            cx,
         )
     }
 }

--- a/components/script/dom/webgl/webglbuffer.rs
+++ b/components/script/dom/webgl/webglbuffer.rs
@@ -7,7 +7,7 @@ use std::cell::Cell;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::{DomObject, reflect_dom_object, reflect_dom_object_with_cx};
+use script_bindings::reflector::{DomObject, reflect_dom_object_with_cx};
 use script_bindings::weakref::WeakRef;
 use servo_base::generic_channel;
 use servo_canvas_traits::webgl::{

--- a/components/script/dom/webgl/webglcontextevent.rs
+++ b/components/script/dom/webgl/webglcontextevent.rs
@@ -3,8 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::{
+    reflect_dom_object_with_proto, reflect_dom_object_with_proto_and_cx,
+};
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -17,7 +20,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct WebGLContextEvent {
@@ -28,9 +30,9 @@ pub(crate) struct WebGLContextEvent {
 impl WebGLContextEventMethods<crate::DomTypeHolder> for WebGLContextEvent {
     /// <https://registry.khronos.org/webgl/specs/latest/1.0/#5.15>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         type_: DOMString,
         init: &WebGLContextEventInit,
     ) -> Fallible<DomRoot<WebGLContextEvent>> {
@@ -44,13 +46,13 @@ impl WebGLContextEventMethods<crate::DomTypeHolder> for WebGLContextEvent {
         let cancelable = EventCancelable::from(init.parent.cancelable);
 
         Ok(WebGLContextEvent::new_with_proto(
+            cx,
             window,
             proto,
             Atom::from(type_),
             bubbles,
             cancelable,
             status_message,
-            can_gc,
         ))
     }
 
@@ -74,38 +76,30 @@ impl WebGLContextEvent {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         type_: Atom,
         bubbles: EventBubbles,
         cancelable: EventCancelable,
         status_message: DOMString,
-        can_gc: CanGc,
     ) -> DomRoot<WebGLContextEvent> {
-        Self::new_with_proto(
-            window,
-            None,
-            type_,
-            bubbles,
-            cancelable,
-            status_message,
-            can_gc,
-        )
+        Self::new_with_proto(cx, window, None, type_, bubbles, cancelable, status_message)
     }
 
     fn new_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         type_: Atom,
         bubbles: EventBubbles,
         cancelable: EventCancelable,
         status_message: DOMString,
-        can_gc: CanGc,
     ) -> DomRoot<WebGLContextEvent> {
-        let event = reflect_dom_object_with_proto(
+        let event = reflect_dom_object_with_proto_and_cx(
             Box::new(WebGLContextEvent::new_inherited(status_message)),
             window,
             proto,
-            can_gc,
+            cx,
         );
 
         {

--- a/components/script/dom/webgl/webglcontextevent.rs
+++ b/components/script/dom/webgl/webglcontextevent.rs
@@ -5,9 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::{
-    reflect_dom_object_with_proto, reflect_dom_object_with_proto_and_cx,
-};
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;

--- a/components/script/dom/webgl/webglframebuffer.rs
+++ b/components/script/dom/webgl/webglframebuffer.rs
@@ -11,7 +11,7 @@ use euclid::Size2D;
 #[cfg(feature = "webxr")]
 use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{reflect_dom_object, reflect_dom_object_with_cx};
+use script_bindings::reflector::reflect_dom_object_with_cx;
 use script_bindings::weakref::WeakRef;
 use servo_canvas_traits::webgl::{
     WebGLCommand, WebGLError, WebGLFramebufferBindingRequest, WebGLFramebufferId,

--- a/components/script/dom/webgl/webglframebuffer.rs
+++ b/components/script/dom/webgl/webglframebuffer.rs
@@ -11,7 +11,7 @@ use euclid::Size2D;
 #[cfg(feature = "webxr")]
 use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object;
+use script_bindings::reflector::{reflect_dom_object, reflect_dom_object_with_cx};
 use script_bindings::weakref::WeakRef;
 use servo_canvas_traits::webgl::{
     WebGLCommand, WebGLError, WebGLFramebufferBindingRequest, WebGLFramebufferId,
@@ -32,7 +32,6 @@ use crate::dom::webgl::webglrenderingcontext::{Operation, WebGLRenderingContext}
 use crate::dom::webgl::webgltexture::WebGLTexture;
 #[cfg(feature = "webxr")]
 use crate::dom::xrsession::XRSession;
-use crate::script_runtime::CanGc;
 
 pub(crate) enum CompleteForRendering {
     Complete,
@@ -192,13 +191,13 @@ impl WebGLFramebuffer {
     }
 
     pub(crate) fn maybe_new(
+        cx: &mut js::context::JSContext,
         context: &WebGLRenderingContext,
-        can_gc: CanGc,
     ) -> Option<DomRoot<Self>> {
         let (sender, receiver) = webgl_channel().unwrap();
         context.send_command(WebGLCommand::CreateFramebuffer(sender));
         let id = receiver.recv().unwrap()?;
-        let framebuffer = WebGLFramebuffer::new(context, id, can_gc);
+        let framebuffer = WebGLFramebuffer::new(cx, context, id);
         Some(framebuffer)
     }
 
@@ -211,7 +210,7 @@ impl WebGLFramebuffer {
         context: &WebGLRenderingContext,
         size: Size2D<i32, Viewport>,
     ) -> Option<DomRoot<Self>> {
-        let framebuffer = Self::maybe_new(context, CanGc::from_cx(cx))?;
+        let framebuffer = Self::maybe_new(cx, context)?;
         framebuffer.size.set(Some((size.width, size.height)));
         framebuffer.status.set(constants::FRAMEBUFFER_COMPLETE);
         framebuffer.xr_session.set(Some(session));
@@ -219,14 +218,14 @@ impl WebGLFramebuffer {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         context: &WebGLRenderingContext,
         id: WebGLFramebufferId,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(WebGLFramebuffer::new_inherited(context, id)),
             &*context.global(),
-            can_gc,
+            cx,
         )
     }
 }

--- a/components/script/dom/webgl/webglprogram.rs
+++ b/components/script/dom/webgl/webglprogram.rs
@@ -7,8 +7,9 @@ use std::cell::{Cell, RefCell};
 use std::collections::HashSet;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use script_bindings::cell::{DomRefCell, Ref};
-use script_bindings::reflector::reflect_dom_object;
+use script_bindings::reflector::reflect_dom_object_with_cx;
 use script_bindings::weakref::WeakRef;
 use servo_canvas_traits::webgl::{
     ActiveAttribInfo, ActiveUniformBlockInfo, ActiveUniformInfo, WebGLCommand, WebGLError,
@@ -27,7 +28,6 @@ use crate::dom::webgl::webglrenderingcontext::{Operation, WebGLRenderingContext}
 use crate::dom::webgl::webglshader::WebGLShader;
 use crate::dom::webgl::webgluniformlocation::WebGLUniformLocation;
 use crate::dom::webglrenderingcontext::capture_webgl_backtrace;
-use crate::script_runtime::CanGc;
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableWebGLProgram {
@@ -210,26 +210,26 @@ impl WebGLProgram {
     }
 
     pub(crate) fn maybe_new(
+        cx: &mut JSContext,
         context: &WebGLRenderingContext,
-        can_gc: CanGc,
     ) -> Option<DomRoot<Self>> {
         let (sender, receiver) = webgl_channel().unwrap();
         context.send_command(WebGLCommand::CreateProgram(sender));
         receiver
             .recv()
             .unwrap()
-            .map(|id| WebGLProgram::new(context, id, can_gc))
+            .map(|id| WebGLProgram::new(cx, context, id))
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         context: &WebGLRenderingContext,
         id: WebGLProgramId,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(WebGLProgram::new_inherited(context, id)),
             &*context.global(),
-            can_gc,
+            cx,
         )
     }
 }
@@ -443,8 +443,8 @@ impl WebGLProgram {
 
     pub(crate) fn get_active_uniform(
         &self,
+        cx: &mut JSContext,
         index: u32,
-        can_gc: CanGc,
     ) -> WebGLResult<DomRoot<WebGLActiveInfo>> {
         if self.is_deleted() {
             return Err(WebGLError::InvalidValue);
@@ -454,19 +454,19 @@ impl WebGLProgram {
             .get(index as usize)
             .ok_or(WebGLError::InvalidValue)?;
         Ok(WebGLActiveInfo::new(
+            cx,
             self.global().as_window(),
             data.size.unwrap_or(1),
             data.type_,
             data.name().into(),
-            can_gc,
         ))
     }
 
     /// glGetActiveAttrib
     pub(crate) fn get_active_attrib(
         &self,
+        cx: &mut JSContext,
         index: u32,
-        can_gc: CanGc,
     ) -> WebGLResult<DomRoot<WebGLActiveInfo>> {
         if self.is_deleted() {
             return Err(WebGLError::InvalidValue);
@@ -476,11 +476,11 @@ impl WebGLProgram {
             .get(index as usize)
             .ok_or(WebGLError::InvalidValue)?;
         Ok(WebGLActiveInfo::new(
+            cx,
             self.global().as_window(),
             data.size,
             data.type_,
             data.name.clone().into(),
-            can_gc,
         ))
     }
 
@@ -533,8 +533,8 @@ impl WebGLProgram {
     /// glGetUniformLocation
     pub(crate) fn get_uniform_location(
         &self,
+        cx: &mut JSContext,
         name: DOMString,
-        can_gc: CanGc,
     ) -> WebGLResult<Option<DomRoot<WebGLUniformLocation>>> {
         if !self.is_linked() || self.is_deleted() {
             return Err(WebGLError::InvalidOperation);
@@ -578,6 +578,7 @@ impl WebGLProgram {
         let context_id = self.upcast().context_id();
 
         Ok(Some(WebGLUniformLocation::new(
+            cx,
             self.global().as_window(),
             location,
             context_id,
@@ -585,7 +586,6 @@ impl WebGLProgram {
             self.link_generation.get(),
             size,
             type_,
-            can_gc,
         )))
     }
 

--- a/components/script/dom/webgl/webglquery.rs
+++ b/components/script/dom/webgl/webglquery.rs
@@ -5,7 +5,8 @@
 use std::cell::Cell;
 
 use dom_struct::dom_struct;
-use script_bindings::reflector::reflect_dom_object;
+use js::context::JSContext;
+use script_bindings::reflector::{reflect_dom_object, reflect_dom_object_with_cx};
 use script_bindings::weakref::WeakRef;
 use servo_canvas_traits::webgl::WebGLError::*;
 use servo_canvas_traits::webgl::{WebGLCommand, WebGLQueryId, webgl_channel};
@@ -17,7 +18,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::webgl::webglobject::WebGLObject;
 use crate::dom::webgl::webglrenderingcontext::{Operation, WebGLRenderingContext};
 use crate::dom::webglrenderingcontext::capture_webgl_backtrace;
-use crate::script_runtime::CanGc;
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableWebGLQuery {
@@ -78,15 +78,15 @@ impl WebGLQuery {
         }
     }
 
-    pub(crate) fn new(context: &WebGLRenderingContext, can_gc: CanGc) -> DomRoot<Self> {
+    pub(crate) fn new(cx: &mut JSContext, context: &WebGLRenderingContext) -> DomRoot<Self> {
         let (sender, receiver) = webgl_channel().unwrap();
         context.send_command(WebGLCommand::GenerateQuery(sender));
         let id = receiver.recv().unwrap();
 
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(Self::new_inherited(context, id)),
             &*context.global(),
-            can_gc,
+            cx,
         )
     }
 

--- a/components/script/dom/webgl/webglquery.rs
+++ b/components/script/dom/webgl/webglquery.rs
@@ -6,7 +6,7 @@ use std::cell::Cell;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::{reflect_dom_object, reflect_dom_object_with_cx};
+use script_bindings::reflector::reflect_dom_object_with_cx;
 use script_bindings::weakref::WeakRef;
 use servo_canvas_traits::webgl::WebGLError::*;
 use servo_canvas_traits::webgl::{WebGLCommand, WebGLQueryId, webgl_channel};

--- a/components/script/dom/webgl/webglrenderbuffer.rs
+++ b/components/script/dom/webgl/webglrenderbuffer.rs
@@ -6,7 +6,8 @@
 use std::cell::Cell;
 
 use dom_struct::dom_struct;
-use script_bindings::reflector::reflect_dom_object;
+use js::context::JSContext;
+use script_bindings::reflector::{reflect_dom_object, reflect_dom_object_with_cx};
 use script_bindings::weakref::WeakRef;
 use servo_canvas_traits::webgl::{
     GlType, InternalFormatIntVec, WebGLCommand, WebGLError, WebGLRenderbufferId, WebGLResult,
@@ -23,7 +24,6 @@ use crate::dom::webgl::webglframebuffer::WebGLFramebuffer;
 use crate::dom::webgl::webglobject::WebGLObject;
 use crate::dom::webgl::webglrenderingcontext::{Operation, WebGLRenderingContext};
 use crate::dom::webglrenderingcontext::capture_webgl_backtrace;
-use crate::script_runtime::CanGc;
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableWebGLRenderbuffer {
@@ -107,24 +107,27 @@ impl WebGLRenderbuffer {
         }
     }
 
-    pub(crate) fn maybe_new(context: &WebGLRenderingContext) -> Option<DomRoot<Self>> {
+    pub(crate) fn maybe_new(
+        cx: &mut JSContext,
+        context: &WebGLRenderingContext,
+    ) -> Option<DomRoot<Self>> {
         let (sender, receiver) = webgl_channel().unwrap();
         context.send_command(WebGLCommand::CreateRenderbuffer(sender));
         receiver
             .recv()
             .unwrap()
-            .map(|id| WebGLRenderbuffer::new(context, id, CanGc::deprecated_note()))
+            .map(|id| WebGLRenderbuffer::new(cx, context, id))
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         context: &WebGLRenderingContext,
         id: WebGLRenderbufferId,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(WebGLRenderbuffer::new_inherited(context, id)),
             &*context.global(),
-            can_gc,
+            cx,
         )
     }
 }

--- a/components/script/dom/webgl/webglrenderbuffer.rs
+++ b/components/script/dom/webgl/webglrenderbuffer.rs
@@ -7,7 +7,7 @@ use std::cell::Cell;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::{reflect_dom_object, reflect_dom_object_with_cx};
+use script_bindings::reflector::reflect_dom_object_with_cx;
 use script_bindings::weakref::WeakRef;
 use servo_canvas_traits::webgl::{
     GlType, InternalFormatIntVec, WebGLCommand, WebGLError, WebGLRenderbufferId, WebGLResult,

--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -2179,14 +2179,16 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5>
+    #[expect(unsafe_code, reason = "transfer to jscontext")]
     fn GetBufferParameter(
         &self,
-        cx: &mut js::context::JSContext,
         _cx: SafeJSContext,
         target: u32,
         parameter: u32,
         mut retval: MutableHandleValue,
     ) {
+        let mut cx = unsafe { temp_cx() };
+        let cx = &mut cx;
         let buffer = handle_potential_webgl_error!(
             self,
             self.bound_buffer(cx, target),
@@ -2804,13 +2806,10 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5>
-    fn BufferData_(
-        &self,
-        cx: &mut js::context::JSContext,
-        target: u32,
-        data: Option<ArrayBufferViewOrArrayBuffer>,
-        usage: u32,
-    ) {
+    #[expect(unsafe_code, reason = "transfer to jscontext")]
+    fn BufferData_(&self, target: u32, data: Option<ArrayBufferViewOrArrayBuffer>, usage: u32) {
+        let mut cx = unsafe { temp_cx() };
+        let cx = &mut cx;
         let usage = handle_potential_webgl_error!(self, self.buffer_usage(usage), return);
         let bound_buffer =
             handle_potential_webgl_error!(self, self.bound_buffer(cx, target), return);
@@ -2818,7 +2817,10 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5>
-    fn BufferData(&self, cx: &mut js::context::JSContext, target: u32, size: i64, usage: u32) {
+    #[expect(unsafe_code, reason = "transfer to jscontext")]
+    fn BufferData(&self, target: u32, size: i64, usage: u32) {
+        let mut cx = unsafe { temp_cx() };
+        let cx = &mut cx;
         let usage = handle_potential_webgl_error!(self, self.buffer_usage(usage), return);
         let bound_buffer =
             handle_potential_webgl_error!(self, self.bound_buffer(cx, target), return);
@@ -3319,7 +3321,14 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11>
-    fn DrawElements(&self, mode: u32, count: i32, type_: u32, offset: i64) {
+    fn DrawElements(
+        &self,
+        cx: &mut js::context::JSContext,
+        mode: u32,
+        count: i32,
+        type_: u32,
+        offset: i64,
+    ) {
         handle_potential_webgl_error!(
             self,
             self.draw_elements_instanced(cx, mode, count, type_, offset, 1)
@@ -3378,6 +3387,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn GetActiveAttrib(
         &self,
+        cx: &mut js::context::JSContext,
         program: &WebGLProgram,
         index: u32,
     ) -> Option<DomRoot<WebGLActiveInfo>> {
@@ -3697,6 +3707,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn GetUniformLocation(
         &self,
+        cx: &mut js::context::JSContext,
         program: &WebGLProgram,
         name: DOMString,
     ) -> Option<DomRoot<WebGLUniformLocation>> {
@@ -3789,7 +3800,8 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
             }
         };
 
-        let cx = unsafe { js::context::temp_cx() };
+        let mut cx = unsafe { temp_cx() };
+        let cx = &mut cx;
         match self.webgl_version() {
             WebGLVersion::WebGL1 => {
                 let current_vao = self.current_vao(cx);

--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -23,6 +23,7 @@ use pixels::{self, Alpha, PixelFormat, Snapshot, SnapshotPixelFormat};
 use script_bindings::cell::{DomRefCell, Ref, RefMut};
 use script_bindings::conversions::SafeToJSValConvertible;
 use script_bindings::reflector::{AssociatedMemory, Reflector, reflect_dom_object_with_cx};
+use script_bindings::script_runtime::{CanGc, temp_cx};
 use serde::{Deserialize, Serialize};
 use servo_base::generic_channel::GenericSharedMemory;
 use servo_base::{Epoch, generic_channel};
@@ -87,7 +88,7 @@ use crate::dom::webgl::webgluniformlocation::WebGLUniformLocation;
 use crate::dom::webgl::webglvertexarrayobject::WebGLVertexArrayObject;
 use crate::dom::webgl::webglvertexarrayobjectoes::WebGLVertexArrayObjectOES;
 use crate::dom::window::Window;
-use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
+use crate::script_runtime::JSContext as SafeJSContext;
 
 fn has_invalid_blend_constants(arg1: u32, arg2: u32) -> bool {
     match (arg1, arg2) {
@@ -301,12 +302,12 @@ impl WebGLRenderingContext {
             Err(msg) => {
                 error!("Couldn't create WebGLRenderingContext: {}", msg);
                 let event = WebGLContextEvent::new(
+                    cx,
                     window,
                     atom!("webglcontextcreationerror"),
                     EventBubbles::DoesNotBubble,
                     EventCancelable::Cancelable,
                     DOMString::from(msg),
-                    CanGc::from_cx(cx),
                 );
                 match canvas {
                     RootedHTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(canvas) => {
@@ -362,22 +363,26 @@ impl WebGLRenderingContext {
         self.bound_draw_framebuffer.get()
     }
 
-    pub(crate) fn current_vao(&self) -> DomRoot<WebGLVertexArrayObjectOES> {
+    pub(crate) fn current_vao(
+        &self,
+        cx: &mut js::context::JSContext,
+    ) -> DomRoot<WebGLVertexArrayObjectOES> {
         self.current_vao.or_init(|| {
             DomRoot::from_ref(
-                self.default_vao.init_once(|| {
-                    WebGLVertexArrayObjectOES::new(self, None, CanGc::deprecated_note())
-                }),
+                self.default_vao
+                    .init_once(|| WebGLVertexArrayObjectOES::new(cx, self, None)),
             )
         })
     }
 
-    pub(crate) fn current_vao_webgl2(&self) -> DomRoot<WebGLVertexArrayObject> {
+    pub(crate) fn current_vao_webgl2(
+        &self,
+        cx: &mut js::context::JSContext,
+    ) -> DomRoot<WebGLVertexArrayObject> {
         self.current_vao_webgl2.or_init(|| {
             DomRoot::from_ref(
-                self.default_vao_webgl2.init_once(|| {
-                    WebGLVertexArrayObject::new(self, None, CanGc::deprecated_note())
-                }),
+                self.default_vao_webgl2
+                    .init_once(|| WebGLVertexArrayObject::new(cx, self, None)),
             )
         })
     }
@@ -526,17 +531,25 @@ impl WebGLRenderingContext {
         }
     }
 
-    fn vertex_attrib(&self, indx: u32, x: f32, y: f32, z: f32, w: f32) {
+    fn vertex_attrib(
+        &self,
+        cx: &mut js::context::JSContext,
+        indx: u32,
+        x: f32,
+        y: f32,
+        z: f32,
+        w: f32,
+    ) {
         if indx >= self.limits.max_vertex_attribs {
             return self.webgl_error(InvalidValue);
         }
 
         match self.webgl_version() {
             WebGLVersion::WebGL1 => self
-                .current_vao()
+                .current_vao(cx)
                 .set_vertex_attrib_type(indx, constants::FLOAT),
             WebGLVersion::WebGL2 => self
-                .current_vao_webgl2()
+                .current_vao_webgl2(cx)
                 .set_vertex_attrib_type(indx, constants::FLOAT),
         };
         self.current_vertex_attribs.borrow_mut()[indx as usize] = VertexAttrib::Float(x, y, z, w);
@@ -982,6 +995,7 @@ impl WebGLRenderingContext {
     // https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/
     pub(crate) fn draw_arrays_instanced(
         &self,
+        cx: &mut js::context::JSContext,
         mode: u32,
         first: i32,
         count: i32,
@@ -1015,12 +1029,12 @@ impl WebGLRenderingContext {
         };
 
         match self.webgl_version() {
-            WebGLVersion::WebGL1 => self.current_vao().validate_for_draw(
+            WebGLVersion::WebGL1 => self.current_vao(cx).validate_for_draw(
                 required_len,
                 primcount as u32,
                 &current_program.active_attribs(),
             )?,
-            WebGLVersion::WebGL2 => self.current_vao_webgl2().validate_for_draw(
+            WebGLVersion::WebGL2 => self.current_vao_webgl2(cx).validate_for_draw(
                 required_len,
                 primcount as u32,
                 &current_program.active_attribs(),
@@ -1050,6 +1064,7 @@ impl WebGLRenderingContext {
     // https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/
     pub(crate) fn draw_elements_instanced(
         &self,
+        cx: &mut js::context::JSContext,
         mode: u32,
         count: i32,
         type_: u32,
@@ -1087,8 +1102,8 @@ impl WebGLRenderingContext {
 
         let current_program = self.current_program.get().ok_or(InvalidOperation)?;
         let array_buffer = match self.webgl_version() {
-            WebGLVersion::WebGL1 => self.current_vao().element_array_buffer().get(),
-            WebGLVersion::WebGL2 => self.current_vao_webgl2().element_array_buffer().get(),
+            WebGLVersion::WebGL1 => self.current_vao(cx).element_array_buffer().get(),
+            WebGLVersion::WebGL2 => self.current_vao_webgl2(cx).element_array_buffer().get(),
         }
         .ok_or(InvalidOperation)?;
 
@@ -1102,12 +1117,12 @@ impl WebGLRenderingContext {
 
         // TODO(nox): Pass the correct number of vertices required.
         match self.webgl_version() {
-            WebGLVersion::WebGL1 => self.current_vao().validate_for_draw(
+            WebGLVersion::WebGL1 => self.current_vao(cx).validate_for_draw(
                 0,
                 primcount as u32,
                 &current_program.active_attribs(),
             )?,
-            WebGLVersion::WebGL2 => self.current_vao_webgl2().validate_for_draw(
+            WebGLVersion::WebGL2 => self.current_vao_webgl2(cx).validate_for_draw(
                 0,
                 primcount as u32,
                 &current_program.active_attribs(),
@@ -1141,15 +1156,20 @@ impl WebGLRenderingContext {
         Ok(())
     }
 
-    pub(crate) fn vertex_attrib_divisor(&self, index: u32, divisor: u32) {
+    pub(crate) fn vertex_attrib_divisor(
+        &self,
+        cx: &mut js::context::JSContext,
+        index: u32,
+        divisor: u32,
+    ) {
         if index >= self.limits.max_vertex_attribs {
             return self.webgl_error(InvalidValue);
         }
 
         match self.webgl_version() {
-            WebGLVersion::WebGL1 => self.current_vao().vertex_attrib_divisor(index, divisor),
+            WebGLVersion::WebGL1 => self.current_vao(cx).vertex_attrib_divisor(index, divisor),
             WebGLVersion::WebGL2 => self
-                .current_vao_webgl2()
+                .current_vao_webgl2(cx)
                 .vertex_attrib_divisor(index, divisor),
         };
         self.send_command(WebGLCommand::VertexAttribDivisor { index, divisor });
@@ -1163,10 +1183,16 @@ impl WebGLRenderingContext {
         &self.bound_buffer_array
     }
 
-    pub(crate) fn bound_buffer(&self, target: u32) -> WebGLResult<Option<DomRoot<WebGLBuffer>>> {
+    pub(crate) fn bound_buffer(
+        &self,
+        cx: &mut js::context::JSContext,
+        target: u32,
+    ) -> WebGLResult<Option<DomRoot<WebGLBuffer>>> {
         match target {
             constants::ARRAY_BUFFER => Ok(self.bound_buffer_array.get()),
-            constants::ELEMENT_ARRAY_BUFFER => Ok(self.current_vao().element_array_buffer().get()),
+            constants::ELEMENT_ARRAY_BUFFER => {
+                Ok(self.current_vao(cx).element_array_buffer().get())
+            },
             _ => Err(WebGLError::InvalidEnum),
         }
     }
@@ -1178,25 +1204,35 @@ impl WebGLRenderingContext {
         }
     }
 
-    pub(crate) fn create_vertex_array(&self) -> Option<DomRoot<WebGLVertexArrayObjectOES>> {
+    pub(crate) fn create_vertex_array(
+        &self,
+        cx: &mut js::context::JSContext,
+    ) -> Option<DomRoot<WebGLVertexArrayObjectOES>> {
         let (sender, receiver) = webgl_channel().unwrap();
         self.send_command(WebGLCommand::CreateVertexArray(sender));
         receiver
             .recv()
             .unwrap()
-            .map(|id| WebGLVertexArrayObjectOES::new(self, Some(id), CanGc::deprecated_note()))
+            .map(|id| WebGLVertexArrayObjectOES::new(cx, self, Some(id)))
     }
 
-    pub(crate) fn create_vertex_array_webgl2(&self) -> Option<DomRoot<WebGLVertexArrayObject>> {
+    pub(crate) fn create_vertex_array_webgl2(
+        &self,
+        cx: &mut js::context::JSContext,
+    ) -> Option<DomRoot<WebGLVertexArrayObject>> {
         let (sender, receiver) = webgl_channel().unwrap();
         self.send_command(WebGLCommand::CreateVertexArray(sender));
         receiver
             .recv()
             .unwrap()
-            .map(|id| WebGLVertexArrayObject::new(self, Some(id), CanGc::deprecated_note()))
+            .map(|id| WebGLVertexArrayObject::new(cx, self, Some(id)))
     }
 
-    pub(crate) fn delete_vertex_array(&self, vao: Option<&WebGLVertexArrayObjectOES>) {
+    pub(crate) fn delete_vertex_array(
+        &self,
+        cx: &mut js::context::JSContext,
+        vao: Option<&WebGLVertexArrayObjectOES>,
+    ) {
         if let Some(vao) = vao {
             handle_potential_webgl_error!(self, self.validate_ownership(vao), return);
             // The default vertex array has no id and should never be passed around.
@@ -1204,7 +1240,7 @@ impl WebGLRenderingContext {
             if vao.is_deleted() {
                 return;
             }
-            if vao == &*self.current_vao() {
+            if vao == &*self.current_vao(cx) {
                 // Setting it to None will make self.current_vao() reset it to the default one
                 // next time it is called.
                 self.current_vao.set(None);
@@ -1214,7 +1250,11 @@ impl WebGLRenderingContext {
         }
     }
 
-    pub(crate) fn delete_vertex_array_webgl2(&self, vao: Option<&WebGLVertexArrayObject>) {
+    pub(crate) fn delete_vertex_array_webgl2(
+        &self,
+        cx: &mut js::context::JSContext,
+        vao: Option<&WebGLVertexArrayObject>,
+    ) {
         if let Some(vao) = vao {
             handle_potential_webgl_error!(self, self.validate_ownership(vao), return);
             // The default vertex array has no id and should never be passed around.
@@ -1222,7 +1262,7 @@ impl WebGLRenderingContext {
             if vao.is_deleted() {
                 return;
             }
-            if vao == &*self.current_vao_webgl2() {
+            if vao == &*self.current_vao_webgl2(cx) {
                 // Setting it to None will make self.current_vao() reset it to the default one
                 // next time it is called.
                 self.current_vao_webgl2.set(None);
@@ -2141,6 +2181,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5>
     fn GetBufferParameter(
         &self,
+        cx: &mut js::context::JSContext,
         _cx: SafeJSContext,
         target: u32,
         parameter: u32,
@@ -2148,7 +2189,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     ) {
         let buffer = handle_potential_webgl_error!(
             self,
-            self.bound_buffer(target),
+            self.bound_buffer(cx, target),
             return retval.set(NullValue())
         );
         self.get_buffer_param(buffer, parameter, retval)
@@ -2179,7 +2220,10 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                 return;
             },
             constants::ELEMENT_ARRAY_BUFFER_BINDING => {
-                let buffer = self.current_vao().element_array_buffer().get();
+                let buffer = {
+                    let mut cx = unsafe { temp_cx() };
+                    self.current_vao(&mut cx).element_array_buffer().get()
+                };
                 buffer.safe_to_jsval(cx, retval, CanGc::deprecated_note());
                 return;
             },
@@ -2662,12 +2706,17 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5>
-    fn BindBuffer(&self, target: u32, buffer: Option<&WebGLBuffer>) {
+    fn BindBuffer(
+        &self,
+        cx: &mut js::context::JSContext,
+        target: u32,
+        buffer: Option<&WebGLBuffer>,
+    ) {
         let current_vao;
         let slot = match target {
             constants::ARRAY_BUFFER => &self.bound_buffer_array,
             constants::ELEMENT_ARRAY_BUFFER => {
-                current_vao = self.current_vao();
+                current_vao = self.current_vao(cx);
                 current_vao.element_array_buffer()
             },
             _ => return self.webgl_error(InvalidEnum),
@@ -2755,22 +2804,37 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5>
-    fn BufferData_(&self, target: u32, data: Option<ArrayBufferViewOrArrayBuffer>, usage: u32) {
+    fn BufferData_(
+        &self,
+        cx: &mut js::context::JSContext,
+        target: u32,
+        data: Option<ArrayBufferViewOrArrayBuffer>,
+        usage: u32,
+    ) {
         let usage = handle_potential_webgl_error!(self, self.buffer_usage(usage), return);
-        let bound_buffer = handle_potential_webgl_error!(self, self.bound_buffer(target), return);
+        let bound_buffer =
+            handle_potential_webgl_error!(self, self.bound_buffer(cx, target), return);
         self.buffer_data(target, data, usage, bound_buffer)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5>
-    fn BufferData(&self, target: u32, size: i64, usage: u32) {
+    fn BufferData(&self, cx: &mut js::context::JSContext, target: u32, size: i64, usage: u32) {
         let usage = handle_potential_webgl_error!(self, self.buffer_usage(usage), return);
-        let bound_buffer = handle_potential_webgl_error!(self, self.bound_buffer(target), return);
+        let bound_buffer =
+            handle_potential_webgl_error!(self, self.bound_buffer(cx, target), return);
         self.buffer_data_(target, size, usage, bound_buffer)
     }
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5
-    fn BufferSubData(&self, target: u32, offset: i64, data: ArrayBufferViewOrArrayBuffer) {
-        let bound_buffer = handle_potential_webgl_error!(self, self.bound_buffer(target), return);
+    fn BufferSubData(
+        &self,
+        cx: &mut js::context::JSContext,
+        target: u32,
+        offset: i64,
+        data: ArrayBufferViewOrArrayBuffer,
+    ) {
+        let bound_buffer =
+            handle_potential_webgl_error!(self, self.bound_buffer(cx, target), return);
         self.buffer_sub_data(target, offset, data, bound_buffer)
     }
 
@@ -3096,32 +3160,42 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5>
-    fn CreateBuffer(&self) -> Option<DomRoot<WebGLBuffer>> {
-        WebGLBuffer::maybe_new(self, CanGc::deprecated_note())
+    fn CreateBuffer(&self, cx: &mut js::context::JSContext) -> Option<DomRoot<WebGLBuffer>> {
+        WebGLBuffer::maybe_new(cx, self)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6>
-    fn CreateFramebuffer(&self) -> Option<DomRoot<WebGLFramebuffer>> {
-        WebGLFramebuffer::maybe_new(self, CanGc::deprecated_note())
+    fn CreateFramebuffer(
+        &self,
+        cx: &mut js::context::JSContext,
+    ) -> Option<DomRoot<WebGLFramebuffer>> {
+        WebGLFramebuffer::maybe_new(cx, self)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.7>
-    fn CreateRenderbuffer(&self) -> Option<DomRoot<WebGLRenderbuffer>> {
-        WebGLRenderbuffer::maybe_new(self)
+    fn CreateRenderbuffer(
+        &self,
+        cx: &mut js::context::JSContext,
+    ) -> Option<DomRoot<WebGLRenderbuffer>> {
+        WebGLRenderbuffer::maybe_new(cx, self)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8>
-    fn CreateTexture(&self) -> Option<DomRoot<WebGLTexture>> {
-        WebGLTexture::maybe_new(self)
+    fn CreateTexture(&self, cx: &mut js::context::JSContext) -> Option<DomRoot<WebGLTexture>> {
+        WebGLTexture::maybe_new(cx, self)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
-    fn CreateProgram(&self) -> Option<DomRoot<WebGLProgram>> {
-        WebGLProgram::maybe_new(self, CanGc::deprecated_note())
+    fn CreateProgram(&self, cx: &mut js::context::JSContext) -> Option<DomRoot<WebGLProgram>> {
+        WebGLProgram::maybe_new(cx, self)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
-    fn CreateShader(&self, shader_type: u32) -> Option<DomRoot<WebGLShader>> {
+    fn CreateShader(
+        &self,
+        cx: &mut js::context::JSContext,
+        shader_type: u32,
+    ) -> Option<DomRoot<WebGLShader>> {
         match shader_type {
             constants::VERTEX_SHADER | constants::FRAGMENT_SHADER => {},
             _ => {
@@ -3129,11 +3203,11 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                 return None;
             },
         }
-        WebGLShader::maybe_new(self, shader_type)
+        WebGLShader::maybe_new(cx, self, shader_type)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5>
-    fn DeleteBuffer(&self, buffer: Option<&WebGLBuffer>) {
+    fn DeleteBuffer(&self, cx: &mut js::context::JSContext, buffer: Option<&WebGLBuffer>) {
         let buffer = match buffer {
             Some(buffer) => buffer,
             None => return,
@@ -3142,7 +3216,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
         if buffer.is_marked_for_deletion() {
             return;
         }
-        self.current_vao().unbind_buffer(buffer);
+        self.current_vao(cx).unbind_buffer(buffer);
         if self.bound_buffer_array.get().is_some_and(|b| buffer == &*b) {
             self.bound_buffer_array.set(None);
             buffer.decrement_attached_counter(Operation::Infallible);
@@ -3240,45 +3314,45 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11>
-    fn DrawArrays(&self, mode: u32, first: i32, count: i32) {
-        handle_potential_webgl_error!(self, self.draw_arrays_instanced(mode, first, count, 1));
+    fn DrawArrays(&self, cx: &mut js::context::JSContext, mode: u32, first: i32, count: i32) {
+        handle_potential_webgl_error!(self, self.draw_arrays_instanced(cx, mode, first, count, 1));
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11>
     fn DrawElements(&self, mode: u32, count: i32, type_: u32, offset: i64) {
         handle_potential_webgl_error!(
             self,
-            self.draw_elements_instanced(mode, count, type_, offset, 1)
+            self.draw_elements_instanced(cx, mode, count, type_, offset, 1)
         );
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
-    fn EnableVertexAttribArray(&self, attrib_id: u32) {
+    fn EnableVertexAttribArray(&self, cx: &mut js::context::JSContext, attrib_id: u32) {
         if attrib_id >= self.limits.max_vertex_attribs {
             return self.webgl_error(InvalidValue);
         }
         match self.webgl_version() {
             WebGLVersion::WebGL1 => self
-                .current_vao()
+                .current_vao(cx)
                 .enabled_vertex_attrib_array(attrib_id, true),
             WebGLVersion::WebGL2 => self
-                .current_vao_webgl2()
+                .current_vao_webgl2(cx)
                 .enabled_vertex_attrib_array(attrib_id, true),
         };
         self.send_command(WebGLCommand::EnableVertexAttribArray(attrib_id));
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
-    fn DisableVertexAttribArray(&self, attrib_id: u32) {
+    fn DisableVertexAttribArray(&self, cx: &mut js::context::JSContext, attrib_id: u32) {
         if attrib_id >= self.limits.max_vertex_attribs {
             return self.webgl_error(InvalidValue);
         }
         match self.webgl_version() {
             WebGLVersion::WebGL1 => self
-                .current_vao()
+                .current_vao(cx)
                 .enabled_vertex_attrib_array(attrib_id, false),
             WebGLVersion::WebGL2 => self
-                .current_vao_webgl2()
+                .current_vao_webgl2(cx)
                 .enabled_vertex_attrib_array(attrib_id, false),
         };
         self.send_command(WebGLCommand::DisableVertexAttribArray(attrib_id));
@@ -3287,11 +3361,12 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn GetActiveUniform(
         &self,
+        cx: &mut js::context::JSContext,
         program: &WebGLProgram,
         index: u32,
     ) -> Option<DomRoot<WebGLActiveInfo>> {
         handle_potential_webgl_error!(self, self.validate_ownership(program), return None);
-        match program.get_active_uniform(index, CanGc::deprecated_note()) {
+        match program.get_active_uniform(cx, index) {
             Ok(ret) => Some(ret),
             Err(e) => {
                 self.webgl_error(e);
@@ -3307,13 +3382,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
         index: u32,
     ) -> Option<DomRoot<WebGLActiveInfo>> {
         handle_potential_webgl_error!(self, self.validate_ownership(program), return None);
-        handle_potential_webgl_error!(
-            self,
-            program
-                .get_active_attrib(index, CanGc::deprecated_note())
-                .map(Some),
-            None
-        )
+        handle_potential_webgl_error!(self, program.get_active_attrib(cx, index).map(Some), None)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
@@ -3583,6 +3652,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
     fn GetShaderPrecisionFormat(
         &self,
+        cx: &mut js::context::JSContext,
         shader_type: u32,
         precision_type: u32,
     ) -> Option<DomRoot<WebGLShaderPrecisionFormat>> {
@@ -3616,11 +3686,11 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
 
         let (range_min, range_max, precision) = receiver.recv().unwrap();
         Some(WebGLShaderPrecisionFormat::new(
+            cx,
             self.global().as_window(),
             range_min,
             range_max,
             precision,
-            CanGc::deprecated_note(),
         ))
     }
 
@@ -3631,11 +3701,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
         name: DOMString,
     ) -> Option<DomRoot<WebGLUniformLocation>> {
         handle_potential_webgl_error!(self, self.validate_ownership(program), return None);
-        handle_potential_webgl_error!(
-            self,
-            program.get_uniform_location(name, CanGc::deprecated_note()),
-            None
-        )
+        handle_potential_webgl_error!(self, program.get_uniform_location(cx, name), None)
     }
 
     #[expect(unsafe_code)]
@@ -3723,9 +3789,10 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
             }
         };
 
+        let cx = unsafe { js::context::temp_cx() };
         match self.webgl_version() {
             WebGLVersion::WebGL1 => {
-                let current_vao = self.current_vao();
+                let current_vao = self.current_vao(cx);
                 let data = handle_potential_webgl_error!(
                     self,
                     current_vao.get_vertex_attrib(index).ok_or(InvalidValue),
@@ -3734,7 +3801,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                 get_attrib(data)
             },
             WebGLVersion::WebGL2 => {
-                let current_vao = self.current_vao_webgl2();
+                let current_vao = self.current_vao_webgl2(cx);
                 let data = handle_potential_webgl_error!(
                     self,
                     current_vao.get_vertex_attrib(index).ok_or(InvalidValue),
@@ -3746,14 +3813,19 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
-    fn GetVertexAttribOffset(&self, index: u32, pname: u32) -> i64 {
+    fn GetVertexAttribOffset(
+        &self,
+        cx: &mut js::context::JSContext,
+        index: u32,
+        pname: u32,
+    ) -> i64 {
         if pname != constants::VERTEX_ATTRIB_ARRAY_POINTER {
             self.webgl_error(InvalidEnum);
             return 0;
         }
         match self.webgl_version() {
             WebGLVersion::WebGL1 => {
-                let current_vao = self.current_vao();
+                let current_vao = self.current_vao(cx);
                 let data = handle_potential_webgl_error!(
                     self,
                     current_vao.get_vertex_attrib(index).ok_or(InvalidValue),
@@ -3762,7 +3834,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                 data.offset as i64
             },
             WebGLVersion::WebGL2 => {
-                let current_vao = self.current_vao_webgl2();
+                let current_vao = self.current_vao_webgl2(cx);
                 let data = handle_potential_webgl_error!(
                     self,
                     current_vao.get_vertex_attrib(index).ok_or(InvalidValue),
@@ -4437,12 +4509,17 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
-    fn VertexAttrib1f(&self, indx: u32, x: f32) {
-        self.vertex_attrib(indx, x, 0f32, 0f32, 1f32)
+    fn VertexAttrib1f(&self, cx: &mut js::context::JSContext, indx: u32, x: f32) {
+        self.vertex_attrib(cx, indx, x, 0f32, 0f32, 1f32)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
-    fn VertexAttrib1fv(&self, indx: u32, v: Float32ArrayOrUnrestrictedFloatSequence) {
+    fn VertexAttrib1fv(
+        &self,
+        cx: &mut js::context::JSContext,
+        indx: u32,
+        v: Float32ArrayOrUnrestrictedFloatSequence,
+    ) {
         let values = match v {
             Float32ArrayOrUnrestrictedFloatSequence::Float32Array(v) => v.to_vec(),
             Float32ArrayOrUnrestrictedFloatSequence::UnrestrictedFloatSequence(v) => v,
@@ -4451,16 +4528,21 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
             // https://github.com/KhronosGroup/WebGL/issues/2700
             return self.webgl_error(InvalidValue);
         }
-        self.vertex_attrib(indx, values[0], 0f32, 0f32, 1f32);
+        self.vertex_attrib(cx, indx, values[0], 0f32, 0f32, 1f32);
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
-    fn VertexAttrib2f(&self, indx: u32, x: f32, y: f32) {
-        self.vertex_attrib(indx, x, y, 0f32, 1f32)
+    fn VertexAttrib2f(&self, cx: &mut js::context::JSContext, indx: u32, x: f32, y: f32) {
+        self.vertex_attrib(cx, indx, x, y, 0f32, 1f32)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
-    fn VertexAttrib2fv(&self, indx: u32, v: Float32ArrayOrUnrestrictedFloatSequence) {
+    fn VertexAttrib2fv(
+        &self,
+        cx: &mut js::context::JSContext,
+        indx: u32,
+        v: Float32ArrayOrUnrestrictedFloatSequence,
+    ) {
         let values = match v {
             Float32ArrayOrUnrestrictedFloatSequence::Float32Array(v) => v.to_vec(),
             Float32ArrayOrUnrestrictedFloatSequence::UnrestrictedFloatSequence(v) => v,
@@ -4469,16 +4551,21 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
             // https://github.com/KhronosGroup/WebGL/issues/2700
             return self.webgl_error(InvalidValue);
         }
-        self.vertex_attrib(indx, values[0], values[1], 0f32, 1f32);
+        self.vertex_attrib(cx, indx, values[0], values[1], 0f32, 1f32);
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
-    fn VertexAttrib3f(&self, indx: u32, x: f32, y: f32, z: f32) {
-        self.vertex_attrib(indx, x, y, z, 1f32)
+    fn VertexAttrib3f(&self, cx: &mut js::context::JSContext, indx: u32, x: f32, y: f32, z: f32) {
+        self.vertex_attrib(cx, indx, x, y, z, 1f32)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
-    fn VertexAttrib3fv(&self, indx: u32, v: Float32ArrayOrUnrestrictedFloatSequence) {
+    fn VertexAttrib3fv(
+        &self,
+        cx: &mut js::context::JSContext,
+        indx: u32,
+        v: Float32ArrayOrUnrestrictedFloatSequence,
+    ) {
         let values = match v {
             Float32ArrayOrUnrestrictedFloatSequence::Float32Array(v) => v.to_vec(),
             Float32ArrayOrUnrestrictedFloatSequence::UnrestrictedFloatSequence(v) => v,
@@ -4487,16 +4574,29 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
             // https://github.com/KhronosGroup/WebGL/issues/2700
             return self.webgl_error(InvalidValue);
         }
-        self.vertex_attrib(indx, values[0], values[1], values[2], 1f32);
+        self.vertex_attrib(cx, indx, values[0], values[1], values[2], 1f32);
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
-    fn VertexAttrib4f(&self, indx: u32, x: f32, y: f32, z: f32, w: f32) {
-        self.vertex_attrib(indx, x, y, z, w)
+    fn VertexAttrib4f(
+        &self,
+        cx: &mut js::context::JSContext,
+        indx: u32,
+        x: f32,
+        y: f32,
+        z: f32,
+        w: f32,
+    ) {
+        self.vertex_attrib(cx, indx, x, y, z, w)
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
-    fn VertexAttrib4fv(&self, indx: u32, v: Float32ArrayOrUnrestrictedFloatSequence) {
+    fn VertexAttrib4fv(
+        &self,
+        cx: &mut js::context::JSContext,
+        indx: u32,
+        v: Float32ArrayOrUnrestrictedFloatSequence,
+    ) {
         let values = match v {
             Float32ArrayOrUnrestrictedFloatSequence::Float32Array(v) => v.to_vec(),
             Float32ArrayOrUnrestrictedFloatSequence::UnrestrictedFloatSequence(v) => v,
@@ -4505,12 +4605,13 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
             // https://github.com/KhronosGroup/WebGL/issues/2700
             return self.webgl_error(InvalidValue);
         }
-        self.vertex_attrib(indx, values[0], values[1], values[2], values[3]);
+        self.vertex_attrib(cx, indx, values[0], values[1], values[2], values[3]);
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn VertexAttribPointer(
         &self,
+        cx: &mut js::context::JSContext,
         index: u32,
         size: i32,
         type_: u32,
@@ -4520,10 +4621,10 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     ) {
         let res = match self.webgl_version() {
             WebGLVersion::WebGL1 => self
-                .current_vao()
+                .current_vao(cx)
                 .vertex_attrib_pointer(index, size, type_, normalized, stride, offset),
             WebGLVersion::WebGL2 => self
-                .current_vao_webgl2()
+                .current_vao_webgl2(cx)
                 .vertex_attrib_pointer(index, size, type_, normalized, stride, offset),
         };
         handle_potential_webgl_error!(self, res);

--- a/components/script/dom/webgl/webglsampler.rs
+++ b/components/script/dom/webgl/webglsampler.rs
@@ -6,7 +6,7 @@ use std::cell::Cell;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::{reflect_dom_object, reflect_dom_object_with_cx};
+use script_bindings::reflector::reflect_dom_object_with_cx;
 use script_bindings::weakref::WeakRef;
 use servo_canvas_traits::webgl::WebGLError::*;
 use servo_canvas_traits::webgl::{WebGLCommand, WebGLSamplerId, webgl_channel};

--- a/components/script/dom/webgl/webglsampler.rs
+++ b/components/script/dom/webgl/webglsampler.rs
@@ -5,7 +5,8 @@
 use std::cell::Cell;
 
 use dom_struct::dom_struct;
-use script_bindings::reflector::reflect_dom_object;
+use js::context::JSContext;
+use script_bindings::reflector::{reflect_dom_object, reflect_dom_object_with_cx};
 use script_bindings::weakref::WeakRef;
 use servo_canvas_traits::webgl::WebGLError::*;
 use servo_canvas_traits::webgl::{WebGLCommand, WebGLSamplerId, webgl_channel};
@@ -16,7 +17,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::webgl::webglobject::WebGLObject;
 use crate::dom::webgl::webglrenderingcontext::{Operation, WebGLRenderingContext};
 use crate::dom::webglrenderingcontext::capture_webgl_backtrace;
-use crate::script_runtime::CanGc;
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableWebGLSampler {
@@ -121,15 +121,15 @@ impl WebGLSampler {
         }
     }
 
-    pub(crate) fn new(context: &WebGLRenderingContext, can_gc: CanGc) -> DomRoot<Self> {
+    pub(crate) fn new(cx: &mut JSContext, context: &WebGLRenderingContext) -> DomRoot<Self> {
         let (sender, receiver) = webgl_channel().unwrap();
         context.send_command(WebGLCommand::GenerateSampler(sender));
         let id = receiver.recv().unwrap();
 
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(Self::new_inherited(context, id)),
             &*context.global(),
-            can_gc,
+            cx,
         )
     }
 

--- a/components/script/dom/webgl/webglshader.rs
+++ b/components/script/dom/webgl/webglshader.rs
@@ -8,9 +8,10 @@ use std::os::raw::c_int;
 use std::sync::Once;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use mozangle::shaders::{BuiltInResources, CompileOptions, Output, ShaderValidator};
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object;
+use script_bindings::reflector::reflect_dom_object_with_cx;
 use script_bindings::weakref::WeakRef;
 use servo_canvas_traits::webgl::{
     GLLimits, GlType, WebGLCommand, WebGLError, WebGLResult, WebGLSLVersion, WebGLShaderId,
@@ -28,7 +29,6 @@ use crate::dom::webgl::extensions::oesstandardderivatives::OESStandardDerivative
 use crate::dom::webgl::webglobject::WebGLObject;
 use crate::dom::webgl::webglrenderingcontext::{Operation, WebGLRenderingContext};
 use crate::dom::webglrenderingcontext::capture_webgl_backtrace;
-use crate::script_runtime::CanGc;
 
 #[derive(Clone, Copy, Debug, JSTraceable, MallocSizeOf, PartialEq)]
 pub(crate) enum ShaderCompilationStatus {
@@ -101,6 +101,7 @@ impl WebGLShader {
     }
 
     pub(crate) fn maybe_new(
+        cx: &mut js::context::JSContext,
         context: &WebGLRenderingContext,
         shader_type: u32,
     ) -> Option<DomRoot<Self>> {
@@ -109,19 +110,19 @@ impl WebGLShader {
         receiver
             .recv()
             .unwrap()
-            .map(|id| WebGLShader::new(context, id, shader_type, CanGc::deprecated_note()))
+            .map(|id| WebGLShader::new(cx, context, id, shader_type))
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         context: &WebGLRenderingContext,
         id: WebGLShaderId,
         shader_type: u32,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(WebGLShader::new_inherited(context, id, shader_type)),
             &*context.global(),
-            can_gc,
+            cx,
         )
     }
 }

--- a/components/script/dom/webgl/webglshader.rs
+++ b/components/script/dom/webgl/webglshader.rs
@@ -8,7 +8,6 @@ use std::os::raw::c_int;
 use std::sync::Once;
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
 use mozangle::shaders::{BuiltInResources, CompileOptions, Output, ShaderValidator};
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::reflect_dom_object_with_cx;

--- a/components/script/dom/webgl/webglshaderprecisionformat.rs
+++ b/components/script/dom/webgl/webglshaderprecisionformat.rs
@@ -5,7 +5,7 @@
 // https://www.khronos.org/registry/webgl/specs/latest/1.0/webgl.idl
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::{Reflector, reflect_dom_object, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 
 use crate::dom::bindings::codegen::Bindings::WebGLShaderPrecisionFormatBinding::WebGLShaderPrecisionFormatMethods;
 use crate::dom::bindings::root::DomRoot;

--- a/components/script/dom/webgl/webglshaderprecisionformat.rs
+++ b/components/script/dom/webgl/webglshaderprecisionformat.rs
@@ -4,12 +4,12 @@
 
 // https://www.khronos.org/registry/webgl/specs/latest/1.0/webgl.idl
 use dom_struct::dom_struct;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use js::context::JSContext;
+use script_bindings::reflector::{Reflector, reflect_dom_object, reflect_dom_object_with_cx};
 
 use crate::dom::bindings::codegen::Bindings::WebGLShaderPrecisionFormatBinding::WebGLShaderPrecisionFormatMethods;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct WebGLShaderPrecisionFormat {
@@ -30,18 +30,18 @@ impl WebGLShaderPrecisionFormat {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         range_min: i32,
         range_max: i32,
         precision: i32,
-        can_gc: CanGc,
     ) -> DomRoot<WebGLShaderPrecisionFormat> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(WebGLShaderPrecisionFormat::new_inherited(
                 range_min, range_max, precision,
             )),
             window,
-            can_gc,
+            cx,
         )
     }
 }

--- a/components/script/dom/webgl/webglsync.rs
+++ b/components/script/dom/webgl/webglsync.rs
@@ -5,7 +5,8 @@
 use std::cell::Cell;
 
 use dom_struct::dom_struct;
-use script_bindings::reflector::reflect_dom_object;
+use js::context::JSContext;
+use script_bindings::reflector::{reflect_dom_object, reflect_dom_object_with_cx};
 use script_bindings::weakref::WeakRef;
 use servo_canvas_traits::webgl::{WebGLCommand, WebGLSyncId, webgl_channel};
 
@@ -16,7 +17,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::webgl::webglobject::WebGLObject;
 use crate::dom::webgl::webglrenderingcontext::{Operation, WebGLRenderingContext};
 use crate::dom::webglrenderingcontext::capture_webgl_backtrace;
-use crate::script_runtime::CanGc;
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableWebGLSync {
@@ -79,15 +79,15 @@ impl WebGLSync {
         }
     }
 
-    pub(crate) fn new(context: &WebGLRenderingContext, can_gc: CanGc) -> DomRoot<Self> {
+    pub(crate) fn new(cx: &mut JSContext, context: &WebGLRenderingContext) -> DomRoot<Self> {
         let (sender, receiver) = webgl_channel().unwrap();
         context.send_command(WebGLCommand::FenceSync(sender));
         let sync_id = receiver.recv().unwrap();
 
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(WebGLSync::new_inherited(context, sync_id)),
             &*context.global(),
-            can_gc,
+            cx,
         )
     }
 }

--- a/components/script/dom/webgl/webglsync.rs
+++ b/components/script/dom/webgl/webglsync.rs
@@ -6,7 +6,7 @@ use std::cell::Cell;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::{reflect_dom_object, reflect_dom_object_with_cx};
+use script_bindings::reflector::reflect_dom_object_with_cx;
 use script_bindings::weakref::WeakRef;
 use servo_canvas_traits::webgl::{WebGLCommand, WebGLSyncId, webgl_channel};
 

--- a/components/script/dom/webgl/webgltexture.rs
+++ b/components/script/dom/webgl/webgltexture.rs
@@ -11,9 +11,9 @@ use dom_struct::dom_struct;
 #[cfg(feature = "webxr")]
 use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
+use script_bindings::reflector::DomObject as _;
 #[cfg(feature = "webxr")]
 use script_bindings::reflector::reflect_dom_object_with_cx;
-use script_bindings::reflector::{DomObject as _, reflect_dom_object};
 use script_bindings::weakref::WeakRef;
 use servo_canvas_traits::webgl::{
     TexDataType, TexFormat, TexParameter, TexParameterBool, TexParameterInt, WebGLCommand,

--- a/components/script/dom/webgl/webgltexture.rs
+++ b/components/script/dom/webgl/webgltexture.rs
@@ -32,7 +32,6 @@ use crate::dom::webgl::webglrenderingcontext::{Operation, WebGLRenderingContext}
 use crate::dom::webglrenderingcontext::capture_webgl_backtrace;
 #[cfg(feature = "webxr")]
 use crate::dom::xrsession::XRSession;
-use crate::script_runtime::CanGc;
 
 pub(crate) enum TexParameterValue {
     Float(f32),
@@ -162,21 +161,24 @@ impl WebGLTexture {
         }
     }
 
-    pub(crate) fn maybe_new(context: &WebGLRenderingContext) -> Option<DomRoot<Self>> {
+    pub(crate) fn maybe_new(
+        cx: &mut JSContext,
+        context: &WebGLRenderingContext,
+    ) -> Option<DomRoot<Self>> {
         let (sender, receiver) = webgl_channel().unwrap();
         context.send_command(WebGLCommand::CreateTexture(sender));
         receiver
             .recv()
             .unwrap()
-            .map(|id| WebGLTexture::new(context, id, CanGc::deprecated_note()))
+            .map(|id| WebGLTexture::new(cx, context, id))
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         context: &WebGLRenderingContext,
         id: WebGLTextureId,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(WebGLTexture::new_inherited(
                 context,
                 id,
@@ -184,7 +186,7 @@ impl WebGLTexture {
                 None,
             )),
             &*context.global(),
-            can_gc,
+            cx,
         )
     }
 

--- a/components/script/dom/webgl/webgltransformfeedback.rs
+++ b/components/script/dom/webgl/webgltransformfeedback.rs
@@ -5,7 +5,8 @@
 use std::cell::Cell;
 
 use dom_struct::dom_struct;
-use script_bindings::reflector::reflect_dom_object;
+use js::context::JSContext;
+use script_bindings::reflector::{reflect_dom_object, reflect_dom_object_with_cx};
 use script_bindings::weakref::WeakRef;
 use servo_canvas_traits::webgl::{WebGLCommand, webgl_channel};
 
@@ -14,7 +15,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::webgl::webglobject::WebGLObject;
 use crate::dom::webgl::webglrenderingcontext::{Operation, WebGLRenderingContext};
 use crate::dom::webglrenderingcontext::capture_webgl_backtrace;
-use crate::script_runtime::CanGc;
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableWebGLTransformFeedback {
@@ -82,15 +82,15 @@ impl WebGLTransformFeedback {
         }
     }
 
-    pub(crate) fn new(context: &WebGLRenderingContext, can_gc: CanGc) -> DomRoot<Self> {
+    pub(crate) fn new(cx: &mut JSContext, context: &WebGLRenderingContext) -> DomRoot<Self> {
         let (sender, receiver) = webgl_channel().unwrap();
         context.send_command(WebGLCommand::CreateTransformFeedback(sender));
         let id = receiver.recv().unwrap();
 
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(WebGLTransformFeedback::new_inherited(context, id)),
             &*context.global(),
-            can_gc,
+            cx,
         )
     }
 }

--- a/components/script/dom/webgl/webgltransformfeedback.rs
+++ b/components/script/dom/webgl/webgltransformfeedback.rs
@@ -6,7 +6,7 @@ use std::cell::Cell;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::{reflect_dom_object, reflect_dom_object_with_cx};
+use script_bindings::reflector::reflect_dom_object_with_cx;
 use script_bindings::weakref::WeakRef;
 use servo_canvas_traits::webgl::{WebGLCommand, webgl_channel};
 

--- a/components/script/dom/webgl/webgluniformlocation.rs
+++ b/components/script/dom/webgl/webgluniformlocation.rs
@@ -4,12 +4,12 @@
 
 // https://www.khronos.org/registry/webgl/specs/latest/1.0/webgl.idl
 use dom_struct::dom_struct;
-use script_bindings::reflector::{Reflector, reflect_dom_object};
+use js::context::JSContext;
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use servo_canvas_traits::webgl::{WebGLContextId, WebGLProgramId};
 
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct WebGLUniformLocation {
@@ -46,6 +46,7 @@ impl WebGLUniformLocation {
 
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         id: i32,
         context_id: WebGLContextId,
@@ -53,9 +54,8 @@ impl WebGLUniformLocation {
         link_generation: u64,
         size: Option<i32>,
         type_: u32,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(Self::new_inherited(
                 id,
                 context_id,
@@ -65,7 +65,7 @@ impl WebGLUniformLocation {
                 type_,
             )),
             window,
-            can_gc,
+            cx,
         )
     }
 

--- a/components/script/dom/webgl/webglvertexarrayobject.rs
+++ b/components/script/dom/webgl/webglvertexarrayobject.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use script_bindings::cell::Ref;
-use script_bindings::reflector::{reflect_dom_object, reflect_dom_object_with_cx};
+use script_bindings::reflector::reflect_dom_object_with_cx;
 use servo_canvas_traits::webgl::{ActiveAttribInfo, WebGLResult, WebGLVertexArrayId};
 
 use crate::dom::bindings::reflector::DomGlobal;

--- a/components/script/dom/webgl/webglvertexarrayobject.rs
+++ b/components/script/dom/webgl/webglvertexarrayobject.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use script_bindings::cell::Ref;
-use script_bindings::reflector::reflect_dom_object;
+use script_bindings::reflector::{reflect_dom_object, reflect_dom_object_with_cx};
 use servo_canvas_traits::webgl::{ActiveAttribInfo, WebGLResult, WebGLVertexArrayId};
 
 use crate::dom::bindings::reflector::DomGlobal;
@@ -13,7 +14,6 @@ use crate::dom::webgl::vertexarrayobject::{VertexArrayObject, VertexAttribData};
 use crate::dom::webgl::webglbuffer::WebGLBuffer;
 use crate::dom::webgl::webglobject::WebGLObject;
 use crate::dom::webgl::webglrenderingcontext::{Operation, WebGLRenderingContext};
-use crate::script_runtime::CanGc;
 
 #[dom_struct(associated_memory)]
 pub(crate) struct WebGLVertexArrayObject {
@@ -30,14 +30,14 @@ impl WebGLVertexArrayObject {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         context: &WebGLRenderingContext,
         id: Option<WebGLVertexArrayId>,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(WebGLVertexArrayObject::new_inherited(context, id)),
             &*context.global(),
-            can_gc,
+            cx,
         )
     }
 

--- a/components/script/dom/webgl/webglvertexarrayobjectoes.rs
+++ b/components/script/dom/webgl/webglvertexarrayobjectoes.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use script_bindings::cell::Ref;
-use script_bindings::reflector::reflect_dom_object;
+use script_bindings::reflector::{reflect_dom_object, reflect_dom_object_with_cx};
 use servo_canvas_traits::webgl::{ActiveAttribInfo, WebGLResult, WebGLVertexArrayId};
 
 use crate::dom::bindings::reflector::DomGlobal;
@@ -13,7 +14,6 @@ use crate::dom::webgl::vertexarrayobject::{VertexArrayObject, VertexAttribData};
 use crate::dom::webgl::webglbuffer::WebGLBuffer;
 use crate::dom::webgl::webglobject::WebGLObject;
 use crate::dom::webgl::webglrenderingcontext::{Operation, WebGLRenderingContext};
-use crate::script_runtime::CanGc;
 
 #[dom_struct(associated_memory)]
 pub(crate) struct WebGLVertexArrayObjectOES {
@@ -30,14 +30,14 @@ impl WebGLVertexArrayObjectOES {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         context: &WebGLRenderingContext,
         id: Option<WebGLVertexArrayId>,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(WebGLVertexArrayObjectOES::new_inherited(context, id)),
             &*context.global(),
-            can_gc,
+            cx,
         )
     }
 

--- a/components/script/dom/webgl/webglvertexarrayobjectoes.rs
+++ b/components/script/dom/webgl/webglvertexarrayobjectoes.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use script_bindings::cell::Ref;
-use script_bindings::reflector::{reflect_dom_object, reflect_dom_object_with_cx};
+use script_bindings::reflector::reflect_dom_object_with_cx;
 use servo_canvas_traits::webgl::{ActiveAttribInfo, WebGLResult, WebGLVertexArrayId};
 
 use crate::dom::bindings::reflector::DomGlobal;

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -14,6 +14,7 @@
 
 DOMInterfaces = {
 
+
 'AbortController': {
     'cx': ['Constructor'],
     'realm': ['Abort'],
@@ -1393,12 +1394,13 @@ DOMInterfaces = {
 },
 
 'WebGLRenderingContext': {
-    'cx': ['GetExtension', 'MakeXRCompatible','BindBuffer', 'BufferData_', 'BufferData_', 'BufferSubData',
-            'CreateBuffer', 'CreateFramebuffer',
-            'CreateTexture', 'CreateShader',
-            'GetActiveAttrib',
-            'CreateRenderbuffer', 'DeleteBuffer', 'GetBufferParameter',
+    'cx': ['GetExtension', 'MakeXRCompatible','BindBuffer',  'BufferSubData',
+            'CreateBuffer', 'CreateFramebuffer', 'CreateProgram',
+            'CreateTexture', 'CreateShader', 'GetActiveAttrib',
+            'CreateRenderbuffer', 'DeleteBuffer', 'DrawElements', 'DrawArrays',
+            'EnableVertexAttribArray', 'DisableVertexAttribArray',
             'GetActiveUniform', 'GetUniformLocation', 'GetShaderPrecisionFormat',
+            'GetVertexAttribOffset',
             'VertexAttrib1f', 'VertexAttrib1fv', 'VertexAttrib2f', 'VertexAttrib2fv',
             'VertexAttrib3f', 'VertexAttrib4f', 'VertexAttrib4fv', 'VertexAttrib3fv', 'VertexAttribPointer'],
     'weakReferenceable': True,
@@ -1407,13 +1409,19 @@ DOMInterfaces = {
 'WebGL2RenderingContext': {
     'cx': ['BindBuffer', 'BufferData_', 'BufferData__', 'BufferData', 'BufferSubData', 'BufferSubData_',
         'CopyBufferSubData',
-        'CreateQuery', 'CreateBuffer', 'CreateShader', 'CreateTexture', 'CreateVertexArray',
-        'DeleteBuffer', 'DeleteVertexArray', 'DrawArrays', 'DrawArrayInstance', 'DrawElements', 'DrawElementsInstanced',
+        'CreateQuery', 'CreateBuffer', 'CreateShader', 'CreateSampler', 'CreateTexture', 'CreateProgram',
+        'CreateVertexArray', 'CreateFramebuffer', 'CreateRenderbuffer',
+        'CreateTransformFeedback',
+        'DeleteBuffer', 'DeleteVertexArray', 'DrawArrays', 'DrawArraysInstanced', 'DrawElements', 'DrawElementsInstanced',
+        'DrawRangeElements',
+        'EnableVertexAttribArray', 'DisableVertexAttribArray',
         'GetExtension', 'GetBufferSubData', 'GetActiveUniform', 'GetActiveAttrib', 'GetShaderPrecisionFormat',
-        'GetUniformLocation',
+        'GetUniformLocation', 'FenceSync', 'GetTransformFeedbackVarying',
+        'GetVertexAttribOffset',
+        'VertexAttributepointer', 'VertexAttribIPointer', 'VertexAttrib1f',
         'VertexAttrib1fv', 'VertexAttrib2f', 'VertexAttrib2fv', 'VertexAttrib3f', 'VertexAttrib3fv', 'VertexAttrib4f',
-        'VertexAttrib4fv', 'VertexAttribI4iv', 'VertexAttribI4ui',
-        'MakeXRCompatible'],
+        'VertexAttrib4fv', 'VertexAttribI4i', 'VertexAttribI4iv', 'VertexAttribI4ui', 'VertexAttribI4uiv', 'VertexAttribDivisor',
+        'VertexAttribPointer', 'MakeXRCompatible'],
     'additionalTraits': ['crate::interfaces::WebGL2RenderingContextHelpers'],
 },
 

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1388,13 +1388,32 @@ DOMInterfaces = {
     'cx': ['Constructor'],
 },
 
+'WebGLContextEvent': {
+    'cx': ['Constructor'],
+},
+
 'WebGLRenderingContext': {
-    'cx': ['GetExtension', 'MakeXRCompatible'],
+    'cx': ['GetExtension', 'MakeXRCompatible','BindBuffer', 'BufferData_', 'BufferData_', 'BufferSubData',
+            'CreateBuffer', 'CreateFramebuffer',
+            'CreateTexture', 'CreateShader',
+            'GetActiveAttrib',
+            'CreateRenderbuffer', 'DeleteBuffer', 'GetBufferParameter',
+            'GetActiveUniform', 'GetUniformLocation', 'GetShaderPrecisionFormat',
+            'VertexAttrib1f', 'VertexAttrib1fv', 'VertexAttrib2f', 'VertexAttrib2fv',
+            'VertexAttrib3f', 'VertexAttrib4f', 'VertexAttrib4fv', 'VertexAttrib3fv', 'VertexAttribPointer'],
     'weakReferenceable': True,
 },
 
 'WebGL2RenderingContext': {
-    'cx': ['GetExtension', 'MakeXRCompatible'],
+    'cx': ['BindBuffer', 'BufferData_', 'BufferData__', 'BufferData', 'BufferSubData', 'BufferSubData_',
+        'CopyBufferSubData',
+        'CreateQuery', 'CreateBuffer', 'CreateShader', 'CreateTexture', 'CreateVertexArray',
+        'DeleteBuffer', 'DeleteVertexArray', 'DrawArrays', 'DrawArrayInstance', 'DrawElements', 'DrawElementsInstanced',
+        'GetExtension', 'GetBufferSubData', 'GetActiveUniform', 'GetActiveAttrib', 'GetShaderPrecisionFormat',
+        'GetUniformLocation',
+        'VertexAttrib1fv', 'VertexAttrib2f', 'VertexAttrib2fv', 'VertexAttrib3f', 'VertexAttrib3fv', 'VertexAttrib4f',
+        'VertexAttrib4fv', 'VertexAttribI4iv', 'VertexAttribI4ui',
+        'MakeXRCompatible'],
     'additionalTraits': ['crate::interfaces::WebGL2RenderingContextHelpers'],
 },
 


### PR DESCRIPTION
This moves most of WebGL to using JSContex.
We use several escape hatches (temp_cx()) for these reason:
- Methods with buffer seem to be called somewhere in codegen without the correct cx.
- Extension Bindings did not work correctly.
- Having script_bindings::script_runtime::JSContext and js::context::JSContext in the same function.

Most of these problems are probably user error :D

Testing: Compilation is the test.
