### PR TITLE
script: Move some pipeline-specific members from Window to Document

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -422,7 +422,8 @@ impl ExtractedBody {
         let trusted_stream = Trusted::new(&*stream);
 
         let global = stream.global();
-        let task_source = global.task_manager().networking_task_source();
+        let task_manager = global.task_manager();
+        let task_source = task_manager.networking_task_source();
 
         // In case of the data being in-memory, send everything in one chunk, by-passing SM.
         // Empty extracted bodies are always representable as an in-memory empty payload.

--- a/components/script/dom/audio/audiotracklist.rs
+++ b/components/script/dom/audio/audiotracklist.rs
@@ -91,7 +91,8 @@ impl AudioTrackList {
         // Queue a task to fire an event named change.
         let global = &self.global();
         let this = Trusted::new(self);
-        let task_source = global.task_manager().media_element_task_source();
+        let task_manager = global.task_manager();
+        let task_source = task_manager.media_element_task_source();
         task_source.queue(task!(media_track_change: move |cx| {
             let this = this.root();
             this.upcast::<EventTarget>().fire_event(cx, atom!("change"));

--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -71,6 +71,8 @@ pub(crate) struct DebuggerGlobalScope {
     get_list_frame_result_sender: RefCell<Option<GenericSender<Vec<String>>>>,
     #[no_trace]
     get_environment_result_sender: RefCell<Option<GenericSender<String>>>,
+    #[no_trace]
+    pipeline_id: PipelineId,
 }
 
 impl DebuggerGlobalScope {
@@ -97,7 +99,6 @@ impl DebuggerGlobalScope {
     ) -> DomRoot<Self> {
         let global = Box::new(Self {
             global_scope: GlobalScope::new_inherited(
-                debugger_pipeline_id,
                 script_to_devtools_sender,
                 mem_profiler_chan,
                 time_profiler_chan,
@@ -120,6 +121,7 @@ impl DebuggerGlobalScope {
             get_list_frame_result_sender: RefCell::new(None),
             get_environment_result_sender: RefCell::new(None),
             eval_result_sender: RefCell::new(None),
+            pipeline_id: debugger_pipeline_id,
         });
         let global = DebuggerGlobalScopeBinding::Wrap::<crate::DomTypeHolder>(cx, global);
 
@@ -391,6 +393,10 @@ impl DebuggerGlobalScope {
             event.fire(cx, self.upcast()),
             "Guaranteed by DebuggerUnblackboxEvent::new"
         );
+    }
+
+    pub(crate) fn pipeline_id(&self) -> PipelineId {
+        self.pipeline_id
     }
 }
 

--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -18,7 +18,7 @@ use profile_traits::{mem, time};
 use script_bindings::reflector::DomObject;
 use servo_base::generic_channel::{GenericCallback, GenericSender, channel};
 use servo_base::id::{Index, PipelineId, PipelineNamespaceId};
-use servo_constellation_traits::ScriptToConstellationChan;
+use servo_constellation_traits::ScriptToConstellationSender;
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
 use storage_traits::StorageThreads;
 
@@ -90,7 +90,7 @@ impl DebuggerGlobalScope {
         devtools_to_script_sender: GenericSender<DevtoolScriptControlMsg>,
         mem_profiler_chan: mem::ProfilerChan,
         time_profiler_chan: time::ProfilerChan,
-        script_to_constellation_chan: ScriptToConstellationChan,
+        script_to_constellation_sender: ScriptToConstellationSender,
         script_to_embedder_chan: ScriptToEmbedderChan,
         resource_threads: ResourceThreads,
         storage_threads: StorageThreads,
@@ -102,7 +102,7 @@ impl DebuggerGlobalScope {
                 script_to_devtools_sender,
                 mem_profiler_chan,
                 time_profiler_chan,
-                script_to_constellation_chan,
+                script_to_constellation_sender,
                 script_to_embedder_chan,
                 resource_threads,
                 storage_threads,

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -210,6 +210,7 @@ use crate::script_runtime::CanGc;
 use crate::script_thread::{ScriptThread, SharedRwLocks};
 use crate::stylesheet_set::StylesheetSetRef;
 use crate::task::NonSendTaskBox;
+use crate::task_manager::TaskManager;
 use crate::task_source::TaskSourceName;
 use crate::timers::{OneshotTimerCallback, OneshotTimers};
 use crate::xpath::parse_expression;
@@ -676,9 +677,17 @@ pub(crate) struct Document {
 
     #[no_trace]
     pipeline_id: PipelineId,
+
+    /// A [`TaskManager`] for this [`Window`].
+    #[conditional_malloc_size_of]
+    task_manager: Rc<TaskManager>,
 }
 
 impl Document {
+    pub(crate) fn task_manager(&self) -> Rc<TaskManager> {
+        self.task_manager.clone()
+    }
+
     pub(crate) fn timers(&self) -> &OneshotTimers {
         &self.timers
     }
@@ -3709,6 +3718,11 @@ impl Document {
             mute_iframe_load: Default::default(),
             timers: OneshotTimers::new(window.upcast()),
             pipeline_id,
+            task_manager: Rc::new(TaskManager::new(
+                Some(window.event_loop_sender()),
+                pipeline_id,
+                None,
+            )),
         }
     }
 

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -151,6 +151,7 @@ use crate::dom::execcommand::execcommands::DocumentExecCommandSupport;
 use crate::dom::focusevent::FocusEvent;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::hashchangeevent::HashChangeEvent;
+use crate::dom::history::History;
 use crate::dom::html::htmlanchorelement::HTMLAnchorElement;
 use crate::dom::html::htmlareaelement::HTMLAreaElement;
 use crate::dom::html::htmlbaseelement::HTMLBaseElement;
@@ -686,9 +687,16 @@ pub(crate) struct Document {
     #[ignore_malloc_size_of = "ImageCache"]
     #[no_trace]
     image_cache: StdArc<dyn ImageCache>,
+
+    /// <https://html.spec.whatwg.org/multipage/#doc-history>
+    history: MutNullableDom<History>,
 }
 
 impl Document {
+    pub(crate) fn history(&self, cx: &mut JSContext) -> DomRoot<History> {
+        self.history.or_init(|| History::new(cx, &self.window))
+    }
+
     pub(crate) fn image_cache(&self) -> StdArc<dyn ImageCache> {
         self.image_cache.clone()
     }
@@ -3734,6 +3742,7 @@ impl Document {
                 None,
             )),
             image_cache,
+            history: Default::default(),
         }
     }
 

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -211,7 +211,7 @@ use crate::script_thread::{ScriptThread, SharedRwLocks};
 use crate::stylesheet_set::StylesheetSetRef;
 use crate::task::NonSendTaskBox;
 use crate::task_source::TaskSourceName;
-use crate::timers::OneshotTimerCallback;
+use crate::timers::{OneshotTimerCallback, OneshotTimers};
 use crate::xpath::parse_expression;
 
 #[derive(Clone, Copy, PartialEq)]
@@ -669,9 +669,17 @@ pub(crate) struct Document {
     iframe_load_in_progress: Cell<bool>,
     /// <https://html.spec.whatwg.org/multipage/#mute-iframe-load>
     mute_iframe_load: Cell<bool>,
+
+    /// The mechanism by which time-outs and intervals are scheduled.
+    /// <https://html.spec.whatwg.org/multipage/#timers>
+    timers: OneshotTimers,
 }
 
 impl Document {
+    pub(crate) fn timers(&self) -> &OneshotTimers {
+        &self.timers
+    }
+
     /// <https://html.spec.whatwg.org/multipage/#unloading-document-cleanup-steps>
     fn unloading_cleanup_steps(&self) {
         // Step 1. Let window be document's relevant global object.
@@ -3691,6 +3699,7 @@ impl Document {
             accessibility_data: Default::default(),
             iframe_load_in_progress: Default::default(),
             mute_iframe_load: Default::default(),
+            timers: OneshotTimers::new(window.upcast()),
         }
     }
 

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -55,7 +55,7 @@ use script_traits::{DocumentActivity, ProgressiveWebMetricType};
 use servo_arc::Arc;
 use servo_base::cross_process_instant::CrossProcessInstant;
 use servo_base::generic_channel::GenericSend;
-use servo_base::id::WebViewId;
+use servo_base::id::{PipelineId, WebViewId};
 use servo_base::{Epoch, generic_channel};
 use servo_config::pref;
 use servo_constellation_traits::{NavigationHistoryBehavior, ScriptToConstellationMessage};
@@ -673,11 +673,18 @@ pub(crate) struct Document {
     /// The mechanism by which time-outs and intervals are scheduled.
     /// <https://html.spec.whatwg.org/multipage/#timers>
     timers: OneshotTimers,
+
+    #[no_trace]
+    pipeline_id: PipelineId,
 }
 
 impl Document {
     pub(crate) fn timers(&self) -> &OneshotTimers {
         &self.timers
+    }
+
+    pub(crate) fn pipeline_id(&self) -> PipelineId {
+        self.pipeline_id
     }
 
     /// <https://html.spec.whatwg.org/multipage/#unloading-document-cleanup-steps>
@@ -3537,6 +3544,7 @@ impl Document {
         custom_element_reaction_stack: Rc<CustomElementReactionStack>,
         creation_sandboxing_flag_set: SandboxingFlagSet,
         timeline: &DocumentTimeline,
+        pipeline_id: PipelineId,
     ) -> Document {
         let url = url.unwrap_or_else(|| ServoUrl::parse("about:blank").unwrap());
 
@@ -3700,6 +3708,7 @@ impl Document {
             iframe_load_in_progress: Default::default(),
             mute_iframe_load: Default::default(),
             timers: OneshotTimers::new(window.upcast()),
+            pipeline_id,
         }
     }
 
@@ -3816,6 +3825,7 @@ impl Document {
         has_trustworthy_ancestor_origin: bool,
         custom_element_reaction_stack: Rc<CustomElementReactionStack>,
         creation_sandboxing_flag_set: SandboxingFlagSet,
+        pipeline_id: PipelineId,
         can_gc: CanGc,
     ) -> DomRoot<Document> {
         Self::new_with_proto(
@@ -3840,6 +3850,7 @@ impl Document {
             has_trustworthy_ancestor_origin,
             custom_element_reaction_stack,
             creation_sandboxing_flag_set,
+            pipeline_id,
             can_gc,
         )
     }
@@ -3867,6 +3878,7 @@ impl Document {
         has_trustworthy_ancestor_origin: bool,
         custom_element_reaction_stack: Rc<CustomElementReactionStack>,
         creation_sandboxing_flag_set: SandboxingFlagSet,
+        pipeline_id: PipelineId,
         can_gc: CanGc,
     ) -> DomRoot<Document> {
         let timeline = DocumentTimeline::new(window, can_gc);
@@ -3893,6 +3905,7 @@ impl Document {
                 custom_element_reaction_stack,
                 creation_sandboxing_flag_set,
                 &timeline,
+                pipeline_id,
             )),
             window,
             proto,
@@ -4093,6 +4106,7 @@ impl Document {
                     self.has_trustworthy_ancestor_or_current_origin(),
                     self.custom_element_reaction_stack.clone(),
                     self.creation_sandboxing_flag_set(),
+                    self.pipeline_id(),
                     can_gc,
                 );
                 new_doc
@@ -4851,6 +4865,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             doc.has_trustworthy_ancestor_or_current_origin(),
             doc.custom_element_reaction_stack(),
             doc.active_sandboxing_flag_set.get(),
+            doc.pipeline_id(),
             can_gc,
         ))
     }
@@ -4902,6 +4917,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             doc.has_trustworthy_ancestor_or_current_origin(),
             doc.custom_element_reaction_stack(),
             doc.creation_sandboxing_flag_set(),
+            doc.pipeline_id(),
             CanGc::from_cx(cx),
         );
         // Step 4. Parse HTML from string given document and compliantHTML.
@@ -4955,6 +4971,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             doc.has_trustworthy_ancestor_or_current_origin(),
             doc.custom_element_reaction_stack(),
             doc.creation_sandboxing_flag_set(),
+            doc.pipeline_id(),
             CanGc::from_cx(cx),
         );
 

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -10,7 +10,7 @@ use std::default::Default;
 use std::ops::Deref;
 use std::rc::Rc;
 use std::str::FromStr;
-use std::sync::{LazyLock, Mutex};
+use std::sync::{Arc as StdArc, LazyLock, Mutex};
 use std::time::Duration;
 
 use bitflags::bitflags;
@@ -37,6 +37,7 @@ use layout_api::{
 use metrics::{InteractiveFlag, InteractiveWindow, ProgressiveWebMetrics};
 use net_traits::CookieSource::NonHTTP;
 use net_traits::CoreResourceMsg::{GetCookieStringForUrl, SetCookiesForUrl};
+use net_traits::image_cache::ImageCache;
 use net_traits::policy_container::PolicyContainer;
 use net_traits::pub_domains::is_pub_domain;
 use net_traits::request::{
@@ -681,9 +682,17 @@ pub(crate) struct Document {
     /// A [`TaskManager`] for this [`Window`].
     #[conditional_malloc_size_of]
     task_manager: Rc<TaskManager>,
+
+    #[ignore_malloc_size_of = "ImageCache"]
+    #[no_trace]
+    image_cache: StdArc<dyn ImageCache>,
 }
 
 impl Document {
+    pub(crate) fn image_cache(&self) -> StdArc<dyn ImageCache> {
+        self.image_cache.clone()
+    }
+
     pub(crate) fn task_manager(&self) -> Rc<TaskManager> {
         self.task_manager.clone()
     }
@@ -3554,6 +3563,7 @@ impl Document {
         creation_sandboxing_flag_set: SandboxingFlagSet,
         timeline: &DocumentTimeline,
         pipeline_id: PipelineId,
+        image_cache: StdArc<dyn ImageCache>,
     ) -> Document {
         let url = url.unwrap_or_else(|| ServoUrl::parse("about:blank").unwrap());
 
@@ -3723,6 +3733,7 @@ impl Document {
                 pipeline_id,
                 None,
             )),
+            image_cache,
         }
     }
 
@@ -3840,6 +3851,7 @@ impl Document {
         custom_element_reaction_stack: Rc<CustomElementReactionStack>,
         creation_sandboxing_flag_set: SandboxingFlagSet,
         pipeline_id: PipelineId,
+        image_cache: StdArc<dyn ImageCache>,
         can_gc: CanGc,
     ) -> DomRoot<Document> {
         Self::new_with_proto(
@@ -3865,6 +3877,7 @@ impl Document {
             custom_element_reaction_stack,
             creation_sandboxing_flag_set,
             pipeline_id,
+            image_cache,
             can_gc,
         )
     }
@@ -3893,6 +3906,7 @@ impl Document {
         custom_element_reaction_stack: Rc<CustomElementReactionStack>,
         creation_sandboxing_flag_set: SandboxingFlagSet,
         pipeline_id: PipelineId,
+        image_cache: StdArc<dyn ImageCache>,
         can_gc: CanGc,
     ) -> DomRoot<Document> {
         let timeline = DocumentTimeline::new(window, can_gc);
@@ -3920,6 +3934,7 @@ impl Document {
                 creation_sandboxing_flag_set,
                 &timeline,
                 pipeline_id,
+                image_cache,
             )),
             window,
             proto,
@@ -4121,6 +4136,7 @@ impl Document {
                     self.custom_element_reaction_stack.clone(),
                     self.creation_sandboxing_flag_set(),
                     self.pipeline_id(),
+                    self.image_cache.clone(),
                     can_gc,
                 );
                 new_doc
@@ -4880,6 +4896,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             doc.custom_element_reaction_stack(),
             doc.active_sandboxing_flag_set.get(),
             doc.pipeline_id(),
+            doc.image_cache(),
             can_gc,
         ))
     }
@@ -4932,6 +4949,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             doc.custom_element_reaction_stack(),
             doc.creation_sandboxing_flag_set(),
             doc.pipeline_id(),
+            doc.image_cache(),
             CanGc::from_cx(cx),
         );
         // Step 4. Parse HTML from string given document and compliantHTML.
@@ -4986,6 +5004,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             doc.custom_element_reaction_stack(),
             doc.creation_sandboxing_flag_set(),
             doc.pipeline_id(),
+            doc.image_cache(),
             CanGc::from_cx(cx),
         );
 

--- a/components/script/dom/domimplementation.rs
+++ b/components/script/dom/domimplementation.rs
@@ -116,6 +116,7 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
             Some(self.document.insecure_requests_policy()),
             self.document.has_trustworthy_ancestor_or_current_origin(),
             self.document.custom_element_reaction_stack(),
+            self.document.image_cache(),
             CanGc::from_cx(cx),
         );
 
@@ -193,6 +194,7 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
             self.document.custom_element_reaction_stack(),
             self.document.creation_sandboxing_flag_set(),
             self.document.pipeline_id(),
+            self.document.image_cache(),
             CanGc::from_cx(cx),
         );
 

--- a/components/script/dom/domimplementation.rs
+++ b/components/script/dom/domimplementation.rs
@@ -192,6 +192,7 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
             self.document.has_trustworthy_ancestor_or_current_origin(),
             self.document.custom_element_reaction_stack(),
             self.document.creation_sandboxing_flag_set(),
+            self.document.pipeline_id(),
             CanGc::from_cx(cx),
         );
 

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -112,6 +112,7 @@ impl DOMParserMethods<crate::DomTypeHolder> for DOMParser {
                     doc.custom_element_reaction_stack(),
                     doc.creation_sandboxing_flag_set(),
                     doc.pipeline_id(),
+                    doc.image_cache(),
                     CanGc::from_cx(cx),
                 );
                 // Step switch-1. Parse HTML from a string given document and compliantString.
@@ -150,6 +151,7 @@ impl DOMParserMethods<crate::DomTypeHolder> for DOMParser {
                     doc.custom_element_reaction_stack(),
                     doc.creation_sandboxing_flag_set(),
                     doc.pipeline_id(),
+                    doc.image_cache(),
                     CanGc::from_cx(cx),
                 );
                 // Step switch-1. Create an XML parser parser, associated with document,

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -111,6 +111,7 @@ impl DOMParserMethods<crate::DomTypeHolder> for DOMParser {
                     doc.has_trustworthy_ancestor_or_current_origin(),
                     doc.custom_element_reaction_stack(),
                     doc.creation_sandboxing_flag_set(),
+                    doc.pipeline_id(),
                     CanGc::from_cx(cx),
                 );
                 // Step switch-1. Parse HTML from a string given document and compliantString.
@@ -148,6 +149,7 @@ impl DOMParserMethods<crate::DomTypeHolder> for DOMParser {
                     doc.has_trustworthy_ancestor_or_current_origin(),
                     doc.custom_element_reaction_stack(),
                     doc.creation_sandboxing_flag_set(),
+                    doc.pipeline_id(),
                     CanGc::from_cx(cx),
                 );
                 // Step switch-1. Create an XML parser parser, associated with document,

--- a/components/script/dom/globalscope/globalscope.rs
+++ b/components/script/dom/globalscope/globalscope.rs
@@ -1124,7 +1124,7 @@ impl GlobalScope {
             dom_port.upcast().fire_event(cx, atom!("close"));
         }
 
-        let chan = self.script_to_constellation_chan().clone();
+        let chan = self.script_to_constellation_chan();
         let initiator_port = *initiator_port;
         self.task_manager()
             .port_message_queue()

--- a/components/script/dom/globalscope/globalscope.rs
+++ b/components/script/dom/globalscope/globalscope.rs
@@ -63,12 +63,13 @@ use servo_base::generic_channel;
 use servo_base::generic_channel::{GenericCallback, GenericSend};
 use servo_base::id::{
     BlobId, BroadcastChannelRouterId, MessagePortId, MessagePortRouterId, PipelineId,
-    ServiceWorkerId, ServiceWorkerRegistrationId, WebViewId,
+    ServiceWorkerId, ServiceWorkerRegistrationId, TEST_WEBVIEW_ID, WebViewId,
 };
 use servo_config::pref;
 use servo_constellation_traits::{
     BlobData, BlobImpl, BroadcastChannelMsg, ConstellationInterest, FileBlob, MessagePortImpl,
     MessagePortMsg, PortMessageTask, ScriptToConstellationChan, ScriptToConstellationMessage,
+    ScriptToConstellationSender,
 };
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
 use storage_traits::StorageThreads;
@@ -112,6 +113,7 @@ use crate::dom::broadcastchannel::BroadcastChannel;
 use crate::dom::dedicatedworkerglobalscope::{
     DedicatedWorkerControlMsg, DedicatedWorkerGlobalScope,
 };
+use crate::dom::dissimilaroriginwindow::DissimilarOriginWindow;
 use crate::dom::errorevent::ErrorEvent;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventsource::EventSource;
@@ -266,7 +268,7 @@ pub(crate) struct GlobalScope {
 
     /// A handle for communicating messages to the constellation thread.
     #[no_trace]
-    script_to_constellation_chan: ScriptToConstellationChan,
+    script_to_constellation_sender: ScriptToConstellationSender,
 
     /// A handle for communicating messages to the Embedder.
     #[no_trace]
@@ -782,7 +784,7 @@ impl GlobalScope {
         devtools_chan: Option<GenericCallback<ScriptToDevtoolsControlMsg>>,
         mem_profiler_chan: profile_mem::ProfilerChan,
         time_profiler_chan: profile_time::ProfilerChan,
-        script_to_constellation_chan: ScriptToConstellationChan,
+        script_to_constellation_sender: ScriptToConstellationSender,
         script_to_embedder_chan: ScriptToEmbedderChan,
         resource_threads: ResourceThreads,
         storage_threads: StorageThreads,
@@ -808,7 +810,7 @@ impl GlobalScope {
             devtools_chan,
             mem_profiler_chan,
             time_profiler_chan,
-            script_to_constellation_chan,
+            script_to_constellation_sender,
             script_to_embedder_chan,
             in_error_reporting_mode: Default::default(),
             resource_threads,
@@ -2489,8 +2491,12 @@ impl GlobalScope {
     }
 
     /// Get a sender to the constellation thread.
-    pub(crate) fn script_to_constellation_chan(&self) -> &ScriptToConstellationChan {
-        &self.script_to_constellation_chan
+    pub(crate) fn script_to_constellation_chan(&self) -> ScriptToConstellationChan {
+        ScriptToConstellationChan {
+            sender: self.script_to_constellation_sender.clone(),
+            webview_id: self.webview_id().unwrap_or(TEST_WEBVIEW_ID),
+            pipeline_id: self.pipeline_id(),
+        }
     }
 
     pub(crate) fn script_to_embedder_chan(&self) -> &ScriptToEmbedderChan {
@@ -2511,6 +2517,8 @@ impl GlobalScope {
             debugger.pipeline_id()
         } else if let Some(worklet) = self.downcast::<WorkletGlobalScope>() {
             worklet.pipeline_id()
+        } else if let Some(dissimilar) = self.downcast::<DissimilarOriginWindow>() {
+            dissimilar.pipeline_id()
         } else {
             unreachable!("Unsupported global type for pipeline id")
         }

--- a/components/script/dom/globalscope/globalscope.rs
+++ b/components/script/dom/globalscope/globalscope.rs
@@ -247,10 +247,6 @@ pub(crate) struct GlobalScope {
     /// <https://w3c.github.io/ServiceWorker/#environment-settings-object-service-worker-object-map>
     worker_map: DomRefCell<HashMapTracedValues<ServiceWorkerId, Dom<ServiceWorker>, FxBuildHasher>>,
 
-    /// Pipeline id associated with this global.
-    #[no_trace]
-    pipeline_id: PipelineId,
-
     /// Timers (milliseconds) used by the Console API.
     console_timers: DomRefCell<HashMap<DOMString, Instant>>,
 
@@ -786,7 +782,6 @@ impl GlobalScope {
 
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new_inherited(
-        pipeline_id: PipelineId,
         devtools_chan: Option<GenericCallback<ScriptToDevtoolsControlMsg>>,
         mem_profiler_chan: profile_mem::ProfilerChan,
         time_profiler_chan: profile_time::ProfilerChan,
@@ -812,8 +807,6 @@ impl GlobalScope {
             registration_map: DomRefCell::new(HashMapTracedValues::new_fx()),
             indexeddb: Default::default(),
             worker_map: DomRefCell::new(HashMapTracedValues::new_fx()),
-            pipeline_id,
-
             console_timers: DomRefCell::new(Default::default()),
             module_map: DomRefCell::new(Default::default()),
             devtools_chan,
@@ -2514,7 +2507,17 @@ impl GlobalScope {
 
     /// Get the `PipelineId` for this global scope.
     pub(crate) fn pipeline_id(&self) -> PipelineId {
-        self.pipeline_id
+        if let Some(worker) = self.downcast::<WorkerGlobalScope>() {
+            worker.pipeline_id()
+        } else if let Some(window) = self.downcast::<Window>() {
+            window.pipeline_id()
+        } else if let Some(debugger) = self.downcast::<DebuggerGlobalScope>() {
+            debugger.pipeline_id()
+        } else if let Some(worklet) = self.downcast::<WorkletGlobalScope>() {
+            worklet.pipeline_id()
+        } else {
+            unreachable!("Unsupported global type for pipeline id")
+        }
     }
 
     /// Register interest in a notification category. Sends a `RegisterInterest`
@@ -2861,7 +2864,7 @@ impl GlobalScope {
                 // Step 7.3. Otherwise, the user agent may report exception to a developer console.
                 if let Some(ref chan) = self.devtools_chan {
                     let _ = chan.send(ScriptToDevtoolsControlMsg::ReportPageError(
-                        self.pipeline_id,
+                        self.pipeline_id(),
                         PageError {
                             error_message: error_info.message.clone(),
                             source_name: error_info.filename.clone(),

--- a/components/script/dom/globalscope/globalscope.rs
+++ b/components/script/dom/globalscope/globalscope.rs
@@ -214,9 +214,6 @@ impl Drop for AutoCloseWorker {
 pub(crate) struct GlobalScope {
     eventtarget: EventTarget,
 
-    /// A [`TaskManager`] for this [`GlobalScope`].
-    task_manager: OnceCell<TaskManager>,
-
     /// The message-port router id for this global, if it is managing ports.
     message_port_state: DomRefCell<MessagePortState>,
 
@@ -798,7 +795,6 @@ impl GlobalScope {
         font_context: Option<Arc<FontContext>>,
     ) -> Self {
         Self {
-            task_manager: Default::default(),
             message_port_state: DomRefCell::new(MessagePortState::UnManaged),
             broadcast_channel_state: DomRefCell::new(BroadcastChannelState::UnManaged),
             constellation_interest_counts: RefCell::new(HashMap::new()),
@@ -2914,17 +2910,14 @@ impl GlobalScope {
     }
 
     /// A reference to the [`TaskManager`] used to schedule tasks for this [`GlobalScope`].
-    pub(crate) fn task_manager(&self) -> &TaskManager {
-        let shared_canceller = self
-            .downcast::<WorkerGlobalScope>()
-            .map(WorkerGlobalScope::shared_task_canceller);
-        self.task_manager.get_or_init(|| {
-            TaskManager::new(
-                self.event_loop_sender(),
-                self.pipeline_id(),
-                shared_canceller,
-            )
-        })
+    pub(crate) fn task_manager(&self) -> Rc<TaskManager> {
+        if let Some(worker) = self.downcast::<WorkerGlobalScope>() {
+            worker.task_manager()
+        } else if let Some(window) = self.downcast::<Window>() {
+            window.task_manager()
+        } else {
+            unreachable!("Attempted to use task manager with unsupported global");
+        }
     }
 
     /// Evaluate JS code on this global scope.

--- a/components/script/dom/globalscope/globalscope.rs
+++ b/components/script/dom/globalscope/globalscope.rs
@@ -292,10 +292,6 @@ pub(crate) struct GlobalScope {
     #[no_trace]
     storage_threads: StorageThreads,
 
-    /// The mechanism by which time-outs and intervals are scheduled.
-    /// <https://html.spec.whatwg.org/multipage/#timers>
-    timers: OnceCell<OneshotTimers>,
-
     /// The origin of the globalscope
     #[no_trace]
     origin: MutableOrigin,
@@ -828,7 +824,6 @@ impl GlobalScope {
             in_error_reporting_mode: Default::default(),
             resource_threads,
             storage_threads,
-            timers: OnceCell::default(),
             origin,
             creation_url: DomRefCell::new(creation_url),
             top_level_creation_url,
@@ -876,8 +871,14 @@ impl GlobalScope {
         false
     }
 
-    fn timers(&self) -> &OneshotTimers {
-        self.timers.get_or_init(|| OneshotTimers::new(self))
+    fn with_timers<T>(&self, f: impl FnOnce(&OneshotTimers) -> T) -> T {
+        if let Some(worker) = self.downcast::<WorkerGlobalScope>() {
+            f(worker.timers())
+        } else if let Some(window) = self.downcast::<Window>() {
+            window.with_timers(f)
+        } else {
+            unreachable!("Unsupported global type retrieving timers")
+        }
     }
 
     pub(crate) fn font_context(&self) -> Option<&Arc<FontContext>> {
@@ -2974,12 +2975,11 @@ impl GlobalScope {
         callback: OneshotTimerCallback,
         duration: Duration,
     ) -> OneshotTimerHandle {
-        self.timers()
-            .schedule_callback(callback, duration, self.timer_source())
+        self.with_timers(|timers| timers.schedule_callback(callback, duration, self.timer_source()))
     }
 
     pub(crate) fn unschedule_callback(&self, handle: OneshotTimerHandle) {
-        self.timers().unschedule_callback(handle);
+        self.with_timers(|timers| timers.unschedule_callback(handle));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#timer-initialisation-steps>
@@ -2991,39 +2991,41 @@ impl GlobalScope {
         timeout: Duration,
         is_interval: IsInterval,
     ) -> Fallible<i32> {
-        self.timers().set_timeout_or_interval(
-            cx,
-            self,
-            callback,
-            arguments,
-            timeout,
-            is_interval,
-            self.timer_source(),
-        )
+        self.with_timers(|timers| {
+            timers.set_timeout_or_interval(
+                cx,
+                self,
+                callback,
+                arguments,
+                timeout,
+                is_interval,
+                self.timer_source(),
+            )
+        })
     }
 
     pub(crate) fn clear_timeout_or_interval(&self, handle: i32) {
-        self.timers().clear_timeout_or_interval(self, handle);
+        self.with_timers(|timers| timers.clear_timeout_or_interval(self, handle));
     }
 
     pub(crate) fn fire_timer(&self, handle: TimerEventId, cx: &mut js::context::JSContext) {
-        self.timers().fire_timer(handle, self, cx);
+        self.with_timers(|timers| timers.fire_timer(handle, self, cx));
     }
 
     pub(crate) fn resume(&self) {
-        self.timers().resume();
+        self.with_timers(|timers| timers.resume());
     }
 
     pub(crate) fn suspend(&self) {
-        self.timers().suspend();
+        self.with_timers(|timers| timers.suspend());
     }
 
     pub(crate) fn slow_down_timers(&self) {
-        self.timers().slow_down();
+        self.with_timers(|timers| timers.slow_down());
     }
 
     pub(crate) fn speed_up_timers(&self) {
-        self.timers().speed_up();
+        self.with_timers(|timers| timers.speed_up());
     }
 
     fn timer_source(&self) -> TimerSource {
@@ -3515,32 +3517,34 @@ impl GlobalScope {
     where
         F: 'static + FnOnce(&mut js::context::JSContext, &GlobalScope),
     {
-        let timers = self.timers();
-
-        // Step 1. Let timerKey be a new unique internal value.
-        let timer_key = timers.fresh_runsteps_key();
-
-        // Step 2. Let startTime be the current high resolution time given global.
-        let start_time = timers.now_for_runsteps();
-
-        // Step 3. Set global's map of active timers[timerKey] to startTime plus milliseconds.
         let ms = milliseconds.max(0) as u64;
         let delay = std::time::Duration::from_millis(ms);
-        let deadline = start_time + delay;
-        timers.runsteps_set_active(timer_key, deadline);
 
-        // Step 4. Run the following steps in parallel:
-        //   (We schedule a oneshot that will enforce the sub-steps when it fires.)
-        let callback = crate::timers::OneshotTimerCallback::RunStepsAfterTimeout {
-            // Step 1. timerKey
-            timer_key,
-            // Step 4. orderingIdentifier
-            ordering_id: ordering_identifier,
-            // Spec: milliseconds
-            milliseconds: ms,
-            // Step 4.4 Perform completionSteps.
-            completion: Box::new(completion_steps),
-        };
+        let (callback, timer_key) = self.with_timers(|timers| {
+            // Step 1. Let timerKey be a new unique internal value.
+            let timer_key = timers.fresh_runsteps_key();
+
+            // Step 2. Let startTime be the current high resolution time given global.
+            let start_time = timers.now_for_runsteps();
+
+            // Step 3. Set global's map of active timers[timerKey] to startTime plus milliseconds.
+            let deadline = start_time + delay;
+            timers.runsteps_set_active(timer_key, deadline);
+
+            // Step 4. Run the following steps in parallel:
+            //   (We schedule a oneshot that will enforce the sub-steps when it fires.)
+            let callback = crate::timers::OneshotTimerCallback::RunStepsAfterTimeout {
+                // Step 1. timerKey
+                timer_key,
+                // Step 4. orderingIdentifier
+                ordering_id: ordering_identifier,
+                // Spec: milliseconds
+                milliseconds: ms,
+                // Step 4.4 Perform completionSteps.
+                completion: Box::new(completion_steps),
+            };
+            (callback, timer_key)
+        });
         let _ = self.schedule_callback(callback, delay);
 
         // Step 5. Return timerKey.

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -2960,6 +2960,7 @@ impl Node {
                     document.custom_element_reaction_stack(),
                     document.creation_sandboxing_flag_set(),
                     document.pipeline_id(),
+                    document.image_cache(),
                     CanGc::from_cx(cx),
                 );
                 // Step 2. If node’s custom element registry’s is scoped is true,

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -2959,6 +2959,7 @@ impl Node {
                     document.has_trustworthy_ancestor_or_current_origin(),
                     document.custom_element_reaction_stack(),
                     document.creation_sandboxing_flag_set(),
+                    document.pipeline_id(),
                     CanGc::from_cx(cx),
                 );
                 // Step 2. If node’s custom element registry’s is scoped is true,

--- a/components/script/dom/serviceworker/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworker/serviceworkerglobalscope.rs
@@ -261,6 +261,7 @@ impl ServiceWorkerGlobalScope {
                 // FIXME: investigate what environment this value comes from for service workers.
                 InsecureRequestsPolicy::DoNotUpgrade,
                 Some(font_context),
+                Some(ScriptEventLoopSender::ServiceWorker(own_sender.clone())),
             ),
             task_queue: TaskQueue::new(receiver, own_sender.clone()),
             own_sender,

--- a/components/script/dom/servointernals.rs
+++ b/components/script/dom/servointernals.rs
@@ -71,7 +71,8 @@ impl ServoInternalsMethods<crate::DomTypeHolder> for ServoInternals {
     fn ReportMemory(&self, cx: &mut CurrentRealm) -> Rc<Promise> {
         let promise = Promise::new_in_realm(cx);
         let global = self.global();
-        let task_source = global.task_manager().dom_manipulation_task_source();
+        let task_manager = global.task_manager();
+        let task_source = task_manager.dom_manipulation_task_source();
         let callback = callback_promise(&promise, self, task_source);
 
         let script_to_constellation_chan = global.script_to_constellation_chan();

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -269,6 +269,7 @@ impl ServoParser {
             context_document.has_trustworthy_ancestor_or_current_origin(),
             context_document.custom_element_reaction_stack(),
             context_document.creation_sandboxing_flag_set(),
+            context_document.pipeline_id(),
             CanGc::from_cx(cx),
         );
 

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -270,6 +270,7 @@ impl ServoParser {
             context_document.custom_element_reaction_stack(),
             context_document.creation_sandboxing_flag_set(),
             context_document.pipeline_id(),
+            context_document.image_cache(),
             CanGc::from_cx(cx),
         );
 

--- a/components/script/dom/testing/testworkletglobalscope.rs
+++ b/components/script/dom/testing/testworkletglobalscope.rs
@@ -8,7 +8,7 @@ use crossbeam_channel::Sender;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
-use servo_base::id::{PipelineId, WebViewId};
+use servo_base::id::PipelineId;
 use servo_url::ServoUrl;
 
 use crate::dom::bindings::codegen::Bindings::TestWorkletGlobalScopeBinding;
@@ -30,7 +30,6 @@ pub(crate) struct TestWorkletGlobalScope {
 
 impl TestWorkletGlobalScope {
     pub(crate) fn new(
-        webview_id: WebViewId,
         pipeline_id: PipelineId,
         base_url: ServoUrl,
         inherited_secure_context: Option<bool>,
@@ -44,7 +43,6 @@ impl TestWorkletGlobalScope {
         );
         let global = Box::new(TestWorkletGlobalScope {
             worklet_global: WorkletGlobalScope::new_inherited(
-                webview_id,
                 pipeline_id,
                 base_url,
                 inherited_secure_context,

--- a/components/script/dom/wakelock/wakelock.rs
+++ b/components/script/dom/wakelock/wakelock.rs
@@ -83,7 +83,8 @@ impl WakeLockMethods<crate::DomTypeHolder> for WakeLock {
         };
 
         self.type_.set(type_);
-        let task_source = global.task_manager().dom_manipulation_task_source();
+        let task_manager = global.task_manager();
+        let task_source = task_manager.dom_manipulation_task_source();
         let callback = callback_promise(&promise, self, task_source);
         global.send_to_embedder(EmbedderMsg::RequestWakeLockPermission(
             webview_id,

--- a/components/script/dom/webgpu/gpu.rs
+++ b/components/script/dom/webgpu/gpu.rs
@@ -57,7 +57,8 @@ impl GPUMethods<crate::DomTypeHolder> for GPU {
         let global = &self.global();
         // 1. Let promise be a new promise.
         let promise = Promise::new_in_realm(cx);
-        let task_source = global.task_manager().dom_manipulation_task_source();
+        let task_manager = global.task_manager();
+        let task_source = task_manager.dom_manipulation_task_source();
         let callback = callback_promise(&promise, self, task_source);
 
         let power_preference = match options.powerPreference {

--- a/components/script/dom/webgpu/gpuqueue.rs
+++ b/components/script/dom/webgpu/gpuqueue.rs
@@ -386,7 +386,8 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
     fn OnSubmittedWorkDone(&self, cx: &mut JSContext) -> Rc<Promise> {
         let global = self.global();
         let promise = Promise::new(cx, &global);
-        let task_source = global.task_manager().dom_manipulation_task_source();
+        let task_manager = global.task_manager();
+        let task_source = task_manager.dom_manipulation_task_source();
         let callback = callback_promise(&promise, self, task_source);
 
         if let Err(e) = self

--- a/components/script/dom/window/dissimilaroriginwindow.rs
+++ b/components/script/dom/window/dissimilaroriginwindow.rs
@@ -7,7 +7,6 @@ use js::context::JSContext;
 use js::jsapi::{Heap, JSObject};
 use js::jsval::UndefinedValue;
 use js::rust::{CustomAutoRooter, CustomAutoRooterGuard, HandleValue, MutableHandleValue};
-use servo_base::id::PipelineId;
 use servo_constellation_traits::{
     RemoteFocusOperation, ScriptToConstellationMessage, StructuredSerializedData,
 };
@@ -55,7 +54,6 @@ impl DissimilarOriginWindow {
     ) -> DomRoot<Self> {
         let win = Box::new(Self {
             globalscope: GlobalScope::new_inherited(
-                PipelineId::new(),
                 global_to_clone_from.devtools_chan().cloned(),
                 global_to_clone_from.mem_profiler_chan().clone(),
                 global_to_clone_from.time_profiler_chan().clone(),

--- a/components/script/dom/window/dissimilaroriginwindow.rs
+++ b/components/script/dom/window/dissimilaroriginwindow.rs
@@ -7,6 +7,7 @@ use js::context::JSContext;
 use js::jsapi::{Heap, JSObject};
 use js::jsval::UndefinedValue;
 use js::rust::{CustomAutoRooter, CustomAutoRooterGuard, HandleValue, MutableHandleValue};
+use servo_base::id::PipelineId;
 use servo_constellation_traits::{
     RemoteFocusOperation, ScriptToConstellationMessage, StructuredSerializedData,
 };
@@ -44,6 +45,9 @@ pub(crate) struct DissimilarOriginWindow {
 
     /// The location of this window, initialized lazily.
     location: MutNullableDom<DissimilarOriginLocation>,
+
+    #[no_trace]
+    pipeline_id: PipelineId,
 }
 
 impl DissimilarOriginWindow {
@@ -57,7 +61,7 @@ impl DissimilarOriginWindow {
                 global_to_clone_from.devtools_chan().cloned(),
                 global_to_clone_from.mem_profiler_chan().clone(),
                 global_to_clone_from.time_profiler_chan().clone(),
-                global_to_clone_from.script_to_constellation_chan().clone(),
+                global_to_clone_from.script_to_constellation_chan().sender,
                 global_to_clone_from.script_to_embedder_chan().clone(),
                 global_to_clone_from.resource_threads().clone(),
                 global_to_clone_from.storage_threads().clone(),
@@ -72,12 +76,17 @@ impl DissimilarOriginWindow {
             ),
             window_proxy: Dom::from_ref(window_proxy),
             location: Default::default(),
+            pipeline_id: PipelineId::new(),
         });
         DissimilarOriginWindowBinding::Wrap::<crate::DomTypeHolder>(cx, win)
     }
 
     pub(crate) fn window_proxy(&self) -> DomRoot<WindowProxy> {
         DomRoot::from_ref(&*self.window_proxy)
+    }
+
+    pub(crate) fn pipeline_id(&self) -> PipelineId {
+        self.pipeline_id
     }
 }
 

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -294,7 +294,6 @@ pub(crate) struct Window {
     window_proxy: MutNullableDom<WindowProxy>,
     document: MutNullableDom<Document>,
     location: MutNullableDom<Location>,
-    history: MutNullableDom<History>,
     performance: MutNullableDom<Performance>,
     #[no_trace]
     navigation_start: Cell<CrossProcessInstant>,
@@ -1424,7 +1423,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-history>
     fn History(&self, cx: &mut JSContext) -> DomRoot<History> {
-        self.history.or_init(|| History::new(cx, self))
+        self.Document().history(cx)
     }
 
     /// <https://w3c.github.io/IndexedDB/#factory-interface>
@@ -3730,7 +3729,6 @@ impl Window {
             navigator: Default::default(),
             crypto: Default::default(),
             location: Default::default(),
-            history: Default::default(),
             window_proxy: Default::default(),
             document: Default::default(),
             performance: Default::default(),

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -79,8 +79,8 @@ use servo_bluetooth_traits::BluetoothRequest;
 use servo_canvas_traits::webgl::WebGLChan;
 use servo_config::pref;
 use servo_constellation_traits::{
-    LoadData, LoadOrigin, ScreenshotReadinessResponse, ScriptToConstellationChan,
-    ScriptToConstellationMessage, StructuredSerializedData, WindowSizeType,
+    LoadData, LoadOrigin, ScreenshotReadinessResponse, ScriptToConstellationMessage,
+    ScriptToConstellationSender, StructuredSerializedData, WindowSizeType,
 };
 use servo_geometry::DeviceIndependentIntRect;
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
@@ -3680,7 +3680,7 @@ impl Window {
         mem_profiler_chan: MemProfilerChan,
         time_profiler_chan: TimeProfilerChan,
         devtools_chan: Option<GenericCallback<ScriptToDevtoolsControlMsg>>,
-        constellation_chan: ScriptToConstellationChan,
+        script_to_constellation_sender: ScriptToConstellationSender,
         embedder_chan: ScriptToEmbedderChan,
         control_chan: GenericSender<ScriptThreadMessage>,
         pipeline_id: PipelineId,
@@ -3714,7 +3714,7 @@ impl Window {
                 devtools_chan,
                 mem_profiler_chan,
                 time_profiler_chan,
-                constellation_chan,
+                script_to_constellation_sender,
                 embedder_chan,
                 resource_threads,
                 storage_threads,

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -3710,7 +3710,6 @@ impl Window {
         let win = Box::new(Self {
             webview_id,
             globalscope: GlobalScope::new_inherited(
-                pipeline_id,
                 devtools_chan,
                 mem_profiler_chan,
                 time_profiler_chan,
@@ -3804,7 +3803,7 @@ impl Window {
     }
 
     pub(crate) fn pipeline_id(&self) -> PipelineId {
-        self.as_global_scope().pipeline_id()
+        self.Document().pipeline_id()
     }
 
     pub(crate) fn live_devtools_updates(&self) -> bool {

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -192,6 +192,7 @@ use crate::realms::{enter_auto_realm, enter_realm};
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext, Runtime};
 use crate::script_thread::ScriptThread;
 use crate::script_window_proxies::ScriptWindowProxies;
+use crate::task_manager::TaskManager;
 use crate::task_source::SendableTaskSource;
 use crate::timers::{IsInterval, OneshotTimers, TimerCallback};
 use crate::unminify::unminified_path;
@@ -3800,6 +3801,10 @@ impl Window {
         });
 
         WindowBinding::Wrap::<crate::DomTypeHolder>(cx, win)
+    }
+
+    pub(crate) fn task_manager(&self) -> Rc<TaskManager> {
+        self.Document().task_manager()
     }
 
     pub(crate) fn pipeline_id(&self) -> PipelineId {

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -193,7 +193,7 @@ use crate::script_runtime::{CanGc, JSContext as SafeJSContext, Runtime};
 use crate::script_thread::ScriptThread;
 use crate::script_window_proxies::ScriptWindowProxies;
 use crate::task_source::SendableTaskSource;
-use crate::timers::{IsInterval, TimerCallback};
+use crate::timers::{IsInterval, OneshotTimers, TimerCallback};
 use crate::unminify::unminified_path;
 use crate::webdriver_handlers::{find_node_by_unique_id_in_document, jsval_to_webdriver};
 use crate::{fetch, window_named_properties};
@@ -946,6 +946,11 @@ impl Window {
         unsafe {
             JS_GC(cx, GCReason::API);
         }
+    }
+
+    pub(crate) fn with_timers<T>(&self, f: impl FnOnce(&OneshotTimers) -> T) -> T {
+        let document = self.Document();
+        f(document.timers())
     }
 }
 

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -289,9 +289,6 @@ pub(crate) struct Window {
     layout: RefCell<Box<dyn Layout>>,
     navigator: MutNullableDom<Navigator>,
     crypto: MutNullableDom<Crypto>,
-    #[ignore_malloc_size_of = "ImageCache"]
-    #[no_trace]
-    image_cache: Arc<dyn ImageCache>,
     #[no_trace]
     image_cache_sender: Sender<ImageCacheResponseMessage>,
     window_proxy: MutNullableDom<WindowProxy>,
@@ -576,7 +573,7 @@ impl Window {
     }
 
     pub(crate) fn image_cache(&self) -> Arc<dyn ImageCache> {
-        self.image_cache.clone()
+        self.Document().image_cache()
     }
 
     /// This can panic if it is called after the browsing context has been discarded
@@ -3543,6 +3540,7 @@ impl Window {
         pending_svg_element_for_serialization: Vec<UntrustedNodeAddress>,
     ) {
         let pipeline_id = self.pipeline_id();
+        let image_cache = self.image_cache();
         for image in pending_images {
             let id = image.id;
             let node = unsafe { from_untrusted_node_address(image.node) };
@@ -3553,7 +3551,7 @@ impl Window {
                     &node,
                     id,
                     image.is_internal_request,
-                    self.image_cache.clone(),
+                    image_cache.clone(),
                 );
             }
 
@@ -3567,8 +3565,7 @@ impl Window {
                         .pending_layout_image_notification(response);
                 });
 
-                self.image_cache
-                    .add_listener(ImageLoadListener::new(sender, pipeline_id, id));
+                image_cache.add_listener(ImageLoadListener::new(sender, pipeline_id, id));
             }
 
             let nodes = images.entry(id).or_default();
@@ -3586,7 +3583,7 @@ impl Window {
             let mut images = self.pending_images_for_rasterization.borrow_mut();
             if !images.contains_key(&(image.id, image.size)) {
                 let image_cache_sender = self.image_cache_sender.clone();
-                self.image_cache.add_rasterization_complete_listener(
+                image_cache.add_rasterization_complete_listener(
                     pipeline_id,
                     image.id,
                     image.size,
@@ -3673,7 +3670,6 @@ impl Window {
         layout: Box<dyn Layout>,
         font_context: Arc<FontContext>,
         image_cache_sender: Sender<ImageCacheResponseMessage>,
-        image_cache: Arc<dyn ImageCache>,
         resource_threads: ResourceThreads,
         storage_threads: StorageThreads,
         #[cfg(feature = "bluetooth")] bluetooth_thread: GenericSender<BluetoothRequest>,
@@ -3731,7 +3727,6 @@ impl Window {
             script_chan,
             layout: RefCell::new(layout),
             image_cache_sender,
-            image_cache,
             navigator: Default::default(),
             crypto: Default::default(),
             location: Default::default(),

--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -293,6 +293,7 @@ impl DedicatedWorkerGlobalScope {
                 gpu_id_hub,
                 insecure_requests_policy,
                 font_context,
+                None,
             ),
             webview_id,
             task_queue: TaskQueue::new(receiver, own_sender.clone()),

--- a/components/script/dom/workers/sharedworkerglobalscope.rs
+++ b/components/script/dom/workers/sharedworkerglobalscope.rs
@@ -272,7 +272,7 @@ impl SharedWorkerGlobalScope {
                 gpu_id_hub,
                 insecure_requests_policy,
                 font_context,
-                Some(ScriptEventLoopSender::SharedWorker(own_sender.clone()))
+                Some(ScriptEventLoopSender::SharedWorker(own_sender.clone())),
             ),
             webview_id,
             task_queue: TaskQueue::new(receiver, own_sender.clone()),

--- a/components/script/dom/workers/sharedworkerglobalscope.rs
+++ b/components/script/dom/workers/sharedworkerglobalscope.rs
@@ -272,6 +272,7 @@ impl SharedWorkerGlobalScope {
                 gpu_id_hub,
                 insecure_requests_policy,
                 font_context,
+                Some(ScriptEventLoopSender::SharedWorker(own_sender.clone()))
             ),
             webview_id,
             task_queue: TaskQueue::new(receiver, own_sender.clone()),

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -333,6 +333,9 @@ pub(crate) struct WorkerGlobalScope {
     /// this global's compartment.
     #[ignore_malloc_size_of = "Measured by the JS engine"]
     debugger_global: Heap<Value>,
+
+    #[no_trace]
+    pipeline_id: PipelineId,
 }
 
 impl WorkerGlobalScope {
@@ -359,7 +362,6 @@ impl WorkerGlobalScope {
 
         Self {
             globalscope: GlobalScope::new_inherited(
-                init.pipeline_id,
                 init.to_devtools_sender,
                 init.mem_profiler_chan,
                 init.time_profiler_chan,
@@ -400,6 +402,7 @@ impl WorkerGlobalScope {
             report_list: Default::default(),
             endpoints_list: Default::default(),
             debugger_global: Default::default(),
+            pipeline_id: init.pipeline_id,
         }
     }
 

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -92,6 +92,7 @@ use crate::realms::enter_auto_realm;
 use crate::script_module::ScriptFetchOptions;
 use crate::script_runtime::{CanGc, IntroductionType, Runtime, get_reports};
 use crate::task::TaskCanceller;
+use crate::task_manager::TaskManager;
 use crate::timers::{IsInterval, OneshotTimers, TimerCallback};
 
 pub(crate) fn prepare_workerscope_init(
@@ -336,6 +337,10 @@ pub(crate) struct WorkerGlobalScope {
 
     #[no_trace]
     pipeline_id: PipelineId,
+
+    /// A [`TaskManager`] for this [`WorkerGlobalScope`].
+    #[conditional_malloc_size_of]
+    task_manager: Rc<TaskManager>,
 }
 
 impl WorkerGlobalScope {
@@ -351,6 +356,7 @@ impl WorkerGlobalScope {
         #[cfg(feature = "webgpu")] gpu_id_hub: Arc<IdentityHub>,
         insecure_requests_policy: InsecureRequestsPolicy,
         font_context: Option<Arc<FontContext>>,
+        event_loop_sender: Option<ScriptEventLoopSender>,
     ) -> Self {
         // Install a pipeline-namespace in the current thread.
         PipelineNamespace::auto_install();
@@ -383,7 +389,7 @@ impl WorkerGlobalScope {
             worker_name,
             worker_type,
             worker_url: DomRefCell::new(worker_url),
-            closing,
+            closing: closing.clone(),
             execution_ready: AtomicBool::new(false),
             runtime: DomRefCell::new(Some(runtime)),
             location: Default::default(),
@@ -403,6 +409,11 @@ impl WorkerGlobalScope {
             endpoints_list: Default::default(),
             debugger_global: Default::default(),
             pipeline_id: init.pipeline_id,
+            task_manager: Rc::new(TaskManager::new(
+                event_loop_sender,
+                init.pipeline_id,
+                Some(TaskCanceller { cancelled: closing }),
+            )),
         }
     }
 
@@ -479,7 +490,11 @@ impl WorkerGlobalScope {
     }
 
     pub(crate) fn pipeline_id(&self) -> PipelineId {
-        self.globalscope.pipeline_id()
+        self.pipeline_id
+    }
+
+    pub(crate) fn task_manager(&self) -> Rc<TaskManager> {
+        self.task_manager.clone()
     }
 
     pub(crate) fn policy_container(&self) -> Ref<'_, PolicyContainer> {
@@ -546,14 +561,6 @@ impl WorkerGlobalScope {
     /// Get a mutable reference to the [`TimerScheduler`] for this [`ServiceWorkerGlobalScope`].
     pub(crate) fn timer_scheduler(&self) -> RefMut<'_, TimerScheduler> {
         self.timer_scheduler.borrow_mut()
-    }
-
-    /// Return a copy to the shared task canceller that is used to cancel all tasks
-    /// when this worker is closing.
-    pub(crate) fn shared_task_canceller(&self) -> TaskCanceller {
-        TaskCanceller {
-            cancelled: self.closing.clone(),
-        }
     }
 
     /// <https://html.spec.whatwg.org/multipage/#initialize-worker-policy-container> and

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -108,7 +108,7 @@ pub(crate) fn prepare_workerscope_init(
         to_devtools_sender: global.devtools_chan().cloned(),
         time_profiler_chan: global.time_profiler_chan().clone(),
         from_devtools_sender: devtools_sender,
-        script_to_constellation_chan: global.script_to_constellation_chan().clone(),
+        script_to_constellation_chan: global.script_to_constellation_chan().sender,
         script_to_embedder_chan: global.script_to_embedder_chan().clone(),
         worker_id: worker_id.unwrap_or_else(|| WorkerId(Uuid::new_v4())),
         pipeline_id: global.pipeline_id(),

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::{RefCell, RefMut};
+use std::cell::{OnceCell, RefCell, RefMut};
 use std::default::Default;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -31,6 +31,7 @@ use script_bindings::cell::{DomRefCell, Ref};
 use script_bindings::conversions::{SafeToJSValConvertible, root_from_handlevalue};
 use script_bindings::reflector::DomObject;
 use script_bindings::root::rooted_heap_handle;
+use script_bindings::trace::CustomTraceable;
 use servo_base::cross_process_instant::CrossProcessInstant;
 use servo_base::generic_channel::{GenericSend, GenericSender, RoutedReceiver};
 use servo_base::id::{PipelineId, PipelineNamespace};
@@ -91,7 +92,7 @@ use crate::realms::enter_auto_realm;
 use crate::script_module::ScriptFetchOptions;
 use crate::script_runtime::{CanGc, IntroductionType, Runtime, get_reports};
 use crate::task::TaskCanceller;
-use crate::timers::{IsInterval, TimerCallback};
+use crate::timers::{IsInterval, OneshotTimers, TimerCallback};
 
 pub(crate) fn prepare_workerscope_init(
     global: &GlobalScope,
@@ -309,6 +310,10 @@ pub(crate) struct WorkerGlobalScope {
     #[no_trace]
     timer_scheduler: RefCell<TimerScheduler>,
 
+    /// The mechanism by which time-outs and intervals are scheduled.
+    /// <https://html.spec.whatwg.org/multipage/#timers>
+    timers: OnceCell<OneshotTimers>,
+
     #[no_trace]
     insecure_requests_policy: InsecureRequestsPolicy,
 
@@ -388,6 +393,7 @@ impl WorkerGlobalScope {
             navigation_start: CrossProcessInstant::now(),
             performance: Default::default(),
             timer_scheduler: RefCell::default(),
+            timers: Default::default(),
             insecure_requests_policy,
             trusted_types: Default::default(),
             reporting_observer_list: Default::default(),
@@ -395,6 +401,11 @@ impl WorkerGlobalScope {
             endpoints_list: Default::default(),
             debugger_global: Default::default(),
         }
+    }
+
+    pub(crate) fn timers(&self) -> &OneshotTimers {
+        self.timers
+            .get_or_init(|| OneshotTimers::new(self.upcast()))
     }
 
     pub(crate) fn enqueue_microtask(&self, job: Microtask) {

--- a/components/script/dom/worklet/paintworkletglobalscope.rs
+++ b/components/script/dom/worklet/paintworkletglobalscope.rs
@@ -26,7 +26,7 @@ use pixels::PixelFormat;
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::DomObject;
 use script_traits::{DrawAPaintImageResult, PaintWorkletError, Painter};
-use servo_base::id::{PipelineId, WebViewId};
+use servo_base::id::PipelineId;
 use servo_config::pref;
 use servo_url::ServoUrl;
 use style_traits::{CSSPixel, SpeculativePainter};
@@ -86,7 +86,6 @@ pub(crate) struct PaintWorkletGlobalScope {
 
 impl PaintWorkletGlobalScope {
     pub(crate) fn new(
-        webview_id: WebViewId,
         pipeline_id: PipelineId,
         base_url: ServoUrl,
         inherited_secure_context: Option<bool>,
@@ -100,7 +99,6 @@ impl PaintWorkletGlobalScope {
         );
         let global = Box::new(PaintWorkletGlobalScope {
             worklet_global: WorkletGlobalScope::new_inherited(
-                webview_id,
                 pipeline_id,
                 base_url,
                 inherited_secure_context,

--- a/components/script/dom/worklet/worklet.rs
+++ b/components/script/dom/worklet/worklet.rs
@@ -627,7 +627,6 @@ impl WorkletThread {
         );
     }
 
-    #[expect(clippy::too_many_arguments)]
     /// Get the worklet global scope for a given worklet.
     /// Creates the worklet global scope if it doesn't exist.
     fn get_worklet_global_scope(

--- a/components/script/dom/worklet/worklet.rs
+++ b/components/script/dom/worklet/worklet.rs
@@ -31,7 +31,7 @@ use net_traits::request::{Destination, RequestBuilder, RequestMode};
 use rustc_hash::FxHashMap;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use servo_base::generic_channel::GenericSend;
-use servo_base::id::{PipelineId, WebViewId};
+use servo_base::id::PipelineId;
 use servo_url::{ImmutableOrigin, ServoUrl};
 use style::thread_state::{self, ThreadState};
 use swapper::{Swapper, swapper};
@@ -163,7 +163,6 @@ impl WorkletMethods<crate::DomTypeHolder> for Worklet {
             .thread_pool
             .get_or_init(|| ScriptThread::worklet_thread_pool(self.global().image_cache()))
             .fetch_and_invoke_a_worklet_script(
-                self.window.webview_id(),
                 self.window.pipeline_id(),
                 self.droppable_field.worklet_id,
                 self.global_type,
@@ -323,7 +322,6 @@ impl WorkletThreadPool {
     #[allow(clippy::too_many_arguments)]
     fn fetch_and_invoke_a_worklet_script(
         &self,
-        webview_id: WebViewId,
         pipeline_id: PipelineId,
         worklet_id: WorkletId,
         global_type: WorkletGlobalScopeType,
@@ -343,7 +341,6 @@ impl WorkletThreadPool {
             &self.control_sender_2,
         ] {
             let _ = sender.send(WorkletControl::FetchAndInvokeAWorkletScript {
-                webview_id,
                 pipeline_id,
                 worklet_id,
                 global_type,
@@ -401,7 +398,6 @@ enum WorkletData {
 enum WorkletControl {
     ExitWorklet(WorkletId),
     FetchAndInvokeAWorkletScript {
-        webview_id: WebViewId,
         pipeline_id: PipelineId,
         worklet_id: WorkletId,
         global_type: WorkletGlobalScopeType,
@@ -636,7 +632,6 @@ impl WorkletThread {
     /// Creates the worklet global scope if it doesn't exist.
     fn get_worklet_global_scope(
         &mut self,
-        webview_id: WebViewId,
         pipeline_id: PipelineId,
         worklet_id: WorkletId,
         inherited_secure_context: Option<bool>,
@@ -651,7 +646,6 @@ impl WorkletThread {
                 let executor = WorkletExecutor::new(worklet_id, self.primary_sender.clone());
                 let result = WorkletGlobalScope::new(
                     global_type,
-                    webview_id,
                     pipeline_id,
                     base_url,
                     inherited_secure_context,
@@ -757,7 +751,6 @@ impl WorkletThread {
                 self.global_scopes.remove(&worklet_id);
             },
             WorkletControl::FetchAndInvokeAWorkletScript {
-                webview_id,
                 pipeline_id,
                 worklet_id,
                 global_type,
@@ -771,7 +764,6 @@ impl WorkletThread {
                 inherited_secure_context,
             } => {
                 let global = self.get_worklet_global_scope(
-                    webview_id,
                     pipeline_id,
                     worklet_id,
                     inherited_secure_context,

--- a/components/script/dom/worklet/workletglobalscope.rs
+++ b/components/script/dom/worklet/workletglobalscope.rs
@@ -48,6 +48,10 @@ pub(crate) struct WorkletGlobalScope {
     to_script_thread_sender: Sender<MainThreadScriptMsg>,
     /// Worklet task executor
     executor: WorkletExecutor,
+
+    #[no_trace]
+    /// The pipeline that created this worklet.
+    pipeline_id: PipelineId,
 }
 
 impl WorkletGlobalScope {
@@ -108,7 +112,6 @@ impl WorkletGlobalScope {
         };
         Self {
             globalscope: GlobalScope::new_inherited(
-                pipeline_id,
                 init.devtools_chan.clone(),
                 init.mem_profiler_chan.clone(),
                 init.time_profiler_chan.clone(),
@@ -128,7 +131,12 @@ impl WorkletGlobalScope {
             base_url,
             to_script_thread_sender: init.to_script_thread_sender.clone(),
             executor,
+            pipeline_id,
         }
+    }
+
+    pub(crate) fn pipeline_id(&self) -> PipelineId {
+        self.pipeline_id
     }
 
     /// Evaluate a JS script in this global.

--- a/components/script/dom/worklet/workletglobalscope.rs
+++ b/components/script/dom/worklet/workletglobalscope.rs
@@ -15,7 +15,7 @@ use net_traits::image_cache::ImageCache;
 use profile_traits::{mem, time};
 use script_traits::Painter;
 use servo_base::generic_channel::GenericCallback;
-use servo_base::id::{PipelineId, WebViewId};
+use servo_base::id::PipelineId;
 use servo_constellation_traits::ScriptToConstellationSender;
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
 use storage_traits::StorageThreads;
@@ -59,7 +59,6 @@ impl WorkletGlobalScope {
     /// Create a new heap-allocated `WorkletGlobalScope`.
     pub(crate) fn new(
         scope_type: WorkletGlobalScopeType,
-        webview_id: WebViewId,
         pipeline_id: PipelineId,
         base_url: ServoUrl,
         inherited_secure_context: Option<bool>,
@@ -70,7 +69,6 @@ impl WorkletGlobalScope {
         let scope: DomRoot<WorkletGlobalScope> = match scope_type {
             #[cfg(feature = "testbinding")]
             WorkletGlobalScopeType::Test => DomRoot::upcast(TestWorkletGlobalScope::new(
-                webview_id,
                 pipeline_id,
                 base_url,
                 inherited_secure_context,
@@ -79,7 +77,6 @@ impl WorkletGlobalScope {
                 cx,
             )),
             WorkletGlobalScopeType::Paint => DomRoot::upcast(PaintWorkletGlobalScope::new(
-                webview_id,
                 pipeline_id,
                 base_url,
                 inherited_secure_context,
@@ -98,7 +95,6 @@ impl WorkletGlobalScope {
 
     /// Create a new stack-allocated `WorkletGlobalScope`.
     pub(crate) fn new_inherited(
-        _webview_id: WebViewId,
         pipeline_id: PipelineId,
         base_url: ServoUrl,
         inherited_secure_context: Option<bool>,

--- a/components/script/dom/worklet/workletglobalscope.rs
+++ b/components/script/dom/worklet/workletglobalscope.rs
@@ -55,7 +55,6 @@ pub(crate) struct WorkletGlobalScope {
 }
 
 impl WorkletGlobalScope {
-    #[expect(clippy::too_many_arguments)]
     /// Create a new heap-allocated `WorkletGlobalScope`.
     pub(crate) fn new(
         scope_type: WorkletGlobalScopeType,

--- a/components/script/dom/worklet/workletglobalscope.rs
+++ b/components/script/dom/worklet/workletglobalscope.rs
@@ -14,9 +14,9 @@ use net_traits::ResourceThreads;
 use net_traits::image_cache::ImageCache;
 use profile_traits::{mem, time};
 use script_traits::Painter;
-use servo_base::generic_channel::{GenericCallback, GenericSender};
+use servo_base::generic_channel::GenericCallback;
 use servo_base::id::{PipelineId, WebViewId};
-use servo_constellation_traits::{ScriptToConstellationChan, ScriptToConstellationMessage};
+use servo_constellation_traits::ScriptToConstellationSender;
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
 use storage_traits::StorageThreads;
 use stylo_atoms::Atom;
@@ -98,24 +98,19 @@ impl WorkletGlobalScope {
 
     /// Create a new stack-allocated `WorkletGlobalScope`.
     pub(crate) fn new_inherited(
-        webview_id: WebViewId,
+        _webview_id: WebViewId,
         pipeline_id: PipelineId,
         base_url: ServoUrl,
         inherited_secure_context: Option<bool>,
         executor: WorkletExecutor,
         init: &WorkletGlobalScopeInit,
     ) -> Self {
-        let script_to_constellation_chan = ScriptToConstellationChan {
-            sender: init.to_constellation_sender.clone(),
-            webview_id,
-            pipeline_id,
-        };
         Self {
             globalscope: GlobalScope::new_inherited(
                 init.devtools_chan.clone(),
                 init.mem_profiler_chan.clone(),
                 init.time_profiler_chan.clone(),
-                script_to_constellation_chan,
+                init.script_to_constellation_sender.clone(),
                 init.to_embedder_sender.clone(),
                 init.resource_threads.clone(),
                 init.storage_threads.clone(),
@@ -216,9 +211,6 @@ pub(crate) struct WorkletGlobalScopeInit {
     pub(crate) time_profiler_chan: time::ProfilerChan,
     /// Channel to devtools
     pub(crate) devtools_chan: Option<GenericCallback<ScriptToDevtoolsControlMsg>>,
-    /// Messages to send to constellation
-    pub(crate) to_constellation_sender:
-        GenericSender<(WebViewId, PipelineId, ScriptToConstellationMessage)>,
     /// Messages to send to the Embedder
     pub(crate) to_embedder_sender: ScriptToEmbedderChan,
     /// The image cache
@@ -226,6 +218,7 @@ pub(crate) struct WorkletGlobalScopeInit {
     /// Identity manager for WebGPU resources
     #[cfg(feature = "webgpu")]
     pub(crate) gpu_id_hub: Arc<IdentityHub>,
+    pub(crate) script_to_constellation_sender: ScriptToConstellationSender,
 }
 
 /// <https://drafts.css-houdini.org/worklets/#worklet-global-scope-type>

--- a/components/script/dom/xmldocument.rs
+++ b/components/script/dom/xmldocument.rs
@@ -76,6 +76,7 @@ impl XMLDocument {
                 custom_element_reaction_stack,
                 window.Document().creation_sandboxing_flag_set(),
                 timeline,
+                window.pipeline_id(),
             ),
         }
     }

--- a/components/script/dom/xmldocument.rs
+++ b/components/script/dom/xmldocument.rs
@@ -3,10 +3,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::rc::Rc;
+use std::sync::Arc;
 
 use data_url::mime::Mime;
 use dom_struct::dom_struct;
 use js::context::{JSContext, NoGC};
+use net_traits::image_cache::ImageCache;
 use net_traits::request::InsecureRequestsPolicy;
 use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
 use script_bindings::reflector::reflect_dom_object;
@@ -52,6 +54,7 @@ impl XMLDocument {
         has_trustworthy_ancestor_origin: bool,
         custom_element_reaction_stack: Rc<CustomElementReactionStack>,
         timeline: &DocumentTimeline,
+        image_cache: Arc<dyn ImageCache>,
     ) -> XMLDocument {
         XMLDocument {
             document: Document::new_inherited(
@@ -77,6 +80,7 @@ impl XMLDocument {
                 window.Document().creation_sandboxing_flag_set(),
                 timeline,
                 window.pipeline_id(),
+                image_cache,
             ),
         }
     }
@@ -96,6 +100,7 @@ impl XMLDocument {
         inherited_insecure_requests_policy: Option<InsecureRequestsPolicy>,
         has_trustworthy_ancestor_origin: bool,
         custom_element_reaction_stack: Rc<CustomElementReactionStack>,
+        image_cache: Arc<dyn ImageCache>,
         can_gc: CanGc,
     ) -> DomRoot<XMLDocument> {
         let timeline = DocumentTimeline::new(window, can_gc);
@@ -115,6 +120,7 @@ impl XMLDocument {
                 has_trustworthy_ancestor_origin,
                 custom_element_reaction_stack,
                 &timeline,
+                image_cache,
             )),
             window,
             can_gc,

--- a/components/script/dom/xmlhttprequest/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest/xmlhttprequest.rs
@@ -1584,6 +1584,7 @@ impl XMLHttpRequest {
             doc.has_trustworthy_ancestor_origin(),
             doc.custom_element_reaction_stack(),
             doc.creation_sandboxing_flag_set(),
+            doc.pipeline_id(),
             can_gc,
         )
     }

--- a/components/script/dom/xmlhttprequest/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest/xmlhttprequest.rs
@@ -1585,6 +1585,7 @@ impl XMLHttpRequest {
             doc.custom_element_reaction_stack(),
             doc.creation_sandboxing_flag_set(),
             doc.pipeline_id(),
+            doc.image_cache(),
             can_gc,
         )
     }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -83,8 +83,7 @@ use servo_arc::Arc as ServoArc;
 use servo_base::cross_process_instant::CrossProcessInstant;
 use servo_base::generic_channel::GenericSender;
 use servo_base::id::{
-    BrowsingContextId, HistoryStateId, PipelineId, PipelineNamespace, ScriptEventLoopId,
-    TEST_WEBVIEW_ID, WebViewId,
+    BrowsingContextId, HistoryStateId, PipelineId, PipelineNamespace, ScriptEventLoopId, WebViewId,
 };
 use servo_base::{Epoch, generic_channel};
 use servo_canvas_traits::webgl::WebGLPipeline;
@@ -796,7 +795,7 @@ impl ScriptThread {
                         mem_profiler_chan: script_thread.senders.memory_profiler_sender.clone(),
                         time_profiler_chan: script_thread.senders.time_profiler_sender.clone(),
                         devtools_chan: script_thread.senders.devtools_server_sender.clone(),
-                        to_constellation_sender: script_thread
+                        script_to_constellation_sender: script_thread
                             .senders
                             .pipeline_to_constellation_sender
                             .clone(),
@@ -971,22 +970,13 @@ impl ScriptThread {
         #[cfg(feature = "webgpu")]
         let gpu_id_hub = Arc::new(IdentityHub::default());
 
-        let debugger_pipeline_id = PipelineId::new();
-        let script_to_constellation_chan = ScriptToConstellationChan {
-            sender: senders.pipeline_to_constellation_sender.clone(),
-            // This channel is not expected to be used, so the `WebViewId` that we set here
-            // does not matter.
-            // TODO: Look at ways of removing the channel entirely for debugger globals.
-            webview_id: TEST_WEBVIEW_ID,
-            pipeline_id: debugger_pipeline_id,
-        };
         let debugger_global = DebuggerGlobalScope::new(
             PipelineId::new(),
             senders.devtools_server_sender.clone(),
             senders.devtools_client_to_script_thread_sender.clone(),
             senders.memory_profiler_sender.clone(),
             senders.time_profiler_sender.clone(),
-            script_to_constellation_chan,
+            senders.pipeline_to_constellation_sender.clone(),
             senders.pipeline_to_embedder_sender.clone(),
             state.resource_threads.clone(),
             state.storage_threads.clone(),
@@ -3475,7 +3465,7 @@ impl ScriptThread {
             self.senders.memory_profiler_sender.clone(),
             self.senders.time_profiler_sender.clone(),
             self.senders.devtools_server_sender.clone(),
-            script_to_constellation_chan,
+            self.senders.pipeline_to_constellation_sender.clone(),
             self.senders.pipeline_to_embedder_sender.clone(),
             self.senders.constellation_sender.clone(),
             incomplete.pipeline_id,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3605,6 +3605,7 @@ impl ScriptThread {
             incomplete.load_data.has_trustworthy_ancestor_origin,
             self.custom_element_reaction_stack.clone(),
             incomplete.load_data.creation_sandboxing_flag_set,
+            incomplete.pipeline_id,
             CanGc::from_cx(cx),
         );
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3457,7 +3457,6 @@ impl ScriptThread {
             self.layout_factory.create(layout_config),
             font_context,
             self.senders.image_cache_sender.clone(),
-            image_cache.clone(),
             self.resource_threads.clone(),
             self.storage_threads.clone(),
             #[cfg(feature = "bluetooth")]
@@ -3596,6 +3595,7 @@ impl ScriptThread {
             self.custom_element_reaction_stack.clone(),
             incomplete.load_data.creation_sandboxing_flag_set,
             incomplete.pipeline_id,
+            image_cache,
             CanGc::from_cx(cx),
         );
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3505,26 +3505,6 @@ impl ScriptThread {
         let mut realm = enter_auto_realm(cx, &*window);
         let cx = &mut realm;
 
-        // Initialize the browsing context for the window.
-        let window_proxy = self.window_proxies.local_window_proxy(
-            cx,
-            &self.senders,
-            &self.documents,
-            &window,
-            incomplete.browsing_context_id,
-            incomplete.webview_id,
-            incomplete.parent_info,
-            incomplete.opener,
-        );
-        if window_proxy.parent().is_some() {
-            // https://html.spec.whatwg.org/multipage/#navigating-across-documents:delaying-load-events-mode-2
-            // The user agent must take this nested browsing context
-            // out of the delaying load events mode
-            // when this navigation algorithm later matures.
-            window_proxy.stop_delaying_load_events_mode();
-        }
-        window.init_window_proxy(&window_proxy);
-
         // https://html.spec.whatwg.org/multipage/#resource-metadata-management
         // > The Document's source file's last modification date and time must be derived from
         // > relevant features of the networking protocols used, e.g.
@@ -3622,6 +3602,26 @@ impl ScriptThread {
             .insert(incomplete.pipeline_id, &document);
 
         window.init_document(&document);
+
+        // Initialize the browsing context for the window.
+        let window_proxy = self.window_proxies.local_window_proxy(
+            cx,
+            &self.senders,
+            &self.documents,
+            &window,
+            incomplete.browsing_context_id,
+            incomplete.webview_id,
+            incomplete.parent_info,
+            incomplete.opener,
+        );
+        if window_proxy.parent().is_some() {
+            // https://html.spec.whatwg.org/multipage/#navigating-across-documents:delaying-load-events-mode-2
+            // The user agent must take this nested browsing context
+            // out of the delaying load events mode
+            // when this navigation algorithm later matures.
+            window_proxy.stop_delaying_load_events_mode();
+        }
+        window.init_window_proxy(&window_proxy);
 
         // For any similar-origin iframe, ensure that the contentWindow/contentDocument
         // APIs resolve to the new window/document as soon as parsing starts.

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -518,7 +518,7 @@ pub struct WorkerGlobalScopeInit {
     /// From devtools sender
     pub from_devtools_sender: Option<GenericSender<DevtoolScriptControlMsg>>,
     /// Messages to send to constellation
-    pub script_to_constellation_chan: ScriptToConstellationChan,
+    pub script_to_constellation_chan: ScriptToConstellationSender,
     /// Messages to send to the Embedder
     pub script_to_embedder_chan: ScriptToEmbedderChan,
     /// The worker id


### PR DESCRIPTION
As part of implementing spec-compliant document replacement (when a Window switches out its active document, instead of Servo creating a new Window and Document), I've found a bunch of data in Window/GlobalScope that embed assumptions that a global's pipeline ID never changes. These changes remove those assumptions by making GlobalScope/Window delegate to the window's active document.

It's best to read these commit by commit. I could split them up into separate PRs if desired, but rebasing them all with the massive JSContext refactoring that's happening right now is a pain.

Testing: No behaviour change expected, so existing tests suffice.
Part of #43149
