### PR TITLE
script: Pass `&mut JSContext` to `safe_to_jsval`

### DIFF
--- a/components/script/dom/bindings/constructor.rs
+++ b/components/script/dom/bindings/constructor.rs
@@ -53,7 +53,6 @@ use crate::dom::element::{Element, ElementCreator};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 /// <https://html.spec.whatwg.org/multipage/#htmlconstructor>
 fn html_constructor(
@@ -229,11 +228,7 @@ fn html_constructor(
             return Err(());
         }
 
-        result.safe_to_jsval(
-            cx.into(),
-            MutableHandleValue::from_raw(call_args.rval()),
-            CanGc::from_cx(cx),
-        );
+        result.safe_to_jsval(cx, MutableHandleValue::from_raw(call_args.rval()));
     }
     Ok(())
 }

--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -74,7 +74,7 @@ pub(crate) fn throw_dom_exception(cx: &mut JSContext, global: &GlobalScope, resu
         Ok(exception) => unsafe {
             assert!(!JS_IsExceptionPending(cx));
             rooted!(&in(cx) let mut thrown = UndefinedValue());
-            exception.safe_to_jsval(cx.into(), thrown.handle_mut(), CanGc::from_cx(cx));
+            exception.safe_to_jsval(cx, thrown.handle_mut());
             JS_SetPendingException(cx, thrown.handle(), ExceptionStackBehavior::Capture);
         },
 

--- a/components/script/dom/bindings/structuredclone.rs
+++ b/components/script/dom/bindings/structuredclone.rs
@@ -64,7 +64,6 @@ use crate::dom::types::{
     QuotaExceededError, TransformStream,
 };
 use crate::realms::enter_auto_realm;
-use crate::script_runtime::CanGc;
 
 // TODO: Should we add Min and Max const to https://github.com/servo/rust-mozjs/blob/master/src/consts.rs?
 // TODO: Determine for sure which value Min and Max should have.
@@ -738,7 +737,7 @@ pub(crate) fn write(
     unsafe {
         rooted!(&in(cx) let mut val = UndefinedValue());
         if let Some(transfer) = transfer {
-            transfer.safe_to_jsval(cx.into(), val.handle_mut(), CanGc::from_cx(cx));
+            transfer.safe_to_jsval(cx, val.handle_mut());
         }
         let mut sc_writer = StructuredDataWriter::default();
         let sc_writer_ptr = &mut sc_writer as *mut _;

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -59,9 +59,8 @@ pub(crate) fn to_frozen_array<T: ToJSValConvertible>(
 ) {
     script_bindings::conversions::SafeToJSValConvertible::safe_to_jsval(
         convertibles,
-        cx.into(),
+        cx,
         rval.reborrow(),
-        CanGc::from_cx(cx),
     );
 
     rooted!(&in(cx) let obj = rval.to_object());

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -56,7 +56,6 @@ use crate::dom::shadowroot::ShadowRoot;
 use crate::dom::window::Window;
 use crate::microtask::Microtask;
 use crate::realms::enter_auto_realm;
-use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 
 /// <https://dom.spec.whatwg.org/#concept-element-custom-element-state>
@@ -560,11 +559,9 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
         let promise = self.when_defined.borrow_mut().remove(&name);
         if let Some(promise) = promise {
             rooted!(&in(cx) let mut constructor = UndefinedValue());
-            definition.constructor.safe_to_jsval(
-                cx.into(),
-                constructor.handle_mut(),
-                CanGc::from_cx(cx),
-            );
+            definition
+                .constructor
+                .safe_to_jsval(cx, constructor.handle_mut());
             // Step 19.1: Resolve this's when-defined promise map[name] with constructor.
             promise.resolve_native(cx, &constructor.get());
         }
@@ -574,11 +571,7 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
     /// <https://html.spec.whatwg.org/multipage/#dom-customelementregistry-get>
     fn Get(&self, cx: &mut JSContext, name: DOMString, mut retval: MutableHandleValue) {
         match self.definitions.borrow().get(&LocalName::from(name)) {
-            Some(definition) => {
-                definition
-                    .constructor
-                    .safe_to_jsval(cx.into(), retval, CanGc::from_cx(cx))
-            },
+            Some(definition) => definition.constructor.safe_to_jsval(cx, retval),
             None => retval.set(UndefinedValue()),
         }
     }
@@ -612,11 +605,9 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
         // Step 2
         if let Some(definition) = self.definitions.borrow().get(&LocalName::from(&*name)) {
             rooted!(&in(*realm) let mut constructor = UndefinedValue());
-            definition.constructor.safe_to_jsval(
-                realm.into(),
-                constructor.handle_mut(),
-                CanGc::from_cx(realm),
-            );
+            definition
+                .constructor
+                .safe_to_jsval(realm, constructor.handle_mut());
             let promise = Promise::new_in_realm(realm);
             promise.resolve_native(realm, &constructor.get());
             return promise;
@@ -960,7 +951,7 @@ fn run_upgrade_constructor(
     let window = element.owner_window();
     rooted!(&in(cx) let constructor_val = ObjectValue(constructor.callback()));
     rooted!(&in(cx) let mut element_val = UndefinedValue());
-    element.safe_to_jsval(cx.into(), element_val.handle_mut(), CanGc::from_cx(cx));
+    element.safe_to_jsval(cx, element_val.handle_mut());
     rooted!(&in(cx) let mut construct_result = ptr::null_mut::<JSObject>());
     {
         // Step 9.1. If definition's disable shadow is true and element's shadow root is non-null,
@@ -1215,26 +1206,22 @@ impl CustomElementReactionStack {
 
                 let local_name = DOMString::from(&*local_name);
                 rooted!(&in(cx) let mut name_value = UndefinedValue());
-                local_name.safe_to_jsval(cx.into(), name_value.handle_mut(), CanGc::from_cx(cx));
+                local_name.safe_to_jsval(cx, name_value.handle_mut());
 
                 rooted!(&in(cx) let mut old_value = NullValue());
                 if let Some(old_val) = old_val {
-                    old_val.safe_to_jsval(cx.into(), old_value.handle_mut(), CanGc::from_cx(cx));
+                    old_val.safe_to_jsval(cx, old_value.handle_mut());
                 }
 
                 rooted!(&in(cx) let mut value = NullValue());
                 if let Some(val) = val {
-                    val.safe_to_jsval(cx.into(), value.handle_mut(), CanGc::from_cx(cx));
+                    val.safe_to_jsval(cx, value.handle_mut());
                 }
 
                 rooted!(&in(cx) let mut namespace_value = NullValue());
                 if namespace != ns!() {
                     let namespace = DOMString::from(&*namespace);
-                    namespace.safe_to_jsval(
-                        cx.into(),
-                        namespace_value.handle_mut(),
-                        CanGc::from_cx(cx),
-                    );
+                    namespace.safe_to_jsval(cx, namespace_value.handle_mut());
                 }
 
                 let args = vec![

--- a/components/script/dom/debugger/debuggeradddebuggeeevent.rs
+++ b/components/script/dom/debugger/debuggeradddebuggeeevent.rs
@@ -3,10 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::jsapi::{Heap, JSObject, Value};
 use js::rust::MutableHandleObject;
 use script_bindings::conversions::SafeToJSValConvertible;
-use script_bindings::reflector::{DomObject, reflect_dom_object};
+use script_bindings::reflector::{DomObject, reflect_dom_object_with_cx};
 use script_bindings::str::DOMString;
 
 use crate::dom::bindings::codegen::Bindings::DebuggerAddDebuggeeEventBinding::DebuggerAddDebuggeeEventMethods;
@@ -14,7 +15,6 @@ use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventM
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::event::Event;
 use crate::dom::types::{GlobalScope, PipelineId};
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 /// Event for Rust → JS calls in [`crate::dom::debugger::DebuggerGlobalScope`].
@@ -28,11 +28,11 @@ pub(crate) struct DebuggerAddDebuggeeEvent {
 
 impl DebuggerAddDebuggeeEvent {
     pub(crate) fn new(
+        cx: &mut JSContext,
         debugger_global: &GlobalScope,
         global: &GlobalScope,
         pipeline_id: &PipelineId,
         worker_id: Option<DOMString>,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
         let result = Box::new(Self {
             event: Event::new_inherited(),
@@ -40,16 +40,15 @@ impl DebuggerAddDebuggeeEvent {
             pipeline_id: Dom::from_ref(pipeline_id),
             worker_id,
         });
-        let result = reflect_dom_object(result, debugger_global, can_gc);
+        let result = reflect_dom_object_with_cx(result, debugger_global, cx);
         result.event.init_event("addDebuggee".into(), false, false);
 
         // Convert the debuggee global’s reflector to a Value, wrapping it from its originating realm (debuggee realm)
         // into the active realm (debugger realm) so that it can be passed across compartments.
-        let cx = GlobalScope::get_cx();
-        rooted!(in(*cx) let mut wrapped_global: Value);
+        rooted!(&in(cx) let mut wrapped_global: Value);
         global
             .reflector()
-            .safe_to_jsval(cx, wrapped_global.handle_mut(), can_gc);
+            .safe_to_jsval(cx, wrapped_global.handle_mut());
         result.global.set(wrapped_global.to_object());
 
         result

--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -168,11 +168,11 @@ impl DebuggerGlobalScope {
             CanGc::from_cx(cx),
         );
         let event = DomRoot::upcast::<Event>(DebuggerAddDebuggeeEvent::new(
+            cx,
             self.upcast(),
             debuggee_global,
             &debuggee_pipeline_id,
             debuggee_worker_id.map(|id| id.to_string().into()),
-            CanGc::from_cx(cx),
         ));
         assert!(
             event.fire(cx, self.upcast()),

--- a/components/script/dom/encoding/textencoderstream.rs
+++ b/components/script/dom/encoding/textencoderstream.rs
@@ -277,7 +277,7 @@ pub(crate) fn encode_and_enqueue_a_chunk(
     )
     .map_err(|_| Error::Type(c"Cannot convert byte sequence to Uint8Array".to_owned()))?;
     rooted!(&in(cx) let mut rval = UndefinedValue());
-    chunk.safe_to_jsval(cx.into(), rval.handle_mut(), CanGc::from_cx(cx));
+    chunk.safe_to_jsval(cx, rval.handle_mut());
     // Step 4.2.2.2 Enqueue chunk into encoder’s transform.
     controller.enqueue(cx, global, rval.handle())?;
     Ok(())
@@ -303,7 +303,7 @@ pub(crate) fn encode_and_flush(
         )
         .map_err(|_| Error::Type(c"Cannot convert byte sequence to Uint8Array".to_owned()))?;
         rooted!(&in(cx) let mut rval = UndefinedValue());
-        chunk.safe_to_jsval(cx.into(), rval.handle_mut(), CanGc::from_cx(cx));
+        chunk.safe_to_jsval(cx, rval.handle_mut());
         // Step 1.2 Enqueue chunk into encoder’s transform.
         return controller.enqueue(cx, global, rval.handle());
     }

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -277,8 +277,7 @@ impl EventSourceContext {
         let event = {
             let _ac = enter_realm(&*event_source);
             rooted!(&in(cx) let mut data = UndefinedValue());
-            self.data
-                .safe_to_jsval(cx.into(), data.handle_mut(), CanGc::from_cx(cx));
+            self.data.safe_to_jsval(cx, data.handle_mut());
             MessageEvent::new(
                 cx,
                 &event_source.global(),

--- a/components/script/dom/globalscope/messageport.rs
+++ b/components/script/dom/globalscope/messageport.rs
@@ -214,7 +214,7 @@ impl MessagePort {
         // Let message be OrdinaryObjectCreate(null).
         rooted!(&in(cx) let mut message = unsafe { JS_NewObject(cx, ptr::null()) });
         rooted!(&in(cx) let mut type_string = UndefinedValue());
-        type_.safe_to_jsval(cx.into(), type_string.handle_mut(), CanGc::from_cx(cx));
+        type_.safe_to_jsval(cx, type_string.handle_mut());
 
         // Perform ! CreateDataProperty(message, "type", type).
         set_dictionary_property(cx.into(), message.handle(), c"type", type_string.handle())
@@ -233,7 +233,7 @@ impl MessagePort {
 
         // Run the message port post message steps providing targetPort, message, and options.
         rooted!(&in(cx) let mut message_val = UndefinedValue());
-        message.safe_to_jsval(cx.into(), message_val.handle_mut(), CanGc::from_cx(cx));
+        message.safe_to_jsval(cx, message_val.handle_mut());
         self.post_message_impl(cx, message_val.handle(), transfer)
     }
 }

--- a/components/script/dom/indexeddb/idbindex.rs
+++ b/components/script/dom/indexeddb/idbindex.rs
@@ -7,7 +7,6 @@ use js::gc::MutableHandleValue;
 use script_bindings::codegen::GenericBindings::IDBIndexBinding::IDBIndexMethods;
 use script_bindings::conversions::SafeToJSValConvertible;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
-use script_bindings::script_runtime::CanGc;
 use script_bindings::str::DOMString;
 
 use crate::dom::bindings::root::DomRoot;
@@ -86,10 +85,10 @@ impl IDBIndexMethods<crate::DomTypeHolder> for IDBIndex {
     fn KeyPath(&self, cx: &mut JSContext, retval: MutableHandleValue) {
         match &self.key_path {
             KeyPath::String(string) => {
-                string.safe_to_jsval(cx.into(), retval, CanGc::from_cx(cx));
+                string.safe_to_jsval(cx, retval);
             },
             KeyPath::StringSequence(sequence) => {
-                sequence.safe_to_jsval(cx.into(), retval, CanGc::from_cx(cx));
+                sequence.safe_to_jsval(cx, retval);
             },
         }
     }

--- a/components/script/dom/indexeddb/idbopendbrequest.rs
+++ b/components/script/dom/indexeddb/idbopendbrequest.rs
@@ -32,7 +32,6 @@ use crate::dom::indexeddb::idbtransaction::IDBTransaction;
 use crate::dom::indexeddb::idbversionchangeevent::IDBVersionChangeEvent;
 use crate::indexeddb::map_backend_error_to_dom_error;
 use crate::realms::enter_auto_realm;
-use crate::script_runtime::CanGc;
 
 #[derive(Clone)]
 struct OpenRequestListener {
@@ -186,7 +185,7 @@ impl IDBOpenDBRequest {
         transaction.set_active_flag(false);
 
         rooted!(&in(cx) let mut connection_val = UndefinedValue());
-        connection.safe_to_jsval(cx.into(), connection_val.handle_mut(), CanGc::from_cx(cx));
+        connection.safe_to_jsval(cx, connection_val.handle_mut());
 
         // Step 10.1: Set request’s result to connection.
         self.idbrequest.set_result(connection_val.handle());
@@ -298,7 +297,7 @@ impl IDBOpenDBRequest {
         let mut realm = enter_auto_realm(cx, &*result);
         let cx = &mut realm.current_realm();
         rooted!(&in(cx) let mut result_val = UndefinedValue());
-        result.safe_to_jsval(cx.into(), result_val.handle_mut(), CanGc::from_cx(cx));
+        result.safe_to_jsval(cx, result_val.handle_mut());
         self.set_result(result_val.handle());
 
         let event = Event::new(

--- a/components/script/dom/promise/promise.rs
+++ b/components/script/dom/promise/promise.rs
@@ -46,7 +46,6 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::microtask::{Microtask, MicrotaskRunnable};
 use crate::realms::enter_auto_realm;
-use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 
 #[dom_struct]
@@ -168,7 +167,7 @@ impl Promise {
         let mut realm = enter_auto_realm(cx, global);
         let cx = &mut realm.current_realm();
         rooted!(&in(cx) let mut rval = UndefinedValue());
-        value.safe_to_jsval(cx.into(), rval.handle_mut(), CanGc::from_cx(cx));
+        value.safe_to_jsval(cx, rval.handle_mut());
         rooted!(&in(cx) let p = unsafe { CallOriginalPromiseResolve(cx, rval.handle()) });
         assert!(!p.handle().is_null());
         Promise::new_with_js_promise(cx, p.handle())
@@ -183,7 +182,7 @@ impl Promise {
         let mut realm = enter_auto_realm(cx, global);
         let cx = &mut realm.current_realm();
         rooted!(&in(cx) let mut rval = UndefinedValue());
-        value.safe_to_jsval(cx.into(), rval.handle_mut(), CanGc::from_cx(cx));
+        value.safe_to_jsval(cx, rval.handle_mut());
         rooted!(&in(cx) let p = unsafe { CallOriginalPromiseReject(cx, rval.handle()) });
         assert!(!p.handle().is_null());
         Promise::new_with_js_promise(cx, p.handle())
@@ -196,7 +195,7 @@ impl Promise {
         let mut realm = enter_auto_realm(cx, self);
         let cx = &mut realm.current_realm();
         rooted!(&in(cx) let mut v = UndefinedValue());
-        val.safe_to_jsval(cx.into(), v.handle_mut(), CanGc::from_cx(cx));
+        val.safe_to_jsval(cx, v.handle_mut());
         self.resolve(cx, v.handle());
     }
 
@@ -216,7 +215,7 @@ impl Promise {
         let mut realm = enter_auto_realm(cx, self);
         let cx = &mut realm.current_realm();
         rooted!(&in(cx) let mut v = UndefinedValue());
-        val.safe_to_jsval(cx.into(), v.handle_mut(), CanGc::from_cx(cx));
+        val.safe_to_jsval(cx, v.handle_mut());
         self.reject(cx, v.handle());
     }
 

--- a/components/script/dom/servointernals.rs
+++ b/components/script/dom/servointernals.rs
@@ -15,13 +15,11 @@ use script_bindings::conversions::SafeToJSValConvertible;
 use script_bindings::error::{Error, Fallible};
 use script_bindings::interfaces::ServoInternalsHelpers;
 use script_bindings::reflector::{Reflector, reflect_dom_object};
-use script_bindings::script_runtime::JSContext;
 use script_bindings::str::USVString;
 use servo_config::prefs::{self, PrefValue, Preferences};
 use servo_constellation_traits::ScriptToConstellationMessage;
 
 use crate::dom::bindings::codegen::Bindings::ServoInternalsBinding::ServoInternalsMethods;
-use crate::dom::bindings::import::base::SafeJSContext;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
@@ -30,21 +28,21 @@ use crate::routed_promise::{RoutedPromiseListener, callback_promise};
 use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 
-fn pref_to_jsval(pref: &PrefValue, cx: JSContext, rval: MutableHandleValue, can_gc: CanGc) {
+fn pref_to_jsval(cx: &mut js::context::JSContext, pref: &PrefValue, rval: MutableHandleValue) {
     match pref {
-        PrefValue::Bool(b) => b.safe_to_jsval(cx, rval, can_gc),
-        PrefValue::Int(i) => i.safe_to_jsval(cx, rval, can_gc),
-        PrefValue::UInt(u) => u.safe_to_jsval(cx, rval, can_gc),
-        PrefValue::Str(s) => s.safe_to_jsval(cx, rval, can_gc),
-        PrefValue::Float(f) => f.safe_to_jsval(cx, rval, can_gc),
+        PrefValue::Bool(b) => b.safe_to_jsval(cx, rval),
+        PrefValue::Int(i) => i.safe_to_jsval(cx, rval),
+        PrefValue::UInt(u) => u.safe_to_jsval(cx, rval),
+        PrefValue::Str(s) => s.safe_to_jsval(cx, rval),
+        PrefValue::Float(f) => f.safe_to_jsval(cx, rval),
         PrefValue::Array(arr) => {
             rooted_vec!(let mut js_arr);
             for item in arr {
-                rooted!(in(*cx) let mut js_val = UndefinedValue());
-                pref_to_jsval(item, cx, js_val.handle_mut(), can_gc);
+                rooted!(&in(cx) let mut js_val = UndefinedValue());
+                pref_to_jsval(cx, item, js_val.handle_mut());
                 js_arr.push(Heap::boxed(js_val.get()));
             }
-            js_arr.safe_to_jsval(cx, rval, can_gc);
+            js_arr.safe_to_jsval(cx, rval);
         },
     }
 }
@@ -114,7 +112,7 @@ impl ServoInternalsMethods<crate::DomTypeHolder> for ServoInternals {
     /// <https://servo.org/internal-no-spec>
     fn DefaultPreferenceValue(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         name: USVString,
         rval: MutableHandleValue,
     ) -> Fallible<()> {
@@ -122,14 +120,14 @@ impl ServoInternalsMethods<crate::DomTypeHolder> for ServoInternals {
             return Err(Error::NotFound(None));
         }
         let pref = Preferences::default().get_value(&name);
-        pref_to_jsval(&pref, cx, rval, CanGc::deprecated_note());
+        pref_to_jsval(cx, &pref, rval);
         Ok(())
     }
 
     /// <https://servo.org/internal-no-spec>
     fn GetPreference(
         &self,
-        cx: JSContext,
+        cx: &mut js::context::JSContext,
         name: USVString,
         rval: MutableHandleValue,
     ) -> Fallible<()> {
@@ -137,7 +135,7 @@ impl ServoInternalsMethods<crate::DomTypeHolder> for ServoInternals {
             return Err(Error::NotFound(None));
         }
         let pref = prefs::get().get_value(&name);
-        pref_to_jsval(&pref, cx, rval, CanGc::deprecated_note());
+        pref_to_jsval(cx, &pref, rval);
         Ok(())
     }
 

--- a/components/script/dom/stream/compressionstream.rs
+++ b/components/script/dom/stream/compressionstream.rs
@@ -158,7 +158,7 @@ pub(crate) fn compress_and_enqueue_a_chunk(
     )
     .map_err(|_| Error::Type(c"Cannot convert byte sequence to Uint8Array".to_owned()))?;
     rooted!(&in(cx) let mut rval = UndefinedValue());
-    buffer_source.safe_to_jsval(cx.into(), rval.handle_mut(), CanGc::from_cx(cx));
+    buffer_source.safe_to_jsval(cx, rval.handle_mut());
     controller.enqueue(cx, global, rval.handle())?;
 
     Ok(())
@@ -197,7 +197,7 @@ pub(crate) fn compress_flush_and_enqueue(
     )
     .map_err(|_| Error::Type(c"Cannot convert byte sequence to Uint8Array".to_owned()))?;
     rooted!(&in(cx) let mut rval = UndefinedValue());
-    buffer_source.safe_to_jsval(cx.into(), rval.handle_mut(), CanGc::from_cx(cx));
+    buffer_source.safe_to_jsval(cx, rval.handle_mut());
     controller.enqueue(cx, global, rval.handle())?;
 
     Ok(())

--- a/components/script/dom/stream/decompressionstream.rs
+++ b/components/script/dom/stream/decompressionstream.rs
@@ -154,7 +154,7 @@ pub(crate) fn decompress_and_enqueue_a_chunk(
     )
     .map_err(|_| Error::Type(c"Cannot convert byte sequence to Uint8Array".to_owned()))?;
     rooted!(&in(cx) let mut rval = UndefinedValue());
-    array.safe_to_jsval(cx.into(), rval.handle_mut(), CanGc::from_cx(cx));
+    array.safe_to_jsval(cx, rval.handle_mut());
     controller.enqueue(cx, global, rval.handle())?;
 
     // Step 6. If the end of the compressed input has been reached, and ds’s context has not fully
@@ -198,7 +198,7 @@ pub(crate) fn decompress_flush_and_enqueue(
         )
         .map_err(|_| Error::Type(c"Cannot convert byte sequence to Uint8Array".to_owned()))?;
         rooted!(&in(cx) let mut rval = UndefinedValue());
-        array.safe_to_jsval(cx.into(), rval.handle_mut(), CanGc::from_cx(cx));
+        array.safe_to_jsval(cx, rval.handle_mut());
         controller.enqueue(cx, global, rval.handle())?;
     }
 

--- a/components/script/dom/stream/readablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/readablestreamdefaultcontroller.rs
@@ -36,7 +36,7 @@ use crate::dom::stream::underlyingsourcecontainer::{
     UnderlyingSourceContainer, UnderlyingSourceType,
 };
 use crate::realms::enter_auto_realm;
-use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
+use crate::script_runtime::CanGc;
 
 /// The fulfillment handler for
 /// <https://streams.spec.whatwg.org/#readable-stream-default-controller-call-pull-if-needed>
@@ -152,17 +152,20 @@ impl EnqueuedValue {
         }
     }
 
-    fn to_jsval(&self, cx: SafeJSContext, rval: MutableHandleValue, can_gc: CanGc) {
+    fn to_jsval(&self, cx: &mut JSContext, rval: MutableHandleValue) {
         match self {
             EnqueuedValue::Native(chunk) => {
-                rooted!(in(*cx) let mut array_buffer_ptr = ptr::null_mut::<JSObject>());
-                create_buffer_source::<Uint8>(cx, chunk, array_buffer_ptr.handle_mut(), can_gc)
-                    .expect("failed to create buffer source for native chunk.");
-                array_buffer_ptr.safe_to_jsval(cx, rval, can_gc);
+                rooted!(&in(cx) let mut array_buffer_ptr = ptr::null_mut::<JSObject>());
+                create_buffer_source::<Uint8>(
+                    cx.into(),
+                    chunk,
+                    array_buffer_ptr.handle_mut(),
+                    CanGc::from_cx(cx),
+                )
+                .expect("failed to create buffer source for native chunk.");
+                array_buffer_ptr.safe_to_jsval(cx, rval);
             },
-            EnqueuedValue::Js(value_with_size) => {
-                value_with_size.value.safe_to_jsval(cx, rval, can_gc)
-            },
+            EnqueuedValue::Js(value_with_size) => value_with_size.value.safe_to_jsval(cx, rval),
             EnqueuedValue::CloseSentinel => {
                 unreachable!("The close sentinel is never made available as a js val.")
             },
@@ -215,7 +218,7 @@ impl QueueWithSizes {
             };
             self.total_size.set(self.total_size.get() - value.size());
             if let Some(rval) = rval {
-                value.to_jsval(cx.into(), rval, CanGc::from_cx(cx));
+                value.to_jsval(cx, rval);
             } else {
                 assert_eq!(value, &EnqueuedValue::CloseSentinel);
             }
@@ -267,7 +270,7 @@ impl QueueWithSizes {
         }
 
         // Return valueWithSize’s value.
-        value_with_size.to_jsval(cx.into(), rval, CanGc::from_cx(cx));
+        value_with_size.to_jsval(cx, rval);
         false
     }
 
@@ -720,11 +723,7 @@ impl ReadableStreamDefaultController {
             .expect("Controller must have a stream when a chunk is enqueued.");
         if stream.is_locked() && stream.get_num_read_requests() > 0 {
             rooted!(&in(cx) let mut rval = UndefinedValue());
-            EnqueuedValue::Native(chunk.into_boxed_slice()).to_jsval(
-                cx.into(),
-                rval.handle_mut(),
-                CanGc::from_cx(cx),
-            );
+            EnqueuedValue::Native(chunk.into_boxed_slice()).to_jsval(cx, rval.handle_mut());
             stream.fulfill_read_request(cx, rval.handle(), false);
         } else {
             self.queue

--- a/components/script/dom/stream/writablestream.rs
+++ b/components/script/dom/stream/writablestream.rs
@@ -22,7 +22,6 @@ use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::MessagePortBinding::MessagePortMethods;
 use script_bindings::conversions::SafeToJSValConvertible;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
-use script_bindings::script_runtime::CanGc;
 use servo_base::id::{MessagePortId, MessagePortIndex};
 use servo_constellation_traits::MessagePortImpl;
 
@@ -1178,7 +1177,7 @@ impl CrossRealmTransformWritable {
         // Let error be a new "DataCloneError" DOMException.
         let error = DOMException::new(cx, global, DOMErrorName::DataCloneError);
         rooted!(&in(cx) let mut rooted_error = UndefinedValue());
-        error.safe_to_jsval(cx.into(), rooted_error.handle_mut(), CanGc::from_cx(cx));
+        error.safe_to_jsval(cx, rooted_error.handle_mut());
 
         // Perform ! CrossRealmTransformSendError(port, error).
         port.cross_realm_transform_send_error(cx, rooted_error.handle());

--- a/components/script/dom/trustedtypes/trustedtypepolicyfactory.rs
+++ b/components/script/dom/trustedtypes/trustedtypepolicyfactory.rs
@@ -32,7 +32,7 @@ use crate::dom::trustedtypes::trustedscripturl::TrustedScriptURL;
 use crate::dom::trustedtypes::trustedtypepolicy::{TrustedType, TrustedTypePolicy};
 use crate::dom::types::WorkerGlobalScope;
 use crate::dom::window::Window;
-use crate::script_runtime::{CanGc, JSContext};
+use crate::script_runtime::JSContext;
 
 #[dom_struct]
 pub struct TrustedTypePolicyFactory {
@@ -259,14 +259,12 @@ impl TrustedTypePolicyFactory {
         // Step 2: Let policyValue be the result of executing Get Trusted Type policy value,
         // with the following arguments:
         rooted!(&in(cx) let mut trusted_type_name_value = NullValue());
-        expected_type.as_ref().safe_to_jsval(
-            cx.into(),
-            trusted_type_name_value.handle_mut(),
-            CanGc::from_cx(cx),
-        );
+        expected_type
+            .as_ref()
+            .safe_to_jsval(cx, trusted_type_name_value.handle_mut());
 
         rooted!(&in(cx) let mut sink_value = NullValue());
-        sink.safe_to_jsval(cx.into(), sink_value.handle_mut(), CanGc::from_cx(cx));
+        sink.safe_to_jsval(cx, sink_value.handle_mut());
 
         let arguments = vec![trusted_type_name_value.handle(), sink_value.handle()];
         let policy_value = default_policy.get_trusted_type_policy_value(

--- a/components/script/dom/webcrypto/cryptokey.rs
+++ b/components/script/dom/webcrypto/cryptokey.rs
@@ -25,7 +25,7 @@ use crate::dom::bindings::serializable::Serializable;
 use crate::dom::bindings::structuredclone::StructuredData;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::KeyAlgorithmAndDerivatives;
-use crate::script_runtime::{CanGc, JSContext};
+use crate::script_runtime::JSContext;
 
 pub(crate) enum CryptoKeyOrCryptoKeyPair {
     CryptoKey(DomRoot<CryptoKey>),
@@ -151,22 +151,14 @@ impl CryptoKey {
 
         // Create and store a cached object of algorithm
         rooted!(&in(cx) let mut algorithm_object_value: Value);
-        algorithm.safe_to_jsval(
-            cx.into(),
-            algorithm_object_value.handle_mut(),
-            CanGc::from_cx(cx),
-        );
+        algorithm.safe_to_jsval(cx, algorithm_object_value.handle_mut());
         crypto_key
             .algorithm_cached
             .set(algorithm_object_value.to_object());
 
         // Create and store a cached object of usages
         rooted!(&in(cx) let mut usages_object_value: Value);
-        usages.safe_to_jsval(
-            cx.into(),
-            usages_object_value.handle_mut(),
-            CanGc::from_cx(cx),
-        );
+        usages.safe_to_jsval(cx, usages_object_value.handle_mut());
         crypto_key
             .usages_cached
             .set(usages_object_value.to_object());
@@ -195,11 +187,7 @@ impl CryptoKey {
 
         // Create and store a cached object of usages
         rooted!(&in(cx) let mut usages_object_value: Value);
-        usages.safe_to_jsval(
-            cx.into(),
-            usages_object_value.handle_mut(),
-            CanGc::from_cx(cx),
-        );
+        usages.safe_to_jsval(cx, usages_object_value.handle_mut());
         self.usages_cached.set(usages_object_value.to_object());
     }
 }

--- a/components/script/dom/webcrypto/subtlecrypto.rs
+++ b/components/script/dom/webcrypto/subtlecrypto.rs
@@ -79,7 +79,7 @@ use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::cryptokey::{CryptoKey, CryptoKeyOrCryptoKeyPair};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
-use crate::script_runtime::{CanGc, JSContext};
+use crate::script_runtime::CanGc;
 
 // Named elliptic curves
 const NAMED_CURVE_P256: &str = "P-256";
@@ -259,7 +259,7 @@ impl SubtleCrypto {
                 match JsonWebKey::parse(cx, stringified_jwk.as_bytes()) {
                     Ok(jwk) => {
                         rooted!(&in(cx) let mut rval = UndefinedValue());
-                        jwk.safe_to_jsval(cx.into(), rval.handle_mut(), CanGc::from_cx(cx));
+                        jwk.safe_to_jsval(cx, rval.handle_mut());
                         rooted!(&in(cx) let mut object = rval.to_object());
                         promise.resolve_native(cx, &*object);
                     },
@@ -2901,11 +2901,11 @@ pub(crate) struct SubtleKeyAlgorithm {
 }
 
 impl SafeToJSValConvertible for SubtleKeyAlgorithm {
-    fn safe_to_jsval(&self, cx: JSContext, rval: MutableHandleValue, can_gc: CanGc) {
+    fn safe_to_jsval(&self, cx: &mut js::context::JSContext, rval: MutableHandleValue) {
         let dictionary = KeyAlgorithm {
             name: self.name.as_str().into(),
         };
-        dictionary.safe_to_jsval(cx, rval, can_gc);
+        dictionary.safe_to_jsval(cx, rval);
     }
 }
 
@@ -2990,11 +2990,15 @@ pub(crate) struct SubtleRsaHashedKeyAlgorithm {
 }
 
 impl SafeToJSValConvertible for SubtleRsaHashedKeyAlgorithm {
-    fn safe_to_jsval(&self, cx: JSContext, rval: MutableHandleValue, can_gc: CanGc) {
-        rooted!(in(*cx) let mut js_object = ptr::null_mut::<JSObject>());
-        let public_exponent =
-            create_buffer_source(cx, &self.public_exponent, js_object.handle_mut(), can_gc)
-                .expect("Fail to convert publicExponent to Uint8Array");
+    fn safe_to_jsval(&self, cx: &mut js::context::JSContext, rval: MutableHandleValue) {
+        rooted!(&in(cx) let mut js_object = ptr::null_mut::<JSObject>());
+        let public_exponent = create_buffer_source(
+            cx.into(),
+            &self.public_exponent,
+            js_object.handle_mut(),
+            CanGc::from_cx(cx),
+        )
+        .expect("Fail to convert publicExponent to Uint8Array");
         let key_algorithm = KeyAlgorithm {
             name: self.name.as_str().into(),
         };
@@ -3009,7 +3013,7 @@ impl SafeToJSValConvertible for SubtleRsaHashedKeyAlgorithm {
                 name: self.hash.name().as_str().into(),
             },
         });
-        rsa_hashed_key_algorithm.safe_to_jsval(cx, rval, can_gc);
+        rsa_hashed_key_algorithm.safe_to_jsval(cx, rval);
     }
 }
 
@@ -3187,7 +3191,7 @@ pub(crate) struct SubtleEcKeyAlgorithm {
 }
 
 impl SafeToJSValConvertible for SubtleEcKeyAlgorithm {
-    fn safe_to_jsval(&self, cx: JSContext, rval: MutableHandleValue, can_gc: CanGc) {
+    fn safe_to_jsval(&self, cx: &mut js::context::JSContext, rval: MutableHandleValue) {
         let parent = KeyAlgorithm {
             name: self.name.as_str().into(),
         };
@@ -3195,7 +3199,7 @@ impl SafeToJSValConvertible for SubtleEcKeyAlgorithm {
             parent,
             namedCurve: self.named_curve.clone().into(),
         };
-        dictionary.safe_to_jsval(cx, rval, can_gc);
+        dictionary.safe_to_jsval(cx, rval);
     }
 }
 
@@ -3321,7 +3325,7 @@ pub(crate) struct SubtleAesKeyAlgorithm {
 }
 
 impl SafeToJSValConvertible for SubtleAesKeyAlgorithm {
-    fn safe_to_jsval(&self, cx: JSContext, rval: MutableHandleValue, can_gc: CanGc) {
+    fn safe_to_jsval(&self, cx: &mut js::context::JSContext, rval: MutableHandleValue) {
         let parent = KeyAlgorithm {
             name: self.name.as_str().into(),
         };
@@ -3329,7 +3333,7 @@ impl SafeToJSValConvertible for SubtleAesKeyAlgorithm {
             parent,
             length: self.length,
         };
-        dictionary.safe_to_jsval(cx, rval, can_gc);
+        dictionary.safe_to_jsval(cx, rval);
     }
 }
 
@@ -3516,7 +3520,7 @@ pub(crate) struct SubtleHmacKeyAlgorithm {
 }
 
 impl SafeToJSValConvertible for SubtleHmacKeyAlgorithm {
-    fn safe_to_jsval(&self, cx: JSContext, rval: MutableHandleValue, can_gc: CanGc) {
+    fn safe_to_jsval(&self, cx: &mut js::context::JSContext, rval: MutableHandleValue) {
         let parent = KeyAlgorithm {
             name: self.name.as_str().into(),
         };
@@ -3528,7 +3532,7 @@ impl SafeToJSValConvertible for SubtleHmacKeyAlgorithm {
             hash,
             length: self.length,
         };
-        dictionary.safe_to_jsval(cx, rval, can_gc);
+        dictionary.safe_to_jsval(cx, rval);
     }
 }
 
@@ -3971,18 +3975,23 @@ struct SubtleEncapsulatedKey {
 }
 
 impl SafeToJSValConvertible for SubtleEncapsulatedKey {
-    fn safe_to_jsval(&self, cx: JSContext, rval: MutableHandleValue, can_gc: CanGc) {
+    fn safe_to_jsval(&self, cx: &mut js::context::JSContext, rval: MutableHandleValue) {
         let shared_key = self.shared_key.as_ref().map(|shared_key| shared_key.root());
         let ciphertext = self.ciphertext.as_ref().map(|data| {
-            rooted!(in(*cx) let mut ciphertext_ptr = ptr::null_mut::<JSObject>());
-            create_buffer_source::<ArrayBufferU8>(cx, data, ciphertext_ptr.handle_mut(), can_gc)
-                .expect("Failed to convert ciphertext to ArrayBufferU8")
+            rooted!(&in(cx) let mut ciphertext_ptr = ptr::null_mut::<JSObject>());
+            create_buffer_source::<ArrayBufferU8>(
+                cx.into(),
+                data,
+                ciphertext_ptr.handle_mut(),
+                CanGc::from_cx(cx),
+            )
+            .expect("Failed to convert ciphertext to ArrayBufferU8")
         });
         let encapsulated_key = RootedTraceableBox::new(EncapsulatedKey {
             sharedKey: shared_key,
             ciphertext,
         });
-        encapsulated_key.safe_to_jsval(cx, rval, can_gc);
+        encapsulated_key.safe_to_jsval(cx, rval);
     }
 }
 
@@ -3996,22 +4005,32 @@ struct SubtleEncapsulatedBits {
 }
 
 impl SafeToJSValConvertible for SubtleEncapsulatedBits {
-    fn safe_to_jsval(&self, cx: JSContext, rval: MutableHandleValue, can_gc: CanGc) {
+    fn safe_to_jsval(&self, cx: &mut js::context::JSContext, rval: MutableHandleValue) {
         let shared_key = self.shared_key.as_ref().map(|data| {
-            rooted!(in(*cx) let mut shared_key_ptr = ptr::null_mut::<JSObject>());
-            create_buffer_source::<ArrayBufferU8>(cx, data, shared_key_ptr.handle_mut(), can_gc)
-                .expect("Failed to convert shared key to ArrayBufferU8")
+            rooted!(&in(cx) let mut shared_key_ptr = ptr::null_mut::<JSObject>());
+            create_buffer_source::<ArrayBufferU8>(
+                cx.into(),
+                data,
+                shared_key_ptr.handle_mut(),
+                CanGc::from_cx(cx),
+            )
+            .expect("Failed to convert shared key to ArrayBufferU8")
         });
         let ciphertext = self.ciphertext.as_ref().map(|data| {
-            rooted!(in(*cx) let mut ciphertext_ptr = ptr::null_mut::<JSObject>());
-            create_buffer_source::<ArrayBufferU8>(cx, data, ciphertext_ptr.handle_mut(), can_gc)
-                .expect("Failed to convert ciphertext to ArrayBufferU8")
+            rooted!(&in(cx) let mut ciphertext_ptr = ptr::null_mut::<JSObject>());
+            create_buffer_source::<ArrayBufferU8>(
+                cx.into(),
+                data,
+                ciphertext_ptr.handle_mut(),
+                CanGc::from_cx(cx),
+            )
+            .expect("Failed to convert ciphertext to ArrayBufferU8")
         });
         let encapsulated_bits = RootedTraceableBox::new(EncapsulatedBits {
             sharedKey: shared_key,
             ciphertext,
         });
-        encapsulated_bits.safe_to_jsval(cx, rval, can_gc);
+        encapsulated_bits.safe_to_jsval(cx, rval);
     }
 }
 
@@ -4110,21 +4129,13 @@ impl KeyAlgorithmAndDerivatives {
 }
 
 impl SafeToJSValConvertible for KeyAlgorithmAndDerivatives {
-    fn safe_to_jsval(&self, cx: JSContext, rval: MutableHandleValue, can_gc: CanGc) {
+    fn safe_to_jsval(&self, cx: &mut js::context::JSContext, rval: MutableHandleValue) {
         match self {
-            KeyAlgorithmAndDerivatives::KeyAlgorithm(algo) => algo.safe_to_jsval(cx, rval, can_gc),
-            KeyAlgorithmAndDerivatives::RsaHashedKeyAlgorithm(algo) => {
-                algo.safe_to_jsval(cx, rval, can_gc)
-            },
-            KeyAlgorithmAndDerivatives::EcKeyAlgorithm(algo) => {
-                algo.safe_to_jsval(cx, rval, can_gc)
-            },
-            KeyAlgorithmAndDerivatives::AesKeyAlgorithm(algo) => {
-                algo.safe_to_jsval(cx, rval, can_gc)
-            },
-            KeyAlgorithmAndDerivatives::HmacKeyAlgorithm(algo) => {
-                algo.safe_to_jsval(cx, rval, can_gc)
-            },
+            KeyAlgorithmAndDerivatives::KeyAlgorithm(algo) => algo.safe_to_jsval(cx, rval),
+            KeyAlgorithmAndDerivatives::RsaHashedKeyAlgorithm(algo) => algo.safe_to_jsval(cx, rval),
+            KeyAlgorithmAndDerivatives::EcKeyAlgorithm(algo) => algo.safe_to_jsval(cx, rval),
+            KeyAlgorithmAndDerivatives::AesKeyAlgorithm(algo) => algo.safe_to_jsval(cx, rval),
+            KeyAlgorithmAndDerivatives::HmacKeyAlgorithm(algo) => algo.safe_to_jsval(cx, rval),
         }
     }
 }
@@ -4284,7 +4295,7 @@ impl JsonWebKeyExt for JsonWebKey {
     /// bytes.
     fn stringify(&self, cx: &mut js::context::JSContext) -> Result<Zeroizing<DOMString>, Error> {
         rooted!(&in(cx) let mut data = UndefinedValue());
-        self.safe_to_jsval(cx.into(), data.handle_mut(), CanGc::from_cx(cx));
+        self.safe_to_jsval(cx, data.handle_mut());
         serialize_jsval_to_json_utf8(cx.into(), data.handle()).map(Zeroizing::new)
     }
 
@@ -4502,7 +4513,7 @@ fn normalize_algorithm<Op: Operation>(
                 name: name.to_owned(),
             };
             rooted!(&in(cx) let mut algorithm_value = UndefinedValue());
-            algorithm.safe_to_jsval(cx.into(), algorithm_value.handle_mut(), CanGc::from_cx(cx));
+            algorithm.safe_to_jsval(cx, algorithm_value.handle_mut());
             let algorithm_object = RootedTraceableBox::new(Heap::default());
             algorithm_object.set(algorithm_value.to_object());
             normalize_algorithm::<Op>(cx, &ObjectOrString::Object(algorithm_object))

--- a/components/script/dom/webgl/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl/webgl2renderingcontext.rs
@@ -19,7 +19,6 @@ use pixels::{Alpha, Snapshot};
 use script_bindings::conversions::SafeToJSValConvertible;
 use script_bindings::interfaces::WebGL2RenderingContextHelpers;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
-use script_bindings::script_runtime::CanGc;
 use servo_base::generic_channel::{self, GenericSharedMemory};
 use servo_canvas_traits::webgl::WebGLError::*;
 use servo_canvas_traits::webgl::{
@@ -708,10 +707,10 @@ impl WebGL2RenderingContext {
         if pname == constants::FRAMEBUFFER_ATTACHMENT_OBJECT_NAME {
             match fb.attachment(attachment) {
                 Some(Renderbuffer(rb)) => {
-                    rb.safe_to_jsval(cx.into(), rval, CanGc::from_cx(cx));
+                    rb.safe_to_jsval(cx, rval);
                 },
                 Some(Texture(texture)) => {
-                    texture.safe_to_jsval(cx.into(), rval, CanGc::from_cx(cx));
+                    texture.safe_to_jsval(cx, rval);
                 },
                 _ => rval.set(NullValue()),
             }
@@ -1052,11 +1051,11 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     fn GetParameter(&self, cx: &mut JSContext, parameter: u32, mut rval: MutableHandleValue) {
         match parameter {
             constants::VERSION => {
-                "WebGL 2.0".safe_to_jsval(cx.into(), rval, CanGc::from_cx(cx));
+                "WebGL 2.0".safe_to_jsval(cx, rval);
                 return;
             },
             constants::SHADING_LANGUAGE_VERSION => {
-                "WebGL GLSL ES 3.00".safe_to_jsval(cx.into(), rval, CanGc::from_cx(cx));
+                "WebGL GLSL ES 3.00".safe_to_jsval(cx, rval);
                 return;
             },
             constants::MAX_CLIENT_WAIT_TIMEOUT_WEBGL => {
@@ -1075,81 +1074,58 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
                 let idx = (self.base.textures().active_unit_enum() - constants::TEXTURE0) as usize;
                 assert!(idx < self.samplers.len());
                 let sampler = self.samplers[idx].get();
-                sampler.safe_to_jsval(cx.into(), rval, CanGc::from_cx(cx));
+                sampler.safe_to_jsval(cx, rval);
                 return;
             },
             constants::COPY_READ_BUFFER_BINDING => {
-                self.bound_copy_read_buffer.get().safe_to_jsval(
-                    cx.into(),
-                    rval,
-                    CanGc::from_cx(cx),
-                );
+                self.bound_copy_read_buffer.get().safe_to_jsval(cx, rval);
                 return;
             },
             constants::COPY_WRITE_BUFFER_BINDING => {
-                self.bound_copy_write_buffer.get().safe_to_jsval(
-                    cx.into(),
-                    rval,
-                    CanGc::from_cx(cx),
-                );
+                self.bound_copy_write_buffer.get().safe_to_jsval(cx, rval);
                 return;
             },
             constants::PIXEL_PACK_BUFFER_BINDING => {
-                self.bound_pixel_pack_buffer.get().safe_to_jsval(
-                    cx.into(),
-                    rval,
-                    CanGc::from_cx(cx),
-                );
+                self.bound_pixel_pack_buffer.get().safe_to_jsval(cx, rval);
                 return;
             },
             constants::PIXEL_UNPACK_BUFFER_BINDING => {
-                self.bound_pixel_unpack_buffer.get().safe_to_jsval(
-                    cx.into(),
-                    rval,
-                    CanGc::from_cx(cx),
-                );
+                self.bound_pixel_unpack_buffer.get().safe_to_jsval(cx, rval);
                 return;
             },
             constants::TRANSFORM_FEEDBACK_BUFFER_BINDING => {
-                self.bound_transform_feedback_buffer.get().safe_to_jsval(
-                    cx.into(),
-                    rval,
-                    CanGc::from_cx(cx),
-                );
+                self.bound_transform_feedback_buffer
+                    .get()
+                    .safe_to_jsval(cx, rval);
                 return;
             },
             constants::UNIFORM_BUFFER_BINDING => {
-                self.bound_uniform_buffer
-                    .get()
-                    .safe_to_jsval(cx.into(), rval, CanGc::from_cx(cx));
+                self.bound_uniform_buffer.get().safe_to_jsval(cx, rval);
                 return;
             },
             constants::TRANSFORM_FEEDBACK_BINDING => {
-                self.current_transform_feedback.get().safe_to_jsval(
-                    cx.into(),
-                    rval,
-                    CanGc::from_cx(cx),
-                );
+                self.current_transform_feedback
+                    .get()
+                    .safe_to_jsval(cx, rval);
                 return;
             },
             constants::ELEMENT_ARRAY_BUFFER_BINDING => {
                 let buffer = self.current_vao(cx).element_array_buffer().get();
-                buffer.safe_to_jsval(cx.into(), rval, CanGc::from_cx(cx));
+                buffer.safe_to_jsval(cx, rval);
                 return;
             },
             constants::VERTEX_ARRAY_BINDING => {
                 let vao = self.current_vao(cx);
                 let vao = vao.id().map(|_| &*vao);
-                vao.safe_to_jsval(cx.into(), rval, CanGc::from_cx(cx));
+                vao.safe_to_jsval(cx, rval);
                 return;
             },
             // NOTE: DRAW_FRAMEBUFFER_BINDING is the same as FRAMEBUFFER_BINDING, handled on the WebGL1 side
             constants::READ_FRAMEBUFFER_BINDING => {
-                self.base.get_read_framebuffer_slot().get().safe_to_jsval(
-                    cx.into(),
-                    rval,
-                    CanGc::from_cx(cx),
-                );
+                self.base
+                    .get_read_framebuffer_slot()
+                    .get()
+                    .safe_to_jsval(cx, rval);
                 return;
             },
             constants::READ_BUFFER => {
@@ -2136,10 +2112,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
 
         match target {
             constants::TRANSFORM_FEEDBACK_BUFFER_BINDING | constants::UNIFORM_BUFFER_BINDING => {
-                binding
-                    .buffer
-                    .get()
-                    .safe_to_jsval(cx.into(), retval, CanGc::from_cx(cx))
+                binding.buffer.get().safe_to_jsval(cx, retval)
             },
             constants::TRANSFORM_FEEDBACK_BUFFER_START | constants::UNIFORM_BUFFER_START => {
                 retval.set(Int32Value(binding.start.get() as _))
@@ -4683,11 +4656,11 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
             constants::UNIFORM_OFFSET |
             constants::UNIFORM_ARRAY_STRIDE |
             constants::UNIFORM_MATRIX_STRIDE => {
-                values.safe_to_jsval(cx.into(), rval, CanGc::from_cx(cx));
+                values.safe_to_jsval(cx, rval);
             },
             constants::UNIFORM_IS_ROW_MAJOR => {
                 let values = values.iter().map(|&v| v != 0).collect::<Vec<_>>();
-                values.safe_to_jsval(cx.into(), rval, CanGc::from_cx(cx));
+                values.safe_to_jsval(cx, rval);
             },
             _ => unreachable!(),
         }

--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -88,7 +88,6 @@ use crate::dom::webgl::webgluniformlocation::WebGLUniformLocation;
 use crate::dom::webgl::webglvertexarrayobject::WebGLVertexArrayObject;
 use crate::dom::webgl::webglvertexarrayobjectoes::WebGLVertexArrayObjectOES;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 fn has_invalid_blend_constants(arg1: u32, arg2: u32) -> bool {
     match (arg1, arg2) {
@@ -2192,34 +2191,24 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
 
         match parameter {
             constants::ARRAY_BUFFER_BINDING => {
-                self.bound_buffer_array
-                    .get()
-                    .safe_to_jsval(cx.into(), retval, CanGc::from_cx(cx));
+                self.bound_buffer_array.get().safe_to_jsval(cx, retval);
                 return;
             },
             constants::CURRENT_PROGRAM => {
-                self.current_program
-                    .get()
-                    .safe_to_jsval(cx.into(), retval, CanGc::from_cx(cx));
+                self.current_program.get().safe_to_jsval(cx, retval);
                 return;
             },
             constants::ELEMENT_ARRAY_BUFFER_BINDING => {
                 let buffer = self.current_vao(cx).element_array_buffer().get();
-                buffer.safe_to_jsval(cx.into(), retval, CanGc::from_cx(cx));
+                buffer.safe_to_jsval(cx, retval);
                 return;
             },
             constants::FRAMEBUFFER_BINDING => {
-                self.bound_draw_framebuffer.get().safe_to_jsval(
-                    cx.into(),
-                    retval,
-                    CanGc::from_cx(cx),
-                );
+                self.bound_draw_framebuffer.get().safe_to_jsval(cx, retval);
                 return;
             },
             constants::RENDERBUFFER_BINDING => {
-                self.bound_renderbuffer
-                    .get()
-                    .safe_to_jsval(cx.into(), retval, CanGc::from_cx(cx));
+                self.bound_renderbuffer.get().safe_to_jsval(cx, retval);
                 return;
             },
             constants::TEXTURE_BINDING_2D => {
@@ -2228,7 +2217,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                     .active_texture_slot(constants::TEXTURE_2D, self.webgl_version())
                     .unwrap()
                     .get();
-                texture.safe_to_jsval(cx.into(), retval, CanGc::from_cx(cx));
+                texture.safe_to_jsval(cx, retval);
                 return;
             },
             WebGL2RenderingContextConstants::TEXTURE_BINDING_2D_ARRAY => {
@@ -2240,7 +2229,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                     )
                     .unwrap()
                     .get();
-                texture.safe_to_jsval(cx.into(), retval, CanGc::from_cx(cx));
+                texture.safe_to_jsval(cx, retval);
                 return;
             },
             WebGL2RenderingContextConstants::TEXTURE_BINDING_3D => {
@@ -2252,7 +2241,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                     )
                     .unwrap()
                     .get();
-                texture.safe_to_jsval(cx.into(), retval, CanGc::from_cx(cx));
+                texture.safe_to_jsval(cx, retval);
                 return;
             },
             constants::TEXTURE_BINDING_CUBE_MAP => {
@@ -2261,12 +2250,12 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                     .active_texture_slot(constants::TEXTURE_CUBE_MAP, self.webgl_version())
                     .unwrap()
                     .get();
-                texture.safe_to_jsval(cx.into(), retval, CanGc::from_cx(cx));
+                texture.safe_to_jsval(cx, retval);
                 return;
             },
             OESVertexArrayObjectConstants::VERTEX_ARRAY_BINDING_OES => {
                 let vao = self.current_vao.get().filter(|vao| vao.id().is_some());
-                vao.safe_to_jsval(cx.into(), retval, CanGc::from_cx(cx));
+                vao.safe_to_jsval(cx, retval);
                 return;
             },
             // In readPixels we currently support RGBA/UBYTE only.  If
@@ -2301,15 +2290,15 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                 return retval.set(ObjectValue(rval.get()));
             },
             constants::VERSION => {
-                "WebGL 1.0".safe_to_jsval(cx.into(), retval, CanGc::from_cx(cx));
+                "WebGL 1.0".safe_to_jsval(cx, retval);
                 return;
             },
             constants::RENDERER | constants::VENDOR => {
-                "Mozilla/Servo".safe_to_jsval(cx.into(), retval, CanGc::from_cx(cx));
+                "Mozilla/Servo".safe_to_jsval(cx, retval);
                 return;
             },
             constants::SHADING_LANGUAGE_VERSION => {
-                "WebGL GLSL ES 1.0".safe_to_jsval(cx.into(), retval, CanGc::from_cx(cx));
+                "WebGL GLSL ES 1.0".safe_to_jsval(cx, retval);
                 return;
             },
             constants::UNPACK_FLIP_Y_WEBGL => {
@@ -2390,10 +2379,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
             Parameter::Bool4(param) => {
                 let (sender, receiver) = webgl_channel().unwrap();
                 self.send_command(WebGLCommand::GetParameterBool4(param, sender));
-                receiver
-                    .recv()
-                    .unwrap()
-                    .safe_to_jsval(cx.into(), retval, CanGc::from_cx(cx));
+                receiver.recv().unwrap().safe_to_jsval(cx, retval);
             },
             Parameter::Int(param) => {
                 let (sender, receiver) = webgl_channel().unwrap();
@@ -3459,11 +3445,11 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
             if let Some(webgl_attachment) = fb.attachment(attachment) {
                 match webgl_attachment {
                     WebGLFramebufferAttachmentRoot::Renderbuffer(rb) => {
-                        rb.safe_to_jsval(cx.into(), retval, CanGc::from_cx(cx));
+                        rb.safe_to_jsval(cx, retval);
                         return;
                     },
                     WebGLFramebufferAttachmentRoot::Texture(texture) => {
-                        texture.safe_to_jsval(cx.into(), retval, CanGc::from_cx(cx));
+                        texture.safe_to_jsval(cx, retval);
                         return;
                     },
                 }
@@ -3750,7 +3736,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                 constants::VERTEX_ATTRIB_ARRAY_STRIDE => retval.set(Int32Value(data.stride as i32)),
                 constants::VERTEX_ATTRIB_ARRAY_BUFFER_BINDING => {
                     if let Some(buffer) = data.buffer() {
-                        buffer.safe_to_jsval(cx.into(), retval.reborrow(), CanGc::from_cx(cx));
+                        buffer.safe_to_jsval(cx, retval.reborrow());
                     } else {
                         retval.set(NullValue());
                     }
@@ -4373,12 +4359,15 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                 triple,
                 WebGLCommand::GetUniformBool,
             ))),
-            constants::BOOL_VEC2 => uniform_get(triple, WebGLCommand::GetUniformBool2)
-                .safe_to_jsval(cx.into(), rval, CanGc::from_cx(cx)),
-            constants::BOOL_VEC3 => uniform_get(triple, WebGLCommand::GetUniformBool3)
-                .safe_to_jsval(cx.into(), rval, CanGc::from_cx(cx)),
-            constants::BOOL_VEC4 => uniform_get(triple, WebGLCommand::GetUniformBool4)
-                .safe_to_jsval(cx.into(), rval, CanGc::from_cx(cx)),
+            constants::BOOL_VEC2 => {
+                uniform_get(triple, WebGLCommand::GetUniformBool2).safe_to_jsval(cx, rval)
+            },
+            constants::BOOL_VEC3 => {
+                uniform_get(triple, WebGLCommand::GetUniformBool3).safe_to_jsval(cx, rval)
+            },
+            constants::BOOL_VEC4 => {
+                uniform_get(triple, WebGLCommand::GetUniformBool4).safe_to_jsval(cx, rval)
+            },
             constants::INT |
             constants::SAMPLER_2D |
             constants::SAMPLER_CUBE |

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -618,14 +618,12 @@ impl TaskOnce for MessageReceivedTask {
         let cx = &mut *realm;
         rooted!(&in(cx) let mut message = UndefinedValue());
         match self.message {
-            MessageData::Text(text) => {
-                text.safe_to_jsval(cx.into(), message.handle_mut(), CanGc::from_cx(cx))
-            },
+            MessageData::Text(text) => text.safe_to_jsval(cx, message.handle_mut()),
             MessageData::Binary(data) => match ws.binary_type.get() {
                 BinaryType::Blob => {
                     let blob =
                         Blob::new(cx, &global, BlobImpl::new_from_bytes(data, "".to_owned()));
-                    blob.safe_to_jsval(cx.into(), message.handle_mut(), CanGc::from_cx(cx));
+                    blob.safe_to_jsval(cx, message.handle_mut());
                 },
                 BinaryType::Arraybuffer => {
                     rooted!(&in(cx) let mut array_buffer = ptr::null_mut::<JSObject>());
@@ -641,11 +639,7 @@ impl TaskOnce for MessageReceivedTask {
                         )
                     };
 
-                    (*array_buffer).safe_to_jsval(
-                        cx.into(),
-                        message.handle_mut(),
-                        CanGc::from_cx(cx),
-                    );
+                    (*array_buffer).safe_to_jsval(cx, message.handle_mut());
                 },
             },
         }

--- a/components/script/dom/webxr/xrinputsource.rs
+++ b/components/script/dom/webxr/xrinputsource.rs
@@ -23,7 +23,7 @@ use crate::dom::xrhand::XRHand;
 use crate::dom::xrsession::XRSession;
 use crate::dom::xrspace::XRSpace;
 use crate::realms::enter_auto_realm;
-use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
+use crate::script_runtime::JSContext as SafeJSContext;
 
 #[dom_struct]
 pub(crate) struct XRInputSource {
@@ -91,7 +91,7 @@ impl XRInputSource {
         source
             .info
             .profiles
-            .safe_to_jsval(cx.into(), profiles.handle_mut(), CanGc::from_cx(cx));
+            .safe_to_jsval(cx, profiles.handle_mut());
         source.profiles.set(profiles.get());
         source
     }

--- a/components/script/dom/webxr/xrviewerpose.rs
+++ b/components/script/dom/webxr/xrviewerpose.rs
@@ -22,7 +22,6 @@ use crate::dom::xrrigidtransform::XRRigidTransform;
 use crate::dom::xrsession::{BaseSpace, BaseTransform, XRSession, cast_transform};
 use crate::dom::xrview::XRView;
 use crate::realms::enter_auto_realm;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct XRViewerPose {
@@ -184,7 +183,7 @@ impl XRViewerPose {
         );
 
         rooted!(&in(cx) let mut jsval = UndefinedValue());
-        views.safe_to_jsval(cx.into(), jsval.handle_mut(), CanGc::from_cx(cx));
+        views.safe_to_jsval(cx, jsval.handle_mut());
         pose.views.set(jsval.get());
 
         pose

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -2224,12 +2224,9 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-window-event>
-    fn Event(&self, cx: SafeJSContext, rval: MutableHandleValue) {
+    fn Event(&self, cx: &mut JSContext, rval: MutableHandleValue) {
         if let Some(ref event) = *self.current_event.borrow() {
-            event
-                .reflector()
-                .get_jsobject()
-                .safe_to_jsval(cx, rval, CanGc::deprecated_note());
+            event.reflector().get_jsobject().safe_to_jsval(cx, rval);
         }
     }
 

--- a/components/script/dom/workers/sharedworkerglobalscope.rs
+++ b/components/script/dom/workers/sharedworkerglobalscope.rs
@@ -682,10 +682,8 @@ impl SharedWorkerGlobalScope {
                 let inside_port = inside_port.root();
 
                 rooted!(&in(cx) let mut data = UndefinedValue());
-                DOMString::from("").safe_to_jsval(
-                    cx.into(),
+                DOMString::from("").safe_to_jsval(cx,
                     data.handle_mut(),
-                    CanGc::from_cx(cx),
                 );
 
                 let source = WindowProxyOrMessagePortOrServiceWorker::MessagePort(

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -1093,11 +1093,9 @@ impl WorkerGlobalScope {
         // Convert the debugger global’s reflector to a Value, wrapping it from its originating realm (debugger realm)
         // into the active realm (debuggee realm) so that it can be passed across compartments.
         rooted!(&in(cx) let mut wrapped_global: Value);
-        debugger_global.reflector().safe_to_jsval(
-            cx.into(),
-            wrapped_global.handle_mut(),
-            CanGc::from_cx(cx),
-        );
+        debugger_global
+            .reflector()
+            .safe_to_jsval(cx, wrapped_global.handle_mut());
         self.debugger_global.set(*wrapped_global);
     }
 

--- a/components/script/dom/xmlhttprequest/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest/xmlhttprequest.rs
@@ -957,11 +957,10 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
                 if ready_state == XMLHttpRequestState::Done ||
                     ready_state == XMLHttpRequestState::Loading
                 {
-                    self.text_response()
-                        .safe_to_jsval(cx.into(), rval, CanGc::from_cx(cx));
+                    self.text_response().safe_to_jsval(cx, rval);
                 } else {
                     // Step 1
-                    "".safe_to_jsval(cx.into(), rval, CanGc::from_cx(cx));
+                    "".safe_to_jsval(cx, rval);
                 }
             },
             // Step 1
@@ -970,18 +969,12 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
             },
             // Step 2
             XMLHttpRequestResponseType::Document => {
-                self.document_response(cx)
-                    .safe_to_jsval(cx.into(), rval, CanGc::from_cx(cx))
+                self.document_response(cx).safe_to_jsval(cx, rval)
             },
             XMLHttpRequestResponseType::Json => self.json_response(cx.into(), rval),
-            XMLHttpRequestResponseType::Blob => {
-                self.blob_response(cx)
-                    .safe_to_jsval(cx.into(), rval, CanGc::from_cx(cx))
-            },
+            XMLHttpRequestResponseType::Blob => self.blob_response(cx).safe_to_jsval(cx, rval),
             XMLHttpRequestResponseType::Arraybuffer => match self.arraybuffer_response(cx) {
-                Some(array_buffer) => {
-                    array_buffer.safe_to_jsval(cx.into(), rval, CanGc::from_cx(cx))
-                },
+                Some(array_buffer) => array_buffer.safe_to_jsval(cx, rval),
                 None => rval.set(NullValue()),
             },
         }

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -82,7 +82,7 @@ use crate::module_loading::{
 };
 use crate::network_listener::{self, FetchResponseListener, ResourceTimingListener};
 use crate::realms::enter_auto_realm;
-use crate::script_runtime::{CanGc, IntroductionType};
+use crate::script_runtime::IntroductionType;
 use crate::task::NonSendTaskBox;
 use crate::url::ensure_blob_referenced_by_url_is_kept_alive;
 
@@ -1157,11 +1157,8 @@ unsafe extern "C" fn import_meta_resolve(cx: *mut RawJSContext, argc: u32, vp: *
     match url {
         Ok(url) => {
             // Step 4.3. Return the serialization of url.
-            url.as_str().safe_to_jsval(
-                cx.into(),
-                unsafe { MutableHandleValue::from_raw(args.rval()) },
-                CanGc::from_cx(cx),
-            );
+            url.as_str()
+                .safe_to_jsval(cx, unsafe { MutableHandleValue::from_raw(args.rval()) });
             true
         },
         Err(error) => {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1248,6 +1248,7 @@ DOMInterfaces = {
 },
 
 'ServoInternals': {
+    'cx': ['DefaultPreferenceValue', 'GetPreference'],
     'realm': ['ReportMemory'],
     'additionalTraits': ['crate::interfaces::ServoInternalsHelpers'],
 },
@@ -1544,6 +1545,7 @@ DOMInterfaces = {
     'cx': [
         'Close',
         'CustomElements',
+        'Event',
         'Focus',
         'FetchLater',
         'GetComputedStyle',

--- a/components/script_bindings/conversions.rs
+++ b/components/script_bindings/conversions.rs
@@ -32,19 +32,19 @@ use crate::inheritance::Castable;
 use crate::num::Finite;
 use crate::reflector::{DomObject, Reflector};
 use crate::root::DomRoot;
-use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
+use crate::script_runtime::JSContext as SafeJSContext;
 use crate::str::{ByteString, DOMString, USVString};
 use crate::trace::RootedTraceableBox;
 use crate::utils::{DOMClass, DOMJSClass};
 
 /// A safe wrapper for `ToJSValConvertible`.
 pub trait SafeToJSValConvertible {
-    fn safe_to_jsval(&self, cx: SafeJSContext, rval: MutableHandleValue, can_gc: CanGc);
+    fn safe_to_jsval(&self, cx: &mut js::context::JSContext, rval: MutableHandleValue);
 }
 
 impl<T: ToJSValConvertible + ?Sized> SafeToJSValConvertible for T {
-    fn safe_to_jsval(&self, cx: SafeJSContext, rval: MutableHandleValue, _can_gc: CanGc) {
-        unsafe { self.to_jsval(*cx, rval) };
+    fn safe_to_jsval(&self, cx: &mut js::context::JSContext, rval: MutableHandleValue) {
+        ToJSValConvertible::safe_to_jsval(self, cx, rval);
     }
 }
 


### PR DESCRIPTION
This removes the final `CanGc` usage from `promise.rs` :tada:

Part of #40600

Testing: it compiles