### PR TITLE
android: Convert history empty state to Compose UI

### DIFF
--- a/support/android/apk/servoapp/src/main/java/org/servo/servoshell/HistoryFragment.kt
+++ b/support/android/apk/servoapp/src/main/java/org/servo/servoshell/HistoryFragment.kt
@@ -7,14 +7,20 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
@@ -28,7 +34,7 @@ class HistoryFragment : Fragment() {
     private val timeFormat = SimpleDateFormat("HH:mm", Locale.getDefault())
 
     private lateinit var listView: ComposeView
-    private lateinit var emptyState: View
+    private lateinit var emptyState: ComposeView
     private lateinit var historyManager: HistoryManager
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -65,6 +71,24 @@ class HistoryFragment : Fragment() {
         if (historyEntries.isEmpty()) {
             listView.isGone = true
             emptyState.isVisible = true
+
+            emptyState.setContent {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterVertically),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Text(
+                        stringResource(R.string.history_placeholder_title),
+                        style = MaterialTheme.typography.headlineSmall,
+                    )
+                    Text(
+                        stringResource(R.string.history_placeholder_message),
+                        color = MaterialTheme.colorScheme.secondary,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+            }
         } else {
             listView.isVisible = true
             emptyState.isGone = true

--- a/support/android/apk/servoapp/src/main/res/layout/fragment_history.xml
+++ b/support/android/apk/servoapp/src/main/res/layout/fragment_history.xml
@@ -28,33 +28,10 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent" />
 
-        <LinearLayout
+        <androidx.compose.ui.platform.ComposeView
             android:id="@+id/empty_state"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="vertical"
-            android:padding="16dp"
-            android:gravity="center"
-            android:visibility="gone">
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/history_placeholder_title"
-                android:textAppearance="?attr/textAppearanceHeadlineSmall"
-                android:textColor="?android:attr/textColorPrimary"
-                android:layout_marginTop="48dp" />
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:text="@string/history_placeholder_message"
-                android:textAppearance="?attr/textAppearanceBodyMedium"
-                android:textColor="?android:attr/textColorSecondary"
-                android:gravity="center" />
-
-        </LinearLayout>
+            android:layout_height="match_parent" />
 
     </FrameLayout>
 


### PR DESCRIPTION
|Before|After|
|---|---|
|<img width="1116" height="2484" alt="Screenshot_20260623_192845" src="https://github.com/user-attachments/assets/310dbff2-a6bf-4619-811e-cc7449d1c0fd" />|<img width="1116" height="2484" alt="image" src="https://github.com/user-attachments/assets/c4461989-f755-4d7d-97e9-25529a0f1ff5" />|

Testing: There are no automated tests for Android.
Fixes: Part of #45715.