### PR TITLE
script: Return a truely empty stream for `Request.textStream()`&`Response.textStream()` with empty body

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -1179,8 +1179,8 @@ pub(crate) fn body_text_stream<T: BodyMixin + DomObject>(
     // Step 3: Let stream be this’s body’s stream.
     let Some(stream) = object.body() else {
         // Step 2: If this's body is null:
-        // set up a ReadableStream, close it, and return it.
-        return ReadableStream::new_from_bytes(cx, &object.global(), vec![]);
+        // set up a ReadableStream emptyStream, close it, and return it.
+        return ReadableStream::new_empty(cx, &object.global());
     };
 
     // Step 4: Let decoder be a new TextDecoderStream object in this’s relevant realm.

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -970,6 +970,25 @@ impl ReadableStream {
         Ok(stream)
     }
 
+    /// Build an empty stream.
+    /// Used as step 2 of <https://fetch.spec.whatwg.org/#dom-body-textstream>
+    pub(crate) fn new_empty(
+        cx: &mut JSContext,
+        global: &GlobalScope,
+    ) -> Fallible<DomRoot<ReadableStream>> {
+        // Step 1. Let emptyStream be a new ReadableStream in this’s relevant realm.
+        // Step 2. Set up emptyStream.
+        let empty_stream = ReadableStream::new_with_external_underlying_source(
+            cx,
+            global,
+            UnderlyingSourceType::Memory(0),
+        )?;
+        // Step 3. Close emptyStream.
+        empty_stream.controller_close_native(cx);
+        // Step 4. Return emptyStream.
+        Ok(empty_stream)
+    }
+
     /// <https://streams.spec.whatwg.org/#readablestream-set-up-with-byte-reading-support>
     pub(crate) fn new_from_bytes_with_byte_reading_support(
         cx: &mut JSContext,

--- a/tests/wpt/meta/fetch/api/body/textstream.any.js.ini
+++ b/tests/wpt/meta/fetch/api/body/textstream.any.js.ini
@@ -5,21 +5,12 @@
   [Response.textStream() with null body]
     expected: FAIL
 
-  [Request.textStream() with null body]
-    expected: FAIL
-
 
 [textstream.any.sharedworker.html]
   [Response.textStream() with null body]
     expected: FAIL
 
-  [Request.textStream() with null body]
-    expected: FAIL
-
 
 [textstream.any.html]
   [Response.textStream() with null body]
-    expected: FAIL
-
-  [Request.textStream() with null body]
     expected: FAIL


### PR DESCRIPTION
Instead of returning a stream with a single empty chunk, return an empty stream with no chunk as requested by spec.

Testing: New passing.
Fixes: Part of #45860