### PR TITLE
pixels: Do not copy the rgba buffer needlesly

### DIFF
--- a/components/pixels/lib.rs
+++ b/components/pixels/lib.rs
@@ -800,7 +800,7 @@ fn decode_static_image(
         },
         format: PixelFormat::RGBA8,
         frames: vec![frame],
-        bytes: Arc::new(rgba.to_vec()),
+        bytes: Arc::new(rgba.into_vec()),
         id: None,
         cors_status,
         is_opaque,


### PR DESCRIPTION
Use rgba.into_vec() instead of to_vec(). to_vec() is copying while we do not need the buffer afterwards. This reduces the amount of time spend in copying the ImageBuffer to a vector by 17% in the time slice.

Testing: The functionality should be the same, hence, no extra tests are necessary.
