### PR TITLE
layout: Apply reference frame clips via stacking contexts

### DIFF
--- a/components/layout/display_list/hit_test.rs
+++ b/components/layout/display_list/hit_test.rs
@@ -38,6 +38,10 @@ pub(crate) struct HitTest<'a> {
     results: Vec<ElementsFromPointResult>,
     /// A cache of hit test results for shared clip nodes.
     clip_hit_test_results: FxHashMap<ClipId, bool>,
+    /// Collected reference frame clips. For painting, reference frame clips are handled
+    /// by enclosing reference frames in stacking contexts, but we don't have that option
+    /// here, so we must handle them manually.
+    collected_reference_frame_clips: Vec<ClipId>,
 }
 
 impl<'a> HitTest<'a> {
@@ -51,6 +55,7 @@ impl<'a> HitTest<'a> {
             stacking_context_tree,
             results: Vec::new(),
             clip_hit_test_results: FxHashMap::default(),
+            collected_reference_frame_clips: Default::default(),
         };
 
         PaintTraversal::traverse(&stacking_context_tree.root_stacking_context, &mut hit_test);
@@ -66,9 +71,19 @@ impl<'a> HitTest<'a> {
         hit_test.results
     }
 
-    /// Perform a hit test against a the clip node for the given [`ClipId`], returning
+    /// Perform a hit test against the clip node for the given [`ClipId`], returning
     /// true if it is not clipped out or false if is clipped out.
     fn hit_test_clip_id(&mut self, clip_id: ClipId) -> bool {
+        // Using the index here is necessary to avoid a double borrow of `self`.
+        for index in 0..self.collected_reference_frame_clips.len() {
+            if !self.hit_test_individual_clip_id(self.collected_reference_frame_clips[index]) {
+                return false;
+            }
+        }
+        self.hit_test_individual_clip_id(clip_id)
+    }
+
+    fn hit_test_individual_clip_id(&mut self, clip_id: ClipId) -> bool {
         if clip_id == ClipId::INVALID {
             return true;
         }
@@ -81,7 +96,7 @@ impl<'a> HitTest<'a> {
         let result = self
             .location_in_spatial_node(clip.parent_scroll_node_id)
             .is_some_and(|(point, _)| {
-                clip.contains(point) && self.hit_test_clip_id(clip.parent_clip_id)
+                clip.contains(point) && self.hit_test_individual_clip_id(clip.parent_clip_id)
             });
         self.clip_hit_test_results.insert(clip_id, result);
         result
@@ -117,10 +132,32 @@ impl<'a> HitTest<'a> {
 }
 
 impl PaintTraversalHandler for HitTest<'_> {
-    type StackingContextState = ();
+    /// `true` if we pushed a reference frame clip and `false` otherwise.
+    type StackingContextState = bool;
 
-    fn visit_stacking_context(&mut self, _: &StackingContext) -> Self::StackingContextState {}
-    fn leave_stacking_context(&mut self, _: &TraversalState, _: Self::StackingContextState) {}
+    fn visit_stacking_context(
+        &mut self,
+        stacking_context: &StackingContext,
+    ) -> Self::StackingContextState {
+        if let Some(reference_frame_info) = stacking_context.reference_frame_info.as_ref() &&
+            reference_frame_info.captured_clip_id != ClipId::INVALID
+        {
+            self.collected_reference_frame_clips
+                .push(reference_frame_info.captured_clip_id);
+            return true;
+        }
+        false
+    }
+
+    fn leave_stacking_context(
+        &mut self,
+        _: &TraversalState,
+        pushed_reference_frame_clip: Self::StackingContextState,
+    ) {
+        if pushed_reference_frame_clip {
+            self.collected_reference_frame_clips.pop();
+        }
+    }
     fn visit_box(&mut self, state: &TraversalState, fragment: &BoxFragmentWithStyle<'_>) {
         Fragment::Box(fragment.box_fragment.clone()).hit_test(state, self);
     }

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -634,34 +634,71 @@ impl DisplayListBuilder<'_> {
         self.paint_timing_handler
             .update_lcp_candidate(tag, bounds, clip_rect, transform, url);
     }
+
+    fn visit_stacking_context_reference_frame_info(
+        &mut self,
+        stacking_context: &StackingContext,
+    ) -> (usize, Option<ScrollTreeNodeId>) {
+        let Some(reference_frame_info) = &stacking_context.reference_frame_info else {
+            return (0, None);
+        };
+
+        // Note: Reference frames always establish a stacking context, so it is fine to check if
+        // this stacking context establishes a reference frame as well. We don't need to check
+        // every fragment.
+        let old_reference_frame_spatial_id = std::mem::replace(
+            &mut self.current_reference_frame_scroll_node_id,
+            stacking_context.scroll_tree_node_id,
+        );
+
+        if reference_frame_info.captured_clip_id == ClipId::INVALID {
+            return (0, Some(old_reference_frame_spatial_id));
+        }
+
+        // Although there is nothing in the display list API that prevents it, WebRender
+        // expects that reference frames that alter the coordinate space of their contents do
+        // not propagate clips to those contents. In order to achieve this, push an extra
+        // stacking context here that only specifies a clip. This stacking context will contain
+        // all of the contents of the reference frame, but because it is added in the parent
+        // spatial node, it has the coordinate space of the reference frame parent. In addition
+        // to this, reference frames reset the base `ClipId` value for descendants to
+        // `ClipId::INVALID` during stacking context tree construction.
+        let clip_chain_id = Some(self.clip_chain_id(reference_frame_info.captured_clip_id));
+        let spatial_id = self.spatial_id(reference_frame_info.parent_spatial_node_id);
+        self.wr().push_stacking_context(
+            spatial_id,
+            PrimitiveFlags::default(),
+            clip_chain_id,
+            webrender_api::TransformStyle::Flat,
+            webrender_api::MixBlendMode::Normal,
+            &[], // filters,
+            &[], // filter_datas
+            wr::RasterSpace::Screen,
+            wr::StackingContextFlags::empty(),
+            None, // snapshot
+        );
+
+        (1, Some(old_reference_frame_spatial_id))
+    }
 }
 
 impl PaintTraversalHandler for DisplayListBuilder<'_> {
-    type StackingContextState = (bool, Option<ScrollTreeNodeId>);
+    /// A tuple composed of the number of real WebRender stacking contexts pushed
+    /// and the previous `Self::current_reference_frame_scroll_node_id` value of
+    /// the `DisplayListBuilder` when a stacking context was visited (or `None` if
+    /// the value was unmodified).
+    type StackingContextState = (usize, Option<ScrollTreeNodeId>);
 
     fn visit_stacking_context(
         &mut self,
         stacking_context: &StackingContext,
     ) -> Self::StackingContextState {
-        let pushed_stacking_context =
-            self.push_webrender_stacking_context_if_necessary(stacking_context);
-
-        // Note: Reference frames always establish a stacking context, so it is fine to check if
-        // this stacking context establishes a reference frame as well. We don't need to check
-        // every fragment.
-        let root_fragment = stacking_context.fragment();
-        let old_reference_frame = root_fragment.and_then(|root_fragment| {
-            root_fragment
-                .style()
-                .has_effective_transform_or_perspective(root_fragment.base.flags)
-                .then(|| {
-                    std::mem::replace(
-                        &mut self.current_reference_frame_scroll_node_id,
-                        stacking_context.scroll_tree_node_id,
-                    )
-                })
-        });
-        (pushed_stacking_context, old_reference_frame)
+        let (mut stacking_contexts_pushed, old_reference_frame) =
+            self.visit_stacking_context_reference_frame_info(stacking_context);
+        if self.push_webrender_stacking_context_if_necessary(stacking_context) {
+            stacking_contexts_pushed += 1;
+        }
+        (stacking_contexts_pushed, old_reference_frame)
     }
 
     fn leave_stacking_context(
@@ -669,8 +706,8 @@ impl PaintTraversalHandler for DisplayListBuilder<'_> {
         _: &TraversalState,
         stacking_context_state: Self::StackingContextState,
     ) {
-        let (pushed_stacking_context, old_reference_frame) = stacking_context_state;
-        if pushed_stacking_context {
+        let (stacking_contexts_pushed, old_reference_frame) = stacking_context_state;
+        for _ in 0..stacking_contexts_pushed {
             self.wr().pop_stacking_context();
         }
 

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -324,9 +324,15 @@ pub(crate) enum StackingContextType {
 }
 
 #[derive(MallocSizeOf)]
-pub enum StackingContextFragments {
+pub(crate) enum StackingContextFragments {
     Root,
     Fragment(#[conditional_malloc_size_of] Arc<BoxFragment>),
+}
+
+#[derive(MallocSizeOf)]
+pub(crate) struct StackingContextReferenceFrameInfo {
+    pub(crate) parent_spatial_node_id: ScrollTreeNodeId,
+    pub(crate) captured_clip_id: ClipId,
 }
 
 /// Either a stacking context or a stacking container, per the definitions in
@@ -366,6 +372,10 @@ pub struct StackingContext {
     /// The text decorations that apply to this [`StackingContext`] propagated via the box tree.
     #[conditional_malloc_size_of]
     pub(crate) text_decorations: Rc<Vec<FragmentTextDecoration>>,
+
+    /// If this [`StackingContext`] also created a WebRender reference frame, this field
+    /// holds information about that reference frame.
+    pub(crate) reference_frame_info: Option<StackingContextReferenceFrameInfo>,
 }
 
 impl StackingContext {
@@ -379,9 +389,11 @@ impl StackingContext {
             clip_id: ClipId::INVALID,
             z_index: 0,
             text_decorations: Default::default(),
+            reference_frame_info: None,
         }
     }
 
+    #[expect(clippy::too_many_arguments)]
     fn create_descendant(
         &self,
         context_type: StackingContextType,
@@ -390,6 +402,7 @@ impl StackingContext {
         clip_id: ClipId,
         initializing_fragment: Arc<BoxFragment>,
         text_decorations: Rc<Vec<FragmentTextDecoration>>,
+        reference_frame_info: Option<StackingContextReferenceFrameInfo>,
     ) -> Self {
         let z_index = initializing_fragment
             .style()
@@ -403,6 +416,7 @@ impl StackingContext {
             clip_id,
             z_index,
             text_decorations,
+            reference_frame_info,
         }
     }
 
@@ -594,6 +608,7 @@ impl BoxFragment {
                         containing_block_info,
                         parent_stacking_context,
                         text_decorations,
+                        None, /* reference_frame_info */
                     );
                 },
             };
@@ -637,11 +652,16 @@ impl BoxFragment {
             containing_block.rect.translate(-reference_frame_offset),
             new_spatial_id,
             None,
-            containing_block.clip_id,
+            ClipId::INVALID,
             containing_block.accumulated_reference_frame_offset + reference_frame_offset,
         );
         let new_containing_block_info =
             containing_block_info.new_for_non_absolute_descendants(&adjusted_containing_block);
+
+        let reference_frame_info = StackingContextReferenceFrameInfo {
+            parent_spatial_node_id: containing_block.scroll_node_id,
+            captured_clip_id: containing_block.clip_id,
+        };
 
         self.build_stacking_context_tree_maybe_creating_stacking_context(
             fragment,
@@ -650,9 +670,11 @@ impl BoxFragment {
             &new_containing_block_info,
             parent_stacking_context,
             text_decorations,
+            Some(reference_frame_info),
         );
     }
 
+    #[expect(clippy::too_many_arguments)]
     fn build_stacking_context_tree_maybe_creating_stacking_context(
         self: &Arc<Self>,
         fragment: Fragment,
@@ -661,6 +683,7 @@ impl BoxFragment {
         containing_block_info: &ContainingBlockInfo,
         parent_stacking_context: &mut StackingContext,
         text_decorations: &Rc<Vec<FragmentTextDecoration>>,
+        reference_frame_info: Option<StackingContextReferenceFrameInfo>,
     ) {
         let with_style = &self.with_style();
         let style = with_style.style();
@@ -730,6 +753,7 @@ impl BoxFragment {
             containing_block.clip_id,
             box_fragment,
             text_decorations.clone(),
+            reference_frame_info,
         );
         with_style.build_stacking_context_tree_for_children(
             stacking_context_tree,

--- a/tests/wpt/meta/css/filter-effects/drop-shadow-with-3d-transform.html.ini
+++ b/tests/wpt/meta/css/filter-effects/drop-shadow-with-3d-transform.html.ini
@@ -1,2 +1,0 @@
-[drop-shadow-with-3d-transform.html]
-  expected: FAIL

--- a/tests/wpt/tests/css/css-transforms/transform-2d-clip-and-filter-crash.html
+++ b/tests/wpt/tests/css/css-transforms/transform-2d-clip-and-filter-crash.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html class="test-wait">
+<link rel="help" href="https://github.com/servo/servo/issues/45732">
+<script src="/common/rendering-utils.js"></script>
+<style>
+  html, body { overflow-x: clip; }
+  meter {
+      transform: rotate(-45deg);
+      filter: grayscale(1);
+      padding-top: 100vh;
+  }
+</style>
+<meter></meter>
+<script>
+  waitForAtLeastOneFrame().then(() => {
+    document.documentElement.classList.remove("test-wait");
+  });
+</script>
+</html>


### PR DESCRIPTION
Although the WebRender display list API allows assigning a clip from
outside a reference frame to display list items inside that reference
frame, the current version of WebRender we have panics when this
happens. The alternative is to surround all the display list items
inside the reference frame with a stacking context that has the clip
assigned. This is the approach that Gecko takes and it fixes a panic we
see frequently when fuzzing.

Testing: This change adds a new WPT crash test and causes one WPT test to start passing.
Fixes: #45732.
