### PR TITLE
webgl: Ensure that surfman `Device`s are dropped in the main thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7808,6 +7808,7 @@ dependencies = [
  "euclid",
  "glow",
  "kurbo",
+ "log",
  "malloc_size_of_derive",
  "serde",
  "servo-base",

--- a/components/paint/paint.rs
+++ b/components/paint/paint.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 use std::env;
 use std::fs::create_dir_all;
 use std::rc::Rc;
+use std::thread::JoinHandle;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use bitflags::bitflags;
@@ -30,7 +31,7 @@ use profile_traits::mem::{
 };
 use profile_traits::path;
 use profile_traits::time::{self as profile_time};
-use servo_base::generic_channel::{self, GenericSender, RoutedReceiver};
+use servo_base::generic_channel::{GenericSender, RoutedReceiver};
 use servo_base::id::{PainterId, PipelineId, WebViewId};
 use servo_canvas_traits::webgl::{WebGLContextId, WebGLThreads};
 use servo_config::pref;
@@ -118,6 +119,9 @@ pub struct Paint {
     /// The [`WebGLThreads`] for this renderer.
     webgl_threads: WebGLThreads,
 
+    /// A [`JoinHandle`] for joining the WebGL thread once the exit message is sent.
+    webgl_join_handle: Cell<Option<JoinHandle<()>>>,
+
     /// The shared [`SwapChains`] used by [`WebGLThreads`] for this renderer.
     pub(crate) swap_chains: SwapChains<WebGLContextId, Device>,
 
@@ -174,6 +178,7 @@ impl Paint {
             busy_webgl_context_map,
             #[cfg(feature = "webxr")]
             webxr_layer_grand_manager,
+            join_handle: webgl_join_handle,
         } = WebGLComm::new(
             state.paint_proxy.cross_process_paint_api.clone(),
             webrender_external_image_id_manager.clone(),
@@ -205,6 +210,7 @@ impl Paint {
             embedder_to_constellation_sender: state.embedder_to_constellation_sender.clone(),
             webrender_external_image_id_manager,
             webgl_threads,
+            webgl_join_handle: Cell::new(Some(webgl_join_handle)),
             swap_chains,
             time_profiler_chan: state.time_profiler_chan,
             _mem_profiler_registration: registration,
@@ -253,9 +259,17 @@ impl Paint {
     }
 
     fn remove_painter(&mut self, painter_id: PainterId) {
+        // The shared details map must be removed first in order to avoid the creation of new
+        // devices after `clear_painter_resources` is called.
+        self.painter_surfman_details_map.remove(painter_id);
+
+        if !self.webgl_threads.clear_painter_resources(painter_id) {
+            warn!("Could not clear {painter_id:?} resources in WebGLThread");
+        }
+
+        // This is called last so that the surfman `Device` is dropped on this thread.
         self.painters
             .retain(|painter| painter.borrow().painter_id != painter_id);
-        self.painter_surfman_details_map.remove(painter_id);
     }
 
     pub(crate) fn maybe_painter<'a>(&'a self, painter_id: PainterId) -> Option<Ref<'a, Painter>> {
@@ -334,14 +348,11 @@ impl Paint {
         // another thread from finishing (i.e. SetFrameTree).
         while self.paint_receiver.try_recv().is_ok() {}
 
-        let (webgl_exit_sender, webgl_exit_receiver) =
-            generic_channel::channel().expect("Failed to create IPC channel!");
-        if !self
-            .webgl_threads
-            .exit(webgl_exit_sender)
-            .is_ok_and(|_| webgl_exit_receiver.recv().is_ok())
+        self.webgl_threads.exit();
+        if let Some(webgl_join_handle) = self.webgl_join_handle.take() &&
+            webgl_join_handle.join().is_err()
         {
-            warn!("Could not exit WebGLThread.");
+            warn!("Could not join WebGLThread.");
         }
 
         // Tell the profiler, memory profiler, and scrolling timer to shut down.

--- a/components/shared/canvas/Cargo.toml
+++ b/components/shared/canvas/Cargo.toml
@@ -22,6 +22,7 @@ euclid = { workspace = true }
 fonts_traits = { workspace = true }
 glow = { workspace = true }
 kurbo = { workspace = true, features = ["serde"] }
+log = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 pixels = { workspace = true }

--- a/components/shared/canvas/webgl.rs
+++ b/components/shared/canvas/webgl.rs
@@ -12,10 +12,10 @@ use glow::{
     self as gl, NativeBuffer, NativeFence, NativeFramebuffer, NativeProgram, NativeQuery,
     NativeRenderbuffer, NativeSampler, NativeShader, NativeTexture, NativeVertexArray,
 };
+use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
 use pixels::{PixelFormat, SnapshotAlphaMode};
 use serde::{Deserialize, Serialize};
-use servo_base::Epoch;
 /// Receiver type used in WebGLCommands.
 pub use servo_base::generic_channel::GenericReceiver;
 /// Sender type used in WebGLCommands.
@@ -24,6 +24,7 @@ use servo_base::generic_channel::GenericSharedMemory;
 /// Result type for send()/recv() calls in in WebGLCommands.
 pub use servo_base::generic_channel::SendResult as WebGLSendResult;
 use servo_base::id::PainterId;
+use servo_base::{Epoch, generic_channel};
 use webrender_api::ImageKey;
 use webxr_api::{
     ContextId as WebXRContextId, Error as WebXRError, LayerId as WebXRLayerId,
@@ -78,9 +79,24 @@ impl WebGLThreads {
         WebGLPipeline(WebGLChan(self.0.clone()))
     }
 
-    /// Sends a exit message to close the WebGLThreads and release all WebGLContexts.
-    pub fn exit(&self, sender: GenericSender<()>) -> WebGLSendResult {
-        self.0.send(WebGLMsg::Exit(sender))
+    /// Sends an exit message to close the WebGLThreads and release all WebGLContexts.
+    pub fn exit(&self) {
+        if self.0.send(WebGLMsg::Exit).is_err() {
+            warn!("Could not exit WebGLThread.");
+        }
+    }
+
+    /// Sends a message to remove the resources for a `Painter` with the given [`PainterId`].
+    /// Returns `true` if clearing resources was successful and `false` otherwise.
+    pub fn clear_painter_resources(&self, painter_id: PainterId) -> bool {
+        let (webgl_exit_sender, webgl_exit_receiver) =
+            generic_channel::channel().expect("Failed to create IPC channel!");
+        self.0
+            .send(WebGLMsg::ClearPainterResources(
+                painter_id,
+                webgl_exit_sender,
+            ))
+            .is_ok_and(|_| webgl_exit_receiver.recv().is_ok())
     }
 
     /// Inform the WebGLThreads that WebRender has finished rendering a particular WebGL context,
@@ -127,8 +143,10 @@ pub enum WebGLMsg {
     /// readily releaseable via the `SwapChain`. This can happen when the context is
     /// released in the WebGLThread while the contents are being rendered by WebRender.
     FinishedRenderingToContext(WebGLContextId),
+    /// Frees all resources associated with a particular `Painter`.
+    ClearPainterResources(PainterId, GenericSender<()>),
     /// Frees all resources and closes the thread.
-    Exit(GenericSender<()>),
+    Exit,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]

--- a/components/webgl/webgl_mode/inprocess.rs
+++ b/components/webgl/webgl_mode/inprocess.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::thread::JoinHandle;
+
 use log::debug;
 use paint_api::{CrossProcessPaintApi, PainterSurfmanDetailsMap, WebRenderExternalImageIdManager};
 use servo_canvas_traits::webgl::{WebGLContextId, WebGLMsg, WebGLThreads, webgl_channel};
@@ -20,6 +22,9 @@ pub struct WebGLComm {
     pub busy_webgl_context_map: WebGLContextBusyMap,
     #[cfg(feature = "webxr")]
     pub webxr_layer_grand_manager: WebXRLayerGrandManager<WebXRSurfman>,
+    /// A `JoinHandle` which can be joined after sending the `WebGLMsg::Exit`
+    /// message to the `WebGLThread`.
+    pub join_handle: JoinHandle<()>,
 }
 
 impl WebGLComm {
@@ -52,7 +57,7 @@ impl WebGLComm {
             webxr_init,
         };
 
-        WebGLThread::run_on_own_thread(init);
+        let join_handle = WebGLThread::run_on_own_thread(init);
 
         WebGLComm {
             webgl_threads: WebGLThreads(sender),
@@ -60,6 +65,7 @@ impl WebGLComm {
             busy_webgl_context_map,
             #[cfg(feature = "webxr")]
             webxr_layer_grand_manager,
+            join_handle,
         }
     }
 }

--- a/components/webgl/webgl_thread.rs
+++ b/components/webgl/webgl_thread.rs
@@ -8,6 +8,7 @@ use std::collections::hash_map::Entry;
 use std::num::NonZeroU32;
 use std::rc::Rc;
 use std::sync::Arc;
+use std::thread::JoinHandle;
 use std::{slice, thread};
 
 use bitflags::bitflags;
@@ -298,14 +299,14 @@ impl WebGLThread {
 
     /// Perform all initialization required to run an instance of WebGLThread
     /// in parallel on its own dedicated thread.
-    pub(crate) fn run_on_own_thread(init: WebGLThreadInit) {
+    pub(crate) fn run_on_own_thread(init: WebGLThreadInit) -> JoinHandle<()> {
         thread::Builder::new()
             .name("WebGL".to_owned())
             .spawn(move || {
                 let mut data = WebGLThread::new(init);
                 data.process();
             })
-            .expect("Thread spawning failed");
+            .expect("Thread spawning failed")
     }
 
     fn process(&mut self) {
@@ -391,15 +392,17 @@ impl WebGLThread {
             WebGLMsg::FinishedRenderingToContext(context_id) => {
                 self.handle_finished_rendering_to_context(context_id);
             },
-            WebGLMsg::Exit(sender) => {
+            WebGLMsg::ClearPainterResources(painter_id, sender) => {
+                self.device_map.remove(&painter_id);
+                if let Err(error) = sender.send(()) {
+                    warn!("Failed to send response to WebGLMsg::ClearPainterResources ({error})");
+                }
+            },
+            WebGLMsg::Exit => {
                 // Call remove_context functions in order to correctly delete WebRender image keys.
                 let context_ids: Vec<WebGLContextId> = self.contexts.keys().copied().collect();
                 for id in context_ids {
                     self.remove_webgl_context(id);
-                }
-
-                if let Err(e) = sender.send(()) {
-                    warn!("Failed to send response to WebGLMsg::Exit ({e})");
                 }
                 return true;
             },


### PR DESCRIPTION
This is a speculative fix for #45670. It's possible that llvmpipe is
sensitive to the EGL display being destroyed on a different thread from
the one that it is created on. This change ensures that this doesn't
happen in two ways:

1. When exiting the WebGL thread, ensure that all `Device`s are released
   before returning control back to the main thread. Then ensure the main
   thread drops its handle to all `Device`s after control is returned
   from the exiting WebGL thread.
2. Clean up `Device` resources when dropping a `Painter` in a similar
   fashion, after the last `WebView` using that `RenderingContext` is
   dropped.

Testing: This is a speculative fix for an issue that is very difficult to
reproduce and only occurs in X11 headless mode. I have not personally been
able to reproduce the issue.
Fixes: #45670.
