### PR TITLE
script: Fix `new Response()` construction

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -21,7 +21,6 @@ use mime::{self, Mime};
 use net_traits::request::{
     BodyChunkRequest, BodyChunkResponse, BodySource as NetBodySource, RequestBody,
 };
-use script_bindings::codegen::GenericBindings::TextDecoderStreamBinding::TextDecoderStreamMethods;
 use script_bindings::reflector::DomObject;
 use servo_base::generic_channel::GenericSharedMemory;
 use servo_constellation_traits::BlobImpl;
@@ -1190,11 +1189,5 @@ pub(crate) fn body_text_stream<T: BodyMixin + DomObject>(
         TextDecoderStream::new_with_proto(cx, &object.global(), None, UTF_8, false, false)?;
 
     // Step 6. Return the result of stream, piped through decoder.
-    Ok(pipe_through(
-        &stream,
-        cx,
-        &object.global(),
-        &decoder.Writable(),
-        decoder.Readable(),
-    ))
+    Ok(pipe_through(&stream, cx, &object.global(), &decoder))
 }

--- a/components/script/dom/fetch/response.rs
+++ b/components/script/dom/fetch/response.rs
@@ -196,7 +196,7 @@ impl ResponseMethods<crate::DomTypeHolder> for Response {
         };
 
         // 5. Perform *initialize a response* given this, init, and bodyWithType.
-        initialize_response(cx, global, body_with_type, init, response)
+        initialize_response(cx, body_with_type, init, response)
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-response-error>
@@ -275,7 +275,7 @@ impl ResponseMethods<crate::DomTypeHolder> for Response {
 
         // 4. Perform initialize a response given responseObject, init, and (body, "application/json").
         body.content_type = Some("application/json".into());
-        initialize_response(cx, global, Some(body), init, response)
+        initialize_response(cx, Some(body), init, response)
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-response-type>
@@ -410,7 +410,6 @@ impl ResponseMethods<crate::DomTypeHolder> for Response {
 /// <https://fetch.spec.whatwg.org/#initialize-a-response>
 fn initialize_response(
     cx: &mut js::context::JSContext,
-    global: &GlobalScope,
     body: Option<ExtractedBody>,
     init: &ResponseBinding::ResponseInit,
     response: DomRoot<Response>,
@@ -470,12 +469,8 @@ fn initialize_response(
             )?;
         };
     } else {
-        // Reset FetchResponse to an in-memory stream with empty byte sequence here for
-        // no-init-body case. This is because the Response/Body types here do not hold onto a
-        // fetch Response object.
-        let stream = ReadableStream::new_from_bytes(cx, global, Vec::with_capacity(0))?;
-        response.body_stream.set(Some(&*stream));
-        response.fetch_body_stream.set(Some(&*stream));
+        response.body_stream.set(None);
+        response.fetch_body_stream.set(None);
     }
 
     Ok(response)

--- a/components/script/dom/file/blob.rs
+++ b/components/script/dom/file/blob.rs
@@ -14,7 +14,6 @@ use js::rust::HandleObject;
 use js::typedarray::{ArrayBufferU8, Uint8};
 use net_traits::filemanager_thread::RelativePos;
 use rustc_hash::FxHashMap;
-use script_bindings::codegen::GenericBindings::TextDecoderStreamBinding::TextDecoderStreamMethods;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
 use servo_base::id::{BlobId, BlobIndex};
 use servo_constellation_traits::{BlobData, BlobImpl};
@@ -301,13 +300,7 @@ impl BlobMethods<crate::DomTypeHolder> for Blob {
             false, // ignoreBOM
         )?;
         // Step 4: Return the result of calling stream, piped through decoder.
-        Ok(pipe_through(
-            &stream,
-            cx,
-            &self.global(),
-            &decoder.Writable(),
-            decoder.Readable(),
-        ))
+        Ok(pipe_through(&stream, cx, &self.global(), &decoder))
     }
 
     /// <https://w3c.github.io/FileAPI/#slice-method-algo>

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -32,6 +32,8 @@ use crate::dom::bindings::codegen::Bindings::ReadableStreamBinding::{
 use script_bindings::str::DOMString;
 
 use crate::dom::domexception::{DOMErrorName, DOMException};
+use crate::dom::encoding::textdecoderstream::TextDecoderStream;
+use script_bindings::codegen::GenericBindings::TextDecoderStreamBinding::TextDecoderStreamMethods;
 use script_bindings::conversions::{is_array_like, StringificationBehavior};
 use crate::dom::bindings::codegen::Bindings::QueuingStrategyBinding::QueuingStrategySize;
 use crate::dom::abortsignal::{AbortAlgorithm, AbortSignal};
@@ -2559,8 +2561,7 @@ pub(crate) fn pipe_through(
     source: &ReadableStream,
     cx: &mut JSContext,
     global: &GlobalScope,
-    dest: &WritableStream,
-    readable: DomRoot<ReadableStream>,
+    transform: &TextDecoderStream,
 ) -> DomRoot<ReadableStream> {
     // Step 1. Assert: `! IsReadableStreamLocked(readable)` is false.
 
@@ -2571,7 +2572,10 @@ pub(crate) fn pipe_through(
     // Step 4. Let promise be ! ReadableStreamPipeTo(readable,
     // transform.[[writable]], preventClose, preventAbort, preventCancel, signalArg).
     let promise = source.pipe_to(
-        &mut realm, global, dest, false, // preventClose
+        &mut realm,
+        global,
+        &transform.Writable(),
+        false, // preventClose
         false, // preventAbort
         false, // preventCancel
         None,  // signal
@@ -2580,5 +2584,5 @@ pub(crate) fn pipe_through(
     // Step 5. Set promise.[[PromiseIsHandled]] to true.
     promise.set_promise_is_handled(cx);
     // Step 6. Return transform.[[readable]].
-    readable
+    transform.Readable()
 }

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -217,7 +217,7 @@ pub(crate) fn Fetch(
     let promise = Promise::new_in_realm(cx);
 
     // Step 7. Let responseObject be null.
-    // NOTE: We do initialize the object earlier earlier so we can use it to track errors
+    // NOTE: We do initialize the object earlier so we can use it to track errors.
     let response = Response::new(cx, global);
     response.Headers(cx).set_guard(Guard::Immutable);
 

--- a/components/script_bindings/webidls/Response.webidl
+++ b/components/script_bindings/webidls/Response.webidl
@@ -19,8 +19,6 @@ interface Response {
   readonly attribute boolean ok;
   readonly attribute ByteString statusText;
   [SameObject] readonly attribute Headers headers;
-  // readonly attribute ReadableStream? body;
-  // [SameObject] readonly attribute Promise<Headers> trailer;
 
   [NewObject, Throws] Response clone();
 };

--- a/tests/wpt/meta/fetch/api/body/textstream.any.js.ini
+++ b/tests/wpt/meta/fetch/api/body/textstream.any.js.ini
@@ -1,16 +1,2 @@
 [textstream.any.serviceworker.html]
   expected: ERROR
-
-[textstream.any.worker.html]
-  [Response.textStream() with null body]
-    expected: FAIL
-
-
-[textstream.any.sharedworker.html]
-  [Response.textStream() with null body]
-    expected: FAIL
-
-
-[textstream.any.html]
-  [Response.textStream() with null body]
-    expected: FAIL

--- a/tests/wpt/meta/fetch/api/response/response-init-001.any.js.ini
+++ b/tests/wpt/meta/fetch/api/response/response-init-001.any.js.ini
@@ -1,16 +1,2 @@
 [response-init-001.any.serviceworker.html]
   expected: ERROR
-
-[response-init-001.any.sharedworker.html]
-  [Check default value for body attribute]
-    expected: FAIL
-
-
-[response-init-001.any.html]
-  [Check default value for body attribute]
-    expected: FAIL
-
-
-[response-init-001.any.worker.html]
-  [Check default value for body attribute]
-    expected: FAIL

--- a/tests/wpt/meta/fetch/api/response/response-init-002.any.js.ini
+++ b/tests/wpt/meta/fetch/api/response/response-init-002.any.js.ini
@@ -1,16 +1,2 @@
 [response-init-002.any.serviceworker.html]
   expected: ERROR
-
-[response-init-002.any.sharedworker.html]
-  [Testing null Response body]
-    expected: FAIL
-
-
-[response-init-002.any.worker.html]
-  [Testing null Response body]
-    expected: FAIL
-
-
-[response-init-002.any.html]
-  [Testing null Response body]
-    expected: FAIL


### PR DESCRIPTION
`new Response().body` should be `null`. We achieve this by fixing `fn initialize_response`.
This is safe for fetch, as `fn initialize_response` is only reachable by `Constructor` and `CreateFromJson`.

Also refactor `fn pipe_through` to be closer to spec to fix my own mistake earlier.

Testing: New passing in `fetch/api/body/` and `/fetch/api/response/`.
Fixes: #45860