### PR TITLE
wpt: Add missing message type to autoplay permission query.

### DIFF
--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/autoplay-allowed-by-permissions-policy.https.sub.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/autoplay-allowed-by-permissions-policy.https.sub.html.ini
@@ -2,9 +2,3 @@
   expected: TIMEOUT
   [Permissions-Policy header: autoplay * allows the top-level document.]
     expected: TIMEOUT
-
-  [Permissions-Policy header: autoplay * allows same-origin iframes.]
-    expected: TIMEOUT
-
-  [Permissions-Policy header: autoplay * allows cross-origin iframes.]
-    expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/autoplay-default-permissions-policy.https.sub.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/autoplay-default-permissions-policy.https.sub.html.ini
@@ -7,4 +7,4 @@
     expected: TIMEOUT
 
   [Default "autoplay" feature policy ["self"\] disallows cross-origin iframes.]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/autoplay-disabled-by-permissions-policy.https.sub.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/autoplay-disabled-by-permissions-policy.https.sub.html.ini
@@ -1,10 +1,6 @@
 [autoplay-disabled-by-permissions-policy.https.sub.html]
-  expected: TIMEOUT
-  [Permissions-Policy header: autoplay "none" has no effect on the top level document.]
-    expected: TIMEOUT
-
   [Permissions-Policy header: autoplay "none" disallows same-origin iframes.]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Permissions-Policy header: autoplay "none" disallows cross-origin iframes.]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/tests/permissions-policy/resources/permissions-policy-autoplay.html
+++ b/tests/wpt/tests/permissions-policy/resources/permissions-policy-autoplay.html
@@ -5,7 +5,7 @@
 
 window.addEventListener('load', () => {
   isAutoplayAllowed().then((result) => {
-    window.parent.postMessage({ enabled: result }, '*');
+    window.parent.postMessage({ enabled: result, type: 'availability-result' }, '*');
   });
 }, { once: true });
 </script>


### PR DESCRIPTION
The missing field is present in every other similar permissions check file in https://github.com/servo/servo/tree/main/tests/wpt/tests/permissions-policy/resources . The tests are all timing out consistently in every browser as a result: https://wpt.fyi/results/html/semantics/embedded-content/media-elements?label=master&label=experimental&aligned

Testing: Several media subtests stop timing out.