### PR TITLE
script: Replace usages of `enter_realm` with `enter_auto_realm`

### DIFF
--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -47,7 +47,7 @@ use crate::dom::element::Element;
 use crate::dom::iterators::ShadowIncluding;
 use crate::dom::node::{Node, NodeTraits};
 use crate::dom::types::{CSSGroupingRule, CSSLayerBlockRule, EventTarget, HTMLElement};
-use crate::realms::enter_realm;
+use crate::realms::enter_auto_realm;
 
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 #[derive(JSTraceable)]
@@ -467,7 +467,8 @@ pub(crate) fn handle_get_selectors(
         let node = state.find_node_by_unique_id(pipeline, node_id)?;
         let elem = node.downcast::<Element>()?;
         let document = documents.find_document(pipeline)?;
-        let _realm = enter_realm(document.window());
+        let mut realm = enter_auto_realm(cx, document.window());
+        let cx = &mut realm.current_realm();
         let owner = node.stylesheet_list_owner();
 
         let mut decl_map = HashMap::new();
@@ -516,7 +517,8 @@ pub(crate) fn handle_get_stylesheet_style(
     let msg = (|| {
         let node = state.find_node_by_unique_id(pipeline, node_id)?;
         let document = documents.find_document(pipeline)?;
-        let _realm = enter_realm(document.window());
+        let mut realm = enter_auto_realm(cx, document.window());
+        let cx = &mut realm.current_realm();
         let owner = node.stylesheet_list_owner();
 
         let stylesheet = owner.stylesheet_at(matched_rule.stylesheet_index)?;
@@ -691,7 +693,8 @@ pub(crate) fn handle_modify_attribute(
     let Some(document) = documents.find_document(pipeline) else {
         return warn!("document for pipeline id {} is not found", &pipeline);
     };
-    let _realm = enter_realm(document.window());
+    let mut realm = enter_auto_realm(cx, document.window());
+    let cx = &mut realm.current_realm();
 
     let node = match state.find_node_by_unique_id(pipeline, node_id) {
         None => {
@@ -732,7 +735,8 @@ pub(crate) fn handle_modify_rule(
     let Some(document) = documents.find_document(pipeline) else {
         return warn!("Document for pipeline id {} is not found", &pipeline);
     };
-    let _realm = enter_realm(document.window());
+    let mut realm = enter_auto_realm(cx, document.window());
+    let cx = &mut realm.current_realm();
 
     let Some(node) = state.find_node_by_unique_id(pipeline, node_id) else {
         return warn!(

--- a/components/script/dom/audio/audiobuffer.rs
+++ b/components/script/dom/audio/audiobuffer.rs
@@ -23,7 +23,7 @@ use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
-use crate::realms::enter_realm;
+use crate::realms::enter_auto_realm;
 
 // Spec mandates at least [8000, 96000], we use [8000, 192000] to match Firefox
 // https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createbuffer
@@ -133,7 +133,8 @@ impl AudioBuffer {
     }
 
     fn restore_js_channel_data(&self, cx: &mut JSContext) -> bool {
-        let _ac = enter_realm(self);
+        let mut realm = enter_auto_realm(cx, self);
+        let cx = &mut realm.current_realm();
         for (i, channel) in self.js_channels.borrow().iter().enumerate() {
             if channel.is_initialized() {
                 // Already have data in JS array.

--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -50,7 +50,7 @@ use crate::dom::types::{
 };
 #[cfg(feature = "webgpu")]
 use crate::dom::webgpu::identityhub::IdentityHub;
-use crate::realms::{enter_auto_realm, enter_realm};
+use crate::realms::enter_auto_realm;
 use crate::script_runtime::{CanGc, IntroductionType};
 use crate::script_thread::with_script_thread;
 
@@ -226,7 +226,8 @@ impl DebuggerGlobalScope {
                 .replace(Some(result_sender))
                 .is_none()
         );
-        let _realm = enter_realm(self);
+        let mut realm = enter_auto_realm(cx, self);
+        let cx = &mut realm.current_realm();
         let event = DomRoot::upcast::<Event>(DebuggerGetPossibleBreakpointsEvent::new(
             self.upcast(),
             spidermonkey_id,
@@ -282,7 +283,8 @@ impl DebuggerGlobalScope {
                 .replace(Some(result_sender))
                 .is_none()
         );
-        let _realm = enter_realm(self);
+        let mut realm = enter_auto_realm(cx, self);
+        let cx = &mut realm.current_realm();
         let pipeline_id =
             crate::dom::pipelineid::PipelineId::new(self.upcast(), pipeline_id, CanGc::from_cx(cx));
         let event = DomRoot::upcast::<Event>(DebuggerFrameEvent::new(
@@ -309,7 +311,8 @@ impl DebuggerGlobalScope {
                 .replace(Some(result_sender))
                 .is_none()
         );
-        let _realm = enter_realm(self);
+        let mut realm = enter_auto_realm(cx, self);
+        let cx = &mut realm.current_realm();
         let event = DomRoot::upcast::<Event>(DebuggerGetEnvironmentEvent::new(
             self.upcast(),
             frame_actor_id.into(),

--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -75,7 +75,7 @@ use crate::dom::types::{
     WheelEvent, Window,
 };
 use crate::drag_data_store::{DragDataStore, Kind, Mode};
-use crate::realms::{enter_auto_realm, enter_realm};
+use crate::realms::enter_auto_realm;
 
 /// A data structure used for tracking the current click count. This can be
 /// reset to 0 if a mouse button event happens at a sufficient distance or time
@@ -308,7 +308,8 @@ impl DocumentEventHandler {
             !self.pending_input_events.borrow().is_empty(),
             "handle_pending_input_events called with no events"
         );
-        let _realm = enter_realm(&*self.window);
+        let mut realm = enter_auto_realm(cx, &*self.window);
+        let cx = &mut realm.current_realm();
 
         // Reset the mouse and wheel event indices.
         *self.mouse_move_event_index.borrow_mut() = None;

--- a/components/script/dom/document/focus.rs
+++ b/components/script/dom/document/focus.rs
@@ -27,7 +27,7 @@ use crate::dom::types::{
     Element, EventTarget, FocusEvent, HTMLElement, HTMLIFrameElement, KeyboardEvent, Window,
 };
 use crate::dom::{Document, Event, EventBubbles, EventCancelable, Node, NodeTraits};
-use crate::realms::enter_realm;
+use crate::realms::enter_auto_realm;
 
 /// The kind of focusable area a [`FocusableArea`] is. A [`FocusableArea`] may be click focusable,
 /// sequentially focusable, or both.
@@ -747,7 +747,8 @@ impl DocumentFocusHandler {
         browsing_context_id: Option<BrowsingContextId>,
         direction: SequentialFocusDirection,
     ) {
-        let _realm = enter_realm(&*self.window);
+        let mut realm = enter_auto_realm(cx, &*self.window);
+        let cx = &mut realm.current_realm();
         let starting_point = browsing_context_id.and_then(|browsing_context_id| {
             self.window
                 .Document()

--- a/components/script/dom/event/eventtarget.rs
+++ b/components/script/dom/event/eventtarget.rs
@@ -72,7 +72,7 @@ use crate::dom::node::{Node, NodeTraits};
 use crate::dom::shadowroot::ShadowRoot;
 use crate::dom::window::Window;
 use crate::dom::workerglobalscope::WorkerGlobalScope;
-use crate::realms::{enter_auto_realm, enter_realm};
+use crate::realms::enter_auto_realm;
 use crate::script_runtime::IntroductionType;
 
 /// <https://html.spec.whatwg.org/multipage/#event-handler-content-attributes>
@@ -670,7 +670,8 @@ impl EventTarget {
 
         // Step 3.8 TODO: settings objects not implemented
         let window = document.window();
-        let _ac = enter_realm(window);
+        let mut realm = enter_auto_realm(cx, window);
+        let cx = &mut realm.current_realm();
 
         // Step 3.9
 

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -40,7 +40,7 @@ use crate::dom::messageevent::MessageEvent;
 use crate::dom::performance::performanceresourcetiming::InitiatorType;
 use crate::fetch::{FetchCanceller, RequestWithGlobalScope, create_a_potential_cors_request};
 use crate::network_listener::{self, FetchResponseListener, ResourceTimingListener};
-use crate::realms::enter_realm;
+use crate::realms::enter_auto_realm;
 use crate::script_runtime::CanGc;
 use crate::timers::OneshotTimerCallback;
 
@@ -275,7 +275,8 @@ impl EventSourceContext {
         };
         // Steps 4-5
         let event = {
-            let _ac = enter_realm(&*event_source);
+            let mut realm = enter_auto_realm(cx, &*event_source);
+            let cx = &mut realm.current_realm();
             rooted!(&in(cx) let mut data = UndefinedValue());
             self.data.safe_to_jsval(cx, data.handle_mut());
             MessageEvent::new(

--- a/components/script/dom/file/filereader.rs
+++ b/components/script/dom/file/filereader.rs
@@ -37,7 +37,7 @@ use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::progressevent::ProgressEvent;
-use crate::realms::enter_realm;
+use crate::realms::enter_auto_realm;
 use crate::script_runtime::{CanGc, JSContext};
 use crate::task::TaskOnce;
 
@@ -320,12 +320,9 @@ impl FileReader {
                 FileReader::perform_readastext(&fr.result, data, &blob_contents)
             },
             FileReaderFunction::ArrayBuffer => {
-                let _ac = enter_realm(&*fr);
-                FileReader::perform_readasarraybuffer(
-                    &fr.result,
-                    GlobalScope::get_cx(),
-                    &blob_contents,
-                )
+                let mut realm = enter_auto_realm(cx, &*fr);
+                let cx = &mut realm.current_realm();
+                FileReader::perform_readasarraybuffer(cx, &fr.result, &blob_contents)
             },
             FileReaderFunction::BinaryString => {
                 FileReader::perform_readasbinarystring(&fr.result, &blob_contents)
@@ -381,15 +378,19 @@ impl FileReader {
     /// > Return a new ArrayBuffer whose contents are bytes.
     #[expect(unsafe_code)]
     fn perform_readasarraybuffer(
+        cx: &mut js::context::JSContext,
         result: &DomRefCell<Option<FileReaderResult>>,
-        cx: JSContext,
         bytes: &[u8],
     ) {
         unsafe {
-            rooted!(in(*cx) let mut array_buffer = ptr::null_mut::<JSObject>());
+            rooted!(&in(cx) let mut array_buffer = ptr::null_mut::<JSObject>());
             assert!(
-                ArrayBuffer::create(*cx, CreateWith::Slice(bytes), array_buffer.handle_mut())
-                    .is_ok()
+                ArrayBuffer::create(
+                    cx.raw_cx(),
+                    CreateWith::Slice(bytes),
+                    array_buffer.handle_mut()
+                )
+                .is_ok()
             );
 
             *result.borrow_mut() =

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -92,7 +92,7 @@ use crate::dom::text::Text;
 use crate::dom::types::{HTMLElement, HTMLMediaElement, HTMLOptionElement};
 use crate::navigation::determine_the_origin;
 use crate::network_listener::FetchResponseListener;
-use crate::realms::{enter_auto_realm, enter_realm};
+use crate::realms::enter_auto_realm;
 use crate::script_runtime::{CanGc, IntroductionType};
 use crate::script_thread::ScriptThread;
 
@@ -688,7 +688,8 @@ impl ServoParser {
     }
 
     fn parse_bytes_chunk(&self, cx: &mut JSContext, input: Vec<u8>) {
-        let _realm = enter_realm(&*self.document);
+        let mut realm = enter_auto_realm(cx, &*self.document);
+        let cx = &mut realm.current_realm();
         self.document.set_current_parser(Some(self));
         self.push_bytes_input_chunk(input);
         if !self.suspended.get() {

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -187,7 +187,7 @@ use crate::layout_image::fetch_image_for_layout;
 use crate::messaging::{MainThreadScriptMsg, ScriptEventLoopReceiver, ScriptEventLoopSender};
 use crate::microtask::{Microtask, UserMicrotask};
 use crate::network_listener::{ResourceTimingListener, submit_timing};
-use crate::realms::{enter_auto_realm, enter_realm};
+use crate::realms::enter_auto_realm;
 use crate::script_runtime::{CanGc, Runtime};
 use crate::script_thread::ScriptThread;
 use crate::script_window_proxies::ScriptWindowProxies;
@@ -3355,7 +3355,8 @@ impl Window {
             return false;
         }
 
-        let _realm = enter_realm(self);
+        let mut realm = enter_auto_realm(cx, self);
+        let cx = &mut realm.current_realm();
         debug!(
             "Resizing Window for pipeline {:?} from {:?} to {new_size:?}",
             self.pipeline_id(),

--- a/components/script/dom/workers/abstractworkerglobalscope.rs
+++ b/components/script/dom/workers/abstractworkerglobalscope.rs
@@ -12,7 +12,7 @@ use crate::dom::dedicatedworkerglobalscope::AutoWorkerReset;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::worker::TrustedWorkerAddress;
 use crate::dom::workerglobalscope::WorkerGlobalScope;
-use crate::realms::enter_realm;
+use crate::realms::enter_auto_realm;
 use crate::task_queue::{QueuedTaskConversion, TaskQueue};
 
 pub(crate) trait WorkerEventLoopMethods {
@@ -99,7 +99,8 @@ pub(crate) fn run_worker_event_loop<T, WorkerMsg, Event>(
 
     // Step 3
     for event in sequential {
-        let _realm = enter_realm(worker_scope);
+        let mut realm = enter_auto_realm(cx, worker_scope);
+        let cx = &mut realm.current_realm();
         if !worker_scope.handle_event(event, cx) {
             // Shutdown
             return;

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -58,7 +58,7 @@ use crate::dom::window::Window;
 use crate::network_listener::{
     self, FetchResponseListener, NetworkListener, ResourceTimingListener, submit_timing_data,
 };
-use crate::realms::{enter_auto_realm, enter_realm};
+use crate::realms::enter_auto_realm;
 use crate::script_runtime::CanGc;
 
 /// Fetch canceller object. By default initialized to having a
@@ -625,7 +625,8 @@ impl FetchResponseListener for FetchContext {
         timing: ResourceFetchTiming,
     ) {
         let response_object = self.response_object.root();
-        let _ac = enter_realm(&*response_object);
+        let mut realm = enter_auto_realm(cx, &*response_object);
+        let cx = &mut realm.current_realm();
         if let Err(ref error) = response &&
             *error == NetworkError::DecompressionError
         {


### PR DESCRIPTION
In all of these cases, we already have a `cx` in scope, thus we can use the safer variant.

Part of #40600

Testing: it compiles