### PR TITLE
script: Do not copy CharacterData to string

### DIFF
--- a/components/script/dom/characterdata/characterdata.rs
+++ b/components/script/dom/characterdata/characterdata.rs
@@ -39,7 +39,7 @@ impl CharacterData {
     pub(crate) fn new_inherited(data: DOMString, document: &Document) -> CharacterData {
         CharacterData {
             node: Node::new_inherited(document),
-            data: DomRefCell::new(String::from(data.str())),
+            data: DomRefCell::new(String::from(data)),
         }
     }
 


### PR DESCRIPTION
Let CharacterData use String::from directly from DOMString (instead of on str()). Removes an allocation if the DOMString was already instantiated.

Testing: This does not change functionality.
Fixes: Partially https://github.com/servo/servo/issues/44996 
