### PR TITLE
deps: Bump elliptic-curve to latest stable release 0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2178,9 +2178,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.20"
+version = "0.17.0-rc.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f7195c1205cec99025b3004e8034e1ddc12746333aa0a3945df7f9b80882ca2"
+checksum = "b7c72d1455753a703ad4b90ed2a759f2bc4562024a303176439cf6e593b5ade4"
 dependencies = [
  "der",
  "digest 0.11.3",
@@ -2305,9 +2305,9 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.35"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51c58d86e2f3cebbf2dfd94c4bf049585c7def71058ba506bfdafcb57652a34b"
+checksum = "3273f1195b6f6253ebda493d6742c8baa9b26a291674cd96d92a0f09e90e9b46"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -6129,9 +6129,9 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.14.0-rc.12"
+version = "0.14.0-rc.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7d8ed70255af8fecea30f284e523066cb19918cb2b4c17f41f78cda3291d64"
+checksum = "c855a8d2ffd346aa03122626f22e96e3aa75e3bfe64e6bf6cb82f71821ed6ae7"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -6142,9 +6142,9 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.14.0-rc.12"
+version = "0.14.0-rc.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "563b53b275b129c6f070e538bf0845f8e6abd0b5ffeb3f53f1d6ea5f8dbb3b2c"
+checksum = "62941b68907ddf996ac20f0debf700c236ccc3d874637731a93c631129ca042f"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -6156,9 +6156,9 @@ dependencies = [
 
 [[package]]
 name = "p521"
-version = "0.14.0-rc.12"
+version = "0.14.0-rc.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71bed4316a8e79ff1f728527a4334da0c57256ed7ca8b34c2297d9cc34e70511"
+checksum = "0dd6f2fe6e76c8d5e8828e92aafa463777d1e72e70b78acc724214757e92479a"
 dependencies = [
  "base16ct",
  "ecdsa",
@@ -6604,9 +6604,9 @@ dependencies = [
 
 [[package]]
 name = "primefield"
-version = "0.14.0-rc.12"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8675564771a62f69a0af716b03e89b917b963c7b173b5855575e84fd4f605ca0"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
 dependencies = [
  "crypto-bigint",
  "crypto-common 0.2.2",
@@ -6618,9 +6618,9 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-rc.12"
+version = "0.14.0-rc.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44545bd63647ac77eaed1589000a031632b0f7175e2c1cc48778787e9783baaf"
+checksum = "4e56e6d67fdf5744e9e245ae571450fe584b91f5af261d0e40163b618e53a1f6"
 dependencies = [
  "elliptic-curve",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,13 +75,13 @@ data-url = "0.3"
 dirs = "6.0"
 dpi = "0.1"
 dwrote = "0.11.5"
-ecdsa = "=0.17.0-rc.20"
+ecdsa = "=0.17.0-rc.22"
 ed25519-dalek = { version = "=3.0.0-rc.1", features = ["alloc", "pkcs8", "rand_core", "zeroize"] }
 egui = "0.34.3"
 egui-file-dialog = "0.13.0"
 egui-winit = { version = "0.34.3", default-features = false }
 egui_glow = "0.34.3"
-elliptic-curve = { version = "=0.14.0-rc.35", features = ["pkcs8"] }
+elliptic-curve = { version = "0.14", features = ["pkcs8"] }
 encoding_rs = { version = "0.8", features = ["serde"] }
 env_filter = "0.1.4"
 env_logger = "0.11"
@@ -182,9 +182,9 @@ ohos-window-manager-sys = "0.1"
 ohos-window-sys = "0.1.7"
 once_cell = "1.21.4"
 openxr = "0.21"
-p256 = { version = "=0.14.0-rc.12", features = ["ecdh"] }
-p384 = { version = "=0.14.0-rc.12", features = ["ecdh"] }
-p521 = { version = "=0.14.0-rc.12", features = ["ecdh"] }
+p256 = { version = "=0.14.0-rc.14", features = ["ecdh"] }
+p384 = { version = "=0.14.0-rc.14", features = ["ecdh"] }
+p521 = { version = "=0.14.0-rc.14", features = ["ecdh"] }
 parking_lot = { version = "0.12", features = ["serde"] }
 peniko = "0.6"
 percent-encoding = "2.3"


### PR DESCRIPTION
New stable release of elliptic-curve has been published. Bump elliptic-curve from 0.14.0-rc.35 to 0.14.0. The following dependencies are also bumped to match elliptic-curve 0.14.0.

- ecdsa: from 0.17.0-rc.20 to 0.17.0-rc.22.
- p256: from 0.14.0-rc.12 to 0.14.0-rc.14
- p384: from 0.14.0-rc.12 to 0.14.0-rc.14
- p521: from 0.14.0-rc.12 to 0.14.0-rc.14

Testing: No code changes. It compiles.
Part of: #45823
