### PR TITLE
allocator: Move custom HeapReport into servo-allocator 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8749,7 +8749,6 @@ dependencies = [
  "servo-base",
  "servo-config",
  "servo-profile-traits",
- "tikv-jemalloc-sys",
  "time",
 ]
 

--- a/components/allocator/lib.rs
+++ b/components/allocator/lib.rs
@@ -28,6 +28,11 @@ pub fn dump_unmeasured(_writer: impl std::io::Write) {
     ALLOC.dump_unmeasured_allocations(_writer);
 }
 
+pub struct HeapReport {
+    pub path: &'static str,
+    pub size: Option<usize>,
+}
+
 pub use crate::platform::*;
 
 type EnclosingSizeFn = unsafe extern "C" fn(*const c_void) -> usize;
@@ -55,9 +60,75 @@ pub static enclosing_size: Option<EnclosingSizeFn> = None;
 
 #[cfg(not(any(windows, feature = "use-system-allocator", target_env = "ohos")))]
 mod platform {
+    use std::ffi::CString;
+    use std::mem::size_of;
     use std::os::raw::c_void;
+    use std::ptr::null_mut;
 
+    use tikv_jemalloc_sys::mallctl;
     pub use tikv_jemallocator::Jemalloc as Allocator;
+
+    pub fn heap_reports() -> Vec<crate::HeapReport> {
+        vec![
+            crate::HeapReport {
+                path: "jemalloc-heap-allocated",
+                size: jemalloc_stat("stats.allocated"),
+            },
+            crate::HeapReport {
+                path: "jemalloc-heap-active",
+                size: jemalloc_stat("stats.active"),
+            },
+            crate::HeapReport {
+                path: "jemalloc-heap-mapped",
+                size: jemalloc_stat("stats.mapped"),
+            },
+        ]
+    }
+
+    fn jemalloc_stat(value_name: &str) -> Option<usize> {
+        // Before we request the measurement of interest, we first send an "epoch"
+        // request. Without that jemalloc gives cached statistics(!) which can be
+        // highly inaccurate.
+        let epoch_c_name = CString::new("epoch").unwrap();
+        let mut epoch: u64 = 0;
+        let epoch_ptr = &mut epoch as *mut _ as *mut c_void;
+        let mut epoch_len = size_of::<u64>();
+
+        let value_c_name = CString::new(value_name).unwrap();
+        let mut value: usize = 0;
+        let value_ptr = &mut value as *mut _ as *mut c_void;
+        let mut value_len = size_of::<usize>();
+
+        // Using the same values for the `old` and `new` parameters is enough
+        // to get the statistics updated.
+        let rv = unsafe {
+            mallctl(
+                epoch_c_name.as_ptr(),
+                epoch_ptr,
+                &mut epoch_len,
+                epoch_ptr,
+                epoch_len,
+            )
+        };
+        if rv != 0 {
+            return None;
+        }
+
+        let rv = unsafe {
+            mallctl(
+                value_c_name.as_ptr(),
+                value_ptr,
+                &mut value_len,
+                null_mut(),
+                0,
+            )
+        };
+        if rv != 0 {
+            return None;
+        }
+
+        Some(value as usize)
+    }
 
     /// Get the size of a heap block.
     ///
@@ -111,6 +182,10 @@ mod platform {
     pub mod libc_compat {
         pub use libc::{free, malloc, realloc};
     }
+
+    pub fn heap_reports() -> Vec<crate::HeapReport> {
+        Vec::new()
+    }
 }
 
 #[cfg(windows)]
@@ -139,5 +214,9 @@ mod platform {
             crate::ALLOC.note_allocation(ptr, size);
             size
         }
+    }
+
+    pub fn heap_reports() -> Vec<crate::HeapReport> {
+        Vec::new()
     }
 }

--- a/components/allocator/lib.rs
+++ b/components/allocator/lib.rs
@@ -60,10 +60,10 @@ pub static enclosing_size: Option<EnclosingSizeFn> = None;
 
 #[cfg(not(any(windows, feature = "use-system-allocator", target_env = "ohos")))]
 mod platform {
-    use std::ffi::CString;
-    use std::mem::size_of;
+    use std::ffi::CStr;
+    use std::mem::size_of_val;
     use std::os::raw::c_void;
-    use std::ptr::null_mut;
+    use std::ptr;
 
     use tikv_jemalloc_sys::mallctl;
     pub use tikv_jemallocator::Jemalloc as Allocator;
@@ -72,41 +72,40 @@ mod platform {
         vec![
             crate::HeapReport {
                 path: "jemalloc-heap-allocated",
-                size: jemalloc_stat("stats.allocated"),
+                size: jemalloc_stat(c"stats.allocated"),
             },
             crate::HeapReport {
                 path: "jemalloc-heap-active",
-                size: jemalloc_stat("stats.active"),
+                size: jemalloc_stat(c"stats.active"),
             },
             crate::HeapReport {
                 path: "jemalloc-heap-mapped",
-                size: jemalloc_stat("stats.mapped"),
+                size: jemalloc_stat(c"stats.mapped"),
             },
         ]
     }
 
-    fn jemalloc_stat(value_name: &str) -> Option<usize> {
+    fn jemalloc_stat(value_name: &CStr) -> Option<usize> {
         // Before we request the measurement of interest, we first send an "epoch"
         // request. Without that jemalloc gives cached statistics(!) which can be
         // highly inaccurate.
-        let epoch_c_name = CString::new("epoch").unwrap();
+        let epoch_c_name = c"epoch";
         let mut epoch: u64 = 0;
-        let epoch_ptr = &mut epoch as *mut _ as *mut c_void;
-        let mut epoch_len = size_of::<u64>();
+        let epoch_ptr = &raw mut epoch;
+        let mut epoch_len = size_of_val(&epoch);
 
-        let value_c_name = CString::new(value_name).unwrap();
         let mut value: usize = 0;
-        let value_ptr = &mut value as *mut _ as *mut c_void;
-        let mut value_len = size_of::<usize>();
+        let value_ptr = &raw mut value;
+        let mut value_len = size_of_val(&value);
 
         // Using the same values for the `old` and `new` parameters is enough
         // to get the statistics updated.
         let rv = unsafe {
             mallctl(
                 epoch_c_name.as_ptr(),
-                epoch_ptr,
+                epoch_ptr.cast(),
                 &mut epoch_len,
-                epoch_ptr,
+                epoch_ptr.cast(),
                 epoch_len,
             )
         };
@@ -116,10 +115,10 @@ mod platform {
 
         let rv = unsafe {
             mallctl(
-                value_c_name.as_ptr(),
-                value_ptr,
+                value_name.as_ptr(),
+                value_ptr.cast(),
                 &mut value_len,
-                null_mut(),
+                ptr::null_mut(),
                 0,
             )
         };
@@ -127,7 +126,7 @@ mod platform {
             return None;
         }
 
-        Some(value as usize)
+        Some(value)
     }
 
     /// Get the size of a heap block.

--- a/components/profile/Cargo.toml
+++ b/components/profile/Cargo.toml
@@ -31,6 +31,3 @@ regex = { workspace = true }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 libc = { workspace = true }
-
-[target.'cfg(not(any(target_os = "windows", target_env = "ohos")))'.dependencies]
-tikv-jemalloc-sys = { workspace = true }

--- a/components/profile/system_reporter.rs
+++ b/components/profile/system_reporter.rs
@@ -2,21 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#[cfg(not(any(target_os = "windows", target_env = "ohos")))]
-use std::ffi::CString;
-#[cfg(not(any(target_os = "windows", target_env = "ohos")))]
-use std::mem::size_of;
-#[cfg(not(any(target_os = "windows", target_env = "ohos")))]
-use std::ptr::null_mut;
+#[cfg(target_os = "macos")]
+use std::ptr;
 
 #[cfg(all(target_os = "linux", target_env = "gnu"))]
 use libc::c_int;
-#[cfg(not(any(target_os = "windows", target_env = "ohos")))]
-use libc::{c_void, size_t};
 use profile_traits::mem::{ProcessReports, Report, ReportKind, ReporterRequest};
 use profile_traits::path;
 
-const JEMALLOC_HEAP_ALLOCATED_STR: &str = "jemalloc-heap-allocated";
 const SYSTEM_HEAP_ALLOCATED_STR: &str = "system-heap-allocated";
 const SYSTEM_HEAP_RESERVED_STR: &str = "system-heap-reserved";
 
@@ -52,29 +45,18 @@ pub fn collect_reports(request: ReporterRequest) {
         }
 
         // Total number of bytes allocated by the application on the system
-        // heap.
+        // heap. Even if we use a custom global allocator, this doesn't affect
+        // everything, e.g. C/C++ libraries might still use the default system allocator
+        // unless we explicitly patch  / configure them.
+        // Hence we always check system-heap info, since it allows us to know
+        // how much memory bypasses the global allocator we defined.
         let system_heap = system_heap_info();
         report(path![SYSTEM_HEAP_ALLOCATED_STR], system_heap.allocated);
         report(path![SYSTEM_HEAP_RESERVED_STR], system_heap.reserved);
 
-        // The descriptions of the following jemalloc measurements are taken
-        // directly from the jemalloc documentation.
-
-        // "Total number of bytes allocated by the application."
-        report(
-            path![JEMALLOC_HEAP_ALLOCATED_STR],
-            jemalloc_stat("stats.allocated"),
-        );
-
-        // "Total number of bytes in active pages allocated by the application.
-        // This is a multiple of the page size, and greater than or equal to
-        // |stats.allocated|."
-        report(path!["jemalloc-heap-active"], jemalloc_stat("stats.active"));
-
-        // "Total number of bytes in chunks mapped on behalf of the application.
-        // This is a multiple of the chunk size, and is at least as large as
-        // |stats.active|. This does not include inactive chunks."
-        report(path!["jemalloc-heap-mapped"], jemalloc_stat("stats.mapped"));
+        for heap_report in servo_allocator::heap_reports() {
+            report(path![heap_report.path], heap_report.size);
+        }
     }
 
     request.reports_channel.send(ProcessReports::new(reports));
@@ -142,7 +124,7 @@ fn macos_malloc_statistics() -> libc::malloc_statistics_t {
     };
     unsafe {
         // A null zone aggregates statistics across all malloc zones.
-        libc::malloc_zone_statistics(null_mut(), &mut stats);
+        libc::malloc_zone_statistics(ptr::null_mut(), &mut stats);
     }
     stats
 }
@@ -162,61 +144,6 @@ fn system_heap_info() -> SystemHeapInfo {
         allocated: None,
         reserved: None,
     }
-}
-
-#[cfg(not(any(target_os = "windows", target_env = "ohos")))]
-use tikv_jemalloc_sys::mallctl;
-
-#[cfg(not(any(target_os = "windows", target_env = "ohos")))]
-fn jemalloc_stat(value_name: &str) -> Option<usize> {
-    // Before we request the measurement of interest, we first send an "epoch"
-    // request. Without that jemalloc gives cached statistics(!) which can be
-    // highly inaccurate.
-    let epoch_name = "epoch";
-    let epoch_c_name = CString::new(epoch_name).unwrap();
-    let mut epoch: u64 = 0;
-    let epoch_ptr = &mut epoch as *mut _ as *mut c_void;
-    let mut epoch_len = size_of::<u64>() as size_t;
-
-    let value_c_name = CString::new(value_name).unwrap();
-    let mut value: size_t = 0;
-    let value_ptr = &mut value as *mut _ as *mut c_void;
-    let mut value_len = size_of::<size_t>() as size_t;
-
-    // Using the same values for the `old` and `new` parameters is enough
-    // to get the statistics updated.
-    let rv = unsafe {
-        mallctl(
-            epoch_c_name.as_ptr(),
-            epoch_ptr,
-            &mut epoch_len,
-            epoch_ptr,
-            epoch_len,
-        )
-    };
-    if rv != 0 {
-        return None;
-    }
-
-    let rv = unsafe {
-        mallctl(
-            value_c_name.as_ptr(),
-            value_ptr,
-            &mut value_len,
-            null_mut(),
-            0,
-        )
-    };
-    if rv != 0 {
-        return None;
-    }
-
-    Some(value as usize)
-}
-
-#[cfg(any(target_os = "windows", target_env = "ohos"))]
-fn jemalloc_stat(_value_name: &str) -> Option<usize> {
-    None
 }
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
The profiler crate shouldn't need to depend on tikv-jemalloc crates.
Instead it makes more sense that the allocator crate provides the
relevant reports to the profiler crate.

The second commit does several minor improvements to the jemalloc_stat internals, which don't affect behavior.

Testing: The heap reports are not covered by automated tests. 
