### PR TITLE
script: Store `DocumentLoader::blocking_loads` in a `HashSet` instead of a `Vec`

### DIFF
--- a/components/script/document_loader.rs
+++ b/components/script/document_loader.rs
@@ -6,6 +6,8 @@
 //!
 //! <https://html.spec.whatwg.org/multipage/#the-end>
 
+use std::collections::HashSet;
+
 use net_traits::request::RequestBuilder;
 use net_traits::{BoxedFetchCallback, ResourceThreads, fetch_async};
 use script_bindings::cell::DomRefCell;
@@ -16,7 +18,7 @@ use crate::dom::bindings::root::Dom;
 use crate::dom::document::Document;
 use crate::fetch::FetchCanceller;
 
-#[derive(Clone, Debug, JSTraceable, MallocSizeOf, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, JSTraceable, MallocSizeOf, PartialEq)]
 pub(crate) enum LoadType {
     Image(#[no_trace] ServoUrl),
     Script(#[no_trace] ServoUrl),
@@ -93,7 +95,7 @@ impl Drop for LoadBlocker {
 pub(crate) struct DocumentLoader {
     #[no_trace]
     resource_threads: ResourceThreads,
-    blocking_loads: Vec<LoadType>,
+    blocking_loads: HashSet<LoadType>,
     events_inhibited: bool,
     cancellers: Vec<FetchCanceller>,
 }
@@ -130,7 +132,7 @@ impl DocumentLoader {
             load,
             self.blocking_loads.len()
         );
-        self.blocking_loads.push(load);
+        self.blocking_loads.insert(load);
     }
 
     /// Initiate a new fetch given a response callback.
@@ -165,15 +167,8 @@ impl DocumentLoader {
             load,
             self.blocking_loads.len()
         );
-        let idx = self
-            .blocking_loads
-            .iter()
-            .position(|unfinished| *unfinished == *load);
-        match idx {
-            Some(i) => {
-                self.blocking_loads.remove(i);
-            },
-            None => warn!("unknown completed load {:?}", load),
+        if self.blocking_loads.remove(load) {
+            warn!("unknown completed load {:?}", load)
         }
     }
 

--- a/components/script/document_loader.rs
+++ b/components/script/document_loader.rs
@@ -95,7 +95,8 @@ impl Drop for LoadBlocker {
 pub(crate) struct DocumentLoader {
     #[no_trace]
     resource_threads: ResourceThreads,
-    /// Maps Load Type to number of blocking loads.
+    /// A map from [`LoadType`] to the number of blocking loads. When a particular [`LoadType`]
+    /// reaches zero, it is removed from the map and no longer blocks the load.
     blocking_loads: HashMap<LoadType, u32>,
     events_inhibited: bool,
     cancellers: Vec<FetchCanceller>,
@@ -176,15 +177,15 @@ impl DocumentLoader {
             self.blocking_loads.len()
         );
 
-        if let Some(entry) = self.blocking_loads.get_mut(&load) {
-            if *entry > 0 {
-                *entry -= 1;
-                return;
-            } else {
-                self.blocking_loads.remove(&load);
-            }
+        let Some(entry) = self.blocking_loads.get_mut(load) else {
+            warn!("unknown completed load {load:?}");
+            return;
+        };
+
+        *entry = entry.saturating_sub(1);
+        if *entry == 0 {
+            self.blocking_loads.remove(load);
         }
-        warn!("unknown completed load {load:?}");
     }
 
     pub(crate) fn is_blocked(&self) -> bool {

--- a/components/script/document_loader.rs
+++ b/components/script/document_loader.rs
@@ -6,7 +6,7 @@
 //!
 //! <https://html.spec.whatwg.org/multipage/#the-end>
 
-use std::collections::HashSet;
+use std::collections::HashMap;
 
 use net_traits::request::RequestBuilder;
 use net_traits::{BoxedFetchCallback, ResourceThreads, fetch_async};
@@ -95,7 +95,8 @@ impl Drop for LoadBlocker {
 pub(crate) struct DocumentLoader {
     #[no_trace]
     resource_threads: ResourceThreads,
-    blocking_loads: HashSet<LoadType>,
+    /// Maps Load Type to number of blocking loads.
+    blocking_loads: HashMap<LoadType, u32>,
     events_inhibited: bool,
     cancellers: Vec<FetchCanceller>,
 }
@@ -110,7 +111,11 @@ impl DocumentLoader {
         initial_load: Option<ServoUrl>,
     ) -> DocumentLoader {
         debug!("Initial blocking load {:?}.", initial_load);
-        let initial_loads = initial_load.into_iter().map(LoadType::PageSource).collect();
+
+        let initial_loads = initial_load
+            .into_iter()
+            .map(|url| (LoadType::PageSource(url), 1))
+            .collect();
 
         DocumentLoader {
             resource_threads,
@@ -132,7 +137,10 @@ impl DocumentLoader {
             load,
             self.blocking_loads.len()
         );
-        self.blocking_loads.insert(load);
+        self.blocking_loads
+            .entry(load)
+            .and_modify(|load_number| *load_number += 1)
+            .or_insert(1);
     }
 
     /// Initiate a new fetch given a response callback.
@@ -167,9 +175,16 @@ impl DocumentLoader {
             load,
             self.blocking_loads.len()
         );
-        if self.blocking_loads.remove(load) {
-            warn!("unknown completed load {:?}", load)
+
+        if let Some(entry) = self.blocking_loads.get_mut(&load) {
+            if *entry > 0 {
+                *entry -= 1;
+                return;
+            } else {
+                self.blocking_loads.remove(&load);
+            }
         }
+        warn!("unknown completed load {load:?}");
     }
 
     pub(crate) fn is_blocked(&self) -> bool {
@@ -179,7 +194,7 @@ impl DocumentLoader {
 
     pub(crate) fn is_only_blocked_by_iframes(&self) -> bool {
         self.blocking_loads
-            .iter()
+            .keys()
             .all(|load| matches!(*load, LoadType::Subframe(_)))
     }
 


### PR DESCRIPTION
This moves the BlockingLoads from Vector to a HashSet. This saves us roughly 0.3% on a sample run of the script thread execution as previously we had to search through the vector. As the LoadBlockers contain urls we use the std HashSet.

The only change in functionality is that we do not add the same blocker multiple times which could have happened in the previous case. This does not look like part of the design as blockers are removed at the same code point and do not get a handle.

Testing: This does not change observable behavior, so is covered by existing WPT tests.
