### PR TITLE
script: Don't act as if response had finished in parse_media_document

### DIFF
--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1166,9 +1166,10 @@ impl ParserContext {
         // Step 1. Let document be the result of creating and initializing a Document
         // object given "html", type, and navigationParams.
         self.initialize_document_object(&parser.document);
+
         // Step 8. Act as if the user agent had stopped parsing document.
         self.is_synthesized_document = true;
-        parser.last_chunk_received.set(true);
+
         // Step 3. Populate with html/head/body given document.
         let page = "<html><body></body></html>".into();
         parser.push_string_input_chunk(page);
@@ -1246,8 +1247,8 @@ impl ParserContext {
         self.is_synthesized_document = true;
         parser.document.mark_as_internal();
         parser.push_string_input_chunk(page);
+
         // Step 7. Act as if the user agent had stopped parsing document.
-        parser.last_chunk_received.set(true);
         parser.parse_sync(cx);
     }
 


### PR DESCRIPTION
`last_chunk_received` is set when the response reaches EOF, and it causes to parser to finish the next time `parse_sync` is called. In `parse_media_document' setting the flag causes a panic, since we don't want the parser to finish yet.

Note that even with this fix the source content does not appear, because we never create any source actors for some reason. But we do send the source content to the devtools server without panicking.

Fixes: https://github.com/servo/servo/issues/44372
Testing: Triggering the panic requires having devtools enabled (which we only have for devtools tests) and a server that serves a specific MIME type. I don't think our testing infrastructure supports that yet.
