### PR TITLE
android: Convert individual settings items to Compose UI

### DIFF
--- a/support/android/apk/servoapp/src/main/java/org/servo/servoshell/SettingsFragment.kt
+++ b/support/android/apk/servoapp/src/main/java/org/servo/servoshell/SettingsFragment.kt
@@ -5,15 +5,22 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.res.stringResource
 import androidx.fragment.app.Fragment
 import androidx.preference.PreferenceManager
-import com.google.android.material.switchmaterial.SwitchMaterial
 import androidx.core.content.edit
 
 class SettingsFragment : Fragment() {
     private lateinit var preferences: SharedPreferences
-    private lateinit var experimentalSwitch: SwitchMaterial
-    private lateinit var animatingSwitch: SwitchMaterial
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -27,47 +34,41 @@ class SettingsFragment : Fragment() {
     ): View = inflater.inflate(R.layout.fragment_settings, container, false)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        experimentalSwitch = view.findViewById(R.id.experimental_switch)
-        animatingSwitch = view.findViewById(R.id.animating_switch)
-        val experimentalContainer = view.findViewById<View>(R.id.experimental_container)
-        val animatingContainer = view.findViewById<View>(R.id.animating_container)
-
-        loadPreferences()
-
-        experimentalContainer.setOnClickListener {
-            val newValue = !experimentalSwitch.isChecked
-            experimentalSwitch.isChecked = newValue
-            savePreference("experimental", newValue)
+        view.findViewById<ComposeView>(R.id.experimental).setContent {
+            SettingsItem(
+                title = stringResource(R.string.settings_experimental_title),
+                summary = stringResource(R.string.settings_experimental_summary),
+                preferenceKey = "experimental",
+            )
         }
-
-        animatingContainer.setOnClickListener {
-            val newValue = !animatingSwitch.isChecked
-            animatingSwitch.isChecked = newValue
-            savePreference("animating_indicator", newValue)
-        }
-
-        experimentalSwitch.setOnCheckedChangeListener { buttonView, isChecked ->
-            if (buttonView.isPressed) {
-                savePreference("experimental", isChecked)
-            }
-        }
-
-        animatingSwitch.setOnCheckedChangeListener { buttonView, isChecked ->
-            if (buttonView.isPressed) {
-                savePreference("animating_indicator", isChecked)
-            }
+        view.findViewById<ComposeView>(R.id.animating_indicator).setContent {
+            SettingsItem(
+                title = stringResource(R.string.settings_animating_title),
+                summary = stringResource(R.string.settings_animating_summary),
+                preferenceKey = "animating_indicator",
+            )
         }
     }
 
-    private fun loadPreferences() {
-        val experimental = preferences.getBoolean("experimental", false)
-        val animatingIndicator = preferences.getBoolean("animating_indicator", false)
-
-        experimentalSwitch.isChecked = experimental
-        animatingSwitch.isChecked = animatingIndicator
-    }
-
-    private fun savePreference(key: String, value: Boolean) {
-        preferences.edit { putBoolean(key, value) }
+    @Composable
+    private fun SettingsItem(title: String, summary: String, preferenceKey: String) {
+        ListItem(
+            headlineContent = {
+                Text(title)
+            },
+            supportingContent = {
+                Text(summary)
+            },
+            trailingContent = {
+                var checked by remember { mutableStateOf(preferences.getBoolean(preferenceKey, false)) }
+                Switch(
+                    checked = checked,
+                    onCheckedChange = {
+                        checked = it
+                        preferences.edit { putBoolean(preferenceKey, it) }
+                    },
+                )
+            },
+        )
     }
 }

--- a/support/android/apk/servoapp/src/main/res/layout/fragment_settings.xml
+++ b/support/android/apk/servoapp/src/main/res/layout/fragment_settings.xml
@@ -40,59 +40,10 @@
                 android:textAppearance="?attr/textAppearanceTitleSmall"
                 android:textColor="?attr/colorPrimary" />
 
-            <LinearLayout
+            <androidx.compose.ui.platform.ComposeView
+                android:id="@+id/experimental"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:paddingStart="16dp"
-                android:paddingEnd="16dp"
-                android:paddingTop="12dp"
-                android:paddingBottom="12dp"
-                android:background="?attr/selectableItemBackground"
-                android:clickable="true"
-                android:focusable="true"
-                android:id="@+id/experimental_container">
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal"
-                    android:gravity="center_vertical">
-
-                    <LinearLayout
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:orientation="vertical">
-
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="@string/settings_experimental_title"
-                            android:textAppearance="?attr/textAppearanceBodyLarge"
-                            android:textColor="?android:attr/textColorPrimary" />
-
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_marginTop="4dp"
-                            android:text="@string/settings_experimental_summary"
-                            android:textAppearance="?attr/textAppearanceBodyMedium"
-                            android:textColor="?android:attr/textColorSecondary" />
-
-                    </LinearLayout>
-
-                    <com.google.android.material.switchmaterial.SwitchMaterial
-                        android:id="@+id/experimental_switch"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginStart="16dp"
-                        android:clickable="false"
-                        android:focusable="false" />
-
-                </LinearLayout>
-
-            </LinearLayout>
+                android:layout_height="wrap_content" />
 
             <com.google.android.material.divider.MaterialDivider
                 android:layout_width="match_parent"
@@ -100,59 +51,10 @@
                 android:layout_marginStart="16dp"
                 android:layout_marginEnd="16dp" />
 
-            <LinearLayout
+            <androidx.compose.ui.platform.ComposeView
+                android:id="@+id/animating_indicator"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:paddingStart="16dp"
-                android:paddingEnd="16dp"
-                android:paddingTop="12dp"
-                android:paddingBottom="12dp"
-                android:background="?attr/selectableItemBackground"
-                android:clickable="true"
-                android:focusable="true"
-                android:id="@+id/animating_container">
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal"
-                    android:gravity="center_vertical">
-
-                    <LinearLayout
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:orientation="vertical">
-
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="@string/settings_animating_title"
-                            android:textAppearance="?attr/textAppearanceBodyLarge"
-                            android:textColor="?android:attr/textColorPrimary" />
-
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_marginTop="4dp"
-                            android:text="@string/settings_animating_summary"
-                            android:textAppearance="?attr/textAppearanceBodyMedium"
-                            android:textColor="?android:attr/textColorSecondary" />
-
-                    </LinearLayout>
-
-                    <com.google.android.material.switchmaterial.SwitchMaterial
-                        android:id="@+id/animating_switch"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginStart="16dp"
-                        android:clickable="false"
-                        android:focusable="false" />
-
-                </LinearLayout>
-
-            </LinearLayout>
+                android:layout_height="wrap_content" />
 
         </LinearLayout>
 


### PR DESCRIPTION
|Before|After|
|---|---|
|<img width="1116" height="2484" alt="image" src="https://github.com/user-attachments/assets/1ad8fd2c-0e32-40b1-96ea-11b74408a2dd" />|<img width="1116" height="2484" src="https://github.com/user-attachments/assets/a9585ef6-25ec-4fba-9174-5ccc36dbec89" />|


Testing: There are no automated tests for Android.
Fixes: Part of #45715.