### PR TITLE
script: Remove unnessecary reflows in IntersectionObserver

### DIFF
--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -580,6 +580,13 @@ impl Element {
             .is_some_and(|overflow| overflow.establishes_scroll_container())
     }
 
+    /// Like [`Self::establishes_scroll_container`], but without forcing a reflow.
+    pub(crate) fn establishes_scroll_container_without_reflow(&self) -> bool {
+        self.upcast::<Node>()
+            .effective_overflow_without_reflow()
+            .is_some_and(|overflow| overflow.establishes_scroll_container())
+    }
+
     pub(crate) fn has_overflow(&self) -> bool {
         self.ScrollHeight() > self.ClientHeight() || self.ScrollWidth() > self.ClientWidth()
     }

--- a/components/script/dom/intersectionobserver/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver/intersectionobserver.rs
@@ -962,15 +962,16 @@ fn compute_the_intersection(
                 .upcast::<Node>()
                 .padding_box_without_reflow()
         {
-            let container_padding_box = if containing_element.establishes_scroll_container() {
-                let margin = IntersectionObserver::resolve_percentages_with_basis(
-                    scroll_margin,
-                    container_padding_box,
-                );
-                container_padding_box.outer_rect(margin)
-            } else {
-                container_padding_box
-            };
+            let container_padding_box =
+                if containing_element.establishes_scroll_container_without_reflow() {
+                    let margin = IntersectionObserver::resolve_percentages_with_basis(
+                        scroll_margin,
+                        container_padding_box,
+                    );
+                    container_padding_box.outer_rect(margin)
+                } else {
+                    container_padding_box
+                };
 
             if let Some(rect) = intersect_rectangle(&intersection_rect, &container_padding_box) {
                 intersection_rect = rect;


### PR DESCRIPTION
…intersection computation.
This follows the pattern of surrounding code also doing `_without_reflow()`, since once upfront should be sufficient.

Testing: This optimization should hopefully be covered by wpt test (which pass)

