### PR TITLE
script: Remove `InRealm` usage from codegen

### DIFF
--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -15,7 +15,7 @@ use js::realm::CurrentRealm;
 use js::rust::wrappers2::JS_FreezeObject;
 use js::rust::{HandleObject, MutableHandleValue, get_object_class, is_dom_class};
 use script_bindings::interfaces::{DomHelpers, Interface};
-use script_bindings::reflector::{DomObject, DomObjectWrap, reflect_dom_object};
+use script_bindings::reflector::{DomObject, DomObjectWrap, reflect_dom_object_with_cx};
 use script_bindings::settings_stack::StackEntry;
 
 use crate::DomTypes;
@@ -28,7 +28,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::settings_stack;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::windowproxy::WindowProxyHandler;
-use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 
 #[derive(JSTraceable, MallocSizeOf)]
@@ -170,12 +169,12 @@ impl DomHelpers<crate::DomTypeHolder> for crate::DomTypeHolder {
         ScriptThread::custom_element_reaction_stack().pop_current_element_queue(cx)
     }
 
-    fn reflect_dom_object<T, U>(obj: Box<T>, global: &U, can_gc: CanGc) -> DomRoot<T>
+    fn reflect_dom_object_with_cx<T, U>(cx: &mut JSContext, obj: Box<T>, global: &U) -> DomRoot<T>
     where
         T: DomObject + DomObjectWrap<crate::DomTypeHolder>,
         U: DerivedFrom<GlobalScope>,
     {
-        reflect_dom_object(obj, global, can_gc)
+        reflect_dom_object_with_cx(obj, global, cx)
     }
 
     fn report_pending_exception(cx: &mut CurrentRealm) {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -66,7 +66,6 @@ DOMInterfaces = {
 },
 
 'BaseAudioContext': {
-    'inRealms': ['ParseFromString', 'GetBounds', 'GetClientRects'],
     'cx': ['CreateBuffer', 'CreateGain', 'CreateOscillator', 'CreatePanner', 'CreateStereoPanner', 'CreateBiquadFilter', 'CreateIIRFilter', 'CreateAnalyser', 'CreateConstantSource', 'CreateChannelMerger', 'CreateChannelSplitter', 'CreateBufferSource', 'Destination', 'Listener'],
     'realm': ['DecodeAudioData', 'Resume'],
 },
@@ -1021,7 +1020,6 @@ DOMInterfaces = {
 'MediaDevices': {
     'realm': ['GetUserMedia'],
     'cx': ['EnumerateDevices'],
-    'inRealms': ['GetUserMedia', 'GetClientRects', 'GetBoundingClientRect'],
 },
 
 'MediaElementAudioSourceNode': {
@@ -1102,7 +1100,6 @@ DOMInterfaces = {
 },
 
 'Navigator': {
-    'inRealms': ['GetVRDisplays'],
     'cx': ['Bluetooth', 'Clipboard', 'Geolocation', 'Gpu', 'Languages', 'SendBeacon', 'ServiceWorker', 'Storage', 'UserActivation', 'WakeLock', 'Xr'],
 },
 

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -4217,8 +4217,6 @@ class CGCallGenerator(CGThing):
         else:
             if "cx" not in argsPre and needsCx:
                 args.prepend(CGGeneric("SafeJSContext::from_ptr(cx.raw_cx())"))
-            if nativeMethodName in descriptor.inRealmMethods:
-                args.append(CGGeneric("InRealm::already(&AlreadyInRealm::assert_for_cx(SafeJSContext::from_ptr(cx.raw_cx())))"))
             if nativeMethodName in descriptor.canGcMethods:
                 args.append(CGGeneric("CanGc::deprecated_note()"))
         if rootType:
@@ -6979,7 +6977,6 @@ class CGInterfaceTrait(CGThing):
                                 cx_no_gc: bool = False,
                                 cx: bool = False,
                                 realm: bool = False,
-                                inRealm: bool = False,
                                 canGc: bool = False,
                                 retval: bool = False
                                 ) -> Iterable[tuple[str, str]]:
@@ -6997,9 +6994,6 @@ class CGInterfaceTrait(CGThing):
 
             if argument:
                 yield "value", argument_type(descriptor, argument)
-
-            if inRealm and not safe_cx:
-                yield "_comp", "InRealm"
 
             if canGc and not safe_cx:
                 yield "_can_gc", "CanGc"
@@ -7028,7 +7022,6 @@ class CGInterfaceTrait(CGThing):
                                                      cx_no_gc=name in descriptor.cx_no_gcMethods,
                                                      cx=name in descriptor.cxMethods,
                                                      realm=name in descriptor.realmMethods,
-                                                     inRealm=name in descriptor.inRealmMethods,
                                                      canGc=name in descriptor.canGcMethods)
                         rettype = return_type(descriptor, rettype, infallible)
                         yield f"{name}{'_' * idx}", arguments, rettype, m.isStatic()
@@ -7048,7 +7041,6 @@ class CGInterfaceTrait(CGThing):
                                cx_no_gc=name in descriptor.cx_no_gcMethods,
                                cx=name in descriptor.cxMethods or isEventHandlerCallback(m),
                                realm=name in descriptor.realmMethods,
-                               inRealm=name in descriptor.inRealmMethods,
                                canGc=name in descriptor.canGcMethods,
                                retval=True
                            ),
@@ -7069,7 +7061,6 @@ class CGInterfaceTrait(CGThing):
                                    cx_no_gc=name in descriptor.cx_no_gcMethods,
                                    cx=name in descriptor.cxMethods or descriptor.implicitCxSetters or isEventHandlerCallback(m),
                                    realm=name in descriptor.realmMethods,
-                                   inRealm=name in descriptor.inRealmMethods,
                                    canGc=name in descriptor.canGcMethods,
                                    retval=False,
                                ),
@@ -7092,7 +7083,6 @@ class CGInterfaceTrait(CGThing):
                                                      cx_no_gc=name in descriptor.cx_no_gcMethods,
                                                      cx=name in descriptor.cxMethods,
                                                      realm=name in descriptor.realmMethods,
-                                                     inRealm=name in descriptor.inRealmMethods,
                                                      canGc=name in descriptor.canGcMethods)
 
                         # If this interface 'supports named properties', then we
@@ -7107,7 +7097,6 @@ class CGInterfaceTrait(CGThing):
                                                      cx_no_gc=name in descriptor.cx_no_gcMethods,
                                                      cx=name in descriptor.cxMethods,
                                                      realm=name in descriptor.realmMethods,
-                                                     inRealm=name in descriptor.inRealmMethods,
                                                      canGc=name in descriptor.canGcMethods)
                     rettype = return_type(descriptor, rettype, infallible)
                     yield name, arguments, rettype, False
@@ -8340,7 +8329,6 @@ def method_arguments(descriptorProvider: DescriptorProvider,
                      cx_no_gc: bool = False,
                      cx: bool = False,
                      realm: bool = False,
-                     inRealm: bool = False,
                      canGc: bool = False
                      ) -> Iterator[tuple[str, str]]:
     old_cx = False
@@ -8372,9 +8360,6 @@ def method_arguments(descriptorProvider: DescriptorProvider,
 
     if trailing:
         yield trailing
-
-    if inRealm and not safe_cx:
-        yield "_comp", "InRealm"
 
     if canGc and not safe_cx:
         yield "_can_gc", "CanGc"
@@ -9022,8 +9007,8 @@ class CGIterableMethodGenerator(CGGeneric):
             return
         CGGeneric.__init__(self, fill(
             """
-            let realm = AlreadyInRealm::assert_for_cx(SafeJSContext::from_ptr(cx.raw_cx()));
-            let result = ${iterClass}::new(this, IteratorType::${itrMethod}, InRealm::already(&realm));
+            let mut realm = CurrentRealm::assert(cx);
+            let result = ${iterClass}::new(&mut realm, this, IteratorType::${itrMethod});
             """,
             iterClass=iteratorNativeType(descriptor, True),
             ifaceName=descriptor.interface.identifier.name,

--- a/components/script_bindings/import.rs
+++ b/components/script_bindings/import.rs
@@ -118,7 +118,6 @@ pub(crate) mod module {
     pub(crate) use crate::mem::malloc_size_of_including_raw_self;
     pub(crate) use crate::namespace::NamespaceObjectClass;
     pub(crate) use crate::proxyhandler::{get_expando_object, set_property_descriptor};
-    pub(crate) use crate::realms::{AlreadyInRealm, InRealm};
     #[cfg(feature = "testbinding")]
     pub(crate) use crate::root::{Dom, DomSlice};
     pub(crate) use crate::root::{MaybeUnreflectedDom, Root};

--- a/components/script_bindings/interfaces.rs
+++ b/components/script_bindings/interfaces.rs
@@ -19,7 +19,7 @@ use crate::error::Error;
 use crate::realms::InRealm;
 use crate::reflector::{DomObject, DomObjectWrap};
 use crate::root::DomRoot;
-use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
+use crate::script_runtime::JSContext as SafeJSContext;
 use crate::settings_stack::StackEntry;
 use crate::utils::ProtoOrIfaceArray;
 
@@ -55,7 +55,7 @@ pub trait DomHelpers<D: DomTypes> {
     fn push_new_element_queue();
     fn pop_current_element_queue(cx: &mut JSContext);
 
-    fn reflect_dom_object<T, U>(obj: Box<T>, global: &U, can_gc: CanGc) -> DomRoot<T>
+    fn reflect_dom_object_with_cx<T, U>(cx: &mut JSContext, obj: Box<T>, global: &U) -> DomRoot<T>
     where
         T: DomObject + DomObjectWrap<D>,
         U: DerivedFrom<D::GlobalScope>;

--- a/components/script_bindings/iterable.rs
+++ b/components/script_bindings/iterable.rs
@@ -12,6 +12,7 @@ use dom_struct::dom_struct;
 use js::conversions::ToJSValConvertible;
 use js::jsapi::{Heap, JS_NewObject};
 use js::jsval::UndefinedValue;
+use js::realm::CurrentRealm;
 use js::rust::{HandleObject, HandleValue, MutableHandleObject};
 
 use crate::codegen::GenericBindings::IterableIteratorBinding::{
@@ -19,11 +20,10 @@ use crate::codegen::GenericBindings::IterableIteratorBinding::{
 };
 use crate::conversions::IDLInterface;
 use crate::error::Fallible;
-use crate::interfaces::DomHelpers;
-use crate::realms::InRealm;
+use crate::interfaces::{DomHelpers, GlobalScopeHelpers};
 use crate::reflector::{DomGlobalGeneric, DomObjectIteratorWrap, DomObjectWrap, Reflector};
 use crate::root::{Dom, DomRoot, Root};
-use crate::script_runtime::{CanGc, JSContext};
+use crate::script_runtime::JSContext;
 use crate::trace::{NoTrace, RootedTraceableBox};
 use crate::utils::DOMClass;
 use crate::{DomTypes, JSTraceable};
@@ -93,7 +93,11 @@ impl<D: DomTypes, T: DomObjectIteratorWrap<D> + JSTraceable + Iterable + DomGlob
     IterableIterator<D, T>
 {
     /// Create a new iterator instance for the provided iterable DOM interface.
-    pub(crate) fn new(iterable: &T, type_: IteratorType, realm: InRealm) -> DomRoot<Self> {
+    pub(crate) fn new(
+        realm: &mut CurrentRealm,
+        iterable: &T,
+        type_: IteratorType,
+    ) -> DomRoot<Self> {
         let iterator = Box::new(IterableIterator {
             reflector: Reflector::new(),
             type_,
@@ -101,11 +105,8 @@ impl<D: DomTypes, T: DomObjectIteratorWrap<D> + JSTraceable + Iterable + DomGlob
             index: Cell::new(0),
             _marker: NoTrace(PhantomData),
         });
-        <D as DomHelpers<D>>::reflect_dom_object(
-            iterator,
-            &*iterable.global_from_reflector(realm),
-            CanGc::deprecated_note(),
-        )
+        let global = D::GlobalScope::from_current_realm(realm);
+        <D as DomHelpers<D>>::reflect_dom_object_with_cx(realm, iterator, &*global)
     }
 
     /// Return the next value from the iterable object.


### PR DESCRIPTION
The entries in `Bindings.conf` were unused and thus all of the relevant code can be removed.

Part of #40600

Testing: it compiles