### PR TITLE
script: Expose `ml` on `navigator`

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -116,6 +116,8 @@ pub struct Preferences {
     pub dom_webgpu_enabled: bool,
     /// List of comma-separated backends to be used by wgpu.
     pub dom_webgpu_wgpu_backend: String,
+    // feature: WebNN | #45452 | Web/API/WebNN_API
+    pub dom_webnn_enabled: bool,
     // feature: AbortController | #34866 | Web/API/AbortController
     pub dom_abort_controller_enabled: bool,
     // feature: Adopted Stylesheet | #38132 | Web/API/Document/adoptedStyleSheets
@@ -467,6 +469,7 @@ impl Preferences {
             dom_webgl2_enabled: false,
             dom_webgpu_enabled: false,
             dom_webgpu_wgpu_backend: String::new(),
+            dom_webnn_enabled: false,
             dom_webrtc_enabled: false,
             dom_webrtc_transceiver_enabled: false,
             dom_webvtt_enabled: false,

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -128,6 +128,8 @@ pub struct Preferences {
     pub dom_webgpu_enabled: bool,
     /// List of comma-separated backends to be used by wgpu.
     pub dom_webgpu_wgpu_backend: String,
+    // feature: WebNN | #45452 | Web/API/WebNN_API
+    pub dom_webnn_enabled: bool,
     // feature: AbortController | #34866 | Web/API/AbortController
     pub dom_abort_controller_enabled: bool,
     // feature: Adopted Stylesheet | #38132 | Web/API/Document/adoptedStyleSheets
@@ -501,6 +503,7 @@ impl Preferences {
             dom_webgl2_enabled: false,
             dom_webgpu_enabled: false,
             dom_webgpu_wgpu_backend: String::new(),
+            dom_webnn_enabled: false,
             dom_webrtc_enabled: false,
             dom_webrtc_transceiver_enabled: false,
             dom_webxr_enabled: true,

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -33,6 +33,7 @@ webgpu = [
     "script_bindings/webgpu",
     "script_traits/webgpu",
 ]
+webnn = ["script_bindings/webnn"]
 webxr = ["gamepad", "webxr-api", "script_bindings/webxr"]
 
 [lints.rust]

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -42,6 +42,7 @@ webgpu = [
     "script_bindings/webgpu",
     "script_traits/webgpu",
 ]
+webnn = ["script_bindings/webnn"]
 webxr = ["webgl", "gamepad", "webxr-api", "script_bindings/webxr"]
 
 [lints.rust]

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -357,6 +357,10 @@ pub(crate) mod webgpu;
 pub(crate) use self::webgpu::*;
 #[cfg(not(feature = "webgpu"))]
 pub(crate) mod gpucanvascontext;
+#[cfg(feature = "webnn")]
+pub(crate) mod webnn;
+#[cfg(feature = "webnn")]
+pub(crate) use self::webnn::*;
 pub(crate) mod webcrypto;
 pub(crate) use self::webcrypto::*;
 pub(crate) mod webrtc;

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -353,6 +353,10 @@ pub(crate) mod webgpu;
 pub(crate) use self::webgpu::*;
 #[cfg(not(feature = "webgpu"))]
 pub(crate) mod gpucanvascontext;
+#[cfg(feature = "webnn")]
+pub(crate) mod webnn;
+#[cfg(feature = "webnn")]
+pub(crate) use self::webnn::*;
 pub(crate) mod webcrypto;
 pub(crate) use self::webcrypto::*;
 pub(crate) mod webrtc;

--- a/components/script/dom/navigator/navigator.rs
+++ b/components/script/dom/navigator/navigator.rs
@@ -12,7 +12,7 @@ use dom_struct::dom_struct;
 use embedder_traits::{EmbedderMsg, ProtocolHandlerUpdateRegistration, RegisterOrUnregister};
 use headers::HeaderMap;
 use http::header::{self, HeaderValue};
-#[cfg(feature = "webgpu")]
+#[cfg(any(feature = "webgpu", feature = "webnn"))]
 use js::context::JSContext;
 use js::rust::MutableHandleValue;
 use net_traits::blob_url_store::UrlWithBlobClaim;
@@ -64,6 +64,8 @@ use crate::dom::types::UserActivation;
 use crate::dom::wakelock::WakeLock;
 #[cfg(feature = "webgpu")]
 use crate::dom::webgpu::gpu::GPU;
+#[cfg(feature = "webnn")]
+use crate::dom::webnn::ml::ML;
 use crate::dom::window::Window;
 #[cfg(feature = "webxr")]
 use crate::dom::xrsystem::XRSystem;
@@ -134,6 +136,8 @@ pub(crate) struct Navigator {
     storage: MutNullableDom<StorageManager>,
     #[cfg(feature = "webgpu")]
     gpu: MutNullableDom<GPU>,
+    #[cfg(feature = "webnn")]
+    ml: MutNullableDom<ML>,
     /// <https://www.w3.org/TR/gamepad/#dfn-hasgamepadgesture>
     #[cfg(feature = "gamepad")]
     has_gamepad_gesture: Cell<bool>,
@@ -163,6 +167,8 @@ impl Navigator {
             storage: Default::default(),
             #[cfg(feature = "webgpu")]
             gpu: Default::default(),
+            #[cfg(feature = "webnn")]
+            ml: Default::default(),
             #[cfg(feature = "gamepad")]
             has_gamepad_gesture: Cell::new(false),
             servo_internals: Default::default(),
@@ -500,10 +506,16 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
         })
     }
 
-    // https://gpuweb.github.io/gpuweb/#dom-navigator-gpu
+    /// <https://gpuweb.github.io/gpuweb/#dom-navigator-gpu>
     #[cfg(feature = "webgpu")]
     fn Gpu(&self, cx: &mut JSContext) -> DomRoot<GPU> {
         self.gpu.or_init(|| GPU::new(cx, &self.global()))
+    }
+
+    /// <https://www.w3.org/TR/webnn/#api-navigatorml>
+    #[cfg(feature = "webnn")]
+    fn Ml(&self, cx: &mut JSContext) -> DomRoot<ML> {
+        self.ml.or_init(|| ML::new(cx, &self.global()))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-navigator-hardwareconcurrency>

--- a/components/script/dom/navigator/navigator.rs
+++ b/components/script/dom/navigator/navigator.rs
@@ -63,6 +63,8 @@ use crate::dom::types::UserActivation;
 use crate::dom::wakelock::WakeLock;
 #[cfg(feature = "webgpu")]
 use crate::dom::webgpu::gpu::GPU;
+#[cfg(feature = "webnn")]
+use crate::dom::webnn::ml::ML;
 use crate::dom::window::Window;
 #[cfg(feature = "webxr")]
 use crate::dom::xrsystem::XRSystem;
@@ -132,6 +134,8 @@ pub(crate) struct Navigator {
     storage: MutNullableDom<StorageManager>,
     #[cfg(feature = "webgpu")]
     gpu: MutNullableDom<GPU>,
+    #[cfg(feature = "webnn")]
+    ml: MutNullableDom<ML>,
     /// <https://www.w3.org/TR/gamepad/#dfn-hasgamepadgesture>
     #[cfg(feature = "gamepad")]
     has_gamepad_gesture: Cell<bool>,
@@ -161,6 +165,8 @@ impl Navigator {
             storage: Default::default(),
             #[cfg(feature = "webgpu")]
             gpu: Default::default(),
+            #[cfg(feature = "webnn")]
+            ml: Default::default(),
             #[cfg(feature = "gamepad")]
             has_gamepad_gesture: Cell::new(false),
             servo_internals: Default::default(),
@@ -498,10 +504,16 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
         })
     }
 
-    // https://gpuweb.github.io/gpuweb/#dom-navigator-gpu
+    /// <https://gpuweb.github.io/gpuweb/#dom-navigator-gpu>
     #[cfg(feature = "webgpu")]
     fn Gpu(&self, cx: &mut JSContext) -> DomRoot<GPU> {
         self.gpu.or_init(|| GPU::new(cx, &self.global()))
+    }
+
+    /// <https://www.w3.org/TR/webnn/#api-navigatorml>
+    #[cfg(feature = "webnn")]
+    fn Ml(&self, cx: &mut JSContext) -> DomRoot<ML> {
+        self.ml.or_init(|| ML::new(cx, &self.global()))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-navigator-hardwareconcurrency>

--- a/components/script/dom/webnn/ml.rs
+++ b/components/script/dom/webnn/ml.rs
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::rc::Rc;
+
+use dom_struct::dom_struct;
+use js::context::JSContext;
+use js::realm::CurrentRealm;
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+
+use crate::dom::bindings::codegen::Bindings::WebNNBinding::{MLContextOptions, MLMethods};
+use crate::dom::bindings::reflector::DomGlobal;
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::globalscope::GlobalScope;
+use crate::dom::promise::Promise;
+use crate::dom::webnn::mlcontext::MLContext;
+
+/// <https://www.w3.org/TR/webnn/#ml>
+#[dom_struct]
+pub(crate) struct ML {
+    reflector_: Reflector,
+}
+
+impl ML {
+    pub(crate) fn new_inherited() -> ML {
+        ML {
+            reflector_: Reflector::new(),
+        }
+    }
+
+    pub(crate) fn new(cx: &mut JSContext, global: &GlobalScope) -> DomRoot<ML> {
+        reflect_dom_object_with_cx(Box::new(ML::new_inherited()), global, cx)
+    }
+}
+
+impl MLMethods<crate::DomTypeHolder> for ML {
+    /// <https://www.w3.org/TR/webnn/#dom-ml-createcontext>
+    fn CreateContext(&self, cx: &mut CurrentRealm, options: &MLContextOptions) -> Rc<Promise> {
+        // Step 1. Let global be this's relevant global object.
+        // Step 2. Let realm be this's relevant realm.
+        // TODO Step 3. If global's associated Document is not allowed to
+        //         use the webnn feature, then return a new promise in realm
+        //         rejected with a "SecurityError" DOMException.
+        // Step 4. Let promise be a new promise in realm.
+        let promise = Promise::new_in_realm(cx);
+
+        // Step 5. Run the following steps in parallel.
+        // Step 5.1. Let context be the result of creating a context given
+        //         realm and options. If that returns failure, then queue an
+        //         ML task with global to reject promise with a
+        //         "NotSupportedError" DOMException and abort these steps.
+        let context = MLContext::new(&self.global(), cx, options);
+        // TODO: Step 5.2. Queue an ML task with global to resolve promise with
+        //         context.
+        promise.resolve_native(cx, &context);
+        // Step 6. Return promise.
+        promise
+    }
+}

--- a/components/script/dom/webnn/mlcontext.rs
+++ b/components/script/dom/webnn/mlcontext.rs
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use dom_struct::dom_struct;
+use js::context::JSContext;
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::root::DomRoot;
+
+use crate::dom::bindings::codegen::Bindings::WebNNBinding::MLContextOptions;
+use crate::dom::globalscope::GlobalScope;
+
+/// <https://www.w3.org/TR/webnn/#api-mlcontext>
+#[dom_struct]
+pub(crate) struct MLContext {
+    reflector_: Reflector,
+}
+
+impl MLContext {
+    pub(crate) fn new_inherited(_options: &MLContextOptions) -> MLContext {
+        MLContext {
+            reflector_: Reflector::new(),
+        }
+    }
+
+    pub(crate) fn new(
+        global: &GlobalScope,
+        cx: &mut JSContext,
+        options: &MLContextOptions,
+    ) -> DomRoot<MLContext> {
+        reflect_dom_object_with_cx(Box::new(MLContext::new_inherited(options)), global, cx)
+    }
+}

--- a/components/script/dom/webnn/mod.rs
+++ b/components/script/dom/webnn/mod.rs
@@ -1,0 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+pub(crate) mod ml;
+pub(crate) mod mlcontext;

--- a/components/script/dom/workers/workernavigator.rs
+++ b/components/script/dom/workers/workernavigator.rs
@@ -19,6 +19,8 @@ use crate::dom::permissions::Permissions;
 use crate::dom::storagemanager::StorageManager;
 #[cfg(feature = "webgpu")]
 use crate::dom::webgpu::gpu::GPU;
+#[cfg(feature = "webnn")]
+use crate::dom::webnn::ml::ML;
 use crate::dom::workerglobalscope::WorkerGlobalScope;
 use crate::script_runtime::CanGc;
 
@@ -30,6 +32,8 @@ pub(crate) struct WorkerNavigator {
     storage: MutNullableDom<StorageManager>,
     #[cfg(feature = "webgpu")]
     gpu: MutNullableDom<GPU>,
+    #[cfg(feature = "webnn")]
+    ml: MutNullableDom<ML>,
 }
 
 impl WorkerNavigator {
@@ -40,6 +44,8 @@ impl WorkerNavigator {
             storage: Default::default(),
             #[cfg(feature = "webgpu")]
             gpu: Default::default(),
+            #[cfg(feature = "webnn")]
+            ml: Default::default(),
         }
     }
 
@@ -126,10 +132,16 @@ impl WorkerNavigatorMethods<crate::DomTypeHolder> for WorkerNavigator {
             .or_init(|| StorageManager::new(&self.global(), CanGc::from_cx(cx)))
     }
 
-    // https://gpuweb.github.io/gpuweb/#dom-navigator-gpu
+    /// <https://gpuweb.github.io/gpuweb/#dom-navigator-gpu>
     #[cfg(feature = "webgpu")]
     fn Gpu(&self, cx: &mut JSContext) -> DomRoot<GPU> {
         self.gpu.or_init(|| GPU::new(cx, &self.global()))
+    }
+
+    /// <https://www.w3.org/TR/webnn/#api-navigatorml>
+    #[cfg(feature = "webnn")]
+    fn Ml(&self, cx: &mut JSContext) -> DomRoot<ML> {
+        self.ml.or_init(|| ML::new(cx, &self.global()))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-navigator-hardwareconcurrency>

--- a/components/script/dom/workers/workernavigator.rs
+++ b/components/script/dom/workers/workernavigator.rs
@@ -19,6 +19,8 @@ use crate::dom::permissions::Permissions;
 use crate::dom::storagemanager::StorageManager;
 #[cfg(feature = "webgpu")]
 use crate::dom::webgpu::gpu::GPU;
+#[cfg(feature = "webnn")]
+use crate::dom::webnn::ml::ML;
 use crate::dom::workerglobalscope::WorkerGlobalScope;
 
 // https://html.spec.whatwg.org/multipage/#workernavigator
@@ -29,6 +31,8 @@ pub(crate) struct WorkerNavigator {
     storage: MutNullableDom<StorageManager>,
     #[cfg(feature = "webgpu")]
     gpu: MutNullableDom<GPU>,
+    #[cfg(feature = "webnn")]
+    ml: MutNullableDom<ML>,
 }
 
 impl WorkerNavigator {
@@ -39,6 +43,8 @@ impl WorkerNavigator {
             storage: Default::default(),
             #[cfg(feature = "webgpu")]
             gpu: Default::default(),
+            #[cfg(feature = "webnn")]
+            ml: Default::default(),
         }
     }
 
@@ -125,10 +131,16 @@ impl WorkerNavigatorMethods<crate::DomTypeHolder> for WorkerNavigator {
             .or_init(|| StorageManager::new(cx, &self.global()))
     }
 
-    // https://gpuweb.github.io/gpuweb/#dom-navigator-gpu
+    /// <https://gpuweb.github.io/gpuweb/#dom-navigator-gpu>
     #[cfg(feature = "webgpu")]
     fn Gpu(&self, cx: &mut JSContext) -> DomRoot<GPU> {
         self.gpu.or_init(|| GPU::new(cx, &self.global()))
+    }
+
+    /// <https://www.w3.org/TR/webnn/#api-navigatorml>
+    #[cfg(feature = "webnn")]
+    fn Ml(&self, cx: &mut JSContext) -> DomRoot<ML> {
+        self.ml.or_init(|| ML::new(cx, &self.global()))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-navigator-hardwareconcurrency>

--- a/components/script_bindings/Cargo.toml
+++ b/components/script_bindings/Cargo.toml
@@ -63,6 +63,7 @@ gamepad = []
 testbinding = []
 tracing = ["dep:tracing"]
 webgpu = []
+webnn = []
 webxr = ["webxr-api"]
 
 [lints.rust]

--- a/components/script_bindings/Cargo.toml
+++ b/components/script_bindings/Cargo.toml
@@ -74,6 +74,7 @@ testbinding = []
 tracing = ["dep:tracing"]
 webgpu = []
 webgl = []
+webnn = []
 webxr = ["gamepad", "webgl", "webxr-api"]
 
 [lints.rust]

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1100,7 +1100,7 @@ DOMInterfaces = {
 },
 
 'Navigator': {
-    'cx': ['Bluetooth', 'Clipboard', 'Geolocation', 'Gpu', 'Languages', 'SendBeacon', 'ServiceWorker', 'Storage', 'UserActivation', 'WakeLock', 'Xr'],
+    'cx': ['Bluetooth', 'Clipboard', 'Geolocation', 'Gpu', 'Languages', 'Ml', 'SendBeacon', 'ServiceWorker', 'Storage', 'UserActivation', 'WakeLock', 'Xr'],
 },
 
 'CredentialsContainer': {
@@ -1778,9 +1778,15 @@ DOMInterfaces = {
 },
 
 'WorkerNavigator': {
-    'cx': ['Gpu', 'Languages', 'Storage'],
+    'cx': ['Gpu', 'Languages', 'Ml', 'Storage'],
 },
 
+'ML': {
+    'realm': ['CreateContext'],
+},
+
+'MLContext': {
+}
 }
 
 Dictionaries = {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -891,6 +891,13 @@ DOMInterfaces = {
     'cx': ['Data', 'InitMessageEvent', 'Ports'],
 },
 
+'ML': {
+    'realm': ['CreateContext'],
+},
+
+'MLContext': {
+},
+
 'MutationRecord': {
     'cx': ['AddedNodes', 'RemovedNodes'],
 },
@@ -915,7 +922,7 @@ DOMInterfaces = {
 },
 
 'Navigator': {
-    'cx': ['Bluetooth', 'Credentials', 'Clipboard', 'Geolocation', 'Gpu', 'MimeTypes', 'Languages', 'SendBeacon', 'ServiceWorker', 'Servo',
+    'cx': ['Bluetooth', 'Credentials', 'Clipboard', 'Geolocation', 'Gpu', 'MimeTypes', 'Languages', 'Ml', 'SendBeacon', 'ServiceWorker', 'Servo',
         'Storage', 'Plugins', 'UserActivation', 'WakeLock', 'Xr', 'MediaDevices', 'MediaSession', 'Permissions', 'GetGamepads'],
 },
 
@@ -1415,7 +1422,7 @@ DOMInterfaces = {
 },
 
 'WorkerNavigator': {
-    'cx': ['Gpu', 'Languages', 'Storage', 'Permissions'],
+    'cx': ['Gpu', 'Languages', 'Ml', 'Storage', 'Permissions'],
 },
 
 'Worklet': {

--- a/components/script_bindings/webidls/WebNN.webidl
+++ b/components/script_bindings/webidls/WebNN.webidl
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// Source: Web Neural Network API (https://www.w3.org/TR/webnn/#navigatorml)
+
+// skip-unless CARGO_FEATURE_WEBGPU
+
+interface mixin NavigatorML {
+  [SecureContext, SameObject, Pref="dom_webnn_enabled"] readonly attribute ML ml;
+};
+Navigator includes NavigatorML;
+WorkerNavigator includes NavigatorML;
+
+dictionary MLContextOptions {
+  boolean accelerated = true;
+};
+
+[Exposed=(Window, Worker), SecureContext, Pref="dom_webnn_enabled"]
+interface ML {
+  Promise<MLContext> createContext(optional MLContextOptions options = {});
+};
+
+[Exposed=(Window, Worker), SecureContext, Pref="dom_webnn_enabled"]
+interface MLContext {
+};

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -72,6 +72,9 @@ webgpu = [
     "servo-constellation/webgpu",
     "servo-constellation-traits/webgpu",
 ]
+webnn = [
+    "script/webnn",
+]
 webxr = [
     "dep:webxr",
     "dep:webxr-api",

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -94,6 +94,9 @@ webgpu = [
     "servo-constellation/webgpu",
     "servo-constellation-traits/webgpu",
 ]
+webnn = [
+    "script/webnn",
+]
 webxr = [
     "webgl",
     "gamepad",

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -41,7 +41,7 @@ OriginalFilename = "servoshell.exe"
 ProductName = "ServoShell"
 
 [features]
-default = ["baked-in-resources", "gamepad", "servo/clipboard", "js_jit", "max_log_level", "webgpu", "webxr"]
+default = ["baked-in-resources", "gamepad", "servo/clipboard", "js_jit", "max_log_level", "webgpu", "webnn", "webxr"]
 baked-in-resources = ["servo/baked-in-resources"]
 crown = ["servo/crown"]
 debugmozjs = ["servo/debugmozjs"]
@@ -59,6 +59,7 @@ tracing-perfetto = ["tracing", "dep:tracing-perfetto"]
 vello = ["servo/vello"]
 webgl_backtrace = ["servo/webgl_backtrace"]
 webgpu = ["servo/webgpu"]
+webnn = ["servo/webnn"]
 webxr = ["servo/webxr"]
 
 [dependencies]

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -48,7 +48,7 @@ default = ["default_without_allocator", "servo-allocator/use-jemalloc"]
 default_without_allocator = ["bundled", "default_web_features", "max_log_level", "js_jit"]
 # Default web features should be kept in sync with the list in servo/Cargo.toml.
 # We also need to enable our own features, since we also have `cfg` gated code here.
-default_web_features = ["servo/default_web_features", "gamepad", "webgpu", "webxr"]
+default_web_features = ["servo/default_web_features", "gamepad", "webgpu", "webnn", "webxr"]
 # Bundle required resources in the binary.
 bundled = ["servo/bundled"]
 
@@ -72,6 +72,7 @@ vello = ["servo/vello"]
 webgl_backtrace = ["servo/webgl_backtrace"]
 webgl = ["servo/webgl"]
 webgpu = ["servo/webgpu"]
+webnn = ["servo/webnn"]
 webxr = ["servo/webxr"]
 
 [dependencies]

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -121,6 +121,7 @@ WEBIDL_STANDARDS = [
     b"//www.w3.org/TR/trusted-types/",
     b"//www.w3.org/TR/credential-management",
     b"//www.w3.org/TR/geolocation",
+    b"//www.w3.org/TR/webnn",
     b"//dom.spec.whatwg.org",
     b"//drafts.csswg.org",
     b"//drafts.css-houdini.org",

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -124,6 +124,7 @@ WEBIDL_STANDARDS = [
     b"//www.w3.org/TR/trusted-types/",
     b"//www.w3.org/TR/credential-management",
     b"//www.w3.org/TR/geolocation",
+    b"//www.w3.org/TR/webnn",
     b"//dom.spec.whatwg.org",
     b"//drafts.csswg.org",
     b"//drafts.css-houdini.org",

--- a/tests/wpt/meta/webnn/__dir__.ini
+++ b/tests/wpt/meta/webnn/__dir__.ini
@@ -1,0 +1,1 @@
+prefs: [dom_webnn_enabled: true]

--- a/tests/wpt/meta/webnn/conformance_tests/abs.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/abs.https.any.js.ini
@@ -1,13 +1,25 @@
 [abs.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise abs operation]
+    expected: NOTRUN
 
 
 [abs.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise abs operation]
+    expected: NOTRUN
 
 
 [abs.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise abs operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/add.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/add.https.any.js.ini
@@ -1,13 +1,25 @@
 [add.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise add operation]
+    expected: NOTRUN
 
 
 [add.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise add operation]
+    expected: NOTRUN
 
 
 [add.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise add operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/arg_min_max.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/arg_min_max.https.any.js.ini
@@ -1,13 +1,25 @@
 [arg_min_max.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API argMin/Max operations]
+    expected: NOTRUN
 
 
 [arg_min_max.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API argMin/Max operations]
+    expected: NOTRUN
 
 
 [arg_min_max.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API argMin/Max operations]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/averagePool2d.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/averagePool2d.https.any.js.ini
@@ -1,13 +1,25 @@
 [averagePool2d.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API averagePool2d operation]
+    expected: NOTRUN
 
 
 [averagePool2d.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API averagePool2d operation]
+    expected: NOTRUN
 
 
 [averagePool2d.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API averagePool2d operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/batch_normalization.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/batch_normalization.https.any.js.ini
@@ -1,13 +1,25 @@
 [batch_normalization.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API batchNormalization operation]
+    expected: NOTRUN
 
 
 [batch_normalization.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API batchNormalization operation]
+    expected: NOTRUN
 
 
 [batch_normalization.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API batchNormalization operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/batch_normalization_constant.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/batch_normalization_constant.https.any.js.ini
@@ -1,13 +1,25 @@
 [batch_normalization_constant.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API batchNormalization operation with constant inputs]
+    expected: NOTRUN
 
 
 [batch_normalization_constant.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API batchNormalization operation with constant inputs]
+    expected: NOTRUN
 
 
 [batch_normalization_constant.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API batchNormalization operation with constant inputs]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/byob_readtensor.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/byob_readtensor.https.any.js.ini
@@ -1,8 +1,5 @@
 [byob_readtensor.https.any.html?cpu]
   expected: ERROR
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [readTensor() with an ArrayBuffer that is too small should reject]
     expected: NOTRUN
 
@@ -42,9 +39,6 @@
 
 [byob_readtensor.https.any.html?npu]
   expected: ERROR
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [readTensor() with an ArrayBuffer that is too small should reject]
     expected: NOTRUN
 
@@ -84,9 +78,6 @@
 
 [byob_readtensor.https.any.html?gpu]
   expected: ERROR
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [readTensor() with an ArrayBuffer that is too small should reject]
     expected: NOTRUN
 

--- a/tests/wpt/meta/webnn/conformance_tests/cast.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/cast.https.any.js.ini
@@ -1,13 +1,25 @@
 [cast.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API cast operation]
+    expected: NOTRUN
 
 
 [cast.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API cast operation]
+    expected: NOTRUN
 
 
 [cast.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API cast operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/ceil.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/ceil.https.any.js.ini
@@ -1,13 +1,25 @@
 [ceil.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise ceil operation]
+    expected: NOTRUN
 
 
 [ceil.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise ceil operation]
+    expected: NOTRUN
 
 
 [ceil.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise ceil operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/clamp.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/clamp.https.any.js.ini
@@ -1,13 +1,25 @@
 [clamp.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API clamp operation]
+    expected: NOTRUN
 
 
 [clamp.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API clamp operation]
+    expected: NOTRUN
 
 
 [clamp.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API clamp operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/concat.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/concat.https.any.js.ini
@@ -1,13 +1,25 @@
 [concat.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API concat operation]
+    expected: NOTRUN
 
 
 [concat.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API concat operation]
+    expected: NOTRUN
 
 
 [concat.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API concat operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/constant-reshape-optimization.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/constant-reshape-optimization.https.any.js.ini
@@ -1,13 +1,25 @@
 [constant-reshape-optimization.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test constant reshape optimization]
+    expected: NOTRUN
 
 
 [constant-reshape-optimization.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test constant reshape optimization]
+    expected: NOTRUN
 
 
 [constant-reshape-optimization.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test constant reshape optimization]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/conv2d.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/conv2d.https.any.js.ini
@@ -1,13 +1,25 @@
 [conv2d.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API conv2d operation]
+    expected: NOTRUN
 
 
 [conv2d.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API conv2d operation]
+    expected: NOTRUN
 
 
 [conv2d.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API conv2d operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/conv_transpose2d.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/conv_transpose2d.https.any.js.ini
@@ -1,13 +1,25 @@
 [conv_transpose2d.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API convTranspose2d operation]
+    expected: NOTRUN
 
 
 [conv_transpose2d.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API convTranspose2d operation]
+    expected: NOTRUN
 
 
 [conv_transpose2d.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API convTranspose2d operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/cos.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/cos.https.any.js.ini
@@ -1,13 +1,25 @@
 [cos.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise cos operation]
+    expected: NOTRUN
 
 
 [cos.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise cos operation]
+    expected: NOTRUN
 
 
 [cos.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise cos operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/cumulative_sum.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/cumulative_sum.https.any.js.ini
@@ -1,13 +1,25 @@
 [cumulative_sum.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API cumulativeSum operation]
+    expected: NOTRUN
 
 
 [cumulative_sum.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API cumulativeSum operation]
+    expected: NOTRUN
 
 
 [cumulative_sum.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API cumulativeSum operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/dequantizeLinear.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/dequantizeLinear.https.any.js.ini
@@ -1,13 +1,25 @@
 [dequantizeLinear.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API dequantizeLinear operation]
+    expected: NOTRUN
 
 
 [dequantizeLinear.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API dequantizeLinear operation]
+    expected: NOTRUN
 
 
 [dequantizeLinear.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API dequantizeLinear operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/div.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/div.https.any.js.ini
@@ -1,13 +1,25 @@
 [div.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise div operation]
+    expected: NOTRUN
 
 
 [div.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise div operation]
+    expected: NOTRUN
 
 
 [div.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise div operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/elu.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/elu.https.any.js.ini
@@ -1,13 +1,25 @@
 [elu.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API elu operation]
+    expected: NOTRUN
 
 
 [elu.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API elu operation]
+    expected: NOTRUN
 
 
 [elu.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API elu operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/equal.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/equal.https.any.js.ini
@@ -1,13 +1,25 @@
 [equal.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise equal operation]
+    expected: NOTRUN
 
 
 [equal.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise equal operation]
+    expected: NOTRUN
 
 
 [equal.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise equal operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/erf.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/erf.https.any.js.ini
@@ -1,13 +1,25 @@
 [erf.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise erf operation]
+    expected: NOTRUN
 
 
 [erf.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise erf operation]
+    expected: NOTRUN
 
 
 [erf.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise erf operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/exp.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/exp.https.any.js.ini
@@ -1,13 +1,25 @@
 [exp.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise exp operation]
+    expected: NOTRUN
 
 
 [exp.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise exp operation]
+    expected: NOTRUN
 
 
 [exp.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise exp operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/expand.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/expand.https.any.js.ini
@@ -1,13 +1,25 @@
 [expand.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API expand operation]
+    expected: NOTRUN
 
 
 [expand.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API expand operation]
+    expected: NOTRUN
 
 
 [expand.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API expand operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/floor.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/floor.https.any.js.ini
@@ -1,13 +1,25 @@
 [floor.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise floor operation]
+    expected: NOTRUN
 
 
 [floor.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise floor operation]
+    expected: NOTRUN
 
 
 [floor.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise floor operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/gather.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/gather.https.any.js.ini
@@ -1,13 +1,25 @@
 [gather.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API gather operation]
+    expected: NOTRUN
 
 
 [gather.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API gather operation]
+    expected: NOTRUN
 
 
 [gather.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API gather operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/gatherElements.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/gatherElements.https.any.js.ini
@@ -1,13 +1,25 @@
 [gatherElements.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API gatherElements operation]
+    expected: NOTRUN
 
 
 [gatherElements.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API gatherElements operation]
+    expected: NOTRUN
 
 
 [gatherElements.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API gatherElements operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/gatherND.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/gatherND.https.any.js.ini
@@ -1,13 +1,25 @@
 [gatherND.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API gatherND operation]
+    expected: NOTRUN
 
 
 [gatherND.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API gatherND operation]
+    expected: NOTRUN
 
 
 [gatherND.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API gatherND operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/gelu.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/gelu.https.any.js.ini
@@ -1,13 +1,25 @@
 [gelu.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API gelu operation]
+    expected: NOTRUN
 
 
 [gelu.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API gelu operation]
+    expected: NOTRUN
 
 
 [gelu.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API gelu operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/gemm.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/gemm.https.any.js.ini
@@ -1,13 +1,25 @@
 [gemm.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API gemm operation]
+    expected: NOTRUN
 
 
 [gemm.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API gemm operation]
+    expected: NOTRUN
 
 
 [gemm.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API gemm operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/graph_devices.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/graph_devices.https.any.js.ini
@@ -2,12 +2,21 @@
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
 
+  [test graph.devices]
+    expected: FAIL
+
 
 [graph_devices.https.any.html?cpu]
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
 
+  [test graph.devices]
+    expected: FAIL
+
 
 [graph_devices.https.any.html?npu]
   [assert_implements(navigator.ml, 'missing navigator.ml')]
+    expected: FAIL
+
+  [test graph.devices]
     expected: FAIL

--- a/tests/wpt/meta/webnn/conformance_tests/greater.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/greater.https.any.js.ini
@@ -1,13 +1,25 @@
 [greater.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise greater operation]
+    expected: NOTRUN
 
 
 [greater.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise greater operation]
+    expected: NOTRUN
 
 
 [greater.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise greater operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/greater_or_equal.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/greater_or_equal.https.any.js.ini
@@ -1,13 +1,25 @@
 [greater_or_equal.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise greaterOrEqual operation]
+    expected: NOTRUN
 
 
 [greater_or_equal.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise greaterOrEqual operation]
+    expected: NOTRUN
 
 
 [greater_or_equal.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise greaterOrEqual operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/gru.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/gru.https.any.js.ini
@@ -1,13 +1,25 @@
 [gru.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API gru operation]
+    expected: NOTRUN
 
 
 [gru.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API gru operation]
+    expected: NOTRUN
 
 
 [gru.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API gru operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/gru_cell.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/gru_cell.https.any.js.ini
@@ -1,13 +1,25 @@
 [gru_cell.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API gruCell operation]
+    expected: NOTRUN
 
 
 [gru_cell.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API gruCell operation]
+    expected: NOTRUN
 
 
 [gru_cell.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API gruCell operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/hard_sigmoid.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/hard_sigmoid.https.any.js.ini
@@ -1,13 +1,25 @@
 [hard_sigmoid.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API hardSigmoid operation]
+    expected: NOTRUN
 
 
 [hard_sigmoid.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API hardSigmoid operation]
+    expected: NOTRUN
 
 
 [hard_sigmoid.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API hardSigmoid operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/hard_swish.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/hard_swish.https.any.js.ini
@@ -1,13 +1,25 @@
 [hard_swish.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API tanh operation]
+    expected: NOTRUN
 
 
 [hard_swish.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API tanh operation]
+    expected: NOTRUN
 
 
 [hard_swish.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API tanh operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/identity.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/identity.https.any.js.ini
@@ -1,13 +1,25 @@
 [identity.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise identity operation]
+    expected: NOTRUN
 
 
 [identity.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise identity operation]
+    expected: NOTRUN
 
 
 [identity.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise identity operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/inputs-are-not-modified.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/inputs-are-not-modified.https.any.js.ini
@@ -1,25 +1,22 @@
 [inputs-are-not-modified.https.any.html?npu]
-  expected: ERROR
   [input tensor is not modified: hardSwish]
-    expected: NOTRUN
+    expected: FAIL
 
   [input tensor is not modified: mul]
-    expected: NOTRUN
+    expected: FAIL
 
 
 [inputs-are-not-modified.https.any.html?gpu]
-  expected: ERROR
   [input tensor is not modified: hardSwish]
-    expected: NOTRUN
+    expected: FAIL
 
   [input tensor is not modified: mul]
-    expected: NOTRUN
+    expected: FAIL
 
 
 [inputs-are-not-modified.https.any.html?cpu]
-  expected: ERROR
   [input tensor is not modified: hardSwish]
-    expected: NOTRUN
+    expected: FAIL
 
   [input tensor is not modified: mul]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/webnn/conformance_tests/inputs-with-special-names.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/inputs-with-special-names.https.any.js.ini
@@ -1,88 +1,85 @@
 [inputs-with-special-names.https.any.html?npu]
-  expected: ERROR
   [abs input with special character name '12-L#!.☺']
-    expected: NOTRUN
+    expected: FAIL
 
   [abs input with special character name '🤦🏼‍♂️124DS#!F']
-    expected: NOTRUN
+    expected: FAIL
 
   [abs input with special character name 'hello\n\t\r\x08\x0c\x0b'"\x00\\webnn']
-    expected: NOTRUN
+    expected: FAIL
 
   [abs input with special character name '\x00']
-    expected: NOTRUN
+    expected: FAIL
 
   [abs input with special character name '\x00startWithNullCharacter']
-    expected: NOTRUN
+    expected: FAIL
 
   [abs input with special character name 'AAA']
-    expected: NOTRUN
+    expected: FAIL
 
   [abs input with special character name '©©♥…']
-    expected: NOTRUN
+    expected: FAIL
 
   [abs input with special character name 'U0001F600']
-    expected: NOTRUN
+    expected: FAIL
 
   [[add\] inputs with null character name in the middle]
-    expected: NOTRUN
+    expected: FAIL
 
 
 [inputs-with-special-names.https.any.html?cpu]
-  expected: ERROR
   [abs input with special character name '12-L#!.☺']
-    expected: NOTRUN
+    expected: FAIL
 
   [abs input with special character name '🤦🏼‍♂️124DS#!F']
-    expected: NOTRUN
+    expected: FAIL
 
   [abs input with special character name 'hello\n\t\r\x08\x0c\x0b'"\x00\\webnn']
-    expected: NOTRUN
+    expected: FAIL
 
   [abs input with special character name '\x00']
-    expected: NOTRUN
+    expected: FAIL
 
   [abs input with special character name '\x00startWithNullCharacter']
-    expected: NOTRUN
+    expected: FAIL
 
   [abs input with special character name 'AAA']
-    expected: NOTRUN
+    expected: FAIL
 
   [abs input with special character name '©©♥…']
-    expected: NOTRUN
+    expected: FAIL
 
   [abs input with special character name 'U0001F600']
-    expected: NOTRUN
+    expected: FAIL
 
   [[add\] inputs with null character name in the middle]
-    expected: NOTRUN
+    expected: FAIL
 
 
 [inputs-with-special-names.https.any.html?gpu]
-  expected: ERROR
   [abs input with special character name '12-L#!.☺']
-    expected: NOTRUN
+    expected: FAIL
 
   [abs input with special character name '🤦🏼‍♂️124DS#!F']
-    expected: NOTRUN
+    expected: FAIL
 
   [abs input with special character name 'hello\n\t\r\x08\x0c\x0b'"\x00\\webnn']
-    expected: NOTRUN
+    expected: FAIL
 
   [abs input with special character name '\x00']
-    expected: NOTRUN
+    expected: FAIL
 
   [abs input with special character name '\x00startWithNullCharacter']
-    expected: NOTRUN
+    expected: FAIL
 
   [abs input with special character name 'AAA']
-    expected: NOTRUN
+    expected: FAIL
 
   [abs input with special character name '©©♥…']
-    expected: NOTRUN
+    expected: FAIL
 
   [abs input with special character name 'U0001F600']
-    expected: NOTRUN
+    expected: FAIL
 
   [[add\] inputs with null character name in the middle]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/webnn/conformance_tests/instance_normalization.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/instance_normalization.https.any.js.ini
@@ -1,13 +1,25 @@
 [instance_normalization.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API instanceNormalization operation]
+    expected: NOTRUN
 
 
 [instance_normalization.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API instanceNormalization operation]
+    expected: NOTRUN
 
 
 [instance_normalization.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API instanceNormalization operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/is_infinite.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/is_infinite.https.any.js.ini
@@ -1,13 +1,25 @@
 [is_infinite.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API Element-wise logical isInfinite operation]
+    expected: NOTRUN
 
 
 [is_infinite.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API Element-wise logical isInfinite operation]
+    expected: NOTRUN
 
 
 [is_infinite.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API Element-wise logical isInfinite operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/is_nan.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/is_nan.https.any.js.ini
@@ -1,13 +1,25 @@
 [is_nan.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API Element-wise logical isNaN operation]
+    expected: NOTRUN
 
 
 [is_nan.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API Element-wise logical isNaN operation]
+    expected: NOTRUN
 
 
 [is_nan.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API Element-wise logical isNaN operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/l2Pool2d.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/l2Pool2d.https.any.js.ini
@@ -1,13 +1,25 @@
 [l2Pool2d.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API l2Pool2d operation]
+    expected: NOTRUN
 
 
 [l2Pool2d.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API l2Pool2d operation]
+    expected: NOTRUN
 
 
 [l2Pool2d.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API l2Pool2d operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/layer_normalization.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/layer_normalization.https.any.js.ini
@@ -1,13 +1,25 @@
 [layer_normalization.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API layerNormalization operation]
+    expected: NOTRUN
 
 
 [layer_normalization.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API layerNormalization operation]
+    expected: NOTRUN
 
 
 [layer_normalization.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API layerNormalization operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/leaky_relu.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/leaky_relu.https.any.js.ini
@@ -1,13 +1,25 @@
 [leaky_relu.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API leakyRelu operation]
+    expected: NOTRUN
 
 
 [leaky_relu.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API leakyRelu operation]
+    expected: NOTRUN
 
 
 [leaky_relu.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API leakyRelu operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/lesser.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/lesser.https.any.js.ini
@@ -1,13 +1,25 @@
 [lesser.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise lesser operation]
+    expected: NOTRUN
 
 
 [lesser.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise lesser operation]
+    expected: NOTRUN
 
 
 [lesser.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise lesser operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/lesser_or_equal.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/lesser_or_equal.https.any.js.ini
@@ -1,13 +1,25 @@
 [lesser_or_equal.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise lesserOrEqual operation]
+    expected: NOTRUN
 
 
 [lesser_or_equal.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise lesserOrEqual operation]
+    expected: NOTRUN
 
 
 [lesser_or_equal.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise lesserOrEqual operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/linear.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/linear.https.any.js.ini
@@ -1,13 +1,25 @@
 [linear.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API linear operation]
+    expected: NOTRUN
 
 
 [linear.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API linear operation]
+    expected: NOTRUN
 
 
 [linear.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API linear operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/log.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/log.https.any.js.ini
@@ -1,13 +1,25 @@
 [log.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise log operation]
+    expected: NOTRUN
 
 
 [log.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise log operation]
+    expected: NOTRUN
 
 
 [log.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise log operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/logical_and.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/logical_and.https.any.js.ini
@@ -1,13 +1,25 @@
 [logical_and.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise logicalAnd operation]
+    expected: NOTRUN
 
 
 [logical_and.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise logicalAnd operation]
+    expected: NOTRUN
 
 
 [logical_and.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise logicalAnd operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/logical_not.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/logical_not.https.any.js.ini
@@ -1,13 +1,25 @@
 [logical_not.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise logicalNot operation]
+    expected: NOTRUN
 
 
 [logical_not.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise logicalNot operation]
+    expected: NOTRUN
 
 
 [logical_not.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise logicalNot operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/logical_or.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/logical_or.https.any.js.ini
@@ -1,13 +1,25 @@
 [logical_or.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise logicalOr operation]
+    expected: NOTRUN
 
 
 [logical_or.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise logicalOr operation]
+    expected: NOTRUN
 
 
 [logical_or.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise logicalOr operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/logical_xor.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/logical_xor.https.any.js.ini
@@ -1,13 +1,25 @@
 [logical_xor.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise logicalXor operation]
+    expected: NOTRUN
 
 
 [logical_xor.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise logicalXor operation]
+    expected: NOTRUN
 
 
 [logical_xor.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise logicalXor operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/lstm.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/lstm.https.any.js.ini
@@ -1,13 +1,25 @@
 [lstm.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API lstm operation]
+    expected: NOTRUN
 
 
 [lstm.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API lstm operation]
+    expected: NOTRUN
 
 
 [lstm.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API lstm operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/lstm_cell.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/lstm_cell.https.any.js.ini
@@ -1,13 +1,25 @@
 [lstm_cell.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API lstmCell operation]
+    expected: NOTRUN
 
 
 [lstm_cell.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API lstmCell operation]
+    expected: NOTRUN
 
 
 [lstm_cell.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API lstmCell operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/matmul.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/matmul.https.any.js.ini
@@ -1,13 +1,25 @@
 [matmul.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API matmul operation]
+    expected: NOTRUN
 
 
 [matmul.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API matmul operation]
+    expected: NOTRUN
 
 
 [matmul.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API matmul operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/max.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/max.https.any.js.ini
@@ -1,13 +1,25 @@
 [max.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise max operation]
+    expected: NOTRUN
 
 
 [max.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise max operation]
+    expected: NOTRUN
 
 
 [max.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise max operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/maxPool2d.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/maxPool2d.https.any.js.ini
@@ -1,13 +1,25 @@
 [maxPool2d.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API maxPool2d operation]
+    expected: NOTRUN
 
 
 [maxPool2d.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API maxPool2d operation]
+    expected: NOTRUN
 
 
 [maxPool2d.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API maxPool2d operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/min.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/min.https.any.js.ini
@@ -1,13 +1,25 @@
 [min.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise min operation]
+    expected: NOTRUN
 
 
 [min.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise min operation]
+    expected: NOTRUN
 
 
 [min.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise min operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/mlNumber.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/mlNumber.https.any.js.ini
@@ -1,13 +1,25 @@
 [mlNumber.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN MLNumber]
+    expected: NOTRUN
 
 
 [mlNumber.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN MLNumber]
+    expected: NOTRUN
 
 
 [mlNumber.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN MLNumber]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/mul.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/mul.https.any.js.ini
@@ -1,13 +1,25 @@
 [mul.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise mul operation]
+    expected: NOTRUN
 
 
 [mul.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise mul operation]
+    expected: NOTRUN
 
 
 [mul.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise mul operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/neg.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/neg.https.any.js.ini
@@ -1,13 +1,25 @@
 [neg.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise neg operation]
+    expected: NOTRUN
 
 
 [neg.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise neg operation]
+    expected: NOTRUN
 
 
 [neg.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise neg operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/not_equal.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/not_equal.https.any.js.ini
@@ -1,13 +1,25 @@
 [not_equal.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise notEqual operation]
+    expected: NOTRUN
 
 
 [not_equal.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise notEqual operation]
+    expected: NOTRUN
 
 
 [not_equal.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise notEqual operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/operations-with-special-names.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/operations-with-special-names.https.any.js.ini
@@ -1,52 +1,49 @@
 [operations-with-special-names.https.any.html?gpu]
-  expected: ERROR
   ['add' nodes with special character name '12-L#!.☺' and '🤦🏼‍♂️124DS#!F']
-    expected: NOTRUN
+    expected: FAIL
 
   ['add' nodes with special character name '\x00node_a' and '\x00node_b']
-    expected: NOTRUN
+    expected: FAIL
 
   ['add' nodes with special character name 'node\x00a' and 'node\x00b']
-    expected: NOTRUN
+    expected: FAIL
 
   ['add' nodes with special character name 'AAA' and 'BBB']
-    expected: NOTRUN
+    expected: FAIL
 
   ['add' nodes with special character name '©©♥…' and 'U0001F600']
-    expected: NOTRUN
+    expected: FAIL
 
 
 [operations-with-special-names.https.any.html?cpu]
-  expected: ERROR
   ['add' nodes with special character name '12-L#!.☺' and '🤦🏼‍♂️124DS#!F']
-    expected: NOTRUN
+    expected: FAIL
 
   ['add' nodes with special character name '\x00node_a' and '\x00node_b']
-    expected: NOTRUN
+    expected: FAIL
 
   ['add' nodes with special character name 'node\x00a' and 'node\x00b']
-    expected: NOTRUN
+    expected: FAIL
 
   ['add' nodes with special character name 'AAA' and 'BBB']
-    expected: NOTRUN
+    expected: FAIL
 
   ['add' nodes with special character name '©©♥…' and 'U0001F600']
-    expected: NOTRUN
+    expected: FAIL
 
 
 [operations-with-special-names.https.any.html?npu]
-  expected: ERROR
   ['add' nodes with special character name '12-L#!.☺' and '🤦🏼‍♂️124DS#!F']
-    expected: NOTRUN
+    expected: FAIL
 
   ['add' nodes with special character name '\x00node_a' and '\x00node_b']
-    expected: NOTRUN
+    expected: FAIL
 
   ['add' nodes with special character name 'node\x00a' and 'node\x00b']
-    expected: NOTRUN
+    expected: FAIL
 
   ['add' nodes with special character name 'AAA' and 'BBB']
-    expected: NOTRUN
+    expected: FAIL
 
   ['add' nodes with special character name '©©♥…' and 'U0001F600']
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/webnn/conformance_tests/pad.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/pad.https.any.js.ini
@@ -1,13 +1,25 @@
 [pad.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API pad operation]
+    expected: NOTRUN
 
 
 [pad.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API pad operation]
+    expected: NOTRUN
 
 
 [pad.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API pad operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/parallel-dispatch.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/parallel-dispatch.https.any.js.ini
@@ -1,88 +1,85 @@
 [parallel-dispatch.https.any.html?cpu]
-  expected: ERROR
   [dispatch queues behind readTensor]
-    expected: NOTRUN
+    expected: FAIL
 
   [same graph: write/dispatch/read, write/dispatch/read, ...]
-    expected: NOTRUN
+    expected: FAIL
 
   [same graph: write/write..., dispatch/read, dispatch/read, ...]
-    expected: NOTRUN
+    expected: FAIL
 
   [same graph: write/write..., dispatch/dispatch..., read/read...]
-    expected: NOTRUN
+    expected: FAIL
 
   [same graph serial inputs: dispatch/dispatch..., read/read...]
-    expected: NOTRUN
+    expected: FAIL
 
   [different graphs: write/write..., dispatch/read, dispatch/read, ...]
-    expected: NOTRUN
+    expected: FAIL
 
   [different graphs: write/write..., dispatch/dispatch..., read/read...]
-    expected: NOTRUN
+    expected: FAIL
 
   [different graphs serial inputs: dispatch/dispatch..., read/read...]
-    expected: NOTRUN
+    expected: FAIL
 
   [different graphs using the same tensors]
-    expected: NOTRUN
+    expected: FAIL
 
 
 [parallel-dispatch.https.any.html?gpu]
-  expected: ERROR
   [dispatch queues behind readTensor]
-    expected: NOTRUN
+    expected: FAIL
 
   [same graph: write/dispatch/read, write/dispatch/read, ...]
-    expected: NOTRUN
+    expected: FAIL
 
   [same graph: write/write..., dispatch/read, dispatch/read, ...]
-    expected: NOTRUN
+    expected: FAIL
 
   [same graph: write/write..., dispatch/dispatch..., read/read...]
-    expected: NOTRUN
+    expected: FAIL
 
   [same graph serial inputs: dispatch/dispatch..., read/read...]
-    expected: NOTRUN
+    expected: FAIL
 
   [different graphs: write/write..., dispatch/read, dispatch/read, ...]
-    expected: NOTRUN
+    expected: FAIL
 
   [different graphs: write/write..., dispatch/dispatch..., read/read...]
-    expected: NOTRUN
+    expected: FAIL
 
   [different graphs serial inputs: dispatch/dispatch..., read/read...]
-    expected: NOTRUN
+    expected: FAIL
 
   [different graphs using the same tensors]
-    expected: NOTRUN
+    expected: FAIL
 
 
 [parallel-dispatch.https.any.html?npu]
-  expected: ERROR
   [dispatch queues behind readTensor]
-    expected: NOTRUN
+    expected: FAIL
 
   [same graph: write/dispatch/read, write/dispatch/read, ...]
-    expected: NOTRUN
+    expected: FAIL
 
   [same graph: write/write..., dispatch/read, dispatch/read, ...]
-    expected: NOTRUN
+    expected: FAIL
 
   [same graph: write/write..., dispatch/dispatch..., read/read...]
-    expected: NOTRUN
+    expected: FAIL
 
   [same graph serial inputs: dispatch/dispatch..., read/read...]
-    expected: NOTRUN
+    expected: FAIL
 
   [different graphs: write/write..., dispatch/read, dispatch/read, ...]
-    expected: NOTRUN
+    expected: FAIL
 
   [different graphs: write/write..., dispatch/dispatch..., read/read...]
-    expected: NOTRUN
+    expected: FAIL
 
   [different graphs serial inputs: dispatch/dispatch..., read/read...]
-    expected: NOTRUN
+    expected: FAIL
 
   [different graphs using the same tensors]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/webnn/conformance_tests/pow.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/pow.https.any.js.ini
@@ -1,13 +1,25 @@
 [pow.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise pow operation]
+    expected: NOTRUN
 
 
 [pow.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise pow operation]
+    expected: NOTRUN
 
 
 [pow.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise pow operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/prelu.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/prelu.https.any.js.ini
@@ -1,13 +1,25 @@
 [prelu.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API prelu operation]
+    expected: NOTRUN
 
 
 [prelu.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API prelu operation]
+    expected: NOTRUN
 
 
 [prelu.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API prelu operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/qdq_subgraph.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/qdq_subgraph.https.any.js.ini
@@ -1,13 +1,25 @@
 [qdq_subgraph.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN `dequantization -> operators -> quantization` subgraph]
+    expected: NOTRUN
 
 
 [qdq_subgraph.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN `dequantization -> operators -> quantization` subgraph]
+    expected: NOTRUN
 
 
 [qdq_subgraph.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN `dequantization -> operators -> quantization` subgraph]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/quantizeLinear.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/quantizeLinear.https.any.js.ini
@@ -1,13 +1,25 @@
 [quantizeLinear.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API quantizeLinear operation]
+    expected: NOTRUN
 
 
 [quantizeLinear.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API quantizeLinear operation]
+    expected: NOTRUN
 
 
 [quantizeLinear.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API quantizeLinear operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/reciprocal.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/reciprocal.https.any.js.ini
@@ -1,13 +1,25 @@
 [reciprocal.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise reciprocal operation]
+    expected: NOTRUN
 
 
 [reciprocal.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise reciprocal operation]
+    expected: NOTRUN
 
 
 [reciprocal.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise reciprocal operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/reduce_l1.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/reduce_l1.https.any.js.ini
@@ -1,13 +1,25 @@
 [reduce_l1.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reduction operations]
+    expected: NOTRUN
 
 
 [reduce_l1.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reduction operations]
+    expected: NOTRUN
 
 
 [reduce_l1.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reduction operations]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/reduce_l2.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/reduce_l2.https.any.js.ini
@@ -1,13 +1,25 @@
 [reduce_l2.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reduction operations]
+    expected: NOTRUN
 
 
 [reduce_l2.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reduction operations]
+    expected: NOTRUN
 
 
 [reduce_l2.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reduction operations]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/reduce_log_sum.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/reduce_log_sum.https.any.js.ini
@@ -1,13 +1,25 @@
 [reduce_log_sum.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reduction operations]
+    expected: NOTRUN
 
 
 [reduce_log_sum.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reduction operations]
+    expected: NOTRUN
 
 
 [reduce_log_sum.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reduction operations]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/reduce_log_sum_exp.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/reduce_log_sum_exp.https.any.js.ini
@@ -1,13 +1,25 @@
 [reduce_log_sum_exp.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reduction operations]
+    expected: NOTRUN
 
 
 [reduce_log_sum_exp.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reduction operations]
+    expected: NOTRUN
 
 
 [reduce_log_sum_exp.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reduction operations]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/reduce_max.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/reduce_max.https.any.js.ini
@@ -1,13 +1,25 @@
 [reduce_max.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reduction operations]
+    expected: NOTRUN
 
 
 [reduce_max.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reduction operations]
+    expected: NOTRUN
 
 
 [reduce_max.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reduction operations]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/reduce_mean.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/reduce_mean.https.any.js.ini
@@ -1,13 +1,25 @@
 [reduce_mean.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reduction operations]
+    expected: NOTRUN
 
 
 [reduce_mean.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reduction operations]
+    expected: NOTRUN
 
 
 [reduce_mean.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reduction operations]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/reduce_min.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/reduce_min.https.any.js.ini
@@ -1,13 +1,25 @@
 [reduce_min.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reduction operations]
+    expected: NOTRUN
 
 
 [reduce_min.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reduction operations]
+    expected: NOTRUN
 
 
 [reduce_min.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reduction operations]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/reduce_product.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/reduce_product.https.any.js.ini
@@ -1,13 +1,25 @@
 [reduce_product.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reduction operations]
+    expected: NOTRUN
 
 
 [reduce_product.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reduction operations]
+    expected: NOTRUN
 
 
 [reduce_product.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reduction operations]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/reduce_sum.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/reduce_sum.https.any.js.ini
@@ -1,13 +1,25 @@
 [reduce_sum.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reduction operations]
+    expected: NOTRUN
 
 
 [reduce_sum.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reduction operations]
+    expected: NOTRUN
 
 
 [reduce_sum.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reduction operations]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/reduce_sum_square.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/reduce_sum_square.https.any.js.ini
@@ -1,13 +1,25 @@
 [reduce_sum_square.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reduction operations]
+    expected: NOTRUN
 
 
 [reduce_sum_square.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reduction operations]
+    expected: NOTRUN
 
 
 [reduce_sum_square.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reduction operations]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/relu.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/relu.https.any.js.ini
@@ -1,13 +1,25 @@
 [relu.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API relu operation]
+    expected: NOTRUN
 
 
 [relu.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API relu operation]
+    expected: NOTRUN
 
 
 [relu.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API relu operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/resample2d.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/resample2d.https.any.js.ini
@@ -1,13 +1,25 @@
 [resample2d.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API resample2d operation]
+    expected: NOTRUN
 
 
 [resample2d.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API resample2d operation]
+    expected: NOTRUN
 
 
 [resample2d.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API resample2d operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/reshape.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/reshape.https.any.js.ini
@@ -1,13 +1,25 @@
 [reshape.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reshape operation]
+    expected: NOTRUN
 
 
 [reshape.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reshape operation]
+    expected: NOTRUN
 
 
 [reshape.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reshape operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/reverse.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/reverse.https.any.js.ini
@@ -1,13 +1,25 @@
 [reverse.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reverse operation]
+    expected: NOTRUN
 
 
 [reverse.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reverse operation]
+    expected: NOTRUN
 
 
 [reverse.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API reverse operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/round_even.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/round_even.https.any.js.ini
@@ -1,13 +1,25 @@
 [round_even.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise roundEven operation]
+    expected: NOTRUN
 
 
 [round_even.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise roundEven operation]
+    expected: NOTRUN
 
 
 [round_even.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise roundEven operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/scalars.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/scalars.https.any.js.ini
@@ -1,61 +1,58 @@
 [scalars.https.any.html?gpu]
-  expected: ERROR
   [scalar input]
-    expected: NOTRUN
+    expected: FAIL
 
   [float32 scalar input, constant, and output]
-    expected: NOTRUN
+    expected: FAIL
 
   [int32 scalar input, constant, and output]
-    expected: NOTRUN
+    expected: FAIL
 
   [scalar constant created with constant(type, value) - float32]
-    expected: NOTRUN
+    expected: FAIL
 
   [scalar constant created with constant(type, value) - int32]
-    expected: NOTRUN
+    expected: FAIL
 
   [multiple scalar constants in expression - float16]
-    expected: NOTRUN
+    expected: FAIL
 
 
 [scalars.https.any.html?cpu]
-  expected: ERROR
   [scalar input]
-    expected: NOTRUN
+    expected: FAIL
 
   [float32 scalar input, constant, and output]
-    expected: NOTRUN
+    expected: FAIL
 
   [int32 scalar input, constant, and output]
-    expected: NOTRUN
+    expected: FAIL
 
   [scalar constant created with constant(type, value) - float32]
-    expected: NOTRUN
+    expected: FAIL
 
   [scalar constant created with constant(type, value) - int32]
-    expected: NOTRUN
+    expected: FAIL
 
   [multiple scalar constants in expression - float16]
-    expected: NOTRUN
+    expected: FAIL
 
 
 [scalars.https.any.html?npu]
-  expected: ERROR
   [scalar input]
-    expected: NOTRUN
+    expected: FAIL
 
   [float32 scalar input, constant, and output]
-    expected: NOTRUN
+    expected: FAIL
 
   [int32 scalar input, constant, and output]
-    expected: NOTRUN
+    expected: FAIL
 
   [scalar constant created with constant(type, value) - float32]
-    expected: NOTRUN
+    expected: FAIL
 
   [scalar constant created with constant(type, value) - int32]
-    expected: NOTRUN
+    expected: FAIL
 
   [multiple scalar constants in expression - float16]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/webnn/conformance_tests/scatterElements.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/scatterElements.https.any.js.ini
@@ -1,13 +1,25 @@
 [scatterElements.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API scatterElements operation]
+    expected: NOTRUN
 
 
 [scatterElements.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API scatterElements operation]
+    expected: NOTRUN
 
 
 [scatterElements.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API scatterElements operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/scatterND.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/scatterND.https.any.js.ini
@@ -1,13 +1,25 @@
 [scatterND.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API scatterND operation]
+    expected: NOTRUN
 
 
 [scatterND.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API scatterND operation]
+    expected: NOTRUN
 
 
 [scatterND.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API scatterND operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/shared_arraybuffer_constant.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/shared_arraybuffer_constant.https.any.js.ini
@@ -1,16 +1,8 @@
 [shared_arraybuffer_constant.https.any.html?gpu]
   expected: ERROR
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
 
 [shared_arraybuffer_constant.https.any.html?npu]
   expected: ERROR
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
 
 [shared_arraybuffer_constant.https.any.html?cpu]
   expected: ERROR
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL

--- a/tests/wpt/meta/webnn/conformance_tests/sigmoid.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/sigmoid.https.any.js.ini
@@ -1,13 +1,25 @@
 [sigmoid.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API sigmoid operation]
+    expected: NOTRUN
 
 
 [sigmoid.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API sigmoid operation]
+    expected: NOTRUN
 
 
 [sigmoid.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API sigmoid operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/sign.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/sign.https.any.js.ini
@@ -1,13 +1,25 @@
 [sign.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API sign operation]
+    expected: NOTRUN
 
 
 [sign.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API sign operation]
+    expected: NOTRUN
 
 
 [sign.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API sign operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/sin.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/sin.https.any.js.ini
@@ -1,13 +1,25 @@
 [sin.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise sin operation]
+    expected: NOTRUN
 
 
 [sin.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise sin operation]
+    expected: NOTRUN
 
 
 [sin.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise sin operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/slice.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/slice.https.any.js.ini
@@ -1,13 +1,25 @@
 [slice.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API slice operation]
+    expected: NOTRUN
 
 
 [slice.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API slice operation]
+    expected: NOTRUN
 
 
 [slice.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API slice operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/softmax.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/softmax.https.any.js.ini
@@ -1,13 +1,25 @@
 [softmax.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API softmax operation]
+    expected: NOTRUN
 
 
 [softmax.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API softmax operation]
+    expected: NOTRUN
 
 
 [softmax.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API softmax operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/softplus.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/softplus.https.any.js.ini
@@ -1,13 +1,25 @@
 [softplus.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API softplus operation]
+    expected: NOTRUN
 
 
 [softplus.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API softplus operation]
+    expected: NOTRUN
 
 
 [softplus.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API softplus operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/softsign.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/softsign.https.any.js.ini
@@ -1,13 +1,25 @@
 [softsign.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API softsign operation]
+    expected: NOTRUN
 
 
 [softsign.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API softsign operation]
+    expected: NOTRUN
 
 
 [softsign.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API softsign operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/split.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/split.https.any.js.ini
@@ -1,13 +1,25 @@
 [split.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API split operation]
+    expected: NOTRUN
 
 
 [split.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API split operation]
+    expected: NOTRUN
 
 
 [split.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API split operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/sqrt.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/sqrt.https.any.js.ini
@@ -1,13 +1,25 @@
 [sqrt.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise sqrt operation]
+    expected: NOTRUN
 
 
 [sqrt.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise sqrt operation]
+    expected: NOTRUN
 
 
 [sqrt.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise sqrt operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/sub.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/sub.https.any.js.ini
@@ -1,13 +1,25 @@
 [sub.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise sub operation]
+    expected: NOTRUN
 
 
 [sub.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise sub operation]
+    expected: NOTRUN
 
 
 [sub.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise sub operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/subgraph.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/subgraph.https.any.js.ini
@@ -1,13 +1,25 @@
 [subgraph.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API subgraph with multiple operations]
+    expected: NOTRUN
 
 
 [subgraph.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API subgraph with multiple operations]
+    expected: NOTRUN
 
 
 [subgraph.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API subgraph with multiple operations]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/tan.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/tan.https.any.js.ini
@@ -1,13 +1,25 @@
 [tan.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise tan operation]
+    expected: NOTRUN
 
 
 [tan.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise tan operation]
+    expected: NOTRUN
 
 
 [tan.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API element-wise tan operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/tanh.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/tanh.https.any.js.ini
@@ -1,13 +1,25 @@
 [tanh.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API tanh operation]
+    expected: NOTRUN
 
 
 [tanh.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API tanh operation]
+    expected: NOTRUN
 
 
 [tanh.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API tanh operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/tensor.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/tensor.https.any.js.ini
@@ -1,25 +1,961 @@
 [tensor.https.any.html?cpu]
   expected: ERROR
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [create too large tensor byte length that exceeds limit]
     expected: FAIL
 
-  [create too large tensor byte length that exceeds limit]
+  [create / float16]
+    expected: FAIL
+
+  [create / float32]
+    expected: FAIL
+
+  [create / int32]
+    expected: FAIL
+
+  [create / uint8]
+    expected: FAIL
+
+  [createFailsEmptyDimension / int32]
+    expected: FAIL
+
+  [createFailsTooLarge / int32]
+    expected: FAIL
+
+  [createConstant / int32]
+    expected: NOTRUN
+
+  [createConstant / int32 / source data too big]
+    expected: NOTRUN
+
+  [createConstant / int32 / source data too small]
+    expected: NOTRUN
+
+  [createConstant / uint8]
+    expected: NOTRUN
+
+  [createConstant / uint8 / source data too big]
+    expected: NOTRUN
+
+  [createConstant / uint8 / source data too small]
+    expected: NOTRUN
+
+  [createConstantFailsEmptyDimension / int32]
+    expected: NOTRUN
+
+  [destroyTwice]
+    expected: NOTRUN
+
+  [read / read_after_destroy]
+    expected: NOTRUN
+
+  [read / read_before_destroy]
+    expected: NOTRUN
+
+  [read / uninitialized]
+    expected: NOTRUN
+
+  [read / overwrite]
+    expected: NOTRUN
+
+  [read / context_mismatch]
+    expected: NOTRUN
+
+  [read / read with larger array]
+    expected: NOTRUN
+
+  [write / write with buffer of wrong size]
+    expected: NOTRUN
+
+  [write / destroy]
+    expected: NOTRUN
+
+  [write / context_mismatch]
+    expected: NOTRUN
+
+  [write / scalar]
+    expected: NOTRUN
+
+  [write / detached]
+    expected: NOTRUN
+
+  [dispatch / context_mismatch]
+    expected: NOTRUN
+
+  [dispatch / invalid shape]
+    expected: NOTRUN
+
+  [dispatch / invalid data type]
+    expected: NOTRUN
+
+  [dispatch / invalid_name]
+    expected: NOTRUN
+
+  [dispatch / invalid_tensor]
+    expected: NOTRUN
+
+  [dispatch / same_inputs]
+    expected: NOTRUN
+
+  [dispatch / same_outputs]
+    expected: NOTRUN
+
+  [dispatch / same_inputs_and_outputs]
+    expected: NOTRUN
+
+  [dispatch / outputs_as_inputs]
+    expected: NOTRUN
+
+  [dispatch / same name diff input tensors]
+    expected: NOTRUN
+
+  [dispatch / same name diff outputs tensors]
+    expected: NOTRUN
+
+  [dispatch / same name diff inputs tensors destroy]
+    expected: NOTRUN
+
+  [dispatch / same name diff outputs tensors destroy]
+    expected: NOTRUN
+
+  [dispatch / same constant same graph]
+    expected: NOTRUN
+
+  [dispatch / same constant multiple graphs]
+    expected: NOTRUN
+
+  [dispatch / default tensor uninitialized]
+    expected: NOTRUN
+
+  [interop float16 low-power / export tensor]
+    expected: NOTRUN
+
+  [interop float16 low-power / export wrong tensor]
+    expected: NOTRUN
+
+  [interop float16 low-power / export big tensor]
+    expected: NOTRUN
+
+  [interop float16 low-power / export then destroy buffer]
+    expected: NOTRUN
+
+  [interop float16 low-power / export then destroy tensor]
+    expected: NOTRUN
+
+  [interop float16 low-power / write tensor after export]
+    expected: NOTRUN
+
+  [interop float16 low-power / read after export]
+    expected: NOTRUN
+
+  [interop float16 low-power / dispatch as input after export]
+    expected: NOTRUN
+
+  [interop float16 low-power / dispatch as output after export]
+    expected: NOTRUN
+
+  [interop float16 low-power / export twice]
+    expected: NOTRUN
+
+  [interop float16 low-power / dispatch gpu twice]
+    expected: NOTRUN
+
+  [interop float16 low-power / webnn dispatch only]
+    expected: NOTRUN
+
+  [interop float16 low-power / dispatch from webgpu then webnn]
+    expected: NOTRUN
+
+  [interop float16 low-power / destroy context after export]
+    expected: NOTRUN
+
+  [interop float16 low-power / destroy device after export]
+    expected: NOTRUN
+
+  [interop float16 low-power / destroy device before export]
+    expected: NOTRUN
+
+  [interop float16 high-performance / export tensor]
+    expected: NOTRUN
+
+  [interop float16 high-performance / export wrong tensor]
+    expected: NOTRUN
+
+  [interop float16 high-performance / export big tensor]
+    expected: NOTRUN
+
+  [interop float16 high-performance / export then destroy buffer]
+    expected: NOTRUN
+
+  [interop float16 high-performance / export then destroy tensor]
+    expected: NOTRUN
+
+  [interop float16 high-performance / write tensor after export]
+    expected: NOTRUN
+
+  [interop float16 high-performance / read after export]
+    expected: NOTRUN
+
+  [interop float16 high-performance / dispatch as input after export]
+    expected: NOTRUN
+
+  [interop float16 high-performance / dispatch as output after export]
+    expected: NOTRUN
+
+  [interop float16 high-performance / export twice]
+    expected: NOTRUN
+
+  [interop float16 high-performance / dispatch gpu twice]
+    expected: NOTRUN
+
+  [interop float16 high-performance / webnn dispatch only]
+    expected: NOTRUN
+
+  [interop float16 high-performance / dispatch from webgpu then webnn]
+    expected: NOTRUN
+
+  [interop float16 high-performance / destroy context after export]
+    expected: NOTRUN
+
+  [interop float16 high-performance / destroy device after export]
+    expected: NOTRUN
+
+  [interop float16 high-performance / destroy device before export]
+    expected: NOTRUN
+
+  [interop float32 low-power / export tensor]
+    expected: NOTRUN
+
+  [interop float32 low-power / export wrong tensor]
+    expected: NOTRUN
+
+  [interop float32 low-power / export big tensor]
+    expected: NOTRUN
+
+  [interop float32 low-power / export then destroy buffer]
+    expected: NOTRUN
+
+  [interop float32 low-power / export then destroy tensor]
+    expected: NOTRUN
+
+  [interop float32 low-power / write tensor after export]
+    expected: NOTRUN
+
+  [interop float32 low-power / read after export]
+    expected: NOTRUN
+
+  [interop float32 low-power / dispatch as input after export]
+    expected: NOTRUN
+
+  [interop float32 low-power / dispatch as output after export]
+    expected: NOTRUN
+
+  [interop float32 low-power / export twice]
+    expected: NOTRUN
+
+  [interop float32 low-power / dispatch gpu twice]
+    expected: NOTRUN
+
+  [interop float32 low-power / webnn dispatch only]
+    expected: NOTRUN
+
+  [interop float32 low-power / dispatch from webgpu then webnn]
+    expected: NOTRUN
+
+  [interop float32 low-power / destroy context after export]
+    expected: NOTRUN
+
+  [interop float32 low-power / destroy device after export]
+    expected: NOTRUN
+
+  [interop float32 low-power / destroy device before export]
+    expected: NOTRUN
+
+  [interop float32 high-performance / export tensor]
+    expected: NOTRUN
+
+  [interop float32 high-performance / export wrong tensor]
+    expected: NOTRUN
+
+  [interop float32 high-performance / export big tensor]
+    expected: NOTRUN
+
+  [interop float32 high-performance / export then destroy buffer]
+    expected: NOTRUN
+
+  [interop float32 high-performance / export then destroy tensor]
+    expected: NOTRUN
+
+  [interop float32 high-performance / write tensor after export]
+    expected: NOTRUN
+
+  [interop float32 high-performance / read after export]
+    expected: NOTRUN
+
+  [interop float32 high-performance / dispatch as input after export]
+    expected: NOTRUN
+
+  [interop float32 high-performance / dispatch as output after export]
+    expected: NOTRUN
+
+  [interop float32 high-performance / export twice]
+    expected: NOTRUN
+
+  [interop float32 high-performance / dispatch gpu twice]
+    expected: NOTRUN
+
+  [interop float32 high-performance / webnn dispatch only]
+    expected: NOTRUN
+
+  [interop float32 high-performance / dispatch from webgpu then webnn]
+    expected: NOTRUN
+
+  [interop float32 high-performance / destroy context after export]
+    expected: NOTRUN
+
+  [interop float32 high-performance / destroy device after export]
+    expected: NOTRUN
+
+  [interop float32 high-performance / destroy device before export]
     expected: NOTRUN
 
 
 [tensor.https.any.html?npu]
   expected: ERROR
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [create too large tensor byte length that exceeds limit]
     expected: FAIL
 
-  [create too large tensor byte length that exceeds limit]
+  [create / float16]
+    expected: FAIL
+
+  [create / float32]
+    expected: FAIL
+
+  [create / int32]
+    expected: FAIL
+
+  [create / uint8]
+    expected: FAIL
+
+  [createFailsEmptyDimension / int32]
+    expected: FAIL
+
+  [createFailsTooLarge / int32]
+    expected: FAIL
+
+  [createConstant / int32]
+    expected: NOTRUN
+
+  [createConstant / int32 / source data too big]
+    expected: NOTRUN
+
+  [createConstant / int32 / source data too small]
+    expected: NOTRUN
+
+  [createConstant / uint8]
+    expected: NOTRUN
+
+  [createConstant / uint8 / source data too big]
+    expected: NOTRUN
+
+  [createConstant / uint8 / source data too small]
+    expected: NOTRUN
+
+  [createConstantFailsEmptyDimension / int32]
+    expected: NOTRUN
+
+  [destroyTwice]
+    expected: NOTRUN
+
+  [read / read_after_destroy]
+    expected: NOTRUN
+
+  [read / read_before_destroy]
+    expected: NOTRUN
+
+  [read / uninitialized]
+    expected: NOTRUN
+
+  [read / overwrite]
+    expected: NOTRUN
+
+  [read / context_mismatch]
+    expected: NOTRUN
+
+  [read / read with larger array]
+    expected: NOTRUN
+
+  [write / write with buffer of wrong size]
+    expected: NOTRUN
+
+  [write / destroy]
+    expected: NOTRUN
+
+  [write / context_mismatch]
+    expected: NOTRUN
+
+  [write / scalar]
+    expected: NOTRUN
+
+  [write / detached]
+    expected: NOTRUN
+
+  [dispatch / context_mismatch]
+    expected: NOTRUN
+
+  [dispatch / invalid shape]
+    expected: NOTRUN
+
+  [dispatch / invalid data type]
+    expected: NOTRUN
+
+  [dispatch / invalid_name]
+    expected: NOTRUN
+
+  [dispatch / invalid_tensor]
+    expected: NOTRUN
+
+  [dispatch / same_inputs]
+    expected: NOTRUN
+
+  [dispatch / same_outputs]
+    expected: NOTRUN
+
+  [dispatch / same_inputs_and_outputs]
+    expected: NOTRUN
+
+  [dispatch / outputs_as_inputs]
+    expected: NOTRUN
+
+  [dispatch / same name diff input tensors]
+    expected: NOTRUN
+
+  [dispatch / same name diff outputs tensors]
+    expected: NOTRUN
+
+  [dispatch / same name diff inputs tensors destroy]
+    expected: NOTRUN
+
+  [dispatch / same name diff outputs tensors destroy]
+    expected: NOTRUN
+
+  [dispatch / same constant same graph]
+    expected: NOTRUN
+
+  [dispatch / same constant multiple graphs]
+    expected: NOTRUN
+
+  [dispatch / default tensor uninitialized]
+    expected: NOTRUN
+
+  [interop float16 low-power / export tensor]
+    expected: NOTRUN
+
+  [interop float16 low-power / export wrong tensor]
+    expected: NOTRUN
+
+  [interop float16 low-power / export big tensor]
+    expected: NOTRUN
+
+  [interop float16 low-power / export then destroy buffer]
+    expected: NOTRUN
+
+  [interop float16 low-power / export then destroy tensor]
+    expected: NOTRUN
+
+  [interop float16 low-power / write tensor after export]
+    expected: NOTRUN
+
+  [interop float16 low-power / read after export]
+    expected: NOTRUN
+
+  [interop float16 low-power / dispatch as input after export]
+    expected: NOTRUN
+
+  [interop float16 low-power / dispatch as output after export]
+    expected: NOTRUN
+
+  [interop float16 low-power / export twice]
+    expected: NOTRUN
+
+  [interop float16 low-power / dispatch gpu twice]
+    expected: NOTRUN
+
+  [interop float16 low-power / webnn dispatch only]
+    expected: NOTRUN
+
+  [interop float16 low-power / dispatch from webgpu then webnn]
+    expected: NOTRUN
+
+  [interop float16 low-power / destroy context after export]
+    expected: NOTRUN
+
+  [interop float16 low-power / destroy device after export]
+    expected: NOTRUN
+
+  [interop float16 low-power / destroy device before export]
+    expected: NOTRUN
+
+  [interop float16 high-performance / export tensor]
+    expected: NOTRUN
+
+  [interop float16 high-performance / export wrong tensor]
+    expected: NOTRUN
+
+  [interop float16 high-performance / export big tensor]
+    expected: NOTRUN
+
+  [interop float16 high-performance / export then destroy buffer]
+    expected: NOTRUN
+
+  [interop float16 high-performance / export then destroy tensor]
+    expected: NOTRUN
+
+  [interop float16 high-performance / write tensor after export]
+    expected: NOTRUN
+
+  [interop float16 high-performance / read after export]
+    expected: NOTRUN
+
+  [interop float16 high-performance / dispatch as input after export]
+    expected: NOTRUN
+
+  [interop float16 high-performance / dispatch as output after export]
+    expected: NOTRUN
+
+  [interop float16 high-performance / export twice]
+    expected: NOTRUN
+
+  [interop float16 high-performance / dispatch gpu twice]
+    expected: NOTRUN
+
+  [interop float16 high-performance / webnn dispatch only]
+    expected: NOTRUN
+
+  [interop float16 high-performance / dispatch from webgpu then webnn]
+    expected: NOTRUN
+
+  [interop float16 high-performance / destroy context after export]
+    expected: NOTRUN
+
+  [interop float16 high-performance / destroy device after export]
+    expected: NOTRUN
+
+  [interop float16 high-performance / destroy device before export]
+    expected: NOTRUN
+
+  [interop float32 low-power / export tensor]
+    expected: NOTRUN
+
+  [interop float32 low-power / export wrong tensor]
+    expected: NOTRUN
+
+  [interop float32 low-power / export big tensor]
+    expected: NOTRUN
+
+  [interop float32 low-power / export then destroy buffer]
+    expected: NOTRUN
+
+  [interop float32 low-power / export then destroy tensor]
+    expected: NOTRUN
+
+  [interop float32 low-power / write tensor after export]
+    expected: NOTRUN
+
+  [interop float32 low-power / read after export]
+    expected: NOTRUN
+
+  [interop float32 low-power / dispatch as input after export]
+    expected: NOTRUN
+
+  [interop float32 low-power / dispatch as output after export]
+    expected: NOTRUN
+
+  [interop float32 low-power / export twice]
+    expected: NOTRUN
+
+  [interop float32 low-power / dispatch gpu twice]
+    expected: NOTRUN
+
+  [interop float32 low-power / webnn dispatch only]
+    expected: NOTRUN
+
+  [interop float32 low-power / dispatch from webgpu then webnn]
+    expected: NOTRUN
+
+  [interop float32 low-power / destroy context after export]
+    expected: NOTRUN
+
+  [interop float32 low-power / destroy device after export]
+    expected: NOTRUN
+
+  [interop float32 low-power / destroy device before export]
+    expected: NOTRUN
+
+  [interop float32 high-performance / export tensor]
+    expected: NOTRUN
+
+  [interop float32 high-performance / export wrong tensor]
+    expected: NOTRUN
+
+  [interop float32 high-performance / export big tensor]
+    expected: NOTRUN
+
+  [interop float32 high-performance / export then destroy buffer]
+    expected: NOTRUN
+
+  [interop float32 high-performance / export then destroy tensor]
+    expected: NOTRUN
+
+  [interop float32 high-performance / write tensor after export]
+    expected: NOTRUN
+
+  [interop float32 high-performance / read after export]
+    expected: NOTRUN
+
+  [interop float32 high-performance / dispatch as input after export]
+    expected: NOTRUN
+
+  [interop float32 high-performance / dispatch as output after export]
+    expected: NOTRUN
+
+  [interop float32 high-performance / export twice]
+    expected: NOTRUN
+
+  [interop float32 high-performance / dispatch gpu twice]
+    expected: NOTRUN
+
+  [interop float32 high-performance / webnn dispatch only]
+    expected: NOTRUN
+
+  [interop float32 high-performance / dispatch from webgpu then webnn]
+    expected: NOTRUN
+
+  [interop float32 high-performance / destroy context after export]
+    expected: NOTRUN
+
+  [interop float32 high-performance / destroy device after export]
+    expected: NOTRUN
+
+  [interop float32 high-performance / destroy device before export]
     expected: NOTRUN
 
 
 [tensor.https.any.html?gpu]
   expected: ERROR
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [create too large tensor byte length that exceeds limit]
     expected: FAIL
 
-  [create too large tensor byte length that exceeds limit]
+  [create / float16]
+    expected: FAIL
+
+  [create / float32]
+    expected: FAIL
+
+  [create / int32]
+    expected: FAIL
+
+  [create / uint8]
+    expected: FAIL
+
+  [createFailsEmptyDimension / int32]
+    expected: FAIL
+
+  [createFailsTooLarge / int32]
+    expected: FAIL
+
+  [createConstant / int32]
+    expected: NOTRUN
+
+  [createConstant / int32 / source data too big]
+    expected: NOTRUN
+
+  [createConstant / int32 / source data too small]
+    expected: NOTRUN
+
+  [createConstant / uint8]
+    expected: NOTRUN
+
+  [createConstant / uint8 / source data too big]
+    expected: NOTRUN
+
+  [createConstant / uint8 / source data too small]
+    expected: NOTRUN
+
+  [createConstantFailsEmptyDimension / int32]
+    expected: NOTRUN
+
+  [destroyTwice]
+    expected: NOTRUN
+
+  [read / read_after_destroy]
+    expected: NOTRUN
+
+  [read / read_before_destroy]
+    expected: NOTRUN
+
+  [read / uninitialized]
+    expected: NOTRUN
+
+  [read / overwrite]
+    expected: NOTRUN
+
+  [read / context_mismatch]
+    expected: NOTRUN
+
+  [read / read with larger array]
+    expected: NOTRUN
+
+  [write / write with buffer of wrong size]
+    expected: NOTRUN
+
+  [write / destroy]
+    expected: NOTRUN
+
+  [write / context_mismatch]
+    expected: NOTRUN
+
+  [write / scalar]
+    expected: NOTRUN
+
+  [write / detached]
+    expected: NOTRUN
+
+  [dispatch / context_mismatch]
+    expected: NOTRUN
+
+  [dispatch / invalid shape]
+    expected: NOTRUN
+
+  [dispatch / invalid data type]
+    expected: NOTRUN
+
+  [dispatch / invalid_name]
+    expected: NOTRUN
+
+  [dispatch / invalid_tensor]
+    expected: NOTRUN
+
+  [dispatch / same_inputs]
+    expected: NOTRUN
+
+  [dispatch / same_outputs]
+    expected: NOTRUN
+
+  [dispatch / same_inputs_and_outputs]
+    expected: NOTRUN
+
+  [dispatch / outputs_as_inputs]
+    expected: NOTRUN
+
+  [dispatch / same name diff input tensors]
+    expected: NOTRUN
+
+  [dispatch / same name diff outputs tensors]
+    expected: NOTRUN
+
+  [dispatch / same name diff inputs tensors destroy]
+    expected: NOTRUN
+
+  [dispatch / same name diff outputs tensors destroy]
+    expected: NOTRUN
+
+  [dispatch / same constant same graph]
+    expected: NOTRUN
+
+  [dispatch / same constant multiple graphs]
+    expected: NOTRUN
+
+  [dispatch / default tensor uninitialized]
+    expected: NOTRUN
+
+  [interop float16 low-power / export tensor]
+    expected: NOTRUN
+
+  [interop float16 low-power / export wrong tensor]
+    expected: NOTRUN
+
+  [interop float16 low-power / export big tensor]
+    expected: NOTRUN
+
+  [interop float16 low-power / export then destroy buffer]
+    expected: NOTRUN
+
+  [interop float16 low-power / export then destroy tensor]
+    expected: NOTRUN
+
+  [interop float16 low-power / write tensor after export]
+    expected: NOTRUN
+
+  [interop float16 low-power / read after export]
+    expected: NOTRUN
+
+  [interop float16 low-power / dispatch as input after export]
+    expected: NOTRUN
+
+  [interop float16 low-power / dispatch as output after export]
+    expected: NOTRUN
+
+  [interop float16 low-power / export twice]
+    expected: NOTRUN
+
+  [interop float16 low-power / dispatch gpu twice]
+    expected: NOTRUN
+
+  [interop float16 low-power / webnn dispatch only]
+    expected: NOTRUN
+
+  [interop float16 low-power / dispatch from webgpu then webnn]
+    expected: NOTRUN
+
+  [interop float16 low-power / destroy context after export]
+    expected: NOTRUN
+
+  [interop float16 low-power / destroy device after export]
+    expected: NOTRUN
+
+  [interop float16 low-power / destroy device before export]
+    expected: NOTRUN
+
+  [interop float16 high-performance / export tensor]
+    expected: NOTRUN
+
+  [interop float16 high-performance / export wrong tensor]
+    expected: NOTRUN
+
+  [interop float16 high-performance / export big tensor]
+    expected: NOTRUN
+
+  [interop float16 high-performance / export then destroy buffer]
+    expected: NOTRUN
+
+  [interop float16 high-performance / export then destroy tensor]
+    expected: NOTRUN
+
+  [interop float16 high-performance / write tensor after export]
+    expected: NOTRUN
+
+  [interop float16 high-performance / read after export]
+    expected: NOTRUN
+
+  [interop float16 high-performance / dispatch as input after export]
+    expected: NOTRUN
+
+  [interop float16 high-performance / dispatch as output after export]
+    expected: NOTRUN
+
+  [interop float16 high-performance / export twice]
+    expected: NOTRUN
+
+  [interop float16 high-performance / dispatch gpu twice]
+    expected: NOTRUN
+
+  [interop float16 high-performance / webnn dispatch only]
+    expected: NOTRUN
+
+  [interop float16 high-performance / dispatch from webgpu then webnn]
+    expected: NOTRUN
+
+  [interop float16 high-performance / destroy context after export]
+    expected: NOTRUN
+
+  [interop float16 high-performance / destroy device after export]
+    expected: NOTRUN
+
+  [interop float16 high-performance / destroy device before export]
+    expected: NOTRUN
+
+  [interop float32 low-power / export tensor]
+    expected: NOTRUN
+
+  [interop float32 low-power / export wrong tensor]
+    expected: NOTRUN
+
+  [interop float32 low-power / export big tensor]
+    expected: NOTRUN
+
+  [interop float32 low-power / export then destroy buffer]
+    expected: NOTRUN
+
+  [interop float32 low-power / export then destroy tensor]
+    expected: NOTRUN
+
+  [interop float32 low-power / write tensor after export]
+    expected: NOTRUN
+
+  [interop float32 low-power / read after export]
+    expected: NOTRUN
+
+  [interop float32 low-power / dispatch as input after export]
+    expected: NOTRUN
+
+  [interop float32 low-power / dispatch as output after export]
+    expected: NOTRUN
+
+  [interop float32 low-power / export twice]
+    expected: NOTRUN
+
+  [interop float32 low-power / dispatch gpu twice]
+    expected: NOTRUN
+
+  [interop float32 low-power / webnn dispatch only]
+    expected: NOTRUN
+
+  [interop float32 low-power / dispatch from webgpu then webnn]
+    expected: NOTRUN
+
+  [interop float32 low-power / destroy context after export]
+    expected: NOTRUN
+
+  [interop float32 low-power / destroy device after export]
+    expected: NOTRUN
+
+  [interop float32 low-power / destroy device before export]
+    expected: NOTRUN
+
+  [interop float32 high-performance / export tensor]
+    expected: NOTRUN
+
+  [interop float32 high-performance / export wrong tensor]
+    expected: NOTRUN
+
+  [interop float32 high-performance / export big tensor]
+    expected: NOTRUN
+
+  [interop float32 high-performance / export then destroy buffer]
+    expected: NOTRUN
+
+  [interop float32 high-performance / export then destroy tensor]
+    expected: NOTRUN
+
+  [interop float32 high-performance / write tensor after export]
+    expected: NOTRUN
+
+  [interop float32 high-performance / read after export]
+    expected: NOTRUN
+
+  [interop float32 high-performance / dispatch as input after export]
+    expected: NOTRUN
+
+  [interop float32 high-performance / dispatch as output after export]
+    expected: NOTRUN
+
+  [interop float32 high-performance / export twice]
+    expected: NOTRUN
+
+  [interop float32 high-performance / dispatch gpu twice]
+    expected: NOTRUN
+
+  [interop float32 high-performance / webnn dispatch only]
+    expected: NOTRUN
+
+  [interop float32 high-performance / dispatch from webgpu then webnn]
+    expected: NOTRUN
+
+  [interop float32 high-performance / destroy context after export]
+    expected: NOTRUN
+
+  [interop float32 high-performance / destroy device after export]
+    expected: NOTRUN
+
+  [interop float32 high-performance / destroy device before export]
     expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/tile.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/tile.https.any.js.ini
@@ -1,13 +1,25 @@
 [tile.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API tile operation]
+    expected: NOTRUN
 
 
 [tile.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API tile operation]
+    expected: NOTRUN
 
 
 [tile.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API tile operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/transpose.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/transpose.https.any.js.ini
@@ -1,13 +1,25 @@
 [transpose.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API transpose operation]
+    expected: NOTRUN
 
 
 [transpose.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API transpose operation]
+    expected: NOTRUN
 
 
 [transpose.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API transpose operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/triangular.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/triangular.https.any.js.ini
@@ -1,13 +1,25 @@
 [triangular.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API triangular operation]
+    expected: NOTRUN
 
 
 [triangular.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API triangular operation]
+    expected: NOTRUN
 
 
 [triangular.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API triangular operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/conformance_tests/where.https.any.js.ini
+++ b/tests/wpt/meta/webnn/conformance_tests/where.https.any.js.ini
@@ -1,13 +1,25 @@
 [where.https.any.html?cpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API where operation]
+    expected: NOTRUN
 
 
 [where.https.any.html?npu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API where operation]
+    expected: NOTRUN
 
 
 [where.https.any.html?gpu]
+  expected: ERROR
   [assert_implements(navigator.ml, 'missing navigator.ml')]
     expected: FAIL
+
+  [test WebNN API where operation]
+    expected: NOTRUN

--- a/tests/wpt/meta/webnn/idlharness.https.any.js.ini
+++ b/tests/wpt/meta/webnn/idlharness.https.any.js.ini
@@ -2,66 +2,6 @@
   [idl_test setup]
     expected: FAIL
 
-  [ML interface: existence and properties of interface object]
-    expected: FAIL
-
-  [ML interface object length]
-    expected: FAIL
-
-  [ML interface object name]
-    expected: FAIL
-
-  [ML interface: existence and properties of interface prototype object]
-    expected: FAIL
-
-  [ML interface: existence and properties of interface prototype object's "constructor" property]
-    expected: FAIL
-
-  [ML interface: existence and properties of interface prototype object's @@unscopables property]
-    expected: FAIL
-
-  [ML interface: operation createContext(optional MLContextOptions)]
-    expected: FAIL
-
-  [ML interface: operation createContext(GPUDevice)]
-    expected: FAIL
-
-  [ML must be primary interface of navigator.ml]
-    expected: FAIL
-
-  [Stringification of navigator.ml]
-    expected: FAIL
-
-  [ML interface: navigator.ml must inherit property "createContext(optional MLContextOptions)" with the proper type]
-    expected: FAIL
-
-  [ML interface: calling createContext(optional MLContextOptions) on navigator.ml with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [ML interface: navigator.ml must inherit property "createContext(GPUDevice)" with the proper type]
-    expected: FAIL
-
-  [ML interface: calling createContext(GPUDevice) on navigator.ml with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [MLContext interface: existence and properties of interface object]
-    expected: FAIL
-
-  [MLContext interface object length]
-    expected: FAIL
-
-  [MLContext interface object name]
-    expected: FAIL
-
-  [MLContext interface: existence and properties of interface prototype object]
-    expected: FAIL
-
-  [MLContext interface: existence and properties of interface prototype object's "constructor" property]
-    expected: FAIL
-
-  [MLContext interface: existence and properties of interface prototype object's @@unscopables property]
-    expected: FAIL
-
   [MLContext interface: operation dispatch(MLGraph, MLNamedTensors, MLNamedTensors)]
     expected: FAIL
 
@@ -83,19 +23,10 @@
   [MLContext interface: operation opSupportLimits()]
     expected: FAIL
 
-  [MLContext interface: operation destroy()]
-    expected: FAIL
-
   [MLContext interface: attribute accelerated]
     expected: FAIL
 
   [MLContext interface: attribute lost]
-    expected: FAIL
-
-  [MLContext must be primary interface of context]
-    expected: FAIL
-
-  [Stringification of context]
     expected: FAIL
 
   [MLContext interface: context must inherit property "dispatch(MLGraph, MLNamedTensors, MLNamedTensors)" with the proper type]
@@ -135,9 +66,6 @@
     expected: FAIL
 
   [MLContext interface: context must inherit property "opSupportLimits()" with the proper type]
-    expected: FAIL
-
-  [MLContext interface: context must inherit property "destroy()" with the proper type]
     expected: FAIL
 
   [MLContext interface: context must inherit property "accelerated" with the proper type]
@@ -1220,10 +1148,10 @@
   [MLGraphBuilder interface: calling where(MLOperand, MLOperand, MLOperand, optional MLOperatorOptions) on builder with too few arguments must throw TypeError]
     expected: FAIL
 
-  [Navigator interface: attribute ml]
+  [MLContext interface: operation destroy()]
     expected: FAIL
 
-  [Navigator interface: navigator must inherit property "ml" with the proper type]
+  [MLContext interface: context must inherit property "destroy()" with the proper type]
     expected: FAIL
 
 
@@ -1231,66 +1159,6 @@
   [idl_test setup]
     expected: FAIL
 
-  [ML interface: existence and properties of interface object]
-    expected: FAIL
-
-  [ML interface object length]
-    expected: FAIL
-
-  [ML interface object name]
-    expected: FAIL
-
-  [ML interface: existence and properties of interface prototype object]
-    expected: FAIL
-
-  [ML interface: existence and properties of interface prototype object's "constructor" property]
-    expected: FAIL
-
-  [ML interface: existence and properties of interface prototype object's @@unscopables property]
-    expected: FAIL
-
-  [ML interface: operation createContext(optional MLContextOptions)]
-    expected: FAIL
-
-  [ML interface: operation createContext(GPUDevice)]
-    expected: FAIL
-
-  [ML must be primary interface of navigator.ml]
-    expected: FAIL
-
-  [Stringification of navigator.ml]
-    expected: FAIL
-
-  [ML interface: navigator.ml must inherit property "createContext(optional MLContextOptions)" with the proper type]
-    expected: FAIL
-
-  [ML interface: calling createContext(optional MLContextOptions) on navigator.ml with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [ML interface: navigator.ml must inherit property "createContext(GPUDevice)" with the proper type]
-    expected: FAIL
-
-  [ML interface: calling createContext(GPUDevice) on navigator.ml with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [MLContext interface: existence and properties of interface object]
-    expected: FAIL
-
-  [MLContext interface object length]
-    expected: FAIL
-
-  [MLContext interface object name]
-    expected: FAIL
-
-  [MLContext interface: existence and properties of interface prototype object]
-    expected: FAIL
-
-  [MLContext interface: existence and properties of interface prototype object's "constructor" property]
-    expected: FAIL
-
-  [MLContext interface: existence and properties of interface prototype object's @@unscopables property]
-    expected: FAIL
-
   [MLContext interface: operation dispatch(MLGraph, MLNamedTensors, MLNamedTensors)]
     expected: FAIL
 
@@ -1312,19 +1180,10 @@
   [MLContext interface: operation opSupportLimits()]
     expected: FAIL
 
-  [MLContext interface: operation destroy()]
-    expected: FAIL
-
   [MLContext interface: attribute accelerated]
     expected: FAIL
 
   [MLContext interface: attribute lost]
-    expected: FAIL
-
-  [MLContext must be primary interface of context]
-    expected: FAIL
-
-  [Stringification of context]
     expected: FAIL
 
   [MLContext interface: context must inherit property "dispatch(MLGraph, MLNamedTensors, MLNamedTensors)" with the proper type]
@@ -1364,9 +1223,6 @@
     expected: FAIL
 
   [MLContext interface: context must inherit property "opSupportLimits()" with the proper type]
-    expected: FAIL
-
-  [MLContext interface: context must inherit property "destroy()" with the proper type]
     expected: FAIL
 
   [MLContext interface: context must inherit property "accelerated" with the proper type]
@@ -2449,8 +2305,8 @@
   [MLGraphBuilder interface: calling where(MLOperand, MLOperand, MLOperand, optional MLOperatorOptions) on builder with too few arguments must throw TypeError]
     expected: FAIL
 
-  [WorkerNavigator interface: attribute ml]
+  [MLContext interface: operation destroy()]
     expected: FAIL
 
-  [WorkerNavigator interface: navigator must inherit property "ml" with the proper type]
+  [MLContext interface: context must inherit property "destroy()" with the proper type]
     expected: FAIL

--- a/tests/wpt/meta/webnn/permissions-policy/webnn-allowed-by-permissions-policy.https.html.ini
+++ b/tests/wpt/meta/webnn/permissions-policy/webnn-allowed-by-permissions-policy.https.html.ini
@@ -1,10 +1,6 @@
 [webnn-allowed-by-permissions-policy.https.html]
-  expected: TIMEOUT
-  [Permissions policy header "webnn=*" allows same-origin iframes.]
-    expected: TIMEOUT
-
   [Permissions policy header "webnn=*" disallows cross-origin iframes.]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Permissions policy header "webnn=*" allows cross-origin iframes with allow="webnn" attribute.]
     expected: FAIL

--- a/tests/wpt/meta/webnn/permissions-policy/webnn-allowed-on-self-origin-by-permissions-policy.https.html.ini
+++ b/tests/wpt/meta/webnn/permissions-policy/webnn-allowed-on-self-origin-by-permissions-policy.https.html.ini
@@ -1,7 +1,3 @@
 [webnn-allowed-on-self-origin-by-permissions-policy.https.html]
-  expected: TIMEOUT
-  [Permissions policy header "webnn=self" allows same-origin iframes.]
-    expected: TIMEOUT
-
   [Permissions policy header "webnn=self" disallows cross-origin iframes.]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/webnn/permissions-policy/webnn-default-permissions-policy.https.html.ini
+++ b/tests/wpt/meta/webnn/permissions-policy/webnn-default-permissions-policy.https.html.ini
@@ -1,7 +1,3 @@
 [webnn-default-permissions-policy.https.html]
-  expected: TIMEOUT
-  [Default "webnn" permissions policy allows same-origin iframes.]
-    expected: TIMEOUT
-
   [Default "webnn" permissions policy disallows cross-origin iframes.]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/webnn/permissions-policy/webnn-disabled-by-permissions-policy.https.html.ini
+++ b/tests/wpt/meta/webnn/permissions-policy/webnn-disabled-by-permissions-policy.https.html.ini
@@ -1,13 +1,12 @@
 [webnn-disabled-by-permissions-policy.https.html]
-  expected: TIMEOUT
   [Permissions policy header "webnn=()" disallows the top-level document.]
     expected: FAIL
 
   [Permissions policy header "webnn=()" disallows same-origin iframes.]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Permissions policy header "webnn=()" disallows cross-origin iframes.]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Permissions policy header "webnn=()" disallows same-origin iframes despite the allow="webnn" attribute.]
     expected: FAIL

--- a/tests/wpt/meta/webnn/validation_tests/argMinMax.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/argMinMax.https.any.js.ini
@@ -1,7 +1,4 @@
 [argMinMax.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[argMin\] throw if input is from another builder]
     expected: FAIL
 
@@ -52,9 +49,6 @@
 
 
 [argMinMax.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[argMin\] throw if input is from another builder]
     expected: FAIL
 
@@ -105,9 +99,6 @@
 
 
 [argMinMax.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[argMin\] throw if input is from another builder]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/batchNormalization.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/batchNormalization.https.any.js.ini
@@ -1,7 +1,4 @@
 [batchNormalization.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[batchNormalization\] throw if input is from another builder]
     expected: FAIL
 
@@ -70,9 +67,6 @@
 
 
 [batchNormalization.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[batchNormalization\] throw if input is from another builder]
     expected: FAIL
 
@@ -141,9 +135,6 @@
 
 
 [batchNormalization.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[batchNormalization\] throw if input is from another builder]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/build-more-than-once.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/build-more-than-once.https.any.js.ini
@@ -1,7 +1,4 @@
 [build-more-than-once.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [Throw if attempting to build a second graph with an MLGraphBuilder]
     expected: FAIL
 
@@ -28,9 +25,6 @@
 
 
 [build-more-than-once.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [Throw if attempting to build a second graph with an MLGraphBuilder]
     expected: FAIL
 
@@ -57,9 +51,6 @@
 
 
 [build-more-than-once.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [Throw if attempting to build a second graph with an MLGraphBuilder]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/cast.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/cast.https.any.js.ini
@@ -1,7 +1,4 @@
 [cast.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[cast\] throw if input is from another builder]
     expected: FAIL
 
@@ -10,9 +7,6 @@
 
 
 [cast.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[cast\] throw if input is from another builder]
     expected: FAIL
 
@@ -21,9 +15,6 @@
 
 
 [cast.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[cast\] throw if input is from another builder]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/clamp.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/clamp.https.any.js.ini
@@ -1,7 +1,4 @@
 [clamp.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[clamp\] throw if input is from another builder]
     expected: FAIL
 
@@ -31,9 +28,6 @@
 
 
 [clamp.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[clamp\] throw if input is from another builder]
     expected: FAIL
 
@@ -63,9 +57,6 @@
 
 
 [clamp.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[clamp\] throw if input is from another builder]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/concat.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/concat.https.any.js.ini
@@ -1,7 +1,4 @@
 [concat.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[concat\] Test building Concat with one input.]
     expected: FAIL
 
@@ -46,9 +43,6 @@
 
 
 [concat.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[concat\] Test building Concat with one input.]
     expected: FAIL
 
@@ -93,9 +87,6 @@
 
 
 [concat.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[concat\] Test building Concat with one input.]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/constant-changed-buffer.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/constant-changed-buffer.https.any.js.ini
@@ -1,7 +1,4 @@
 [constant-changed-buffer.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [Constant data is unaffected by detaching the buffer]
     expected: FAIL
 
@@ -13,9 +10,6 @@
 
 
 [constant-changed-buffer.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [Constant data is unaffected by detaching the buffer]
     expected: FAIL
 
@@ -27,9 +21,6 @@
 
 
 [constant-changed-buffer.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [Constant data is unaffected by detaching the buffer]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/constant.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/constant.https.any.js.ini
@@ -1,7 +1,4 @@
 [constant.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[constant\] Test building a 0-D scalar constant with empty dimensions]
     expected: FAIL
 
@@ -133,9 +130,6 @@
 
 
 [constant.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[constant\] Test building a 0-D scalar constant with empty dimensions]
     expected: FAIL
 
@@ -267,9 +261,6 @@
 
 
 [constant.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[constant\] Test building a 0-D scalar constant with empty dimensions]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/conv2d.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/conv2d.https.any.js.ini
@@ -1,7 +1,4 @@
 [conv2d.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[conv2d\] throw if input is from another builder]
     expected: FAIL
 
@@ -163,9 +160,6 @@
 
 
 [conv2d.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[conv2d\] throw if input is from another builder]
     expected: FAIL
 
@@ -327,9 +321,6 @@
 
 
 [conv2d.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[conv2d\] throw if input is from another builder]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/convTranspose2d.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/convTranspose2d.https.any.js.ini
@@ -1,7 +1,4 @@
 [convTranspose2d.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[convTranspose2d\] throw if input is from another builder]
     expected: FAIL
 
@@ -160,9 +157,6 @@
 
 
 [convTranspose2d.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[convTranspose2d\] throw if input is from another builder]
     expected: FAIL
 
@@ -321,9 +315,6 @@
 
 
 [convTranspose2d.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[convTranspose2d\] throw if input is from another builder]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/createContext.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/createContext.https.any.js.ini
@@ -1,94 +1,22 @@
 [createContext.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
-  [Create context with default MLContextOptions.]
-    expected: FAIL
-
-  [Create context with device type: cpu.]
-    expected: FAIL
-
   [Throw if deviceType is not a valid enum value of type MLDeviceType when creating the context.]
     expected: FAIL
 
-  [Create context with power preference: default.]
-    expected: FAIL
-
-  [Create context with power preference: high-performance.]
-    expected: FAIL
-
-  [Create context with power preference: low-power.]
-    expected: FAIL
-
   [Throw if powerPreference is not a valid enum value of type MLPowerPreference when creating the context.]
-    expected: FAIL
-
-  [[createContext\] Test creating context with deviceType=cpu, powerPreference=high-performance.]
-    expected: FAIL
-
-  [Create context with GPUDevice.]
     expected: FAIL
 
 
 [createContext.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
-  [Create context with default MLContextOptions.]
-    expected: FAIL
-
-  [Create context with device type: cpu.]
-    expected: FAIL
-
   [Throw if deviceType is not a valid enum value of type MLDeviceType when creating the context.]
     expected: FAIL
 
-  [Create context with power preference: default.]
-    expected: FAIL
-
-  [Create context with power preference: high-performance.]
-    expected: FAIL
-
-  [Create context with power preference: low-power.]
-    expected: FAIL
-
   [Throw if powerPreference is not a valid enum value of type MLPowerPreference when creating the context.]
-    expected: FAIL
-
-  [[createContext\] Test creating context with deviceType=cpu, powerPreference=high-performance.]
-    expected: FAIL
-
-  [Create context with GPUDevice.]
     expected: FAIL
 
 
 [createContext.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
-  [Create context with default MLContextOptions.]
-    expected: FAIL
-
-  [Create context with device type: cpu.]
-    expected: FAIL
-
   [Throw if deviceType is not a valid enum value of type MLDeviceType when creating the context.]
     expected: FAIL
 
-  [Create context with power preference: default.]
-    expected: FAIL
-
-  [Create context with power preference: high-performance.]
-    expected: FAIL
-
-  [Create context with power preference: low-power.]
-    expected: FAIL
-
   [Throw if powerPreference is not a valid enum value of type MLPowerPreference when creating the context.]
-    expected: FAIL
-
-  [[createContext\] Test creating context with deviceType=cpu, powerPreference=high-performance.]
-    expected: FAIL
-
-  [Create context with GPUDevice.]
     expected: FAIL

--- a/tests/wpt/meta/webnn/validation_tests/cumulativeSum.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/cumulativeSum.https.any.js.ini
@@ -1,7 +1,4 @@
 [cumulativeSum.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[cumulativeSum\] Test with default options]
     expected: FAIL
 
@@ -28,9 +25,6 @@
 
 
 [cumulativeSum.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[cumulativeSum\] Test with default options]
     expected: FAIL
 
@@ -57,9 +51,6 @@
 
 
 [cumulativeSum.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[cumulativeSum\] Test with default options]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/dequantizeLinear.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/dequantizeLinear.https.any.js.ini
@@ -1,7 +1,4 @@
 [dequantizeLinear.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[dequantizeLinear\] Test scale's shape = [3, 2, 5\] and zeroPoint's shape = [3, 2, 5\] which is the same as input's shape.]
     expected: FAIL
 
@@ -49,9 +46,6 @@
 
 
 [dequantizeLinear.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[dequantizeLinear\] Test scale's shape = [3, 2, 5\] and zeroPoint's shape = [3, 2, 5\] which is the same as input's shape.]
     expected: FAIL
 
@@ -99,9 +93,6 @@
 
 
 [dequantizeLinear.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[dequantizeLinear\] Test scale's shape = [3, 2, 5\] and zeroPoint's shape = [3, 2, 5\] which is the same as input's shape.]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/destroyContext.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/destroyContext.https.any.js.ini
@@ -1,10 +1,4 @@
 [destroyContext.https.any.html?npu]
-  [Context will be lost by destroyed.]
-    expected: FAIL
-
-  [Context can be destroyed twice.]
-    expected: FAIL
-
   [Destroyed context can not build operator.]
     expected: FAIL
 
@@ -30,16 +24,16 @@
     expected: FAIL
 
   [Destroyed context can not write tensor.]
+    expected: FAIL
+
+  [Context will be lost by destroyed.]
+    expected: FAIL
+
+  [Context can be destroyed twice.]
     expected: FAIL
 
 
 [destroyContext.https.any.html?gpu]
-  [Context will be lost by destroyed.]
-    expected: FAIL
-
-  [Context can be destroyed twice.]
-    expected: FAIL
-
   [Destroyed context can not build operator.]
     expected: FAIL
 
@@ -65,16 +59,16 @@
     expected: FAIL
 
   [Destroyed context can not write tensor.]
+    expected: FAIL
+
+  [Context will be lost by destroyed.]
+    expected: FAIL
+
+  [Context can be destroyed twice.]
     expected: FAIL
 
 
 [destroyContext.https.any.html?cpu]
-  [Context will be lost by destroyed.]
-    expected: FAIL
-
-  [Context can be destroyed twice.]
-    expected: FAIL
-
   [Destroyed context can not build operator.]
     expected: FAIL
 
@@ -100,4 +94,10 @@
     expected: FAIL
 
   [Destroyed context can not write tensor.]
+    expected: FAIL
+
+  [Context will be lost by destroyed.]
+    expected: FAIL
+
+  [Context can be destroyed twice.]
     expected: FAIL

--- a/tests/wpt/meta/webnn/validation_tests/destroyGraph.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/destroyGraph.https.any.js.ini
@@ -1,34 +1,31 @@
 [destroyGraph.https.any.html?npu]
-  expected: ERROR
   [Graph can be destroyed twice.]
-    expected: NOTRUN
+    expected: FAIL
 
   [Destroyed graph can not dispatch.]
-    expected: NOTRUN
+    expected: FAIL
 
   [Destroying graph after dispatch() and before readTensor() is OK.]
-    expected: NOTRUN
+    expected: FAIL
 
 
 [destroyGraph.https.any.html?gpu]
-  expected: ERROR
   [Graph can be destroyed twice.]
-    expected: NOTRUN
+    expected: FAIL
 
   [Destroyed graph can not dispatch.]
-    expected: NOTRUN
+    expected: FAIL
 
   [Destroying graph after dispatch() and before readTensor() is OK.]
-    expected: NOTRUN
+    expected: FAIL
 
 
 [destroyGraph.https.any.html?cpu]
-  expected: ERROR
   [Graph can be destroyed twice.]
-    expected: NOTRUN
+    expected: FAIL
 
   [Destroyed graph can not dispatch.]
-    expected: NOTRUN
+    expected: FAIL
 
   [Destroying graph after dispatch() and before readTensor() is OK.]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/webnn/validation_tests/elementwise-binary.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/elementwise-binary.https.any.js.ini
@@ -1,7 +1,4 @@
 [elementwise-binary.https.any.html?op=pow&device=cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[pow\] Test bidirectionally broadcastable dimensions.]
     expected: FAIL
 
@@ -21,13 +18,19 @@
     expected: FAIL
 
   [[pow\] throw if second input is from another builder]
+    expected: FAIL
+
+  [[pow\] TypeError is expected if two inputs aren't of same data type]
+    expected: FAIL
+
+  [[pow\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+  [[pow\] throw if the output tensor byte length exceeds limit]
     expected: FAIL
 
 
 [elementwise-binary.https.any.html?op=div&device=npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[div\] Test bidirectionally broadcastable dimensions.]
     expected: FAIL
 
@@ -47,13 +50,19 @@
     expected: FAIL
 
   [[div\] throw if second input is from another builder]
+    expected: FAIL
+
+  [[div\] TypeError is expected if two inputs aren't of same data type]
+    expected: FAIL
+
+  [[div\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+  [[div\] throw if the output tensor byte length exceeds limit]
     expected: FAIL
 
 
 [elementwise-binary.https.any.html?op=mul&device=gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[mul\] Test bidirectionally broadcastable dimensions.]
     expected: FAIL
 
@@ -73,13 +82,19 @@
     expected: FAIL
 
   [[mul\] throw if second input is from another builder]
+    expected: FAIL
+
+  [[mul\] TypeError is expected if two inputs aren't of same data type]
+    expected: FAIL
+
+  [[mul\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+  [[mul\] throw if the output tensor byte length exceeds limit]
     expected: FAIL
 
 
 [elementwise-binary.https.any.html?op=div&device=cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[div\] Test bidirectionally broadcastable dimensions.]
     expected: FAIL
 
@@ -99,13 +114,19 @@
     expected: FAIL
 
   [[div\] throw if second input is from another builder]
+    expected: FAIL
+
+  [[div\] TypeError is expected if two inputs aren't of same data type]
+    expected: FAIL
+
+  [[div\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+  [[div\] throw if the output tensor byte length exceeds limit]
     expected: FAIL
 
 
 [elementwise-binary.https.any.html?op=div&device=gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[div\] Test bidirectionally broadcastable dimensions.]
     expected: FAIL
 
@@ -127,11 +148,17 @@
   [[div\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-binary.https.any.html?op=min&device=gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[div\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[div\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+  [[div\] throw if the output tensor byte length exceeds limit]
+    expected: FAIL
+
+
+[elementwise-binary.https.any.html?op=min&device=gpu]
   [[min\] Test bidirectionally broadcastable dimensions.]
     expected: FAIL
 
@@ -151,13 +178,19 @@
     expected: FAIL
 
   [[min\] throw if second input is from another builder]
+    expected: FAIL
+
+  [[min\] TypeError is expected if two inputs aren't of same data type]
+    expected: FAIL
+
+  [[min\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+  [[min\] throw if the output tensor byte length exceeds limit]
     expected: FAIL
 
 
 [elementwise-binary.https.any.html?op=sub&device=npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[sub\] Test bidirectionally broadcastable dimensions.]
     expected: FAIL
 
@@ -177,13 +210,19 @@
     expected: FAIL
 
   [[sub\] throw if second input is from another builder]
+    expected: FAIL
+
+  [[sub\] TypeError is expected if two inputs aren't of same data type]
+    expected: FAIL
+
+  [[sub\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+  [[sub\] throw if the output tensor byte length exceeds limit]
     expected: FAIL
 
 
 [elementwise-binary.https.any.html?op=max&device=gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[max\] Test bidirectionally broadcastable dimensions.]
     expected: FAIL
 
@@ -203,13 +242,19 @@
     expected: FAIL
 
   [[max\] throw if second input is from another builder]
+    expected: FAIL
+
+  [[max\] TypeError is expected if two inputs aren't of same data type]
+    expected: FAIL
+
+  [[max\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+  [[max\] throw if the output tensor byte length exceeds limit]
     expected: FAIL
 
 
 [elementwise-binary.https.any.html?op=pow&device=gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[pow\] Test bidirectionally broadcastable dimensions.]
     expected: FAIL
 
@@ -229,13 +274,19 @@
     expected: FAIL
 
   [[pow\] throw if second input is from another builder]
+    expected: FAIL
+
+  [[pow\] TypeError is expected if two inputs aren't of same data type]
+    expected: FAIL
+
+  [[pow\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+  [[pow\] throw if the output tensor byte length exceeds limit]
     expected: FAIL
 
 
 [elementwise-binary.https.any.html?op=add&device=cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[add\] Test bidirectionally broadcastable dimensions.]
     expected: FAIL
 
@@ -255,13 +306,19 @@
     expected: FAIL
 
   [[add\] throw if second input is from another builder]
+    expected: FAIL
+
+  [[add\] TypeError is expected if two inputs aren't of same data type]
+    expected: FAIL
+
+  [[add\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+  [[add\] throw if the output tensor byte length exceeds limit]
     expected: FAIL
 
 
 [elementwise-binary.https.any.html?op=max&device=cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[max\] Test bidirectionally broadcastable dimensions.]
     expected: FAIL
 
@@ -281,13 +338,19 @@
     expected: FAIL
 
   [[max\] throw if second input is from another builder]
+    expected: FAIL
+
+  [[max\] TypeError is expected if two inputs aren't of same data type]
+    expected: FAIL
+
+  [[max\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+  [[max\] throw if the output tensor byte length exceeds limit]
     expected: FAIL
 
 
 [elementwise-binary.https.any.html?op=max&device=npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[max\] Test bidirectionally broadcastable dimensions.]
     expected: FAIL
 
@@ -309,11 +372,17 @@
   [[max\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-binary.https.any.html?op=add&device=gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[max\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[max\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+  [[max\] throw if the output tensor byte length exceeds limit]
+    expected: FAIL
+
+
+[elementwise-binary.https.any.html?op=add&device=gpu]
   [[add\] Test bidirectionally broadcastable dimensions.]
     expected: FAIL
 
@@ -335,11 +404,17 @@
   [[add\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-binary.https.any.html?op=mul&device=npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[add\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[add\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+  [[add\] throw if the output tensor byte length exceeds limit]
+    expected: FAIL
+
+
+[elementwise-binary.https.any.html?op=mul&device=npu]
   [[mul\] Test bidirectionally broadcastable dimensions.]
     expected: FAIL
 
@@ -361,11 +436,17 @@
   [[mul\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-binary.https.any.html?op=add&device=npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[mul\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[mul\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+  [[mul\] throw if the output tensor byte length exceeds limit]
+    expected: FAIL
+
+
+[elementwise-binary.https.any.html?op=add&device=npu]
   [[add\] Test bidirectionally broadcastable dimensions.]
     expected: FAIL
 
@@ -387,11 +468,17 @@
   [[add\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-binary.https.any.html?op=sub&device=cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[add\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[add\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+  [[add\] throw if the output tensor byte length exceeds limit]
+    expected: FAIL
+
+
+[elementwise-binary.https.any.html?op=sub&device=cpu]
   [[sub\] Test bidirectionally broadcastable dimensions.]
     expected: FAIL
 
@@ -411,13 +498,19 @@
     expected: FAIL
 
   [[sub\] throw if second input is from another builder]
+    expected: FAIL
+
+  [[sub\] TypeError is expected if two inputs aren't of same data type]
+    expected: FAIL
+
+  [[sub\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+  [[sub\] throw if the output tensor byte length exceeds limit]
     expected: FAIL
 
 
 [elementwise-binary.https.any.html?op=sub&device=gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[sub\] Test bidirectionally broadcastable dimensions.]
     expected: FAIL
 
@@ -439,11 +532,17 @@
   [[sub\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-binary.https.any.html?op=min&device=npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[sub\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[sub\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+  [[sub\] throw if the output tensor byte length exceeds limit]
+    expected: FAIL
+
+
+[elementwise-binary.https.any.html?op=min&device=npu]
   [[min\] Test bidirectionally broadcastable dimensions.]
     expected: FAIL
 
@@ -465,11 +564,17 @@
   [[min\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-binary.https.any.html?op=pow&device=npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[min\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[min\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+  [[min\] throw if the output tensor byte length exceeds limit]
+    expected: FAIL
+
+
+[elementwise-binary.https.any.html?op=pow&device=npu]
   [[pow\] Test bidirectionally broadcastable dimensions.]
     expected: FAIL
 
@@ -491,11 +596,17 @@
   [[pow\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-binary.https.any.html?op=min&device=cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[pow\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[pow\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+  [[pow\] throw if the output tensor byte length exceeds limit]
+    expected: FAIL
+
+
+[elementwise-binary.https.any.html?op=min&device=cpu]
   [[min\] Test bidirectionally broadcastable dimensions.]
     expected: FAIL
 
@@ -517,11 +628,17 @@
   [[min\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-binary.https.any.html?op=mul&device=cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[min\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[min\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+  [[min\] throw if the output tensor byte length exceeds limit]
+    expected: FAIL
+
+
+[elementwise-binary.https.any.html?op=mul&device=cpu]
   [[mul\] Test bidirectionally broadcastable dimensions.]
     expected: FAIL
 
@@ -541,4 +658,13 @@
     expected: FAIL
 
   [[mul\] throw if second input is from another builder]
+    expected: FAIL
+
+  [[mul\] TypeError is expected if two inputs aren't of same data type]
+    expected: FAIL
+
+  [[mul\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+  [[mul\] throw if the output tensor byte length exceeds limit]
     expected: FAIL

--- a/tests/wpt/meta/webnn/validation_tests/elementwise-logical.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/elementwise-logical.https.any.js.ini
@@ -1,367 +1,421 @@
 [elementwise-logical.https.any.html?op=greaterOrEqual&device=npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[greaterOrEqual\] throw if first input is from another builder]
     expected: FAIL
 
   [[greaterOrEqual\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-logical.https.any.html?op=logicalOr&device=gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[greaterOrEqual\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[greaterOrEqual\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+
+[elementwise-logical.https.any.html?op=logicalOr&device=gpu]
   [[logicalOr\] throw if first input is from another builder]
     expected: FAIL
 
   [[logicalOr\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-logical.https.any.html?op=logicalXor&device=cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[logicalOr\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[logicalOr\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+
+[elementwise-logical.https.any.html?op=logicalXor&device=cpu]
   [[logicalXor\] throw if first input is from another builder]
     expected: FAIL
 
   [[logicalXor\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-logical.https.any.html?op=equal&device=gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[logicalXor\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[logicalXor\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+
+[elementwise-logical.https.any.html?op=equal&device=gpu]
   [[equal\] throw if first input is from another builder]
     expected: FAIL
 
   [[equal\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-logical.https.any.html?op=lesserOrEqual&device=gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[equal\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[equal\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+
+[elementwise-logical.https.any.html?op=lesserOrEqual&device=gpu]
   [[lesserOrEqual\] throw if first input is from another builder]
     expected: FAIL
 
   [[lesserOrEqual\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-logical.https.any.html?op=logicalNot&device=cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[lesserOrEqual\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[lesserOrEqual\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+
+[elementwise-logical.https.any.html?op=logicalNot&device=cpu]
   [[logicalNot\] throw if input is from another builder]
     expected: FAIL
 
 
 [elementwise-logical.https.any.html?op=logicalAnd&device=cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[logicalAnd\] throw if first input is from another builder]
     expected: FAIL
 
   [[logicalAnd\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-logical.https.any.html?op=lesserOrEqual&device=npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[logicalAnd\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[logicalAnd\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+
+[elementwise-logical.https.any.html?op=lesserOrEqual&device=npu]
   [[lesserOrEqual\] throw if first input is from another builder]
     expected: FAIL
 
   [[lesserOrEqual\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-logical.https.any.html?op=isNaN&device=npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[lesserOrEqual\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[lesserOrEqual\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+
+[elementwise-logical.https.any.html?op=isNaN&device=npu]
   [[isNaN\] throw if input is from another builder]
     expected: FAIL
 
 
 [elementwise-logical.https.any.html?op=equal&device=npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[equal\] throw if first input is from another builder]
     expected: FAIL
 
   [[equal\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-logical.https.any.html?op=isNaN&device=cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[equal\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[equal\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+
+[elementwise-logical.https.any.html?op=isNaN&device=cpu]
   [[isNaN\] throw if input is from another builder]
     expected: FAIL
 
 
 [elementwise-logical.https.any.html?op=logicalOr&device=cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[logicalOr\] throw if first input is from another builder]
     expected: FAIL
 
   [[logicalOr\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-logical.https.any.html?op=logicalXor&device=npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[logicalOr\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[logicalOr\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+
+[elementwise-logical.https.any.html?op=logicalXor&device=npu]
   [[logicalXor\] throw if first input is from another builder]
     expected: FAIL
 
   [[logicalXor\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-logical.https.any.html?op=isInfinite&device=npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[logicalXor\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[logicalXor\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+
+[elementwise-logical.https.any.html?op=isInfinite&device=npu]
   [[isInfinite\] throw if input is from another builder]
     expected: FAIL
 
 
 [elementwise-logical.https.any.html?op=logicalXor&device=gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[logicalXor\] throw if first input is from another builder]
     expected: FAIL
 
   [[logicalXor\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-logical.https.any.html?op=lesser&device=npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[logicalXor\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[logicalXor\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+
+[elementwise-logical.https.any.html?op=lesser&device=npu]
   [[lesser\] throw if first input is from another builder]
     expected: FAIL
 
   [[lesser\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-logical.https.any.html?op=equal&device=cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[lesser\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[lesser\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+
+[elementwise-logical.https.any.html?op=equal&device=cpu]
   [[equal\] throw if first input is from another builder]
     expected: FAIL
 
   [[equal\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-logical.https.any.html?op=greaterOrEqual&device=cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[equal\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[equal\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+
+[elementwise-logical.https.any.html?op=greaterOrEqual&device=cpu]
   [[greaterOrEqual\] throw if first input is from another builder]
     expected: FAIL
 
   [[greaterOrEqual\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-logical.https.any.html?op=isInfinite&device=cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[greaterOrEqual\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[greaterOrEqual\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+
+[elementwise-logical.https.any.html?op=isInfinite&device=cpu]
   [[isInfinite\] throw if input is from another builder]
     expected: FAIL
 
 
 [elementwise-logical.https.any.html?op=lesserOrEqual&device=cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[lesserOrEqual\] throw if first input is from another builder]
     expected: FAIL
 
   [[lesserOrEqual\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-logical.https.any.html?op=logicalOr&device=npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[lesserOrEqual\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[lesserOrEqual\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+
+[elementwise-logical.https.any.html?op=logicalOr&device=npu]
   [[logicalOr\] throw if first input is from another builder]
     expected: FAIL
 
   [[logicalOr\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-logical.https.any.html?op=greater&device=gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[logicalOr\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[logicalOr\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+
+[elementwise-logical.https.any.html?op=greater&device=gpu]
   [[greater\] throw if first input is from another builder]
     expected: FAIL
 
   [[greater\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-logical.https.any.html?op=logicalAnd&device=gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[greater\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[greater\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+
+[elementwise-logical.https.any.html?op=logicalAnd&device=gpu]
   [[logicalAnd\] throw if first input is from another builder]
     expected: FAIL
 
   [[logicalAnd\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-logical.https.any.html?op=greater&device=npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[logicalAnd\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[logicalAnd\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+
+[elementwise-logical.https.any.html?op=greater&device=npu]
   [[greater\] throw if first input is from another builder]
     expected: FAIL
 
   [[greater\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-logical.https.any.html?op=greaterOrEqual&device=gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[greater\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[greater\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+
+[elementwise-logical.https.any.html?op=greaterOrEqual&device=gpu]
   [[greaterOrEqual\] throw if first input is from another builder]
     expected: FAIL
 
   [[greaterOrEqual\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-logical.https.any.html?op=lesser&device=cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[greaterOrEqual\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[greaterOrEqual\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+
+[elementwise-logical.https.any.html?op=lesser&device=cpu]
   [[lesser\] throw if first input is from another builder]
     expected: FAIL
 
   [[lesser\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-logical.https.any.html?op=logicalAnd&device=npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[lesser\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[lesser\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+
+[elementwise-logical.https.any.html?op=logicalAnd&device=npu]
   [[logicalAnd\] throw if first input is from another builder]
     expected: FAIL
 
   [[logicalAnd\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-logical.https.any.html?op=greater&device=cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[logicalAnd\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[logicalAnd\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+
+[elementwise-logical.https.any.html?op=greater&device=cpu]
   [[greater\] throw if first input is from another builder]
     expected: FAIL
 
   [[greater\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-logical.https.any.html?op=notEqual&device=gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[greater\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[greater\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+
+[elementwise-logical.https.any.html?op=notEqual&device=gpu]
   [[notEqual\] throw if first input is from another builder]
     expected: FAIL
 
   [[notEqual\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-logical.https.any.html?op=lesser&device=gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[notEqual\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[notEqual\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+
+[elementwise-logical.https.any.html?op=lesser&device=gpu]
   [[lesser\] throw if first input is from another builder]
     expected: FAIL
 
   [[lesser\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-logical.https.any.html?op=notEqual&device=npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[lesser\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[lesser\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+
+[elementwise-logical.https.any.html?op=notEqual&device=npu]
   [[notEqual\] throw if first input is from another builder]
     expected: FAIL
 
   [[notEqual\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-logical.https.any.html?op=logicalNot&device=npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[notEqual\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[notEqual\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+
+[elementwise-logical.https.any.html?op=logicalNot&device=npu]
   [[logicalNot\] throw if input is from another builder]
     expected: FAIL
 
 
 [elementwise-logical.https.any.html?op=isInfinite&device=gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[isInfinite\] throw if input is from another builder]
     expected: FAIL
 
 
 [elementwise-logical.https.any.html?op=notEqual&device=cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[notEqual\] throw if first input is from another builder]
     expected: FAIL
 
   [[notEqual\] throw if second input is from another builder]
     expected: FAIL
 
-
-[elementwise-logical.https.any.html?op=logicalNot&device=gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
+  [[notEqual\] TypeError is expected if two inputs aren't of same data type]
     expected: FAIL
 
+  [[notEqual\] TypeError is expected if two inputs aren't broadcastable]
+    expected: FAIL
+
+
+[elementwise-logical.https.any.html?op=logicalNot&device=gpu]
   [[logicalNot\] throw if input is from another builder]
     expected: FAIL
 
 
 [elementwise-logical.https.any.html?op=isNaN&device=gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[isNaN\] throw if input is from another builder]
     expected: FAIL

--- a/tests/wpt/meta/webnn/validation_tests/elementwise-unary.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/elementwise-unary.https.any.js.ini
@@ -1,7 +1,4 @@
 [elementwise-unary.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[abs\] throw if input is from another builder]
     expected: FAIL
 
@@ -139,9 +136,6 @@
 
 
 [elementwise-unary.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[abs\] throw if input is from another builder]
     expected: FAIL
 
@@ -279,9 +273,6 @@
 
 
 [elementwise-unary.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[abs\] throw if input is from another builder]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/elu.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/elu.https.any.js.ini
@@ -1,7 +1,4 @@
 [elu.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[elu\] throw if input is from another builder]
     expected: FAIL
 
@@ -22,9 +19,6 @@
 
 
 [elu.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[elu\] throw if input is from another builder]
     expected: FAIL
 
@@ -45,9 +39,6 @@
 
 
 [elu.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[elu\] throw if input is from another builder]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/expand.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/expand.https.any.js.ini
@@ -1,7 +1,4 @@
 [expand.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[expand\] throw if input is from another builder]
     expected: FAIL
 
@@ -37,9 +34,6 @@
 
 
 [expand.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[expand\] throw if input is from another builder]
     expected: FAIL
 
@@ -75,9 +69,6 @@
 
 
 [expand.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[expand\] throw if input is from another builder]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/gather.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/gather.https.any.js.ini
@@ -1,7 +1,4 @@
 [gather.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[gather\] Test gather with default options and 0-D indices]
     expected: FAIL
 
@@ -37,9 +34,6 @@
 
 
 [gather.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[gather\] Test gather with default options and 0-D indices]
     expected: FAIL
 
@@ -75,9 +69,6 @@
 
 
 [gather.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[gather\] Test gather with default options and 0-D indices]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/gatherElements.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/gatherElements.https.any.js.ini
@@ -1,7 +1,4 @@
 [gatherElements.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[gatherElements\] Test gatherElements with default options]
     expected: FAIL
 
@@ -31,9 +28,6 @@
 
 
 [gatherElements.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[gatherElements\] Test gatherElements with default options]
     expected: FAIL
 
@@ -63,9 +57,6 @@
 
 
 [gatherElements.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[gatherElements\] Test gatherElements with default options]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/gatherND.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/gatherND.https.any.js.ini
@@ -1,7 +1,4 @@
 [gatherND.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[gatherND\] Test gatherND with 5D input 3D indices]
     expected: FAIL
 
@@ -28,9 +25,6 @@
 
 
 [gatherND.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[gatherND\] Test gatherND with 5D input 3D indices]
     expected: FAIL
 
@@ -57,9 +51,6 @@
 
 
 [gatherND.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[gatherND\] Test gatherND with 5D input 3D indices]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/gelu.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/gelu.https.any.js.ini
@@ -1,7 +1,4 @@
 [gelu.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[gelu\] throw if input is from another builder]
     expected: FAIL
 
@@ -13,9 +10,6 @@
 
 
 [gelu.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[gelu\] throw if input is from another builder]
     expected: FAIL
 
@@ -27,9 +21,6 @@
 
 
 [gelu.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[gelu\] throw if input is from another builder]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/gemm.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/gemm.https.any.js.ini
@@ -1,7 +1,4 @@
 [gemm.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[gemm\] throw if first input is from another builder]
     expected: FAIL
 
@@ -54,13 +51,13 @@
     expected: FAIL
 
   [[gemm\] Throw if the rank of inputC is 3.]
+    expected: FAIL
+
+  [[gemm\] throw if the output tensor byte length exceeds limit]
     expected: FAIL
 
 
 [gemm.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[gemm\] throw if first input is from another builder]
     expected: FAIL
 
@@ -113,13 +110,13 @@
     expected: FAIL
 
   [[gemm\] Throw if the rank of inputC is 3.]
+    expected: FAIL
+
+  [[gemm\] throw if the output tensor byte length exceeds limit]
     expected: FAIL
 
 
 [gemm.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[gemm\] throw if first input is from another builder]
     expected: FAIL
 
@@ -172,4 +169,7 @@
     expected: FAIL
 
   [[gemm\] Throw if the rank of inputC is 3.]
+    expected: FAIL
+
+  [[gemm\] throw if the output tensor byte length exceeds limit]
     expected: FAIL

--- a/tests/wpt/meta/webnn/validation_tests/gru.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/gru.https.any.js.ini
@@ -1,7 +1,4 @@
 [gru.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[gru\] Test with default options]
     expected: FAIL
 
@@ -76,9 +73,6 @@
 
 
 [gru.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[gru\] Test with default options]
     expected: FAIL
 
@@ -153,9 +147,6 @@
 
 
 [gru.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[gru\] Test with default options]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/gruCell.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/gruCell.https.any.js.ini
@@ -1,7 +1,4 @@
 [gruCell.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[gruCell\] Test with default options]
     expected: FAIL
 
@@ -91,9 +88,6 @@
 
 
 [gruCell.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[gruCell\] Test with default options]
     expected: FAIL
 
@@ -183,9 +177,6 @@
 
 
 [gruCell.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[gruCell\] Test with default options]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/hardSigmoid.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/hardSigmoid.https.any.js.ini
@@ -1,7 +1,4 @@
 [hardSigmoid.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[hardSigmoid\] throw if input is from another builder]
     expected: FAIL
 
@@ -22,9 +19,6 @@
 
 
 [hardSigmoid.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[hardSigmoid\] throw if input is from another builder]
     expected: FAIL
 
@@ -45,9 +39,6 @@
 
 
 [hardSigmoid.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[hardSigmoid\] throw if input is from another builder]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/hardSwish.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/hardSwish.https.any.js.ini
@@ -1,7 +1,4 @@
 [hardSwish.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[hardSwish\] throw if input is from another builder]
     expected: FAIL
 
@@ -13,9 +10,6 @@
 
 
 [hardSwish.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[hardSwish\] throw if input is from another builder]
     expected: FAIL
 
@@ -27,9 +21,6 @@
 
 
 [hardSwish.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[hardSwish\] throw if input is from another builder]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/input.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/input.https.any.js.ini
@@ -1,7 +1,4 @@
 [input.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[input\] Test building a 0-D scalar input with empty shape]
     expected: FAIL
 
@@ -28,9 +25,6 @@
 
 
 [input.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[input\] Test building a 0-D scalar input with empty shape]
     expected: FAIL
 
@@ -57,9 +51,6 @@
 
 
 [input.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[input\] Test building a 0-D scalar input with empty shape]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/instanceNormalization.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/instanceNormalization.https.any.js.ini
@@ -1,7 +1,4 @@
 [instanceNormalization.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[instanceNormalization\] throw if input is from another builder]
     expected: FAIL
 
@@ -58,9 +55,6 @@
 
 
 [instanceNormalization.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[instanceNormalization\] throw if input is from another builder]
     expected: FAIL
 
@@ -117,9 +111,6 @@
 
 
 [instanceNormalization.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[instanceNormalization\] throw if input is from another builder]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/invalid-rank.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/invalid-rank.https.any.js.ini
@@ -1,22 +1,13 @@
 [invalid-rank.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [Throw if rank is too large]
     expected: FAIL
 
 
 [invalid-rank.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [Throw if rank is too large]
     expected: FAIL
 
 
 [invalid-rank.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [Throw if rank is too large]
     expected: FAIL

--- a/tests/wpt/meta/webnn/validation_tests/layerNormalization.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/layerNormalization.https.any.js.ini
@@ -1,7 +1,4 @@
 [layerNormalization.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[layerNormalization\] throw if input is from another builder]
     expected: FAIL
 
@@ -64,9 +61,6 @@
 
 
 [layerNormalization.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[layerNormalization\] throw if input is from another builder]
     expected: FAIL
 
@@ -129,9 +123,6 @@
 
 
 [layerNormalization.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[layerNormalization\] throw if input is from another builder]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/leakyRelu.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/leakyRelu.https.any.js.ini
@@ -1,7 +1,4 @@
 [leakyRelu.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[leakyRelu\] throw if input is from another builder]
     expected: FAIL
 
@@ -22,9 +19,6 @@
 
 
 [leakyRelu.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[leakyRelu\] throw if input is from another builder]
     expected: FAIL
 
@@ -45,9 +39,6 @@
 
 
 [leakyRelu.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[leakyRelu\] throw if input is from another builder]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/linear.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/linear.https.any.js.ini
@@ -1,7 +1,4 @@
 [linear.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[linear\] throw if input is from another builder]
     expected: FAIL
 
@@ -22,9 +19,6 @@
 
 
 [linear.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[linear\] throw if input is from another builder]
     expected: FAIL
 
@@ -45,9 +39,6 @@
 
 
 [linear.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[linear\] throw if input is from another builder]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/lstm.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/lstm.https.any.js.ini
@@ -1,7 +1,4 @@
 [lstm.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[lstm\] Test with default options]
     expected: FAIL
 
@@ -76,9 +73,6 @@
 
 
 [lstm.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[lstm\] Test with default options]
     expected: FAIL
 
@@ -153,9 +147,6 @@
 
 
 [lstm.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[lstm\] Test with default options]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/lstmCell.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/lstmCell.https.any.js.ini
@@ -1,7 +1,4 @@
 [lstmCell.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[lstmCell\] throw if input is from another builder]
     expected: FAIL
 
@@ -115,9 +112,6 @@
 
 
 [lstmCell.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[lstmCell\] throw if input is from another builder]
     expected: FAIL
 
@@ -231,9 +225,6 @@
 
 
 [lstmCell.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[lstmCell\] throw if input is from another builder]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/matmul.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/matmul.https.any.js.ini
@@ -1,7 +1,4 @@
 [matmul.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[matmul\] throw if first input is from another builder]
     expected: FAIL
 
@@ -39,13 +36,13 @@
     expected: FAIL
 
   [[matmul\] Throw if batchShapes aren't bidirectionally broadcastable]
+    expected: FAIL
+
+  [[matmul\] throw if the output tensor byte length exceeds limit]
     expected: FAIL
 
 
 [matmul.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[matmul\] throw if first input is from another builder]
     expected: FAIL
 
@@ -83,13 +80,13 @@
     expected: FAIL
 
   [[matmul\] Throw if batchShapes aren't bidirectionally broadcastable]
+    expected: FAIL
+
+  [[matmul\] throw if the output tensor byte length exceeds limit]
     expected: FAIL
 
 
 [matmul.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[matmul\] throw if first input is from another builder]
     expected: FAIL
 
@@ -127,4 +124,7 @@
     expected: FAIL
 
   [[matmul\] Throw if batchShapes aren't bidirectionally broadcastable]
+    expected: FAIL
+
+  [[matmul\] throw if the output tensor byte length exceeds limit]
     expected: FAIL

--- a/tests/wpt/meta/webnn/validation_tests/opSupportLimits.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/opSupportLimits.https.any.js.ini
@@ -1,7 +1,4 @@
 [opSupportLimits.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [check opSupportLimits data types of logicalAnd]
     expected: FAIL
 
@@ -16,9 +13,6 @@
 
 
 [opSupportLimits.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [check opSupportLimits data types of logicalAnd]
     expected: FAIL
 
@@ -33,9 +27,6 @@
 
 
 [opSupportLimits.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [check opSupportLimits data types of logicalAnd]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/pad.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/pad.https.any.js.ini
@@ -1,7 +1,4 @@
 [pad.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[pad\] throw if input is from another builder]
     expected: FAIL
 
@@ -37,9 +34,6 @@
 
 
 [pad.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[pad\] throw if input is from another builder]
     expected: FAIL
 
@@ -75,9 +69,6 @@
 
 
 [pad.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[pad\] throw if input is from another builder]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/pooling-and-reduction-keep-dims.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/pooling-and-reduction-keep-dims.https.any.js.ini
@@ -1,7 +1,4 @@
 [pooling-and-reduction-keep-dims.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [Test global average pool operator's output shape for ResNetV2 50 model.]
     expected: FAIL
 
@@ -10,9 +7,6 @@
 
 
 [pooling-and-reduction-keep-dims.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [Test global average pool operator's output shape for ResNetV2 50 model.]
     expected: FAIL
 
@@ -21,9 +15,6 @@
 
 
 [pooling-and-reduction-keep-dims.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [Test global average pool operator's output shape for ResNetV2 50 model.]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/pooling.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/pooling.https.any.js.ini
@@ -1,7 +1,4 @@
 [pooling.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[averagePool2d\] throw if input is from another builder]
     expected: FAIL
 
@@ -127,9 +124,6 @@
 
 
 [pooling.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[averagePool2d\] throw if input is from another builder]
     expected: FAIL
 
@@ -255,9 +249,6 @@
 
 
 [pooling.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[averagePool2d\] throw if input is from another builder]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/prelu.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/prelu.https.any.js.ini
@@ -1,7 +1,4 @@
 [prelu.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[prelu\] throw if first input is from another builder]
     expected: FAIL
 
@@ -31,9 +28,6 @@
 
 
 [prelu.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[prelu\] throw if first input is from another builder]
     expected: FAIL
 
@@ -63,9 +57,6 @@
 
 
 [prelu.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[prelu\] throw if first input is from another builder]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/quantizeLinear.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/quantizeLinear.https.any.js.ini
@@ -1,7 +1,4 @@
 [quantizeLinear.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[quantizeLinear\] Test scale's shape = [3, 2, 5\] and zeroPoint's shape = [3, 2, 5\] which is the same as input's shape.]
     expected: FAIL
 
@@ -46,9 +43,6 @@
 
 
 [quantizeLinear.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[quantizeLinear\] Test scale's shape = [3, 2, 5\] and zeroPoint's shape = [3, 2, 5\] which is the same as input's shape.]
     expected: FAIL
 
@@ -93,9 +87,6 @@
 
 
 [quantizeLinear.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[quantizeLinear\] Test scale's shape = [3, 2, 5\] and zeroPoint's shape = [3, 2, 5\] which is the same as input's shape.]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/reduction.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/reduction.https.any.js.ini
@@ -1,7 +1,4 @@
 [reduction.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[reduceL1\] throw if input is from another builder]
     expected: FAIL
 
@@ -184,9 +181,6 @@
 
 
 [reduction.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[reduceL1\] throw if input is from another builder]
     expected: FAIL
 
@@ -369,9 +363,6 @@
 
 
 [reduction.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[reduceL1\] throw if input is from another builder]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/relu.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/relu.https.any.js.ini
@@ -1,7 +1,4 @@
 [relu.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[relu\] throw if input is from another builder]
     expected: FAIL
 
@@ -13,9 +10,6 @@
 
 
 [relu.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[relu\] throw if input is from another builder]
     expected: FAIL
 
@@ -27,9 +21,6 @@
 
 
 [relu.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[relu\] throw if input is from another builder]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/resample2d.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/resample2d.https.any.js.ini
@@ -1,7 +1,4 @@
 [resample2d.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[resample2d\] Test building resample2d with default options]
     expected: FAIL
 
@@ -85,9 +82,6 @@
 
 
 [resample2d.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[resample2d\] Test building resample2d with default options]
     expected: FAIL
 
@@ -171,9 +165,6 @@
 
 
 [resample2d.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[resample2d\] Test building resample2d with default options]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/reshape.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/reshape.https.any.js.ini
@@ -1,7 +1,4 @@
 [reshape.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[reshape\] throw if input is from another builder]
     expected: FAIL
 
@@ -34,9 +31,6 @@
 
 
 [reshape.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[reshape\] throw if input is from another builder]
     expected: FAIL
 
@@ -69,9 +63,6 @@
 
 
 [reshape.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[reshape\] throw if input is from another builder]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/reverse.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/reverse.https.any.js.ini
@@ -1,7 +1,4 @@
 [reverse.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[reverse\] Test reverse with default options]
     expected: FAIL
 
@@ -19,9 +16,6 @@
 
 
 [reverse.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[reverse\] Test reverse with default options]
     expected: FAIL
 
@@ -39,9 +33,6 @@
 
 
 [reverse.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[reverse\] Test reverse with default options]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/scatterElements.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/scatterElements.https.any.js.ini
@@ -1,7 +1,4 @@
 [scatterElements.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[scatterElements\] Test scatterElements with default options]
     expected: FAIL
 
@@ -46,9 +43,6 @@
 
 
 [scatterElements.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[scatterElements\] Test scatterElements with default options]
     expected: FAIL
 
@@ -93,9 +87,6 @@
 
 
 [scatterElements.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[scatterElements\] Test scatterElements with default options]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/scatterND.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/scatterND.https.any.js.ini
@@ -1,7 +1,4 @@
 [scatterND.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[scatterND\] Test scatterND with valid tensors]
     expected: FAIL
 
@@ -31,9 +28,6 @@
 
 
 [scatterND.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[scatterND\] Test scatterND with valid tensors]
     expected: FAIL
 
@@ -63,9 +57,6 @@
 
 
 [scatterND.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[scatterND\] Test scatterND with valid tensors]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/sigmoid.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/sigmoid.https.any.js.ini
@@ -1,7 +1,4 @@
 [sigmoid.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[sigmoid\] throw if input is from another builder]
     expected: FAIL
 
@@ -13,9 +10,6 @@
 
 
 [sigmoid.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[sigmoid\] throw if input is from another builder]
     expected: FAIL
 
@@ -27,9 +21,6 @@
 
 
 [sigmoid.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[sigmoid\] throw if input is from another builder]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/slice.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/slice.https.any.js.ini
@@ -1,7 +1,4 @@
 [slice.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[slice\] throw if input is from another builder]
     expected: FAIL
 
@@ -40,9 +37,6 @@
 
 
 [slice.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[slice\] throw if input is from another builder]
     expected: FAIL
 
@@ -81,9 +75,6 @@
 
 
 [slice.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[slice\] throw if input is from another builder]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/softmax.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/softmax.https.any.js.ini
@@ -1,7 +1,4 @@
 [softmax.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[softmax\] Test building Softmax with float32 input.]
     expected: FAIL
 
@@ -22,9 +19,6 @@
 
 
 [softmax.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[softmax\] Test building Softmax with float32 input.]
     expected: FAIL
 
@@ -45,9 +39,6 @@
 
 
 [softmax.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[softmax\] Test building Softmax with float32 input.]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/softplus.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/softplus.https.any.js.ini
@@ -1,7 +1,4 @@
 [softplus.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[softplus\] throw if input is from another builder]
     expected: FAIL
 
@@ -13,9 +10,6 @@
 
 
 [softplus.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[softplus\] throw if input is from another builder]
     expected: FAIL
 
@@ -27,9 +21,6 @@
 
 
 [softplus.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[softplus\] throw if input is from another builder]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/softsign.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/softsign.https.any.js.ini
@@ -1,7 +1,4 @@
 [softsign.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[softsign\] throw if input is from another builder]
     expected: FAIL
 
@@ -13,9 +10,6 @@
 
 
 [softsign.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[softsign\] throw if input is from another builder]
     expected: FAIL
 
@@ -27,9 +21,6 @@
 
 
 [softsign.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[softsign\] throw if input is from another builder]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/split.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/split.https.any.js.ini
@@ -1,7 +1,4 @@
 [split.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[split\] throw if input is from another builder]
     expected: FAIL
 
@@ -40,9 +37,6 @@
 
 
 [split.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[split\] throw if input is from another builder]
     expected: FAIL
 
@@ -81,9 +75,6 @@
 
 
 [split.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[split\] throw if input is from another builder]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/tanh.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/tanh.https.any.js.ini
@@ -1,7 +1,4 @@
 [tanh.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[tanh\] throw if input is from another builder]
     expected: FAIL
 
@@ -13,9 +10,6 @@
 
 
 [tanh.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[tanh\] throw if input is from another builder]
     expected: FAIL
 
@@ -27,9 +21,6 @@
 
 
 [tanh.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[tanh\] throw if input is from another builder]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/tile.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/tile.https.any.js.ini
@@ -1,7 +1,4 @@
 [tile.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[tile\] throw if input is from another builder]
     expected: FAIL
 
@@ -28,9 +25,6 @@
 
 
 [tile.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[tile\] throw if input is from another builder]
     expected: FAIL
 
@@ -57,9 +51,6 @@
 
 
 [tile.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[tile\] throw if input is from another builder]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/transpose.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/transpose.https.any.js.ini
@@ -1,7 +1,4 @@
 [transpose.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[transpose\] throw if input is from another builder]
     expected: FAIL
 
@@ -25,9 +22,6 @@
 
 
 [transpose.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[transpose\] throw if input is from another builder]
     expected: FAIL
 
@@ -51,9 +45,6 @@
 
 
 [transpose.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[transpose\] throw if input is from another builder]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/triangular.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/triangular.https.any.js.ini
@@ -1,7 +1,4 @@
 [triangular.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[triangular\] TypeError is expected if input's rank is less than 2]
     expected: FAIL
 
@@ -10,9 +7,6 @@
 
 
 [triangular.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[triangular\] TypeError is expected if input's rank is less than 2]
     expected: FAIL
 
@@ -21,9 +15,6 @@
 
 
 [triangular.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[triangular\] TypeError is expected if input's rank is less than 2]
     expected: FAIL
 

--- a/tests/wpt/meta/webnn/validation_tests/unprintableNames.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/unprintableNames.https.any.js.ini
@@ -1,16 +1,13 @@
 [unprintableNames.https.any.html?cpu]
-  expected: ERROR
   [tensor names can include null bytes]
-    expected: NOTRUN
+    expected: FAIL
 
 
 [unprintableNames.https.any.html?npu]
-  expected: ERROR
   [tensor names can include null bytes]
-    expected: NOTRUN
+    expected: FAIL
 
 
 [unprintableNames.https.any.html?gpu]
-  expected: ERROR
   [tensor names can include null bytes]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/webnn/validation_tests/where.https.any.js.ini
+++ b/tests/wpt/meta/webnn/validation_tests/where.https.any.js.ini
@@ -1,7 +1,4 @@
 [where.https.any.html?gpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[where\] Throw if the condition data type is not uint8.]
     expected: FAIL
 
@@ -40,9 +37,6 @@
 
 
 [where.https.any.html?cpu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[where\] Throw if the condition data type is not uint8.]
     expected: FAIL
 
@@ -81,9 +75,6 @@
 
 
 [where.https.any.html?npu]
-  [assert_not_equals(navigator.ml, undefined, "ml property is defined on navigator")]
-    expected: FAIL
-
   [[where\] Throw if the condition data type is not uint8.]
     expected: FAIL
 


### PR DESCRIPTION
Due to early return of WPT on missing `navigator.ml`, WPT din't ran completely in #45879

Hence adding `ml` on `navigator` separately to correctly update WPT. Apart from that it includes

- A `webnn` cfg feature flag
- A pref named `dom_webnn_enaled`, by deafult set as false. 



Testing: WPT Expectations Updated (Results from local run : [wpt.log](https://github.com/user-attachments/files/29371326/wpt.log))

Fixes: Part of #45452
