### PR TITLE
script: Middle click opens link in new tab

### DIFF
--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -21,6 +21,7 @@ use embedder_traits::{
     GamepadEvent as EmbedderGamepadEvent, GamepadSupportedHapticEffects, GamepadUpdateType,
 };
 use euclid::{Point2D, Vector2D};
+use html5ever::local_name;
 use js::context::JSContext;
 use keyboard_types::{Code, Key, KeyState, Modifiers, NamedKey};
 use layout_api::{ScrollContainerQueryFlags, node_id_from_scroll_id};
@@ -1093,10 +1094,6 @@ impl DocumentEventHandler {
         hit_test_result: &HitTestResult,
         element: &Element,
     ) {
-        if event.button != MouseButton::Left {
-            return;
-        }
-
         let Some(last_mouse_button_down_point) = self.last_mouse_button_down_point.take() else {
             return;
         };
@@ -1107,49 +1104,75 @@ impl DocumentEventHandler {
             return;
         }
 
-        // From <https://w3c.github.io/pointerevents/#click>
-        // > The click event type MUST be dispatched on the topmost event target indicated by the
-        // > pointer, when the user presses down and releases the primary pointer button.
-        let element = &element.inclusive_ancestor_element_in_non_ua_shadow_root();
-        self.most_recently_clicked_element.set(Some(element));
+        match event.button {
+            MouseButton::Left => {
+                // From <https://w3c.github.io/pointerevents/#click>
+                // > The click event type MUST be dispatched on the topmost event target indicated by the
+                // > pointer, when the user presses down and releases the primary pointer button.
+                let element = &element.inclusive_ancestor_element_in_non_ua_shadow_root();
+                self.most_recently_clicked_element.set(Some(element));
 
-        let click_count = self.click_counting_info.borrow().count;
-        element.set_click_in_progress(true);
-        MouseEvent::for_platform_button_event(
-            cx,
-            atom!("click"),
-            event,
-            input_event.pressed_mouse_buttons,
-            &self.window,
-            hit_test_result,
-            input_event.active_keyboard_modifiers,
-            click_count,
-        )
-        .upcast::<Event>()
-        .dispatch(cx, element.upcast(), false);
-        element.set_click_in_progress(false);
+                let click_count = self.click_counting_info.borrow().count;
+                element.set_click_in_progress(true);
+                MouseEvent::for_platform_button_event(
+                    cx,
+                    atom!("click"),
+                    event,
+                    input_event.pressed_mouse_buttons,
+                    &self.window,
+                    hit_test_result,
+                    input_event.active_keyboard_modifiers,
+                    click_count,
+                )
+                .upcast::<Event>()
+                .dispatch(cx, element.upcast(), false);
+                element.set_click_in_progress(false);
 
-        // The firing of "dbclick" events is dependent on the platform, so we have
-        // some flexibility here. Some browsers on some platforms only fire a
-        // "dbclick" when the click count is 2 and others essentially fire one for
-        // every 2 clicks in a sequence. In all cases, browsers set the click count
-        // `detail` property to 2.
-        //
-        // We follow the latter approach here, considering that every sequence of
-        // even numbered clicks is a series of double clicks.
-        if click_count.is_multiple_of(2) {
-            MouseEvent::for_platform_button_event(
-                cx,
-                Atom::from("dblclick"),
-                event,
-                input_event.pressed_mouse_buttons,
-                &self.window,
-                hit_test_result,
-                input_event.active_keyboard_modifiers,
-                2,
-            )
-            .upcast::<Event>()
-            .dispatch(cx, element.upcast(), false);
+                // The firing of "dbclick" events is dependent on the platform, so we have
+                // some flexibility here. Some browsers on some platforms only fire a
+                // "dbclick" when the click count is 2 and others essentially fire one for
+                // every 2 clicks in a sequence. In all cases, browsers set the click count
+                // `detail` property to 2.
+                //
+                // We follow the latter approach here, considering that every sequence of
+                // even numbered clicks is a series of double clicks.
+                if click_count.is_multiple_of(2) {
+                    MouseEvent::for_platform_button_event(
+                        cx,
+                        Atom::from("dblclick"),
+                        event,
+                        input_event.pressed_mouse_buttons,
+                        &self.window,
+                        hit_test_result,
+                        input_event.active_keyboard_modifiers,
+                        2,
+                    )
+                    .upcast::<Event>()
+                    .dispatch(cx, element.upcast(), false);
+                }
+            },
+            MouseButton::Middle => {
+                let element = &element.inclusive_ancestor_element_in_non_ua_shadow_root();
+                self.most_recently_clicked_element.set(Some(element));
+
+                let click_count = self.click_counting_info.borrow().count;
+                element.set_string_attribute(cx, &local_name!("target"), DOMString::from("_blank"));
+                element.set_click_in_progress(true);
+                MouseEvent::for_platform_button_event(
+                    cx,
+                    Atom::from("auxclick"),
+                    event,
+                    input_event.pressed_mouse_buttons,
+                    &self.window,
+                    hit_test_result,
+                    input_event.active_keyboard_modifiers,
+                    click_count,
+                )
+                .upcast::<Event>()
+                .dispatch(cx, element.upcast(), false);
+                element.set_click_in_progress(false);
+            },
+            _ => {},
         }
     }
 

--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -1152,11 +1152,17 @@ impl DocumentEventHandler {
                 }
             },
             MouseButton::Middle => {
+                // From <https://w3c.github.io/pointerevents/#dfn-auxclick>
+                // > The auxclick event type MUST be dispatched on the topmost event target indicated by the
+                // > pointer, when the user presses down and releases the non-primary pointer button.
                 let element = &element.inclusive_ancestor_element_in_non_ua_shadow_root();
                 self.most_recently_clicked_element.set(Some(element));
 
                 let click_count = self.click_counting_info.borrow().count;
+
+                // target set to "_blank" so that middle click opens link in new tab
                 element.set_string_attribute(cx, &local_name!("target"), DOMString::from("_blank"));
+
                 element.set_click_in_progress(true);
                 MouseEvent::for_platform_button_event(
                     cx,

--- a/components/script/dom/event/event.rs
+++ b/components/script/dom/event/event.rs
@@ -369,7 +369,8 @@ impl Event {
 
             // Step 6.4. Let isActivationEvent be true, if event is a MouseEvent object and
             // event’s type attribute is "click"; otherwise false.
-            let is_activation_event = self.is::<MouseEvent>() && self.type_() == atom!("click");
+            let is_activation_event = self.is::<MouseEvent>() &&
+                (self.type_() == atom!("click") || self.type_() == *"auxclick");
 
             // Step 6.5. If isActivationEvent is true and target has activation behavior,
             // then set activationTarget to target.

--- a/components/script/dom/event/event.rs
+++ b/components/script/dom/event/event.rs
@@ -368,7 +368,7 @@ impl Event {
             );
 
             // Step 6.4. Let isActivationEvent be true, if event is a MouseEvent object and
-            // event’s type attribute is "click"; otherwise false.
+            // event’s type attribute is "click" or "auxclick"; otherwise false.
             let is_activation_event = self.is::<MouseEvent>() &&
                 (self.type_() == atom!("click") || self.type_() == *"auxclick");
 

--- a/tests/wpt/meta/html/semantics/disabled-elements/disabled-event-dispatch-additional.tentative.html.ini
+++ b/tests/wpt/meta/html/semantics/disabled-elements/disabled-event-dispatch-additional.tentative.html.ini
@@ -5,12 +5,6 @@
   [Testing dblclick events when clicking child of disabled my-control.]
     expected: FAIL
 
-  [Testing auxclick events when clicking child of disabled button.]
-    expected: FAIL
-
-  [Testing auxclick events when clicking child of disabled my-control.]
-    expected: FAIL
-
   [Testing auxclick events when clicking disabled button.]
     expected: FAIL
 

--- a/tests/wpt/meta/pointerevents/pointerevent_auxclick_is_a_pointerevent.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_auxclick_is_a_pointerevent.html.ini
@@ -1,10 +1,9 @@
 [pointerevent_auxclick_is_a_pointerevent.html?mouse]
-  expected: TIMEOUT
   [auxclick using mouse is a PointerEvent with correct properties]
-    expected: TIMEOUT
+    expected: FAIL
 
   [auxclick using mouse is a PointerEvent with correct properties when no other PointerEvent listeners are present]
-    expected: NOTRUN
+    expected: FAIL
 
 
 [pointerevent_auxclick_is_a_pointerevent.html?pen]

--- a/tests/wpt/meta/uievents/click/auxclick_event.html.ini
+++ b/tests/wpt/meta/uievents/click/auxclick_event.html.ini
@@ -1,4 +1,0 @@
-[auxclick_event.html]
-  expected: TIMEOUT
-  [auxclick event sequence received.]
-    expected: NOTRUN


### PR DESCRIPTION
Dispatches `auxclick` event for middle click which opens link in new tab. 

Testing: Existing wpt tests for auxclick were run, expectations for tests updated.
Fixes: #45332 
