### PR TITLE
script: Use `enter_auto_realm` in `DomObject.global()`

### DIFF
--- a/components/script/dom/bindings/reflector.rs
+++ b/components/script/dom/bindings/reflector.rs
@@ -23,7 +23,7 @@ impl<T: DomGlobalGeneric<DomTypeHolder>> DomGlobal for T {
     #[expect(unsafe_code)]
     fn global(&self) -> DomRoot<GlobalScope> {
         // SAFETY: We only use this `cx` to enter a realm. That does not
-        // incur a gc and hence is safe to perform. We do not want to
+        // incur a GC and hence is safe to perform. We do not want to
         // pass a `cx` as parameter to this function, as this used in
         // loads of places. At the same time, it also isn't necessary in
         // nearly all cases to enter realm, since we are already in the

--- a/components/script/dom/bindings/reflector.rs
+++ b/components/script/dom/bindings/reflector.rs
@@ -2,29 +2,39 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use script_bindings::realms::InRealm;
+use js::context::JSContext;
 use script_bindings::reflector::DomGlobalGeneric;
 use script_bindings::root::DomRoot;
 
 use crate::DomTypeHolder;
 use crate::dom::types::GlobalScope;
-use crate::realms::enter_realm;
+use crate::realms::enter_auto_realm;
 
 pub(crate) trait DomGlobal {
     /// Returns the [relevant global] in the same realm as the callee object.
-    /// If you know the callee's realm is already the current realm, it is
-    /// more efficient to call [DomGlobal::global_] instead.
+    /// Will enter the realm of the global to ensure the global is only
+    /// accessed from the correct realm.
     ///
     /// [relevant global]: https://html.spec.whatwg.org/multipage/#concept-relevant-global
     fn global(&self) -> DomRoot<GlobalScope>;
 }
 
 impl<T: DomGlobalGeneric<DomTypeHolder>> DomGlobal for T {
+    #[expect(unsafe_code)]
     fn global(&self) -> DomRoot<GlobalScope> {
-        let realm = enter_realm(self);
-        <Self as DomGlobalGeneric<DomTypeHolder>>::global_from_reflector(
-            self,
-            InRealm::entered(&realm),
-        )
+        // SAFETY: We only use this `cx` to enter a realm. That does not
+        // incur a gc and hence is safe to perform. We do not want to
+        // pass a `cx` as parameter to this function, as this used in
+        // loads of places. At the same time, it also isn't necessary in
+        // nearly all cases to enter realm, since we are already in the
+        // correct realm.
+        //
+        // However, there are cases where it is difficult to ensure that
+        // we are in the correct realm. Hence we always enter a realm here
+        // even if that is unnecessary at times.
+        let cx = unsafe { JSContext::get_from_thread() };
+        let cx = &mut cx.expect("JS runtime has shut down");
+        let _realm = enter_auto_realm(cx, self);
+        <Self as DomGlobalGeneric<DomTypeHolder>>::global_from_reflector(self)
     }
 }

--- a/components/script/dom/globalscope/globalscope.rs
+++ b/components/script/dom/globalscope/globalscope.rs
@@ -148,7 +148,7 @@ use crate::fetch::{DeferredFetchRecordId, FetchGroup, QueuedDeferredFetchRecord}
 use crate::messaging::{CommonScriptMsg, ScriptEventLoopReceiver, ScriptEventLoopSender};
 use crate::microtask::Microtask;
 use crate::network_listener::{FetchResponseListener, NetworkListener};
-use crate::realms::{InRealm, enter_auto_realm};
+use crate::realms::enter_auto_realm;
 use crate::script_module::{
     ImportMap, ModuleRequest, ModuleStatus, ResolvedModule, ScriptFetchOptions,
 };
@@ -2344,7 +2344,7 @@ impl GlobalScope {
     /// Returns the global scope of the realm that the given DOM object's reflector
     /// was created in.
     #[expect(unsafe_code)]
-    pub(crate) fn from_reflector<T: DomObject>(reflector: &T, _realm: InRealm) -> DomRoot<Self> {
+    pub(crate) fn from_reflector<T: DomObject>(reflector: &T) -> DomRoot<Self> {
         unsafe { GlobalScope::from_object(*reflector.reflector().get_jsobject()) }
     }
 
@@ -3609,8 +3609,8 @@ impl GlobalScopeHelpers<crate::DomTypeHolder> for GlobalScope {
         unsafe { GlobalScope::from_object(obj) }
     }
 
-    fn from_reflector(reflector: &impl DomObject, realm: InRealm) -> DomRoot<Self> {
-        GlobalScope::from_reflector(reflector, realm)
+    fn from_reflector(reflector: &impl DomObject) -> DomRoot<Self> {
+        GlobalScope::from_reflector(reflector)
     }
 
     fn origin(&self) -> MutableOrigin {

--- a/components/script/realms.rs
+++ b/components/script/realms.rs
@@ -3,14 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use js::context::JSContext;
-use js::jsapi::JSAutoRealm;
 use js::realm::AutoRealm;
-pub(crate) use script_bindings::realms::InRealm;
 use script_bindings::reflector::DomObject;
-
-pub(crate) fn enter_realm(object: &impl DomObject) -> JSAutoRealm {
-    script_bindings::realms::enter_realm::<crate::DomTypeHolder>(object)
-}
 
 pub(crate) fn enter_auto_realm<'cx>(
     cx: &'cx mut JSContext,

--- a/components/script_bindings/interfaces.rs
+++ b/components/script_bindings/interfaces.rs
@@ -16,7 +16,6 @@ use crate::DomTypes;
 use crate::codegen::PrototypeList;
 use crate::conversions::DerivedFrom;
 use crate::error::Error;
-use crate::realms::InRealm;
 use crate::reflector::{DomObject, DomObjectWrap};
 use crate::root::DomRoot;
 use crate::script_runtime::JSContext as SafeJSContext;
@@ -71,7 +70,7 @@ pub trait GlobalScopeHelpers<D: DomTypes> {
     /// # Safety
     /// `obj` must point to a valid, non-null JSObject.
     unsafe fn from_object(obj: *mut JSObject) -> DomRoot<D::GlobalScope>;
-    fn from_reflector(reflector: &impl DomObject, realm: InRealm) -> DomRoot<D::GlobalScope>;
+    fn from_reflector(reflector: &impl DomObject) -> DomRoot<D::GlobalScope>;
 
     fn origin(&self) -> MutableOrigin;
 

--- a/components/script_bindings/realms.rs
+++ b/components/script_bindings/realms.rs
@@ -4,76 +4,14 @@
 
 use std::ptr::NonNull;
 
-use js::jsapi::{GetCurrentRealmOrNull, JSAutoRealm};
-use js::realm::{AutoRealm, CurrentRealm};
+use js::context::JSContext;
+use js::realm::AutoRealm;
 
 use crate::DomTypes;
-use crate::interfaces::GlobalScopeHelpers;
 use crate::reflector::DomObject;
-use crate::script_runtime::JSContext;
-
-pub struct AlreadyInRealm(());
-
-impl AlreadyInRealm {
-    #![expect(unsafe_code)]
-    pub fn assert<D: DomTypes>() -> AlreadyInRealm {
-        unsafe {
-            assert!(!GetCurrentRealmOrNull(*D::GlobalScope::get_cx()).is_null());
-        }
-        AlreadyInRealm(())
-    }
-
-    pub fn assert_for_cx(cx: JSContext) -> AlreadyInRealm {
-        unsafe {
-            assert!(!GetCurrentRealmOrNull(*cx).is_null());
-        }
-        AlreadyInRealm(())
-    }
-}
-
-impl<'a, 'b> From<&'a mut CurrentRealm<'b>> for AlreadyInRealm {
-    fn from(_: &'a mut CurrentRealm<'b>) -> AlreadyInRealm {
-        AlreadyInRealm(())
-    }
-}
-
-#[derive(Clone, Copy)]
-pub enum InRealm<'a> {
-    Already(&'a AlreadyInRealm),
-    Entered(&'a JSAutoRealm),
-}
-
-impl<'a> From<&'a AlreadyInRealm> for InRealm<'a> {
-    fn from(token: &'a AlreadyInRealm) -> InRealm<'a> {
-        InRealm::already(token)
-    }
-}
-
-impl<'a> From<&'a JSAutoRealm> for InRealm<'a> {
-    fn from(token: &'a JSAutoRealm) -> InRealm<'a> {
-        InRealm::entered(token)
-    }
-}
-
-impl InRealm<'_> {
-    pub fn already(token: &AlreadyInRealm) -> InRealm<'_> {
-        InRealm::Already(token)
-    }
-
-    pub fn entered(token: &JSAutoRealm) -> InRealm<'_> {
-        InRealm::Entered(token)
-    }
-}
-
-pub fn enter_realm<D: DomTypes>(object: &impl DomObject) -> JSAutoRealm {
-    JSAutoRealm::new(
-        *D::GlobalScope::get_cx(),
-        object.reflector().get_jsobject().get(),
-    )
-}
 
 pub fn enter_auto_realm<'cx, D: DomTypes>(
-    cx: &'cx mut js::context::JSContext,
+    cx: &'cx mut JSContext,
     object: &impl DomObject,
 ) -> AutoRealm<'cx> {
     AutoRealm::new(

--- a/components/script_bindings/reflector.rs
+++ b/components/script_bindings/reflector.rs
@@ -12,7 +12,6 @@ use malloc_size_of_derive::MallocSizeOf;
 use crate::conversions::DerivedFrom;
 use crate::interfaces::GlobalScopeHelpers;
 use crate::iterable::{Iterable, IterableIterator};
-use crate::realms::InRealm;
 use crate::root::{Dom, DomRoot, Root};
 use crate::script_runtime::{CanGc, temp_cx};
 use crate::{DomTypes, JSTraceable};
@@ -219,11 +218,11 @@ pub trait DomGlobalGeneric<D: DomTypes>: DomObject {
     /// Returns the [`GlobalScope`] of the realm that the [`DomObject`] was created in.  If this
     /// object is a `Node`, this will be different from it's owning `Document` if adopted by. For
     /// `Node`s it's almost always better to use `NodeTraits::owning_global`.
-    fn global_from_reflector(&self, realm: InRealm) -> DomRoot<D::GlobalScope>
+    fn global_from_reflector(&self) -> DomRoot<D::GlobalScope>
     where
         Self: Sized,
     {
-        D::GlobalScope::from_reflector(self, realm)
+        D::GlobalScope::from_reflector(self)
     }
 }
 


### PR DESCRIPTION
Rather than `GlobalScope::get_cx` we use `JSContext::get_from_thread` with
a big explanation why it is safe to perform.

Part of #40600

Testing: it compiles