### PR TITLE
layout: Avoid building stacking context tree for most resolved style queries

### DIFF
--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -62,7 +62,7 @@ use style::invalidation::element::restyle_hints::RestyleHint;
 use style::invalidation::stylesheets::StylesheetInvalidationSet;
 use style::media_queries::{MediaList, MediaType};
 use style::properties::style_structs::Font;
-use style::properties::{ComputedValues, PropertyId};
+use style::properties::{ComputedValues, LonghandId, NonCustomPropertyId, PropertyId, ShorthandId};
 use style::queries::values::PrefersColorScheme;
 use style::selector_parser::{PseudoElement, SnapshotMap};
 use style::servo::media_features::PointerCapabilities;
@@ -1855,8 +1855,38 @@ impl ReflowPhases {
     /// [`ReflowGoals`] need the basic restyle + box tree layout + fragment tree layout,
     /// so [`ReflowPhases::empty()`] implies that.
     fn necessary(reflow_goal: &ReflowGoal) -> Self {
+        let is_inset_longhand = |longhand: LonghandId| {
+            matches!(
+                longhand,
+                LonghandId::Top |
+                    LonghandId::Right |
+                    LonghandId::Bottom |
+                    LonghandId::Left |
+                    LonghandId::InsetInlineStart |
+                    LonghandId::InsetInlineEnd |
+                    LonghandId::InsetBlockStart |
+                    LonghandId::InsetBlockEnd
+            )
+        };
+
+        let is_inset_property =
+            |property: NonCustomPropertyId| match property.longhand_or_shorthand() {
+                Ok(longhand) => is_inset_longhand(longhand),
+                // Special case for the `All` shorthand as it has many longhands.
+                Err(ShorthandId::All) => true,
+                Err(shorthand) => shorthand.longhands().any(is_inset_longhand),
+            };
+
         match reflow_goal {
             ReflowGoal::LayoutQuery(query) => match query {
+                // Resolving insets requires the creation of the stacking context, but other style properties
+                // do not. This should be kept in sync with `LayoutThread::query_resolved_style()`.
+                QueryMsg::ResolvedStyleQuery(PropertyId::NonCustom(non_custom_property_id))
+                    if is_inset_property(*non_custom_property_id) =>
+                {
+                    Self::StackingContextTreeConstruction
+                },
+                QueryMsg::ResolvedStyleQuery(_) => Self::empty(),
                 QueryMsg::NodesFromPointQuery => {
                     Self::StackingContextTreeConstruction | Self::DisplayListConstruction
                 },
@@ -1865,7 +1895,6 @@ impl ReflowPhases {
                 QueryMsg::ElementsFromPoint |
                 QueryMsg::FlushForUpdateTheRenderingQuery |
                 QueryMsg::OffsetParentQuery |
-                QueryMsg::ResolvedStyleQuery |
                 QueryMsg::ScrollingAreaOrOffsetQuery |
                 QueryMsg::TextIndexQuery => Self::StackingContextTreeConstruction,
                 QueryMsg::ClientRectQuery |

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -2973,7 +2973,7 @@ impl Window {
         pseudo: Option<PseudoElement>,
         property: PropertyId,
     ) -> DOMString {
-        self.layout_reflow(QueryMsg::ResolvedStyleQuery);
+        self.layout_reflow(QueryMsg::ResolvedStyleQuery(property.clone()));
 
         let document = self.Document();
         let animations = document.animations().sets.clone();

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -550,7 +550,9 @@ pub enum QueryMsg {
     OffsetParentQuery,
     ScrollParentQuery,
     ResolvedFontStyleQuery,
-    ResolvedStyleQuery,
+    /// A style query, with an optional [`PropertyId`], used to limit the phases
+    /// of layout run before the query.
+    ResolvedStyleQuery(PropertyId),
     ScrollingAreaOrOffsetQuery,
     StyleQuery,
     TextIndexQuery,


### PR DESCRIPTION
Previously, all resolved style queries required stacking context tree
construction. This is really only important for calculating insets
of sticky-positioned elements though. This change makes it so that a
stacking context tree construction is not required for non-inset
queries.

Tested on a Linux VM, and saw the following improvements related
to reflow on one webpage:

 - `build_stack_context_tree`: 63M instructions to 24M instructions
 - `Window::reflow`:  197M instructions to 168M instructions

Testing: This should not change observable behavior and is just a performance improvement.
