### PR TITLE
accessibility: Simplify debug assertion

### DIFF
--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -242,7 +242,7 @@ impl AccessibilityTree {
             })
         {
             let node = self.nodes.remove(&id);
-            debug_assert!(node.is_none(), "Node for id {id:?} was already removed");
+            debug_assert!(node.is_some(), "Node for id {id:?} was already removed");
             if let Some(opaque_node) = self.id_to_opaque_node.remove(&id) {
                 self.opaque_node_to_id.remove(&opaque_node);
             }

--- a/components/layout/accessibility_tree.rs
+++ b/components/layout/accessibility_tree.rs
@@ -242,12 +242,7 @@ impl AccessibilityTree {
             })
         {
             let node = self.nodes.remove(&id);
-            {
-                #[cfg(debug_assertions)]
-                let Some(_node) = node else {
-                    panic!("Node for id {id:?} was already removed");
-                };
-            }
+            debug_assert!(node.is_none(), "Node for id {id:?} was already removed");
             if let Some(opaque_node) = self.id_to_opaque_node.remove(&id) {
                 self.opaque_node_to_id.remove(&opaque_node);
             }


### PR DESCRIPTION
The previous code produced an unused variable warning when debug assertions are disabled, which caused build failures in CI in production mode (since merging isn't gated).
I was actually a bit surprised that switching to `debug_assert!` makes the unused variable warning go away, but I won't complain if there is macro magic marking the variable as used in release builds. 

Testing: No functional changes
Fixes: #45980 (although it doesn't prevent it from happening again either)