### PR TITLE
script: Move CLASS_OPS and Class init to non-generated code

### DIFF
--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -2647,7 +2647,7 @@ static CLASS_OPS: ThreadUnsafeOnceLock<JSClassOps> = ThreadUnsafeOnceLock::new()
 pub static Class: ThreadUnsafeOnceLock<DOMJSClass> = ThreadUnsafeOnceLock::new();
 
 pub(crate) fn init_domjs_class<D: DomTypes>() {{
-    let js_class_config = crate::init::InitClassConfig {{
+    let js_class_config = crate::init::InitClassOpsConfig {{
             enumerate_hook: {args["enumerateHook"]},
             resolve_hook: {args["resolveHook"]},
             may_resolve_hook: {args["mayResolveHook"]},

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -2644,39 +2644,23 @@ class CGDOMJSClass(CGThing):
             args["slots"] = "2"
         return f"""
 static CLASS_OPS: ThreadUnsafeOnceLock<JSClassOps> = ThreadUnsafeOnceLock::new();
-
-pub(crate) fn init_class_ops<D: DomTypes>() {{
-    CLASS_OPS.set(JSClassOps {{
-        addProperty: None,
-        delProperty: None,
-        enumerate: None,
-        newEnumerate: {args['enumerateHook']},
-        resolve: {args['resolveHook']},
-        mayResolve: {args['mayResolveHook']},
-        finalize: Some({args['finalizeHook']}),
-        call: None,
-        construct: None,
-        trace: Some({args['traceHook']}),
-    }});
-}}
-
 pub static Class: ThreadUnsafeOnceLock<DOMJSClass> = ThreadUnsafeOnceLock::new();
 
 pub(crate) fn init_domjs_class<D: DomTypes>() {{
-    init_class_ops::<D>();
-    Class.set(DOMJSClass {{
-        base: JSClass {{
-            name: {args['name']},
-            flags: JSCLASS_IS_DOMJSCLASS | {args['flags']} |
-                   ((({args['slots']}) & JSCLASS_RESERVED_SLOTS_MASK) << JSCLASS_RESERVED_SLOTS_SHIFT)
-                   /* JSCLASS_HAS_RESERVED_SLOTS({args['slots']}) */,
-            cOps: unsafe {{ CLASS_OPS.get() }},
-            spec: ptr::null(),
-            ext: ptr::null(),
-            oOps: ptr::null(),
-        }},
-        dom_class: {args['domClass']},
-    }});
+    let js_class_config = crate::init::InitClassConfig {{
+            enumerate_hook: {args["enumerateHook"]},
+            resolve_hook: {args["resolveHook"]},
+            may_resolve_hook: {args["mayResolveHook"]},
+            finalize_hook: {args["finalizeHook"]},
+            trace_hook: {args["traceHook"]}
+            }};
+    let domjs_class_config = crate::init::DomJSClassConfig {{
+        name: {args['name']},
+        flags: {args['flags']},
+        slots: {args['slots']},
+        class: {args['domClass']},
+    }};
+    crate::init::init_domjs_class(&CLASS_OPS, js_class_config, &Class, domjs_class_config);
 }}
 """
 

--- a/components/script_bindings/import.rs
+++ b/components/script_bindings/import.rs
@@ -81,8 +81,8 @@ pub(crate) mod module {
     };
     pub(crate) use js::rust::{CustomAutoRooterGuard, GCMethods, Handle, MutableHandle};
     pub(crate) use js::{
-        JS_CALLEE, JSCLASS_GLOBAL_SLOT_COUNT, JSCLASS_IS_DOMJSCLASS, JSCLASS_IS_GLOBAL,
-        JSCLASS_RESERVED_SLOTS_MASK, typedarray,
+        JS_CALLEE, JSCLASS_GLOBAL_SLOT_COUNT, JSCLASS_IS_GLOBAL, JSCLASS_RESERVED_SLOTS_MASK,
+        typedarray,
     };
     pub(crate) use servo_config::pref;
 

--- a/components/script_bindings/init.rs
+++ b/components/script_bindings/init.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 use std::ptr;
 
 use js::jsapi::{

--- a/components/script_bindings/init.rs
+++ b/components/script_bindings/init.rs
@@ -9,7 +9,7 @@ use js::{JSCLASS_IS_DOMJSCLASS, JSCLASS_RESERVED_SLOTS_MASK};
 use crate::lock::ThreadUnsafeOnceLock;
 use crate::utils::{DOMClass, DOMJSClass};
 
-pub(crate) struct InitClassConfig {
+pub(crate) struct InitClassOpsConfig {
     pub(crate) enumerate_hook: Option<
         unsafe extern "C" fn(
             *mut JSContext,
@@ -34,7 +34,7 @@ pub(crate) struct InitClassConfig {
 
 pub(crate) fn init_class_ops(
     class_ops: &ThreadUnsafeOnceLock<JSClassOps>,
-    config: InitClassConfig,
+    config: InitClassOpsConfig,
 ) {
     class_ops.set(JSClassOps {
         addProperty: None,
@@ -59,7 +59,7 @@ pub(crate) struct DomJSClassConfig {
 
 pub(crate) fn init_domjs_class(
     js_class: &ThreadUnsafeOnceLock<JSClassOps>,
-    js_class_config: InitClassConfig,
+    js_class_config: InitClassOpsConfig,
     class: &ThreadUnsafeOnceLock<DOMJSClass>,
     domjs_class_config: DomJSClassConfig,
 ) {

--- a/components/script_bindings/init.rs
+++ b/components/script_bindings/init.rs
@@ -36,24 +36,6 @@ pub(crate) struct InitClassOpsConfig {
     pub(crate) trace_hook: unsafe extern "C" fn(*mut JSTracer, *mut JSObject),
 }
 
-pub(crate) fn init_class_ops(
-    class_ops: &ThreadUnsafeOnceLock<JSClassOps>,
-    config: InitClassOpsConfig,
-) {
-    class_ops.set(JSClassOps {
-        addProperty: None,
-        delProperty: None,
-        enumerate: None,
-        newEnumerate: config.enumerate_hook,
-        resolve: config.resolve_hook,
-        mayResolve: config.may_resolve_hook,
-        finalize: Some(config.finalize_hook),
-        call: None,
-        construct: None,
-        trace: Some(config.trace_hook),
-    })
-}
-
 pub(crate) struct DomJSClassConfig {
     pub(crate) name: *const i8,
     pub(crate) flags: u32,
@@ -67,14 +49,26 @@ pub(crate) fn init_domjs_class(
     class: &ThreadUnsafeOnceLock<DOMJSClass>,
     domjs_class_config: DomJSClassConfig,
 ) {
-    {
-        init_class_ops(js_class, js_class_config);
-        class.set(DOMJSClass {
+    js_class.set(JSClassOps {
+        addProperty: None,
+        delProperty: None,
+        enumerate: None,
+        newEnumerate: js_class_config.enumerate_hook,
+        resolve: js_class_config.resolve_hook,
+        mayResolve: js_class_config.may_resolve_hook,
+        finalize: Some(js_class_config.finalize_hook),
+        call: None,
+        construct: None,
+        trace: Some(js_class_config.trace_hook),
+    });
+
+    class.set(DOMJSClass {
         base: JSClass {
             name: domjs_class_config.name,
-            flags: JSCLASS_IS_DOMJSCLASS | domjs_class_config.flags |
-                   (((domjs_class_config.slots) & JSCLASS_RESERVED_SLOTS_MASK) << JSCLASS_RESERVED_SLOTS_SHIFT)
-                   /* JSCLASS_HAS_RESERVED_SLOTS({args['slots']}) */,
+            flags: JSCLASS_IS_DOMJSCLASS |
+                domjs_class_config.flags |
+                (((domjs_class_config.slots) & JSCLASS_RESERVED_SLOTS_MASK) <<
+                    JSCLASS_RESERVED_SLOTS_SHIFT), /* JSCLASS_HAS_RESERVED_SLOTS({args['slots']}) */
             cOps: unsafe { js_class.get() },
             spec: ptr::null(),
             ext: ptr::null(),
@@ -82,5 +76,4 @@ pub(crate) fn init_domjs_class(
         },
         dom_class: domjs_class_config.class,
     });
-    }
 }

--- a/components/script_bindings/init.rs
+++ b/components/script_bindings/init.rs
@@ -1,0 +1,82 @@
+use std::ptr;
+
+use js::jsapi::{
+    GCContext, Handle, JSAtomState, JSCLASS_RESERVED_SLOTS_SHIFT, JSClass, JSClassOps, JSContext,
+    JSObject, JSTracer, MutableHandleIdVector, PropertyKey,
+};
+use js::{JSCLASS_IS_DOMJSCLASS, JSCLASS_RESERVED_SLOTS_MASK};
+
+use crate::lock::ThreadUnsafeOnceLock;
+use crate::utils::{DOMClass, DOMJSClass};
+
+pub(crate) struct InitClassConfig {
+    pub(crate) enumerate_hook: Option<
+        unsafe extern "C" fn(
+            *mut JSContext,
+            Handle<*mut JSObject>,
+            MutableHandleIdVector,
+            bool,
+        ) -> bool,
+    >,
+    pub(crate) resolve_hook: Option<
+        unsafe extern "C" fn(
+            *mut JSContext,
+            Handle<*mut JSObject>,
+            Handle<PropertyKey>,
+            *mut bool,
+        ) -> bool,
+    >,
+    pub(crate) may_resolve_hook:
+        Option<unsafe extern "C" fn(*const JSAtomState, PropertyKey, *mut JSObject) -> bool>,
+    pub(crate) finalize_hook: unsafe extern "C" fn(*mut GCContext, *mut JSObject),
+    pub(crate) trace_hook: unsafe extern "C" fn(*mut JSTracer, *mut JSObject),
+}
+
+pub(crate) fn init_class_ops(
+    class_ops: &ThreadUnsafeOnceLock<JSClassOps>,
+    config: InitClassConfig,
+) {
+    class_ops.set(JSClassOps {
+        addProperty: None,
+        delProperty: None,
+        enumerate: None,
+        newEnumerate: config.enumerate_hook,
+        resolve: config.resolve_hook,
+        mayResolve: config.may_resolve_hook,
+        finalize: Some(config.finalize_hook),
+        call: None,
+        construct: None,
+        trace: Some(config.trace_hook),
+    })
+}
+
+pub(crate) struct DomJSClassConfig {
+    pub(crate) name: *const i8,
+    pub(crate) flags: u32,
+    pub(crate) slots: u32,
+    pub(crate) class: DOMClass,
+}
+
+pub(crate) fn init_domjs_class(
+    js_class: &ThreadUnsafeOnceLock<JSClassOps>,
+    js_class_config: InitClassConfig,
+    class: &ThreadUnsafeOnceLock<DOMJSClass>,
+    domjs_class_config: DomJSClassConfig,
+) {
+    {
+        init_class_ops(js_class, js_class_config);
+        class.set(DOMJSClass {
+        base: JSClass {
+            name: domjs_class_config.name,
+            flags: JSCLASS_IS_DOMJSCLASS | domjs_class_config.flags |
+                   (((domjs_class_config.slots) & JSCLASS_RESERVED_SLOTS_MASK) << JSCLASS_RESERVED_SLOTS_SHIFT)
+                   /* JSCLASS_HAS_RESERVED_SLOTS({args['slots']}) */,
+            cOps: unsafe { js_class.get() },
+            spec: ptr::null(),
+            ext: ptr::null(),
+            oOps: ptr::null(),
+        },
+        dom_class: domjs_class_config.class,
+    });
+    }
+}

--- a/components/script_bindings/init.rs
+++ b/components/script_bindings/init.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::ffi::c_char;
 use std::ptr;
 
 use js::jsapi::{
@@ -37,7 +38,7 @@ pub(crate) struct InitClassOpsConfig {
 }
 
 pub(crate) struct DomJSClassConfig {
-    pub(crate) name: *const i8,
+    pub(crate) name: *const c_char,
     pub(crate) flags: u32,
     pub(crate) slots: u32,
     pub(crate) class: DOMClass,

--- a/components/script_bindings/lib.rs
+++ b/components/script_bindings/lib.rs
@@ -28,6 +28,7 @@ mod finalize;
 mod guard;
 mod import;
 pub mod inheritance;
+mod init;
 pub mod interface;
 pub mod interfaces;
 pub mod iterable;


### PR DESCRIPTION
This moves init_domjs_class and init_class_ops to non-generated code saving roughly 8k lines of generated code.

Testing: As this is just a refactor compilation is the test.
