### PR TITLE
CI: Deny warnings only on checked-release profile

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -183,7 +183,7 @@ jobs:
 
       - name: Build (${{ inputs.profile }})
         env:
-          RUSTFLAGS: "-D warnings"
+          RUSTFLAGS: ${{ inputs.profile == 'checked-release' && '-D warnings' || '' }}
         run: |
           ./mach build --use-crown --locked --profile ${{ inputs.profile }} ${{ inputs.build-args }}
           mv target/cargo-timings target/cargo-timings-linux

--- a/.github/workflows/mac-arm64.yml
+++ b/.github/workflows/mac-arm64.yml
@@ -148,7 +148,7 @@ jobs:
           brew install gnu-tar
       - name: Build (${{ inputs.profile }})
         env:
-          RUSTFLAGS: "-D warnings"
+          RUSTFLAGS: ${{ inputs.profile == 'checked-release' && '-D warnings' || '' }}
         run: |
           ./mach build --use-crown --locked --profile ${{ inputs.profile }}  ${{ inputs.build-args }}
           mv target/cargo-timings target/cargo-timings-macos-arm64

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -147,7 +147,7 @@ jobs:
           brew install gnu-tar
       - name: Build (${{ inputs.profile }})
         env:
-          RUSTFLAGS: "-D warnings"
+          RUSTFLAGS: ${{ inputs.profile == 'checked-release' && '-D warnings' || '' }}
         run: |
           ./mach build --use-crown --locked --profile ${{ inputs.profile }}  ${{ inputs.build-args }}
           mv target/cargo-timings target/cargo-timings-macos

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -155,13 +155,13 @@ jobs:
           echo "`$env:PATH now = $env:PATH"
       - name: Build (${{ inputs.profile }})
         env:
-          RUSTFLAGS: "-D warnings"
+          RUSTFLAGS: ${{ inputs.profile == 'checked-release' && '-D warnings' || '' }}
         run: |
           .\mach build --use-crown --locked --profile ${{ inputs.profile }} ${{ inputs.build-args }}
           mv C:\a\servo\servo\target\cargo-timings C:\a\servo\servo\target\cargo-timings-windows
       - name: Build with vello backend (${{ inputs.profile }})
         env:
-          RUSTFLAGS: "-D warnings"
+          RUSTFLAGS: ${{ inputs.profile == 'checked-release' && '-D warnings' || '' }}
         run: |
           .\mach build --use-crown --locked --profile ${{ inputs.profile }} ${{ inputs.build-args }} --feature vello
       - name: Copy resources


### PR DESCRIPTION
Since the merge queue only runs this profile, it previously could happen that warnings which only appear in release or production mode (e.g. due to `#[cfg(debug_assertions)]`) pass the merge queue, and break production builds on main.
Hence, we don't deny warnings on other profiles.

Testing: This is a CI change, so if it passes the MQ it should be good. We already use the same pattern in the release.yml workflow too.
Fixes: #45980
