### PR TITLE
script: Use active document's origin as Window's origin.

### DIFF
--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -396,7 +396,7 @@ impl CanvasState {
     fn is_origin_clean(&self, source: CanvasImageSource) -> bool {
         match source {
             CanvasImageSource::HTMLImageElement(image) => {
-                image.same_origin(GlobalScope::entry().origin())
+                image.same_origin(&GlobalScope::entry().origin())
             },
             CanvasImageSource::HTMLVideoElement(video) => video.origin_is_clean(),
             CanvasImageSource::HTMLCanvasElement(canvas) => canvas.origin_is_clean(),

--- a/components/script/dom/canvas/imagebitmap.rs
+++ b/components/script/dom/canvas/imagebitmap.rs
@@ -377,7 +377,7 @@ impl ImageBitmap {
                 let image_bitmap = Self::new(realm, global_scope, bitmap_data);
                 // Step 6.4. If image is not origin-clean, then set the origin-clean flag
                 // of imageBitmap's bitmap to false.
-                image_bitmap.set_origin_clean(image.same_origin(GlobalScope::entry().origin()));
+                image_bitmap.set_origin_clean(image.same_origin(&GlobalScope::entry().origin()));
 
                 // Step 6.5. Queue a global task, using the bitmap task source,
                 // to resolve promise with imageBitmap.

--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -15,6 +15,7 @@ use js::context::JSContext;
 use js::rust::wrappers2::JS_DefineDebuggerObject;
 use net_traits::ResourceThreads;
 use profile_traits::{mem, time};
+use script_bindings::interfaces::HasOrigin;
 use script_bindings::reflector::DomObject;
 use servo_base::generic_channel::{GenericCallback, GenericSender, channel};
 use servo_base::id::{Index, PipelineId, PipelineNamespaceId};
@@ -73,6 +74,8 @@ pub(crate) struct DebuggerGlobalScope {
     get_environment_result_sender: RefCell<Option<GenericSender<String>>>,
     #[no_trace]
     pipeline_id: PipelineId,
+    #[no_trace]
+    origin: MutableOrigin,
 }
 
 impl DebuggerGlobalScope {
@@ -106,7 +109,6 @@ impl DebuggerGlobalScope {
                 script_to_embedder_chan,
                 resource_threads,
                 storage_threads,
-                MutableOrigin::new(ImmutableOrigin::new_opaque()),
                 ServoUrl::parse_with_base(None, "about:internal/debugger")
                     .expect("Guaranteed by argument"),
                 None,
@@ -122,8 +124,10 @@ impl DebuggerGlobalScope {
             get_environment_result_sender: RefCell::new(None),
             eval_result_sender: RefCell::new(None),
             pipeline_id: debugger_pipeline_id,
+            origin: MutableOrigin::new(ImmutableOrigin::new_opaque()),
         });
-        let global = DebuggerGlobalScopeBinding::Wrap::<crate::DomTypeHolder>(cx, global);
+        let global =
+            DebuggerGlobalScopeBinding::Wrap::<crate::DomTypeHolder>(cx, &global.origin(), global);
 
         let mut realm = enter_auto_realm(cx, &*global);
         let mut realm = realm.current_realm();
@@ -134,6 +138,10 @@ impl DebuggerGlobalScope {
         });
 
         global
+    }
+
+    pub(crate) fn origin(&self) -> MutableOrigin {
+        self.origin.clone()
     }
 
     pub(crate) fn as_global_scope(&self) -> &GlobalScope {
@@ -697,5 +705,11 @@ impl DebuggerGlobalScopeMethods<crate::DomTypeHolder> for DebuggerGlobalScope {
             .expect("Guaranteed by Self::fire_get_environment()");
 
         let _ = sender.send(environment_actor_id.into());
+    }
+}
+
+impl HasOrigin for DebuggerGlobalScope {
+    fn origin(&self) -> MutableOrigin {
+        DebuggerGlobalScope::origin(self)
     }
 }

--- a/components/script/dom/fetch/request.rs
+++ b/components/script/dom/fetch/request.rs
@@ -152,7 +152,8 @@ impl Request {
         }
 
         // Step 7. Let origin be this’s relevant settings object’s origin.
-        let origin = global.origin().immutable();
+        let origin = global.origin();
+        let origin = origin.immutable();
 
         // Step 8. Let traversableForUserPrompts be "client".
         let mut traversable_for_user_prompts = TraversableForUserPrompts::Client;

--- a/components/script/dom/globalscope/globalscope.rs
+++ b/components/script/dom/globalscope/globalscope.rs
@@ -287,10 +287,6 @@ pub(crate) struct GlobalScope {
     #[no_trace]
     storage_threads: StorageThreads,
 
-    /// The origin of the globalscope
-    #[no_trace]
-    origin: MutableOrigin,
-
     /// <https://html.spec.whatwg.org/multipage/#concept-environment-creation-url>
     #[no_trace]
     creation_url: DomRefCell<ServoUrl>,
@@ -788,7 +784,6 @@ impl GlobalScope {
         script_to_embedder_chan: ScriptToEmbedderChan,
         resource_threads: ResourceThreads,
         storage_threads: StorageThreads,
-        origin: MutableOrigin,
         creation_url: ServoUrl,
         top_level_creation_url: Option<ServoUrl>,
         #[cfg(feature = "webgpu")] gpu_id_hub: Arc<IdentityHub>,
@@ -815,7 +810,6 @@ impl GlobalScope {
             in_error_reporting_mode: Default::default(),
             resource_threads,
             storage_threads,
-            origin,
             creation_url: DomRefCell::new(creation_url),
             top_level_creation_url,
             permission_state_invocation_results: Default::default(),
@@ -1908,11 +1902,11 @@ impl GlobalScope {
     }
 
     fn decrement_file_ref(&self, id: Uuid) {
-        let origin = self.origin().immutable();
+        let origin = self.origin().immutable().clone();
 
         let (tx, rx) = profile_generic_channel::channel(self.time_profiler_chan().clone()).unwrap();
 
-        let msg = FileManagerThreadMsg::DecRef(id, origin.clone(), tx);
+        let msg = FileManagerThreadMsg::DecRef(id, origin, tx);
         self.send_to_file_manager(msg);
         let _ = rx.recv();
     }
@@ -2103,11 +2097,10 @@ impl GlobalScope {
         rel_pos: &RelativePos,
         parent_len: u64,
     ) -> Uuid {
-        let origin = self.origin().immutable();
+        let origin = self.origin().immutable().clone();
 
         let (tx, rx) = profile_generic_channel::channel(self.time_profiler_chan().clone()).unwrap();
-        let msg =
-            FileManagerThreadMsg::AddSlicedURLEntry(*parent_file_id, *rel_pos, tx, origin.clone());
+        let msg = FileManagerThreadMsg::AddSlicedURLEntry(*parent_file_id, *rel_pos, tx, origin);
         self.send_to_file_manager(msg);
         match rx.recv().expect("File manager thread is down.") {
             Ok(new_id) => {
@@ -2137,7 +2130,7 @@ impl GlobalScope {
         blob_bytes: &[u8],
         set_valid: bool,
     ) -> Uuid {
-        let origin = self.origin().immutable();
+        let origin = self.origin().immutable().clone();
         let blob_buf = BlobBuf {
             filename: None,
             type_string: blob_info.blob_impl.type_string(),
@@ -2145,7 +2138,7 @@ impl GlobalScope {
             bytes: blob_bytes.to_vec(),
         };
         let id = Uuid::new_v4();
-        let msg = FileManagerThreadMsg::PromoteMemory(id, blob_buf, set_valid, origin.clone());
+        let msg = FileManagerThreadMsg::PromoteMemory(id, blob_buf, set_valid, origin);
         self.send_to_file_manager(msg);
         id
     }
@@ -2170,10 +2163,10 @@ impl GlobalScope {
                         return self.promote_memory_entry(blob_info, &cached_bytes, true);
                     }
 
-                    let origin = self.origin().immutable();
+                    let origin = self.origin().immutable().clone();
                     let (tx, rx) = profile_ipc::channel(self.time_profiler_chan().clone()).unwrap();
 
-                    let msg = FileManagerThreadMsg::ActivateBlobURL(f.get_id(), tx, origin.clone());
+                    let msg = FileManagerThreadMsg::ActivateBlobURL(f.get_id(), tx, origin);
                     self.send_to_file_manager(msg);
 
                     match rx.recv().unwrap() {
@@ -2279,8 +2272,8 @@ impl GlobalScope {
     fn send_msg(&self, id: Uuid) -> profile_ipc::IpcReceiver<FileManagerResult<ReadFileProgress>> {
         let resource_threads = self.resource_threads();
         let (chan, recv) = profile_ipc::channel(self.time_profiler_chan().clone()).unwrap();
-        let origin = self.origin().immutable();
-        let msg = FileManagerThreadMsg::ReadFile(chan, id, origin.clone());
+        let origin = self.origin().immutable().clone();
+        let msg = FileManagerThreadMsg::ReadFile(chan, id, origin);
         let _ = resource_threads.send(CoreResourceMsg::ToFileManager(msg));
         recv
     }
@@ -2553,8 +2546,20 @@ impl GlobalScope {
     }
 
     /// Get the origin for this global scope
-    pub(crate) fn origin(&self) -> &MutableOrigin {
-        &self.origin
+    pub(crate) fn origin(&self) -> MutableOrigin {
+        if let Some(window) = self.downcast::<Window>() {
+            window.origin()
+        } else if let Some(worker) = self.downcast::<WorkerGlobalScope>() {
+            worker.origin()
+        } else if let Some(worklet) = self.downcast::<WorkletGlobalScope>() {
+            worklet.origin()
+        } else if let Some(dissimilar_window) = self.downcast::<DissimilarOriginWindow>() {
+            dissimilar_window.origin()
+        } else if let Some(debugger) = self.downcast::<DebuggerGlobalScope>() {
+            debugger.origin()
+        } else {
+            unreachable!("Unexpected origin check against global")
+        }
     }
 
     /// Get the creation_url for this global scope
@@ -3608,7 +3613,7 @@ impl GlobalScopeHelpers<crate::DomTypeHolder> for GlobalScope {
         GlobalScope::from_reflector(reflector, realm)
     }
 
-    fn origin(&self) -> &MutableOrigin {
+    fn origin(&self) -> MutableOrigin {
         GlobalScope::origin(self)
     }
 

--- a/components/script/dom/globalscope/origin.rs
+++ b/components/script/dom/globalscope/origin.rs
@@ -72,7 +72,7 @@ impl Origin {
         // <https://html.spec.whatwg.org/multipage/#window:extract-an-origin>
         if let Ok(window_obj) = root_from_handlevalue::<Window>(value, cx) {
             let window_origin = window_obj.origin();
-            if !current_global.origin().same_origin_domain(window_origin) {
+            if !current_global.origin().same_origin_domain(&window_origin) {
                 return None;
             }
             return Some(window_origin.immutable().clone());

--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -534,7 +534,7 @@ impl HTMLIFrameElement {
             (None, document.about_base_url())
         };
 
-        let propagate_encoding_to_child_document = url.origin().same_origin(window.origin());
+        let propagate_encoding_to_child_document = url.origin().same_origin(&window.origin());
         let mut load_data = LoadData::new(
             LoadOrigin::Script(document.origin().snapshot()),
             url,

--- a/components/script/dom/serviceworker/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworker/serviceworkerglobalscope.rs
@@ -21,13 +21,14 @@ use net_traits::request::{
     CredentialsMode, Destination, InsecureRequestsPolicy, ParserMetadata, Referrer, RequestBuilder,
 };
 use rand::random;
+use script_bindings::interfaces::HasOrigin;
 use servo_base::generic_channel::{GenericReceiver, GenericSend, GenericSender, RoutedReceiver};
 use servo_base::id::{PipelineId, ServiceWorkerId};
 use servo_config::pref;
 use servo_constellation_traits::{
     ScopeThings, ServiceWorkerMsg, WorkerGlobalScopeInit, WorkerScriptLoadOrigin,
 };
-use servo_url::ServoUrl;
+use servo_url::{MutableOrigin, ServoUrl};
 use style::thread_state::{self, ThreadState};
 
 use crate::dom::abstractworker::WorkerScriptMsg;
@@ -306,7 +307,11 @@ impl ServiceWorkerGlobalScope {
             font_context,
             worker_id,
         ));
-        let scope = ServiceWorkerGlobalScopeBinding::Wrap::<crate::DomTypeHolder>(cx, scope);
+        let scope = ServiceWorkerGlobalScopeBinding::Wrap::<crate::DomTypeHolder>(
+            cx,
+            &scope.origin(),
+            scope,
+        );
         scope
             .upcast::<WorkerGlobalScope>()
             .init_debugger_global(debugger_global, cx);
@@ -600,4 +605,10 @@ impl ServiceWorkerGlobalScopeMethods<crate::DomTypeHolder> for ServiceWorkerGlob
 
     // https://w3c.github.io/ServiceWorker/#dom-serviceworkerglobalscope-onmessageerror
     event_handler!(messageerror, GetOnmessageerror, SetOnmessageerror);
+}
+
+impl HasOrigin for ServiceWorkerGlobalScope {
+    fn origin(&self) -> MutableOrigin {
+        self.upcast::<WorkerGlobalScope>().origin()
+    }
 }

--- a/components/script/dom/testing/testworkletglobalscope.rs
+++ b/components/script/dom/testing/testworkletglobalscope.rs
@@ -8,8 +8,10 @@ use crossbeam_channel::Sender;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use script_bindings::cell::DomRefCell;
+use script_bindings::inheritance::Castable;
+use script_bindings::interfaces::HasOrigin;
 use servo_base::id::PipelineId;
-use servo_url::ServoUrl;
+use servo_url::{MutableOrigin, ServoUrl};
 
 use crate::dom::bindings::codegen::Bindings::TestWorkletGlobalScopeBinding;
 use crate::dom::bindings::codegen::Bindings::TestWorkletGlobalScopeBinding::TestWorkletGlobalScopeMethods;
@@ -51,7 +53,7 @@ impl TestWorkletGlobalScope {
             ),
             lookup_table: Default::default(),
         });
-        TestWorkletGlobalScopeBinding::Wrap::<crate::DomTypeHolder>(cx, global)
+        TestWorkletGlobalScopeBinding::Wrap::<crate::DomTypeHolder>(cx, &global.origin(), global)
     }
 
     pub(crate) fn perform_a_worklet_task(&self, task: TestWorkletTask) {
@@ -77,4 +79,10 @@ impl TestWorkletGlobalScopeMethods<crate::DomTypeHolder> for TestWorkletGlobalSc
 /// Tasks which can be performed by test worklets.
 pub(crate) enum TestWorkletTask {
     Lookup(String, Sender<Option<String>>),
+}
+
+impl HasOrigin for TestWorkletGlobalScope {
+    fn origin(&self) -> MutableOrigin {
+        self.upcast::<WorkletGlobalScope>().origin()
+    }
 }

--- a/components/script/dom/url/url.rs
+++ b/components/script/dom/url/url.rs
@@ -189,11 +189,11 @@ impl URLMethods<crate::DomTypeHolder> for URL {
     fn CreateObjectURL(global: &GlobalScope, blob: &Blob) -> DOMString {
         // XXX: Second field is an unicode-serialized Origin, it is a temporary workaround
         //      and should not be trusted. See issue https://github.com/servo/servo/issues/11722
-        let origin = global.origin().immutable();
+        let origin = global.origin();
 
         let id = blob.get_blob_url_id();
 
-        DOMString::from(URL::unicode_serialization_blob_url(origin, &id))
+        DOMString::from(URL::unicode_serialization_blob_url(origin.immutable(), &id))
     }
 
     /// <https://w3c.github.io/FileAPI/#dfn-revokeObjectURL>
@@ -201,7 +201,7 @@ impl URLMethods<crate::DomTypeHolder> for URL {
         // If the value provided for the url argument is not a Blob URL OR
         // if the value provided for the url argument does not have an entry in the Blob URL Store,
         // this method call does nothing. User agents may display a message on the error console.
-        let origin = global.origin().immutable();
+        let origin = global.origin().immutable().clone();
 
         if let Ok(url) = ServoUrl::parse(&url.str()) &&
             url.fragment().is_none() &&
@@ -209,7 +209,7 @@ impl URLMethods<crate::DomTypeHolder> for URL {
         {
             let resource_threads = global.resource_threads();
             let (tx, rx) = generic_channel::channel(global.time_profiler_chan().clone()).unwrap();
-            let msg = FileManagerThreadMsg::RevokeBlobURL(id, origin.clone(), tx);
+            let msg = FileManagerThreadMsg::RevokeBlobURL(id, origin, tx);
             let _ = resource_threads.send(CoreResourceMsg::ToFileManager(msg));
 
             let _ = rx.recv().unwrap();

--- a/components/script/dom/webgpu/gpuqueue.rs
+++ b/components/script/dom/webgpu/gpuqueue.rs
@@ -242,7 +242,7 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
             GPUCopyExternalImageSource::ImageBitmap(inner) => inner.origin_is_clean(),
             GPUCopyExternalImageSource::ImageData(_) => true,
             GPUCopyExternalImageSource::HTMLImageElement(inner) => {
-                inner.same_origin(GlobalScope::entry().origin())
+                inner.same_origin(&GlobalScope::entry().origin())
             },
             GPUCopyExternalImageSource::HTMLVideoElement(inner) => inner.origin_is_clean(),
             GPUCopyExternalImageSource::HTMLCanvasElement(inner) => inner.origin_is_clean(),

--- a/components/script/dom/window/dissimilaroriginwindow.rs
+++ b/components/script/dom/window/dissimilaroriginwindow.rs
@@ -7,11 +7,12 @@ use js::context::JSContext;
 use js::jsapi::{Heap, JSObject};
 use js::jsval::UndefinedValue;
 use js::rust::{CustomAutoRooter, CustomAutoRooterGuard, HandleValue, MutableHandleValue};
+use script_bindings::interfaces::HasOrigin;
 use servo_base::id::PipelineId;
 use servo_constellation_traits::{
     RemoteFocusOperation, ScriptToConstellationMessage, StructuredSerializedData,
 };
-use servo_url::ServoUrl;
+use servo_url::{MutableOrigin, ServoUrl};
 
 use crate::dom::bindings::codegen::Bindings::DissimilarOriginWindowBinding;
 use crate::dom::bindings::codegen::Bindings::DissimilarOriginWindowBinding::DissimilarOriginWindowMethods;
@@ -48,6 +49,9 @@ pub(crate) struct DissimilarOriginWindow {
 
     #[no_trace]
     pipeline_id: PipelineId,
+
+    #[no_trace]
+    origin: MutableOrigin,
 }
 
 impl DissimilarOriginWindow {
@@ -65,7 +69,6 @@ impl DissimilarOriginWindow {
                 global_to_clone_from.script_to_embedder_chan().clone(),
                 global_to_clone_from.resource_threads().clone(),
                 global_to_clone_from.storage_threads().clone(),
-                global_to_clone_from.origin().clone(),
                 global_to_clone_from.creation_url(),
                 global_to_clone_from.top_level_creation_url().clone(),
                 #[cfg(feature = "webgpu")]
@@ -77,8 +80,13 @@ impl DissimilarOriginWindow {
             window_proxy: Dom::from_ref(window_proxy),
             location: Default::default(),
             pipeline_id: PipelineId::new(),
+            origin: global_to_clone_from.origin().clone(),
         });
-        DissimilarOriginWindowBinding::Wrap::<crate::DomTypeHolder>(cx, win)
+        DissimilarOriginWindowBinding::Wrap::<crate::DomTypeHolder>(cx, &win.origin(), win)
+    }
+
+    pub(crate) fn origin(&self) -> MutableOrigin {
+        self.origin.clone()
     }
 
     pub(crate) fn window_proxy(&self) -> DomRoot<WindowProxy> {
@@ -265,5 +273,11 @@ impl DissimilarOriginWindow {
         // Step 8
         let _ = incumbent.script_to_constellation_chan().send(msg);
         Ok(())
+    }
+}
+
+impl HasOrigin for DissimilarOriginWindow {
+    fn origin(&self) -> MutableOrigin {
+        DissimilarOriginWindow::origin(self)
     }
 }

--- a/components/script/dom/window/dissimilaroriginwindow.rs
+++ b/components/script/dom/window/dissimilaroriginwindow.rs
@@ -80,7 +80,7 @@ impl DissimilarOriginWindow {
             window_proxy: Dom::from_ref(window_proxy),
             location: Default::default(),
             pipeline_id: PipelineId::new(),
-            origin: global_to_clone_from.origin().clone(),
+            origin: global_to_clone_from.origin(),
         });
         DissimilarOriginWindowBinding::Wrap::<crate::DomTypeHolder>(cx, &win.origin(), win)
     }

--- a/components/script/dom/window/location.rs
+++ b/components/script/dom/window/location.rs
@@ -7,7 +7,7 @@ use js::context::JSContext;
 use net_traits::request::Referrer;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use servo_constellation_traits::{LoadData, LoadOrigin, NavigationHistoryBehavior};
-use servo_url::{MutableOrigin, ServoUrl};
+use servo_url::ServoUrl;
 
 use crate::dom::bindings::codegen::Bindings::LocationBinding::LocationMethods;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::Window_Binding::WindowMethods;
@@ -288,11 +288,6 @@ impl Location {
             NavigationHistoryBehavior::Replace,
             NavigationType::ReloadByConstellation,
         );
-    }
-
-    #[expect(dead_code)]
-    pub(crate) fn origin(&self) -> &MutableOrigin {
-        self.window.origin()
     }
 }
 

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -64,7 +64,7 @@ use rustc_hash::{FxBuildHasher, FxHashMap};
 use script_bindings::cell::{DomRefCell, Ref};
 use script_bindings::codegen::GenericBindings::WindowBinding::ScrollToOptions;
 use script_bindings::conversions::SafeToJSValConvertible;
-use script_bindings::interfaces::WindowHelpers;
+use script_bindings::interfaces::{HasOrigin, WindowHelpers};
 use script_bindings::reflector::DomObject;
 use script_bindings::root::Root;
 use script_traits::{ConstellationInputEvent, ScriptThreadMessage};
@@ -546,8 +546,8 @@ impl Window {
         self.globalscope.time_profiler_chan()
     }
 
-    pub(crate) fn origin(&self) -> &MutableOrigin {
-        self.globalscope.origin()
+    pub(crate) fn origin(&self) -> MutableOrigin {
+        self.Document().origin().clone()
     }
 
     pub(crate) fn main_thread_script_chan(&self) -> &Sender<MainThreadScriptMsg> {
@@ -3697,7 +3697,6 @@ impl Window {
                 embedder_chan,
                 resource_threads,
                 storage_threads,
-                origin,
                 creation_url,
                 Some(top_level_creation_url),
                 #[cfg(feature = "webgpu")]
@@ -3777,7 +3776,7 @@ impl Window {
             devtools_wants_updates: Default::default(),
         });
 
-        WindowBinding::Wrap::<crate::DomTypeHolder>(cx, win)
+        WindowBinding::Wrap::<crate::DomTypeHolder>(cx, &origin, win)
     }
 
     pub(crate) fn task_manager(&self) -> Rc<TaskManager> {
@@ -3964,5 +3963,11 @@ impl WindowHelpers for Window {
         object: MutableHandleObject,
     ) {
         Self::create_named_properties_object(cx, proto, object)
+    }
+}
+
+impl HasOrigin for Window {
+    fn origin(&self) -> MutableOrigin {
+        Window::origin(self)
     }
 }

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -546,7 +546,9 @@ impl Window {
         self.globalscope.time_profiler_chan()
     }
 
+    /// <https://html.spec.whatwg.org/multipage/#script-settings-for-window-objects:concept-settings-object-origin>
     pub(crate) fn origin(&self) -> MutableOrigin {
+        // > Return the origin of window's associated Document.
         self.Document().origin().clone()
     }
 

--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -22,10 +22,11 @@ use net_traits::request::{
     PreloadedResources, Referrer, RequestBuilder, RequestClient, RequestMode,
 };
 use script_bindings::cell::DomRefCell;
+use script_bindings::interfaces::HasOrigin;
 use servo_base::generic_channel::{GenericReceiver, RoutedReceiver};
 use servo_base::id::{BrowsingContextId, PipelineId, ScriptEventLoopId, WebViewId};
 use servo_constellation_traits::{WorkerGlobalScopeInit, WorkerScriptLoadOrigin};
-use servo_url::{ImmutableOrigin, ServoUrl};
+use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
 use style::thread_state::{self, ThreadState};
 
 use crate::conversions::Convert;
@@ -349,7 +350,11 @@ impl DedicatedWorkerGlobalScope {
             insecure_requests_policy,
             font_context,
         ));
-        let scope = DedicatedWorkerGlobalScopeBinding::Wrap::<crate::DomTypeHolder>(cx, scope);
+        let scope = DedicatedWorkerGlobalScopeBinding::Wrap::<crate::DomTypeHolder>(
+            cx,
+            &scope.origin(),
+            scope,
+        );
         scope
             .upcast::<WorkerGlobalScope>()
             .init_debugger_global(debugger_global, cx);
@@ -871,4 +876,10 @@ impl DedicatedWorkerGlobalScopeMethods<crate::DomTypeHolder> for DedicatedWorker
 
     // https://html.spec.whatwg.org/multipage/#handler-dedicatedworkerglobalscope-onmessageerror
     event_handler!(messageerror, GetOnmessageerror, SetOnmessageerror);
+}
+
+impl HasOrigin for DedicatedWorkerGlobalScope {
+    fn origin(&self) -> MutableOrigin {
+        self.upcast::<WorkerGlobalScope>().origin()
+    }
 }

--- a/components/script/dom/workers/sharedworkerglobalscope.rs
+++ b/components/script/dom/workers/sharedworkerglobalscope.rs
@@ -24,10 +24,11 @@ use net_traits::request::{
 };
 use script_bindings::cell::DomRefCell;
 use script_bindings::conversions::SafeToJSValConvertible;
+use script_bindings::interfaces::HasOrigin;
 use servo_base::generic_channel::{GenericReceiver, RoutedReceiver};
 use servo_base::id::{BrowsingContextId, ScriptEventLoopId, WebViewId};
 use servo_constellation_traits::{MessagePortImpl, WorkerGlobalScopeInit, WorkerScriptLoadOrigin};
-use servo_url::{ImmutableOrigin, ServoUrl};
+use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
 use style::thread_state::{self, ThreadState};
 use stylo_atoms::Atom;
 use uuid::Uuid;
@@ -350,7 +351,7 @@ impl SharedWorkerGlobalScope {
             extended_lifetime,
             registration_id,
         ));
-        SharedWorkerGlobalScopeBinding::Wrap::<crate::DomTypeHolder>(cx, scope)
+        SharedWorkerGlobalScopeBinding::Wrap::<crate::DomTypeHolder>(cx, &scope.origin(), scope)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#run-a-worker>
@@ -804,4 +805,10 @@ impl SharedWorkerGlobalScopeMethods<crate::DomTypeHolder> for SharedWorkerGlobal
 
     // <https://html.spec.whatwg.org/multipage/#handler-sharedworkerglobalscope-onconnect>
     event_handler!(connect, GetOnconnect, SetOnconnect);
+}
+
+impl HasOrigin for SharedWorkerGlobalScope {
+    fn origin(&self) -> MutableOrigin {
+        self.upcast::<WorkerGlobalScope>().origin()
+    }
 }

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -342,6 +342,9 @@ pub(crate) struct WorkerGlobalScope {
     /// A [`TaskManager`] for this [`WorkerGlobalScope`].
     #[conditional_malloc_size_of]
     task_manager: Rc<TaskManager>,
+
+    #[no_trace]
+    origin: MutableOrigin,
 }
 
 impl WorkerGlobalScope {
@@ -376,7 +379,6 @@ impl WorkerGlobalScope {
                 init.script_to_embedder_chan,
                 init.resource_threads,
                 init.storage_threads,
-                MutableOrigin::new(init.origin),
                 worker_url.clone(),
                 None,
                 #[cfg(feature = "webgpu")]
@@ -415,6 +417,7 @@ impl WorkerGlobalScope {
                 init.pipeline_id,
                 Some(TaskCanceller { cancelled: closing }),
             )),
+            origin: MutableOrigin::new(init.origin),
         }
     }
 
@@ -681,6 +684,10 @@ impl WorkerGlobalScope {
             &metadata.final_url.clone(),
             &metadata.headers,
         ));
+    }
+
+    pub(crate) fn origin(&self) -> MutableOrigin {
+        self.origin.clone()
     }
 }
 

--- a/components/script/dom/worklet/paintworkletglobalscope.rs
+++ b/components/script/dom/worklet/paintworkletglobalscope.rs
@@ -24,11 +24,12 @@ use js::rust::wrappers2::{
 use net_traits::image_cache::ImageCache;
 use pixels::PixelFormat;
 use script_bindings::cell::DomRefCell;
+use script_bindings::interfaces::HasOrigin;
 use script_bindings::reflector::DomObject;
 use script_traits::{DrawAPaintImageResult, PaintWorkletError, Painter};
 use servo_base::id::PipelineId;
 use servo_config::pref;
-use servo_url::ServoUrl;
+use servo_url::{MutableOrigin, ServoUrl};
 use style_traits::{CSSPixel, SpeculativePainter};
 use stylo_atoms::Atom;
 use webrender_api::units::DevicePixel;
@@ -121,7 +122,7 @@ impl PaintWorkletGlobalScope {
                 missing_image_urls: Vec::new(),
             }),
         });
-        PaintWorkletGlobalScopeBinding::Wrap::<crate::DomTypeHolder>(cx, global)
+        PaintWorkletGlobalScopeBinding::Wrap::<crate::DomTypeHolder>(cx, &global.origin(), global)
     }
 
     pub(crate) fn image_cache(&self) -> Arc<dyn ImageCache> {
@@ -609,5 +610,11 @@ impl PaintWorkletGlobalScopeMethods<crate::DomTypeHolder> for PaintWorkletGlobal
     /// check-tidy: no specs after this line
     fn Sleep(&self, ms: u64) {
         thread::sleep(Duration::from_millis(ms));
+    }
+}
+
+impl HasOrigin for PaintWorkletGlobalScope {
+    fn origin(&self) -> MutableOrigin {
+        self.upcast::<WorkletGlobalScope>().origin()
     }
 }

--- a/components/script/dom/worklet/workletglobalscope.rs
+++ b/components/script/dom/worklet/workletglobalscope.rs
@@ -52,6 +52,9 @@ pub(crate) struct WorkletGlobalScope {
     #[no_trace]
     /// The pipeline that created this worklet.
     pipeline_id: PipelineId,
+
+    #[no_trace]
+    origin: MutableOrigin,
 }
 
 impl WorkletGlobalScope {
@@ -109,7 +112,6 @@ impl WorkletGlobalScope {
                 init.to_embedder_sender.clone(),
                 init.resource_threads.clone(),
                 init.storage_threads.clone(),
-                MutableOrigin::new(ImmutableOrigin::new_opaque()),
                 base_url.clone(),
                 None,
                 #[cfg(feature = "webgpu")]
@@ -122,7 +124,12 @@ impl WorkletGlobalScope {
             to_script_thread_sender: init.to_script_thread_sender.clone(),
             executor,
             pipeline_id,
+            origin: MutableOrigin::new(ImmutableOrigin::new_opaque()),
         }
+    }
+
+    pub(crate) fn origin(&self) -> MutableOrigin {
+        self.origin.clone()
     }
 
     pub(crate) fn pipeline_id(&self) -> PipelineId {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -275,6 +275,7 @@ DOMInterfaces = {
 },
 
 'DebuggerGlobalScope': {
+    'additionalTraits': ["crate::interfaces::HasOrigin"],
     'useSystemCompartment': True,
 },
 
@@ -283,6 +284,7 @@ DOMInterfaces = {
 },
 
 'DedicatedWorkerGlobalScope': {
+    'additionalTraits': ["crate::interfaces::HasOrigin"],
     'cx': ['PostMessage', 'PostMessage_'],
 },
 
@@ -352,6 +354,7 @@ DOMInterfaces = {
 },
 
 'DissimilarOriginWindow': {
+    'additionalTraits': ["crate::interfaces::HasOrigin"],
     'canGc': ['Location'],
     'cx': ['PostMessage', 'PostMessage_', 'SetOpener', 'Opener']
 },
@@ -1157,6 +1160,7 @@ DOMInterfaces = {
 },
 
 'PaintWorkletGlobalScope': {
+    'additionalTraits': ["crate::interfaces::HasOrigin"],
     'cx': ['RegisterPaint'],
 },
 
@@ -1254,6 +1258,10 @@ DOMInterfaces = {
     'realm': ['GetRegistration', 'Register'],
 },
 
+'ServiceWorkerGlobalScope': {
+    'additionalTraits': ["crate::interfaces::HasOrigin"],
+},
+
 'ServiceWorkerRegistration': {
     'cx': ['NavigationPreload', 'Unregister'],
 },
@@ -1349,6 +1357,10 @@ DOMInterfaces = {
 'TestWorklet': {
     'cx': ['Constructor'],
     'realm': ['AddModule'],
+},
+
+'TestWorkletGlobalScope': {
+    'additionalTraits': ["crate::interfaces::HasOrigin"],
 },
 
 'Text': {
@@ -1552,7 +1564,7 @@ DOMInterfaces = {
 
 'Window': {
     'canGc': ['CookieStore', 'GetVisualViewport', 'Screen'],
-    'additionalTraits': ['crate::interfaces::WindowHelpers'],
+    'additionalTraits': ['crate::interfaces::WindowHelpers', 'crate::interfaces::HasOrigin'],
     'realm': ['CreateImageBitmap', 'CreateImageBitmap_', 'WebdriverCallback', 'GetOpener', 'Fetch'],
     'cx': [
         'Close',
@@ -1599,6 +1611,7 @@ DOMInterfaces = {
 },
 
 'SharedWorkerGlobalScope': {
+    'additionalTraits': ["crate::interfaces::HasOrigin"],
 },
 
 'Worker': {

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -3400,6 +3400,7 @@ class CGWrapGlobalMethod(CGAbstractMethod):
         assert not descriptor.interface.isCallback()
         assert descriptor.isGlobal()
         args = [Argument('&mut JSContext', 'cx'),
+                Argument('&servo_url::MutableOrigin', 'origin'),
                 Argument(f"Box<{descriptor.concreteType}>", 'object')]
         retval = f'DomRoot<{descriptor.concreteType}>'
         CGAbstractMethod.__init__(self, descriptor, 'Wrap', retval, args,
@@ -3422,7 +3423,6 @@ class CGWrapGlobalMethod(CGAbstractMethod):
         return CGGeneric(f"""
 unsafe {{
     let raw = Root::new(MaybeUnreflectedDom::from_box(object));
-    let origin = (*raw.as_ptr()).upcast::<D::GlobalScope>().origin();
 
     rooted!(&in(cx) let mut obj = ptr::null_mut::<JSObject>());
     create_global_object::<D>(

--- a/components/script_bindings/interfaces.rs
+++ b/components/script_bindings/interfaces.rs
@@ -73,7 +73,7 @@ pub trait GlobalScopeHelpers<D: DomTypes> {
     unsafe fn from_object(obj: *mut JSObject) -> DomRoot<D::GlobalScope>;
     fn from_reflector(reflector: &impl DomObject, realm: InRealm) -> DomRoot<D::GlobalScope>;
 
-    fn origin(&self) -> &MutableOrigin;
+    fn origin(&self) -> MutableOrigin;
 
     fn incumbent() -> Option<DomRoot<D::GlobalScope>>;
 
@@ -107,4 +107,8 @@ pub trait WindowHelpers {
         proto: HandleObject,
         object: MutableHandleObject,
     );
+}
+
+pub trait HasOrigin {
+    fn origin(&self) -> MutableOrigin;
 }


### PR DESCRIPTION
This change is preparation for spec-compliant document replacement. We need to ensure that the global inherits whatever origin is computed for the document that replaces the initial about:blank. Instead of storing a copy of the origin in GlobalScope, we delegate origin logic to each kind of global. Every global but window just stores its origin that is computed at creation; window globals now return the active document's origin instead.

Testing: Existing test coverage is sufficient.
Part of #43149
