### PR TITLE
layout: Prevent animations from producing invalid color values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2496,7 +2496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3065,7 +3065,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7213,7 +7213,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7270,7 +7270,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7451,7 +7451,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.38.0"
-source = "git+https://github.com/servo/stylo?rev=93f1ccf721a5049ead29cf2389188597fdc062ad#93f1ccf721a5049ead29cf2389188597fdc062ad"
+source = "git+https://github.com/servo/stylo?rev=44bdcc6a017141ff8b6a856cd717c52a476d90cb#44bdcc6a017141ff8b6a856cd717c52a476d90cb"
 dependencies = [
  "bitflags 2.13.0",
  "cssparser",
@@ -9202,7 +9202,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=93f1ccf721a5049ead29cf2389188597fdc062ad#93f1ccf721a5049ead29cf2389188597fdc062ad"
+source = "git+https://github.com/servo/stylo?rev=44bdcc6a017141ff8b6a856cd717c52a476d90cb#44bdcc6a017141ff8b6a856cd717c52a476d90cb"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -9673,7 +9673,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=93f1ccf721a5049ead29cf2389188597fdc062ad#93f1ccf721a5049ead29cf2389188597fdc062ad"
+source = "git+https://github.com/servo/stylo?rev=44bdcc6a017141ff8b6a856cd717c52a476d90cb#44bdcc6a017141ff8b6a856cd717c52a476d90cb"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -9729,7 +9729,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=93f1ccf721a5049ead29cf2389188597fdc062ad#93f1ccf721a5049ead29cf2389188597fdc062ad"
+source = "git+https://github.com/servo/stylo?rev=44bdcc6a017141ff8b6a856cd717c52a476d90cb#44bdcc6a017141ff8b6a856cd717c52a476d90cb"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -9738,7 +9738,7 @@ dependencies = [
 [[package]]
 name = "stylo_derive"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=93f1ccf721a5049ead29cf2389188597fdc062ad#93f1ccf721a5049ead29cf2389188597fdc062ad"
+source = "git+https://github.com/servo/stylo?rev=44bdcc6a017141ff8b6a856cd717c52a476d90cb#44bdcc6a017141ff8b6a856cd717c52a476d90cb"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -9750,7 +9750,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=93f1ccf721a5049ead29cf2389188597fdc062ad#93f1ccf721a5049ead29cf2389188597fdc062ad"
+source = "git+https://github.com/servo/stylo?rev=44bdcc6a017141ff8b6a856cd717c52a476d90cb#44bdcc6a017141ff8b6a856cd717c52a476d90cb"
 dependencies = [
  "bitflags 2.13.0",
  "stylo_malloc_size_of",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=93f1ccf721a5049ead29cf2389188597fdc062ad#93f1ccf721a5049ead29cf2389188597fdc062ad"
+source = "git+https://github.com/servo/stylo?rev=44bdcc6a017141ff8b6a856cd717c52a476d90cb#44bdcc6a017141ff8b6a856cd717c52a476d90cb"
 dependencies = [
  "app_units",
  "cssparser",
@@ -9776,7 +9776,7 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=93f1ccf721a5049ead29cf2389188597fdc062ad#93f1ccf721a5049ead29cf2389188597fdc062ad"
+source = "git+https://github.com/servo/stylo?rev=44bdcc6a017141ff8b6a856cd717c52a476d90cb#44bdcc6a017141ff8b6a856cd717c52a476d90cb"
 dependencies = [
  "toml",
 ]
@@ -9784,7 +9784,7 @@ dependencies = [
 [[package]]
 name = "stylo_traits"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=93f1ccf721a5049ead29cf2389188597fdc062ad#93f1ccf721a5049ead29cf2389188597fdc062ad"
+source = "git+https://github.com/servo/stylo?rev=44bdcc6a017141ff8b6a856cd717c52a476d90cb#44bdcc6a017141ff8b6a856cd717c52a476d90cb"
 dependencies = [
  "app_units",
  "bitflags 2.13.0",
@@ -9961,7 +9961,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10204,7 +10204,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.4.0"
-source = "git+https://github.com/servo/stylo?rev=93f1ccf721a5049ead29cf2389188597fdc062ad#93f1ccf721a5049ead29cf2389188597fdc062ad"
+source = "git+https://github.com/servo/stylo?rev=44bdcc6a017141ff8b6a856cd717c52a476d90cb#44bdcc6a017141ff8b6a856cd717c52a476d90cb"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -10217,7 +10217,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=93f1ccf721a5049ead29cf2389188597fdc062ad#93f1ccf721a5049ead29cf2389188597fdc062ad"
+source = "git+https://github.com/servo/stylo?rev=44bdcc6a017141ff8b6a856cd717c52a476d90cb#44bdcc6a017141ff8b6a856cd717c52a476d90cb"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -11503,7 +11503,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,14 +215,14 @@ rustls-pki-types = "1.14"
 rustls-platform-verifier = "0.7.0"
 sea-query = { version = "=1.0.0-rc.31", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = "=0.8.0-rc.15"
-selectors = { git = "https://github.com/servo/stylo", rev = "93f1ccf721a5049ead29cf2389188597fdc062ad" }
+selectors = { git = "https://github.com/servo/stylo", rev = "44bdcc6a017141ff8b6a856cd717c52a476d90cb" }
 seq-macro = "0.3.6"
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
 serde_json = "1.0"
 serde_test = "1.0"
-servo_arc = { git = "https://github.com/servo/stylo", rev = "93f1ccf721a5049ead29cf2389188597fdc062ad" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "44bdcc6a017141ff8b6a856cd717c52a476d90cb" }
 sha1 = "0.11"
 sha2 = "0.11"
 sha3 = "0.12"
@@ -232,12 +232,12 @@ smallvec = { version = "1.15", features = ["serde", "union"] }
 speexdsp-resampler = "0.1.0"
 string_cache = "0.9"
 strum = { version = "0.28", features = ["derive"] }
-stylo = { git = "https://github.com/servo/stylo", rev = "93f1ccf721a5049ead29cf2389188597fdc062ad" }
-stylo_atoms = { git = "https://github.com/servo/stylo", rev = "93f1ccf721a5049ead29cf2389188597fdc062ad" }
-stylo_dom = { git = "https://github.com/servo/stylo", rev = "93f1ccf721a5049ead29cf2389188597fdc062ad" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "93f1ccf721a5049ead29cf2389188597fdc062ad" }
-stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "93f1ccf721a5049ead29cf2389188597fdc062ad" }
-stylo_traits = { git = "https://github.com/servo/stylo", rev = "93f1ccf721a5049ead29cf2389188597fdc062ad" }
+stylo = { git = "https://github.com/servo/stylo", rev = "44bdcc6a017141ff8b6a856cd717c52a476d90cb" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "44bdcc6a017141ff8b6a856cd717c52a476d90cb" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "44bdcc6a017141ff8b6a856cd717c52a476d90cb" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "44bdcc6a017141ff8b6a856cd717c52a476d90cb" }
+stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "44bdcc6a017141ff8b6a856cd717c52a476d90cb" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "44bdcc6a017141ff8b6a856cd717c52a476d90cb" }
 surfman = { version = "0.13.0", features = ["chains"] }
 swapper = "0.1"
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -2195,7 +2195,7 @@ fn rgba(color: AbsoluteColor) -> wr::ColorF {
         rgba.components.0.clamp(0.0, 1.0),
         rgba.components.1.clamp(0.0, 1.0),
         rgba.components.2.clamp(0.0, 1.0),
-        rgba.alpha,
+        rgba.alpha.clamp(0.0, 1.0),
     )
 }
 

--- a/tests/wpt/tests/css/css-animations/animation-transition-color-crash.html
+++ b/tests/wpt/tests/css/css-animations/animation-transition-color-crash.html
@@ -1,0 +1,29 @@
+<html>
+<head>
+    <link rel="help" href="https://github.com/servo/servo/issues/45945">
+    <style>
+    :root {
+        animation: keyframes 1s normal;
+        transition: border-right 1ms;
+        border: solid;
+        translate: 10px;
+    }
+    @keyframes keyframes {
+        to { border: inset; }
+    }
+    </style>
+</head>
+
+<body onload="main()">
+
+<script>
+function main() {
+    document.styleSheets[0].insertRule("nonexistent-tag {}");
+    document.body.clientHeight;
+    document.styleSheets[0].insertRule("nonexistent-tag2 {}");
+    window.scroll(1, 1);
+}
+
+document.body.clientHeight;
+</script>
+


### PR DESCRIPTION
This commits makes two changes to prevent animations from producing
invalid color values (defense in depth):

1. Update Stylo to a version that fixing an issue with interpolation of
   values in interrupted transitions that are reversing[^1].
2. Prevents the creation of WebRender color values with alpha that is
   out of range.

[^1]: https://www.w3.org/TR/css-transitions-1/#reversing

Stylo PR: servo/style#403
Testing: This change adds a WPT crash test.
Fixes: #45945
