### PR TITLE
layout: Clear `BoxFragment` data from previous stacking context tree traversals

### DIFF
--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -564,6 +564,7 @@ impl BoxFragment {
         parent_stacking_context: &mut StackingContext,
         text_decorations: &Rc<Vec<FragmentTextDecoration>>,
     ) {
+        self.clear_stacking_context_tree_traversal_data();
         self.build_stacking_context_tree_maybe_creating_reference_frame(
             fragment,
             stacking_context_tree,
@@ -602,7 +603,7 @@ impl BoxFragment {
         // > If a transform function causes the current transformation matrix of an object
         // > to be non-invertible, the object and its content do not get displayed.
         if !reference_frame_data.transform.is_invertible() {
-            self.clear_spatial_tree_node_including_descendants();
+            self.clear_stacking_context_tree_traversal_data_recursively();
             return;
         }
 
@@ -1303,18 +1304,20 @@ impl BoxFragment {
         }
     }
 
-    fn clear_spatial_tree_node_including_descendants(&self) {
-        fn assign_spatial_tree_node_on_fragments(fragments: &[Fragment]) {
+    fn clear_stacking_context_tree_traversal_data_recursively(&self) {
+        fn clear_stacking_context_tree_traversal_data_on_fragments(fragments: &[Fragment]) {
             for fragment in fragments.iter() {
                 match fragment {
                     Fragment::LayoutRoot(layout_root_fragment) => layout_root_fragment
                         .inner_box_fragment()
-                        .clear_spatial_tree_node_including_descendants(),
+                        .clear_stacking_context_tree_traversal_data_recursively(),
                     Fragment::Box(box_fragment) | Fragment::Float(box_fragment) => {
-                        box_fragment.clear_spatial_tree_node_including_descendants();
+                        box_fragment.clear_stacking_context_tree_traversal_data_recursively();
                     },
                     Fragment::Positioning(positioning_fragment) => {
-                        assign_spatial_tree_node_on_fragments(&positioning_fragment.children);
+                        clear_stacking_context_tree_traversal_data_on_fragments(
+                            &positioning_fragment.children,
+                        );
                     },
                     _ => {},
                 }
@@ -1322,7 +1325,8 @@ impl BoxFragment {
         }
 
         self.spatial_tree_node.set(None);
-        assign_spatial_tree_node_on_fragments(&self.children);
+        self.clear_stacking_context_tree_traversal_data();
+        clear_stacking_context_tree_traversal_data_on_fragments(&self.children);
     }
 }
 

--- a/components/layout/fragment_tree/box_fragment.rs
+++ b/components/layout/fragment_tree/box_fragment.rs
@@ -255,6 +255,15 @@ impl BoxFragment {
         })
     }
 
+    pub(crate) fn clear_stacking_context_tree_traversal_data(&self) {
+        if let Some(rare_data) = self.rare_data.get() {
+            let mut rare_data = rare_data.borrow_mut();
+            rare_data.generated_clip_id = None;
+            rare_data.generated_scroll_tree_node_id = None;
+            rare_data.resolved_sticky_insets = None;
+        }
+    }
+
     pub(crate) fn resolved_sticky_insets(
         &self,
     ) -> Option<AtomicRef<'_, Box<PhysicalSides<AuOrAuto>>>> {

--- a/tests/wpt/tests/css/css-masking/clip-path/clip-path-restyle-crash.html
+++ b/tests/wpt/tests/css/css-masking/clip-path/clip-path-restyle-crash.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+
+<link rel="help" href="https://github.com/servo/servo/issues/46021">
+
+<style>
+    .clip {
+        clip-path: padding-box
+    }
+</style>
+
+<div id="target" class="clip">Content</div>
+
+<script>
+  document.body.scrollHeight;
+  target.classList.remove("clip");
+</script>


### PR DESCRIPTION
`Fragment`s can be preserved between layouts. This means that stale data
set during previous stacking context tree traversals will stick around
if it's not cleared. This can lead to references to non-existant clips
persisting between layouts. This change addresses that.

Testing: This change adds a new WPT crash test.
Fixes: #46021.
Fixes: #46026.
