### PR TITLE
android: Remove today's date from title on history screen

### DIFF
--- a/support/android/apk/servoapp/src/main/java/org/servo/servoshell/HistoryFragment.kt
+++ b/support/android/apk/servoapp/src/main/java/org/servo/servoshell/HistoryFragment.kt
@@ -175,7 +175,7 @@ class HistoryFragment : Fragment() {
 
             var dayHeader = dayFormat.format(Date(entry.timestamp))
             if (currentCal.getTimeInMillis() == todayCal.getTimeInMillis()) {
-                dayHeader = "Today – $dayHeader"
+                dayHeader = "Today"
             }
 
             if (dayHeader != lastDay) {

--- a/support/android/apk/servoapp/src/main/java/org/servo/servoshell/HistoryFragment.kt
+++ b/support/android/apk/servoapp/src/main/java/org/servo/servoshell/HistoryFragment.kt
@@ -173,9 +173,10 @@ class HistoryFragment : Fragment() {
             currentCal.set(Calendar.SECOND, 0)
             currentCal.set(Calendar.MILLISECOND, 0)
 
-            var dayHeader = dayFormat.format(Date(entry.timestamp))
-            if (currentCal.getTimeInMillis() == todayCal.getTimeInMillis()) {
-                dayHeader = "Today"
+            val dayHeader = if (currentCal.getTimeInMillis() == todayCal.getTimeInMillis()) {
+                "Today"
+            } else {
+                dayFormat.format(Date(entry.timestamp))
             }
 
             if (dayHeader != lastDay) {


### PR DESCRIPTION
This is just a pet peeve, but if we're formatting dates relatively (e.g., showing saying "Today" instead of the current date), then we don't need to also show the current date as it's implicitly known. This changes the title of history items for today from "Today - Saturday, June 27" (at least as of today) to "Today".

Testing: There are no automated tests for Android.