### PR TITLE
layout: Ensure accurate `FragmentFlags` when starting BoxTree layout from IFC

### DIFF
--- a/components/layout/formatting_contexts.rs
+++ b/components/layout/formatting_contexts.rs
@@ -126,6 +126,11 @@ impl IndependentFormattingContext {
             },
             Display::GeneratingBox(display) => display.used_value_for_contents(&contents),
         };
+
+        // This ensures that the `FragmentFlags` of this `BaseFragmentInfo` reflect the
+        // current layout and not the set that was calculated during previous layouts.
+        self.base.base_fragment_info = node_and_style_info.into();
+
         self.contents = Self::construct_contents(
             layout_context,
             node_and_style_info,

--- a/tests/wpt/tests/css/css-lists/marker-content-incremental-layout-crash.html
+++ b/tests/wpt/tests/css/css-lists/marker-content-incremental-layout-crash.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/45740">
+<style>
+#bar { content: url(doesnotexist); }
+</style>
+<body onload='bar.id = "baz"'>
+  <li id="bar" style="overflow: scroll"></li>
+</body>


### PR DESCRIPTION
This change ensures that when starting a `BoxTree` incremental layout from an
`IndependentFormattingContext` that the `FragmentFlags` of the newly
generated box reflect the current style, rather than wrongly preserving
them between incremental layouts. This fixes an issue where restyling an
`<li>` element with replaced content to one that was not replaced content
did not remove the `IS_REPLACED` flag.

Testing: This change adds a new WPT crash test.
Fixes: #45740.
