### PR TITLE
android: Remove settings section title

### DIFF
--- a/support/android/apk/servoapp/src/main/res/layout/fragment_settings.xml
+++ b/support/android/apk/servoapp/src/main/res/layout/fragment_settings.xml
@@ -29,17 +29,6 @@
             android:paddingTop="8dp"
             android:paddingBottom="16dp">
 
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:paddingStart="16dp"
-                android:paddingEnd="16dp"
-                android:paddingTop="16dp"
-                android:paddingBottom="8dp"
-                android:text="@string/settings_section_features"
-                android:textAppearance="?attr/textAppearanceTitleSmall"
-                android:textColor="?attr/colorPrimary" />
-
             <androidx.compose.ui.platform.ComposeView
                 android:id="@+id/experimental"
                 android:layout_width="match_parent"

--- a/support/android/apk/servoapp/src/main/res/values/strings.xml
+++ b/support/android/apk/servoapp/src/main/res/values/strings.xml
@@ -12,7 +12,6 @@
   
   <!-- Settings -->
   <string name="settings_title">Settings</string>
-  <string name="settings_section_features">Features</string>
   <string name="settings_experimental_title">Experimental features</string>
   <string name="settings_experimental_summary">Enable experimental web platform features</string>
   <string name="settings_animating_title">Idle/animating indicator</string>


### PR DESCRIPTION
The settings screen currently consists of two settings: "Experimental features" and "Idle/animating indicator".

The "Features" subsection title only applies to the former. The latter would probably be under "Debugging" (or debatably removed altogether). Regardless of whether it's kept, it's not really a "feature" though, at least in the eyes of a user.

Adding another subsection title seems a bit overkill for a settings screen with two options on it, so we can just remove the subsection header, removing any perceived grouping of the two. We can add back subsection headers if/when we have more settings items, as the benefit of subsections (namely scannability) will be realised.

Testing: There are no automated tests for Android.