### PR TITLE
android: Convert settings toolbar to Compose UI

### DIFF
--- a/support/android/apk/servoapp/src/main/java/org/servo/servoshell/SettingsFragment.kt
+++ b/support/android/apk/servoapp/src/main/java/org/servo/servoshell/SettingsFragment.kt
@@ -5,9 +5,11 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -34,6 +36,12 @@ class SettingsFragment : Fragment() {
     ): View = inflater.inflate(R.layout.fragment_settings, container, false)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        view.findViewById<ComposeView>(R.id.toolbar).setContent {
+            @OptIn(ExperimentalMaterial3Api::class)
+            TopAppBar(
+                title = { Text(stringResource(R.string.settings_title)) },
+            )
+        }
         view.findViewById<ComposeView>(R.id.experimental).setContent {
             SettingsItem(
                 title = stringResource(R.string.settings_experimental_title),

--- a/support/android/apk/servoapp/src/main/res/layout/fragment_settings.xml
+++ b/support/android/apk/servoapp/src/main/res/layout/fragment_settings.xml
@@ -8,12 +8,10 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <com.google.android.material.appbar.MaterialToolbar
+        <androidx.compose.ui.platform.ComposeView
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
-            android:elevation="4dp"
-            app:title="@string/settings_title" />
+            android:layout_height="wrap_content" />
 
     </com.google.android.material.appbar.AppBarLayout>
 


### PR DESCRIPTION
Similar to a6d47df7dcbf1760e2b62894e97b786fd5df5ee1 but for the settings screen.

Testing: There are no automated tests for Android.
Fixes: Part of #45715.