### PR TITLE
android: Remove settings divider

### DIFF
--- a/support/android/apk/servoapp/src/main/res/layout/fragment_settings.xml
+++ b/support/android/apk/servoapp/src/main/res/layout/fragment_settings.xml
@@ -34,12 +34,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
 
-            <com.google.android.material.divider.MaterialDivider
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="16dp"
-                android:layout_marginEnd="16dp" />
-
             <androidx.compose.ui.platform.ComposeView
                 android:id="@+id/animating_indicator"
                 android:layout_width="match_parent"


### PR DESCRIPTION
Settings categories should be divided by a divider, but ideally the individual settings shouldn't be. Since we don't have any categories, we shouldn't need any dividers.

These "shoulds" are [from the Android guidelines](https://developer.android.com/develop/ui/views/components/settings/organize-your-settings?hl=en#categories) (alluded to, not particularly explicit though). Obviously we can do whatever we want, but it's usually good to stick with them unless there's a reason not to.

Testing: There are no automated tests for Android.