### PR TITLE
LTS: Update mozjs to SM ESR 140.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5078,9 +5078,9 @@ dependencies = [
 
 [[package]]
 name = "mozjs"
-version = "0.15.14"
+version = "0.15.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ae3dcd73fd1aa7ab08c33c128d27243d07574874338b902872802c2b1d4b7d4"
+checksum = "8db6d571d4113e3995670789e56338a957409e9c10be9e88e96c34814f7daca7"
 dependencies = [
  "bindgen",
  "cc",
@@ -5093,9 +5093,9 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "140.10.1-0"
+version = "140.12.0-0-lts"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf708f34816a335a5c019451a3776196d2c66eb7d4d950c04d4b781821e8feff"
+checksum = "ea960ac2bb2b162810aa36f1f1b7fb8e27cd92a3fe9d0458b48940f24b13c19e"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ indexmap = { version = "2.11.4", features = ["std"] }
 inventory = { version = "0.3.24" }
 ipc-channel = "0.21"
 itertools = "0.14"
-js = { package = "mozjs", version = "=0.15.14", default-features = false, features = ["libz-sys", "intl"] }
+js = { package = "mozjs", version = "=0.15.15", default-features = false, features = ["libz-sys", "intl"] }
 keyboard-types = { version = "0.8.3", features = ["serde", "webdriver"] }
 kurbo = { version = "0.12", features = ["euclid"] }
 libc = "0.2"


### PR DESCRIPTION
This bumps spidermonkey from ESR 140.10 to ESR 140.12 on the 0.1 LTS branch.


Testing: Pure Spidermonkey update, hence covered by existing tests. [mach try](https://github.com/jschwe/servo/actions/runs/28298302120)

