### PR TITLE
android: Don't highlight all navigation buttons

### DIFF
--- a/support/android/apk/servoapp/src/main/res/layout-sw600dp/activity_main.xml
+++ b/support/android/apk/servoapp/src/main/res/layout-sw600dp/activity_main.xml
@@ -26,7 +26,7 @@
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/history_back_menu_item"
-                    style="@style/Widget.Material3.Button.IconButton.Filled.Tonal"
+                    style="@style/Widget.Material3.Button.IconButton"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     app:icon="@drawable/arrow_back"
@@ -36,8 +36,9 @@
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/history_forward_menu_item"
-                    style="@style/Widget.Material3.Button.IconButton.Filled.Tonal"
+                    style="@style/Widget.Material3.Button.IconButton"
                     app:icon="@drawable/arrow_forward"
+                    app:iconTint="?colorOnBackground"
                     android:contentDescription="@string/history_forward"
                     android:enabled="false"
                     android:layout_width="wrap_content"
@@ -46,19 +47,21 @@
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/refresh_menu_item"
-                    style="@style/Widget.Material3.Button.IconButton.Filled.Tonal"
+                    style="@style/Widget.Material3.Button.IconButton"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:contentDescription="@string/refresh"
-                    app:icon="@drawable/refresh"/>
+                    app:icon="@drawable/refresh"
+                    app:iconTint="?colorOnBackground" />
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/cancel_menu_item"
-                    style="@style/Widget.Material3.Button.IconButton.Filled.Tonal"
+                    style="@style/Widget.Material3.Button.IconButton"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:contentDescription="@string/cancel"
                     app:icon="@drawable/cancel"
+                    app:iconTint="?colorOnBackground"
                     android:visibility="gone"
                     />
 
@@ -113,24 +116,26 @@
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/settings_menu_item"
-                style="@style/Widget.Material3.Button.IconButton.Filled.Tonal"
+                style="@style/Widget.Material3.Button.IconButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:contentDescription="@string/options"
                 app:layout_constraintEnd_toStartOf="@id/history_menu_item"
                 app:layout_constraintTop_toTopOf="parent"
                 app:icon="@drawable/settings"
+                app:iconTint="?colorOnBackground"
                 />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/history_menu_item"
-                style="@style/Widget.Material3.Button.IconButton.Filled.Tonal"
+                style="@style/Widget.Material3.Button.IconButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:contentDescription="@string/history_title"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
                 app:icon="@drawable/history"
+                app:iconTint="?colorOnBackground"
                 />
 
         </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
By having all the buttons be filled, we're essentially making them all CTA buttons, when at most one should be. Since we don't have any specific button that needs to be pushed, we should unfill them all.

If you highlight everything, you've highlighted nothing :smile: 

|Before|After|
|---|---|
|<img width="1920" height="144" src="https://github.com/user-attachments/assets/995d3e23-7dec-4203-a1e8-9b0e643775b1" />|<img width="1920" height="140" src="https://github.com/user-attachments/assets/4c506e7c-b092-4d57-b067-32524dc1e958" />|

Testing: There are no automated tests for Android.