### PR TITLE
script: Always pass `&mut JSContext` to `Constructor`

### DIFF
--- a/components/script/dom/animations/documenttimeline.rs
+++ b/components/script/dom/animations/documenttimeline.rs
@@ -3,10 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::gc::HandleObject;
 use num_traits::ToPrimitive;
 use script_bindings::codegen::GenericBindings::DocumentTimelineBinding::DocumentTimelineOptions;
-use script_bindings::reflector::{reflect_dom_object, reflect_dom_object_with_proto};
+use script_bindings::reflector::{reflect_dom_object, reflect_dom_object_with_proto_and_cx};
 use script_bindings::root::DomRoot;
 use script_bindings::script_runtime::CanGc;
 use servo_base::cross_process_instant::CrossProcessInstant;
@@ -32,22 +33,22 @@ pub(crate) struct DocumentTimeline {
 }
 
 impl DocumentTimeline {
-    pub(crate) fn new_with_duration(
+    fn new_with_duration(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         origin_time: Duration,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
         let duration_since_time_origin =
             CrossProcessInstant::now() - window.navigation_start() - origin_time;
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(Self {
                 animation_timeline: AnimationTimeline::new_inherited(duration_since_time_origin),
                 origin_offset: origin_time,
             }),
             window,
             proto,
-            can_gc,
+            cx,
         )
     }
 
@@ -84,16 +85,16 @@ impl DocumentTimeline {
 
 impl DocumentTimelineMethods<crate::DomTypeHolder> for DocumentTimeline {
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         options: &DocumentTimelineOptions,
     ) -> DomRoot<Self> {
         Self::new_with_duration(
+            cx,
             window,
             proto,
             Duration::seconds_f64(options.originTime.to_f64().unwrap_or_default() / 1000.),
-            can_gc,
         )
     }
 }

--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -38,7 +38,6 @@ use crate::dom::bindings::str::USVString;
 use crate::dom::domexception::{DOMErrorName, DOMException};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::types::QuotaExceededError;
-use crate::script_runtime::CanGc;
 
 #[cfg(feature = "js_backtrace")]
 thread_local! {
@@ -198,11 +197,11 @@ pub(crate) fn create_dom_exception(
         Error::NoModificationAllowed(None) => DOMErrorName::NoModificationAllowedError,
         Error::QuotaExceeded { quota, requested } => {
             return Ok(DomRoot::upcast(QuotaExceededError::new(
+                cx,
                 global,
                 DOMString::new(),
                 quota,
                 requested,
-                CanGc::from_cx(cx),
             )));
         },
         Error::TypeMismatch(Some(custom_message)) => {

--- a/components/script/dom/credentialmanagement/passwordcredential.rs
+++ b/components/script/dom/credentialmanagement/passwordcredential.rs
@@ -3,10 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::gc::HandleObject;
 use script_bindings::codegen::GenericBindings::PasswordCredentialBinding::PasswordCredentialData;
 use script_bindings::error::{Error, Fallible};
-use script_bindings::reflector::{reflect_dom_object, reflect_dom_object_with_proto};
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use script_bindings::str::USVString;
 
 use crate::dom::bindings::codegen::Bindings::PasswordCredentialBinding::PasswordCredentialMethods;
@@ -16,7 +17,6 @@ use crate::dom::credentialmanagement::credential::Credential;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlformelement::HTMLFormElement;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct PasswordCredential {
@@ -34,34 +34,19 @@ impl PasswordCredential {
         }
     }
 
-    #[expect(dead_code)]
-    pub(crate) fn new(
-        global: &GlobalScope,
-        id: USVString,
-        origin: USVString,
-        password: USVString,
-        can_gc: CanGc,
-    ) -> DomRoot<PasswordCredential> {
-        reflect_dom_object(
-            Box::new(PasswordCredential::new_inherited(id, origin, password)),
-            global,
-            can_gc,
-        )
-    }
-
-    pub(crate) fn new_with_proto(
+    fn new_with_proto(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
         id: USVString,
         origin: USVString,
         password: USVString,
-        can_gc: CanGc,
     ) -> DomRoot<PasswordCredential> {
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(PasswordCredential::new_inherited(id, origin, password)),
             global,
             proto,
-            can_gc,
+            cx,
         )
     }
 }
@@ -72,27 +57,27 @@ impl PasswordCredentialMethods<DomTypeHolder> for PasswordCredential {
     }
 
     fn Constructor(
+        _cx: &mut JSContext,
         _global: &Window,
         _proto: Option<HandleObject>,
-        _can_gc: CanGc,
         _form: &HTMLFormElement,
     ) -> Fallible<DomRoot<PasswordCredential>> {
         Err(Error::NotSupported(None))
     }
 
     fn Constructor_(
+        cx: &mut JSContext,
         global: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         data: &PasswordCredentialData,
     ) -> Fallible<DomRoot<PasswordCredential>> {
         Ok(Self::new_with_proto(
+            cx,
             global.as_global_scope(),
             proto,
             data.parent.id.clone(),
             data.origin.clone(),
             data.password.clone(),
-            can_gc,
         ))
     }
 }

--- a/components/script/dom/css/cssstylesheet.rs
+++ b/components/script/dom/css/cssstylesheet.rs
@@ -12,7 +12,7 @@ use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::StyleSheetBinding::StyleSheetMethods;
 use script_bindings::inheritance::Castable;
-use script_bindings::reflector::{reflect_dom_object, reflect_dom_object_with_proto};
+use script_bindings::reflector::{reflect_dom_object, reflect_dom_object_with_proto_and_cx};
 use script_bindings::root::Dom;
 use servo_arc::Arc;
 use style::media_queries::MediaList as StyleMediaList;
@@ -131,6 +131,7 @@ impl CSSStyleSheet {
 
     #[allow(clippy::too_many_arguments)]
     fn new_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         owner: Option<&Element>,
@@ -139,9 +140,8 @@ impl CSSStyleSheet {
         title: Option<DOMString>,
         stylesheet: Arc<StyleStyleSheet>,
         constructor_document: Option<&Document>,
-        can_gc: CanGc,
     ) -> DomRoot<CSSStyleSheet> {
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(CSSStyleSheet::new_inherited(
                 owner,
                 type_,
@@ -152,7 +152,7 @@ impl CSSStyleSheet {
             )),
             window,
             proto,
-            can_gc,
+            cx,
         )
     }
 
@@ -345,9 +345,9 @@ impl CSSStyleSheet {
 impl CSSStyleSheetMethods<crate::DomTypeHolder> for CSSStyleSheet {
     /// <https://drafts.csswg.org/cssom/#dom-cssstylesheet-cssstylesheet>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         options: &CSSStyleSheetInit,
     ) -> DomRoot<Self> {
         let doc = window.Document();
@@ -374,6 +374,7 @@ impl CSSStyleSheetMethods<crate::DomTypeHolder> for CSSStyleSheet {
             stylesheet.set_disabled(true);
         }
         Self::new_with_proto(
+            cx,
             window,
             proto,
             None, // owner
@@ -382,7 +383,6 @@ impl CSSStyleSheetMethods<crate::DomTypeHolder> for CSSStyleSheet {
             None, // title
             stylesheet,
             Some(&window.Document()), // constructor_document
-            can_gc,
         )
     }
 

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -4875,9 +4875,9 @@ impl Document {
 impl DocumentMethods<crate::DomTypeHolder> for Document {
     /// <https://dom.spec.whatwg.org/#dom-document-document>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<Document>> {
         // The new Document() constructor steps are to set this’s origin to the origin of current global object’s associated Document. [HTML]
         let doc = window.Document();
@@ -4906,7 +4906,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             doc.active_sandboxing_flag_set.get(),
             doc.pipeline_id(),
             doc.image_cache(),
-            can_gc,
+            CanGc::from_cx(cx),
         ))
     }
 

--- a/components/script/dom/encoding/textdecoder.rs
+++ b/components/script/dom/encoding/textdecoder.rs
@@ -7,8 +7,9 @@ use std::cell::Cell;
 
 use dom_struct::dom_struct;
 use encoding_rs::Encoding;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
 
 use crate::dom::bindings::codegen::Bindings::TextDecoderBinding;
 use crate::dom::bindings::codegen::Bindings::TextDecoderBinding::{
@@ -20,7 +21,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::encoding::textdecodercommon::TextDecoderCommon;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::CanGc;
 
 /// <https://encoding.spec.whatwg.org/#textdecoder>
 #[dom_struct]
@@ -34,10 +34,9 @@ pub(crate) struct TextDecoder {
     do_not_flush: Cell<bool>,
 }
 
-#[expect(non_snake_case)]
 impl TextDecoder {
-    fn new_inherited(encoding: &'static Encoding, fatal: bool, ignoreBOM: bool) -> TextDecoder {
-        let decoder = TextDecoderCommon::new_inherited(encoding, fatal, ignoreBOM);
+    fn new_inherited(encoding: &'static Encoding, fatal: bool, ignore_bom: bool) -> TextDecoder {
+        let decoder = TextDecoderCommon::new_inherited(encoding, fatal, ignore_bom);
         TextDecoder {
             reflector_: Reflector::new(),
             decoder,
@@ -52,18 +51,18 @@ impl TextDecoder {
     }
 
     fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
         encoding: &'static Encoding,
         fatal: bool,
-        ignoreBOM: bool,
-        can_gc: CanGc,
+        ignore_bom: bool,
     ) -> DomRoot<TextDecoder> {
-        reflect_dom_object_with_proto(
-            Box::new(TextDecoder::new_inherited(encoding, fatal, ignoreBOM)),
+        reflect_dom_object_with_proto_and_cx(
+            Box::new(TextDecoder::new_inherited(encoding, fatal, ignore_bom)),
             global,
             proto,
-            can_gc,
+            cx,
         )
     }
 }
@@ -71,9 +70,9 @@ impl TextDecoder {
 impl TextDecoderMethods<crate::DomTypeHolder> for TextDecoder {
     /// <https://encoding.spec.whatwg.org/#dom-textdecoder>
     fn Constructor(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         label: DOMString,
         options: &TextDecoderBinding::TextDecoderOptions,
     ) -> Fallible<DomRoot<TextDecoder>> {
@@ -82,12 +81,12 @@ impl TextDecoderMethods<crate::DomTypeHolder> for TextDecoder {
             Some(enc) => enc,
         };
         Ok(TextDecoder::new(
+            cx,
             global,
             proto,
             encoding,
             options.fatal,
             options.ignoreBOM,
-            can_gc,
         ))
     }
 

--- a/components/script/dom/encoding/textencoder.rs
+++ b/components/script/dom/encoding/textencoder.rs
@@ -11,7 +11,7 @@ use js::jsapi::JSObject;
 use js::rust::HandleObject;
 use js::typedarray;
 use js::typedarray::HeapUint8Array;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
 use script_bindings::trace::RootedTraceableBox;
 
 use crate::dom::bindings::buffer_source::create_buffer_source;
@@ -22,7 +22,6 @@ use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::CanGc;
 
 /// <https://encoding.spec.whatwg.org/#textencoder>
 #[dom_struct]
@@ -38,15 +37,15 @@ impl TextEncoder {
     }
 
     fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<TextEncoder> {
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(TextEncoder::new_inherited()),
             global,
             proto,
-            can_gc,
+            cx,
         )
     }
 }
@@ -54,11 +53,11 @@ impl TextEncoder {
 impl TextEncoderMethods<crate::DomTypeHolder> for TextEncoder {
     /// <https://encoding.spec.whatwg.org/#dom-textencoder>
     fn Constructor(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<TextEncoder>> {
-        Ok(TextEncoder::new(global, proto, can_gc))
+        Ok(TextEncoder::new(cx, global, proto))
     }
 
     /// <https://encoding.spec.whatwg.org/#dom-textencoder-encoding>

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -12,6 +12,7 @@ use encoding_rs::{Decoder, UTF_8};
 use headers::ContentType;
 use http::StatusCode;
 use http::header::{self, HeaderName, HeaderValue};
+use js::context::JSContext;
 use js::jsval::UndefinedValue;
 use js::rust::HandleObject;
 use mime::{self, Mime};
@@ -19,7 +20,7 @@ use net_traits::request::{CacheMode, CorsSettings, Destination, RequestBuilder, 
 use net_traits::{FetchMetadata, FilteredMetadata, NetworkError, ResourceFetchTiming};
 use script_bindings::cell::DomRefCell;
 use script_bindings::conversions::SafeToJSValConvertible;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use servo_url::ServoUrl;
 use stylo_atoms::Atom;
 
@@ -41,7 +42,6 @@ use crate::dom::performance::performanceresourcetiming::InitiatorType;
 use crate::fetch::{FetchCanceller, RequestWithGlobalScope, create_a_potential_cors_request};
 use crate::network_listener::{self, FetchResponseListener, ResourceTimingListener};
 use crate::realms::enter_auto_realm;
-use crate::script_runtime::CanGc;
 use crate::timers::OneshotTimerCallback;
 
 const DEFAULT_RECONNECTION_TIME: Duration = Duration::from_millis(5000);
@@ -251,7 +251,7 @@ impl EventSourceContext {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dispatchMessage>
-    fn dispatch_event(&mut self, cx: &mut js::context::JSContext) {
+    fn dispatch_event(&mut self, cx: &mut JSContext) {
         let event_source = self.event_source.root();
         // Step 1
         *event_source.last_event_id.borrow_mut() = DOMString::from(self.last_event_id.clone());
@@ -311,7 +311,7 @@ impl EventSourceContext {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#event-stream-interpretation>
-    fn parse(&mut self, cx: &mut js::context::JSContext, stream: Chars) {
+    fn parse(&mut self, cx: &mut JSContext, stream: Chars) {
         let mut stream = stream.peekable();
 
         while let Some(ch) = stream.next() {
@@ -387,7 +387,7 @@ impl FetchResponseListener for EventSourceContext {
 
     fn process_response(
         &mut self,
-        _: &mut js::context::JSContext,
+        _: &mut JSContext,
         _: RequestId,
         metadata: Result<FetchMetadata, NetworkError>,
     ) {
@@ -431,12 +431,7 @@ impl FetchResponseListener for EventSourceContext {
         }
     }
 
-    fn process_response_chunk(
-        &mut self,
-        cx: &mut js::context::JSContext,
-        _: RequestId,
-        chunk: Vec<u8>,
-    ) {
+    fn process_response_chunk(&mut self, cx: &mut JSContext, _: RequestId, chunk: Vec<u8>) {
         let mut output = String::with_capacity(chunk.len());
         let mut input = &chunk[..];
 
@@ -469,7 +464,7 @@ impl FetchResponseListener for EventSourceContext {
 
     fn process_response_eof(
         mut self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         _: RequestId,
         response: Result<(), NetworkError>,
         timing: ResourceFetchTiming,
@@ -493,7 +488,7 @@ impl FetchResponseListener for EventSourceContext {
 
     fn process_csp_violations(
         &mut self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         _request_id: RequestId,
         violations: Vec<Violation>,
     ) {
@@ -529,17 +524,17 @@ impl EventSource {
     }
 
     fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
         url: ServoUrl,
         with_credentials: bool,
-        can_gc: CanGc,
     ) -> DomRoot<EventSource> {
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(EventSource::new_inherited(url, with_credentials)),
             global,
             proto,
-            can_gc,
+            cx,
         )
     }
 
@@ -576,9 +571,9 @@ impl EventSource {
 impl EventSourceMethods<crate::DomTypeHolder> for EventSource {
     /// <https://html.spec.whatwg.org/multipage/#dom-eventsource>
     fn Constructor(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         url: DOMString,
         event_source_init: &EventSourceInit,
     ) -> Fallible<DomRoot<EventSource>> {
@@ -592,12 +587,12 @@ impl EventSourceMethods<crate::DomTypeHolder> for EventSource {
         };
         // Step 1 Let ev be a new EventSource object.
         let event_source = EventSource::new(
+            cx,
             global,
             proto,
             // Step 5 Set ev's url to urlRecord.
             url_record.clone(),
             event_source_init.withCredentials,
-            can_gc,
         );
         global.track_event_source(&event_source);
         let cors_attribute_state = if event_source_init.withCredentials {

--- a/components/script/dom/fetch/headers.rs
+++ b/components/script/dom/fetch/headers.rs
@@ -7,6 +7,7 @@ use std::str::{self, FromStr};
 
 use dom_struct::dom_struct;
 use http::header::{HeaderMap as HyperHeaders, HeaderName, HeaderValue};
+use js::context::JSContext;
 use js::rust::HandleObject;
 use net_traits::fetch::headers::{
     extract_mime_type, get_decode_and_split_header_value, get_value_from_header_list,
@@ -69,12 +70,12 @@ impl Headers {
 impl HeadersMethods<crate::DomTypeHolder> for Headers {
     /// <https://fetch.spec.whatwg.org/#dom-headers>
     fn Constructor(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         init: Option<HeadersInit>,
     ) -> Fallible<DomRoot<Headers>> {
-        let dom_headers_new = Headers::new_with_proto(global, proto, can_gc);
+        let dom_headers_new = Headers::new_with_proto(global, proto, CanGc::from_cx(cx));
         dom_headers_new.fill(init)?;
         Ok(dom_headers_new)
     }

--- a/components/script/dom/file/file.rs
+++ b/components/script/dom/file/file.rs
@@ -191,9 +191,9 @@ impl FileMethods<crate::DomTypeHolder> for File {
     // https://w3c.github.io/FileAPI/#file-constructor
     #[expect(non_snake_case)]
     fn Constructor(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         fileBits: Vec<ArrayBufferOrArrayBufferViewOrBlobOrString>,
         filename: DOMString,
         filePropertyBag: &FileBinding::FilePropertyBag,
@@ -217,7 +217,7 @@ impl FileMethods<crate::DomTypeHolder> for File {
             filename,
             modified,
             USVString::default(),
-            can_gc,
+            CanGc::from_cx(cx),
         ))
     }
 

--- a/components/script/dom/file/filereader.rs
+++ b/components/script/dom/file/filereader.rs
@@ -16,7 +16,7 @@ use js::typedarray::{ArrayBuffer, CreateWith};
 use mime::{self, Mime};
 use script_bindings::cell::DomRefCell;
 use script_bindings::num::Finite;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::BlobBinding::BlobMethods;
@@ -38,7 +38,7 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::progressevent::ProgressEvent;
 use crate::realms::enter_auto_realm;
-use crate::script_runtime::{CanGc, JSContext};
+use crate::script_runtime::JSContext;
 use crate::task::TaskOnce;
 
 pub(crate) enum FileReadingTask {
@@ -205,11 +205,16 @@ impl FileReader {
     }
 
     fn new(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<FileReader> {
-        reflect_dom_object_with_proto(Box::new(FileReader::new_inherited()), global, proto, can_gc)
+        reflect_dom_object_with_proto_and_cx(
+            Box::new(FileReader::new_inherited()),
+            global,
+            proto,
+            cx,
+        )
     }
 
     // https://w3c.github.io/FileAPI/#dfn-error-steps
@@ -406,11 +411,11 @@ impl FileReader {
 impl FileReaderMethods<crate::DomTypeHolder> for FileReader {
     /// <https://w3c.github.io/FileAPI/#filereaderConstrctr>
     fn Constructor(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<FileReader>> {
-        Ok(FileReader::new(global, proto, can_gc))
+        Ok(FileReader::new(cx, global, proto))
     }
 
     // https://w3c.github.io/FileAPI/#dfn-onloadstart

--- a/components/script/dom/file/filereadersync.rs
+++ b/components/script/dom/file/filereadersync.rs
@@ -9,7 +9,7 @@ use js::context::JSContext;
 use js::jsapi::JSObject;
 use js::rust::HandleObject;
 use js::typedarray::{ArrayBufferU8, HeapArrayBuffer};
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
 use script_bindings::trace::RootedTraceableBox;
 
 use crate::dom::bindings::buffer_source::create_buffer_source;
@@ -21,7 +21,6 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::blob::Blob;
 use crate::dom::filereader::FileReaderSharedFunctionality;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct FileReaderSync {
@@ -36,15 +35,15 @@ impl FileReaderSync {
     }
 
     fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<FileReaderSync> {
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(FileReaderSync::new_inherited()),
             global,
             proto,
-            can_gc,
+            cx,
         )
     }
 
@@ -56,11 +55,11 @@ impl FileReaderSync {
 impl FileReaderSyncMethods<crate::DomTypeHolder> for FileReaderSync {
     /// <https://w3c.github.io/FileAPI/#filereadersyncConstrctr>
     fn Constructor(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<FileReaderSync>> {
-        Ok(FileReaderSync::new(global, proto, can_gc))
+        Ok(FileReaderSync::new(cx, global, proto))
     }
 
     /// <https://w3c.github.io/FileAPI/#readAsBinaryStringSyncSection>

--- a/components/script/dom/globalscope/origin.rs
+++ b/components/script/dom/globalscope/origin.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::rust::{HandleObject, HandleValue};
 use net_traits::pub_domains::is_same_site;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
 use servo_url::{ImmutableOrigin, ServoUrl};
 
 use crate::dom::bindings::codegen::Bindings::OriginBinding::OriginMethods;
@@ -21,7 +21,7 @@ use crate::dom::html::htmlareaelement::HTMLAreaElement;
 use crate::dom::html::htmlhyperlinkelementutils::{HyperlinkElement, HyperlinkElementTraits};
 use crate::dom::url::URL;
 use crate::dom::window::Window;
-use crate::script_runtime::{CanGc, JSContext};
+use crate::script_runtime::JSContext;
 
 /// <https://html.spec.whatwg.org/multipage/#the-origin-interface>
 #[dom_struct]
@@ -40,16 +40,16 @@ impl Origin {
     }
 
     fn new(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
         origin: ImmutableOrigin,
-        can_gc: CanGc,
     ) -> DomRoot<Origin> {
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(Origin::new_inherited(origin)),
             global,
             proto,
-            can_gc,
+            cx,
         )
     }
 
@@ -103,11 +103,11 @@ impl Origin {
 impl OriginMethods<crate::DomTypeHolder> for Origin {
     /// <https://html.spec.whatwg.org/multipage/#dom-origin-constructor>
     fn Constructor(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<Origin> {
-        Origin::new(global, proto, ImmutableOrigin::new_opaque(), can_gc)
+        Origin::new(cx, global, proto, ImmutableOrigin::new_opaque())
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-origin-from>
@@ -116,15 +116,13 @@ impl OriginMethods<crate::DomTypeHolder> for Origin {
         global: &GlobalScope,
         value: HandleValue,
     ) -> Fallible<DomRoot<Origin>> {
-        let can_gc = CanGc::deprecated_note();
-
         // Step 1. If value is a platform object:
         //   1. Let origin be the result of executing value's extract an origin operation.
         //   2. If origin is not null, then return a new Origin object whose origin is origin.
         if let Some(origin) =
             Origin::extract_an_origin_from_platform_object(value, cx.into(), global)
         {
-            return Ok(Origin::new(global, None, origin, can_gc));
+            return Ok(Origin::new(cx, global, None, origin));
         }
 
         // Step 2. If value is a string:
@@ -138,7 +136,7 @@ impl OriginMethods<crate::DomTypeHolder> for Origin {
             // Step 2.2. If parsedURL is not failure, then return a new Origin object whose
             //           origin is set to parsedURL's origin.
             match ServoUrl::parse(&s.str()) {
-                Ok(url) => return Ok(Origin::new(global, None, url.origin(), can_gc)),
+                Ok(url) => return Ok(Origin::new(cx, global, None, url.origin())),
                 Err(_) => return Err(Error::Type(c"Failed to parse URL".to_owned())),
             }
         }

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -2460,12 +2460,12 @@ impl HTMLMediaElement {
             // Step 7. Fire an event named addtrack at this AudioTrackList object, using TrackEvent,
             // with the track attribute initialized to the new AudioTrack object.
             let event = TrackEvent::new(
+                cx,
                 self.global().as_window(),
                 atom!("addtrack"),
                 false,
                 false,
                 &Some(VideoTrackOrAudioTrackOrTextTrack::AudioTrack(audio_track)),
-                CanGc::from_cx(cx),
             );
 
             event
@@ -2528,12 +2528,12 @@ impl HTMLMediaElement {
             // Step 7. Fire an event named addtrack at this VideoTrackList object, using TrackEvent,
             // with the track attribute initialized to the new VideoTrack object.
             let event = TrackEvent::new(
+                cx,
                 self.global().as_window(),
                 atom!("addtrack"),
                 false,
                 false,
                 &Some(VideoTrackOrAudioTrackOrTextTrack::VideoTrack(video_track)),
-                CanGc::from_cx(cx),
             );
 
             event

--- a/components/script/dom/media/mediametadata.rs
+++ b/components/script/dom/media/mediametadata.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
@@ -71,12 +72,17 @@ impl MediaMetadata {
 impl MediaMetadataMethods<crate::DomTypeHolder> for MediaMetadata {
     /// <https://w3c.github.io/mediasession/#dom-mediametadata-mediametadata>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         init: &MediaMetadataInit,
     ) -> Fallible<DomRoot<MediaMetadata>> {
-        Ok(MediaMetadata::new_with_proto(window, proto, init, can_gc))
+        Ok(MediaMetadata::new_with_proto(
+            window,
+            proto,
+            init,
+            CanGc::from_cx(cx),
+        ))
     }
 
     /// <https://w3c.github.io/mediasession/#dom-mediametadata-title>

--- a/components/script/dom/media/mediaquerylistevent.rs
+++ b/components/script/dom/media/mediaquerylistevent.rs
@@ -5,8 +5,9 @@
 use std::cell::Cell;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -20,7 +21,6 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::event::Event;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 // https://drafts.csswg.org/cssom-view/#dom-mediaquerylistevent-mediaquerylistevent
 #[dom_struct]
@@ -32,36 +32,35 @@ pub(crate) struct MediaQueryListEvent {
 
 impl MediaQueryListEvent {
     fn new_initialized(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
         media: DOMString,
         matches: bool,
-        can_gc: CanGc,
     ) -> DomRoot<MediaQueryListEvent> {
         let ev = Box::new(MediaQueryListEvent {
             event: Event::new_inherited(),
             media,
             matches: Cell::new(matches),
         });
-        reflect_dom_object_with_proto(ev, global, proto, can_gc)
+        reflect_dom_object_with_proto_and_cx(ev, global, proto, cx)
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         type_: Atom,
         bubbles: bool,
         cancelable: bool,
         media: DOMString,
         matches: bool,
-        can_gc: CanGc,
     ) -> DomRoot<MediaQueryListEvent> {
-        Self::new_with_proto(
-            global, None, type_, bubbles, cancelable, media, matches, can_gc,
-        )
+        Self::new_with_proto(cx, global, None, type_, bubbles, cancelable, media, matches)
     }
 
     #[expect(clippy::too_many_arguments)]
     fn new_with_proto(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
         type_: Atom,
@@ -69,9 +68,8 @@ impl MediaQueryListEvent {
         cancelable: bool,
         media: DOMString,
         matches: bool,
-        can_gc: CanGc,
     ) -> DomRoot<MediaQueryListEvent> {
-        let ev = MediaQueryListEvent::new_initialized(global, proto, media, matches, can_gc);
+        let ev = MediaQueryListEvent::new_initialized(cx, global, proto, media, matches);
         {
             let event = ev.upcast::<Event>();
             event.init_event(type_, bubbles, cancelable);
@@ -83,13 +81,14 @@ impl MediaQueryListEvent {
 impl MediaQueryListEventMethods<crate::DomTypeHolder> for MediaQueryListEvent {
     /// <https://drafts.csswg.org/cssom-view/#dom-mediaquerylistevent-mediaquerylistevent>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         type_: DOMString,
         init: &MediaQueryListEventInit,
     ) -> Fallible<DomRoot<MediaQueryListEvent>> {
         Ok(MediaQueryListEvent::new_with_proto(
+            cx,
             window.as_global_scope(),
             proto,
             Atom::from(type_),
@@ -97,7 +96,6 @@ impl MediaQueryListEventMethods<crate::DomTypeHolder> for MediaQueryListEvent {
             init.parent.cancelable,
             init.media.clone(),
             init.matches,
-            can_gc,
         ))
     }
 

--- a/components/script/dom/mutationobserver/mutationobserver.rs
+++ b/components/script/dom/mutationobserver/mutationobserver.rs
@@ -8,9 +8,10 @@ use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Namespace, ns};
+use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
 
 use crate::dom::bindings::codegen::Bindings::MutationObserverBinding::MutationObserver_Binding::MutationObserverMethods;
 use crate::dom::bindings::codegen::Bindings::MutationObserverBinding::{
@@ -73,13 +74,13 @@ pub(crate) struct ObserverOptions {
 
 impl MutationObserver {
     fn new_with_proto(
+        cx: &mut JSContext,
         global: &Window,
         proto: Option<HandleObject>,
         callback: Rc<MutationCallback>,
-        can_gc: CanGc,
     ) -> DomRoot<MutationObserver> {
         let boxed_observer = Box::new(MutationObserver::new_inherited(callback));
-        reflect_dom_object_with_proto(boxed_observer, global, proto, can_gc)
+        reflect_dom_object_with_proto_and_cx(boxed_observer, global, proto, cx)
     }
 
     fn new_inherited(callback: Rc<MutationCallback>) -> MutationObserver {
@@ -256,13 +257,13 @@ impl MutationObserver {
 impl MutationObserverMethods<crate::DomTypeHolder> for MutationObserver {
     /// <https://dom.spec.whatwg.org/#dom-mutationobserver-mutationobserver>
     fn Constructor(
+        cx: &mut JSContext,
         global: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         callback: Rc<MutationCallback>,
     ) -> Fallible<DomRoot<MutationObserver>> {
         global.set_exists_mut_observer();
-        let observer = MutationObserver::new_with_proto(global, proto, callback, can_gc);
+        let observer = MutationObserver::new_with_proto(cx, global, proto, callback);
         ScriptThread::mutation_observers().add_mutation_observer(&observer);
         Ok(observer)
     }

--- a/components/script/dom/quotaexceedederror.rs
+++ b/components/script/dom/quotaexceedederror.rs
@@ -10,9 +10,10 @@ use script_bindings::codegen::GenericBindings::QuotaExceededErrorBinding::{
     QuotaExceededErrorMethods, QuotaExceededErrorOptions,
 };
 use script_bindings::num::Finite;
-use script_bindings::reflector::{reflect_dom_object, reflect_dom_object_with_proto};
+use script_bindings::reflector::{
+    reflect_dom_object_with_cx, reflect_dom_object_with_proto_and_cx,
+};
 use script_bindings::root::DomRoot;
-use script_bindings::script_runtime::CanGc;
 use script_bindings::str::DOMString;
 use servo_base::id::{QuotaExceededErrorId, QuotaExceededErrorIndex};
 use servo_constellation_traits::SerializableQuotaExceededError;
@@ -47,16 +48,16 @@ impl QuotaExceededError {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         message: DOMString,
         quota: Option<Finite<f64>>,
         requested: Option<Finite<f64>>,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(Self::new_inherited(message, quota, requested)),
             global,
-            can_gc,
+            cx,
         )
     }
 }
@@ -64,9 +65,9 @@ impl QuotaExceededError {
 impl QuotaExceededErrorMethods<crate::DomTypeHolder> for QuotaExceededError {
     /// <https://webidl.spec.whatwg.org/#dom-quotaexceedederror-quotaexceedederror>
     fn Constructor(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         message: DOMString,
         options: &QuotaExceededErrorOptions,
     ) -> Result<DomRoot<Self>, Error> {
@@ -95,7 +96,7 @@ impl QuotaExceededErrorMethods<crate::DomTypeHolder> for QuotaExceededError {
         {
             return Err(Error::Range(c"requested is less than quota".to_owned()));
         }
-        Ok(reflect_dom_object_with_proto(
+        Ok(reflect_dom_object_with_proto_and_cx(
             Box::new(QuotaExceededError::new_inherited(
                 message,
                 options.quota,
@@ -103,7 +104,7 @@ impl QuotaExceededErrorMethods<crate::DomTypeHolder> for QuotaExceededError {
             )),
             global,
             proto,
-            can_gc,
+            cx,
         ))
     }
 
@@ -145,6 +146,7 @@ impl Serializable for QuotaExceededError {
         Self: Sized,
     {
         Ok(Self::new(
+            cx,
             owner,
             DOMString::from(serialized.dom_exception.message),
             serialized
@@ -155,7 +157,6 @@ impl Serializable for QuotaExceededError {
                 .requested
                 .map(|val| Finite::new(val).ok_or(()))
                 .transpose()?,
-            CanGc::from_cx(cx),
         ))
     }
 

--- a/components/script/dom/reporting/reportingobserver.rs
+++ b/components/script/dom/reporting/reportingobserver.rs
@@ -11,7 +11,7 @@ use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
 use script_bindings::match_domstring_ascii;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
 use script_bindings::str::DOMString;
 use servo_url::ServoUrl;
 
@@ -29,7 +29,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
 use crate::dom::workerglobalscope::WorkerGlobalScope;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct ReportingObserver {
@@ -56,18 +55,18 @@ impl ReportingObserver {
         }
     }
 
-    pub(crate) fn new_with_proto(
+    fn new_with_proto(
+        cx: &mut JSContext,
         callback: Rc<ReportingObserverCallback>,
         options: &ReportingObserverOptions,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(Self::new_inherited(callback, options)),
             global,
             proto,
-            can_gc,
+            cx,
         )
     }
 
@@ -236,9 +235,9 @@ impl ReportingObserver {
 impl ReportingObserverMethods<crate::DomTypeHolder> for ReportingObserver {
     /// <https://w3c.github.io/reporting/#dom-reportingobserver-reportingobserver>
     fn Constructor(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         callback: Rc<ReportingObserverCallback>,
         options: &ReportingObserverOptions,
     ) -> DomRoot<ReportingObserver> {
@@ -246,7 +245,7 @@ impl ReportingObserverMethods<crate::DomTypeHolder> for ReportingObserver {
         // Step 2. Set observer’s callback to callback.
         // Step 3. Set observer’s options to options.
         // Step 4. Return observer.
-        ReportingObserver::new_with_proto(callback, options, global, proto, can_gc)
+        ReportingObserver::new_with_proto(cx, callback, options, global, proto)
     }
 
     /// <https://w3c.github.io/reporting/#dom-reportingobserver-observe>

--- a/components/script/dom/testing/testbindingiterable.rs
+++ b/components/script/dom/testing/testbindingiterable.rs
@@ -5,16 +5,16 @@
 // check-tidy: no specs after this line
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
 
 use crate::dom::bindings::codegen::Bindings::TestBindingIterableBinding::TestBindingIterableMethods;
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct TestBindingIterable {
@@ -24,29 +24,29 @@ pub(crate) struct TestBindingIterable {
 
 impl TestBindingIterable {
     fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<TestBindingIterable> {
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(TestBindingIterable {
                 reflector: Reflector::new(),
                 vals: DomRefCell::new(vec![]),
             }),
             global,
             proto,
-            can_gc,
+            cx,
         )
     }
 }
 
 impl TestBindingIterableMethods<crate::DomTypeHolder> for TestBindingIterable {
     fn Constructor(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<TestBindingIterable>> {
-        Ok(TestBindingIterable::new(global, proto, can_gc))
+        Ok(TestBindingIterable::new(cx, global, proto))
     }
 
     fn Add(&self, v: DOMString) {

--- a/components/script/dom/testing/testbindingmaplikewithinterface.rs
+++ b/components/script/dom/testing/testbindingmaplikewithinterface.rs
@@ -6,11 +6,12 @@
 
 use dom_struct::dom_struct;
 use indexmap::IndexMap;
+use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
 use script_bindings::cformat;
 use script_bindings::like::Maplike;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
 
 use crate::dom::bindings::codegen::Bindings::TestBindingMaplikeWithInterfaceBinding::TestBindingMaplikeWithInterfaceMethods;
 use crate::dom::bindings::error::{Error, Fallible};
@@ -19,7 +20,6 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::testbinding::TestBinding;
 use crate::maplike;
-use crate::script_runtime::CanGc;
 
 /// maplike<DOMString, TestBinding>
 #[dom_struct]
@@ -31,18 +31,18 @@ pub(crate) struct TestBindingMaplikeWithInterface {
 
 impl TestBindingMaplikeWithInterface {
     fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<TestBindingMaplikeWithInterface> {
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(TestBindingMaplikeWithInterface {
                 reflector: Reflector::new(),
                 internal: DomRefCell::new(IndexMap::new()),
             }),
             global,
             proto,
-            can_gc,
+            cx,
         )
     }
 }
@@ -51,11 +51,11 @@ impl TestBindingMaplikeWithInterfaceMethods<crate::DomTypeHolder>
     for TestBindingMaplikeWithInterface
 {
     fn Constructor(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<TestBindingMaplikeWithInterface>> {
-        Ok(TestBindingMaplikeWithInterface::new(global, proto, can_gc))
+        Ok(TestBindingMaplikeWithInterface::new(cx, global, proto))
     }
 
     fn SetInternal(&self, key: DOMString, value: &TestBinding) {

--- a/components/script/dom/testing/testbindingmaplikewithprimitive.rs
+++ b/components/script/dom/testing/testbindingmaplikewithprimitive.rs
@@ -6,11 +6,12 @@
 
 use dom_struct::dom_struct;
 use indexmap::IndexMap;
+use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
 use script_bindings::cformat;
 use script_bindings::like::Maplike;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
 
 use crate::dom::bindings::codegen::Bindings::TestBindingMaplikeWithPrimitiveBinding::TestBindingMaplikeWithPrimitiveMethods;
 use crate::dom::bindings::error::{Error, Fallible};
@@ -18,7 +19,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 use crate::maplike;
-use crate::script_runtime::CanGc;
 
 /// maplike<DOMString, long>
 #[dom_struct]
@@ -30,18 +30,18 @@ pub(crate) struct TestBindingMaplikeWithPrimitive {
 
 impl TestBindingMaplikeWithPrimitive {
     fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<TestBindingMaplikeWithPrimitive> {
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(TestBindingMaplikeWithPrimitive {
                 reflector: Reflector::new(),
                 internal: DomRefCell::new(IndexMap::new()),
             }),
             global,
             proto,
-            can_gc,
+            cx,
         )
     }
 }
@@ -50,11 +50,11 @@ impl TestBindingMaplikeWithPrimitiveMethods<crate::DomTypeHolder>
     for TestBindingMaplikeWithPrimitive
 {
     fn Constructor(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<TestBindingMaplikeWithPrimitive>> {
-        Ok(TestBindingMaplikeWithPrimitive::new(global, proto, can_gc))
+        Ok(TestBindingMaplikeWithPrimitive::new(cx, global, proto))
     }
 
     fn SetInternal(&self, key: DOMString, value: i32) {

--- a/components/script/dom/testing/testbindingpairiterable.rs
+++ b/components/script/dom/testing/testbindingpairiterable.rs
@@ -5,9 +5,10 @@
 // check-tidy: no specs after this line
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
 
 use crate::dom::bindings::codegen::Bindings::TestBindingPairIterableBinding::TestBindingPairIterableMethods;
 use crate::dom::bindings::error::Fallible;
@@ -15,7 +16,6 @@ use crate::dom::bindings::iterable::Iterable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct TestBindingPairIterable {
@@ -44,29 +44,29 @@ impl Iterable for TestBindingPairIterable {
 
 impl TestBindingPairIterable {
     fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<TestBindingPairIterable> {
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(TestBindingPairIterable {
                 reflector: Reflector::new(),
                 map: DomRefCell::new(vec![]),
             }),
             global,
             proto,
-            can_gc,
+            cx,
         )
     }
 }
 
 impl TestBindingPairIterableMethods<crate::DomTypeHolder> for TestBindingPairIterable {
     fn Constructor(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<TestBindingPairIterable>> {
-        Ok(TestBindingPairIterable::new(global, proto, can_gc))
+        Ok(TestBindingPairIterable::new(cx, global, proto))
     }
 
     fn Add(&self, key: DOMString, value: u32) {

--- a/components/script/dom/testing/testbindingsetlikewithinterface.rs
+++ b/components/script/dom/testing/testbindingsetlikewithinterface.rs
@@ -6,17 +6,17 @@
 
 use dom_struct::dom_struct;
 use indexmap::IndexSet;
+use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
 use script_bindings::like::Setlike;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
 
 use crate::dom::bindings::codegen::Bindings::TestBindingSetlikeWithInterfaceBinding::TestBindingSetlikeWithInterfaceMethods;
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::testbinding::TestBinding;
-use crate::script_runtime::CanGc;
 use crate::setlike;
 
 // setlike<TestBinding>
@@ -29,18 +29,18 @@ pub(crate) struct TestBindingSetlikeWithInterface {
 
 impl TestBindingSetlikeWithInterface {
     fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<TestBindingSetlikeWithInterface> {
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(TestBindingSetlikeWithInterface {
                 reflector: Reflector::new(),
                 internal: DomRefCell::new(IndexSet::new()),
             }),
             global,
             proto,
-            can_gc,
+            cx,
         )
     }
 }
@@ -49,11 +49,11 @@ impl TestBindingSetlikeWithInterfaceMethods<crate::DomTypeHolder>
     for TestBindingSetlikeWithInterface
 {
     fn Constructor(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<TestBindingSetlikeWithInterface>> {
-        Ok(TestBindingSetlikeWithInterface::new(global, proto, can_gc))
+        Ok(TestBindingSetlikeWithInterface::new(cx, global, proto))
     }
 
     fn Size(&self) -> u32 {

--- a/components/script/dom/testing/testbindingsetlikewithprimitive.rs
+++ b/components/script/dom/testing/testbindingsetlikewithprimitive.rs
@@ -6,17 +6,17 @@
 
 use dom_struct::dom_struct;
 use indexmap::IndexSet;
+use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
 use script_bindings::like::Setlike;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
 
 use crate::dom::bindings::codegen::Bindings::TestBindingSetlikeWithPrimitiveBinding::TestBindingSetlikeWithPrimitiveMethods;
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::CanGc;
 use crate::setlike;
 
 // setlike<DOMString>
@@ -29,18 +29,18 @@ pub(crate) struct TestBindingSetlikeWithPrimitive {
 
 impl TestBindingSetlikeWithPrimitive {
     fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<TestBindingSetlikeWithPrimitive> {
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(TestBindingSetlikeWithPrimitive {
                 reflector: Reflector::new(),
                 internal: DomRefCell::new(IndexSet::new()),
             }),
             global,
             proto,
-            can_gc,
+            cx,
         )
     }
 }
@@ -49,11 +49,11 @@ impl TestBindingSetlikeWithPrimitiveMethods<crate::DomTypeHolder>
     for TestBindingSetlikeWithPrimitive
 {
     fn Constructor(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<TestBindingSetlikeWithPrimitive>> {
-        Ok(TestBindingSetlikeWithPrimitive::new(global, proto, can_gc))
+        Ok(TestBindingSetlikeWithPrimitive::new(cx, global, proto))
     }
 
     fn Size(&self) -> u32 {

--- a/components/script/dom/webrtc/rtcdatachannel.rs
+++ b/components/script/dom/webrtc/rtcdatachannel.rs
@@ -189,15 +189,8 @@ impl RTCDataChannel {
         let message = match error {
             WebRtcError::Backend(message) => DOMString::from(message),
         };
-        let error = RTCError::new(window, &init, message, CanGc::from_cx(cx));
-        let event = RTCErrorEvent::new(
-            window,
-            atom!("error"),
-            false,
-            false,
-            &error,
-            CanGc::from_cx(cx),
-        );
+        let error = RTCError::new(cx, window, &init, message);
+        let event = RTCErrorEvent::new(cx, window, atom!("error"), false, false, &error);
         event.upcast::<Event>().fire(cx, self.upcast());
     }
 

--- a/components/script/dom/webrtc/rtcdatachannelevent.rs
+++ b/components/script/dom/webrtc/rtcdatachannelevent.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -17,7 +18,6 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::event::Event;
 use crate::dom::rtcdatachannel::RTCDataChannel;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct RTCDataChannelEvent {
@@ -34,30 +34,30 @@ impl RTCDataChannelEvent {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         type_: Atom,
         bubbles: bool,
         cancelable: bool,
         channel: &RTCDataChannel,
-        can_gc: CanGc,
     ) -> DomRoot<RTCDataChannelEvent> {
-        Self::new_with_proto(window, None, type_, bubbles, cancelable, channel, can_gc)
+        Self::new_with_proto(cx, window, None, type_, bubbles, cancelable, channel)
     }
 
     fn new_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         type_: Atom,
         bubbles: bool,
         cancelable: bool,
         channel: &RTCDataChannel,
-        can_gc: CanGc,
     ) -> DomRoot<RTCDataChannelEvent> {
-        let event = reflect_dom_object_with_proto(
+        let event = reflect_dom_object_with_proto_and_cx(
             Box::new(RTCDataChannelEvent::new_inherited(channel)),
             window,
             proto,
-            can_gc,
+            cx,
         );
         {
             let event = event.upcast::<Event>();
@@ -70,20 +70,20 @@ impl RTCDataChannelEvent {
 impl RTCDataChannelEventMethods<crate::DomTypeHolder> for RTCDataChannelEvent {
     /// <https://www.w3.org/TR/webrtc/#dom-rtcdatachannelevent-constructor>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         type_: DOMString,
         init: &RTCDataChannelEventInit,
     ) -> DomRoot<RTCDataChannelEvent> {
         RTCDataChannelEvent::new_with_proto(
+            cx,
             window,
             proto,
             Atom::from(type_),
             init.parent.bubbles,
             init.parent.cancelable,
             &init.channel,
-            can_gc,
         )
     }
 

--- a/components/script/dom/webrtc/rtcerror.rs
+++ b/components/script/dom/webrtc/rtcerror.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 
 use crate::dom::bindings::codegen::Bindings::RTCErrorBinding::{
     RTCErrorDetailType, RTCErrorInit, RTCErrorMethods,
@@ -13,7 +14,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::domexception::DOMException;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct RTCError {
@@ -40,26 +40,26 @@ impl RTCError {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         init: &RTCErrorInit,
         message: DOMString,
-        can_gc: CanGc,
     ) -> DomRoot<RTCError> {
-        Self::new_with_proto(window, None, init, message, can_gc)
+        Self::new_with_proto(cx, window, None, init, message)
     }
 
     fn new_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         init: &RTCErrorInit,
         message: DOMString,
-        can_gc: CanGc,
     ) -> DomRoot<RTCError> {
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(RTCError::new_inherited(init, message)),
             window,
             proto,
-            can_gc,
+            cx,
         )
     }
 }
@@ -67,13 +67,13 @@ impl RTCError {
 impl RTCErrorMethods<crate::DomTypeHolder> for RTCError {
     /// <https://www.w3.org/TR/webrtc/#dom-rtcerror-constructor>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         init: &RTCErrorInit,
         message: DOMString,
     ) -> DomRoot<RTCError> {
-        RTCError::new_with_proto(window, proto, init, message, can_gc)
+        RTCError::new_with_proto(cx, window, proto, init, message)
     }
 
     /// <https://www.w3.org/TR/webrtc/#dom-rtcerror-errordetail>

--- a/components/script/dom/webrtc/rtcerrorevent.rs
+++ b/components/script/dom/webrtc/rtcerrorevent.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -17,7 +18,6 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::event::Event;
 use crate::dom::rtcerror::RTCError;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct RTCErrorEvent {
@@ -34,30 +34,30 @@ impl RTCErrorEvent {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         type_: Atom,
         bubbles: bool,
         cancelable: bool,
         error: &RTCError,
-        can_gc: CanGc,
     ) -> DomRoot<RTCErrorEvent> {
-        Self::new_with_proto(window, None, type_, bubbles, cancelable, error, can_gc)
+        Self::new_with_proto(cx, window, None, type_, bubbles, cancelable, error)
     }
 
     fn new_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         type_: Atom,
         bubbles: bool,
         cancelable: bool,
         error: &RTCError,
-        can_gc: CanGc,
     ) -> DomRoot<RTCErrorEvent> {
-        let event = reflect_dom_object_with_proto(
+        let event = reflect_dom_object_with_proto_and_cx(
             Box::new(RTCErrorEvent::new_inherited(error)),
             window,
             proto,
-            can_gc,
+            cx,
         );
         {
             let event = event.upcast::<Event>();
@@ -70,20 +70,20 @@ impl RTCErrorEvent {
 impl RTCErrorEventMethods<crate::DomTypeHolder> for RTCErrorEvent {
     /// <https://www.w3.org/TR/webrtc/#dom-rtcerrorevent-constructor>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         type_: DOMString,
         init: &RTCErrorEventInit,
     ) -> DomRoot<RTCErrorEvent> {
         RTCErrorEvent::new_with_proto(
+            cx,
             window,
             proto,
             Atom::from(type_),
             init.parent.bubbles,
             init.parent.cancelable,
             &init.error,
-            can_gc,
         )
     }
 

--- a/components/script/dom/webrtc/rtcicecandidate.rs
+++ b/components/script/dom/webrtc/rtcicecandidate.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
 
 use crate::dom::bindings::codegen::Bindings::RTCIceCandidateBinding::{
     RTCIceCandidateInit, RTCIceCandidateMethods,
@@ -13,7 +14,6 @@ use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct RTCIceCandidate {
@@ -41,34 +41,34 @@ impl RTCIceCandidate {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         candidate: DOMString,
         sdp_m_id: Option<DOMString>,
         sdp_m_line_index: Option<u16>,
         username_fragment: Option<DOMString>,
-        can_gc: CanGc,
     ) -> DomRoot<RTCIceCandidate> {
         Self::new_with_proto(
+            cx,
             window,
             None,
             candidate,
             sdp_m_id,
             sdp_m_line_index,
             username_fragment,
-            can_gc,
         )
     }
 
     fn new_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         candidate: DOMString,
         sdp_m_id: Option<DOMString>,
         sdp_m_line_index: Option<u16>,
         username_fragment: Option<DOMString>,
-        can_gc: CanGc,
     ) -> DomRoot<RTCIceCandidate> {
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(RTCIceCandidate::new_inherited(
                 candidate,
                 sdp_m_id,
@@ -77,7 +77,7 @@ impl RTCIceCandidate {
             )),
             window,
             proto,
-            can_gc,
+            cx,
         )
     }
 }
@@ -85,9 +85,9 @@ impl RTCIceCandidate {
 impl RTCIceCandidateMethods<crate::DomTypeHolder> for RTCIceCandidate {
     /// <https://w3c.github.io/webrtc-pc/#dom-rtcicecandidate-constructor>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         config: &RTCIceCandidateInit,
     ) -> Fallible<DomRoot<RTCIceCandidate>> {
         if config.sdpMid.is_none() && config.sdpMLineIndex.is_none() {
@@ -96,13 +96,13 @@ impl RTCIceCandidateMethods<crate::DomTypeHolder> for RTCIceCandidate {
             ));
         }
         Ok(RTCIceCandidate::new_with_proto(
+            cx,
             window,
             proto,
             config.candidate.clone(),
             config.sdpMid.clone(),
             config.sdpMLineIndex,
             config.usernameFragment.clone(),
-            can_gc,
         ))
     }
 

--- a/components/script/dom/webrtc/rtcpeerconnection.rs
+++ b/components/script/dom/webrtc/rtcpeerconnection.rs
@@ -11,7 +11,7 @@ use js::realm::CurrentRealm;
 use js::rust::HandleObject;
 use rustc_hash::FxHashMap;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use servo_media::ServoMedia;
 use servo_media::streams::MediaStreamType;
 use servo_media::streams::registry::MediaStreamId;
@@ -30,7 +30,7 @@ use crate::dom::bindings::codegen::Bindings::RTCPeerConnectionBinding::{
     RTCSignalingState,
 };
 use crate::dom::bindings::codegen::Bindings::RTCSessionDescriptionBinding::{
-    RTCSdpType, RTCSessionDescriptionInit, RTCSessionDescriptionMethods,
+    RTCSdpType, RTCSessionDescriptionInit,
 };
 use crate::dom::bindings::codegen::UnionTypes::{MediaStreamTrackOrString, StringOrStringSequence};
 use crate::dom::bindings::error::{Error, Fallible};
@@ -179,16 +179,16 @@ impl RTCPeerConnection {
     }
 
     fn new(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         config: &RTCConfiguration,
-        can_gc: CanGc,
     ) -> DomRoot<RTCPeerConnection> {
-        let this = reflect_dom_object_with_proto(
+        let this = reflect_dom_object_with_proto_and_cx(
             Box::new(RTCPeerConnection::new_inherited()),
             window,
             proto,
-            can_gc,
+            cx,
         );
         let signaller = this.make_signaller();
         *this.controller.borrow_mut() = Some(ServoMedia::get().create_webrtc(signaller));
@@ -227,30 +227,30 @@ impl RTCPeerConnection {
         })
     }
 
-    fn on_ice_candidate(&self, cx: &mut js::context::JSContext, candidate: IceCandidate) {
+    fn on_ice_candidate(&self, cx: &mut JSContext, candidate: IceCandidate) {
         if self.closed.get() {
             return;
         }
         let candidate = RTCIceCandidate::new(
+            cx,
             self.global().as_window(),
             candidate.candidate.into(),
             None,
             Some(candidate.sdp_mline_index as u16),
             None,
-            CanGc::from_cx(cx),
         );
         let event = RTCPeerConnectionIceEvent::new(
+            cx,
             self.global().as_window(),
             atom!("icecandidate"),
             Some(&candidate),
             None,
             true,
-            CanGc::from_cx(cx),
         );
         event.upcast::<Event>().fire(cx, self.upcast());
     }
 
-    fn on_negotiation_needed(&self, cx: &mut js::context::JSContext) {
+    fn on_negotiation_needed(&self, cx: &mut JSContext) {
         if self.closed.get() {
             return;
         }
@@ -302,12 +302,12 @@ impl RTCPeerConnection {
                 );
 
                 let event = RTCDataChannelEvent::new(
+                    cx,
                     self.global().as_window(),
                     atom!("datachannel"),
                     false,
                     false,
                     &channel,
-                    CanGc::from_cx(cx),
                 );
                 event.upcast::<Event>().fire(cx, self.upcast());
             },
@@ -351,7 +351,7 @@ impl RTCPeerConnection {
     }
 
     /// <https://www.w3.org/TR/webrtc/#update-ice-gathering-state>
-    fn update_gathering_state(&self, cx: &mut js::context::JSContext, state: GatheringState) {
+    fn update_gathering_state(&self, cx: &mut JSContext, state: GatheringState) {
         // step 1
         if self.closed.get() {
             return;
@@ -381,12 +381,12 @@ impl RTCPeerConnection {
         // step 6
         if state == RTCIceGatheringState::Complete {
             let event = RTCPeerConnectionIceEvent::new(
+                cx,
                 self.global().as_window(),
                 atom!("icecandidate"),
                 None,
                 None,
                 true,
-                CanGc::from_cx(cx),
             );
             event.upcast::<Event>().fire(cx, self.upcast());
         }
@@ -421,7 +421,7 @@ impl RTCPeerConnection {
         event.upcast::<Event>().fire(cx, self.upcast());
     }
 
-    fn update_signaling_state(&self, cx: &mut js::context::JSContext, state: SignalingState) {
+    fn update_signaling_state(&self, cx: &mut JSContext, state: SignalingState) {
         if self.closed.get() {
             return;
         }
@@ -506,12 +506,12 @@ impl RTCPeerConnection {
 impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
     /// <https://w3c.github.io/webrtc-pc/#dom-peerconnection>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         config: &RTCConfiguration,
     ) -> Fallible<DomRoot<RTCPeerConnection>> {
-        Ok(RTCPeerConnection::new(window, proto, config, can_gc))
+        Ok(RTCPeerConnection::new(cx, window, proto, config))
     }
 
     // https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-icecandidate
@@ -662,12 +662,13 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
                         // dance between pending/current local/remote descriptions
                         let this = this.root();
                         let desc = desc.convert();
-                        let desc = RTCSessionDescription::Constructor(
+                        let desc = RTCSessionDescription::new(
+                            current_realm,
                             this.global().as_window(),
                             None,
-                            CanGc::deprecated_note(),
-                            &desc,
-                        ).unwrap();
+                            desc.type_,
+                            desc.sdp,
+                        );
                         this.local_description.set(Some(&desc));
                         trusted_promise.root().resolve_native(current_realm, &())
                     }));
@@ -704,12 +705,13 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
                         // dance between pending/current local/remote descriptions
                         let this = this.root();
                         let desc = desc.convert();
-                        let desc = RTCSessionDescription::Constructor(
+                        let desc = RTCSessionDescription::new(
+                            current_realm,
                             this.global().as_window(),
                             None,
-                            CanGc::from_cx(current_realm),
-                            &desc,
-                        ).unwrap();
+                            desc.type_,
+                            desc.sdp,
+                        );
                         this.remote_description.set(Some(&desc));
                         trusted_promise.root().resolve_native(current_realm, &())
                     }));
@@ -745,7 +747,7 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
     }
 
     /// <https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-close>
-    fn Close(&self, cx: &mut js::context::JSContext) {
+    fn Close(&self, cx: &mut JSContext) {
         // Step 1
         if self.closed.get() {
             return;

--- a/components/script/dom/webrtc/rtcpeerconnectioniceevent.rs
+++ b/components/script/dom/webrtc/rtcpeerconnectioniceevent.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
@@ -18,7 +19,6 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::event::Event;
 use crate::dom::rtcicecandidate::RTCIceCandidate;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct RTCPeerConnectionIceEvent {
@@ -40,30 +40,30 @@ impl RTCPeerConnectionIceEvent {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         ty: Atom,
         candidate: Option<&RTCIceCandidate>,
         url: Option<DOMString>,
         trusted: bool,
-        can_gc: CanGc,
     ) -> DomRoot<RTCPeerConnectionIceEvent> {
-        Self::new_with_proto(window, None, ty, candidate, url, trusted, can_gc)
+        Self::new_with_proto(cx, window, None, ty, candidate, url, trusted)
     }
 
     fn new_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         ty: Atom,
         candidate: Option<&RTCIceCandidate>,
         url: Option<DOMString>,
         trusted: bool,
-        can_gc: CanGc,
     ) -> DomRoot<RTCPeerConnectionIceEvent> {
-        let e = reflect_dom_object_with_proto(
+        let e = reflect_dom_object_with_proto_and_cx(
             Box::new(RTCPeerConnectionIceEvent::new_inherited(candidate, url)),
             window,
             proto,
-            can_gc,
+            cx,
         );
         let evt = e.upcast::<Event>();
         evt.init_event(ty, false, false); // XXXManishearth bubbles/cancelable?
@@ -75,13 +75,14 @@ impl RTCPeerConnectionIceEvent {
 impl RTCPeerConnectionIceEventMethods<crate::DomTypeHolder> for RTCPeerConnectionIceEvent {
     /// <https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnectioniceevent-constructor>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         ty: DOMString,
         init: &RTCPeerConnectionIceEventInit,
     ) -> Fallible<DomRoot<RTCPeerConnectionIceEvent>> {
         Ok(RTCPeerConnectionIceEvent::new_with_proto(
+            cx,
             window,
             proto,
             ty.into(),
@@ -91,7 +92,6 @@ impl RTCPeerConnectionIceEventMethods<crate::DomTypeHolder> for RTCPeerConnectio
                 .map(|x| &**x),
             init.url.as_ref().and_then(|x| x.clone()),
             false,
-            can_gc,
         ))
     }
 

--- a/components/script/dom/webrtc/rtcsessiondescription.rs
+++ b/components/script/dom/webrtc/rtcsessiondescription.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
 
 use crate::dom::bindings::codegen::Bindings::RTCSessionDescriptionBinding::{
     RTCSdpType, RTCSessionDescriptionInit, RTCSessionDescriptionMethods,
@@ -13,7 +14,6 @@ use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct RTCSessionDescription {
@@ -31,18 +31,18 @@ impl RTCSessionDescription {
         }
     }
 
-    fn new(
+    pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         ty: RTCSdpType,
         sdp: DOMString,
-        can_gc: CanGc,
     ) -> DomRoot<RTCSessionDescription> {
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(RTCSessionDescription::new_inherited(ty, sdp)),
             window,
             proto,
-            can_gc,
+            cx,
         )
     }
 }
@@ -50,17 +50,17 @@ impl RTCSessionDescription {
 impl RTCSessionDescriptionMethods<crate::DomTypeHolder> for RTCSessionDescription {
     /// <https://w3c.github.io/webrtc-pc/#dom-sessiondescription>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         config: &RTCSessionDescriptionInit,
     ) -> Fallible<DomRoot<RTCSessionDescription>> {
         Ok(RTCSessionDescription::new(
+            cx,
             window,
             proto,
             config.type_,
             config.sdp.clone(),
-            can_gc,
         ))
     }
 

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -8,6 +8,7 @@ use std::ptr::{self, NonNull};
 
 use dom_struct::dom_struct;
 use ipc_channel::router::ROUTER;
+use js::context::JSContext;
 use js::jsapi::JSObject;
 use js::jsval::UndefinedValue;
 use js::realm::AutoRealm;
@@ -24,7 +25,7 @@ use net_traits::{
 use profile_traits::ipc as ProfiledIpc;
 use script_bindings::cell::DomRefCell;
 use script_bindings::conversions::SafeToJSValConvertible;
-use script_bindings::reflector::{DomObject, reflect_dom_object_with_proto};
+use script_bindings::reflector::{DomObject, reflect_dom_object_with_proto_and_cx};
 use servo_base::generic_channel::{LazyCallback, lazy_callback};
 use servo_constellation_traits::BlobImpl;
 use servo_url::{ImmutableOrigin, ServoUrl};
@@ -48,7 +49,6 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::messageevent::MessageEvent;
 use crate::dom::window::Window;
 use crate::fetch::RequestWithGlobalScope;
-use crate::script_runtime::CanGc;
 use crate::task::TaskOnce;
 use crate::task_source::SendableTaskSource;
 
@@ -130,17 +130,17 @@ impl WebSocket {
     }
 
     fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
         url: ServoUrl,
         sender: LazyCallback<WebSocketDomAction>,
-        can_gc: CanGc,
     ) -> DomRoot<WebSocket> {
-        let websocket = reflect_dom_object_with_proto(
+        let websocket = reflect_dom_object_with_proto_and_cx(
             Box::new(WebSocket::new_inherited(url, sender)),
             global,
             proto,
-            can_gc,
+            cx,
         );
         if let Some(window) = global.downcast::<Window>() {
             window.Document().track_websocket(&websocket);
@@ -198,9 +198,9 @@ impl WebSocket {
 impl WebSocketMethods<crate::DomTypeHolder> for WebSocket {
     /// <https://html.spec.whatwg.org/multipage/#dom-websocket>
     fn Constructor(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         url: DOMString,
         protocols: Option<StringOrStringSequence>,
     ) -> Fallible<DomRoot<WebSocket>> {
@@ -270,7 +270,7 @@ impl WebSocketMethods<crate::DomTypeHolder> for WebSocket {
             ProfiledIpc::channel(global.time_profiler_chan().clone()).unwrap();
 
         // Step 12. Establish a WebSocket connection given urlRecord, protocols, and client.
-        let ws = WebSocket::new(global, proto, url_record.clone(), dom_action_sender, can_gc);
+        let ws = WebSocket::new(cx, global, proto, url_record.clone(), dom_action_sender);
         let address = Trusted::new(&*ws);
 
         // https://websockets.spec.whatwg.org/#concept-websocket-establish
@@ -492,7 +492,7 @@ struct ReportCSPViolationTask {
 }
 
 impl TaskOnce for ReportCSPViolationTask {
-    fn run_once(self, cx: &mut js::context::JSContext) {
+    fn run_once(self, cx: &mut JSContext) {
         let global = self.websocket.root().global();
         global.report_csp_violations(cx, self.violations, None, None);
     }
@@ -507,7 +507,7 @@ struct ConnectionEstablishedTask {
 
 impl TaskOnce for ConnectionEstablishedTask {
     /// <https://html.spec.whatwg.org/multipage/#feedback-from-the-protocol:concept-websocket-established>
-    fn run_once(self, cx: &mut js::context::JSContext) {
+    fn run_once(self, cx: &mut JSContext) {
         let ws = self.address.root();
 
         // Step 1.
@@ -536,7 +536,7 @@ impl TaskOnce for BufferedAmountTask {
     // To be compliant with standards, we need to reset bufferedAmount only when the event loop
     // reaches step 1.  In our implementation, the bytes will already have been sent on a background
     // thread.
-    fn run_once(self, _cx: &mut js::context::JSContext) {
+    fn run_once(self, _cx: &mut JSContext) {
         let ws = self.address.root();
 
         ws.buffered_amount.set(0);
@@ -552,7 +552,7 @@ struct CloseTask {
 }
 
 impl TaskOnce for CloseTask {
-    fn run_once(self, cx: &mut js::context::JSContext) {
+    fn run_once(self, cx: &mut JSContext) {
         let ws = self.address.root();
 
         if ws.ready_state.get() == WebSocketRequestState::Closed {
@@ -596,7 +596,7 @@ struct MessageReceivedTask {
 
 impl TaskOnce for MessageReceivedTask {
     #[expect(unsafe_code)]
-    fn run_once(self, cx: &mut js::context::JSContext) {
+    fn run_once(self, cx: &mut JSContext) {
         let ws = self.address.root();
         debug!(
             "MessageReceivedTask::handler({:p}): readyState={:?}",

--- a/components/script/dom/webvtt/texttracklist.rs
+++ b/components/script/dom/webvtt/texttracklist.rs
@@ -79,7 +79,7 @@ impl TextTrackList {
                     let this = this.root();
 
                     if let Some(track) = this.item(idx) {
-                        let event = TrackEvent::new(
+                        let event = TrackEvent::new(cx,
                             this.global().as_window(),
                             atom!("addtrack"),
                             false,
@@ -87,7 +87,6 @@ impl TextTrackList {
                             &Some(VideoTrackOrAudioTrackOrTextTrack::TextTrack(
                                 DomRoot::from_ref(&track)
                             )),
-                            CanGc::from_cx(cx),
                         );
 
                         event.upcast::<Event>().fire(cx, this.upcast::<EventTarget>());

--- a/components/script/dom/webvtt/trackevent.rs
+++ b/components/script/dom/webvtt/trackevent.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use stylo_atoms::Atom;
 
 use crate::dom::audio::audiotrack::AudioTrack;
@@ -20,7 +21,6 @@ use crate::dom::event::Event;
 use crate::dom::texttrack::TextTrack;
 use crate::dom::videotrack::VideoTrack;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 #[derive(JSTraceable, MallocSizeOf)]
@@ -60,30 +60,30 @@ impl TrackEvent {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         type_: Atom,
         bubbles: bool,
         cancelable: bool,
         track: &Option<VideoTrackOrAudioTrackOrTextTrack>,
-        can_gc: CanGc,
     ) -> DomRoot<TrackEvent> {
-        Self::new_with_proto(window, None, type_, bubbles, cancelable, track, can_gc)
+        Self::new_with_proto(cx, window, None, type_, bubbles, cancelable, track)
     }
 
     fn new_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         type_: Atom,
         bubbles: bool,
         cancelable: bool,
         track: &Option<VideoTrackOrAudioTrackOrTextTrack>,
-        can_gc: CanGc,
     ) -> DomRoot<TrackEvent> {
-        let te = reflect_dom_object_with_proto(
+        let te = reflect_dom_object_with_proto_and_cx(
             Box::new(TrackEvent::new_inherited(track)),
             window,
             proto,
-            can_gc,
+            cx,
         );
         {
             let event = te.upcast::<Event>();
@@ -96,20 +96,20 @@ impl TrackEvent {
 impl TrackEventMethods<crate::DomTypeHolder> for TrackEvent {
     /// <https://html.spec.whatwg.org/multipage/#trackevent>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         type_: DOMString,
         init: &TrackEventBinding::TrackEventInit,
     ) -> Fallible<DomRoot<TrackEvent>> {
         Ok(TrackEvent::new_with_proto(
+            cx,
             window,
             proto,
             Atom::from(type_),
             init.parent.bubbles,
             init.parent.cancelable,
             &init.track,
-            can_gc,
         ))
     }
 

--- a/components/script/dom/webvtt/vttcue.rs
+++ b/components/script/dom/webvtt/vttcue.rs
@@ -5,9 +5,10 @@
 use std::cell::Cell;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 
 use crate::dom::bindings::codegen::Bindings::VTTCueBinding::{
     self, AlignSetting, AutoKeyword, DirectionSetting, LineAlignSetting, PositionAlignSetting,
@@ -21,7 +22,6 @@ use crate::dom::documentfragment::DocumentFragment;
 use crate::dom::texttrackcue::TextTrackCue;
 use crate::dom::vttregion::VTTRegion;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct VTTCue {
@@ -61,18 +61,18 @@ impl VTTCue {
     }
 
     fn new(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         start_time: f64,
         end_time: f64,
         text: DOMString,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(Self::new_inherited(start_time, end_time, text)),
             window,
             proto,
-            can_gc,
+            cx,
         )
     }
 }
@@ -80,14 +80,14 @@ impl VTTCue {
 impl VTTCueMethods<crate::DomTypeHolder> for VTTCue {
     /// <https://w3c.github.io/webvtt/#dom-vttcue-vttcue>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         start_time: Finite<f64>,
         end_time: Finite<f64>,
         text: DOMString,
     ) -> DomRoot<Self> {
-        VTTCue::new(window, proto, *start_time, *end_time, text, can_gc)
+        VTTCue::new(cx, window, proto, *start_time, *end_time, text)
     }
 
     /// <https://w3c.github.io/webvtt/#dom-vttcue-region>

--- a/components/script/dom/webvtt/vttregion.rs
+++ b/components/script/dom/webvtt/vttregion.rs
@@ -5,9 +5,10 @@
 use std::cell::Cell;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
 
 use crate::dom::bindings::codegen::Bindings::VTTRegionBinding::{ScrollSetting, VTTRegionMethods};
 use crate::dom::bindings::error::{Error, ErrorResult, Fallible};
@@ -15,7 +16,6 @@ use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct VTTRegion {
@@ -45,19 +45,19 @@ impl VTTRegion {
         }
     }
 
-    fn new(window: &Window, proto: Option<HandleObject>, can_gc: CanGc) -> DomRoot<Self> {
-        reflect_dom_object_with_proto(Box::new(Self::new_inherited()), window, proto, can_gc)
+    fn new(cx: &mut JSContext, window: &Window, proto: Option<HandleObject>) -> DomRoot<Self> {
+        reflect_dom_object_with_proto_and_cx(Box::new(Self::new_inherited()), window, proto, cx)
     }
 }
 
 impl VTTRegionMethods<crate::DomTypeHolder> for VTTRegion {
     /// <https://w3c.github.io/webvtt/#dom-vttregion-vttregion>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<Self>> {
-        Ok(VTTRegion::new(window, proto, can_gc))
+        Ok(VTTRegion::new(cx, window, proto))
     }
 
     /// <https://w3c.github.io/webvtt/#dom-vttregion-id>

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -3440,13 +3440,13 @@ impl Window {
         // Sending change events for all changed Media Queries
         for mql in mql_list.iter() {
             let event = MediaQueryListEvent::new(
+                cx,
                 &mql.global(),
                 atom!("change"),
                 false,
                 false,
                 mql.Media(),
                 mql.Matches(),
-                CanGc::from_cx(cx),
             );
             event
                 .upcast::<Event>()

--- a/components/script/dom/xmlhttprequest/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest/xmlhttprequest.rs
@@ -37,7 +37,7 @@ use net_traits::{
 use script_bindings::cell::DomRefCell;
 use script_bindings::conversions::SafeToJSValConvertible;
 use script_bindings::num::Finite;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use script_bindings::trace::RootedTraceableBox;
 use script_traits::DocumentActivity;
 use servo_constellation_traits::BlobImpl;
@@ -241,13 +241,13 @@ pub(crate) struct XMLHttpRequest {
 }
 
 impl XMLHttpRequest {
-    fn new_inherited(global: &GlobalScope, can_gc: CanGc) -> XMLHttpRequest {
+    fn new_inherited(global: &GlobalScope, upload: &XMLHttpRequestUpload) -> XMLHttpRequest {
         XMLHttpRequest {
             eventtarget: XMLHttpRequestEventTarget::new_inherited(),
             ready_state: Cell::new(XMLHttpRequestState::Unsent),
             timeout: Cell::new(Duration::ZERO),
             with_credentials: Cell::new(false),
-            upload: Dom::from_ref(&*XMLHttpRequestUpload::new(global, can_gc)),
+            upload: Dom::from_ref(upload),
             response_url: DomRefCell::new(String::new()),
             status: DomRefCell::new(HttpStatus::new_error()),
             response: DomRefCell::new(vec![]),
@@ -279,15 +279,16 @@ impl XMLHttpRequest {
     }
 
     fn new(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<XMLHttpRequest> {
-        reflect_dom_object_with_proto(
-            Box::new(XMLHttpRequest::new_inherited(global, can_gc)),
+        let upload = XMLHttpRequestUpload::new(cx, global);
+        reflect_dom_object_with_proto_and_cx(
+            Box::new(XMLHttpRequest::new_inherited(global, &upload)),
             global,
             proto,
-            can_gc,
+            cx,
         )
     }
 
@@ -299,11 +300,11 @@ impl XMLHttpRequest {
 impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
     /// <https://xhr.spec.whatwg.org/#constructors>
     fn Constructor(
+        cx: &mut JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<XMLHttpRequest>> {
-        Ok(XMLHttpRequest::new(global, proto, can_gc))
+        Ok(XMLHttpRequest::new(cx, global, proto))
     }
 
     // https://xhr.spec.whatwg.org/#handler-xhr-onreadystatechange

--- a/components/script/dom/xmlhttprequest/xmlhttprequestupload.rs
+++ b/components/script/dom/xmlhttprequest/xmlhttprequestupload.rs
@@ -3,12 +3,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use script_bindings::reflector::reflect_dom_object;
+use js::context::JSContext;
+use script_bindings::reflector::reflect_dom_object_with_cx;
 
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::xmlhttprequesteventtarget::XMLHttpRequestEventTarget;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct XMLHttpRequestUpload {
@@ -21,11 +21,7 @@ impl XMLHttpRequestUpload {
             eventtarget: XMLHttpRequestEventTarget::new_inherited(),
         }
     }
-    pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<XMLHttpRequestUpload> {
-        reflect_dom_object(
-            Box::new(XMLHttpRequestUpload::new_inherited()),
-            global,
-            can_gc,
-        )
+    pub(crate) fn new(cx: &mut JSContext, global: &GlobalScope) -> DomRoot<XMLHttpRequestUpload> {
+        reflect_dom_object_with_cx(Box::new(XMLHttpRequestUpload::new_inherited()), global, cx)
     }
 }

--- a/components/script/dom/xmlserializer.rs
+++ b/components/script/dom/xmlserializer.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto};
+use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
 use xml5ever::serialize::{SerializeOpts, TraversalScope, serialize};
 
 use crate::dom::bindings::codegen::Bindings::XMLSerializerBinding::XMLSerializerMethods;
@@ -14,7 +15,6 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::node::Node;
 use crate::dom::servoparser::html::HtmlSerialize;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct XMLSerializer {
@@ -31,15 +31,15 @@ impl XMLSerializer {
     }
 
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<XMLSerializer> {
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(XMLSerializer::new_inherited(window)),
             window,
             proto,
-            can_gc,
+            cx,
         )
     }
 }
@@ -47,11 +47,11 @@ impl XMLSerializer {
 impl XMLSerializerMethods<crate::DomTypeHolder> for XMLSerializer {
     /// <https://w3c.github.io/DOM-Parsing/#dom-xmlserializer>
     fn Constructor(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<XMLSerializer>> {
-        Ok(XMLSerializer::new(window, proto, can_gc))
+        Ok(XMLSerializer::new(cx, window, proto))
     }
 
     /// <https://w3c.github.io/DOM-Parsing/#the-xmlserializer-interface>

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -92,7 +92,6 @@ use crate::dom::validitystate::ValidationFlags;
 use crate::dom::window::Window;
 use crate::dom::xmlserializer::XMLSerializer;
 use crate::realms::enter_auto_realm;
-use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 
 /// <https://w3c.github.io/webdriver/#dfn-is-stale>
@@ -1377,7 +1376,7 @@ pub(crate) fn handle_get_page_source(
                     Some(element) => match element.outer_html(cx) {
                         Ok(source) => Ok(String::from(source)),
                         Err(_) => {
-                            match XMLSerializer::new(document.window(), None, CanGc::from_cx(cx))
+                            match XMLSerializer::new(cx, document.window(), None)
                                 .SerializeToString(element.upcast::<Node>())
                             {
                                 Ok(source) => Ok(String::from(source)),

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -15,7 +15,6 @@
 DOMInterfaces = {
 
 'AbortController': {
-    'cx': ['Constructor'],
     'realm': ['Abort'],
 },
 
@@ -28,24 +27,8 @@ DOMInterfaces = {
     'weakReferenceable': True,
 },
 
-'AnalyserNode': {
-    'cx': ['Constructor'],
-},
-
 'ANGLEInstancedArrays': {
     'cx': ['DrawArraysInstancedANGLE', 'DrawElementsInstancedANGLE', 'VertexAttribDivisorANGLE']
-},
-
-'Animation': {
-    'cx': ['Constructor']
-},
-
-'AnimationEffect': {
-    'cx': ['Constructor']
-},
-
-'AnimationEvent': {
-    'cx': ['Constructor']
 },
 
 'Attr': {
@@ -53,16 +36,16 @@ DOMInterfaces = {
 },
 
 'AudioBuffer': {
-    'cx': ['Constructor', 'CopyFromChannel', 'CopyToChannel', 'GetChannelData'],
+    'cx': ['CopyFromChannel', 'CopyToChannel', 'GetChannelData'],
 },
 
 'AudioBufferSourceNode': {
-    'cx': ['Constructor', 'SetBuffer', 'Start'],
+    'cx': ['SetBuffer', 'Start'],
 },
 
 'AudioContext': {
     'realm': ['Close', 'Suspend'],
-    'cx':['Constructor', 'CreateMediaElementSource', 'CreateMediaStreamDestination', 'CreateMediaStreamSource', 'CreateMediaStreamTrackSource'],
+    'cx':['CreateMediaElementSource', 'CreateMediaStreamDestination', 'CreateMediaStreamSource', 'CreateMediaStreamTrackSource'],
 },
 
 'BaseAudioContext': {
@@ -70,26 +53,14 @@ DOMInterfaces = {
     'realm': ['DecodeAudioData', 'Resume'],
 },
 
-'BeforeUnloadEvent': {
-    'cx': ['Constructor']
-},
-
-'BiquadFilterNode': {
-    'cx': ['Constructor'],
-},
-
 'Blob': {
     'weakReferenceable': True,
     'realm': ['ArrayBuffer', 'Bytes', 'Text'],
-    'cx': ['Stream', 'Slice', 'TextStream', 'Constructor']
+    'cx': ['Stream', 'Slice', 'TextStream']
 },
 
 'Bluetooth': {
     'realm': ['GetAvailability', 'RequestDevice'],
-},
-
-'BluetoothAdvertisingEvent': {
-    'cx': ['Constructor'],
 },
 
 'BluetoothDevice': {
@@ -115,23 +86,15 @@ DOMInterfaces = {
 },
 
 'BroadcastChannel': {
-    'cx': ['Constructor', 'PostMessage'],
+    'cx': ['PostMessage'],
 },
 
 'ByteLengthQueuingStrategy': {
-    'cx': ['Constructor', 'GetSize'],
+    'cx': ['GetSize'],
 },
 
 'CanvasRenderingContext2D': {
     'cx': ['GetTransform', 'MeasureText', 'CreateLinearGradient', 'CreatePattern', 'CreateRadialGradient', 'CreateImageData', 'GetImageData', 'CreateImageData_'],
-},
-
-'ChannelMergerNode': {
-    'cx': ['Constructor'],
-},
-
-'ChannelSplitterNode': {
-    'cx': ['Constructor'],
 },
 
 'CharacterData': {
@@ -146,41 +109,13 @@ DOMInterfaces = {
     'realm': ['ReadText', 'WriteText']
 },
 
-'ClipboardEvent': {
-    'cx': ['Constructor']
-},
-
 'ClipboardItem': {
-    'cx': ['Constructor', 'Types'],
+    'cx': ['Types'],
     'realm': ['GetType']
-},
-
-'CloseEvent': {
-    'cx': ['Constructor']
-},
-
-'CommandEvent': {
-    'cx': ['Constructor']
-},
-
-'Comment': {
-    'cx': ['Constructor']
-},
-
-'CompositionEvent': {
-    'cx': ['Constructor']
-},
-
-'CompressionStream': {
-    'cx': ['Constructor'],
 },
 
 'console': {
     'cx': ['Assert', 'Count', 'CountReset', 'Debug', 'Dir', 'Error', 'Group', 'GroupCollapsed', 'Info', 'Log', 'Time', 'TimeEnd', 'TimeLog', 'Trace', 'Warn'],
-},
-
-'ConstantSourceNode': {
-    'cx': ['Constructor'],
 },
 
 'CookieStore': {
@@ -188,7 +123,7 @@ DOMInterfaces = {
 },
 
 'CountQueuingStrategy': {
-    'cx': ['Constructor', 'GetSize'],
+    'cx': ['GetSize'],
 },
 
 'Credential': {
@@ -254,16 +189,12 @@ DOMInterfaces = {
 },
 
 'CustomElementRegistry': {
-    'cx': ['Constructor', 'Define', 'Get'],
+    'cx': ['Define', 'Get'],
     'realm': ['WhenDefined']
 },
 
-'CustomEvent': {
-    'cx': ['Constructor']
-},
-
 'DataTransfer': {
-    'cx': ['Constructor', 'Files', 'Types']
+    'cx': ['Files', 'Types']
 },
 
 'DataTransferItem': {
@@ -277,10 +208,6 @@ DOMInterfaces = {
 'DebuggerGlobalScope': {
     'additionalTraits': ["crate::interfaces::HasOrigin"],
     'useSystemCompartment': True,
-},
-
-'DecompressionStream': {
-    'cx': ['Constructor'],
 },
 
 'DedicatedWorkerGlobalScope': {
@@ -377,41 +304,37 @@ DOMInterfaces = {
     'cx': ['After', 'Before', 'Remove', 'ReplaceWith']
 },
 
-'DOMException': {
-    'cx': ['Constructor'],
-},
-
 'DOMImplementation': {
     'cx': ['CreateDocument', 'CreateDocumentType', 'CreateHTMLDocument'],
 },
 
 'DOMMatrix': {
-    'cx': ['Constructor', 'FromMatrix', 'FromFloat32Array', 'FromFloat64Array'],
+    'cx': ['FromMatrix', 'FromFloat32Array', 'FromFloat64Array'],
 },
 
 'DOMMatrixReadOnly': {
-    'cx': ['Constructor', 'Stringifier', 'TransformPoint', 'Multiply', 'Inverse', 'Scale', 'Translate', 'Rotate', 'RotateFromVector', 'FlipY', 'ScaleNonUniform', 'Scale3d', 'RotateAxisAngle', 'SkewX', 'SkewY', 'FlipX', 'FromFloat32Array', 'FromFloat64Array', 'FromMatrix', 'ToFloat32Array', 'ToFloat64Array'],
+    'cx': ['Stringifier', 'TransformPoint', 'Multiply', 'Inverse', 'Scale', 'Translate', 'Rotate', 'RotateFromVector', 'FlipY', 'ScaleNonUniform', 'Scale3d', 'RotateAxisAngle', 'SkewX', 'SkewY', 'FlipX', 'FromFloat32Array', 'FromFloat64Array', 'FromMatrix', 'ToFloat32Array', 'ToFloat64Array'],
 },
 
 'DOMParser': {
-    'cx': ['Constructor', 'ParseFromString'],
+    'cx': ['ParseFromString'],
 },
 
 'DOMPoint': {
-    'cx': ['Constructor', 'FromPoint'],
+    'cx': ['FromPoint'],
 },
 'DOMPointReadOnly': {
-    'cx': ['Constructor', 'FromPoint', 'MatrixTransform'],
+    'cx': ['FromPoint', 'MatrixTransform'],
 },
 
 'DOMQuad': {
-    'cx': ['Constructor', 'FromRect', 'FromQuad', 'GetBounds'],
+    'cx': ['FromRect', 'FromQuad', 'GetBounds'],
 },
 'DOMRect': {
-    'cx': ['Constructor', 'FromRect'],
+    'cx': ['FromRect'],
 },
 'DOMRectReadOnly': {
-    'cx': ['Constructor', 'FromRect'],
+    'cx': ['FromRect'],
 },
 
 'DOMStringMap': {
@@ -533,28 +456,16 @@ DOMInterfaces = {
     'cx': ['CheckValidity', 'GetValidity', 'ReportValidity', 'SetValidity'],
 },
 
-'ErrorEvent': {
-    'cx': ['Constructor']
-},
-
-'Event': {
-    'cx': ['Constructor']
-},
-
 'EventSource': {
     'weakReferenceable': True,
 },
 
 'EventTarget': {
-    'cx': ['Constructor', 'DispatchEvent'],
-},
-
-'ExtendableEvent': {
-    'cx': ['Constructor']
+    'cx': ['DispatchEvent'],
 },
 
 'ExtendableMessageEvent': {
-    'cx': ['Constructor', 'Data', 'Ports'],
+    'cx': ['Data', 'Ports'],
 },
 
 'FakeXRDevice': {
@@ -574,36 +485,16 @@ DOMInterfaces = {
     'cx': ['ReadAsArrayBuffer'],
 },
 
-'FocusEvent': {
-    'cx': ['Constructor'],
-},
-
 'FontFace': {
-    'cx': ['Constructor', 'Load'],
+    'cx': ['Load'],
 },
 
 'FontFaceSet': {
     'cx': ['Add', 'Load'],
 },
 
-'FormData': {
-    'cx': ['Constructor'],
-},
-
-'FormDataEvent': {
-    'cx': ['Constructor']
-},
-
-'GainNode': {
-    'cx': ['Constructor'],
-},
-
 'Gamepad': {
     'cx': ['Axes', 'Buttons']
-},
-
-'GamepadEvent': {
-    'cx': ['Constructor'],
 },
 
 'GamepadHapticActuator': {
@@ -669,18 +560,6 @@ DOMInterfaces = {
     'weakReferenceable': True, # for usage in GlobalScope https://github.com/servo/servo/issues/32519
 },
 
-'GPUInternalError': {
-    'cx': ['Constructor'],
-},
-
-'GPUOutOfMemoryError': {
-    'cx': ['Constructor'],
-},
-
-'GPUPipelineError': {
-    'cx': ['Constructor'],
-},
-
 'GPUQueue': {
     'cx': ['OnSubmittedWorkDone', 'CopyExternalImageToTexture'],
 },
@@ -695,18 +574,6 @@ DOMInterfaces = {
 
 'GPUTexture': {
     'cx': ['CreateView'],
-},
-
-'GPUUncapturedErrorEvent': {
-    'cx': ['Constructor'],
-},
-
-'GPUValidationError': {
-    'cx': ['Constructor'],
-},
-
-'HashChangeEvent': {
-    'cx': ['Constructor'],
 },
 
 'History': {
@@ -980,35 +847,11 @@ DOMInterfaces = {
     'cx': ['Abort', 'ObjectStore', 'ObjectStoreNames'],
 },
 
-'IDBVersionChangeEvent': {
-    'cx': ['Constructor'],
-},
-
-'IIRFilterNode': {
-    'cx': ['Constructor'],
-},
-
-'ImageData': {
-    'cx': ['Constructor', 'Constructor_']
-},
-
-'InputEvent': {
-    'cx': ['Constructor']
-},
-
 'IntersectionObserver': {
-    'cx': ['Constructor', 'Thresholds']
+    'cx': ['Thresholds']
 },
-'IntersectionObserverEntry': {
-    'cx': ['Constructor'],
-},
-
-'KeyboardEvent': {
-    'cx': ['Constructor'],
-},
-
 'KeyframeEffect': {
-    'cx': ['Constructor', 'SetKeyframes']
+    'cx': ['SetKeyframes']
 },
 
 'LayoutResult': {
@@ -1025,28 +868,12 @@ DOMInterfaces = {
     'cx': ['EnumerateDevices'],
 },
 
-'MediaElementAudioSourceNode': {
-    'cx': ['Constructor'],
-},
-
 'MediaList': {
     'cx': [
         'AppendMedium',
         'DeleteMedium',
         'SetMediaText',
     ],
-},
-
-'MediaStreamAudioSourceNode': {
-    'cx': ['Constructor'],
-},
-
-'MediaStreamAudioDestinationNode': {
-    'cx': ['Constructor'],
-},
-
-'MediaStreamTrackAudioSourceNode': {
-    'cx': ['Constructor'],
 },
 
 'MediaQueryList': {
@@ -1062,11 +889,7 @@ DOMInterfaces = {
 },
 
 'MediaStream': {
-    'cx': ['Constructor', 'Constructor_', 'Constructor__', 'Clone'],
-},
-
-'MessageChannel': {
-    'cx': ['Constructor']
+    'cx': ['Clone'],
 },
 
 'MessagePort': {
@@ -1076,11 +899,7 @@ DOMInterfaces = {
 },
 
 'MessageEvent': {
-    'cx': ['Constructor', 'Data', 'InitMessageEvent', 'Ports'],
-},
-
-'MouseEvent': {
-    'cx': ['Constructor'],
+    'cx': ['Data', 'InitMessageEvent', 'Ports'],
 },
 
 'NamedNodeMap': {
@@ -1123,36 +942,23 @@ DOMInterfaces = {
 },
 
 'Notification': {
-    'cx': ['Actions', 'Constructor', 'RequestPermission', 'Vibrate']
+    'cx': ['Actions', 'RequestPermission', 'Vibrate']
 },
 
 'OESVertexArrayObject': {
     'cx': ['CreateVertexArrayOES', 'DeleteVertexArrayOES']
 },
 
-'OfflineAudioCompletionEvent': {
-    'cx': ['Constructor',],
-},
-
 'OfflineAudioContext': {
-    'cx': ['Constructor', 'Constructor_'],
     'realm': ['StartRendering'],
 },
 
 'OffscreenCanvas': {
-    'cx': ['Constructor', 'ConvertToBlob', 'GetContext', 'SetHeight', 'SetWidth', 'TransferToImageBitmap'],
+    'cx': ['ConvertToBlob', 'GetContext', 'SetHeight', 'SetWidth', 'TransferToImageBitmap'],
 },
 
 'OffscreenCanvasRenderingContext2D': {
     'cx': ['CreateImageData', 'CreateImageData_', 'GetImageData', 'GetTransform', 'MeasureText', 'CreateLinearGradient', 'CreatePattern', 'CreateRadialGradient'],
-},
-
-'OscillatorNode': {
-    'cx': ['Constructor'],
-},
-
-'PageTransitionEvent': {
-    'cx': ['Constructor'],
 },
 
 'PaintRenderingContext2D': {
@@ -1164,50 +970,22 @@ DOMInterfaces = {
     'cx': ['RegisterPaint'],
 },
 
-'PannerNode': {
-    'cx': ['Constructor'],
-},
-
-'Path2D': {
-    'cx': ['Constructor', 'Constructor_', 'Constructor__']
-},
-
 'Performance': {
     'cx': ['Mark', 'Measure'],
 },
 
-'PerformanceMark': {
-    'cx': ['Constructor'],
-},
-
 'PerformanceObserver': {
-    'cx': ['Constructor', 'Observe', 'SupportedEntryTypes'],
+    'cx': ['Observe', 'SupportedEntryTypes'],
 },
 
 'Permissions': {
     'realm': ['Query', 'Request', 'Revoke'],
 },
 
-'PointerEvent': {
-    'cx': ['Constructor'],
-},
-
-'PopStateEvent': {
-    'cx': ['Constructor'],
-},
-
-'ProgressEvent': {
-    'cx': ['Constructor'],
-},
-
 'Promise': {
     'spiderMonkeyInterface': True,
     'additionalTraits': ["js::conversions::FromJSValConvertibleRc"],
     'allowDropImpl': True,
-},
-
-'PromiseRejectionEvent': {
-    'cx': ['Constructor'],
 },
 
 'RadioNodeList': {
@@ -1217,15 +995,15 @@ DOMInterfaces = {
 
 'Range': {
     'weakReferenceable': True,
-    'cx': ['Constructor', 'CloneContents', 'CloneRange', 'CreateContextualFragment', 'DeleteContents', 'ExtractContents', 'GetBoundingClientRect', 'GetClientRects', 'InsertNode', 'SurroundContents'],
+    'cx': ['CloneContents', 'CloneRange', 'CreateContextualFragment', 'DeleteContents', 'ExtractContents', 'GetBoundingClientRect', 'GetClientRects', 'InsertNode', 'SurroundContents'],
 },
 
 'Request': {
-    'cx': ['Constructor', 'Headers', 'Clone', 'Text', 'Blob', 'FormData', 'Json', 'ArrayBuffer', 'Bytes', 'TextStream'],
+    'cx': ['Headers', 'Clone', 'Text', 'Blob', 'FormData', 'Json', 'ArrayBuffer', 'Bytes', 'TextStream'],
 },
 
 'Response': {
-    'cx': ['Constructor', 'CreateFromJson', 'Clone', 'Error', 'Redirect', 'Text', 'Blob', 'FormData', 'Json', 'ArrayBuffer', 'Bytes', 'Headers', 'TextStream'],
+    'cx': ['CreateFromJson', 'Clone', 'Error', 'Redirect', 'Text', 'Blob', 'FormData', 'Json', 'ArrayBuffer', 'Bytes', 'Headers', 'TextStream'],
 },
 
 'RTCPeerConnection': {
@@ -1238,12 +1016,8 @@ DOMInterfaces = {
     'cx': ['SetParameters'],
 },
 
-'RTCTrackEvent': {
-    'cx': ['Constructor'],
-},
-
 'Sanitizer': {
-    'cx': ['Constructor', 'AllowElement'],
+    'cx': ['AllowElement'],
 },
 
 'Selection': {
@@ -1289,16 +1063,7 @@ DOMInterfaces = {
 },
 
 'StaticRange': {
-    'cx': ['Constructor'],
     'weakReferenceable': True,
-},
-
-'StereoPannerNode': {
-    'cx': ['Constructor'],
-},
-
-'StorageEvent': {
-    'cx': ['Constructor'],
 },
 
 'StorageManager': {
@@ -1307,10 +1072,6 @@ DOMInterfaces = {
 
 'StyleSheet': {
     'cx': ['Media'],
-},
-
-'SubmitEvent': {
-    'cx': ['Constructor'],
 },
 
 'SubtleCrypto': {
@@ -1327,9 +1088,6 @@ DOMInterfaces = {
     'additionalTraits': ['crate::interfaces::TestBindingHelpers'],
     'cx': [
         'ArrayAttribute',
-        'Constructor',
-        'Constructor_',
-        'Constructor__',
         'GetDictionaryWithTypedArray',
         'GetInterfaceAttributeNullable',
         'InterfaceAttribute',
@@ -1355,7 +1113,6 @@ DOMInterfaces = {
 },
 
 'TestWorklet': {
-    'cx': ['Constructor'],
     'realm': ['AddModule'],
 },
 
@@ -1364,36 +1121,12 @@ DOMInterfaces = {
 },
 
 'Text': {
-    'cx': ['Constructor', 'SplitText'],
+    'cx': ['SplitText'],
     'cx_no_gc': ['WholeText']
-},
-
-'TextDecoderStream': {
-    'cx': ['Constructor'],
 },
 
 'TextEncoder': {
     'cx': ['Encode']
-},
-
-'TextEncoderStream': {
-    'cx': ['Constructor'],
-},
-
-'ToggleEvent': {
-    'cx': ['Constructor'],
-},
-
-'TouchEvent': {
-    'cx': ['Constructor'],
-},
-
-'TransformStream': {
-    'cx': ['Constructor'],
-},
-
-'TransitionEvent': {
-    'cx': ['Constructor'],
 },
 
 'TreeWalker': {
@@ -1408,25 +1141,9 @@ DOMInterfaces = {
     'cx': ['CreatePolicy', 'EmptyHTML', 'EmptyScript']
 },
 
-'UIEvent': {
-    'cx': ['Constructor'],
-},
-
 'URL': {
     'weakReferenceable': True,
-    'cx': ['Constructor', 'Parse', 'SearchParams'],
-},
-
-'URLPattern': {
-    'cx': ['Constructor', 'Constructor_']
-},
-
-'URLSearchParams': {
-    'cx': ['Constructor'],
-},
-
-'WebGLContextEvent': {
-    'cx': ['Constructor'],
+    'cx': ['Parse', 'SearchParams'],
 },
 
 'WebGLRenderingContext': {
@@ -1554,10 +1271,6 @@ DOMInterfaces = {
     'weakReferenceable': True,
 },
 
-'WheelEvent': {
-    'cx': ['Constructor'],
-},
-
 'WindowClient': {
     'cx': ['Focus', 'Navigate'],
 },
@@ -1606,16 +1319,12 @@ DOMInterfaces = {
     'register': False,
 },
 
-'SharedWorker': {
-    'cx': ['Constructor'],
-},
-
 'SharedWorkerGlobalScope': {
     'additionalTraits': ["crate::interfaces::HasOrigin"],
 },
 
 'Worker': {
-    'cx': ['Constructor', 'PostMessage', 'PostMessage_'],
+    'cx': ['PostMessage', 'PostMessage_'],
 },
 
 'WorkerGlobalScope': {
@@ -1635,12 +1344,8 @@ DOMInterfaces = {
     'cx': ['Abort', 'Open', 'Open_', 'Send', 'GetResponseXML', 'Response'],
 },
 
-'XRMediaBinding': {
-    'cx': ['Constructor'],
-},
-
 'XPathEvaluator': {
-    'cx': ['Constructor', 'CreateExpression', 'Evaluate'],
+    'cx': ['CreateExpression', 'Evaluate'],
 },
 
 'XPathExpression': {
@@ -1667,28 +1372,12 @@ DOMInterfaces = {
     'cx': ['GetHand', 'GetGripSpace', 'TargetRaySpace'],
 },
 
-'XRInputSourceEvent': {
-    'cx': ['Constructor'],
-},
-
-'XRInputSourcesChangeEvent': {
-    'cx': ['Constructor'],
-},
-
-'XRLayerEvent': {
-    'cx': ['Constructor'],
-},
-
 'XRRay': {
-    'cx': ['Constructor', 'Constructor_', 'Origin', 'Direction', 'Matrix'],
+    'cx': ['Origin', 'Direction', 'Matrix'],
 },
 
 'XRReferenceSpace': {
     'cx': ['GetOffsetReferenceSpace'],
-},
-
-'XRReferenceSpaceEvent': {
-    'cx': ['Constructor'],
 },
 
 'XRRenderState': {
@@ -1696,17 +1385,13 @@ DOMInterfaces = {
 },
 
 'XRRigidTransform': {
-    'cx': ['Constructor', 'Inverse', 'Matrix', 'Orientation', 'Position'],
+    'cx': ['Inverse', 'Matrix', 'Orientation', 'Position'],
 },
 
 'XRSession': {
     'cx': ['EnabledFeatures', 'GetSupportedFrameRates', 'UpdateRenderState'],
     'realm': ['End', 'RequestHitTestSource', 'RequestReferenceSpace', 'UpdateTargetFrameRate'],
     'weakReferenceable': True,
-},
-
-'XRSessionEvent': {
-    'cx': ['Constructor'],
 },
 
 'XRSystem': {
@@ -1723,17 +1408,13 @@ DOMInterfaces = {
     'cx': ['ProjectionMatrix'],
 },
 
-'XRWebGLBinding': {
-    'cx': ['Constructor'],
-},
-
 'XRWebGLLayer': {
-    'cx': ['Constructor', 'GetViewport'],
+    'cx': ['GetViewport'],
 },
 
 'ReadableStream': {
     'realm': ['PipeTo', 'PipeThrough'],
-    'cx': ['Cancel', 'Constructor', 'GetReader', 'Tee']
+    'cx': ['Cancel', 'GetReader', 'Tee']
 },
 
 "ReadableStreamDefaultController": {
@@ -1764,16 +1445,11 @@ DOMInterfaces = {
     'cx': ['BorderBoxSize', 'ContentBoxSize', 'DevicePixelContentBoxSize'],
 },
 
-'SecurityPolicyViolationEvent': {
-    'cx': ['Constructor']
-},
-
 'WebSocket': {
     'weakReferenceable': True,
 },
 
 'WritableStream': {
-    'cx': ['Constructor'],
     'realm': ['Abort', 'Close', 'GetWriter']
 },
 

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -4206,13 +4206,13 @@ class CGCallGenerator(CGThing):
 
         # Build up our actual call
         self.cgRoot = CGList([], "\n")
-        if nativeMethodName in descriptor.cx_no_gcMethods or nativeMethodName in descriptor.cxMethods:
-            args.prepend(CGGeneric("cx"))
-        elif nativeMethodName in descriptor.realmMethods:
+        if nativeMethodName in descriptor.realmMethods:
             self.cgRoot.append(CGList([
                 CGGeneric("let mut realm = CurrentRealm::assert(cx);"),
                 CGGeneric("let cx = &mut realm;"),
             ]))
+            args.prepend(CGGeneric("cx"))
+        elif nativeMethodName in descriptor.cx_no_gcMethods or nativeMethodName in descriptor.cxMethods or nativeMethodName.startswith("Constructor"):
             args.prepend(CGGeneric("cx"))
         # Workaround for iterators `Next` method until `safe_cx` is the default
         elif descriptor.interface.isIteratorInterface():
@@ -6929,9 +6929,6 @@ let global = D::GlobalScope::from_object(JS_CALLEE(cx.raw_cx(), vp).to_object())
                     "Some(desired_proto)",
                 ]
 
-            if nativeName not in self.descriptor.cxMethods and nativeName not in self.descriptor.realmMethods:
-                args += ['CanGc::from_cx(cx)']
-
             constructor = CGMethodCall(args, nativeName, True, self.descriptor, self.constructor)
             constructorCall = f"""
             call_default_constructor::<D>(
@@ -7147,19 +7144,13 @@ class CGInterfaceTrait(CGThing):
             infallible = 'infallible' in descriptor.getExtendedAttributes(ctor)
             for (i, (rettype, arguments)) in enumerate(ctor.signatures()):
                 name = (baseName or ctor.identifier.name) + ('_' * i)
-                cx = name in descriptor.cxMethods
                 realm = name in descriptor.realmMethods
-                args = list(method_arguments(descriptor, rettype, arguments, cx=cx, realm=realm))
+                args = list(method_arguments(descriptor, rettype, arguments, cx=True, realm=realm))
                 extra = [
                     ("global", f"&D::{exposedGlobal}"),
                     ("proto", "Option<HandleObject>"),
                 ]
-                if not cx and not realm:
-                    extra += [("can_gc", "CanGc")]
-                if args and (args[0][0] == "cx" or args[0][0] == "realm"):
-                    args = [args[0]] + extra + args[1:]
-                else:
-                    args = extra + args
+                args = [args[0]] + extra + args[1:]
                 yield CGGeneric(
                     f"fn {name}({fmt(args, leadingComma=False)}) -> "
                     f"{return_type(descriptorProvider, rettype, infallible)};\n"
@@ -8359,10 +8350,10 @@ def method_arguments(descriptorProvider: DescriptorProvider,
             pass
     if cx_no_gc:
         yield "cx", "&JSContext"
-    elif cx:
-        yield "cx", "&mut JSContext"
     elif realm:
         yield "realm", "&mut CurrentRealm"
+    elif cx:
+        yield "cx", "&mut JSContext"
 
     safe_cx = cx or cx_no_gc or realm
 

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -8348,12 +8348,13 @@ def method_arguments(descriptorProvider: DescriptorProvider,
             old_cx = True
         case Context.No:
             pass
-    if cx_no_gc:
-        yield "cx", "&JSContext"
-    elif realm:
+    
+    if realm:
         yield "realm", "&mut CurrentRealm"
     elif cx:
         yield "cx", "&mut JSContext"
+    elif cx_no_gc:
+        yield "cx", "&JSContext"
 
     safe_cx = cx or cx_no_gc or realm
 

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -8348,7 +8348,7 @@ def method_arguments(descriptorProvider: DescriptorProvider,
             old_cx = True
         case Context.No:
             pass
-    
+
     if realm:
         yield "realm", "&mut CurrentRealm"
     elif cx:


### PR DESCRIPTION
Ports all relevant constructors that are generated bindings to pass a `&mut JSContext` rather than `can_gc`. It got a bit out of hand as I underestimated the amount of affected constructors. However, all of it is purely mechanical, so should be straightforward to review.

It also updates some of the ordering of determining which argument type to pass. Since realms have higher priority than just JSContext, these are also now checked first. This is required since 1 Constructor is marked as `realm` and otherwise it would have always taken a `JSContext` since that would be checked first.

Part of #40600

Testing: it compiles
