### PR TITLE
script: Force a turn of the event loop in response to document activity transitions.

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2878,6 +2878,13 @@ impl ScriptThread {
             activity,
             thread::current().name()
         );
+
+        // If a pipeline transitions to fully active, the next turn of the event
+        // loop will release any pending tasks targeting that pipeline. To ensure
+        // we always run those as soon as possible, not just whenever we happen to
+        // receive another event, we make sure the event loop has an event waiting.
+        let _ = self.senders.self_sender.send(MainThreadScriptMsg::Inactive);
+
         let document = self.documents.borrow().find_document(id);
         if let Some(document) = document {
             document.set_activity(cx, activity);


### PR DESCRIPTION
Tasks targeting not-fully-active document are held back until the documents are marked fully active. However, if the message from the constellation marking a document active is the last event in a headless session (apart from the held back tasks), the script thread event loop will block until another message is ready receive in one of the channels. This change ensures that a message is ready to receive, allowing the held back tasks to be processed immediately after the document's activity status is updated.

Testing: Extremely timing-dependent; I can't see a way to write a test that tickles this deterministically.
Fixes: #46044
