### PR TITLE
servoshell: Remove `window_of_webview_under_construction` workaround

### DIFF
--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -292,6 +292,11 @@ impl WebView {
         self.inner().id
     }
 
+    /// Get the [`RenderingContext`] associated with this [`WebView`].
+    pub fn rendering_context(&self) -> Rc<dyn RenderingContext> {
+        self.inner().rendering_context.clone()
+    }
+
     /// Get the load status for the page that is currently loading or loaded in this [`WebView`].
     ///
     /// The embedder can use [`WebViewDelegate::notify_load_status_changed`] to subscribe

--- a/ports/servoshell/egl/app.rs
+++ b/ports/servoshell/egl/app.rs
@@ -404,7 +404,10 @@ impl App {
 
     /// The active webview will be immediately valid via `active_or_newest_webview()`
     pub(crate) fn activate_webview(&self, id: WebViewId) {
-        self.state.window_for_webview_id(id).activate_webview(id);
+        let Some(webview) = self.state.webview_by_id(id) else {
+            return;
+        };
+        self.state.window_for_webview(&webview).activate_webview(id);
     }
 
     /// This is the Servo heartbeat. This needs to be called

--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -89,10 +89,6 @@ impl WebViewCollection {
         self.webviews.get(&id)
     }
 
-    pub fn contains(&self, id: WebViewId) -> bool {
-        self.webviews.contains_key(&id)
-    }
-
     pub fn active(&self) -> Option<&WebView> {
         self.active_webview_id.and_then(|id| self.webviews.get(&id))
     }
@@ -223,10 +219,6 @@ pub(crate) struct RunningAppState {
     /// [`WebView::set_accessibility_active()`], in [`Self::set_accessibility_active()`] and
     /// and [`ServoShellWindow::create_toplevel_webview()`].
     accessibility_active: Cell<bool>,
-
-    /// Temporary storage to allow calling `WebviewDelegate` methods while the
-    /// `WebView` is being constructed.
-    window_of_webview_under_construction: RefCell<Option<Rc<ServoShellWindow>>>,
 }
 
 impl RunningAppState {
@@ -277,7 +269,6 @@ impl RunningAppState {
             user_content_manager,
             experimental_preferences_enabled,
             accessibility_active: Cell::new(false),
-            window_of_webview_under_construction: Default::default(),
         }
     }
 
@@ -321,8 +312,9 @@ impl RunningAppState {
     }
 
     pub(crate) fn webview_by_id(&self, webview_id: WebViewId) -> Option<WebView> {
-        self.maybe_window_for_webview_id(webview_id)?
-            .webview_by_id(webview_id)
+        self.windows()
+            .values()
+            .find_map(|window| window.webview_by_id(webview_id))
     }
 
     pub(crate) fn webdriver_receiver(&self) -> Option<&Receiver<WebDriverCommandMsg>> {
@@ -455,33 +447,29 @@ impl RunningAppState {
         !self.exit_scheduled.get()
     }
 
-    pub(crate) fn maybe_window_for_webview_id(
-        &self,
-        webview_id: WebViewId,
-    ) -> Option<Rc<ServoShellWindow>> {
-        for window in self.windows.borrow().values() {
-            if window.contains_webview(webview_id) {
-                return Some(window.clone());
-            }
-        }
-        None
+    fn maybe_window_for_webview(&self, webview: &WebView) -> Option<Rc<ServoShellWindow>> {
+        // Look up the ServoShellWindow by RenderingContext. This method can be called while a
+        // WebView is being constructed, which means that it may not fully be associated with a
+        // ServoShellWindow yet.
+        let rendering_context = webview.rendering_context();
+        self.windows()
+            .values()
+            .find(|window| {
+                Rc::ptr_eq(
+                    &window.platform_window().rendering_context(),
+                    &rendering_context,
+                )
+            })
+            .cloned()
     }
 
-    pub(crate) fn window_for_webview_id(&self, webview_id: WebViewId) -> Rc<ServoShellWindow> {
-        self.maybe_window_for_webview_id(webview_id)
-            .or_else(|| self.window_of_webview_under_construction.borrow().clone())
-            .unwrap_or_else(|| panic!("Looking for unexpected WebView: {webview_id:?}"))
+    pub(crate) fn window_for_webview(&self, webview: &WebView) -> Rc<ServoShellWindow> {
+        self.maybe_window_for_webview(webview)
+            .unwrap_or_else(|| panic!("Looking for unexpected WebView: {:?}", webview.id()))
     }
 
-    pub(crate) fn set_window_for_webview_construction(&self, window: Option<Rc<ServoShellWindow>>) {
-        *self.window_of_webview_under_construction.borrow_mut() = window;
-    }
-
-    pub(crate) fn platform_window_for_webview_id(
-        &self,
-        webview_id: WebViewId,
-    ) -> Rc<dyn PlatformWindow> {
-        self.window_for_webview_id(webview_id).platform_window()
+    pub(crate) fn platform_window_for_webview(&self, webview: &WebView) -> Rc<dyn PlatformWindow> {
+        self.window_for_webview(webview).platform_window()
     }
 
     /// If we are exiting after achieving a stable image or we want to save the display of the
@@ -628,7 +616,7 @@ impl RunningAppState {
             return;
         };
 
-        self.platform_window_for_webview_id(webview_id)
+        self.platform_window_for_webview(&webview)
             .dismiss_embedder_controls_for_webview(webview_id);
 
         info!("Loading URL in webview {}: {}", webview_id, url);
@@ -704,22 +692,19 @@ impl RunningAppState {
 
 impl WebViewDelegate for RunningAppState {
     fn screen_geometry(&self, webview: WebView) -> Option<servo::ScreenGeometry> {
-        Some(
-            self.platform_window_for_webview_id(webview.id())
-                .screen_geometry(),
-        )
+        Some(self.platform_window_for_webview(&webview).screen_geometry())
     }
 
     fn notify_status_text_changed(&self, webview: WebView, _status: Option<String>) {
-        self.window_for_webview_id(webview.id()).set_needs_update();
+        self.window_for_webview(&webview).set_needs_update();
     }
 
     fn notify_history_changed(&self, webview: WebView, _entries: Vec<Url>, _current: usize) {
-        self.window_for_webview_id(webview.id()).set_needs_update();
+        self.window_for_webview(&webview).set_needs_update();
     }
 
     fn notify_page_title_changed(&self, webview: WebView, _: Option<String>) {
-        self.window_for_webview_id(webview.id()).set_needs_update();
+        self.window_for_webview(&webview).set_needs_update();
     }
 
     fn notify_traversal_complete(&self, _webview: WebView, traversal_id: TraversalId) {
@@ -731,12 +716,12 @@ impl WebViewDelegate for RunningAppState {
     }
 
     fn request_move_to(&self, webview: WebView, new_position: DeviceIntPoint) {
-        self.platform_window_for_webview_id(webview.id())
+        self.platform_window_for_webview(&webview)
             .set_position(new_position);
     }
 
     fn request_resize_to(&self, webview: WebView, requested_outer_size: DeviceIntSize) {
-        self.platform_window_for_webview_id(webview.id())
+        self.platform_window_for_webview(&webview)
             .request_resize(&webview, requested_outer_size);
     }
 
@@ -745,29 +730,19 @@ impl WebViewDelegate for RunningAppState {
         webview: WebView,
         authentication_request: AuthenticationRequest,
     ) {
-        self.platform_window_for_webview_id(webview.id())
+        self.platform_window_for_webview(&webview)
             .show_http_authentication_dialog(webview.id(), authentication_request);
     }
 
     fn request_create_new(&self, parent_webview: WebView, request: CreateNewWebViewRequest) {
-        let window = self.window_for_webview_id(parent_webview.id());
+        let window = self.window_for_webview(&parent_webview);
         let platform_window = window.platform_window();
-
-        // As part of building the WebView, we may receive WebviewDelegate calls
-        // before we have set up the association between this window and the new
-        // webview. We stash this window in a known location so we can find it
-        // when this occurs.
-        self.set_window_for_webview_construction(Some(window.clone()));
 
         let webview = request
             .builder(platform_window.rendering_context())
             .hidpi_scale_factor(platform_window.hidpi_scale_factor())
             .delegate(parent_webview.delegate())
             .build();
-
-        // This window is now associated with the WebView, so the fallback
-        // is no longer needed.
-        self.set_window_for_webview_construction(None);
 
         webview.notify_theme_change(platform_window.theme());
         window.add_webview(webview.clone());
@@ -783,7 +758,7 @@ impl WebViewDelegate for RunningAppState {
     }
 
     fn notify_closed(&self, webview: WebView) {
-        self.window_for_webview_id(webview.id())
+        self.window_for_webview(&webview)
             .close_webview(webview.id())
     }
 
@@ -793,7 +768,7 @@ impl WebViewDelegate for RunningAppState {
         id: InputEventId,
         result: InputEventResult,
     ) {
-        self.platform_window_for_webview_id(webview.id())
+        self.platform_window_for_webview(&webview)
             .notify_input_event_handled(&webview, id, result);
         if let Some(response_sender) = self.pending_webdriver_events.borrow_mut().remove(&id) {
             let _ = response_sender.send(());
@@ -801,12 +776,12 @@ impl WebViewDelegate for RunningAppState {
     }
 
     fn notify_cursor_changed(&self, webview: WebView, cursor: servo::Cursor) {
-        self.platform_window_for_webview_id(webview.id())
+        self.platform_window_for_webview(&webview)
             .set_cursor(cursor);
     }
 
     fn notify_load_status_changed(&self, webview: WebView, status: LoadStatus) {
-        self.window_for_webview_id(webview.id()).set_needs_update();
+        self.window_for_webview(&webview).set_needs_update();
 
         if status == LoadStatus::Complete {
             if let Some(sender) = self
@@ -822,7 +797,7 @@ impl WebViewDelegate for RunningAppState {
     }
 
     fn notify_fullscreen_state_changed(&self, webview: WebView, fullscreen_state: bool) {
-        self.platform_window_for_webview_id(webview.id())
+        self.platform_window_for_webview(&webview)
             .set_fullscreen(fullscreen_state);
     }
 
@@ -831,17 +806,17 @@ impl WebViewDelegate for RunningAppState {
         webview: WebView,
         request: BluetoothDeviceSelectionRequest,
     ) {
-        self.platform_window_for_webview_id(webview.id())
+        self.platform_window_for_webview(&webview)
             .show_bluetooth_device_dialog(webview.id(), request);
     }
 
     fn request_permission(&self, webview: WebView, permission_request: PermissionRequest) {
-        self.platform_window_for_webview_id(webview.id())
+        self.platform_window_for_webview(&webview)
             .show_permission_dialog(webview.id(), permission_request);
     }
 
     fn notify_new_frame_ready(&self, webview: WebView) {
-        self.window_for_webview_id(webview.id()).set_needs_repaint();
+        self.window_for_webview(&webview).set_needs_repaint();
     }
 
     fn show_embedder_control(&self, webview: WebView, embedder_control: EmbedderControl) {
@@ -865,7 +840,7 @@ impl WebViewDelegate for RunningAppState {
             return;
         }
 
-        self.window_for_webview_id(webview.id())
+        self.window_for_webview(&webview)
             .show_embedder_control(webview, embedder_control);
     }
 
@@ -876,27 +851,27 @@ impl WebViewDelegate for RunningAppState {
             return;
         }
 
-        self.window_for_webview_id(webview.id())
+        self.window_for_webview(&webview)
             .hide_embedder_control(webview, embedder_control_id);
     }
 
     fn notify_favicon_changed(&self, webview: WebView) {
-        self.window_for_webview_id(webview.id())
+        self.window_for_webview(&webview)
             .notify_favicon_changed(webview);
     }
 
     fn notify_media_session_event(&self, webview: WebView, event: MediaSessionEvent) {
-        self.platform_window_for_webview_id(webview.id())
+        self.platform_window_for_webview(&webview)
             .notify_media_session_event(event);
     }
 
     fn notify_crashed(&self, webview: WebView, reason: String, backtrace: Option<String>) {
-        self.platform_window_for_webview_id(webview.id())
+        self.platform_window_for_webview(&webview)
             .notify_crashed(webview, reason, backtrace);
     }
 
     fn show_console_message(&self, webview: WebView, level: ConsoleLogLevel, message: String) {
-        self.platform_window_for_webview_id(webview.id())
+        self.platform_window_for_webview(&webview)
             .show_console_message(level, &message);
     }
 
@@ -905,7 +880,7 @@ impl WebViewDelegate for RunningAppState {
         webview: WebView,
         tree_update: accesskit::TreeUpdate,
     ) {
-        self.platform_window_for_webview_id(webview.id())
+        self.platform_window_for_webview(&webview)
             .notify_accessibility_tree_update(webview, tree_update);
     }
 }

--- a/ports/servoshell/webdriver.rs
+++ b/ports/servoshell/webdriver.rs
@@ -180,14 +180,19 @@ impl RunningAppState {
                     }
                 },
                 WebDriverCommandMsg::CloseWebView(webview_id, response_sender) => {
-                    self.window_for_webview_id(webview_id)
-                        .close_webview(webview_id);
+                    let Some(webview) = self.webview_by_id(webview_id) else {
+                        continue;
+                    };
+                    self.window_for_webview(&webview).close_webview(webview_id);
                     if let Err(error) = response_sender.send(()) {
                         warn!("Failed to send response of CloseWebView: {error}");
                     }
                 },
                 WebDriverCommandMsg::FocusWebView(webview_id) => {
-                    let window = self.window_for_webview_id(webview_id);
+                    let Some(webview) = self.webview_by_id(webview_id) else {
+                        continue;
+                    };
+                    let window = self.window_for_webview(&webview);
                     window.activate_webview(webview_id);
                     self.focus_window(window);
                 },
@@ -205,7 +210,10 @@ impl RunningAppState {
                     }
                 },
                 WebDriverCommandMsg::GetWindowRect(webview_id, response_sender) => {
-                    let platform_window = self.platform_window_for_webview_id(webview_id);
+                    let Some(webview) = self.webview_by_id(webview_id) else {
+                        continue;
+                    };
+                    let platform_window = self.platform_window_for_webview(&webview);
                     if let Err(error) = response_sender.send(platform_window.window_rect()) {
                         warn!("Failed to send response of GetWindowSize: {error}");
                     }
@@ -214,7 +222,7 @@ impl RunningAppState {
                     let Some(webview) = self.webview_by_id(webview_id) else {
                         continue;
                     };
-                    let platform_window = self.platform_window_for_webview_id(webview_id);
+                    let platform_window = self.platform_window_for_webview(&webview);
                     platform_window.maximize(&webview);
 
                     if let Err(error) = response_sender.send(platform_window.window_rect()) {
@@ -226,7 +234,7 @@ impl RunningAppState {
                         continue;
                     };
 
-                    let platform_window = self.platform_window_for_webview_id(webview_id);
+                    let platform_window = self.platform_window_for_webview(&webview);
                     let scale = platform_window.hidpi_scale_factor();
 
                     let requested_physical_rect =
@@ -243,7 +251,10 @@ impl RunningAppState {
                     }
                 },
                 WebDriverCommandMsg::GetViewportSize(webview_id, response_sender) => {
-                    let platform_window = self.platform_window_for_webview_id(webview_id);
+                    let Some(webview) = self.webview_by_id(webview_id) else {
+                        continue;
+                    };
+                    let platform_window = self.platform_window_for_webview(&webview);
                     let size = platform_window.rendering_context().size2d().to_f32() /
                         platform_window.hidpi_scale_factor();
                     if let Err(error) = response_sender.send(size) {

--- a/ports/servoshell/window.rs
+++ b/ports/servoshell/window.rs
@@ -102,12 +102,6 @@ impl ServoShellWindow {
         state: Rc<RunningAppState>,
         url: Url,
     ) -> WebView {
-        // As part of building the WebView, we may receive WebviewDelegate calls
-        // before we have set up the association between this window and the new
-        // webview. We stash this window in a known location so we can find it
-        // when this occurs.
-        state.set_window_for_webview_construction(Some(self.clone()));
-
         #[cfg_attr(any(target_os = "android", target_env = "ohos"), expect(unused_mut))]
         let mut webview_builder =
             WebViewBuilder::new(state.servo(), self.platform_window.rendering_context())
@@ -127,10 +121,6 @@ impl ServoShellWindow {
         let webview = webview_builder.build();
         webview.notify_theme_change(self.platform_window.theme());
         self.add_webview(webview.clone());
-
-        // This window is now associated with the WebView, so the fallback
-        // is no longer needed.
-        state.set_window_for_webview_construction(None);
 
         // If `self` is not in `state.windows`, our notify_accessibility_tree_update() will panic.
         if state.accessibility_active() {
@@ -158,10 +148,6 @@ impl ServoShellWindow {
     /// Whether or not this [`ServoShellWindow`] has any [`WebView`]s.
     pub(crate) fn should_close(&self) -> bool {
         self.webview_collection.borrow().is_empty() || self.close_scheduled.get()
-    }
-
-    pub(crate) fn contains_webview(&self, id: WebViewId) -> bool {
-        self.webview_collection.borrow().contains(id)
     }
 
     pub(crate) fn webview_by_id(&self, id: WebViewId) -> Option<WebView> {


### PR DESCRIPTION
Remove the `window_of_webview_under_construction` workaround which
allows finding the `ServoShellWindow` for a `WebView` under construction
by doing this association based on the `RenderingContext`. This allows a
more reliable and simpler matching of `WebView` to `Window` which can be
done at any point in the `WebView` lifecycle.

As part of this change a `WebView::rendering_context` getter is exposed
in the API.

Testing: This change is covered by existing tests as it shouldn't change behavior.
