### PR TITLE
android: Simplify menu item click listener addition

### DIFF
--- a/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
+++ b/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
@@ -54,10 +54,7 @@ class MainActivity : Activity(), Servo.Client {
     // Binds a click listener to a View if it exists.
     // Useful for handling buttons that only exist in the tablet+ layout
     private fun bindClick(id: Int) {
-        val v = findViewById<View>(id)
-        if (v != null) {
-            v.setOnClickListener(actionClickListener)
-        }
+        findViewById<View>(id)?.setOnClickListener(actionClickListener)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
+++ b/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
@@ -51,12 +51,6 @@ class MainActivity : Activity(), Servo.Client {
 
     private val actionClickListener = View.OnClickListener { v -> dispatchAction(v.id) }
 
-    // Binds a click listener to a View if it exists.
-    // Useful for handling buttons that only exist in the tablet+ layout
-    private fun bindClick(id: Int) {
-        findViewById<View>(id)?.setOnClickListener(actionClickListener)
-    }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
@@ -84,12 +78,14 @@ class MainActivity : Activity(), Servo.Client {
         bottomNav = findViewById(R.id.bottom_bar)
         bottomNav?.setOnItemSelectedListener { item -> dispatchAction(item.itemId) }
 
-        bindClick(R.id.history_back_menu_item)
-        bindClick(R.id.history_forward_menu_item)
-        bindClick(R.id.refresh_menu_item)
-        bindClick(R.id.cancel_menu_item)
-        bindClick(R.id.settings_menu_item)
-        bindClick(R.id.history_menu_item)
+        findViewById<View>(R.id.toolbar)?.apply {
+            findViewById<View>(R.id.history_back_menu_item).setOnClickListener(actionClickListener)
+            findViewById<View>(R.id.history_forward_menu_item).setOnClickListener(actionClickListener)
+            findViewById<View>(R.id.refresh_menu_item).setOnClickListener(actionClickListener)
+            findViewById<View>(R.id.cancel_menu_item).setOnClickListener(actionClickListener)
+            findViewById<View>(R.id.settings_menu_item).setOnClickListener(actionClickListener)
+            findViewById<View>(R.id.history_menu_item).setOnClickListener(actionClickListener)
+        }
 
         servoView.setClient(this)
         servoView.requestFocus()

--- a/support/android/apk/servoapp/src/main/res/layout-sw600dp/activity_main.xml
+++ b/support/android/apk/servoapp/src/main/res/layout-sw600dp/activity_main.xml
@@ -8,6 +8,7 @@
     android:orientation="vertical">
 
     <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         >


### PR DESCRIPTION
Since the toolbar is only present on the wider layout, we can just do a null check on that. If it's non-null, then our remaining `findViewById`s can be asserted to be non-null. This reduces the number of null checks from 6 down to 1.

Testing: There are no automated tests for Android.