### PR TITLE
script: Support `no_gc` in codegen, add `safe_borrow_mut` and use it in webgpu

### DIFF
--- a/components/script/dom/webgpu/gpubindgroup.rs
+++ b/components/script/dom/webgpu/gpubindgroup.rs
@@ -5,7 +5,7 @@
 use std::borrow::Cow;
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{WebGPU, WebGPUBindGroup, WebGPUDevice, WebGPURequest};
@@ -150,7 +150,7 @@ impl GPUBindGroupMethods<crate::DomTypeHolder> for GPUBindGroup {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, value: USVString) {
-        *self.label.borrow_mut() = value;
+    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
+        *self.label.safe_borrow_mut(no_gc) = value;
     }
 }

--- a/components/script/dom/webgpu/gpubindgrouplayout.rs
+++ b/components/script/dom/webgpu/gpubindgrouplayout.rs
@@ -5,7 +5,7 @@
 use std::borrow::Cow;
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{WebGPU, WebGPUBindGroupLayout, WebGPURequest};
@@ -146,7 +146,7 @@ impl GPUBindGroupLayoutMethods<crate::DomTypeHolder> for GPUBindGroupLayout {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, value: USVString) {
-        *self.label.borrow_mut() = value;
+    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
+        *self.label.safe_borrow_mut(no_gc) = value;
     }
 }

--- a/components/script/dom/webgpu/gpubuffer.rs
+++ b/components/script/dom/webgpu/gpubuffer.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 use std::string::String;
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::realm::CurrentRealm;
 use js::typedarray::HeapArrayBuffer;
 use script_bindings::cell::DomRefCell;
@@ -206,12 +206,12 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpubuffer-unmap>
     fn Unmap(&self, cx: &mut js::context::JSContext) {
         // Step 1
-        let promise = self.pending_map.borrow_mut().take();
+        let promise = self.pending_map.safe_borrow_mut(cx).take();
         if let Some(promise) = promise {
             promise.reject_error(cx, Error::Abort(None));
         }
         // Step 2
-        let mut mapping = RootedTraceableBox::new(self.mapping.borrow_mut().take());
+        let mut mapping = RootedTraceableBox::new(self.mapping.safe_borrow_mut(cx).take());
         let mapping = if let Some(mapping) = mapping.as_mut() {
             mapping
         } else {
@@ -269,7 +269,7 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
             return promise;
         }
         // Step 4
-        *self.pending_map.borrow_mut() = Some(promise.clone());
+        *self.pending_map.safe_borrow_mut(cx) = Some(promise.clone());
         // Step 5
         let host_map = match mode {
             GPUMapModeConstants::READ => HostMap::Read,
@@ -323,7 +323,7 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
         // Step 2: validation
         let mut mapping = self
             .mapping
-            .borrow_mut()
+            .safe_borrow_mut(cx)
             .take()
             .map(RootedTraceableBox::new)
             .ok_or(Error::Operation(None))?;
@@ -333,7 +333,9 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
             offset >= mapping.range.start &&
             offset + range_size <= mapping.range.end;
         if !valid {
-            self.mapping.borrow_mut().replace(*mapping.into_box());
+            self.mapping
+                .safe_borrow_mut(cx)
+                .replace(*mapping.into_box());
             return Err(Error::Operation(None));
         }
 
@@ -347,7 +349,9 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
             .map(|view| view.array_buffer())
             .map_err(|()| Error::Operation(None));
 
-        self.mapping.borrow_mut().replace(*mapping.into_box());
+        self.mapping
+            .safe_borrow_mut(cx)
+            .replace(*mapping.into_box());
         result
     }
 
@@ -357,8 +361,8 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, value: USVString) {
-        *self.label.borrow_mut() = value;
+    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
+        *self.label.safe_borrow_mut(no_gc) = value;
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpubuffer-size>
@@ -394,7 +398,7 @@ impl GPUBuffer {
         // Step 2
         assert!(p.is_pending());
         // Step 3
-        self.pending_map.borrow_mut().take();
+        self.pending_map.safe_borrow_mut(cx).take();
         // Step 4
         let is_lost = self.device.is_lost();
         if is_lost {
@@ -425,16 +429,18 @@ impl GPUBuffer {
 
         match mapping {
             Err(error) => {
-                *self.pending_map.borrow_mut() = None;
+                *self.pending_map.safe_borrow_mut(cx) = None;
                 p.reject_error(cx, error);
             },
             Ok(mut mapping) => {
                 // Step 5
                 mapping.data.load(&wgpu_mapping.data);
                 // Step 6
-                self.mapping.borrow_mut().replace(*mapping.into_box());
+                self.mapping
+                    .safe_borrow_mut(cx)
+                    .replace(*mapping.into_box());
                 // Step 7
-                self.pending_map.borrow_mut().take();
+                self.pending_map.safe_borrow_mut(cx).take();
                 p.resolve_native(cx, &());
             },
         }

--- a/components/script/dom/webgpu/gpucommandbuffer.rs
+++ b/components/script/dom/webgpu/gpucommandbuffer.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{WebGPU, WebGPUCommandBuffer, WebGPURequest};
@@ -91,7 +91,7 @@ impl GPUCommandBufferMethods<crate::DomTypeHolder> for GPUCommandBuffer {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, value: USVString) {
-        *self.label.borrow_mut() = value;
+    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
+        *self.label.safe_borrow_mut(no_gc) = value;
     }
 }

--- a/components/script/dom/webgpu/gpucommandencoder.rs
+++ b/components/script/dom/webgpu/gpucommandencoder.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{
@@ -140,8 +140,8 @@ impl GPUCommandEncoderMethods<crate::DomTypeHolder> for GPUCommandEncoder {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, value: USVString) {
-        *self.label.borrow_mut() = value;
+    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
+        *self.label.safe_borrow_mut(no_gc) = value;
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-begincomputepass>

--- a/components/script/dom/webgpu/gpucomputepassencoder.rs
+++ b/components/script/dom/webgpu/gpucomputepassencoder.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{WebGPU, WebGPUComputePass, WebGPURequest};
@@ -91,8 +91,8 @@ impl GPUComputePassEncoderMethods<crate::DomTypeHolder> for GPUComputePassEncode
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, value: USVString) {
-        *self.label.borrow_mut() = value;
+    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
+        *self.label.safe_borrow_mut(no_gc) = value;
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpucomputepassencoder-dispatchworkgroups>

--- a/components/script/dom/webgpu/gpucomputepipeline.rs
+++ b/components/script/dom/webgpu/gpucomputepipeline.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use servo_base::generic_channel::GenericCallback;
@@ -136,8 +136,8 @@ impl GPUComputePipelineMethods<crate::DomTypeHolder> for GPUComputePipeline {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, value: USVString) {
-        *self.label.borrow_mut() = value;
+    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
+        *self.label.safe_borrow_mut(no_gc) = value;
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpupipelinebase-getbindgrouplayout>

--- a/components/script/dom/webgpu/gpudevice.rs
+++ b/components/script/dom/webgpu/gpudevice.rs
@@ -7,7 +7,7 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::jsapi::{HandleObject, Heap, JSObject};
 use js::realm::CurrentRealm;
 use script_bindings::cell::DomRefCell;
@@ -182,7 +182,7 @@ impl GPUDevice {
             global,
             cx,
         );
-        queue.set_device(&device);
+        queue.set_device(cx, &device);
         device.extensions.set(*extensions);
         device
     }
@@ -433,8 +433,8 @@ impl GPUDeviceMethods<crate::DomTypeHolder> for GPUDevice {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, value: USVString) {
-        *self.label.borrow_mut() = value;
+    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
+        *self.label.safe_borrow_mut(no_gc) = value;
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-lost>

--- a/components/script/dom/webgpu/gpupipelinelayout.rs
+++ b/components/script/dom/webgpu/gpupipelinelayout.rs
@@ -5,7 +5,7 @@
 use std::borrow::Cow;
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{WebGPU, WebGPUBindGroupLayout, WebGPUPipelineLayout, WebGPURequest};
@@ -150,7 +150,7 @@ impl GPUPipelineLayoutMethods<crate::DomTypeHolder> for GPUPipelineLayout {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, value: USVString) {
-        *self.label.borrow_mut() = value;
+    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
+        *self.label.safe_borrow_mut(no_gc) = value;
     }
 }

--- a/components/script/dom/webgpu/gpuqueryset.rs
+++ b/components/script/dom/webgpu/gpuqueryset.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::WebGPUBinding::{GPUDeviceMethods, GPUQueryType};
 use script_bindings::error::{Error, Fallible};
@@ -147,8 +147,8 @@ impl GPUQuerySetMethods<crate::DomTypeHolder> for GPUQuerySet {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, value: USVString) {
-        *self.label.borrow_mut() = value;
+    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
+        *self.label.safe_borrow_mut(no_gc) = value;
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuqueryset-type>

--- a/components/script/dom/webgpu/gpuqueue.rs
+++ b/components/script/dom/webgpu/gpuqueue.rs
@@ -5,7 +5,7 @@
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use pixels::{SnapshotAlphaMode, SnapshotPixelFormat};
 use script_bindings::cell::DomRefCell;
 use script_bindings::codegen::GenericBindings::CanvasRenderingContext2DBinding::ImageDataMethods;
@@ -76,8 +76,8 @@ impl GPUQueue {
 }
 
 impl GPUQueue {
-    pub(crate) fn set_device(&self, device: &GPUDevice) {
-        *self.device.borrow_mut() = Some(Dom::from_ref(device));
+    pub(crate) fn set_device(&self, no_gc: &NoGC, device: &GPUDevice) {
+        *self.device.safe_borrow_mut(no_gc) = Some(Dom::from_ref(device));
     }
 
     pub(crate) fn id(&self) -> WebGPUQueue {
@@ -92,8 +92,8 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, value: USVString) {
-        *self.label.borrow_mut() = value;
+    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
+        *self.label.safe_borrow_mut(no_gc) = value;
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuqueue-submit>

--- a/components/script/dom/webgpu/gpurenderbundle.rs
+++ b/components/script/dom/webgpu/gpurenderbundle.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{WebGPU, WebGPUDevice, WebGPURenderBundle, WebGPURequest};
@@ -97,7 +97,7 @@ impl GPURenderBundleMethods<crate::DomTypeHolder> for GPURenderBundle {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, value: USVString) {
-        *self.label.borrow_mut() = value;
+    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
+        *self.label.safe_borrow_mut(no_gc) = value;
     }
 }

--- a/components/script/dom/webgpu/gpurenderbundleencoder.rs
+++ b/components/script/dom/webgpu/gpurenderbundleencoder.rs
@@ -6,7 +6,7 @@ use std::borrow::Cow;
 use std::ffi::CString;
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{WebGPU, WebGPURenderBundle, WebGPURequest};
@@ -138,14 +138,20 @@ impl GPURenderBundleEncoderMethods<crate::DomTypeHolder> for GPURenderBundleEnco
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, value: USVString) {
-        *self.label.borrow_mut() = value;
+    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
+        *self.label.safe_borrow_mut(no_gc) = value;
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuprogrammablepassencoder-setbindgroup>
     #[expect(unsafe_code)]
-    fn SetBindGroup(&self, index: u32, bind_group: &GPUBindGroup, dynamic_offsets: Vec<u32>) {
-        if let Some(encoder) = self.render_bundle_encoder.borrow_mut().as_mut() {
+    fn SetBindGroup(
+        &self,
+        no_gc: &NoGC,
+        index: u32,
+        bind_group: &GPUBindGroup,
+        dynamic_offsets: Vec<u32>,
+    ) {
+        if let Some(encoder) = self.render_bundle_encoder.safe_borrow_mut(no_gc).as_mut() {
             unsafe {
                 wgpu_bundle::wgpu_render_bundle_set_bind_group(
                     encoder,
@@ -159,8 +165,8 @@ impl GPURenderBundleEncoderMethods<crate::DomTypeHolder> for GPURenderBundleEnco
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-setpipeline>
-    fn SetPipeline(&self, pipeline: &GPURenderPipeline) {
-        if let Some(encoder) = self.render_bundle_encoder.borrow_mut().as_mut() {
+    fn SetPipeline(&self, no_gc: &NoGC, pipeline: &GPURenderPipeline) {
+        if let Some(encoder) = self.render_bundle_encoder.safe_borrow_mut(no_gc).as_mut() {
             wgpu_bundle::wgpu_render_bundle_set_pipeline(encoder, pipeline.id().0);
         }
     }
@@ -168,12 +174,13 @@ impl GPURenderBundleEncoderMethods<crate::DomTypeHolder> for GPURenderBundleEnco
     /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-setindexbuffer>
     fn SetIndexBuffer(
         &self,
+        no_gc: &NoGC,
         buffer: &GPUBuffer,
         index_format: GPUIndexFormat,
         offset: u64,
         size: u64,
     ) {
-        if let Some(encoder) = self.render_bundle_encoder.borrow_mut().as_mut() {
+        if let Some(encoder) = self.render_bundle_encoder.safe_borrow_mut(no_gc).as_mut() {
             wgpu_bundle::wgpu_render_bundle_set_index_buffer(
                 encoder,
                 buffer.id().0,
@@ -188,8 +195,8 @@ impl GPURenderBundleEncoderMethods<crate::DomTypeHolder> for GPURenderBundleEnco
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-setvertexbuffer>
-    fn SetVertexBuffer(&self, slot: u32, buffer: &GPUBuffer, offset: u64, size: u64) {
-        if let Some(encoder) = self.render_bundle_encoder.borrow_mut().as_mut() {
+    fn SetVertexBuffer(&self, no_gc: &NoGC, slot: u32, buffer: &GPUBuffer, offset: u64, size: u64) {
+        if let Some(encoder) = self.render_bundle_encoder.safe_borrow_mut(no_gc).as_mut() {
             wgpu_bundle::wgpu_render_bundle_set_vertex_buffer(
                 encoder,
                 slot,
@@ -201,8 +208,15 @@ impl GPURenderBundleEncoderMethods<crate::DomTypeHolder> for GPURenderBundleEnco
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-draw>
-    fn Draw(&self, vertex_count: u32, instance_count: u32, first_vertex: u32, first_instance: u32) {
-        if let Some(encoder) = self.render_bundle_encoder.borrow_mut().as_mut() {
+    fn Draw(
+        &self,
+        no_gc: &NoGC,
+        vertex_count: u32,
+        instance_count: u32,
+        first_vertex: u32,
+        first_instance: u32,
+    ) {
+        if let Some(encoder) = self.render_bundle_encoder.safe_borrow_mut(no_gc).as_mut() {
             wgpu_bundle::wgpu_render_bundle_draw(
                 encoder,
                 vertex_count,
@@ -216,13 +230,14 @@ impl GPURenderBundleEncoderMethods<crate::DomTypeHolder> for GPURenderBundleEnco
     /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-drawindexed>
     fn DrawIndexed(
         &self,
+        no_gc: &NoGC,
         index_count: u32,
         instance_count: u32,
         first_index: u32,
         base_vertex: i32,
         first_instance: u32,
     ) {
-        if let Some(encoder) = self.render_bundle_encoder.borrow_mut().as_mut() {
+        if let Some(encoder) = self.render_bundle_encoder.safe_borrow_mut(no_gc).as_mut() {
             wgpu_bundle::wgpu_render_bundle_draw_indexed(
                 encoder,
                 index_count,
@@ -235,8 +250,8 @@ impl GPURenderBundleEncoderMethods<crate::DomTypeHolder> for GPURenderBundleEnco
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-drawindirect>
-    fn DrawIndirect(&self, indirect_buffer: &GPUBuffer, indirect_offset: u64) {
-        if let Some(encoder) = self.render_bundle_encoder.borrow_mut().as_mut() {
+    fn DrawIndirect(&self, no_gc: &NoGC, indirect_buffer: &GPUBuffer, indirect_offset: u64) {
+        if let Some(encoder) = self.render_bundle_encoder.safe_borrow_mut(no_gc).as_mut() {
             wgpu_bundle::wgpu_render_bundle_draw_indirect(
                 encoder,
                 indirect_buffer.id().0,
@@ -246,8 +261,8 @@ impl GPURenderBundleEncoderMethods<crate::DomTypeHolder> for GPURenderBundleEnco
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-drawindexedindirect>
-    fn DrawIndexedIndirect(&self, indirect_buffer: &GPUBuffer, indirect_offset: u64) {
-        if let Some(encoder) = self.render_bundle_encoder.borrow_mut().as_mut() {
+    fn DrawIndexedIndirect(&self, no_gc: &NoGC, indirect_buffer: &GPUBuffer, indirect_offset: u64) {
+        if let Some(encoder) = self.render_bundle_encoder.safe_borrow_mut(no_gc).as_mut() {
             wgpu_bundle::wgpu_render_bundle_draw_indexed_indirect(
                 encoder,
                 indirect_buffer.id().0,
@@ -258,8 +273,8 @@ impl GPURenderBundleEncoderMethods<crate::DomTypeHolder> for GPURenderBundleEnco
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudebugcommandsmixin-pushdebuggroup>
     #[expect(unsafe_code)]
-    fn PushDebugGroup(&self, group_label: USVString) {
-        if let Some(encoder) = self.render_bundle_encoder.borrow_mut().as_mut() {
+    fn PushDebugGroup(&self, no_gc: &NoGC, group_label: USVString) {
+        if let Some(encoder) = self.render_bundle_encoder.safe_borrow_mut(no_gc).as_mut() {
             let label = CString::new(group_label.0).unwrap_or_default();
             unsafe {
                 wgpu_bundle::wgpu_render_bundle_push_debug_group(encoder, label.as_ptr());
@@ -268,16 +283,16 @@ impl GPURenderBundleEncoderMethods<crate::DomTypeHolder> for GPURenderBundleEnco
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudebugcommandsmixin-popdebuggroup>
-    fn PopDebugGroup(&self) {
-        if let Some(encoder) = self.render_bundle_encoder.borrow_mut().as_mut() {
+    fn PopDebugGroup(&self, no_gc: &NoGC) {
+        if let Some(encoder) = self.render_bundle_encoder.safe_borrow_mut(no_gc).as_mut() {
             wgpu_bundle::wgpu_render_bundle_pop_debug_group(encoder);
         }
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudebugcommandsmixin-insertdebugmarker>
     #[expect(unsafe_code)]
-    fn InsertDebugMarker(&self, marker_label: USVString) {
-        if let Some(encoder) = self.render_bundle_encoder.borrow_mut().as_mut() {
+    fn InsertDebugMarker(&self, no_gc: &NoGC, marker_label: USVString) {
+        if let Some(encoder) = self.render_bundle_encoder.safe_borrow_mut(no_gc).as_mut() {
             let label = CString::new(marker_label.0).unwrap_or_default();
             unsafe {
                 wgpu_bundle::wgpu_render_bundle_insert_debug_marker(encoder, label.as_ptr());
@@ -294,7 +309,11 @@ impl GPURenderBundleEncoderMethods<crate::DomTypeHolder> for GPURenderBundleEnco
         let desc = wgpu_types::RenderBundleDescriptor {
             label: (&descriptor.parent).convert(),
         };
-        let encoder = self.render_bundle_encoder.borrow_mut().take().unwrap();
+        let encoder = self
+            .render_bundle_encoder
+            .safe_borrow_mut(cx)
+            .take()
+            .unwrap();
         let render_bundle_id = self.global().wgpu_id_hub().create_render_bundle_id();
 
         self.channel

--- a/components/script/dom/webgpu/gpurenderpassencoder.rs
+++ b/components/script/dom/webgpu/gpurenderpassencoder.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{RenderCommand, WebGPU, WebGPURenderPass, WebGPURequest};
@@ -117,8 +117,8 @@ impl GPURenderPassEncoderMethods<crate::DomTypeHolder> for GPURenderPassEncoder 
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, value: USVString) {
-        *self.label.borrow_mut() = value;
+    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
+        *self.label.safe_borrow_mut(no_gc) = value;
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuprogrammablepassencoder-setbindgroup>

--- a/components/script/dom/webgpu/gpurenderpipeline.rs
+++ b/components/script/dom/webgpu/gpurenderpipeline.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use servo_base::generic_channel::GenericCallback;
@@ -124,8 +124,8 @@ impl GPURenderPipelineMethods<crate::DomTypeHolder> for GPURenderPipeline {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, value: USVString) {
-        *self.label.borrow_mut() = value;
+    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
+        *self.label.safe_borrow_mut(no_gc) = value;
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpupipelinebase-getbindgrouplayout>

--- a/components/script/dom/webgpu/gpusampler.rs
+++ b/components/script/dom/webgpu/gpusampler.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{WebGPU, WebGPUDevice, WebGPURequest, WebGPUSampler};
@@ -150,7 +150,7 @@ impl GPUSamplerMethods<crate::DomTypeHolder> for GPUSampler {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, value: USVString) {
-        *self.label.borrow_mut() = value;
+    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
+        *self.label.safe_borrow_mut(no_gc) = value;
     }
 }

--- a/components/script/dom/webgpu/gpushadermodule.rs
+++ b/components/script/dom/webgpu/gpushadermodule.rs
@@ -5,7 +5,7 @@
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::realm::CurrentRealm;
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
@@ -146,8 +146,8 @@ impl GPUShaderModuleMethods<crate::DomTypeHolder> for GPUShaderModule {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, value: USVString) {
-        *self.label.borrow_mut() = value;
+    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
+        *self.label.safe_borrow_mut(no_gc) = value;
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpushadermodule-getcompilationinfo>

--- a/components/script/dom/webgpu/gputexture.rs
+++ b/components/script/dom/webgpu/gputexture.rs
@@ -5,7 +5,7 @@
 use std::string::String;
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{WebGPU, WebGPURequest, WebGPUTexture, WebGPUTextureView};
@@ -201,8 +201,8 @@ impl GPUTextureMethods<crate::DomTypeHolder> for GPUTexture {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, value: USVString) {
-        *self.label.borrow_mut() = value;
+    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
+        *self.label.safe_borrow_mut(no_gc) = value;
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gputexture-createview>

--- a/components/script/dom/webgpu/gputextureview.rs
+++ b/components/script/dom/webgpu/gputextureview.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use script_bindings::cell::DomRefCell;
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 use webgpu_traits::{WebGPU, WebGPURequest, WebGPUTextureView};
@@ -98,7 +98,7 @@ impl GPUTextureViewMethods<crate::DomTypeHolder> for GPUTextureView {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
-    fn SetLabel(&self, value: USVString) {
-        *self.label.borrow_mut() = value;
+    fn SetLabel(&self, no_gc: &NoGC, value: USVString) {
+        *self.label.safe_borrow_mut(no_gc) = value;
     }
 }

--- a/components/script_bindings/cell.rs
+++ b/components/script_bindings/cell.rs
@@ -7,6 +7,7 @@
 use std::cell::{BorrowError, BorrowMutError};
 pub use std::cell::{Ref, RefCell, RefMut};
 
+use js::context::NoGC;
 use js::jsapi::JSTracer;
 use malloc_size_of::{MallocConditionalSizeOf, MallocSizeOfOps};
 
@@ -90,6 +91,93 @@ impl<T> DomRefCell<T> {
     pub unsafe fn borrow_mut_for_layout(&self) -> &mut T {
         assert_in_layout();
         unsafe { &mut *self.value.as_ptr() }
+    }
+
+    /// Mutably borrows the wrapped value.
+    ///
+    /// The borrow lasts until the returned `RefMut` exits scope. The value
+    /// cannot be borrowed while this borrow is active.
+    ///
+    /// By passing a `&NoGC` we statically prevent GC from being run while the borrow is active,
+    /// to prevent panic when tracing (which calls `borrow`).
+    ///
+    /// # Example
+    ///
+    /// In simple cases one can use `NoGC` to statically ensure no GC can happen in the whole DOM method:
+    ///
+    /// ```
+    /// use js::context::{JSContext, NoGC};
+    /// use script_bindings::cell::DomRefCell;
+    /// fn DomMethod(no_gc: &NoGC, cell: &DomRefCell<usize>) {
+    ///     let mut mutably_borrowed = cell.safe_borrow_mut(no_gc);
+    /// }
+    /// ```
+    ///
+    /// But in more complex cases, method might trigger a GC, and thus require a `&mut JSContext`.
+    /// In that case `&JSContext` can be used in place of `NoGC`,
+    /// which will make `RefMut` bounded to the lifetime of the `&JSContext`
+    /// and thus prevent any GC from happening while it is alive.
+    ///
+    /// ```
+    /// use js::context::{JSContext, NoGC};
+    /// use script_bindings::cell::DomRefCell;
+    /// fn GC(cx: &mut JSContext) {}
+    ///
+    /// fn DomMethod(cell: &DomRefCell<usize>, cx: &mut JSContext) {
+    ///     {
+    ///         let mut mutably_borrowed = cell.safe_borrow_mut(cx);
+    ///         // do something with mutably_borrowed
+    ///
+    ///         // only &JSContext is available here
+    ///     } // mutably_borrowed goes out of scope here
+    ///     // so one can now use &mut JSContext
+    ///     GC(cx);
+    /// }
+    /// ```
+    ///
+    /// ```compile_fail
+    /// use js::context::{JSContext, NoGC};
+    /// use script_bindings::cell::DomRefCell;
+    /// fn GC(cx: &mut JSContext) {}
+    ///
+    /// fn DomMethod(cell: &DomRefCell<usize>, cx: &mut JSContext) {
+    ///     {
+    ///         let mut mutably_borrowed = cell.safe_borrow_mut(cx);
+    ///         // do something with mutably_borrowed
+    ///
+    ///         // here one cannot use anything that might trigger a GC
+    ///         // as that would require &mut JSContext
+    ///         // but there is already existing &JSContext bounded at RefMut
+    ///         GC(cx);
+    ///     } // mutably_borrowed goes out of scope here
+    /// }
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is currently borrowed.
+    #[track_caller]
+    pub fn safe_borrow_mut<'a: 'r, 'no_cx: 'r, 'r>(
+        &'a self,
+        _no_gc: &'no_cx NoGC,
+    ) -> RefMut<'r, T> {
+        self.value.borrow_mut()
+    }
+
+    /// Mutably borrows the wrapped value.
+    ///
+    /// The borrow lasts until the returned `RefMut` exits scope. The value
+    /// cannot be borrowed while this borrow is active.
+    ///
+    /// By passing a `&NoGC` we statically prevent GC from being run while the borrow is active,
+    /// to prevent panic when tracing (which calls `borrow`).
+    ///
+    /// Returns `None` if the value is currently borrowed.
+    pub fn safe_try_borrow_mut<'a: 'r, 'no_cx: 'r, 'r>(
+        &'a self,
+        _no_gc: &'no_cx NoGC,
+    ) -> Result<RefMut<'r, T>, BorrowMutError> {
+        self.value.try_borrow_mut()
     }
 }
 

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -520,10 +520,19 @@ DOMInterfaces = {
     'canGc': ['RequestDevice'],
 },
 
+'GPUBindGroup': {
+    'no_gc': ['SetLabel'],
+},
+
+'GPUBindGroupLayout': {
+    'no_gc': ['SetLabel'],
+},
+
 'GPUBuffer': {
     'realm': ['MapAsync'],
     'cx': ['Destroy', 'GetMappedRange',  'Unmap', 'PopErrorScope'],
     'allowDropImpl': True,
+    'no_gc': ['SetLabel'],
 },
 
 'GPUCanvasContext': {
@@ -533,6 +542,11 @@ DOMInterfaces = {
 
 'GPUCommandEncoder': {
     'cx': ['BeginComputePass', 'BeginRenderPass', 'Finish'],
+    'no_gc': ['SetLabel'],
+},
+
+'GPUCommandBuffer': {
+    'no_gc': ['SetLabel'],
 },
 
 'GPUCompilationInfo': {
@@ -541,6 +555,11 @@ DOMInterfaces = {
 
 'GPUComputePipeline': {
     'cx': ['GetBindGroupLayout'],
+    'no_gc': ['SetLabel'],
+},
+
+'GPUComputePassEncoder': {
+    'no_gc': ['SetLabel'],
 },
 
 'GPUDevice': {
@@ -558,22 +577,68 @@ DOMInterfaces = {
         'CreateQuerySet',
     ],
     'weakReferenceable': True, # for usage in GlobalScope https://github.com/servo/servo/issues/32519
+    'no_gc': ['SetLabel'],
 },
 
 'GPUQueue': {
     'cx': ['OnSubmittedWorkDone', 'CopyExternalImageToTexture'],
+    'no_gc': ['SetLabel'],
+},
+
+'GPUPipelineLayout': {
+    'no_gc': ['SetLabel'],
+},
+
+'GPUQuerySet': {
+    'no_gc': ['SetLabel'],
 },
 
 'GPURenderBundleEncoder': {
     'cx': ['Finish'],
+    'no_gc': [
+        'SetLabel',
+        'SetBindGroup',
+        'SetPipeline',
+        'SetIndexBuffer',
+        'SetVertexBuffer',
+        'Draw',
+        'DrawIndexed',
+        'DrawIndirect',
+        'DrawIndexedIndirect',
+        'PushDebugGroup',
+        'PopDebugGroup',
+        'InsertDebugMarker',
+    ],
+},
+
+'GPURenderBundle': {
+    'no_gc': ['SetLabel'],
 },
 
 'GPURenderPipeline': {
     'cx': ['GetBindGroupLayout'],
+    'no_gc': ['SetLabel'],
+},
+
+'GPURenderPassEncoder': {
+    'no_gc': ['SetLabel'],
+},
+
+'GPUSampler': {
+    'no_gc': ['SetLabel'],
+},
+
+'GPUShaderModule': {
+    'no_gc': ['SetLabel'],
 },
 
 'GPUTexture': {
     'cx': ['CreateView'],
+    'no_gc': ['SetLabel'],
+},
+
+'GPUTextureView': {
+    'no_gc': ['SetLabel'],
 },
 
 'History': {

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -4212,7 +4212,7 @@ class CGCallGenerator(CGThing):
                 CGGeneric("let cx = &mut realm;"),
             ]))
             args.prepend(CGGeneric("cx"))
-        elif nativeMethodName in descriptor.cx_no_gcMethods or nativeMethodName in descriptor.cxMethods or nativeMethodName.startswith("Constructor"):
+        elif nativeMethodName in descriptor.no_gcMethods or nativeMethodName in descriptor.cx_no_gcMethods or nativeMethodName in descriptor.cxMethods or nativeMethodName.startswith("Constructor"):
             args.prepend(CGGeneric("cx"))
         # Workaround for iterators `Next` method until `safe_cx` is the default
         elif descriptor.interface.isIteratorInterface():
@@ -6980,20 +6980,23 @@ class CGInterfaceTrait(CGThing):
 
         def attribute_arguments(attribute_type: IDLType,
                                 argument: IDLType | None = None,
+                                no_gc: bool = False,
                                 cx_no_gc: bool = False,
                                 cx: bool = False,
                                 realm: bool = False,
                                 canGc: bool = False,
                                 retval: bool = False
                                 ) -> Iterable[tuple[str, str]]:
-            if cx_no_gc:
-                yield "cx", "&JSContext"
+            if realm:
+                yield "realm", "&mut CurrentRealm"
             elif cx:
                 yield "cx", "&mut JSContext"
-            elif realm:
-                yield "realm", "&mut CurrentRealm"
+            elif cx_no_gc:
+                yield "cx", "&JSContext"
+            elif no_gc:
+                yield "cx", "&NoGC"
 
-            safe_cx = cx or cx_no_gc or realm
+            safe_cx = cx or cx_no_gc or realm or no_gc
 
             if typeNeedsCx(attribute_type, retval) and not safe_cx:
                 yield "cx", "SafeJSContext"
@@ -7025,6 +7028,7 @@ class CGInterfaceTrait(CGThing):
                         rettype = cast(IDLType, rettype)
                         arguments = cast(list[IDLArgument], arguments)
                         arguments = method_arguments(descriptor, rettype, arguments,
+                                                     no_gc=name in descriptor.no_gcMethods,
                                                      cx_no_gc=name in descriptor.cx_no_gcMethods,
                                                      cx=name in descriptor.cxMethods or descriptor.interface.isIteratorInterface(),
                                                      realm=name in descriptor.realmMethods,
@@ -7044,6 +7048,7 @@ class CGInterfaceTrait(CGThing):
                     yield (name,
                            attribute_arguments(
                                m.type,
+                               no_gc=name in descriptor.no_gcMethods,
                                cx_no_gc=name in descriptor.cx_no_gcMethods,
                                cx=name in descriptor.cxMethods or isEventHandlerCallback(m),
                                realm=name in descriptor.realmMethods,
@@ -7064,6 +7069,7 @@ class CGInterfaceTrait(CGThing):
                                attribute_arguments(
                                    m.type,
                                    m.type,
+                                   no_gc=name in descriptor.no_gcMethods,
                                    cx_no_gc=name in descriptor.cx_no_gcMethods,
                                    cx=name in descriptor.cxMethods or descriptor.implicitCxSetters or isEventHandlerCallback(m),
                                    realm=name in descriptor.realmMethods,
@@ -7086,6 +7092,7 @@ class CGInterfaceTrait(CGThing):
                         if not rettype.nullable():
                             rettype = IDLNullableType(rettype.location, rettype)
                         arguments = method_arguments(descriptor, rettype, arguments,
+                                                     no_gc=name in descriptor.no_gcMethods,
                                                      cx_no_gc=name in descriptor.cx_no_gcMethods,
                                                      cx=name in descriptor.cxMethods,
                                                      realm=name in descriptor.realmMethods,
@@ -7100,6 +7107,7 @@ class CGInterfaceTrait(CGThing):
                             yield "SupportedPropertyNames", [("no_gc", "&NoGC")], "Vec<DOMString>", False
                     else:
                         arguments = method_arguments(descriptor, rettype, arguments,
+                                                     no_gc=name in descriptor.no_gcMethods,
                                                      cx_no_gc=name in descriptor.cx_no_gcMethods,
                                                      cx=name in descriptor.cxMethods,
                                                      realm=name in descriptor.realmMethods,
@@ -8333,6 +8341,7 @@ def method_arguments(descriptorProvider: DescriptorProvider,
                      arguments: Iterable[IDLArgument | FakeArgument],
                      passJSBits: bool = True,
                      trailing: tuple[str, str] | None = None,
+                     no_gc: bool = False,
                      cx_no_gc: bool = False,
                      cx: bool = False,
                      realm: bool = False,
@@ -8355,8 +8364,10 @@ def method_arguments(descriptorProvider: DescriptorProvider,
         yield "cx", "&mut JSContext"
     elif cx_no_gc:
         yield "cx", "&JSContext"
+    elif no_gc:
+        yield "cx", "&NoGC"
 
-    safe_cx = cx or cx_no_gc or realm
+    safe_cx = cx or cx_no_gc or realm or no_gc
 
     if old_cx and not safe_cx:
         yield "cx", "SafeJSContext"

--- a/components/script_bindings/codegen/configuration.py
+++ b/components/script_bindings/codegen/configuration.py
@@ -289,6 +289,7 @@ class Descriptor(DescriptorProvider):
         self.register = desc.get('register', True)
         self.path = desc.get('path', pathDefault)
 
+        self.no_gcMethods = [name for name in desc.get('no_gc', [])]
         self.cx_no_gcMethods = [name for name in desc.get('cx_no_gc', [])]
         self.cxMethods = [name for name in desc.get('cx', [])]
         self.realmMethods = [name for name in desc.get('realm', [])]


### PR DESCRIPTION
This is what is know as Phase 2 of https://github.com/servo/servo/issues/40600

The main idea is that we require `&NoGC` (which can be coerced from `&JSContext`) or passed directly from codegen. By passing a `&NoGC` we statically prevent GC from being run while the mutable borrow is active (GC causes tracing which calls `borrow()` thus panicking if we also have mutable borrow).

Technically we could allow this and move requiring `&NoGC` only when doing deref of `RefMut`, but that would be less clear and brings more complications.

I also demonstrated migration on WebGPU code, but that is not the best representative code for migration as the code was reviewed and fixed for borrow hazards beforehand. The migration will uncover and require fixing all of borrow hazards.

Future extensions:
Enforce DomRefCell for JSManaged stuff (the one that has actual trace impl not just nop) and enforce normal RefCell for the rest (with no/empty tracing for it) and forbidding JSManaged stuff in std RefCell. (will needed to be part of phase 3)

Testing: New doc tests
Fixes: #33140
