### PR TITLE
script: Remove `GlobalScope::get_cx()` usages from slot handling

### DIFF
--- a/components/script/dom/characterdata/text.rs
+++ b/components/script/dom/characterdata/text.rs
@@ -17,7 +17,6 @@ use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::characterdata::CharacterData;
 use crate::dom::document::Document;
-use crate::dom::globalscope::GlobalScope;
 use crate::dom::html::htmlslotelement::{HTMLSlotElement, Slottable};
 use crate::dom::node::Node;
 use crate::dom::window::Window;
@@ -127,12 +126,10 @@ impl TextMethods<crate::DomTypeHolder> for Text {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-slotable-assignedslot>
-    fn GetAssignedSlot(&self) -> Option<DomRoot<HTMLSlotElement>> {
-        let cx = GlobalScope::get_cx();
-
+    fn GetAssignedSlot(&self, cx: &JSContext) -> Option<DomRoot<HTMLSlotElement>> {
         // > The assignedSlot getter steps are to return the result of
         // > find a slot given this and with the open flag set.
-        rooted!(in(*cx) let slottable = Slottable(Dom::from_ref(self.upcast::<Node>())));
+        rooted!(&in(cx) let slottable = Slottable(Dom::from_ref(self.upcast::<Node>())));
         slottable.find_a_slot(true)
     }
 }

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -4494,12 +4494,10 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-slotable-assignedslot>
-    fn GetAssignedSlot(&self) -> Option<DomRoot<HTMLSlotElement>> {
-        let cx = GlobalScope::get_cx();
-
+    fn GetAssignedSlot(&self, cx: &JSContext) -> Option<DomRoot<HTMLSlotElement>> {
         // > The assignedSlot getter steps are to return the result of
         // > find a slot given this and with the open flag set.
-        rooted!(in(*cx) let slottable = Slottable(Dom::from_ref(self.upcast::<Node>())));
+        rooted!(&in(cx) let slottable = Slottable(Dom::from_ref(self.upcast::<Node>())));
         slottable.find_a_slot(true)
     }
 
@@ -4702,9 +4700,9 @@ impl VirtualMethods for Element {
 
                 // Slottable name change steps from https://dom.spec.whatwg.org/#light-tree-slotables
                 if let Some(assigned_slot) = slottable.assigned_slot() {
-                    assigned_slot.assign_slottables(cx.no_gc());
+                    assigned_slot.assign_slottables(cx);
                 }
-                slottable.assign_a_slot(cx.no_gc());
+                slottable.assign_a_slot(cx);
             },
             _ => {
                 // FIXME(emilio): This is pretty dubious, and should be done in

--- a/components/script/dom/html/htmlslotelement.rs
+++ b/components/script/dom/html/htmlslotelement.rs
@@ -6,7 +6,7 @@ use std::cell::{Cell, Ref, RefCell};
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, local_name, ns};
-use js::context::{JSContext, NoGC};
+use js::context::JSContext;
 use js::gc::RootedVec;
 use js::rust::HandleObject;
 use script_bindings::codegen::InheritTypes::{CharacterDataTypeId, NodeTypeId};
@@ -27,7 +27,6 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
 use crate::dom::element::attributes::storage::AttrRef;
 use crate::dom::element::{AttributeMutation, Element};
-use crate::dom::globalscope::GlobalScope;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::virtualmethods::VirtualMethods;
 use crate::dom::node::{
@@ -74,7 +73,7 @@ impl HTMLSlotElementMethods<crate::DomTypeHolder> for HTMLSlotElement {
 
         // Step 2. Return the result of finding flattened slottables with this.
         rooted_vec!(let mut flattened_slottables);
-        self.find_flattened_slottables(cx.no_gc(), &mut flattened_slottables);
+        self.find_flattened_slottables(cx, &mut flattened_slottables);
 
         flattened_slottables
             .iter()
@@ -138,7 +137,7 @@ impl HTMLSlotElementMethods<crate::DomTypeHolder> for HTMLSlotElement {
         // Step 5. Run assign slottables for a tree for this's root.
         self.upcast::<Node>()
             .GetRootNode(&GetRootNodeOptions::empty())
-            .assign_slottables_for_a_tree(cx.no_gc(), ForceSlottableNodeReconciliation::Force);
+            .assign_slottables_for_a_tree(cx, ForceSlottableNodeReconciliation::Force);
     }
 }
 
@@ -184,7 +183,7 @@ impl HTMLSlotElement {
     }
 
     pub(crate) fn new(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
@@ -203,7 +202,7 @@ impl HTMLSlotElement {
     }
 
     /// <https://dom.spec.whatwg.org/#find-flattened-slotables>
-    fn find_flattened_slottables(&self, no_gc: &NoGC, result: &mut RootedVec<Slottable>) {
+    fn find_flattened_slottables(&self, cx: &JSContext, result: &mut RootedVec<Slottable>) {
         // Step 1. Let result be an empty list.
         // NOTE: In our case "result" is not necessarily empty, because it contains
         // the results of multiple successive calls to "find_flattened_slottables". This method
@@ -216,12 +215,12 @@ impl HTMLSlotElement {
 
         // Step 3. Let slottables be the result of finding slottables given slot.
         rooted_vec!(let mut slottables);
-        self.find_slottables(no_gc, &mut slottables);
+        self.find_slottables(cx, &mut slottables);
 
         // Step 4. If slottables is the empty list, then append each slottable
         // child of slot, in tree order, to slottables.
         if slottables.is_empty() {
-            for child in self.upcast::<Node>().children_unrooted(no_gc) {
+            for child in self.upcast::<Node>().children_unrooted(cx) {
                 let is_slottable = matches!(
                     child.type_id(),
                     NodeTypeId::Element(_) |
@@ -240,7 +239,7 @@ impl HTMLSlotElement {
                 Some(slot_element) if slot_element.upcast::<Node>().is_in_a_shadow_tree() => {
                     // Step 5.1.1 Let temporaryResult be the result of finding flattened slottables given node.
                     // Step 5.1.2 Append each slottable in temporaryResult, in order, to result.
-                    slot_element.find_flattened_slottables(no_gc, result);
+                    slot_element.find_flattened_slottables(cx, result);
                 },
                 // Step 5.2 Otherwise, append node to result.
                 _ => {
@@ -256,9 +255,7 @@ impl HTMLSlotElement {
     ///
     /// To avoid rooting shenanigans, this writes the returned slottables
     /// into the `result` argument
-    fn find_slottables(&self, no_gc: &NoGC, result: &mut RootedVec<Slottable>) {
-        let cx = GlobalScope::get_cx();
-
+    fn find_slottables(&self, cx: &JSContext, result: &mut RootedVec<Slottable>) {
         // Step 1. Let result be an empty list.
         debug_assert!(result.is_empty());
 
@@ -290,14 +287,14 @@ impl HTMLSlotElement {
         }
         // Step 6. Otherwise, for each slottable child slottable of host, in tree order:
         else {
-            for child in host.upcast::<Node>().children_unrooted(no_gc) {
+            for child in host.upcast::<Node>().children_unrooted(cx) {
                 let is_slottable = matches!(
                     child.type_id(),
                     NodeTypeId::Element(_) |
                         NodeTypeId::CharacterData(CharacterDataTypeId::Text(_))
                 );
                 if is_slottable {
-                    rooted!(in(*cx) let slottable = Slottable(Dom::from_ref(&*child)));
+                    rooted!(&in(cx) let slottable = Slottable(Dom::from_ref(&*child)));
                     // Step 6.1 Let foundSlot be the result of finding a slot given slottable.
                     let found_slot = slottable.find_a_slot(false);
 
@@ -313,10 +310,10 @@ impl HTMLSlotElement {
     }
 
     /// <https://dom.spec.whatwg.org/#assign-slotables>
-    pub(crate) fn assign_slottables(&self, no_gc: &NoGC) {
+    pub(crate) fn assign_slottables(&self, cx: &JSContext) {
         // Step 1. Let slottables be the result of finding slottables for slot.
         rooted_vec!(let mut slottables);
-        self.find_slottables(no_gc, &mut slottables);
+        self.find_slottables(cx, &mut slottables);
 
         // Step 2. If slottables and slot’s assigned nodes are not identical,
         // then run signal a slot change for slot.
@@ -331,7 +328,7 @@ impl HTMLSlotElement {
         for slottable in self.assigned_nodes().iter() {
             slottable
                 .node()
-                .remove_style_and_layout_data_from_subtree(no_gc);
+                .remove_style_and_layout_data_from_subtree(cx);
             slottable.node().dirty(NodeDamage::Other);
         }
 
@@ -365,7 +362,7 @@ impl HTMLSlotElement {
         for slottable in slottables.iter() {
             slottable
                 .node()
-                .remove_style_and_layout_data_from_subtree(no_gc);
+                .remove_style_and_layout_data_from_subtree(cx);
             slottable.node().dirty(NodeDamage::Other);
         }
     }
@@ -428,13 +425,13 @@ impl Slottable {
     }
 
     /// <https://dom.spec.whatwg.org/#assign-a-slot>
-    pub(crate) fn assign_a_slot(&self, no_gc: &NoGC) {
+    pub(crate) fn assign_a_slot(&self, cx: &JSContext) {
         // Step 1. Let slot be the result of finding a slot with slottable.
         let slot = self.find_a_slot(false);
 
         // Step 2. If slot is non-null, then run assign slottables for slot.
         if let Some(slot) = slot {
-            slot.assign_slottables(no_gc);
+            slot.assign_slottables(cx);
         }
     }
 
@@ -480,7 +477,7 @@ impl VirtualMethods for HTMLSlotElement {
     /// <https://dom.spec.whatwg.org/#shadow-tree-slots>
     fn attribute_mutated(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         attr: AttrRef<'_>,
         mutation: AttributeMutation,
     ) {
@@ -506,7 +503,7 @@ impl VirtualMethods for HTMLSlotElement {
             // Changing the name might cause slot assignments to change
             self.upcast::<Node>()
                 .GetRootNode(&GetRootNodeOptions::empty())
-                .assign_slottables_for_a_tree(cx.no_gc(), ForceSlottableNodeReconciliation::Skip);
+                .assign_slottables_for_a_tree(cx, ForceSlottableNodeReconciliation::Skip);
         }
     }
 
@@ -521,7 +518,7 @@ impl VirtualMethods for HTMLSlotElement {
         }
     }
 
-    fn unbind_from_tree(&self, cx: &mut js::context::JSContext, context: &UnbindContext) {
+    fn unbind_from_tree(&self, cx: &mut JSContext, context: &UnbindContext) {
         if let Some(s) = self.super_type() {
             s.unbind_from_tree(cx, context);
         }

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -1475,7 +1475,7 @@ impl Node {
 
         // Step 14. If node is assigned, then run assign slottables for node’s assigned slot.
         if let Some(slot) = node.assigned_slot() {
-            slot.assign_slottables(cx.no_gc());
+            slot.assign_slottables(cx);
         }
 
         // Step 15. If oldParent’s root is a shadow root, and oldParent is a slot whose assigned
@@ -1495,10 +1495,10 @@ impl Node {
             // Step 16.1. Run assign slottables for a tree with oldParent’s root.
             old_parent
                 .GetRootNode(&GetRootNodeOptions::empty())
-                .assign_slottables_for_a_tree(cx.no_gc(), ForceSlottableNodeReconciliation::Skip);
+                .assign_slottables_for_a_tree(cx, ForceSlottableNodeReconciliation::Skip);
 
             // Step 16.2. Run assign slottables for a tree with node.
-            node.assign_slottables_for_a_tree(cx.no_gc(), ForceSlottableNodeReconciliation::Skip);
+            node.assign_slottables_for_a_tree(cx, ForceSlottableNodeReconciliation::Skip);
         }
 
         // Step 17. If child is non-null:
@@ -1532,7 +1532,7 @@ impl Node {
             (node.is::<Element>() || node.is::<Text>())
         {
             rooted!(&in(cx) let slottable = Slottable(Dom::from_ref(node)));
-            slottable.assign_a_slot(cx.no_gc());
+            slottable.assign_a_slot(cx);
         }
 
         // Step 22. If newParent’s root is a shadow root, and newParent is a slot whose assigned
@@ -1546,7 +1546,7 @@ impl Node {
 
         // Step 23. Run assign slottables for a tree with node’s root.
         node.GetRootNode(&GetRootNodeOptions::empty())
-            .assign_slottables_for_a_tree(cx.no_gc(), ForceSlottableNodeReconciliation::Skip);
+            .assign_slottables_for_a_tree(cx, ForceSlottableNodeReconciliation::Skip);
 
         // Step 24. For each shadow-including inclusive descendant inclusiveDescendant of node, in
         // shadow-including tree order:
@@ -2001,7 +2001,7 @@ impl Node {
     /// <https://dom.spec.whatwg.org/#assign-slotables-for-a-tree>
     pub(crate) fn assign_slottables_for_a_tree(
         &self,
-        no_gc: &NoGC,
+        cx: &JSContext,
         force: ForceSlottableNodeReconciliation,
     ) {
         // NOTE: This method traverses all descendants of the node and is potentially very
@@ -2022,9 +2022,9 @@ impl Node {
 
         // > To assign slottables for a tree, given a node root, run assign slottables for each slot
         // > slot in root’s inclusive descendants, in tree order.
-        for node in self.traverse_preorder_non_rooting(no_gc, ShadowIncluding::No) {
+        for node in self.traverse_preorder_non_rooting(cx, ShadowIncluding::No) {
             if let Some(slot) = node.downcast::<HTMLSlotElement>() {
-                slot.assign_slottables(no_gc);
+                slot.assign_slottables(cx);
             }
         }
     }
@@ -2205,7 +2205,7 @@ pub(super) fn as_uintptr<T>(t: &T) -> uintptr_t {
 
 impl Node {
     pub(crate) fn reflect_node<N>(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         node: Box<N>,
         document: &Document,
     ) -> DomRoot<N>
@@ -2216,7 +2216,7 @@ impl Node {
     }
 
     pub(crate) fn reflect_node_with_proto<N>(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         node: Box<N>,
         document: &Document,
         proto: Option<HandleObject>,
@@ -2591,7 +2591,7 @@ impl Node {
                 (kid.is::<Element>() || kid.is::<Text>())
             {
                 rooted!(&in(cx) let slottable = Slottable(Dom::from_ref(kid)));
-                slottable.assign_a_slot(cx.no_gc());
+                slottable.assign_a_slot(cx);
             }
 
             // Step 7.5 If parent’s root is a shadow root, and parent is a slot whose assigned nodes
@@ -2605,7 +2605,7 @@ impl Node {
 
             // Step 7.6 Run assign slottables for a tree with node’s root.
             kid.GetRootNode(&GetRootNodeOptions::empty())
-                .assign_slottables_for_a_tree(cx.no_gc(), ForceSlottableNodeReconciliation::Skip);
+                .assign_slottables_for_a_tree(cx, ForceSlottableNodeReconciliation::Skip);
 
             // Step 7.7. For each shadow-including inclusive descendant inclusiveDescendant of node,
             // in shadow-including tree order:
@@ -2797,7 +2797,7 @@ impl Node {
 
         // Step 8. If node is assigned, then run assign slottables for node’s assigned slot.
         if let Some(slot) = node.assigned_slot() {
-            slot.assign_slottables(cx.no_gc());
+            slot.assign_slottables(cx);
         }
 
         // Step 9. If parent’s root is a shadow root, and parent is a slot whose assigned nodes is the empty list,
@@ -2817,10 +2817,10 @@ impl Node {
             // Step 10.1 Run assign slottables for a tree with parent’s root.
             parent
                 .GetRootNode(&GetRootNodeOptions::empty())
-                .assign_slottables_for_a_tree(cx.no_gc(), ForceSlottableNodeReconciliation::Skip);
+                .assign_slottables_for_a_tree(cx, ForceSlottableNodeReconciliation::Skip);
 
             // Step 10.2 Run assign slottables for a tree with node.
-            node.assign_slottables_for_a_tree(cx.no_gc(), ForceSlottableNodeReconciliation::Force);
+            node.assign_slottables_for_a_tree(cx, ForceSlottableNodeReconciliation::Force);
         }
 
         // TODO: Step 15. transient registered observers
@@ -3197,7 +3197,7 @@ impl Node {
 
     pub(crate) fn html_serialize(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         traversal_scope: html_serialize::TraversalScope,
         serialize_shadow_roots: bool,
         shadow_roots: Vec<DomRoot<ShadowRoot>>,
@@ -3253,7 +3253,7 @@ impl Node {
     /// <https://html.spec.whatwg.org/multipage/#fragment-serializing-algorithm-steps>
     pub(crate) fn fragment_serialization_algorithm(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         require_well_formed: bool,
     ) -> Fallible<DOMString> {
         // Step 1. Let context document be node's node document.
@@ -4213,7 +4213,7 @@ impl VirtualMethods for Node {
 
     // This handles the ranges mentioned in steps 2-3 when removing a node.
     /// <https://dom.spec.whatwg.org/#concept-node-remove>
-    fn unbind_from_tree(&self, cx: &mut js::context::JSContext, context: &UnbindContext) {
+    fn unbind_from_tree(&self, cx: &mut JSContext, context: &UnbindContext) {
         self.super_type().unwrap().unbind_from_tree(cx, context);
 
         // Ranges should only drain to the parent from inclusive non-shadow
@@ -4252,7 +4252,7 @@ impl VirtualMethods for Node {
         self.owner_doc().content_and_heritage_changed(self);
     }
 
-    fn handle_event(&self, cx: &mut js::context::JSContext, event: &Event) {
+    fn handle_event(&self, cx: &mut JSContext, event: &Event) {
         if event.DefaultPrevented() || event.flags().contains(EventFlags::Handled) {
             return;
         }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -449,6 +449,7 @@ DOMInterfaces = {
     ],
     'realm': ['RequestFullscreen'],
     'canGc': ['Attributes'],
+    'cx_no_gc': ['GetAssignedSlot'],
 },
 
 'ElementInternals': {
@@ -1122,7 +1123,7 @@ DOMInterfaces = {
 
 'Text': {
     'cx': ['SplitText'],
-    'cx_no_gc': ['WholeText']
+    'cx_no_gc': ['WholeText', 'GetAssignedSlot']
 },
 
 'TextEncoder': {


### PR DESCRIPTION
We now pass in a `&JSContext` instead. Since `&JSContext` derefs into `NoGc`, we can keep on using the unrooted iterators to maintain equal performance.

Part of #40600

Testing: it compiles