### PR TITLE
android: Convert history button on large screen to Compose UI

### DIFF
--- a/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
+++ b/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
@@ -5,7 +5,6 @@
  */
 package org.servo.servoshell
 
-import android.app.Activity
 import android.app.AlertDialog
 import android.content.Intent
 import android.content.SharedPreferences
@@ -19,6 +18,12 @@ import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.core.content.getSystemService
 import androidx.core.view.isVisible
 import androidx.preference.PreferenceManager
@@ -27,7 +32,7 @@ import com.google.android.material.progressindicator.CircularProgressIndicator
 import org.servo.servoview.Servo
 import org.servo.servoview.ServoView
 
-class MainActivity : Activity(), Servo.Client {
+class MainActivity : AppCompatActivity(), Servo.Client {
     private lateinit var servoView: ServoView
     private var bottomNav: BottomNavigationView? = null
 
@@ -84,7 +89,13 @@ class MainActivity : Activity(), Servo.Client {
             findViewById<View>(R.id.refresh_menu_item).setOnClickListener(actionClickListener)
             findViewById<View>(R.id.cancel_menu_item).setOnClickListener(actionClickListener)
             findViewById<View>(R.id.settings_menu_item).setOnClickListener(actionClickListener)
-            findViewById<View>(R.id.history_menu_item).setOnClickListener(actionClickListener)
+            findViewById<ComposeView>(R.id.history_menu_item)?.apply {
+                setContent {
+                    IconButton(onClick = { dispatchAction(id) }) {
+                        Icon(painterResource(R.drawable.history), stringResource(R.string.history_title))
+                    }
+                }
+            }
         }
 
         servoView.setClient(this)

--- a/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
+++ b/support/android/apk/servoapp/src/main/java/org/servo/servoshell/MainActivity.kt
@@ -89,7 +89,7 @@ class MainActivity : AppCompatActivity(), Servo.Client {
             findViewById<View>(R.id.refresh_menu_item).setOnClickListener(actionClickListener)
             findViewById<View>(R.id.cancel_menu_item).setOnClickListener(actionClickListener)
             findViewById<View>(R.id.settings_menu_item).setOnClickListener(actionClickListener)
-            findViewById<ComposeView>(R.id.history_menu_item)?.apply {
+            findViewById<ComposeView>(R.id.history_menu_item).apply {
                 setContent {
                     IconButton(onClick = { dispatchAction(id) }) {
                         Icon(painterResource(R.drawable.history), stringResource(R.string.history_title))

--- a/support/android/apk/servoapp/src/main/res/layout-sw600dp/activity_main.xml
+++ b/support/android/apk/servoapp/src/main/res/layout-sw600dp/activity_main.xml
@@ -127,16 +127,12 @@
                 app:iconTint="?colorOnBackground"
                 />
 
-            <com.google.android.material.button.MaterialButton
+            <androidx.compose.ui.platform.ComposeView
                 android:id="@+id/history_menu_item"
-                style="@style/Widget.Material3.Button.IconButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:contentDescription="@string/history_title"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
-                app:icon="@drawable/history"
-                app:iconTint="?colorOnBackground"
                 />
 
         </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
`MainActivity` had to be switched from an `Activity` to an `AppCompatActivity` as the usage of Compose UI in a View requires it. Otherwise, we get the runtime exception `ViewTreeLifecycleOwner not found from android.widget.LinearLayout`. `AppCompatActivity` is just a backwards-compatible version of `Activity`, and should generally be used anyway for reasons such as this.

Testing: There are no automated tests for Android.
Fixes: Part of #45715.