### PR TITLE
stylo: Relax assert for paused animations to include equality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7451,7 +7451,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.38.0"
-source = "git+https://github.com/servo/stylo?rev=44bdcc6a017141ff8b6a856cd717c52a476d90cb#44bdcc6a017141ff8b6a856cd717c52a476d90cb"
+source = "git+https://github.com/servo/stylo?rev=6b4eb30c6a312babd3bf12f5a75a3479c6b840ec#6b4eb30c6a312babd3bf12f5a75a3479c6b840ec"
 dependencies = [
  "bitflags 2.13.0",
  "cssparser",
@@ -9202,7 +9202,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=44bdcc6a017141ff8b6a856cd717c52a476d90cb#44bdcc6a017141ff8b6a856cd717c52a476d90cb"
+source = "git+https://github.com/servo/stylo?rev=6b4eb30c6a312babd3bf12f5a75a3479c6b840ec#6b4eb30c6a312babd3bf12f5a75a3479c6b840ec"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -9673,7 +9673,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=44bdcc6a017141ff8b6a856cd717c52a476d90cb#44bdcc6a017141ff8b6a856cd717c52a476d90cb"
+source = "git+https://github.com/servo/stylo?rev=6b4eb30c6a312babd3bf12f5a75a3479c6b840ec#6b4eb30c6a312babd3bf12f5a75a3479c6b840ec"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -9729,7 +9729,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=44bdcc6a017141ff8b6a856cd717c52a476d90cb#44bdcc6a017141ff8b6a856cd717c52a476d90cb"
+source = "git+https://github.com/servo/stylo?rev=6b4eb30c6a312babd3bf12f5a75a3479c6b840ec#6b4eb30c6a312babd3bf12f5a75a3479c6b840ec"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -9738,7 +9738,7 @@ dependencies = [
 [[package]]
 name = "stylo_derive"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=44bdcc6a017141ff8b6a856cd717c52a476d90cb#44bdcc6a017141ff8b6a856cd717c52a476d90cb"
+source = "git+https://github.com/servo/stylo?rev=6b4eb30c6a312babd3bf12f5a75a3479c6b840ec#6b4eb30c6a312babd3bf12f5a75a3479c6b840ec"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -9750,7 +9750,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=44bdcc6a017141ff8b6a856cd717c52a476d90cb#44bdcc6a017141ff8b6a856cd717c52a476d90cb"
+source = "git+https://github.com/servo/stylo?rev=6b4eb30c6a312babd3bf12f5a75a3479c6b840ec#6b4eb30c6a312babd3bf12f5a75a3479c6b840ec"
 dependencies = [
  "bitflags 2.13.0",
  "stylo_malloc_size_of",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=44bdcc6a017141ff8b6a856cd717c52a476d90cb#44bdcc6a017141ff8b6a856cd717c52a476d90cb"
+source = "git+https://github.com/servo/stylo?rev=6b4eb30c6a312babd3bf12f5a75a3479c6b840ec#6b4eb30c6a312babd3bf12f5a75a3479c6b840ec"
 dependencies = [
  "app_units",
  "cssparser",
@@ -9776,7 +9776,7 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=44bdcc6a017141ff8b6a856cd717c52a476d90cb#44bdcc6a017141ff8b6a856cd717c52a476d90cb"
+source = "git+https://github.com/servo/stylo?rev=6b4eb30c6a312babd3bf12f5a75a3479c6b840ec#6b4eb30c6a312babd3bf12f5a75a3479c6b840ec"
 dependencies = [
  "toml",
 ]
@@ -9784,7 +9784,7 @@ dependencies = [
 [[package]]
 name = "stylo_traits"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=44bdcc6a017141ff8b6a856cd717c52a476d90cb#44bdcc6a017141ff8b6a856cd717c52a476d90cb"
+source = "git+https://github.com/servo/stylo?rev=6b4eb30c6a312babd3bf12f5a75a3479c6b840ec#6b4eb30c6a312babd3bf12f5a75a3479c6b840ec"
 dependencies = [
  "app_units",
  "bitflags 2.13.0",
@@ -10204,7 +10204,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.4.0"
-source = "git+https://github.com/servo/stylo?rev=44bdcc6a017141ff8b6a856cd717c52a476d90cb#44bdcc6a017141ff8b6a856cd717c52a476d90cb"
+source = "git+https://github.com/servo/stylo?rev=6b4eb30c6a312babd3bf12f5a75a3479c6b840ec#6b4eb30c6a312babd3bf12f5a75a3479c6b840ec"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -10217,7 +10217,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=44bdcc6a017141ff8b6a856cd717c52a476d90cb#44bdcc6a017141ff8b6a856cd717c52a476d90cb"
+source = "git+https://github.com/servo/stylo?rev=6b4eb30c6a312babd3bf12f5a75a3479c6b840ec#6b4eb30c6a312babd3bf12f5a75a3479c6b840ec"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,14 +215,14 @@ rustls-pki-types = "1.14"
 rustls-platform-verifier = "0.7.0"
 sea-query = { version = "=1.0.0-rc.31", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = "=0.8.0-rc.15"
-selectors = { git = "https://github.com/servo/stylo", rev = "44bdcc6a017141ff8b6a856cd717c52a476d90cb" }
+selectors = { git = "https://github.com/servo/stylo", rev = "6b4eb30c6a312babd3bf12f5a75a3479c6b840ec" }
 seq-macro = "0.3.6"
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
 serde_json = "1.0"
 serde_test = "1.0"
-servo_arc = { git = "https://github.com/servo/stylo", rev = "44bdcc6a017141ff8b6a856cd717c52a476d90cb" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "6b4eb30c6a312babd3bf12f5a75a3479c6b840ec" }
 sha1 = "0.11"
 sha2 = "0.11"
 sha3 = "0.12"
@@ -232,12 +232,12 @@ smallvec = { version = "1.15", features = ["serde", "union"] }
 speexdsp-resampler = "0.1.0"
 string_cache = "0.9"
 strum = { version = "0.28", features = ["derive"] }
-stylo = { git = "https://github.com/servo/stylo", rev = "44bdcc6a017141ff8b6a856cd717c52a476d90cb" }
-stylo_atoms = { git = "https://github.com/servo/stylo", rev = "44bdcc6a017141ff8b6a856cd717c52a476d90cb" }
-stylo_dom = { git = "https://github.com/servo/stylo", rev = "44bdcc6a017141ff8b6a856cd717c52a476d90cb" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "44bdcc6a017141ff8b6a856cd717c52a476d90cb" }
-stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "44bdcc6a017141ff8b6a856cd717c52a476d90cb" }
-stylo_traits = { git = "https://github.com/servo/stylo", rev = "44bdcc6a017141ff8b6a856cd717c52a476d90cb" }
+stylo = { git = "https://github.com/servo/stylo", rev = "6b4eb30c6a312babd3bf12f5a75a3479c6b840ec" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "6b4eb30c6a312babd3bf12f5a75a3479c6b840ec" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "6b4eb30c6a312babd3bf12f5a75a3479c6b840ec" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "6b4eb30c6a312babd3bf12f5a75a3479c6b840ec" }
+stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "6b4eb30c6a312babd3bf12f5a75a3479c6b840ec" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "6b4eb30c6a312babd3bf12f5a75a3479c6b840ec" }
 surfman = { version = "0.13.0", features = ["chains"] }
 swapper = "0.1"
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }

--- a/tests/wpt/tests/css/css-animations/animation-iteration-count-010.html
+++ b/tests/wpt/tests/css/css-animations/animation-iteration-count-010.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<title>CSS Animation Test: paused animation with various animation-iteration-count</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-animations/#animation-iteration-count">
+<meta name="assert" content="
+  The animation has a duration of 1s and a delay of -2s, meaning that it has already
+  completed 2 iterations.
+  Therefore, if the animation-iteration-count is 2 or less, the animation is finished,
+  so the background should be transparent.
+  If it's more than 2, then the animation is at the very beginning of the 3rd iteration,
+  and thus the background should be green.
+">
+
+<style>
+@keyframes keyframes {
+  from { background: green }
+  to { background: red }
+}
+div {
+  animation: 1s -2s infinite paused keyframes;
+  width: 100px;
+  height: 100px;
+  border: solid;
+  margin: 1em;
+  float: left;
+}
+</style>
+
+<div style="animation-iteration-count: 1"        data-expected="rgba(0, 0, 0, 0)"></div>
+<div style="animation-iteration-count: 2"        data-expected="rgba(0, 0, 0, 0)"></div>
+<div style="animation-iteration-count: 2.1"      data-expected="rgb(0, 128, 0)"></div>
+<div style="animation-iteration-count: 3"        data-expected="rgb(0, 128, 0)"></div>
+<div style="animation-iteration-count: 4"        data-expected="rgb(0, 128, 0)"></div>
+<div style="animation-iteration-count: infinite" data-expected="rgb(0, 128, 0)"></div>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+for (let element of document.querySelectorAll("div")) {
+  test(function() {
+    assert_equals(
+      getComputedStyle(element).backgroundColor,
+      element.dataset.expected,
+      "background-color",
+    );
+  }, element.style.cssText);
+}
+</script>


### PR DESCRIPTION
Bumps Stylo to https://github.com/servo/stylo/pull/404/

Testing: Adds a test that works both as a crashtest for the old `*progress > n` assertion in Stylo, and also as test coverage for the following `*progress -= n`, since attempting to remove that didn't fail any existing test.

Fixes: #45950 
