### PR TITLE
script: Introduce end of loading phases

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -282,6 +282,16 @@ pub(crate) enum IsHTMLDocument {
     NonHTMLDocument,
 }
 
+#[derive(Clone, Copy, Default, MallocSizeOf, PartialEq)]
+pub(crate) enum TheEndLoadingPhase {
+    #[default]
+    Initial,
+    ProcessingDeferredScripts,
+    ProcessingAsSoonAsPossibleScripts,
+    WaitingForLoadEventBlockers,
+    Done,
+}
+
 /// Information about a declarative refresh
 #[derive(JSTraceable, MallocSizeOf)]
 pub(crate) enum DeclarativeRefresh {
@@ -411,9 +421,12 @@ pub(crate) struct Document {
     stylesheet_list: MutNullableDom<StyleSheetList>,
     ready_state: Cell<DocumentReadyState>,
     /// Whether the DOMContentLoaded event has already been dispatched.
+    /// TODO(43149): Remove when document replacement is implemented
     domcontentloaded_dispatched: Cell<bool>,
     /// The script element that is currently executing.
     current_script: MutNullableDom<HTMLScriptElement>,
+    #[no_trace]
+    current_the_end_loading_phase: Cell<TheEndLoadingPhase>,
     /// <https://html.spec.whatwg.org/multipage/#pending-parsing-blocking-script>
     pending_parsing_blocking_script: DomRefCell<Option<PendingScript>>,
     /// Number of stylesheets that block executing the next parser-inserted script
@@ -1999,8 +2012,8 @@ impl Document {
             }));
     }
 
-    // https://html.spec.whatwg.org/multipage/#the-end
-    // https://html.spec.whatwg.org/multipage/#delay-the-load-event
+    /// Step 8 of <https://html.spec.whatwg.org/multipage/#the-end>
+    /// <https://html.spec.whatwg.org/multipage/#delay-the-load-event>
     pub(crate) fn finish_load(&self, load: LoadType, cx: &mut JSContext) {
         // This does not delay the load event anymore.
         debug!("Document got finish_load: {:?}", load);
@@ -2031,6 +2044,8 @@ impl Document {
             _ => {},
         }
 
+        // TODO(43149): Remove when document replacement is implemented
+
         // Step 4 is in another castle, namely at the end of
         // process_deferred_scripts.
 
@@ -2056,6 +2071,17 @@ impl Document {
         }
 
         ScriptThread::mark_document_with_no_blocked_loads(self);
+
+        // END TODO(43149): Remove when document replacement is implemented
+
+        // Step 8. Spin the event loop until there is nothing that delays the load event in the Document.
+        let document = Trusted::new(self);
+        self.owner_global()
+            .task_manager()
+            .dom_manipulation_task_source()
+            .queue(task!(fire_load_event: move |cx| {
+                document.root().wait_until_load_blockers_have_resolved(cx);
+            }));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#checking-if-unloading-is-canceled>
@@ -2238,6 +2264,7 @@ impl Document {
     }
 
     // https://html.spec.whatwg.org/multipage/#the-end
+    // TODO(43149): Remove when document replacement is implemented
     pub(crate) fn maybe_queue_document_completion(&self, cx: &mut JSContext) {
         // https://html.spec.whatwg.org/multipage/#delaying-load-events-mode
         let is_in_delaying_load_events_mode = match self.window.undiscarded_window_proxy() {
@@ -2261,6 +2288,11 @@ impl Document {
             return;
         }
 
+        self.queue_document_completion(cx);
+    }
+
+    /// Step 9 of <https://html.spec.whatwg.org/multipage/#the-end>
+    fn queue_document_completion(&self, cx: &mut JSContext) {
         self.loader.borrow_mut().inhibit_events();
 
         // The rest will ever run only once per document.
@@ -2368,6 +2400,11 @@ impl Document {
         self.completely_loaded.get()
     }
 
+    pub(crate) fn start_the_end_loading_phase(&self) {
+        self.current_the_end_loading_phase
+            .set(TheEndLoadingPhase::ProcessingDeferredScripts);
+    }
+
     // https://html.spec.whatwg.org/multipage/#pending-parsing-blocking-script
     pub(crate) fn set_pending_parsing_blocking_script(
         &self,
@@ -2441,6 +2478,7 @@ impl Document {
             scripts.swap_remove(idx);
         }
         element.execute(cx, result);
+        self.wait_until_asap_scripts_have_executed();
     }
 
     // https://html.spec.whatwg.org/multipage/#list-of-scripts-that-will-execute-in-order-as-soon-as-possible
@@ -2463,9 +2501,11 @@ impl Document {
         {
             element.execute(cx, result);
         }
+
+        self.wait_until_asap_scripts_have_executed();
     }
 
-    // https://html.spec.whatwg.org/multipage/#list-of-scripts-that-will-execute-when-the-document-has-finished-parsing
+    /// <https://html.spec.whatwg.org/multipage/#list-of-scripts-that-will-execute-when-the-document-has-finished-parsing>
     pub(crate) fn add_deferred_script(&self, script: &HTMLScriptElement) {
         self.deferred_scripts.push(script);
     }
@@ -2482,67 +2522,82 @@ impl Document {
         self.process_deferred_scripts(cx);
     }
 
-    /// <https://html.spec.whatwg.org/multipage/#the-end> step 3.
+    /// Step 5 of <https://html.spec.whatwg.org/multipage/#the-end>
     fn process_deferred_scripts(&self, cx: &mut JSContext) {
-        if self.ready_state.get() != DocumentReadyState::Interactive {
+        if self.current_the_end_loading_phase.get() != TheEndLoadingPhase::ProcessingDeferredScripts
+        {
             return;
         }
-        // Part of substep 1.
+
+        // Step 5.1. Spin the event loop until the first script in the list of scripts that will execute when the
+        // document has finished parsing has its ready to be parser-executed set to true and the parser's Document
+        // has no style sheet that is blocking scripts.
         loop {
             if self.script_blocking_stylesheets_count.get() > 0 {
                 return;
             }
+            // Step 5.3. Remove the first script element from the list of scripts that will execute when the
+            // document has finished parsing (i.e. shift out the first entry in the list).
             if let Some((element, result)) = self.deferred_scripts.take_next_ready_to_be_executed()
             {
+                // Step 5.2. Execute the script element given by the first script in the list of scripts that will execute when the document has finished parsing.
                 element.execute(cx, result);
             } else {
                 break;
             }
         }
+        // Step 5. While the list of scripts that will execute when the document has finished parsing is not empty:
         if self.deferred_scripts.is_empty() {
-            // https://html.spec.whatwg.org/multipage/#the-end step 4.
+            self.current_the_end_loading_phase
+                .set(TheEndLoadingPhase::ProcessingAsSoonAsPossibleScripts);
+            // TODO(43149): Use `dispatch_dom_content_loaded` when document replacement is implemented
             self.maybe_dispatch_dom_content_loaded();
         }
     }
 
     /// Step 6. of <https://html.spec.whatwg.org/multipage/#the-end>
     pub(crate) fn maybe_dispatch_dom_content_loaded(&self) {
+        // TODO(43149): Remove when document replacement is implemented
         if self.domcontentloaded_dispatched.get() {
             return;
         }
         self.domcontentloaded_dispatched.set(true);
+
+        self.dispatch_dom_content_loaded();
+    }
+
+    /// Step 6 of <https://html.spec.whatwg.org/multipage/#the-end>
+    fn dispatch_dom_content_loaded(&self) {
         assert_ne!(
             self.ReadyState(),
             DocumentReadyState::Complete,
             "Complete before DOMContentLoaded?"
         );
 
-        // Step 6 Queue a global task on the DOM manipulation task source given the Document's
+        // Step 6. Queue a global task on the DOM manipulation task source given the Document's
         // relevant global object to run the following substeps:
         let document = Trusted::new(self);
         self.owner_global()
             .task_manager()
             .dom_manipulation_task_source()
             .queue(task!(fire_dom_content_loaded_event: move |cx| {
-            let document = document.root();
+                // Step 6.1. Set the Document's load timing info's DOM content loaded event start time to
+                // the current high resolution time given the Document's relevant global object.
+                let document = document.root();
+                update_with_current_instant(&document.navigation_timing.dom_content_loaded_event_start);
+                // Step 6.2. Fire an event named DOMContentLoaded at the Document object, with its bubbles attribute initialized to true.
+                document.upcast::<EventTarget>().fire_bubbling_event(cx, atom!("DOMContentLoaded"));
+                // Step 6.3. Set the Document's load timing info's DOM content loaded event end time to
+                // the current high resolution time given the Document's relevant global object.
+                update_with_current_instant(&document.navigation_timing.dom_content_loaded_event_end);
+                // Step 6.4. Enable the client message queue of the ServiceWorkerContainer object
+                // whose associated service worker client is the Document object's relevant settings object.
+                // TODO
 
-            // Step 6.1 Set the Document's load timing info's DOM content loaded event start time
-            // to the current high resolution time given the Document's relevant global object.
-            update_with_current_instant(&document.navigation_timing.dom_content_loaded_event_start);
-            // Step 6.2 Fire an event named DOMContentLoaded at the Document object, with its bubbles
-            // attribute initialized to true.
-            document.upcast::<EventTarget>().fire_bubbling_event(cx, atom!("DOMContentLoaded"));
-
-            // Step 6.3 Set the Document's load timing info's DOM content loaded event end time to the current
-            // high resolution time given the Document's relevant global object.
-            update_with_current_instant(&document.navigation_timing.dom_content_loaded_event_end);
-
-            // TODO Step 6.4 Enable the client message queue of the ServiceWorkerContainer object whose associated
-            // service worker client is the Document object's relevant settings object.
-
-            // TODO Step 6.5 Invoke WebDriver BiDi DOM content loaded with the Document's browsing context, and
-            // a new WebDriver BiDi navigation status whose id is the Document object's during-loading
-            // navigation ID for WebDriver BiDi, status is "pending", and url is the Document object's URL.
+                // Step 6.5. Invoke WebDriver BiDi DOM content loaded with the Document's browsing context,
+                // and a new WebDriver BiDi navigation status whose id is the Document object's during-loading
+                // navigation ID for WebDriver BiDi, status is "pending", and url is the Document object's URL.
+                // TODO
             }));
 
         // html parsing has finished - set dom content loaded
@@ -2550,8 +2605,79 @@ impl Document {
             .borrow()
             .maybe_set_tti(InteractiveFlag::DOMContentLoaded);
 
-        // Step 4.2.
-        // TODO: client message queue.
+        self.wait_until_asap_scripts_have_executed();
+    }
+
+    fn has_finished_all_asap_scripts(&self) -> bool {
+        self.asap_scripts_set.borrow().is_empty() && self.asap_in_order_scripts_list.is_empty()
+    }
+
+    /// Step 7 of <https://html.spec.whatwg.org/multipage/#the-end>
+    fn wait_until_asap_scripts_have_executed(&self) {
+        if self.current_the_end_loading_phase.get() !=
+            TheEndLoadingPhase::ProcessingAsSoonAsPossibleScripts
+        {
+            return;
+        }
+        // Step 7. Spin the event loop until the set of scripts that will execute as soon as possible
+        // and the list of scripts that will execute in order as soon as possible are empty.
+        if self.has_finished_all_asap_scripts() {
+            let document = Trusted::new(self);
+            self.owner_global()
+                .task_manager()
+                .dom_manipulation_task_source()
+                .queue(task!(fire_load_event: move |cx| {
+                    let document = document.root();
+                    // Ensure that if this task is fired multiple times, we only progress the
+                    // end of loading phase once.
+                    if document.current_the_end_loading_phase.get() !=
+                        TheEndLoadingPhase::ProcessingAsSoonAsPossibleScripts
+                    {
+                        return;
+                    }
+                    // Check again if we still fulfil the goal
+                    if !document.has_finished_all_asap_scripts() {
+                        return;
+                    }
+                    document.current_the_end_loading_phase
+                        .set(TheEndLoadingPhase::WaitingForLoadEventBlockers);
+                    document.wait_until_load_blockers_have_resolved(cx);
+                }));
+        }
+    }
+
+    /// Step 8 of <https://html.spec.whatwg.org/multipage/#the-end>
+    pub(crate) fn wait_until_load_blockers_have_resolved(&self, _cx: &mut JSContext) {
+        if self.current_the_end_loading_phase.get() !=
+            TheEndLoadingPhase::WaitingForLoadEventBlockers
+        {
+            return;
+        }
+        // Step 8. Spin the event loop until there is nothing that delays the load event in the Document.
+        {
+            let loader = self.loader.borrow();
+
+            // Servo measures when the top-level content (not iframes) is loaded.
+            if self
+                .navigation_timing
+                .top_level_dom_complete
+                .get()
+                .is_none() &&
+                loader.is_only_blocked_by_iframes()
+            {
+                update_with_current_instant(&self.navigation_timing.top_level_dom_complete);
+            }
+
+            let not_ready_for_load = loader.is_blocked() || loader.events_inhibited();
+            if not_ready_for_load {
+                return;
+            }
+        }
+
+        self.current_the_end_loading_phase
+            .set(TheEndLoadingPhase::Done);
+        // TODO(43149): Add when document replacement is implemented
+        // self.queue_document_completion(cx);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#destroy-a-document-and-its-descendants>
@@ -3648,8 +3774,8 @@ impl Document {
             stylesheet_list: MutNullableDom::new(None),
             ready_state: Cell::new(ready_state),
             domcontentloaded_dispatched: Cell::new(domcontentloaded_dispatched),
-
             current_script: Default::default(),
+            current_the_end_loading_phase: Default::default(),
             pending_parsing_blocking_script: Default::default(),
             script_blocking_stylesheets_count: Default::default(),
             render_blocking_element_count: Default::default(),

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -2079,7 +2079,7 @@ impl Document {
         self.owner_global()
             .task_manager()
             .dom_manipulation_task_source()
-            .queue(task!(fire_load_event: move |cx| {
+            .queue(task!(wait_for_load_blockers: move |cx| {
                 document.root().wait_until_load_blockers_have_resolved(cx);
             }));
     }
@@ -2626,7 +2626,7 @@ impl Document {
             self.owner_global()
                 .task_manager()
                 .dom_manipulation_task_source()
-                .queue(task!(fire_load_event: move |cx| {
+                .queue(task!(transition_away_from_asap_scripts: move |cx| {
                     let document = document.root();
                     // Ensure that if this task is fired multiple times, we only progress the
                     // end of loading phase once.

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -2044,7 +2044,7 @@ impl Document {
             _ => {},
         }
 
-        // TODO(43149): Remove when document replacement is implemented
+        // START TODO(43149): Remove when document replacement is implemented
 
         // Step 4 is in another castle, namely at the end of
         // process_deferred_scripts.

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -764,18 +764,15 @@ impl ServoParser {
         // Step 1. If the active speculative HTML parser is not null,
         // then stop the speculative HTML parser and return.
         // TODO
-
         // Step 2. Set the insertion point to undefined.
-        self.document.set_current_parser(None);
-
+        self.tokenizer.end(cx);
         // Step 3. Update the current document readiness to "interactive".
         self.document
             .set_ready_state(cx, DocumentReadyState::Interactive);
-
         // Step 4. Pop all the nodes off the stack of open elements.
-        self.tokenizer.end(cx);
-
-        // Steps 5-11 are in another castle, namely finish_load.
+        self.document.set_current_parser(None);
+        // Step 5. While the list of scripts that will execute when the document has finished parsing is not empty:
+        self.document.start_the_end_loading_phase();
         let url = self.tokenizer.url().clone();
         self.document.finish_load(LoadType::PageSource(url), cx);
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -346,6 +346,7 @@ pub struct ScriptThread {
 
     /// A list of pipelines containing documents that finished loading all their blocking
     /// resources during a turn of the event loop.
+    /// TODO(43149): Remove when document replacement is implemented
     docs_with_no_blocking_loads: DomRefCell<FxHashSet<Dom<Document>>>,
 
     /// <https://html.spec.whatwg.org/multipage/#custom-element-reactions-stack>
@@ -1555,6 +1556,7 @@ impl ScriptThread {
                 .perform_a_dom_garbage_collection_checkpoint();
         }
 
+        // TODO(43149): Remove when document replacement is implemented
         {
             // https://html.spec.whatwg.org/multipage/#the-end step 6
             let mut docs = self.docs_with_no_blocking_loads.borrow_mut();


### PR DESCRIPTION
Since the steps for https://html.spec.whatwg.org/multipage/parsing.html#the-end are scattered throughout various pieces, it has been difficult to figure out when to run what.

To remedy that, introduce the concept of phases. These phases are checked in every method that needs to
"Spin the event loop" to know whether

1. It is the appropriate time to continue with #the-end
2. It has fully achieved its goal

For example, when processing deferred scripts, we need to do this after a deferred script has finished loading. But we also need to do it at the start of parsing, since we might not have any deferred scripts at all.

Therefore, each previous step sets the appropriate phase and calls the corresponding next step. Each step then verifies its conditions and continues if required.

The code is not in effect until document replacement is implemented, which comes in a follow-up.

Fixes #41972

Testing: no observable behavior, only preparation plumbing