### PR TITLE
net: Support stale-while-revalidate directive

### DIFF
--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -257,6 +257,32 @@ fn get_response_expiry(response: &Response) -> Duration {
     Duration::ZERO
 }
 
+
+/// The `headers` crate's `CacheControl` does not understand `stale-while-revalidate` directive,
+/// so we need to parse the raw `Cache-Control` header values.
+/// <https://datatracker.ietf.org/doc/html/rfc5861#section-3>
+fn get_stale_while_revalidate(headers: &HeaderMap) -> Duration {
+    for value in headers.get_all(header::CACHE_CONTROL) {
+        let Ok(value) = value.to_str() else {
+            continue;
+        };
+        for directive in value.split(',') {
+            let directive = directive.trim();
+            let Some((name, argument)) = directive.split_once('=') else {
+                continue;
+            };
+            if !name.trim().eq_ignore_ascii_case("stale-while-revalidate") {
+                continue;
+            }
+            // The argument is a number of seconds, optionally quoted.
+            let argument = argument.trim().trim_matches('"');
+            if let Ok(seconds) = argument.parse::<u64>() {
+                return Duration::from_secs(seconds);
+            }
+        }
+    }
+    Duration::ZERO
+}
 /// Request Cache-Control Directives
 /// <https://tools.ietf.org/html/rfc7234#section-5.2.1>
 fn get_expiry_adjustment_from_request_headers(request: &Request, expires: Duration) -> Duration {

--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -9,6 +9,7 @@
 
 use std::ops::Bound;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc as StdArc;
 use std::time::{Duration, Instant, SystemTime};
 
 use headers::{
@@ -19,7 +20,7 @@ use log::{debug, error};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use malloc_size_of_derive::MallocSizeOf;
 use net_traits::http_status::HttpStatus;
-use net_traits::request::Request;
+use net_traits::request::{CacheMode, Request};
 use net_traits::response::{Response, ResponseBody};
 use net_traits::{CacheEntryDescriptor, FetchMetadata, Metadata, ResourceFetchTiming};
 use parking_lot::Mutex as ParkingLotMutex;
@@ -69,6 +70,9 @@ pub struct CachedResource {
     status: HttpStatus,
     url_list: Vec<ServoUrl>,
     expires: Duration,
+    stale_while_revalidate: Duration,
+    #[conditional_malloc_size_of]
+    revalidating: StdArc<AtomicBool>,
     last_validated: Instant,
 }
 
@@ -91,8 +95,14 @@ struct CachedMetadata {
 pub(crate) struct CachedResponse {
     /// The response constructed from the cached resource
     pub response: Response,
-    /// The revalidation flag for the stored response
-    pub needs_validation: bool,
+    /// The revalidation flag for the stored response. When set, the response is
+    /// stale and must be synchronously revalidated before being used.
+    pub needs_synchronous_validation: bool,
+    /// When this is set, `needs_synchronous_validation` is `false` and the caller is responsible
+    /// for spawning the background revalidation, claiming the single-flight guard.
+    pub revalidate_in_background: bool,
+    /// Single-flight guard for the background revalidation.
+    pub revalidation_guard: StdArc<AtomicBool>,
 }
 
 type CacheEntry = std::sync::Arc<TokioRwLock<Vec<CachedResource>>>;
@@ -283,6 +293,31 @@ fn get_stale_while_revalidate(headers: &HeaderMap) -> Duration {
     }
     Duration::ZERO
 }
+
+/// Determine whether the request itself demands revalidation.
+/// <https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.1>
+fn request_demands_revalidation(request: &Request) -> bool {
+    if matches!(
+        request.cache_mode,
+        CacheMode::NoCache | CacheMode::Reload | CacheMode::NoStore
+    ) {
+        return true;
+    }
+    if let Some(directive) = request.headers.typed_get::<CacheControl>() {
+        // The request's `no-store` directive is deliberately *not* treated as
+        // demanding revalidation: https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.1.5
+        // > "does not apply to the already stored response".
+        if directive.no_cache() {
+            return true;
+        }
+
+        if directive.max_age() == Some(Duration::ZERO) {
+            return true;
+        }
+    }
+    false
+}
+
 /// Request Cache-Control Directives
 /// <https://tools.ietf.org/html/rfc7234#section-5.2.1>
 fn get_expiry_adjustment_from_request_headers(request: &Request, expires: Duration) -> Duration {
@@ -352,9 +387,27 @@ fn create_cached_response(
     // TODO: if this cache is to be considered shared, take proxy-revalidate into account
     // <https://tools.ietf.org/html/rfc7234#section-5.2.2.7>
     let has_expired = adjusted_expires <= time_since_validated;
+
+
+    // - fresh: return immediately, no validation.
+    // - stale:
+    //    - within the SWR window: return immediately + revalidate in the background
+    //    - beyond the SWR window: synchronous validation is required.
+    let stale_for = time_since_validated.saturating_sub(adjusted_expires);
+    let within_swr_window = stale_for <= cached_resource.stale_while_revalidate;
+    let revalidate_in_background = has_expired &&
+        within_swr_window &&
+        !cached_resource.stale_while_revalidate.is_zero() &&
+        !request_demands_revalidation(request);
+
     let cached_response = CachedResponse {
         response,
-        needs_validation: has_expired,
+        // When we can serve a stale response under the s-w-r window, we treat it
+        // as not needing synchronous validation, and signal the background
+        // revalidation separately.
+        needs_synchronous_validation: has_expired && !revalidate_in_background,
+        revalidate_in_background,
+        revalidation_guard: cached_resource.revalidating.clone(),
     };
     Some(cached_response)
 }
@@ -375,6 +428,8 @@ fn create_resource_with_bytes_from_resource(
         status: StatusCode::PARTIAL_CONTENT.into(),
         url_list: resource.url_list.clone(),
         expires: resource.expires,
+        stale_while_revalidate: resource.stale_while_revalidate,
+        revalidating: resource.revalidating.clone(),
         last_validated: resource.last_validated,
     }
 }
@@ -719,6 +774,9 @@ pub fn refresh(
             constructed_response.headers = stored_headers.clone();
         }
         cached_resource.expires = get_response_expiry(constructed_response);
+        cached_resource.stale_while_revalidate =
+            get_stale_while_revalidate(&constructed_response.headers);
+        cached_resource.last_validated = Instant::now();
     }
 
     constructed_response
@@ -898,6 +956,7 @@ impl<'a> CachedResourcesOrGuard<'a> {
             return;
         }
         let expiry = get_response_expiry(response);
+        let stale_while_revalidate = get_stale_while_revalidate(&response.headers);
         let cacheable_metadata = CachedMetadata {
             headers: Arc::new(ParkingLotMutex::new(response.headers.clone())),
             final_url: metadata.final_url,
@@ -915,6 +974,8 @@ impl<'a> CachedResourcesOrGuard<'a> {
             status: response.status.clone(),
             url_list: response.url_list.clone(),
             expires: expiry,
+            stale_while_revalidate,
+            revalidating: StdArc::new(AtomicBool::new(false)),
             last_validated: Instant::now(),
         };
 

--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -91,16 +91,26 @@ struct CachedMetadata {
     /// HTTP Status
     pub status: HttpStatus,
 }
+
+/// Whether a cached response is fresh or requires validation before or after use.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ValidationStatus {
+    /// The response is fresh and can be used without any revalidation.
+    Valid,
+    /// The response is stale.
+    Stale {
+        /// Whether the stale response can be served immediately, leaving the
+        /// caller responsible for revalidating it in the background.
+        revalidate_in_background: bool,
+    },
+}
+
 /// Wrapper around a cached response, including information on re-validation needs
 pub(crate) struct CachedResponse {
     /// The response constructed from the cached resource
     pub response: Response,
-    /// The revalidation flag for the stored response. When set, the response is
-    /// stale and must be synchronously revalidated before being used.
-    pub needs_synchronous_validation: bool,
-    /// When this is set, `needs_synchronous_validation` is `false` and the caller is responsible
-    /// for spawning the background revalidation, claiming the single-flight guard.
-    pub revalidate_in_background: bool,
+    /// Whether the stored response is fresh or stale
+    pub validation_status: ValidationStatus,
     /// Single-flight guard for the background revalidation.
     pub revalidation_guard: StdArc<AtomicBool>,
 }
@@ -393,18 +403,19 @@ fn create_cached_response(
     //    - beyond the stale-while-revalidate window: synchronous validation is required.
     let stale_for = time_since_validated.saturating_sub(adjusted_expires);
     let within_stale_while_revalidate_window = stale_for <= cached_resource.stale_while_revalidate;
-    let revalidate_in_background = has_expired &&
-        within_stale_while_revalidate_window &&
-        !cached_resource.stale_while_revalidate.is_zero() &&
-        !request_demands_revalidation(request);
+    let validation_status = if !has_expired {
+        ValidationStatus::Valid
+    } else {
+        ValidationStatus::Stale {
+            revalidate_in_background: within_stale_while_revalidate_window &&
+                !cached_resource.stale_while_revalidate.is_zero() &&
+                !request_demands_revalidation(request),
+        }
+    };
 
     let cached_response = CachedResponse {
         response,
-        // When we can serve a stale response under the stale-while-revalidate window, we treat it
-        // as not needing synchronous validation, and signal the background
-        // revalidation separately.
-        needs_synchronous_validation: has_expired && !revalidate_in_background,
-        revalidate_in_background,
+        validation_status,
         revalidation_guard: cached_resource.revalidating.clone(),
     };
     Some(cached_response)
@@ -879,22 +890,17 @@ impl HttpCache {
     }
 
     /// Like [`construct_response`](Self::construct_response), but additionally
-    /// reports the cache freshness state of the constructed response:
-    /// `(needs_validation, revalidate_in_background)`
+    /// reports the [`ValidationStatus`] of the constructed response.
     #[cfg(feature = "test-util")]
     pub async fn construct_response_freshness(
         &self,
         request: &Request,
         done_chan: &mut DoneChannel,
-    ) -> Option<(bool, bool)> {
+    ) -> Option<ValidationStatus> {
         let entry = self.entries.get(&CacheKey::new(request))?;
         let cached_resources = entry.read().await;
-        construct_response(request, done_chan, cached_resources.as_slice()).map(|cached| {
-            (
-                cached.needs_synchronous_validation,
-                cached.revalidate_in_background,
-            )
-        })
+        construct_response(request, done_chan, cached_resources.as_slice())
+            .map(|cached| cached.validation_status)
     }
 
     /// Invalidate cache entries referenced by Location/Content-Location headers.

--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -389,18 +389,18 @@ fn create_cached_response(
 
     // - fresh: return immediately, no validation.
     // - stale:
-    //    - within the SWR window: return immediately + revalidate in the background
-    //    - beyond the SWR window: synchronous validation is required.
+    //    - within the stale-while-revalidate window: return immediately + revalidate in the background
+    //    - beyond the stale-while-revalidate window: synchronous validation is required.
     let stale_for = time_since_validated.saturating_sub(adjusted_expires);
-    let within_swr_window = stale_for <= cached_resource.stale_while_revalidate;
+    let within_stale_while_revalidate_window = stale_for <= cached_resource.stale_while_revalidate;
     let revalidate_in_background = has_expired &&
-        within_swr_window &&
+        within_stale_while_revalidate_window &&
         !cached_resource.stale_while_revalidate.is_zero() &&
         !request_demands_revalidation(request);
 
     let cached_response = CachedResponse {
         response,
-        // When we can serve a stale response under the s-w-r window, we treat it
+        // When we can serve a stale response under the stale-while-revalidate window, we treat it
         // as not needing synchronous validation, and signal the background
         // revalidation separately.
         needs_synchronous_validation: has_expired && !revalidate_in_background,

--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -8,8 +8,8 @@
 //! and <http://tools.ietf.org/html/rfc7232>.
 
 use std::ops::Bound;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc as StdArc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant, SystemTime};
 
 use headers::{
@@ -267,7 +267,6 @@ fn get_response_expiry(response: &Response) -> Duration {
     Duration::ZERO
 }
 
-
 /// The `headers` crate's `CacheControl` does not understand `stale-while-revalidate` directive,
 /// so we need to parse the raw `Cache-Control` header values.
 /// <https://datatracker.ietf.org/doc/html/rfc5861#section-3>
@@ -387,7 +386,6 @@ fn create_cached_response(
     // TODO: if this cache is to be considered shared, take proxy-revalidate into account
     // <https://tools.ietf.org/html/rfc7234#section-5.2.2.7>
     let has_expired = adjusted_expires <= time_since_validated;
-
 
     // - fresh: return immediately, no validation.
     // - stale:
@@ -891,8 +889,12 @@ impl HttpCache {
     ) -> Option<(bool, bool)> {
         let entry = self.entries.get(&CacheKey::new(request))?;
         let cached_resources = entry.read().await;
-        construct_response(request, done_chan, cached_resources.as_slice())
-            .map(|cached| (cached.needs_synchronous_validation, cached.revalidate_in_background))
+        construct_response(request, done_chan, cached_resources.as_slice()).map(|cached| {
+            (
+                cached.needs_synchronous_validation,
+                cached.revalidate_in_background,
+            )
+        })
     }
 
     /// Invalidate cache entries referenced by Location/Content-Location headers.

--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -880,6 +880,21 @@ impl HttpCache {
             .map(|cached| cached.response)
     }
 
+    /// Like [`construct_response`](Self::construct_response), but additionally
+    /// reports the cache freshness state of the constructed response:
+    /// `(needs_validation, revalidate_in_background)`
+    #[cfg(feature = "test-util")]
+    pub async fn construct_response_freshness(
+        &self,
+        request: &Request,
+        done_chan: &mut DoneChannel,
+    ) -> Option<(bool, bool)> {
+        let entry = self.entries.get(&CacheKey::new(request))?;
+        let cached_resources = entry.read().await;
+        construct_response(request, done_chan, cached_resources.as_slice())
+            .map(|cached| (cached.needs_synchronous_validation, cached.revalidate_in_background))
+    }
+
     /// Invalidate cache entries referenced by Location/Content-Location headers.
     pub(crate) async fn invalidate_related_urls(
         &self,

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -90,8 +90,8 @@ use crate::fetch::headers::{SecFetchDest, SecFetchMode, SecFetchSite, SecFetchUs
 use crate::fetch::methods::{Data, DoneChannel, FetchContext, Target, fetch, main_fetch};
 use crate::hsts::HstsList;
 use crate::http_cache::{
-    CacheKey, CachedResourcesOrGuard, HttpCache, construct_response, invalidate_cached_resources,
-    refresh,
+    CacheKey, CachedResourcesOrGuard, HttpCache, ValidationStatus, construct_response,
+    invalidate_cached_resources, refresh,
 };
 use crate::resource_thread::{AuthCache, AuthCacheEntry};
 use crate::websocket_loader::start_websocket;
@@ -1794,7 +1794,7 @@ async fn block_for_cache_ready<'a>(
             // Step 8.25.2 If storedResponse is non-null, then:
             if let Some(response_from_cache) = stored_response {
                 let response_headers = response_from_cache.response.headers.clone();
-                let revalidate_in_background = response_from_cache.revalidate_in_background;
+                let validation_status = response_from_cache.validation_status;
                 let revalidation_guard = response_from_cache.revalidation_guard.clone();
 
                 // Substep 1, 2, 3, 4
@@ -1809,7 +1809,10 @@ async fn block_for_cache_ready<'a>(
                         (CacheMode::Reload, _) => (None, false),
                         (_, _) => (
                             Some(response_from_cache.response),
-                            response_from_cache.needs_synchronous_validation,
+                            validation_status ==
+                                (ValidationStatus::Stale {
+                                    revalidate_in_background: false,
+                                }),
                         ),
                     };
 
@@ -1830,6 +1833,10 @@ async fn block_for_cache_ready<'a>(
                 } else {
                     // Substep 6
                     // If it's a stale-while-revalidate response, also refresh it in the background.
+                    let revalidate_in_background = validation_status ==
+                        (ValidationStatus::Stale {
+                            revalidate_in_background: true,
+                        });
                     if revalidate_in_background && cached_response.is_some() {
                         spawn_stale_while_revalidate(context, http_request, revalidation_guard);
                     }

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -1813,8 +1813,10 @@ async fn block_for_cache_ready<'a>(
                         ),
                     };
 
-
-                if revalidate_in_background && cached_response.is_some() && !needs_synchronous_revalidation {
+                if revalidate_in_background &&
+                    cached_response.is_some() &&
+                    !needs_synchronous_revalidation
+                {
                     spawn_stale_while_revalidate(context, http_request, revalidation_guard);
                 }
 

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -5,6 +5,7 @@
 use std::collections::HashSet;
 use std::iter::FromIterator;
 use std::sync::Arc as StdArc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, SystemTime};
 
 use async_recursion::async_recursion;
@@ -50,9 +51,9 @@ use net_traits::request::{
 };
 use net_traits::response::{CacheState, RedirectTaint, Response, ResponseBody, ResponseType};
 use net_traits::{
-    CookieSource, DOCUMENT_ACCEPT_HEADER_VALUE, NetworkError, RedirectEndValue, RedirectStartValue,
-    ReferrerPolicy, ResourceAttribute, ResourceFetchTimingContainer, ResourceTimeValue,
-    TlsSecurityInfo, TlsSecurityState,
+    CookieSource, DOCUMENT_ACCEPT_HEADER_VALUE, DiscardFetch, NetworkError, RedirectEndValue,
+    RedirectStartValue, ReferrerPolicy, ResourceAttribute, ResourceFetchTimingContainer,
+    ResourceTimeValue, TlsSecurityInfo, TlsSecurityState,
 };
 use parking_lot::{Mutex, RwLock};
 use profile_traits::mem::{Report, ReportKind};
@@ -86,7 +87,7 @@ use crate::embedder::NetToEmbedderMsg;
 use crate::fetch::cors_cache::CorsCache;
 use crate::fetch::fetch_params::FetchParams;
 use crate::fetch::headers::{SecFetchDest, SecFetchMode, SecFetchSite, SecFetchUser};
-use crate::fetch::methods::{Data, DoneChannel, FetchContext, Target, main_fetch};
+use crate::fetch::methods::{Data, DoneChannel, FetchContext, Target, fetch, main_fetch};
 use crate::hsts::HstsList;
 use crate::http_cache::{
     CacheKey, CachedResourcesOrGuard, HttpCache, construct_response, invalidate_cached_resources,
@@ -1793,8 +1794,11 @@ async fn block_for_cache_ready<'a>(
             // Step 8.25.2 If storedResponse is non-null, then:
             if let Some(response_from_cache) = stored_response {
                 let response_headers = response_from_cache.response.headers.clone();
+                let revalidate_in_background = response_from_cache.revalidate_in_background;
+                let revalidation_guard = response_from_cache.revalidation_guard.clone();
+
                 // Substep 1, 2, 3, 4
-                let (cached_response, needs_revalidation) =
+                let (cached_response, needs_synchronous_revalidation) =
                     match (http_request.cache_mode, &http_request.mode) {
                         (CacheMode::ForceCache, _) => (Some(response_from_cache.response), false),
                         (CacheMode::OnlyIfCached, &RequestMode::SameOrigin) => {
@@ -1805,11 +1809,16 @@ async fn block_for_cache_ready<'a>(
                         (CacheMode::Reload, _) => (None, false),
                         (_, _) => (
                             Some(response_from_cache.response),
-                            response_from_cache.needs_validation,
+                            response_from_cache.needs_synchronous_validation,
                         ),
                     };
 
-                if needs_revalidation {
+
+                if revalidate_in_background && cached_response.is_some() && !needs_synchronous_revalidation {
+                    spawn_stale_while_revalidate(context, http_request, revalidation_guard);
+                }
+
+                if needs_synchronous_revalidation {
                     *revalidating_flag = true;
                     // Substep 5
                     if let Some(http_date) = response_headers.typed_get::<LastModified>() {
@@ -1839,6 +1848,42 @@ async fn block_for_cache_ready<'a>(
         },
     }
     guard_result
+}
+
+/// The cached (stale) response has already been returned to the caller; here we
+/// fire off an independent fetch whose only purpose is to refresh the stored response.
+fn spawn_stale_while_revalidate(
+    context: &FetchContext,
+    http_request: &Request,
+    revalidation_guard: StdArc<AtomicBool>,
+) {
+    // Only proceed if we are the one who flips the guard from `false` to `true`.
+    if revalidation_guard
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return;
+    }
+
+    // By setting `CacheMode::NoCache` to the cloned request,
+    // we ensure that the background revalidation fetch will always go to the network, and preventing an inifinite loop.
+    let mut revalidation_request = http_request.clone();
+    revalidation_request.cache_mode = CacheMode::NoCache;
+
+    // A background revalidation must not itself spin up service workers
+    revalidation_request.service_workers_mode = ServiceWorkersMode::None;
+
+    let context = context.clone();
+    debug!(
+        "spawning stale-while-revalidate background revalidation for {:?}",
+        revalidation_request.current_url()
+    );
+    spawn_task(async move {
+        let mut target = DiscardFetch;
+
+        let _ = fetch(revalidation_request, &mut target, &context).await;
+        revalidation_guard.store(false, Ordering::Release);
+    });
 }
 
 /// Wait for a cached response from channel.

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -1813,13 +1813,6 @@ async fn block_for_cache_ready<'a>(
                         ),
                     };
 
-                if revalidate_in_background &&
-                    cached_response.is_some() &&
-                    !needs_synchronous_revalidation
-                {
-                    spawn_stale_while_revalidate(context, http_request, revalidation_guard);
-                }
-
                 if needs_synchronous_revalidation {
                     *revalidating_flag = true;
                     // Substep 5
@@ -1836,6 +1829,10 @@ async fn block_for_cache_ready<'a>(
                     }
                 } else {
                     // Substep 6
+                    // If it's a stale-while-revalidate response, also refresh it in the background.
+                    if revalidate_in_background && cached_response.is_some() {
+                        spawn_stale_while_revalidate(context, http_request, revalidation_guard);
+                    }
                     *response = cached_response;
                     if let Some(response) = response {
                         response.cache_state = CacheState::Local;

--- a/components/net/tests/http_cache.rs
+++ b/components/net/tests/http_cache.rs
@@ -132,6 +132,7 @@ fn build_stale_while_revalidate_test_request() -> net_traits::request::Request {
 }
 
 /// Store a response with the given `Cache-Control` value, then return the
+/// freshness state [`ValidationStatus`] reported by the cache for a subsequent request.
 async fn stale_while_revalidate_freshness_for_cache_control(
     cache_control: &str,
 ) -> ValidationStatus {

--- a/components/net/tests/http_cache.rs
+++ b/components/net/tests/http_cache.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use http::header::{CONTENT_LENGTH, CONTENT_RANGE, EXPIRES, HeaderValue, RANGE};
+use http::header::{CACHE_CONTROL, CONTENT_LENGTH, CONTENT_RANGE, EXPIRES, HeaderValue, RANGE};
 use http::{HeaderMap, StatusCode};
 use net::http_cache::{CacheKey, HttpCache, refresh};
 use net_traits::blob_url_store::UrlWithBlobClaim;
@@ -116,5 +116,109 @@ async fn test_skip_incomplete_cache_for_range_request_with_no_end_bound() {
     assert!(
         consecutive_response.is_none(),
         "Should not construct response from incomplete response!"
+    );
+}
+
+fn build_swr_test_request() -> net_traits::request::Request {
+    let url = ServoUrl::parse("https://servo.org").unwrap();
+    RequestBuilder::new(
+        None,
+        UrlWithBlobClaim::new(url.clone(), None),
+        Referrer::NoReferrer,
+    )
+    .pipeline_id(Some(TEST_PIPELINE_ID))
+    .origin(url.origin())
+    .build()
+}
+
+/// Store a response with the given `Cache-Control` value, then return the
+/// freshness state `(needs_validation, revalidate_in_background)` reported by
+/// the cache for a subsequent request.
+async fn swr_freshness_for_cache_control(cache_control: &str) -> (bool, bool) {
+    let url = ServoUrl::parse("https://servo.org").unwrap();
+    let request = build_swr_test_request();
+
+    let timing = ResourceFetchTiming::new(ResourceTimingType::Navigation);
+    let mut response = Response::new(url, timing);
+    *response.body.lock() = ResponseBody::Done(vec![1, 2, 3]);
+    response
+        .headers
+        .insert(CACHE_CONTROL, HeaderValue::from_str(cache_control).unwrap());
+
+    let cache = HttpCache::default();
+    cache.store(&request, &response).await;
+
+    let mut done_chan = None;
+    cache
+        .construct_response_freshness(&request, &mut done_chan)
+        .await
+        .expect("a response should be constructable from the cache")
+}
+
+#[tokio::test]
+async fn test_stale_within_swr_window_serves_immediately_and_revalidates_in_background() {
+    let (needs_validation, revalidate_in_background) =
+        swr_freshness_for_cache_control("max-age=0, stale-while-revalidate=30").await;
+    assert!(
+        !needs_validation,
+        "stale response within the SWR window should be served immediately"
+    );
+    assert!(
+        revalidate_in_background,
+        "stale response within the SWR window should be revalidated in the background"
+    );
+}
+
+#[tokio::test]
+async fn test_stale_without_swr_requires_synchronous_validation() {
+    let (needs_validation, revalidate_in_background) =
+        swr_freshness_for_cache_control("max-age=0").await;
+    assert!(
+        needs_validation,
+        "stale response without SWR must be synchronously revalidated"
+    );
+    assert!(!revalidate_in_background);
+}
+
+#[tokio::test]
+async fn test_swr_not_used_when_request_demands_revalidation() {
+    let url = ServoUrl::parse("https://servo.org").unwrap();
+
+    let timing = ResourceFetchTiming::new(ResourceTimingType::Navigation);
+    let mut response = Response::new(url.clone(), timing);
+    *response.body.lock() = ResponseBody::Done(vec![1, 2, 3]);
+    response.headers.insert(
+        CACHE_CONTROL,
+        HeaderValue::from_str("max-age=0, stale-while-revalidate=30").unwrap(),
+    );
+
+    let store_request = build_swr_test_request();
+    let cache = HttpCache::default();
+    cache.store(&store_request, &response).await;
+
+    let mut req_headers = HeaderMap::new();
+    req_headers.insert(CACHE_CONTROL, HeaderValue::from_static("no-cache"));
+    let request = RequestBuilder::new(
+        None,
+        UrlWithBlobClaim::new(url.clone(), None),
+        Referrer::NoReferrer,
+    )
+    .pipeline_id(Some(TEST_PIPELINE_ID))
+    .origin(url.origin())
+    .headers(req_headers)
+    .build();
+
+    let mut done_chan = None;
+    let (needs_validation, revalidate_in_background) = cache
+        .construct_response_freshness(&request, &mut done_chan)
+        .await
+        .expect("a response should be constructable from the cache");
+    assert!(
+        needs_validation,
+        "a no-cache request must trigger synchronous validation"
+    );
+    assert!(
+        !revalidate_in_background,
+        "a no-cache request must not use background revalidation"
     );
 }

--- a/components/net/tests/http_cache.rs
+++ b/components/net/tests/http_cache.rs
@@ -4,7 +4,7 @@
 
 use http::header::{CACHE_CONTROL, CONTENT_LENGTH, CONTENT_RANGE, EXPIRES, HeaderValue, RANGE};
 use http::{HeaderMap, StatusCode};
-use net::http_cache::{CacheKey, HttpCache, refresh};
+use net::http_cache::{CacheKey, HttpCache, ValidationStatus, refresh};
 use net_traits::blob_url_store::UrlWithBlobClaim;
 use net_traits::request::{Referrer, RequestBuilder};
 use net_traits::response::{Response, ResponseBody};
@@ -132,9 +132,9 @@ fn build_stale_while_revalidate_test_request() -> net_traits::request::Request {
 }
 
 /// Store a response with the given `Cache-Control` value, then return the
-/// freshness state `(needs_validation, revalidate_in_background)` reported by
-/// the cache for a subsequent request.
-async fn stale_while_revalidate_freshness_for_cache_control(cache_control: &str) -> (bool, bool) {
+async fn stale_while_revalidate_freshness_for_cache_control(
+    cache_control: &str,
+) -> ValidationStatus {
     let url = ServoUrl::parse("https://servo.org").unwrap();
     let request = build_stale_while_revalidate_test_request();
 
@@ -158,28 +158,29 @@ async fn stale_while_revalidate_freshness_for_cache_control(cache_control: &str)
 #[tokio::test]
 async fn test_stale_within_stale_while_revalidate_window_serves_immediately_and_revalidates_in_background()
  {
-    let (needs_validation, revalidate_in_background) =
+    let validation_status =
         stale_while_revalidate_freshness_for_cache_control("max-age=0, stale-while-revalidate=30")
             .await;
-    assert!(
-        !needs_validation,
-        "stale response within the stale-while-revalidate window should be served immediately"
-    );
-    assert!(
-        revalidate_in_background,
-        "stale response within the stale-while-revalidate window should be revalidated in the background"
+    assert_eq!(
+        validation_status,
+        ValidationStatus::Stale {
+            revalidate_in_background: true
+        },
+        "stale response within the stale-while-revalidate window should be served immediately \
+         and revalidated in the background"
     );
 }
 
 #[tokio::test]
 async fn test_stale_without_stale_while_revalidate_requires_synchronous_validation() {
-    let (needs_validation, revalidate_in_background) =
-        stale_while_revalidate_freshness_for_cache_control("max-age=0").await;
-    assert!(
-        needs_validation,
+    let validation_status = stale_while_revalidate_freshness_for_cache_control("max-age=0").await;
+    assert_eq!(
+        validation_status,
+        ValidationStatus::Stale {
+            revalidate_in_background: false
+        },
         "stale response without stale-while-revalidate must be synchronously revalidated"
     );
-    assert!(!revalidate_in_background);
 }
 
 #[tokio::test]
@@ -211,16 +212,15 @@ async fn test_stale_while_revalidate_not_used_when_request_demands_revalidation(
     .build();
 
     let mut done_chan = None;
-    let (needs_validation, revalidate_in_background) = cache
+    let validation_status = cache
         .construct_response_freshness(&request, &mut done_chan)
         .await
         .expect("a response should be constructable from the cache");
-    assert!(
-        needs_validation,
-        "a no-cache request must trigger synchronous validation"
-    );
-    assert!(
-        !revalidate_in_background,
-        "a no-cache request must not use background revalidation"
+    assert_eq!(
+        validation_status,
+        ValidationStatus::Stale {
+            revalidate_in_background: false
+        },
+        "a no-cache request must trigger synchronous validation, not background revalidation"
     );
 }

--- a/components/net/tests/http_cache.rs
+++ b/components/net/tests/http_cache.rs
@@ -119,7 +119,7 @@ async fn test_skip_incomplete_cache_for_range_request_with_no_end_bound() {
     );
 }
 
-fn build_swr_test_request() -> net_traits::request::Request {
+fn build_stale_while_revalidate_test_request() -> net_traits::request::Request {
     let url = ServoUrl::parse("https://servo.org").unwrap();
     RequestBuilder::new(
         None,
@@ -134,9 +134,9 @@ fn build_swr_test_request() -> net_traits::request::Request {
 /// Store a response with the given `Cache-Control` value, then return the
 /// freshness state `(needs_validation, revalidate_in_background)` reported by
 /// the cache for a subsequent request.
-async fn swr_freshness_for_cache_control(cache_control: &str) -> (bool, bool) {
+async fn stale_while_revalidate_freshness_for_cache_control(cache_control: &str) -> (bool, bool) {
     let url = ServoUrl::parse("https://servo.org").unwrap();
-    let request = build_swr_test_request();
+    let request = build_stale_while_revalidate_test_request();
 
     let timing = ResourceFetchTiming::new(ResourceTimingType::Navigation);
     let mut response = Response::new(url, timing);
@@ -156,32 +156,34 @@ async fn swr_freshness_for_cache_control(cache_control: &str) -> (bool, bool) {
 }
 
 #[tokio::test]
-async fn test_stale_within_swr_window_serves_immediately_and_revalidates_in_background() {
+async fn test_stale_within_stale_while_revalidate_window_serves_immediately_and_revalidates_in_background()
+ {
     let (needs_validation, revalidate_in_background) =
-        swr_freshness_for_cache_control("max-age=0, stale-while-revalidate=30").await;
+        stale_while_revalidate_freshness_for_cache_control("max-age=0, stale-while-revalidate=30")
+            .await;
     assert!(
         !needs_validation,
-        "stale response within the SWR window should be served immediately"
+        "stale response within the stale-while-revalidate window should be served immediately"
     );
     assert!(
         revalidate_in_background,
-        "stale response within the SWR window should be revalidated in the background"
+        "stale response within the stale-while-revalidate window should be revalidated in the background"
     );
 }
 
 #[tokio::test]
-async fn test_stale_without_swr_requires_synchronous_validation() {
+async fn test_stale_without_stale_while_revalidate_requires_synchronous_validation() {
     let (needs_validation, revalidate_in_background) =
-        swr_freshness_for_cache_control("max-age=0").await;
+        stale_while_revalidate_freshness_for_cache_control("max-age=0").await;
     assert!(
         needs_validation,
-        "stale response without SWR must be synchronously revalidated"
+        "stale response without stale-while-revalidate must be synchronously revalidated"
     );
     assert!(!revalidate_in_background);
 }
 
 #[tokio::test]
-async fn test_swr_not_used_when_request_demands_revalidation() {
+async fn test_stale_while_revalidate_not_used_when_request_demands_revalidation() {
     let url = ServoUrl::parse("https://servo.org").unwrap();
 
     let timing = ResourceFetchTiming::new(ResourceTimingType::Navigation);
@@ -192,7 +194,7 @@ async fn test_swr_not_used_when_request_demands_revalidation() {
         HeaderValue::from_str("max-age=0, stale-while-revalidate=30").unwrap(),
     );
 
-    let store_request = build_swr_test_request();
+    let store_request = build_stale_while_revalidate_test_request();
     let cache = HttpCache::default();
     cache.store(&store_request, &response).await;
 

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -5,8 +5,8 @@
 use std::collections::HashMap;
 use std::io::Write;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
 
 use content_security_policy as csp;
 use cookie::Cookie as CookiePair;
@@ -2111,4 +2111,54 @@ fn test_no_security_info_for_http_connection() {
             "HTTP connection should not have TLS security info"
         );
     }
+}
+
+#[test]
+fn test_stale_while_revalidate_serves_cached_and_revalidates_in_background() {
+    let request_count = Arc::new(AtomicUsize::new(0));
+    let request_count_clone = request_count.clone();
+    let handler =
+        move |_: HyperRequest<Incoming>,
+              response: &mut HyperResponse<BoxBody<Bytes, hyper::Error>>| {
+            request_count_clone.fetch_add(1, Ordering::SeqCst);
+            response.headers_mut().insert(
+                header::CACHE_CONTROL,
+                HeaderValue::from_static("max-age=0, stale-while-revalidate=30"),
+            );
+            *response.body_mut() = make_body(b"content".to_vec());
+        };
+    let (server, url) = make_server(handler);
+
+    let mut context = new_fetch_context(None, None);
+
+    let build_request = || {
+        RequestBuilder::new(None, url.clone(), Referrer::NoReferrer)
+            .method(Method::GET)
+            .destination(Destination::Document)
+            .origin(url.clone().origin())
+            .pipeline_id(Some(TEST_PIPELINE_ID))
+            .policy_container(Default::default())
+            .build()
+    };
+
+    let response = fetch_with_context(build_request(), &mut context);
+    assert!(response.actual_response().status.code().is_success());
+    assert_eq!(request_count.load(Ordering::SeqCst), 1);
+
+    // the stored response is stale but within the SWR window, so
+    // it is served from cache immediately and a background revalidation is spawned.
+    let response = fetch_with_context(build_request(), &mut context);
+    assert!(response.actual_response().status.code().is_success());
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while request_count.load(Ordering::SeqCst) < 2 && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    assert_eq!(
+        request_count.load(Ordering::SeqCst),
+        2,
+        "exactly one background revalidation should have hit the server"
+    );
+
+    let _ = server.close();
 }

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -2145,7 +2145,7 @@ fn test_stale_while_revalidate_serves_cached_and_revalidates_in_background() {
     assert!(response.actual_response().status.code().is_success());
     assert_eq!(request_count.load(Ordering::SeqCst), 1);
 
-    // the stored response is stale but within the SWR window, so
+    // the stored response is stale but within the stale-while-revalidate window, so
     // it is served from cache immediately and a background revalidation is spawned.
     let response = fetch_with_context(build_request(), &mut context);
     assert!(response.actual_response().status.code().is_success());

--- a/tests/wpt/meta/fetch/stale-while-revalidate/fetch.any.js.ini
+++ b/tests/wpt/meta/fetch/stale-while-revalidate/fetch.any.js.ini
@@ -1,16 +1,8 @@
 [fetch.any.html]
-  [Second fetch returns same response]
-    expected: FAIL
-
 
 [fetch.any.worker.html]
-  [Second fetch returns same response]
-    expected: FAIL
-
 
 [fetch.any.serviceworker.html]
   expected: ERROR
 
 [fetch.any.sharedworker.html]
-  [Second fetch returns same response]
-    expected: FAIL

--- a/tests/wpt/meta/fetch/stale-while-revalidate/stale-css.html.ini
+++ b/tests/wpt/meta/fetch/stale-while-revalidate/stale-css.html.ini
@@ -1,3 +1,0 @@
-[stale-css.html]
-  [Cache returns stale resource]
-    expected: FAIL

--- a/tests/wpt/meta/fetch/stale-while-revalidate/stale-image.html.ini
+++ b/tests/wpt/meta/fetch/stale-while-revalidate/stale-image.html.ini
@@ -1,3 +1,0 @@
-[stale-image.html]
-  [Cache returns stale resource]
-    expected: FAIL

--- a/tests/wpt/meta/fetch/stale-while-revalidate/stale-script.html.ini
+++ b/tests/wpt/meta/fetch/stale-while-revalidate/stale-script.html.ini
@@ -1,3 +1,0 @@
-[stale-script.html]
-  [Cache returns stale resource]
-    expected: FAIL


### PR DESCRIPTION
Support `stale-while-revalidate` cache-control response header directive.

During the s-w-r window, even if the cached object is stale, reuse the cached response immediately and sends the revalidation request in the background.


Testing: added unit tests on https://github.com/servo/servo/pull/46060/commits/f745046687e462c17481fe572231200cca87f279
Fixes:  #42130 