### PR TITLE
script: Do not clone script data unnecessarily

### DIFF
--- a/components/script/dom/globalscope/script_execution.rs
+++ b/components/script/dom/globalscope/script_execution.rs
@@ -89,13 +89,19 @@ impl GlobalScope {
         line_number: u32,
         external: bool,
     ) -> ClassicScript {
-        let mut script_source = ModuleSource {
-            source: Rc::new(DOMString::from(source)),
-            unminified_dir: self.unminified_js_dir(),
-            external,
-            url: url.clone(),
+        let mut source = if self.unminified_js_dir().is_some() {
+            let source = Rc::new(DOMString::from(source.into_owned()));
+            let mut script_source = ModuleSource {
+                source: source.clone(),
+                unminified_dir: self.unminified_js_dir(),
+                external,
+                url: url.clone(),
+            };
+            unminify_js(&mut script_source);
+            transform_str_to_source_text(&source.str())
+        } else {
+            transform_str_to_source_text(&source)
         };
-        unminify_js(&mut script_source);
 
         // TODO Step 1. If mutedErrors is true, then set baseURL to about:blank.
 
@@ -113,7 +119,6 @@ impl GlobalScope {
             true, // noScriptRval
             line_number,
         );
-        let mut source = transform_str_to_source_text(&script_source.source.str());
 
         // Step 10. Let result be ParseScript(source, settings's realm, script).
         rooted!(&in(cx) let compiled_script = unsafe { Compile1(cx, options.ptr, &mut source) });

--- a/components/script/dom/globalscope/script_execution.rs
+++ b/components/script/dom/globalscope/script_execution.rs
@@ -28,7 +28,6 @@ use crate::DomTypeHolder;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use crate::dom::bindings::error::{Error, ErrorInfo, ErrorResult, report_pending_exception};
 use crate::dom::bindings::inheritance::Castable;
-use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
 use crate::realms::enter_auto_realm;
@@ -90,15 +89,14 @@ impl GlobalScope {
         external: bool,
     ) -> ClassicScript {
         let mut source = if self.unminified_js_dir().is_some() {
-            let source = Rc::new(DOMString::from(source.into_owned()));
             let mut script_source = ModuleSource {
-                source: source.clone(),
+                source,
                 unminified_dir: self.unminified_js_dir(),
                 external,
                 url: url.clone(),
             };
             unminify_js(&mut script_source);
-            transform_str_to_source_text(&source.str())
+            transform_str_to_source_text(&script_source.source)
         } else {
             transform_str_to_source_text(&source)
         };

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -927,7 +927,7 @@ impl HTMLScriptElement {
                 ScriptType::ImportMap => {
                     // Step 32.1 Let result be the result of creating an import map
                     // parse result given source text and base URL.
-                    let import_map_result = parse_an_import_map_string(cx, global, text, base_url);
+                    let import_map_result = parse_an_import_map_string(cx, global, &text, base_url);
                     let script = Script::ImportMap(import_map_result);
 
                     // Step 34.3

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -616,7 +616,7 @@ impl HTMLScriptElement {
             return;
         }
         // Step 5a. Let source text be el’s script text value.
-        let text = self.script_text.borrow().clone();
+        let text: Cow<'_, str> = Cow::Owned(String::from(self.script_text.borrow().str()));
         // Step 6. If el has no src attribute, and source text is the empty string, then return.
         if text.is_empty() && !element.has_attribute(&local_name!("src")) {
             return;
@@ -678,7 +678,7 @@ impl HTMLScriptElement {
                     global,
                     element,
                     InlineCheckType::Script,
-                    &text.str(),
+                    &text,
                     self.line_number as u32,
                 )
         {
@@ -849,8 +849,6 @@ impl HTMLScriptElement {
 
             assert!(!text.is_empty());
 
-            let text_rc = Rc::new(text.clone());
-
             // Step 32.2: Switch on el's type:
             match script_type {
                 ScriptType::Classic => {
@@ -858,7 +856,7 @@ impl HTMLScriptElement {
                     // using source text, settings object, base URL, and options.
                     let script = self.global().create_a_classic_script(
                         cx,
-                        std::borrow::Cow::Borrowed(&text.str()),
+                        text,
                         base_url,
                         options,
                         ErrorReporting::Unmuted,
@@ -903,7 +901,7 @@ impl HTMLScriptElement {
                     fetch_inline_module_script(
                         cx,
                         global,
-                        text_rc,
+                        text,
                         base_url,
                         options,
                         self.line_number as u32,
@@ -929,8 +927,7 @@ impl HTMLScriptElement {
                 ScriptType::ImportMap => {
                     // Step 32.1 Let result be the result of creating an import map
                     // parse result given source text and base URL.
-                    let import_map_result =
-                        parse_an_import_map_string(cx, global, Rc::clone(&text_rc), base_url);
+                    let import_map_result = parse_an_import_map_string(cx, global, text, base_url);
                     let script = Script::ImportMap(import_map_result);
 
                     // Step 34.3

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -47,7 +47,6 @@ use net_traits::request::{
 };
 use net_traits::{FetchMetadata, Metadata, NetworkError, ReferrerPolicy, ResourceFetchTiming};
 use script_bindings::cell::DomRefCell;
-use script_bindings::domstring::BytesView;
 use script_bindings::error::Fallible;
 use script_bindings::reflector::DomObject;
 use script_bindings::settings_stack::run_a_callback;
@@ -252,24 +251,24 @@ impl ModuleTree {
     }
 }
 
-pub(crate) struct ModuleSource {
-    pub source: Rc<DOMString>,
+pub(crate) struct ModuleSource<'a> {
+    pub source: Cow<'a, str>,
     pub unminified_dir: Option<String>,
     pub external: bool,
     pub url: ServoUrl,
 }
 
-impl crate::unminify::ScriptSource for ModuleSource {
+impl<'a> crate::unminify::ScriptSource for ModuleSource<'a> {
     fn unminified_dir(&self) -> Option<String> {
         self.unminified_dir.clone()
     }
 
-    fn extract_bytes(&self) -> BytesView<'_> {
+    fn extract_bytes(&self) -> &[u8] {
         self.source.as_bytes()
     }
 
-    fn rewrite_source(&mut self, source: Rc<DOMString>) {
-        self.source = source;
+    fn rewrite_source(&mut self, source: String) {
+        self.source = source.into();
     }
 
     fn url(&self) -> ServoUrl {
@@ -323,15 +322,14 @@ impl ModuleTree {
         );
 
         let mut source = if global.unminified_js_dir().is_some() {
-            let source = Rc::new(DOMString::from(source.into_owned()));
             let mut module_source = ModuleSource {
-                source: source.clone(),
+                source,
                 unminified_dir: global.unminified_js_dir(),
                 external,
                 url: url.clone(),
             };
             crate::unminify::unminify_js(&mut module_source);
-            transform_str_to_source_text(&source.str())
+            transform_str_to_source_text(&module_source.source)
         } else {
             transform_str_to_source_text(&source)
         };
@@ -1868,11 +1866,11 @@ fn merge_module_specifier_maps(
 pub(crate) fn parse_an_import_map_string(
     cx: &mut JSContext,
     global: &GlobalScope,
-    input: Cow<'_, str>,
+    input: &str,
     base_url: ServoUrl,
 ) -> Fallible<ImportMap> {
     // Step 1. Let parsed be the result of parsing a JSON string to an Infra value given input.
-    let parsed: JsonValue = serde_json::from_str(&input)
+    let parsed: JsonValue = serde_json::from_str(input)
         .map_err(|_| Error::Type(c"The value needs to be a JSON object.".to_owned()))?;
     // Step 2. If parsed is not an ordered map, then throw a TypeError indicating that the
     // top-level value needs to be a JSON object.

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -5,6 +5,7 @@
 //! The script module mod contains common traits and structs
 //! related to `type=module` for script thread or worker threads.
 
+use std::borrow::Cow;
 use std::cell::{OnceCell, RefCell};
 use std::ffi::CStr;
 use std::fmt::Debug;
@@ -286,7 +287,7 @@ impl ModuleTree {
     /// <https://html.spec.whatwg.org/multipage/#creating-a-javascript-module-script>
     fn create_a_javascript_module_script(
         cx: &mut JSContext,
-        source: Rc<DOMString>,
+        source: Cow<'_, str>,
         global: &GlobalScope,
         url: &ServoUrl,
         options: ScriptFetchOptions,
@@ -321,22 +322,24 @@ impl ModuleTree {
             line_number,
         );
 
-        let mut module_source = ModuleSource {
-            source,
-            unminified_dir: global.unminified_js_dir(),
-            external,
-            url: url.clone(),
+        let mut source = if global.unminified_js_dir().is_some() {
+            let source = Rc::new(DOMString::from(source.into_owned()));
+            let mut module_source = ModuleSource {
+                source: source.clone(),
+                unminified_dir: global.unminified_js_dir(),
+                external,
+                url: url.clone(),
+            };
+            crate::unminify::unminify_js(&mut module_source);
+            transform_str_to_source_text(&source.str())
+        } else {
+            transform_str_to_source_text(&source)
         };
-        crate::unminify::unminify_js(&mut module_source);
 
         unsafe {
             // Step 7. Let result be ParseModule(source, settings's realm, script).
             rooted!(&in(cx) let mut module_script: *mut JSObject = std::ptr::null_mut());
-            module_script.set(CompileModule1(
-                cx,
-                compile_options.ptr,
-                &mut transform_str_to_source_text(&module_source.source.str()),
-            ));
+            module_script.set(CompileModule1(cx, compile_options.ptr, &mut source));
 
             // Step 8. If result is a list of errors, then:
             if module_script.is_null() {
@@ -820,7 +823,7 @@ impl FetchResponseListener for ModuleContext {
 
                 let module_tree = Rc::new(ModuleTree::create_a_javascript_module_script(
                     cx,
-                    Rc::new(DOMString::from(source_text.clone())),
+                    source_text,
                     &global,
                     &final_url,
                     self.options,
@@ -829,11 +832,9 @@ impl FetchResponseListener for ModuleContext {
                     self.introduction_type,
                 ));
                 module_script = Some(module_tree);
-            }
-
-            // Step 7.4 If mimeType is a JSON MIME type and moduleType is "json",
-            // then set moduleScript to the result of creating a JSON module script given sourceText and settingsObject.
-            if MimeClassifier::is_json(&mime) && matches!(module_type, ModuleType::JSON) {
+            } else if MimeClassifier::is_json(&mime) && matches!(module_type, ModuleType::JSON) {
+                // Step 7.4 If mimeType is a JSON MIME type and moduleType is "json",
+                // then set moduleScript to the result of creating a JSON module script given sourceText and settingsObject.
                 let module_tree = Rc::new(ModuleTree::create_a_json_module_script(
                     cx,
                     &source_text,
@@ -1350,7 +1351,7 @@ pub(crate) fn fetch_a_modulepreload_module(
 pub(crate) fn fetch_inline_module_script(
     cx: &mut JSContext,
     global: &GlobalScope,
-    module_script_text: Rc<DOMString>,
+    module_script_text: Cow<'_, str>,
     url: ServoUrl,
     options: ScriptFetchOptions,
     line_number: u32,
@@ -1867,11 +1868,11 @@ fn merge_module_specifier_maps(
 pub(crate) fn parse_an_import_map_string(
     cx: &mut JSContext,
     global: &GlobalScope,
-    input: Rc<DOMString>,
+    input: Cow<'_, str>,
     base_url: ServoUrl,
 ) -> Fallible<ImportMap> {
     // Step 1. Let parsed be the result of parsing a JSON string to an Infra value given input.
-    let parsed: JsonValue = serde_json::from_str(&input.str())
+    let parsed: JsonValue = serde_json::from_str(&input)
         .map_err(|_| Error::Type(c"The value needs to be a JSON object.".to_owned()))?;
     // Step 2. If parsed is not an ordered map, then throw a TypeError indicating that the
     // top-level value needs to be a JSON object.

--- a/components/script/unminify.rs
+++ b/components/script/unminify.rs
@@ -7,19 +7,15 @@ use std::fs::{File, create_dir_all};
 use std::io::{Error, Read, Seek, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::rc::Rc;
 
-use script_bindings::domstring::BytesView;
 use servo_url::ServoUrl;
 use tempfile::NamedTempFile;
 use uuid::Uuid;
 
-use crate::dom::bindings::str::DOMString;
-
 pub(crate) trait ScriptSource {
     fn unminified_dir(&self) -> Option<String>;
-    fn extract_bytes(&self) -> BytesView<'_>;
-    fn rewrite_source(&mut self, source: Rc<DOMString>);
+    fn extract_bytes(&self) -> &[u8];
+    fn rewrite_source(&mut self, source: String);
     fn url(&self) -> ServoUrl;
     fn is_external(&self) -> bool;
 }
@@ -103,7 +99,7 @@ pub(crate) fn unminify_js(script: &mut dyn ScriptSource) {
     };
 
     if let Some((mut input, mut output)) = create_temp_files() {
-        input.write_all(&script.extract_bytes()).unwrap();
+        input.write_all(script.extract_bytes()).unwrap();
 
         if execute_js_beautify(
             input.path(),
@@ -113,12 +109,12 @@ pub(crate) fn unminify_js(script: &mut dyn ScriptSource) {
             let mut script_content = String::new();
             output.seek(std::io::SeekFrom::Start(0)).unwrap();
             output.read_to_string(&mut script_content).unwrap();
-            script.rewrite_source(Rc::new(DOMString::from(script_content)));
+            script.rewrite_source(script_content);
         }
     }
 
     match create_output_file(unminified_dir, &script.url(), Some(script.is_external())) {
-        Ok(mut file) => file.write_all(&script.extract_bytes()).unwrap(),
+        Ok(mut file) => file.write_all(script.extract_bytes()).unwrap(),
         Err(why) => warn!("Could not store script {:?}", why),
     }
 }


### PR DESCRIPTION
Previously scripts where cloned potentially. encoding_rs spits out a Cow<'_, str> which was previously transformed into an owned string. Now we use the Cow directly as much as possible only cloning when needed by unminify.
This, however, decreases the performance for inline script elements (see Step 5a in the diff). Where it previously was a simple clone of a DOMString but now is a transform into a Cow (potentially instantiating + clone).
As far as I understand this case is only for inline script text which are less on modern web pages.

Testing: WPT will find if there are any problems with transforming the Cow into a string spidermonkey can understand.
