### PR TITLE
libservo: Introduce `WebViewPreferences` to provide per-`WebView` preferences

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7451,7 +7451,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.38.0"
-source = "git+https://github.com/servo/stylo?rev=9d12364ecccb69cd26622391180f130c5346e393#9d12364ecccb69cd26622391180f130c5346e393"
+source = "git+https://github.com/servo/stylo?branch=expose-setter-on-servo-device#9bc9c343679a7b660c07901fda12b2d589439b96"
 dependencies = [
  "bitflags 2.13.0",
  "cssparser",
@@ -9203,7 +9203,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=9d12364ecccb69cd26622391180f130c5346e393#9d12364ecccb69cd26622391180f130c5346e393"
+source = "git+https://github.com/servo/stylo?branch=expose-setter-on-servo-device#9bc9c343679a7b660c07901fda12b2d589439b96"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -9674,7 +9674,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=9d12364ecccb69cd26622391180f130c5346e393#9d12364ecccb69cd26622391180f130c5346e393"
+source = "git+https://github.com/servo/stylo?branch=expose-setter-on-servo-device#9bc9c343679a7b660c07901fda12b2d589439b96"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -9730,7 +9730,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=9d12364ecccb69cd26622391180f130c5346e393#9d12364ecccb69cd26622391180f130c5346e393"
+source = "git+https://github.com/servo/stylo?branch=expose-setter-on-servo-device#9bc9c343679a7b660c07901fda12b2d589439b96"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -9739,7 +9739,7 @@ dependencies = [
 [[package]]
 name = "stylo_derive"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=9d12364ecccb69cd26622391180f130c5346e393#9d12364ecccb69cd26622391180f130c5346e393"
+source = "git+https://github.com/servo/stylo?branch=expose-setter-on-servo-device#9bc9c343679a7b660c07901fda12b2d589439b96"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -9751,7 +9751,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=9d12364ecccb69cd26622391180f130c5346e393#9d12364ecccb69cd26622391180f130c5346e393"
+source = "git+https://github.com/servo/stylo?branch=expose-setter-on-servo-device#9bc9c343679a7b660c07901fda12b2d589439b96"
 dependencies = [
  "bitflags 2.13.0",
  "stylo_malloc_size_of",
@@ -9760,7 +9760,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=9d12364ecccb69cd26622391180f130c5346e393#9d12364ecccb69cd26622391180f130c5346e393"
+source = "git+https://github.com/servo/stylo?branch=expose-setter-on-servo-device#9bc9c343679a7b660c07901fda12b2d589439b96"
 dependencies = [
  "app_units",
  "cssparser",
@@ -9777,7 +9777,7 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=9d12364ecccb69cd26622391180f130c5346e393#9d12364ecccb69cd26622391180f130c5346e393"
+source = "git+https://github.com/servo/stylo?branch=expose-setter-on-servo-device#9bc9c343679a7b660c07901fda12b2d589439b96"
 dependencies = [
  "toml",
 ]
@@ -9785,7 +9785,7 @@ dependencies = [
 [[package]]
 name = "stylo_traits"
 version = "0.18.0"
-source = "git+https://github.com/servo/stylo?rev=9d12364ecccb69cd26622391180f130c5346e393#9d12364ecccb69cd26622391180f130c5346e393"
+source = "git+https://github.com/servo/stylo?branch=expose-setter-on-servo-device#9bc9c343679a7b660c07901fda12b2d589439b96"
 dependencies = [
  "app_units",
  "bitflags 2.13.0",
@@ -10205,7 +10205,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.4.0"
-source = "git+https://github.com/servo/stylo?rev=9d12364ecccb69cd26622391180f130c5346e393#9d12364ecccb69cd26622391180f130c5346e393"
+source = "git+https://github.com/servo/stylo?branch=expose-setter-on-servo-device#9bc9c343679a7b660c07901fda12b2d589439b96"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -10218,7 +10218,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=9d12364ecccb69cd26622391180f130c5346e393#9d12364ecccb69cd26622391180f130c5346e393"
+source = "git+https://github.com/servo/stylo?branch=expose-setter-on-servo-device#9bc9c343679a7b660c07901fda12b2d589439b96"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8053,6 +8053,7 @@ name = "servo-fonts"
 version = "0.3.0"
 dependencies = [
  "app_units",
+ "atomic_refcell",
  "bitflags 2.13.0",
  "byteorder",
  "content-security-policy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,14 +215,14 @@ rustls-pki-types = "1.14"
 rustls-platform-verifier = "0.7.0"
 sea-query = { version = "=1.0.0-rc.31", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = "=0.8.0-rc.15"
-selectors = { git = "https://github.com/servo/stylo", rev = "9d12364ecccb69cd26622391180f130c5346e393" }
+selectors = { git = "https://github.com/servo/stylo", branch = "expose-setter-on-servo-device" }
 seq-macro = "0.3.6"
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
 serde_json = "1.0"
 serde_test = "1.0"
-servo_arc = { git = "https://github.com/servo/stylo", rev = "9d12364ecccb69cd26622391180f130c5346e393" }
+servo_arc = { git = "https://github.com/servo/stylo", branch = "expose-setter-on-servo-device" }
 sha1 = "0.11"
 sha2 = "0.11"
 sha3 = "0.12"
@@ -232,12 +232,12 @@ smallvec = { version = "1.15", features = ["serde", "union"] }
 speexdsp-resampler = "0.1.0"
 string_cache = "0.9"
 strum = { version = "0.28", features = ["derive"] }
-stylo = { git = "https://github.com/servo/stylo", rev = "9d12364ecccb69cd26622391180f130c5346e393" }
-stylo_atoms = { git = "https://github.com/servo/stylo", rev = "9d12364ecccb69cd26622391180f130c5346e393" }
-stylo_dom = { git = "https://github.com/servo/stylo", rev = "9d12364ecccb69cd26622391180f130c5346e393" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "9d12364ecccb69cd26622391180f130c5346e393" }
-stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "9d12364ecccb69cd26622391180f130c5346e393" }
-stylo_traits = { git = "https://github.com/servo/stylo", rev = "9d12364ecccb69cd26622391180f130c5346e393" }
+stylo = { git = "https://github.com/servo/stylo", branch = "expose-setter-on-servo-device" }
+stylo_atoms = { git = "https://github.com/servo/stylo", branch = "expose-setter-on-servo-device" }
+stylo_dom = { git = "https://github.com/servo/stylo", branch = "expose-setter-on-servo-device" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", branch = "expose-setter-on-servo-device" }
+stylo_static_prefs = { git = "https://github.com/servo/stylo", branch = "expose-setter-on-servo-device" }
+stylo_traits = { git = "https://github.com/servo/stylo", branch = "expose-setter-on-servo-device" }
 surfman = { version = "0.13.0", features = ["chains"] }
 swapper = "0.1"
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -106,6 +106,7 @@ use devtools_traits::{
 };
 use embedder_traits::resources::{self, Resource};
 use embedder_traits::user_contents::{UserContentManagerId, UserContents};
+use embedder_traits::webview_preferences::{WebViewPreferencesData, WebViewPreferencesId};
 use embedder_traits::{
     AnimationState, EmbedderControlId, EmbedderControlResponse, EmbedderProxy, FocusSequenceNumber,
     GenericEmbedderProxy, InputEvent, InputEventAndId, InputEventOutcome, JSValue,
@@ -522,6 +523,10 @@ pub struct Constellation<STF, SWF> {
     /// to the `UserContents` need to be forwared to all the `ScriptThread`s that host
     /// the relevant `WebView`.
     pub(crate) user_contents_for_manager_id: FxHashMap<UserContentManagerId, UserContents>,
+    /// A map from `WebViewPreferencesId` to the `WebViewPreferencesData` for that ID.
+    /// Multiple `WebView`s can share the same `WebViewPreferences` and any mutations
+    /// to the latter must be forwarded to all `ScriptThread`s that host the relevant `WebView`s.
+    pub(crate) webview_preferences_for_id: FxHashMap<WebViewPreferencesId, WebViewPreferencesData>,
 }
 
 /// State needed to construct a constellation.
@@ -667,6 +672,12 @@ where
 
                 let broken_image_icon_data = resources::read_bytes(Resource::BrokenImageIcon);
 
+                // Intialize constellation with state for default `WebViewPreferencesId` that
+                // will be shared by `WebView`s that don't override their associated `WebViewPreferences`.
+                let webview_preferences_for_id = FxHashMap::from_iter([
+                    (WebViewPreferencesId::DEFAULT, WebViewPreferencesData::default()),
+                ]);
+
                 let mut constellation: Constellation<STF, SWF> = Constellation {
                     event_loops: Default::default(),
                     namespace_receiver,
@@ -741,6 +752,7 @@ where
                     pending_viewport_changes: Default::default(),
                     screenshot_readiness_requests: Vec::new(),
                     user_contents_for_manager_id: Default::default(),
+                    webview_preferences_for_id,
                 };
 
                 constellation.run();
@@ -1053,6 +1065,12 @@ where
             .get(&webview_id)
             .and_then(|webview| webview.user_content_manager_id);
 
+        let webview_preferences_id = self
+            .webviews
+            .get(&webview_id)
+            .map(|webview| webview.webview_preferences_id)
+            .expect("webview_id must have an associated ConstellationWebView");
+
         let new_pipeline_info = NewPipelineInfo {
             parent_info: parent_pipeline_id,
             new_pipeline_id,
@@ -1062,6 +1080,7 @@ where
             load_data,
             viewport_details: initial_viewport_details,
             user_content_manager_id,
+            webview_preferences_id,
             theme,
             target_snapshot_params,
         };
@@ -1552,6 +1571,23 @@ where
             },
             EmbedderToConstellationMessage::SetAccessibilityActive(webview_id, active) => {
                 self.set_accessibility_active(webview_id, active);
+            },
+            EmbedderToConstellationMessage::SetWebViewPreferences(id, preference_updates) => {
+                let webview_preferences_data =
+                    self.webview_preferences_for_id.entry(id).or_default();
+                webview_preferences_data.apply_preference_updates(&preference_updates);
+                for event_loop in self.event_loops() {
+                    let _ = event_loop.send(ScriptThreadMessage::SetWebViewPreferences(
+                        id,
+                        preference_updates.clone(),
+                    ));
+                }
+            },
+            EmbedderToConstellationMessage::DestroyWebViewPreferences(id) => {
+                self.webview_preferences_for_id.remove(&id);
+                for event_loop in self.event_loops() {
+                    let _ = event_loop.send(ScriptThreadMessage::DestroyWebViewPreferences(id));
+                }
             },
         }
     }
@@ -3266,6 +3302,7 @@ where
             webview_id,
             viewport_details,
             user_content_manager_id,
+            webview_preferences_id,
         }: NewWebViewDetails,
     ) {
         let pipeline_id = PipelineId::new();
@@ -3278,7 +3315,12 @@ where
         // its focused browsing context to be itself.
         self.webviews.insert(
             webview_id,
-            ConstellationWebView::new(webview_id, browsing_context_id, user_content_manager_id),
+            ConstellationWebView::new(
+                webview_id,
+                browsing_context_id,
+                user_content_manager_id,
+                webview_preferences_id,
+            ),
         );
 
         // https://html.spec.whatwg.org/multipage/#creating-a-new-browsing-context-group
@@ -3617,6 +3659,7 @@ where
             webview_id: new_webview_id,
             viewport_details,
             user_content_manager_id,
+            webview_preferences_id,
         } = match webview_id_receiver.recv() {
             Ok(Some(new_webview_details)) => new_webview_details,
             Ok(None) | Err(_) => {
@@ -3661,6 +3704,7 @@ where
             new_webview_id,
             new_pipeline_id,
             user_content_manager_id,
+            webview_preferences_id,
         }));
 
         assert!(!self.pipelines.contains_key(&new_pipeline_id));
@@ -3671,6 +3715,7 @@ where
                 new_webview_id,
                 new_browsing_context_id,
                 user_content_manager_id,
+                webview_preferences_id,
             ),
         );
 

--- a/components/constellation/constellation_webview.rs
+++ b/components/constellation/constellation_webview.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use embedder_traits::user_contents::UserContentManagerId;
-use embedder_traits::{InputEvent, MouseLeftViewportEvent, Theme};
+use embedder_traits::{InputEvent, MouseLeftViewportEvent, Theme, WebViewPreferencesId};
 use euclid::Point2D;
 use log::warn;
 use rustc_hash::FxHashMap;
@@ -59,6 +59,12 @@ pub(crate) struct ConstellationWebView {
     /// via [`ScriptThreadMessage::SetAccessibilityActive`] in `set_accessibility_active()`
     /// and [`crate::Constellation::set_frame_tree_for_webview()`].
     pub accessibility_active: bool,
+
+    /// The [`WebViewPreferencesId`] for all pipelines in this `WebView`.
+    ///
+    ///  This will be [`WebViewPreferencesId::DEFAULT`] if the embedder has not set a different
+    /// `WebViewPreferences` using the `WebViewBuilder` API.
+    pub webview_preferences_id: WebViewPreferencesId,
 }
 
 impl ConstellationWebView {
@@ -66,10 +72,12 @@ impl ConstellationWebView {
         webview_id: WebViewId,
         focused_browsing_context_id: BrowsingContextId,
         user_content_manager_id: Option<UserContentManagerId>,
+        webview_preferences_id: WebViewPreferencesId,
     ) -> Self {
         Self {
             webview_id,
             user_content_manager_id,
+            webview_preferences_id,
             active_top_level_pipeline_id: None,
             active_top_level_pipeline_epoch: Epoch::default(),
             focused_browsing_context_id,

--- a/components/constellation/event_loop.rs
+++ b/components/constellation/event_loop.rs
@@ -111,6 +111,7 @@ impl EventLoop {
             player_context: WindowGLContext::get(),
             privileged_urls: constellation.privileged_urls.clone(),
             user_contents_for_manager_id: constellation.user_contents_for_manager_id.clone(),
+            webview_preferences_for_id: constellation.webview_preferences_for_id.clone(),
         };
 
         let event_loop = if opts::get().multiprocess {

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -83,6 +83,8 @@ mod from_embedder {
                 Self::UserContentManagerAction(..) => target!("UserContentManagerAction"),
                 Self::UpdatePinchZoomInfos(..) => target!("UpdatePinchZoomInfos"),
                 Self::SetAccessibilityActive(..) => target!("SetAccessibilityActive"),
+                Self::SetWebViewPreferences(..) => target!("SetWebViewPreferences"),
+                Self::DestroyWebViewPreferences(..) => target!("DestroyWebViewPreferences"),
             }
         }
     }

--- a/components/fonts/Cargo.toml
+++ b/components/fonts/Cargo.toml
@@ -20,6 +20,7 @@ tracing = ["dep:tracing"]
 
 [dependencies]
 app_units = { workspace = true }
+atomic_refcell = { workspace = true }
 bitflags = { workspace = true }
 content-security-policy = { workspace = true }
 euclid = { workspace = true }

--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use app_units::Au;
+use atomic_refcell::AtomicRefCell;
 use content_security_policy::Violation;
 use fonts_traits::{
     CSSFontFaceDescriptors, FontDescriptor, FontIdentifier, FontTemplate, FontTemplateRef,
@@ -67,6 +68,14 @@ pub(crate) struct FontParameters {
 
 pub type FontGroupRef = Arc<FontGroup>;
 
+/// The default font size settings derived from per-WebView preferences
+/// which can be updated at runtime.
+#[derive(Clone, Copy, Debug, Default, MallocSizeOf)]
+pub struct DefaultFontSettings {
+    pub default_font_size: i64,
+    pub default_monospace_font_size: i64,
+}
+
 /// The FontContext represents the per-thread/thread state necessary for
 /// working with fonts. It is the public API used by the layout and
 /// paint code. It talks directly to the system font service where
@@ -106,10 +115,13 @@ pub struct FontContext {
     font_data: RwLock<HashMap<FontIdentifier, FontData>>,
 
     have_removed_web_fonts: AtomicBool,
-
     /// Maps from a URL to all the `@font-face` rules that are currently waiting for the load to
     /// finish.
     currently_downloading_fonts: Mutex<HashMap<ServoUrl, Vec<WebFontDownloadState>>>,
+
+    /// The default font size settings derived from `WebViewPreferences`
+    /// which can be updated at runtime.
+    default_font_settings: AtomicRefCell<DefaultFontSettings>,
 }
 
 /// A callback that will be invoked on the Fetch thread if a web font download
@@ -158,6 +170,7 @@ impl FontContext {
         system_font_service_proxy: Arc<SystemFontServiceProxy>,
         paint_api: CrossProcessPaintApi,
         resource_threads: ResourceThreads,
+        default_font_settings: DefaultFontSettings,
     ) -> Self {
         Self {
             system_font_service_proxy,
@@ -171,7 +184,16 @@ impl FontContext {
             have_removed_web_fonts: AtomicBool::new(false),
             font_data: RwLock::default(),
             currently_downloading_fonts: Default::default(),
+            default_font_settings: AtomicRefCell::new(default_font_settings),
         }
+    }
+
+    pub fn set_default_font_settings(&self, settings: DefaultFontSettings) {
+        *self.default_font_settings.borrow_mut() = settings;
+    }
+
+    pub fn default_font_settings(&self) -> DefaultFontSettings {
+        *self.default_font_settings.borrow()
     }
 
     pub fn web_fonts_still_loading(&self) -> usize {

--- a/components/fonts/lib.rs
+++ b/components/fonts/lib.rs
@@ -21,8 +21,8 @@ pub use font::{
     ShapingOptions,
 };
 pub use font_context::{
-    CspViolationHandler, FontContext, FontContextWebFontMethods, NetworkTimingHandler,
-    WebFontDocumentContext,
+    CspViolationHandler, DefaultFontSettings, FontContext, FontContextWebFontMethods,
+    NetworkTimingHandler, WebFontDocumentContext,
 };
 pub use font_store::FontTemplates;
 pub use fonts_traits::*;

--- a/components/fonts/tests/font_context.rs
+++ b/components/fonts/tests/font_context.rs
@@ -58,7 +58,12 @@ mod font_context {
                 start_fetch_thread();
             });
             Self {
-                context: FontContext::new(proxy_clone, mock_paint_api, mock_resource_threads),
+                context: FontContext::new(
+                    proxy_clone,
+                    mock_paint_api,
+                    mock_resource_threads,
+                    DefaultFontSettings::default(),
+                ),
                 system_font_service,
                 system_font_service_proxy,
             }

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -14,9 +14,10 @@ use app_units::Au;
 use bitflags::bitflags;
 use embedder_traits::{
     EmbedderMsg, ScriptToEmbedderChan, Theme, UntrustedNodeAddress, ViewportDetails,
+    WebViewPreference, WebViewPreferencesData,
 };
 use euclid::{Point2D, Rect, Scale, Size2D};
-use fonts::{FontContext, FontContextWebFontMethods, WebFontDocumentContext};
+use fonts::{DefaultFontSettings, FontContext, FontContextWebFontMethods, WebFontDocumentContext};
 use fonts_traits::StylesheetWebFontLoadFinishedCallback;
 use icu_locid::subtags::Language;
 use layout_api::{
@@ -774,6 +775,44 @@ impl Layout for LayoutThread {
 
     fn set_needs_accessibility_update(&self) {
         self.needs_accessibility_update.set(true);
+    }
+
+    fn on_preferences_changed(
+        &mut self,
+        preference_updates: &[WebViewPreference],
+        preferences: &WebViewPreferencesData,
+    ) -> bool {
+        if !preference_updates.iter().any(|preference| {
+            matches!(
+                preference,
+                WebViewPreference::DefaultFontSize(..) |
+                    WebViewPreference::DefaultMonospaceFontSize(..)
+            )
+        }) {
+            return false;
+        }
+
+        // Update `FontContext` instance that is used by Stylo as `FontMetricsProvider`.
+        let settings = DefaultFontSettings {
+            default_font_size: preferences.default_font_size,
+            default_monospace_font_size: preferences.default_monospace_font_size,
+        };
+        self.font_context.set_default_font_settings(settings);
+
+        // Update the device's default computed values so that Stylo uses
+        // the new font size as the initial value for `font-size: medium`.
+        let mut font = Font::initial_values();
+        font.font_size = FontSize {
+            computed_size: NonNegativeLength::new(preferences.default_font_size as f32),
+            used_size: NonNegativeLength::new(preferences.default_font_size as f32),
+            keyword_info: KeywordInfo::medium(),
+        };
+        let device = self.stylist.device_mut();
+        device.set_default_computed_values(ComputedValues::initial_values_with_font_override(font));
+        // Ensure that a relayout is triggered.
+        self.device_has_changed = true;
+        // Return true so the document is marked as needing a restyle.
+        true
     }
 }
 

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -785,7 +785,7 @@ impl LayoutThread {
             .send_initial_transaction(config.webview_id, config.id.into());
 
         let mut font = Font::initial_values();
-        let default_font_size = pref!(fonts_default_size);
+        let default_font_size = config.default_font_size;
         font.font_size = FontSize {
             computed_size: NonNegativeLength::new(default_font_size as f32),
             used_size: NonNegativeLength::new(default_font_size as f32),
@@ -1784,9 +1784,10 @@ impl FontMetricsProvider for LayoutFontMetricsProvider {
     }
 
     fn base_size_for_generic(&self, generic: GenericFontFamily) -> Length {
+        let default_font_settings = self.0.default_font_settings();
         Length::new(match generic {
-            GenericFontFamily::Monospace => pref!(fonts_default_monospace_size),
-            _ => pref!(fonts_default_size),
+            GenericFontFamily::Monospace => default_font_settings.default_monospace_font_size,
+            _ => default_font_settings.default_font_size,
         } as f32)
         .max(Length::new(0.0))
     }

--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -10,6 +10,7 @@ use content_security_policy::sandboxing_directive::{
 };
 use dom_struct::dom_struct;
 use embedder_traits::ViewportDetails;
+use embedder_traits::webview_preferences::WebViewPreferencesId;
 use html5ever::{LocalName, Prefix, local_name, ns};
 use js::context::JSContext;
 use js::rust::HandleObject;
@@ -309,6 +310,7 @@ impl HTMLIFrameElement {
                     user_content_manager_id: None,
                     theme: window.theme(),
                     target_snapshot_params,
+                    webview_preferences_id: WebViewPreferencesId::DEFAULT,
                 };
 
                 self.pipeline_id.set(Some(new_pipeline_id));

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -23,6 +23,7 @@ use cssparser::SourceLocation;
 use devtools_traits::{ScriptToDevtoolsControlMsg, TimelineMarker, TimelineMarkerType};
 use dom_struct::dom_struct;
 use embedder_traits::user_contents::UserScript;
+use embedder_traits::webview_preferences::WebViewPreferencesId;
 use embedder_traits::{
     AlertResponse, ConfirmResponse, EmbedderMsg, JavaScriptEvaluationError, PromptResponse,
     ScriptToEmbedderChan, SimpleDialogRequest, Theme, UntrustedNodeAddress, ViewportDetails,
@@ -283,6 +284,13 @@ pub(crate) struct Window {
     /// This may not be the top-level [`Window`], in the case of frames.
     #[no_trace]
     webview_id: WebViewId,
+
+    /// The ID of the `WebViewPreferences` associated with this [`Window`].
+    /// This is used to filter preference change notifications to only
+    /// affect documents belonging to the correct webview.
+    #[no_trace]
+    webview_preferences_id: WebViewPreferencesId,
+
     script_chan: Sender<MainThreadScriptMsg>,
     #[no_trace]
     #[ignore_malloc_size_of = "TODO: Add MallocSizeOf support to layout"]
@@ -490,6 +498,10 @@ impl Window {
 
     pub(crate) fn webview_id(&self) -> WebViewId {
         self.webview_id
+    }
+
+    pub(crate) fn webview_preferences_id(&self) -> WebViewPreferencesId {
+        self.webview_preferences_id
     }
 
     pub(crate) fn as_global_scope(&self) -> &GlobalScope {
@@ -3659,6 +3671,7 @@ impl Window {
     pub(crate) fn new(
         cx: &mut JSContext,
         webview_id: WebViewId,
+        webview_preferences_id: WebViewPreferencesId,
         runtime: Rc<Runtime>,
         script_chan: Sender<MainThreadScriptMsg>,
         layout: Box<dyn Layout>,
@@ -3700,6 +3713,7 @@ impl Window {
 
         let win = Box::new(Self {
             webview_id,
+            webview_preferences_id,
             globalscope: GlobalScope::new_inherited(
                 devtools_chan,
                 mem_profiler_chan,

--- a/components/script/dom/window/windowproxy.rs
+++ b/components/script/dom/window/windowproxy.rs
@@ -372,6 +372,7 @@ impl WindowProxy {
             load_data,
             viewport_details: window.viewport_details(),
             user_content_manager_id: response.user_content_manager_id,
+            webview_preferences_id: response.webview_preferences_id,
             // Use the current `WebView`'s theme initially, but the embedder may
             // change this later.
             theme: window.theme(),

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -110,6 +110,8 @@ impl MixedMessage {
                 ScriptThreadMessage::UpdatePinchZoomInfos(id, _) => Some(*id),
                 ScriptThreadMessage::SetAccessibilityActive(..) => None,
                 ScriptThreadMessage::TriggerGarbageCollection => None,
+                ScriptThreadMessage::SetWebViewPreferences(..) => None,
+                ScriptThreadMessage::DestroyWebViewPreferences(..) => None,
             },
             MixedMessage::FromScript(inner_msg) => match inner_msg {
                 MainThreadScriptMsg::Common(CommonScriptMsg::Task(_, _, pipeline_id, _)) => {

--- a/components/script/navigation.rs
+++ b/components/script/navigation.rs
@@ -11,7 +11,7 @@ use std::cell::Cell;
 use content_security_policy::sandboxing_directive::SandboxingFlagSet;
 use crossbeam_channel::Sender;
 use embedder_traits::user_contents::UserContentManagerId;
-use embedder_traits::{Theme, ViewportDetails, WebDriverLoadStatus};
+use embedder_traits::{Theme, ViewportDetails, WebDriverLoadStatus, WebViewPreferencesId};
 use http::header;
 use js::context::JSContext;
 use net_traits::blob_url_store::UrlWithBlobClaim;
@@ -185,6 +185,9 @@ pub(crate) struct InProgressLoad {
     /// The [`TargetSnapshotParams`] to use when creating this document.
     #[no_trace]
     pub(crate) target_snapshot_params: TargetSnapshotParams,
+    /// The [`WebViewPreferencesId`] for this load's `WebView`.
+    #[no_trace]
+    pub(crate) webview_preferences_id: WebViewPreferencesId,
 }
 
 impl InProgressLoad {
@@ -207,6 +210,7 @@ impl InProgressLoad {
             user_content_manager_id: new_pipeline_info.user_content_manager_id,
             theme: new_pipeline_info.theme,
             target_snapshot_params: new_pipeline_info.target_snapshot_params,
+            webview_preferences_id: new_pipeline_info.webview_preferences_id,
         }
     }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -40,13 +40,14 @@ use devtools_traits::{
     ScriptToDevtoolsControlMsg, WorkerId,
 };
 use embedder_traits::user_contents::{UserContentManagerId, UserContents, UserScript};
+use embedder_traits::webview_preferences::{WebViewPreferencesData, WebViewPreferencesId};
 use embedder_traits::{
     EmbedderControlId, EmbedderControlResponse, EmbedderMsg, FocusSequenceNumber,
     InputEventOutcome, JavaScriptEvaluationError, JavaScriptEvaluationId, MediaSessionActionType,
     Theme, ViewportDetails, WebDriverScriptCommand,
 };
 use encoding_rs::Encoding;
-use fonts::{FontContext, SystemFontServiceProxy};
+use fonts::{DefaultFontSettings, FontContext, SystemFontServiceProxy};
 use headers::{HeaderMapExt, LastModified, ReferrerPolicy as ReferrerPolicyHeader};
 use http::header::REFRESH;
 use hyper_serde::Serde;
@@ -422,6 +423,12 @@ pub struct ScriptThread {
     privileged_urls: Vec<ServoUrl>,
 
     devtools_state: DevtoolsState,
+
+    /// A map from [`WebViewPreferencesId`] to its [`WebViewPreferencesData`].
+    /// Initially populated from [`InitialScriptState`] and updated via
+    /// constellation messages when preferences are changed.
+    #[no_trace]
+    webview_preferences_for_id: RefCell<FxHashMap<WebViewPreferencesId, WebViewPreferencesData>>,
 }
 
 struct BHMExitSignal {
@@ -1044,6 +1051,9 @@ impl ScriptThread {
                     privileged_urls: state.privileged_urls,
                     this: weak_script_thread.clone(),
                     devtools_state: Default::default(),
+                    webview_preferences_for_id: RefCell::new(FxHashMap::from_iter(
+                        state.webview_preferences_for_id,
+                    )),
                 }
             }),
             cx,
@@ -2018,6 +2028,16 @@ impl ScriptThread {
             },
             ScriptThreadMessage::TriggerGarbageCollection => unsafe {
                 JS_GC(cx, GCReason::API);
+            },
+            ScriptThreadMessage::SetWebViewPreferences(id, preference_updates) => {
+                self.webview_preferences_for_id
+                    .borrow_mut()
+                    .entry(id)
+                    .or_default()
+                    .apply_preference_updates(&preference_updates);
+            },
+            ScriptThreadMessage::DestroyWebViewPreferences(id) => {
+                self.webview_preferences_for_id.borrow_mut().remove(&id);
             },
         }
     }
@@ -3438,10 +3458,21 @@ impl ScriptThread {
             incomplete.load_data.url, incomplete.pipeline_id
         );
 
+        let webview_preferences = self
+            .webview_preferences_for_id
+            .borrow()
+            .get(&incomplete.webview_preferences_id)
+            .cloned()
+            .unwrap_or_default();
+
         let font_context = Arc::new(FontContext::new(
             self.system_font_service.clone(),
             self.paint_api.clone(),
             self.resource_threads.clone(),
+            DefaultFontSettings {
+                default_font_size: webview_preferences.default_font_size,
+                default_monospace_font_size: webview_preferences.default_monospace_font_size,
+            },
         ));
 
         let image_cache = self.image_cache_factory.create(
@@ -3479,6 +3510,8 @@ impl ScriptThread {
             user_stylesheets,
             theme: incomplete.theme,
             embedder_chan: self.senders.pipeline_to_embedder_sender.clone(),
+            default_font_size: webview_preferences.default_font_size,
+            default_monospace_font_size: webview_preferences.default_monospace_font_size,
         };
 
         // Create the window and document objects.

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2035,6 +2035,21 @@ impl ScriptThread {
                     .entry(id)
                     .or_default()
                     .apply_preference_updates(&preference_updates);
+
+                let preferences_for_id = self.webview_preferences_for_id.borrow();
+                let preferences = preferences_for_id.get(&id).unwrap();
+                for (_, document) in self.documents.borrow().iter() {
+                    if document.window().webview_preferences_id() != id {
+                        continue;
+                    }
+                    let needs_restyle = document
+                        .window()
+                        .layout_mut()
+                        .on_preferences_changed(&preference_updates, preferences);
+                    if needs_restyle {
+                        document.add_restyle_reason(RestyleReason::PreferencesChanged);
+                    }
+                }
             },
             ScriptThreadMessage::DestroyWebViewPreferences(id) => {
                 self.webview_preferences_for_id.borrow_mut().remove(&id);
@@ -3518,6 +3533,7 @@ impl ScriptThread {
         let window = Window::new(
             cx,
             incomplete.webview_id,
+            incomplete.webview_preferences_id,
             self.js_runtime.clone(),
             self.senders.self_sender.clone(),
             self.layout_factory.create(layout_config),

--- a/components/script/serviceworker_manager.rs
+++ b/components/script/serviceworker_manager.rs
@@ -14,7 +14,7 @@ use std::thread::{self, JoinHandle};
 
 use crossbeam_channel::{Receiver, Sender, select, unbounded};
 use devtools_traits::{DevtoolsPageInfo, ScriptToDevtoolsControlMsg};
-use fonts::FontContext;
+use fonts::{DefaultFontSettings, FontContext};
 use ipc_channel::ipc;
 use ipc_channel::router::ROUTER;
 use net_traits::{CoreResourceMsg, CustomResponseMediator};
@@ -801,6 +801,13 @@ impl ServiceWorkerManagerFactory for ServiceWorkerManager {
             Arc::new(system_font_service_sender.to_proxy()),
             paint_api,
             resource_threads,
+            // TODO: How should the font size be chosen here if ServiceWorkers are
+            // shared between `WebView`s. WebKit seems to use the font size from the webview
+            // that first spawned the ServiceWorker.
+            DefaultFontSettings {
+                default_font_size: pref!(fonts_default_size),
+                default_monospace_font_size: pref!(fonts_default_monospace_size),
+            },
         ));
 
         let swmanager_thread = move || {

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -19,6 +19,7 @@ mod gamepad_delegate;
 mod gstreamer_plugins;
 mod javascript_evaluator;
 mod network_manager;
+mod preferences;
 mod proxies;
 mod responders;
 mod servo;
@@ -78,6 +79,7 @@ pub use crate::gamepad_delegate::{
     GamepadDelegate, GamepadHapticEffectRequest, GamepadHapticEffectRequestType,
 };
 pub use crate::network_manager::{CacheEntry, NetworkManager};
+pub use crate::preferences::WebViewPreferences;
 pub use crate::servo::{Servo, ServoBuilder, run_content_process};
 pub use crate::servo_delegate::{ServoDelegate, ServoError};
 pub use crate::site_data_manager::{SiteData, SiteDataManager, StorageType};

--- a/components/servo/preferences.rs
+++ b/components/servo/preferences.rs
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::cell::RefCell;
+
+use embedder_traits::{WebViewPreference, WebViewPreferencesData, WebViewPreferencesId};
+use servo_constellation_traits::EmbedderToConstellationMessage;
+
+use crate::Servo;
+use crate::proxies::ConstellationProxy;
+
+/// The [`WebViewPreferences`] allows configuring preferences for
+/// each `WebView` independently. The same [`WebViewPreferences`] instance
+/// can be shared among multiple `WebView`s. `WebView`s that don't set a
+/// custom [`WebViewPreferences`] during creation via `WebViewBuilder` will
+/// use a shared "default" `WebViewPreferences` instance.
+///
+/// Changes to preferences made using the setters on [`WebViewPreferences`]
+/// affect all `WebView`s that are associated with the [`WebViewPreferences`] .
+/// The change will take effect when pages are reloaded.
+#[derive(Clone)]
+pub struct WebViewPreferences {
+    pub(crate) id: WebViewPreferencesId,
+    constellation_proxy: ConstellationProxy,
+    data: RefCell<WebViewPreferencesData>,
+}
+
+impl WebViewPreferences {
+    /// Create a new [`WebViewPreferences`] with all values set to their defaults.
+    pub fn new(servo: &Servo) -> Self {
+        Self::new_with_proxy(servo.constellation_proxy(), WebViewPreferencesId::next())
+    }
+
+    /// Create a new [`WebViewPreferences`] directly from a [`ConstellationProxy`].
+    /// Used internally to create the DEFAULT preferences before `Servo` exists.
+    pub(crate) fn new_with_proxy(
+        constellation_proxy: &ConstellationProxy,
+        id: WebViewPreferencesId,
+    ) -> Self {
+        // Send a message with empty preferences to register this id.
+        constellation_proxy.send(EmbedderToConstellationMessage::SetWebViewPreferences(
+            id,
+            vec![],
+        ));
+
+        Self {
+            id,
+            constellation_proxy: constellation_proxy.clone(),
+            data: RefCell::new(WebViewPreferencesData::default()),
+        }
+    }
+
+    pub(crate) fn id(&self) -> WebViewPreferencesId {
+        self.id
+    }
+
+    /// Get the default font size for proportional (variable-width) fonts, in CSS pixels.
+    pub fn default_font_size(&self) -> i64 {
+        self.data.borrow().default_font_size
+    }
+
+    /// Set the default font size for proportional (variable-width) fonts, in CSS pixels.
+    pub fn set_default_font_size(&self, size: i64) {
+        self.data.borrow_mut().default_font_size = size;
+        self.constellation_proxy
+            .send(EmbedderToConstellationMessage::SetWebViewPreferences(
+                self.id,
+                vec![WebViewPreference::DefaultFontSize(size)],
+            ));
+    }
+
+    /// Get the default font size for monospace fonts, in CSS pixels.
+    pub fn default_monospace_font_size(&self) -> i64 {
+        self.data.borrow().default_monospace_font_size
+    }
+
+    /// Set the default font size for monospace fonts, in CSS pixels.
+    pub fn set_default_monospace_font_size(&self, size: i64) {
+        self.data.borrow_mut().default_monospace_font_size = size;
+        self.constellation_proxy
+            .send(EmbedderToConstellationMessage::SetWebViewPreferences(
+                self.id,
+                vec![WebViewPreference::DefaultMonospaceFontSize(size)],
+            ));
+    }
+}
+
+impl Drop for WebViewPreferences {
+    fn drop(&mut self) {
+        // The DEFAULT preferences don't have to be destroyed — they live as long
+        // as Servo itself and DestroyWebViewPreferences for DEFAULT
+        // during shutdown will not be processed as the script threads may
+        // already be disconnected.
+        if self.id != WebViewPreferencesId::DEFAULT {
+            self.constellation_proxy.send(
+                EmbedderToConstellationMessage::DestroyWebViewPreferences(self.id),
+            );
+        }
+    }
+}

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -83,6 +83,7 @@ use crate::clipboard_delegate::StringRequest;
 use crate::gamepad_delegate::{GamepadHapticEffectRequest, GamepadHapticEffectRequestType};
 use crate::javascript_evaluator::JavaScriptEvaluator;
 use crate::network_manager::NetworkManager;
+use crate::preferences::WebViewPreferences;
 use crate::proxies::ConstellationProxy;
 use crate::responders::ServoErrorChannel;
 use crate::servo_delegate::{DefaultServoDelegate, ServoDelegate, ServoError};
@@ -249,6 +250,9 @@ struct ServoInner {
     pending_handled_input_events: RefCell<Vec<PendingHandledInputEvent>>,
     /// An [`EventLoopWaker`] used to wake up the main embedder event loop.
     event_loop_waker: Box<dyn EventLoopWaker>,
+    /// The default [`WebViewPreferences`] instance shared by all [`WebView`]s that
+    /// don't set a custom [`WebViewPreferences`] during creation via `WebViewBuilder`.
+    default_preferences: Rc<WebViewPreferences>,
 }
 
 impl ServoInner {
@@ -1002,6 +1006,11 @@ impl Servo {
             prefs::add_observer(Box::new(constellation_proxy.clone()));
         }
 
+        let default_preferences = Rc::new(WebViewPreferences::new_with_proxy(
+            &constellation_proxy,
+            WebViewPreferencesId::DEFAULT,
+        ));
+
         Servo(Rc::new(ServoInner {
             delegate: RefCell::new(Rc::new(DefaultServoDelegate)),
             paint,
@@ -1028,6 +1037,7 @@ impl Servo {
             _js_engine_setup: js_engine_setup,
             pending_handled_input_events: Default::default(),
             event_loop_waker,
+            default_preferences,
         }))
     }
 
@@ -1113,6 +1123,10 @@ impl Servo {
 
     pub(crate) fn constellation_proxy(&self) -> &ConstellationProxy {
         &self.0.constellation_proxy
+    }
+
+    pub(crate) fn default_preferences(&self) -> Rc<WebViewPreferences> {
+        self.0.default_preferences.clone()
     }
 
     pub(crate) fn javascript_evaluator_mut<'a>(&'a self) -> RefMut<'a, JavaScriptEvaluator> {

--- a/components/servo/tests/preferences.rs
+++ b/components/servo/tests/preferences.rs
@@ -78,9 +78,9 @@ fn test_webview_preferences_default_font_size() {
 }
 
 /// Verify that changes to default font size preferences take effect after the
-/// page is reloaded.
+/// without a reload.
 #[test]
-fn test_webview_preferences_default_font_size_changes_after_reload() {
+fn test_webview_preferences_default_font_size_changes_without_reload() {
     let servo_test = ServoTest::new();
 
     // Use an HTTP server instead of a `data:` URL so the reload witl reuse the
@@ -100,10 +100,19 @@ fn test_webview_preferences_default_font_size_changes_after_reload() {
     let result = evaluate_javascript(&servo_test, webview.clone(), script);
     assert_eq!(result, Ok(JSValue::String("16px".into())));
 
-    // Change the font size and assert that it takes effect after reload.
+    // Change the font size and assert that it takes effect *without* a reload.
     let preferences = webview.preferences();
     preferences.set_default_font_size(32);
-    webview.reload();
+
+    // Reset the delegate before we wait so we don't see the stale `true` from the
+    // initial load.
+    delegate.reset();
+    // Wait for a new frame — the preference change should trigger a restyle
+    // and rendering update without needing a reload.
+    servo_test.spin({
+        let delegate = delegate.clone();
+        move || !delegate.new_frame_ready.get()
+    });
 
     let result = evaluate_javascript(&servo_test, webview.clone(), script);
     assert_eq!(result, Ok(JSValue::String("32px".into())));

--- a/components/servo/tests/preferences.rs
+++ b/components/servo/tests/preferences.rs
@@ -1,0 +1,287 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+mod common;
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use net::test_util::{make_body, make_server};
+use servo::{
+    CreateNewWebViewRequest, JSValue, LoadStatus, RenderingContext, Servo, WebView, WebViewBuilder,
+    WebViewDelegate, WebViewPreferences,
+};
+use url::Url;
+
+use crate::common::{ServoTest, WebViewDelegateImpl, evaluate_javascript};
+
+/// Verify basic `WebViewPreferences` behaviour - creating a new `WebViewPreferences`
+/// with different default font sizes should affect the computed style.
+#[test]
+fn test_webview_preferences_default_font_size() {
+    let servo_test = ServoTest::new();
+
+    // Three divs to validate different paths in layout/stylo:
+    // #plain — stylo intializes computed values with default_font_size
+    // #sans & #mono  — stylo uses FontMetricsProvider
+    let html = "data:text/html,<!DOCTYPE html>\
+                     <div id=plain>Plain</div>\
+                     <div id=sans style='font-family: sans-serif'>Sans</div>\
+                     <div id=mono style='font-family: monospace'>Mono</div>";
+    // Create a new `WebViewPreferences` with custom font sizes.
+    let preferences = Rc::new(WebViewPreferences::new(servo_test.servo()));
+    preferences.set_default_font_size(32);
+    preferences.set_default_monospace_font_size(18);
+
+    // Verify the getters.
+    assert_eq!(preferences.default_font_size(), 32);
+    assert_eq!(preferences.default_monospace_font_size(), 18);
+
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .preferences(preferences.clone())
+        .url(Url::parse(html).unwrap())
+        .build();
+
+    let script = "[
+        getComputedStyle(plain).fontSize,
+        getComputedStyle(sans).fontSize,
+        getComputedStyle(mono).fontSize
+    ]";
+
+    assert_eq!(
+        evaluate_javascript(&servo_test, webview.clone(), script),
+        Ok(JSValue::Array(vec![
+            JSValue::String("32px".into()),
+            JSValue::String("32px".into()),
+            JSValue::String("18px".into())
+        ]))
+    );
+
+    // Build a second WebView with the font sizes from the default preferences.
+    let delegate2 = Rc::new(WebViewDelegateImpl::default());
+    let webview2 = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate2.clone())
+        .url(Url::parse(html).unwrap())
+        .build();
+
+    assert_eq!(
+        evaluate_javascript(&servo_test, webview2.clone(), script),
+        Ok(JSValue::Array(vec![
+            JSValue::String("16px".into()),
+            JSValue::String("16px".into()),
+            JSValue::String("13px".into())
+        ]))
+    );
+}
+
+/// Verify that changes to default font size preferences take effect after the
+/// page is reloaded.
+#[test]
+fn test_webview_preferences_default_font_size_changes_after_reload() {
+    let servo_test = ServoTest::new();
+
+    // Use an HTTP server instead of a `data:` URL so the reload witl reuse the
+    // existing script thread instead of spawning a new one.
+    let (server, url) = make_server(move |_, response| {
+        *response.body_mut() = make_body(b"<!DOCTYPE html>\n<div>Hello</div>".to_vec());
+    });
+
+    // Create a new `WebView` and ensure it has the default font size preference.
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .url(url.as_url().clone())
+        .build();
+
+    let script = "getComputedStyle(document.querySelector('div')).fontSize";
+    let result = evaluate_javascript(&servo_test, webview.clone(), script);
+    assert_eq!(result, Ok(JSValue::String("16px".into())));
+
+    // Change the font size and assert that it takes effect after reload.
+    let preferences = webview.preferences();
+    preferences.set_default_font_size(32);
+    webview.reload();
+
+    let result = evaluate_javascript(&servo_test, webview.clone(), script);
+    assert_eq!(result, Ok(JSValue::String("32px".into())));
+
+    let _ = server.close();
+}
+
+/// Verify that an auxiliary webview can use a `WebViewPreferences` that is
+/// different from that of the opener webview.
+#[test]
+fn test_webview_preferences_for_auxiliary_webviews() {
+    let servo_test = ServoTest::new();
+
+    struct WebViewAuxiliaryPreferencesDelegate {
+        servo: Servo,
+        rendering_context: Rc<dyn RenderingContext>,
+        auxiliary_webview: RefCell<Option<WebView>>,
+    }
+
+    impl WebViewDelegate for WebViewAuxiliaryPreferencesDelegate {
+        fn request_create_new(&self, _parent_webview: WebView, request: CreateNewWebViewRequest) {
+            // Create a new `WebViewPreferences`  for the auxiliary webview with
+            // a larger font size than the parent (which uses the default).
+            let auxiliary_preferences = WebViewPreferences::new(&self.servo);
+            auxiliary_preferences.set_default_font_size(32);
+
+            let auxiliary_webview = request
+                .builder(self.rendering_context.clone())
+                .preferences(Rc::new(auxiliary_preferences))
+                .build();
+            self.auxiliary_webview
+                .borrow_mut()
+                .replace(auxiliary_webview.clone());
+        }
+    }
+
+    let delegate = Rc::new(WebViewAuxiliaryPreferencesDelegate {
+        servo: servo_test.servo.clone(),
+        rendering_context: servo_test.rendering_context.clone(),
+        auxiliary_webview: RefCell::new(None),
+    });
+
+    // Create the parent `WebView` which uses default font size preference.
+    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .url(
+            Url::parse(
+                "data:text/html,<!DOCTYPE html>\
+                <div>Parent</div>\
+                <script>\
+                    onload = () => window.open('data:text/html,\
+                        <title>Auxiliary</title><div>Child</div>')\
+                </script>",
+            )
+            .unwrap(),
+        )
+        .build();
+
+    let load_webview = webview.clone();
+    let delegate_clone = delegate.clone();
+    let _ = servo_test.spin(move || {
+        load_webview.load_status() != LoadStatus::Complete ||
+            delegate_clone
+                .auxiliary_webview
+                .borrow()
+                .as_ref()
+                .is_none_or(|auxiliary_webview| {
+                    auxiliary_webview.page_title() != Some("Auxiliary".into())
+                })
+    });
+
+    // The parent `WebView` should use the default font size.
+    let script = "getComputedStyle(document.querySelector('div')).fontSize";
+    let result = evaluate_javascript(&servo_test, webview.clone(), script);
+    assert_eq!(result, Ok(JSValue::String("16px".into())));
+
+    let auxiliary_webview = delegate
+        .auxiliary_webview
+        .borrow_mut()
+        .take()
+        .expect("Guaranteed by spin");
+
+    // The auxiliary webview should use the font size from its own `WebViewPreferences`.
+    let result = evaluate_javascript(&servo_test, auxiliary_webview.clone(), script);
+    assert_eq!(result, Ok(JSValue::String("32px".into())));
+}
+
+/// Verify that mutating the default `WebViewPreferences` handle affects
+/// all `WebView`s associated with the default preferences.
+#[test]
+fn test_webview_preferences_default_shared_between_webviews() {
+    let servo_test = ServoTest::new();
+    let script = "getComputedStyle(document.querySelector('div')).fontSize";
+
+    let (server, url) = make_server(move |_, response| {
+        *response.body_mut() = make_body(b"<!DOCTYPE html>\n<div>Hello</div>".to_vec());
+    });
+
+    // First webview without explicit preferences.
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .url(url.as_url().clone())
+        .build();
+
+    // Verify the first webview uses default font size.
+    let result = evaluate_javascript(&servo_test, webview.clone(), script);
+    assert_eq!(result, Ok(JSValue::String("16px".into())));
+
+    // Mutate the default `WebViewPreferences` through the first webview's handle and
+    // check that it uses the new font size.
+    webview.preferences().set_default_font_size(32);
+    webview.reload();
+    let result = evaluate_javascript(&servo_test, webview.clone(), script);
+    assert_eq!(result, Ok(JSValue::String("32px".into())));
+
+    // Create a second webview, also using the default preferences.
+    // Use a `data:` URL so it gets its own script thread.
+    let html = "data:text/html,<!DOCTYPE html><div>Hello</div>";
+    let delegate2 = Rc::new(WebViewDelegateImpl::default());
+    let webview2 = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate2.clone())
+        .url(Url::parse(html).unwrap())
+        .build();
+
+    // The second webview should also use the new font size, since it shares
+    // the default `WebViewPreferences`.
+    let result = evaluate_javascript(&servo_test, webview2.clone(), script);
+    assert_eq!(result, Ok(JSValue::String("32px".into())));
+
+    let _ = server.close();
+}
+
+/// Verify that a page in an iframe inherits the parent's `WebViewPreferences`.
+#[test]
+fn test_webview_preferences_inherited_by_iframe() {
+    let servo_test = ServoTest::new();
+
+    let iframe_html = b"<!DOCTYPE html>\n<div>Iframe</div>\n".to_vec();
+    let parent_html = b"<!DOCTYPE html>\
+        <div>Parent</div>\
+        <iframe id=child src=/iframe.html></iframe>"
+        .to_vec();
+
+    let (server, url) = make_server(move |request, response| {
+        let body = match request.uri().path() {
+            "/iframe.html" => make_body(iframe_html.clone()),
+            _ => make_body(parent_html.clone()),
+        };
+        *response.body_mut() = body;
+    });
+
+    let preferences = Rc::new(WebViewPreferences::new(servo_test.servo()));
+    preferences.set_default_font_size(32);
+
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .preferences(preferences)
+        .url(url.as_url().clone())
+        .build();
+
+    // The parent and the iframe should both use the custom font size.
+    assert_eq!(
+        evaluate_javascript(
+            &servo_test,
+            webview.clone(),
+            "\
+            [\
+                getComputedStyle(document.querySelector('div')).fontSize,\
+                getComputedStyle(child.contentDocument.querySelector('div')).fontSize\
+            ]"
+        ),
+        Ok(JSValue::Array(vec![
+            JSValue::String("32px".into()),
+            JSValue::String("32px".into()),
+        ]))
+    );
+
+    let _ = server.close();
+}

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -41,7 +41,7 @@ use crate::servo::PendingHandledInputEvent;
 use crate::webview_delegate::{CreateNewWebViewRequest, DefaultWebViewDelegate, WebViewDelegate};
 use crate::{
     ColorPicker, ContextMenu, EmbedderControl, InputMethodControl, SelectElement, Servo,
-    UserContentManager, WebRenderDebugOption,
+    UserContentManager, WebRenderDebugOption, WebViewPreferences,
 };
 
 pub(crate) const MINIMUM_WEBVIEW_SIZE: Size2D<i32, DevicePixel> = Size2D::new(1, 1);
@@ -113,6 +113,7 @@ pub(crate) struct WebViewInner {
     grafted_accesskit_tree_epoch: Option<Epoch>,
 
     rendering_context: Rc<dyn RenderingContext>,
+    preferences: Rc<WebViewPreferences>,
     user_content_manager: Option<Rc<UserContentManager>>,
     hidpi_scale_factor: Scale<f32, DeviceIndependentPixel, DevicePixel>,
     load_status: LoadStatus,
@@ -172,6 +173,9 @@ impl WebView {
             cursor: Cursor::Pointer,
             back_forward_list: Default::default(),
             back_forward_list_index: 0,
+            preferences: builder
+                .preferences
+                .unwrap_or_else(|| servo.default_preferences()),
             user_content_manager: builder.user_content_manager.clone(),
         })));
 
@@ -197,6 +201,7 @@ impl WebView {
             webview_id: webview.id(),
             viewport_details,
             user_content_manager_id,
+            webview_preferences_id: webview.inner().preferences.id(),
         };
 
         // There are two possibilities here. Either the WebView is a new toplevel
@@ -761,6 +766,11 @@ impl WebView {
         self.inner().user_content_manager.clone()
     }
 
+    /// Get the [`WebViewPreferences`] associated with this [`WebView`].
+    pub fn preferences(&self) -> Rc<WebViewPreferences> {
+        self.inner().preferences.clone()
+    }
+
     /// Evaluate the specified string of JavaScript code. Once execution is complete or an error
     /// occurs, Servo will call `callback`.
     pub fn evaluate_javascript<T: ToString>(
@@ -1032,6 +1042,7 @@ pub struct WebViewBuilder {
     url: Option<Url>,
     hidpi_scale_factor: Scale<f32, DeviceIndependentPixel, DevicePixel>,
     create_new_webview_responder: Option<IpcResponder<Option<NewWebViewDetails>>>,
+    preferences: Option<Rc<WebViewPreferences>>,
     user_content_manager: Option<Rc<UserContentManager>>,
     clipboard_delegate: Option<Rc<dyn ClipboardDelegate>>,
     #[cfg(feature = "gamepad")]
@@ -1051,6 +1062,7 @@ impl WebViewBuilder {
             hidpi_scale_factor: Scale::new(1.0),
             delegate: Rc::new(DefaultWebViewDelegate),
             create_new_webview_responder: None,
+            preferences: None,
             user_content_manager: None,
             clipboard_delegate: None,
             #[cfg(feature = "gamepad")]
@@ -1095,6 +1107,13 @@ impl WebViewBuilder {
     /// to the `UserContentManager` will take effect only after the document is reloaded.
     pub fn user_content_manager(mut self, user_content_manager: Rc<UserContentManager>) -> Self {
         self.user_content_manager = Some(user_content_manager);
+        self
+    }
+
+    /// Set the [`WebViewPreferences`] for the `WebView` being created. The same
+    /// [`WebViewPreferences`] can be shared among multiple `WebView`s.
+    pub fn preferences(mut self, preferences: Rc<WebViewPreferences>) -> Self {
+        self.preferences = Some(preferences);
         self
     }
 

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -9,6 +9,7 @@ use std::fmt;
 use content_security_policy::sandboxing_directive::SandboxingFlagSet;
 use devtools_traits::{DevtoolScriptControlMsg, ScriptToDevtoolsControlMsg, WorkerId};
 use embedder_traits::user_contents::UserContentManagerId;
+use embedder_traits::webview_preferences::WebViewPreferencesId;
 use embedder_traits::{
     AnimationState, FocusSequenceNumber, JSValue, JavaScriptEvaluationError,
     JavaScriptEvaluationId, MediaSessionEvent, ScriptToEmbedderChan, Theme, ViewportDetails,
@@ -462,6 +463,8 @@ pub struct AuxiliaryWebViewCreationResponse {
     pub new_pipeline_id: PipelineId,
     /// The [`UserContentManagerId`] for this new auxiliary browsing context.
     pub user_content_manager_id: Option<UserContentManagerId>,
+    /// The [`WebViewPreferencesId`] for this new auxiliary browsing context.
+    pub webview_preferences_id: WebViewPreferencesId,
 }
 
 /// Specifies the information required to load an iframe.

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -18,6 +18,7 @@ use std::time::Duration;
 use embedder_traits::user_contents::{
     UserContentManagerId, UserScript, UserScriptId, UserStyleSheet, UserStyleSheetId,
 };
+use embedder_traits::webview_preferences::{WebViewPreference, WebViewPreferencesId};
 use embedder_traits::{
     EmbedderControlId, EmbedderControlResponse, InputEventAndId, JavaScriptEvaluationId,
     MediaSessionActionType, NewWebViewDetails, PaintHitTestResult, Theme, TraversalId, UrlRequest,
@@ -116,6 +117,13 @@ pub enum EmbedderToConstellationMessage {
     UpdatePinchZoomInfos(PipelineId, PinchZoomInfos),
     /// Activate or deactivate accessibility features for the given `WebView`.
     SetAccessibilityActive(WebViewId, bool),
+    /// Update preferences for the given `WebViewPreferencesId`. The second
+    /// value is a delta of the preferences that have been mutated from their
+    /// previous value.
+    SetWebViewPreferences(WebViewPreferencesId, Vec<WebViewPreference>),
+    /// Release all state for the given `WebViewPreferencesId` maintained
+    /// by constellation and notify `ScriptThread`s to do the same.
+    DestroyWebViewPreferences(WebViewPreferencesId),
 }
 
 pub enum UserContentManagerAction {

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -13,6 +13,7 @@ pub mod input_events;
 pub mod resources;
 pub mod user_contents;
 pub mod webdriver;
+pub mod webview_preferences;
 
 use std::collections::HashMap;
 use std::ffi::c_void;
@@ -53,6 +54,9 @@ pub use crate::embedder_controls::*;
 pub use crate::input_events::*;
 use crate::user_contents::UserContentManagerId;
 pub use crate::webdriver::*;
+pub use crate::webview_preferences::{
+    WebViewPreference, WebViewPreferencesData, WebViewPreferencesId,
+};
 
 /// A point in a `WebView`, either expressed in device pixels or page pixels.
 /// Page pixels are CSS pixels, which take into account device pixel scale,
@@ -1153,6 +1157,7 @@ pub struct NewWebViewDetails {
     pub webview_id: WebViewId,
     pub viewport_details: ViewportDetails,
     pub user_content_manager_id: Option<UserContentManagerId>,
+    pub webview_preferences_id: WebViewPreferencesId,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/components/shared/embedder/webview_preferences.rs
+++ b/components/shared/embedder/webview_preferences.rs
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use serde::{Deserialize, Serialize};
+
+static NEXT_WEBVIEW_PREFERENCES_ID: AtomicU32 = AtomicU32::new(1);
+
+/// An opaque identifier for a `WebViewPreferences` type in Servo.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct WebViewPreferencesId(pub u32);
+
+impl WebViewPreferencesId {
+    /// The ID for the default preferences used by Servo when creating a
+    /// `WebView` that doesn't set a custom `WebViewPreferences` in
+    /// `WebViewBuilder`.
+    pub const DEFAULT: Self = Self(0);
+
+    /// Generate the next unique [`WebViewPreferencesId`].
+    pub fn next() -> Self {
+        Self(NEXT_WEBVIEW_PREFERENCES_ID.fetch_add(1, Ordering::Relaxed))
+    }
+}
+
+/// The backing preference data for a [`WebViewPreferencesId`].
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub struct WebViewPreferencesData {
+    /// The default font size for proportional (variable-width) fonts, in CSS pixels.
+    pub default_font_size: i64,
+    /// The default font size for monospace fonts, in CSS pixels.
+    pub default_monospace_font_size: i64,
+}
+
+impl Default for WebViewPreferencesData {
+    fn default() -> Self {
+        Self {
+            default_font_size: 16,
+            default_monospace_font_size: 13,
+        }
+    }
+}
+
+impl WebViewPreferencesData {
+    /// Create a new [`WebViewPreferencesData`] with all values set to their defaults.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Apply a list of (partial) preference updates to this `WebViewPreferencesData`.
+    pub fn apply_preference_updates(&mut self, preference_updates: &[WebViewPreference]) {
+        for preference in preference_updates {
+            match *preference {
+                WebViewPreference::DefaultFontSize(size) => self.default_font_size = size,
+                WebViewPreference::DefaultMonospaceFontSize(size) => {
+                    self.default_monospace_font_size = size
+                },
+            }
+        }
+    }
+}
+
+/// A single preference value that can be sent to constellation and script threads
+/// during updates.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub enum WebViewPreference {
+    DefaultFontSize(i64),
+    DefaultMonospaceFontSize(i64),
+}

--- a/components/shared/embedder/webview_preferences.rs
+++ b/components/shared/embedder/webview_preferences.rs
@@ -4,12 +4,15 @@
 
 use std::sync::atomic::{AtomicU32, Ordering};
 
+use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
 
 static NEXT_WEBVIEW_PREFERENCES_ID: AtomicU32 = AtomicU32::new(1);
 
 /// An opaque identifier for a `WebViewPreferences` type in Servo.
-#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Default, Deserialize, Eq, Hash, MallocSizeOf, PartialEq, Serialize,
+)]
 pub struct WebViewPreferencesId(pub u32);
 
 impl WebViewPreferencesId {

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -261,6 +261,8 @@ pub struct LayoutConfig {
     pub user_stylesheets: Rc<Vec<DocumentStyleSheet>>,
     pub theme: Theme,
     pub embedder_chan: ScriptToEmbedderChan,
+    pub default_font_size: i64,
+    pub default_monospace_font_size: i64,
 }
 
 pub trait LayoutFactory: Send + Sync {

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -26,7 +26,10 @@ use app_units::Au;
 use atomic_refcell::AtomicRefCell;
 use background_hang_monitor_api::BackgroundHangMonitorRegister;
 use bitflags::bitflags;
-use embedder_traits::{Cursor, ScriptToEmbedderChan, Theme, UntrustedNodeAddress, ViewportDetails};
+use embedder_traits::{
+    Cursor, ScriptToEmbedderChan, Theme, UntrustedNodeAddress, ViewportDetails, WebViewPreference,
+    WebViewPreferencesData,
+};
 use euclid::{Point2D, Rect};
 use fonts::{FontContext, TextByteRange, WebFontDocumentContext};
 pub use layout_damage::LayoutDamage;
@@ -429,6 +432,16 @@ pub trait Layout {
 
     /// See [Self::needs_accessibility_update()].
     fn set_needs_accessibility_update(&self);
+
+    /// Notification to layout that the `WebView`s preferences have changed.
+    ///
+    /// Layout should update relevant state and must return true if the document needs
+    /// to be restyled.
+    fn on_preferences_changed(
+        &mut self,
+        preference_updates: &[WebViewPreference],
+        preferences_data: &WebViewPreferencesData,
+    ) -> bool;
 }
 
 /// This trait is part of `layout_api` because it depends on both `script_traits`
@@ -604,6 +617,7 @@ bitflags! {
         const ThemeChanged = 1 << 4;
         const ViewportChanged = 1 << 5;
         const PaintWorkletLoaded = 1 << 6;
+        const PreferencesChanged = 1 << 7;
     }
 }
 

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -14,6 +14,9 @@ use std::fmt;
 use crossbeam_channel::RecvTimeoutError;
 use devtools_traits::ScriptToDevtoolsControlMsg;
 use embedder_traits::user_contents::{UserContentManagerId, UserContents};
+use embedder_traits::webview_preferences::{
+    WebViewPreference, WebViewPreferencesData, WebViewPreferencesId,
+};
 use embedder_traits::{
     EmbedderControlId, EmbedderControlResponse, FocusSequenceNumber, InputEventAndId,
     JavaScriptEvaluationId, MediaSessionActionType, PaintHitTestResult, ScriptToEmbedderChan,
@@ -77,6 +80,8 @@ pub struct NewPipelineInfo {
     pub viewport_details: ViewportDetails,
     /// The ID of the `UserContentManager` associated with this new pipeline's `WebView`.
     pub user_content_manager_id: Option<UserContentManagerId>,
+    /// The ID of the `WebViewPreferences` associated with this new pipeline's `WebView`.
+    pub webview_preferences_id: WebViewPreferencesId,
     /// The [`Theme`] of the new layout.
     pub theme: Theme,
     /// A snapshot of the navigation parameters of the target of this navigation.
@@ -329,6 +334,11 @@ pub enum ScriptThreadMessage {
     SetAccessibilityActive(PipelineId, bool, Epoch),
     /// Force a garbage collection in this script thread.
     TriggerGarbageCollection,
+    /// Set (or update) preferences for the given ID with partial updates.
+    SetWebViewPreferences(WebViewPreferencesId, Vec<WebViewPreference>),
+    /// Release all data for the given `WebViewPreferencesId` from the `ScriptThread`'s
+    /// `webview_preferences_for_id` map.
+    DestroyWebViewPreferences(WebViewPreferencesId),
 }
 
 impl fmt::Debug for ScriptThreadMessage {
@@ -410,6 +420,8 @@ pub struct InitialScriptState {
     pub privileged_urls: Vec<ServoUrl>,
     /// A copy of constellation's `UserContentManagerId` to `UserContents` map.
     pub user_contents_for_manager_id: FxHashMap<UserContentManagerId, UserContents>,
+    /// A copy of constellation's `WebViewPreferencesId` to `WebViewPreferencesData` map.
+    pub webview_preferences_for_id: FxHashMap<WebViewPreferencesId, WebViewPreferencesData>,
 }
 
 /// Errors from executing a paint worklet


### PR DESCRIPTION
This works similarly to the `UserContentManager` API - the embedder can create a new `WebViewPreferences` handle and associate it with a `WebView` at creation using the `WebViewPreferences`. Multiple `WebView`s can share the same `WebViewPreferences` handle. `WebView`s that don't configure a custom `WebViewPreferences` handle will use a singleton "default" instance, similar to what WebKit does.

The first commit adds the basic API, unit tests and exposes only the default font size related settings. Changes to the preferences don't take effect until the page is reloaded. The way preferences are stored and the changes are transmitted is very naive and can be optimized in follow-up patches.

The second commit adds support for updating the font size preferences without requiring the page to be reloaded. This required some changes in Stylo and so this patch currently uses a patched version in
https://github.com/servo/stylo/tree/expose-setter-on-servo-device
This requires some discussion with experts in Stylo to ensure the API and documentation makes sense.

Testing: New integration tests are added to validate the API.