### PR TITLE
script_bindings: Split  loop in CGConcreteBindingRoot into separate function and move impl IDLInterface to separate directory

### DIFF
--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -8068,64 +8068,7 @@ class CGConcreteBindingRoot(CGThing):
 
         cgthings += [CGGeneric(f"pub(crate) use {originalBinding} as GenericBindings;")]
         for d in descriptors:
-            ifaceName = d.interface.identifier.name
-            cgthings += [
-                CGGeneric(
-                    f"pub(crate) use {originalBinding}::{firstCap(ifaceName)}_Binding as {firstCap(ifaceName)}_Binding;"
-                ),
-            ]
-
-            for marker in ["Serializable", "Transferable"]:
-                if d.interface.getExtendedAttribute(marker):
-                    cgthings += [CGStructuredCloneMarker(d, marker)]
-
-            if d.concrete:
-                if not d.interface.isIteratorInterface():
-                    cgthings.append(CGAssertInheritance(d))
-                else:
-                    cgthings.append(CGIteratorDerives(d))
-
-            if (
-                (d.concrete or d.hasDescendants())
-                and not d.interface.isIteratorInterface()
-            ):
-                cgthings.append(CGIDLInterface(d))
-
-            if d.interface.isIteratorInterface():
-                cgthings.append(CGDomObjectIteratorWrap(d))
-            elif d.concrete and not d.isGlobal():
-                cgthings.append(CGDomObjectWrap(d))
-
-            if d.weakReferenceable:
-                cgthings.append(CGWeakReferenceableTrait(d))
-
-            if (
-                not d.interface.isIteratorInterface() and
-                not d.interface.isCallback() and
-                not d.allowDropImpl
-            ):
-                cgthings.append(CGForbidDrop(d))
-
-            if not d.interface.isCallback():
-                traitName = f"{ifaceName}Methods"
-                cgthings += [
-                    CGGeneric(f"pub(crate) use self::{firstCap(ifaceName)}_Binding::{traitName} as {traitName};"),
-                ]
-                if len(descriptors) == 1 and d.concrete:
-                    cgthings += [CGGeneric(f"pub(crate) use self::{firstCap(ifaceName)}_Binding::Wrap;")]
-                    if d.interface.hasInterfaceObject() and d.shouldHaveGetConstructorObjectMethod():
-                        cgthings += [CGGeneric(f"""
-pub(crate) fn GetConstructorObject(
-    cx: &mut JSContext, global: HandleObject, rval: MutableHandleObject
-) {{
-    self::{firstCap(ifaceName)}_Binding::GetConstructorObject::<crate::DomTypeHolder>(cx, global, rval)
-}}
-""")]
-
-            constMembers = [m for m in d.interface.members if m.isConst()]
-            if constMembers:
-                constants = f"{ifaceName}Constants"
-                cgthings += [CGGeneric(f"pub(crate) use {originalBinding}::{constants} as {constants};")]
+            self.make_descriptors_(d, descriptors, originalBinding, cgthings)
 
         for c in callbackDescriptors:
             ifaceName = c.interface.identifier.name
@@ -8150,6 +8093,67 @@ pub(crate) fn GetConstructorObject(
 
         # Store the final result.
         self.root = curr
+
+    def make_descriptors_(self, d: Descriptor, descriptors: list[Descriptor], originalBinding: str, cgthings: list[Any]) -> None:
+        ifaceName = d.interface.identifier.name
+        cgthings += [
+            CGGeneric(
+                f"pub(crate) use {originalBinding}::{firstCap(ifaceName)}_Binding as {firstCap(ifaceName)}_Binding;"
+            ),
+        ]
+
+        for marker in ["Serializable", "Transferable"]:
+            if d.interface.getExtendedAttribute(marker):
+                cgthings += [CGStructuredCloneMarker(d, marker)]
+
+        if d.concrete:
+            if not d.interface.isIteratorInterface():
+                cgthings.append(CGAssertInheritance(d))
+            else:
+                cgthings.append(CGIteratorDerives(d))
+
+        if (
+            (d.concrete or d.hasDescendants())
+            and not d.interface.isIteratorInterface()
+        ):
+            cgthings.append(CGIDLInterface(d))
+
+        if d.interface.isIteratorInterface():
+            cgthings.append(CGDomObjectIteratorWrap(d))
+        elif d.concrete and not d.isGlobal():
+            cgthings.append(CGDomObjectWrap(d))
+
+        if d.weakReferenceable:
+            cgthings.append(CGWeakReferenceableTrait(d))
+
+        if (
+            not d.interface.isIteratorInterface() and
+            not d.interface.isCallback() and
+            not d.allowDropImpl
+        ):
+            cgthings.append(CGForbidDrop(d))
+
+        if not d.interface.isCallback():
+            traitName = f"{ifaceName}Methods"
+            cgthings += [
+                CGGeneric(f"pub(crate) use self::{firstCap(ifaceName)}_Binding::{traitName} as {traitName};"),
+            ]
+            if len(descriptors) == 1 and d.concrete:
+                cgthings += [CGGeneric(f"pub(crate) use self::{firstCap(ifaceName)}_Binding::Wrap;")]
+                if d.interface.hasInterfaceObject() and d.shouldHaveGetConstructorObjectMethod():
+                    cgthings += [CGGeneric(f"""
+pub(crate) fn GetConstructorObject(
+cx: &mut JSContext, global: HandleObject, rval: MutableHandleObject
+) {{
+self::{firstCap(ifaceName)}_Binding::GetConstructorObject::<crate::DomTypeHolder>(cx, global, rval)
+}}
+""")]
+
+        constMembers = [m for m in d.interface.members if m.isConst()]
+        if constMembers:
+            constants = f"{ifaceName}Constants"
+            cgthings += [CGGeneric(f"pub(crate) use {originalBinding}::{constants} as {constants};")]
+
 
     def define(self) -> str:
         if not self.root:

--- a/components/script_bindings/codegen/run.py
+++ b/components/script_bindings/codegen/run.py
@@ -36,7 +36,6 @@ def main() -> None:
     config_file = "Bindings.conf"
 
     import WebIDL
-    from codegen import CGBindingRoot, CGConcreteBindingRoot
     from configuration import Configuration
 
     parser = WebIDL.Parser(make_dir(os.path.join(out_dir, "cache")))

--- a/components/script_bindings/codegen/run.py
+++ b/components/script_bindings/codegen/run.py
@@ -6,12 +6,12 @@
 
 from __future__ import annotations
 
-import os
-import sys
 import json
+import os
 import re
-from typing import TYPE_CHECKING
+import sys
 from collections.abc import Iterator
+from typing import TYPE_CHECKING
 
 SCRIPT_PATH = os.path.abspath(os.path.dirname(__file__))
 SCRIPT_BINDINGS_ROOT = os.path.abspath(os.path.join(SCRIPT_PATH, ".."))
@@ -36,8 +36,8 @@ def main() -> None:
     config_file = "Bindings.conf"
 
     import WebIDL
-    from configuration import Configuration
     from codegen import CGBindingRoot, CGConcreteBindingRoot
+    from configuration import Configuration
 
     parser = WebIDL.Parser(make_dir(os.path.join(out_dir, "cache")))
     webidls = [name for name in os.listdir(webidls_dir) if name.endswith(".webidl")]
@@ -79,7 +79,12 @@ def main() -> None:
         generate(config, name, os.path.join(out_dir, filename))
     make_dir(doc_servo)
     generate(config, "SupportedDomApis", os.path.join(doc_servo, "apis.html"))
+    generate_concrete_bindings(config, out_dir, webidls_dir, webidls)
+    generate_bindings(config, out_dir, webidls_dir, webidls)
 
+
+def generate_bindings(config: Configuration, out_dir: str, webidls_dir: str, webidls: list[str]) -> None:
+    from codegen import CGBindingRoot
     for webidl in webidls:
         filename = os.path.join(webidls_dir, webidl)
         prefix = "Bindings/%sBinding" % webidl[:-len(".webidl")]
@@ -87,12 +92,16 @@ def main() -> None:
         if module:
             with open(os.path.join(out_dir, prefix + ".rs"), "wb") as f:
                 f.write(module.encode("utf-8"))
+
+def generate_concrete_bindings(config: Configuration, out_dir: str, webidls_dir: str, webidls: list[str]) -> None:
+    from codegen import CGConcreteBindingRoot
+    for webidl in webidls:
+        filename = os.path.join(webidls_dir, webidl)
         prefix = "ConcreteBindings/%sBinding" % webidl[:-len(".webidl")]
         module = CGConcreteBindingRoot(config, prefix, filename).define()
         if module:
             with open(os.path.join(out_dir, prefix + ".rs"), "wb") as f:
                 f.write(module.encode("utf-8"))
-
 
 def make_dir(path: str)-> str:
     if not os.path.exists(path):


### PR DESCRIPTION
This PR does two things:
- Splits the big for loop in CGConcreteBindings into a separate loop for easier understanding.
- Move calling of functions in run.py into separate functions.
This does not change functionality.

Testing: This is just a refactor of the codegen.
