### PR TITLE
backport: script: Pass rooted UnderlyingSourceContainer to ReadableSt…

### DIFF
--- a/components/script/dom/stream/readablebytestreamcontroller.rs
+++ b/components/script/dom/stream/readablebytestreamcontroller.rs
@@ -219,21 +219,16 @@ pub(crate) struct ReadableByteStreamController {
 }
 
 impl ReadableByteStreamController {
-    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn new_inherited(
-        underlying_source_type: UnderlyingSourceType,
+        underlying_source_container: &UnderlyingSourceContainer,
         strategy_hwm: f64,
-        global: &GlobalScope,
-        can_gc: CanGc,
     ) -> ReadableByteStreamController {
-        let underlying_source_container =
-            UnderlyingSourceContainer::new(global, underlying_source_type, can_gc);
         let auto_allocate_chunk_size = underlying_source_container.auto_allocate_chunk_size();
         ReadableByteStreamController {
             reflector_: Reflector::new(),
             byob_request: MutNullableDom::new(None),
             stream: MutNullableDom::new(None),
-            underlying_source: MutNullableDom::new(Some(&*underlying_source_container)),
+            underlying_source: MutNullableDom::new(Some(underlying_source_container)),
             auto_allocate_chunk_size,
             pending_pull_intos: DomRefCell::new(Vec::new()),
             strategy_hwm,
@@ -253,12 +248,12 @@ impl ReadableByteStreamController {
         global: &GlobalScope,
         can_gc: CanGc,
     ) -> DomRoot<ReadableByteStreamController> {
+        let underlying_source_container =
+            UnderlyingSourceContainer::new(global, underlying_source_type, can_gc);
         reflect_dom_object(
             Box::new(ReadableByteStreamController::new_inherited(
-                underlying_source_type,
+                &underlying_source_container,
                 strategy_hwm,
-                global,
-                can_gc,
             )),
             global,
             can_gc,

--- a/components/script/dom/stream/readablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/readablestreamdefaultcontroller.rs
@@ -345,23 +345,16 @@ pub(crate) struct ReadableStreamDefaultController {
 }
 
 impl ReadableStreamDefaultController {
-    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn new_inherited(
-        global: &GlobalScope,
-        underlying_source_type: UnderlyingSourceType,
         strategy_hwm: f64,
         strategy_size: Rc<QueuingStrategySize>,
-        can_gc: CanGc,
+        underlying_source: &UnderlyingSourceContainer,
     ) -> ReadableStreamDefaultController {
         ReadableStreamDefaultController {
             reflector_: Reflector::new(),
             queue: Default::default(),
             stream: MutNullableDom::new(None),
-            underlying_source: MutNullableDom::new(Some(&*UnderlyingSourceContainer::new(
-                global,
-                underlying_source_type,
-                can_gc,
-            ))),
+            underlying_source: MutNullableDom::new(Some(underlying_source)),
             strategy_hwm,
             strategy_size: RefCell::new(Some(strategy_size)),
             close_requested: Default::default(),
@@ -379,13 +372,12 @@ impl ReadableStreamDefaultController {
         strategy_size: Rc<QueuingStrategySize>,
         can_gc: CanGc,
     ) -> DomRoot<ReadableStreamDefaultController> {
+        let underlying_source = UnderlyingSourceContainer::new(global, underlying_source, can_gc);
         reflect_dom_object(
             Box::new(ReadableStreamDefaultController::new_inherited(
-                global,
-                underlying_source,
                 strategy_hwm,
                 strategy_size,
-                can_gc,
+                &underlying_source,
             )),
             global,
             can_gc,


### PR DESCRIPTION
…reamDefaultController constructor. (#45850)

This backports #45850 to the 0.1 LTS branch.

This change fixes an unsafe pattern, where we allocate a new object and store it inside an unrooted object. When the reflector for the unrooted object is allocated, a GC can occur which can cause the first object to be collected since it's not yet reachable from a rooted location, leaving a dangling pointer.

Testing: Requires zealous GC to be enabled to write a deterministic test.


(cherry picked from commit 1f979aa77f3)
