### PR TITLE
script: JSContextify document creation

### DIFF
--- a/components/script/dom/animations/documenttimeline.rs
+++ b/components/script/dom/animations/documenttimeline.rs
@@ -7,9 +7,10 @@ use js::context::JSContext;
 use js::gc::HandleObject;
 use num_traits::ToPrimitive;
 use script_bindings::codegen::GenericBindings::DocumentTimelineBinding::DocumentTimelineOptions;
-use script_bindings::reflector::{reflect_dom_object, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{
+    reflect_dom_object_with_cx, reflect_dom_object_with_proto_and_cx,
+};
 use script_bindings::root::DomRoot;
-use script_bindings::script_runtime::CanGc;
 use servo_base::cross_process_instant::CrossProcessInstant;
 use servo_config::pref;
 use time::Duration;
@@ -52,19 +53,19 @@ impl DocumentTimeline {
         )
     }
 
-    pub(crate) fn new(window: &Window, can_gc: CanGc) -> DomRoot<DocumentTimeline> {
+    pub(crate) fn new(cx: &mut JSContext, window: &Window) -> DomRoot<DocumentTimeline> {
         let duration = if pref!(layout_animations_test_enabled) {
             Duration::ZERO
         } else {
             CrossProcessInstant::now() - window.navigation_start()
         };
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(Self {
                 animation_timeline: AnimationTimeline::new_inherited(duration),
                 origin_offset: Duration::ZERO,
             }),
             window,
-            can_gc,
+            cx,
         )
     }
 

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -52,7 +52,7 @@ use regex::bytes::Regex;
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use script_bindings::cell::{DomRefCell, Ref, RefMut};
 use script_bindings::interfaces::DocumentHelpers;
-use script_bindings::reflector::reflect_dom_object_with_proto;
+use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use script_bindings::trace::CustomTraceable;
 use script_traits::{DocumentActivity, ProgressiveWebMetricType};
 use servo_arc::Arc;
@@ -3969,6 +3969,7 @@ impl Document {
 
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         has_browsing_context: HasBrowsingContext,
         url: Option<ServoUrl>,
@@ -3991,9 +3992,9 @@ impl Document {
         creation_sandboxing_flag_set: SandboxingFlagSet,
         pipeline_id: PipelineId,
         image_cache: StdArc<dyn ImageCache>,
-        can_gc: CanGc,
     ) -> DomRoot<Document> {
         Self::new_with_proto(
+            cx,
             window,
             None,
             has_browsing_context,
@@ -4017,12 +4018,12 @@ impl Document {
             creation_sandboxing_flag_set,
             pipeline_id,
             image_cache,
-            can_gc,
         )
     }
 
     #[allow(clippy::too_many_arguments)]
     fn new_with_proto(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
         has_browsing_context: HasBrowsingContext,
@@ -4046,10 +4047,9 @@ impl Document {
         creation_sandboxing_flag_set: SandboxingFlagSet,
         pipeline_id: PipelineId,
         image_cache: StdArc<dyn ImageCache>,
-        can_gc: CanGc,
     ) -> DomRoot<Document> {
-        let timeline = DocumentTimeline::new(window, can_gc);
-        let document = reflect_dom_object_with_proto(
+        let timeline = DocumentTimeline::new(cx, window);
+        let document = reflect_dom_object_with_proto_and_cx(
             Box::new(Document::new_inherited(
                 window,
                 has_browsing_context,
@@ -4077,7 +4077,7 @@ impl Document {
             )),
             window,
             proto,
-            can_gc,
+            cx,
         );
         {
             let node = document.upcast::<Node>();
@@ -4243,7 +4243,7 @@ impl Document {
     /// <https://html.spec.whatwg.org/multipage/#appropriate-template-contents-owner-document>
     pub(crate) fn appropriate_template_contents_owner_document(
         &self,
-        can_gc: CanGc,
+        cx: &mut JSContext,
     ) -> DomRoot<Document> {
         self.appropriate_template_contents_owner_document
             .or_init(|| {
@@ -4253,6 +4253,7 @@ impl Document {
                     IsHTMLDocument::NonHTMLDocument
                 };
                 let new_doc = Document::new(
+                    cx,
                     self.window(),
                     HasBrowsingContext::No,
                     None,
@@ -4276,7 +4277,6 @@ impl Document {
                     self.creation_sandboxing_flag_set(),
                     self.pipeline_id(),
                     self.image_cache.clone(),
-                    can_gc,
                 );
                 new_doc
                     .appropriate_template_contents_owner_document
@@ -5013,6 +5013,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         let doc = window.Document();
         let docloader = DocumentLoader::new(&doc.loader());
         Ok(Document::new_with_proto(
+            cx,
             window,
             proto,
             HasBrowsingContext::No,
@@ -5036,7 +5037,6 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             doc.active_sandboxing_flag_set.get(),
             doc.pipeline_id(),
             doc.image_cache(),
-            CanGc::from_cx(cx),
         ))
     }
 
@@ -5067,6 +5067,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         // Step 2. Let document be a new Document, whose content type is "text/html".
         // Step 3. Set document's allow declarative shadow roots to true.
         let document = Document::new(
+            cx,
             window,
             HasBrowsingContext::No,
             Some(ServoUrl::parse("about:blank").unwrap()),
@@ -5089,7 +5090,6 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             doc.creation_sandboxing_flag_set(),
             doc.pipeline_id(),
             doc.image_cache(),
-            CanGc::from_cx(cx),
         );
         // Step 4. Parse HTML from string given document and compliantHTML.
         ServoParser::parse_html_document(cx, &document, Some(compliant_html), url, None, None);
@@ -5122,6 +5122,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             .parse()
             .expect("Supported type is not a MIME type");
         let document = Document::new(
+            cx,
             window,
             HasBrowsingContext::No,
             Some(ServoUrl::parse("about:blank").unwrap()),
@@ -5144,7 +5145,6 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             doc.creation_sandboxing_flag_set(),
             doc.pipeline_id(),
             doc.image_cache(),
-            CanGc::from_cx(cx),
         );
 
         // Step 3. Parse HTML from a string given document and html.

--- a/components/script/dom/domimplementation.rs
+++ b/components/script/dom/domimplementation.rs
@@ -103,6 +103,7 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
 
         // Step 1. Let document be a new XMLDocument.
         let doc = XMLDocument::new(
+            cx,
             win,
             HasBrowsingContext::No,
             None,
@@ -117,7 +118,6 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
             self.document.has_trustworthy_ancestor_or_current_origin(),
             self.document.custom_element_reaction_stack(),
             self.document.image_cache(),
-            CanGc::from_cx(cx),
         );
 
         // Step 2. Let element be null.
@@ -172,6 +172,7 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
         // Step 1. Let doc be a new document that is an HTML document.
         // Step 2. Set doc’s content type to "text/html".
         let doc = Document::new(
+            cx,
             win,
             HasBrowsingContext::No,
             None,
@@ -195,7 +196,6 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
             self.document.creation_sandboxing_flag_set(),
             self.document.pipeline_id(),
             self.document.image_cache(),
-            CanGc::from_cx(cx),
         );
 
         {

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -22,7 +22,6 @@ use crate::dom::document::{Document, DocumentSource, HasBrowsingContext, IsHTMLD
 use crate::dom::servoparser::ServoParser;
 use crate::dom::trustedtypes::trustedhtml::TrustedHTML;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct DOMParser {
@@ -91,6 +90,7 @@ impl DOMParserMethods<crate::DomTypeHolder> for DOMParser {
                 // Step 2. Let document be a new Document, whose content type is type
                 // and URL is this's relevant global object's associated Document's URL.
                 let document = Document::new(
+                    cx,
                     &self.window,
                     HasBrowsingContext::No,
                     Some(url.clone()),
@@ -113,7 +113,6 @@ impl DOMParserMethods<crate::DomTypeHolder> for DOMParser {
                     doc.creation_sandboxing_flag_set(),
                     doc.pipeline_id(),
                     doc.image_cache(),
-                    CanGc::from_cx(cx),
                 );
                 // Step switch-1. Parse HTML from a string given document and compliantString.
                 ServoParser::parse_html_document(
@@ -130,6 +129,7 @@ impl DOMParserMethods<crate::DomTypeHolder> for DOMParser {
                 // Step 2. Let document be a new Document, whose content type is type
                 // and URL is this's relevant global object's associated Document's URL.
                 let document = Document::new(
+                    cx,
                     &self.window,
                     HasBrowsingContext::No,
                     Some(url.clone()),
@@ -152,7 +152,6 @@ impl DOMParserMethods<crate::DomTypeHolder> for DOMParser {
                     doc.creation_sandboxing_flag_set(),
                     doc.pipeline_id(),
                     doc.image_cache(),
-                    CanGc::from_cx(cx),
                 );
                 // Step switch-1. Create an XML parser parser, associated with document,
                 // and with XML scripting support disabled.

--- a/components/script/dom/html/htmltemplateelement.rs
+++ b/components/script/dom/html/htmltemplateelement.rs
@@ -18,7 +18,6 @@ use crate::dom::documentfragment::DocumentFragment;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::virtualmethods::VirtualMethods;
 use crate::dom::node::{CloneChildrenFlag, Node, NodeTraits};
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLTemplateElement {
@@ -117,7 +116,7 @@ impl HTMLTemplateElementMethods<crate::DomTypeHolder> for HTMLTemplateElement {
             let doc = self.owner_document();
             // Step 2. Create a DocumentFragment object whose node document is document and host is the template element.
             let document_fragment = doc
-                .appropriate_template_contents_owner_document(CanGc::from_cx(cx))
+                .appropriate_template_contents_owner_document(cx)
                 .CreateDocumentFragment(cx);
             document_fragment.set_host(self.upcast());
             // Step 3. Set the template element's template contents to the newly created DocumentFragment object.
@@ -137,7 +136,7 @@ impl VirtualMethods for HTMLTemplateElement {
         // Step 1.
         let doc = self
             .owner_document()
-            .appropriate_template_contents_owner_document(CanGc::from_cx(cx));
+            .appropriate_template_contents_owner_document(cx);
         // Step 2.
         let content = self.Content(cx);
         Node::adopt(cx, content.upcast(), &doc);

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -2938,6 +2938,7 @@ impl Node {
                 let window = document.window();
                 let loader = DocumentLoader::new(&document.loader());
                 let document = Document::new(
+                    cx,
                     window,
                     HasBrowsingContext::No,
                     Some(document.url()),
@@ -2961,7 +2962,6 @@ impl Node {
                     document.creation_sandboxing_flag_set(),
                     document.pipeline_id(),
                     document.image_cache(),
-                    CanGc::from_cx(cx),
                 );
                 // Step 2. If node’s custom element registry’s is scoped is true,
                 // then set copy’s custom element registry to node’s custom element registry.

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -249,6 +249,7 @@ impl ServoParser {
             Some(url.clone()),
         );
         let document = Document::new(
+            cx,
             window,
             HasBrowsingContext::No,
             Some(url.clone()),
@@ -271,7 +272,6 @@ impl ServoParser {
             context_document.creation_sandboxing_flag_set(),
             context_document.pipeline_id(),
             context_document.image_cache(),
-            CanGc::from_cx(cx),
         );
 
         // Step 2. If context's node document is in quirks mode, then set document's mode to "quirks".

--- a/components/script/dom/xmldocument.rs
+++ b/components/script/dom/xmldocument.rs
@@ -11,7 +11,7 @@ use js::context::{JSContext, NoGC};
 use net_traits::image_cache::ImageCache;
 use net_traits::request::InsecureRequestsPolicy;
 use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
-use script_bindings::reflector::reflect_dom_object;
+use script_bindings::reflector::reflect_dom_object_with_cx;
 use script_traits::DocumentActivity;
 use servo_url::{MutableOrigin, ServoUrl};
 
@@ -29,7 +29,6 @@ use crate::dom::document::{Document, DocumentSource, HasBrowsingContext, IsHTMLD
 use crate::dom::location::Location;
 use crate::dom::node::Node;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 // https://dom.spec.whatwg.org/#xmldocument
 #[dom_struct]
@@ -87,6 +86,7 @@ impl XMLDocument {
 
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
+        cx: &mut JSContext,
         window: &Window,
         has_browsing_context: HasBrowsingContext,
         url: Option<ServoUrl>,
@@ -101,10 +101,9 @@ impl XMLDocument {
         has_trustworthy_ancestor_origin: bool,
         custom_element_reaction_stack: Rc<CustomElementReactionStack>,
         image_cache: Arc<dyn ImageCache>,
-        can_gc: CanGc,
     ) -> DomRoot<XMLDocument> {
-        let timeline = DocumentTimeline::new(window, can_gc);
-        let doc = reflect_dom_object(
+        let timeline = DocumentTimeline::new(cx, window);
+        let doc = reflect_dom_object_with_cx(
             Box::new(XMLDocument::new_inherited(
                 window,
                 has_browsing_context,
@@ -123,7 +122,7 @@ impl XMLDocument {
                 image_cache,
             )),
             window,
-            can_gc,
+            cx,
         );
         {
             let node = doc.upcast::<Node>();

--- a/components/script/dom/xmlhttprequest/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest/xmlhttprequest.rs
@@ -79,7 +79,6 @@ use crate::dom::xmlhttprequestupload::XMLHttpRequestUpload;
 use crate::fetch::{FetchCanceller, RequestWithGlobalScope};
 use crate::mime::{APPLICATION, CHARSET, HTML, MimeExt, TEXT, XML};
 use crate::network_listener::{self, FetchResponseListener, ResourceTimingListener};
-use crate::script_runtime::CanGc;
 use crate::task_source::{SendableTaskSource, TaskSourceName};
 use crate::timers::{OneshotTimerCallback, OneshotTimerHandle};
 use crate::url::ensure_blob_referenced_by_url_is_kept_alive;
@@ -1507,7 +1506,7 @@ impl XMLHttpRequest {
         let wr = self.global();
         let response = self.response.borrow();
         let (decoded, _, _) = charset.decode(&response);
-        let document = self.new_doc(IsHTMLDocument::HTMLDocument, CanGc::from_cx(cx));
+        let document = self.new_doc(cx, IsHTMLDocument::HTMLDocument);
         // TODO: Disable scripting while parsing
         ServoParser::parse_html_document(
             cx,
@@ -1525,7 +1524,7 @@ impl XMLHttpRequest {
         let wr = self.global();
         let response = self.response.borrow();
         let (decoded, _, _) = charset.decode(&response);
-        let document = self.new_doc(IsHTMLDocument::NonHTMLDocument, CanGc::from_cx(cx));
+        let document = self.new_doc(cx, IsHTMLDocument::NonHTMLDocument);
         // TODO: Disable scripting while parsing
         ServoParser::parse_xml_document(
             cx,
@@ -1537,7 +1536,7 @@ impl XMLHttpRequest {
         document
     }
 
-    fn new_doc(&self, is_html_document: IsHTMLDocument, can_gc: CanGc) -> DomRoot<Document> {
+    fn new_doc(&self, cx: &mut JSContext, is_html_document: IsHTMLDocument) -> DomRoot<Document> {
         let wr = self.global();
         let win = wr.as_window();
         let doc = win.Document();
@@ -1546,6 +1545,7 @@ impl XMLHttpRequest {
         let parsed_url = base.join(&self.ResponseURL().0).ok();
         let content_type = Some(self.final_mime_type());
         Document::new(
+            cx,
             win,
             HasBrowsingContext::No,
             parsed_url,
@@ -1568,7 +1568,6 @@ impl XMLHttpRequest {
             doc.creation_sandboxing_flag_set(),
             doc.pipeline_id(),
             doc.image_cache(),
-            can_gc,
         )
     }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3587,6 +3587,7 @@ impl ScriptThread {
         let is_initial_about_blank = final_url.as_str() == "about:blank";
 
         let document = Document::new(
+            cx,
             &window,
             HasBrowsingContext::Yes,
             Some(final_url.clone()),
@@ -3609,7 +3610,6 @@ impl ScriptThread {
             incomplete.load_data.creation_sandboxing_flag_set,
             incomplete.pipeline_id,
             image_cache,
-            CanGc::from_cx(cx),
         );
 
         let referrer_policy = metadata


### PR DESCRIPTION
This switches to JSContext instead of CanGc for document creation.

Testing: Compilation is the test.
