### PR TITLE
script: Use unrooted iterator for stringify

### DIFF
--- a/components/script/dom/range/range.rs
+++ b/components/script/dom/range/range.rs
@@ -1141,7 +1141,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
         // in tree order, to string.
         let ancestor = self.CommonAncestorContainer();
         let iter = start_node
-            .following_nodes_unrooted(&cx, &ancestor, ShadowIncluding::No)
+            .following_nodes_unrooted(cx, &ancestor, ShadowIncluding::No)
             .filter_map(UnrootedDom::downcast::<Text>);
 
         for child in iter {

--- a/components/script/dom/range/range.rs
+++ b/components/script/dom/range/range.rs
@@ -9,7 +9,7 @@ use std::iter;
 use app_units::Au;
 use dom_struct::dom_struct;
 use euclid::Rect;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use js::jsapi::JSTracer;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
@@ -1105,7 +1105,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-range-stringifier>
-    fn Stringifier(&self, cx: &JSContext) -> DOMString {
+    fn Stringifier(&self, no_gc: &NoGC) -> DOMString {
         let start_node = self.start_container();
         let end_node = self.end_container();
 
@@ -1141,7 +1141,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
         // in tree order, to string.
         let ancestor = self.CommonAncestorContainer();
         let iter = start_node
-            .following_nodes_unrooted(cx, &ancestor, ShadowIncluding::No)
+            .following_nodes_unrooted(no_gc, &ancestor, ShadowIncluding::No)
             .filter_map(UnrootedDom::downcast::<Text>);
 
         for child in iter {

--- a/components/script/dom/range/range.rs
+++ b/components/script/dom/range/range.rs
@@ -13,6 +13,7 @@ use js::context::JSContext;
 use js::jsapi::JSTracer;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
+use script_bindings::dom::UnrootedDom;
 use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use style_traits::CSSPixel;
 
@@ -1104,7 +1105,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-range-stringifier>
-    fn Stringifier(&self) -> DOMString {
+    fn Stringifier(&self, cx: &JSContext) -> DOMString {
         let start_node = self.start_container();
         let end_node = self.end_container();
 
@@ -1140,8 +1141,8 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
         // in tree order, to string.
         let ancestor = self.CommonAncestorContainer();
         let iter = start_node
-            .following_nodes(&ancestor, ShadowIncluding::No)
-            .filter_map(DomRoot::downcast::<Text>);
+            .following_nodes_unrooted(&cx, &ancestor, ShadowIncluding::No)
+            .filter_map(UnrootedDom::downcast::<Text>);
 
         for child in iter {
             if self.contains(child.upcast()) {

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -5,7 +5,7 @@
 use std::cell::Cell;
 
 use dom_struct::dom_struct;
-use js::context::JSContext;
+use js::context::{JSContext, NoGC};
 use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
 
 use crate::dom::bindings::codegen::Bindings::NodeBinding::{GetRootNodeOptions, NodeMethods};
@@ -547,13 +547,13 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-stringifier>
-    fn Stringifier(&self, cx: &JSContext) -> DOMString {
+    fn Stringifier(&self, no_gc: &NoGC) -> DOMString {
         // The spec as of Jan 31 2020 just says
         // "See W3C bug 10583." for this method.
         // Stringifying the range seems at least approximately right
         // and passes the non-style-dependent case in the WPT tests.
         if let Some(range) = self.range.get() {
-            range.Stringifier(cx)
+            range.Stringifier(no_gc)
         } else {
             DOMString::from("")
         }

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -547,13 +547,13 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-stringifier>
-    fn Stringifier(&self) -> DOMString {
+    fn Stringifier(&self, cx: &JSContext) -> DOMString {
         // The spec as of Jan 31 2020 just says
         // "See W3C bug 10583." for this method.
         // Stringifying the range seems at least approximately right
         // and passes the non-style-dependent case in the WPT tests.
         if let Some(range) = self.range.get() {
-            range.Stringifier()
+            range.Stringifier(cx)
         } else {
             DOMString::from("")
         }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1062,7 +1062,7 @@ DOMInterfaces = {
 'Range': {
     'weakReferenceable': True,
     'cx': ['CloneContents', 'CloneRange', 'CreateContextualFragment', 'DeleteContents', 'ExtractContents', 'GetBoundingClientRect', 'GetClientRects', 'InsertNode', 'SurroundContents'],
-    'cx_no_gc': ['Stringifier'],
+    'no_gc': ['Stringifier'],
 },
 
 'Request': {
@@ -1089,7 +1089,7 @@ DOMInterfaces = {
 
 'Selection': {
     'cx': ['Collapse', 'CollapseToEnd', 'CollapseToStart', 'DeleteFromDocument', 'Extend', 'SelectAllChildren', 'SetBaseAndExtent', 'SetPosition'],
-    'cx_no_gc': ['Stringifier'],
+    'no_gc': ['Stringifier'],
 },
 
 'ServiceWorker': {
@@ -1379,7 +1379,7 @@ DOMInterfaces = {
         'TrustedTypes',
         'WebdriverException',
         'IndexedDB',
-    ]
+    ],
 },
 
 'WindowProxy' : {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1062,6 +1062,7 @@ DOMInterfaces = {
 'Range': {
     'weakReferenceable': True,
     'cx': ['CloneContents', 'CloneRange', 'CreateContextualFragment', 'DeleteContents', 'ExtractContents', 'GetBoundingClientRect', 'GetClientRects', 'InsertNode', 'SurroundContents'],
+    'cx_no_gc': ['Stringifier'],
 },
 
 'Request': {
@@ -1087,7 +1088,8 @@ DOMInterfaces = {
 },
 
 'Selection': {
-    'cx': ['Collapse', 'CollapseToEnd', 'CollapseToStart', 'DeleteFromDocument', 'Extend', 'SelectAllChildren', 'SetBaseAndExtent', 'SetPosition']
+    'cx': ['Collapse', 'CollapseToEnd', 'CollapseToStart', 'DeleteFromDocument', 'Extend', 'SelectAllChildren', 'SetBaseAndExtent', 'SetPosition'],
+    'cx_no_gc': ['Stringifier'],
 },
 
 'ServiceWorker': {


### PR DESCRIPTION
This moves the stringify method in dom/range and dom/selection to use the unrooted iterator.

Testing: This only changes the rooting behavior and, hence, compilation is the test.
