### PR TITLE
canvas: Discard message buffer before `CanvasCommand::Recreate` and `Drop` trait

### DIFF
--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -2532,7 +2532,8 @@ impl CanvasState {
 
 impl Drop for CanvasState {
     fn drop(&mut self) {
-        // Flush any buffered commands before closing the canvas.
+        // Discard buffered commands before closing the canvas.
+        self.buffered_sender.discard();
         if let Err(err) = self.buffered_sender.send_immediate(CanvasCommand::Destroy) {
             warn!("Could not close canvas: {}", err)
         }

--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -322,6 +322,8 @@ impl CanvasState {
 
         // Step 2. Resize the output bitmap to the new width and height.
         self.size.replace(adjust_canvas_size(size));
+        // Discard buffered commands targeting the old canvas.
+        self.buffered_sender.discard();
         // Flushing is not required for correctness, but optimization heuristics for heavy command.
         self.send_canvas_command_immediate(CanvasCommand::Recreate(Some(self.size.get())));
     }
@@ -335,6 +337,8 @@ impl CanvasState {
         }
 
         // Step 1. Clear canvas's bitmap to transparent black.
+        // Discard buffered commands targeting the old canvas.
+        self.buffered_sender.discard();
         // Flushing is not required for correctness, but optimization heuristics for heavy command.
         self.send_canvas_command_immediate(CanvasCommand::Recreate(None));
     }

--- a/components/shared/base/generic_channel/buffered.rs
+++ b/components/shared/base/generic_channel/buffered.rs
@@ -57,11 +57,6 @@ impl<T: Serialize, U> GenericBufferedSender<T, U> {
         self.buffer.borrow().len()
     }
 
-    /// Change the auto-flush threshold.
-    pub fn set_max_buffer(&mut self, max: usize) {
-        self.max_buffer = max;
-    }
-
     /// Buffer a message for later batched delivery.
     ///
     /// If the buffer reaches `max_buffer` items an automatic flush is triggered.
@@ -135,6 +130,11 @@ impl<T: Serialize, U> GenericBufferedSender<T, U> {
             let location = Location::caller();
             log::warn!("Failed to flush buffered messages due to `{error}` at {location:?}");
         }
+    }
+
+    /// Discard all buffered messages without sending them.
+    pub fn discard(&self) {
+        self.buffer.borrow_mut().clear();
     }
 }
 


### PR DESCRIPTION
It's a waste to deal with message buffer if canvas is gonna recreate/Drop.

Testing: Existing wpt tests [results](https://github.com/servo/servo/actions/runs/28382086081) does not change, which is the expected behaviour.

Benchmark: 

For example in #45199, mate 60 Pro, tested 4 times, 1 min per time. Power consumption measured without plugged in.
85% battery.
|  | FPS | Power (mw) | Power/Frame |
| :--- | :--- | :--- | :---  |
| Previous | 32 | 2778.3 | 86.821875 |
| Clear buffer for Recreate | No statistically significant change from previous | . | . | 
| Clear buffer for Recreate and Destroy| 34.3 | 2940.9 | 85.74052478 |

Part of #45199

I am happy with benchmark result, as `Recreate` command is not involved at all in the example.
This matches my expectation.