### PR TITLE
script: Add optional no_gc argument to GlobalScope::request_client()

### DIFF
--- a/components/script/dom/css/fontface.rs
+++ b/components/script/dom/css/fontface.rs
@@ -652,7 +652,7 @@ impl FontFaceMethods<crate::DomTypeHolder> for FontFace {
             .expect("Parsing shouldn't fail as descriptors are valid by construction");
 
         // Construct a WebFontDocumentContext object for the current document.
-        let document_context = global.as_window().web_font_context();
+        let document_context = global.as_window().web_font_context(cx.no_gc());
 
         // Step 4. Using the value of font face’s [[Urls]] slot, attempt to load a font as defined
         // in [CSS-FONTS-3], as if it was the value of a @font-face rule’s src descriptor.

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -4566,7 +4566,7 @@ impl Document {
     ) {
         self.window
             .layout()
-            .load_web_fonts_from_stylesheet(stylesheet, &self.window.web_font_context());
+            .load_web_fonts_from_stylesheet(stylesheet, &self.window.web_font_context(cx.no_gc()));
         self.switch_font_face_set_to_loading_if_needed(cx);
     }
 
@@ -4579,7 +4579,7 @@ impl Document {
         self.window.layout_mut().add_stylesheet(
             stylesheet,
             before_stylesheet,
-            &self.window.web_font_context(),
+            &self.window.web_font_context(cx.no_gc()),
         );
         self.switch_font_face_set_to_loading_if_needed(cx);
     }

--- a/components/script/dom/globalscope/globalscope.rs
+++ b/components/script/dom/globalscope/globalscope.rs
@@ -26,6 +26,7 @@ use embedder_traits::{
 use fonts::FontContext;
 use indexmap::IndexSet;
 use ipc_channel::router::ROUTER;
+use js::context::NoGC;
 use js::jsapi::{
     CurrentGlobalOrNull, GetNonCCWObjectGlobal, HandleObject, Heap, JSContext, JSObject,
 };
@@ -2629,12 +2630,21 @@ impl GlobalScope {
     }
 
     /// Part of <https://fetch.spec.whatwg.org/#populate-request-from-client>
-    pub(crate) fn request_client(&self) -> RequestClient {
+    pub(crate) fn request_client(&self, no_gc: Option<&NoGC>) -> RequestClient {
         // Step 1.2.2. If global is a Window object and global’s navigable is not null,
         // then set request’s traversable for user prompts to global’s navigable’s traversable navigable.
         let window = self.downcast::<Window>();
         let preloaded_resources = window
-            .map(|window: &Window| window.Document().preloaded_resources().clone())
+            .map(|window: &Window| {
+                if let Some(no_gc) = no_gc {
+                    window
+                        .document_unrooted(no_gc)
+                        .preloaded_resources()
+                        .clone()
+                } else {
+                    window.Document().preloaded_resources().clone()
+                }
+            })
             .unwrap_or_default();
         let is_nested_browsing_context = window.is_some_and(|window| !window.is_top_level());
         RequestClient {

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -520,7 +520,7 @@ impl HTMLLinkElement {
             base_url: document.borrow().base_url(),
             insecure_requests_policy: document.insecure_requests_policy(),
             has_trustworthy_ancestor_origin: document.has_trustworthy_ancestor_or_current_origin(),
-            request_client: global.request_client(),
+            request_client: global.request_client(None),
             referrer: global.get_referrer(),
         };
 

--- a/components/script/dom/processingoptions.rs
+++ b/components/script/dom/processingoptions.rs
@@ -413,7 +413,7 @@ pub(crate) fn process_link_headers(
             base_url: document.base_url(),
             insecure_requests_policy: document.insecure_requests_policy(),
             has_trustworthy_ancestor_origin: document.has_trustworthy_ancestor_or_current_origin(),
-            request_client: global.request_client(),
+            request_client: global.request_client(None),
             referrer: global.get_referrer(),
         };
         // Step 2.7. Apply link options from parsed header attributes to options given attribs and rel.

--- a/components/script/dom/servoparser/prefetch.rs
+++ b/components/script/dom/servoparser/prefetch.rs
@@ -80,7 +80,7 @@ impl Tokenizer {
             insecure_requests_policy: document.insecure_requests_policy(),
             has_trustworthy_ancestor_origin: document.has_trustworthy_ancestor_or_current_origin(),
             policy_container: global.policy_container(),
-            request_client: global.request_client(),
+            request_client: global.request_client(None),
         };
         let options = Default::default();
         let inner = TraceableTokenizer(HtmlTokenizer::new(sink, options));

--- a/components/script/dom/window/window.rs
+++ b/components/script/dom/window/window.rs
@@ -64,6 +64,7 @@ use rustc_hash::{FxBuildHasher, FxHashMap};
 use script_bindings::cell::{DomRefCell, Ref};
 use script_bindings::codegen::GenericBindings::WindowBinding::ScrollToOptions;
 use script_bindings::conversions::SafeToJSValConvertible;
+use script_bindings::dom::UnrootedDom;
 use script_bindings::interfaces::{HasOrigin, WindowHelpers};
 use script_bindings::reflector::DomObject;
 use script_bindings::root::Root;
@@ -914,11 +915,11 @@ impl Window {
         self.script_thread().perform_a_microtask_checkpoint(cx);
     }
 
-    pub(crate) fn web_font_context(&self) -> WebFontDocumentContext {
+    pub(crate) fn web_font_context(&self, no_gc: &NoGC) -> WebFontDocumentContext {
         let global = self.as_global_scope();
         WebFontDocumentContext {
             policy_container: global.policy_container(),
-            request_client: global.request_client(),
+            request_client: global.request_client(Some(no_gc)),
             document_url: global.api_base_url(),
             has_trustworthy_ancestor_origin: global.has_trustworthy_ancestor_origin(),
             insecure_requests_policy: global.insecure_requests_policy(),
@@ -2563,7 +2564,8 @@ impl Window {
             return Default::default();
         }
 
-        self.Document().ensure_safe_to_run_script_or_layout();
+        self.document_unrooted(cx.no_gc())
+            .ensure_safe_to_run_script_or_layout();
 
         // If layouts are blocked, we block all layouts that are for display only. Other
         // layouts (for queries and scrolling) are not blocked, as they do not display
@@ -2614,7 +2616,7 @@ impl Window {
         // layout runs, so that the map can gather their elements in DOM order.
         document.id_map().resolve_all(cx.no_gc(), document.upcast());
 
-        let document_context = self.web_font_context();
+        let document_context = self.web_font_context(cx.no_gc());
 
         let rooted_nodes_for_accessibility_integrity_check =
             document.rooted_nodes_for_accessibility_integrity_check();
@@ -2908,6 +2910,13 @@ impl Window {
         self.layout
             .borrow()
             .query_current_css_zoom(node.to_trusted_node_address())
+    }
+
+    /// <https://html.spec.whatwg.org/multipage/#dom-document-2>
+    pub(crate) fn document_unrooted<'a>(&self, no_gc: &'a NoGC) -> UnrootedDom<'a, Document> {
+        self.document
+            .get_unrooted(no_gc)
+            .expect("Document accessed before initialization.")
     }
 
     /// Find the scroll area of the given node, if it is not None. If the node

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -168,7 +168,7 @@ fn request_init_from_request(request: NetTraitsRequest, global: &GlobalScope) ->
     .cryptographic_nonce_metadata(request.cryptographic_nonce_metadata)
     .parser_metadata(request.parser_metadata)
     .initiator(request.initiator)
-    .client(global.request_client())
+    .client(global.request_client(None))
     .insecure_requests_policy(request.insecure_requests_policy)
     .has_trustworthy_ancestor_origin(request.has_trustworthy_ancestor_origin)
     .response_tainting(request.response_tainting);
@@ -306,7 +306,7 @@ fn queue_deferred_fetch(
     let trusted_global = Trusted::new(global);
     let mut request = request;
     // Step 1. Populate request from client given request.
-    request.client = Some(global.request_client());
+    request.client = Some(global.request_client(None));
     request.populate_request_from_client();
     // Step 2. Set request’s service-workers mode to "none".
     request.service_workers_mode = ServiceWorkersMode::None;
@@ -774,7 +774,7 @@ impl RequestWithGlobalScope for RequestBuilder {
         self.insecure_requests_policy(global.insecure_requests_policy())
             .has_trustworthy_ancestor_origin(global.has_trustworthy_ancestor_or_current_origin())
             .policy_container(global.policy_container())
-            .client(global.request_client())
+            .client(global.request_client(None))
             .pipeline_id(Some(global.pipeline_id()))
             .origin(global.origin().immutable().clone())
     }

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -661,7 +661,7 @@ impl ModuleFetchClient {
             insecure_requests_policy: global.insecure_requests_policy(),
             has_trustworthy_ancestor_origin: global.has_trustworthy_ancestor_or_current_origin(),
             policy_container: global.policy_container(),
-            client: global.request_client(),
+            client: global.request_client(None),
             pipeline_id: global.pipeline_id(),
             origin: global.origin().immutable().clone(),
         }


### PR DESCRIPTION
Currently a Window::reflow still has to handle rooting/unrooting operations of Document which can be about 1.7% of total operation in a specific slice.
This uses now an optional NoGC argument to prevent the rooting and unrooting whn possible. As this seems to be a high impact function, saving every little bit helps.

I decided to use the Option<&NoGC> instead of simple NoGC because carrying it throughout all the functions would produce very little gains.

Testing: This just changes the rooting behaviour so no extra tests are necessary.
