### PR TITLE
net: Small clean up of spec comments

### DIFF
--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -433,6 +433,8 @@ pub async fn main_fetch(
         RequestPolicyContainer::Client => unreachable!(),
         RequestPolicyContainer::PolicyContainer(container) => container.to_owned(),
     };
+
+    // Step 4. Run report Content Security Policy violations for request.
     let csp_request = convert_request_to_csp_request(request);
     if let Some(csp_request) = csp_request.as_ref() {
         // Step 2.2.
@@ -443,10 +445,8 @@ pub async fn main_fetch(
         }
     };
 
-    // Step 3.
-    // TODO: handle request abort.
-
-    // Step 4. Upgrade request to a potentially trustworthy URL, if appropriate.
+    // Step 5. Upgrade request to a potentially trustworthy URL, if appropriate.
+    // Step 6. Upgrade a mixed content request to a potentially trustworthy URL, if appropriate.
     if should_upgrade_request_to_potentially_trustworthy(request, context) ||
         should_upgrade_mixed_content_request(request, &context.protocols)
     {
@@ -503,6 +503,8 @@ pub async fn main_fetch(
         request.referrer_policy = policy_container.get_referrer_policy();
     }
 
+    // Step 9, If request’s referrer is not "no-referrer", then set request’s referrer to the result
+    // of invoking determine request’s referrer.
     let referrer_url = match mem::replace(&mut request.referrer, Referrer::NoReferrer) {
         Referrer::NoReferrer => None,
         Referrer::ReferrerUrl(referrer_source) | Referrer::Client(referrer_source) => {
@@ -516,9 +518,6 @@ pub async fn main_fetch(
     };
     request.referrer = referrer_url.map_or(Referrer::NoReferrer, Referrer::ReferrerUrl);
 
-    // Step 9.
-    // TODO: handle FTP URLs.
-
     // Step 10.
     context
         .state
@@ -526,7 +525,7 @@ pub async fn main_fetch(
         .read()
         .apply_hsts_rules(request.current_url_mut());
 
-    // Step 11.
+    // Step 11. If recursive is false, then run the remaining steps in parallel.
     // Not applicable: see fetch_async.
 
     let current_url = request.current_url();
@@ -542,9 +541,9 @@ pub async fn main_fetch(
 
     let mut response = match response {
         Some(response) => response,
+        // Step 12. If response is null, then set response to the result
+        // of running the steps corresponding to the first matching statement:
         None => {
-            // Step 12. If response is null, then set response to the result
-            // of running the steps corresponding to the first matching statement:
             let same_origin = if let Origin::Origin(ref origin) = request.origin {
                 *origin == request.current_url_with_blob_claim().origin()
             } else {
@@ -604,9 +603,11 @@ pub async fn main_fetch(
                             !is_cors_safelisted_request_header(&name, &value)
                         })))
             {
-                // Substep 1.
+                // Substep 1. Set request’s response tainting to "cors".
                 request.response_tainting = ResponseTainting::CorsTainting;
-                // Substep 2.
+
+                // Substep 2. Let corsWithPreflightResponse be the result of running override fetch
+                // given "http-fetch", fetchParams, and true.
                 let response = http_fetch(
                     fetch_params,
                     cache,
@@ -625,9 +626,10 @@ pub async fn main_fetch(
                 // Substep 4.
                 response
             } else {
-                // Substep 1.
+                // Substep 1. Set request’s response tainting to "cors".
                 request.response_tainting = ResponseTainting::CorsTainting;
-                // Substep 2.
+
+                // Substep 2. Return the result of running override fetch given "http-fetch" and fetchParams.
                 http_fetch(
                     fetch_params,
                     cache,
@@ -652,7 +654,7 @@ pub async fn main_fetch(
     let request = &mut fetch_params.request;
 
     // Step 14. If response is not a network error and response is not a filtered response, then:
-    let mut response = if !response.is_network_error() && response.internal_response.is_none() {
+    if !response.is_network_error() && response.internal_response.is_none() {
         // Step 14.1 If request’s response tainting is "cors", then:
         if request.response_tainting == ResponseTainting::CorsTainting {
             // Step 14.1.1 Let headerNames be the result of extracting header list values given
@@ -661,24 +663,25 @@ pub async fn main_fetch(
                 .headers
                 .typed_get::<AccessControlExposeHeaders>()
                 .map(|v| v.iter().collect());
-            match header_names {
-                // Subsubstep 2.
-                Some(ref list)
-                    if request.credentials_mode != CredentialsMode::Include &&
-                        list.iter().any(|header| header == "*") =>
+
+            if let Some(ref list) = header_names {
+                // Step 14.1.2. If request’s credentials mode is not "include" and headerNames
+                // contains `*`, then set response’s CORS-exposed header-name list to all unique
+                // header names in response’s header list.
+                if request.credentials_mode != CredentialsMode::Include &&
+                    list.iter().any(|header| header == "*")
                 {
                     response.cors_exposed_header_name_list = response
                         .headers
                         .iter()
                         .map(|(name, _)| name.as_str().to_owned())
                         .collect();
-                },
-                // Subsubstep 3.
-                Some(list) => {
+                } else {
+                    // Step 14.1.3. Otherwise, if headerNames is non-null or failure, then set
+                    // response’s CORS-exposed header-name list to headerNames.
                     response.cors_exposed_header_name_list =
                         list.iter().map(|h| h.as_str().to_owned()).collect();
-                },
-                _ => (),
+                }
             }
         }
 
@@ -689,10 +692,8 @@ pub async fn main_fetch(
             ResponseTainting::CorsTainting => ResponseType::Cors,
             ResponseTainting::Opaque => ResponseType::Opaque,
         };
-        response.to_filtered(response_type)
-    } else {
-        response
-    };
+        response = response.to_filtered(response_type);
+    }
 
     let internal_error = {
         // Tests for steps 17 and 18, before step 15 for borrowing concerns.
@@ -739,7 +740,13 @@ pub async fn main_fetch(
         // Step 17. Set internalResponse’s redirect taint to request’s redirect-taint.
         internal_response.redirect_taint = request.redirect_taint_for_request();
 
-        // Step 19. If response is not a network error and any of the following returns blocked
+        // TODO Step 18. If request is a navigation request, then set internalResponse’s navigation
+        // timing allow values list to a clone of request’s navigation timing allow values list.
+
+        // TODO Step 19. If request’s timing allow failed flag is unset, then set internalResponse’s
+        // timing allow passed flag.
+
+        // Step 20. If response is not a network error and any of the following returns blocked
         // * should internalResponse to request be blocked as mixed content
         // * should internalResponse to request be blocked by Content Security Policy
         // * should internalResponse to request be blocked due to its MIME type
@@ -765,14 +772,14 @@ pub async fn main_fetch(
             internal_response
         };
 
-        // Step 20. If response’s type is "opaque", internalResponse’s status is 206, internalResponse’s
-        // range-requested flag is set, and request’s header list does not contain `Range`, then set
-        // response and internalResponse to a network error.
+        // Step 21. If response’s type is "opaque", internalResponse’s status is a range status,
+        // internalResponse’s range-requested flag is set, and request’s header list does not
+        // contain `Range`, then set response and internalResponse to a network error.
         // Also checking if internal response is a network error to prevent crash from attemtping to
         // read status of a network error if we blocked the request above.
         let internal_response = if !internal_response.is_network_error() &&
             response_type == ResponseType::Opaque &&
-            internal_response.status.code() == StatusCode::PARTIAL_CONTENT &&
+            internal_response.status.is_a_range_status() &&
             internal_response.range_requested &&
             !request.headers.contains_key(RANGE)
         {
@@ -784,7 +791,7 @@ pub async fn main_fetch(
             internal_response
         };
 
-        // Step 21. If response is not a network error and either request’s method is `HEAD` or `CONNECT`,
+        // Step 22. If response is not a network error and either request’s method is `HEAD` or `CONNECT`,
         // or internalResponse’s status is a null body status, set internalResponse’s body to null and
         // disregard any enqueuing toward it (if any).
         // NOTE: We check `internal_response` since we did not mutate `response` in the previous steps.
@@ -803,11 +810,9 @@ pub async fn main_fetch(
     };
 
     // Execute deferred rebinding of response.
-    let mut response = if let Some(error) = internal_error {
-        Response::network_error(error)
-    } else {
-        response
-    };
+    if let Some(error) = internal_error {
+        response = Response::network_error(error);
+    }
 
     // Step 19. If response is not a network error and any of the following returns blocked
     let mut response_loaded = false;

--- a/components/net/hsts.rs
+++ b/components/net/hsts.rs
@@ -199,7 +199,7 @@ impl HstsList {
         entries.retain(|e| !e.is_expired());
     }
 
-    /// Step 2.9 of <https://fetch.spec.whatwg.org/#concept-main-fetch>.
+    /// Step 10 of <https://fetch.spec.whatwg.org/#concept-main-fetch>.
     pub fn apply_hsts_rules(&self, url: &mut ServoUrl) {
         if url.scheme() != "http" && url.scheme() != "ws" {
             return;

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -1972,16 +1972,15 @@ async fn http_network_fetch(
     // Step 1: Let request be fetchParams’s request.
     let request = &mut fetch_params.request;
 
-    // Step 2
-    // TODO be able to create connection using current url's origin and credentials
+    // TODO Step 2. If request’s client is offline, then return a network error.
 
-    // Step 3
-    // TODO be able to tell if the connection is a failure
+    // TODO Step 3. Let response be null.
 
-    // Step 4
-    // TODO: check whether the connection is HTTP/2
+    // TODO Step 4. Let timingInfo be fetchParams’s timing info.
 
-    // Step 5
+    // TODO Step 5. Let networkPartitionKey be the result of determining the network partition key
+    // given request.
+
     let url = request.current_url();
     let request_id = request.id.0.to_string();
     if log_enabled!(log::Level::Info) {
@@ -2011,7 +2010,11 @@ async fn http_network_fetch(
 
     let browsing_context_id = request.target_webview_id.map(Into::into);
 
+    // Step 6. Let newConnection be "yes" if forceNewConnection is true; otherwise "no".
+
+    // Step 7. Switch on request’s mode:
     let (res, msg) = match &request.mode {
+        // Let connection be the result of obtaining a WebSocket connection, given request’s current URL.
         RequestMode::WebSocket {
             protocols,
             original_url: _,
@@ -2059,6 +2062,8 @@ async fn http_network_fetch(
             });
             (Decoder::detect(response, url.is_secure_scheme()), None)
         },
+        // Let connection be the result of obtaining a connection, given networkPartitionKey,
+        // request’s current URL, includeCredentials, and newConnection.
         _ => {
             let response_future = obtain_response(
                 &context.state.client,
@@ -2103,6 +2108,8 @@ async fn http_network_fetch(
         _ => warn!("Failed to receive confirmation request was streamed without error."),
     }
 
+    // This seems to be https://fetch.spec.whatwg.org/#concept-tao-check
+    // which is performed as step 4.5 of https://fetch.spec.whatwg.org/#concept-http-fetch
     let header_strings: Vec<&str> = res
         .headers()
         .get_all("Timing-Allow-Origin")

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -41,7 +41,6 @@ use net_traits::fetch::headers::get_value_from_header_list;
 use net_traits::http_status::HttpStatus;
 use net_traits::policy_container::{EmbedderPolicyValue, RequestPolicyContainer};
 use net_traits::pub_domains::{is_same_site, reg_suffix};
-use net_traits::request::Origin::Origin as SpecificOrigin;
 use net_traits::request::{
     BodyChunkRequest, BodyChunkResponse, CacheMode, CredentialsMode, Destination, Initiator,
     Origin, RedirectMode, Referrer, Request, RequestBuilder, RequestClient, RequestMode,
@@ -861,13 +860,20 @@ pub(crate) async fn http_fetch(
         if cors_preflight_flag {
             let method_cache_match = cache.match_method(request, request.method.clone());
 
+            // There is no method cache entry match for request’s method using request, and either
+            // request’s method is not a CORS-safelisted method or request’s use-CORS-preflight flag
+            // is set.
             let method_mismatch = !method_cache_match &&
                 (!is_cors_safelisted_method(&request.method) || request.use_cors_preflight);
+
+            // There is at least one item in the CORS-unsafe request-header names with request’s
+            // header list for which there is no header-name cache entry match using request.
             let header_mismatch = request.headers.iter().any(|(name, value)| {
                 !cache.match_header(request, name) &&
                     !is_cors_safelisted_request_header(&name, &value)
             });
 
+            // Then:
             if method_mismatch || header_mismatch {
                 // Step 4.1.1. Let preflightResponse be the result of running
                 // CORS-preflight fetch given request.
@@ -902,8 +908,11 @@ pub(crate) async fn http_fetch(
             return Response::network_error(NetworkError::CorsGeneral);
         }
 
-        // TODO: Step 4.5. If the TAO check for request and response returns failure,
+        // Step 4.5. If the TAO check for request and response returns failure,
         // then set request’s timing allow failed flag.
+        if let Err(()) = tao_check(&fetch_params.request, &fetch_result) {
+            context.timing.inner().mark_timing_check_failed();
+        }
         fetch_result.return_internal = false;
         response = Some(fetch_result);
     }
@@ -937,19 +946,22 @@ pub(crate) async fn http_fetch(
         .try_code()
         .is_some_and(is_redirect_status)
     {
-        // Step 6.1. If internalResponse’s status is not 303, request’s body is non-null,
+        // TODO Step 6.1. If request is a navigation request, then append to a request’s navigation
+        // timing allow values list given request and internalResponse.
+
+        // Step 6.2. If internalResponse’s status is not 303, request’s body is non-null,
         // and the connection uses HTTP/2, then user agents may, and are even encouraged to,
         // transmit an RST_STREAM frame.
         if response.actual_response().status != StatusCode::SEE_OTHER {
             // TODO: send RST_STREAM frame
         }
 
-        // Step 6.2. Switch on request’s redirect mode:
+        // Step 6.3. Switch on request’s redirect mode:
         response = match request.redirect_mode {
-            // Step 6.2."error".1. Set response to a network error.
+            // Step 6.3."error".1. Set response to a network error.
             RedirectMode::Error => Response::network_error(NetworkError::RedirectError),
             RedirectMode::Manual => {
-                // Step 6.2."manual".1. If request’s mode is "navigate", then set fetchParams’s controller’s
+                // Step 6.3."manual".1. If request’s mode is "navigate", then set fetchParams’s controller’s
                 // next manual redirect steps to run HTTP-redirect fetch given fetchParams and response.
                 if request.mode == RequestMode::Navigate {
                     // TODO: We don't implement Fetch controller. Instead, we update the location url
@@ -960,13 +972,19 @@ pub(crate) async fn http_fetch(
                     response.actual_response_mut().location_url = location_url;
                     response
                 } else {
-                    // Step 6.2."manual".2. Otherwise, set response to an opaque-redirect filtered response whose internal response is internalResponse.
+                    // Step 6.3."manual".2. Otherwise, set response to an opaque-redirect filtered
+                    // response whose internal response is internalResponse.
                     response.to_filtered(ResponseType::OpaqueRedirect)
                 }
             },
             RedirectMode::Follow => {
+                // TODO Step 6.3."follow".1. Run the WebDriver BiDi response completed steps with
+                // request and response.
                 // set back to default
                 response.return_internal = true;
+
+                // Step 6.3."follow".2. Set response to the result of running HTTP-redirect fetch
+                // given fetchParams and response.
                 http_redirect_fetch(
                     fetch_params,
                     cache,
@@ -991,8 +1009,55 @@ pub(crate) async fn http_fetch(
 
     response.resource_timing = context.timing.clone();
 
-    // Step 6
+    // Step 7. Return response
     response
+}
+
+/// <https://fetch.spec.whatwg.org/#concept-tao-check>
+fn tao_check(request: &Request, response: &Response) -> Result<(), ()> {
+    // Step 1. Assert: request’s origin is not "client".
+    let Origin::Origin(ref request_origin) = request.origin else {
+        unreachable!("origin cannot be \"client\" at this point");
+    };
+
+    // Step 2. If request’s timing allow failed flag is set, then return failure.
+
+    // Step 3. Let values be the result of getting, decoding, and splitting `Timing-Allow-Origin`
+    // from response’s header list.
+    let values: Vec<&str> = response
+        .headers
+        .get_all("Timing-Allow-Origin")
+        .iter()
+        .map(|header_value| header_value.to_str().unwrap_or(""))
+        .collect();
+
+    // Step 4. If values contains "*", then return success.
+    if values.contains(&"*") {
+        return Ok(());
+    }
+
+    // Step 5. If values contains the result of serializing a request origin with request, then
+    // return success.
+    if values
+        .iter()
+        .any(|header_str| *header_str == request_origin.ascii_serialization())
+    {
+        return Ok(());
+    }
+
+    // Step 6. If request’s mode is "navigate" and request’s current URL’s origin is not same origin
+    // with request’s origin, then return failure.
+    if request.mode == RequestMode::Navigate && request.current_url().origin() != *request_origin {
+        return Err(());
+    }
+
+    // Step 7. If request’s response tainting is "basic", then return success.
+    if request.response_tainting == ResponseTainting::Basic {
+        return Ok(());
+    }
+
+    // Step 8. Return failure.
+    Err(())
 }
 
 // Convenience struct that implements Drop, for setting redirectEnd on function return
@@ -2106,36 +2171,6 @@ async fn http_network_fetch(
         Some(true) => return Response::network_error(NetworkError::ConnectionFailure),
         Some(false) => {},
         _ => warn!("Failed to receive confirmation request was streamed without error."),
-    }
-
-    // This seems to be https://fetch.spec.whatwg.org/#concept-tao-check
-    // which is performed as step 4.5 of https://fetch.spec.whatwg.org/#concept-http-fetch
-    let header_strings: Vec<&str> = res
-        .headers()
-        .get_all("Timing-Allow-Origin")
-        .iter()
-        .map(|header_value| header_value.to_str().unwrap_or(""))
-        .collect();
-    let wildcard_present = header_strings.contains(&"*");
-    // The spec: https://www.w3.org/TR/resource-timing-2/#sec-timing-allow-origin
-    // says that a header string is either an origin or a wildcard so we can just do a straight
-    // check against the document origin
-    let req_origin_in_timing_allow = header_strings
-        .iter()
-        .any(|header_str| match request.origin {
-            SpecificOrigin(ref immutable_request_origin) => {
-                *header_str == immutable_request_origin.ascii_serialization()
-            },
-            _ => false,
-        });
-
-    let is_same_origin = request.url_list.iter().all(|url| match request.origin {
-        SpecificOrigin(ref immutable_request_origin) => url.origin() == *immutable_request_origin,
-        _ => false,
-    });
-
-    if !(is_same_origin || req_origin_in_timing_allow || wildcard_present) {
-        context.timing.inner().mark_timing_check_failed();
     }
 
     let timing = context.timing.inner().clone();

--- a/components/shared/net/http_status.rs
+++ b/components/shared/net/http_status.rs
@@ -85,6 +85,14 @@ impl HttpStatus {
     pub fn in_range<T: RangeBounds<u16>>(&self, range: T) -> bool {
         self.code != 0 && range.contains(&self.code)
     }
+
+    /// <https://fetch.spec.whatwg.org/#range-status>
+    pub fn is_a_range_status(&self) -> bool {
+        matches!(
+            self.code(),
+            StatusCode::PARTIAL_CONTENT | StatusCode::RANGE_NOT_SATISFIABLE
+        )
+    }
 }
 
 impl Default for HttpStatus {


### PR DESCRIPTION
Update part of the fetch steps to match the current spec; also, the TAO check is now performed in `http_fetch` as step 4.5 instead of `http_network_fetch`.

Testing: Covered by existing tests
