### PR TITLE
script: Remove duplicated incorrect version of `FormControl::is_listed()`

### DIFF
--- a/components/script/dom/html/htmlbuttonelement.rs
+++ b/components/script/dom/html/htmlbuttonelement.rs
@@ -442,8 +442,8 @@ impl FormControl for HTMLButtonElement {
         self.form_owner.set(form);
     }
 
-    fn to_element(&self) -> &Element {
-        self.upcast::<Element>()
+    fn to_html_element(&self) -> &HTMLElement {
+        self.upcast::<HTMLElement>()
     }
 }
 

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -1467,14 +1467,7 @@ impl FormControl for HTMLElement {
             .set_form_owner(form);
     }
 
-    fn to_element(&self) -> &Element {
-        &self.element
+    fn to_html_element(&self) -> &HTMLElement {
+        self
     }
-
-    fn is_listed(&self) -> bool {
-        debug_assert!(self.is_form_associated_custom_element());
-        true
-    }
-
-    // TODO satisfies_constraints traits
 }

--- a/components/script/dom/html/htmlfieldsetelement.rs
+++ b/components/script/dom/html/htmlfieldsetelement.rs
@@ -265,8 +265,8 @@ impl FormControl for HTMLFieldSetElement {
         self.form_owner.set(form);
     }
 
-    fn to_element(&self) -> &Element {
-        self.upcast::<Element>()
+    fn to_html_element(&self) -> &HTMLElement {
+        self.upcast::<HTMLElement>()
     }
 }
 

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -1649,13 +1649,15 @@ impl FormSubmitterElement<'_> {
 
 pub(crate) trait FormControl: DomObject<ReflectorType = ()> + NodeTraits {
     fn form_owner(&self) -> Option<DomRoot<HTMLFormElement>>;
-
     fn set_form_owner(&self, form: Option<&HTMLFormElement>);
+    fn to_html_element(&self) -> &HTMLElement;
 
-    fn to_element(&self) -> &Element;
+    fn to_element(&self) -> &Element {
+        self.to_html_element().upcast::<Element>()
+    }
 
     fn is_listed(&self) -> bool {
-        true
+        self.to_html_element().is_listed_element()
     }
 
     // https://html.spec.whatwg.org/multipage/#create-an-element-for-the-token

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -2165,12 +2165,8 @@ impl FormControl for HTMLImageElement {
         self.form_owner.set(form);
     }
 
-    fn to_element(&self) -> &Element {
-        self.upcast::<Element>()
-    }
-
-    fn is_listed(&self) -> bool {
-        false
+    fn to_html_element(&self) -> &HTMLElement {
+        self.upcast::<HTMLElement>()
     }
 }
 

--- a/components/script/dom/html/htmllabelelement.rs
+++ b/components/script/dom/html/htmllabelelement.rs
@@ -196,7 +196,7 @@ impl FormControl for HTMLLabelElement {
         // form owner. Therefore it doesn't hold form owner itself.
     }
 
-    fn to_element(&self) -> &Element {
-        self.upcast::<Element>()
+    fn to_html_element(&self) -> &HTMLElement {
+        self.upcast::<HTMLElement>()
     }
 }

--- a/components/script/dom/html/htmllegendelement.rs
+++ b/components/script/dom/html/htmllegendelement.rs
@@ -105,7 +105,7 @@ impl FormControl for HTMLLegendElement {
         self.form_owner.set(form);
     }
 
-    fn to_element(&self) -> &Element {
-        self.upcast::<Element>()
+    fn to_html_element(&self) -> &HTMLElement {
+        self.upcast::<HTMLElement>()
     }
 }

--- a/components/script/dom/html/htmlobjectelement.rs
+++ b/components/script/dom/html/htmlobjectelement.rs
@@ -190,7 +190,7 @@ impl FormControl for HTMLObjectElement {
         self.form_owner.set(form);
     }
 
-    fn to_element(&self) -> &Element {
-        self.upcast::<Element>()
+    fn to_html_element(&self) -> &HTMLElement {
+        self.upcast::<HTMLElement>()
     }
 }

--- a/components/script/dom/html/htmloutputelement.rs
+++ b/components/script/dom/html/htmloutputelement.rs
@@ -183,8 +183,8 @@ impl FormControl for HTMLOutputElement {
         self.form_owner.set(form);
     }
 
-    fn to_element(&self) -> &Element {
-        self.upcast::<Element>()
+    fn to_html_element(&self) -> &HTMLElement {
+        self.upcast::<HTMLElement>()
     }
 }
 

--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -935,8 +935,8 @@ impl FormControl for HTMLSelectElement {
         self.form_owner.set(form);
     }
 
-    fn to_element(&self) -> &Element {
-        self.upcast::<Element>()
+    fn to_html_element(&self) -> &HTMLElement {
+        self.upcast::<HTMLElement>()
     }
 }
 

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -871,8 +871,8 @@ impl FormControl for HTMLTextAreaElement {
         self.form_owner.set(form);
     }
 
-    fn to_element(&self) -> &Element {
-        self.upcast::<Element>()
+    fn to_html_element(&self) -> &HTMLElement {
+        self.upcast::<HTMLElement>()
     }
 }
 

--- a/components/script/dom/html/input_element/mod.rs
+++ b/components/script/dom/html/input_element/mod.rs
@@ -2438,8 +2438,8 @@ impl FormControl for HTMLInputElement {
         self.form_owner.set(form);
     }
 
-    fn to_element(&self) -> &Element {
-        self.upcast::<Element>()
+    fn to_html_element(&self) -> &HTMLElement {
+        self.upcast::<HTMLElement>()
     }
 }
 

--- a/tests/wpt/tests/html/semantics/forms/the-label-element/move-label-into-form-and-then-move-form-into-ancestor-crash.html
+++ b/tests/wpt/tests/html/semantics/forms/the-label-element/move-label-into-form-and-then-move-form-into-ancestor-crash.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/45947">
+<select id="select" form="form">
+  <input form="form">
+  <data id="labelParent">
+      <label id="label" form="form"></label>
+  </data>
+  <form id="form"></form>
+</select>
+
+<script>
+    let newElement = document.createElement("div");
+    form.prepend(newElement);
+    newElement.appendChild(label);
+    select.prepend(form);
+</script>


### PR DESCRIPTION
There were two versions of this check: `FormControl::is_listed()` and
`HTMLElement::is_element_listed()`. The latter was incomplete and
incorrect. Both were used inconsistently. This led to non-specification
aligned behavior when moving form-associated elements in the page,
ultimately leading to a panic. This change fixes that issue by making
`FormControl::is_listed()` rely on `HTMLElement::is_element_listed()`,
matching the specification more closely.

Testing: This change adds a WPT crash test, though the crash only reproduces inconsistently.
Fixes: #45947.
