### PR TITLE
deny: Bypass `RUSTSEC-2026-0192` unmaintained `ttf-parser`

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -31,6 +31,10 @@ ignore = [
     # The crate `bincode` is unmaintained. This crate is now pinned in Servo.
     # See the comment above `bincode` entry in Cargo.toml.
     "RUSTSEC-2025-0141",
+    # The crate `ttf-parser` is unmaintained.
+    # This is a dependency of `usvg`, `rustybuzz`, `fontdb`.
+    # We will need to wait for upstream actions.
+    "RUSTSEC-2026-0192",
 ]
 
 # This section is considered when running `cargo deny check licenses`


### PR DESCRIPTION
This is to bypass CI. `ttf-parser` is a dependency of `usvg`, `rustybuzz`, `fontdb`.