### PR TITLE
release: Bump version to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5016,7 +5016,7 @@ dependencies = [
 
 [[package]]
 name = "malloc_size_of_tests"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "servo-malloc-size-of",
  "servo_arc",
@@ -6670,7 +6670,7 @@ dependencies = [
 
 [[package]]
 name = "profile_tests"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "ipc-channel",
  "servo-config",
@@ -7353,7 +7353,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "script_tests"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "encoding_rs",
  "euclid",
@@ -7605,7 +7605,7 @@ dependencies = [
 
 [[package]]
 name = "servo"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -7684,7 +7684,7 @@ dependencies = [
 
 [[package]]
 name = "servo-allocator"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "backtrace",
  "libc",
@@ -7697,7 +7697,7 @@ dependencies = [
 
 [[package]]
 name = "servo-background-hang-monitor"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "backtrace",
  "crossbeam-channel",
@@ -7714,7 +7714,7 @@ dependencies = [
 
 [[package]]
 name = "servo-background-hang-monitor-api"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "servo-base",
@@ -7722,7 +7722,7 @@ dependencies = [
 
 [[package]]
 name = "servo-base"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "accesskit",
  "crossbeam-channel",
@@ -7746,7 +7746,7 @@ dependencies = [
 
 [[package]]
 name = "servo-bluetooth"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bitflags 2.13.0",
  "blurmock",
@@ -7764,7 +7764,7 @@ dependencies = [
 
 [[package]]
 name = "servo-bluetooth-traits"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "regex",
  "serde",
@@ -7774,7 +7774,7 @@ dependencies = [
 
 [[package]]
 name = "servo-canvas"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bytemuck",
  "crossbeam-channel",
@@ -7802,7 +7802,7 @@ dependencies = [
 
 [[package]]
 name = "servo-canvas-traits"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "crossbeam-channel",
  "euclid",
@@ -7823,7 +7823,7 @@ dependencies = [
 
 [[package]]
 name = "servo-capi"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "dpi",
  "libc",
@@ -7834,14 +7834,14 @@ dependencies = [
 
 [[package]]
 name = "servo-capi-tests"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "servo-config"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "num_enum",
  "serde",
@@ -7853,7 +7853,7 @@ dependencies = [
 
 [[package]]
 name = "servo-config-macro"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7863,7 +7863,7 @@ dependencies = [
 
 [[package]]
 name = "servo-constellation"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "accesskit",
  "backtrace",
@@ -7910,7 +7910,7 @@ dependencies = [
 
 [[package]]
 name = "servo-constellation-traits"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "content-security-policy",
@@ -7946,14 +7946,14 @@ dependencies = [
 
 [[package]]
 name = "servo-default-resources"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "servo-embedder-traits",
 ]
 
 [[package]]
 name = "servo-deny-public-fields"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -7962,7 +7962,7 @@ dependencies = [
 
 [[package]]
 name = "servo-devtools"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "atomic_refcell",
  "base64",
@@ -7991,7 +7991,7 @@ dependencies = [
 
 [[package]]
 name = "servo-devtools-traits"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "http 1.4.2",
  "malloc_size_of_derive",
@@ -8007,7 +8007,7 @@ dependencies = [
 
 [[package]]
 name = "servo-dom-struct"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -8017,7 +8017,7 @@ dependencies = [
 
 [[package]]
 name = "servo-embedder-traits"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "accesskit",
  "bitflags 2.13.0",
@@ -8050,7 +8050,7 @@ dependencies = [
 
 [[package]]
 name = "servo-fonts"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "app_units",
  "bitflags 2.13.0",
@@ -8107,7 +8107,7 @@ dependencies = [
 
 [[package]]
 name = "servo-fonts-traits"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "atomic_refcell",
  "dwrote",
@@ -8130,7 +8130,7 @@ dependencies = [
 
 [[package]]
 name = "servo-geometry"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "app_units",
  "euclid",
@@ -8142,7 +8142,7 @@ dependencies = [
 
 [[package]]
 name = "servo-hyper-serde"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "cookie 0.18.1",
  "headers",
@@ -8159,7 +8159,7 @@ dependencies = [
 
 [[package]]
 name = "servo-jstraceable-derive"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -8168,7 +8168,7 @@ dependencies = [
 
 [[package]]
 name = "servo-layout"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "accesskit",
  "app_units",
@@ -8226,7 +8226,7 @@ dependencies = [
 
 [[package]]
 name = "servo-layout-api"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "app_units",
  "atomic_refcell",
@@ -8258,7 +8258,7 @@ dependencies = [
 
 [[package]]
 name = "servo-malloc-size-of"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "app_units",
  "atomic_refcell",
@@ -8300,7 +8300,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "servo-base",
  "servo-media-audio",
@@ -8312,7 +8312,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-audio"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "byte-slice-cast",
  "euclid",
@@ -8334,7 +8334,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-auto"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "servo-media-dummy",
  "servo-media-gstreamer",
@@ -8342,7 +8342,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-derive"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8351,7 +8351,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-dummy"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "servo-base",
  "servo-media",
@@ -8364,7 +8364,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-examples"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "euclid",
  "rand 0.10.1",
@@ -8376,7 +8376,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-gstreamer"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "byte-slice-cast",
  "glib",
@@ -8407,7 +8407,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-gstreamer-render"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "gstreamer",
  "servo-media-player",
@@ -8415,7 +8415,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-gstreamer-render-android"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "glib",
  "gstreamer",
@@ -8428,7 +8428,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-gstreamer-render-unix"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "glib",
  "gstreamer",
@@ -8443,7 +8443,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-ohos"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "crossbeam-channel",
  "libc",
@@ -8465,7 +8465,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-player"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "malloc_size_of_derive",
  "serde",
@@ -8477,7 +8477,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-streams"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "malloc_size_of_derive",
  "servo-malloc-size-of",
@@ -8486,7 +8486,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-thread"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "euclid",
  "ipc-channel",
@@ -8504,7 +8504,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-traits"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "malloc_size_of_derive",
  "servo-malloc-size-of",
@@ -8512,7 +8512,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-webrtc"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "log",
  "servo-media-streams",
@@ -8521,7 +8521,7 @@ dependencies = [
 
 [[package]]
 name = "servo-metrics"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "malloc_size_of_derive",
  "servo-base",
@@ -8535,7 +8535,7 @@ dependencies = [
 
 [[package]]
 name = "servo-net"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-compression",
  "async-recursion",
@@ -8608,7 +8608,7 @@ dependencies = [
 
 [[package]]
 name = "servo-net-traits"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "content-security-policy",
  "cookie 0.18.1",
@@ -8648,7 +8648,7 @@ dependencies = [
 
 [[package]]
 name = "servo-paint"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bitflags 2.13.0",
  "crossbeam-channel",
@@ -8688,7 +8688,7 @@ dependencies = [
 
 [[package]]
 name = "servo-paint-api"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bitflags 2.13.0",
  "crossbeam-channel",
@@ -8723,7 +8723,7 @@ dependencies = [
 
 [[package]]
 name = "servo-pixels"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "criterion",
  "euclid",
@@ -8738,7 +8738,7 @@ dependencies = [
 
 [[package]]
 name = "servo-profile"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "libc",
  "log",
@@ -8755,7 +8755,7 @@ dependencies = [
 
 [[package]]
 name = "servo-profile-traits"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "crossbeam-channel",
  "ipc-channel",
@@ -8771,7 +8771,7 @@ dependencies = [
 
 [[package]]
 name = "servo-script"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -8914,7 +8914,7 @@ dependencies = [
 
 [[package]]
 name = "servo-script-bindings"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bitflags 2.13.0",
  "crossbeam-channel",
@@ -8954,7 +8954,7 @@ dependencies = [
 
 [[package]]
 name = "servo-script-traits"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "accesskit",
  "crossbeam-channel",
@@ -8989,7 +8989,7 @@ dependencies = [
 
 [[package]]
 name = "servo-storage"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "libc",
  "log",
@@ -9016,7 +9016,7 @@ dependencies = [
 
 [[package]]
 name = "servo-storage-traits"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "malloc_size_of_derive",
  "serde",
@@ -9029,7 +9029,7 @@ dependencies = [
 
 [[package]]
 name = "servo-timers"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "crossbeam-channel",
  "malloc_size_of_derive",
@@ -9038,7 +9038,7 @@ dependencies = [
 
 [[package]]
 name = "servo-tracing"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -9048,7 +9048,7 @@ dependencies = [
 
 [[package]]
 name = "servo-url"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "encoding_rs",
  "malloc_size_of_derive",
@@ -9061,7 +9061,7 @@ dependencies = [
 
 [[package]]
 name = "servo-wakelock"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "servo-embedder-traits",
@@ -9069,7 +9069,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webdriver-server"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "bytes",
@@ -9100,7 +9100,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webgl"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bitflags 2.13.0",
  "byteorder",
@@ -9125,7 +9125,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webgpu"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "arrayvec",
  "euclid",
@@ -9143,7 +9143,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webgpu-traits"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "arrayvec",
  "malloc_size_of_derive",
@@ -9158,7 +9158,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webxr"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "crossbeam-channel",
  "euclid",
@@ -9176,7 +9176,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webxr-api"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "euclid",
  "ipc-channel",
@@ -9191,7 +9191,7 @@ dependencies = [
 
 [[package]]
 name = "servo-xpath"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "log",
  "malloc_size_of_derive",
@@ -9210,7 +9210,7 @@ dependencies = [
 
 [[package]]
 name = "servoshell"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "accesskit",
  "android_logger",
@@ -9654,7 +9654,7 @@ dependencies = [
 
 [[package]]
 name = "style_tests"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "app_units",
  "cssparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ default-members = ["ports/servoshell"]
 exclude = [".cargo", "support/crown"]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 authors = ["The Servo Project Developers"]
 repository = "https://github.com/servo/servo"
 # A generic description for packages that don't have a meaningful description yet.
@@ -297,72 +297,72 @@ zeroize = "1.8"
 # be listed here, between the `Begin` and `End` comments, so that we can easily find and
 # update the version requirements when bumping the workspace version.
 # Begin workspace-version dependencies - Don't change this comment, we grep for it in scripts!
-deny_public_fields = { package = "servo-deny-public-fields", version = "=0.3.0", path = "components/deny_public_fields" }
-devtools = { package = "servo-devtools", version = "=0.3.0", path = "components/devtools" }
-devtools_traits = { package = "servo-devtools-traits", version = "=0.3.0", path = "components/shared/devtools" }
-dom_struct = { package = "servo-dom-struct", version = "=0.3.0", path = "components/dom_struct" }
-embedder_traits = { package = "servo-embedder-traits", version = "=0.3.0", path = "components/shared/embedder" }
-fonts = { package = "servo-fonts", version = "=0.3.0", path = "components/fonts" }
-fonts_traits = { package = "servo-fonts-traits", version = "=0.3.0", path = "components/shared/fonts" }
-hyper_serde = { package = "servo-hyper-serde", version = "=0.3.0", path = "components/hyper_serde" }
-jstraceable_derive = { package = "servo-jstraceable-derive", version = "=0.3.0", path = "components/jstraceable_derive" }
-layout = { package = "servo-layout", version = "=0.3.0", path = "components/layout" }
-layout_api = { package = "servo-layout-api", version = "=0.3.0", path = "components/shared/layout" }
-malloc_size_of = { package = "servo-malloc-size-of", version = "=0.3.0", path = "components/malloc_size_of" }
-media = { package = "servo-media-thread", version = "=0.3.0", path = "components/media/media-thread" }
-metrics = { package = "servo-metrics", version = "=0.3.0", path = "components/metrics" }
-net = { package = "servo-net", version = "=0.3.0", path = "components/net" }
-net_traits = { package = "servo-net-traits", version = "=0.3.0", path = "components/shared/net" }
-paint = { package = "servo-paint", version = "=0.3.0", path = "components/paint" }
-paint_api = { package = "servo-paint-api", version = "=0.3.0", path = "components/shared/paint" }
-pixels = { package = "servo-pixels", version = "=0.3.0", path = "components/pixels" }
-profile = { package = "servo-profile", version = "=0.3.0", path = "components/profile" }
-profile_traits = { package = "servo-profile-traits", version = "=0.3.0", path = "components/shared/profile" }
-script = { package = "servo-script", version = "=0.3.0", path = "components/script" }
-script_bindings = { package = "servo-script-bindings", version = "=0.3.0", path = "components/script_bindings" }
-script_traits = { package = "servo-script-traits", version = "=0.3.0", path = "components/shared/script" }
-servo = { version = "=0.3.0", path = "components/servo", default-features = false }
-servo-allocator = { version = "=0.3.0", path = "components/allocator" }
-servo-background-hang-monitor = { version = "=0.3.0", path = "components/background_hang_monitor" }
-servo-background-hang-monitor-api = { version = "=0.3.0", path = "components/shared/background_hang_monitor" }
-servo-base = { version = "=0.3.0", path = "components/shared/base" }
-servo-bluetooth = { version = "=0.3.0", path = "components/bluetooth" }
-servo-bluetooth-traits = { version = "=0.3.0", path = "components/shared/bluetooth" }
-servo-canvas = { version = "=0.3.0", path = "components/canvas" }
-servo-canvas-traits = { version = "=0.3.0", path = "components/shared/canvas" }
-servo-config = { version = "=0.3.0", path = "components/config" }
-servo-config-macro = { version = "=0.3.0", path = "components/config/macro" }
-servo-constellation = { version = "=0.3.0", path = "components/constellation" }
-servo-constellation-traits = { version = "=0.3.0", path = "components/shared/constellation" }
-servo-default-resources = { version = "=0.3.0", path = "components/default-resources" }
-servo-geometry = { version = "=0.3.0", path = "components/geometry" }
-servo-media = { version = "=0.3.0", path = "components/media/servo-media" }
-servo-media-audio = { version = "=0.3.0", path = "components/media/audio" }
-servo-media-auto = { version = "=0.3.0", path = "components/media/backends/auto" }
-servo-media-derive = { version = "=0.3.0", path = "components/media/servo-media-derive" }
-servo-media-dummy = { version = "=0.3.0", path = "components/media/backends/dummy" }
-servo-media-gstreamer = { version = "=0.3.0", path = "components/media/backends/gstreamer" }
-servo-media-gstreamer-render = { version = "=0.3.0", path = "components/media/backends/gstreamer/render" }
-servo-media-gstreamer-render-android = { version = "=0.3.0", path = "components/media/backends/gstreamer/render-android" }
-servo-media-gstreamer-render-unix = { version = "=0.3.0", path = "components/media/backends/gstreamer/render-unix" }
-servo-media-ohos = { version = "=0.3.0", path = "components/media/backends/ohos" }
-servo-media-player = { version = "=0.3.0", path = "components/media/player" }
-servo-media-streams = { version = "=0.3.0", path = "components/media/streams" }
-servo-media-traits = { version = "=0.3.0", path = "components/media/traits" }
-servo-media-webrtc = { version = "=0.3.0", path = "components/media/webrtc" }
-servo-tracing = { version = "=0.3.0", path = "components/servo_tracing" }
-servo-url = { version = "=0.3.0", path = "components/url" }
-servo-wakelock = { version = "=0.3.0", path = "components/wakelock" }
-storage = { package = "servo-storage", version = "=0.3.0", path = "components/storage" }
-storage_traits = { package = "servo-storage-traits", version = "=0.3.0", path = "components/shared/storage" }
-timers = { package = "servo-timers", version = "=0.3.0", path = "components/timers" }
-webdriver_server = { package = "servo-webdriver-server", version = "=0.3.0", path = "components/webdriver_server" }
-webgl = { package = "servo-webgl", version = "=0.3.0", path = "components/webgl", default-features = false }
-webgpu = { package = "servo-webgpu", version = "=0.3.0", path = "components/webgpu" }
-webgpu_traits = { package = "servo-webgpu-traits", version = "=0.3.0", path = "components/shared/webgpu" }
-webxr = { package = "servo-webxr", version = "=0.3.0", path = "components/webxr" }
-webxr-api = { package = "servo-webxr-api", version = "=0.3.0", path = "components/shared/webxr" }
-xpath = { package = "servo-xpath", version = "=0.3.0", path = "components/xpath" }
+deny_public_fields = { package = "servo-deny-public-fields", version = "=0.4.0", path = "components/deny_public_fields" }
+devtools = { package = "servo-devtools", version = "=0.4.0", path = "components/devtools" }
+devtools_traits = { package = "servo-devtools-traits", version = "=0.4.0", path = "components/shared/devtools" }
+dom_struct = { package = "servo-dom-struct", version = "=0.4.0", path = "components/dom_struct" }
+embedder_traits = { package = "servo-embedder-traits", version = "=0.4.0", path = "components/shared/embedder" }
+fonts = { package = "servo-fonts", version = "=0.4.0", path = "components/fonts" }
+fonts_traits = { package = "servo-fonts-traits", version = "=0.4.0", path = "components/shared/fonts" }
+hyper_serde = { package = "servo-hyper-serde", version = "=0.4.0", path = "components/hyper_serde" }
+jstraceable_derive = { package = "servo-jstraceable-derive", version = "=0.4.0", path = "components/jstraceable_derive" }
+layout = { package = "servo-layout", version = "=0.4.0", path = "components/layout" }
+layout_api = { package = "servo-layout-api", version = "=0.4.0", path = "components/shared/layout" }
+malloc_size_of = { package = "servo-malloc-size-of", version = "=0.4.0", path = "components/malloc_size_of" }
+media = { package = "servo-media-thread", version = "=0.4.0", path = "components/media/media-thread" }
+metrics = { package = "servo-metrics", version = "=0.4.0", path = "components/metrics" }
+net = { package = "servo-net", version = "=0.4.0", path = "components/net" }
+net_traits = { package = "servo-net-traits", version = "=0.4.0", path = "components/shared/net" }
+paint = { package = "servo-paint", version = "=0.4.0", path = "components/paint" }
+paint_api = { package = "servo-paint-api", version = "=0.4.0", path = "components/shared/paint" }
+pixels = { package = "servo-pixels", version = "=0.4.0", path = "components/pixels" }
+profile = { package = "servo-profile", version = "=0.4.0", path = "components/profile" }
+profile_traits = { package = "servo-profile-traits", version = "=0.4.0", path = "components/shared/profile" }
+script = { package = "servo-script", version = "=0.4.0", path = "components/script" }
+script_bindings = { package = "servo-script-bindings", version = "=0.4.0", path = "components/script_bindings" }
+script_traits = { package = "servo-script-traits", version = "=0.4.0", path = "components/shared/script" }
+servo = { version = "=0.4.0", path = "components/servo", default-features = false }
+servo-allocator = { version = "=0.4.0", path = "components/allocator" }
+servo-background-hang-monitor = { version = "=0.4.0", path = "components/background_hang_monitor" }
+servo-background-hang-monitor-api = { version = "=0.4.0", path = "components/shared/background_hang_monitor" }
+servo-base = { version = "=0.4.0", path = "components/shared/base" }
+servo-bluetooth = { version = "=0.4.0", path = "components/bluetooth" }
+servo-bluetooth-traits = { version = "=0.4.0", path = "components/shared/bluetooth" }
+servo-canvas = { version = "=0.4.0", path = "components/canvas" }
+servo-canvas-traits = { version = "=0.4.0", path = "components/shared/canvas" }
+servo-config = { version = "=0.4.0", path = "components/config" }
+servo-config-macro = { version = "=0.4.0", path = "components/config/macro" }
+servo-constellation = { version = "=0.4.0", path = "components/constellation" }
+servo-constellation-traits = { version = "=0.4.0", path = "components/shared/constellation" }
+servo-default-resources = { version = "=0.4.0", path = "components/default-resources" }
+servo-geometry = { version = "=0.4.0", path = "components/geometry" }
+servo-media = { version = "=0.4.0", path = "components/media/servo-media" }
+servo-media-audio = { version = "=0.4.0", path = "components/media/audio" }
+servo-media-auto = { version = "=0.4.0", path = "components/media/backends/auto" }
+servo-media-derive = { version = "=0.4.0", path = "components/media/servo-media-derive" }
+servo-media-dummy = { version = "=0.4.0", path = "components/media/backends/dummy" }
+servo-media-gstreamer = { version = "=0.4.0", path = "components/media/backends/gstreamer" }
+servo-media-gstreamer-render = { version = "=0.4.0", path = "components/media/backends/gstreamer/render" }
+servo-media-gstreamer-render-android = { version = "=0.4.0", path = "components/media/backends/gstreamer/render-android" }
+servo-media-gstreamer-render-unix = { version = "=0.4.0", path = "components/media/backends/gstreamer/render-unix" }
+servo-media-ohos = { version = "=0.4.0", path = "components/media/backends/ohos" }
+servo-media-player = { version = "=0.4.0", path = "components/media/player" }
+servo-media-streams = { version = "=0.4.0", path = "components/media/streams" }
+servo-media-traits = { version = "=0.4.0", path = "components/media/traits" }
+servo-media-webrtc = { version = "=0.4.0", path = "components/media/webrtc" }
+servo-tracing = { version = "=0.4.0", path = "components/servo_tracing" }
+servo-url = { version = "=0.4.0", path = "components/url" }
+servo-wakelock = { version = "=0.4.0", path = "components/wakelock" }
+storage = { package = "servo-storage", version = "=0.4.0", path = "components/storage" }
+storage_traits = { package = "servo-storage-traits", version = "=0.4.0", path = "components/shared/storage" }
+timers = { package = "servo-timers", version = "=0.4.0", path = "components/timers" }
+webdriver_server = { package = "servo-webdriver-server", version = "=0.4.0", path = "components/webdriver_server" }
+webgl = { package = "servo-webgl", version = "=0.4.0", path = "components/webgl", default-features = false }
+webgpu = { package = "servo-webgpu", version = "=0.4.0", path = "components/webgpu" }
+webgpu_traits = { package = "servo-webgpu-traits", version = "=0.4.0", path = "components/shared/webgpu" }
+webxr = { package = "servo-webxr", version = "=0.4.0", path = "components/webxr" }
+webxr-api = { package = "servo-webxr-api", version = "=0.4.0", path = "components/shared/webxr" }
+xpath = { package = "servo-xpath", version = "=0.4.0", path = "components/xpath" }
 # End workspace-version dependencies - Don't change this comment, we grep for it in scripts!
 
 # RSA key generation could be very slow without compilation

--- a/ports/servoshell/platform/macos/Info.plist
+++ b/ports/servoshell/platform/macos/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.0</string>
+	<string>0.4.0</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>NSPrincipalClass</key>

--- a/ports/servoshell/platform/windows/servoshell.exe.manifest
+++ b/ports/servoshell/platform/windows/servoshell.exe.manifest
@@ -4,7 +4,7 @@
           xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
   <assemblyIdentity type="win32"
                     name="servo.ServoShell"
-                    version="0.3.0.0"/>
+                    version="0.4.0.0"/>
 
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>

--- a/resources/resource_protocol/license.html
+++ b/resources/resource_protocol/license.html
@@ -1122,6 +1122,8 @@
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/psychon/as-raw-xcb-connection ">as-raw-xcb-connection 1.0.1</a></li>
                         <li><a href=" https://github.com/hsivonen/chardetng ">chardetng 0.1.17</a></li>
+                        <li><a href=" https://github.com/RustCrypto/utils ">cmov 0.5.4</a></li>
+                        <li><a href=" https://github.com/RustCrypto/utils ">ctutils 0.4.2</a></li>
                         <li><a href=" https://github.com/hsivonen/encoding_c ">encoding_c 0.9.8</a></li>
                         <li><a href=" https://github.com/hsivonen/encoding_c_mem ">encoding_c_mem 0.2.6</a></li>
                         <li><a href=" https://github.com/hsivonen/encoding_rs ">encoding_rs 0.8.35</a></li>
@@ -1137,8 +1139,8 @@
                         <li><a href=" https://github.com/hsivonen/write16 ">write16 1.0.0</a></li>
                         <li><a href=" https://github.com/psychon/x11rb ">x11rb-protocol 0.13.2</a></li>
                         <li><a href=" https://github.com/psychon/x11rb ">x11rb 0.13.2</a></li>
-                        <li><a href=" https://github.com/RustCrypto/utils ">zeroize 1.8.2</a></li>
-                        <li><a href=" https://github.com/RustCrypto/utils/tree/master/zeroize/derive ">zeroize_derive 1.4.3</a></li>
+                        <li><a href=" https://github.com/RustCrypto/utils ">zeroize 1.9.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/utils ">zeroize_derive 1.5.0</a></li>
                     </ul>
                 <pre class="license-text">
                                  Apache License
@@ -1348,7 +1350,7 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/bytecodealliance/target-lexicon ">target-lexicon 0.13.3</a>
+                            <a href=" https://github.com/bytecodealliance/target-lexicon ">target-lexicon 0.13.5</a>
                     </p>
                 <pre class="license-text">
                                  Apache License
@@ -2655,8 +2657,8 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/google/zerocopy ">zerocopy-derive 0.8.49</a></li>
-                        <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.8.49</a></li>
+                        <li><a href=" https://github.com/google/zerocopy ">zerocopy-derive 0.8.52</a></li>
+                        <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.8.52</a></li>
                     </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -3285,7 +3287,7 @@ Software.
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/awxkee/moxcms.git ">moxcms 0.8.1</a></li>
                         <li><a href=" https://github.com/awxkee/pxfm ">pxfm 0.1.29</a></li>
-                        <li><a href=" https://github.com/awxkee/yuvutils-rs ">yuv 0.8.14</a></li>
+                        <li><a href=" https://github.com/awxkee/yuvutils-rs ">yuv 0.8.16</a></li>
                     </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -3499,7 +3501,8 @@ Software.
                         <li><a href=" https://github.com/enarx/ciborium ">ciborium-ll 0.2.2</a></li>
                         <li><a href=" https://github.com/enarx/ciborium ">ciborium 0.2.2</a></li>
                         <li><a href=" https://github.com/brendanzab/codespan ">codespan-reporting 0.13.1</a></li>
-                        <li><a href=" https://github.com/kornelski/imgref ">imgref 1.12.1</a></li>
+                        <li><a href=" https://github.com/entropyxyz/crypto-primes ">crypto-primes 0.7.2</a></li>
+                        <li><a href=" https://github.com/kornelski/imgref ">imgref 1.12.2</a></li>
                         <li><a href=" https://github.com/rustls/rustls-platform-verifier ">rustls-platform-verifier 0.7.0</a></li>
                         <li><a href=" https://github.com/Voultapher/self_cell ">self_cell 1.2.2</a></li>
                         <li><a href=" https://github.com/1Password/sys-locale ">sys-locale 0.3.2</a></li>
@@ -4164,7 +4167,7 @@ Software.
                         <li><a href=" https://github.com/toml-rs/toml ">serde_spanned 1.1.1</a></li>
                         <li><a href=" https://github.com/toml-rs/toml ">toml 1.1.2+spec-1.1.0</a></li>
                         <li><a href=" https://github.com/toml-rs/toml ">toml_datetime 1.1.1+spec-1.1.0</a></li>
-                        <li><a href=" https://github.com/toml-rs/toml ">toml_edit 0.25.11+spec-1.1.0</a></li>
+                        <li><a href=" https://github.com/toml-rs/toml ">toml_edit 0.25.12+spec-1.1.0</a></li>
                         <li><a href=" https://github.com/toml-rs/toml ">toml_parser 1.1.2+spec-1.1.0</a></li>
                         <li><a href=" https://github.com/toml-rs/toml ">toml_writer 1.1.1+spec-1.1.0</a></li>
                         <li><a href=" https://github.com/gifnksm/topological-sort-rs ">topological-sort 0.1.0</a></li>
@@ -4794,7 +4797,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/paholg/typenum ">typenum 1.20.0</a>
+                            <a href=" https://github.com/paholg/typenum ">typenum 1.20.1</a>
                     </p>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -5214,7 +5217,7 @@ limitations under the License.
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/hyperium/http ">http 0.2.12</a></li>
-                        <li><a href=" https://github.com/hyperium/http ">http 1.4.1</a></li>
+                        <li><a href=" https://github.com/hyperium/http ">http 1.4.2</a></li>
                     </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -5632,8 +5635,9 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/RustCrypto/signatures/tree/master/ecdsa ">ecdsa 0.16.9</a></li>
-                        <li><a href=" https://github.com/RustCrypto/signatures/tree/master/rfc6979 ">rfc6979 0.4.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/signatures ">ecdsa 0.17.0-rc.22</a></li>
+                        <li><a href=" https://github.com/RustCrypto/signatures ">ed25519 3.0.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/signatures ">rfc6979 0.6.0-pre.0</a></li>
                     </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -6890,7 +6894,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/RustCrypto/signatures ">ml-dsa 0.0.4</a>
+                            <a href=" https://github.com/RustCrypto/signatures ">ml-dsa 0.1.1</a>
                     </p>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -7098,7 +7102,7 @@ limitations under the License.</pre>
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/RazrFalcon/memmap2-rs ">memmap2 0.9.10</a>
+                            <a href=" https://github.com/RazrFalcon/memmap2-rs ">memmap2 0.9.11</a>
                     </p>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -7311,7 +7315,7 @@ limitations under the License.
                         <li><a href=" https://github.com/image-rs/image-gif ">gif 0.14.2</a></li>
                         <li><a href=" https://github.com/rust-windowing/keyboard-types ">keyboard-types 0.8.3</a></li>
                         <li><a href=" https://github.com/Elzair/page_size_rs ">page_size 0.6.0</a></li>
-                        <li><a href=" https://github.com/RustCrypto/RSA ">rsa 0.9.10</a></li>
+                        <li><a href=" https://github.com/RustCrypto/RSA ">rsa 0.10.0-rc.18</a></li>
                         <li><a href=" https://github.com/SeaQL/sea-query ">sea-query 1.0.0-rc.31</a></li>
                         <li><a href=" https://github.com/image-rs/weezl ">weezl 0.1.12</a></li>
                     </ul>
@@ -7522,14 +7526,14 @@ limitations under the License.</pre>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/servo/stylo ">servo_arc 0.4.3</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_malloc_size_of 0.17.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-malloc-size-of 0.3.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_malloc_size_of 0.18.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-malloc-size-of 0.4.0</a></li>
                         <li><a href=" https://github.com/gimli-rs/addr2line ">addr2line 0.25.1</a></li>
                         <li><a href=" https://github.com/tkaitchuck/ahash ">ahash 0.8.12</a></li>
                         <li><a href=" https://github.com/rust-embedded-community/aligned ">aligned 0.4.3</a></li>
                         <li><a href=" https://github.com/rust-fuzz/arbitrary/ ">arbitrary 1.4.2</a></li>
                         <li><a href=" https://github.com/vorner/arc-swap ">arc-swap 1.9.1</a></li>
-                        <li><a href=" https://github.com/bluss/arrayvec ">arrayvec 0.7.6</a></li>
+                        <li><a href=" https://github.com/bluss/arrayvec ">arrayvec 0.7.7</a></li>
                         <li><a href=" https://github.com/japaric/as-slice ">as-slice 0.2.1</a></li>
                         <li><a href=" https://github.com/smol-rs/async-channel ">async-channel 2.5.0</a></li>
                         <li><a href=" https://github.com/Nullus157/async-compression ">async-compression 0.4.42</a></li>
@@ -7544,7 +7548,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/rust-lang/backtrace-rs ">backtrace 0.3.76</a></li>
                         <li><a href=" https://github.com/marshallpierce/rust-base64 ">base64 0.22.1</a></li>
                         <li><a href=" https://github.com/bitflags/bitflags ">bitflags 1.3.2</a></li>
-                        <li><a href=" https://github.com/bitflags/bitflags ">bitflags 2.11.1</a></li>
+                        <li><a href=" https://github.com/bitflags/bitflags ">bitflags 2.13.0</a></li>
                         <li><a href=" https://github.com/tuffy/bitstream-io ">bitstream-io 4.10.0</a></li>
                         <li><a href=" https://github.com/smol-rs/blocking ">blocking 1.6.2</a></li>
                         <li><a href=" https://github.com/pacak/bpaf ">bpaf 0.9.26</a></li>
@@ -7595,7 +7599,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/gimli-rs/gimli ">gimli 0.32.3</a></li>
                         <li><a href=" https://github.com/servo/gleam ">gleam 0.15.1</a></li>
                         <li><a href=" https://github.com/rust-lang/glob ">glob 0.3.3</a></li>
-                        <li><a href=" https://github.com/zkcrypto/group ">group 0.13.0</a></li>
+                        <li><a href=" https://github.com/zkcrypto/group ">group 0.14.0</a></li>
                         <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-app 0.25.0</a></li>
                         <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-audio 0.25.0</a></li>
                         <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-base 0.25.0</a></li>
@@ -7621,25 +7625,24 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/servo/ipc-channel ">ipc-channel 0.22.0</a></li>
                         <li><a href=" https://github.com/rust-itertools/itertools ">itertools 0.13.0</a></li>
                         <li><a href=" https://github.com/rust-itertools/itertools ">itertools 0.14.0</a></li>
+                        <li><a href=" https://github.com/rust-itertools/itertools ">itertools 0.15.0</a></li>
                         <li><a href=" https://github.com/rust-lang/jobserver-rs ">jobserver 0.1.34</a></li>
                         <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys ">js-sys 0.3.94</a></li>
                         <li><a href=" https://github.com/timothee-haudebourg/khronos-egl ">khronos-egl 6.0.0</a></li>
                         <li><a href=" https://github.com/rust-lang-nursery/lazy-static.rs ">lazy_static 1.5.0</a></li>
-                        <li><a href=" https://github.com/rust-fuzz/libfuzzer ">libfuzzer-sys 0.4.12</a></li>
-                        <li><a href=" https://github.com/rust-lang/libz-sys ">libz-sys 1.1.28</a></li>
+                        <li><a href=" https://github.com/rust-fuzz/libfuzzer ">libfuzzer-sys 0.4.13</a></li>
+                        <li><a href=" https://github.com/rust-lang/libz-sys ">libz-sys 1.1.29</a></li>
                         <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys 0.12.1</a></li>
                         <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys 0.4.15</a></li>
                         <li><a href=" https://github.com/Amanieu/parking_lot ">lock_api 0.4.14</a></li>
-                        <li><a href=" https://github.com/rust-lang/log ">log 0.4.30</a></li>
+                        <li><a href=" https://github.com/rust-lang/log ">log 0.4.33</a></li>
                         <li><a href=" https://github.com/bholley/malloc_size_of_derive ">malloc_size_of_derive 0.1.3</a></li>
                         <li><a href=" https://github.com/servo/html5ever ">markup5ever 0.39.0</a></li>
                         <li><a href=" https://github.com/hyperium/mime ">mime 0.3.17</a></li>
-                        <li><a href=" https://github.com/dignifiedquire/num-bigint ">num-bigint-dig 0.8.6</a></li>
                         <li><a href=" https://github.com/rust-num/num-bigint ">num-bigint 0.4.6</a></li>
                         <li><a href=" https://github.com/rust-num/num-complex ">num-complex 0.4.6</a></li>
                         <li><a href=" https://github.com/rust-num/num-derive ">num-derive 0.4.2</a></li>
                         <li><a href=" https://github.com/rust-num/num-integer ">num-integer 0.1.46</a></li>
-                        <li><a href=" https://github.com/rust-num/num-iter ">num-iter 0.1.45</a></li>
                         <li><a href=" https://github.com/rust-num/num-rational ">num-rational 0.4.2</a></li>
                         <li><a href=" https://github.com/rust-num/num-traits ">num-traits 0.2.19</a></li>
                         <li><a href=" https://github.com/seanmonstar/num_cpus ">num_cpus 1.17.0</a></li>
@@ -7664,9 +7667,9 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/rayon-rs/rayon ">rayon-core 1.13.0</a></li>
                         <li><a href=" https://github.com/rayon-rs/rayon ">rayon 1.12.0</a></li>
                         <li><a href=" https://github.com/rust-lang/regex ">regex-automata 0.4.13</a></li>
-                        <li><a href=" https://github.com/rust-lang/regex ">regex-syntax 0.8.10</a></li>
-                        <li><a href=" https://github.com/rust-lang/regex ">regex 1.12.3</a></li>
-                        <li><a href=" https://github.com/ron-rs/ron ">ron 0.10.1</a></li>
+                        <li><a href=" https://github.com/rust-lang/regex ">regex-syntax 0.8.11</a></li>
+                        <li><a href=" https://github.com/rust-lang/regex ">regex 1.12.4</a></li>
+                        <li><a href=" https://github.com/ron-rs/ron ">ron 0.12.2</a></li>
                         <li><a href=" https://github.com/RazrFalcon/roxmltree ">roxmltree 0.20.0</a></li>
                         <li><a href=" https://github.com/RazrFalcon/roxmltree ">roxmltree 0.21.1</a></li>
                         <li><a href=" https://github.com/rust-lang/rustc-demangle ">rustc-demangle 0.1.27</a></li>
@@ -7674,8 +7677,8 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/djc/rustc-version-rs ">rustc_version 0.4.1</a></li>
                         <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 0.38.44</a></li>
                         <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 1.1.4</a></li>
-                        <li><a href=" https://github.com/rustls/rustls-native-certs ">rustls-native-certs 0.8.3</a></li>
-                        <li><a href=" https://github.com/rustls/rustls ">rustls 0.23.40</a></li>
+                        <li><a href=" https://github.com/rustls/rustls-native-certs ">rustls-native-certs 0.8.4</a></li>
+                        <li><a href=" https://github.com/rustls/rustls ">rustls 0.23.41</a></li>
                         <li><a href=" https://github.com/alexcrichton/scoped-tls ">scoped-tls 1.0.1</a></li>
                         <li><a href=" https://github.com/bluss/scopeguard ">scopeguard 1.2.0</a></li>
                         <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework-sys 2.17.0</a></li>
@@ -7684,13 +7687,13 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/seancroach/simd_cesu8 ">simd_cesu8 1.1.1</a></li>
                         <li><a href=" https://github.com/linebender/simplecss ">simplecss 0.2.2</a></li>
                         <li><a href=" https://github.com/servo/smallbitvec ">smallbitvec 2.6.1</a></li>
-                        <li><a href=" https://github.com/servo/rust-smallvec ">smallvec 1.15.1</a></li>
+                        <li><a href=" https://github.com/servo/rust-smallvec ">smallvec 1.15.2</a></li>
                         <li><a href=" https://github.com/rust-analyzer/smol_str ">smol_str 0.2.2</a></li>
-                        <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.6.3</a></li>
+                        <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.6.4</a></li>
                         <li><a href=" https://github.com/storyyeller/stable_deref_trait ">stable_deref_trait 1.2.1</a></li>
                         <li><a href=" https://github.com/servo/string-cache ">string_cache 0.9.0</a></li>
                         <li><a href=" https://github.com/servo/string-cache ">string_cache_codegen 0.6.1</a></li>
-                        <li><a href=" https://github.com/servo/surfman ">surfman 0.12.1</a></li>
+                        <li><a href=" https://github.com/servo/surfman ">surfman 0.13.0</a></li>
                         <li><a href=" https://github.com/linebender/svgtypes ">svgtypes 0.16.1</a></li>
                         <li><a href=" https://github.com/gdesmott/system-deps ">system-deps 7.0.8</a></li>
                         <li><a href=" https://github.com/composefs/tar-rs ">tar 0.4.46</a></li>
@@ -7706,11 +7709,11 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/servo/unicode-bidi ">unicode-bidi 0.3.18</a></li>
                         <li><a href=" https://github.com/RazrFalcon/unicode-ccc ">unicode-ccc 0.4.0</a></li>
                         <li><a href=" https://github.com/unicode-rs/unicode-properties ">unicode-properties 0.1.4</a></li>
-                        <li><a href=" https://github.com/unicode-rs/unicode-segmentation ">unicode-segmentation 1.13.2</a></li>
+                        <li><a href=" https://github.com/unicode-rs/unicode-segmentation ">unicode-segmentation 1.13.3</a></li>
                         <li><a href=" https://github.com/RazrFalcon/unicode-vo ">unicode-vo 0.1.0</a></li>
                         <li><a href=" https://github.com/unicode-rs/unicode-width ">unicode-width 0.2.2</a></li>
                         <li><a href=" https://github.com/servo/rust-url ">url 2.5.8</a></li>
-                        <li><a href=" https://github.com/uuid-rs/uuid ">uuid 1.23.1</a></li>
+                        <li><a href=" https://github.com/uuid-rs/uuid ">uuid 1.23.4</a></li>
                         <li><a href=" https://github.com/SergioBenitez/version_check ">version_check 0.9.5</a></li>
                         <li><a href=" https://github.com/bytecodealliance/wasi ">wasi 0.11.1+wasi-snapshot-preview1</a></li>
                         <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/futures ">wasm-bindgen-futures 0.4.67</a></li>
@@ -7719,7 +7722,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared ">wasm-bindgen-shared 0.2.117</a></li>
                         <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen ">wasm-bindgen 0.2.117</a></li>
                         <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys ">web-sys 0.3.94</a></li>
-                        <li><a href=" https://github.com/servo/html5ever ">web_atoms 0.2.4</a></li>
+                        <li><a href=" https://github.com/servo/html5ever ">web_atoms 0.2.5</a></li>
                         <li><a href=" https://github.com/bytecodealliance/wit-bindgen ">wit-bindgen 0.51.0</a></li>
                         <li><a href=" https://crates.io/crates/wr_malloc_size_of ">wr_malloc_size_of 0.2.2</a></li>
                         <li><a href=" https://github.com/Stebalien/xattr ">xattr 1.6.1</a></li>
@@ -7932,7 +7935,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/zkcrypto/ff ">ff 0.13.1</a>
+                            <a href=" https://github.com/zkcrypto/ff ">ff 0.14.0</a>
                     </p>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -8352,7 +8355,7 @@ limitations under the License.</pre>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/contain-rs/bit-set ">bit-set 0.9.1</a></li>
                         <li><a href=" https://github.com/contain-rs/bit-vec ">bit-vec 0.9.1</a></li>
-                        <li><a href=" https://github.com/EmbarkStudios/cfg-expr ">cfg-expr 0.20.7</a></li>
+                        <li><a href=" https://github.com/EmbarkStudios/cfg-expr ">cfg-expr 0.20.8</a></li>
                         <li><a href=" https://github.com/marcianx/downcast-rs ">downcast-rs 1.2.1</a></li>
                         <li><a href=" https://github.com/Alexhuszagh/minimal-lexical ">minimal-lexical 0.2.1</a></li>
                         <li><a href=" https://github.com/EmbarkStudios/presser ">presser 0.3.1</a></li>
@@ -8565,8 +8568,8 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/RustCrypto/key-wraps/tree/aes-kw ">aes-kw 0.2.1</a></li>
-                        <li><a href=" https://github.com/RustCrypto/KDFs/ ">hkdf 0.12.4</a></li>
+                        <li><a href=" https://github.com/RustCrypto/key-wraps ">aes-kw 0.3.1</a></li>
+                        <li><a href=" https://github.com/RustCrypto/KDFs/ ">hkdf 0.13.0</a></li>
                     </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -8774,53 +8777,67 @@ limitations under the License.</pre>
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/RustCrypto/AEADs ">aes-gcm 0.10.3</a></li>
-                        <li><a href=" https://github.com/RustCrypto/block-ciphers ">aes 0.8.4</a></li>
-                        <li><a href=" https://github.com/RustCrypto/password-hashes/tree/master/argon2 ">argon2 0.5.3</a></li>
-                        <li><a href=" https://github.com/RustCrypto/formats/tree/master/base16ct ">base16ct 0.2.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/AEADs ">aes-gcm 0.11.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/block-ciphers ">aes 0.9.1</a></li>
+                        <li><a href=" https://github.com/RustCrypto/password-hashes ">argon2 0.6.0-rc.8</a></li>
+                        <li><a href=" https://github.com/RustCrypto/formats ">base16ct 1.0.0</a></li>
                         <li><a href=" https://github.com/RustCrypto/formats ">base64ct 1.8.3</a></li>
-                        <li><a href=" https://github.com/RustCrypto/hashes ">blake2 0.10.6</a></li>
+                        <li><a href=" https://github.com/RustCrypto/hashes ">blake2 0.11.0-rc.6</a></li>
                         <li><a href=" https://github.com/RustCrypto/utils ">block-buffer 0.10.4</a></li>
-                        <li><a href=" https://github.com/RustCrypto/utils ">block-padding 0.3.3</a></li>
-                        <li><a href=" https://github.com/RustCrypto/block-modes ">cbc 0.1.2</a></li>
-                        <li><a href=" https://github.com/RustCrypto/stream-ciphers ">chacha20 0.9.1</a></li>
-                        <li><a href=" https://github.com/RustCrypto/AEADs/tree/master/chacha20poly1305 ">chacha20poly1305 0.10.1</a></li>
-                        <li><a href=" https://github.com/RustCrypto/traits ">cipher 0.4.4</a></li>
-                        <li><a href=" https://github.com/RustCrypto/formats/tree/master/const-oid ">const-oid 0.9.6</a></li>
+                        <li><a href=" https://github.com/RustCrypto/utils ">block-buffer 0.12.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/utils ">block-padding 0.4.2</a></li>
+                        <li><a href=" https://github.com/RustCrypto/block-modes ">cbc 0.2.1</a></li>
+                        <li><a href=" https://github.com/RustCrypto/stream-ciphers ">chacha20 0.10.1</a></li>
+                        <li><a href=" https://github.com/RustCrypto/AEADs ">chacha20poly1305 0.11.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/traits ">cipher 0.5.2</a></li>
+                        <li><a href=" https://github.com/RustCrypto/formats ">const-oid 0.10.2</a></li>
+                        <li><a href=" https://github.com/RustCrypto/utils ">cpubits 0.1.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/utils ">cpufeatures 0.2.17</a></li>
-                        <li><a href=" https://github.com/RustCrypto/crypto-bigint ">crypto-bigint 0.5.5</a></li>
+                        <li><a href=" https://github.com/RustCrypto/utils ">cpufeatures 0.3.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/crypto-bigint ">crypto-bigint 0.7.5</a></li>
                         <li><a href=" https://github.com/RustCrypto/traits ">crypto-common 0.1.7</a></li>
-                        <li><a href=" https://github.com/RustCrypto/block-modes ">ctr 0.9.2</a></li>
-                        <li><a href=" https://github.com/RustCrypto/formats/tree/master/der ">der 0.7.10</a></li>
-                        <li><a href=" https://github.com/RustCrypto/formats/tree/master/der/derive ">der_derive 0.7.3</a></li>
+                        <li><a href=" https://github.com/RustCrypto/traits ">crypto-common 0.2.2</a></li>
+                        <li><a href=" https://github.com/RustCrypto/XOFs ">cshake 0.2.1</a></li>
+                        <li><a href=" https://github.com/RustCrypto/block-modes ">ctr 0.10.1</a></li>
+                        <li><a href=" https://github.com/RustCrypto/utils ">dbl 0.5.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/formats ">der 0.8.0</a></li>
                         <li><a href=" https://github.com/RustCrypto/traits ">digest 0.10.7</a></li>
-                        <li><a href=" https://github.com/RustCrypto/traits/tree/master/elliptic-curve ">elliptic-curve 0.13.8</a></li>
-                        <li><a href=" https://github.com/RustCrypto/universal-hashes ">ghash 0.5.1</a></li>
-                        <li><a href=" https://github.com/RustCrypto/MACs ">hmac 0.12.1</a></li>
-                        <li><a href=" https://github.com/RustCrypto/hybrid-array ">hybrid-array 0.2.3</a></li>
-                        <li><a href=" https://github.com/RustCrypto/hybrid-array ">hybrid-array 0.3.1</a></li>
-                        <li><a href=" https://github.com/RustCrypto/utils ">inout 0.1.4</a></li>
-                        <li><a href=" https://github.com/RustCrypto/sponges/tree/master/keccak ">keccak 0.1.6</a></li>
-                        <li><a href=" https://github.com/RustCrypto/KEMs ">ml-kem 0.2.3</a></li>
-                        <li><a href=" https://github.com/RustCrypto/AEADs ">ocb3 0.1.0</a></li>
-                        <li><a href=" https://github.com/RustCrypto/utils ">opaque-debug 0.3.1</a></li>
-                        <li><a href=" https://github.com/RustCrypto/elliptic-curves/tree/master/p256 ">p256 0.13.2</a></li>
-                        <li><a href=" https://github.com/RustCrypto/elliptic-curves/tree/master/p384 ">p384 0.13.1</a></li>
-                        <li><a href=" https://github.com/RustCrypto/elliptic-curves/tree/master/p521 ">p521 0.13.3</a></li>
-                        <li><a href=" https://github.com/RustCrypto/traits/tree/master/password-hash ">password-hash 0.5.0</a></li>
-                        <li><a href=" https://github.com/RustCrypto/formats/tree/master/pem-rfc7468 ">pem-rfc7468 0.7.0</a></li>
-                        <li><a href=" https://github.com/RustCrypto/formats/tree/master/pkcs1 ">pkcs1 0.7.5</a></li>
-                        <li><a href=" https://github.com/RustCrypto/formats/tree/master/pkcs8 ">pkcs8 0.10.2</a></li>
-                        <li><a href=" https://github.com/RustCrypto/universal-hashes ">poly1305 0.8.0</a></li>
-                        <li><a href=" https://github.com/RustCrypto/universal-hashes ">polyval 0.6.2</a></li>
-                        <li><a href=" https://github.com/RustCrypto/elliptic-curves/tree/master/primeorder ">primeorder 0.13.6</a></li>
-                        <li><a href=" https://github.com/RustCrypto/formats/tree/master/sec1 ">sec1 0.7.3</a></li>
+                        <li><a href=" https://github.com/RustCrypto/traits ">digest 0.11.3</a></li>
+                        <li><a href=" https://github.com/RustCrypto/traits ">elliptic-curve 0.14.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/universal-hashes ">ghash 0.6.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/MACs ">hmac 0.13.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/hybrid-array ">hybrid-array 0.4.12</a></li>
+                        <li><a href=" https://github.com/RustCrypto/utils ">inout 0.2.2</a></li>
+                        <li><a href=" https://github.com/RustCrypto/XOFs ">k12 0.5.1</a></li>
+                        <li><a href=" https://github.com/RustCrypto/sponges ">keccak 0.2.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/KEMs ">ml-kem 0.3.2</a></li>
+                        <li><a href=" https://github.com/RustCrypto/KEMs ">module-lattice 0.2.3</a></li>
+                        <li><a href=" https://github.com/RustCrypto/AEADs ">ocb3 0.2.0-rc.3</a></li>
+                        <li><a href=" https://github.com/RustCrypto/elliptic-curves ">p256 0.14.0-rc.14</a></li>
+                        <li><a href=" https://github.com/RustCrypto/elliptic-curves ">p384 0.14.0-rc.14</a></li>
+                        <li><a href=" https://github.com/RustCrypto/elliptic-curves ">p521 0.14.0-rc.14</a></li>
+                        <li><a href=" https://github.com/RustCrypto/traits ">password-hash 0.6.1</a></li>
+                        <li><a href=" https://github.com/RustCrypto/formats ">pem-rfc7468 1.0.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/formats ">phc 0.6.1</a></li>
+                        <li><a href=" https://github.com/RustCrypto/formats ">pkcs1 0.8.0-rc.4</a></li>
+                        <li><a href=" https://github.com/RustCrypto/formats ">pkcs8 0.11.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/universal-hashes ">poly1305 0.9.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/universal-hashes ">polyval 0.7.1</a></li>
+                        <li><a href=" https://github.com/RustCrypto/elliptic-curves ">primefield 0.14.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/elliptic-curves ">primeorder 0.14.0-rc.14</a></li>
+                        <li><a href=" https://github.com/RustCrypto/formats ">sec1 0.8.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/hashes ">sha1 0.10.6</a></li>
+                        <li><a href=" https://github.com/RustCrypto/hashes ">sha1 0.11.0</a></li>
                         <li><a href=" https://github.com/RustCrypto/hashes ">sha2 0.10.9</a></li>
-                        <li><a href=" https://github.com/RustCrypto/hashes ">sha3 0.10.8</a></li>
-                        <li><a href=" https://github.com/RustCrypto/traits/tree/master/signature ">signature 2.2.0</a></li>
-                        <li><a href=" https://github.com/RustCrypto/formats/tree/master/spki ">spki 0.7.3</a></li>
-                        <li><a href=" https://github.com/RustCrypto/traits ">universal-hash 0.5.1</a></li>
+                        <li><a href=" https://github.com/RustCrypto/hashes ">sha2 0.11.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/hashes ">sha3 0.11.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/hashes ">sha3 0.12.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/XOFs ">shake 0.1.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/traits ">signature 3.0.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/formats ">spki 0.8.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/utils ">sponge-cursor 0.1.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/XOFs ">turboshake 0.7.1</a></li>
+                        <li><a href=" https://github.com/RustCrypto/traits ">universal-hash 0.6.1</a></li>
                     </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -9029,7 +9046,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/RustCrypto/traits ">aead 0.5.2</a>
+                            <a href=" https://github.com/RustCrypto/traits ">aead 0.6.1</a>
                     </p>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -9239,9 +9256,8 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/rust-random/rand_core ">rand_core 0.10.0</a></li>
-                        <li><a href=" https://github.com/rust-random/rand ">rand_core 0.6.4</a></li>
-                        <li><a href=" https://github.com/rust-random/rand ">rand_core 0.9.3</a></li>
+                        <li><a href=" https://github.com/rust-random/rand_core ">rand_core 0.10.1</a></li>
+                        <li><a href=" https://github.com/rust-random/rand ">rand_core 0.9.5</a></li>
                     </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -9439,7 +9455,6 @@ APPENDIX: How to apply the Apache License to your work.
                         <li><a href=" https://github.com/rust-random/getrandom ">getrandom 0.2.17</a></li>
                         <li><a href=" https://github.com/rust-random/getrandom ">getrandom 0.3.4</a></li>
                         <li><a href=" https://github.com/rust-random/getrandom ">getrandom 0.4.1</a></li>
-                        <li><a href=" https://github.com/rust-random/rand ">rand_chacha 0.3.1</a></li>
                     </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -11420,7 +11435,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/mmastrac/linktime ">ctor 1.0.6</a>
+                            <a href=" https://github.com/mmastrac/linktime ">ctor 1.0.7</a>
                     </p>
                 <pre class="license-text">Apache License
                            Version 2.0, January 2004
@@ -12326,7 +12341,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/servo/servo ">servo-hyper-serde 0.3.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-hyper-serde 0.4.0</a></li>
                         <li><a href=" https://github.com/alexheretic/ab-glyph ">ab_glyph 0.2.32</a></li>
                         <li><a href=" https://github.com/alexheretic/ab-glyph ">ab_glyph_rasterizer 0.1.10</a></li>
                         <li><a href=" https://github.com/AccessKit/accesskit ">accesskit 0.24.0</a></li>
@@ -12365,7 +12380,7 @@ limitations under the License.
                         <li><a href=" https://github.com/image-rs/fdeflate ">fdeflate 0.3.7</a></li>
                         <li><a href=" https://github.com/linebender/fearless_simd ">fearless_simd 0.3.0</a></li>
                         <li><a href=" https://github.com/linebender/fearless_simd ">fearless_simd 0.4.1</a></li>
-                        <li><a href=" https://github.com/mit-plv/fiat-crypto ">fiat-crypto 0.2.9</a></li>
+                        <li><a href=" https://github.com/mit-plv/fiat-crypto ">fiat-crypto 0.3.0</a></li>
                         <li><a href=" https://gitlab.com/gilrs-project/gilrs ">gilrs-core 0.6.7</a></li>
                         <li><a href=" https://gitlab.com/gilrs-project/gilrs ">gilrs 0.11.1</a></li>
                         <li><a href=" https://github.com/brendanzab/gl-rs/ ">gl_generator 0.14.0</a></li>
@@ -12385,7 +12400,7 @@ limitations under the License.
                         <li><a href=" https://github.com/jni-rs/jni-rs ">jni-macros 0.22.4</a></li>
                         <li><a href=" https://github.com/jni-rs/jni-sys ">jni-sys-macros 0.4.1</a></li>
                         <li><a href=" https://github.com/jni-rs/jni-rs ">jni 0.22.4</a></li>
-                        <li><a href=" https://github.com/RustCrypto/traits/tree/master/kem ">kem 0.3.0-pre.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/traits ">kem 0.3.0</a></li>
                         <li><a href=" https://github.com/brendanzab/gl-rs/ ">khronos_api 3.1.0</a></li>
                         <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.186</a></li>
                         <li><a href=" https://github.com/linebender/raw_resource_handle ">linebender_resource_handle 0.1.1</a></li>
@@ -12411,13 +12426,13 @@ limitations under the License.
                         <li><a href=" https://github.com/madsmtm/objc2 ">objc2-quartz-core 0.3.2</a></li>
                         <li><a href=" https://github.com/madsmtm/objc2 ">objc2-ui-kit 0.3.2</a></li>
                         <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-abilitykit-sys 0.1.6</a></li>
-                        <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-deviceinfo-sys 0.1.6</a></li>
+                        <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-deviceinfo-sys 0.1.7</a></li>
                         <li><a href=" https://github.com/openharmony-rs/ohos-deviceinfo ">ohos-deviceinfo 0.1.0</a></li>
                         <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-ime-sys 0.2.4</a></li>
                         <li><a href=" https://github.com/openharmony-rs/ohos-ime ">ohos-ime 0.4.2</a></li>
-                        <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-media-sys 0.1.0</a></li>
+                        <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-media-sys 0.1.1</a></li>
                         <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-sys-opaque-types 0.1.10</a></li>
-                        <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-vsync-sys 0.1.5</a></li>
+                        <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-vsync-sys 0.1.6</a></li>
                         <li><a href=" https://github.com/openharmony-rs/ohos-vsync ">ohos-vsync 0.1.3</a></li>
                         <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-window-manager-sys 0.1.4</a></li>
                         <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-window-sys 0.1.7</a></li>
@@ -12435,11 +12450,10 @@ limitations under the License.
                         <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2 1.0.106</a></li>
                         <li><a href=" https://github.com/aclysma/profiling ">profiling-procmacros 1.0.18</a></li>
                         <li><a href=" https://github.com/aclysma/profiling ">profiling 1.0.18</a></li>
-                        <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.45</a></li>
+                        <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.46</a></li>
                         <li><a href=" https://github.com/r-efi/r-efi ">r-efi 5.3.0</a></li>
-                        <li><a href=" https://github.com/rust-random/rand ">rand 0.10.0</a></li>
-                        <li><a href=" https://github.com/rust-random/rand ">rand 0.8.5</a></li>
-                        <li><a href=" https://github.com/rust-random/rand ">rand 0.9.2</a></li>
+                        <li><a href=" https://github.com/rust-random/rand ">rand 0.10.1</a></li>
+                        <li><a href=" https://github.com/rust-random/rand ">rand 0.9.4</a></li>
                         <li><a href=" https://github.com/rust-random/rand ">rand_chacha 0.9.0</a></li>
                         <li><a href=" https://github.com/gfx-rs/range-alloc ">range-alloc 0.1.5</a></li>
                         <li><a href=" https://github.com/rust-windowing/raw-window-handle ">raw-window-handle 0.6.2</a></li>
@@ -12451,6 +12465,7 @@ limitations under the License.
                         <li><a href=" https://github.com/SeaQL/sea-query ">sea-query-derive 1.0.0</a></li>
                         <li><a href=" https://github.com/SeaQL/sea-query ">sea-query-rusqlite 0.8.0-rc.15</a></li>
                         <li><a href=" https://github.com/dtolnay/semver ">semver 1.0.28</a></li>
+                        <li><a href=" https://github.com/dtolnay/seq-macro ">seq-macro 0.3.6</a></li>
                         <li><a href=" https://github.com/serde-rs/serde ">serde 1.0.228</a></li>
                         <li><a href=" https://github.com/serde-rs/bytes ">serde_bytes 0.11.19</a></li>
                         <li><a href=" https://github.com/serde-rs/serde ">serde_core 1.0.228</a></li>
@@ -12464,16 +12479,17 @@ limitations under the License.
                         <li><a href=" https://github.com/jedisct1/rust-siphash ">siphasher 1.0.3</a></li>
                         <li><a href=" https://github.com/gfx-rs/rspirv ">spirv 0.4.0+sdk-1.4.341.0</a></li>
                         <li><a href=" https://github.com/nical/rust_debug ">svg_fmt 0.4.5</a></li>
-                        <li><a href=" https://github.com/dtolnay/syn ">syn 2.0.117</a></li>
+                        <li><a href=" https://github.com/dtolnay/syn ">syn 2.0.118</a></li>
                         <li><a href=" https://github.com/Actyx/sync_wrapper ">sync_wrapper 1.0.2</a></li>
                         <li><a href=" https://github.com/mozilla/thin-vec ">thin-vec 0.2.18</a></li>
                         <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl 1.0.69</a></li>
                         <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl 2.0.18</a></li>
                         <li><a href=" https://github.com/dtolnay/thiserror ">thiserror 1.0.69</a></li>
                         <li><a href=" https://github.com/dtolnay/thiserror ">thiserror 2.0.18</a></li>
-                        <li><a href=" https://github.com/time-rs/time ">time-core 0.1.8</a></li>
-                        <li><a href=" https://github.com/time-rs/time ">time-macros 0.2.27</a></li>
-                        <li><a href=" https://github.com/time-rs/time ">time 0.3.47</a></li>
+                        <li><a href=" https://github.com/time-rs/time ">time-core 0.1.9</a></li>
+                        <li><a href=" https://github.com/time-rs/time ">time-macros 0.2.30</a></li>
+                        <li><a href=" https://github.com/time-rs/time ">time 0.3.51</a></li>
+                        <li><a href=" https://github.com/dtolnay/typeid ">typeid 1.0.3</a></li>
                         <li><a href=" https://github.com/open-i18n/rust-unic/ ">unic-char-property 0.9.0</a></li>
                         <li><a href=" https://github.com/open-i18n/rust-unic/ ">unic-char-range 0.9.0</a></li>
                         <li><a href=" https://github.com/open-i18n/rust-unic/ ">unic-common 0.9.0</a></li>
@@ -12581,7 +12597,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/chronotope/chrono ">chrono 0.4.44</a>
+                            <a href=" https://github.com/chronotope/chrono ">chrono 0.4.45</a>
                     </p>
                 <pre class="license-text">Rust-chrono is dual-licensed under The MIT License [1] and
 Apache 2.0 License [2]. Copyright (c) 2014--2026, Kang Seonghoon and
@@ -13224,7 +13240,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/dropbox/rust-alloc-no-stdlib ">alloc-no-stdlib 2.0.4</a></li>
-                        <li><a href=" https://github.com/dropbox/rust-brotli-decompressor ">brotli-decompressor 5.0.0</a></li>
+                        <li><a href=" https://github.com/dropbox/rust-brotli-decompressor ">brotli-decompressor 5.0.3</a></li>
+                        <li><a href=" https://github.com/dropbox/rust-brotli ">brotli 8.0.4</a></li>
                     </ul>
                 <pre class="license-text">Copyright (c) 2016 Dropbox, Inc.
 All rights reserved.
@@ -13281,7 +13298,80 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/dalek-cryptography/curve25519-dalek/tree/main/x25519-dalek ">x25519-dalek 2.0.1</a>
+                            <a href=" https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek ">curve25519-dalek 5.0.0-rc.1</a>
+                    </p>
+                <pre class="license-text">Copyright (c) 2016-2021 isis agora lovecruft. All rights reserved.
+Copyright (c) 2016-2021 Henry de Valence. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS
+IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
+                    <p>
+                        Used by
+                            <a href=" https://github.com/dalek-cryptography/curve25519-dalek/tree/main/ed25519-dalek ">ed25519-dalek 3.0.0-rc.1</a>
+                    </p>
+                <pre class="license-text">Copyright (c) 2017-2019 isis agora lovecruft. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS
+IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
+                    <p>
+                        Used by
+                            <a href=" https://github.com/dalek-cryptography/curve25519-dalek/tree/main/x25519-dalek ">x25519-dalek 3.0.0-rc.1</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2017-2021 isis agora lovecruft. All rights reserved.
 Copyright (c) 2019-2021 DebugSteven. All rights reserved.
@@ -13318,11 +13408,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/servo/servo ">servo-script-bindings 0.3.0</a></li>
-                        <li><a href=" https://github.com/dropbox/rust-alloc-no-stdlib ">alloc-stdlib 0.2.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-script-bindings 0.4.0</a></li>
+                        <li><a href=" https://github.com/dropbox/rust-alloc-no-stdlib ">alloc-stdlib 0.2.4</a></li>
                         <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.41.0</a></li>
-                        <li><a href=" https://github.com/dropbox/rust-brotli ">brotli 8.0.2</a></li>
-                        <li><a href=" https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek ">curve25519-dalek 4.1.3</a></li>
                         <li><a href=" https://github.com/mitsuhiko/sha1-smol ">sha1_smol 1.0.1</a></li>
                     </ul>
                 <pre class="license-text">Copyright (c) &lt;year&gt; &lt;owner&gt;. 
@@ -13594,8 +13682,8 @@ express Statement of Purpose.
                 <h3 id="CDLA-Permissive-2.0">Community Data License Agreement Permissive 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/rustls/webpki-roots ">webpki-root-certs 1.0.7</a></li>
-                        <li><a href=" https://github.com/rustls/webpki-roots ">webpki-roots 1.0.7</a></li>
+                        <li><a href=" https://github.com/rustls/webpki-roots ">webpki-root-certs 1.0.8</a></li>
+                        <li><a href=" https://github.com/rustls/webpki-roots ">webpki-roots 1.0.8</a></li>
                     </ul>
                 <pre class="license-text"># Community Data License Agreement - Permissive - Version 2.0
 
@@ -13705,7 +13793,7 @@ THIS SOFTWARE.</pre>
                 <h3 id="ISC">ISC License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/hannobraun/inotify ">inotify 0.11.1</a>
+                            <a href=" https://github.com/hannobraun/inotify-rs ">inotify 0.11.2</a>
                     </p>
                 <pre class="license-text">Copyright (c) Hanno Braun and contributors
 
@@ -13849,7 +13937,7 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot; AND ISC DISCLAIMS ALL WARRANTIES WITH
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/dropbox/rust-brotli ">brotli 8.0.2</a>
+                            <a href=" https://github.com/dropbox/rust-brotli ">brotli 8.0.4</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2009, 2010, 2013-2016 by the Brotli Authors.
 
@@ -13903,7 +13991,7 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/tokio-rs/mio ">mio 1.2.0</a>
+                            <a href=" https://github.com/tokio-rs/mio ">mio 1.2.1</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2014 Carl Lerche and other MIO contributors
 
@@ -14070,7 +14158,7 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/hyperium/hyper ">hyper 1.9.0</a>
+                            <a href=" https://github.com/hyperium/hyper ">hyper 1.10.1</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2014-2026 Sean McArthur
 
@@ -14130,7 +14218,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                         <li><a href=" https://github.com/smithay/wayland-rs ">wayland-cursor 0.31.14</a></li>
                         <li><a href=" https://github.com/smithay/wayland-rs ">wayland-protocols-plasma 0.3.12</a></li>
                         <li><a href=" https://github.com/smithay/wayland-rs ">wayland-protocols-wlr 0.3.12</a></li>
-                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-protocols 0.32.12</a></li>
+                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-protocols 0.32.13</a></li>
                         <li><a href=" https://github.com/smithay/wayland-rs ">wayland-scanner 0.31.10</a></li>
                         <li><a href=" https://github.com/smithay/wayland-rs ">wayland-sys 0.31.11</a></li>
                     </ul>
@@ -14160,7 +14248,7 @@ THE SOFTWARE.
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/mbrubeck/rust-debug-unreachable ">new_debug_unreachable 1.0.6</a></li>
-                        <li><a href=" https://github.com/reem/rust-ordered-float ">ordered-float 5.0.0</a></li>
+                        <li><a href=" https://github.com/reem/rust-ordered-float ">ordered-float 5.3.0</a></li>
                     </ul>
                 <pre class="license-text">Copyright (c) 2015 Jonathan Reem
 
@@ -14348,7 +14436,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/hyperium/h2 ">h2 0.4.14</a>
+                            <a href=" https://github.com/hyperium/h2 ">h2 0.4.15</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2017 h2 authors
 
@@ -14381,7 +14469,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/tokio-rs/bytes ">bytes 1.11.1</a>
+                            <a href=" https://github.com/tokio-rs/bytes ">bytes 1.12.0</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2018 Carl Lerche
 
@@ -14883,12 +14971,12 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus 5.15.0</a></li>
-                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus_macros 5.15.0</a></li>
+                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus 5.16.0</a></li>
+                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus_macros 5.16.0</a></li>
                         <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus_names 4.3.2</a></li>
                         <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus_xml 5.1.1</a></li>
-                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zvariant 5.11.0</a></li>
-                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zvariant_derive 5.11.0</a></li>
+                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zvariant 5.12.0</a></li>
+                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zvariant_derive 5.12.0</a></li>
                     </ul>
                 <pre class="license-text">Copyright (c) 2024 Zeeshan Ali Khan &amp; zbus contributors
 
@@ -15561,7 +15649,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/arthurprs/quick-cache ">quick_cache 0.6.22</a>
+                            <a href=" https://github.com/arthurprs/quick-cache ">quick_cache 0.6.24</a>
                     </p>
                 <pre class="license-text">MIT License
 
@@ -15788,7 +15876,7 @@ SOFTWARE.</pre>
                         <li><a href=" https://github.com/plotters-rs/plotters.git ">plotters-svg 0.3.7</a></li>
                         <li><a href=" https://github.com/plotters-rs/plotters ">plotters 0.3.7</a></li>
                         <li><a href=" https://github.com/lu-zero/simd_helpers ">simd_helpers 0.1.0</a></li>
-                        <li><a href=" https://github.com/DioxusLabs/taffy ">taffy 0.10.1</a></li>
+                        <li><a href=" https://github.com/DioxusLabs/taffy ">taffy 0.11.0</a></li>
                         <li><a href=" https://github.com/reem/rust-void.git ">void 1.0.2</a></li>
                     </ul>
                 <pre class="license-text">MIT License
@@ -16005,7 +16093,7 @@ SOFTWARE.
                         <li><a href=" https://github.com/luukvanderduim/zbus-lockstep ">zbus-lockstep-macros 0.5.2</a></li>
                         <li><a href=" https://github.com/luukvanderduim/zbus-lockstep ">zbus-lockstep 0.5.2</a></li>
                         <li><a href=" https://github.com/dtolnay/zmij ">zmij 1.0.21</a></li>
-                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zvariant_utils 3.3.1</a></li>
+                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zvariant_utils 3.4.0</a></li>
                     </ul>
                 <pre class="license-text">Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated
@@ -16087,34 +16175,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 </pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/mvdnes/spin-rs.git ">spin 0.9.8</a>
-                    </p>
-                <pre class="license-text">The MIT License (MIT)
-
-Copyright (c) 2014 Mathijs van de Nes
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.</pre>
             </li>
             <li class="license">
                 <h3 id="MIT">MIT License</h3>
@@ -16216,8 +16276,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                         <li><a href=" https://github.com/image-rs/byteorder-lite ">byteorder-lite 0.1.0</a></li>
                         <li><a href=" https://github.com/BurntSushi/byteorder ">byteorder 1.5.0</a></li>
                         <li><a href=" https://github.com/BurntSushi/fst ">fst 0.4.7</a></li>
-                        <li><a href=" https://github.com/BurntSushi/jiff ">jiff 0.2.24</a></li>
-                        <li><a href=" https://github.com/BurntSushi/memchr ">memchr 2.8.0</a></li>
+                        <li><a href=" https://github.com/BurntSushi/jiff ">jiff 0.2.29</a></li>
+                        <li><a href=" https://github.com/BurntSushi/memchr ">memchr 2.8.2</a></li>
                         <li><a href=" https://github.com/BurntSushi/quickcheck ">quickcheck 1.1.0</a></li>
                         <li><a href=" https://github.com/BurntSushi/walkdir ">walkdir 2.5.0</a></li>
                     </ul>
@@ -18081,7 +18141,7 @@ defined by the Mozilla Public License, v. 2.0.
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/upsuper/dtoa-short ">dtoa-short 0.3.5</a></li>
                         <li><a href=" https://github.com/asajeffrey/swapper ">swapper 0.1.0</a></li>
-                        <li><a href=" https://github.com/badboy/zeitstempel ">zeitstempel 0.1.2</a></li>
+                        <li><a href=" https://github.com/badboy/zeitstempel ">zeitstempel 0.2.1</a></li>
                     </ul>
                 <pre class="license-text">Mozilla Public License Version 2.0
 &#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;
@@ -18844,94 +18904,96 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                 <h3 id="MPL-2.0">Mozilla Public License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/servo/stylo ">stylo 0.17.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo 0.18.0</a></li>
                         <li><a href=" https://github.com/servo/stylo ">selectors 0.38.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_atoms 0.17.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_derive 0.17.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_dom 0.17.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_static_prefs 0.17.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_traits 0.17.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_atoms 0.18.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_derive 0.18.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_dom 0.18.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_static_prefs 0.18.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_traits 0.18.0</a></li>
                         <li><a href=" https://github.com/servo/stylo ">to_shmem 0.4.0</a></li>
                         <li><a href=" https://github.com/servo/stylo ">to_shmem_derive 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-allocator 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-background-hang-monitor 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-bluetooth 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-canvas 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-config 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-config-macro 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-constellation 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-default-resources 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-deny-public-fields 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-devtools 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-dom-struct 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-fonts 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-geometry 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-jstraceable-derive 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-layout 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-audio 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-auto 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-dummy 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer-render 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer-render-android 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer-render-unix 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-ohos 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-examples 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-thread 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-player 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-derive 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-streams 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-traits 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-media-webrtc 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-metrics 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-net 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-paint 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-pixels 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-profile 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-script 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-script-bindings 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-tracing 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-background-hang-monitor-api 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-base 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-bluetooth-traits 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-canvas-traits 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-constellation-traits 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-devtools-traits 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-embedder-traits 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-fonts-traits 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-layout-api 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-net-traits 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-paint-api 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-profile-traits 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-script-traits 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-storage-traits 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-webgpu-traits 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-webxr-api 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-storage 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-timers 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-url 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-wakelock 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-webdriver-server 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-webgl 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-webgpu 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-webxr 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servo-xpath 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/servo ">servoshell 0.3.0</a></li>
-                        <li><a href=" https://crates.io/crates/malloc_size_of_tests ">malloc_size_of_tests 0.3.0</a></li>
-                        <li><a href=" https://crates.io/crates/profile_tests ">profile_tests 0.3.0</a></li>
-                        <li><a href=" https://crates.io/crates/script_tests ">script_tests 0.3.0</a></li>
-                        <li><a href=" https://crates.io/crates/style_tests ">style_tests 0.3.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-allocator 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-background-hang-monitor 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-bluetooth 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-canvas 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-config 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-config-macro 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-constellation 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-default-resources 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-deny-public-fields 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-devtools 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-dom-struct 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-fonts 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-geometry 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-jstraceable-derive 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-layout 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-audio 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-auto 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-dummy 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer-render 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer-render-android 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer-render-unix 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-ohos 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-examples 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-thread 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-player 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-derive 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-streams 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-traits 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-webrtc 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-metrics 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-net 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-paint 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-pixels 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-profile 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-script 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-script-bindings 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-tracing 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-background-hang-monitor-api 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-base 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-bluetooth-traits 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-canvas-traits 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-constellation-traits 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-devtools-traits 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-embedder-traits 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-fonts-traits 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-layout-api 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-net-traits 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-paint-api 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-profile-traits 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-script-traits 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-storage-traits 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webgpu-traits 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webxr-api 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-storage 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-timers 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-url 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-wakelock 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webdriver-server 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webgl 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webgpu 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webxr 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-xpath 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-capi 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servoshell 0.4.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-capi-tests 0.4.0</a></li>
+                        <li><a href=" https://crates.io/crates/malloc_size_of_tests ">malloc_size_of_tests 0.4.0</a></li>
+                        <li><a href=" https://crates.io/crates/profile_tests ">profile_tests 0.4.0</a></li>
+                        <li><a href=" https://crates.io/crates/script_tests ">script_tests 0.4.0</a></li>
+                        <li><a href=" https://crates.io/crates/style_tests ">style_tests 0.4.0</a></li>
                         <li><a href=" https://github.com/servo/app_units ">app_units 0.7.8</a></li>
                         <li><a href=" https://github.com/servo/dwrote-rs ">dwrote 0.11.5</a></li>
-                        <li><a href=" https://github.com/servo/mozjs/ ">mozjs_sys 140.10.1-0</a></li>
+                        <li><a href=" https://github.com/servo/mozjs/ ">mozjs_sys 140.12.0-0</a></li>
                         <li><a href=" https://github.com/soc/option-ext.git ">option-ext 0.2.0</a></li>
                         <li><a href=" https://hg.mozilla.org/mozilla-central/file/tip/testing/webdriver ">webdriver 0.53.0</a></li>
-                        <li><a href=" https://github.com/servo/webrender ">webrender 0.68.0</a></li>
-                        <li><a href=" https://github.com/servo/webrender ">webrender_api 0.68.0</a></li>
-                        <li><a href=" https://github.com/servo/webrender ">webrender_build 0.68.0</a></li>
-                        <li><a href=" https://crates.io/crates/wr_glyph_rasterizer ">wr_glyph_rasterizer 0.68.0</a></li>
+                        <li><a href=" https://github.com/servo/webrender ">webrender 0.69.0</a></li>
+                        <li><a href=" https://github.com/servo/webrender ">webrender_api 0.69.0</a></li>
+                        <li><a href=" https://github.com/servo/webrender ">webrender_build 0.69.0</a></li>
+                        <li><a href=" https://crates.io/crates/wr_glyph_rasterizer ">wr_glyph_rasterizer 0.69.0</a></li>
                     </ul>
                 <pre class="license-text">Mozilla Public License Version 2.0
 &#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;
@@ -19312,7 +19374,7 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                 <h3 id="MPL-2.0">Mozilla Public License 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/servo/mozjs/ ">mozjs 0.15.14</a>
+                            <a href=" https://github.com/servo/mozjs/ ">mozjs 0.16.4</a>
                     </p>
                 <pre class="license-text">Mozilla Public License Version 2.0
 &#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;
@@ -19694,7 +19756,7 @@ defined by the Mozilla Public License, v. 2.0.
                 <h3 id="NCSA">University of Illinois/NCSA Open Source License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/rust-fuzz/libfuzzer ">libfuzzer-sys 0.4.12</a>
+                            <a href=" https://github.com/rust-fuzz/libfuzzer ">libfuzzer-sys 0.4.13</a>
                     </p>
                 <pre class="license-text">University of Illinois/NCSA Open Source License
 

--- a/support/android/apk/servoapp/build.gradle.kts
+++ b/support/android/apk/servoapp/build.gradle.kts
@@ -16,7 +16,7 @@ android {
         minSdk = 30
         targetSdk = 34
         versionCode = generatedVersionCode
-        versionName = "0.3.0"
+        versionName = "0.4.0"
     }
 
     compileOptions {

--- a/support/openharmony/entry/oh-package.json5
+++ b/support/openharmony/entry/oh-package.json5
@@ -5,7 +5,7 @@
   "name": "servoshell",
   "description": "Please describe the basic information.",
   "main": "",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "dependencies": {
     "libservoshell.so": "file:./src/main/cpp/types/libentry"
   }

--- a/support/openharmony/oh-package.json5
+++ b/support/openharmony/oh-package.json5
@@ -8,6 +8,6 @@
   "name": "servoshell",
   "description": "Servo browser shell",
   "main": "",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "dependencies": {}
 }

--- a/support/windows/servoshell.wxs.mako
+++ b/support/windows/servoshell.wxs.mako
@@ -6,7 +6,7 @@
            UpgradeCode="060cd15d-eab1-4614-b438-3988e3efdcf1"
            Language="1033"
            Codepage="1252"
-           Version="0.3.0">
+           Version="0.4.0">
     <Package Id="*"
              Keywords="Installer"
              Description="Servo Tech Demo Installer"


### PR DESCRIPTION
Created via `/mach release 0.4.0`.

Testing: Version bump, no testing required.

