### PR TITLE
android: Bump minSdk to 33

### DIFF
--- a/support/android/apk/servoapp/build.gradle.kts
+++ b/support/android/apk/servoapp/build.gradle.kts
@@ -13,7 +13,7 @@ android {
 
     defaultConfig {
         applicationId = "org.servo.servoshell"
-        minSdk = 34
+        minSdk = 33
         targetSdk = 34
         versionCode = generatedVersionCode
         versionName = "0.3.0"

--- a/support/android/apk/servoapp/build.gradle.kts
+++ b/support/android/apk/servoapp/build.gradle.kts
@@ -13,7 +13,7 @@ android {
 
     defaultConfig {
         applicationId = "org.servo.servoshell"
-        minSdk = 30
+        minSdk = 34
         targetSdk = 34
         versionCode = generatedVersionCode
         versionName = "0.3.0"


### PR DESCRIPTION
We have received multiple issues about servo not working on older android versions (11 or 12).
Hence we bump the `minSdk` version to 33, which should give users better errors, that their android version is too old.
Tested on an android emulator (Pixel 7, API-33) and servo seems to work fine.
Note: If someone investigates the issues on older android versions and fixes them, then we could downgrade the minSdk version again. But until then we should use minSdk to document our expectation that it currently doesn't work on older android versions. This is tracked in https://github.com/servo/servo/issues/46115.

Testing: If it builds, it works.
