### PR TITLE
script: Fix intermittent readyState for HTML documents

### DIFF
--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -156,11 +156,11 @@ impl DOMParserMethods<crate::DomTypeHolder> for DOMParser {
                 // Step switch-1. Create an XML parser parser, associated with document,
                 // and with XML scripting support disabled.
                 ServoParser::parse_xml_document(cx, &document, Some(compliant_string), url, None);
+                document.set_ready_state(cx, DocumentReadyState::Complete);
                 document
             },
         };
         // Step 4. Return document.
-        document.set_ready_state(cx, DocumentReadyState::Complete);
         Ok(document)
     }
 }


### PR DESCRIPTION
Only XML documents need their explicit ready state set when parsing with DOMParser. For HTML documents, this now already happens as part of parsing a document and firing the relevant events.

Fixes #46066

Testing: reran the intermittent test to verify it no longer flakes