### PR TITLE
script: Remove unused SafeJSContext arguments

### DIFF
--- a/components/script/dom/abort/abortsignal.rs
+++ b/components/script/dom/abort/abortsignal.rs
@@ -32,7 +32,6 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::readablestream::PipeTo;
 use crate::fetch::{DeferredFetchRecordId, FetchContext};
 use crate::realms::enter_auto_realm;
-use crate::script_runtime::JSContext as SafeJSContext;
 
 impl js::gc::Rootable for AbortAlgorithm {}
 
@@ -431,7 +430,7 @@ impl AbortSignalMethods<crate::DomTypeHolder> for AbortSignal {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-abortsignal-reason>
-    fn Reason(&self, _cx: SafeJSContext, mut rval: MutableHandleValue) {
+    fn Reason(&self, mut rval: MutableHandleValue) {
         // The reason getter steps are to return this’s abort reason.
         rval.set(self.abort_reason.get());
     }

--- a/components/script/dom/canvas/imagedata.rs
+++ b/components/script/dom/canvas/imagedata.rs
@@ -363,10 +363,7 @@ impl ImageDataMethods<crate::DomTypeHolder> for ImageData {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-imagedata-data>
-    fn GetData(
-        &self,
-        _: script_bindings::script_runtime::JSContext,
-    ) -> Fallible<RootedTraceableBox<HeapUint8ClampedArray>> {
+    fn GetData(&self) -> Fallible<RootedTraceableBox<HeapUint8ClampedArray>> {
         self.data.get_typed_array().map_err(|_| Error::JSFailed)
     }
 

--- a/components/script/dom/debugger/debuggeradddebuggeeevent.rs
+++ b/components/script/dom/debugger/debuggeradddebuggeeevent.rs
@@ -57,11 +57,7 @@ impl DebuggerAddDebuggeeEvent {
 
 impl DebuggerAddDebuggeeEventMethods<crate::DomTypeHolder> for DebuggerAddDebuggeeEvent {
     // check-tidy: no specs after this line
-    fn Global(
-        &self,
-        _cx: script_bindings::script_runtime::JSContext,
-        mut return_value: MutableHandleObject,
-    ) {
+    fn Global(&self, mut return_value: MutableHandleObject) {
         return_value.set(self.global.get());
     }
 

--- a/components/script/dom/event/customevent.rs
+++ b/components/script/dom/event/customevent.rs
@@ -19,7 +19,6 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::event::Event;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::JSContext as SafeJSContext;
 
 // https://dom.spec.whatwg.org/#interface-customevent
 #[dom_struct]
@@ -111,14 +110,13 @@ impl CustomEventMethods<crate::DomTypeHolder> for CustomEvent {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-customevent-detail>
-    fn Detail(&self, _cx: SafeJSContext, mut retval: MutableHandleValue) {
+    fn Detail(&self, mut retval: MutableHandleValue) {
         retval.set(self.detail.get())
     }
 
     /// <https://dom.spec.whatwg.org/#dom-customevent-initcustomevent>
     fn InitCustomEvent(
         &self,
-        _cx: SafeJSContext,
         type_: DOMString,
         can_bubble: bool,
         cancelable: bool,

--- a/components/script/dom/event/errorevent.rs
+++ b/components/script/dom/event/errorevent.rs
@@ -23,7 +23,6 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::JSContext as SafeJSContext;
 
 #[dom_struct]
 pub(crate) struct ErrorEvent {
@@ -172,7 +171,7 @@ impl ErrorEventMethods<crate::DomTypeHolder> for ErrorEvent {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-errorevent-error>
-    fn Error(&self, _cx: SafeJSContext, mut retval: MutableHandleValue) {
+    fn Error(&self, mut retval: MutableHandleValue) {
         retval.set(self.error.get());
     }
 

--- a/components/script/dom/event/eventtarget.rs
+++ b/components/script/dom/event/eventtarget.rs
@@ -223,7 +223,7 @@ impl CompiledEventListener {
                             (object.is::<Window>() || object.is::<WorkerGlobalScope>())
                         {
                             rooted!(&in(cx) let mut error: JSVal);
-                            event.Error(cx.into(), error.handle_mut());
+                            event.Error(error.handle_mut());
                             rooted!(&in(cx) let mut rooted_return_value: JSVal);
                             let return_value = handler.Call_(
                                 cx,

--- a/components/script/dom/event/popstateevent.rs
+++ b/components/script/dom/event/popstateevent.rs
@@ -21,7 +21,6 @@ use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::event::Event;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::window::Window;
-use crate::script_runtime::JSContext as SafeJSContext;
 
 // https://html.spec.whatwg.org/multipage/#the-popstateevent-interface
 #[dom_struct]
@@ -102,7 +101,7 @@ impl PopStateEventMethods<crate::DomTypeHolder> for PopStateEvent {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-popstateevent-state>
-    fn State(&self, _cx: SafeJSContext, mut retval: MutableHandleValue) {
+    fn State(&self, mut retval: MutableHandleValue) {
         retval.set(self.state.get())
     }
 

--- a/components/script/dom/event/promiserejectionevent.rs
+++ b/components/script/dom/event/promiserejectionevent.rs
@@ -23,7 +23,6 @@ use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
-use crate::script_runtime::JSContext as SafeJSContext;
 
 #[dom_struct]
 pub(crate) struct PromiseRejectionEvent {
@@ -120,12 +119,12 @@ impl PromiseRejectionEventMethods<crate::DomTypeHolder> for PromiseRejectionEven
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-promiserejectionevent-promise>
-    fn Promise(&self, _cx: SafeJSContext, mut return_value: MutableHandleObject) {
+    fn Promise(&self, mut return_value: MutableHandleObject) {
         return_value.set(self.promise.get());
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-promiserejectionevent-reason>
-    fn Reason(&self, _cx: SafeJSContext, mut retval: MutableHandleValue) {
+    fn Reason(&self, mut retval: MutableHandleValue) {
         retval.set(self.reason.get())
     }
 

--- a/components/script/dom/file/filereader.rs
+++ b/components/script/dom/file/filereader.rs
@@ -38,7 +38,6 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::progressevent::ProgressEvent;
 use crate::realms::enter_auto_realm;
-use crate::script_runtime::JSContext;
 use crate::task::TaskOnce;
 
 pub(crate) enum FileReadingTask {
@@ -494,7 +493,7 @@ impl FileReaderMethods<crate::DomTypeHolder> for FileReader {
 
     #[expect(unsafe_code)]
     /// <https://w3c.github.io/FileAPI/#dfn-result>
-    fn GetResult(&self, _: JSContext) -> Option<StringOrObject> {
+    fn GetResult(&self) -> Option<StringOrObject> {
         self.result.borrow().as_ref().map(|r| match *r {
             FileReaderResult::String(ref string) => StringOrObject::String(string.clone()),
             FileReaderResult::ArrayBuffer(ref arr_buffer) => {

--- a/components/script/dom/gamepad/gamepadpose.rs
+++ b/components/script/dom/gamepad/gamepadpose.rs
@@ -11,7 +11,6 @@ use crate::dom::bindings::buffer_source::HeapBufferSource;
 use crate::dom::bindings::codegen::Bindings::GamepadPoseBinding::GamepadPoseMethods;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::JSContext;
 
 #[dom_struct]
 pub(crate) struct GamepadPose {
@@ -55,7 +54,7 @@ impl GamepadPose {
 
 impl GamepadPoseMethods<crate::DomTypeHolder> for GamepadPose {
     /// <https://w3c.github.io/gamepad/extensions.html#dom-gamepadpose-position>
-    fn GetPosition(&self, _cx: JSContext) -> Option<RootedTraceableBox<HeapFloat32Array>> {
+    fn GetPosition(&self) -> Option<RootedTraceableBox<HeapFloat32Array>> {
         self.position.typed_array_to_option()
     }
 
@@ -65,20 +64,17 @@ impl GamepadPoseMethods<crate::DomTypeHolder> for GamepadPose {
     }
 
     /// <https://w3c.github.io/gamepad/extensions.html#dom-gamepadpose-linearvelocity>
-    fn GetLinearVelocity(&self, _cx: JSContext) -> Option<RootedTraceableBox<HeapFloat32Array>> {
+    fn GetLinearVelocity(&self) -> Option<RootedTraceableBox<HeapFloat32Array>> {
         self.linear_vel.typed_array_to_option()
     }
 
     /// <https://w3c.github.io/gamepad/extensions.html#dom-gamepadpose-linearacceleration>
-    fn GetLinearAcceleration(
-        &self,
-        _cx: JSContext,
-    ) -> Option<RootedTraceableBox<HeapFloat32Array>> {
+    fn GetLinearAcceleration(&self) -> Option<RootedTraceableBox<HeapFloat32Array>> {
         self.linear_acc.typed_array_to_option()
     }
 
     /// <https://w3c.github.io/gamepad/extensions.html#dom-gamepadpose-orientation>
-    fn GetOrientation(&self, _cx: JSContext) -> Option<RootedTraceableBox<HeapFloat32Array>> {
+    fn GetOrientation(&self) -> Option<RootedTraceableBox<HeapFloat32Array>> {
         self.orientation.typed_array_to_option()
     }
 
@@ -88,15 +84,12 @@ impl GamepadPoseMethods<crate::DomTypeHolder> for GamepadPose {
     }
 
     /// <https://w3c.github.io/gamepad/extensions.html#dom-gamepadpose-angularvelocity>
-    fn GetAngularVelocity(&self, _cx: JSContext) -> Option<RootedTraceableBox<HeapFloat32Array>> {
+    fn GetAngularVelocity(&self) -> Option<RootedTraceableBox<HeapFloat32Array>> {
         self.angular_vel.typed_array_to_option()
     }
 
     /// <https://w3c.github.io/gamepad/extensions.html#dom-gamepadpose-angularacceleration>
-    fn GetAngularAcceleration(
-        &self,
-        _cx: JSContext,
-    ) -> Option<RootedTraceableBox<HeapFloat32Array>> {
+    fn GetAngularAcceleration(&self) -> Option<RootedTraceableBox<HeapFloat32Array>> {
         self.angular_acc.typed_array_to_option()
     }
 }

--- a/components/script/dom/html/htmlcanvaselement.rs
+++ b/components/script/dom/html/htmlcanvaselement.rs
@@ -62,7 +62,6 @@ use crate::dom::webgl::webgl2renderingcontext::WebGL2RenderingContext;
 use crate::dom::webgl::webglrenderingcontext::WebGLRenderingContext;
 #[cfg(feature = "webgpu")]
 use crate::dom::webgpu::gpucanvascontext::GPUCanvasContext;
-use crate::script_runtime::JSContext;
 
 const DEFAULT_WIDTH: u32 = 300;
 const DEFAULT_HEIGHT: u32 = 150;
@@ -498,12 +497,7 @@ impl HTMLCanvasElementMethods<crate::DomTypeHolder> for HTMLCanvasElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-canvas-todataurl>
-    fn ToDataURL(
-        &self,
-        _context: JSContext,
-        mime_type: DOMString,
-        quality: HandleValue,
-    ) -> Fallible<USVString> {
+    fn ToDataURL(&self, mime_type: DOMString, quality: HandleValue) -> Fallible<USVString> {
         // Step 1: If this canvas element's bitmap's origin-clean flag is set to false,
         // then throw a "SecurityError" DOMException.
         if !self.origin_is_clean() {
@@ -549,7 +543,6 @@ impl HTMLCanvasElementMethods<crate::DomTypeHolder> for HTMLCanvasElement {
     /// <https://html.spec.whatwg.org/multipage/#dom-canvas-toblob>
     fn ToBlob(
         &self,
-        _cx: JSContext,
         callback: Rc<BlobCallback>,
         mime_type: DOMString,
         quality: HandleValue,

--- a/components/script/dom/notification.rs
+++ b/components/script/dom/notification.rs
@@ -58,7 +58,7 @@ use crate::dom::serviceworkerglobalscope::ServiceWorkerGlobalScope;
 use crate::dom::serviceworkerregistration::ServiceWorkerRegistration;
 use crate::fetch::{RequestWithGlobalScope, create_a_potential_cors_request};
 use crate::network_listener::{self, FetchResponseListener, ResourceTimingListener};
-use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
+use crate::script_runtime::CanGc;
 // TODO: Service Worker API (persistent notification)
 // https://notifications.spec.whatwg.org/#service-worker-api
 
@@ -515,7 +515,7 @@ impl NotificationMethods<crate::DomTypeHolder> for Notification {
     }
 
     /// <https://notifications.spec.whatwg.org/#dom-notification-data>
-    fn Data(&self, _cx: SafeJSContext, mut retval: MutableHandleValue) {
+    fn Data(&self, mut retval: MutableHandleValue) {
         retval.set(self.data.get());
     }
 

--- a/components/script/dom/performance/performancemark.rs
+++ b/components/script/dom/performance/performancemark.rs
@@ -23,7 +23,6 @@ use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::performance::performanceentry::{EntryType, PerformanceEntry};
 use crate::dom::window::Window;
-use crate::script_runtime::JSContext;
 
 #[dom_struct]
 pub(crate) struct PerformanceMark {
@@ -72,7 +71,7 @@ impl PerformanceMark {
 
 impl PerformanceMarkMethods<crate::DomTypeHolder> for PerformanceMark {
     /// <https://w3c.github.io/user-timing/#dom-performancemark-detail>
-    fn Detail(&self, _cx: JSContext, mut retval: MutableHandleValue) {
+    fn Detail(&self, mut retval: MutableHandleValue) {
         retval.set(self.detail.get())
     }
 

--- a/components/script/dom/performance/performancemeasure.rs
+++ b/components/script/dom/performance/performancemeasure.rs
@@ -16,7 +16,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::performance::performanceentry::{EntryType, PerformanceEntry};
-use crate::script_runtime::{CanGc, JSContext};
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct PerformanceMeasure {
@@ -64,7 +64,7 @@ impl PerformanceMeasure {
 
 impl PerformanceMeasureMethods<crate::DomTypeHolder> for PerformanceMeasure {
     /// <https://w3c.github.io/user-timing/#dom-performancemeasure-detail>
-    fn Detail(&self, _cx: JSContext, mut retval: MutableHandleValue) {
+    fn Detail(&self, mut retval: MutableHandleValue) {
         retval.set(self.detail.get())
     }
 }

--- a/components/script/dom/serviceworker/extendableevent.rs
+++ b/components/script/dom/serviceworker/extendableevent.rs
@@ -18,7 +18,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::event::Event;
 use crate::dom::serviceworkerglobalscope::ServiceWorkerGlobalScope;
-use crate::script_runtime::JSContext as SafeJSContext;
 
 // https://w3c.github.io/ServiceWorker/#extendable-event
 #[dom_struct]
@@ -87,7 +86,7 @@ impl ExtendableEventMethods<crate::DomTypeHolder> for ExtendableEvent {
     }
 
     /// <https://w3c.github.io/ServiceWorker/#wait-until-method>
-    fn WaitUntil(&self, _cx: SafeJSContext, _val: HandleValue) -> ErrorResult {
+    fn WaitUntil(&self, _val: HandleValue) -> ErrorResult {
         // Step 1
         if !self.extensions_allowed {
             return Err(Error::InvalidState(None));

--- a/components/script/dom/stream/readablestreambyobrequest.rs
+++ b/components/script/dom/stream/readablestreambyobrequest.rs
@@ -16,7 +16,6 @@ use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::stream::readablebytestreamcontroller::ReadableByteStreamController;
 use crate::dom::types::GlobalScope;
-use crate::script_runtime::JSContext as SafeJSContext;
 
 /// <https://streams.spec.whatwg.org/#readablestreambyobrequest>
 #[dom_struct]
@@ -68,10 +67,7 @@ impl ReadableStreamBYOBRequest {
 
 impl ReadableStreamBYOBRequestMethods<crate::DomTypeHolder> for ReadableStreamBYOBRequest {
     /// <https://streams.spec.whatwg.org/#rs-byob-request-view>
-    fn GetView(
-        &self,
-        _cx: SafeJSContext,
-    ) -> Option<RootedTraceableBox<js::typedarray::HeapArrayBufferView>> {
+    fn GetView(&self) -> Option<RootedTraceableBox<js::typedarray::HeapArrayBufferView>> {
         // Return this.[[view]].
         self.view.borrow().typed_array_to_option()
     }

--- a/components/script/dom/testing/testbinding.rs
+++ b/components/script/dom/testing/testbinding.rs
@@ -12,9 +12,10 @@ use std::time::Duration;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::gc::RootedVec;
-use js::jsapi::{Heap, JS_NewPlainObject, JSObject};
+use js::jsapi::{Heap, JSObject};
 use js::jsval::JSVal;
 use js::realm::CurrentRealm;
+use js::rust::wrappers2::JS_NewPlainObject;
 use js::rust::{
     CustomAutoRooterGuard, HandleObject, HandleValue, MutableHandleObject, MutableHandleValue,
 };
@@ -57,7 +58,6 @@ use crate::dom::node::Node;
 use crate::dom::promise::Promise;
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::url::URL;
-use crate::script_runtime::JSContext as SafeJSContext;
 use crate::timers::OneshotTimerCallback;
 
 #[dom_struct]
@@ -236,13 +236,13 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
         create_buffer_source(cx, &data, array.handle_mut())
             .expect("Creating ClampedU8 array should never fail")
     }
-    fn AnyAttribute(&self, _: SafeJSContext, _: MutableHandleValue) {}
-    fn SetAnyAttribute(&self, _: SafeJSContext, _: HandleValue) {}
+    fn AnyAttribute(&self, _: MutableHandleValue) {}
+    fn SetAnyAttribute(&self, _: HandleValue) {}
     #[expect(unsafe_code)]
-    fn ObjectAttribute(&self, cx: SafeJSContext, mut return_value: MutableHandleObject) {
-        return_value.set(unsafe { JS_NewPlainObject(*cx) });
+    fn ObjectAttribute(&self, cx: &mut JSContext, mut return_value: MutableHandleObject) {
+        return_value.set(unsafe { JS_NewPlainObject(cx) });
     }
-    fn SetObjectAttribute(&self, _: SafeJSContext, _: *mut JSObject) {}
+    fn SetObjectAttribute(&self, _: *mut JSObject) {}
 
     fn GetBooleanAttributeNullable(&self) -> Option<bool> {
         Some(false)
@@ -340,10 +340,10 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
     fn SetInterfaceAttributeWeak(&self, url: Option<&URL>) {
         self.url.set(url);
     }
-    fn GetObjectAttributeNullable(&self, _: SafeJSContext, mut return_value: MutableHandleObject) {
+    fn GetObjectAttributeNullable(&self, mut return_value: MutableHandleObject) {
         return_value.set(ptr::null_mut());
     }
-    fn SetObjectAttributeNullable(&self, _: SafeJSContext, _: *mut JSObject) {}
+    fn SetObjectAttributeNullable(&self, _: *mut JSObject) {}
     fn GetUnionAttributeNullable(&self) -> Option<HTMLElementOrLong> {
         Some(HTMLElementOrLong::Long(0))
     }
@@ -428,8 +428,8 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
             BlobImpl::new_from_bytes(vec![], "".to_owned()),
         )
     }
-    fn ReceiveAny(&self, _: SafeJSContext, _: MutableHandleValue) {}
-    fn ReceiveObject(&self, cx: SafeJSContext, return_value: MutableHandleObject) {
+    fn ReceiveAny(&self, _: MutableHandleValue) {}
+    fn ReceiveObject(&self, cx: &mut JSContext, return_value: MutableHandleObject) {
         self.ObjectAttribute(cx, return_value);
     }
     fn ReceiveUnion(&self) -> HTMLElementOrLong {
@@ -475,11 +475,7 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
             BlobImpl::new_from_bytes(vec![], "".to_owned()),
         )]
     }
-    fn ReceiveUnionIdentity(
-        &self,
-        _: SafeJSContext,
-        arg: UnionTypes::StringOrObject,
-    ) -> UnionTypes::StringOrObject {
+    fn ReceiveUnionIdentity(&self, arg: UnionTypes::StringOrObject) -> UnionTypes::StringOrObject {
         arg
     }
 
@@ -541,8 +537,8 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
             BlobImpl::new_from_bytes(vec![], "".to_owned()),
         ))
     }
-    fn ReceiveNullableObject(&self, cx: SafeJSContext, return_value: MutableHandleObject) {
-        self.GetObjectAttributeNullable(cx, return_value)
+    fn ReceiveNullableObject(&self, return_value: MutableHandleObject) {
+        self.GetObjectAttributeNullable(return_value)
     }
     fn ReceiveNullableUnion(&self) -> Option<HTMLElementOrLong> {
         Some(HTMLElementOrLong::Long(0))
@@ -568,10 +564,10 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
     #[expect(unsafe_code)]
     fn ReceiveObjectSequence(
         &self,
-        cx: SafeJSContext,
+        cx: &mut JSContext,
         return_value: &mut RootedVec<'_, Box<Heap<*mut JSObject>>>,
     ) {
-        return_value.push(Heap::boxed(unsafe { JS_NewPlainObject(*cx) }));
+        return_value.push(Heap::boxed(unsafe { JS_NewPlainObject(cx) }));
     }
     fn GetDictionaryWithTypedArray(
         &self,
@@ -688,25 +684,25 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
     fn PassUnion7(&self, _: StringSequenceOrUnsignedLong) {}
     fn PassUnion8(&self, _: ByteStringSequenceOrLong) {}
     fn PassUnion9(&self, _: UnionTypes::TestDictionaryOrLong) {}
-    fn PassUnion10(&self, _: SafeJSContext, _: UnionTypes::StringOrObject) {}
+    fn PassUnion10(&self, _: UnionTypes::StringOrObject) {}
     fn PassUnion11(&self, _: UnionTypes::ArrayBufferOrArrayBufferView) {}
     fn PassUnionWithTypedef(&self, _: UnionTypes::DocumentOrStringOrURLOrBlob) {}
     fn PassUnionWithTypedef2(&self, _: UnionTypes::LongSequenceOrStringOrURLOrBlob) {}
-    fn PassAny(&self, _: SafeJSContext, _: HandleValue) {}
-    fn PassObject(&self, _: SafeJSContext, _: *mut JSObject) {}
+    fn PassAny(&self, _: HandleValue) {}
+    fn PassObject(&self, _: *mut JSObject) {}
     fn PassCallbackFunction(&self, _: Rc<Function>) {}
     fn PassCallbackInterface(&self, _: Rc<EventListener>) {}
     fn PassSequence(&self, _: Vec<i32>) {}
-    fn PassAnySequence(&self, _: SafeJSContext, _: CustomAutoRooterGuard<Vec<JSVal>>) {}
+    fn PassAnySequence(&self, _: CustomAutoRooterGuard<Vec<JSVal>>) {}
     fn AnySequencePassthrough(
         &self,
-        _: SafeJSContext,
+
         seq: CustomAutoRooterGuard<Vec<JSVal>>,
         return_value: &mut RootedVec<'_, Box<Heap<JSVal>>>,
     ) {
         return_value.extend(seq.handle().iter().map(|value| Heap::boxed(*value)));
     }
-    fn PassObjectSequence(&self, _: SafeJSContext, _: CustomAutoRooterGuard<Vec<*mut JSObject>>) {}
+    fn PassObjectSequence(&self, _: CustomAutoRooterGuard<Vec<*mut JSObject>>) {}
     fn PassStringSequence(&self, _: Vec<DOMString>) {}
     fn PassInterfaceSequence(&self, _: Vec<DomRoot<Blob>>) {}
 
@@ -721,27 +717,19 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
         u.href.clone()
     }
 
-    fn PassOverloadedUnionOfObjectAndString(
-        &self,
-        _: SafeJSContext,
-        _: ObjectOrString,
-    ) -> DOMString {
+    fn PassOverloadedUnionOfObjectAndString(&self, _: ObjectOrString) -> DOMString {
         "union".into()
     }
     fn PassOverloadedUnionOfObjectAndString_(&self, _: bool) -> DOMString {
         "boolean".into()
     }
-    fn PassOverloadedUnionOfObjectAndNumber(&self, _: SafeJSContext, _: ObjectOrLong) -> DOMString {
+    fn PassOverloadedUnionOfObjectAndNumber(&self, _: ObjectOrLong) -> DOMString {
         "union".into()
     }
     fn PassOverloadedUnionOfObjectAndNumber_(&self, _: bool) -> DOMString {
         "boolean".into()
     }
-    fn PassOverloadedUnionOfObjectAndBoolean(
-        &self,
-        _: SafeJSContext,
-        _: ObjectOrBoolean,
-    ) -> DOMString {
+    fn PassOverloadedUnionOfObjectAndBoolean(&self, _: ObjectOrBoolean) -> DOMString {
         "union".into()
     }
     fn PassOverloadedUnionOfObjectAndBoolean_(&self, _: i32) -> DOMString {
@@ -784,7 +772,7 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
     fn PassNullableByteString(&self, _: Option<ByteString>) {}
     // fn PassNullableEnum(self, _: Option<TestEnum>) {}
     fn PassNullableInterface(&self, _: Option<&Blob>) {}
-    fn PassNullableObject(&self, _: SafeJSContext, _: *mut JSObject) {}
+    fn PassNullableObject(&self, _: *mut JSObject) {}
     fn PassNullableTypedArray(&self, _: CustomAutoRooterGuard<Option<typedarray::Int8Array>>) {}
     fn PassNullableUnion(&self, _: Option<HTMLElementOrLong>) {}
     fn PassNullableUnion2(&self, _: Option<EventOrString>) {}
@@ -820,8 +808,8 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
     fn PassOptionalUnion4(&self, _: Option<LongSequenceOrBoolean>) {}
     fn PassOptionalUnion5(&self, _: Option<UnsignedLongOrBoolean>) {}
     fn PassOptionalUnion6(&self, _: Option<ByteStringOrLong>) {}
-    fn PassOptionalAny(&self, _: SafeJSContext, _: HandleValue) {}
-    fn PassOptionalObject(&self, _: SafeJSContext, _: Option<*mut JSObject>) {}
+    fn PassOptionalAny(&self, _: HandleValue) {}
+    fn PassOptionalObject(&self, _: Option<*mut JSObject>) {}
     fn PassOptionalCallbackFunction(&self, _: Option<Rc<Function>>) {}
     fn PassOptionalCallbackInterface(&self, _: Option<Rc<EventListener>>) {}
     fn PassOptionalSequence(&self, _: Option<Vec<i32>>) {}
@@ -844,7 +832,7 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
     fn PassOptionalNullableByteString(&self, _: Option<Option<ByteString>>) {}
     // fn PassOptionalNullableEnum(self, _: Option<Option<TestEnum>>) {}
     fn PassOptionalNullableInterface(&self, _: Option<Option<&Blob>>) {}
-    fn PassOptionalNullableObject(&self, _: SafeJSContext, _: Option<*mut JSObject>) {}
+    fn PassOptionalNullableObject(&self, _: Option<*mut JSObject>) {}
     fn PassOptionalNullableUnion(&self, _: Option<Option<HTMLElementOrLong>>) {}
     fn PassOptionalNullableUnion2(&self, _: Option<Option<EventOrString>>) {}
     fn PassOptionalNullableUnion3(&self, _: Option<Option<StringOrLongSequence>>) {}
@@ -888,12 +876,12 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
     fn PassOptionalNullableByteStringWithDefault(&self, _: Option<ByteString>) {}
     // fn PassOptionalNullableEnumWithDefault(self, _: Option<TestEnum>) {}
     fn PassOptionalNullableInterfaceWithDefault(&self, _: Option<&Blob>) {}
-    fn PassOptionalNullableObjectWithDefault(&self, _: SafeJSContext, _: *mut JSObject) {}
+    fn PassOptionalNullableObjectWithDefault(&self, _: *mut JSObject) {}
     fn PassOptionalNullableUnionWithDefault(&self, _: Option<HTMLElementOrLong>) {}
     fn PassOptionalNullableUnion2WithDefault(&self, _: Option<EventOrString>) {}
     // fn PassOptionalNullableCallbackFunctionWithDefault(self, _: Option<Function>) {}
     fn PassOptionalNullableCallbackInterfaceWithDefault(&self, _: Option<Rc<EventListener>>) {}
-    fn PassOptionalAnyWithDefault(&self, _: SafeJSContext, _: HandleValue) {}
+    fn PassOptionalAnyWithDefault(&self, _: HandleValue) {}
 
     fn PassOptionalNullableBooleanWithNonNullDefault(&self, _: Option<bool>) {}
     fn PassOptionalNullableByteWithNonNullDefault(&self, _: Option<i8>) {}
@@ -942,8 +930,8 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
     fn PassVariadicUnion5(&self, _: Vec<StringOrUnsignedLong>) {}
     fn PassVariadicUnion6(&self, _: Vec<UnsignedLongOrBoolean>) {}
     fn PassVariadicUnion7(&self, _: Vec<ByteStringOrLong>) {}
-    fn PassVariadicAny(&self, _: SafeJSContext, _: Vec<HandleValue>) {}
-    fn PassVariadicObject(&self, _: SafeJSContext, _: Vec<*mut JSObject>) {}
+    fn PassVariadicAny(&self, _: Vec<HandleValue>) {}
+    fn PassVariadicObject(&self, _: Vec<*mut JSObject>) {}
     fn BooleanMozPreference(&self, pref_name: DOMString) -> bool {
         prefs::get()
             .get_value(&pref_name.str())

--- a/components/script/dom/trustedtypes/trustedscript.rs
+++ b/components/script/dom/trustedtypes/trustedscript.rs
@@ -87,8 +87,7 @@ impl TrustedScript {
         };
         // Step 2.2. Let isTrusted be true if bodyArg implements TrustedScript,
         // and false otherwise.
-        let mut is_trusted = match TrustedTypePolicyFactory::is_trusted_script(cx.into(), body_arg)
-        {
+        let mut is_trusted = match TrustedTypePolicyFactory::is_trusted_script(cx, body_arg) {
             // Step 2.3. If isTrusted is true then:
             Ok(trusted_script) => {
                 // Step 2.3.1. If bodyString is not equal to bodyArg’s data, set isTrusted to false.

--- a/components/script/dom/trustedtypes/trustedtypepolicyfactory.rs
+++ b/components/script/dom/trustedtypes/trustedtypepolicyfactory.rs
@@ -5,6 +5,7 @@ use std::cell::RefCell;
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Namespace, QualName, local_name, ns};
+use js::context::JSContext;
 use js::jsval::NullValue;
 use js::rust::HandleValue;
 use script_bindings::conversions::SafeToJSValConvertible;
@@ -32,7 +33,6 @@ use crate::dom::trustedtypes::trustedscripturl::TrustedScriptURL;
 use crate::dom::trustedtypes::trustedtypepolicy::{TrustedType, TrustedTypePolicy};
 use crate::dom::types::WorkerGlobalScope;
 use crate::dom::window::Window;
-use crate::script_runtime::JSContext;
 
 #[dom_struct]
 pub struct TrustedTypePolicyFactory {
@@ -68,14 +68,14 @@ impl TrustedTypePolicyFactory {
         }
     }
 
-    pub(crate) fn new(cx: &mut js::context::JSContext, global: &GlobalScope) -> DomRoot<Self> {
+    pub(crate) fn new(cx: &mut JSContext, global: &GlobalScope) -> DomRoot<Self> {
         reflect_dom_object_with_cx(Box::new(Self::new_inherited()), global, cx)
     }
 
     /// <https://www.w3.org/TR/trusted-types/#create-trusted-type-policy-algorithm>
     fn create_trusted_type_policy(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         policy_name: String,
         options: &TrustedTypePolicyOptions,
         global: &GlobalScope,
@@ -190,7 +190,7 @@ impl TrustedTypePolicyFactory {
 
     /// <https://w3c.github.io/trusted-types/dist/spec/#validate-attribute-mutation>
     pub(crate) fn get_trusted_types_compliant_attribute_value(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         element_namespace: &Namespace,
         element_name: &LocalName,
         attribute: &str,
@@ -244,7 +244,7 @@ impl TrustedTypePolicyFactory {
 
     /// <https://w3c.github.io/trusted-types/dist/spec/#process-value-with-a-default-policy-algorithm>
     pub(crate) fn process_value_with_default_policy(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         expected_type: TrustedType,
         global: &GlobalScope,
         input: DOMString,
@@ -289,7 +289,7 @@ impl TrustedTypePolicyFactory {
     /// Step 1 is implemented by the caller
     /// <https://w3c.github.io/trusted-types/dist/spec/#get-trusted-type-compliant-string-algorithm>
     pub(crate) fn get_trusted_type_compliant_string(
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         expected_type: TrustedType,
         global: &GlobalScope,
         input: DOMString,
@@ -349,10 +349,10 @@ impl TrustedTypePolicyFactory {
 
     /// <https://www.w3.org/TR/trusted-types/#dom-trustedtypepolicyfactory-isscript>
     pub(crate) fn is_trusted_script(
-        cx: JSContext,
+        cx: &mut JSContext,
         value: HandleValue,
     ) -> Result<DomRoot<TrustedScript>, ()> {
-        root_from_handlevalue::<TrustedScript>(value, cx)
+        root_from_handlevalue::<TrustedScript>(value, cx.into())
     }
 }
 
@@ -360,30 +360,30 @@ impl TrustedTypePolicyFactoryMethods<crate::DomTypeHolder> for TrustedTypePolicy
     /// <https://www.w3.org/TR/trusted-types/#dom-trustedtypepolicyfactory-createpolicy>
     fn CreatePolicy(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
         policy_name: DOMString,
         options: &TrustedTypePolicyOptions,
     ) -> Fallible<DomRoot<TrustedTypePolicy>> {
         self.create_trusted_type_policy(cx, String::from(policy_name), options, &self.global())
     }
     /// <https://www.w3.org/TR/trusted-types/#dom-trustedtypepolicyfactory-ishtml>
-    fn IsHTML(&self, cx: JSContext, value: HandleValue) -> bool {
-        root_from_handlevalue::<TrustedHTML>(value, cx).is_ok()
+    fn IsHTML(&self, cx: &mut JSContext, value: HandleValue) -> bool {
+        root_from_handlevalue::<TrustedHTML>(value, cx.into()).is_ok()
     }
     /// <https://www.w3.org/TR/trusted-types/#dom-trustedtypepolicyfactory-isscript>
-    fn IsScript(&self, cx: JSContext, value: HandleValue) -> bool {
+    fn IsScript(&self, cx: &mut JSContext, value: HandleValue) -> bool {
         TrustedTypePolicyFactory::is_trusted_script(cx, value).is_ok()
     }
     /// <https://www.w3.org/TR/trusted-types/#dom-trustedtypepolicyfactory-isscripturl>
-    fn IsScriptURL(&self, cx: JSContext, value: HandleValue) -> bool {
-        root_from_handlevalue::<TrustedScriptURL>(value, cx).is_ok()
+    fn IsScriptURL(&self, cx: &mut JSContext, value: HandleValue) -> bool {
+        root_from_handlevalue::<TrustedScriptURL>(value, cx.into()).is_ok()
     }
     /// <https://www.w3.org/TR/trusted-types/#dom-trustedtypepolicyfactory-emptyhtml>
-    fn EmptyHTML(&self, cx: &mut js::context::JSContext) -> DomRoot<TrustedHTML> {
+    fn EmptyHTML(&self, cx: &mut JSContext) -> DomRoot<TrustedHTML> {
         TrustedHTML::new(cx, DOMString::new(), &self.global())
     }
     /// <https://www.w3.org/TR/trusted-types/#dom-trustedtypepolicyfactory-emptyscript>
-    fn EmptyScript(&self, cx: &mut js::context::JSContext) -> DomRoot<TrustedScript> {
+    fn EmptyScript(&self, cx: &mut JSContext) -> DomRoot<TrustedScript> {
         TrustedScript::new(cx, DOMString::new(), &self.global())
     }
     /// <https://www.w3.org/TR/trusted-types/#dom-trustedtypepolicyfactory-getattributetype>
@@ -486,7 +486,7 @@ impl TrustedTypePolicyFactoryMethods<crate::DomTypeHolder> for TrustedTypePolicy
 }
 
 impl GlobalScope {
-    fn trusted_types(&self, cx: &mut js::context::JSContext) -> DomRoot<TrustedTypePolicyFactory> {
+    fn trusted_types(&self, cx: &mut JSContext) -> DomRoot<TrustedTypePolicyFactory> {
         if let Some(window) = self.downcast::<Window>() {
             return window.TrustedTypes(cx);
         }

--- a/components/script/dom/webcrypto/crypto.rs
+++ b/components/script/dom/webcrypto/crypto.rs
@@ -19,7 +19,7 @@ use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::SubtleCrypto;
-use crate::script_runtime::{CanGc, JSContext};
+use crate::script_runtime::CanGc;
 
 // https://developer.mozilla.org/en-US/docs/Web/API/Crypto
 #[dom_struct]
@@ -52,7 +52,6 @@ impl CryptoMethods<crate::DomTypeHolder> for Crypto {
     /// <https://w3c.github.io/webcrypto/#Crypto-method-getRandomValues>
     fn GetRandomValues(
         &self,
-        _cx: JSContext,
         mut input: CustomAutoRooterGuard<ArrayBufferView>,
     ) -> Fallible<RootedTraceableBox<HeapArrayBufferView>> {
         let array_type = input.get_array_type();

--- a/components/script/dom/webcrypto/cryptokey.rs
+++ b/components/script/dom/webcrypto/cryptokey.rs
@@ -25,7 +25,6 @@ use crate::dom::bindings::serializable::Serializable;
 use crate::dom::bindings::structuredclone::StructuredData;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::KeyAlgorithmAndDerivatives;
-use crate::script_runtime::JSContext;
 
 pub(crate) enum CryptoKeyOrCryptoKeyPair {
     CryptoKey(DomRoot<CryptoKey>),
@@ -207,13 +206,13 @@ impl CryptoKeyMethods<crate::DomTypeHolder> for CryptoKey {
     }
 
     /// <https://w3c.github.io/webcrypto/#dom-cryptokey-algorithm>
-    fn Algorithm(&self, _cx: JSContext, mut return_value: MutableHandleObject) {
+    fn Algorithm(&self, mut return_value: MutableHandleObject) {
         // Returns the cached ECMAScript object associated with the [[algorithm]] internal slot.
         return_value.set(self.algorithm_cached.get())
     }
 
     /// <https://w3c.github.io/webcrypto/#dom-cryptokey-usages>
-    fn Usages(&self, _cx: JSContext, mut return_value: MutableHandleObject) {
+    fn Usages(&self, mut return_value: MutableHandleObject) {
         // Returns the cached ECMAScript object associated with the [[usages]] internal slot, which
         // indicates which cryptographic operations are permissible to be used with this key.
         return_value.set(self.usages_cached.get())

--- a/components/script/dom/webxr/xrinputsource.rs
+++ b/components/script/dom/webxr/xrinputsource.rs
@@ -23,7 +23,6 @@ use crate::dom::xrhand::XRHand;
 use crate::dom::xrsession::XRSession;
 use crate::dom::xrspace::XRSpace;
 use crate::realms::enter_auto_realm;
-use crate::script_runtime::JSContext as SafeJSContext;
 
 #[dom_struct]
 pub(crate) struct XRInputSource {
@@ -162,7 +161,7 @@ impl XRInputSourceMethods<crate::DomTypeHolder> for XRInputSource {
         }
     }
     /// <https://immersive-web.github.io/webxr/#dom-xrinputsource-profiles>
-    fn Profiles(&self, _cx: SafeJSContext, mut retval: MutableHandleValue) {
+    fn Profiles(&self, mut retval: MutableHandleValue) {
         retval.set(self.profiles.get())
     }
 

--- a/components/script/dom/webxr/xrinputsourceschangeevent.rs
+++ b/components/script/dom/webxr/xrinputsourceschangeevent.rs
@@ -23,7 +23,6 @@ use crate::dom::window::Window;
 use crate::dom::xrinputsource::XRInputSource;
 use crate::dom::xrsession::XRSession;
 use crate::realms::enter_auto_realm;
-use crate::script_runtime::JSContext as SafeJSContext;
 
 #[dom_struct]
 pub(crate) struct XRInputSourcesChangeEvent {
@@ -122,12 +121,12 @@ impl XRInputSourcesChangeEventMethods<crate::DomTypeHolder> for XRInputSourcesCh
     }
 
     /// <https://immersive-web.github.io/webxr/#dom-xrinputsourceschangeevent-added>
-    fn Added(&self, _cx: SafeJSContext, mut retval: MutableHandleValue) {
+    fn Added(&self, mut retval: MutableHandleValue) {
         retval.set(self.added.get())
     }
 
     /// <https://immersive-web.github.io/webxr/#dom-xrinputsourceschangeevent-removed>
-    fn Removed(&self, _cx: SafeJSContext, mut retval: MutableHandleValue) {
+    fn Removed(&self, mut retval: MutableHandleValue) {
         retval.set(self.removed.get())
     }
 

--- a/components/script/dom/webxr/xrviewerpose.rs
+++ b/components/script/dom/webxr/xrviewerpose.rs
@@ -10,7 +10,6 @@ use js::jsval::{JSVal, UndefinedValue};
 use js::rust::MutableHandleValue;
 use script_bindings::conversions::SafeToJSValConvertible;
 use script_bindings::reflector::reflect_dom_object_with_cx;
-use script_bindings::script_runtime::JSContext as SafeJSContext;
 use webxr_api::{Viewer, ViewerPose, Views};
 
 use crate::dom::bindings::codegen::Bindings::XRViewBinding::XREye;
@@ -192,7 +191,7 @@ impl XRViewerPose {
 
 impl XRViewerPoseMethods<crate::DomTypeHolder> for XRViewerPose {
     /// <https://immersive-web.github.io/webxr/#dom-xrviewerpose-views>
-    fn Views(&self, _cx: SafeJSContext, mut retval: MutableHandleValue) {
+    fn Views(&self, mut retval: MutableHandleValue) {
         retval.set(self.views.get())
     }
 }

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -241,7 +241,7 @@ pub(crate) fn Fetch(
     if signal.aborted() {
         // Step 4.1. Abort the fetch() call with p, request, null, and requestObject’s signal’s abort reason.
         rooted!(&in(cx) let mut abort_reason = UndefinedValue());
-        signal.Reason(cx.into(), abort_reason.handle_mut());
+        signal.Reason(abort_reason.handle_mut());
         abort_fetch_call(
             promise.clone(),
             &request_object,
@@ -362,7 +362,7 @@ pub(crate) fn FetchLater(
     let signal = request_object.Signal();
     if signal.aborted() {
         rooted!(&in(cx) let mut abort_reason = UndefinedValue());
-        signal.Reason(cx.into(), abort_reason.handle_mut());
+        signal.Reason(abort_reason.handle_mut());
         unsafe {
             assert!(!JS_IsExceptionPending(cx));
             JS_SetPendingException(cx, abort_reason.handle(), ExceptionStackBehavior::Capture)

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -1160,12 +1160,15 @@ DOMInterfaces = {
         'GetDictionaryWithTypedArray',
         'GetInterfaceAttributeNullable',
         'InterfaceAttribute',
+        'ObjectAttribute',
         'PromiseRejectNative',
         'PromiseRejectWithTypeError',
         'PromiseResolveNative',
         'ReceiveInterface',
         'ReceiveInterfaceSequence',
         'ReceiveNullableInterface',
+        'ReceiveObject',
+        'ReceiveObjectSequence',
         'ResolvePromiseDelayed',
         'ReturnRejectedPromise',
         'ReturnResolvedPromise',
@@ -1207,7 +1210,7 @@ DOMInterfaces = {
 },
 
 'TrustedTypePolicyFactory': {
-    'cx': ['CreatePolicy', 'EmptyHTML', 'EmptyScript']
+    'cx': ['CreatePolicy', 'EmptyHTML', 'EmptyScript', 'IsHTML', 'IsScript', 'IsScriptURL'],
 },
 
 'URL': {

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -1012,6 +1012,7 @@ def getJSToNativeConversionInfo(type: IDLType, descriptorProvider: DescriptorPro
             return handleOptional(template, declType, handleDefault("None"))
 
         conversionFunction = "root_from_handlevalue"
+        maybeCx = ", SafeJSContext::from_ptr(cx.raw_cx())"
         descriptorType = descriptor.returnType
         if isMember == "Variadic":
             conversionFunction = "native_from_handlevalue"
@@ -1020,6 +1021,7 @@ def getJSToNativeConversionInfo(type: IDLType, descriptorProvider: DescriptorPro
             descriptorType = descriptor.argumentType
         elif descriptor.interface.identifier.name == "WindowProxy":
             conversionFunction = "windowproxy_from_handlevalue::<D>"
+            maybeCx = ""
 
         if failureCode is None:
             unwrapFailureCode = (
@@ -1031,7 +1033,7 @@ def getJSToNativeConversionInfo(type: IDLType, descriptorProvider: DescriptorPro
 
         templateBody = fill(
             """
-            match ${function}($${val}, SafeJSContext::from_ptr(cx.raw_cx())) {
+            match ${function}($${val}${maybeCx}) {
                 Ok(val) => val,
                 Err(()) => {
                     $*{failureCode}
@@ -1039,7 +1041,8 @@ def getJSToNativeConversionInfo(type: IDLType, descriptorProvider: DescriptorPro
             }
             """,
             failureCode=unwrapFailureCode + "\n",
-            function=conversionFunction)
+            function=conversionFunction,
+            maybeCx=maybeCx)
 
 
         declType = CGGeneric(descriptorType)
@@ -4206,14 +4209,11 @@ class CGCallGenerator(CGThing):
                 name = f"&{name}"
             args.append(CGGeneric(name))
 
-        needsCx = False
         match max([needCx(returnType, (a for (a, _) in arguments), True), Context.Cx if is_implicit_cx_attribute else Context.No]):
             case Context.Cx:
                 descriptor.cxMethods.append(nativeMethodName)
             case Context.CurrentRealm:
                 descriptor.realmMethods.append(nativeMethodName)
-            case Context.OldCx:
-                needsCx = True
             case Context.No:
                 pass
 
@@ -4231,8 +4231,6 @@ class CGCallGenerator(CGThing):
         elif descriptor.interface.isIteratorInterface():
             args.prepend(CGGeneric("cx"))
         else:
-            if "cx" not in argsPre and needsCx:
-                args.prepend(CGGeneric("SafeJSContext::from_ptr(cx.raw_cx())"))
             if nativeMethodName in descriptor.canGcMethods:
                 args.append(CGGeneric("CanGc::deprecated_note()"))
 
@@ -7017,9 +7015,6 @@ class CGInterfaceTrait(CGThing):
 
             safe_cx = cx or cx_no_gc or realm or no_gc
 
-            if typeNeedsCx(attribute_type, retval) and not safe_cx:
-                yield "cx", "SafeJSContext"
-
             if argument:
                 yield "value", argument_type(descriptor, argument)
 
@@ -8366,14 +8361,12 @@ def method_arguments(descriptorProvider: DescriptorProvider,
                      realm: bool = False,
                      canGc: bool = False
                      ) -> Iterator[tuple[str, str]]:
-    old_cx = False
+
     match needCx(returnType, arguments, passJSBits):
         case Context.Cx:
             cx = True
         case Context.CurrentRealm:
             realm = True
-        case Context.OldCx:
-            old_cx = True
         case Context.No:
             pass
 
@@ -8387,9 +8380,6 @@ def method_arguments(descriptorProvider: DescriptorProvider,
         yield "cx", "&NoGC"
 
     safe_cx = cx or cx_no_gc or realm or no_gc
-
-    if old_cx and not safe_cx:
-        yield "cx", "SafeJSContext"
 
     for argument in arguments:
         ty = argument_type(descriptorProvider, argument.type, argument.optional,

--- a/components/script_bindings/conversions.rs
+++ b/components/script_bindings/conversions.rs
@@ -622,7 +622,6 @@ pub fn is_array_like<D: crate::DomTypes>(
 /// Caller is responsible for throwing a JS exception if needed in case of error.
 pub(crate) unsafe fn windowproxy_from_handlevalue<D: crate::DomTypes>(
     v: HandleValue,
-    _cx: SafeJSContext,
 ) -> Result<DomRoot<D::WindowProxy>, ()> {
     if !v.get().is_object() {
         return Err(());


### PR DESCRIPTION
These were added by default whenever it was determined to be required. However, in many cases this was not the case. Therefore, instead of always adding it, we now use the Bindings.conf to specify when to do so.

Part of #40600

Testing: it compiles