### PR TITLE
script: Add specification comments and flesh out `Selection` DOM APIs

### DIFF
--- a/components/script/dom/range/range.rs
+++ b/components/script/dom/range/range.rs
@@ -319,8 +319,8 @@ impl Range {
     }
 
     pub(crate) fn start_and_end_are_in_document_tree(&self) -> bool {
-        self.start_container().containing_shadow_root().is_none() &&
-            self.end_container().containing_shadow_root().is_none()
+        self.start_container().is_in_a_document_tree() &&
+            self.end_container().is_in_a_document_tree()
     }
 
     pub(crate) fn start_container(&self) -> DomRoot<Node> {

--- a/components/script/dom/range/range.rs
+++ b/components/script/dom/range/range.rs
@@ -318,6 +318,11 @@ impl Range {
         self.abstract_range().end()
     }
 
+    pub(crate) fn start_and_end_are_in_document_tree(&self) -> bool {
+        self.start_container().containing_shadow_root().is_none() &&
+            self.end_container().containing_shadow_root().is_none()
+    }
+
     pub(crate) fn start_container(&self) -> DomRoot<Node> {
         self.abstract_range().StartContainer()
     }

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -162,11 +162,31 @@ impl Selection {
         })
     }
 
+    pub(crate) fn anchor_offset(&self) -> u32 {
+        self.range
+            .get()
+            .map(|range| match self.direction.get() {
+                Direction::Forwards => range.start_offset(),
+                _ => range.end_offset(),
+            })
+            .unwrap_or(0)
+    }
+
     pub(crate) fn focus_node(&self) -> Option<DomRoot<Node>> {
         self.range.get().map(|range| match self.direction.get() {
             Direction::Forwards => range.end_container(),
             _ => range.start_container(),
         })
+    }
+
+    pub(crate) fn focus_offset(&self) -> u32 {
+        self.range
+            .get()
+            .map(|range| match self.direction.get() {
+                Direction::Forwards => range.end_offset(),
+                _ => range.start_offset(),
+            })
+            .unwrap_or(0)
     }
 }
 
@@ -176,7 +196,7 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         // > The attribute must return the anchor node of this, or null if the anchor is
         // > null or anchor is not in the document tree.
         let anchor_node = self.anchor_node()?;
-        if anchor_node.containing_shadow_root().is_some() {
+        if anchor_node.is_in_a_document_tree() {
             return None;
         }
         Some(anchor_node)
@@ -186,20 +206,13 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
     fn AnchorOffset(&self) -> u32 {
         // > The attribute must return the anchor offset of this, or 0 if the anchor is null
         // > or anchor is not in the document tree.
-        let Some(range) = self.range.get() else {
-            return 0;
-        };
         if self
             .anchor_node()
-            .is_none_or(|anchor_node| anchor_node.containing_shadow_root().is_some())
+            .is_none_or(|anchor_node| anchor_node.is_in_a_document_tree())
         {
             return 0;
         }
-
-        match self.direction.get() {
-            Direction::Forwards => range.start_offset(),
-            _ => range.end_offset(),
-        }
+        self.anchor_offset()
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-focusnode>
@@ -207,7 +220,7 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         // > The attribute must return the focus node of this, or null if the focus is
         // > null or focus is not in the document tree.
         let focus_node = self.focus_node()?;
-        if focus_node.containing_shadow_root().is_some() {
+        if focus_node.is_in_a_document_tree() {
             return None;
         }
         Some(focus_node)
@@ -217,20 +230,13 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
     fn FocusOffset(&self) -> u32 {
         // > The attribute must return the focus offset of this, or 0 if the focus is null
         // > or focus is not in the document tree.
-        let Some(range) = self.range.get() else {
-            return 0;
-        };
         if self
             .focus_node()
-            .is_none_or(|focus_node| focus_node.containing_shadow_root().is_some())
+            .is_none_or(|focus_node| focus_node.is_in_a_document_tree())
         {
             return 0;
         }
-
-        match self.direction.get() {
-            Direction::Forwards => range.end_offset(),
-            _ => range.start_offset(),
-        }
+        self.focus_offset()
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-iscollapsed>
@@ -439,9 +445,9 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         //
         // Note: oldFocus is unused, so we do not set it here.
         let old_anchor_node = &*self
-            .GetAnchorNode()
+            .anchor_node()
             .expect("has range, therefore has anchor node");
-        let old_anchor_offset = self.AnchorOffset();
+        let old_anchor_offset = self.anchor_offset();
 
         // Step 4. Let newRange be a new range.
         let new_range;

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -155,6 +155,7 @@ impl Selection {
         }
     }
 
+    /// <https://w3c.github.io/selection-api/#dfn-anchor>
     pub(crate) fn anchor_node(&self) -> Option<DomRoot<Node>> {
         self.range.get().map(|range| match self.direction.get() {
             Direction::Forwards => range.start_container(),
@@ -162,6 +163,7 @@ impl Selection {
         })
     }
 
+    /// <https://w3c.github.io/selection-api/#dfn-anchor>
     pub(crate) fn anchor_offset(&self) -> u32 {
         self.range
             .get()
@@ -172,6 +174,7 @@ impl Selection {
             .unwrap_or(0)
     }
 
+    /// <https://w3c.github.io/selection-api/#dfn-focus>
     pub(crate) fn focus_node(&self) -> Option<DomRoot<Node>> {
         self.range.get().map(|range| match self.direction.get() {
             Direction::Forwards => range.end_container(),
@@ -179,6 +182,7 @@ impl Selection {
         })
     }
 
+    /// <https://w3c.github.io/selection-api/#dfn-focus>
     pub(crate) fn focus_offset(&self) -> u32 {
         self.range
             .get()
@@ -367,6 +371,9 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
 
         // Step 4. If document associated with this is not a shadow-including inclusive
         // ancestor of node, abort these steps.
+        //
+        // TODO: `is_same_root` does reach beyond shadow root boundaries, so this check is
+        // wrong.
         if !self.is_same_root(node) {
             return Ok(());
         }
@@ -419,6 +426,9 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
     fn Extend(&self, cx: &mut JSContext, node: &Node, offset: u32) -> ErrorResult {
         // Step 1. If the document associated with this is not a shadow-including
         // inclusive ancestor of node, abort these steps.
+        //
+        // TODO: `is_same_root` does reach beyond shadow root boundaries, so this check is
+        // wrong.
         if !self.is_same_root(node) {
             return Ok(());
         }
@@ -527,6 +537,9 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
 
         // Step 2. If document associated with this is not a shadow-including inclusive
         // ancestor of anchorNode or focusNode, abort these steps.
+        //
+        // TODO: `is_same_root` does reach beyond shadow root boundaries, so this check is
+        // wrong.
         if !self.is_same_root(anchor_node) || !self.is_same_root(focus_node) {
             return Ok(());
         }

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -86,9 +86,10 @@ impl Selection {
     pub(crate) fn queue_selectionchange_task(&self) {
         // https://w3c.github.io/editing/docs/execCommand/#state-override
         // https://w3c.github.io/editing/docs/execCommand/#value-override
-        // > Whenever the number of ranges in the selection changes to something different,
-        // > and whenever a boundary point of the range at a given index in the selection changes
-        // > to something different, the state override and value override must be unset for every command.
+        // > Whenever the number of ranges in the selection changes to something
+        // > different, and whenever a boundary point of the range at a given index in the
+        // > selection changes to something different, the state override and value
+        // > override must be unset for every command.
         self.document.clear_command_overrides();
 
         // Step 1. If target's has scheduled selectionchange event is true, abort these steps.
@@ -97,7 +98,8 @@ impl Selection {
         }
         // Step 2. Set target's has scheduled selectionchange event to true.
         self.has_scheduled_selectionchange_event.set(true);
-        // Step 3. Queue a task on the user interaction task source to fire a selectionchange event on target.
+        // Step 3. Queue a task on the user interaction task source to fire a
+        // selectionchange event on target.
         let this = Trusted::new(self);
         self.document
             .owner_global()
@@ -109,12 +111,14 @@ impl Selection {
                     let this = this.root();
                     // Step 1. Set target's has scheduled selectionchange event to false.
                     this.has_scheduled_selectionchange_event.set(false);
-                    // Step 2. If target is an element, fire an event named selectionchange, which bubbles and not cancelable, at target.
+                    // Step 2. If target is an element, fire an event named
+                    // selectionchange, which bubbles and not cancelable, at target.
                     //
                     // n/a
 
-                    // Step 3. Otherwise, if target is a document, fire an event named selectionchange,
-                    // which does not bubble and not cancelable, at target.
+                    // Step 3. Otherwise, if target is a document, fire an event named
+                    // selectionchange, which does not bubble and not cancelable, at
+                    // target.
                     this.document.upcast::<EventTarget>().fire_event(cx, atom!("selectionchange"));
                 }),
             );
@@ -126,7 +130,8 @@ impl Selection {
 
     /// <https://w3c.github.io/editing/docs/execCommand/#active-range>
     pub(crate) fn active_range(&self) -> Option<DomRoot<Range>> {
-        // > The active range is the range of the selection given by calling getSelection() on the context object. (Thus the active range may be null.)
+        // > The active range is the range of the selection given by calling
+        // > getSelection() on the context object. (Thus the active range may be null.)
         self.range.get()
     }
 
@@ -149,115 +154,168 @@ impl Selection {
             self.direction.set(Direction::Backwards);
         }
     }
+
+    pub(crate) fn anchor_node(&self) -> Option<DomRoot<Node>> {
+        self.range.get().map(|range| match self.direction.get() {
+            Direction::Forwards => range.start_container(),
+            _ => range.end_container(),
+        })
+    }
+
+    pub(crate) fn focus_node(&self) -> Option<DomRoot<Node>> {
+        self.range.get().map(|range| match self.direction.get() {
+            Direction::Forwards => range.end_container(),
+            _ => range.start_container(),
+        })
+    }
 }
 
 impl SelectionMethods<crate::DomTypeHolder> for Selection {
     /// <https://w3c.github.io/selection-api/#dom-selection-anchornode>
     fn GetAnchorNode(&self) -> Option<DomRoot<Node>> {
-        if let Some(range) = self.range.get() {
-            match self.direction.get() {
-                Direction::Forwards => Some(range.start_container()),
-                _ => Some(range.end_container()),
-            }
-        } else {
-            None
+        // > The attribute must return the anchor node of this, or null if the anchor is
+        // > null or anchor is not in the document tree.
+        let anchor_node = self.anchor_node()?;
+        if anchor_node.containing_shadow_root().is_some() {
+            return None;
         }
+        Some(anchor_node)
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-anchoroffset>
     fn AnchorOffset(&self) -> u32 {
-        if let Some(range) = self.range.get() {
-            match self.direction.get() {
-                Direction::Forwards => range.start_offset(),
-                _ => range.end_offset(),
-            }
-        } else {
-            0
+        // > The attribute must return the anchor offset of this, or 0 if the anchor is null
+        // > or anchor is not in the document tree.
+        let Some(range) = self.range.get() else {
+            return 0;
+        };
+        if self
+            .anchor_node()
+            .is_none_or(|anchor_node| anchor_node.containing_shadow_root().is_some())
+        {
+            return 0;
+        }
+
+        match self.direction.get() {
+            Direction::Forwards => range.start_offset(),
+            _ => range.end_offset(),
         }
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-focusnode>
     fn GetFocusNode(&self) -> Option<DomRoot<Node>> {
-        if let Some(range) = self.range.get() {
-            match self.direction.get() {
-                Direction::Forwards => Some(range.end_container()),
-                _ => Some(range.start_container()),
-            }
-        } else {
-            None
+        // > The attribute must return the focus node of this, or null if the focus is
+        // > null or focus is not in the document tree.
+        let focus_node = self.focus_node()?;
+        if focus_node.containing_shadow_root().is_some() {
+            return None;
         }
+        Some(focus_node)
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-focusoffset>
     fn FocusOffset(&self) -> u32 {
-        if let Some(range) = self.range.get() {
-            match self.direction.get() {
-                Direction::Forwards => range.end_offset(),
-                _ => range.start_offset(),
-            }
-        } else {
-            0
+        // > The attribute must return the focus offset of this, or 0 if the focus is null
+        // > or focus is not in the document tree.
+        let Some(range) = self.range.get() else {
+            return 0;
+        };
+        if self
+            .focus_node()
+            .is_none_or(|focus_node| focus_node.containing_shadow_root().is_some())
+        {
+            return 0;
+        }
+
+        match self.direction.get() {
+            Direction::Forwards => range.end_offset(),
+            _ => range.start_offset(),
         }
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-iscollapsed>
     fn IsCollapsed(&self) -> bool {
-        if let Some(range) = self.range.get() {
-            range.collapsed()
-        } else {
-            true
-        }
+        // > The attribute must return true if and only if the anchor and focus are the
+        // > same (including if both are null). Otherwise it must return false.
+        self.range.get().is_none_or(|range| range.collapsed())
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-rangecount>
     fn RangeCount(&self) -> u32 {
-        if self.range.get().is_some() { 1 } else { 0 }
+        // > The attribute must return 0 if this is empty or either focus or anchor is not
+        // > in the document tree, and must return 1 otherwise.
+        let Some(range) = self.range.get() else {
+            return 0;
+        };
+        if !range.start_and_end_are_in_document_tree() {
+            return 0;
+        }
+        1
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-type>
     fn Type(&self) -> DOMString {
-        if let Some(range) = self.range.get() {
-            if range.collapsed() {
-                DOMString::from("Caret")
-            } else {
-                DOMString::from("Range")
-            }
+        // > The attribute must return "None" if this is empty or either focus or anchor
+        // > is not in the document tree, "Caret" if this's range is collapsed, and "Range"
+        // > otherwise.
+        let Some(range) = self.range.get() else {
+            return DOMString::from("None");
+        };
+        if !range.start_and_end_are_in_document_tree() {
+            return DOMString::from("None");
+        }
+
+        if range.collapsed() {
+            DOMString::from("Caret")
         } else {
-            DOMString::from("None")
+            DOMString::from("Range")
         }
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-getrangeat>
     fn GetRangeAt(&self, index: u32) -> Fallible<DomRoot<Range>> {
+        // > The method must throw an IndexSizeError exception if index is not 0, or if this
+        // > is empty or either focus or anchor is not in the document tree. Otherwise, it
+        // > must return a reference to (not a copy of) this's range.
         if index != 0 {
-            Err(Error::IndexSize(None))
-        } else if let Some(range) = self.range.get() {
-            Ok(DomRoot::from_ref(&range))
-        } else {
-            Err(Error::IndexSize(None))
+            return Err(Error::IndexSize(None));
         }
+
+        let Some(range) = self.range.get() else {
+            return Err(Error::IndexSize(None));
+        };
+
+        if !range.start_and_end_are_in_document_tree() {
+            return Err(Error::IndexSize(None));
+        }
+
+        Ok(DomRoot::from_ref(&range))
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-addrange>
     fn AddRange(&self, range: &Range) {
-        // Step 1
+        // Step 1. If the root of the range's boundary points are not the document
+        // associated with this, abort these steps.
         if !self.is_same_root(&range.start_container()) {
             return;
         }
 
-        // Step 2
+        // Step 2. If rangeCount is not 0, abort these steps.
         if self.RangeCount() != 0 {
             return;
         }
 
-        // Step 3
+        // Step 3. Set this's range to range by a strong reference (not by making a copy).
         self.set_range(range);
+
         // Are we supposed to set Direction here? w3c/selection-api#116
         self.direction.set(Direction::Forwards);
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-removerange>
     fn RemoveRange(&self, range: &Range) -> ErrorResult {
+        // > The method must make this empty by disassociating its range if this's range
+        // > is range. Otherwise, it must throw a NotFoundError.
         if let Some(own_range) = self.range.get() &&
             &*own_range == range
         {
@@ -269,58 +327,69 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
 
     /// <https://w3c.github.io/selection-api/#dom-selection-removeallranges>
     fn RemoveAllRanges(&self) {
+        // > The method must make this empty by disassociating its range if this has an
+        // > associated range.
         self.clear_range();
     }
 
-    // https://w3c.github.io/selection-api/#dom-selection-empty
-    // TODO: When implementing actual selection UI, this may be the correct
-    // method to call as the abandon-selection action
+    /// <https://w3c.github.io/selection-api/#dom-selection-empty>
     fn Empty(&self) {
+        // > The method must be an alias, and behave identically, to removeAllRanges().
         self.clear_range();
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-collapse>
     fn Collapse(&self, cx: &mut JSContext, node: Option<&Node>, offset: u32) -> ErrorResult {
-        if let Some(node) = node {
-            if node.is_doctype() {
-                // w3c/selection-api#118
-                return Err(Error::InvalidNodeType(None));
-            }
-            if offset > node.len() {
-                // Step 2
-                return Err(Error::IndexSize(None));
-            }
-
-            if !self.is_same_root(node) {
-                // Step 3
-                return Ok(());
-            }
-
-            // Steps 4-5
-            let range = Range::new(cx, &self.document, node, offset, node, offset);
-
-            // Step 6
-            self.set_range(&range);
-            // Are we supposed to set Direction here? w3c/selection-api#116
-            //
-            self.direction.set(Direction::Forwards);
-        } else {
-            // Step 1
+        // Step 1. If node is null, this method must behave identically as
+        // removeAllRanges() and abort these steps.
+        let Some(node) = node else {
             self.clear_range();
+            return Ok(());
+        };
+
+        // Step 2. If node is a DocumentType, throw an InvalidNodeTypeError exception and
+        // abort these steps.
+        if node.is_doctype() {
+            return Err(Error::InvalidNodeType(None));
         }
+
+        // Step 3. The method must throw an IndexSizeError exception if offset is longer
+        // than node's length and abort these steps.
+        if offset > node.len() {
+            return Err(Error::IndexSize(None));
+        }
+
+        // Step 4. If document associated with this is not a shadow-including inclusive
+        // ancestor of node, abort these steps.
+        if !self.is_same_root(node) {
+            return Ok(());
+        }
+
+        // Step 5. Otherwise, let newRange be a new range.
+        // Step 6. Set the start the start and the end of newRange to (node, offset).
+        let new_range = Range::new(cx, &self.document, node, offset, node, offset);
+
+        // Step 7. Set this's range to newRange.
+        self.set_range(&new_range);
+
+        // Are we supposed to set Direction here? w3c/selection-api#116
+        self.direction.set(Direction::Forwards);
+
         Ok(())
     }
 
-    // https://w3c.github.io/selection-api/#dom-selection-setposition
-    // TODO: When implementing actual selection UI, this may be the correct
-    // method to call as the start-of-selection action, after a
-    // selectstart event has fired and not been cancelled.
+    /// <https://w3c.github.io/selection-api/#dom-selection-setposition>
     fn SetPosition(&self, cx: &mut JSContext, node: Option<&Node>, offset: u32) -> ErrorResult {
+        // > The method must be an alias, and behave identically, to collapse().
         self.Collapse(cx, node, offset)
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-collapsetostart>
     fn CollapseToStart(&self, cx: &mut JSContext) -> ErrorResult {
+        // > The method must throw InvalidStateError exception if the this is empty.
+        // > Otherwise, it must create a new range, set the start both its start and end to
+        // > the start of this's range, and then set this's range to the newly-created
+        // > range.
         if let Some(range) = self.range.get() {
             self.Collapse(cx, Some(&*range.start_container()), range.start_offset())
         } else {
@@ -330,6 +399,9 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
 
     /// <https://w3c.github.io/selection-api/#dom-selection-collapsetoend>
     fn CollapseToEnd(&self, cx: &mut JSContext) -> ErrorResult {
+        // > The method must throw InvalidStateError exception if the this is empty.
+        // > Otherwise, it must create a new range, set the start both its start and end to
+        // > the end of this's range, and then set this's range to the newly-created range.
         if let Some(range) = self.range.get() {
             self.Collapse(cx, Some(&*range.end_container()), range.end_offset())
         } else {
@@ -337,69 +409,91 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         }
     }
 
-    // https://w3c.github.io/selection-api/#dom-selection-extend
-    // TODO: When implementing actual selection UI, this may be the correct
-    // method to call as the continue-selection action
+    /// <https://w3c.github.io/selection-api/#dom-selection-extend>
     fn Extend(&self, cx: &mut JSContext, node: &Node, offset: u32) -> ErrorResult {
+        // Step 1. If the document associated with this is not a shadow-including
+        // inclusive ancestor of node, abort these steps.
         if !self.is_same_root(node) {
-            // Step 1
             return Ok(());
         }
-        if let Some(range) = self.range.get() {
-            if node.is_doctype() {
-                // w3c/selection-api#118
-                return Err(Error::InvalidNodeType(None));
-            }
 
-            if offset > node.len() {
-                // As with is_doctype, not explicit in selection spec steps here
-                // but implied by which exceptions are thrown in WPT tests
-                return Err(Error::IndexSize(None));
-            }
+        // Step 2. If this is empty, throw an InvalidStateError exception and abort these steps.
+        let Some(range) = self.range.get() else {
+            return Err(Error::InvalidState(None));
+        };
 
-            // Step 4
-            if !self.is_same_root(&range.start_container()) {
-                // Step 5, and its following 8 and 9
-                self.set_range(&Range::new(cx, &self.document, node, offset, node, offset));
-                self.direction.set(Direction::Forwards);
-            } else {
-                let old_anchor_node = &*self.GetAnchorNode().unwrap(); // has range, therefore has anchor node
-                let old_anchor_offset = self.AnchorOffset();
-                let is_old_anchor_before_or_equal = {
-                    if old_anchor_node == node {
-                        old_anchor_offset <= offset
-                    } else {
-                        old_anchor_node.is_before(node)
-                    }
-                };
-                if is_old_anchor_before_or_equal {
-                    // Step 6, and its following 8 and 9
-                    self.set_range(&Range::new(
-                        cx,
-                        &self.document,
-                        old_anchor_node,
-                        old_anchor_offset,
-                        node,
-                        offset,
-                    ));
-                    self.direction.set(Direction::Forwards);
+        // This isn't specified, but it appears to be implementation behavior of other
+        // browsers. See w3c/selection-api#118.
+        if node.is_doctype() {
+            return Err(Error::InvalidNodeType(None));
+        }
+
+        // As with is_doctype, this is not explicit in the selection specification steps
+        // here but implied by which exceptions are thrown in WPT tests.
+        if offset > node.len() {
+            return Err(Error::IndexSize(None));
+        }
+
+        // Step 3. Let oldAnchor and oldFocus be the this's anchor and focus, and let
+        // newFocus be the boundary point (node, offset).
+        //
+        // Note: oldFocus is unused, so we do not set it here.
+        let old_anchor_node = &*self
+            .GetAnchorNode()
+            .expect("has range, therefore has anchor node");
+        let old_anchor_offset = self.AnchorOffset();
+
+        // Step 4. Let newRange be a new range.
+        let new_range;
+        let direction;
+
+        // Step 5. If node's root is not the same as the this's range's root, set the
+        // start newRange's start and end to newFocus.
+        if !self.is_same_root(&range.start_container()) {
+            new_range = Range::new(cx, &self.document, node, offset, node, offset);
+            direction = Direction::Forwards;
+        } else {
+            let is_old_anchor_before_or_equal = {
+                if old_anchor_node == node {
+                    old_anchor_offset <= offset
                 } else {
-                    // Step 7, and its following 8 and 9
-                    self.set_range(&Range::new(
-                        cx,
-                        &self.document,
-                        node,
-                        offset,
-                        old_anchor_node,
-                        old_anchor_offset,
-                    ));
-                    self.direction.set(Direction::Backwards);
+                    old_anchor_node.is_before(node)
                 }
             };
-        } else {
-            // Step 2
-            return Err(Error::InvalidState(None));
+            if is_old_anchor_before_or_equal {
+                // Step 6. Otherwise, if oldAnchor is before or equal to newFocus, set the start
+                // newRange's start to oldAnchor, then set its end to newFocus.
+                new_range = Range::new(
+                    cx,
+                    &self.document,
+                    old_anchor_node,
+                    old_anchor_offset,
+                    node,
+                    offset,
+                );
+                direction = Direction::Forwards;
+            } else {
+                // Step 7. Otherwise, set the start newRange's start to newFocus, then set
+                // its end to oldAnchor.
+                new_range = Range::new(
+                    cx,
+                    &self.document,
+                    node,
+                    offset,
+                    old_anchor_node,
+                    old_anchor_offset,
+                );
+                direction = Direction::Backwards;
+            }
         }
+
+        // Step 8. Set this's range to newRange.
+        self.set_range(&new_range);
+
+        // Step 9. If newFocus is before oldAnchor, set this's direction to backwards.
+        // Otherwise, set it to forwards.
+        self.direction.set(direction);
+
         Ok(())
     }
 
@@ -412,22 +506,37 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         focus_node: &Node,
         focus_offset: u32,
     ) -> ErrorResult {
-        // Step 1
+        // This isn't specified, but it appears to be implementation behavior of other
+        // browsers. See w3c/selection-api#118.
         if anchor_node.is_doctype() || focus_node.is_doctype() {
-            // w3c/selection-api#118
             return Err(Error::InvalidNodeType(None));
         }
 
+        // Step 1. If anchorOffset is longer than anchorNode's length or if focusOffset is
+        // longer than focusNode's length, throw an IndexSizeError exception and abort
+        // these steps.
         if anchor_offset > anchor_node.len() || focus_offset > focus_node.len() {
             return Err(Error::IndexSize(None));
         }
 
-        // Step 2
+        // Step 2. If document associated with this is not a shadow-including inclusive
+        // ancestor of anchorNode or focusNode, abort these steps.
         if !self.is_same_root(anchor_node) || !self.is_same_root(focus_node) {
             return Ok(());
         }
 
-        // Steps 5-7
+        // Step 3. Let anchor be the boundary point (anchorNode, anchorOffset) and let
+        // focus be the boundary point (focusNode, focusOffset).
+        //
+        // Note: We do not model the boundary point in this way.
+
+        // Step 4. Let newRange be a new range.
+        let new_range;
+        let direction;
+
+        // Step 5. If anchor is before focus, set the start the newRange's start to anchor
+        // and its end to focus. Otherwise, set the start them to focus and anchor
+        // respectively.
         let is_focus_before_anchor = {
             if anchor_node == focus_node {
                 focus_offset < anchor_offset
@@ -436,67 +545,97 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
             }
         };
         if is_focus_before_anchor {
-            self.set_range(&Range::new(
+            new_range = Range::new(
                 cx,
                 &self.document,
                 focus_node,
                 focus_offset,
                 anchor_node,
                 anchor_offset,
-            ));
-            self.direction.set(Direction::Backwards);
+            );
+            direction = Direction::Backwards;
         } else {
-            self.set_range(&Range::new(
+            new_range = Range::new(
                 cx,
                 &self.document,
                 anchor_node,
                 anchor_offset,
                 focus_node,
                 focus_offset,
-            ));
-            self.direction.set(Direction::Forwards);
+            );
+            direction = Direction::Forwards;
         }
+
+        // Step 6. Set this's range to newRange.
+        self.set_range(&new_range);
+
+        // Step 7. If focus is before anchor, set this's direction to backwards.
+        // Otherwise, set it to forwards
+        self.direction.set(direction);
+
         Ok(())
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-selectallchildren>
     fn SelectAllChildren(&self, cx: &mut JSContext, node: &Node) -> ErrorResult {
+        // Step 1. If node is a DocumentType, throw an InvalidNodeTypeError exception and
+        // abort these steps.
         if node.is_doctype() {
-            // w3c/selection-api#118
             return Err(Error::InvalidNodeType(None));
         }
+
+        // Step 2. If node's root is not the document associated with this, abort these
+        // steps.
         if !self.is_same_root(node) {
             return Ok(());
         }
 
-        // Spec wording just says node length here, but WPT specifically
-        // wants number of children (the main difference is that it's 0
-        // for cdata).
-        self.set_range(&Range::new(
-            cx,
-            &self.document,
-            node,
-            0,
-            node,
-            node.children_count(),
-        ));
+        // Let newRange be a new range and childCount be the number of children of node.
+        let child_count = node.children_count();
 
+        // Step 4. Set newRange's start to (node, 0).
+        // Step 5. Set newRange's end to (node, childCount).
+        let new_range = Range::new(cx, &self.document, node, 0, node, child_count);
+
+        // Step 6. Set this's range to newRange.
+        self.set_range(&new_range);
+
+        // Step 7. Set this's direction to forwards.
         self.direction.set(Direction::Forwards);
+
         Ok(())
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-deletecontents>
     fn DeleteFromDocument(&self, cx: &mut JSContext) -> ErrorResult {
-        if let Some(range) = self.range.get() {
-            // Since the range is changing, it should trigger a
-            // selectionchange event as it would if if mutated any other way
-            return range.DeleteContents(cx);
+        // > The method must invoke deleteContents() on this's range if this is not empty
+        // > and both focus and anchor are in the document tree. Otherwise the method must
+        // > do nothing.
+        let Some(range) = self.range.get() else {
+            return Ok(());
+        };
+        if !range.start_and_end_are_in_document_tree() {
+            return Ok(());
         }
-        Ok(())
+
+        range.DeleteContents(cx)
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-containsnode>
     fn ContainsNode(&self, node: &Node, allow_partial_containment: bool) -> bool {
+        // > The method must return false if this is empty or if node's root is not the document
+        // > associated with this.
+        // >
+        // > Otherwise, if allowPartialContainment is false, the method must return true if and only
+        // > if start of its range is before or visually equivalent to the first boundary point in
+        // > the node and end of its range is after or visually equivalent to the last boundary
+        // > point in the node.
+        // >
+        // > If allowPartialContainment is true, the method must return true if and only if start of
+        // > its range is before or visually equivalent to the last boundary point in the node and
+        // > end of its range is after or visually equivalent to the first boundary point in the
+        // > node.
+
         // TODO: Spec requires a "visually equivalent to" check, which is
         // probably up to a layout query. This is therefore not a full implementation.
         if !self.is_same_root(node) {
@@ -548,10 +687,15 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
 
     /// <https://w3c.github.io/selection-api/#dom-selection-stringifier>
     fn Stringifier(&self, no_gc: &NoGC) -> DOMString {
-        // The spec as of Jan 31 2020 just says
-        // "See W3C bug 10583." for this method.
-        // Stringifying the range seems at least approximately right
-        // and passes the non-style-dependent case in the WPT tests.
+        // > The stringification must return the string, which is the concatenation of the
+        // > rendered text if there is a range associated with this.
+        // >
+        // > If the selection is within a textarea or input element, it must return the
+        // > selected substring in its value.
+        //
+        // TODO: This implementation should be examined in depth. Does rendered text take
+        // into account `display: none`. The case for textarea and input elements is
+        // completely unhandled here.
         if let Some(range) = self.range.get() {
             range.Stringifier(no_gc)
         } else {

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -200,7 +200,7 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         // > The attribute must return the anchor node of this, or null if the anchor is
         // > null or anchor is not in the document tree.
         let anchor_node = self.anchor_node()?;
-        if anchor_node.is_in_a_document_tree() {
+        if !anchor_node.is_in_a_document_tree() {
             return None;
         }
         Some(anchor_node)
@@ -212,7 +212,7 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         // > or anchor is not in the document tree.
         if self
             .anchor_node()
-            .is_none_or(|anchor_node| anchor_node.is_in_a_document_tree())
+            .is_none_or(|anchor_node| !anchor_node.is_in_a_document_tree())
         {
             return 0;
         }
@@ -224,7 +224,7 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         // > The attribute must return the focus node of this, or null if the focus is
         // > null or focus is not in the document tree.
         let focus_node = self.focus_node()?;
-        if focus_node.is_in_a_document_tree() {
+        if !focus_node.is_in_a_document_tree() {
             return None;
         }
         Some(focus_node)
@@ -236,7 +236,7 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         // > or focus is not in the document tree.
         if self
             .focus_node()
-            .is_none_or(|focus_node| focus_node.is_in_a_document_tree())
+            .is_none_or(|focus_node| !focus_node.is_in_a_document_tree())
         {
             return 0;
         }


### PR DESCRIPTION
This change adds specification comments, updates code to match those
comments, and filling in very minor specification steps to the DOM APIs
in `Selection`.  This is prepatory work for implementation of visible
selection in Servo.

Testing: TBD
