### PR TITLE
script: Stop treating `<label>` as a form-associated element

### DIFF
--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -68,7 +68,6 @@ use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::html::htmlfieldsetelement::HTMLFieldSetElement;
 use crate::dom::html::htmlformcontrolscollection::HTMLFormControlsCollection;
 use crate::dom::html::htmlimageelement::HTMLImageElement;
-use crate::dom::html::htmllabelelement::HTMLLabelElement;
 use crate::dom::html::htmllegendelement::HTMLLegendElement;
 use crate::dom::html::htmlobjectelement::HTMLObjectElement;
 use crate::dom::html::htmloutputelement::HTMLOutputElement;
@@ -1950,9 +1949,6 @@ impl FormControlElementHelpers for Element {
             NodeTypeId::Element(ElementTypeId::HTMLElement(
                 HTMLElementTypeId::HTMLInputElement,
             )) => Some(self.downcast::<HTMLInputElement>().unwrap() as &dyn FormControl),
-            NodeTypeId::Element(ElementTypeId::HTMLElement(
-                HTMLElementTypeId::HTMLLabelElement,
-            )) => Some(self.downcast::<HTMLLabelElement>().unwrap() as &dyn FormControl),
             NodeTypeId::Element(ElementTypeId::HTMLElement(
                 HTMLElementTypeId::HTMLLegendElement,
             )) => Some(self.downcast::<HTMLLegendElement>().unwrap() as &dyn FormControl),

--- a/components/script/dom/html/htmllabelelement.rs
+++ b/components/script/dom/html/htmllabelelement.rs
@@ -21,7 +21,7 @@ use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::event::Event;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::html::htmlelement::HTMLElement;
-use crate::dom::html::htmlformelement::{FormControl, FormControlElementHelpers, HTMLFormElement};
+use crate::dom::html::htmlformelement::{FormControlElementHelpers, HTMLFormElement};
 use crate::dom::iterators::ShadowIncluding;
 use crate::dom::node::Node;
 use crate::dom::node::virtualmethods::VirtualMethods;
@@ -87,9 +87,21 @@ impl Activatable for HTMLLabelElement {
 }
 
 impl HTMLLabelElementMethods<crate::DomTypeHolder> for HTMLLabelElement {
-    /// <https://html.spec.whatwg.org/multipage/#dom-fae-form>
+    /// <https://html.spec.whatwg.org/multipage/#dom-label-form>
     fn GetForm(&self) -> Option<DomRoot<HTMLFormElement>> {
-        self.form_owner()
+        // > The form IDL attribute must run the following steps:
+        // > 1. If the label element has no labeled control, then return null.
+        // > 2. If the label element's labeled control is not a form-associated element, then
+        // >    return null.
+        // > 3. Return the label element's labeled control's form owner (which can still be
+        // >    null).
+        self.GetControl()
+            .map(DomRoot::upcast::<Element>)
+            .and_then(|element| {
+                element
+                    .as_maybe_form_control()
+                    .and_then(|control| control.form_owner())
+            })
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-label-htmlfor
@@ -166,9 +178,6 @@ impl VirtualMethods for HTMLLabelElement {
         self.super_type()
             .unwrap()
             .attribute_mutated(cx, attr, mutation);
-        if *attr.local_name() == local_name!("form") {
-            self.form_attribute_mutated(cx, mutation);
-        }
     }
 }
 
@@ -178,25 +187,5 @@ impl HTMLLabelElement {
             .traverse_preorder(ShadowIncluding::No)
             .filter_map(DomRoot::downcast::<HTMLElement>)
             .find(|elem| elem.is_labelable_element())
-    }
-}
-
-impl FormControl for HTMLLabelElement {
-    fn form_owner(&self) -> Option<DomRoot<HTMLFormElement>> {
-        self.GetControl()
-            .map(DomRoot::upcast::<Element>)
-            .and_then(|elem| {
-                elem.as_maybe_form_control()
-                    .and_then(|control| control.form_owner())
-            })
-    }
-
-    fn set_form_owner(&self, _: Option<&HTMLFormElement>) {
-        // Label is a special case for form owner, it reflects its control's
-        // form owner. Therefore it doesn't hold form owner itself.
-    }
-
-    fn to_html_element(&self) -> &HTMLElement {
-        self.upcast::<HTMLElement>()
     }
 }

--- a/tests/wpt/tests/html/semantics/forms/the-label-element/move-form-associated-element-into-label-crash.html
+++ b/tests/wpt/tests/html/semantics/forms/the-label-element/move-form-associated-element-into-label-crash.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/46108">
+<form>
+  <select id="select">
+    <label id="label">
+<script>
+    label.outerHTML = select.outerHTML;
+</script>


### PR DESCRIPTION
`<label>` was being treated as a form-associated element, but the
spec[^1] does not list it as one. This led to it being added to
`HTMLFormElement::controls`, but not removed consistently. This change
stops treating it as a special-case form-associated element which fixes
a panic in debug builds.

[^1]: https://html.spec.whatwg.org/multipage/forms.html#form-associated-element

Testing: This change adds a WPT crash test.
Fixes: #46108.
